### PR TITLE
perf(rob-268): collapse KIS mock VTS inquire-balance duplicate calls

### DIFF
--- a/app/services/brokers/kis/account.py
+++ b/app/services/brokers/kis/account.py
@@ -248,16 +248,14 @@ class AccountClient:
                 "tr_cont": tr_cont_req,
             }
 
-            js, resp_headers = (
-                await self._parent._request_with_rate_limit_with_headers(
-                    "GET",
-                    self._parent._kis_url(constants.DOMESTIC_BALANCE_URL),
-                    headers=hdr,
-                    params=params,
-                    timeout=5,
-                    api_name="fetch_domestic_balance_snapshot",
-                    tr_id=tr_id,
-                )
+            js, resp_headers = await self._parent._request_with_rate_limit_with_headers(
+                "GET",
+                self._parent._kis_url(constants.DOMESTIC_BALANCE_URL),
+                headers=hdr,
+                params=params,
+                timeout=5,
+                api_name="fetch_domestic_balance_snapshot",
+                tr_id=tr_id,
             )
 
             if js.get("rt_cd") != "0":

--- a/app/services/brokers/kis/account.py
+++ b/app/services/brokers/kis/account.py
@@ -183,6 +183,138 @@ class AccountClient:
             "raw": output,
         }
 
+    async def fetch_domestic_balance_snapshot(
+        self,
+        *,
+        is_mock: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch domestic balance as a single snapshot of holdings + cash.
+
+        Issues one or more requests to KIS ``/uapi/domestic-stock/v1/trading/inquire-balance``
+        (TR ``VTTC8434R`` mock / ``TTTC8434R`` live) and consolidates:
+
+        * ``output1`` across all pages (filtered: hldg_qty > 0) → ``holdings``
+        * ``output2[0]`` from page 1 → ``cash``
+
+        Pagination is gated by the **response** ``tr_cont`` header rather than
+        the body cursor: KIS signals continuation with ``F``/``M`` and
+        end-of-stream with ``D``/``E``/empty. The helper stops on end-of-stream
+        even if the body still carries a non-empty cursor (this is the ROB-268
+        phantom-page case that was causing duplicate VTS calls).
+
+        Returns:
+            ``{"holdings": list[dict], "cash": dict, "page_count": int}``.
+        """
+        await self._parent._ensure_token()
+
+        cano, acnt_prdt_cd = self._resolve_account_parts()
+        tr_id = (
+            constants.DOMESTIC_BALANCE_TR_MOCK
+            if is_mock
+            else constants.DOMESTIC_BALANCE_TR
+        )
+
+        all_stocks: list[dict[str, Any]] = []
+        cash: dict[str, Any] = {}
+        ctx_area_fk = ""
+        ctx_area_nk = ""
+        tr_cont_req = ""
+        page = 1
+        max_pages = 10
+        stop_reason = "max_pages"
+
+        logging.info(
+            "국내 balance snapshot 조회 시작 (is_mock=%s)",
+            is_mock,
+        )
+
+        while page <= max_pages:
+            params = {
+                "CANO": cano,
+                "ACNT_PRDT_CD": acnt_prdt_cd,
+                "AFHR_FLPR_YN": "N",
+                "OFL_YN": "",
+                "INQR_DVSN": "00",
+                "UNPR_DVSN": "01",
+                "FUND_STTL_ICLD_YN": "N",
+                "FNCG_AMT_AUTO_RDPT_YN": "N",
+                "PRCS_DVSN": "01",
+                "CTX_AREA_FK100": ctx_area_fk,
+                "CTX_AREA_NK100": ctx_area_nk,
+            }
+            hdr = self._parent._hdr_base | {
+                "authorization": f"Bearer {self._settings.kis_access_token}",
+                "tr_id": tr_id,
+                "tr_cont": tr_cont_req,
+            }
+
+            js, resp_headers = (
+                await self._parent._request_with_rate_limit_with_headers(
+                    "GET",
+                    self._parent._kis_url(constants.DOMESTIC_BALANCE_URL),
+                    headers=hdr,
+                    params=params,
+                    timeout=5,
+                    api_name="fetch_domestic_balance_snapshot",
+                    tr_id=tr_id,
+                )
+            )
+
+            if js.get("rt_cd") != "0":
+                if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+                    await self._parent._token_manager.clear_token()
+                    await self._parent._ensure_token()
+                    continue
+                error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
+                logging.error("국내 balance snapshot 조회 실패: %s", error_msg)
+                raise RuntimeError(error_msg)
+
+            stocks = js.get("output1") or []
+            all_stocks.extend(stocks)
+
+            if page == 1:
+                output2 = js.get("output2") or []
+                if isinstance(output2, list) and output2:
+                    first = output2[0]
+                    if isinstance(first, dict):
+                        cash = first
+
+            next_tr_cont = (resp_headers.get("tr_cont") or "").strip().upper()
+            new_ctx_area_fk = js.get("CTX_AREA_FK100", "") or ""
+            new_ctx_area_nk = js.get("CTX_AREA_NK100", "") or ""
+
+            if next_tr_cont not in ("F", "M"):
+                stop_reason = "tr_cont_end"
+                break
+            if not new_ctx_area_nk:
+                stop_reason = "empty_cursor"
+                break
+            if new_ctx_area_nk == ctx_area_nk:
+                stop_reason = "repeated_cursor"
+                break
+
+            ctx_area_fk = new_ctx_area_fk
+            ctx_area_nk = new_ctx_area_nk
+            tr_cont_req = "N"
+            page += 1
+            await asyncio.sleep(0.1)
+
+        holdings = self._filter_nonzero_holdings(all_stocks, is_overseas=False)
+
+        logging.info(
+            "국내 balance snapshot 조회 완료: %d건 (보유수량 > 0), %d페이지 (stop=%s)",
+            len(holdings),
+            page,
+            stop_reason,
+        )
+
+        return {
+            "holdings": holdings,
+            "cash": cash,
+            "page_count": page,
+            "stop_reason": stop_reason,
+        }
+
     async def fetch_my_stocks(
         self,
         is_mock: bool = False,

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -403,6 +403,42 @@ class BaseKISClient:
             RateLimitExceededError: When rate limit retries exhausted
             httpx.HTTPStatusError: On HTTP errors after retries exhausted
         """
+        data, _headers = await self._request_with_rate_limit_with_headers(
+            method,
+            url,
+            headers=headers,
+            params=params,
+            json_body=json_body,
+            timeout=timeout,
+            api_name=api_name,
+            tr_id=tr_id,
+        )
+        return data
+
+    async def _request_with_rate_limit_with_headers(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout: float = 5.0,
+        api_name: str = "unknown",
+        tr_id: str | None = None,
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        """Like :meth:`_request_with_rate_limit` but also returns response headers.
+
+        Returns:
+            ``(parsed_data, response_headers)`` — headers are a plain ``dict[str, str]``
+            (httpx Headers flattened, case-preserved per item).
+
+        Notes:
+            Some KIS endpoints (notably ``/uapi/domestic-stock/v1/trading/inquire-balance``)
+            signal continuation through the ``tr_cont`` response header rather than the
+            response body. Callers that need that signal use this method; everyone else
+            should keep using :meth:`_request_with_rate_limit`.
+        """
         parsed_url = urlparse(url)
         api_path = parsed_url.path or "/unknown"
         api_key = f"{tr_id or 'unknown'}|{api_path}"
@@ -475,7 +511,7 @@ class BaseKISClient:
                     await asyncio.sleep(wait_time)
                     continue
 
-                return data
+                return data, dict(response.headers)
 
             except httpx.HTTPStatusError as e:
                 last_error = e

--- a/app/services/brokers/kis/protocols.py
+++ b/app/services/brokers/kis/protocols.py
@@ -58,6 +58,21 @@ class KISClientProtocol(Protocol):
         """Make HTTP request with rate limiting and retry logic."""
         ...
 
+    async def _request_with_rate_limit_with_headers(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        timeout: float = 5.0,
+        api_name: str = "unknown",
+        tr_id: str | None = None,
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        """Make HTTP request with rate limiting and return parsed data plus headers."""
+        ...
+
     def _get_rate_limit_for_api(self, api_key: str) -> tuple[int, float]:
         """Get rate limit for a specific API key."""
         ...

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Protocol
 
+import sentry_sdk
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.manual_holdings import MarketType
@@ -730,9 +731,15 @@ class KISMockHomeReader:
 
         try:
             client = SafeKISMockClient()
-            stocks_kr = await client.account.fetch_my_stocks(
-                is_mock=True, is_overseas=False
+            # ROB-268: single inquire-balance snapshot supplies both holdings
+            # (output1) and cash (output2). Previously this reader issued
+            # fetch_my_stocks + inquire_domestic_cash_balance — two duplicate
+            # round trips to the same KIS VTS endpoint.
+            snapshot = await client.account.fetch_domestic_balance_snapshot(
+                is_mock=True
             )
+            stocks_kr = snapshot.get("holdings") or []
+            cash_payload = snapshot.get("cash") or {}
 
             holdings: list[Holding] = []
             for s in stocks_kr:
@@ -791,28 +798,34 @@ class KISMockHomeReader:
             cash_krw: float | None = None
             buying_power_krw: float | None = None
             cash_warning: InvestHomeWarning | None = None
-            try:
-                cash_data = await client.account.inquire_domestic_cash_balance(
-                    is_mock=True
-                )
-                raw_balance = cash_data.get("dnca_tot_amt")
-                raw_orderable = cash_data.get("stck_cash_ord_psbl_amt")
-                if raw_balance is not None:
-                    try:
-                        cash_krw = float(raw_balance)
-                    except (TypeError, ValueError):
-                        cash_krw = None
-                if raw_orderable is not None:
-                    try:
-                        buying_power_krw = float(raw_orderable)
-                    except (TypeError, ValueError):
-                        buying_power_krw = None
-            except Exception as exc:
-                logger.warning("KIS mock cash balance fetch failed: %s", exc)
-                cash_warning = InvestHomeWarning(
-                    source="kis_mock",
-                    message="KIS 모의투자 예수금/주문가능 조회 실패",
-                )
+            raw_balance = cash_payload.get("dnca_tot_amt")
+            raw_orderable = cash_payload.get("stck_cash_ord_psbl_amt")
+            if raw_balance is not None:
+                try:
+                    cash_krw = float(raw_balance)
+                except (TypeError, ValueError):
+                    cash_krw = None
+            if raw_orderable is not None:
+                try:
+                    buying_power_krw = float(raw_orderable)
+                except (TypeError, ValueError):
+                    buying_power_krw = None
+
+            # ROB-268: surface snapshot observability on the enclosing
+            # `invest.home.kis_mock` span so deploy-time Sentry verification can
+            # confirm the duplicate-call regression has been eliminated.
+            # Best-effort: no-op when Sentry has no active span.
+            span = sentry_sdk.get_current_span()
+            if span is not None:
+                page_count = int(snapshot.get("page_count") or 1)
+                cash_fallback = cash_krw is None or buying_power_krw is None
+                span.set_tag("kis_mock.used_cash_from_snapshot", True)
+                span.set_tag("kis_mock.cash_fallback", cash_fallback)
+                stop_reason = snapshot.get("stop_reason")
+                if stop_reason:
+                    span.set_tag("kis_mock.pagination_stop_reason", stop_reason)
+                span.set_data("kis_mock.balance_page_count", page_count)
+                span.set_data("kis_mock.balance_call_count", page_count)
 
             account = Account(
                 accountId="kis_mock_account",

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -480,32 +480,28 @@ async def test_manual_reader_does_not_fabricate_value_from_cost_basis(
 
 
 class _FakeKISMockAccount:
-    async def fetch_my_stocks(
-        self, *, is_mock: bool, is_overseas: bool
-    ) -> list[dict[str, Any]]:
-        assert is_mock is True
-        assert is_overseas is False
-        return [
-            {
-                "pdno": "005935",
-                "prdt_name": "삼성전자우",
-                "hldg_qty": "5",
-                "pchs_avg_pric": "60000",
-                "pchs_amt": "300000",
-                "evlu_amt": "310000",
-                "evlu_pfls_amt": "10000",
-                "evlu_pfls_rt": "3.3333",
-            }
-        ]
-
-    async def inquire_domestic_cash_balance(
-        self, is_mock: bool = False
+    async def fetch_domestic_balance_snapshot(
+        self, *, is_mock: bool = False
     ) -> dict[str, Any]:
         assert is_mock is True
         return {
-            "dnca_tot_amt": 200_000.0,
-            "stck_cash_ord_psbl_amt": 180_000.0,
-            "raw": {},
+            "holdings": [
+                {
+                    "pdno": "005935",
+                    "prdt_name": "삼성전자우",
+                    "hldg_qty": "5",
+                    "pchs_avg_pric": "60000",
+                    "pchs_amt": "300000",
+                    "evlu_amt": "310000",
+                    "evlu_pfls_amt": "10000",
+                    "evlu_pfls_rt": "3.3333",
+                }
+            ],
+            "cash": {
+                "dnca_tot_amt": 200_000.0,
+                "stck_cash_ord_psbl_amt": 180_000.0,
+            },
+            "page_count": 1,
         }
 
 
@@ -555,29 +551,26 @@ async def test_kis_mock_reader_reports_zero_cost_basis_gain(
     """Zero recorded cost basis should not hide an otherwise valued mock position."""
 
     class _ZeroCostAccount:
-        async def fetch_my_stocks(
-            self, *, is_mock: bool, is_overseas: bool
-        ) -> list[dict[str, Any]]:
-            assert is_mock is True
-            assert is_overseas is False
-            return [
-                {
-                    "pdno": "000000",
-                    "prdt_name": "무상입고",
-                    "hldg_qty": "1",
-                    "pchs_avg_pric": "0",
-                    "pchs_amt": "0",
-                    "evlu_amt": "12345",
-                    "evlu_pfls_amt": "12345",
-                    "evlu_pfls_rt": "0",
-                }
-            ]
-
-        async def inquire_domestic_cash_balance(
-            self, is_mock: bool = False
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
         ) -> dict[str, Any]:
             assert is_mock is True
-            return {"dnca_tot_amt": 0, "stck_cash_ord_psbl_amt": 0, "raw": {}}
+            return {
+                "holdings": [
+                    {
+                        "pdno": "000000",
+                        "prdt_name": "무상입고",
+                        "hldg_qty": "1",
+                        "pchs_avg_pric": "0",
+                        "pchs_amt": "0",
+                        "evlu_amt": "12345",
+                        "evlu_pfls_amt": "12345",
+                        "evlu_pfls_rt": "0",
+                    }
+                ],
+                "cash": {"dnca_tot_amt": 0, "stck_cash_ord_psbl_amt": 0},
+                "page_count": 1,
+            }
 
     class _ZeroCostClient:
         def __init__(self) -> None:
@@ -603,21 +596,17 @@ async def test_kis_mock_reader_ignores_unparseable_cash_amounts(
     """Bad mock cash strings should not poison holdings or account valuation."""
 
     class _BadCashAccount:
-        async def fetch_my_stocks(
-            self, *, is_mock: bool, is_overseas: bool
-        ) -> list[dict[str, Any]]:
-            assert is_mock is True
-            assert is_overseas is False
-            return []
-
-        async def inquire_domestic_cash_balance(
-            self, is_mock: bool = False
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
         ) -> dict[str, Any]:
             assert is_mock is True
             return {
-                "dnca_tot_amt": "not-a-number",
-                "stck_cash_ord_psbl_amt": "also-bad",
-                "raw": {},
+                "holdings": [],
+                "cash": {
+                    "dnca_tot_amt": "not-a-number",
+                    "stck_cash_ord_psbl_amt": "also-bad",
+                },
+                "page_count": 1,
             }
 
     class _BadCashClient:
@@ -681,81 +670,177 @@ async def test_kis_mock_reader_partial_failure_returns_warning(
     assert result.warning.source == "kis_mock"
 
 
+# ---------------------------------------------------------------------------
+# ROB-268: KISMockHomeReader uses balance snapshot (no duplicate VTS calls)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_kis_mock_reader_cash_balance_called_with_is_mock_true(
+async def test_kis_mock_reader_uses_balance_snapshot_and_skips_inquire_cash(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """inquire_domestic_cash_balance must be called with is_mock=True."""
-    cash_balance_calls: list[bool] = []
+    """ROB-268: KISMockHomeReader pulls cash from the holdings snapshot.
 
-    class _TrackingAccount:
-        async def fetch_my_stocks(
-            self, *, is_mock: bool, is_overseas: bool
-        ) -> list[dict[str, Any]]:
-            return []
+    The reader must not issue a second /inquire-balance via
+    ``inquire_domestic_cash_balance`` when the snapshot already carries cash.
+    """
+    snapshot_calls: list[bool] = []
+    legacy_calls: list[str] = []
+
+    class _SnapshotAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            snapshot_calls.append(is_mock)
+            return {
+                "holdings": [
+                    {
+                        "pdno": "005930",
+                        "prdt_name": "삼성전자",
+                        "hldg_qty": "1",
+                        "pchs_avg_pric": "70000",
+                        "pchs_amt": "70000",
+                        "evlu_amt": "72000",
+                        "evlu_pfls_amt": "2000",
+                        "evlu_pfls_rt": "2.857",
+                    }
+                ],
+                "cash": {
+                    "dnca_tot_amt": "200000",
+                    "stck_cash_ord_psbl_amt": "180000",
+                },
+                "page_count": 1,
+            }
 
         async def inquire_domestic_cash_balance(
             self, is_mock: bool = False
         ) -> dict[str, Any]:
-            cash_balance_calls.append(is_mock)
-            return {
-                "dnca_tot_amt": 50_000.0,
-                "stck_cash_ord_psbl_amt": 40_000.0,
-                "raw": {},
-            }
+            legacy_calls.append("inquire_domestic_cash_balance")
+            return {}
 
-    class _TrackingClient:
+        async def fetch_my_stocks(self, **kwargs: Any) -> list[dict[str, Any]]:
+            legacy_calls.append("fetch_my_stocks")
+            return []
+
+    class _SnapshotClient:
         def __init__(self) -> None:
-            self.account = _TrackingAccount()
+            self.account = _SnapshotAccount()
 
-    monkeypatch.setattr(readers, "SafeKISMockClient", _TrackingClient)
+    monkeypatch.setattr(readers, "SafeKISMockClient", _SnapshotClient)
     monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
 
     result = await readers.KISMockHomeReader().fetch(user_id=1)
 
-    assert cash_balance_calls == [True], (
-        "inquire_domestic_cash_balance was not called with is_mock=True"
+    assert snapshot_calls == [True], (
+        "Expected one fetch_domestic_balance_snapshot(is_mock=True) call; "
+        f"got {snapshot_calls}"
     )
+    assert legacy_calls == [], (
+        "Reader must not call legacy duplicate paths when snapshot is "
+        f"available; got {legacy_calls}"
+    )
+
     account = result.accounts[0]
-    assert account.cashBalances.krw == pytest.approx(50_000.0)
-    assert account.buyingPower.krw == pytest.approx(40_000.0)
+    assert account.source == "kis_mock"
+    assert account.valueKrw == 72_000
+    assert account.cashBalances.krw == pytest.approx(200_000.0)
+    assert account.buyingPower.krw == pytest.approx(180_000.0)
+
+    holding = result.holdings[0]
+    assert holding.symbol == "005930"
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_kis_mock_reader_cash_failure_is_non_fatal(
+async def test_kis_mock_reader_snapshot_unparseable_cash_no_extra_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cash balance fetch failure must not block holdings/account — produces a warning."""
+    """ROB-268: snapshot cash that is unparseable must degrade gracefully.
 
-    class _CashFailAccount:
-        async def fetch_my_stocks(
-            self, *, is_mock: bool, is_overseas: bool
-        ) -> list[dict[str, Any]]:
-            return [
-                {
-                    "pdno": "005930",
-                    "prdt_name": "삼성전자",
-                    "hldg_qty": "1",
-                    "pchs_avg_pric": "70000",
-                    "pchs_amt": "70000",
-                    "evlu_amt": "72000",
-                    "evlu_pfls_amt": "2000",
-                    "evlu_pfls_rt": "2.857",
-                }
-            ]
+    The reader must surface cash=None without falling back to a duplicate
+    /inquire-balance — the fallback path is exactly what we are eliminating.
+    """
+    extra_calls: list[str] = []
+
+    class _BadCashSnapshotAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            return {
+                "holdings": [],
+                "cash": {
+                    "dnca_tot_amt": "not-a-number",
+                    "stck_cash_ord_psbl_amt": "also-bad",
+                },
+                "page_count": 1,
+            }
 
         async def inquire_domestic_cash_balance(
             self, is_mock: bool = False
         ) -> dict[str, Any]:
-            raise RuntimeError("cash API unavailable")
+            extra_calls.append("inquire_domestic_cash_balance")
+            return {}
 
-    class _CashFailClient:
+        async def fetch_my_stocks(self, **kwargs: Any) -> list[dict[str, Any]]:
+            extra_calls.append("fetch_my_stocks")
+            return []
+
+    class _BadCashSnapshotClient:
         def __init__(self) -> None:
-            self.account = _CashFailAccount()
+            self.account = _BadCashSnapshotAccount()
 
-    monkeypatch.setattr(readers, "SafeKISMockClient", _CashFailClient)
+    monkeypatch.setattr(readers, "SafeKISMockClient", _BadCashSnapshotClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert extra_calls == [], (
+        f"Bad cash parsing must not trigger duplicate VTS calls; got {extra_calls}"
+    )
+    account = result.accounts[0]
+    assert account.cashBalances.krw is None
+    assert account.buyingPower.krw is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_snapshot_missing_cash_keys_does_not_break(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-268: snapshot with no output2 (empty ``cash`` dict) must not fail the reader.
+
+    Distinct from the unparseable-cash case: this models KIS returning output1
+    only, with no output2 array — e.g. KIS-side schema drift.
+    """
+
+    class _MissingCashAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            return {
+                "holdings": [
+                    {
+                        "pdno": "005930",
+                        "prdt_name": "삼성전자",
+                        "hldg_qty": "1",
+                        "pchs_avg_pric": "70000",
+                        "pchs_amt": "70000",
+                        "evlu_amt": "72000",
+                        "evlu_pfls_amt": "2000",
+                        "evlu_pfls_rt": "2.857",
+                    }
+                ],
+                "cash": {},
+                "page_count": 1,
+                "stop_reason": "tr_cont_end",
+            }
+
+    class _MissingCashClient:
+        def __init__(self) -> None:
+            self.account = _MissingCashAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _MissingCashClient)
     monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
 
     result = await readers.KISMockHomeReader().fetch(user_id=1)
@@ -765,7 +850,159 @@ async def test_kis_mock_reader_cash_failure_is_non_fatal(
     account = result.accounts[0]
     assert account.cashBalances.krw is None
     assert account.buyingPower.krw is None
-    # Warning emitted but result is not empty
+
+
+class _RecordingSpan:
+    """Captures Sentry set_tag / set_data calls for assertion."""
+
+    def __init__(self) -> None:
+        self.tags: dict[str, Any] = {}
+        self.data: dict[str, Any] = {}
+
+    def set_tag(self, key: str, value: Any) -> None:
+        self.tags[key] = value
+
+    def set_data(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_emits_sentry_observability_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-268: tag the current Sentry span with snapshot observability fields.
+
+    Deploy-time verification of the duplicate-call fix depends on these tags;
+    they are part of the acceptance criteria (see Linear ROB-268).
+    """
+
+    class _SnapshotAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            return {
+                "holdings": [],
+                "cash": {
+                    "dnca_tot_amt": "100000",
+                    "stck_cash_ord_psbl_amt": "90000",
+                },
+                "page_count": 1,
+                "stop_reason": "tr_cont_end",
+            }
+
+    class _SnapshotClient:
+        def __init__(self) -> None:
+            self.account = _SnapshotAccount()
+
+    span = _RecordingSpan()
+    monkeypatch.setattr(readers, "SafeKISMockClient", _SnapshotClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+    monkeypatch.setattr(readers.sentry_sdk, "get_current_span", lambda: span)
+
+    await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert span.tags.get("kis_mock.used_cash_from_snapshot") is True
+    assert span.tags.get("kis_mock.cash_fallback") is False
+    assert span.tags.get("kis_mock.pagination_stop_reason") == "tr_cont_end"
+    assert span.data.get("kis_mock.balance_page_count") == 1
+    assert span.data.get("kis_mock.balance_call_count") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_cash_fallback_tag_when_unparseable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-268: ``kis_mock.cash_fallback`` must be True when cash cannot be parsed."""
+
+    class _BadCashSnapshotAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            return {
+                "holdings": [],
+                "cash": {
+                    "dnca_tot_amt": "not-a-number",
+                    "stck_cash_ord_psbl_amt": "also-bad",
+                },
+                "page_count": 1,
+                "stop_reason": "tr_cont_end",
+            }
+
+    class _BadCashClient:
+        def __init__(self) -> None:
+            self.account = _BadCashSnapshotAccount()
+
+    span = _RecordingSpan()
+    monkeypatch.setattr(readers, "SafeKISMockClient", _BadCashClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+    monkeypatch.setattr(readers.sentry_sdk, "get_current_span", lambda: span)
+
+    await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert span.tags.get("kis_mock.cash_fallback") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_no_op_when_no_active_sentry_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-268: reader must not break when Sentry has no active span (disabled / tests)."""
+
+    class _SnapshotAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            return {
+                "holdings": [],
+                "cash": {
+                    "dnca_tot_amt": "100000",
+                    "stck_cash_ord_psbl_amt": "90000",
+                },
+                "page_count": 1,
+                "stop_reason": "tr_cont_end",
+            }
+
+    class _SnapshotClient:
+        def __init__(self) -> None:
+            self.account = _SnapshotAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _SnapshotClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+    monkeypatch.setattr(readers.sentry_sdk, "get_current_span", lambda: None)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert result.accounts and result.accounts[0].source == "kis_mock"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_snapshot_failure_returns_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-268: snapshot exception (e.g. VTS timeout) must yield warning,
+    not propagate up and break live/manual/Upbit sources."""
+
+    class _ExplodingAccount:
+        async def fetch_domestic_balance_snapshot(
+            self, *, is_mock: bool = False
+        ) -> dict[str, Any]:
+            raise RuntimeError("VTS timeout")
+
+    class _ExplodingClient:
+        def __init__(self) -> None:
+            self.account = _ExplodingAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _ExplodingClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert result.accounts == []
+    assert result.holdings == []
     assert result.warning is not None
     assert result.warning.source == "kis_mock"
 

--- a/tests/test_kis_domestic_balance_snapshot.py
+++ b/tests/test_kis_domestic_balance_snapshot.py
@@ -1,0 +1,348 @@
+"""ROB-268 — KIS domestic balance snapshot helper tests.
+
+Validates that ``AccountClient.fetch_domestic_balance_snapshot`` consolidates
+holdings (output1) and cash (output2) from a single KIS inquire-balance
+response lineage, and uses the response header ``tr_cont`` (not just the body
+cursor) to decide whether to request another page.
+
+Reference: see Linear ROB-268 for the original Sentry trace evidence
+(``invest.home.kis_mock`` ~14.3s of 15s total) showing the duplicate-call
+pattern this helper replaces.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.brokers.kis import constants
+from app.services.brokers.kis.account import AccountClient
+
+
+class _FakeSettings:
+    kis_account_no = "12345678-01"
+    kis_access_token = "test-token"
+    kis_app_key = "key"
+    kis_app_secret = "secret"
+
+
+class _FakeParent:
+    """Fake KIS parent client.
+
+    The snapshot helper is expected to drive paging through a new header-aware
+    request method ``_request_with_rate_limit_with_headers`` so that the
+    response header ``tr_cont`` becomes visible to the caller. Tests configure
+    a queue of ``(body, headers)`` pairs that are returned in order.
+    """
+
+    def __init__(
+        self,
+        responses: list[tuple[dict[str, Any], dict[str, str]]],
+    ) -> None:
+        self._settings = _FakeSettings()
+        self._hdr_base = {
+            "appkey": "key",
+            "appsecret": "secret",
+            "tr_id": "X",
+            "custtype": "P",
+        }
+        self.calls: list[dict[str, Any]] = []
+        self._responses = list(responses)
+        self._ensure_token = AsyncMock()
+
+        async def _stub(
+            method: str,
+            url: str,
+            *,
+            headers: dict[str, str],
+            params: dict[str, Any] | None = None,
+            json_body: dict[str, Any] | None = None,
+            timeout: float = 5.0,
+            api_name: str = "unknown",
+            tr_id: str | None = None,
+        ) -> tuple[dict[str, Any], dict[str, str]]:
+            self.calls.append(
+                {
+                    "method": method,
+                    "url": url,
+                    "headers": dict(headers),
+                    "params": dict(params or {}),
+                    "api_name": api_name,
+                    "tr_id": tr_id,
+                }
+            )
+            if not self._responses:
+                raise AssertionError(
+                    "Unexpected KIS request: ran out of queued responses "
+                    f"(call #{len(self.calls)})"
+                )
+            return self._responses.pop(0)
+
+        self._request_with_rate_limit_with_headers = _stub
+
+    def _kis_url(self, path: str) -> str:
+        return f"https://example.com{path}"
+
+
+def _page(
+    *,
+    stocks: list[dict[str, Any]] | None = None,
+    cash: dict[str, Any] | None = None,
+    ctx_fk: str = "",
+    ctx_nk: str = "",
+    tr_cont: str = "",
+) -> tuple[dict[str, Any], dict[str, str]]:
+    body: dict[str, Any] = {
+        "rt_cd": "0",
+        "msg_cd": "",
+        "msg1": "",
+        "output1": stocks or [],
+        "output2": [cash] if cash is not None else [{}],
+        "CTX_AREA_FK100": ctx_fk,
+        "CTX_AREA_NK100": ctx_nk,
+    }
+    return body, {"tr_cont": tr_cont}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_single_page_issues_one_request() -> None:
+    """Normal 1-page case: exactly one /inquire-balance call."""
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[
+                    {
+                        "pdno": "005930",
+                        "prdt_name": "삼성전자",
+                        "hldg_qty": "1",
+                        "pchs_avg_pric": "70000",
+                        "pchs_amt": "70000",
+                        "evlu_amt": "72000",
+                    }
+                ],
+                cash={
+                    "dnca_tot_amt": "1000000",
+                    "stck_cash_ord_psbl_amt": "900000",
+                },
+                tr_cont="D",
+            )
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert len(parent.calls) == 1, (
+        f"Expected exactly 1 inquire-balance call, got {len(parent.calls)}"
+    )
+    assert snapshot["page_count"] == 1
+    assert len(snapshot["holdings"]) == 1
+    assert snapshot["holdings"][0]["pdno"] == "005930"
+    assert snapshot["cash"]["dnca_tot_amt"] == "1000000"
+    assert snapshot["cash"]["stck_cash_ord_psbl_amt"] == "900000"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_does_not_page_when_tr_cont_is_end() -> None:
+    """Phantom page guard: body cursor is non-empty but tr_cont is end → stop.
+
+    Reproduces the ROB-268 root cause: KIS VTS sometimes returns a non-empty
+    CTX_AREA_NK100 even on the last page. Pre-fix code looked only at the
+    body cursor and requested a phantom page 2.
+    """
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                ctx_fk="LEFTOVER_FK",
+                ctx_nk="LEFTOVER_NK",
+                tr_cont="D",  # end-of-stream
+            )
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert len(parent.calls) == 1, (
+        "Must not issue page 2 when response header tr_cont signals end, "
+        "even when body cursor is non-empty"
+    )
+    assert snapshot["page_count"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_pages_when_tr_cont_is_continuation() -> None:
+    """tr_cont=F (or M) with a new cursor → issue the next page."""
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                ctx_fk="FK1",
+                ctx_nk="NK1",
+                tr_cont="F",
+            ),
+            _page(
+                stocks=[{"pdno": "B", "hldg_qty": "2"}],
+                ctx_fk="",
+                ctx_nk="",
+                tr_cont="D",
+            ),
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert len(parent.calls) == 2
+    # Second request must echo the page-1 cursor back and set tr_cont=N
+    assert parent.calls[1]["params"]["CTX_AREA_FK100"] == "FK1"
+    assert parent.calls[1]["params"]["CTX_AREA_NK100"] == "NK1"
+    assert parent.calls[1]["headers"]["tr_cont"] == "N"
+    assert snapshot["page_count"] == 2
+    assert {h["pdno"] for h in snapshot["holdings"]} == {"A", "B"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_cash_comes_from_first_page_only() -> None:
+    """Cash (output2) is captured from page 1; later pages do not override."""
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                cash={"dnca_tot_amt": "100", "stck_cash_ord_psbl_amt": "90"},
+                ctx_fk="FK1",
+                ctx_nk="NK1",
+                tr_cont="M",
+            ),
+            _page(
+                stocks=[{"pdno": "B", "hldg_qty": "1"}],
+                cash={
+                    "dnca_tot_amt": "999999",
+                    "stck_cash_ord_psbl_amt": "888888",
+                },
+                tr_cont="D",
+            ),
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert snapshot["cash"]["dnca_tot_amt"] == "100"
+    assert snapshot["cash"]["stck_cash_ord_psbl_amt"] == "90"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_stops_on_repeated_cursor() -> None:
+    """Defensive: even with tr_cont=M, a repeated cursor must terminate paging."""
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                ctx_fk="FK1",
+                ctx_nk="NK1",
+                tr_cont="F",
+            ),
+            _page(
+                stocks=[{"pdno": "B", "hldg_qty": "1"}],
+                ctx_fk="FK1",
+                ctx_nk="NK1",  # repeated cursor
+                tr_cont="M",
+            ),
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert len(parent.calls) == 2, (
+        "Must terminate when KIS returns the same cursor twice in a row"
+    )
+    assert snapshot["page_count"] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_returns_stop_reason_tr_cont_end() -> None:
+    """stop_reason is part of the snapshot contract used for Sentry tagging."""
+    parent = _FakeParent(
+        responses=[_page(stocks=[{"pdno": "A", "hldg_qty": "1"}], tr_cont="D")]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert snapshot["stop_reason"] == "tr_cont_end"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_returns_stop_reason_empty_cursor() -> None:
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                ctx_nk="",
+                tr_cont="F",
+            )
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert snapshot["stop_reason"] == "empty_cursor"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_returns_stop_reason_repeated_cursor() -> None:
+    parent = _FakeParent(
+        responses=[
+            _page(
+                stocks=[{"pdno": "A", "hldg_qty": "1"}],
+                ctx_nk="NK1",
+                tr_cont="F",
+            ),
+            _page(
+                stocks=[{"pdno": "B", "hldg_qty": "1"}],
+                ctx_nk="NK1",
+                tr_cont="M",
+            ),
+        ]
+    )
+    client = AccountClient(parent)
+
+    snapshot = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert snapshot["stop_reason"] == "repeated_cursor"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_uses_mock_tr_id_when_is_mock_true() -> None:
+    parent = _FakeParent(responses=[_page(stocks=[], tr_cont="")])
+    client = AccountClient(parent)
+
+    await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert parent.calls[0]["tr_id"] == constants.DOMESTIC_BALANCE_TR_MOCK
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_snapshot_uses_real_tr_id_when_is_mock_false() -> None:
+    parent = _FakeParent(responses=[_page(stocks=[], tr_cont="")])
+    client = AccountClient(parent)
+
+    await client.fetch_domestic_balance_snapshot(is_mock=False)
+
+    assert parent.calls[0]["tr_id"] == constants.DOMESTIC_BALANCE_TR


### PR DESCRIPTION
## Summary

- `/invest/api/account-panel` 의 KIS mock 경로에서 `/uapi/domestic-stock/v1/trading/inquire-balance` 호출을 **3회 → 1회**로 축소 — Sentry trace `f6663de8ff5a43079ac854594866aadc` 의 ~15초 지연 (지배 span `invest.home.kis_mock` ~14.3s) 의 직접 원인 제거.
- `output1` (보유) + `output2` (현금) 단일 KIS 응답 lineage 에서 함께 추출하는 `fetch_domestic_balance_snapshot()` 도입. Pagination 은 응답 헤더 `tr_cont` (F/M = 다음 페이지, D/E/빈값 = 종료) 로 결정해 body cursor 만으로 phantom page 2 를 도는 기존 루프 버그를 정리.
- `invest.home.kis_mock` span 에 deploy 후 회귀 검증용 tag/data 부착 (`kis_mock.used_cash_from_snapshot`, `kis_mock.cash_fallback`, `kis_mock.pagination_stop_reason`, `kis_mock.balance_page_count`, `kis_mock.balance_call_count`). credentials / token / 계좌번호 / raw headers 는 부착하지 않음.

Linear: https://linear.app/mgh3326/issue/ROB-268

## Behaviour change

| | Before | After |
|---|---|---|
| 호출 수 (정상 1-page 케이스) | 3 (`fetch_my_stocks` page1 + phantom page2 + `inquire_domestic_cash_balance`) | 1 (snapshot, 실제 continuation 시에만 추가 page) |
| Pagination 종료 결정자 | body cursor (KIS가 마지막 페이지에서 cursor 를 채워 보내는 케이스가 phantom page 유발) | 응답 헤더 `tr_cont` (방어적으로 cursor empty / 반복 / max 10 페이지도 함께) |
| Cash 조회 | 별도 endpoint 한 번 더 | snapshot 에 포함 (`output2[0]`) |

## Compatibility

- `_request_with_rate_limit() -> dict` public contract 유지 — 새로 추가한 `_request_with_rate_limit_with_headers()` 가 core 가 되고 기존 메서드는 thin wrapper.
- `inquire_domestic_cash_balance()` 는 portfolio router / MCP tools / n8n service / KIS live margin 경로에서 여전히 사용 중이라 그대로 둠. ROB-268 의 변경은 `KISMockHomeReader` 만 snapshot 로 전환.
- `KISMockHomeReader` 가 KIS VTS 예외로 실패하면 outer try/except 가 `kis_mock` warning 만 반환하고 live/manual/Upbit source 는 그대로 유지 (기존 fallback 정책 보존).

## Sentry observability (acceptance criteria)

부모 span `invest.home.kis_mock` (생성 위치: `app/services/invest_home_service.py:394`, `:505`) 에 `sentry_sdk.get_current_span()` 으로 best-effort 부착. Sentry 미초기화 / no-span 환경에서는 no-op.

| Key | Type | 값 |
|---|---|---|
| `kis_mock.used_cash_from_snapshot` | tag (bool) | 항상 `True` (snapshot 경로 마커) |
| `kis_mock.cash_fallback` | tag (bool) | `cash_krw is None or buying_power_krw is None` |
| `kis_mock.pagination_stop_reason` | tag (str) | `tr_cont_end` / `empty_cursor` / `repeated_cursor` / `max_pages` |
| `kis_mock.balance_page_count` | data (int) | snapshot `page_count` |
| `kis_mock.balance_call_count` | data (int) | snapshot `page_count` |

## Test plan

- [x] `uv run pytest tests/test_kis_domestic_balance_snapshot.py` — 10 passed (paging / stop_reason / tr_id)
- [x] `uv run pytest tests/test_invest_home_readers.py` — 25 passed (기존 ROB-123/238 + 신규 ROB-268 통합/관측성/missing-cash-keys)
- [x] `uv run pytest tests/test_invest_api_router_includepaper_sweep.py` — 10 passed (`/invest/api/account-panel` paper sweep 회귀)
- [x] KIS helper regression subset 9 files — 153 passed (`_request_with_rate_limit` refactor 비파괴 검증)
- [x] `uv run ruff check` — clean
- [ ] Deploy 후 Sentry `invest.home.kis_mock` span 에서 `kis_mock.balance_call_count` (정상 path 1) / `kis_mock.pagination_stop_reason=tr_cont_end` 다수 확인
- [ ] Sentry `Consecutive HTTP` issue `f6663de8ff5a43079ac854594866aadc` 의 `invest.home.kis_mock` p95 가 ~15s 에서 유의미하게 감소했는지 확인

## Risk

- KIS VTS 자체 지연은 본 PR 범위 밖. 단일 호출만 남으므로 그 영향이 더 직접적으로 드러남 — Sentry 의 `kis_mock.balance_call_count=1 + invest.home.kis_mock=>5s` 케이스가 보이면 그건 KIS upstream issue.
- pagination edge: KIS 가 `tr_cont=M` 인데 cursor 가 empty / 반복 인 비정상 응답은 `empty_cursor` / `repeated_cursor` 로 차단되고 Sentry tag 로 노출됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added domestic stock balance snapshot retrieval with automatic pagination support, consolidating holdings and cash data into a single response.

* **Tests**
  * Added comprehensive test coverage for snapshot pagination logic, error handling, and data parsing.
  * Refactored existing tests to validate the new snapshot-based approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->