### PR TITLE
fix(rob-269): tolerate missing p3a check constraint during migration

### DIFF
--- a/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
+++ b/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
@@ -53,15 +53,25 @@ _NEW_PREDICATE = (
 )
 
 
+def _drop_check_if_exists() -> None:
+    # Production schemas may have the Phase 3 metadata columns but be missing
+    # the original check constraint (for example after fixture/manual drift).
+    # Keep this migration tolerant so it can still converge by creating the
+    # corrected constraint below.
+    op.execute(
+        f"ALTER TABLE review.investment_reports DROP CONSTRAINT IF EXISTS {_CHECK_NAME}"
+    )
+
+
 def upgrade() -> None:
-    op.drop_constraint(_CHECK_NAME, "investment_reports", schema="review")
+    _drop_check_if_exists()
     op.create_check_constraint(
         _CHECK_NAME, "investment_reports", _NEW_PREDICATE, schema="review"
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint(_CHECK_NAME, "investment_reports", schema="review")
+    _drop_check_if_exists()
     op.create_check_constraint(
         _CHECK_NAME, "investment_reports", _OLD_PREDICATE, schema="review"
     )

--- a/tests/test_investment_reports_snapshot_metadata.py
+++ b/tests/test_investment_reports_snapshot_metadata.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
@@ -27,6 +28,16 @@ from app.services.investment_reports.ingestion import (
 
 # ``session`` fixture is auto-discovered via the pytest_plugins entry in
 # tests/conftest.py registering ``tests._investment_reports_helpers``.
+
+
+def test_p3a_migration_tolerates_missing_existing_check_constraint() -> None:
+    """Production drift can leave the p3 check absent; p3a must still converge."""
+    migration = Path(
+        "alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py"
+    ).read_text(encoding="utf-8")
+
+    assert "DROP CONSTRAINT IF EXISTS" in migration
+    assert "op.drop_constraint" not in migration
 
 
 def _base_request(**overrides) -> IngestReportRequest:


### PR DESCRIPTION
## Summary
- make ROB-269 p3a CHECK-constraint migration tolerant of production schema drift where the original p3 check is absent
- replace Alembic `op.drop_constraint` with explicit `ALTER TABLE review.investment_reports DROP CONSTRAINT IF EXISTS ...`
- add regression coverage for the idempotent migration shape

## Why
Production deploy of the PR #879 promotion failed before symlink switch during `alembic upgrade head`:
`constraint "ck_investment_reports_no_published_on_hard_stale" of relation "investment_reports" does not exist`.

## Risk / review note
DB migration behavior change: high_risk_change + needs_stronger_model_review. The change is additive/idempotence-only and keeps the same final CHECK predicate.

## Verification
- RED: `uv run pytest tests/test_investment_reports_snapshot_metadata.py::test_p3a_migration_tolerates_missing_existing_check_constraint -q` failed before the migration change
- GREEN: same test passed after the change
- `uv run ruff check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`
- `uv run ruff format --check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`
- `uv run pytest tests/test_investment_reports_snapshot_metadata.py -q` → 15 passed
- `uv run ty check app/ --error-on-warning`
