### PR TITLE
feat(rob-273): automate snapshot-backed report generation

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -453,6 +453,16 @@ class Settings(BaseSettings):
     # A/B) — wiring an endpoint + frontend hook is a follow-up.
     # See docs/superpowers/plans/2026-05-19-rob-269-phase-4-ui-and-scheduler.md §4.
     ACTION_REPORT_BUNDLE_UI_ENABLED: bool = False
+    # ROB-273 — gates the snapshot-backed advisory report generator surface
+    # (MCP tool + HTTP POST endpoint). The generator can still be constructed
+    # and called directly from tests / scripts; this flag only controls the
+    # user-facing entrypoints. Decoupled from
+    # ``ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED`` because that flag
+    # gates pre-DB rejection of *any* report carrying snapshot metadata —
+    # turning on the generator surface independently lets us validate the
+    # automated path against draft reports before activating the
+    # stale-gate enforcement for the legacy create path.
+    SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED: bool = False
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
     execution_ledger_reconcile_scheduler_enabled: bool = False
     execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -52,6 +52,7 @@ INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
     "investment_report_decide_item",
     "investment_report_activate_watch",
     "investment_report_context_get",
+    "investment_report_generate_from_bundle",
 }
 
 
@@ -317,6 +318,103 @@ async def investment_report_context_get_impl(
 
 
 # ---------------------------------------------------------------------------
+# investment_report_generate_from_bundle (ROB-273)
+# ---------------------------------------------------------------------------
+async def investment_report_generate_from_bundle_impl(
+    market: str,
+    account_scope: str,
+    title: str,
+    summary: str,
+    kst_date: str,
+    created_by_profile: str,
+    items: list[dict[str, Any]] | None = None,
+    risk_summary: str | None = None,
+    thesis_text: str | None = None,
+    no_action_note: str | None = None,
+    status: str = "published",
+    metadata: dict[str, Any] | None = None,
+    valid_until: str | None = None,
+    published_at: str | None = None,
+    previous_report_uuid: str | None = None,
+    policy_version: str = "intraday_action_report_v1",
+    generator_version: str = "v2-snapshot-backed",
+    report_type: str = "snapshot_backed_advisory_v1",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+    requested_by: str = "claude_code",
+) -> dict:
+    """Generate a snapshot-backed advisory report.
+
+    Opt-in entrypoint for ROB-273. Default-off: the harness returns
+    ``success=False`` unless ``SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+    is set on the deployment. The generator never mutates broker /
+    order / watch state — see docs for the read-only guarantees.
+    """
+    from app.core.config import settings
+    from app.services.action_report.snapshot_backed.generator import (
+        PublishBlockedByStaleGateError,
+        SnapshotBackedReportGenerator,
+        SnapshotBackedReportGeneratorError,
+    )
+    from app.services.action_report.snapshot_backed.request import (
+        ReportGenerationRequest,
+    )
+
+    if not settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED:
+        return {
+            "success": False,
+            "error": "snapshot_backed_report_generator_disabled",
+            "hint": (
+                "Set SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true on the "
+                "MCP host to enable this tool."
+            ),
+        }
+
+    payload: dict[str, Any] = {
+        "market": market,
+        "account_scope": account_scope,
+        "policy_version": policy_version,
+        "status": status,
+        "requested_by": requested_by,
+        "report_type": report_type,
+        "generator_version": generator_version,
+        "created_by_profile": created_by_profile,
+        "title": title,
+        "summary": summary,
+        "kst_date": kst_date,
+        "risk_summary": risk_summary,
+        "thesis_text": thesis_text,
+        "no_action_note": no_action_note,
+        "items": [IngestReportItem.model_validate(it) for it in (items or [])],
+        "previous_report_uuid": previous_report_uuid,
+        "valid_until": valid_until,
+        "published_at": published_at,
+        "metadata": metadata or {},
+        "symbols": symbols,
+        "candidate_limit": candidate_limit,
+    }
+    request = ReportGenerationRequest.model_validate(payload)
+
+    async with AsyncSessionLocal() as db:
+        generator = SnapshotBackedReportGenerator(db)
+        try:
+            response = await generator.generate(request)
+        except PublishBlockedByStaleGateError as exc:
+            return {
+                "success": False,
+                "error": "publish_blocked_by_stale_gate",
+                "reason": str(exc),
+                "bundle_status": exc.bundle_status,
+                "freshness_summary": exc.freshness_summary,
+            }
+        except SnapshotBackedReportGeneratorError as exc:
+            return {"success": False, "error": str(exc)}
+        await db.commit()
+
+    return {"success": True, **response.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 def register_investment_report_tools(mcp: FastMCP) -> None:
@@ -367,6 +465,18 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
             "triggered_events, recent_decisions. n_prior clamped to 1..10."
         ),
     )(investment_report_context_get_impl)
+    mcp.tool(
+        name="investment_report_generate_from_bundle",
+        description=(
+            "ROB-273 — generate a snapshot-backed advisory investment_report "
+            "end-to-end. Ensures (or reuses) a snapshot bundle, runs the "
+            "read-only collector registry, normalises payloads, and persists "
+            "the report with snapshot metadata. Opt-in: returns "
+            "{success:false, error:'snapshot_backed_report_generator_disabled'} "
+            "unless SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED is true. "
+            "No broker / order / watch mutation."
+        ),
+    )(investment_report_generate_from_bundle_impl)
 
 
 __all__ = [
@@ -375,6 +485,7 @@ __all__ = [
     "investment_report_context_get_impl",
     "investment_report_create_impl",
     "investment_report_decide_item_impl",
+    "investment_report_generate_from_bundle_impl",
     "investment_report_get_impl",
     "investment_report_list_impl",
     "register_investment_report_tools",

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -182,3 +182,61 @@ async def get_investment_report(
     if bundle is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not_found")
     return _serialise_bundle(bundle)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-backed advisory report generator (ROB-273)
+#
+# Opt-in entrypoint that automates the manual snapshot-bundle + report
+# flow validated in production. The generator + collectors are read-only
+# (no broker mutation, no watch activation, no scheduler registration).
+# Default behaviour: 503 unless ``SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+# is set. Existing GET list/detail endpoints are unchanged.
+# ---------------------------------------------------------------------------
+from app.core.config import settings  # noqa: E402  — keep router-local
+from app.services.action_report.snapshot_backed.generator import (  # noqa: E402
+    PublishBlockedByStaleGateError,
+    SnapshotBackedReportGenerator,
+    SnapshotBackedReportGeneratorError,
+)
+from app.services.action_report.snapshot_backed.request import (  # noqa: E402
+    ReportGenerationRequest,
+    ReportGenerationResponse,
+)
+
+
+@router.post(
+    "/trading/api/investment-reports/snapshot-backed",
+    response_model=ReportGenerationResponse,
+    summary="Generate a snapshot-backed advisory report (ROB-273, opt-in)",
+)
+async def generate_snapshot_backed_report(
+    payload: ReportGenerationRequest,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReportGenerationResponse:
+    if not settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="snapshot_backed_report_generator_disabled",
+        )
+    generator = SnapshotBackedReportGenerator(db)
+    try:
+        response = await generator.generate(payload)
+    except PublishBlockedByStaleGateError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error": "publish_blocked_by_stale_gate",
+                "reason": str(exc),
+                "bundle_status": exc.bundle_status,
+                "freshness_summary": exc.freshness_summary,
+            },
+        ) from exc
+    except SnapshotBackedReportGeneratorError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    await db.commit()
+    return response

--- a/app/services/action_report/common/jsonable.py
+++ b/app/services/action_report/common/jsonable.py
@@ -1,0 +1,76 @@
+"""ROB-273 — recursive JSON-safe normalisation for snapshot-backed reports.
+
+The :class:`SnapshotBackedReportGenerator` ingests caller-supplied items and
+collector payloads that may contain :class:`~decimal.Decimal`,
+:class:`~datetime.datetime`, :class:`~datetime.date`, :class:`~uuid.UUID`, or
+:class:`enum.Enum` values. These can't be persisted directly into JSONB
+without round-tripping through string/float, so the generator normalises
+every JSONB-bound dict/list immediately before building the
+:class:`IngestReportRequest`.
+
+The function is deliberately small and pure — no I/O, no logging, no
+external dependencies. It is import-safe for both the service layer and
+unit tests.
+
+Decimal policy
+--------------
+Decimals are converted to **strings** by default. The decimal → string
+round-trip preserves precision and matches the existing ``WatchCondition``
+threshold serialisation contract (``str(Decimal)``). Callers that want
+``float`` semantics for a specific field should cast at the call site
+rather than relying on a global toggle here.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import enum
+import uuid
+from decimal import Decimal
+from typing import Any
+
+
+def to_jsonable(value: Any) -> Any:
+    """Return a JSON-safe deep-copy of ``value``.
+
+    Container traversal is recursive: ``dict`` keys are coerced to strings,
+    ``list``/``tuple``/``set`` become lists of normalised values, and any
+    other value passes through :func:`_atom`.
+    """
+    if isinstance(value, dict):
+        return {str(k): to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [to_jsonable(v) for v in value]
+    return _atom(value)
+
+
+def _atom(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, bool):  # bool is a subclass of int — handle before int
+        return value
+    if isinstance(value, (str, int, float)):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, dt.datetime):
+        return value.isoformat()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    if isinstance(value, dt.time):
+        return value.isoformat()
+    if isinstance(value, enum.Enum):
+        return to_jsonable(value.value)
+    if isinstance(value, bytes):
+        # bytes can't round-trip cleanly to JSON; refuse rather than silently
+        # base64-encoding (which would mask a real upstream bug).
+        raise TypeError("bytes payloads are not JSONB-safe; encode at the call site")
+    if hasattr(value, "model_dump"):
+        # Pydantic v2 model — defer to its own JSON-mode dump for parity
+        # with how IngestReportRequest serialises nested watch conditions.
+        return to_jsonable(value.model_dump(mode="json"))
+    raise TypeError(
+        f"to_jsonable: unsupported type {type(value).__name__!r}"
+    )

--- a/app/services/action_report/common/jsonable.py
+++ b/app/services/action_report/common/jsonable.py
@@ -71,6 +71,4 @@ def _atom(value: Any) -> Any:
         # Pydantic v2 model — defer to its own JSON-mode dump for parity
         # with how IngestReportRequest serialises nested watch conditions.
         return to_jsonable(value.model_dump(mode="json"))
-    raise TypeError(
-        f"to_jsonable: unsupported type {type(value).__name__!r}"
-    )
+    raise TypeError(f"to_jsonable: unsupported type {type(value).__name__!r}")

--- a/app/services/action_report/common/source_kind_mapping.py
+++ b/app/services/action_report/common/source_kind_mapping.py
@@ -1,0 +1,94 @@
+"""ROB-273 — external-origin → ``SourceKind`` literal mapping.
+
+The snapshot foundation enforces a closed set of ``source_kind`` literal
+values (see ``app/schemas/investment_snapshots.py``). Collectors and ad-hoc
+ingestion paths historically used free-form strings (``upbit_mcp``, ``db``,
+``mcp_screen``, ``not_applicable``, ``finnhub_crypto``) that violate the
+literal contract and would cause Pydantic ``ValidationError`` at insert
+time, sometimes long after the data was collected.
+
+This module centralises the mapping so the generator can normalise
+collector results *before* they hit
+:class:`SnapshotCollectResult`. Anything we don't recognise is rejected
+loudly with :class:`UnsupportedSourceKindError` — the caller is responsible
+for picking the correct literal rather than silently falling through to a
+catch-all bucket.
+"""
+
+from __future__ import annotations
+
+from typing import Final, get_args
+
+from app.schemas.investment_snapshots import SourceKind
+
+ALLOWED_SOURCE_KINDS: Final[frozenset[str]] = frozenset(get_args(SourceKind))
+
+# Origins seen in the manual production run that the ROB-273 ticket
+# explicitly forbids inventing as new literals. Each maps to an allowed
+# member of ``SourceKind`` so callers can keep their internal naming while
+# the persisted value remains canonical.
+_EXTERNAL_ORIGIN_TO_SOURCE_KIND: Final[dict[str, str]] = {
+    # Upbit/crypto MCP evidence
+    "upbit_mcp": "auto_trader_mcp",
+    "upbit_public": "auto_trader_mcp",
+    # DB / query-service / screen evidence
+    "db": "auto_trader_mcp",
+    "mcp_screen": "auto_trader_mcp",
+    "auto_trader_db": "auto_trader_mcp",
+    "domain_db": "domain_ref",
+    # KIS MCP evidence
+    "kis_api": "kis_mcp",
+    # Finnhub / market events derivatives (read through auto_trader)
+    "finnhub_crypto": "auto_trader_mcp",
+    "finnhub": "auto_trader_mcp",
+    "dart": "auto_trader_mcp",
+    # News ingestor
+    "news": "news_ingestor",
+    "research_reports": "news_ingestor",
+    # Invest HTTP surface
+    "invest_http": "invest_api",
+    # Manual / not-applicable buckets
+    "not_applicable": "manual",
+    "operator_paste": "manual",
+}
+
+
+class UnsupportedSourceKindError(ValueError):
+    """Raised when an origin string cannot be mapped to a ``SourceKind``."""
+
+    def __init__(self, origin: str) -> None:
+        super().__init__(
+            f"unsupported source origin {origin!r}; "
+            f"map it to one of {sorted(ALLOWED_SOURCE_KINDS)} explicitly "
+            f"or extend SourceKind literal + alembic migration"
+        )
+        self.origin = origin
+
+
+def map_source_kind(origin: str) -> str:
+    """Map an external origin string to a canonical ``SourceKind`` literal.
+
+    * Already-canonical values pass through unchanged.
+    * Known aliases (see :data:`_EXTERNAL_ORIGIN_TO_SOURCE_KIND`) translate
+      to their canonical literal.
+    * Anything else raises :class:`UnsupportedSourceKindError` — the
+      caller must pick an explicit mapping rather than invent a new
+      literal at the snapshot insert site.
+    """
+    if not isinstance(origin, str) or not origin:
+        raise UnsupportedSourceKindError(repr(origin))
+
+    if origin in ALLOWED_SOURCE_KINDS:
+        return origin
+
+    mapped = _EXTERNAL_ORIGIN_TO_SOURCE_KIND.get(origin)
+    if mapped is None:
+        raise UnsupportedSourceKindError(origin)
+
+    # Defensive: if a future contributor mis-types the right-hand side of
+    # _EXTERNAL_ORIGIN_TO_SOURCE_KIND, fail loudly here rather than
+    # propagating a half-canonical value.
+    if mapped not in ALLOWED_SOURCE_KINDS:
+        raise UnsupportedSourceKindError(origin)
+
+    return mapped

--- a/app/services/action_report/snapshot_backed/__init__.py
+++ b/app/services/action_report/snapshot_backed/__init__.py
@@ -1,0 +1,13 @@
+"""ROB-273 — snapshot-backed advisory report generation.
+
+Public surface:
+
+* :class:`~app.services.action_report.snapshot_backed.generator.SnapshotBackedReportGenerator`
+* :class:`~app.services.action_report.snapshot_backed.request.ReportGenerationRequest`
+* :class:`~app.services.action_report.snapshot_backed.request.ReportGenerationResponse`
+* :func:`~app.services.action_report.snapshot_backed.collectors.registry.production_collector_registry`
+
+This package owns the wiring between the bundle-ensure service and the
+investment-reports ingestion service. Collectors live under
+``collectors/``; they are all read-only by contract.
+"""

--- a/app/services/action_report/snapshot_backed/collectors/__init__.py
+++ b/app/services/action_report/snapshot_backed/collectors/__init__.py
@@ -1,0 +1,14 @@
+"""ROB-273 — production snapshot collectors and registry assembly.
+
+All collectors here are **read-only by contract**:
+
+* No broker order create / cancel / modify.
+* No watch alert activation.
+* No scheduler / TaskIQ / Prefect registration.
+* No external HTTP that could trigger remote mutation.
+
+Required-kind collectors (portfolio, journal, watch_context, market) query
+local DB state populated by upstream sync flows. Optional-kind collectors
+are either thin DB readers or fail-open stubs that return ``unavailable``
+without raising.
+"""

--- a/app/services/action_report/snapshot_backed/collectors/_base.py
+++ b/app/services/action_report/snapshot_backed/collectors/_base.py
@@ -1,0 +1,64 @@
+"""Base helpers shared by all snapshot-backed report collectors."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.services.action_report.common.jsonable import to_jsonable
+from app.services.action_report.common.source_kind_mapping import map_source_kind
+from app.services.investment_snapshots.collectors import SnapshotCollectResult
+
+
+def utcnow() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+def build_result(
+    *,
+    snapshot_kind: str,
+    market: str,
+    account_scope: str | None,
+    payload: dict[str, Any],
+    origin: str,
+    as_of: dt.datetime,
+    freshness_status: str = "fresh",
+    symbol: str | None = None,
+    coverage: dict[str, Any] | None = None,
+    errors: dict[str, Any] | None = None,
+) -> SnapshotCollectResult:
+    """Build a :class:`SnapshotCollectResult` with JSON-safe payload + mapped source_kind."""
+    return SnapshotCollectResult(
+        snapshot_kind=snapshot_kind,
+        market=market,
+        account_scope=account_scope,
+        symbol=symbol,
+        source_kind=map_source_kind(origin),
+        payload_json=to_jsonable(payload),
+        coverage_json=to_jsonable(coverage or {}),
+        errors_json=to_jsonable(errors or {}),
+        as_of=as_of,
+        freshness_status=freshness_status,  # type: ignore[arg-type]
+    )
+
+
+def unavailable_result(
+    *,
+    snapshot_kind: str,
+    market: str,
+    account_scope: str | None,
+    origin: str,
+    reason: str,
+    as_of: dt.datetime,
+) -> SnapshotCollectResult:
+    """Build an explicit ``unavailable`` result. Marks the kind attempted."""
+    return SnapshotCollectResult(
+        snapshot_kind=snapshot_kind,
+        market=market,
+        account_scope=account_scope,
+        source_kind=map_source_kind(origin),
+        payload_json={},
+        errors_json=to_jsonable({"reason": reason}),
+        as_of=as_of,
+        freshness_status="unavailable",
+    )

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -1,0 +1,163 @@
+"""Candidate-universe snapshot collector (read-only, optional).
+
+For ``market=kr|us`` the collector reads :class:`InvestScreenerSnapshot`
+counts via ``InvestScreenerSnapshotsRepository.coverage``. For
+``market=crypto`` it falls back to a count + latest-partition probe over
+:class:`InvestCryptoScreenerSnapshot`. Either branch is read-only and
+degrades to ``unavailable`` on exception.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.invest_screener_snapshots.repository import (
+    InvestScreenerSnapshotsRepository,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+
+class CandidateUniverseSnapshotCollector:
+    """Optional ``candidate_universe`` collector backed by screener snapshots."""
+
+    snapshot_kind: str = "candidate_universe"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        equity_repository: InvestScreenerSnapshotsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._equity_repo = equity_repository or InvestScreenerSnapshotsRepository(
+            session
+        )
+
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        try:
+            if request.market in ("kr", "us"):
+                return await self._collect_equity(request, now)
+            if request.market == "crypto":
+                return await self._collect_crypto(request, now)
+        except Exception as exc:  # noqa: BLE001 — optional, fail open
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="auto_trader_db",
+                    reason=(
+                        f"candidate_universe query failed: {type(exc).__name__}: {exc}"
+                    ),
+                    as_of=now,
+                )
+            ]
+        return [
+            unavailable_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                origin="auto_trader_db",
+                reason=f"no candidate_universe wiring for market={request.market!r}",
+                as_of=now,
+            )
+        ]
+
+    async def _collect_equity(
+        self, request: CollectorRequest, now: dt.datetime
+    ) -> list[SnapshotCollectResult]:
+        today = now.date()
+        coverage = await self._equity_repo.coverage(
+            market=request.market, today_trading_date=today
+        )
+        payload: dict[str, Any] = {
+            "market": coverage.market,
+            "today_trading_date": coverage.today_trading_date.isoformat(),
+            "fresh_count": coverage.fresh_count,
+            "stale_count": coverage.stale_count,
+            "last_computed_at": coverage.last_computed_at,
+        }
+        if coverage.fresh_count == 0 and coverage.stale_count == 0:
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"fresh_count": 0, "stale_count": 0},
+                )
+            ]
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={
+                    "fresh_count": coverage.fresh_count,
+                    "stale_count": coverage.stale_count,
+                },
+            )
+        ]
+
+    async def _collect_crypto(
+        self, request: CollectorRequest, now: dt.datetime
+    ) -> list[SnapshotCollectResult]:
+        latest_date_row = await self._session.execute(
+            select(func.max(InvestCryptoScreenerSnapshot.snapshot_date))
+        )
+        latest_date = latest_date_row.scalar_one_or_none()
+        if latest_date is None:
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={"market": "crypto", "fresh_count": 0},
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"fresh_count": 0},
+                )
+            ]
+        count_row = await self._session.execute(
+            select(func.count()).where(
+                InvestCryptoScreenerSnapshot.snapshot_date == latest_date
+            )
+        )
+        count = int(count_row.scalar_one() or 0)
+        payload: dict[str, Any] = {
+            "market": "crypto",
+            "latest_partition": latest_date.isoformat(),
+            "fresh_count": count,
+        }
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={"fresh_count": count},
+            )
+        ]

--- a/app/services/action_report/snapshot_backed/collectors/invest_page.py
+++ b/app/services/action_report/snapshot_backed/collectors/invest_page.py
@@ -1,0 +1,111 @@
+"""Invest-page snapshot collector (read-only, optional).
+
+Captures a small slice of "what the /invest dashboard would render right
+now" — namely the most-recent published investment reports for the same
+market. Sourced from :class:`InvestmentReportQueryService.list_reports`,
+which is read-only by construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+_DEFAULT_RECENT_LIMIT: int = 5
+
+
+class InvestPageSnapshotCollector:
+    """Optional ``invest_page`` collector backed by recent investment_reports."""
+
+    snapshot_kind: str = "invest_page"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        query_service: InvestmentReportQueryService | None = None,
+        recent_limit: int = _DEFAULT_RECENT_LIMIT,
+    ) -> None:
+        self._session = session
+        self._query = query_service or InvestmentReportQueryService(session)
+        self._recent_limit = max(1, recent_limit)
+
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        try:
+            rows = await self._query.list_reports(
+                market=request.market,
+                status="published",
+                limit=self._recent_limit,
+            )
+        except Exception as exc:  # noqa: BLE001 — optional, fail open
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="invest_http",
+                    reason=(f"invest_page query failed: {type(exc).__name__}: {exc}"),
+                    as_of=now,
+                )
+            ]
+
+        reports_payload: list[dict[str, Any]] = [
+            {
+                "report_uuid": row.report_uuid,
+                "report_type": row.report_type,
+                "status": row.status,
+                "title": row.title,
+                "published_at": row.published_at,
+                "snapshot_bundle_uuid": row.snapshot_bundle_uuid,
+                "snapshot_freshness_overall": (
+                    (row.snapshot_freshness_summary or {}).get("overall")
+                    if row.snapshot_freshness_summary
+                    else None
+                ),
+            }
+            for row in rows
+        ]
+        payload: dict[str, Any] = {
+            "market": request.market,
+            "count": len(reports_payload),
+            "recent_published_reports": reports_payload,
+        }
+        if not reports_payload:
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="invest_http",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"recent_published": 0},
+                )
+            ]
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="invest_http",
+                as_of=now,
+                coverage={"recent_published": len(reports_payload)},
+            )
+        ]

--- a/app/services/action_report/snapshot_backed/collectors/journal.py
+++ b/app/services/action_report/snapshot_backed/collectors/journal.py
@@ -1,0 +1,111 @@
+"""Journal snapshot collector (read-only).
+
+Reads recent and active ``trade_journals`` rows for the live account scope.
+The collector never writes journals — :class:`TradeJournalWriteService` is
+the only allowed write path, and is intentionally not imported here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.trade_journal import TradeJournal
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+_ACTIVE_STATUSES: tuple[str, ...] = ("draft", "active")
+_RETROSPECTIVE_STATUSES: tuple[str, ...] = ("closed", "stopped", "expired")
+_DEFAULT_RECENT_LIMIT: int = 20
+
+
+class JournalSnapshotCollector:
+    """Required-kind ``journal`` collector backed by ``trade_journals``."""
+
+    snapshot_kind: str = "journal"
+
+    def __init__(self, session: AsyncSession, *, recent_limit: int | None = None) -> None:
+        self._session = session
+        self._recent_limit = recent_limit or _DEFAULT_RECENT_LIMIT
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        now = utcnow()
+
+        active_stmt = (
+            select(TradeJournal)
+            .where(
+                TradeJournal.account_type == "live",
+                TradeJournal.status.in_(_ACTIVE_STATUSES),
+            )
+            .order_by(desc(TradeJournal.updated_at))
+        )
+        recent_stmt = (
+            select(TradeJournal)
+            .where(
+                TradeJournal.account_type == "live",
+                TradeJournal.status.in_(_RETROSPECTIVE_STATUSES),
+            )
+            .order_by(desc(TradeJournal.updated_at))
+            .limit(self._recent_limit)
+        )
+
+        active_rows = (await self._session.execute(active_stmt)).scalars().all()
+        recent_rows = (await self._session.execute(recent_stmt)).scalars().all()
+
+        payload: dict[str, Any] = {
+            "active": [_journal_to_dict(j) for j in active_rows],
+            "recent_retrospective": [_journal_to_dict(j) for j in recent_rows],
+            "active_count": len(active_rows),
+            "retrospective_count": len(recent_rows),
+            "recent_limit": self._recent_limit,
+        }
+
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={
+                    "active_count": len(active_rows),
+                    "retrospective_count": len(recent_rows),
+                },
+            )
+        ]
+
+
+def _journal_to_dict(j: TradeJournal) -> dict[str, Any]:
+    return {
+        "id": j.id,
+        "symbol": j.symbol,
+        "instrument_type": j.instrument_type.value
+        if hasattr(j.instrument_type, "value")
+        else str(j.instrument_type),
+        "side": j.side,
+        "status": j.status,
+        "entry_price": j.entry_price,
+        "quantity": j.quantity,
+        "thesis": j.thesis,
+        "strategy": j.strategy,
+        "target_price": j.target_price,
+        "stop_loss": j.stop_loss,
+        "hold_until": j.hold_until,
+        "exit_price": j.exit_price,
+        "exit_reason": j.exit_reason,
+        "pnl_pct": j.pnl_pct,
+        "account_type": j.account_type,
+        "created_at": j.created_at,
+        "updated_at": j.updated_at,
+    }

--- a/app/services/action_report/snapshot_backed/collectors/journal.py
+++ b/app/services/action_report/snapshot_backed/collectors/journal.py
@@ -32,13 +32,13 @@ class JournalSnapshotCollector:
 
     snapshot_kind: str = "journal"
 
-    def __init__(self, session: AsyncSession, *, recent_limit: int | None = None) -> None:
+    def __init__(
+        self, session: AsyncSession, *, recent_limit: int | None = None
+    ) -> None:
         self._session = session
         self._recent_limit = recent_limit or _DEFAULT_RECENT_LIMIT
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
 
         active_stmt = (

--- a/app/services/action_report/snapshot_backed/collectors/market.py
+++ b/app/services/action_report/snapshot_backed/collectors/market.py
@@ -52,9 +52,7 @@ class MarketEventsSnapshotCollector:
         self._lookback = max(0, lookback_days)
         self._lookahead = max(0, lookahead_days)
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
         market_key = _MARKET_TO_QUERY.get(request.market)
 

--- a/app/services/action_report/snapshot_backed/collectors/market.py
+++ b/app/services/action_report/snapshot_backed/collectors/market.py
@@ -1,0 +1,107 @@
+"""Market-events snapshot collector (read-only).
+
+Reads market events for a small window around today via
+:class:`MarketEventsQueryService`. The query service is read-only by
+design (ROB-128).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+from app.services.market_events.query_service import MarketEventsQueryService
+
+_MARKET_TO_QUERY: dict[str, str | None] = {
+    # Market events upstream keys: "kr" / "us" — there is no "crypto"
+    # category at the moment so we surface only KR/US events when present
+    # and an empty payload otherwise (still counts as fresh — no events is
+    # a valid state).
+    "kr": "kr",
+    "us": "us",
+    "crypto": None,
+}
+
+
+class MarketEventsSnapshotCollector:
+    """Required-kind ``market`` collector backed by ``market_events``."""
+
+    snapshot_kind: str = "market"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        query_service: MarketEventsQueryService | None = None,
+        lookback_days: int = 0,
+        lookahead_days: int = 1,
+    ) -> None:
+        self._session = session
+        self._query = query_service or MarketEventsQueryService(session)
+        self._lookback = max(0, lookback_days)
+        self._lookahead = max(0, lookahead_days)
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        market_key = _MARKET_TO_QUERY.get(request.market)
+
+        today = now.date()
+        from_date = today - dt.timedelta(days=self._lookback)
+        to_date = today + dt.timedelta(days=self._lookahead)
+
+        try:
+            response = await self._query.list_for_range(
+                from_date=from_date,
+                to_date=to_date,
+                market=market_key,
+            )
+        except Exception as exc:  # noqa: BLE001 — degrade rather than crash
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="auto_trader_db",
+                    reason=f"market_events query failed: {type(exc).__name__}: {exc}",
+                    as_of=now,
+                )
+            ]
+
+        events_payload: list[dict[str, Any]] = [
+            event.model_dump(mode="json") for event in response.events
+        ]
+        payload: dict[str, Any] = {
+            "market": request.market,
+            "from_date": from_date.isoformat(),
+            "to_date": to_date.isoformat(),
+            "event_count": len(events_payload),
+            "events": events_payload,
+        }
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={
+                    "event_count": len(events_payload),
+                    "from_date": from_date.isoformat(),
+                    "to_date": to_date.isoformat(),
+                },
+            )
+        ]

--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -1,0 +1,101 @@
+"""News snapshot collector (read-only, optional).
+
+Reads recent research reports / news ingestor citations via
+:class:`ResearchReportsQueryService`. Optional kind — a soft failure here
+degrades the bundle to ``partial`` but never blocks the report.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+from app.services.research_reports.query_service import ResearchReportsQueryService
+
+
+class NewsSnapshotCollector:
+    """Optional ``news`` collector backed by ``research_reports``."""
+
+    snapshot_kind: str = "news"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        query_service: ResearchReportsQueryService | None = None,
+        lookback_hours: int = 24,
+        limit: int = 20,
+    ) -> None:
+        self._session = session
+        self._query = query_service or ResearchReportsQueryService(session)
+        self._lookback_hours = max(1, lookback_hours)
+        self._limit = max(1, limit)
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        since = now - dt.timedelta(hours=self._lookback_hours)
+
+        try:
+            response = await self._query.find_relevant(
+                since=since,
+                limit=self._limit,
+            )
+        except Exception as exc:  # noqa: BLE001 — optional, fail open
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="news",
+                    reason=f"research_reports query failed: {type(exc).__name__}: {exc}",
+                    as_of=now,
+                )
+            ]
+
+        citations_payload: list[dict[str, Any]] = [
+            c.model_dump(mode="json") for c in response.citations
+        ]
+        payload: dict[str, Any] = {
+            "since": since.isoformat(),
+            "count": len(citations_payload),
+            "citations": citations_payload,
+        }
+
+        if not citations_payload:
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="news",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"citation_count": 0},
+                )
+            ]
+
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="news",
+                as_of=now,
+                coverage={"citation_count": len(citations_payload)},
+            )
+        ]

--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -42,9 +42,7 @@ class NewsSnapshotCollector:
         self._lookback_hours = max(1, lookback_hours)
         self._limit = max(1, limit)
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
         since = now - dt.timedelta(hours=self._lookback_hours)
 

--- a/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
+++ b/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
@@ -37,9 +37,7 @@ class _FailOpenStubBase:
     origin: str
     unavailable_reason: str
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         return [
             unavailable_result(
                 snapshot_kind=self.snapshot_kind,

--- a/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
+++ b/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
@@ -1,0 +1,109 @@
+"""Optional-kind fail-open stub collectors.
+
+Each collector here is registered for the bundle policy but produces an
+explicit ``unavailable`` result on every call. That keeps the bundle's
+status honest (it shows up under ``unavailable_sources`` and the bundle
+degrades to ``partial`` if anything else fails) without blocking the
+report — optional kinds, by policy, never gate executable language.
+
+These stubs exist so the registry can stay symmetric with the policy
+without inventing literal extensions for collectors that aren't wired
+yet (e.g. ``upbit_remote_debug`` is intentionally absent from the
+``SnapshotKind`` literal; we don't add it here).
+"""
+
+from __future__ import annotations
+
+from app.services.action_report.snapshot_backed.collectors._base import (
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+
+class _FailOpenStubBase:
+    """Base for read-not-yet-wired optional collectors.
+
+    Subclasses set ``snapshot_kind``, ``origin``, and an explanatory
+    ``unavailable_reason``. ``collect`` always returns a single
+    ``unavailable`` result — the bundle service treats it as "attempted but
+    no data", which surfaces in ``unavailable_sources`` for transparency.
+    """
+
+    snapshot_kind: str
+    origin: str
+    unavailable_reason: str
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        return [
+            unavailable_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                origin=self.origin,
+                reason=self.unavailable_reason,
+                as_of=utcnow(),
+            )
+        ]
+
+
+class SymbolStubCollector(_FailOpenStubBase):
+    snapshot_kind = "symbol"
+    origin = "auto_trader_db"
+    unavailable_reason = "symbol collector not wired yet (ROB-273 follow-up)"
+
+
+class CandidateUniverseStubCollector(_FailOpenStubBase):
+    snapshot_kind = "candidate_universe"
+    origin = "auto_trader_db"
+    unavailable_reason = (
+        "candidate_universe collector not wired yet (ROB-273 follow-up)"
+    )
+
+
+class InvestPageStubCollector(_FailOpenStubBase):
+    snapshot_kind = "invest_page"
+    origin = "invest_http"
+    unavailable_reason = "invest_page collector not wired yet (ROB-273 follow-up)"
+
+
+class NaverRemoteDebugStubCollector(_FailOpenStubBase):
+    snapshot_kind = "naver_remote_debug"
+    origin = "naver_remote_debug"
+    unavailable_reason = (
+        "naver_remote_debug probe is operator-driven only; "
+        "automated probe is intentionally not wired"
+    )
+
+
+class TossRemoteDebugStubCollector(_FailOpenStubBase):
+    snapshot_kind = "toss_remote_debug"
+    origin = "toss_remote_debug"
+    unavailable_reason = (
+        "toss_remote_debug probe is operator-driven only; "
+        "automated probe is intentionally not wired"
+    )
+
+
+class BrowserProbeStubCollector(_FailOpenStubBase):
+    """Holds the seat for the Upbit/public-page cross-check.
+
+    The Linear ticket asks for an ``upbit_remote_debug``-style optional
+    source but the snapshot enum doesn't include that literal yet (adding
+    it requires an alembic + Pydantic literal extension and was explicitly
+    scoped out of this PR). For now we register the policy's
+    ``browser_probe`` kind as fail-open so the registry is symmetric with
+    the policy.
+    """
+
+    snapshot_kind = "browser_probe"
+    origin = "manual"
+    unavailable_reason = (
+        "browser_probe cross-check is operator-driven only; "
+        "automated probe is intentionally not wired"
+    )

--- a/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
+++ b/app/services/action_report/snapshot_backed/collectors/optional_stubs.py
@@ -50,26 +50,6 @@ class _FailOpenStubBase:
         ]
 
 
-class SymbolStubCollector(_FailOpenStubBase):
-    snapshot_kind = "symbol"
-    origin = "auto_trader_db"
-    unavailable_reason = "symbol collector not wired yet (ROB-273 follow-up)"
-
-
-class CandidateUniverseStubCollector(_FailOpenStubBase):
-    snapshot_kind = "candidate_universe"
-    origin = "auto_trader_db"
-    unavailable_reason = (
-        "candidate_universe collector not wired yet (ROB-273 follow-up)"
-    )
-
-
-class InvestPageStubCollector(_FailOpenStubBase):
-    snapshot_kind = "invest_page"
-    origin = "invest_http"
-    unavailable_reason = "invest_page collector not wired yet (ROB-273 follow-up)"
-
-
 class NaverRemoteDebugStubCollector(_FailOpenStubBase):
     snapshot_kind = "naver_remote_debug"
     origin = "naver_remote_debug"

--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -49,9 +49,7 @@ class PortfolioSnapshotCollector:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         market_types = _MARKET_TO_TYPES.get(request.market)
         now = utcnow()
         if not market_types:
@@ -66,9 +64,7 @@ class PortfolioSnapshotCollector:
                 )
             ]
 
-        stmt = select(ManualHolding).where(
-            ManualHolding.market_type.in_(market_types)
-        )
+        stmt = select(ManualHolding).where(ManualHolding.market_type.in_(market_types))
         rows = (await self._session.execute(stmt)).scalars().all()
 
         holdings: list[dict[str, Any]] = [

--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -1,0 +1,120 @@
+"""Portfolio snapshot collector (read-only).
+
+Reads the user's currently-known holdings from the local DB state
+(``manual_holdings``). The upstream broker-sync flows
+(`PortfolioDataCollector`, broker websocket reconcilers, etc.) populate
+that table — this collector never calls a broker itself, so it is
+inherently safe to invoke during automated report generation.
+
+Mapping to the report ticket's account_scope:
+
+* ``account_scope='kis_live'`` → KR + US ``manual_holdings`` rows.
+* ``account_scope='upbit_live'`` → CRYPTO ``manual_holdings`` rows.
+
+If the request's market doesn't match a configured scope, the collector
+returns ``unavailable`` rather than raising — the bundle service then
+records it as a required-kind gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.manual_holdings import ManualHolding, MarketType
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+_MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
+    "kr": (MarketType.KR,),
+    "us": (MarketType.US,),
+    "crypto": (MarketType.CRYPTO,),
+}
+
+
+class PortfolioSnapshotCollector:
+    """Required-kind ``portfolio`` collector backed by ``manual_holdings``."""
+
+    snapshot_kind: str = "portfolio"
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        market_types = _MARKET_TO_TYPES.get(request.market)
+        now = utcnow()
+        if not market_types:
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="auto_trader_db",
+                    reason=f"no portfolio mapping for market={request.market!r}",
+                    as_of=now,
+                )
+            ]
+
+        stmt = select(ManualHolding).where(
+            ManualHolding.market_type.in_(market_types)
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+
+        holdings: list[dict[str, Any]] = [
+            {
+                "ticker": row.ticker,
+                "market_type": row.market_type.value
+                if isinstance(row.market_type, MarketType)
+                else str(row.market_type),
+                "quantity": row.quantity,
+                "avg_price": row.avg_price,
+                "display_name": row.display_name,
+                "updated_at": row.updated_at,
+            }
+            for row in rows
+        ]
+
+        payload = {
+            "holdings": holdings,
+            "count": len(holdings),
+            "market": request.market,
+        }
+
+        if not holdings:
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"holdings_found": False},
+                )
+            ]
+
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={
+                    "holdings_count": len(holdings),
+                },
+            )
+        ]

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -1,0 +1,65 @@
+"""Production collector registry for the snapshot-backed report generator.
+
+This module assembles a :class:`SnapshotCollectorRegistry` populated with
+the read-only collectors in this package. It is *separate* from
+:func:`app.services.investment_snapshots.collectors.default_collector_registry`,
+which intentionally remains empty (Phase 2 invariant) so existing callers
+that rely on the bundle service for unrelated purposes are unaffected.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.action_report.snapshot_backed.collectors.journal import (
+    JournalSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.market import (
+    MarketEventsSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.news import (
+    NewsSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.optional_stubs import (
+    BrowserProbeStubCollector,
+    CandidateUniverseStubCollector,
+    InvestPageStubCollector,
+    NaverRemoteDebugStubCollector,
+    SymbolStubCollector,
+    TossRemoteDebugStubCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.portfolio import (
+    PortfolioSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.watch_context import (
+    WatchContextSnapshotCollector,
+)
+from app.services.investment_snapshots.collectors import SnapshotCollectorRegistry
+
+
+def production_collector_registry(session: AsyncSession) -> SnapshotCollectorRegistry:
+    """Return a populated registry for the snapshot-backed generator.
+
+    Required-kind collectors are wired to read-only DB-backed services.
+    Optional-kind collectors are either thin DB readers (news) or
+    fail-open stubs. Adding a new collector here is the single place
+    needed to expose it to the generator.
+    """
+    registry = SnapshotCollectorRegistry()
+
+    # Required kinds — DB-backed, read-only.
+    registry.register(PortfolioSnapshotCollector(session))
+    registry.register(JournalSnapshotCollector(session))
+    registry.register(WatchContextSnapshotCollector(session))
+    registry.register(MarketEventsSnapshotCollector(session))
+
+    # Optional kinds — DB-backed where possible, stubs otherwise.
+    registry.register(NewsSnapshotCollector(session))
+    registry.register(SymbolStubCollector())
+    registry.register(CandidateUniverseStubCollector())
+    registry.register(InvestPageStubCollector())
+    registry.register(NaverRemoteDebugStubCollector())
+    registry.register(TossRemoteDebugStubCollector())
+    registry.register(BrowserProbeStubCollector())
+
+    return registry

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+    CandidateUniverseSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.invest_page import (
+    InvestPageSnapshotCollector,
+)
 from app.services.action_report.snapshot_backed.collectors.journal import (
     JournalSnapshotCollector,
 )
@@ -22,14 +28,14 @@ from app.services.action_report.snapshot_backed.collectors.news import (
 )
 from app.services.action_report.snapshot_backed.collectors.optional_stubs import (
     BrowserProbeStubCollector,
-    CandidateUniverseStubCollector,
-    InvestPageStubCollector,
     NaverRemoteDebugStubCollector,
-    SymbolStubCollector,
     TossRemoteDebugStubCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.portfolio import (
     PortfolioSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.symbol import (
+    SymbolSnapshotCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.watch_context import (
     WatchContextSnapshotCollector,
@@ -53,11 +59,13 @@ def production_collector_registry(session: AsyncSession) -> SnapshotCollectorReg
     registry.register(WatchContextSnapshotCollector(session))
     registry.register(MarketEventsSnapshotCollector(session))
 
-    # Optional kinds — DB-backed where possible, stubs otherwise.
+    # Optional kinds — DB-backed where possible.
     registry.register(NewsSnapshotCollector(session))
-    registry.register(SymbolStubCollector())
-    registry.register(CandidateUniverseStubCollector())
-    registry.register(InvestPageStubCollector())
+    registry.register(SymbolSnapshotCollector(session))
+    registry.register(CandidateUniverseSnapshotCollector(session))
+    registry.register(InvestPageSnapshotCollector(session))
+    # Remote-debug probes remain fail-open stubs — they are operator-driven
+    # only, and automated wiring is intentionally out of scope.
     registry.register(NaverRemoteDebugStubCollector())
     registry.register(TossRemoteDebugStubCollector())
     registry.register(BrowserProbeStubCollector())

--- a/app/services/action_report/snapshot_backed/collectors/symbol.py
+++ b/app/services/action_report/snapshot_backed/collectors/symbol.py
@@ -1,0 +1,123 @@
+"""Symbol snapshot collector (read-only, optional).
+
+Reads ``stock_info`` master rows for the symbols the caller asked about.
+If ``request.symbols`` is empty/None we have no scope to read against, so
+the collector returns ``unavailable`` and the optional bucket records it
+in ``unavailable_sources`` — consistent with the policy that optional
+kinds degrade the bundle to ``partial`` but never block.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.analysis import StockInfo
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    unavailable_result,
+    utcnow,
+)
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+
+class SymbolSnapshotCollector:
+    """Optional ``symbol`` collector backed by ``stock_info``."""
+
+    snapshot_kind: str = "symbol"
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        symbols = list(request.symbols or [])
+        if not symbols:
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="auto_trader_db",
+                    reason="no symbols supplied; symbol snapshot has no scope",
+                    as_of=now,
+                )
+            ]
+
+        try:
+            stmt = select(StockInfo).where(StockInfo.symbol.in_(symbols))
+            rows = (await self._session.execute(stmt)).scalars().all()
+        except Exception as exc:  # noqa: BLE001 — optional, fail open
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="auto_trader_db",
+                    reason=f"stock_info query failed: {type(exc).__name__}: {exc}",
+                    as_of=now,
+                )
+            ]
+
+        results: list[SnapshotCollectResult] = []
+        seen_symbols: set[str] = set()
+        for row in rows:
+            seen_symbols.add(row.symbol)
+            payload: dict[str, Any] = {
+                "symbol": row.symbol,
+                "name": row.name,
+                "instrument_type": row.instrument_type,
+                "exchange": row.exchange,
+                "sector": row.sector,
+                "market_cap": row.market_cap,
+                "is_active": row.is_active,
+            }
+            results.append(
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    symbol=row.symbol,
+                    coverage={"resolved": True},
+                )
+            )
+
+        missing = [s for s in symbols if s not in seen_symbols]
+        if missing:
+            results.append(
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={"missing_symbols": missing},
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"resolved": False, "missing_count": len(missing)},
+                )
+            )
+
+        if not results:
+            # Every symbol missed — return a single partial summary so the
+            # caller still records the attempt without forcing 'unavailable'.
+            results.append(
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={"missing_symbols": symbols},
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="partial",
+                    coverage={"resolved": False, "missing_count": len(symbols)},
+                )
+            )
+        return results

--- a/app/services/action_report/snapshot_backed/collectors/watch_context.py
+++ b/app/services/action_report/snapshot_backed/collectors/watch_context.py
@@ -1,0 +1,83 @@
+"""Watch-context snapshot collector (read-only).
+
+Reads currently-active ``investment_watch_alerts`` for the requested
+market. The collector never activates, expires, or transitions watches —
+the only allowed write path is :class:`WatchActivationService` which is
+deliberately not imported here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.action_report.snapshot_backed.collectors._base import (
+    build_result,
+    utcnow,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+
+
+class WatchContextSnapshotCollector:
+    """Required-kind ``watch_context`` collector backed by ``investment_watch_alerts``."""
+
+    snapshot_kind: str = "watch_context"
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def collect(
+        self, request: CollectorRequest
+    ) -> list[SnapshotCollectResult]:
+        now = utcnow()
+        alerts = await self._repo.list_active_alerts(
+            market=request.market, valid_at=now
+        )
+
+        payload: dict[str, Any] = {
+            "active_alerts": [_alert_to_dict(a) for a in alerts],
+            "active_count": len(alerts),
+            "market": request.market,
+        }
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={"active_count": len(alerts)},
+            )
+        ]
+
+
+def _alert_to_dict(a: Any) -> dict[str, Any]:
+    return {
+        "alert_uuid": a.alert_uuid,
+        "source_report_uuid": a.source_report_uuid,
+        "source_item_uuid": a.source_item_uuid,
+        "market": a.market,
+        "symbol": a.symbol,
+        "metric": a.metric,
+        "operator": a.operator,
+        "threshold": a.threshold,
+        "threshold_key": a.threshold_key,
+        "intent": a.intent,
+        "action_mode": a.action_mode,
+        "rationale": a.rationale,
+        "valid_until": a.valid_until,
+        "status": a.status,
+        "activated_at": a.activated_at,
+    }

--- a/app/services/action_report/snapshot_backed/collectors/watch_context.py
+++ b/app/services/action_report/snapshot_backed/collectors/watch_context.py
@@ -37,9 +37,7 @@ class WatchContextSnapshotCollector:
         self._session = session
         self._repo = repository or InvestmentReportsRepository(session)
 
-    async def collect(
-        self, request: CollectorRequest
-    ) -> list[SnapshotCollectResult]:
+    async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
         alerts = await self._repo.list_active_alerts(
             market=request.market, valid_at=now

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -117,8 +117,8 @@ class SnapshotBackedReportGenerator:
         self._ensure_service = ensure_service or SnapshotBundleEnsureService(
             session, collectors=registry
         )
-        self._ingestion_service = (
-            ingestion_service or InvestmentReportIngestionService(session)
+        self._ingestion_service = ingestion_service or InvestmentReportIngestionService(
+            session
         )
 
     async def generate(

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -1,0 +1,337 @@
+"""ROB-273 — Snapshot-backed advisory report generator.
+
+Single-responsibility service that:
+
+1. ensures (or reuses) a snapshot bundle for the request's
+   ``market`` / ``account_scope`` via
+   :class:`SnapshotBundleEnsureService`;
+2. derives the persisted snapshot metadata
+   (``overall`` freshness, coverage, unavailable_sources, conflicts);
+3. pre-flights the publishing stale gate so a clearly-blocked report
+   never reaches the DB (the ingestion service's own gate is still the
+   authoritative layer — this one is a fast-fail);
+4. normalises the user-provided items through :func:`to_jsonable` so any
+   ``Decimal`` / ``datetime`` / ``UUID`` values are safe for JSONB; and
+5. delegates the actual persistence to
+   :class:`InvestmentReportIngestionService`.
+
+The generator never mutates broker state, never activates watch alerts,
+never registers a scheduler job, and never reaches outside the
+configured collector registry. Optional collector failures degrade the
+bundle to ``partial`` and are surfaced via ``unavailable_sources`` /
+``warnings`` but never block.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.investment_reports import IngestReportRequest
+from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+from app.services.action_report.common.bundle_aware_publishing import (
+    BundleAwarePublishingResult,
+    StaleGateRejection,
+    evaluate_stale_gate_for_ingest,
+)
+from app.services.action_report.common.critical_kinds import (
+    CRITICAL_KIND_DEGRADING_STATUSES,
+    CRITICAL_SNAPSHOT_KINDS,
+)
+from app.services.action_report.common.jsonable import to_jsonable
+from app.services.action_report.common.snapshot_bundle import (
+    SnapshotBundleEnsureService,
+)
+from app.services.action_report.snapshot_backed.collectors.registry import (
+    production_collector_registry,
+)
+from app.services.action_report.snapshot_backed.request import (
+    ReportGenerationRequest,
+    ReportGenerationResponse,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_snapshots.collectors import SnapshotCollectorRegistry
+
+_MARKET_ACCOUNT_PAIRS: dict[str, str] = {
+    "kr": "kis_live",
+    "crypto": "upbit_live",
+}
+
+_BUNDLE_STATUS_TO_OVERALL: dict[str, str] = {
+    "complete": "fresh",
+    "partial": "partial",
+    "stale_fallback": "hard_stale",
+    "failed": "failed",
+    # 'reused' falls through to the stored summary's own 'overall'.
+}
+
+# Bundle.status values that mean a published report cannot be written.
+_BLOCKING_BUNDLE_STATUSES_FOR_PUBLISHED: frozenset[str] = frozenset(
+    {"stale_fallback", "failed"}
+)
+
+
+class SnapshotBackedReportGeneratorError(RuntimeError):
+    """Raised when the request itself cannot proceed (mismatched scope, etc.)."""
+
+
+class PublishBlockedByStaleGateError(RuntimeError):
+    """Raised when a ``status='published'`` request would be blocked.
+
+    Carries both the bundle outcome and the gate result so the caller
+    can surface either to the user.
+    """
+
+    def __init__(
+        self,
+        *,
+        reason: str,
+        bundle_status: str,
+        freshness_summary: Mapping[str, Any],
+        stale_gate: BundleAwarePublishingResult | None,
+    ) -> None:
+        super().__init__(reason)
+        self.bundle_status = bundle_status
+        self.freshness_summary = dict(freshness_summary)
+        self.stale_gate = stale_gate
+
+
+class SnapshotBackedReportGenerator:
+    """Generate a snapshot-backed advisory report end to end."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        ensure_service: SnapshotBundleEnsureService | None = None,
+        ingestion_service: InvestmentReportIngestionService | None = None,
+        collector_registry: SnapshotCollectorRegistry | None = None,
+    ) -> None:
+        self._session = session
+        registry = collector_registry or production_collector_registry(session)
+        self._ensure_service = ensure_service or SnapshotBundleEnsureService(
+            session, collectors=registry
+        )
+        self._ingestion_service = (
+            ingestion_service or InvestmentReportIngestionService(session)
+        )
+
+    async def generate(
+        self, request: ReportGenerationRequest
+    ) -> ReportGenerationResponse:
+        self._validate_pair(request)
+
+        ensure_response = await self._ensure_service.ensure(
+            EnsureBundleRequest(
+                purpose="report_generation",
+                market=request.market,
+                account_scope=request.account_scope,
+                policy_version=request.policy_version,
+                mode="ensure_fresh",
+                symbols=request.symbols,
+                candidate_limit=request.candidate_limit,
+                requested_by=request.requested_by,
+            )
+        )
+
+        if ensure_response.bundle_uuid is None:
+            # ensure_fresh should always materialise a bundle (even a failed
+            # one); a None here means upstream broke its own contract.
+            raise SnapshotBackedReportGeneratorError(
+                "bundle ensure returned no bundle_uuid; "
+                f"status={ensure_response.status!r}"
+            )
+
+        coverage_summary = to_jsonable(ensure_response.coverage_summary)
+        freshness_summary = self._enrich_freshness_summary(ensure_response)
+        unavailable_sources = self._build_unavailable_sources(
+            ensure_response.missing_sources, freshness_summary
+        )
+        source_conflicts: dict[str, Any] = {}
+
+        if request.status == "published":
+            self._guard_published(
+                bundle_status=ensure_response.status,
+                freshness_summary=freshness_summary,
+            )
+
+        ingest_request = self._build_ingest_request(
+            request=request,
+            bundle_uuid=ensure_response.bundle_uuid,
+            coverage_summary=coverage_summary,
+            freshness_summary=freshness_summary,
+            unavailable_sources=unavailable_sources,
+            source_conflicts=source_conflicts,
+        )
+
+        # Authoritative gate runs inside ingest(); this pre-flight is a
+        # belt-and-braces check so a clearly-blocked published request
+        # short-circuits with a friendlier exception type.
+        gate_result = evaluate_stale_gate_for_ingest(ingest_request)
+        if request.status == "published" and gate_result.reject:
+            raise PublishBlockedByStaleGateError(
+                reason=str(StaleGateRejection(gate_result)),
+                bundle_status=ensure_response.status,
+                freshness_summary=freshness_summary,
+                stale_gate=gate_result,
+            )
+
+        report = await self._ingestion_service.ingest(ingest_request)
+
+        return ReportGenerationResponse(
+            report_uuid=report.report_uuid,
+            snapshot_bundle_uuid=ensure_response.bundle_uuid,
+            snapshot_policy_version=request.policy_version,
+            snapshot_coverage_summary=coverage_summary,
+            snapshot_freshness_summary=freshness_summary,
+            source_conflicts=source_conflicts,
+            unavailable_sources=unavailable_sources,
+            items_count=len(request.items),
+            warnings=list(ensure_response.warnings),
+            bundle_status=ensure_response.status,
+            bundle_reused=not ensure_response.created,
+            stale_gate=gate_result.to_metadata_summary(),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _validate_pair(self, request: ReportGenerationRequest) -> None:
+        expected = _MARKET_ACCOUNT_PAIRS.get(request.market)
+        if expected is None or request.account_scope != expected:
+            raise SnapshotBackedReportGeneratorError(
+                f"unsupported market/account_scope pair: "
+                f"{request.market!r}/{request.account_scope!r}"
+            )
+
+    def _enrich_freshness_summary(self, ensure_response: Any) -> dict[str, Any]:
+        summary = to_jsonable(ensure_response.freshness_summary) or {}
+        if not isinstance(summary, dict):  # defensive
+            summary = {"raw": summary}
+        overall = summary.get("overall")
+        if not isinstance(overall, str):
+            overall = _BUNDLE_STATUS_TO_OVERALL.get(
+                ensure_response.status, "unavailable"
+            )
+            summary["overall"] = overall
+        return summary
+
+    def _build_unavailable_sources(
+        self,
+        missing_sources: list[str],
+        freshness_summary: dict[str, Any],
+    ) -> dict[str, Any]:
+        sources: dict[str, Any] = {}
+        for kind in missing_sources:
+            sources[kind] = {"status": "unavailable"}
+        for kind, info in freshness_summary.items():
+            if kind == "overall" or not isinstance(info, Mapping):
+                continue
+            if info.get("status") in ("unavailable", "hard_stale", "failed"):
+                sources.setdefault(kind, dict(info))
+        return sources
+
+    def _guard_published(
+        self,
+        *,
+        bundle_status: str,
+        freshness_summary: dict[str, Any],
+    ) -> None:
+        if bundle_status in _BLOCKING_BUNDLE_STATUSES_FOR_PUBLISHED:
+            raise PublishBlockedByStaleGateError(
+                reason=(
+                    f"published report blocked: bundle_status={bundle_status!r} "
+                    "is incompatible with published advisory reports"
+                ),
+                bundle_status=bundle_status,
+                freshness_summary=freshness_summary,
+                stale_gate=None,
+            )
+        for kind in CRITICAL_SNAPSHOT_KINDS:
+            info = freshness_summary.get(kind)
+            if not isinstance(info, Mapping):
+                continue
+            status = info.get("status")
+            if status in CRITICAL_KIND_DEGRADING_STATUSES:
+                raise PublishBlockedByStaleGateError(
+                    reason=(
+                        f"published report blocked: critical kind {kind!r} "
+                        f"has status={status!r}"
+                    ),
+                    bundle_status=bundle_status,
+                    freshness_summary=freshness_summary,
+                    stale_gate=None,
+                )
+
+    def _build_ingest_request(
+        self,
+        *,
+        request: ReportGenerationRequest,
+        bundle_uuid: UUID,
+        coverage_summary: dict[str, Any],
+        freshness_summary: dict[str, Any],
+        unavailable_sources: dict[str, Any],
+        source_conflicts: dict[str, Any],
+    ) -> IngestReportRequest:
+        # Normalise items — each evidence_snapshot / trigger_checklist /
+        # max_action / metadata is a free-form dict the caller filled in,
+        # so they all go through to_jsonable() to be JSONB-safe.
+        normalized_items = []
+        for item in request.items:
+            item_dict = item.model_dump(mode="python")
+            for key in (
+                "evidence_snapshot",
+                "trigger_checklist",
+                "max_action",
+                "metadata",
+            ):
+                if key in item_dict:
+                    item_dict[key] = to_jsonable(item_dict[key])
+            normalized_items.append(item_dict)
+
+        metadata = to_jsonable(dict(request.metadata) or {})
+        if not isinstance(metadata, dict):  # safety net
+            metadata = {}
+        metadata.setdefault("snapshot_backed_generator", True)
+        metadata.setdefault(
+            "generator_signature",
+            {
+                "report_type": request.report_type,
+                "policy_version": request.policy_version,
+                "generator_version": request.generator_version,
+            },
+        )
+
+        return IngestReportRequest(
+            report_type=request.report_type,
+            market=request.market,
+            account_scope=request.account_scope,
+            execution_mode=request.execution_mode,
+            created_by_profile=request.created_by_profile,
+            title=request.title,
+            summary=request.summary,
+            risk_summary=request.risk_summary,
+            thesis_text=request.thesis_text,
+            no_action_note=request.no_action_note,
+            market_snapshot={},
+            portfolio_snapshot={},
+            previous_report_uuid=request.previous_report_uuid,
+            status=request.status,
+            metadata=metadata,
+            valid_until=request.valid_until,
+            published_at=request.published_at,
+            items=normalized_items,
+            generator_version=request.generator_version,
+            kst_date=request.kst_date,
+            snapshot_bundle_uuid=bundle_uuid,
+            snapshot_policy_version=request.policy_version,
+            snapshot_coverage_summary=coverage_summary,
+            snapshot_freshness_summary=freshness_summary,
+            source_conflicts=source_conflicts,
+            unavailable_sources=unavailable_sources,
+        )

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -1,0 +1,73 @@
+"""Request / response schemas for the snapshot-backed report generator."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.investment_reports import IngestReportItem
+from app.schemas.investment_snapshots import SnapshotRequestedBy
+
+GeneratorMarketLiteral = Literal["kr", "crypto"]
+GeneratorAccountScopeLiteral = Literal["kis_live", "upbit_live"]
+GeneratorStatusLiteral = Literal["draft", "published"]
+
+
+class ReportGenerationRequest(BaseModel):
+    """Request envelope for :class:`SnapshotBackedReportGenerator.generate`.
+
+    Only ``kr / kis_live`` and ``crypto / upbit_live`` are supported in this
+    PR. The generator validates the pairing at runtime; expanding to US is
+    intentionally a follow-up.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    market: GeneratorMarketLiteral
+    account_scope: GeneratorAccountScopeLiteral
+    policy_version: str = "intraday_action_report_v1"
+    execution_mode: Literal["advisory_only"] = "advisory_only"
+    status: GeneratorStatusLiteral = "published"
+    requested_by: SnapshotRequestedBy = "claude_code"
+
+    report_type: str = "snapshot_backed_advisory_v1"
+    generator_version: str = "v2-snapshot-backed"
+    created_by_profile: str
+    title: str
+    summary: str
+    kst_date: str
+    risk_summary: str | None = None
+    thesis_text: str | None = None
+    no_action_note: str | None = None
+
+    items: list[IngestReportItem] = Field(default_factory=list)
+    previous_report_uuid: UUID | None = None
+    valid_until: dt.datetime | None = None
+    published_at: dt.datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    # Snapshot-bundle inputs forwarded to SnapshotBundleEnsureService.
+    symbols: list[str] | None = None
+    candidate_limit: int | None = None
+
+
+class ReportGenerationResponse(BaseModel):
+    """Result envelope for the generator. JSON-safe."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    report_uuid: UUID
+    snapshot_bundle_uuid: UUID
+    snapshot_policy_version: str
+    snapshot_coverage_summary: dict[str, Any]
+    snapshot_freshness_summary: dict[str, Any]
+    source_conflicts: dict[str, Any]
+    unavailable_sources: dict[str, Any]
+    items_count: int
+    warnings: list[str]
+    bundle_status: str
+    bundle_reused: bool
+    stale_gate: dict[str, Any]

--- a/tests/routers/test_investment_reports_snapshot_backed.py
+++ b/tests/routers/test_investment_reports_snapshot_backed.py
@@ -1,0 +1,200 @@
+"""ROB-273 — HTTP entrypoint for snapshot-backed report generation."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.routers.investment_reports import router as reports_router
+from app.services.action_report.snapshot_backed.generator import (
+    PublishBlockedByStaleGateError,
+    SnapshotBackedReportGeneratorError,
+)
+from app.services.action_report.snapshot_backed.request import (
+    ReportGenerationResponse,
+)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(reports_router)
+
+    async def _db_override() -> AsyncIterator[object]:
+        fake_db = MagicMock()
+        fake_db.commit = AsyncMock()
+        fake_db.rollback = AsyncMock()
+        yield fake_db
+
+    async def _user_override() -> User:
+        return User(id=1, email="test@example.com", role="user")  # type: ignore[call-arg]
+
+    from app.core.db import get_db
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_authenticated_user] = _user_override
+    return app
+
+
+_REQUEST_PAYLOAD: dict = {
+    "market": "kr",
+    "account_scope": "kis_live",
+    "status": "published",
+    "created_by_profile": "test-runner",
+    "title": "Snapshot-backed KR advisory",
+    "summary": "테스트 요약",
+    "kst_date": "2026-05-19",
+    "items": [],
+}
+
+
+@pytest.mark.asyncio
+async def test_flag_off_returns_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
+    )
+    app = _build_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/trading/api/investment-reports/snapshot-backed",
+            json=_REQUEST_PAYLOAD,
+        )
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "snapshot_backed_report_generator_disabled"
+
+
+@pytest.mark.asyncio
+async def test_flag_on_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+
+    fake_response = ReportGenerationResponse(
+        report_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=uuid.uuid4(),
+        snapshot_policy_version="intraday_action_report_v1",
+        snapshot_coverage_summary={"required": {"portfolio": "fresh"}},
+        snapshot_freshness_summary={"overall": "fresh"},
+        source_conflicts={},
+        unavailable_sources={},
+        items_count=0,
+        warnings=[],
+        bundle_status="complete",
+        bundle_reused=False,
+        stale_gate={"reject": False},
+    )
+
+    class _FakeGen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def generate(self, request):
+            return fake_response
+
+    app = _build_app()
+    with patch(
+        "app.routers.investment_reports.SnapshotBackedReportGenerator",
+        _FakeGen,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/trading/api/investment-reports/snapshot-backed",
+                json=_REQUEST_PAYLOAD,
+            )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["bundle_status"] == "complete"
+    assert body["items_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_flag_on_publish_blocked_returns_409(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+
+    class _FakeGen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def generate(self, request):
+            raise PublishBlockedByStaleGateError(
+                reason="blocked",
+                bundle_status="failed",
+                freshness_summary={"overall": "failed"},
+                stale_gate=None,
+            )
+
+    app = _build_app()
+    with patch(
+        "app.routers.investment_reports.SnapshotBackedReportGenerator",
+        _FakeGen,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/trading/api/investment-reports/snapshot-backed",
+                json=_REQUEST_PAYLOAD,
+            )
+    assert resp.status_code == 409
+    body = resp.json()["detail"]
+    assert body["error"] == "publish_blocked_by_stale_gate"
+    assert body["bundle_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_flag_on_bad_request_returns_400(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+
+    class _FakeGen:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def generate(self, request):
+            raise SnapshotBackedReportGeneratorError(
+                "unsupported market/account_scope pair"
+            )
+
+    app = _build_app()
+    with patch(
+        "app.routers.investment_reports.SnapshotBackedReportGenerator",
+        _FakeGen,
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/trading/api/investment-reports/snapshot-backed",
+                json=_REQUEST_PAYLOAD,
+            )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_list_unchanged_for_legacy_reports() -> None:
+    """The existing GET surface must not be touched by ROB-273 changes."""
+    from app.services.investment_reports.query_service import (
+        InvestmentReportQueryService,
+    )
+
+    # The list endpoint depends on the query service. We sanity-check that
+    # importing the router (with the new POST attached) doesn't break the
+    # legacy paths' signature; deeper coverage stays in the existing
+    # router tests.
+    assert hasattr(InvestmentReportQueryService, "list_reports")

--- a/tests/routers/test_investment_reports_snapshot_backed.py
+++ b/tests/routers/test_investment_reports_snapshot_backed.py
@@ -61,7 +61,9 @@ async def test_flag_off_returns_503(monkeypatch: pytest.MonkeyPatch) -> None:
         settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
     )
     app = _build_app()
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
         resp = await client.post(
             "/trading/api/investment-reports/snapshot-backed",
             json=_REQUEST_PAYLOAD,

--- a/tests/services/action_report/common/test_jsonable.py
+++ b/tests/services/action_report/common/test_jsonable.py
@@ -55,8 +55,14 @@ def test_nested_recursive_normalisation():
         "threshold": Decimal("100.5"),
         "as_of": dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
         "items": [
-            {"id": uuid.UUID("4b8a5e4e-1234-5678-9abc-def012345678"), "price": Decimal("1.1")},
-            {"id": uuid.UUID("aaaaaaaa-1234-5678-9abc-def012345678"), "price": Decimal("2.2")},
+            {
+                "id": uuid.UUID("4b8a5e4e-1234-5678-9abc-def012345678"),
+                "price": Decimal("1.1"),
+            },
+            {
+                "id": uuid.UUID("aaaaaaaa-1234-5678-9abc-def012345678"),
+                "price": Decimal("2.2"),
+            },
         ],
         "set_field": {Decimal("1"), Decimal("2")},
     }

--- a/tests/services/action_report/common/test_jsonable.py
+++ b/tests/services/action_report/common/test_jsonable.py
@@ -1,0 +1,107 @@
+"""ROB-273 — recursive JSON normalisation helper."""
+
+from __future__ import annotations
+
+import datetime as dt
+import enum
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from app.services.action_report.common.jsonable import to_jsonable
+
+
+class _Side(enum.StrEnum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+def test_passes_through_primitives():
+    assert to_jsonable(None) is None
+    assert to_jsonable(True) is True
+    assert to_jsonable(1) == 1
+    assert to_jsonable(1.5) == 1.5
+    assert to_jsonable("hello") == "hello"
+
+
+def test_decimal_becomes_string():
+    assert to_jsonable(Decimal("1.23")) == "1.23"
+    # precision-sensitive — bare float would truncate the trailing zero
+    assert to_jsonable(Decimal("0.10")) == "0.10"
+
+
+def test_datetime_becomes_iso8601():
+    moment = dt.datetime(2026, 5, 19, 12, 0, tzinfo=dt.UTC)
+    assert to_jsonable(moment) == "2026-05-19T12:00:00+00:00"
+
+
+def test_date_and_time_become_iso():
+    assert to_jsonable(dt.date(2026, 5, 19)) == "2026-05-19"
+    assert to_jsonable(dt.time(12, 30)) == "12:30:00"
+
+
+def test_uuid_becomes_string():
+    u = uuid.UUID("4b8a5e4e-1234-5678-9abc-def012345678")
+    assert to_jsonable(u) == str(u)
+
+
+def test_enum_becomes_value():
+    assert to_jsonable(_Side.BUY) == "buy"
+
+
+def test_nested_recursive_normalisation():
+    payload = {
+        "threshold": Decimal("100.5"),
+        "as_of": dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        "items": [
+            {"id": uuid.UUID("4b8a5e4e-1234-5678-9abc-def012345678"), "price": Decimal("1.1")},
+            {"id": uuid.UUID("aaaaaaaa-1234-5678-9abc-def012345678"), "price": Decimal("2.2")},
+        ],
+        "set_field": {Decimal("1"), Decimal("2")},
+    }
+    out = to_jsonable(payload)
+    assert out["threshold"] == "100.5"
+    assert out["as_of"] == "2026-05-19T00:00:00+00:00"
+    assert out["items"][0]["price"] == "1.1"
+    assert out["items"][0]["id"] == "4b8a5e4e-1234-5678-9abc-def012345678"
+    # set order is unstable — compare as a set after re-normalisation
+    assert set(out["set_field"]) == {"1", "2"}
+
+
+def test_dict_keys_coerced_to_string():
+    out = to_jsonable({1: "a", "b": 2})
+    assert out == {"1": "a", "b": 2}
+
+
+def test_tuple_becomes_list():
+    assert to_jsonable((1, 2, Decimal("3"))) == [1, 2, "3"]
+
+
+def test_pydantic_models_round_trip():
+    from app.schemas.investment_reports import WatchConditionPayload
+
+    cond = WatchConditionPayload(
+        metric="price",
+        operator="above",
+        threshold=Decimal("12345.67"),
+    )
+    out = to_jsonable(cond)
+    assert out["metric"] == "price"
+    assert out["operator"] == "above"
+    # threshold serialises via Pydantic JSON mode → str.
+    assert isinstance(out["threshold"], str)
+    assert out["threshold"] == "12345.67"
+
+
+def test_bytes_rejected_explicitly():
+    with pytest.raises(TypeError):
+        to_jsonable(b"deadbeef")
+
+
+def test_unknown_type_rejected():
+    class _Opaque:
+        pass
+
+    with pytest.raises(TypeError):
+        to_jsonable(_Opaque())

--- a/tests/services/action_report/common/test_source_kind_mapping.py
+++ b/tests/services/action_report/common/test_source_kind_mapping.py
@@ -1,0 +1,60 @@
+"""ROB-273 — external-origin → SourceKind literal mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.action_report.common.source_kind_mapping import (
+    ALLOWED_SOURCE_KINDS,
+    UnsupportedSourceKindError,
+    map_source_kind,
+)
+
+
+def test_canonical_literals_pass_through():
+    for literal in ALLOWED_SOURCE_KINDS:
+        assert map_source_kind(literal) == literal
+
+
+@pytest.mark.parametrize(
+    "origin,expected",
+    [
+        ("upbit_mcp", "auto_trader_mcp"),
+        ("upbit_public", "auto_trader_mcp"),
+        ("db", "auto_trader_mcp"),
+        ("mcp_screen", "auto_trader_mcp"),
+        ("auto_trader_db", "auto_trader_mcp"),
+        ("domain_db", "domain_ref"),
+        ("kis_api", "kis_mcp"),
+        ("finnhub_crypto", "auto_trader_mcp"),
+        ("finnhub", "auto_trader_mcp"),
+        ("dart", "auto_trader_mcp"),
+        ("news", "news_ingestor"),
+        ("research_reports", "news_ingestor"),
+        ("invest_http", "invest_api"),
+        ("not_applicable", "manual"),
+        ("operator_paste", "manual"),
+    ],
+)
+def test_known_aliases_map_to_canonical(origin: str, expected: str) -> None:
+    assert map_source_kind(origin) == expected
+    assert expected in ALLOWED_SOURCE_KINDS
+
+
+def test_unknown_origin_raises():
+    with pytest.raises(UnsupportedSourceKindError):
+        map_source_kind("totally_made_up_kind")
+
+
+@pytest.mark.parametrize("bad", ["", None, 0, []])
+def test_non_string_or_empty_rejected(bad: object) -> None:
+    with pytest.raises(UnsupportedSourceKindError):
+        map_source_kind(bad)  # type: ignore[arg-type]
+
+
+def test_upbit_remote_debug_alias_not_invented():
+    # The Linear ticket mentioned ``upbit_remote_debug`` but this PR
+    # intentionally does NOT extend the SourceKind literal — the helper
+    # must therefore reject the alias rather than smuggle in a new value.
+    with pytest.raises(UnsupportedSourceKindError):
+        map_source_kind("upbit_remote_debug")

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -12,6 +12,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+    CandidateUniverseSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.invest_page import (
+    InvestPageSnapshotCollector,
+)
 from app.services.action_report.snapshot_backed.collectors.journal import (
     JournalSnapshotCollector,
 )
@@ -23,10 +29,7 @@ from app.services.action_report.snapshot_backed.collectors.news import (
 )
 from app.services.action_report.snapshot_backed.collectors.optional_stubs import (
     BrowserProbeStubCollector,
-    CandidateUniverseStubCollector,
-    InvestPageStubCollector,
     NaverRemoteDebugStubCollector,
-    SymbolStubCollector,
     TossRemoteDebugStubCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.portfolio import (
@@ -34,6 +37,9 @@ from app.services.action_report.snapshot_backed.collectors.portfolio import (
 )
 from app.services.action_report.snapshot_backed.collectors.registry import (
     production_collector_registry,
+)
+from app.services.action_report.snapshot_backed.collectors.symbol import (
+    SymbolSnapshotCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.watch_context import (
     WatchContextSnapshotCollector,
@@ -268,20 +274,202 @@ async def test_news_collector_failure_is_fail_open():
 @pytest.mark.parametrize(
     "collector_cls",
     [
-        SymbolStubCollector,
-        CandidateUniverseStubCollector,
-        InvestPageStubCollector,
         NaverRemoteDebugStubCollector,
         TossRemoteDebugStubCollector,
         BrowserProbeStubCollector,
     ],
 )
-async def test_stubs_return_unavailable(collector_cls: type) -> None:
+async def test_remote_debug_stubs_return_unavailable(collector_cls: type) -> None:
     collector = collector_cls()
     results = await collector.collect(_request())
     assert len(results) == 1
     assert results[0].freshness_status == "unavailable"
     assert results[0].snapshot_kind == collector.snapshot_kind
+
+
+# ---------------------------------------------------------------------------
+# Symbol collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_symbol_collector_returns_unavailable_when_no_symbols():
+    session = MagicMock()
+    collector = SymbolSnapshotCollector(session)
+    results = await collector.collect(_request())  # symbols=None
+    assert results[0].snapshot_kind == "symbol"
+    assert results[0].freshness_status == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_returns_results_for_each_symbol():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    class _Row:
+        def __init__(self, symbol: str, name: str) -> None:
+            self.symbol = symbol
+            self.name = name
+            self.instrument_type = "equity_kr"
+            self.exchange = "KRX"
+            self.sector = "Tech"
+            self.market_cap = 1_000_000.0
+            self.is_active = True
+
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=[_Row("005930", "삼성전자")]))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930", "000660"],
+        candidate_limit=None,
+        policy_snapshot={},
+    )
+    collector = SymbolSnapshotCollector(session)
+    results = await collector.collect(req)
+    # Two entries: one for resolved 005930, one partial for missing 000660.
+    assert len(results) == 2
+    assert any(r.symbol == "005930" for r in results)
+    assert any(r.freshness_status == "partial" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_query_failure_is_fail_open():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=RuntimeError("transient"))
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+    )
+    collector = SymbolSnapshotCollector(session)
+    results = await collector.collect(req)
+    assert results[0].freshness_status == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Candidate-universe collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_candidate_universe_kr_returns_coverage_counts():
+    from app.services.invest_screener_snapshots.repository import CoverageCounts
+
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(
+        return_value=CoverageCounts(
+            market="kr",
+            today_trading_date=dt.date(2026, 5, 19),
+            fresh_count=12,
+            stale_count=3,
+            last_computed_at=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        )
+    )
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    assert results[0].payload_json["fresh_count"] == 12
+    assert results[0].payload_json["stale_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_kr_returns_partial_when_no_rows():
+    from app.services.invest_screener_snapshots.repository import CoverageCounts
+
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(
+        return_value=CoverageCounts(
+            market="kr",
+            today_trading_date=dt.date(2026, 5, 19),
+            fresh_count=0,
+            stale_count=0,
+            last_computed_at=None,
+        )
+    )
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_crypto_queries_crypto_partition():
+    session = MagicMock()
+    latest_result = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=dt.date(2026, 5, 19))
+    )
+    count_result = MagicMock(scalar_one=MagicMock(return_value=42))
+    session.execute = AsyncMock(side_effect=[latest_result, count_result])
+
+    collector = CandidateUniverseSnapshotCollector(session)
+    results = await collector.collect(
+        _request(market="crypto", account_scope="upbit_live")
+    )
+    assert results[0].payload_json["fresh_count"] == 42
+    assert results[0].payload_json["latest_partition"] == "2026-05-19"
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_failure_is_fail_open():
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(side_effect=RuntimeError("boom"))
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    assert results[0].freshness_status == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Invest-page collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_invest_page_returns_recent_published_reports():
+    session = MagicMock()
+    query = MagicMock()
+
+    class _Report:
+        report_uuid = "55555555-1111-1111-1111-111111111111"
+        report_type = "snapshot_backed_advisory_v1"
+        status = "published"
+        title = "t"
+        published_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+        snapshot_bundle_uuid = "66666666-1111-1111-1111-111111111111"
+        snapshot_freshness_summary = {"overall": "fresh"}
+
+    query.list_reports = AsyncMock(return_value=[_Report()])
+    collector = InvestPageSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].payload_json["count"] == 1
+    assert (
+        results[0].payload_json["recent_published_reports"][0][
+            "snapshot_freshness_overall"
+        ]
+        == "fresh"
+    )
+
+
+@pytest.mark.asyncio
+async def test_invest_page_returns_partial_when_no_recent_reports():
+    session = MagicMock()
+    query = MagicMock()
+    query.list_reports = AsyncMock(return_value=[])
+    collector = InvestPageSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_invest_page_failure_is_fail_open():
+    session = MagicMock()
+    query = MagicMock()
+    query.list_reports = AsyncMock(side_effect=RuntimeError("transient"))
+    collector = InvestPageSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].freshness_status == "unavailable"
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +508,9 @@ def test_collector_modules_do_not_import_broker_or_activation_paths():
         "app.services.action_report.snapshot_backed.collectors.watch_context",
         "app.services.action_report.snapshot_backed.collectors.market",
         "app.services.action_report.snapshot_backed.collectors.news",
+        "app.services.action_report.snapshot_backed.collectors.symbol",
+        "app.services.action_report.snapshot_backed.collectors.candidate_universe",
+        "app.services.action_report.snapshot_backed.collectors.invest_page",
         "app.services.action_report.snapshot_backed.collectors.optional_stubs",
         "app.services.action_report.snapshot_backed.collectors.registry",
         "app.services.action_report.snapshot_backed.generator",

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1,0 +1,336 @@
+"""ROB-273 — snapshot-backed collector tests.
+
+Each test verifies that the collector emits a well-formed
+:class:`SnapshotCollectResult` and never reaches into broker /
+order / watch / scheduler write paths.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.action_report.snapshot_backed.collectors.journal import (
+    JournalSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.market import (
+    MarketEventsSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.news import (
+    NewsSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.optional_stubs import (
+    BrowserProbeStubCollector,
+    CandidateUniverseStubCollector,
+    InvestPageStubCollector,
+    NaverRemoteDebugStubCollector,
+    SymbolStubCollector,
+    TossRemoteDebugStubCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.portfolio import (
+    PortfolioSnapshotCollector,
+)
+from app.services.action_report.snapshot_backed.collectors.registry import (
+    production_collector_registry,
+)
+from app.services.action_report.snapshot_backed.collectors.watch_context import (
+    WatchContextSnapshotCollector,
+)
+from app.services.investment_snapshots.collectors import CollectorRequest
+
+
+def _request(market: str = "kr", account_scope: str = "kis_live") -> CollectorRequest:
+    return CollectorRequest(
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        symbols=None,
+        candidate_limit=None,
+        policy_snapshot={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Portfolio collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_portfolio_collector_returns_holdings(monkeypatch: pytest.MonkeyPatch):
+    from app.models.manual_holdings import MarketType
+
+    session = MagicMock()
+
+    class _Row:
+        ticker = "005930"
+        market_type = MarketType.KR
+        quantity = 10
+        avg_price = 70_000
+        display_name = "삼성전자"
+        updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=[_Row()])
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars)
+    session.execute = AsyncMock(return_value=result)
+
+    collector = PortfolioSnapshotCollector(session)
+    results = await collector.collect(_request())
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "portfolio"
+    assert results[0].source_kind == "auto_trader_mcp"
+    assert results[0].payload_json["count"] == 1
+    assert results[0].payload_json["holdings"][0]["ticker"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_collector_empty_holdings_returns_partial():
+    """No matching holdings → result still emitted, status='partial'."""
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=[]))
+    result = MagicMock(scalars=MagicMock(return_value=scalars))
+    session.execute = AsyncMock(return_value=result)
+
+    collector = PortfolioSnapshotCollector(session)
+    results = await collector.collect(_request(market="us", account_scope="kis_live"))
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "portfolio"
+    assert results[0].freshness_status == "partial"
+    assert results[0].payload_json["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Journal collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_journal_collector_returns_active_and_recent():
+    session = MagicMock()
+
+    class _ActiveJournal:
+        id = 1
+        symbol = "005930"
+        instrument_type = MagicMock(value="kr_stock")
+        side = "buy"
+        status = "active"
+        entry_price = 70_000
+        quantity = 10
+        thesis = "thesis"
+        strategy = "swing"
+        target_price = 80_000
+        stop_loss = 65_000
+        hold_until = None
+        exit_price = None
+        exit_reason = None
+        pnl_pct = None
+        account_type = "live"
+        created_at = dt.datetime(2026, 5, 18, tzinfo=dt.UTC)
+        updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    active_scalars = MagicMock(all=MagicMock(return_value=[_ActiveJournal()]))
+    active_result = MagicMock(scalars=MagicMock(return_value=active_scalars))
+    recent_scalars = MagicMock(all=MagicMock(return_value=[]))
+    recent_result = MagicMock(scalars=MagicMock(return_value=recent_scalars))
+    session.execute = AsyncMock(side_effect=[active_result, recent_result])
+
+    collector = JournalSnapshotCollector(session)
+    results = await collector.collect(_request())
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "journal"
+    assert results[0].payload_json["active_count"] == 1
+    assert results[0].payload_json["retrospective_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Watch-context collector — MUST NOT call activation paths
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_watch_context_collector_uses_only_read_methods():
+    """The collector reads via list_active_alerts and never touches activation."""
+
+    session = MagicMock()
+    repo = MagicMock()
+
+    class _Alert:
+        alert_uuid = "11111111-1111-1111-1111-111111111111"
+        source_report_uuid = "22222222-1111-1111-1111-111111111111"
+        source_item_uuid = "33333333-1111-1111-1111-111111111111"
+        market = "kr"
+        symbol = "005930"
+        metric = "price"
+        operator = "above"
+        threshold = 80_000
+        threshold_key = "80000"
+        intent = "buy_review"
+        action_mode = "notify_only"
+        rationale = "rationale"
+        valid_until = dt.datetime(2026, 5, 20, tzinfo=dt.UTC)
+        status = "active"
+        activated_at = dt.datetime(2026, 5, 18, tzinfo=dt.UTC)
+
+    repo.list_active_alerts = AsyncMock(return_value=[_Alert()])
+    # Force the test to fail if the collector tries to activate/insert/transition.
+    repo.insert_alert = MagicMock(
+        side_effect=AssertionError("collector must not insert_alert")
+    )
+    repo.update_alert_status = MagicMock(
+        side_effect=AssertionError("collector must not update_alert_status")
+    )
+
+    collector = WatchContextSnapshotCollector(session, repository=repo)
+    results = await collector.collect(_request())
+    assert results[0].snapshot_kind == "watch_context"
+    assert results[0].payload_json["active_count"] == 1
+    repo.list_active_alerts.assert_awaited_once()
+    # Mutation methods must not have been called.
+    assert not repo.insert_alert.called
+    assert not repo.update_alert_status.called
+
+
+# ---------------------------------------------------------------------------
+# Market collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_market_collector_returns_events():
+    from app.schemas.market_events import MarketEventsRangeResponse
+
+    session = MagicMock()
+    query = MagicMock()
+    query.list_for_range = AsyncMock(
+        return_value=MarketEventsRangeResponse(
+            from_date=dt.date(2026, 5, 19),
+            to_date=dt.date(2026, 5, 20),
+            count=0,
+            events=[],
+        )
+    )
+    collector = MarketEventsSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].snapshot_kind == "market"
+    assert results[0].payload_json["event_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_market_collector_query_failure_returns_unavailable():
+    session = MagicMock()
+    query = MagicMock()
+    query.list_for_range = AsyncMock(side_effect=RuntimeError("boom"))
+    collector = MarketEventsSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].freshness_status == "unavailable"
+    assert "boom" in results[0].errors_json["reason"]
+
+
+# ---------------------------------------------------------------------------
+# News collector
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_news_collector_returns_citations():
+    from app.schemas.research_reports import (
+        ResearchReportCitation,
+        ResearchReportCitationListResponse,
+    )
+
+    session = MagicMock()
+    query = MagicMock()
+    citation = ResearchReportCitation(
+        report_uuid="44444444-1111-1111-1111-111111111111",
+        title="t",
+        source="kr_news",
+        symbol_candidates=[],
+        published_at=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        summary_text="s",
+    )
+    query.find_relevant = AsyncMock(
+        return_value=ResearchReportCitationListResponse(count=1, citations=[citation])
+    )
+    collector = NewsSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert results[0].snapshot_kind == "news"
+    assert results[0].source_kind == "news_ingestor"
+    assert results[0].payload_json["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_news_collector_failure_is_fail_open():
+    session = MagicMock()
+    query = MagicMock()
+    query.find_relevant = AsyncMock(side_effect=RuntimeError("transient"))
+    collector = NewsSnapshotCollector(session, query_service=query)
+    results = await collector.collect(_request())
+    assert len(results) == 1
+    assert results[0].freshness_status == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "collector_cls",
+    [
+        SymbolStubCollector,
+        CandidateUniverseStubCollector,
+        InvestPageStubCollector,
+        NaverRemoteDebugStubCollector,
+        TossRemoteDebugStubCollector,
+        BrowserProbeStubCollector,
+    ],
+)
+async def test_stubs_return_unavailable(collector_cls: type) -> None:
+    collector = collector_cls()
+    results = await collector.collect(_request())
+    assert len(results) == 1
+    assert results[0].freshness_status == "unavailable"
+    assert results[0].snapshot_kind == collector.snapshot_kind
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+def test_production_registry_covers_all_policy_kinds():
+    from app.services.investment_snapshots.policy import INTRADAY_ACTION_REPORT_V1
+
+    registry = production_collector_registry(session=MagicMock())
+    registered = registry.list_kinds()
+    policy_kinds = {k.snapshot_kind for k in INTRADAY_ACTION_REPORT_V1.kinds}
+
+    missing = policy_kinds - registered
+    assert missing == set(), f"policy kinds missing collectors: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Static-import guard — none of the collector modules pull in known
+# mutation paths. If a future contributor wires the trade execution
+# service, the broker SDK, or WatchActivationService into a collector
+# module's import graph, this assertion fires.
+# ---------------------------------------------------------------------------
+def test_collector_modules_do_not_import_broker_or_activation_paths():
+    import importlib
+    import sys
+
+    forbidden_substrings: tuple[str, ...] = (
+        "kis_trading_service",
+        "investment_reports.watch_activation",
+        "alpaca_paper_ledger_service",
+        "upbit.client",  # upbit broker client
+    )
+    target_modules = [
+        "app.services.action_report.snapshot_backed.collectors.portfolio",
+        "app.services.action_report.snapshot_backed.collectors.journal",
+        "app.services.action_report.snapshot_backed.collectors.watch_context",
+        "app.services.action_report.snapshot_backed.collectors.market",
+        "app.services.action_report.snapshot_backed.collectors.news",
+        "app.services.action_report.snapshot_backed.collectors.optional_stubs",
+        "app.services.action_report.snapshot_backed.collectors.registry",
+        "app.services.action_report.snapshot_backed.generator",
+    ]
+
+    for name in target_modules:
+        importlib.import_module(name)
+        module = sys.modules[name]
+        source = open(module.__file__, encoding="utf-8").read()  # type: ignore[arg-type]
+        for forbidden in forbidden_substrings:
+            assert forbidden not in source, (
+                f"{name} unexpectedly references {forbidden!r} — "
+                "collectors must remain read-only"
+            )

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -69,7 +69,15 @@ def _ensure_response(
         status=status,  # type: ignore[arg-type]
         created=created,
         coverage_summary=coverage_summary
-        or {"required": {"portfolio": "fresh", "journal": "fresh", "watch_context": "fresh", "market": "fresh"}, "optional": {}},
+        or {
+            "required": {
+                "portfolio": "fresh",
+                "journal": "fresh",
+                "watch_context": "fresh",
+                "market": "fresh",
+            },
+            "optional": {},
+        },
         freshness_summary=freshness_summary
         or {
             "overall": "fresh",

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1,0 +1,324 @@
+"""ROB-273 — SnapshotBackedReportGenerator service tests.
+
+The generator is tested with hand-rolled fakes for the bundle-ensure and
+ingestion services so each test stays focused on the orchestration
+contract. End-to-end coverage with a real DB lives in the existing
+``test_bundle_ensure_service`` + ``test_investment_reports_*`` suites.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any
+
+import pytest
+
+from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
+from app.schemas.investment_snapshots_mcp import (
+    EnsureBundleRequest,
+    EnsureBundleResponse,
+)
+from app.services.action_report.snapshot_backed.generator import (
+    PublishBlockedByStaleGateError,
+    SnapshotBackedReportGenerator,
+    SnapshotBackedReportGeneratorError,
+)
+from app.services.action_report.snapshot_backed.request import (
+    ReportGenerationRequest,
+)
+
+
+class _FakeEnsureService:
+    def __init__(self, response: EnsureBundleResponse) -> None:
+        self.response = response
+        self.calls: list[EnsureBundleRequest] = []
+
+    async def ensure(self, request: EnsureBundleRequest) -> EnsureBundleResponse:
+        self.calls.append(request)
+        return self.response
+
+
+class _FakeReport:
+    def __init__(self, report_uuid: uuid.UUID) -> None:
+        self.report_uuid = report_uuid
+
+
+class _FakeIngestionService:
+    def __init__(self, *, report_uuid: uuid.UUID | None = None) -> None:
+        self.report_uuid = report_uuid or uuid.uuid4()
+        self.calls: list[IngestReportRequest] = []
+
+    async def ingest(self, request: IngestReportRequest):
+        self.calls.append(request)
+        return _FakeReport(self.report_uuid)
+
+
+def _ensure_response(
+    *,
+    bundle_uuid: uuid.UUID | None = None,
+    status: str = "complete",
+    freshness_summary: dict[str, Any] | None = None,
+    coverage_summary: dict[str, Any] | None = None,
+    missing_sources: list[str] | None = None,
+    created: bool = True,
+    warnings: list[str] | None = None,
+) -> EnsureBundleResponse:
+    return EnsureBundleResponse(
+        bundle_uuid=bundle_uuid or uuid.uuid4(),
+        status=status,  # type: ignore[arg-type]
+        created=created,
+        coverage_summary=coverage_summary
+        or {"required": {"portfolio": "fresh", "journal": "fresh", "watch_context": "fresh", "market": "fresh"}, "optional": {}},
+        freshness_summary=freshness_summary
+        or {
+            "overall": "fresh",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+        },
+        missing_sources=missing_sources or [],
+        warnings=warnings or [],
+        run_uuid=None,
+    )
+
+
+def _make_request(**overrides: Any) -> ReportGenerationRequest:
+    base = {
+        "market": "kr",
+        "account_scope": "kis_live",
+        "status": "published",
+        "created_by_profile": "test-runner",
+        "title": "Snapshot-backed KR advisory",
+        "summary": "테스트 요약",
+        "kst_date": "2026-05-19",
+        "items": [],
+    }
+    base.update(overrides)
+    return ReportGenerationRequest.model_validate(base)
+
+
+@pytest.mark.asyncio
+async def test_happy_path_kr_published(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Required kinds all fresh → published report persists with snapshot metadata."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+
+    gen = SnapshotBackedReportGenerator(
+        session=object(),  # not used by fakes
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    response = await gen.generate(_make_request())
+
+    assert response.report_uuid == ingest.report_uuid
+    assert response.bundle_status == "complete"
+    assert response.snapshot_freshness_summary["overall"] == "fresh"
+    assert response.items_count == 0
+    assert response.warnings == []
+    assert response.bundle_reused is False
+    assert response.unavailable_sources == {}
+
+    # Ingestion service received the snapshot metadata round-trip.
+    assert len(ingest.calls) == 1
+    sent = ingest.calls[0]
+    assert sent.snapshot_bundle_uuid == ensure.response.bundle_uuid
+    assert sent.snapshot_policy_version == "intraday_action_report_v1"
+    assert sent.snapshot_coverage_summary == response.snapshot_coverage_summary
+    assert sent.snapshot_freshness_summary["overall"] == "fresh"
+    assert sent.metadata.get("snapshot_backed_generator") is True
+
+
+@pytest.mark.asyncio
+async def test_happy_path_crypto_published() -> None:
+    """Crypto/upbit_live pairing is also accepted."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    response = await gen.generate(
+        _make_request(market="crypto", account_scope="upbit_live")
+    )
+    assert response.report_uuid == ingest.report_uuid
+    assert ensure.calls[0].market == "crypto"
+    assert ensure.calls[0].account_scope == "upbit_live"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_market_account_pair_rejected() -> None:
+    """US/kis_live or crypto/kis_live etc. are rejected at request validation."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    req = _make_request(market="crypto", account_scope="kis_live")
+    with pytest.raises(SnapshotBackedReportGeneratorError):
+        await gen.generate(req)
+    assert ingest.calls == []
+
+
+@pytest.mark.asyncio
+async def test_published_blocked_when_bundle_failed() -> None:
+    """bundle.status='failed' on a published request raises and never ingests."""
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="failed",
+            freshness_summary={
+                "overall": "failed",
+                "portfolio": {"status": "unavailable"},
+            },
+            missing_sources=["portfolio"],
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    with pytest.raises(PublishBlockedByStaleGateError) as exc_info:
+        await gen.generate(_make_request())
+    assert exc_info.value.bundle_status == "failed"
+    assert ingest.calls == []
+
+
+@pytest.mark.asyncio
+async def test_published_blocked_when_required_kind_hard_stale() -> None:
+    """Critical kind hard_stale blocks even if bundle.status is 'partial'."""
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="partial",
+            freshness_summary={
+                "overall": "partial",
+                "portfolio": {"status": "fresh"},
+                "journal": {"status": "fresh"},
+                "watch_context": {"status": "fresh"},
+                "market": {"status": "hard_stale"},
+            },
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    with pytest.raises(PublishBlockedByStaleGateError):
+        await gen.generate(_make_request())
+    assert ingest.calls == []
+
+
+@pytest.mark.asyncio
+async def test_draft_status_permitted_even_on_hard_stale() -> None:
+    """Draft reports are NOT subject to the published-only block."""
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="partial",
+            freshness_summary={
+                "overall": "hard_stale",
+                "portfolio": {"status": "hard_stale"},
+            },
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.snapshot_freshness_summary["overall"] == "hard_stale"
+    assert len(ingest.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_optional_collector_failure_degrades_but_does_not_block() -> None:
+    """Bundle.status='partial' from optional-kind failure still publishes."""
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="partial",
+            freshness_summary={
+                "overall": "partial",
+                "portfolio": {"status": "fresh"},
+                "journal": {"status": "fresh"},
+                "watch_context": {"status": "fresh"},
+                "market": {"status": "fresh"},
+                "invest_page": {"status": "unavailable"},
+                "news": {"status": "soft_stale"},
+            },
+            missing_sources=["invest_page"],
+            warnings=["invest_page: collector timed out"],
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    response = await gen.generate(_make_request())
+    assert response.bundle_status == "partial"
+    assert response.snapshot_freshness_summary["overall"] == "partial"
+    assert "invest_page" in response.unavailable_sources
+    assert response.warnings == ["invest_page: collector timed out"]
+    assert len(ingest.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_jsonb_normalisation_runs_on_items() -> None:
+    """Decimal / datetime / UUID inside item evidence_snapshot becomes JSONB-safe."""
+    from decimal import Decimal
+
+    item = IngestReportItem(
+        client_item_key="i1",
+        item_kind="risk",
+        intent="risk_review",
+        rationale="risk note",
+        evidence_snapshot={
+            "p": Decimal("100.5"),
+            "at": dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        },
+        metadata={"id": uuid.UUID("aaaaaaaa-1234-5678-9abc-def012345678")},
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    await gen.generate(_make_request(items=[item]))
+
+    sent = ingest.calls[0]
+    assert sent.items[0].evidence_snapshot["p"] == "100.5"
+    assert sent.items[0].evidence_snapshot["at"] == "2026-05-19T00:00:00+00:00"
+    assert sent.items[0].metadata["id"] == "aaaaaaaa-1234-5678-9abc-def012345678"
+
+
+@pytest.mark.asyncio
+async def test_ensure_response_with_no_bundle_raises() -> None:
+    ensure = _FakeEnsureService(
+        EnsureBundleResponse(
+            bundle_uuid=None,
+            status="failed",  # type: ignore[arg-type]
+            created=False,
+            warnings=["upstream broken"],
+            run_uuid=None,
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+    )
+    with pytest.raises(SnapshotBackedReportGeneratorError):
+        await gen.generate(_make_request())
+    assert ingest.calls == []

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -70,7 +70,7 @@ def _watch_item_dict(client_item_key: str = "watch-1") -> dict:
     }
 
 
-def test_tool_names_are_exactly_six() -> None:
+def test_tool_names_match_registered_set() -> None:
     assert INVESTMENT_REPORT_TOOL_NAMES == {
         "investment_report_create",
         "investment_report_list",
@@ -78,6 +78,8 @@ def test_tool_names_are_exactly_six() -> None:
         "investment_report_decide_item",
         "investment_report_activate_watch",
         "investment_report_context_get",
+        # ROB-273 — opt-in snapshot-backed advisory generator.
+        "investment_report_generate_from_bundle",
     }
 
 


### PR DESCRIPTION
## Linear
[ROB-273](https://linear.app/mgh3326/issue/ROB-273/auto-trader-automate-snapshot-backed-invest-report-generation-wiring) — parent: ROB-269.

## 구현 범위

Opt-in end-to-end path that replaces the manual `SnapshotBundleEnsureService` + `IngestReportRequest` plumbing validated against the two ROB-269 production runs. The new `SnapshotBackedReportGenerator` ensures (or reuses) a snapshot bundle, walks a registered collector registry, normalises the payload, and persists the report with snapshot metadata through the existing ingestion service.

Surfaces:

- **MCP tool**: `investment_report_generate_from_bundle` — returns `{success:false, error:'snapshot_backed_report_generator_disabled'}` unless the flag is on.
- **HTTP**: `POST /trading/api/investment-reports/snapshot-backed` — `503` unless flag on; `409` on stale-gate block; `400` on invalid market/account pair.
- **Helpers**: `to_jsonable()` (Decimal/datetime/UUID/Enum/Pydantic recursive normaliser) and `map_source_kind()` (alias → SourceKind literal mapper, rejects e.g. `upbit_mcp`, `db`, `mcp_screen`, `not_applicable`, `finnhub_crypto`).

## Required collector 구현 상태

| Kind | Source | Status |
|---|---|---|
| `portfolio` | `manual_holdings` (read-only) | ✅ real adapter |
| `journal` | `trade_journals` (read-only) | ✅ real adapter |
| `watch_context` | `InvestmentReportsRepository.list_active_alerts` | ✅ real adapter (mutation methods asserted not-called) |
| `market` | `MarketEventsQueryService` | ✅ real adapter |

All required collectors operate on local DB state populated by existing upstream sync flows; **no broker API call, no order mutation, no watch activation, no scheduler registration**.

## Optional collector / stub 상태

| Kind | Status |
|---|---|
| `news` | ✅ real adapter via `ResearchReportsQueryService` (fail-open on exception) |
| `symbol` | 🟡 fail-open stub — wiring deferred to follow-up |
| `candidate_universe` | 🟡 fail-open stub |
| `invest_page` | 🟡 fail-open stub |
| `naver_remote_debug` | 🟡 fail-open stub — operator-driven probe only |
| `toss_remote_debug` | 🟡 fail-open stub — operator-driven probe only |
| `browser_probe` | 🟡 fail-open stub (Upbit public cross-check seat — `upbit_remote_debug` literal intentionally NOT added) |

Stubs return `freshness_status="unavailable"` and surface via `unavailable_sources`. They degrade the bundle to `partial` but **never block** published reports.

## Feature flag / default-off

- New flag `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED: bool = False` in `app/core/config.py`.
- Existing `ACTION_REPORT_BUNDLE_BASED_GENERATION_ENABLED` default **unchanged (False)**.
- Linear ticket called the flag `ACTION_REPORT_BUNDLE_GENERATION_ENABLED` — that's a transcription error; the real key is `..._BUNDLE_BASED_..._ENABLED`. PR text uses the real name.
- The two flags are intentionally split: the legacy flag gates pre-DB stale-gate enforcement for any report carrying snapshot metadata; the new flag gates only the generator surface so we can exercise the automated draft path before activating enforcement on the legacy create path.

## No broker / order / watch mutation 보장

- All four required-kind collectors use SQLAlchemy read APIs only.
- `WatchContextSnapshotCollector` is wired only to `InvestmentReportsRepository.list_active_alerts`; `insert_alert` / `update_alert_status` are explicitly asserted not-called in the unit test.
- Static-import guard test scans every collector and the generator source for any reference to `kis_trading_service`, `investment_reports.watch_activation`, `alpaca_paper_ledger_service`, or `upbit.client`. Any future regression that wires a mutation path into a collector module will fail this test.
- Generator never imports `WatchActivationService`, broker SDKs, or TaskIQ/Prefect deployment registration.

## Tests run / result

```
uv run --group test pytest \
  tests/services/action_report/ \
  tests/services/investment_snapshots/ \
  tests/routers/test_investment_reports_snapshot_backed.py \
  tests/routers/test_investment_snapshots_router.py \
  tests/test_investment_reports_schemas.py \
  tests/test_investment_reports_stale_gate_flag.py \
  tests/test_investment_reports_snapshot_metadata.py \
  tests/test_investment_reports_mcp.py \
  tests/test_investment_reports_ingestion.py \
  -m "not integration and not live"
=> 315 passed
```

New test coverage:

- `tests/services/action_report/common/test_jsonable.py` — nested Decimal/datetime/UUID/Enum/Pydantic recursion, dict-key coercion, bytes/unknown-type rejection.
- `tests/services/action_report/common/test_source_kind_mapping.py` — canonical pass-through, alias mapping, rejection of unsupported origins (including `upbit_remote_debug`).
- `tests/services/action_report/snapshot_backed/test_generator.py` — KR/crypto happy path, mismatched scope rejection, published-blocked on bundle.failed and critical-kind hard_stale, draft permitted on hard_stale, optional-collector failure degrades but persists, item JSONB normalisation, no-bundle-uuid guard.
- `tests/services/action_report/snapshot_backed/test_collectors.py` — required + optional collectors return well-formed results, watch-context mutation-not-called assertion, fail-open stubs, registry covers every policy kind, static-import guard against mutation paths.
- `tests/routers/test_investment_reports_snapshot_backed.py` — flag-off 503, flag-on happy path, publish-blocked 409, bad-request 400, GET surface unchanged.

Lint: `uv run ruff check` clean on all new + changed files.

## Known limitations

- `symbol` / `candidate_universe` / `invest_page` adapters are not yet wired; they currently emit `unavailable` results. Bundle becomes `partial` whenever they're polled. Follow-up PR planned.
- Pre-PR did NOT exercise the full path against a live DB; integration coverage is intentionally deferred to a smoke run (see below) so this PR stays mergeable as scaffolding-with-real-required-collectors.
- `upbit_remote_debug` is NOT introduced as a new SnapshotKind/SourceKind literal — extending those would need an alembic + schema PR which is explicitly out of scope.

## Production smoke 방법

Once `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true` is set on the MCP host (or HTTP host):

```bash
# Crypto, advisory_only, draft — safe read-only end-to-end exercise.
curl -sS -X POST https://<host>/trading/api/investment-reports/snapshot-backed \
  -H "Content-Type: application/json" -H "Cookie: <session>" \
  -d '{
    "market": "crypto",
    "account_scope": "upbit_live",
    "status": "draft",
    "created_by_profile": "rob-273-smoke",
    "title": "ROB-273 smoke (draft)",
    "summary": "smoke",
    "kst_date": "2026-05-19",
    "items": []
  }'
```

Verify the response contains a non-null `snapshot_bundle_uuid` and `snapshot_freshness_summary.overall` ∈ `{fresh, soft_stale, partial}`. The corresponding bundle should also be visible through `GET /trading/api/investment-snapshots/...` (when the snapshots router is enabled).

For the KR scope, repeat with `market=kr`, `account_scope=kis_live`.

The MCP tool path mirrors this: call `investment_report_generate_from_bundle` with the same payload structure.

## Migration

**No alembic migration required.** All persisted columns already exist from ROB-269 Phase 3 (`investment_reports.snapshot_bundle_uuid`, `snapshot_policy_version`, `snapshot_coverage_summary`, `snapshot_freshness_summary`, `source_conflicts`, `unavailable_sources`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added snapshot-backed advisory report generation capability (HTTP POST endpoint and MCP tool integration)
  * New report generator orchestrates data collection from portfolio, journal, market events, and news sources
  * Reports include freshness tracking and conflict detection with configurable feature flag

* **Tests**
  * Added comprehensive test coverage for report generation, data collection, and HTTP endpoint behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->