### PR TITLE
feat(rob-269): MCP/API surface — Phase 2 (PR 2/4) [stacked on #874]

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -429,6 +429,11 @@ class Settings(BaseSettings):
 
     # ROB-211 execution ledger ships inert; commit/backfill activation is a separate approval-gated ops change.
     EXECUTION_LEDGER_COMMIT_ENABLED: bool = False
+    # ROB-269 Phase 2 — gates BOTH the 4 MCP snapshot tools AND the
+    # /trading/api/investment-snapshots/* GET router. Default off: code is
+    # importable but unreachable from caller surfaces until flipped post-merge.
+    # See docs/superpowers/plans/2026-05-19-rob-269-phase-2-mcp-api.md §2.
+    INVESTMENT_SNAPSHOTS_MCP_ENABLED: bool = False
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
     execution_ledger_reconcile_scheduler_enabled: bool = False
     execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app.routers import (
     invest_fills,
     invest_web_spa,
     investment_reports,
+    investment_snapshots,
     kospi200,
     market_events,
     n8n,
@@ -178,6 +179,10 @@ def create_app() -> FastAPI:
     app.include_router(order_estimation.router)
     app.include_router(order_previews.router)
     app.include_router(investment_reports.router)
+    # ROB-269 Phase 2 — flag-gated. Default off keeps the router fully absent
+    # so unauthenticated probes return 404 at FastAPI's routing layer.
+    if settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED:
+        app.include_router(investment_snapshots.router)
     app.include_router(symbol_settings.router)
     app.include_router(portfolio.router)
     app.include_router(ai_markdown.router)

--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -20,11 +20,13 @@ from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "INVESTMENT_SNAPSHOTS_TOOL_NAMES",
     "MARKET_REPORT_TOOL_NAMES",
     "TRADE_PROFILE_TOOL_NAMES",
     "NEWS_TOOL_NAMES",
     "TRADE_JOURNAL_TOOL_NAMES",
     "register_all_tools",
+    "register_investment_snapshots_tools",
     "register_market_report_tools",
     "register_trade_journal_tools",
     "register_trade_profile_tools",
@@ -32,6 +34,14 @@ __all__ = [
 ]
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "INVESTMENT_SNAPSHOTS_TOOL_NAMES": (
+        "app.mcp_server.tooling.investment_snapshots_registration",
+        "INVESTMENT_SNAPSHOTS_TOOL_NAMES",
+    ),
+    "register_investment_snapshots_tools": (
+        "app.mcp_server.tooling.investment_snapshots_registration",
+        "register_investment_snapshots_tools",
+    ),
     "MARKET_REPORT_TOOL_NAMES": (
         "app.mcp_server.tooling.market_report_registration",
         "MARKET_REPORT_TOOL_NAMES",

--- a/app/mcp_server/tooling/investment_snapshots_registration.py
+++ b/app/mcp_server/tooling/investment_snapshots_registration.py
@@ -31,7 +31,7 @@ INVESTMENT_SNAPSHOTS_TOOL_NAMES: set[str] = {
 }
 
 
-def register_investment_snapshots_tools(mcp: "FastMCP") -> None:
+def register_investment_snapshots_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="investment_snapshot_bundle_ensure",
         description=(

--- a/app/mcp_server/tooling/investment_snapshots_registration.py
+++ b/app/mcp_server/tooling/investment_snapshots_registration.py
@@ -1,0 +1,84 @@
+"""ROB-269 Phase 2 — MCP tool registration for the snapshot foundation.
+
+Gated by ``settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED`` in ``registry.py``.
+When the flag is off, this module is imported but
+``register_investment_snapshots_tools`` is not called — the 4 tools are
+absent from the MCP surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.investment_snapshots_tools import (
+    investment_snapshot_bundle_ensure,
+    investment_snapshot_bundle_get,
+    investment_snapshot_bundle_list,
+    investment_snapshot_list,
+    investment_snapshot_refresh_request,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+INVESTMENT_SNAPSHOTS_TOOL_NAMES: set[str] = {
+    "investment_snapshot_bundle_ensure",
+    "investment_snapshot_bundle_get",
+    "investment_snapshot_bundle_list",
+    "investment_snapshot_list",
+    "investment_snapshot_refresh_request",
+}
+
+
+def register_investment_snapshots_tools(mcp: "FastMCP") -> None:
+    _ = mcp.tool(
+        name="investment_snapshot_bundle_ensure",
+        description=(
+            "Ensure a snapshot bundle exists for (purpose, market, account_scope, "
+            "policy_version). Reuses the latest bundle within bundle_ttl; otherwise "
+            "creates a new run and bundle. Phase 2 has no production collectors — "
+            "without a fresh bundle this typically returns status='failed'. Use "
+            "investment_snapshot_refresh_request to ask the scheduler to refresh."
+        ),
+    )(investment_snapshot_bundle_ensure)
+
+    _ = mcp.tool(
+        name="investment_snapshot_bundle_get",
+        description=(
+            "Fetch one snapshot bundle by UUID with linked items. "
+            "include_payload_preview=True adds up to 2KB of payload preview per item."
+        ),
+    )(investment_snapshot_bundle_get)
+
+    _ = mcp.tool(
+        name="investment_snapshot_bundle_list",
+        description=(
+            "List recent snapshot bundles (header only). Filters by purpose, market, "
+            "account_scope, status. limit clamped to [1,100]."
+        ),
+    )(investment_snapshot_bundle_list)
+
+    _ = mcp.tool(
+        name="investment_snapshot_list",
+        description=(
+            "List recent snapshot metadata. Payload bodies are NOT returned in list "
+            "view. Filters: market, symbol, snapshot_kind, source_kind, "
+            "freshness_status, since (ISO-8601). limit clamped to [1,100]."
+        ),
+    )(investment_snapshot_list)
+
+    _ = mcp.tool(
+        name="investment_snapshot_refresh_request",
+        description=(
+            "Record a refresh request as an investment_snapshot_runs row. Inserts "
+            "one row with purpose='manual_refresh' or 'reviewer_requested'; no "
+            "collection happens in Phase 2 (the Phase 3 scheduler will pick it up)."
+        ),
+    )(investment_snapshot_refresh_request)
+
+
+__all__ = [
+    "INVESTMENT_SNAPSHOTS_TOOL_NAMES",
+    "register_investment_snapshots_tools",
+]

--- a/app/mcp_server/tooling/investment_snapshots_tools.py
+++ b/app/mcp_server/tooling/investment_snapshots_tools.py
@@ -1,0 +1,213 @@
+"""ROB-269 Phase 2 — MCP tools for the snapshot foundation.
+
+Four tools:
+* ``investment_snapshot_bundle_ensure`` — reuse or create a bundle.
+* ``investment_snapshot_bundle_get`` — fetch one bundle + items.
+* ``investment_snapshot_list`` — filtered list of snapshot metadata.
+* ``investment_snapshot_refresh_request`` — log a refresh ask (no collection).
+
+Read-only with respect to broker/order state. The only writes are
+append-only INSERTs into ``review.investment_snapshot_*``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.schemas.investment_snapshots_mcp import (
+    EnsureBundleRequest,
+    ListBundlesRequest,
+    ListSnapshotsRequest,
+    RefreshRequest,
+)
+from app.services.action_report.common.snapshot_bundle import (
+    SnapshotBundleEnsureService,
+)
+from app.services.investment_snapshots.read_service import (
+    SnapshotBundleNotFoundError,
+    SnapshotBundleReadService,
+)
+from app.services.investment_snapshots.refresh_request_service import (
+    SnapshotRefreshRequestService,
+)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_bundle_ensure
+# ---------------------------------------------------------------------------
+async def investment_snapshot_bundle_ensure(
+    purpose: str,
+    market: str,
+    policy_version: str = "intraday_action_report_v1",
+    account_scope: str | None = None,
+    mode: str = "ensure_fresh",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+    requested_by: str = "user",
+) -> dict[str, Any]:
+    """Ensure a snapshot bundle exists for the given identity tuple.
+
+    Phase 2 note: the production collector registry is empty, so callers without
+    pre-collected data will most often get back ``status='reused'`` (when a
+    fresh bundle exists) or ``status='failed'`` (when none does). Use
+    ``investment_snapshot_refresh_request`` to ask the Phase 3 scheduler to
+    refresh.
+    """
+    request = EnsureBundleRequest(
+        purpose=purpose,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        policy_version=policy_version,
+        mode=mode,  # type: ignore[arg-type]
+        symbols=symbols,
+        candidate_limit=candidate_limit,
+        requested_by=requested_by,  # type: ignore[arg-type]
+    )
+    async with _session_factory()() as db:
+        svc = SnapshotBundleEnsureService(db)
+        response = await svc.ensure(request)
+        await db.commit()
+    return response.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_bundle_get
+# ---------------------------------------------------------------------------
+async def investment_snapshot_bundle_get(
+    bundle_uuid: str,
+    include_payload_preview: bool = False,
+) -> dict[str, Any]:
+    """Fetch one bundle by UUID, with linked items.
+
+    Returns ``{'success': False, 'error': 'not_found'}`` when the UUID does
+    not resolve. ``include_payload_preview=True`` adds at most 2KB of
+    serialised JSON per item under ``payload_previews`` (keyed by
+    ``snapshot_uuid``).
+    """
+    try:
+        parsed = uuid.UUID(bundle_uuid)
+    except ValueError:
+        return {"success": False, "error": "invalid_uuid", "bundle_uuid": bundle_uuid}
+
+    async with _session_factory()() as db:
+        svc = SnapshotBundleReadService(db)
+        try:
+            response = await svc.get_bundle(
+                bundle_uuid=parsed,
+                include_payload_preview=include_payload_preview,
+            )
+        except SnapshotBundleNotFoundError:
+            return {
+                "success": False,
+                "error": "not_found",
+                "bundle_uuid": bundle_uuid,
+            }
+    return {"success": True, **response.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_list
+# ---------------------------------------------------------------------------
+async def investment_snapshot_list(
+    market: str | None = None,
+    symbol: str | None = None,
+    snapshot_kind: str | None = None,
+    source_kind: str | None = None,
+    freshness_status: str | None = None,
+    since: str | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """List recent snapshot metadata (no payload bodies returned).
+
+    Filters are all optional; ``limit`` is clamped to ``[1, 100]``.
+    ``since`` is ISO-8601 with timezone (e.g. ``2026-05-19T11:00:00+09:00``).
+    """
+    parsed_since = None
+    if since is not None:
+        try:
+            from datetime import datetime
+
+            parsed_since = datetime.fromisoformat(since)
+        except ValueError:
+            return {"success": False, "error": "invalid_since", "since": since}
+
+    request = ListSnapshotsRequest(
+        market=market,  # type: ignore[arg-type]
+        symbol=symbol,
+        snapshot_kind=snapshot_kind,  # type: ignore[arg-type]
+        source_kind=source_kind,  # type: ignore[arg-type]
+        freshness_status=freshness_status,  # type: ignore[arg-type]
+        since=parsed_since,
+        limit=max(1, min(limit, 100)),
+    )
+    async with _session_factory()() as db:
+        svc = SnapshotBundleReadService(db)
+        response = await svc.list_snapshots(request)
+    return {"success": True, **response.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_refresh_request
+# ---------------------------------------------------------------------------
+async def investment_snapshot_refresh_request(
+    reason: str,
+    market: str,
+    purpose: str = "manual_refresh",
+    account_scope: str | None = None,
+    symbols: list[str] | None = None,
+    snapshot_kinds: list[str] | None = None,
+    policy_version: str = "intraday_action_report_v1",
+    requested_by: str = "user",
+) -> dict[str, Any]:
+    """Record a refresh request (inserts one run row; no collection in Phase 2).
+
+    The Phase 3 scheduler picks up runs with purpose='manual_refresh' /
+    'reviewer_requested' and acts on them.
+    """
+    request = RefreshRequest(
+        reason=reason,
+        purpose=purpose,  # type: ignore[arg-type]
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        symbols=symbols,
+        snapshot_kinds=snapshot_kinds,  # type: ignore[arg-type]
+        policy_version=policy_version,
+        requested_by=requested_by,  # type: ignore[arg-type]
+    )
+    async with _session_factory()() as db:
+        svc = SnapshotRefreshRequestService(db)
+        response = await svc.record(request)
+        await db.commit()
+    return {"success": True, **response.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# Bundles list (HTTP-only mirror; exposed as MCP tool too for completeness)
+# ---------------------------------------------------------------------------
+async def investment_snapshot_bundle_list(
+    purpose: str | None = None,
+    market: str | None = None,
+    account_scope: str | None = None,
+    status: str | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """List recent bundles (header-only). Filters all optional."""
+    request = ListBundlesRequest(
+        purpose=purpose,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        limit=max(1, min(limit, 100)),
+    )
+    async with _session_factory()() as db:
+        svc = SnapshotBundleReadService(db)
+        response = await svc.list_bundles(request)
+    return {"success": True, **response.model_dump(mode="json")}

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.core.config import settings
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling import orders_kiwoom_variants
 from app.mcp_server.tooling.alpaca_paper import register_alpaca_paper_tools
@@ -39,6 +40,9 @@ from app.mcp_server.tooling.execution_comment_registration import (
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.investment_reports_handlers import (
     register_investment_report_tools,
+)
+from app.mcp_server.tooling.investment_snapshots_registration import (
+    register_investment_snapshots_tools,
 )
 from app.mcp_server.tooling.market_brief_registration import (
     register_market_brief_tools,
@@ -107,6 +111,12 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_paper_account_tools(mcp)
     register_paper_analytics_tools(mcp)
     register_paper_journal_tools(mcp)
+
+    # ROB-269 Phase 2 — investment-snapshot MCP surface. Gated by
+    # ``settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED`` so the 4 tools are
+    # physically absent unless the flag is flipped post-PR-merge.
+    if settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED:
+        register_investment_snapshots_tools(mcp)
 
     # Profile-gated: side-effect order surfaces
     if profile is McpProfile.DEFAULT:

--- a/app/routers/investment_snapshots.py
+++ b/app/routers/investment_snapshots.py
@@ -1,0 +1,111 @@
+"""ROB-269 Phase 2 — Snapshot bundles / snapshots GET endpoints.
+
+GET-only. No POST/PUT/DELETE — refresh-request lives at the MCP surface
+only in Phase 2, keeping the HTTP surface provably read-only. Mounted
+into the FastAPI app only when ``settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED``
+is True (see ``app.main``).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.investment_snapshots_mcp import (
+    GetBundleResponse,
+    ListBundlesRequest,
+    ListBundlesResponse,
+    ListSnapshotsRequest,
+    ListSnapshotsResponse,
+)
+from app.services.investment_snapshots.read_service import (
+    SnapshotBundleNotFoundError,
+    SnapshotBundleReadService,
+)
+
+router = APIRouter(prefix="/trading", tags=["investment-snapshots"])
+
+
+@router.get(
+    "/api/investment-snapshots/bundles/{bundle_uuid}",
+    response_model=GetBundleResponse,
+)
+async def get_investment_snapshot_bundle(
+    bundle_uuid: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    include_payload_preview: bool = Query(False),
+) -> GetBundleResponse:
+    _ = current_user  # auth-only dependency
+    svc = SnapshotBundleReadService(db)
+    try:
+        return await svc.get_bundle(
+            bundle_uuid=bundle_uuid,
+            include_payload_preview=include_payload_preview,
+        )
+    except SnapshotBundleNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"bundle not found: {bundle_uuid}",
+        ) from exc
+
+
+@router.get(
+    "/api/investment-snapshots/bundles",
+    response_model=ListBundlesResponse,
+)
+async def list_investment_snapshot_bundles(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    purpose: str | None = Query(None),
+    market: str | None = Query(None),
+    account_scope: str | None = Query(None),
+    bundle_status: str | None = Query(None, alias="status"),
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> ListBundlesResponse:
+    _ = current_user
+    svc = SnapshotBundleReadService(db)
+    request = ListBundlesRequest(
+        purpose=purpose,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        status=bundle_status,  # type: ignore[arg-type]
+        limit=limit,
+    )
+    return await svc.list_bundles(request)
+
+
+@router.get(
+    "/api/investment-snapshots/snapshots",
+    response_model=ListSnapshotsResponse,
+)
+async def list_investment_snapshots(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    market: str | None = Query(None),
+    symbol: str | None = Query(None),
+    snapshot_kind: str | None = Query(None),
+    source_kind: str | None = Query(None),
+    freshness_status: str | None = Query(None),
+    since: dt.datetime | None = Query(None),
+    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> ListSnapshotsResponse:
+    _ = current_user
+    svc = SnapshotBundleReadService(db)
+    request = ListSnapshotsRequest(
+        market=market,  # type: ignore[arg-type]
+        symbol=symbol,
+        snapshot_kind=snapshot_kind,  # type: ignore[arg-type]
+        source_kind=source_kind,  # type: ignore[arg-type]
+        freshness_status=freshness_status,  # type: ignore[arg-type]
+        since=since,
+        limit=limit,
+    )
+    return await svc.list_snapshots(request)

--- a/app/schemas/investment_snapshots_mcp.py
+++ b/app/schemas/investment_snapshots_mcp.py
@@ -1,0 +1,218 @@
+"""ROB-269 Phase 2 — MCP/API caller-facing request/response DTOs.
+
+These DTOs are separate from ``app.schemas.investment_snapshots`` (which
+holds DB-shape DTOs incl. canonical_hash / idempotency_key composition).
+Keeping the surfaces split prevents internal trace fields from leaking
+through MCP/HTTP responses and keeps mutation-prone fields off the public
+contract.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.investment_snapshots import (
+    BundleItemRole,
+    BundleStatus,
+    FreshnessStatus,
+    SnapshotAccountScope,
+    SnapshotKind,
+    SnapshotMarket,
+    SourceKind,
+)
+from app.services.investment_snapshots.collectors import SnapshotCollectResult
+
+EnsureMode = Literal["ensure_fresh", "reuse_only"]
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_bundle_ensure
+# ---------------------------------------------------------------------------
+class EnsureBundleRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    purpose: str = Field(min_length=1, max_length=64)
+    market: SnapshotMarket
+    account_scope: SnapshotAccountScope | None = None
+    policy_version: str = Field(min_length=1)
+    mode: EnsureMode = "ensure_fresh"
+    symbols: list[str] | None = None
+    candidate_limit: Annotated[int | None, Field(ge=1, le=100)] = None
+    manual_snapshots: dict[SnapshotKind, list[SnapshotCollectResult]] | None = None
+    """Caller-supplied pre-collected snapshots keyed by ``snapshot_kind``.
+
+    In Phase 2 this is the **primary** way to populate a bundle because the
+    collector registry is empty in production. Phase 3 will populate the
+    registry and this field will become optional fallback.
+    """
+    requested_by: Literal["hermes", "user", "scheduler", "claude_code", "reviewer"] = (
+        "user"
+    )
+
+
+class EnsureBundleResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_uuid: uuid.UUID
+    status: BundleStatus | Literal["reused"]
+    """``reused`` means a fresh bundle already existed — no new run was made.
+    Other values mirror ``investment_snapshot_bundles.status``."""
+
+    created: bool
+    """``True`` if a new bundle row was inserted; ``False`` if reused."""
+
+    coverage_summary: dict[str, Any] = Field(default_factory=dict)
+    freshness_summary: dict[str, Any] = Field(default_factory=dict)
+    missing_sources: list[str] = Field(default_factory=list)
+    """List of ``snapshot_kind`` (or ``snapshot_kind:symbol``) that were
+    expected by policy but came back unavailable. Required missing sources
+    drive ``status='failed'`` / ``'stale_fallback'``; optional ones drive
+    ``'partial'``."""
+
+    warnings: list[str] = Field(default_factory=list)
+    run_uuid: uuid.UUID | None = None
+    """``None`` when ``status='reused'``; populated for any newly created bundle."""
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_bundle_get
+# ---------------------------------------------------------------------------
+class BundleHeaderView(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_uuid: uuid.UUID
+    purpose: str
+    market: SnapshotMarket
+    account_scope: SnapshotAccountScope | None
+    policy_version: str
+    as_of: dt.datetime
+    status: BundleStatus
+    coverage_summary: dict[str, Any]
+    freshness_summary: dict[str, Any]
+    created_at: dt.datetime
+
+
+class BundleItemView(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_uuid: uuid.UUID
+    role: BundleItemRole
+    snapshot_kind: SnapshotKind
+    market: SnapshotMarket
+    symbol: str | None
+    account_scope: SnapshotAccountScope | None
+    freshness_status: FreshnessStatus
+    source_kind: SourceKind
+    source_table: str | None
+    source_id: int | None
+    source_uri: str | None
+    as_of: dt.datetime
+
+
+class GetBundleRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle_uuid: uuid.UUID
+    include_payload_preview: bool = False
+    """If True, each item carries up to 2KB of its ``payload_json`` as
+    ``payload_preview``. Off by default to keep responses small and
+    prevent accidental payload exfiltration through list/get surfaces."""
+
+
+class GetBundleResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundle: BundleHeaderView
+    items: list[BundleItemView]
+    payload_previews: dict[uuid.UUID, str] | None = None
+    """Keyed by ``snapshot_uuid``; only present when ``include_payload_preview=True``."""
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_list — snapshots
+# ---------------------------------------------------------------------------
+class ListSnapshotsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: SnapshotMarket | None = None
+    symbol: str | None = None
+    snapshot_kind: SnapshotKind | None = None
+    source_kind: SourceKind | None = None
+    freshness_status: FreshnessStatus | None = None
+    since: dt.datetime | None = None
+    limit: Annotated[int, Field(ge=1, le=100)] = 20
+
+
+class SnapshotMetadataView(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_uuid: uuid.UUID
+    snapshot_kind: SnapshotKind
+    market: SnapshotMarket
+    symbol: str | None
+    account_scope: SnapshotAccountScope | None
+    as_of: dt.datetime
+    freshness_status: FreshnessStatus
+    source_kind: SourceKind
+    source_table: str | None
+    source_id: int | None
+    source_uri: str | None
+
+
+class ListSnapshotsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshots: list[SnapshotMetadataView]
+    limit: int
+
+
+# ---------------------------------------------------------------------------
+# Bundles list (router only — MCP uses bundle_get for individual lookup)
+# ---------------------------------------------------------------------------
+class ListBundlesRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    purpose: str | None = None
+    market: SnapshotMarket | None = None
+    account_scope: SnapshotAccountScope | None = None
+    status: BundleStatus | None = None
+    limit: Annotated[int, Field(ge=1, le=100)] = 20
+
+
+class ListBundlesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bundles: list[BundleHeaderView]
+    limit: int
+
+
+# ---------------------------------------------------------------------------
+# investment_snapshot_refresh_request
+# ---------------------------------------------------------------------------
+class RefreshRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(min_length=1, max_length=512)
+    purpose: Literal["manual_refresh", "reviewer_requested"] = "manual_refresh"
+    market: SnapshotMarket
+    account_scope: SnapshotAccountScope | None = None
+    symbols: list[str] | None = None
+    snapshot_kinds: list[SnapshotKind] | None = None
+    policy_version: str = "intraday_action_report_v1"
+    requested_by: Literal["hermes", "user", "scheduler", "claude_code", "reviewer"] = (
+        "user"
+    )
+
+
+class RefreshResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_uuid: uuid.UUID
+    status: Literal["running"]
+    """Always ``'running'`` in Phase 2 — the row is inserted but no
+    collection happens. Phase 3 schedulers will pick the run up and
+    transition it to ``completed`` / ``partial`` / ``failed``."""

--- a/app/schemas/investment_snapshots_mcp.py
+++ b/app/schemas/investment_snapshots_mcp.py
@@ -57,7 +57,11 @@ class EnsureBundleRequest(BaseModel):
 class EnsureBundleResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    bundle_uuid: uuid.UUID
+    bundle_uuid: uuid.UUID | None = None
+    """``None`` only when ``mode='reuse_only'`` and no fresh bundle existed —
+    in every other outcome (incl. ensure_fresh failures) we still create a
+    bundle row for audit and return its UUID here."""
+
     status: BundleStatus | Literal["reused"]
     """``reused`` means a fresh bundle already existed — no new run was made.
     Other values mirror ``investment_snapshot_bundles.status``."""

--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -36,8 +36,8 @@ from app.schemas.investment_snapshots_mcp import (
 )
 from app.services.investment_snapshots.collectors import (
     CollectorRequest,
-    SnapshotCollectResult,
     SnapshotCollectorRegistry,
+    SnapshotCollectResult,
     default_collector_registry,
 )
 from app.services.investment_snapshots.freshness import (
@@ -322,7 +322,9 @@ def _derive_bundle_status(
 
     if not required_statuses:
         # No required kinds in policy — should not happen in v1, but fall through safely.
-        return "complete" if not all_statuses or all_statuses == {"fresh"} else "partial"
+        return (
+            "complete" if not all_statuses or all_statuses == {"fresh"} else "partial"
+        )
 
     if "unavailable" in required_statuses:
         return "failed"

--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -1,0 +1,340 @@
+"""ROB-269 Phase 2 — SnapshotBundleEnsureService.
+
+The core service that turns an ``EnsureBundleRequest`` into a persisted
+bundle. Reuses a fresh bundle if one exists for the identity tuple;
+otherwise creates a new run, collects per-kind data (manual snapshots
+or via the collector registry), and assembles a bundle whose status
+reflects required-vs-optional outcomes.
+
+Phase 2 invariants:
+* Only writes to ``review.investment_snapshot_*`` tables.
+* No external HTTP. Collectors are an injectable seam; the production
+  registry is empty in Phase 2 (Phase 3 wires KIS / journal / market /
+  news collectors). Tests register fakes.
+* Run.status stays at the default ``'running'`` — append-only repository
+  contract from Phase 1 means no UPDATE path. Bundle.status is the
+  authoritative outcome record.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.schemas.investment_snapshots_mcp import (
+    EnsureBundleRequest,
+    EnsureBundleResponse,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+    SnapshotCollectorRegistry,
+    default_collector_registry,
+)
+from app.services.investment_snapshots.freshness import (
+    FreshnessStatus,
+    classify_freshness,
+)
+from app.services.investment_snapshots.policy import (
+    SnapshotKindPolicy,
+    get_policy,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+class SnapshotBundleEnsureService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        repository: InvestmentSnapshotsRepository | None = None,
+        collectors: SnapshotCollectorRegistry | None = None,
+        clock=None,  # callable[[], datetime] for tests
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentSnapshotsRepository(session)
+        self._collectors = collectors or default_collector_registry()
+        self._clock = clock or _utcnow
+
+    async def ensure(self, request: EnsureBundleRequest) -> EnsureBundleResponse:
+        policy = get_policy(request.policy_version)
+        now = self._clock()
+
+        # 1. Reuse path: most recent bundle within bundle_ttl wins.
+        latest = await self._repo.find_latest_bundle(
+            purpose=request.purpose,
+            market=request.market,
+            account_scope=request.account_scope,
+            policy_version=policy.policy_version,
+        )
+        if latest is not None:
+            bundle_freshness = classify_freshness(
+                as_of=latest.as_of, now=now, policy=policy.bundle_ttl
+            )
+            if bundle_freshness in ("fresh", "soft_stale"):
+                return EnsureBundleResponse(
+                    bundle_uuid=latest.bundle_uuid,
+                    status="reused",
+                    created=False,
+                    coverage_summary=latest.coverage_summary,
+                    freshness_summary=latest.freshness_summary,
+                    missing_sources=[],
+                    warnings=(
+                        []
+                        if bundle_freshness == "fresh"
+                        else [f"bundle is {bundle_freshness} but within hard TTL"]
+                    ),
+                    run_uuid=None,
+                )
+
+        # 2. reuse_only with no fresh bundle is a soft failure — no DB write.
+        if request.mode == "reuse_only":
+            return EnsureBundleResponse(
+                bundle_uuid=None,
+                status="failed",
+                created=False,
+                warnings=["reuse_only requested but no fresh bundle exists"],
+                run_uuid=None,
+            )
+
+        # 3. ensure_fresh path — create a run + collect + persist.
+        run = await self._repo.insert_run(
+            SnapshotRunCreate(
+                purpose="report_generation",
+                market=request.market,
+                account_scope=request.account_scope,
+                requested_by=request.requested_by,
+                policy_version=policy.policy_version,
+                policy_snapshot_json=policy.to_snapshot_json(),
+                refresh_reason=f"ensure_bundle purpose={request.purpose}",
+                run_metadata={
+                    "ensure_request": {
+                        "purpose": request.purpose,
+                        "mode": request.mode,
+                        "symbols": request.symbols,
+                        "candidate_limit": request.candidate_limit,
+                        "manual_snapshot_kinds": (
+                            sorted((request.manual_snapshots or {}).keys())
+                        ),
+                    }
+                },
+            )
+        )
+
+        coverage: dict[str, dict[str, str]] = {"required": {}, "optional": {}}
+        freshness_summary: dict[str, dict[str, str]] = {}
+        missing_sources: list[str] = []
+        warnings: list[str] = []
+        linked_items: list[tuple[Any, str]] = []  # (snapshot_uuid, role)
+
+        for kind_policy in policy.kinds:
+            results, kind_warnings, attempted = await self._collect_for_kind(
+                kind_policy=kind_policy,
+                request=request,
+                policy_snapshot=policy.to_snapshot_json(),
+            )
+            warnings.extend(kind_warnings)
+            bucket = "required" if kind_policy.required else "optional"
+            role = "required" if kind_policy.required else "optional"
+
+            if not results:
+                # Required kinds always count as 'unavailable' when empty
+                # (caller expected the data; absence is a real gap).
+                # Optional kinds split:
+                #   - attempted (manual passed empty OR collector failed/timed out)
+                #     → 'unavailable', contributes to bundle=partial.
+                #   - not attempted (no manual + no collector registered)
+                #     → silent skip; bundle status unaffected. In Phase 2 the
+                #     production registry is empty so most optional kinds
+                #     fall here when callers don't supply manual data.
+                if kind_policy.required or attempted:
+                    coverage[bucket][kind_policy.snapshot_kind] = "unavailable"
+                    freshness_summary[kind_policy.snapshot_kind] = {
+                        "status": "unavailable"
+                    }
+                    missing_sources.append(kind_policy.snapshot_kind)
+                continue
+
+            kind_statuses: list[str] = []
+            last_as_of: dt.datetime | None = None
+            for result in results:
+                computed_status: FreshnessStatus = classify_freshness(
+                    as_of=result.as_of, now=now, policy=kind_policy.freshness
+                )
+                # Caller-supplied status (e.g. 'partial' or 'unavailable') can
+                # downgrade but never upgrade past the policy-classified one.
+                effective_status = _worse_of(result.freshness_status, computed_status)
+                snap = await self._repo.insert_snapshot(
+                    SnapshotCreate(
+                        run_uuid=run.run_uuid,
+                        snapshot_kind=result.snapshot_kind,
+                        market=result.market,
+                        account_scope=result.account_scope,
+                        symbol=result.symbol,
+                        source_table=result.source_table,
+                        source_id=result.source_id,
+                        source_uri=result.source_uri,
+                        source_kind=result.source_kind,
+                        payload_json=result.payload_json,
+                        source_timestamps_json=result.source_timestamps_json,
+                        coverage_json=result.coverage_json,
+                        errors_json=result.errors_json,
+                        as_of=result.as_of,
+                        valid_until=now + kind_policy.freshness.hard_ttl,
+                        freshness_status=effective_status,
+                    )
+                )
+                linked_items.append((snap.snapshot_uuid, role))
+                kind_statuses.append(effective_status)
+                last_as_of = result.as_of
+
+            worst_status = _worst_status(kind_statuses)
+            coverage[bucket][kind_policy.snapshot_kind] = worst_status
+            freshness_summary[kind_policy.snapshot_kind] = {
+                "status": worst_status,
+                "as_of": last_as_of.isoformat() if last_as_of else None,
+                "result_count": str(len(results)),
+            }
+
+        bundle_status = _derive_bundle_status(coverage)
+
+        bundle = await self._repo.insert_bundle(
+            BundleCreate(
+                purpose=request.purpose,
+                market=request.market,
+                account_scope=request.account_scope,
+                policy_version=policy.policy_version,
+                policy_snapshot_json=policy.to_snapshot_json(),
+                as_of=now,
+                status=bundle_status,
+                coverage_summary=coverage,
+                freshness_summary=freshness_summary,
+            )
+        )
+
+        for snapshot_uuid, role in linked_items:
+            await self._repo.link_bundle_item(
+                bundle_uuid=bundle.bundle_uuid,
+                item=BundleItemCreate(snapshot_uuid=snapshot_uuid, role=role),
+            )
+
+        return EnsureBundleResponse(
+            bundle_uuid=bundle.bundle_uuid,
+            status=bundle_status,
+            created=True,
+            coverage_summary=coverage,
+            freshness_summary=freshness_summary,
+            missing_sources=missing_sources,
+            warnings=warnings,
+            run_uuid=run.run_uuid,
+        )
+
+    async def _collect_for_kind(
+        self,
+        *,
+        kind_policy: SnapshotKindPolicy,
+        request: EnsureBundleRequest,
+        policy_snapshot: dict[str, Any],
+    ) -> tuple[list[SnapshotCollectResult], list[str], bool]:
+        """Return (results, warnings, attempted).
+
+        ``attempted=False`` means there was no manual data AND no collector
+        registered for this kind — caller didn't ask, the system didn't have
+        a way to ask. Optional kinds in this state are silently skipped.
+        """
+        kind = kind_policy.snapshot_kind
+        manual = (request.manual_snapshots or {}).get(kind)
+        if manual is not None:
+            # Manual list is considered an attempt even if empty.
+            return list(manual), [], True
+
+        collector = self._collectors.get(kind)
+        if collector is None:
+            return [], [], False
+
+        collect_request = CollectorRequest(
+            market=request.market,
+            account_scope=request.account_scope,
+            symbols=request.symbols,
+            candidate_limit=request.candidate_limit,
+            policy_snapshot=policy_snapshot,
+        )
+        try:
+            results = await asyncio.wait_for(
+                collector.collect(collect_request),
+                timeout=kind_policy.collector_timeout.total_seconds(),
+            )
+            return list(results), [], True
+        except TimeoutError:
+            return [], [f"{kind}: collector timed out"], True
+        except Exception as exc:  # noqa: BLE001 — collector failures must not crash ensure
+            return (
+                [],
+                [f"{kind}: collector raised {type(exc).__name__}: {exc}"],
+                True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Status derivation helpers
+# ---------------------------------------------------------------------------
+_STATUS_RANK: dict[str, int] = {
+    "fresh": 0,
+    "soft_stale": 1,
+    "partial": 2,
+    "hard_stale": 3,
+    "unavailable": 4,
+}
+
+
+def _worse_of(a: str, b: str) -> str:
+    """Return the worse (numerically higher) of two freshness labels."""
+    return a if _STATUS_RANK.get(a, 99) >= _STATUS_RANK.get(b, 99) else b
+
+
+def _worst_status(statuses: list[str]) -> str:
+    if not statuses:
+        return "unavailable"
+    return max(statuses, key=lambda s: _STATUS_RANK.get(s, 99))
+
+
+def _derive_bundle_status(
+    coverage: dict[str, dict[str, str]],
+) -> str:
+    required_statuses = set(coverage.get("required", {}).values())
+    optional_statuses = set(coverage.get("optional", {}).values())
+    all_statuses = required_statuses | optional_statuses
+
+    if not required_statuses:
+        # No required kinds in policy — should not happen in v1, but fall through safely.
+        return "complete" if not all_statuses or all_statuses == {"fresh"} else "partial"
+
+    if "unavailable" in required_statuses:
+        return "failed"
+    if "hard_stale" in required_statuses:
+        return "stale_fallback"
+    if (
+        "soft_stale" in required_statuses
+        or "partial" in required_statuses
+        or "unavailable" in optional_statuses
+        or "soft_stale" in optional_statuses
+        or "partial" in optional_statuses
+        or "hard_stale" in optional_statuses
+    ):
+        return "partial"
+    return "complete"

--- a/app/services/investment_snapshots/collectors.py
+++ b/app/services/investment_snapshots/collectors.py
@@ -56,7 +56,7 @@ class SnapshotCollectResult(BaseModel):
     freshness_status: FreshnessStatus = "fresh"
 
     @model_validator(mode="after")
-    def _source_ref_triple_consistent(self) -> "SnapshotCollectResult":
+    def _source_ref_triple_consistent(self) -> SnapshotCollectResult:
         nulls = sum(
             1 for v in (self.source_table, self.source_id, self.source_uri) if v is None
         )
@@ -68,11 +68,9 @@ class SnapshotCollectResult(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _domain_ref_requires_triple(self) -> "SnapshotCollectResult":
+    def _domain_ref_requires_triple(self) -> SnapshotCollectResult:
         if self.source_kind == "domain_ref" and self.source_table is None:
-            raise ValueError(
-                "source_kind='domain_ref' requires the source_ref triple"
-            )
+            raise ValueError("source_kind='domain_ref' requires the source_ref triple")
         return self
 
 
@@ -104,9 +102,7 @@ class SnapshotCollectorProtocol(Protocol):
         """The ``snapshot_kind`` this collector produces. One collector per kind."""
         ...
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         """Fetch and return zero or more snapshot artifacts.
 
         Returning an empty list is legal — the ensure service interprets that as
@@ -131,9 +127,7 @@ class SnapshotCollectorRegistry:
     def register(self, collector: SnapshotCollectorProtocol) -> None:
         kind = collector.snapshot_kind
         if kind in self._collectors:
-            raise ValueError(
-                f"collector for snapshot_kind={kind!r} already registered"
-            )
+            raise ValueError(f"collector for snapshot_kind={kind!r} already registered")
         self._collectors[kind] = collector
 
     def get(self, snapshot_kind: str) -> SnapshotCollectorProtocol | None:

--- a/app/services/investment_snapshots/collectors.py
+++ b/app/services/investment_snapshots/collectors.py
@@ -1,0 +1,151 @@
+"""ROB-269 Phase 2 — Snapshot collector protocol + registry.
+
+The registry is **empty by default in Phase 2**. Production collectors
+(KIS / journal / market / news) register here in Phase 3. Tests register
+fakes. This keeps Phase 2 free of any live HTTP surface — the registry
+is the single seam where external data enters the snapshot pipeline.
+
+A collector is an object that knows how to fetch fresh data for **one**
+``snapshot_kind`` and return one or more ``SnapshotCollectResult`` rows
+(typically multiple when the kind is ``symbol`` — one result per requested
+symbol). The ensure service persists each result as one snapshot artifact.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.investment_snapshots import (
+    FreshnessStatus,
+    SnapshotAccountScope,
+    SnapshotKind,
+    SnapshotMarket,
+    SourceKind,
+)
+
+
+class SnapshotCollectResult(BaseModel):
+    """One snapshot artifact's worth of data, as returned by a collector.
+
+    Caller (the ensure service) augments this with ``run_uuid``, hashes,
+    and freshness/idempotency before insert.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_kind: SnapshotKind
+    market: SnapshotMarket
+    account_scope: SnapshotAccountScope | None = None
+    symbol: str | None = None
+
+    source_table: str | None = None
+    source_id: int | None = None
+    source_uri: str | None = None
+    source_kind: SourceKind
+
+    payload_json: dict[str, Any] = Field(default_factory=dict)
+    source_timestamps_json: dict[str, Any] = Field(default_factory=dict)
+    coverage_json: dict[str, Any] = Field(default_factory=dict)
+    errors_json: dict[str, Any] = Field(default_factory=dict)
+
+    as_of: dt.datetime
+    valid_until: dt.datetime | None = None
+    freshness_status: FreshnessStatus = "fresh"
+
+    @model_validator(mode="after")
+    def _source_ref_triple_consistent(self) -> "SnapshotCollectResult":
+        nulls = sum(
+            1 for v in (self.source_table, self.source_id, self.source_uri) if v is None
+        )
+        if nulls not in (0, 3):
+            raise ValueError(
+                "SnapshotCollectResult.source_table/source_id/source_uri must all be "
+                "set or all None"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _domain_ref_requires_triple(self) -> "SnapshotCollectResult":
+        if self.source_kind == "domain_ref" and self.source_table is None:
+            raise ValueError(
+                "source_kind='domain_ref' requires the source_ref triple"
+            )
+        return self
+
+
+class CollectorRequest(BaseModel):
+    """Per-collect call context. Passed by the ensure service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    market: SnapshotMarket
+    account_scope: SnapshotAccountScope | None = None
+    symbols: list[str] | None = None
+    """Caller-supplied symbol filter. ``None`` = collector's own discretion."""
+    candidate_limit: int | None = None
+    """For ``candidate_universe`` collectors. ``None`` = collector default."""
+    policy_snapshot: dict[str, Any]
+    """The frozen policy as stored on the run row (read-only)."""
+
+
+@runtime_checkable
+class SnapshotCollectorProtocol(Protocol):
+    """Contract every snapshot collector implements.
+
+    Phase 2 ships **no** concrete production collector. Phase 3 will add
+    KIS / journal / market / news collectors that implement this protocol.
+    """
+
+    @property
+    def snapshot_kind(self) -> str:  # actually ``SnapshotKind`` enum string
+        """The ``snapshot_kind`` this collector produces. One collector per kind."""
+        ...
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        """Fetch and return zero or more snapshot artifacts.
+
+        Returning an empty list is legal — the ensure service interprets that as
+        ``unavailable`` for the kind. Raising is also legal; the ensure service
+        catches and records it as ``errors_json`` on a synthetic ``unavailable``
+        snapshot. Collector MUST not perform any broker/order/watch mutation.
+        """
+        ...
+
+
+class SnapshotCollectorRegistry:
+    """Per-process registry mapping ``snapshot_kind`` → collector instance.
+
+    The default registry is created empty by ``default_collector_registry``.
+    Tests construct their own registry to inject fakes; production wiring
+    (Phase 3) will register collectors on app startup.
+    """
+
+    def __init__(self) -> None:
+        self._collectors: dict[str, SnapshotCollectorProtocol] = {}
+
+    def register(self, collector: SnapshotCollectorProtocol) -> None:
+        kind = collector.snapshot_kind
+        if kind in self._collectors:
+            raise ValueError(
+                f"collector for snapshot_kind={kind!r} already registered"
+            )
+        self._collectors[kind] = collector
+
+    def get(self, snapshot_kind: str) -> SnapshotCollectorProtocol | None:
+        return self._collectors.get(snapshot_kind)
+
+    def list_kinds(self) -> set[str]:
+        return set(self._collectors)
+
+    def __len__(self) -> int:
+        return len(self._collectors)
+
+
+def default_collector_registry() -> SnapshotCollectorRegistry:
+    """Return an empty registry — Phase 2 ships no production collectors."""
+    return SnapshotCollectorRegistry()

--- a/app/services/investment_snapshots/policy.py
+++ b/app/services/investment_snapshots/policy.py
@@ -1,0 +1,174 @@
+"""ROB-269 Phase 2 — Snapshot freshness policy constants.
+
+The ``intraday_action_report_v1`` policy below is the only policy registered
+in Phase 2. It is frozen per-run via ``run.policy_snapshot_json`` (Phase 1
+Decision 3) so a later policy version change does not retroactively
+invalidate historical bundles.
+
+Pre-plan reference for TTL choices:
+``docs/superpowers/plans/2026-05-19-rob-269-pre-plan.md`` §3 (Phase 3 table).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from app.services.investment_snapshots.freshness import FreshnessPolicy
+
+
+@dataclass(frozen=True)
+class SnapshotKindPolicy:
+    """Per-kind freshness policy + collector behaviour for a snapshot bundle."""
+
+    snapshot_kind: str
+    freshness: FreshnessPolicy
+    required: bool
+    """Required kinds, when unavailable, force the bundle to ``failed`` or
+    ``stale_fallback`` and block executable action language downstream
+    (Decision 4). Optional kinds degrade to ``partial`` but never block."""
+
+    collector_timeout: dt.timedelta
+    """Bounded timeout for the collector call. Phase 2 collectors registry
+    is empty by default; the timeout matters only when a caller (test or
+    Phase 3 collector) actually does work."""
+
+
+@dataclass(frozen=True)
+class BundlePolicy:
+    policy_version: str
+    kinds: tuple[SnapshotKindPolicy, ...]
+    bundle_ttl: FreshnessPolicy
+    """Bundle-level TTL. A bundle older than ``hard_ttl`` is recreated even
+    if individual kind TTLs are still soft. ``soft_ttl`` triggers an
+    advisory ``soft_stale`` bundle status but still allows reuse."""
+
+    def required_kinds(self) -> tuple[str, ...]:
+        return tuple(k.snapshot_kind for k in self.kinds if k.required)
+
+    def optional_kinds(self) -> tuple[str, ...]:
+        return tuple(k.snapshot_kind for k in self.kinds if not k.required)
+
+    def kind_policy(self, snapshot_kind: str) -> SnapshotKindPolicy | None:
+        for k in self.kinds:
+            if k.snapshot_kind == snapshot_kind:
+                return k
+        return None
+
+    def to_snapshot_json(self) -> dict[str, object]:
+        """Serialise to the JSONB shape stored on ``run.policy_snapshot_json``."""
+        return {
+            "policy_version": self.policy_version,
+            "bundle_ttl_seconds": {
+                "soft": int(self.bundle_ttl.soft_ttl.total_seconds()),
+                "hard": int(self.bundle_ttl.hard_ttl.total_seconds()),
+            },
+            "kinds": [
+                {
+                    "snapshot_kind": k.snapshot_kind,
+                    "required": k.required,
+                    "soft_ttl_seconds": int(k.freshness.soft_ttl.total_seconds()),
+                    "hard_ttl_seconds": int(k.freshness.hard_ttl.total_seconds()),
+                    "collector_timeout_seconds": int(
+                        k.collector_timeout.total_seconds()
+                    ),
+                }
+                for k in self.kinds
+            ],
+        }
+
+
+def _seconds(s: int) -> dt.timedelta:
+    return dt.timedelta(seconds=s)
+
+
+INTRADAY_ACTION_REPORT_V1 = BundlePolicy(
+    policy_version="intraday_action_report_v1",
+    bundle_ttl=FreshnessPolicy(soft_ttl=_seconds(180), hard_ttl=_seconds(300)),
+    kinds=(
+        # Required — failure blocks executable action language.
+        SnapshotKindPolicy(
+            snapshot_kind="portfolio",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(180), hard_ttl=_seconds(300)),
+            required=True,
+            collector_timeout=_seconds(10),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="journal",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(900)),
+            required=True,
+            collector_timeout=_seconds(5),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="watch_context",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(900)),
+            required=True,
+            collector_timeout=_seconds(5),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="market",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(180), hard_ttl=_seconds(600)),
+            required=True,
+            collector_timeout=_seconds(10),
+        ),
+        # Optional — failure degrades bundle to 'partial', does not block.
+        SnapshotKindPolicy(
+            snapshot_kind="symbol",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(60), hard_ttl=_seconds(180)),
+            required=False,
+            collector_timeout=_seconds(5),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="candidate_universe",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(900), hard_ttl=_seconds(3600)),
+            required=False,
+            collector_timeout=_seconds(15),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="news",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(900), hard_ttl=_seconds(7200)),
+            required=False,
+            collector_timeout=_seconds(10),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="naver_remote_debug",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(1800)),
+            required=False,
+            collector_timeout=_seconds(8),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="toss_remote_debug",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(1800)),
+            required=False,
+            collector_timeout=_seconds(8),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="browser_probe",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(1800)),
+            required=False,
+            collector_timeout=_seconds(8),
+        ),
+        SnapshotKindPolicy(
+            snapshot_kind="invest_page",
+            freshness=FreshnessPolicy(soft_ttl=_seconds(300), hard_ttl=_seconds(1800)),
+            required=False,
+            collector_timeout=_seconds(8),
+        ),
+    ),
+)
+
+
+POLICIES: dict[str, BundlePolicy] = {
+    INTRADAY_ACTION_REPORT_V1.policy_version: INTRADAY_ACTION_REPORT_V1,
+}
+
+
+def get_policy(policy_version: str) -> BundlePolicy:
+    """Return the named policy; raises ``KeyError`` if unknown."""
+    try:
+        return POLICIES[policy_version]
+    except KeyError as exc:
+        known = ", ".join(sorted(POLICIES))
+        raise KeyError(
+            f"unknown policy_version {policy_version!r}; known: {known}"
+        ) from exc

--- a/app/services/investment_snapshots/read_service.py
+++ b/app/services/investment_snapshots/read_service.py
@@ -93,9 +93,7 @@ class SnapshotBundleReadService:
     # ------------------------------------------------------------------
     # Listing bundles (HTTP /bundles)
     # ------------------------------------------------------------------
-    async def list_bundles(
-        self, request: ListBundlesRequest
-    ) -> ListBundlesResponse:
+    async def list_bundles(self, request: ListBundlesRequest) -> ListBundlesResponse:
         rows = await self._repo.list_bundles(
             purpose=request.purpose,
             market=request.market,

--- a/app/services/investment_snapshots/read_service.py
+++ b/app/services/investment_snapshots/read_service.py
@@ -1,0 +1,173 @@
+"""ROB-269 Phase 2 — Read service for snapshot bundles and snapshots.
+
+Pure read path — wraps ``InvestmentSnapshotsRepository`` and transforms ORM
+rows into MCP/API DTOs. Never writes. Never calls collectors.
+
+Used by:
+* MCP tools ``investment_snapshot_bundle_get`` and ``investment_snapshot_list``.
+* HTTP GET endpoints under ``/trading/api/investment-snapshots/``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.investment_snapshots_mcp import (
+    BundleHeaderView,
+    BundleItemView,
+    GetBundleResponse,
+    ListBundlesRequest,
+    ListBundlesResponse,
+    ListSnapshotsRequest,
+    ListSnapshotsResponse,
+    SnapshotMetadataView,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+_PAYLOAD_PREVIEW_BYTES = 2048
+
+
+class SnapshotBundleNotFoundError(LookupError):
+    """Raised when a bundle UUID does not resolve. Caller maps to HTTP 404."""
+
+
+class SnapshotBundleReadService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentSnapshotsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentSnapshotsRepository(session)
+
+    # ------------------------------------------------------------------
+    # Single bundle (MCP get + HTTP /bundles/{uuid})
+    # ------------------------------------------------------------------
+    async def get_bundle(
+        self,
+        *,
+        bundle_uuid: uuid.UUID,
+        include_payload_preview: bool = False,
+    ) -> GetBundleResponse:
+        bundle = await self._repo.get_bundle_by_uuid(bundle_uuid)
+        if bundle is None:
+            raise SnapshotBundleNotFoundError(str(bundle_uuid))
+
+        pairs = await self._repo.list_bundle_items_with_snapshots(bundle.id)
+        items = [
+            BundleItemView(
+                snapshot_uuid=snap.snapshot_uuid,
+                role=item.role,  # type: ignore[arg-type]
+                snapshot_kind=snap.snapshot_kind,  # type: ignore[arg-type]
+                market=snap.market,  # type: ignore[arg-type]
+                symbol=snap.symbol,
+                account_scope=snap.account_scope,  # type: ignore[arg-type]
+                freshness_status=snap.freshness_status,  # type: ignore[arg-type]
+                source_kind=snap.source_kind,  # type: ignore[arg-type]
+                source_table=snap.source_table,
+                source_id=snap.source_id,
+                source_uri=snap.source_uri,
+                as_of=snap.as_of,
+            )
+            for item, snap in pairs
+        ]
+
+        payload_previews: dict[uuid.UUID, str] | None = None
+        if include_payload_preview:
+            payload_previews = {
+                snap.snapshot_uuid: _serialise_preview(snap.payload_json)
+                for _item, snap in pairs
+            }
+
+        return GetBundleResponse(
+            bundle=_bundle_to_view(bundle),
+            items=items,
+            payload_previews=payload_previews,
+        )
+
+    # ------------------------------------------------------------------
+    # Listing bundles (HTTP /bundles)
+    # ------------------------------------------------------------------
+    async def list_bundles(
+        self, request: ListBundlesRequest
+    ) -> ListBundlesResponse:
+        rows = await self._repo.list_bundles(
+            purpose=request.purpose,
+            market=request.market,
+            account_scope=request.account_scope,
+            status=request.status,
+            limit=request.limit,
+        )
+        return ListBundlesResponse(
+            bundles=[_bundle_to_view(b) for b in rows],
+            limit=request.limit,
+        )
+
+    # ------------------------------------------------------------------
+    # Listing snapshots (MCP list + HTTP /snapshots)
+    # ------------------------------------------------------------------
+    async def list_snapshots(
+        self, request: ListSnapshotsRequest
+    ) -> ListSnapshotsResponse:
+        rows = await self._repo.list_snapshots(
+            market=request.market,
+            symbol=request.symbol,
+            snapshot_kind=request.snapshot_kind,
+            source_kind=request.source_kind,
+            freshness_status=request.freshness_status,
+            since=request.since,
+            limit=request.limit,
+        )
+        return ListSnapshotsResponse(
+            snapshots=[
+                SnapshotMetadataView(
+                    snapshot_uuid=r.snapshot_uuid,
+                    snapshot_kind=r.snapshot_kind,  # type: ignore[arg-type]
+                    market=r.market,  # type: ignore[arg-type]
+                    symbol=r.symbol,
+                    account_scope=r.account_scope,  # type: ignore[arg-type]
+                    as_of=r.as_of,
+                    freshness_status=r.freshness_status,  # type: ignore[arg-type]
+                    source_kind=r.source_kind,  # type: ignore[arg-type]
+                    source_table=r.source_table,
+                    source_id=r.source_id,
+                    source_uri=r.source_uri,
+                )
+                for r in rows
+            ],
+            limit=request.limit,
+        )
+
+
+def _bundle_to_view(bundle) -> BundleHeaderView:  # noqa: ANN001 — ORM row
+    return BundleHeaderView(
+        bundle_uuid=bundle.bundle_uuid,
+        purpose=bundle.purpose,
+        market=bundle.market,
+        account_scope=bundle.account_scope,
+        policy_version=bundle.policy_version,
+        as_of=bundle.as_of,
+        status=bundle.status,
+        coverage_summary=bundle.coverage_summary,
+        freshness_summary=bundle.freshness_summary,
+        created_at=bundle.created_at,
+    )
+
+
+def _serialise_preview(payload_json: dict[str, object]) -> str:
+    """Return at most ``_PAYLOAD_PREVIEW_BYTES`` bytes of compact JSON.
+
+    Truncation is byte-level and may produce invalid JSON intentionally —
+    the preview is meant for human eyeballing in MCP responses, not for
+    machine parsing.
+    """
+    encoded = json.dumps(payload_json, ensure_ascii=False, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) <= _PAYLOAD_PREVIEW_BYTES:
+        return encoded
+    truncated = encoded.encode("utf-8")[:_PAYLOAD_PREVIEW_BYTES]
+    return truncated.decode("utf-8", errors="ignore") + "…"

--- a/app/services/investment_snapshots/refresh_request_service.py
+++ b/app/services/investment_snapshots/refresh_request_service.py
@@ -1,0 +1,52 @@
+"""ROB-269 Phase 2 — Snapshot refresh-request service.
+
+Records an operator/reviewer/scheduler request to refresh snapshots. The
+service writes **one** ``investment_snapshot_runs`` row and returns. It
+does **not** collect data — Phase 3 schedulers will discover the row and
+transition it to ``completed`` / ``partial`` / ``failed``.
+
+Allowed because:
+* It is the only write surface that does not require fresh collection.
+* The run row is the audit trail for "who asked, why, when".
+* No broker/order mutation; only snapshot domain write.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.investment_snapshots import SnapshotRunCreate
+from app.schemas.investment_snapshots_mcp import RefreshRequest, RefreshResponse
+from app.services.investment_snapshots.policy import get_policy
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+
+class SnapshotRefreshRequestService:
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentSnapshotsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentSnapshotsRepository(session)
+
+    async def record(self, request: RefreshRequest) -> RefreshResponse:
+        policy = get_policy(request.policy_version)
+        run = await self._repo.insert_run(
+            SnapshotRunCreate(
+                purpose=request.purpose,
+                market=request.market,
+                account_scope=request.account_scope,
+                requested_by=request.requested_by,
+                policy_version=policy.policy_version,
+                policy_snapshot_json=policy.to_snapshot_json(),
+                refresh_reason=request.reason,
+                run_metadata={
+                    "symbols_filter": request.symbols,
+                    "snapshot_kinds_filter": request.snapshot_kinds,
+                },
+            )
+        )
+        return RefreshResponse(run_uuid=run.run_uuid, status="running")

--- a/app/services/investment_snapshots/repository.py
+++ b/app/services/investment_snapshots/repository.py
@@ -12,6 +12,7 @@ dedup UNIQUE constraint can rely on a deterministic input.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import Any
 
 import sqlalchemy as sa
@@ -180,3 +181,117 @@ class InvestmentSnapshotsRepository:
         await self._session.flush()
         await self._session.refresh(row)
         return row
+
+    # ------------------------------------------------------------------
+    # Phase 2 — SELECT-only read methods
+    # ------------------------------------------------------------------
+    # These are pure reads; they do NOT widen the append-only contract.
+    # The ``test_append_only.py`` surface lock includes them so a future PR
+    # cannot quietly add a mutation method by mixing it with a read change.
+
+    async def find_latest_bundle(
+        self,
+        *,
+        purpose: str,
+        market: str,
+        account_scope: str | None,
+        policy_version: str,
+    ) -> InvestmentSnapshotBundle | None:
+        """Return the most recent bundle for the identity tuple, or None."""
+        stmt = (
+            sa.select(InvestmentSnapshotBundle)
+            .where(
+                InvestmentSnapshotBundle.purpose == purpose,
+                InvestmentSnapshotBundle.market == market,
+                InvestmentSnapshotBundle.policy_version == policy_version,
+            )
+            .order_by(InvestmentSnapshotBundle.as_of.desc())
+            .limit(1)
+        )
+        if account_scope is None:
+            stmt = stmt.where(InvestmentSnapshotBundle.account_scope.is_(None))
+        else:
+            stmt = stmt.where(InvestmentSnapshotBundle.account_scope == account_scope)
+        return await self._session.scalar(stmt)
+
+    async def get_bundle_by_uuid(
+        self, bundle_uuid: uuid.UUID
+    ) -> InvestmentSnapshotBundle | None:
+        return await self._session.scalar(
+            sa.select(InvestmentSnapshotBundle).where(
+                InvestmentSnapshotBundle.bundle_uuid == bundle_uuid
+            )
+        )
+
+    async def list_bundle_items_with_snapshots(
+        self, bundle_id: int
+    ) -> list[tuple[InvestmentSnapshotBundleItem, InvestmentSnapshot]]:
+        """Return (item, snapshot) pairs for the given bundle, ordered by item id.
+
+        One query — joined eagerly so the caller does not issue per-item lookups.
+        """
+        stmt = (
+            sa.select(InvestmentSnapshotBundleItem, InvestmentSnapshot)
+            .join(
+                InvestmentSnapshot,
+                InvestmentSnapshot.id == InvestmentSnapshotBundleItem.snapshot_id,
+            )
+            .where(InvestmentSnapshotBundleItem.bundle_id == bundle_id)
+            .order_by(InvestmentSnapshotBundleItem.id.asc())
+        )
+        result = await self._session.execute(stmt)
+        return [(item, snap) for item, snap in result.all()]
+
+    async def list_bundles(
+        self,
+        *,
+        purpose: str | None = None,
+        market: str | None = None,
+        account_scope: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+    ) -> list[InvestmentSnapshotBundle]:
+        stmt = sa.select(InvestmentSnapshotBundle).order_by(
+            InvestmentSnapshotBundle.as_of.desc(), InvestmentSnapshotBundle.id.desc()
+        )
+        if purpose is not None:
+            stmt = stmt.where(InvestmentSnapshotBundle.purpose == purpose)
+        if market is not None:
+            stmt = stmt.where(InvestmentSnapshotBundle.market == market)
+        if account_scope is not None:
+            stmt = stmt.where(InvestmentSnapshotBundle.account_scope == account_scope)
+        if status is not None:
+            stmt = stmt.where(InvestmentSnapshotBundle.status == status)
+        stmt = stmt.limit(min(max(limit, 1), 100))
+        result = await self._session.scalars(stmt)
+        return list(result.all())
+
+    async def list_snapshots(
+        self,
+        *,
+        market: str | None = None,
+        symbol: str | None = None,
+        snapshot_kind: str | None = None,
+        source_kind: str | None = None,
+        freshness_status: str | None = None,
+        since: datetime | None = None,
+        limit: int = 20,
+    ) -> list[InvestmentSnapshot]:
+        stmt = sa.select(InvestmentSnapshot).order_by(
+            InvestmentSnapshot.as_of.desc(), InvestmentSnapshot.id.desc()
+        )
+        if market is not None:
+            stmt = stmt.where(InvestmentSnapshot.market == market)
+        if symbol is not None:
+            stmt = stmt.where(InvestmentSnapshot.symbol == symbol)
+        if snapshot_kind is not None:
+            stmt = stmt.where(InvestmentSnapshot.snapshot_kind == snapshot_kind)
+        if source_kind is not None:
+            stmt = stmt.where(InvestmentSnapshot.source_kind == source_kind)
+        if freshness_status is not None:
+            stmt = stmt.where(InvestmentSnapshot.freshness_status == freshness_status)
+        if since is not None:
+            stmt = stmt.where(InvestmentSnapshot.as_of >= since)
+        stmt = stmt.limit(min(max(limit, 1), 100))
+        result = await self._session.scalars(stmt)
+        return list(result.all())

--- a/docs/superpowers/plans/2026-05-19-rob-269-phase-2-mcp-api.md
+++ b/docs/superpowers/plans/2026-05-19-rob-269-phase-2-mcp-api.md
@@ -1,0 +1,220 @@
+# ROB-269 Phase 2 — MCP/API Surface (Short Plan)
+
+> Phase 2 of ROB-269. Builds on Phase 1 (`docs/superpowers/plans/2026-05-19-rob-269-phase-1-foundation.md`). PR base: `rob-269` (stacked draft until PR 874 merges, then retarget to `main`).
+>
+> **Branch:** `rob-269-phase2-mcp-api` (off `origin/rob-269`)
+> **Worktree:** `/Users/mgh3326/work/auto_trader.rob-269-phase2-mcp-api`
+> **Goal:** Expose Phase 1 foundation through a feature-flagged MCP + HTTP read/audit surface. No report generator, no live collectors, no broker mutation.
+
+---
+
+## 1. MCP/API contract
+
+**4 MCP tools** registered via `app/mcp_server/tooling/investment_snapshots_registration.py`. All read-only with respect to broker/order/watch state; only write paths are append-only into `review.investment_snapshot_*` tables.
+
+| Tool | Request | Response | Side effects |
+|---|---|---|---|
+| `investment_snapshot_bundle_ensure` | `purpose`, `market`, `account_scope?`, `policy_version`, `mode ∈ {ensure_fresh, reuse_only}`, `symbols?`, `candidate_limit?`, `manual_snapshots?` (optional pre-collected payloads, keyed by `snapshot_kind`) | `{bundle_uuid, status ∈ {complete, partial, stale_fallback, failed, reused}, created: bool, coverage_summary, freshness_summary, missing_sources, warnings}` | INSERT into runs/snapshots/bundles/bundle_items only when no fresh bundle exists. In `reuse_only`, never collects — returns `failed` if no fresh bundle. |
+| `investment_snapshot_bundle_get` | `bundle_uuid` | `{bundle: {…header…}, items: [{snapshot_uuid, role, snapshot_kind, freshness_status, source_kind, source_uri?, as_of}]}`. `include_payload_preview: bool` (default `False`) controls whether `payload_json` is partially echoed. | None. |
+| `investment_snapshot_list` | `market?`, `symbol?`, `snapshot_kind?`, `source_kind?`, `freshness_status?`, `since?`, `limit ≤ 100` | `{snapshots: [{snapshot_uuid, snapshot_kind, market, symbol, as_of, freshness_status, source_kind, source_uri?}]}`. No `payload_json` in list view. | None. |
+| `investment_snapshot_refresh_request` | `reason`, `purpose`, `market`, `account_scope?`, `symbols?`, `snapshot_kinds?` | `{run_uuid, status: 'running'}` | INSERT one `investment_snapshot_runs` row with `purpose='manual_refresh'` and `requested_by='reviewer'` or `'user'` based on caller identity. **Does not collect.** Phase 3 schedulers will discover the row and act on it. |
+
+**REST router** `app/routers/investment_snapshots.py`, prefix `/trading/api/investment-snapshots`, **GET-only**:
+
+- `GET /bundles/{bundle_uuid}` — mirrors `investment_snapshot_bundle_get` (no payload preview at this surface — kept for MCP).
+- `GET /bundles` — mirrors `investment_snapshot_list` for bundles (filters: `purpose`, `market`, `account_scope`, `status`, `limit`).
+- `GET /snapshots` — mirrors `investment_snapshot_list`.
+- **No POST/PUT/DELETE.** Refresh-request is MCP-only in Phase 2 (no HTTP write path) so the HTTP surface is provably read-only.
+
+Auth: GET endpoints use existing `Depends(get_authenticated_user)`. MCP tools rely on existing `caller_identity_middleware`.
+
+## 2. Feature flag behavior
+
+`INVESTMENT_SNAPSHOTS_MCP_ENABLED: bool = False` in `app/core/config.py` (mirrors `RESEARCH_REPORTS_INGEST_COMMIT_ENABLED`, `EXECUTION_LEDGER_COMMIT_ENABLED` pattern).
+
+- **`False` (default):**
+  - `register_investment_snapshots_tools(mcp)` is **not** called inside `register_all_tools` → 4 MCP tools absent.
+  - Router is **not** mounted on the FastAPI app → all 3 GET endpoints return 404.
+  - Code paths still import cleanly; tests can override the flag.
+- **`True`:**
+  - 4 MCP tools register.
+  - Router mounts.
+- The same flag gates both surfaces; no separate MCP/router flag. Prevents the "MCP exposed but HTTP hidden" mismatch.
+
+Activation order per pre-plan §5: this flag flips after the PR 2 merge, before Phase 3 work starts.
+
+## 3. Service / repository call graph
+
+```
+MCP tool / GET endpoint
+  │
+  ├──▶ SnapshotBundleEnsureService.ensure(request)
+  │     ├─ repo.find_latest_bundle(purpose, market, account_scope, policy_version)
+  │     ├─ classify_freshness(bundle.as_of, now, policy.bundle_ttl)
+  │     ├─ if fresh: return reused                  ◀── no new run
+  │     ├─ if reuse_only: return failed             ◀── no collection
+  │     ├─ repo.insert_run(...)
+  │     ├─ for kind in policy.required_kinds:
+  │     │    payload = manual_snapshots[kind]                   ── if caller-supplied
+  │     │             or collectors.get(kind).collect(...)      ── if registered (Phase 3+)
+  │     │             or None                                    ── results in 'unavailable'
+  │     │    repo.insert_snapshot(...)
+  │     ├─ same for optional_kinds (with bounded timeout, errors → 'unavailable')
+  │     ├─ derive bundle status from required vs optional outcomes
+  │     ├─ repo.insert_bundle(...) + repo.link_bundle_item(...) per snapshot
+  │     └─ return response DTO
+  │
+  ├──▶ SnapshotBundleReadService.get_bundle(bundle_uuid)
+  │     ├─ repo.get_bundle_by_uuid + repo.list_bundle_items_with_snapshots
+  │     └─ DTO transform
+  │
+  ├──▶ SnapshotBundleReadService.list_bundles / list_snapshots (filtered)
+  │     ├─ repo.list_bundles / list_snapshots (new read methods)
+  │     └─ DTO transform
+  │
+  └──▶ SnapshotRefreshRequestService.record(request)
+        └─ repo.insert_run(purpose='manual_refresh', ...) — single INSERT
+```
+
+`SnapshotCollectorRegistry` is a runtime map of `snapshot_kind → SnapshotCollectorProtocol`. **Empty by default in Phase 2.** Tests register fakes. Phase 3 will register production collectors (KIS / journal / market / news). Ensures Phase 2 has zero live HTTP surface.
+
+New read methods on `InvestmentSnapshotsRepository` (does **not** widen the append-only contract — these are SELECT-only):
+- `find_latest_bundle(purpose, market, account_scope, policy_version) -> Bundle | None`
+- `get_bundle_by_uuid(bundle_uuid) -> Bundle | None`
+- `list_bundle_items_with_snapshots(bundle_id) -> list[(item, snapshot)]`
+- `list_bundles(filters) -> list[Bundle]`
+- `list_snapshots(filters) -> list[Snapshot]`
+
+`test_append_only.py` surface lock list **must be updated** to include these read methods. Adding a new mutation prefix (`update_/delete_/...`) is still rejected.
+
+## 4. Snapshot write boundary / prohibited mutation boundary
+
+**Allowed writes** (snapshot domain only, append-only):
+- INSERT into `review.investment_snapshot_runs`
+- INSERT into `review.investment_snapshots`
+- INSERT into `review.investment_snapshot_bundles`
+- INSERT into `review.investment_snapshot_bundle_items`
+
+**Prohibited writes** (verified by grep guard test):
+- No INSERT/UPDATE/DELETE against any non-snapshot table from new service modules.
+- No imports of `KISTradingService`, `OrderExecutionService`, `AlpacaPaperOrdersService`, `WatchActivationService`, broker MCP handlers.
+- No `httpx`/`aiohttp`/`requests`/`urllib.request` in the new service modules (Phase 2 has no live HTTP at all; even GETs against external systems are deferred to Phase 3 collectors).
+- No `cancel_*` / `submit_*` / `modify_*` method calls anywhere in new code.
+
+**MCP tool surface invariants:**
+- `investment_snapshot_bundle_ensure` is the **only** snapshot-table write path. The other 3 tools are pure reads (or `refresh_request` which is a single INSERT into runs).
+- No tool writes outside `review.investment_snapshot_*`.
+
+## 5. Tests
+
+### Service / repository
+- `test_bundle_ensure_service.py` — 8 cases:
+  - reuse_only with no fresh bundle → `failed`
+  - reuse_only with fresh bundle → `reused`, no new run
+  - ensure_fresh with empty collectors + no manual payloads → `failed` (no data)
+  - ensure_fresh with manual payloads for all required kinds → `complete`
+  - ensure_fresh with manual payloads for required + 1 optional failing → `partial`
+  - ensure_fresh with stale_fallback (hard-stale required, no fresh source) → `stale_fallback`
+  - ensure_fresh second call within soft TTL → bundle reused, no second run
+  - ensure_fresh respects `policy_snapshot_json` freeze on the run
+
+- `test_collectors.py` — registry register/lookup/missing-kind error, protocol-shape conformance test (Pydantic SnapshotCollectResult).
+
+- `test_read_service.py` — get_bundle 404, get_bundle full round trip incl. items + snapshots, list filters (market/symbol/kind), `limit` clamp at 100.
+
+- `test_refresh_request_service.py` — INSERTs one run row with the right `purpose`+`requested_by`, returns `run_uuid`.
+
+- `test_append_only.py` — extends Phase 1 surface lock to include new read methods (mutation prefix rule unchanged).
+
+### MCP / router
+- `test_investment_snapshots_tools.py` — 4 tools each: input validation, happy path against in-memory DB, error mapping (404, validation).
+- `test_investment_snapshots_router.py` — 3 GET endpoints: 200, 404, filter behavior, no POST/PUT/DELETE handlers exist.
+- `test_investment_snapshots_feature_flag.py` — 4 cases:
+  - flag False → MCP registration call skipped, 4 tool names absent from server
+  - flag False → router not mounted, GET returns 404 at FastAPI level
+  - flag True → 4 tools present
+  - flag True → router mounted
+
+### Safety boundary
+- `test_mutation_boundary.py` — static grep guard:
+  - new service modules import no `httpx/aiohttp/requests/urllib.request`
+  - new service modules import no broker/order/watch-intent service classes (allowlist of forbidden names)
+  - new modules contain no `INSERT/UPDATE/DELETE` against non-`review.investment_snapshot_*` tables (SQL string scan, conservative — falses are OK to bypass with `# noqa: rob-269-boundary`)
+
+### Validation (mostly inherited from Phase 1)
+- Existing `SnapshotCreate` validators (source_ref triple + domain_ref) re-exercised through `ensure_bundle` happy paths.
+- New `SnapshotBundleEnsureRequest` DTO validation: `mode` enum, `policy_version` required, `symbols ⊆ kr/us/crypto market constraints`.
+
+**Test count target:** ~30 new tests on top of Phase 1's 25.
+
+## 6. Expected files
+
+**Create (15 new):**
+- `app/services/action_report/common/snapshot_bundle.py` — `SnapshotBundleEnsureService`
+- `app/services/investment_snapshots/collectors.py` — protocol + registry + result DTO
+- `app/services/investment_snapshots/read_service.py` — `SnapshotBundleReadService`
+- `app/services/investment_snapshots/refresh_request_service.py` — `SnapshotRefreshRequestService`
+- `app/services/investment_snapshots/policy.py` — `intraday_action_report_v1` constants (per-kind TTLs from pre-plan §3-defaults)
+- `app/schemas/investment_snapshots_mcp.py` — request/response DTOs for the 4 tools + 3 endpoints
+- `app/mcp_server/tooling/investment_snapshots_tools.py` — 4 tool function implementations
+- `app/mcp_server/tooling/investment_snapshots_registration.py` — registration + `INVESTMENT_SNAPSHOTS_TOOL_NAMES`
+- `app/routers/investment_snapshots.py` — 3 GET endpoints
+- `tests/services/investment_snapshots/test_bundle_ensure_service.py`
+- `tests/services/investment_snapshots/test_collectors.py`
+- `tests/services/investment_snapshots/test_read_service.py`
+- `tests/services/investment_snapshots/test_refresh_request_service.py`
+- `tests/services/investment_snapshots/test_mutation_boundary.py`
+- `tests/test_investment_snapshots_feature_flag.py` (or `tests/mcp_server/` + `tests/routers/` if split is cleaner)
+
+**Modify (4):**
+- `app/core/config.py` — add `INVESTMENT_SNAPSHOTS_MCP_ENABLED: bool = False`
+- `app/mcp_server/tooling/registry.py` — flag-gated `register_investment_snapshots_tools(mcp)` call
+- `app/mcp_server/tooling/__init__.py` — lazy export entries
+- `app/main.py` (or wherever routers are mounted — verify on first commit) — flag-gated router include
+- `app/services/investment_snapshots/repository.py` — add 5 SELECT-only methods (no mutation prefix)
+- `tests/services/investment_snapshots/test_append_only.py` — surface-lock list updated for the new read methods
+
+## 7. Non-goals (explicit out-of-scope for Phase 2)
+
+- ❌ Report generator integration (`investment_report_create` does not call `ensure_snapshot_bundle` in this PR)
+- ❌ KR action report cutover (no LLM/report-builder code touched)
+- ❌ `us_action_report/` → `action_report/<market>/` lift beyond defining `action_report/common/` and the single `snapshot_bundle.py` file inside it (no `us_action_report/` files moved, no renames)
+- ❌ `/invest` frontend provenance rendering (no React/SPA changes)
+- ❌ Prefect / TaskIQ scheduler enablement (no flow files, no recurring jobs)
+- ❌ Production deploy / unpause checklists (this PR is internal-surface only, default-off)
+- ❌ Real broker / order / watch-intent mutation (banned by safety boundary §4)
+- ❌ Live KIS / Upbit / Alpaca HTTP collectors (Phase 3 work; Phase 2 collectors registry is empty in prod, populated only by tests with fakes)
+- ❌ Caller identity / authz changes (use existing `caller_identity_middleware` and `get_authenticated_user`)
+- ❌ Snapshot dedup semantic re-design — Phase 1 §3b-1 decision stands; reviewer-pass note remains the contract
+
+---
+
+## Implementation order (TDD red-green-commit per step)
+
+Each step ends with a focused commit. Commits stay local until the end; final push as one branch.
+
+1. `feat(rob-269-p2): INVESTMENT_SNAPSHOTS_MCP_ENABLED flag in settings` — config.py only + 1 settings test.
+2. `feat(rob-269-p2): snapshot policy constants (intraday_action_report_v1)` — `policy.py` + tests.
+3. `feat(rob-269-p2): snapshot collector protocol + registry` — `collectors.py` + tests.
+4. `feat(rob-269-p2): request/response DTOs for snapshot MCP surface` — `investment_snapshots_mcp.py` + tests.
+5. `feat(rob-269-p2): repository SELECT-only read methods` — repository.py extension + tests (append-only surface lock updated).
+6. `feat(rob-269-p2): SnapshotBundleReadService` — `read_service.py` + 4-test slice.
+7. `feat(rob-269-p2): SnapshotRefreshRequestService` — `refresh_request_service.py` + 2-test slice.
+8. `feat(rob-269-p2): SnapshotBundleEnsureService` — `snapshot_bundle.py` + 8-test slice (the core).
+9. `feat(rob-269-p2): MCP tool functions + registration (flag-gated)` — tools.py + registration.py + registry.py wiring + flag tests.
+10. `feat(rob-269-p2): HTTP router (flag-gated, GET-only)` — `routers/investment_snapshots.py` + main mount + router tests + flag tests.
+11. `test(rob-269-p2): mutation boundary grep guard` — `test_mutation_boundary.py`.
+12. `chore(rob-269-p2): ruff cleanup` if needed.
+
+## Handoff format (at end)
+
+- Branch: `rob-269-phase2-mcp-api`
+- Commits: list with hashes + one-line subjects.
+- Migration: none (Phase 2 is code-only; reuses Phase 1 schema).
+- Tests: pasted `pytest` summary line(s).
+- Lint: clean or list of fixes.
+- Local commits made? Yes, no push until final.
+- Phase 1 dependency check: does this branch still rebase clean onto `origin/rob-269`?
+- Open `# TODO(rob-269 reviewer):` notes: file + line if any.
+
+After implementation, push branch + create stacked draft PR with base `rob-269`. Do not merge anything; wait for PR 874 to land first per user's workflow.

--- a/tests/mcp_server/test_investment_snapshots_tools.py
+++ b/tests/mcp_server/test_investment_snapshots_tools.py
@@ -151,9 +151,7 @@ def test_registry_skips_registration_when_flag_disabled(monkeypatch):
 
     registered_names = {t.name for t in mcp.registered}
     overlap = registered_names & INVESTMENT_SNAPSHOTS_TOOL_NAMES
-    assert overlap == set(), (
-        f"Snapshots tools registered with flag off: {overlap}"
-    )
+    assert overlap == set(), f"Snapshots tools registered with flag off: {overlap}"
 
 
 def test_registry_registers_when_flag_enabled(monkeypatch):

--- a/tests/mcp_server/test_investment_snapshots_tools.py
+++ b/tests/mcp_server/test_investment_snapshots_tools.py
@@ -1,0 +1,172 @@
+"""ROB-269 Phase 2 — MCP tools + flag-gated registration.
+
+These tests use a stand-in MCP recorder instead of real FastMCP so we
+avoid the network / fastmcp init overhead. The recorder captures
+``mcp.tool(...)`` calls, which is exactly what the registration module
+exercises.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling.investment_snapshots_registration import (
+    INVESTMENT_SNAPSHOTS_TOOL_NAMES,
+    register_investment_snapshots_tools,
+)
+from app.mcp_server.tooling.investment_snapshots_tools import (
+    investment_snapshot_bundle_get,
+    investment_snapshot_bundle_list,
+    investment_snapshot_list,
+    investment_snapshot_refresh_request,
+)
+
+
+@dataclass
+class _RecordedTool:
+    name: str
+    description: str
+    func: Any
+
+
+@dataclass
+class _RecorderMcp:
+    """Stand-in for ``FastMCP`` that captures ``.tool()`` registrations."""
+
+    registered: list[_RecordedTool] = field(default_factory=list)
+
+    def tool(self, *, name: str, description: str):
+        def _decorator(func):
+            self.registered.append(
+                _RecordedTool(name=name, description=description, func=func)
+            )
+            return func
+
+        return _decorator
+
+
+def test_register_investment_snapshots_tools_adds_expected_names():
+    mcp = _RecorderMcp()
+    register_investment_snapshots_tools(mcp)
+    registered_names = {t.name for t in mcp.registered}
+    assert registered_names == INVESTMENT_SNAPSHOTS_TOOL_NAMES
+
+
+def test_investment_snapshots_tool_names_lock():
+    # Lock the public surface so adding/renaming a tool is a conscious change.
+    assert INVESTMENT_SNAPSHOTS_TOOL_NAMES == {
+        "investment_snapshot_bundle_ensure",
+        "investment_snapshot_bundle_get",
+        "investment_snapshot_bundle_list",
+        "investment_snapshot_list",
+        "investment_snapshot_refresh_request",
+    }
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_bundle_get_returns_not_found_for_unknown_uuid(
+    db_session,  # noqa: ARG001 — fixture ensures schema is initialised
+):
+    """The tool uses its own session via AsyncSessionLocal — db_session here
+    only exists to ensure the test DB has the migrations applied."""
+    result = await investment_snapshot_bundle_get(
+        bundle_uuid=str(uuid.uuid4()),
+    )
+    assert result == {
+        "success": False,
+        "error": "not_found",
+        "bundle_uuid": result["bundle_uuid"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_bundle_get_rejects_invalid_uuid_string(db_session):
+    """Invalid UUID returns a structured error, not a 500."""
+    _ = db_session  # noqa: F841 — keep schema fixture
+    result = await investment_snapshot_bundle_get(bundle_uuid="not-a-uuid")
+    assert result == {
+        "success": False,
+        "error": "invalid_uuid",
+        "bundle_uuid": "not-a-uuid",
+    }
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_list_clamps_limit(db_session):
+    _ = db_session
+    result = await investment_snapshot_list(limit=9999)
+    assert result["success"] is True
+    # The Pydantic limit is clamped to <= 100 by the tool wrapper.
+    assert result["limit"] <= 100
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_list_invalid_since_returns_error(db_session):
+    _ = db_session
+    result = await investment_snapshot_list(since="not-iso8601")
+    assert result == {
+        "success": False,
+        "error": "invalid_since",
+        "since": "not-iso8601",
+    }
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_refresh_request_inserts_run(db_session):
+    _ = db_session
+    result = await investment_snapshot_refresh_request(
+        reason="manual smoke from tool test",
+        market="kr",
+        account_scope="kis_live",
+    )
+    assert result["success"] is True
+    assert result["status"] == "running"
+    assert uuid.UUID(result["run_uuid"])  # parseable
+
+
+@pytest.mark.asyncio
+async def test_investment_snapshot_bundle_list_empty_filters_ok(db_session):
+    _ = db_session
+    result = await investment_snapshot_bundle_list(limit=5)
+    assert result["success"] is True
+    assert result["limit"] == 5
+    # ``bundles`` is always a list (possibly empty).
+    assert isinstance(result["bundles"], list)
+
+
+def test_registry_skips_registration_when_flag_disabled(monkeypatch):
+    """Flag-off path: register_all_tools must NOT call the snapshots registrar."""
+    from app.core.config import settings
+    from app.mcp_server.profiles import McpProfile
+    from app.mcp_server.tooling import registry as registry_mod
+
+    monkeypatch.setattr(settings, "INVESTMENT_SNAPSHOTS_MCP_ENABLED", False)
+
+    mcp = _RecorderMcp()
+    registry_mod.register_all_tools(mcp, profile=McpProfile.DEFAULT)
+
+    registered_names = {t.name for t in mcp.registered}
+    overlap = registered_names & INVESTMENT_SNAPSHOTS_TOOL_NAMES
+    assert overlap == set(), (
+        f"Snapshots tools registered with flag off: {overlap}"
+    )
+
+
+def test_registry_registers_when_flag_enabled(monkeypatch):
+    from app.core.config import settings
+    from app.mcp_server.profiles import McpProfile
+    from app.mcp_server.tooling import registry as registry_mod
+
+    monkeypatch.setattr(settings, "INVESTMENT_SNAPSHOTS_MCP_ENABLED", True)
+
+    mcp = _RecorderMcp()
+    registry_mod.register_all_tools(mcp, profile=McpProfile.DEFAULT)
+
+    registered_names = {t.name for t in mcp.registered}
+    assert INVESTMENT_SNAPSHOTS_TOOL_NAMES.issubset(registered_names), (
+        f"Snapshots tools missing with flag on. Registered: {registered_names}"
+    )

--- a/tests/routers/test_investment_snapshots_router.py
+++ b/tests/routers/test_investment_snapshots_router.py
@@ -1,0 +1,203 @@
+"""ROB-269 Phase 2 — Investment snapshots HTTP router.
+
+GET-only router, flag-gated. The tests build a minimal FastAPI app with
+just our router + the auth dependency overridden so we can exercise
+endpoint behaviour without spinning the full app and SSO loop.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.routers.investment_snapshots import router as snapshots_router
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+
+def _build_app(db_session) -> FastAPI:
+    """Minimal FastAPI app for testing — uses the shared db_session fixture."""
+    app = FastAPI()
+    app.include_router(snapshots_router)
+
+    async def _db_override() -> AsyncIterator:
+        yield db_session
+
+    async def _user_override() -> User:
+        # Auth dependency is bypassed in tests; the value isn't read by our endpoints.
+        return User(id=1, email="test@example.com", role="user")  # type: ignore[call-arg]
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_authenticated_user] = _user_override
+    return app
+
+
+import datetime as dt
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC)
+
+
+async def _seed_one_bundle(db_session) -> uuid.UUID:
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose = f"router_test_{uuid.uuid4().hex[:8]}"
+    run = await repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    snap = await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={"cash_krw": 1, "u": str(uuid.uuid4())},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    bundle = await repo.insert_bundle(
+        BundleCreate(
+            purpose=purpose,
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_now(),
+            status="complete",
+        )
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="required"),
+    )
+    await db_session.commit()
+    return bundle.bundle_uuid
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_200_with_items(db_session):
+    bundle_uuid = await _seed_one_bundle(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-snapshots/bundles/{bundle_uuid}"
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["bundle"]["bundle_uuid"] == str(bundle_uuid)
+    assert len(body["items"]) == 1
+    assert body["payload_previews"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_404_for_unknown_uuid(db_session):
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-snapshots/bundles/{uuid.uuid4()}"
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_with_payload_preview_query_param(db_session):
+    bundle_uuid = await _seed_one_bundle(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-snapshots/bundles/{bundle_uuid}",
+            params={"include_payload_preview": "true"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["payload_previews"] is not None
+    assert len(body["payload_previews"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_returns_200(db_session):
+    await _seed_one_bundle(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            "/trading/api/investment-snapshots/bundles",
+            params={"limit": 5},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["limit"] == 5
+    assert isinstance(body["bundles"], list)
+
+
+@pytest.mark.asyncio
+async def test_list_snapshots_returns_200(db_session):
+    await _seed_one_bundle(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            "/trading/api/investment-snapshots/snapshots",
+            params={"limit": 5},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["limit"] == 5
+    assert isinstance(body["snapshots"], list)
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_rejects_limit_above_100(db_session):
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            "/trading/api/investment-snapshots/bundles",
+            params={"limit": 9999},
+        )
+    # FastAPI Query(le=100) rejects with 422.
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_router_has_no_post_put_delete_routes(db_session):
+    """Read-only invariant — no write verbs exposed at HTTP layer."""
+    _ = db_session  # noqa: F841
+    methods = set()
+    for route in snapshots_router.routes:
+        if hasattr(route, "methods"):
+            methods |= route.methods  # type: ignore[attr-defined]
+    # HEAD/OPTIONS get added automatically by FastAPI; assert no write verbs.
+    write_verbs = {"POST", "PUT", "DELETE", "PATCH"}
+    overlap = methods & write_verbs
+    assert overlap == set(), f"Snapshots router exposes write verbs: {overlap}"

--- a/tests/routers/test_investment_snapshots_router.py
+++ b/tests/routers/test_investment_snapshots_router.py
@@ -7,8 +7,9 @@ endpoint behaviour without spinning the full app and SSO loop.
 
 from __future__ import annotations
 
+import datetime as dt
 import uuid
-from typing import AsyncIterator
+from collections.abc import AsyncIterator
 
 import pytest
 from fastapi import FastAPI
@@ -44,9 +45,6 @@ def _build_app(db_session) -> FastAPI:
     app.dependency_overrides[get_db] = _db_override
     app.dependency_overrides[get_authenticated_user] = _user_override
     return app
-
-
-import datetime as dt
 
 
 def _now() -> dt.datetime:

--- a/tests/services/investment_snapshots/test_append_only.py
+++ b/tests/services/investment_snapshots/test_append_only.py
@@ -31,11 +31,19 @@ def test_repository_surface_only_inserts_and_links_and_reads():
     )
     # Lock the surface — adding a new method requires this test to be updated
     # which forces reviewer awareness.
+    # Phase 2 (rob-269-phase2-mcp-api) added 5 SELECT-only read methods to
+    # support the MCP/API surface. None of them mutate; the mutation prefix
+    # guard above still rejects update_/delete_/etc.
     assert public_methods == [
+        "find_latest_bundle",
+        "get_bundle_by_uuid",
         "get_run_by_uuid",
         "get_snapshot_by_uuid",
         "insert_bundle",
         "insert_run",
         "insert_snapshot",
         "link_bundle_item",
+        "list_bundle_items_with_snapshots",
+        "list_bundles",
+        "list_snapshots",
     ]

--- a/tests/services/investment_snapshots/test_bundle_ensure_service.py
+++ b/tests/services/investment_snapshots/test_bundle_ensure_service.py
@@ -1,0 +1,303 @@
+"""ROB-269 Phase 2 — SnapshotBundleEnsureService (core)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.investment_snapshots import (
+    InvestmentSnapshotRun,
+)
+from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+from app.services.action_report.common.snapshot_bundle import (
+    SnapshotBundleEnsureService,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+    SnapshotCollectorRegistry,
+)
+
+
+_FIXED_NOW = dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC)
+
+
+def _frozen_clock():
+    return lambda: _FIXED_NOW
+
+
+def _manual_snapshot(
+    kind: str,
+    *,
+    as_of: dt.datetime | None = None,
+    market: str = "kr",
+    account_scope: str | None = "kis_live",
+    payload: dict | None = None,
+) -> SnapshotCollectResult:
+    return SnapshotCollectResult(
+        snapshot_kind=kind,  # type: ignore[arg-type]
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        source_kind="manual",
+        payload_json=payload or {"k": kind, "u": str(uuid.uuid4())},
+        as_of=as_of or _FIXED_NOW,
+        freshness_status="fresh",
+    )
+
+
+def _all_required_manual_snapshots() -> dict[str, list[SnapshotCollectResult]]:
+    return {
+        "portfolio": [_manual_snapshot("portfolio")],
+        "journal": [_manual_snapshot("journal")],
+        "watch_context": [_manual_snapshot("watch_context")],
+        "market": [_manual_snapshot("market", account_scope=None)],
+    }
+
+
+def _unique_purpose(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.asyncio
+async def test_reuse_only_with_no_fresh_bundle_returns_failed_without_db_write(
+    db_session,
+):
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("reuse_only_miss"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            mode="reuse_only",
+        )
+    )
+    assert response.status == "failed"
+    assert response.bundle_uuid is None
+    assert response.created is False
+    assert response.run_uuid is None
+    assert any("reuse_only" in w for w in response.warnings)
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_with_empty_registry_and_no_manual_returns_failed(
+    db_session,
+):
+    """All required kinds unavailable → bundle status=failed, but bundle is created."""
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("empty_collectors"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "failed"
+    assert response.bundle_uuid is not None
+    assert response.created is True
+    assert response.run_uuid is not None
+    assert set(response.missing_sources) >= {
+        "portfolio",
+        "journal",
+        "watch_context",
+        "market",
+    }
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_with_all_required_manual_returns_complete(db_session):
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("all_required"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=_all_required_manual_snapshots(),
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "complete"
+    assert response.created is True
+    assert response.bundle_uuid is not None
+    # All 4 required kinds present in coverage_summary.required as 'fresh'.
+    assert set(response.coverage_summary["required"]) == {
+        "portfolio",
+        "journal",
+        "watch_context",
+        "market",
+    }
+    assert all(s == "fresh" for s in response.coverage_summary["required"].values())
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_with_required_complete_and_one_optional_failing_is_partial(
+    db_session,
+):
+    """All required succeed; one optional collector raises → bundle=partial."""
+
+    class _BrokenNewsCollector:
+        snapshot_kind = "news"
+
+        async def collect(self, request: CollectorRequest):
+            raise RuntimeError("news source unreachable")
+
+    registry = SnapshotCollectorRegistry()
+    registry.register(_BrokenNewsCollector())
+
+    svc = SnapshotBundleEnsureService(
+        db_session, collectors=registry, clock=_frozen_clock()
+    )
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("optional_fail"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=_all_required_manual_snapshots(),
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "partial"
+    # The optional 'news' kind appears as unavailable, others stay fresh.
+    assert response.coverage_summary["optional"]["news"] == "unavailable"
+    assert any("news" in w and "RuntimeError" in w for w in response.warnings)
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_with_hard_stale_required_returns_stale_fallback(
+    db_session,
+):
+    """Required portfolio with very old as_of → hard_stale → bundle=stale_fallback."""
+    old_as_of = _FIXED_NOW - dt.timedelta(hours=1)  # > portfolio hard TTL 300s
+    manual = _all_required_manual_snapshots()
+    manual["portfolio"] = [_manual_snapshot("portfolio", as_of=old_as_of)]
+
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("stale_fallback"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=manual,
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "stale_fallback"
+    assert response.coverage_summary["required"]["portfolio"] == "hard_stale"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_second_call_within_soft_ttl_reuses_bundle(db_session):
+    purpose = _unique_purpose("reuse_round_trip")
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+
+    first = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=purpose,
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=_all_required_manual_snapshots(),
+        )
+    )
+    await db_session.commit()
+    assert first.status == "complete"
+
+    second = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=purpose,
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=_all_required_manual_snapshots(),
+        )
+    )
+    await db_session.commit()
+    assert second.status == "reused"
+    assert second.bundle_uuid == first.bundle_uuid
+    assert second.created is False
+    assert second.run_uuid is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_writes_run_with_frozen_policy_snapshot(db_session):
+    svc = SnapshotBundleEnsureService(db_session, clock=_frozen_clock())
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("policy_freeze"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=_all_required_manual_snapshots(),
+        )
+    )
+    await db_session.commit()
+
+    run = await db_session.scalar(
+        sa.select(InvestmentSnapshotRun).where(
+            InvestmentSnapshotRun.run_uuid == response.run_uuid
+        )
+    )
+    assert run is not None
+    snap = run.policy_snapshot_json
+    assert snap["policy_version"] == "intraday_action_report_v1"
+    assert snap["bundle_ttl_seconds"] == {"soft": 180, "hard": 300}
+    portfolio_entry = next(k for k in snap["kinds"] if k["snapshot_kind"] == "portfolio")
+    assert portfolio_entry["required"] is True
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_uses_collector_registry_when_no_manual(db_session):
+    """When a kind has no manual_snapshot but a collector is registered, the
+    collector populates the bundle."""
+
+    class _FakePortfolioCollector:
+        snapshot_kind = "portfolio"
+
+        async def collect(self, request: CollectorRequest):
+            return [
+                SnapshotCollectResult(
+                    snapshot_kind="portfolio",
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    source_kind="manual",
+                    payload_json={"cash_krw": 999_999, "u": str(uuid.uuid4())},
+                    as_of=_FIXED_NOW,
+                    freshness_status="fresh",
+                )
+            ]
+
+    registry = SnapshotCollectorRegistry()
+    registry.register(_FakePortfolioCollector())
+
+    manual = _all_required_manual_snapshots()
+    # Strip portfolio from manual — collector should provide it.
+    del manual["portfolio"]
+
+    svc = SnapshotBundleEnsureService(
+        db_session, collectors=registry, clock=_frozen_clock()
+    )
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("collector_only"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=manual,
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "complete"
+    assert response.coverage_summary["required"]["portfolio"] == "fresh"

--- a/tests/services/investment_snapshots/test_bundle_ensure_service.py
+++ b/tests/services/investment_snapshots/test_bundle_ensure_service.py
@@ -17,10 +17,9 @@ from app.services.action_report.common.snapshot_bundle import (
 )
 from app.services.investment_snapshots.collectors import (
     CollectorRequest,
-    SnapshotCollectResult,
     SnapshotCollectorRegistry,
+    SnapshotCollectResult,
 )
-
 
 _FIXED_NOW = dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC)
 
@@ -253,7 +252,9 @@ async def test_ensure_fresh_writes_run_with_frozen_policy_snapshot(db_session):
     snap = run.policy_snapshot_json
     assert snap["policy_version"] == "intraday_action_report_v1"
     assert snap["bundle_ttl_seconds"] == {"soft": 180, "hard": 300}
-    portfolio_entry = next(k for k in snap["kinds"] if k["snapshot_kind"] == "portfolio")
+    portfolio_entry = next(
+        k for k in snap["kinds"] if k["snapshot_kind"] == "portfolio"
+    )
     assert portfolio_entry["required"] is True
 
 

--- a/tests/services/investment_snapshots/test_collectors.py
+++ b/tests/services/investment_snapshots/test_collectors.py
@@ -1,0 +1,132 @@
+"""ROB-269 Phase 2 — collector protocol + registry."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+    SnapshotCollectorProtocol,
+    SnapshotCollectorRegistry,
+    default_collector_registry,
+)
+
+
+class _FakeMarketCollector:
+    snapshot_kind = "market"
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        return [
+            SnapshotCollectResult(
+                snapshot_kind="market",
+                market=request.market,
+                source_kind="manual",
+                payload_json={"kospi": 2710.0},
+                as_of=dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC),
+            )
+        ]
+
+
+class _FakePortfolioCollector:
+    snapshot_kind = "portfolio"
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        return [
+            SnapshotCollectResult(
+                snapshot_kind="portfolio",
+                market=request.market,
+                account_scope=request.account_scope,
+                source_kind="manual",
+                payload_json={"cash_krw": 1_000_000, "holdings": []},
+                as_of=dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC),
+            )
+        ]
+
+
+def test_default_registry_is_empty():
+    reg = default_collector_registry()
+    assert len(reg) == 0
+    assert reg.list_kinds() == set()
+
+
+def test_register_and_lookup():
+    reg = SnapshotCollectorRegistry()
+    market = _FakeMarketCollector()
+    reg.register(market)
+    assert reg.get("market") is market
+    assert reg.list_kinds() == {"market"}
+
+
+def test_register_duplicate_kind_raises():
+    reg = SnapshotCollectorRegistry()
+    reg.register(_FakeMarketCollector())
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(_FakeMarketCollector())
+
+
+def test_register_two_different_kinds():
+    reg = SnapshotCollectorRegistry()
+    reg.register(_FakeMarketCollector())
+    reg.register(_FakePortfolioCollector())
+    assert reg.list_kinds() == {"market", "portfolio"}
+    assert reg.get("market") is not reg.get("portfolio")
+
+
+def test_get_missing_kind_returns_none():
+    reg = SnapshotCollectorRegistry()
+    assert reg.get("never_registered") is None
+
+
+def test_fake_collector_satisfies_protocol():
+    # ``runtime_checkable`` means isinstance check works.
+    assert isinstance(_FakeMarketCollector(), SnapshotCollectorProtocol)
+
+
+def test_snapshot_collect_result_source_ref_triple_enforced():
+    # Half-set triple is rejected.
+    with pytest.raises(ValueError, match="all be set or all None"):
+        SnapshotCollectResult(
+            snapshot_kind="market",
+            market="kr",
+            source_kind="manual",
+            source_table="some_table",
+            source_id=None,
+            source_uri=None,
+            payload_json={},
+            as_of=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        )
+
+
+def test_snapshot_collect_result_domain_ref_requires_triple():
+    with pytest.raises(ValueError, match="domain_ref"):
+        SnapshotCollectResult(
+            snapshot_kind="market",
+            market="kr",
+            source_kind="domain_ref",
+            source_table=None,
+            source_id=None,
+            source_uri=None,
+            payload_json={},
+            as_of=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        )
+
+
+@pytest.mark.asyncio
+async def test_collector_round_trip_via_protocol():
+    market = _FakeMarketCollector()
+    request = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        policy_snapshot={"policy_version": "intraday_action_report_v1"},
+    )
+    results = await market.collect(request)
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "market"
+    assert results[0].payload_json == {"kospi": 2710.0}

--- a/tests/services/investment_snapshots/test_collectors.py
+++ b/tests/services/investment_snapshots/test_collectors.py
@@ -8,9 +8,9 @@ import pytest
 
 from app.services.investment_snapshots.collectors import (
     CollectorRequest,
-    SnapshotCollectResult,
     SnapshotCollectorProtocol,
     SnapshotCollectorRegistry,
+    SnapshotCollectResult,
     default_collector_registry,
 )
 
@@ -18,9 +18,7 @@ from app.services.investment_snapshots.collectors import (
 class _FakeMarketCollector:
     snapshot_kind = "market"
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         return [
             SnapshotCollectResult(
                 snapshot_kind="market",
@@ -35,9 +33,7 @@ class _FakeMarketCollector:
 class _FakePortfolioCollector:
     snapshot_kind = "portfolio"
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         return [
             SnapshotCollectResult(
                 snapshot_kind="portfolio",

--- a/tests/services/investment_snapshots/test_mcp_dtos.py
+++ b/tests/services/investment_snapshots/test_mcp_dtos.py
@@ -1,0 +1,168 @@
+"""ROB-269 Phase 2 — MCP/API DTO validation."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.investment_snapshots_mcp import (
+    EnsureBundleRequest,
+    EnsureBundleResponse,
+    ListBundlesRequest,
+    ListSnapshotsRequest,
+    RefreshRequest,
+)
+
+
+def test_ensure_bundle_request_defaults_mode_to_ensure_fresh():
+    req = EnsureBundleRequest(
+        purpose="kr_action_report",
+        market="kr",
+        policy_version="intraday_action_report_v1",
+    )
+    assert req.mode == "ensure_fresh"
+    assert req.requested_by == "user"
+    assert req.manual_snapshots is None
+
+
+def test_ensure_bundle_request_reuse_only_accepted():
+    req = EnsureBundleRequest(
+        purpose="kr_action_report",
+        market="kr",
+        policy_version="intraday_action_report_v1",
+        mode="reuse_only",
+    )
+    assert req.mode == "reuse_only"
+
+
+def test_ensure_bundle_request_rejects_unknown_mode():
+    with pytest.raises(ValidationError):
+        EnsureBundleRequest(
+            purpose="kr_action_report",
+            market="kr",
+            policy_version="intraday_action_report_v1",
+            mode="hypothetical_mode",  # type: ignore[arg-type]
+        )
+
+
+def test_ensure_bundle_request_rejects_unknown_market():
+    with pytest.raises(ValidationError):
+        EnsureBundleRequest(
+            purpose="kr_action_report",
+            market="jp",  # type: ignore[arg-type]
+            policy_version="intraday_action_report_v1",
+        )
+
+
+def test_ensure_bundle_request_candidate_limit_bounded():
+    with pytest.raises(ValidationError):
+        EnsureBundleRequest(
+            purpose="kr_action_report",
+            market="kr",
+            policy_version="intraday_action_report_v1",
+            candidate_limit=0,  # below ge=1
+        )
+    with pytest.raises(ValidationError):
+        EnsureBundleRequest(
+            purpose="kr_action_report",
+            market="kr",
+            policy_version="intraday_action_report_v1",
+            candidate_limit=101,  # above le=100
+        )
+
+
+def test_ensure_bundle_response_reused_status_allowed():
+    resp = EnsureBundleResponse(
+        bundle_uuid=uuid.uuid4(),
+        status="reused",
+        created=False,
+    )
+    assert resp.status == "reused"
+    assert resp.run_uuid is None
+
+
+def test_ensure_bundle_response_complete_with_run_uuid():
+    resp = EnsureBundleResponse(
+        bundle_uuid=uuid.uuid4(),
+        status="complete",
+        created=True,
+        run_uuid=uuid.uuid4(),
+    )
+    assert resp.status == "complete"
+
+
+def test_list_snapshots_request_limit_default_and_bounds():
+    req = ListSnapshotsRequest()
+    assert req.limit == 20
+    with pytest.raises(ValidationError):
+        ListSnapshotsRequest(limit=0)
+    with pytest.raises(ValidationError):
+        ListSnapshotsRequest(limit=200)
+
+
+def test_list_bundles_request_accepts_all_filters_optional():
+    req = ListBundlesRequest()
+    assert req.purpose is None
+    assert req.market is None
+    assert req.status is None
+    assert req.limit == 20
+
+
+def test_refresh_request_requires_reason():
+    with pytest.raises(ValidationError):
+        RefreshRequest(
+            reason="",  # min_length=1
+            market="kr",
+        )
+
+
+def test_refresh_request_defaults():
+    req = RefreshRequest(reason="test smoke", market="kr")
+    assert req.purpose == "manual_refresh"
+    assert req.policy_version == "intraday_action_report_v1"
+    assert req.requested_by == "user"
+    assert req.snapshot_kinds is None
+
+
+def test_refresh_request_with_kinds_filter():
+    req = RefreshRequest(
+        reason="forced refresh after deploy",
+        market="kr",
+        snapshot_kinds=["portfolio", "market"],
+    )
+    assert req.snapshot_kinds == ["portfolio", "market"]
+
+
+def test_refresh_request_extra_field_rejected():
+    with pytest.raises(ValidationError):
+        RefreshRequest(
+            reason="x",
+            market="kr",
+            unknown_field=1,  # type: ignore[call-arg]
+        )
+
+
+def test_ensure_bundle_request_accepts_manual_snapshots_collection():
+    from app.services.investment_snapshots.collectors import SnapshotCollectResult
+
+    snap = SnapshotCollectResult(
+        snapshot_kind="portfolio",
+        market="kr",
+        account_scope="kis_live",
+        source_kind="manual",
+        payload_json={"cash_krw": 1_000_000},
+        as_of=dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC),
+    )
+    req = EnsureBundleRequest(
+        purpose="kr_action_report",
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        manual_snapshots={"portfolio": [snap]},
+    )
+    assert req.manual_snapshots is not None
+    assert "portfolio" in req.manual_snapshots
+    assert req.manual_snapshots["portfolio"][0].payload_json == {"cash_krw": 1_000_000}

--- a/tests/services/investment_snapshots/test_mutation_boundary.py
+++ b/tests/services/investment_snapshots/test_mutation_boundary.py
@@ -1,0 +1,146 @@
+"""ROB-269 Phase 2 — Static mutation-boundary guard.
+
+Reads every Phase 2-touched source file and asserts:
+
+* No HTTP client imports (``httpx``, ``aiohttp``, ``requests``,
+  ``urllib.request``). Phase 2 has no live external surface; collectors
+  are a future Phase 3 entry point.
+* No imports of broker/order/watch-intent service classes that could be
+  used to perform mutations against live or paper accounts.
+* No identifier references to ``submit_*`` / ``cancel_*`` / ``modify_*``
+  method calls (broker mutation verbs).
+
+This is a deliberately conservative static scan. False positives can be
+bypassed with a ``# noqa: rob-269-boundary`` marker on the offending line,
+but the marker must be the only way to opt out — there is no implicit
+allow-list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Files in scope. Order doesn't matter; we read each and run the checks.
+_SCOPED_FILES: list[str] = [
+    "app/services/investment_snapshots/repository.py",
+    "app/services/investment_snapshots/collectors.py",
+    "app/services/investment_snapshots/freshness.py",
+    "app/services/investment_snapshots/policy.py",
+    "app/services/investment_snapshots/read_service.py",
+    "app/services/investment_snapshots/refresh_request_service.py",
+    "app/services/action_report/common/snapshot_bundle.py",
+    "app/services/action_report/common/canonicalize.py",
+    "app/schemas/investment_snapshots.py",
+    "app/schemas/investment_snapshots_mcp.py",
+    "app/mcp_server/tooling/investment_snapshots_tools.py",
+    "app/mcp_server/tooling/investment_snapshots_registration.py",
+    "app/routers/investment_snapshots.py",
+]
+
+# Lines containing this marker are exempted from boundary checks.
+_BYPASS_MARKER = "rob-269-boundary"
+
+# HTTP clients — Phase 2 has no live external surface.
+_HTTP_IMPORT_PATTERNS = [
+    re.compile(r"^\s*import\s+httpx\b"),
+    re.compile(r"^\s*from\s+httpx\b"),
+    re.compile(r"^\s*import\s+aiohttp\b"),
+    re.compile(r"^\s*from\s+aiohttp\b"),
+    re.compile(r"^\s*import\s+requests\b"),
+    re.compile(r"^\s*from\s+requests\b"),
+    re.compile(r"^\s*from\s+urllib\.request\b"),
+    re.compile(r"^\s*import\s+urllib\.request\b"),
+]
+
+# Service classes whose import indicates we may mutate broker/order/watch state.
+_FORBIDDEN_SERVICE_NAMES = {
+    "KISTradingService",
+    "OrderExecutionService",
+    "AlpacaPaperOrdersService",
+    "WatchActivationService",
+    "TradeJournalWriteService",
+}
+
+# Broker mutation verb identifiers used as method *calls* (followed by ``(``).
+# These match against bare identifiers; bound .calls are also covered by the
+# regex (``.cancel_order(`` etc.).
+_FORBIDDEN_VERB_PATTERNS = [
+    re.compile(r"\bsubmit_order\b\s*\("),
+    re.compile(r"\bcancel_order\b\s*\("),
+    re.compile(r"\bmodify_order\b\s*\("),
+    re.compile(r"\bplace_order\b\s*\("),
+    re.compile(r"\bcreate_watch_intent\b\s*\("),
+]
+
+
+def _read(file: str) -> list[str]:
+    path = REPO_ROOT / file
+    if not path.exists():  # pragma: no cover — surface-level guard
+        return []
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def _lines_without_bypass(lines: list[str]) -> list[tuple[int, str]]:
+    return [
+        (i + 1, line) for i, line in enumerate(lines) if _BYPASS_MARKER not in line
+    ]
+
+
+@pytest.mark.parametrize("rel_path", _SCOPED_FILES)
+def test_no_http_client_imports(rel_path: str) -> None:
+    """Phase 2 source must not import live HTTP clients."""
+    violations: list[str] = []
+    for lineno, line in _lines_without_bypass(_read(rel_path)):
+        for pattern in _HTTP_IMPORT_PATTERNS:
+            if pattern.match(line):
+                violations.append(f"{rel_path}:{lineno}: {line.strip()}")
+                break
+    assert violations == [], (
+        f"Phase 2 must have no HTTP client imports. Violations:\n"
+        + "\n".join(violations)
+    )
+
+
+@pytest.mark.parametrize("rel_path", _SCOPED_FILES)
+def test_no_forbidden_service_imports(rel_path: str) -> None:
+    """Phase 2 source must not import broker/order/watch mutation services."""
+    violations: list[str] = []
+    for lineno, line in _lines_without_bypass(_read(rel_path)):
+        for forbidden in _FORBIDDEN_SERVICE_NAMES:
+            # Match in any context (from X import Y, including aliases, attribute use).
+            if re.search(rf"\b{re.escape(forbidden)}\b", line):
+                violations.append(
+                    f"{rel_path}:{lineno}: forbidden name {forbidden!r}: {line.strip()}"
+                )
+                break
+    assert violations == [], (
+        "Phase 2 must not reference broker/order/watch mutation service classes. "
+        f"Violations:\n" + "\n".join(violations)
+    )
+
+
+@pytest.mark.parametrize("rel_path", _SCOPED_FILES)
+def test_no_broker_mutation_verb_calls(rel_path: str) -> None:
+    """Phase 2 source must not call submit_/cancel_/modify_/place_ verbs."""
+    violations: list[str] = []
+    for lineno, line in _lines_without_bypass(_read(rel_path)):
+        for pattern in _FORBIDDEN_VERB_PATTERNS:
+            if pattern.search(line):
+                violations.append(f"{rel_path}:{lineno}: {line.strip()}")
+                break
+    assert violations == [], (
+        "Phase 2 must not call broker mutation verbs (submit_/cancel_/modify_/place_)."
+        " Violations:\n" + "\n".join(violations)
+    )
+
+
+def test_scoped_file_list_is_non_empty_and_all_exist() -> None:
+    """Catch regressions where files were renamed/removed without updating this test."""
+    missing = [f for f in _SCOPED_FILES if not (REPO_ROOT / f).exists()]
+    assert missing == [], f"Scoped files missing: {missing}"
+    assert len(_SCOPED_FILES) >= 10, "Boundary scope shrunk — investigate."

--- a/tests/services/investment_snapshots/test_mutation_boundary.py
+++ b/tests/services/investment_snapshots/test_mutation_boundary.py
@@ -86,9 +86,7 @@ def _read(file: str) -> list[str]:
 
 
 def _lines_without_bypass(lines: list[str]) -> list[tuple[int, str]]:
-    return [
-        (i + 1, line) for i, line in enumerate(lines) if _BYPASS_MARKER not in line
-    ]
+    return [(i + 1, line) for i, line in enumerate(lines) if _BYPASS_MARKER not in line]
 
 
 @pytest.mark.parametrize("rel_path", _SCOPED_FILES)
@@ -101,7 +99,7 @@ def test_no_http_client_imports(rel_path: str) -> None:
                 violations.append(f"{rel_path}:{lineno}: {line.strip()}")
                 break
     assert violations == [], (
-        f"Phase 2 must have no HTTP client imports. Violations:\n"
+        "Phase 2 must have no HTTP client imports. Violations:\n"
         + "\n".join(violations)
     )
 
@@ -120,7 +118,7 @@ def test_no_forbidden_service_imports(rel_path: str) -> None:
                 break
     assert violations == [], (
         "Phase 2 must not reference broker/order/watch mutation service classes. "
-        f"Violations:\n" + "\n".join(violations)
+        "Violations:\n" + "\n".join(violations)
     )
 
 

--- a/tests/services/investment_snapshots/test_policy.py
+++ b/tests/services/investment_snapshots/test_policy.py
@@ -8,9 +8,7 @@ import pytest
 
 from app.services.investment_snapshots.policy import (
     INTRADAY_ACTION_REPORT_V1,
-    BundlePolicy,
     POLICIES,
-    SnapshotKindPolicy,
     get_policy,
 )
 

--- a/tests/services/investment_snapshots/test_policy.py
+++ b/tests/services/investment_snapshots/test_policy.py
@@ -1,0 +1,82 @@
+"""ROB-269 Phase 2 — policy constants."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.investment_snapshots.policy import (
+    INTRADAY_ACTION_REPORT_V1,
+    BundlePolicy,
+    POLICIES,
+    SnapshotKindPolicy,
+    get_policy,
+)
+
+
+def test_intraday_action_report_v1_has_expected_required_kinds():
+    assert set(INTRADAY_ACTION_REPORT_V1.required_kinds()) == {
+        "portfolio",
+        "journal",
+        "watch_context",
+        "market",
+    }
+
+
+def test_intraday_action_report_v1_optional_kinds_match_phase1_whitelist():
+    optional = set(INTRADAY_ACTION_REPORT_V1.optional_kinds())
+    # symbol/candidate_universe/news are domain-ref candidates;
+    # naver/toss/browser/invest_page are whitelisted-generic (pre-plan Decision 1).
+    assert optional == {
+        "symbol",
+        "candidate_universe",
+        "news",
+        "naver_remote_debug",
+        "toss_remote_debug",
+        "browser_probe",
+        "invest_page",
+    }
+
+
+def test_intraday_action_report_v1_all_kinds_have_positive_ttls():
+    for kind in INTRADAY_ACTION_REPORT_V1.kinds:
+        assert kind.freshness.soft_ttl > dt.timedelta(0)
+        assert kind.freshness.hard_ttl > kind.freshness.soft_ttl
+        assert kind.collector_timeout > dt.timedelta(0)
+
+
+def test_kind_policy_lookup():
+    portfolio = INTRADAY_ACTION_REPORT_V1.kind_policy("portfolio")
+    assert portfolio is not None
+    assert portfolio.required is True
+    assert INTRADAY_ACTION_REPORT_V1.kind_policy("never_a_kind") is None
+
+
+def test_to_snapshot_json_round_trip_shape():
+    snapshot = INTRADAY_ACTION_REPORT_V1.to_snapshot_json()
+    assert snapshot["policy_version"] == "intraday_action_report_v1"
+    assert snapshot["bundle_ttl_seconds"] == {"soft": 180, "hard": 300}
+    assert isinstance(snapshot["kinds"], list)
+    portfolio_entry = next(
+        k for k in snapshot["kinds"] if k["snapshot_kind"] == "portfolio"
+    )
+    assert portfolio_entry["required"] is True
+    assert portfolio_entry["soft_ttl_seconds"] == 180
+    assert portfolio_entry["hard_ttl_seconds"] == 300
+
+
+def test_get_policy_returns_intraday_action_report_v1():
+    assert get_policy("intraday_action_report_v1") is INTRADAY_ACTION_REPORT_V1
+
+
+def test_get_policy_unknown_raises_keyerror_with_listed_options():
+    with pytest.raises(KeyError, match="intraday_action_report_v1"):
+        get_policy("nonexistent_policy")
+
+
+def test_policy_registry_only_contains_v1_in_phase2():
+    # Phase 2 ships exactly one policy. Adding new policies should require an
+    # explicit reviewer pass; this test fails if a new policy is added without
+    # also updating the test (forces a reviewer touch).
+    assert set(POLICIES) == {"intraday_action_report_v1"}

--- a/tests/services/investment_snapshots/test_read_service.py
+++ b/tests/services/investment_snapshots/test_read_service.py
@@ -1,0 +1,237 @@
+"""ROB-269 Phase 2 — SnapshotBundleReadService."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.schemas.investment_snapshots_mcp import (
+    ListBundlesRequest,
+    ListSnapshotsRequest,
+)
+from app.services.investment_snapshots.read_service import (
+    SnapshotBundleNotFoundError,
+    SnapshotBundleReadService,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC)
+
+
+async def _seed_bundle_with_two_items(session) -> uuid.UUID:
+    repo = InvestmentSnapshotsRepository(session)
+    purpose = f"read_svc_{uuid.uuid4().hex[:8]}"
+    run = await repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    snap_a = await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={"cash_krw": 1_234_567, "u": str(uuid.uuid4())},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    snap_b = await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="market",
+            market="kr",
+            source_kind="domain_ref",
+            source_table="market_quote_snapshots",
+            source_id=42,
+            source_uri=f"market_quote_snapshots:{uuid.uuid4().hex[:6]}",
+            payload_json={"kospi": 2710.0, "u": str(uuid.uuid4())},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    bundle = await repo.insert_bundle(
+        BundleCreate(
+            purpose=purpose,
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_now(),
+            status="complete",
+        )
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap_a.snapshot_uuid, role="required"),
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap_b.snapshot_uuid, role="required"),
+    )
+    await session.commit()
+    return bundle.bundle_uuid
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_404_for_unknown_uuid(db_session):
+    svc = SnapshotBundleReadService(db_session)
+    with pytest.raises(SnapshotBundleNotFoundError):
+        await svc.get_bundle(bundle_uuid=uuid.uuid4())
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_header_and_items(db_session):
+    bundle_uuid = await _seed_bundle_with_two_items(db_session)
+    svc = SnapshotBundleReadService(db_session)
+    response = await svc.get_bundle(bundle_uuid=bundle_uuid)
+
+    assert response.bundle.bundle_uuid == bundle_uuid
+    assert response.bundle.status == "complete"
+    assert len(response.items) == 2
+    assert {item.snapshot_kind for item in response.items} == {"portfolio", "market"}
+    # By default no payload preview.
+    assert response.payload_previews is None
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_with_payload_preview_truncates(db_session):
+    bundle_uuid = await _seed_bundle_with_two_items(db_session)
+    svc = SnapshotBundleReadService(db_session)
+    response = await svc.get_bundle(
+        bundle_uuid=bundle_uuid, include_payload_preview=True
+    )
+    assert response.payload_previews is not None
+    assert len(response.payload_previews) == 2
+    for preview in response.payload_previews.values():
+        # 2KB cap, leaves some room.
+        assert len(preview.encode("utf-8")) <= 2049  # 2048 + ellipsis byte tolerance
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_payload_preview_caps_oversized_payload(db_session):
+    """Payload > 2KB → preview truncated with ellipsis."""
+    repo = InvestmentSnapshotsRepository(db_session)
+    run = await repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    big_value = "x" * 5_000  # well over 2KB
+    snap = await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={"big": big_value, "u": str(uuid.uuid4())},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    bundle = await repo.insert_bundle(
+        BundleCreate(
+            purpose=f"big_preview_{uuid.uuid4().hex[:8]}",
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_now(),
+            status="complete",
+        )
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="required"),
+    )
+    await db_session.commit()
+
+    svc = SnapshotBundleReadService(db_session)
+    response = await svc.get_bundle(
+        bundle_uuid=bundle.bundle_uuid, include_payload_preview=True
+    )
+    preview = next(iter(response.payload_previews.values()))
+    assert preview.endswith("…")
+    assert len(preview.encode("utf-8")) <= 2048 + 3  # leaves room for ellipsis bytes
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_filters(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    unique_purpose = f"list_bundles_{uuid.uuid4().hex[:8]}"
+    await repo.insert_bundle(
+        BundleCreate(
+            purpose=unique_purpose,
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_now(),
+            status="complete",
+        )
+    )
+    await db_session.commit()
+
+    svc = SnapshotBundleReadService(db_session)
+    response = await svc.list_bundles(
+        ListBundlesRequest(purpose=unique_purpose, limit=10)
+    )
+    assert response.limit == 10
+    assert len(response.bundles) == 1
+    assert response.bundles[0].purpose == unique_purpose
+
+
+@pytest.mark.asyncio
+async def test_list_snapshots_filters(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    run = await repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    sym = f"LS{uuid.uuid4().hex[:6]}"
+    await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="symbol",
+            market="kr",
+            account_scope="kis_live",
+            symbol=sym,
+            source_kind="kis_mcp",
+            payload_json={"price": 100.0, "u": str(uuid.uuid4())},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    await db_session.commit()
+
+    svc = SnapshotBundleReadService(db_session)
+    response = await svc.list_snapshots(ListSnapshotsRequest(symbol=sym, limit=5))
+    assert response.limit == 5
+    assert len(response.snapshots) == 1
+    assert response.snapshots[0].symbol == sym
+    assert response.snapshots[0].snapshot_kind == "symbol"

--- a/tests/services/investment_snapshots/test_refresh_request_service.py
+++ b/tests/services/investment_snapshots/test_refresh_request_service.py
@@ -1,0 +1,84 @@
+"""ROB-269 Phase 2 — SnapshotRefreshRequestService."""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.investment_snapshots import InvestmentSnapshotRun
+from app.schemas.investment_snapshots_mcp import RefreshRequest
+from app.services.investment_snapshots.refresh_request_service import (
+    SnapshotRefreshRequestService,
+)
+
+
+@pytest.mark.asyncio
+async def test_record_inserts_manual_refresh_run(db_session):
+    svc = SnapshotRefreshRequestService(db_session)
+    response = await svc.record(
+        RefreshRequest(
+            reason="local smoke after deploy",
+            market="kr",
+            account_scope="kis_live",
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "running"
+
+    run = await db_session.scalar(
+        sa.select(InvestmentSnapshotRun).where(
+            InvestmentSnapshotRun.run_uuid == response.run_uuid
+        )
+    )
+    assert run is not None
+    assert run.purpose == "manual_refresh"
+    assert run.requested_by == "user"
+    assert run.refresh_reason == "local smoke after deploy"
+    assert run.policy_version == "intraday_action_report_v1"
+    # Policy snapshot frozen onto the run.
+    assert run.policy_snapshot_json["policy_version"] == "intraday_action_report_v1"
+    # Filter metadata captured.
+    assert run.run_metadata["symbols_filter"] is None
+    assert run.run_metadata["snapshot_kinds_filter"] is None
+
+
+@pytest.mark.asyncio
+async def test_record_with_reviewer_requested_purpose_and_filters(db_session):
+    svc = SnapshotRefreshRequestService(db_session)
+    response = await svc.record(
+        RefreshRequest(
+            reason="reviewer wants fresh portfolio for PR re-check",
+            purpose="reviewer_requested",
+            market="kr",
+            account_scope="kis_live",
+            symbols=["035420", "005930"],
+            snapshot_kinds=["portfolio"],
+            requested_by="reviewer",
+        )
+    )
+    await db_session.commit()
+
+    run = await db_session.scalar(
+        sa.select(InvestmentSnapshotRun).where(
+            InvestmentSnapshotRun.run_uuid == response.run_uuid
+        )
+    )
+    assert run is not None
+    assert run.purpose == "reviewer_requested"
+    assert run.requested_by == "reviewer"
+    assert run.run_metadata["symbols_filter"] == ["035420", "005930"]
+    assert run.run_metadata["snapshot_kinds_filter"] == ["portfolio"]
+
+
+@pytest.mark.asyncio
+async def test_record_unknown_policy_raises_keyerror(db_session):
+    svc = SnapshotRefreshRequestService(db_session)
+    with pytest.raises(KeyError, match="nonexistent_policy_v9"):
+        await svc.record(
+            RefreshRequest(
+                reason="bad policy",
+                market="kr",
+                policy_version="nonexistent_policy_v9",
+            )
+        )

--- a/tests/services/investment_snapshots/test_repository_reads.py
+++ b/tests/services/investment_snapshots/test_repository_reads.py
@@ -241,7 +241,5 @@ async def test_list_snapshots_filters(db_session):
     )
     assert len(by_kind_filter) == len(by_symbol)
 
-    none_by_kind = await repo.list_snapshots(
-        symbol=unique_symbol, snapshot_kind="news"
-    )
+    none_by_kind = await repo.list_snapshots(symbol=unique_symbol, snapshot_kind="news")
     assert none_by_kind == []

--- a/tests/services/investment_snapshots/test_repository_reads.py
+++ b/tests/services/investment_snapshots/test_repository_reads.py
@@ -1,0 +1,247 @@
+"""ROB-269 Phase 2 — Repository SELECT-only extensions."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 5, 19, 11, 11, 0, tzinfo=dt.UTC)
+
+
+def _run_payload() -> SnapshotRunCreate:
+    return SnapshotRunCreate(
+        purpose="report_generation",
+        market="kr",
+        account_scope="kis_live",
+        requested_by="user",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+def _snapshot_payload(
+    run_uuid: uuid.UUID,
+    *,
+    symbol: str | None = None,
+    kind: str = "symbol",
+    price: float = 1.0,
+) -> SnapshotCreate:
+    return SnapshotCreate(
+        run_uuid=run_uuid,
+        snapshot_kind=kind,  # type: ignore[arg-type]
+        market="kr",
+        account_scope="kis_live",
+        symbol=symbol,
+        source_kind="kis_mcp",
+        payload_json={"v": price, "u": str(uuid.uuid4())},
+        as_of=_now(),
+        freshness_status="fresh",
+    )
+
+
+def _bundle_payload(*, purpose: str = "kr_action_report") -> BundleCreate:
+    return BundleCreate(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        as_of=_now(),
+        status="complete",
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_latest_bundle_returns_none_when_none_exist(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose = f"never_seen_{uuid.uuid4().hex[:8]}"
+    found = await repo.find_latest_bundle(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+    )
+    assert found is None
+
+
+@pytest.mark.asyncio
+async def test_find_latest_bundle_returns_most_recent_by_as_of(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose = f"latest_test_{uuid.uuid4().hex[:8]}"
+
+    older = BundleCreate(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        as_of=_now() - dt.timedelta(hours=1),
+        status="complete",
+    )
+    newer = BundleCreate(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        as_of=_now(),
+        status="complete",
+    )
+    await repo.insert_bundle(older)
+    newer_row = await repo.insert_bundle(newer)
+    await db_session.commit()
+
+    found = await repo.find_latest_bundle(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+    )
+    assert found is not None
+    assert found.bundle_uuid == newer_row.bundle_uuid
+
+
+@pytest.mark.asyncio
+async def test_find_latest_bundle_account_scope_null_match(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose = f"no_scope_{uuid.uuid4().hex[:8]}"
+    no_scope = BundleCreate(
+        purpose=purpose,
+        market="kr",
+        account_scope=None,
+        policy_version="intraday_action_report_v1",
+        as_of=_now(),
+        status="complete",
+    )
+    inserted = await repo.insert_bundle(no_scope)
+    await db_session.commit()
+
+    found = await repo.find_latest_bundle(
+        purpose=purpose,
+        market="kr",
+        account_scope=None,
+        policy_version="intraday_action_report_v1",
+    )
+    assert found is not None
+    assert found.bundle_uuid == inserted.bundle_uuid
+
+    # Different account scope should not match the NULL one.
+    not_found = await repo.find_latest_bundle(
+        purpose=purpose,
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+    )
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_by_uuid_round_trip(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    bundle = await repo.insert_bundle(
+        _bundle_payload(purpose=f"get_by_uuid_{uuid.uuid4().hex[:8]}")
+    )
+    await db_session.commit()
+
+    fetched = await repo.get_bundle_by_uuid(bundle.bundle_uuid)
+    assert fetched is not None
+    assert fetched.id == bundle.id
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_by_uuid_returns_none_when_missing(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    fetched = await repo.get_bundle_by_uuid(uuid.uuid4())
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_list_bundle_items_with_snapshots_orders_by_item_id(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose = f"items_{uuid.uuid4().hex[:8]}"
+    run = await repo.insert_run(_run_payload())
+    bundle = await repo.insert_bundle(_bundle_payload(purpose=purpose))
+
+    snap_a = await repo.insert_snapshot(
+        _snapshot_payload(run.run_uuid, symbol=f"A{uuid.uuid4().hex[:6]}")
+    )
+    snap_b = await repo.insert_snapshot(
+        _snapshot_payload(run.run_uuid, symbol=f"B{uuid.uuid4().hex[:6]}")
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap_a.snapshot_uuid, role="required"),
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap_b.snapshot_uuid, role="optional"),
+    )
+    await db_session.commit()
+
+    pairs = await repo.list_bundle_items_with_snapshots(bundle.id)
+    assert len(pairs) == 2
+    roles = [item.role for item, _snap in pairs]
+    assert roles == ["required", "optional"]
+    snap_uuids = [snap.snapshot_uuid for _item, snap in pairs]
+    assert snap_uuids == [snap_a.snapshot_uuid, snap_b.snapshot_uuid]
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_filters_by_purpose_and_status(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    purpose_a = f"purpose_a_{uuid.uuid4().hex[:8]}"
+    purpose_b = f"purpose_b_{uuid.uuid4().hex[:8]}"
+    await repo.insert_bundle(_bundle_payload(purpose=purpose_a))
+    await repo.insert_bundle(_bundle_payload(purpose=purpose_b))
+    await db_session.commit()
+
+    only_a = await repo.list_bundles(purpose=purpose_a, limit=10)
+    assert {b.purpose for b in only_a} == {purpose_a}
+
+    only_complete_a = await repo.list_bundles(
+        purpose=purpose_a, status="complete", limit=10
+    )
+    assert all(b.status == "complete" for b in only_complete_a)
+
+
+@pytest.mark.asyncio
+async def test_list_bundles_limit_clamped_to_100(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    # Limit clamp behavior — request 9999, repository must clamp to ≤ 100.
+    rows = await repo.list_bundles(limit=9999)
+    assert len(rows) <= 100
+
+
+@pytest.mark.asyncio
+async def test_list_snapshots_filters(db_session):
+    repo = InvestmentSnapshotsRepository(db_session)
+    run = await repo.insert_run(_run_payload())
+    unique_symbol = f"FIL{uuid.uuid4().hex[:6]}"
+    await repo.insert_snapshot(
+        _snapshot_payload(run.run_uuid, symbol=unique_symbol, kind="symbol")
+    )
+    await db_session.commit()
+
+    by_symbol = await repo.list_snapshots(symbol=unique_symbol)
+    assert len(by_symbol) >= 1
+    assert all(s.symbol == unique_symbol for s in by_symbol)
+
+    by_kind_filter = await repo.list_snapshots(
+        symbol=unique_symbol, snapshot_kind="symbol"
+    )
+    assert len(by_kind_filter) == len(by_symbol)
+
+    none_by_kind = await repo.list_snapshots(
+        symbol=unique_symbol, snapshot_kind="news"
+    )
+    assert none_by_kind == []

--- a/tests/test_investment_snapshots_feature_flag.py
+++ b/tests/test_investment_snapshots_feature_flag.py
@@ -1,0 +1,42 @@
+"""ROB-269 Phase 2 — INVESTMENT_SNAPSHOTS_MCP_ENABLED end-to-end flag tests.
+
+These build the full FastAPI app twice (once flag off, once flag on) and
+assert the snapshots router is physically absent vs present. The MCP-side
+tool flag gating is covered by ``tests/mcp_server/test_investment_snapshots_tools.py``.
+"""
+
+from __future__ import annotations
+
+
+def _snapshots_routes(app) -> set[str]:
+    return {
+        getattr(r, "path", "")
+        for r in app.routes
+        if "investment-snapshots" in getattr(r, "path", "")
+    }
+
+
+def test_main_create_app_does_not_mount_snapshots_router_when_flag_disabled(monkeypatch):
+    from app.core.config import settings
+    from app.main import create_app
+
+    monkeypatch.setattr(settings, "INVESTMENT_SNAPSHOTS_MCP_ENABLED", False)
+
+    app = create_app()
+    assert _snapshots_routes(app) == set(), (
+        "Snapshots router routes leaked with flag off"
+    )
+
+
+def test_main_create_app_mounts_snapshots_router_when_flag_enabled(monkeypatch):
+    from app.core.config import settings
+    from app.main import create_app
+
+    monkeypatch.setattr(settings, "INVESTMENT_SNAPSHOTS_MCP_ENABLED", True)
+
+    app = create_app()
+    routes = _snapshots_routes(app)
+    # All three GET paths present.
+    assert any("/bundles/{bundle_uuid}" in r for r in routes)
+    assert "/trading/api/investment-snapshots/bundles" in routes
+    assert "/trading/api/investment-snapshots/snapshots" in routes

--- a/tests/test_investment_snapshots_feature_flag.py
+++ b/tests/test_investment_snapshots_feature_flag.py
@@ -16,7 +16,9 @@ def _snapshots_routes(app) -> set[str]:
     }
 
 
-def test_main_create_app_does_not_mount_snapshots_router_when_flag_disabled(monkeypatch):
+def test_main_create_app_does_not_mount_snapshots_router_when_flag_disabled(
+    monkeypatch,
+):
     from app.core.config import settings
     from app.main import create_app
 


### PR DESCRIPTION
## Summary

Second of 4 PRs implementing [ROB-269](https://linear.app/mgh3326/issue/ROB-269). Exposes the Phase 1 snapshot foundation through a **feature-flagged MCP + HTTP read/audit surface**. No report generator, no live collectors, no broker mutation.

> **Stacked on #874.** Base is `rob-269`, not `main`. Once #874 merges, I will rebase this branch onto `origin/main` and retarget the PR base to `main`.

## Scope (additive only, default OFF)

- **Feature flag** — `INVESTMENT_SNAPSHOTS_MCP_ENABLED: bool = False` in `app/core/config.py`. Gates BOTH the MCP tools AND the HTTP router. Default off: code imports cleanly but is unreachable from caller surfaces until flipped post-merge.
- **5 MCP tools** (`investment_snapshot_bundle_ensure`, `_get`, `_list`, `bundle_list`, `_refresh_request`)
- **3 GET endpoints** under `/trading/api/investment-snapshots/{bundles/{uuid},bundles,snapshots}` — **no POST/PUT/DELETE handlers exist** (verified by router test).
- **Services**: `SnapshotBundleEnsureService` (core), `SnapshotBundleReadService`, `SnapshotRefreshRequestService`.
- **Collectors registry** — empty by default in production. Phase 2 callers pass `manual_snapshots` directly; Phase 3 will populate the registry with KIS / journal / market / news collectors.
- **Policy constants** — `intraday_action_report_v1` with 4 required kinds (portfolio / journal / watch_context / market) + 7 optional kinds.

## Not in this PR (future phases, all feature-flag-gated)

- ❌ Report generator integration (Phase 3)
- ❌ KR action report cutover (Phase 3)
- ❌ `us_action_report/` → `action_report/<market>/` lift beyond the new `action_report/common/snapshot_bundle.py` seam (Phase 3)
- ❌ `/invest` UI provenance rendering (Phase 4)
- ❌ Scheduler enablement / Prefect deployment (Phase 4)
- ❌ Live KIS/Upbit/Alpaca HTTP collectors (Phase 3)
- ❌ Real broker / order / watch-intent mutation (banned by safety boundary)

## Plan reference

`docs/superpowers/plans/2026-05-19-rob-269-phase-2-mcp-api.md` (7 sections: contract / flag / call graph / write boundary / tests / files / non-goals).

## Safety boundaries (statically enforced)

`tests/services/investment_snapshots/test_mutation_boundary.py` runs a parameterised static scan across 13 scoped source files and asserts:

1. **No HTTP client imports** — `httpx` / `aiohttp` / `requests` / `urllib.request` (Phase 2 has zero live external surface).
2. **No imports of broker mutation service classes** — `KISTradingService`, `OrderExecutionService`, `AlpacaPaperOrdersService`, `WatchActivationService`, `TradeJournalWriteService`.
3. **No calls to broker mutation verbs** — `submit_order(`, `cancel_order(`, `modify_order(`, `place_order(`, `create_watch_intent(`.

Bypassable only via the explicit `rob-269-boundary` marker — no implicit allow-list. The HTTP router test additionally locks the verb set to GET-only (no POST/PUT/DELETE handlers exist).

## Phase 1 (PR #874) invariants honored

- Append-only repository surface — `tests/services/investment_snapshots/test_append_only.py` lock list extended to include 5 new SELECT-only read methods; mutation prefix guard (`update_/delete_/...`) unchanged.
- Run status stays `'running'` — bundle.status is the authoritative outcome record, consistent with the Phase 1 dedup semantic doc (pre-plan §3b-1).
- Cross-run snapshot dedup unchanged; the ensure service explicitly does not assert `snapshot.run_id == my_run.id`.

## Tests

**141/141 passing locally in 12.64s** (Phase 1 25 + Phase 2 116 new):
- Policy: 8 cases
- Collectors: 9 cases
- MCP DTO validation: 14 cases
- Repository read methods: 9 cases
- Append-only lock (updated): 2 cases
- Read service: 6 cases
- Refresh request service: 3 cases
- Ensure service: 8 cases (reuse/reuse_only_miss/empty_collectors/all_required_manual/optional_failing/stale_fallback/second_call_reuse/policy_freeze)
- MCP tools + flag gating: 10 cases (incl. flag-off & flag-on registry tests)
- Router: 7 cases (incl. write-verb absence guard)
- Feature flag end-to-end (full app build): 2 cases
- Mutation boundary static scan: 40 parameterised checks (13 files × 3 checks + manifest)

## Test plan

- [ ] CI: full `make test` suite passes
- [ ] CI: `make lint` clean
- [ ] Reviewer eyeballs: confirm `test_mutation_boundary.py` covers the right files and that no `# noqa: rob-269-boundary` markers were used to silence real findings
- [ ] Reviewer eyeballs: `register_all_tools` flag-gated block correctly defers to `settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED`
- [ ] Reviewer eyeballs: HTTP router's GET-only invariant in `test_router_has_no_post_put_delete_routes`
- [ ] Reviewer eyeballs: `_collect_for_kind` optional-kind semantic — "no manual + no collector = not_requested (silent skip)" is the right contract for Phase 2's empty registry
- [ ] Once #874 merges: rebase onto `origin/main`, retarget PR base to `main`, re-run CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added investment snapshot management tools and read-only HTTP endpoints. Feature is disabled by default; requires configuration flag to enable.
  * Snapshot tools support ensuring bundles exist, retrieving bundle details, listing snapshots, and requesting refreshes.

* **Documentation**
  * Added Phase 2 planning documentation for snapshot management surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->