### PR TITLE
fix: make ROB-269 stale-check migration idempotent

### DIFF
--- a/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
+++ b/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
@@ -15,8 +15,10 @@ The corrected form requires either ``snapshot_freshness_summary IS NULL``
 the allow-set. The ``IS NOT NULL`` guard collapses missing-key and
 JSON-null cases to FALSE (reject), no UNKNOWN.
 
-Drop + recreate is idempotent (PostgreSQL has no ``ALTER CONSTRAINT`` for
-CHECK predicates without IF EXISTS gymnastics).
+Drop + recreate is idempotent. Production may already have applied the
+Phase 3 revision while missing this check constraint because earlier deploy
+attempts or test fixtures managed the table shape independently; the follow-up
+must therefore tolerate the old constraint being absent.
 """
 
 from __future__ import annotations
@@ -53,15 +55,30 @@ _NEW_PREDICATE = (
 )
 
 
+def _drop_check_if_exists() -> None:
+    """Drop the stale-gate CHECK if present.
+
+    Alembic's generic ``drop_constraint`` emits ``ALTER TABLE ... DROP
+    CONSTRAINT`` without ``IF EXISTS`` on the installed stack, which makes this
+    follow-up migration fail on production databases whose schema drift already
+    lacks the old check. Use explicit PostgreSQL DDL so the migration remains
+    safe for both states.
+    """
+
+    op.execute(
+        f"ALTER TABLE review.investment_reports DROP CONSTRAINT IF EXISTS {_CHECK_NAME}"
+    )
+
+
 def upgrade() -> None:
-    op.drop_constraint(_CHECK_NAME, "investment_reports", schema="review")
+    _drop_check_if_exists()
     op.create_check_constraint(
         _CHECK_NAME, "investment_reports", _NEW_PREDICATE, schema="review"
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint(_CHECK_NAME, "investment_reports", schema="review")
+    _drop_check_if_exists()
     op.create_check_constraint(
         _CHECK_NAME, "investment_reports", _OLD_PREDICATE, schema="review"
     )

--- a/tests/test_investment_reports_snapshot_metadata.py
+++ b/tests/test_investment_reports_snapshot_metadata.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
@@ -198,6 +199,16 @@ async def test_db_check_allows_draft_with_hard_stale_freshness(
 # (not FALSE) when ``snapshot_freshness_summary`` was set but ``overall`` was
 # missing / JSON-null, and PostgreSQL CHECK accepts UNKNOWN. The corrected
 # predicate uses an explicit ``IS NOT NULL`` guard so those cases now reject.
+def test_p3a_migration_drops_stale_check_idempotently() -> None:
+    """Production may be missing the old CHECK; p3a must tolerate that drift."""
+    migration = Path(
+        "alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py"
+    ).read_text()
+
+    assert "DROP CONSTRAINT IF EXISTS" in migration
+    assert "op.drop_constraint" not in migration
+
+
 @pytest.mark.asyncio
 async def test_db_check_rejects_published_with_missing_overall_key(
     session: AsyncSession,


### PR DESCRIPTION
## Summary
- Make the ROB-269 p3a stale-check follow-up migration tolerate production schema drift where the old CHECK constraint is already absent.
- Replace Alembic `op.drop_constraint` with explicit PostgreSQL `DROP CONSTRAINT IF EXISTS` before recreating the corrected CHECK.
- Add a regression test that locks the migration to idempotent drop semantics.

## Why
Production deploy for `07d43c0558d732bdb87c2e73e6366abce146810c` failed during `alembic upgrade head` because `review.investment_reports` did not have `ck_investment_reports_no_published_on_hard_stale` when p3a attempted a plain drop.

## Tests
- `uv run pytest tests/test_investment_reports_snapshot_metadata.py::test_p3a_migration_drops_stale_check_idempotently -q`
- `uv run pytest tests/test_investment_reports_snapshot_metadata.py -q`
- `uv run ruff check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`
- `uv run ruff format --check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`

## Safety
- Migration-only hotfix plus test; no broker/order/watch-intent mutation.
- Keeps the corrected stale-gate CHECK predicate unchanged.
