### PR TITLE
feat(rob-269): UI provenance + reviewer handoff + scheduler — Phase 4 (PR 4/4)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -440,9 +440,17 @@ class Settings(BaseSettings):
     # (not flag-gated) — this flag only controls the pre-DB rejection layer.
     # See docs/superpowers/plans/2026-05-19-rob-269-phase-3-report-generator.md §5.
     ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED: bool = False
-    # ROB-269 Phase 4 — gates the /invest SnapshotBundleFreshnessChip render
-    # and any future bundle-aware UI surfaces. Default off so the chip
-    # is physically absent from caller-facing pages until flipped post-merge.
+    # ROB-269 Phase 4 — scaffold only. NOT wired in Phase 4: there is no
+    # HTTP endpoint exposing this flag to the SPA and the frontend chip
+    # does NOT read it. The /invest SnapshotBundleFreshnessChip renders
+    # on data-presence (``snapshotFreshnessSummary != null`` on the
+    # InvestmentReport response) instead. The default-off semantic is
+    # achieved upstream: Phase 3's
+    # ``ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED`` is also default
+    # off, so reports do not carry snapshot metadata, which keeps the
+    # chip absent. This flag is reserved for future bundle-aware UI
+    # surfaces that legitimately need a runtime per-user toggle (e.g. an
+    # A/B) — wiring an endpoint + frontend hook is a follow-up.
     # See docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md §4.
     ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -440,6 +440,11 @@ class Settings(BaseSettings):
     # (not flag-gated) — this flag only controls the pre-DB rejection layer.
     # See docs/superpowers/plans/2026-05-19-rob-269-phase-3-report-generator.md §5.
     ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED: bool = False
+    # ROB-269 Phase 4 — gates the /invest SnapshotBundleFreshnessChip render
+    # and any future bundle-aware UI surfaces. Default off so the chip
+    # is physically absent from caller-facing pages until flipped post-merge.
+    # See docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md §4.
+    ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
     execution_ledger_reconcile_scheduler_enabled: bool = False
     execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"

--- a/app/flows/investment_snapshots_refresh_flow.py
+++ b/app/flows/investment_snapshots_refresh_flow.py
@@ -1,0 +1,148 @@
+"""Prefect wrapper for ROB-269 snapshot bundle refresh.
+
+Mirrors the ``invest_screener_snapshots_us_flow.py`` pattern: the flow is
+**importable only — no deployment is registered in this PR**. A Prefect
+worker / scheduler picking this up is an explicit ops step gated by
+unpausing the future deployment registration. Until then, the function is
+exercised in tests + manual runs only.
+
+Phase 2 design constraint: the production collector registry is empty
+in this codebase. Running ``ensure_snapshot_bundle`` with ``mode='ensure_fresh'``
+against an empty registry returns a ``failed`` bundle (no data) for new
+identity tuples, or ``reused`` for an existing fresh bundle. The flow is
+the seam Phase 5 collectors will populate.
+
+Safety:
+* Read-mostly snapshot service; the only DB writes are the Phase 1
+  append-only INSERTs into ``review.investment_snapshot_*`` tables.
+* No broker / order / watch-intent mutation.
+* No live HTTP fetches in this flow file — the underlying ensure service
+  uses the collector registry, which is empty in production today.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from prefect import flow, task
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.schemas.investment_snapshots_mcp import (
+    EnsureBundleRequest,
+    EnsureBundleResponse,
+)
+from app.services.action_report.common.snapshot_bundle import (
+    SnapshotBundleEnsureService,
+)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _response_to_dict(response: EnsureBundleResponse) -> dict[str, Any]:
+    """JSON-safe shape for Prefect logs / downstream tasks."""
+    return {
+        "bundle_uuid": str(response.bundle_uuid) if response.bundle_uuid else None,
+        "status": response.status,
+        "created": response.created,
+        "coverage_summary": response.coverage_summary,
+        "freshness_summary": response.freshness_summary,
+        "missing_sources": list(response.missing_sources),
+        "warnings": list(response.warnings),
+        "run_uuid": str(response.run_uuid) if response.run_uuid else None,
+    }
+
+
+async def run_snapshot_bundle_refresh(
+    *,
+    purpose: str = "kr_action_report",
+    market: str = "kr",
+    account_scope: str | None = "kis_live",
+    policy_version: str = "intraday_action_report_v1",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+) -> dict[str, Any]:
+    """Ensure a snapshot bundle for the given identity tuple.
+
+    Returns a JSON-safe summary of the resulting bundle. With the empty
+    production collector registry this typically returns:
+
+    * ``status='reused'`` when a fresh bundle exists for the identity tuple.
+    * ``status='failed'`` when no fresh bundle exists and no collectors
+      are registered to populate one.
+
+    Phase 5 will register real collectors so this transitions to
+    ``complete`` / ``partial`` for live operational use.
+    """
+    request = EnsureBundleRequest(
+        purpose=purpose,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        policy_version=policy_version,
+        mode="ensure_fresh",
+        symbols=symbols,
+        candidate_limit=candidate_limit,
+        requested_by="scheduler",
+    )
+
+    async with _session_factory()() as session:
+        service = SnapshotBundleEnsureService(session)
+        response = await service.ensure(request)
+        await session.commit()
+
+    return _response_to_dict(response)
+
+
+@task(name="investment_snapshots_refresh")
+async def investment_snapshots_refresh_task(
+    *,
+    purpose: str = "kr_action_report",
+    market: str = "kr",
+    account_scope: str | None = "kis_live",
+    policy_version: str = "intraday_action_report_v1",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+) -> dict[str, Any]:
+    return await run_snapshot_bundle_refresh(
+        purpose=purpose,
+        market=market,
+        account_scope=account_scope,
+        policy_version=policy_version,
+        symbols=symbols,
+        candidate_limit=candidate_limit,
+    )
+
+
+@flow(name="rob-269 snapshot bundle refresh")
+async def investment_snapshots_refresh_flow(
+    *,
+    purpose: str = "kr_action_report",
+    market: str = "kr",
+    account_scope: str | None = "kis_live",
+    policy_version: str = "intraday_action_report_v1",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+) -> dict[str, Any]:
+    """Top-level flow. Returns the bundle summary dict.
+
+    No Prefect deployment is registered in this PR; this function is
+    callable via Prefect ``run_flow`` or directly (the @flow decorator
+    still allows direct invocation).
+    """
+    return await investment_snapshots_refresh_task(
+        purpose=purpose,
+        market=market,
+        account_scope=account_scope,
+        policy_version=policy_version,
+        symbols=symbols,
+        candidate_limit=candidate_limit,
+    )
+
+
+__all__ = [
+    "investment_snapshots_refresh_flow",
+    "investment_snapshots_refresh_task",
+    "run_snapshot_bundle_refresh",
+]

--- a/app/flows/investment_snapshots_refresh_flow.py
+++ b/app/flows/investment_snapshots_refresh_flow.py
@@ -1,10 +1,22 @@
 """Prefect wrapper for ROB-269 snapshot bundle refresh.
 
 Mirrors the ``invest_screener_snapshots_us_flow.py`` pattern: the flow is
-**importable only — no deployment is registered in this PR**. A Prefect
-worker / scheduler picking this up is an explicit ops step gated by
-unpausing the future deployment registration. Until then, the function is
-exercised in tests + manual runs only.
+**importable only when Prefect is installed**, and **no deployment is
+registered in this PR**. A Prefect worker / scheduler picking this up
+is an explicit ops step gated by unpausing the future deployment
+registration. Until then, the function is exercised in static file
+checks + manual runs only.
+
+Dependency caveat — Prefect is NOT currently a project dependency in
+``pyproject.toml``. Importing this module in the current dev/CI
+environment raises ``ModuleNotFoundError: No module named 'prefect'``.
+That is intentional: the file is validated statically (file-text checks
+for ``@flow`` / ``@task`` / required defaults) by
+``tests/test_investment_snapshots_refresh_flow.py``, mirroring the
+ROB-204 ``invest_screener_snapshots_us_flow.py`` pattern. The runtime
+import test is ``skipif(True, reason="prefect not yet a project
+dependency; import verified when added")`` and flips on once Prefect
+lands as a dep through a separate ops change.
 
 Phase 2 design constraint: the production collector registry is empty
 in this codebase. Running ``ensure_snapshot_bundle`` with ``mode='ensure_fresh'``

--- a/docs/runbooks/snapshot-reviewer-handoff.md
+++ b/docs/runbooks/snapshot-reviewer-handoff.md
@@ -1,0 +1,111 @@
+# Snapshot Reviewer Handoff (ROB-269 Phase 4)
+
+How a reviewer agent (Claude / Codex / Gemini) consumes the ROB-269
+snapshot bundle context produced in Phase 1+2+3. This is the explicit
+"reviewer handoff" surface — there is no dedicated reviewer service; the
+existing Phase 2 MCP tools serve as the contract, and Phase 3's
+``InvestmentReportResponse`` already exposes the 6 snapshot metadata
+fields that a reviewer needs.
+
+## What a reviewer sees on an investment report
+
+The HTTP read surface ``GET /invest/api/investment-reports/{report_uuid}``
+returns an ``InvestmentReport`` with six Phase 3 fields (all nullable;
+legacy reports serialise them as JSON ``null``):
+
+| Field | Meaning |
+|---|---|
+| ``snapshot_bundle_uuid`` | Identity of the snapshot bundle this report was generated against. ``null`` for legacy reports. |
+| ``snapshot_policy_version`` | The frozen policy version (e.g. ``intraday_action_report_v1``). |
+| ``snapshot_coverage_summary`` | ``{"required": {...}, "optional": {...}}`` with per-kind freshness status. |
+| ``snapshot_freshness_summary`` | ``{"overall": ..., "<kind>": {"status": ..., "as_of": ...}}``. DB CHECK rejects ``published`` rows whose ``overall`` is not one of ``fresh / soft_stale / partial``. |
+| ``source_conflicts`` | Optional advisory: any cross-source discrepancies the generator noticed. |
+| ``unavailable_sources`` | Optional advisory: sources that came back ``unavailable`` / ``확인 불가``. |
+
+The ``/invest`` UI renders a ``SnapshotBundleFreshnessChip`` on the
+report header that mirrors this shape — what the user sees, the reviewer
+agent gets via the API.
+
+## MCP tools available to reviewers
+
+All four are read-mostly (snapshot-table appends only, no broker mutation):
+
+### 1. ``investment_snapshot_bundle_get``
+
+Fetches a bundle by UUID, including per-item linkage. Use this to
+reconstruct the full data context behind a report.
+
+```
+investment_snapshot_bundle_get(bundle_uuid=<from report>, include_payload_preview=False)
+```
+
+Set ``include_payload_preview=True`` for a 2KB-truncated preview of each
+linked snapshot's ``payload_json`` (useful for "why does this number
+look like that?" reviewer questions).
+
+### 2. ``investment_snapshot_list``
+
+Recent snapshot metadata, filtered by market / symbol / kind / source.
+Use when a reviewer wants to see "what other portfolio snapshots have we
+captured for this account today?" without committing to a specific
+bundle.
+
+### 3. ``investment_snapshot_bundle_list``
+
+Recent bundle headers, filtered by purpose / market / account_scope /
+status. Use when a reviewer wants to see "what bundles have been built
+today for ``kr_action_report``?"
+
+### 4. ``investment_snapshot_refresh_request``
+
+Records a refresh request. Phase 2 inserts a single
+``investment_snapshot_runs`` row with ``purpose='manual_refresh'`` or
+``'reviewer_requested'``. **No collection happens in Phase 2** — the
+Phase 5+ scheduler picks the row up and acts on it. A reviewer agent
+that needs fresher data should:
+
+1. Call ``investment_snapshot_refresh_request`` with a clear ``reason``.
+2. Wait for the scheduler (or operator) to process the run.
+3. Re-fetch the report / bundle.
+
+Set ``requested_by="reviewer"`` and (optionally) ``snapshot_kinds=[...]``
+or ``symbols=[...]`` to focus the request.
+
+## Interpreting ``snapshot_freshness_summary``
+
+The Decision 4 three-layer stale gate consumes this shape:
+
+* Layer (i) — DB CHECK ``ck_investment_reports_no_published_on_hard_stale``
+  rejects ``published`` rows whose ``overall`` is in
+  ``{hard_stale, failed, unavailable}``.
+* Layer (ii) — ``derive_generator_constraints`` returns
+  ``allow_action_language=False`` when ``overall`` is failed/stale_fallback
+  OR any critical kind (portfolio / journal / watch_context / market) is
+  ``hard_stale / unavailable / failed``.
+* Layer (iii) — ``lint_action_language`` rejects report text containing
+  executable action verbs (매수 / 매도 / buy / sell / ...) when layer (ii)
+  would reject.
+
+**A reviewer must not recommend executable action language** for any
+report whose layer (ii) check returns ``allow_action_language=False``.
+The stale-gate output is attached to ``report.metadata.stale_gate`` for
+every ingested report (whether the flag is on or off — flag enabled just
+turns advisory into raise-before-insert).
+
+## What a reviewer must NOT do
+
+* No broker / order / watch-intent mutation. All four MCP tools above
+  are snapshot-domain only.
+* No bypassing the stale gate. If layer (ii) returned ``False``, the
+  report's no-action language is the contract; recommending a trade
+  anyway is a safety violation.
+* No flipping feature flags (``INVESTMENT_SNAPSHOTS_MCP_ENABLED``,
+  ``ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED``,
+  ``ACTION_REPORT_BUNDLE_UI_ENABLED``).
+* No deploys / Prefect deployment registrations.
+
+## Cross-references
+
+* Phase 1 pre-plan: ``docs/superpowers/plans/2026-05-19-rob-269-pre-plan.md``
+* Phase 3 plan + Decision 4 layers: ``docs/superpowers/plans/2026-05-19-rob-269-phase-3-report-generator.md``
+* Phase 4 plan (this PR): ``docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md``

--- a/docs/runbooks/snapshot-reviewer-handoff.md
+++ b/docs/runbooks/snapshot-reviewer-handoff.md
@@ -101,8 +101,16 @@ turns advisory into raise-before-insert).
   anyway is a safety violation.
 * No flipping feature flags (``INVESTMENT_SNAPSHOTS_MCP_ENABLED``,
   ``ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED``,
-  ``ACTION_REPORT_BUNDLE_UI_ENABLED``).
-* No deploys / Prefect deployment registrations.
+  ``ACTION_REPORT_BUNDLE_UI_ENABLED``). Note:
+  ``ACTION_REPORT_BUNDLE_UI_ENABLED`` is scaffold-only in Phase 4 — no
+  HTTP endpoint surfaces it to the SPA and the frontend chip does not
+  read it. The chip's default-off behaviour comes from data-presence
+  gating (legacy report → null freshness summary → no chip).
+* No deploys / Prefect deployment registrations. The Phase 4 scheduler
+  flow at ``app/flows/investment_snapshots_refresh_flow.py`` is
+  importable only **when Prefect is installed** — Prefect is not
+  currently a project dependency in ``pyproject.toml``. Adding it and
+  registering a deployment are both deferred ops changes.
 
 ## Cross-references
 

--- a/docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md
+++ b/docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md
@@ -1,0 +1,115 @@
+# ROB-269 Phase 4 — UI Provenance + Reviewer + Scheduler (Short Plan)
+
+> Phase 4 of ROB-269. **Single feature branch off `main`**, single PR (no sub-stacking). All previous phases (PR 874 / 875 / 876) are merged.
+>
+> **Branch:** `rob-269-phase4` (off `origin/main` @ `0c50643e`)
+> **Worktree:** `/Users/mgh3326/work/auto_trader.rob-269-phase4`
+> **Goal:** Close the ROB-269 loop — surface bundle freshness in the `/invest` UI, register a Prefect snapshot-refresh flow (importable only, no deployment), and document the reviewer-handoff path (existing Phase 2 MCP tools serve as the surface). All gated by `ACTION_REPORT_BUNDLE_UI_ENABLED` (default off) and Prefect-scheduleless in code.
+
+---
+
+## 1. Frontend `/invest` UI surface
+
+* New typed fields on `frontend/invest/src/api/investmentReports.ts` parser:
+  - `snapshotBundleUuid`, `snapshotPolicyVersion`, `snapshotCoverageSummary`,
+    `snapshotFreshnessSummary`, `sourceConflicts`, `unavailableSources`
+* New component `frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx`:
+  - Inputs: `freshnessSummary` (the JSON shape from Phase 3) + the new feature-flag value.
+  - Renders a Korean-facing chip per source with status colour: `신선` (green) / `일부 지연` (yellow) / `오래됨` (orange) / `확인 불가` (gray) / `실패` (red).
+  - Bundle-level summary line: e.g. `스냅샷 11:11 · 부분 (news 확인 불가)`.
+  - When freshness summary is `null` (legacy report) → render nothing (no chip).
+* Integrate in `InvestmentReportBundleContent.tsx` at the top of the bundle header card.
+* Korean copy lock — labels are constants in the new component, not magic strings.
+* Tests via Vitest in `frontend/invest/src/__tests__/SnapshotBundleFreshnessChip.test.tsx`:
+  - flag off → component is hidden (no DOM render even if data present).
+  - flag on + legacy report → no chip.
+  - flag on + fresh complete → green chip with `신선` label.
+  - flag on + partial with optional unavailable → yellow chip + per-source dim chips.
+  - flag on + hard_stale critical kind → orange/red chip.
+
+## 2. Reviewer handoff
+
+The existing Phase 2 MCP tools (`investment_snapshot_bundle_ensure / _get / _list / _refresh_request`) are the reviewer surface — they already accept `requested_by: 'reviewer'` and expose `snapshot_bundle_uuid` on responses. No new reviewer service or endpoint in this PR.
+
+* `docs/runbooks/snapshot-reviewer-handoff.md` — concise reviewer playbook documenting which MCP tools to call for: (a) reading a report's bundle context, (b) requesting a refresh, (c) interpreting freshness/coverage summaries. **Doc-only, no code.**
+* Phase 3 `InvestmentReportResponse` already exposes the 6 snapshot metadata fields → reviewer agents (Claude / Codex / Gemini) consuming the HTTP read surface get bundle context for free.
+
+## 3. Prefect scheduler
+
+* New flow `app/flows/investment_snapshots_refresh_flow.py`:
+  - Mirrors the `invest_screener_snapshots_us_flow.py` pattern: **importable only, no deployment registered in this PR**.
+  - Wraps `SnapshotBundleEnsureService.ensure` with `mode='ensure_fresh'` for `purpose='kr_action_report'`.
+  - **No env flag for the flow itself** — the production registry is empty (Phase 2 design), so a manual or scheduled run effectively no-ops in `ensure_fresh` mode until Phase 5+ collectors register. The Prefect deployment registration (paused or active) is a separate ops change, not part of this PR.
+* Tests: `tests/flows/test_investment_snapshots_refresh_flow.py` — importability + a single dry-run that hits the empty-collector path and returns the bundle-status payload.
+
+## 4. Feature flag behavior
+
+`ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False` in `app/core/config.py`.
+
+* Exposed to the frontend via the existing user-settings / feature-flags surface (extend whichever endpoint already exposes flags to the SPA — discover during implementation).
+* Frontend's `SnapshotBundleFreshnessChip` reads the flag at render time; flag off → component returns `null`.
+* Backend has no enforcement tied to this flag (the chip is purely a UI surface; Phase 3 stale-gate already gates publication semantics).
+
+## 5. Tests
+
+* **Backend** (~3 new):
+  - `tests/test_config_flags.py` — defaults for `ACTION_REPORT_BUNDLE_UI_ENABLED` (locks at False).
+  - `tests/flows/test_investment_snapshots_refresh_flow.py` — flow importable + dry-run.
+  - Mutation boundary scope updated to include the new flow file (no broker mutation).
+* **Frontend** (~5 new) — Vitest cases for the chip component (flag matrix × data states).
+* **Regression**: Phase 1+2+3 full sweep (370+ tests including Phase 4 additions) plus existing investment_reports tests stay green.
+
+## 6. Expected files
+
+**Create (~7 new):**
+* `app/flows/investment_snapshots_refresh_flow.py`
+* `docs/runbooks/snapshot-reviewer-handoff.md`
+* `frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx`
+* `frontend/invest/src/__tests__/SnapshotBundleFreshnessChip.test.tsx`
+* `tests/flows/test_investment_snapshots_refresh_flow.py` (+ `__init__.py` if needed)
+* `tests/flows/__init__.py`
+
+**Modify (~5):**
+* `app/core/config.py` — add `ACTION_REPORT_BUNDLE_UI_ENABLED`.
+* `frontend/invest/src/api/investmentReports.ts` — parser additions for 6 snapshot fields.
+* `frontend/invest/src/types/investmentReports.ts` — type additions.
+* `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` — render the chip at the header.
+* `tests/services/investment_snapshots/test_mutation_boundary.py` — add flow file to scope (string-only audit, no broker mutation expected).
+* Whichever backend endpoint surfaces flags to SPA (discover; minimal additive change).
+
+## 7. Non-goals (explicit out-of-scope for Phase 4)
+
+* ❌ Prefect deployment registration (paused or active) — this is an ops change.
+* ❌ Production collectors (KIS/Upbit/Naver/Toss/news) for `SnapshotCollectorRegistry` — Phase 5 / future work.
+* ❌ Reviewer-agent automation (Claude/Codex/Gemini orchestration) — runbook documents the handoff but no agent code.
+* ❌ Feature flag flip (`ACTION_REPORT_BUNDLE_UI_ENABLED`, others) — owner-area, post-merge.
+* ❌ Production deploy / service restart.
+* ❌ Broker / order / watch-intent mutation (always banned).
+* ❌ Live KIS / Upbit / Alpaca HTTP calls — Phase 2 boundary still enforced.
+* ❌ Existing UI regression — additive only; no edits to non-`investment-reports` views.
+
+---
+
+## Implementation order (single branch, multiple commits, one PR)
+
+1. `feat(rob-269-p4): ACTION_REPORT_BUNDLE_UI_ENABLED flag (default off)` — config + 1 test.
+2. `feat(rob-269-p4): typed API + types for snapshot metadata on InvestmentReportResponse` — frontend parser/types only.
+3. `feat(rob-269-p4): SnapshotBundleFreshnessChip component + Vitest` — new component + tests.
+4. `feat(rob-269-p4): render freshness chip in InvestmentReportBundleContent` — integration + render guard on flag.
+5. `feat(rob-269-p4): Prefect snapshot-refresh flow (importable only, no deployment)` — flow + flow test.
+6. `docs(rob-269-p4): reviewer handoff runbook` — `docs/runbooks/snapshot-reviewer-handoff.md`.
+7. `test(rob-269-p4): mutation boundary scope` — add flow file.
+8. `chore(rob-269-p4): ruff/format/eslint cleanup` if needed.
+
+Final: push `rob-269-phase4` to origin, single PR base `main`, draft until CI green + owner review.
+
+## Handoff format
+
+* Branch: `rob-269-phase4` (off `origin/main` head)
+* Tests: backend pytest summary + frontend vitest summary
+* Lint: ruff clean + (skip eslint if not configured) report
+* Local commits: list
+* No push other than this branch.
+* Open `# TODO(rob-269 reviewer):` notes: file + line if any.
+
+After completion: owner draft-flip + approval + squash merge close Phase 4 → ROB-269 fully landed on main.

--- a/docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md
+++ b/docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md
@@ -4,7 +4,7 @@
 >
 > **Branch:** `rob-269-phase4` (off `origin/main` @ `0c50643e`)
 > **Worktree:** `/Users/mgh3326/work/auto_trader.rob-269-phase4`
-> **Goal:** Close the ROB-269 loop — surface bundle freshness in the `/invest` UI, register a Prefect snapshot-refresh flow (importable only, no deployment), and document the reviewer-handoff path (existing Phase 2 MCP tools serve as the surface). All gated by `ACTION_REPORT_BUNDLE_UI_ENABLED` (default off) and Prefect-scheduleless in code.
+> **Goal:** Close the ROB-269 loop — surface bundle freshness in the `/invest` UI, scaffold a Prefect snapshot-refresh flow (importable only **when Prefect is installed**, no deployment registered), and document the reviewer-handoff path (existing Phase 2 MCP tools serve as the surface). The chip's default-off behaviour comes from data-presence gating (Phase 3 generation flag stays default off → reports carry no snapshot metadata → chip absent); the `ACTION_REPORT_BUNDLE_UI_ENABLED` setting is **scaffold-only in Phase 4** (no HTTP endpoint, no frontend hook). Prefect is scheduleless in code.
 
 ---
 
@@ -14,18 +14,25 @@
   - `snapshotBundleUuid`, `snapshotPolicyVersion`, `snapshotCoverageSummary`,
     `snapshotFreshnessSummary`, `sourceConflicts`, `unavailableSources`
 * New component `frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx`:
-  - Inputs: `freshnessSummary` (the JSON shape from Phase 3) + the new feature-flag value.
+  - Inputs: `freshnessSummary` (the JSON shape from Phase 3). **The chip does
+    NOT read a runtime feature flag in Phase 4** — the default-off semantic
+    is data-presence-driven (legacy report → no `snapshotFreshnessSummary`
+    → component returns `null`).
   - Renders a Korean-facing chip per source with status colour: `신선` (green) / `일부 지연` (yellow) / `오래됨` (orange) / `확인 불가` (gray) / `실패` (red).
   - Bundle-level summary line: e.g. `스냅샷 11:11 · 부분 (news 확인 불가)`.
   - When freshness summary is `null` (legacy report) → render nothing (no chip).
 * Integrate in `InvestmentReportBundleContent.tsx` at the top of the bundle header card.
 * Korean copy lock — labels are constants in the new component, not magic strings.
 * Tests via Vitest in `frontend/invest/src/__tests__/SnapshotBundleFreshnessChip.test.tsx`:
-  - flag off → component is hidden (no DOM render even if data present).
-  - flag on + legacy report → no chip.
-  - flag on + fresh complete → green chip with `신선` label.
-  - flag on + partial with optional unavailable → yellow chip + per-source dim chips.
-  - flag on + hard_stale critical kind → orange/red chip.
+  - legacy report (`freshnessSummary == null`) → component returns `null`.
+  - undefined → component returns `null`.
+  - fresh complete (no degraded kinds) → green bundle chip with `신선` label, no per-kind chips.
+  - partial with critical kind hard_stale → per-kind chip surfaced.
+  - partial with optional unavailable → per-source dim chips, no critical chips.
+  - failed overall → red modifier class.
+  - missing overall (draft edge case) → neutral `확인 불가` fallback.
+  - bare-status string shorthand on per-kind entries → accepted.
+  - unknown kind → falls back to the raw key.
 
 ## 2. Reviewer handoff
 
@@ -37,17 +44,22 @@ The existing Phase 2 MCP tools (`investment_snapshot_bundle_ensure / _get / _lis
 ## 3. Prefect scheduler
 
 * New flow `app/flows/investment_snapshots_refresh_flow.py`:
-  - Mirrors the `invest_screener_snapshots_us_flow.py` pattern: **importable only, no deployment registered in this PR**.
+  - Mirrors the `invest_screener_snapshots_us_flow.py` pattern: **importable only when Prefect is installed**, no deployment registered.
+  - **Prefect is not currently a project dependency** in `pyproject.toml`. Importing this module today raises `ModuleNotFoundError: No module named 'prefect'`. The flow file is verified statically (file-text checks for `@flow` / `@task` / no deployment-YAML reference) — the runtime import test stays `skipif(True, reason="prefect not yet a project dependency; ...")` mirroring `tests/test_invest_screener_snapshots_us_flow.py`. Adding Prefect as a dependency is a separate ops change.
   - Wraps `SnapshotBundleEnsureService.ensure` with `mode='ensure_fresh'` for `purpose='kr_action_report'`.
   - **No env flag for the flow itself** — the production registry is empty (Phase 2 design), so a manual or scheduled run effectively no-ops in `ensure_fresh` mode until Phase 5+ collectors register. The Prefect deployment registration (paused or active) is a separate ops change, not part of this PR.
-* Tests: `tests/flows/test_investment_snapshots_refresh_flow.py` — importability + a single dry-run that hits the empty-collector path and returns the bundle-status payload.
+* Tests: `tests/test_investment_snapshots_refresh_flow.py` — 8 static checks (file exists, decorators present, defaults locked, no broker mutation verbs, no deployment-YAML reference) + 1 skipped runtime import.
 
 ## 4. Feature flag behavior
 
 `ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False` in `app/core/config.py`.
 
-* Exposed to the frontend via the existing user-settings / feature-flags surface (extend whichever endpoint already exposes flags to the SPA — discover during implementation).
-* Frontend's `SnapshotBundleFreshnessChip` reads the flag at render time; flag off → component returns `null`.
+**Status: scaffold only in Phase 4. NOT actively wired.**
+
+* There is no HTTP endpoint exposing this flag to the SPA.
+* The frontend `SnapshotBundleFreshnessChip` does NOT read this flag — render is data-presence gated (`snapshotFreshnessSummary != null`).
+* Default-off semantic is preserved upstream: Phase 3's `ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED` is also default off, so the ingestion service does not produce reports carrying snapshot metadata, which keeps the chip absent.
+* The setting is reserved for future bundle-aware UI surfaces that legitimately need a runtime per-user toggle (e.g. A/B between two chip variants). Wiring it through an endpoint + frontend hook is a follow-up.
 * Backend has no enforcement tied to this flag (the chip is purely a UI surface; Phase 3 stale-gate already gates publication semantics).
 
 ## 5. Tests

--- a/frontend/invest/src/__tests__/SnapshotBundleFreshnessChip.test.tsx
+++ b/frontend/invest/src/__tests__/SnapshotBundleFreshnessChip.test.tsx
@@ -1,0 +1,159 @@
+// ROB-269 Phase 4 — SnapshotBundleFreshnessChip render tests.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SnapshotBundleFreshnessChip } from "../components/investment-reports/SnapshotBundleFreshnessChip";
+
+describe("SnapshotBundleFreshnessChip", () => {
+  it("returns null when freshnessSummary is null (legacy report)", () => {
+    const { container } = render(
+      <SnapshotBundleFreshnessChip freshnessSummary={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when freshnessSummary is undefined", () => {
+    const { container } = render(
+      <SnapshotBundleFreshnessChip freshnessSummary={undefined} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders bundle-level '신선' chip when overall is fresh with no degraded kinds", () => {
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "fresh",
+          portfolio: { status: "fresh" },
+          journal: { status: "fresh" },
+          watch_context: { status: "fresh" },
+          market: { status: "fresh" },
+        }}
+      />,
+    );
+    const chip = screen.getByTestId("snapshot-bundle-freshness");
+    expect(chip).toHaveTextContent("스냅샷 신선");
+    expect(chip.className).toContain("snapshot-bundle-freshness--fresh");
+    // No degraded per-kind chips should render when all kinds are fresh.
+    expect(screen.queryByTestId(/^snapshot-chip-/)).toBeNull();
+  });
+
+  it("renders per-critical-kind chips when a critical kind is hard_stale", () => {
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "partial",
+          portfolio: { status: "hard_stale" },
+          journal: { status: "fresh" },
+          watch_context: { status: "fresh" },
+          market: { status: "fresh" },
+        }}
+      />,
+    );
+    const chip = screen.getByTestId("snapshot-bundle-freshness");
+    expect(chip).toHaveTextContent("스냅샷 부분");
+    const portfolioChip = screen.getByTestId("snapshot-chip-portfolio");
+    expect(portfolioChip).toHaveTextContent("포지션 오래됨");
+    expect(portfolioChip.className).toContain(
+      "snapshot-bundle-freshness__chip--critical",
+    );
+    expect(portfolioChip.className).toContain(
+      "snapshot-bundle-freshness__chip--hard_stale",
+    );
+  });
+
+  it("renders optional-kind chips dimmed when news/naver/toss are unavailable", () => {
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "partial",
+          portfolio: { status: "fresh" },
+          journal: { status: "fresh" },
+          watch_context: { status: "fresh" },
+          market: { status: "fresh" },
+          news: { status: "unavailable" },
+          naver_remote_debug: { status: "unavailable" },
+          toss_remote_debug: { status: "hard_stale" },
+        }}
+      />,
+    );
+    const newsChip = screen.getByTestId("snapshot-chip-news");
+    expect(newsChip).toHaveTextContent("뉴스 확인 불가");
+    expect(newsChip.className).toContain(
+      "snapshot-bundle-freshness__chip--optional",
+    );
+    expect(screen.getByTestId("snapshot-chip-naver_remote_debug")).toHaveTextContent(
+      "네이버 확인 불가",
+    );
+    expect(screen.getByTestId("snapshot-chip-toss_remote_debug")).toHaveTextContent(
+      "토스 오래됨",
+    );
+    // Critical kinds are all fresh — no critical chips rendered.
+    expect(screen.queryByTestId("snapshot-chip-portfolio")).toBeNull();
+  });
+
+  it("renders 'failed' overall with red modifier class", () => {
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "failed",
+          portfolio: { status: "failed" },
+        }}
+      />,
+    );
+    const chip = screen.getByTestId("snapshot-bundle-freshness");
+    expect(chip.className).toContain("snapshot-bundle-freshness--failed");
+    expect(chip).toHaveTextContent("스냅샷 실패");
+  });
+
+  it("renders neutral '확인 불가' when overall is missing/invalid", () => {
+    // Defensive path — DB CHECK guards published rows, but draft rows can
+    // reach the UI with an unset ``overall``.
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          portfolio: { status: "fresh" },
+        }}
+      />,
+    );
+    const chip = screen.getByTestId("snapshot-bundle-freshness");
+    expect(chip).toHaveTextContent("스냅샷 확인 불가");
+    expect(chip.className).toContain("snapshot-bundle-freshness--unavailable");
+  });
+
+  it("accepts the bare-status shorthand on per-kind entries", () => {
+    // The Python schema allows the per-kind value to be either a dict
+    // (``{status: 'fresh', as_of: '...'}``) or just the status string.
+    // The chip must accept both.
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "partial",
+          portfolio: "hard_stale",
+          news: "unavailable",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("snapshot-chip-portfolio")).toHaveTextContent(
+      "포지션 오래됨",
+    );
+    expect(screen.getByTestId("snapshot-chip-news")).toHaveTextContent(
+      "뉴스 확인 불가",
+    );
+  });
+
+  it("falls back to raw key when an unknown kind appears", () => {
+    render(
+      <SnapshotBundleFreshnessChip
+        freshnessSummary={{
+          overall: "partial",
+          some_future_kind: { status: "unavailable" },
+        }}
+      />,
+    );
+    expect(screen.getByTestId("snapshot-chip-some_future_kind")).toHaveTextContent(
+      "some_future_kind 확인 불가",
+    );
+  });
+});

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -18,6 +18,7 @@ import type {
   MarketSession,
   AccountScope,
   ReportStatus,
+  SnapshotFreshnessSummary,
 } from "../types/investmentReports";
 
 const LIST_ENDPOINT = "/invest/api/investment-reports";
@@ -87,7 +88,26 @@ function normalizeReport(raw: ApiReport): InvestmentReport {
     updatedAt: asString(raw.updated_at),
     publishedAt: asOptionalString(raw.published_at),
     validUntil: asOptionalString(raw.valid_until),
+    // ROB-269 Phase 3 — snapshot metadata. Backend serialises explicit
+    // ``null`` for legacy reports; we round-trip that as ``null`` here so
+    // the UI can distinguish "report has no bundle" (legacy) from "bundle
+    // has incomplete data" (per-kind freshness on the summary).
+    snapshotBundleUuid: asOptionalString(raw.snapshot_bundle_uuid),
+    snapshotPolicyVersion: asOptionalString(raw.snapshot_policy_version),
+    snapshotCoverageSummary: asOptionalRecord(raw.snapshot_coverage_summary),
+    snapshotFreshnessSummary: raw.snapshot_freshness_summary == null
+      ? null
+      : (asRecord(raw.snapshot_freshness_summary) as SnapshotFreshnessSummary),
+    sourceConflicts: asOptionalRecord(raw.source_conflicts),
+    unavailableSources: asOptionalRecord(raw.unavailable_sources),
   };
+}
+
+function asOptionalRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (value === null || value === undefined) return null;
+  return asRecord(value);
 }
 
 function normalizeItem(raw: ApiItem): InvestmentReportItem {

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -14,7 +14,9 @@ import type {
   InvestmentReportItemDecision,
   InvestmentWatchAlert,
   InvestmentWatchEvent,
+  SnapshotFreshnessSummary,
 } from "../../types/investmentReports";
+import { SnapshotBundleFreshnessChip } from "./SnapshotBundleFreshnessChip";
 
 const ITEM_KIND_LABELS: Record<string, string> = {
   action: "액션",
@@ -82,6 +84,7 @@ function ReportHeader({
   thesisText,
   noActionNote,
   createdAt,
+  freshnessSummary,
 }: {
   title: string;
   market: string;
@@ -94,6 +97,7 @@ function ReportHeader({
   thesisText?: string | null;
   noActionNote?: string | null;
   createdAt: string;
+  freshnessSummary?: SnapshotFreshnessSummary | null;
 }) {
   return (
     <Card>
@@ -143,6 +147,10 @@ function ReportHeader({
           <span>·</span>
           <span>{new Date(createdAt).toLocaleString("ko-KR")}</span>
         </div>
+        {/* ROB-269 Phase 4 — bundle provenance chip. Returns null when the
+            report has no snapshot metadata (legacy reports / Phase 3 flag
+            off). Renders Korean-facing summary + degraded per-source chips. */}
+        <SnapshotBundleFreshnessChip freshnessSummary={freshnessSummary ?? null} />
         <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65 }}>{summary}</p>
         {thesisText ? (
           <div style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>
@@ -448,6 +456,7 @@ export function InvestmentReportBundleContent({
         thesisText={bundle.report.thesisText}
         noActionNote={bundle.report.noActionNote}
         createdAt={bundle.report.createdAt}
+        freshnessSummary={bundle.report.snapshotFreshnessSummary}
       />
 
       {(

--- a/frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx
+++ b/frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx
@@ -1,0 +1,162 @@
+// ROB-269 Phase 4 — Snapshot bundle freshness provenance chip.
+//
+// Renders bundle-level + per-source freshness state on an investment report
+// header. Returns ``null`` when the report has no snapshot metadata (legacy
+// reports pre-Phase-3, or Phase 3 reports created with
+// ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED still off).
+//
+// Korean copy is intentionally constant — labels are owned by this file so
+// translation/style changes are localised.
+
+import type { JSX } from "react";
+
+import type {
+  SnapshotFreshnessStatus,
+  SnapshotFreshnessSummary,
+  SnapshotKindFreshness,
+} from "../../types/investmentReports";
+
+const STATUS_LABELS: Record<SnapshotFreshnessStatus, string> = {
+  fresh: "신선",
+  soft_stale: "일부 지연",
+  partial: "부분",
+  hard_stale: "오래됨",
+  failed: "실패",
+  unavailable: "확인 불가",
+};
+
+// Korean-facing labels for per-kind chips. Keys match the snapshot_kind
+// enum on the backend (app/schemas/investment_snapshots.py SnapshotKind).
+const KIND_LABELS: Record<string, string> = {
+  portfolio: "포지션",
+  journal: "거래일지",
+  watch_context: "감시",
+  market: "시장",
+  symbol: "종목",
+  candidate_universe: "후보군",
+  news: "뉴스",
+  naver_remote_debug: "네이버",
+  toss_remote_debug: "토스",
+  browser_probe: "브라우저",
+  invest_page: "인베스트 페이지",
+  llm_input_frozen: "LLM 입력",
+};
+
+// Visual rank: same status across overall + per-kind. Critical kinds get
+// surfaced first; optional kinds collapse to a single "기타" cluster when
+// they don't reach a degraded state.
+const CRITICAL_KIND_ORDER: readonly string[] = [
+  "portfolio",
+  "journal",
+  "watch_context",
+  "market",
+];
+
+function isKindFreshness(value: unknown): value is SnapshotKindFreshness {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as SnapshotKindFreshness).status === "string"
+  );
+}
+
+function isStatusString(value: unknown): value is SnapshotFreshnessStatus {
+  return (
+    typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(STATUS_LABELS, value)
+  );
+}
+
+function statusOf(
+  summary: SnapshotFreshnessSummary,
+  kind: string,
+): SnapshotFreshnessStatus | null {
+  const entry = summary[kind];
+  if (isKindFreshness(entry)) return entry.status;
+  if (isStatusString(entry)) return entry;
+  return null;
+}
+
+export interface SnapshotBundleFreshnessChipProps {
+  freshnessSummary: SnapshotFreshnessSummary | null | undefined;
+}
+
+export function SnapshotBundleFreshnessChip({
+  freshnessSummary,
+}: SnapshotBundleFreshnessChipProps): JSX.Element | null {
+  if (freshnessSummary == null) return null;
+
+  const overall = freshnessSummary.overall ?? null;
+  const overallStatus = isStatusString(overall) ? overall : null;
+  if (overallStatus == null) {
+    // Defensive: the DB CHECK should have stopped a published row from
+    // reaching here without ``overall``, but for draft rows or partial
+    // backfills render a neutral "확인 불가" so the operator sees the gap.
+    return (
+      <div
+        className="snapshot-bundle-freshness snapshot-bundle-freshness--unavailable"
+        data-testid="snapshot-bundle-freshness"
+        aria-live="polite"
+      >
+        <span className="snapshot-bundle-freshness__overall">
+          스냅샷 {STATUS_LABELS.unavailable}
+        </span>
+      </div>
+    );
+  }
+
+  const overallLabel = STATUS_LABELS[overallStatus];
+
+  // Surface critical kinds that are degraded; optional kinds with degraded
+  // status appear after; fresh kinds are hidden to keep the chip compact.
+  const criticalEntries: { kind: string; status: SnapshotFreshnessStatus }[] = [];
+  for (const kind of CRITICAL_KIND_ORDER) {
+    const s = statusOf(freshnessSummary, kind);
+    if (s != null && s !== "fresh") criticalEntries.push({ kind, status: s });
+  }
+
+  const optionalEntries: { kind: string; status: SnapshotFreshnessStatus }[] = [];
+  for (const [kind, entry] of Object.entries(freshnessSummary)) {
+    if (kind === "overall") continue;
+    if (CRITICAL_KIND_ORDER.includes(kind)) continue;
+    let s: SnapshotFreshnessStatus | null = null;
+    if (isKindFreshness(entry)) s = entry.status;
+    else if (isStatusString(entry)) s = entry;
+    if (s != null && s !== "fresh") optionalEntries.push({ kind, status: s });
+  }
+
+  return (
+    <div
+      className={`snapshot-bundle-freshness snapshot-bundle-freshness--${overallStatus}`}
+      data-testid="snapshot-bundle-freshness"
+      aria-live="polite"
+    >
+      <span className="snapshot-bundle-freshness__overall">
+        스냅샷 {overallLabel}
+      </span>
+      {criticalEntries.length === 0 && optionalEntries.length === 0 ? null : (
+        <ul className="snapshot-bundle-freshness__kinds" aria-label="스냅샷 소스별 상태">
+          {criticalEntries.map(({ kind, status }) => (
+            <li
+              key={kind}
+              className={`snapshot-bundle-freshness__chip snapshot-bundle-freshness__chip--critical snapshot-bundle-freshness__chip--${status}`}
+              data-testid={`snapshot-chip-${kind}`}
+            >
+              {KIND_LABELS[kind] ?? kind} {STATUS_LABELS[status]}
+            </li>
+          ))}
+          {optionalEntries.map(({ kind, status }) => (
+            <li
+              key={kind}
+              className={`snapshot-bundle-freshness__chip snapshot-bundle-freshness__chip--optional snapshot-bundle-freshness__chip--${status}`}
+              data-testid={`snapshot-chip-${kind}`}
+            >
+              {KIND_LABELS[kind] ?? kind} {STATUS_LABELS[status]}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx
+++ b/frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx
@@ -1,9 +1,17 @@
 // ROB-269 Phase 4 — Snapshot bundle freshness provenance chip.
 //
 // Renders bundle-level + per-source freshness state on an investment report
-// header. Returns ``null`` when the report has no snapshot metadata (legacy
-// reports pre-Phase-3, or Phase 3 reports created with
-// ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED still off).
+// header. Returns ``null`` when ``freshnessSummary`` is null/undefined.
+//
+// Default-off behaviour is achieved by data-presence gating, NOT by a
+// runtime UI flag: this component does NOT read
+// ``ACTION_REPORT_BUNDLE_UI_ENABLED`` (which is Phase 4 scaffolding only,
+// not wired). Until callers supply ``snapshot_freshness_summary`` on the
+// IngestReportRequest the field stays JSON ``null`` on the response and
+// this component renders nothing. The Phase 3 generation flag
+// ``ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED`` is also default off,
+// so reports stay snapshot-less in practice until both Phase 3 generators
+// and Phase 4 UI rollout are intentionally enabled.
 //
 // Korean copy is intentionally constant — labels are owned by this file so
 // translation/style changes are localised.

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -83,6 +83,43 @@ export interface InvestmentReport {
   updatedAt: string;
   publishedAt?: string | null;
   validUntil?: string | null;
+  // ROB-269 Phase 3 — bundle linkage + 3-layer stale gate inputs. All
+  // optional; legacy reports (pre-Phase-3) serialise these as ``null``.
+  snapshotBundleUuid?: string | null;
+  snapshotPolicyVersion?: string | null;
+  snapshotCoverageSummary?: Record<string, unknown> | null;
+  snapshotFreshnessSummary?: SnapshotFreshnessSummary | null;
+  sourceConflicts?: Record<string, unknown> | null;
+  unavailableSources?: Record<string, unknown> | null;
+}
+
+// ROB-269 Phase 4 — typed shape of the snapshot freshness summary on the
+// report response. ``overall`` is the bundle-level signal the Phase 3 DB
+// CHECK consults; per-kind entries (portfolio / journal / watch_context /
+// market / news / naver_remote_debug / toss_remote_debug / etc.) carry
+// their own ``status`` and optional ``asOf``.
+export type SnapshotFreshnessStatus =
+  | "fresh"
+  | "soft_stale"
+  | "partial"
+  | "hard_stale"
+  | "failed"
+  | "unavailable";
+
+export interface SnapshotKindFreshness {
+  status: SnapshotFreshnessStatus;
+  asOf?: string | null;
+  resultCount?: string | null;
+}
+
+export interface SnapshotFreshnessSummary {
+  overall?: SnapshotFreshnessStatus | null;
+  // Per-kind entries are keyed by snapshot_kind (e.g. ``portfolio``).
+  [snapshotKind: string]:
+    | SnapshotKindFreshness
+    | SnapshotFreshnessStatus
+    | null
+    | undefined;
 }
 
 export interface InvestmentReportItem {

--- a/tests/services/investment_snapshots/test_mutation_boundary.py
+++ b/tests/services/investment_snapshots/test_mutation_boundary.py
@@ -55,6 +55,10 @@ _SCOPED_FILES: list[str] = [
     "app/mcp_server/tooling/investment_snapshots_tools.py",
     "app/mcp_server/tooling/investment_snapshots_registration.py",
     "app/routers/investment_snapshots.py",
+    # ROB-269 Phase 4 — Prefect snapshot-refresh flow scaffold (importable
+    # only, no deployment registered). The flow wraps Phase 2's ensure
+    # service; safety guarantees flow through automatically.
+    "app/flows/investment_snapshots_refresh_flow.py",
 ]
 
 # Lines containing this marker are exempted from boundary checks.

--- a/tests/test_investment_snapshots_refresh_flow.py
+++ b/tests/test_investment_snapshots_refresh_flow.py
@@ -1,0 +1,107 @@
+"""Tests for the ROB-269 snapshot bundle refresh Prefect flow scaffold.
+
+Prefect is not yet a project dependency, so we validate the flow file
+statically (decorator / function names present) and assert no Prefect
+deployment YAML registers the flow. Mirrors the ROB-204 pattern at
+``tests/test_invest_screener_snapshots_us_flow.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "investment_snapshots_refresh_flow.py"
+)
+
+
+def test_flow_file_exists() -> None:
+    assert _FLOW_PATH.exists(), f"Flow file not found at {_FLOW_PATH}"
+
+
+def test_flow_file_declares_prefect_flow_and_task() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text, "Missing @flow decorator"
+    assert "@task" in text, "Missing @task decorator"
+    assert "investment_snapshots_refresh_flow" in text, "Missing flow function"
+    assert "investment_snapshots_refresh_task" in text, "Missing task function"
+
+
+def test_flow_file_defaults_to_kr_action_report_purpose() -> None:
+    text = _FLOW_PATH.read_text()
+    assert 'purpose: str = "kr_action_report"' in text, (
+        "Flow must default to purpose='kr_action_report'"
+    )
+    assert 'policy_version: str = "intraday_action_report_v1"' in text, (
+        "Flow must default to the Phase 2 policy_version"
+    )
+
+
+def test_flow_file_uses_scheduler_requested_by() -> None:
+    text = _FLOW_PATH.read_text()
+    assert 'requested_by="scheduler"' in text, (
+        "Flow must mark snapshot runs with requested_by='scheduler'"
+    )
+
+
+def test_flow_file_uses_ensure_fresh_mode() -> None:
+    text = _FLOW_PATH.read_text()
+    assert 'mode="ensure_fresh"' in text, (
+        "Flow must call ensure_snapshot_bundle with mode='ensure_fresh'"
+    )
+
+
+def test_flow_file_imports_phase2_ensure_service() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "SnapshotBundleEnsureService" in text, (
+        "Flow must import the Phase 2 ensure service"
+    )
+
+
+def test_flow_file_does_not_call_broker_mutation_verbs() -> None:
+    """Safety guard — the flow must not call submit_/cancel_/modify_/place_."""
+    text = _FLOW_PATH.read_text()
+    for verb in (
+        "submit_order(",
+        "cancel_order(",
+        "modify_order(",
+        "place_order(",
+        "create_watch_intent(",
+    ):
+        assert verb not in text, f"Flow file contains forbidden verb: {verb!r}"
+
+
+def test_flow_is_not_registered_via_deployment_yaml() -> None:
+    """Mirrors ROB-204: deployment registration is deferred. Fail loudly if
+    a YAML file references this flow name."""
+    project_root = _FLOW_PATH.parents[2]
+    yaml_files = list(project_root.glob("**/*.yaml")) + list(
+        project_root.glob("**/*.yml")
+    )
+    for yf in yaml_files:
+        if ".venv" in str(yf) or ".git" in str(yf) or "node_modules" in str(yf):
+            continue
+        try:
+            content = yf.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if "investment_snapshots_refresh_flow" in content:
+            pytest.fail(
+                f"Found Prefect deployment YAML referencing the snapshot refresh flow at {yf}. "
+                "Deployment registration is deferred for ROB-269 Phase 4."
+            )
+
+
+@pytest.mark.skipif(
+    True,
+    reason="prefect not yet a project dependency; import verified when added",
+)
+def test_flow_imports_cleanly() -> None:
+    from app.flows.investment_snapshots_refresh_flow import (  # noqa: F401
+        investment_snapshots_refresh_flow,
+    )


### PR DESCRIPTION
## Summary

Final PR of 4 implementing [ROB-269](https://linear.app/mgh3326/issue/ROB-269). Closes the loop by surfacing bundle freshness on the `/invest` UI, registering a Prefect snapshot-refresh flow (importable only — **no deployment registered**), and documenting the reviewer-handoff path. All previous phases (PR #874 / #875 / #876) are merged.

**Single feature branch off `main`** — no sub-stacking, per owner direction ("어차피 다 한번에 merge할거잖아").

## Scope (additive only, default OFF)

* **Feature flag** — `ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False` in `app/core/config.py`. Kept as scaffolding for future bundle-aware UI surfaces; this iteration renders the chip on data-presence (`snapshotFreshnessSummary != null`) rather than threading a runtime HTTP flag through a new endpoint + frontend hook. Default-off semantic is preserved by Phase 3's `ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED` still being off — reports won't carry snapshot metadata until that flips.
* **Frontend `/invest` UI** —
  * `frontend/invest/src/types/investmentReports.ts` — 6 new optional fields on `InvestmentReport` + a typed `SnapshotFreshnessSummary` shape with the 6-value `SnapshotFreshnessStatus` union.
  * `frontend/invest/src/api/investmentReports.ts` — `normalizeReport` parses the 6 snake_case fields.
  * `frontend/invest/src/components/investment-reports/SnapshotBundleFreshnessChip.tsx` — Korean-facing chip: bundle-level summary line + degraded per-kind chips (critical kinds — portfolio/journal/watch_context/market — first; degraded optional kinds after; fresh kinds hidden to keep compact).
  * `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` — renders the chip on the report header (between metadata row and summary).
* **Prefect scheduler** — `app/flows/investment_snapshots_refresh_flow.py`. Mirrors the ROB-204 `invest_screener_snapshots_us_flow.py` pattern: importable only, **no deployment registered**. Calls `SnapshotBundleEnsureService.ensure(mode='ensure_fresh', requested_by='scheduler')` for `purpose='kr_action_report'`. Against the empty Phase 2 production collector registry the flow returns `status='reused'` (existing fresh bundle) or `status='failed'` (no data); Phase 5+ collectors will transition to `complete` / `partial`.
* **Reviewer runbook** — `docs/runbooks/snapshot-reviewer-handoff.md`. Documents which Phase 2 MCP tools serve as the reviewer-handoff surface (no new reviewer service needed), how to interpret `snapshot_freshness_summary`, and the Decision 4 3-layer stale gate.

## Not in this PR

- ❌ Prefect deployment registration (paused or active) — ops change, deferred.
- ❌ Production collectors (KIS/Upbit/Naver/Toss/news) for `SnapshotCollectorRegistry` — Phase 5+ work.
- ❌ Reviewer-agent automation (Claude/Codex/Gemini orchestration) — runbook documents the handoff; no agent code.
- ❌ Feature flag flip (`ACTION_REPORT_BUNDLE_UI_ENABLED`, others) — owner-area post-merge.
- ❌ Production deploy / service restart.
- ❌ Broker / order / watch-intent mutation (always banned).
- ❌ Live KIS / Upbit / Alpaca HTTP calls — Phase 2 boundary still enforced.

## Plan reference

`docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md` (7-section short plan committed as the first commit on this branch).

## Tests

**Backend — 366 pass + 1 skipped (Prefect dep) in 31.79s:**
* 9 Phase 4 new (flow static-validation, including no-deployment-YAML guard)
* 73 mutation boundary checks (24 files × 3 + 1 manifest) — boundary scope extended with the new flow file
* Phase 1+2+3 + investment_reports + lifted us_action_report regression — all green

**Frontend — 14 InvestmentReport-related pass in 2.45s:**
* 9 `SnapshotBundleFreshnessChip` cases (legacy null, undefined, fresh-complete, hard_stale critical, optional unavailable, failed overall, missing overall, bare-status shorthand, unknown-kind fallback)
* 5 existing `InvestmentReport` round-trip tests still pass after parser additions
* `tsc --noEmit` clean
* **Note:** 4 pre-existing calendar test failures (DaySection / DesktopCalendarPage / MonthlyEventsTimeline) are unrelated to ROB-269 — confirmed none of them imports the changed files. These are out of scope.

**Frontend CI coverage caveat:** `.github/workflows/` has `frontend-trading-decision.yml` scoped to `frontend/trading-decision/**` only. There is no workflow covering `frontend/invest/**`, so the new chip + parser changes won't get automatic CI validation against this PR. Local Vitest + `tsc --noEmit` were the verification surface for this iteration.

## Test plan

- [ ] CI: backend `make test` / `make lint` pass on the merged stack
- [ ] CI: SonarCloud / GitGuardian / guardrails / codecov / CodeRabbit per Phase 1-3 disposition policy
- [ ] Local: `cd frontend/invest && npm install && npm run typecheck && npm test` shows the new 9 chip tests passing
- [ ] Local: `uv run python -c "from app.flows.investment_snapshots_refresh_flow import investment_snapshots_refresh_flow"` succeeds **only after Prefect lands as a project dep** (today this raises `ModuleNotFoundError: No module named 'prefect'` — the static tests in `tests/test_investment_snapshots_refresh_flow.py` are file-text-only by design).
- [ ] Reviewer eyeballs: confirm the SnapshotBundleFreshnessChip render guard (`return null` for legacy reports / pre-Phase-3 data) and the Korean copy locked in the component.
- [ ] Reviewer eyeballs: confirm no Prefect deployment YAML references `investment_snapshots_refresh_flow` (the static test `test_flow_is_not_registered_via_deployment_yaml` enforces this).
- [ ] Reviewer eyeballs: confirm `ACTION_REPORT_BUNDLE_UI_ENABLED` is default `False` and the runbook accurately describes the four MCP tools available to reviewers.

## Commits

* `f4ffd18e docs(rob-269-p4): Phase 4 short plan`
* `f28cff36 feat(rob-269-p4): ACTION_REPORT_BUNDLE_UI_ENABLED flag (scaffolding, default off)`
* `e31bfbfc feat(rob-269-p4): typed API + types for snapshot metadata on InvestmentReport`
* `8bd50438 feat(rob-269-p4): SnapshotBundleFreshnessChip component + Vitest`
* `09ea6be1 feat(rob-269-p4): render SnapshotBundleFreshnessChip in report header`
* `c8fbfabe feat(rob-269-p4): Prefect snapshot-refresh flow (importable, no deployment)`
* `7a46dc72 docs(rob-269-p4): snapshot reviewer handoff runbook`
* `6c45d7ab test(rob-269-p4): mutation boundary scope includes Prefect flow`