### PR TITLE
fix: drop ROB-269 generated stale-check name

### DIFF
--- a/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
+++ b/alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py
@@ -18,7 +18,11 @@ JSON-null cases to FALSE (reject), no UNKNOWN.
 Drop + recreate is idempotent. Production may already have applied the
 Phase 3 revision while missing this check constraint because earlier deploy
 attempts or test fixtures managed the table shape independently; the follow-up
-must therefore tolerate the old constraint being absent.
+must therefore tolerate the old constraint being absent. The original Phase 3
+``op.create_check_constraint`` also passed a name that already included the
+``ck_investment_reports`` prefix, so SQLAlchemy's naming convention expanded
+and truncated it to a generated PostgreSQL name; this migration must drop that
+name too before recreating the final constraint with ``op.f``.
 """
 
 from __future__ import annotations
@@ -34,6 +38,12 @@ depends_on: str | Sequence[str] | None = None
 
 
 _CHECK_NAME = "ck_investment_reports_no_published_on_hard_stale"
+
+# Phase 3 used ``op.create_check_constraint`` with ``_CHECK_NAME`` under the
+# global ``ck_%(table_name)s_%(constraint_name)s`` naming convention. Alembic
+# therefore emitted this truncated/hash-suffixed PostgreSQL identifier.
+_GENERATED_CHECK_NAME = "ck_investment_reports_ck_investment_reports_no_publishe_b266"
+_CHECK_NAMES = (_CHECK_NAME, _GENERATED_CHECK_NAME)
 
 # Old (Phase 3 initial) predicate — kept as the downgrade target.
 _OLD_PREDICATE = (
@@ -65,20 +75,21 @@ def _drop_check_if_exists() -> None:
     safe for both states.
     """
 
-    op.execute(
-        f"ALTER TABLE review.investment_reports DROP CONSTRAINT IF EXISTS {_CHECK_NAME}"
-    )
+    for check_name in _CHECK_NAMES:
+        op.execute(
+            f'ALTER TABLE review.investment_reports DROP CONSTRAINT IF EXISTS "{check_name}"'
+        )
 
 
 def upgrade() -> None:
     _drop_check_if_exists()
     op.create_check_constraint(
-        _CHECK_NAME, "investment_reports", _NEW_PREDICATE, schema="review"
+        op.f(_CHECK_NAME), "investment_reports", _NEW_PREDICATE, schema="review"
     )
 
 
 def downgrade() -> None:
     _drop_check_if_exists()
     op.create_check_constraint(
-        _CHECK_NAME, "investment_reports", _OLD_PREDICATE, schema="review"
+        op.f(_CHECK_NAME), "investment_reports", _OLD_PREDICATE, schema="review"
     )

--- a/tests/test_investment_reports_snapshot_metadata.py
+++ b/tests/test_investment_reports_snapshot_metadata.py
@@ -200,13 +200,16 @@ async def test_db_check_allows_draft_with_hard_stale_freshness(
 # missing / JSON-null, and PostgreSQL CHECK accepts UNKNOWN. The corrected
 # predicate uses an explicit ``IS NOT NULL`` guard so those cases now reject.
 def test_p3a_migration_drops_stale_check_idempotently() -> None:
-    """Production may be missing the old CHECK; p3a must tolerate that drift."""
+    """Production may have absent or naming-convention-expanded stale checks."""
     migration = Path(
         "alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py"
     ).read_text()
 
     assert "DROP CONSTRAINT IF EXISTS" in migration
     assert "op.drop_constraint" not in migration
+    assert "ck_investment_reports_no_published_on_hard_stale" in migration
+    assert "ck_investment_reports_ck_investment_reports_no_publishe_b266" in migration
+    assert "op.f(_CHECK_NAME)" in migration
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Drop both ROB-269 p3a stale-check constraint names: the intended explicit name and the SQLAlchemy naming-convention expanded/truncated name observed in production.
- Recreate the corrected CHECK with `op.f(_CHECK_NAME)` so Alembic does not apply the naming convention twice.
- Extend the regression test to lock the generated-name drop and final-name behavior.

## Why
The first production hotfix tolerated a missing explicit CHECK name, but deploy run `26092379641` showed Phase 3 had actually created the naming-convention expanded PostgreSQL identifier `ck_investment_reports_ck_investment_reports_no_publishe_b266`. p3a then attempted to create that same generated name again and failed with `DuplicateObjectError`.

## Tests
- RED observed: `uv run pytest tests/test_investment_reports_snapshot_metadata.py::test_p3a_migration_drops_stale_check_idempotently -q` failed before this migration fix because the generated constraint name was not dropped.
- GREEN: `uv run pytest tests/test_investment_reports_snapshot_metadata.py::test_p3a_migration_drops_stale_check_idempotently -q`
- `uv run pytest tests/test_investment_reports_snapshot_metadata.py -q`
- `uv run ruff check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`
- `uv run ruff format --check alembic/versions/20260519_rob269_p3a_fix_check_overall_null.py tests/test_investment_reports_snapshot_metadata.py`

## Safety
- Migration-only hotfix plus test.
- No broker/order/watch-intent mutation.
- Corrected stale-gate predicate remains unchanged.
