### PR TITLE
feat(rob-276): invest screener 쌍끌이 매수 Toss screenId=18 parity

### DIFF
--- a/app/services/invest_view_model/double_buy_screener.py
+++ b/app/services/invest_view_model/double_buy_screener.py
@@ -87,6 +87,7 @@ async def load_double_buy_from_snapshots(
         .order_by(
             InvestScreenerSnapshot.change_rate.desc().nullslast(),
             InvestorFlowSnapshot.symbol.asc(),
+            InvestorFlowSnapshot.source.asc(),
         )
         .limit(max(limit * 4, limit + 40))
     )
@@ -119,6 +120,11 @@ async def load_double_buy_from_snapshots(
 
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
+    # Multiple investor_flow sources may exist per (symbol, snapshot_date) due to
+    # unique constraint scope. SQL ORDER BY source.asc() above ensures the first
+    # row seen here is the alphabetically-earlier source — currently only
+    # `naver_finance` is live, but this keeps the choice deterministic if `kis` or
+    # other sources are added later.
     for r in candidate_rows:
         sym = r["symbol"]
         if sym in seen:

--- a/app/services/invest_view_model/double_buy_screener.py
+++ b/app/services/invest_view_model/double_buy_screener.py
@@ -1,0 +1,162 @@
+"""Read-only loader for the 쌍끌이 매수 (Toss screenId=18 parity) preset.
+
+Joins the latest investor_flow_snapshots row with the latest
+invest_screener_snapshots row per symbol and applies the Toss-parity filter
+(Interpretation A, locked 2026-05-20 under Task 0 safer-fallback rule — see
+plan Decision 1):
+
+    market = kr
+    foreign_net  > 0   AND institution_net  > 0
+    change_rate >= 0
+    sort by change_rate desc, symbol asc
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+
+logger = logging.getLogger(__name__)
+
+
+async def load_double_buy_from_snapshots(
+    session: AsyncSession | None, *, market: str, limit: int = 50
+) -> list[dict[str, Any]] | None:
+    """Return Toss-parity 쌍끌이 매수 rows or None when no snapshot partition exists.
+
+    None  -> caller should report dataState=missing and warn that snapshots are absent.
+    []    -> latest partition exists but no qualifiers (caller renders empty + stale).
+    Rows  -> ordered by change_rate desc, symbol asc.
+    """
+    if session is None or market != "kr":
+        return None
+
+    latest_flow_stmt = sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+        InvestorFlowSnapshot.market == "kr"
+    )
+    latest_price_stmt = sa.select(
+        sa.func.max(InvestScreenerSnapshot.snapshot_date)
+    ).where(InvestScreenerSnapshot.market == "kr")
+    try:
+        flow_date = (await session.execute(latest_flow_stmt)).scalar_one_or_none()
+        price_date = (await session.execute(latest_price_stmt)).scalar_one_or_none()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("double_buy: latest dates lookup failed: %s", exc, exc_info=True)
+        return None
+    if flow_date is None or price_date is None:
+        return None
+
+    candidate_stmt = (
+        sa.select(
+            InvestorFlowSnapshot.symbol,
+            InvestorFlowSnapshot.foreign_net,
+            InvestorFlowSnapshot.institution_net,
+            InvestorFlowSnapshot.individual_net,
+            InvestorFlowSnapshot.double_buy,
+            InvestorFlowSnapshot.foreign_consecutive_buy_days,
+            InvestorFlowSnapshot.institution_consecutive_buy_days,
+            InvestScreenerSnapshot.latest_close,
+            InvestScreenerSnapshot.prev_close,
+            InvestScreenerSnapshot.change_rate,
+            InvestScreenerSnapshot.daily_volume,
+            InvestScreenerSnapshot.snapshot_date.label("price_snapshot_date"),
+            InvestorFlowSnapshot.snapshot_date.label("flow_snapshot_date"),
+        )
+        .join(
+            InvestScreenerSnapshot,
+            sa.and_(
+                InvestScreenerSnapshot.market == InvestorFlowSnapshot.market,
+                InvestScreenerSnapshot.symbol == InvestorFlowSnapshot.symbol,
+                InvestScreenerSnapshot.snapshot_date == price_date,
+            ),
+        )
+        .where(
+            InvestorFlowSnapshot.market == "kr",
+            InvestorFlowSnapshot.snapshot_date == flow_date,
+            InvestorFlowSnapshot.foreign_net > 0,
+            InvestorFlowSnapshot.institution_net > 0,
+            sa.func.coalesce(InvestScreenerSnapshot.change_rate, 0) >= 0,
+        )
+        .order_by(
+            InvestScreenerSnapshot.change_rate.desc().nullslast(),
+            InvestorFlowSnapshot.symbol.asc(),
+        )
+        .limit(max(limit * 4, limit + 40))
+    )
+    try:
+        result = await session.execute(candidate_stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("double_buy: candidate query failed: %s", exc, exc_info=True)
+        return None
+    candidate_rows = list(result.mappings().all())
+
+    symbols = [r["symbol"] for r in candidate_rows]
+    name_map: dict[str, str] = {}
+    if symbols:
+        try:
+            names = await session.execute(
+                sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                    KRSymbolUniverse.symbol.in_(symbols),
+                    KRSymbolUniverse.is_active.is_(True),
+                )
+            )
+            name_map = {row.symbol: row.name for row in names.all()}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("double_buy: name lookup failed: %s", exc, exc_info=True)
+
+    # Imported inside the function to avoid a circular import at module load
+    # (screener_service imports from this module's neighborhood).
+    from app.services.invest_view_model.screener_service import (
+        _is_kr_toss_common_stock,
+    )
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for r in candidate_rows:
+        sym = r["symbol"]
+        if sym in seen:
+            continue
+        name = name_map.get(sym)
+        if not _is_kr_toss_common_stock(sym, name):
+            continue
+        seen.add(sym)
+        state = (
+            "fresh" if r["price_snapshot_date"] == r["flow_snapshot_date"] else "stale"
+        )
+        rows.append(
+            {
+                "symbol": sym,
+                "market": "kr",
+                "name": name,
+                "latest_close": (
+                    float(r["latest_close"]) if r["latest_close"] is not None else None
+                ),
+                "prev_close": (
+                    float(r["prev_close"]) if r["prev_close"] is not None else None
+                ),
+                "change_rate": (
+                    float(r["change_rate"]) if r["change_rate"] is not None else None
+                ),
+                "volume": r["daily_volume"],
+                "foreign_net": r["foreign_net"],
+                "institution_net": r["institution_net"],
+                "individual_net": r["individual_net"],
+                "double_buy": r["double_buy"],
+                "foreign_consecutive_buy_days": r["foreign_consecutive_buy_days"],
+                "institution_consecutive_buy_days": r[
+                    "institution_consecutive_buy_days"
+                ],
+                "snapshot_date": r["price_snapshot_date"],
+                "_screener_snapshot_state": state,
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows

--- a/app/services/invest_view_model/double_buy_screener.py
+++ b/app/services/invest_view_model/double_buy_screener.py
@@ -160,6 +160,7 @@ async def load_double_buy_from_snapshots(
                     "institution_consecutive_buy_days"
                 ],
                 "snapshot_date": r["price_snapshot_date"],
+                "flow_snapshot_date": r["flow_snapshot_date"],
                 "_screener_snapshot_state": state,
             }
         )

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -12,7 +12,7 @@ from app.schemas.invest_screener import ScreenerFilterChip, ScreenerPreset
 DEFAULT_PRESET_ID = "consecutive_gainers"
 CONSECUTIVE_GAINERS_LIMIT = 80
 CRYPTO_DEFAULT_PRESET_ID = "crypto_high_volume"
-_KR_ONLY_PRESET_IDS = {"investor_flow_momentum"}
+_KR_ONLY_PRESET_IDS = {"investor_flow_momentum", "double_buy"}
 
 
 SCREENER_PRESETS: list[ScreenerPreset] = [
@@ -67,8 +67,8 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         market="kr",
     ),
     ScreenerPreset(
-        id="high_volume_momentum",
-        name="쌍끌이 매수",
+        id="kr_high_volume_surge",
+        name="거래량 급증",
         description="거래량이 폭발적으로 늘어난 종목",
         badges=[],
         filterChips=[
@@ -81,14 +81,29 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
     ScreenerPreset(
         id="investor_flow_momentum",
         name="수급 모멘텀",
-        description="외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+        description="외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)",
         badges=["MVP"],
         filterChips=[
             ScreenerFilterChip(label="국내", detail=None),
-            ScreenerFilterChip(label="투자자별 수급", detail="외국인 3일+ 또는 쌍끌이"),
+            ScreenerFilterChip(label="투자자별 수급", detail="외국인 3일+ 연속 순매수"),
             ScreenerFilterChip(label="데이터", detail="지연 스냅샷 기반"),
         ],
         metricLabel="외국인 순매수",
+        market="kr",
+    ),
+    ScreenerPreset(
+        id="double_buy",
+        name="쌍끌이 매수",
+        description="기관과 외국인이 동시에 매수하는 종목",
+        badges=["NEW"],
+        filterChips=[
+            ScreenerFilterChip(label="국내", detail=None),
+            ScreenerFilterChip(label="외국인", detail="순매수"),
+            ScreenerFilterChip(label="기관", detail="순매수"),
+            ScreenerFilterChip(label="주가등락률", detail="1일 ≥ 0%"),
+            ScreenerFilterChip(label="데이터", detail="지연 스냅샷 기반"),
+        ],
+        metricLabel="주가등락률",
         market="kr",
     ),
     ScreenerPreset(
@@ -182,12 +197,21 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
         "max_rsi": 30.0,
         "limit": 20,
     },
-    "high_volume_momentum": {
+    "kr_high_volume_surge": {
         "market": "kr",
         "asset_type": "stock",
         "sort_by": "volume",
         "sort_order": "desc",
         "limit": 20,
+    },
+    "double_buy": {
+        "market": "kr",
+        "asset_type": "stock",
+        "sort_by": "change_rate",
+        "sort_order": "desc",
+        "min_change_rate": 0.0,
+        "include_double_buy": True,
+        "limit": 50,
     },
     "growth_expectation": {
         "market": "kr",

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -328,9 +328,14 @@ def _double_buy_dependency_warnings(
 ) -> tuple[list[str], str | None]:
     """Return (warnings, state_override) for double_buy by dependency.
 
-    snapshot_rows expected to contain `_screener_snapshot_state` (set by the
-    loader to "fresh" when price_snapshot_date == flow_snapshot_date, else
-    "stale") and `snapshot_date` (the price snapshot date used in the join).
+    snapshot_rows produced by load_double_buy_from_snapshots carry:
+      - `_screener_snapshot_state`: "fresh" iff price_snapshot_date == flow_snapshot_date,
+        else "stale" (price/flow partition divergence)
+      - `snapshot_date`: the PRICE snapshot date used in the join
+      - `flow_snapshot_date`: the investor-flow snapshot date used in the join
+
+    The two warnings target distinct dependencies so the UI can tell whether
+    price or flow is behind today's market date.
     """
     if not snapshot_rows:
         return [], None
@@ -340,9 +345,9 @@ def _double_buy_dependency_warnings(
         warnings.append(
             "시세 스냅샷이 직전 영업일 기준이라 일부 데이터가 1일 지연되었습니다."
         )
-    snapshot_dates = {row.get("snapshot_date") for row in snapshot_rows}
-    if snapshot_dates and all(
-        isinstance(d, dt.date) and d < now_market_date for d in snapshot_dates
+    flow_dates = {row.get("flow_snapshot_date") for row in snapshot_rows}
+    if flow_dates and all(
+        isinstance(d, dt.date) and d < now_market_date for d in flow_dates
     ):
         warnings.append(
             "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -672,7 +672,7 @@ _METRIC_FIELD: dict[str, str] = {
     "cheap_value": "per",
     "steady_dividend": "dividend_yield",
     "oversold_recovery": "rsi",
-    "high_volume_momentum": "volume",
+    "kr_high_volume_surge": "volume",
     "growth_expectation": "change_rate",
     "investor_flow_momentum": "foreign_net",
     "crypto_high_volume": "trade_amount_24h",

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -675,6 +675,7 @@ _METRIC_FIELD: dict[str, str] = {
     "kr_high_volume_surge": "volume",
     "growth_expectation": "change_rate",
     "investor_flow_momentum": "foreign_net",
+    "double_buy": "change_rate",   # NEW — placeholder; Task 3 wires snapshot-first branch
     "crypto_high_volume": "trade_amount_24h",
     "crypto_oversold": "rsi",
     "crypto_momentum": "change_rate",

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -12,6 +12,7 @@ modules — see tests/test_invest_view_model_safety.py.
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
@@ -318,6 +319,36 @@ def _should_use_snapshot_first(screening_service: Any) -> bool:
         screening_service.__class__.__name__ == "ScreenerService"
         and screening_service.__class__.__module__ == "app.services.screener_service"
     )
+
+
+def _double_buy_dependency_warnings(
+    *,
+    snapshot_rows: list[dict[str, Any]],
+    now_market_date: dt.date,
+) -> tuple[list[str], str | None]:
+    """Return (warnings, state_override) for double_buy by dependency.
+
+    snapshot_rows expected to contain `_screener_snapshot_state` (set by the
+    loader to "fresh" when price_snapshot_date == flow_snapshot_date, else
+    "stale") and `snapshot_date` (the price snapshot date used in the join).
+    """
+    if not snapshot_rows:
+        return [], None
+    warnings: list[str] = []
+    price_states = {row.get("_screener_snapshot_state") for row in snapshot_rows}
+    if "stale" in price_states:
+        warnings.append(
+            "시세 스냅샷이 직전 영업일 기준이라 일부 데이터가 1일 지연되었습니다."
+        )
+    snapshot_dates = {row.get("snapshot_date") for row in snapshot_rows}
+    if snapshot_dates and all(
+        isinstance(d, dt.date) and d < now_market_date for d in snapshot_dates
+    ):
+        warnings.append(
+            "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+        )
+    state_override = "stale" if warnings else None
+    return warnings, state_override
 
 
 async def _load_consecutive_gainers_from_snapshots(
@@ -675,7 +706,7 @@ _METRIC_FIELD: dict[str, str] = {
     "kr_high_volume_surge": "volume",
     "growth_expectation": "change_rate",
     "investor_flow_momentum": "foreign_net",
-    "double_buy": "change_rate",   # NEW — placeholder; Task 3 wires snapshot-first branch
+    "double_buy": "change_rate",  # NEW — placeholder; Task 3 wires snapshot-first branch
     "crypto_high_volume": "trade_amount_24h",
     "crypto_oversold": "rsi",
     "crypto_momentum": "change_rate",
@@ -1240,6 +1271,19 @@ async def build_screener_results(
             _snapshot_empty_warning = (
                 "최신 수급 스냅샷에서 조건에 맞는 결과가 없습니다."
             )
+        elif preset_id == "double_buy":
+            from app.services.invest_view_model.double_buy_screener import (
+                load_double_buy_from_snapshots,
+            )
+
+            _snapshot_check_result = await load_double_buy_from_snapshots(
+                session,
+                market=requested_market,
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+            )
+            _snapshot_empty_warning = (
+                "최신 수급/시세 스냅샷에서 쌍끌이 매수 조건에 맞는 종목이 없습니다."
+            )
         elif requested_market == "crypto":
             _crypto_snapshot_result = await _load_crypto_rows_from_snapshots(
                 session,
@@ -1264,6 +1308,12 @@ async def build_screener_results(
         _snapshot_empty_warning = (
             "수급 스냅샷이 아직 적재되지 않아 수급 모멘텀 후보를 표시할 수 없습니다."
         )
+
+    if preset_id == "double_buy" and _snapshot_check_result is None:
+        # snapshot-only preset; generic provider has no Toss-parity filters
+        _snapshot_check_result = []
+        _snapshot_state_override = "missing"
+        _snapshot_empty_warning = "수급 또는 시세 스냅샷이 아직 적재되지 않아 쌍끌이 매수 후보를 표시할 수 없습니다."
 
     _snapshot_was_checked = _snapshot_check_result is not None
     if _snapshot_was_checked:
@@ -1323,6 +1373,23 @@ async def build_screener_results(
             str(r.get("_screener_snapshot_state") or "missing") for r in rows
         ]
         _aggregated_data_state = aggregate_states(_row_states)  # type: ignore[arg-type]
+
+    if preset_id == "double_buy":
+        from app.services.invest_screener_snapshots.freshness import today_trading_date
+
+        _market_date = today_trading_date(requested_market, now=now())
+        _double_buy_warnings, _double_buy_state_override = (
+            _double_buy_dependency_warnings(
+                snapshot_rows=rows,
+                now_market_date=_market_date,
+            )
+        )
+        for w in _double_buy_warnings:
+            if w not in upstream_warnings:
+                upstream_warnings.append(w)
+        if _double_buy_state_override is not None and _aggregated_data_state == "fresh":
+            _aggregated_data_state = _double_buy_state_override
+
     if requested_market == "us" and _aggregated_data_state in {"missing", "stale"}:
         if _US_SCREENER_DATA_NOT_READY_WARNING not in upstream_warnings:
             upstream_warnings.append(_US_SCREENER_DATA_NOT_READY_WARNING)

--- a/docs/runbooks/invest-screener-snapshots.md
+++ b/docs/runbooks/invest-screener-snapshots.md
@@ -189,3 +189,74 @@ stability across at least 24 hours and an explicit reviewer approval.
 
 Intended schedule: `30 21 * * 1-5` UTC (≈17:30 ET, ~30 min after the regular US session close).
 The flow body honors `INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED` (default `False` → dry-run).
+
+---
+
+## 9. ROB-276 — 쌍끌이 매수 (Toss screenId=18 parity)
+
+### Overview
+
+- **Preset**: `double_buy` (KR only, snapshot-only, read-only).
+- **User-facing**: 카드 이름 `쌍끌이 매수`, description `기관과 외국인이 동시에 매수하는 종목`.
+- **Replaces UI label**: 이전에 `쌍끌이 매수`로 잘못 라벨링되어 있던 거래량 기반 preset(`high_volume_momentum`)은 ID 자체가 `kr_high_volume_surge` 로 변경되었고 이름은 `거래량 급증` 으로 분리됨. 구 ID `high_volume_momentum` 는 더 이상 존재하지 않으며 해당 ID 로 들어온 요청은 `unknown preset` 응답을 받음.
+
+### Filter logic (locked: Interpretation A)
+
+```text
+market = kr
+investor_flow_snapshots.foreign_net > 0
+investor_flow_snapshots.institution_net > 0
+COALESCE(invest_screener_snapshots.change_rate, 0) >= 0
+ORDER BY change_rate DESC NULLS LAST, symbol ASC, source ASC
+```
+
+- 최신 `investor_flow_snapshots` partition 과 최신 `invest_screener_snapshots` partition 을 symbol 로 join.
+- `_is_kr_toss_common_stock` 가드로 ETF/ETN/우선주/SPAC/펀드성 종목 제외.
+- 다중 `source` (e.g. `naver_finance` + `kis`) 가 존재할 때 `ORDER BY source.asc()` 로 결정론적 dedupe.
+
+### Decision 1 lock 근거 (2026-05-20, Task 0)
+
+- Live DB 검증은 환경 제약으로 수행하지 못함 (docker/colima 미사용, host Postgres 권한 부재).
+- Toss reference 캡처는 ROB-276 본문의 5개 심볼 (`011000, 439960, 083500, 042520, 042420`) 뿐이라 캡처 size 가 < 50% 의미를 갖기에 부족.
+- Plan 의 safer-fallback rule ("둘 다 < 50% 커버 또는 동률 → A lock") 에 따라 A 채택.
+- 구조적 근거: `InvestorFlowSnapshot.double_buy` 가 이미 `foreign_net > 0 AND institution_net > 0` 의 derived 컬럼이라 별도 backfill 없이 재사용 가능.
+- Live A/B 검증은 Task 4 의 diagnostic (`--interpretation both`) 으로 실제 DB + 더 큰 Toss capture 확보 후 수행. B 가 명백히 우세하면 후속 PR 에서 lock 을 전환 (helper 본체만 교체; preset metadata/freshness 로직은 유지).
+
+### Freshness — 의존성 분리
+
+- **price 스냅샷 stale**: row 의 `_screener_snapshot_state == "stale"` (price_snapshot_date ≠ flow_snapshot_date) → warning `"시세 스냅샷이 직전 영업일 기준이라 일부 데이터가 1일 지연되었습니다."`
+- **flow 스냅샷 stale**: 모든 row 의 `flow_snapshot_date < today_trading_date(market)` (KST) → warning `"수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."`
+- **둘 다 missing**: 최신 partition 자체 부재 → `dataState=missing` + warning `"수급 또는 시세 스냅샷이 아직 적재되지 않아 쌍끌이 매수 후보를 표시할 수 없습니다."`
+- KST/trading-date 산정은 `app/services/invest_screener_snapshots/freshness.today_trading_date` 사용; `dt.date.today()` 직접 사용 금지.
+
+### Diagnostic
+
+```bash
+uv run python -m scripts.diagnose_invest_screener_toss_parity \
+  --market kr \
+  --preset double_buy \
+  --interpretation both \
+  --toss-symbols-file /path/to/toss_ref.json \
+  --limit 80
+```
+
+- `--interpretation` ∈ `{a, b, both}` (default `both`).
+- Toss reference 는 **항상 파일 기반** (CSV/JSON/plain-symbol-per-line). HTTP fetch 금지.
+- 출력 JSON 에 `interpretationA`, `interpretationB` 블록이 항상 emit (skip 모드에서는 `null`).
+- 각 블록: `count`, `overlapCount`, `missingFromAutoTrader`, `extraInAutoTrader`.
+- `lockedInterpretation: "A"` 와 Decision 1 note 가 payload 에 항상 포함.
+- B 해석은 diagnostic 전용 (current vs previous trading day self-join). production 에 wire 되지 않음.
+
+### Safety boundary (이번 PR)
+
+- **No DB migrations** (모델/마이그레이션 추가 없음).
+- **No new ingestion job / TaskIQ task / Prefect deployment / scheduler activation.** 기존 `investor_flow_snapshots`, `invest_screener_snapshots` 적재 경로만 사용.
+- **No broker / order / watch / order-intent mutation path.**
+- **No Toss runtime scraping.** Toss 데이터는 항상 수동 캡처 파일.
+- **Snapshot-only routing.** generic provider fallback 없음 — 스냅샷 부재 시 명시적 `dataState=missing` + warning.
+
+### Known gaps
+
+- Decision 1 lock 은 구조적 (safer-fallback) — live overlap 수치로 empirically 검증되지 않음. Section §9 의 diagnostic 으로 후속 검증 후, 필요 시 follow-up PR 에서 B 전환.
+- 다중 `investor_flow` source 가 활성화되면 `source.asc()` tiebreak 가 결정론을 보장하지만, source 별 net 값 분기가 큰 경우 데이터 product 차원 의사결정이 필요.
+- 구 ID `high_volume_momentum` URL/북마크 호환성 없음 — frontend preset list 진입이 주된 경로라 영향 작음.

--- a/docs/superpowers/plans/2026-05-20-rob-276-invest-screener-double-buy-parity.md
+++ b/docs/superpowers/plans/2026-05-20-rob-276-invest-screener-double-buy-parity.md
@@ -1,0 +1,1244 @@
+# ROB-276 /invest/screener 쌍끌이 매수 Toss screenId=18 Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/invest/screener` 의 `쌍끌이 매수` 프리셋을 거래량 기반(`high_volume_momentum`)에서 Toss screenId=18 의미(외인+기관 동반 매수 + 1일 상승)에 가까운 스냅샷 기반 read-only preset(`double_buy`)으로 교체하고, 라벨/카피/freshness 를 진실되게 표기한다.
+
+**Architecture:** 신규 `double_buy` preset 을 `screener_presets.py` 에 추가, `screener_service.py` 의 snapshot-first 분기에 `investor_flow_snapshots` (current + previous 영업일) 와 `invest_screener_snapshots` (최신 영업일 close/change_rate) 를 join 하는 read-only 분기를 추가한다. `high_volume_momentum` 은 이름을 `거래량 급증`(id `kr_high_volume_surge`) 로 clean-cut 변경. `수급 모멘텀` 은 카피에서 `쌍끌이` 표현을 제거. DB schema/ingestion/scheduler 변경 없음.
+
+**Tech Stack:** Python 3.13, FastAPI, SQLAlchemy 2.x (async), Pydantic v2, PostgreSQL, pytest, Vite/React/TS (frontend), uv.
+
+---
+
+## Locked Decisions (Top of Plan)
+
+> 이 섹션은 implementation 시작 전 lock 된 결정입니다. 변경하려면 plan 을 먼저 갱신하세요.
+
+### Decision 1 — Toss `외국인_순매수_비교` / `기관_순매수_비교` 의미
+
+**LOCKED: 해석 A (절대값) — safer-fallback rule 적용 (2026-05-20, Task 0).**
+
+두 후보:
+
+- **해석 A (절대값)**: `foreign_net > 0` AND `institution_net > 0` (= 기존 `InvestorFlowSnapshot.double_buy` 컬럼 재사용 가능). Toss filter id 가 `NUMBER_RANGE { from: 0, includeFrom: false }` 형태이므로 "1일 순매수액 > 0" 의미일 가능성.
+- **해석 B (delta)**: `foreign_net_current - foreign_net_prev > 0` AND `institution_net_current - institution_net_prev > 0`. Toss filter id 가 `_비교` 로 끝나고, 화면 카피("기관과 외국인이 동시에 사들이는 주식") 가 흐름/추세 뉘앙스이므로 가능성 유지.
+
+**Task 0 verification 결과 (2026-05-20):**
+
+- **DB 접근 불가**: docker / colima / podman 모두 사용 불가, docker-compose Postgres (port 5434) 미기동, 그리고 worktree 가 host Postgres (port 5432) 에 직접 연결할 권한이 없음 — auto-mode classifier 가 차단. 따라서 live A/B overlap 수치를 산출하지 못함.
+- **Toss reference**: 이슈 ROB-276 본문 외 추가 캡처 댓글/첨부 없음. 사용 가능한 reference 는 `011000, 439960, 083500, 042520, 042420` (5개) 뿐 — 캡처 size 가 < 50% 의미를 갖기에 부족.
+- **구조적 reasoning**: 이슈 본문 텍스트("foreign net-buy comparison vs previous trading snapshot > 0", `lag(foreign_net) over ...` 예시) 는 해석 B 쪽을 선호. 다만 plan 의 Lock 규칙 명시("결판이 안 나거나 reference data 가 빈약하면 → safer fallback: A 채택") 가 우선 적용됨. 모델 정의 (`InvestorFlowSnapshot.double_buy` 가 이미 `foreign_net > 0 AND institution_net > 0` 의 derived 컬럼으로 존재) 도 A 의 구현 비용을 낮춤.
+
+**Lock 결정: A.** 새 preset 은 `InvestorFlowSnapshot.double_buy = True AND COALESCE(invest_screener_snapshots.change_rate, 0) >= 0` 으로 구현. Task 2 의 `_load_double_buy_from_snapshots` helper Interpretation A 본체를 그대로 사용.
+
+**남은 gap & 후속 검증 surface:**
+
+- Live verification 은 Task 4 (diagnostic `--interpretation both`) 가 실제 DB 와 더 큰 Toss reference 가 확보된 시점에 수행. A/B overlap 수치가 B 가 명백히 우세함을 보이면 후속 PR 에서 lock 을 B 로 전환 (helper 본체만 교체, preset metadata 유지).
+- `docs/runbooks/invest-screener-snapshots.md` 의 ROB-276 섹션 (Task 6) 에 본 gap 명시.
+- Diagnostic 은 **항상 A/B 양쪽 비교 출력 유지** (plan 의 safer-fallback 절 요구사항).
+
+**Lock 근거 사유 요약:**
+
+- Task 0 spec 의 Step 6 rule: "둘 다 < 50% 커버 또는 동률 → A lock (safer fallback)" — DB 미접근으로 둘 다 측정 불가, 즉 effectively < 50% 상태.
+- A 는 `double_buy` 컬럼을 재사용하여 self-join 없이 단일 query 로 구현 가능 → 첫 PR 범위가 작고 회귀 위험 낮음.
+- B 가 정답일 가능성은 diagnostic 으로 살아있는 검증 경로가 있어 후속 전환 비용이 낮음.
+
+### Decision 2 — `high_volume_momentum` 처리
+
+**Clean cut**:
+
+- 새 preset `double_buy` (id; market="kr") 를 추가하고 `name="쌍끌이 매수"`, `description="기관과 외국인이 동시에 매수하는 종목"` 으로 노출.
+- 기존 `high_volume_momentum` preset 은 다음과 같이 변경:
+  - **ID 도 변경**: `kr_high_volume_surge` (구 ID `high_volume_momentum` 는 폐기)
+  - `name="거래량 급증"`, `description="거래량이 폭발적으로 늘어난 종목"` 유지
+  - 캐시/북마크 영향: 구 URL `?preset=high_volume_momentum` 은 신규 preset registry 에서 찾을 수 없어 `unknown preset` 응답으로 빠짐. 사용자가 직접 입력한 URL/북마크가 있을 경우 빈 결과 + 경고가 나옴 — frontend 의 preset list 진입 경로가 주된 진입이라 영향은 작다고 판단.
+  - **마이그레이션 도움말**: PR description 에 "구 ID `high_volume_momentum` 는 제거됨, 새 거래량 프리셋은 `kr_high_volume_surge`" 한 줄 명시.
+- `_METRIC_FIELD`, `_SCREENING_FILTERS`, 관련 test fixture, frontend preset list 시점의 모든 hard-coded 문자열을 일괄 grep/replace.
+
+### Decision 3 — `investor_flow_momentum`(수급 모멘텀) 카피 정리
+
+- `description` 을 `"외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보"` → `"외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)"` 로 변경 ("쌍끌이" 단어 제거).
+- `filterChips` 의 `detail="외국인 3일+ 또는 쌍끌이"` → `detail="외국인 3일+ 연속 순매수"` 로 변경.
+- 내부 ID/필터/쿼리는 그대로 유지 — 기존 API 호환성/스냅샷 분기는 변경 없음.
+- 사용자 입장에서 "쌍끌이 매수" 카드(신규)와 "수급 모멘텀" 카드(기존)가 시각적으로 구분되도록 보장. 호환성은 `test_invest_view_model_screener_service.py` 의 기존 `investor_flow_momentum` 케이스로 확인.
+
+---
+
+## Scope Guardrails (이번 PR 한정)
+
+- **No DB migrations.** `app/models/*.py`, `alembic/versions/*` 추가/수정 금지.
+- **No new ingestion job, no new TaskIQ task, no Prefect deployment, no scheduler activation.**
+- **No broker / order / watch / order-intent mutation path.** read-only view-model 만 수정.
+- **No Toss runtime scraping.** Toss 데이터는 수동 캡처 JSON 파일을 path/env 로 받는 diagnostic 에서만 사용.
+- **Snapshot-only**: 새 preset 은 `_load_*_from_snapshots` 패턴과 동일하게 snapshot 분기로 추가. generic provider fallback 금지.
+- **Frontend**: 새 preset rendering 만 추가; 기존 `ScreenerResultsTable`/`ScreenerFreshnessLine` 컴포넌트 시그니처 변경 금지.
+
+---
+
+## File Structure
+
+**Modify (backend)**:
+
+- `app/services/invest_view_model/screener_presets.py` — preset metadata, `_SCREENING_FILTERS`, `_KR_ONLY_PRESET_IDS`, `_METRIC_FIELD` (후자는 service 모듈에 있음).
+- `app/services/invest_view_model/screener_service.py`
+  - L670–681 `_METRIC_FIELD` (preset → metric field)
+  - L1220–1265 snapshot-first 분기 (`elif preset_id == "double_buy":` 추가)
+  - 신규 helper `_load_double_buy_from_snapshots(session, *, market, limit, ...) -> list[dict] | None`
+- `app/services/invest_view_model/screener_presets.py` — 새 preset entry + KR-only set 등록.
+
+**Create (backend)**:
+
+- `app/services/invest_view_model/double_buy_screener.py` — Toss screenId=18 parity 쿼리 (read-only). `_load_double_buy_from_snapshots` 의 본체. screener_service 가 import 하여 사용. 단일 책임: snapshot join + filter + ordering + freshness state.
+
+**Modify (diagnostic)**:
+
+- `scripts/diagnose_invest_screener_toss_parity.py`
+  - `_SUPPORTED_PRESETS` 에 `double_buy` 추가.
+  - `--interpretation {a,b,both}` 옵션 추가 (default `both`).
+  - Toss reference 는 기존 `--toss-symbols-file` 인터페이스 재활용.
+  - A/B 양쪽 후보 set 산출 → overlap/missing/extra/rank-delta 출력.
+
+**Modify (tests, backend)**:
+
+- `tests/test_invest_view_model_screener_service.py` — `double_buy` preset 결과/freshness/카피 케이스 추가. 기존 `investor_flow_momentum` 케이스 카피 변경 반영. `high_volume_momentum` → `kr_high_volume_surge` rename 반영.
+- `tests/test_invest_screener_toss_parity_diagnostics.py` — `double_buy` interpretation A/B 비교 출력 케이스 추가.
+- `tests/test_invest_view_model_screener_presets.py` (필요 시 신규) — preset registry 일관성 테스트 (`high_volume_momentum` 미존재, `double_buy` 존재, 모든 preset id 가 `_METRIC_FIELD` 에 있음).
+
+**Modify (frontend)**:
+
+- `frontend/invest/src/types/screener.ts` — 필요 시 새 preset id 상수만 추가 (preset list 는 백엔드에서 옴).
+- `frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx` — 신규 preset 에 맞는 column 표시 확인 (price + 1D change + flow chip). 기존 `investor_flow_momentum` 과 거의 동일하므로 큰 변경 없음.
+- `frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx` — `dataState=stale` 에서 어떤 dependency 가 stale 인지 보여주는 sub-warning 표시 (이미 `warnings` 배열로 들어가므로 별도 시각 변경은 옵셔널).
+
+**Modify (docs)**:
+
+- `docs/runbooks/invest-screener-snapshots.md` — ROB-276 섹션 추가: `double_buy` preset, A/B 해석 lock 근거, `high_volume_momentum` 제거 안내, freshness 다중 의존성 표기.
+
+---
+
+## Task 0: Toss A/B Interpretation Verification (Decision 1 Lock)
+
+> 이 task 의 결과로 Decision 1 을 본 문서 위쪽에서 lock 한다. 검증 없이는 다음 task 로 진행하지 않는다.
+
+**Files:**
+- Read: `app/models/investor_flow_snapshot.py`, `app/models/invest_screener_snapshot.py`
+- Create (임시, 커밋 안 함): `scripts/_rob276_ab_check.py` 또는 inline SQL via `psql`
+
+- [ ] **Step 1: 최신 영업일 + 직전 영업일 결정**
+
+`investor_flow_snapshots` 의 `max(snapshot_date)` 와 그 직전 distinct date 를 구한다.
+
+```sql
+WITH d AS (
+  SELECT DISTINCT snapshot_date
+  FROM investor_flow_snapshots
+  WHERE market = 'kr'
+  ORDER BY snapshot_date DESC
+  LIMIT 2
+)
+SELECT array_agg(snapshot_date ORDER BY snapshot_date DESC) FROM d;
+```
+
+기록: `current_date_kr = <YYYY-MM-DD>`, `prev_date_kr = <YYYY-MM-DD>`.
+
+- [ ] **Step 2: 해석 A 후보 집합 산출**
+
+```sql
+SELECT ifs.symbol
+FROM investor_flow_snapshots ifs
+JOIN invest_screener_snapshots iss
+  ON iss.market = ifs.market
+ AND iss.symbol = ifs.symbol
+ AND iss.snapshot_date = ifs.snapshot_date
+WHERE ifs.market = 'kr'
+  AND ifs.snapshot_date = :current_date_kr
+  AND ifs.foreign_net > 0
+  AND ifs.institution_net > 0
+  AND COALESCE(iss.change_rate, 0) >= 0
+ORDER BY iss.change_rate DESC NULLS LAST
+LIMIT 200;
+```
+
+결과를 `out_a.txt` 로 저장.
+
+- [ ] **Step 3: 해석 B 후보 집합 산출 (delta)**
+
+```sql
+WITH cur AS (
+  SELECT symbol, foreign_net, institution_net
+  FROM investor_flow_snapshots
+  WHERE market = 'kr' AND snapshot_date = :current_date_kr
+),
+prev AS (
+  SELECT symbol, foreign_net, institution_net
+  FROM investor_flow_snapshots
+  WHERE market = 'kr' AND snapshot_date = :prev_date_kr
+)
+SELECT cur.symbol
+FROM cur
+JOIN prev ON prev.symbol = cur.symbol
+JOIN invest_screener_snapshots iss
+  ON iss.market = 'kr'
+ AND iss.symbol = cur.symbol
+ AND iss.snapshot_date = :current_date_kr
+WHERE (cur.foreign_net - prev.foreign_net) > 0
+  AND (cur.institution_net - prev.institution_net) > 0
+  AND COALESCE(iss.change_rate, 0) >= 0
+ORDER BY iss.change_rate DESC NULLS LAST
+LIMIT 200;
+```
+
+결과를 `out_b.txt` 로 저장.
+
+- [ ] **Step 4: Toss reference set 준비**
+
+이슈에 적힌 5개 + 가능하면 더 많은 캡처(Chrome devtools 의 toss `screen` 응답 JSON 의 `symbol`/`code` 필드, ROB-276 댓글에 첨부된 reference 가 있으면 그것). 최소 케이스: `011000, 439960, 083500, 042520, 042420`.
+
+`toss_ref.txt` 1줄 1심볼로 저장 (대문자/zero-padded 6자리).
+
+- [ ] **Step 5: A/B 비교 수치 산출**
+
+```bash
+sort -u toss_ref.txt > _ref.sorted
+sort -u out_a.txt > _a.sorted
+sort -u out_b.txt > _b.sorted
+echo "ref total:     $(wc -l < _ref.sorted)"
+echo "A overlap:     $(comm -12 _ref.sorted _a.sorted | wc -l)"
+echo "B overlap:     $(comm -12 _ref.sorted _b.sorted | wc -l)"
+echo "A only (extra): $(comm -23 _a.sorted _ref.sorted | wc -l)"
+echo "B only (extra): $(comm -23 _b.sorted _ref.sorted | wc -l)"
+echo "ref missed A:  $(comm -23 _ref.sorted _a.sorted | wc -l)"
+echo "ref missed B:  $(comm -23 _ref.sorted _b.sorted | wc -l)"
+```
+
+- [ ] **Step 6: Lock 결정 기록**
+
+- A overlap ≥ B overlap + 1 이고 reference 의 50% 이상 커버 → **A lock**.
+- B overlap ≥ A overlap + 1 이고 reference 의 50% 이상 커버 → **B lock**.
+- 둘 다 < 50% 커버 또는 동률 → **A lock (safer fallback)** + diagnostic 에서 양쪽 표기 유지.
+
+본 plan 의 "Decision 1" 섹션 결론 부분과 Task 4 의 helper 본문을 lock 결과로 갱신.
+
+- [ ] **Step 7: 임시 파일 정리**
+
+```bash
+rm -f _ref.sorted _a.sorted _b.sorted out_a.txt out_b.txt toss_ref.txt
+# scripts/_rob276_ab_check.py 만들었으면 삭제
+```
+
+커밋 없음 (verification 만).
+
+---
+
+## Task 1: Preset Registry — `double_buy` 추가 & `high_volume_momentum` clean cut
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_presets.py:69-80, 185-191, 15`
+- Test: `tests/test_invest_view_model_screener_presets.py` (신규)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```python
+# tests/test_invest_view_model_screener_presets.py
+from app.services.invest_view_model.screener_presets import (
+    SCREENER_PRESETS,
+    preset_definitions,
+    screening_filters_for,
+    _KR_ONLY_PRESET_IDS,
+)
+
+
+def test_high_volume_momentum_removed_and_volume_preset_renamed():
+    ids = {p.id for p in SCREENER_PRESETS}
+    assert "high_volume_momentum" not in ids
+    assert "kr_high_volume_surge" in ids
+    surge = next(p for p in SCREENER_PRESETS if p.id == "kr_high_volume_surge")
+    assert surge.name == "거래량 급증"
+    assert surge.market == "kr"
+
+
+def test_double_buy_preset_present_and_kr_only():
+    ids = {p.id for p in SCREENER_PRESETS}
+    assert "double_buy" in ids
+    db = next(p for p in SCREENER_PRESETS if p.id == "double_buy")
+    assert db.name == "쌍끌이 매수"
+    assert db.market == "kr"
+    assert "double_buy" in _KR_ONLY_PRESET_IDS
+    chips = {c.label for c in db.filterChips}
+    assert "국내" in chips
+    # 외국인+기관 동시 매수가 명시되어야 함
+    assert any("외국인" in c.label or "기관" in c.label for c in db.filterChips)
+
+
+def test_investor_flow_momentum_copy_no_double_buy_wording():
+    ifm = next(p for p in SCREENER_PRESETS if p.id == "investor_flow_momentum")
+    assert "쌍끌이" not in ifm.description
+    for chip in ifm.filterChips:
+        detail = chip.detail or ""
+        assert "쌍끌이" not in detail
+
+
+def test_double_buy_screening_filters_lookup_is_kr_only_snapshot():
+    filters = screening_filters_for("double_buy", "kr")
+    assert filters["market"] == "kr"
+    # 거래량 정렬이어선 안 됨
+    assert filters.get("sort_by") != "volume"
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_presets.py -v
+```
+
+Expected: 4 FAIL (preset 미존재 / 카피 미수정).
+
+- [ ] **Step 3: Preset registry 수정**
+
+`app/services/invest_view_model/screener_presets.py`:
+
+L15 의 `_KR_ONLY_PRESET_IDS` 확장:
+
+```python
+_KR_ONLY_PRESET_IDS = {"investor_flow_momentum", "double_buy"}
+```
+
+L69-80 의 `high_volume_momentum` entry 를 `kr_high_volume_surge` 로 교체:
+
+```python
+ScreenerPreset(
+    id="kr_high_volume_surge",
+    name="거래량 급증",
+    description="거래량이 폭발적으로 늘어난 종목",
+    badges=[],
+    filterChips=[
+        ScreenerFilterChip(label="국내", detail=None),
+        ScreenerFilterChip(label="거래량", detail="상위"),
+    ],
+    metricLabel="거래량",
+    market="kr",
+),
+```
+
+`investor_flow_momentum` (L82-93) 의 카피 정리:
+
+```python
+ScreenerPreset(
+    id="investor_flow_momentum",
+    name="수급 모멘텀",
+    description="외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)",
+    badges=["MVP"],
+    filterChips=[
+        ScreenerFilterChip(label="국내", detail=None),
+        ScreenerFilterChip(label="투자자별 수급", detail="외국인 3일+ 연속 순매수"),
+        ScreenerFilterChip(label="데이터", detail="지연 스냅샷 기반"),
+    ],
+    metricLabel="외국인 순매수",
+    market="kr",
+),
+```
+
+`SCREENER_PRESETS` list 에 `double_buy` 추가 (`investor_flow_momentum` 다음, `growth_expectation` 앞):
+
+```python
+ScreenerPreset(
+    id="double_buy",
+    name="쌍끌이 매수",
+    description="기관과 외국인이 동시에 매수하는 종목",
+    badges=["NEW"],
+    filterChips=[
+        ScreenerFilterChip(label="국내", detail=None),
+        ScreenerFilterChip(label="외국인", detail="순매수"),
+        ScreenerFilterChip(label="기관", detail="순매수"),
+        ScreenerFilterChip(label="주가등락률", detail="1일 ≥ 0%"),
+        ScreenerFilterChip(label="데이터", detail="지연 스냅샷 기반"),
+    ],
+    metricLabel="주가등락률",
+    market="kr",
+),
+```
+
+L185-191 의 `_SCREENING_FILTERS` 의 `high_volume_momentum` 키를 `kr_high_volume_surge` 로 rename. `double_buy` 키 추가:
+
+```python
+"kr_high_volume_surge": {
+    "market": "kr",
+    "asset_type": "stock",
+    "sort_by": "volume",
+    "sort_order": "desc",
+    "limit": 20,
+},
+"double_buy": {
+    "market": "kr",
+    "asset_type": "stock",
+    "sort_by": "change_rate",
+    "sort_order": "desc",
+    "min_change_rate": 0.0,
+    "include_double_buy": True,
+    "limit": 50,
+},
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_presets.py -v
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: 기존 테스트 영향 grep & 정리**
+
+```bash
+grep -rn "high_volume_momentum" --include="*.py" --include="*.ts" --include="*.tsx" --include="*.md"
+```
+
+영향 라인:
+- `app/services/invest_view_model/screener_service.py:675` — `_METRIC_FIELD` 키 rename + `double_buy` 추가 (Task 3 에서 본격 처리하지만 import error 방지를 위해 일단 키만 rename 하고 `double_buy` 는 placeholder `"change_rate"` 로 잡아둠).
+- `tests/test_invest_view_model_screener_service.py:1062` — `("high_volume_momentum", "volume", ...)` → `("kr_high_volume_surge", "volume", ...)` rename.
+- frontend: grep 결과에 따라 `frontend/invest/src/**` 에 `high_volume_momentum` 문자열이 남아있는지 확인. 보통 백엔드 응답에서 받는 ID 라서 hard-coded 가 없을 가능성이 높지만 있다면 동일하게 rename.
+
+- [ ] **Step 6: 전체 invest_view_model 테스트 실행**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py tests/test_invest_view_model_screener_presets.py -v
+```
+
+Expected: 모두 PASS. 만약 다른 테스트가 깨지면 그 테스트가 hard-code 한 ID 도 같이 정리.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/services/invest_view_model/screener_presets.py \
+        app/services/invest_view_model/screener_service.py \
+        tests/test_invest_view_model_screener_presets.py \
+        tests/test_invest_view_model_screener_service.py
+git commit -m "$(cat <<'EOF'
+feat(rob-276): rename high_volume_momentum to kr_high_volume_surge and scaffold double_buy preset
+
+- 쌍끌이 매수 라벨을 거래량 기반 preset 에서 분리 (clean cut)
+- double_buy preset registry/filters scaffold 추가, 본 query 는 후속 task 에서
+- investor_flow_momentum 카피에서 "쌍끌이" 표현 제거
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Snapshot 조회 helper — `_load_double_buy_from_snapshots`
+
+**Files:**
+- Create: `app/services/invest_view_model/double_buy_screener.py`
+- Test: `tests/test_invest_view_model_double_buy_screener.py` (신규)
+
+- [ ] **Step 1: 실패 테스트 작성 (해석 A 기준; Task 0 결과가 B 이면 Step 3 본체만 B 로 교체)**
+
+```python
+# tests/test_invest_view_model_double_buy_screener.py
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+import pytest
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.invest_view_model.double_buy_screener import (
+    load_double_buy_from_snapshots,
+)
+
+
+@pytest.mark.asyncio
+async def test_returns_rows_filtered_by_double_buy_and_positive_change_rate(
+    async_session,
+):
+    today = dt.date(2026, 5, 19)
+    # Universe seed
+    async_session.add_all(
+        [
+            KRSymbolUniverse(symbol="011000", name="진원생명과학", is_active=True),
+            KRSymbolUniverse(symbol="000001", name="제외종목ETF", is_active=True),
+        ]
+    )
+    # Investor flow snapshots: double_buy True + double_buy False
+    async_session.add_all(
+        [
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol="011000",
+                snapshot_date=today,
+                foreign_net=1_000_000,
+                institution_net=2_000_000,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            ),
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol="000001",
+                snapshot_date=today,
+                foreign_net=-1,
+                institution_net=-1,
+                double_buy=False,
+                double_sell=True,
+                source="naver_finance",
+            ),
+        ]
+    )
+    # Screener snapshots: 011000 양수 change_rate, 000001 음수
+    async_session.add_all(
+        [
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol="011000",
+                snapshot_date=today,
+                latest_close=decimal.Decimal("12000"),
+                prev_close=decimal.Decimal("10000"),
+                change_rate=decimal.Decimal("20.0"),
+                daily_volume=100_000,
+            ),
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol="000001",
+                snapshot_date=today,
+                latest_close=decimal.Decimal("900"),
+                prev_close=decimal.Decimal("1000"),
+                change_rate=decimal.Decimal("-10.0"),
+                daily_volume=50_000,
+            ),
+        ]
+    )
+    await async_session.commit()
+
+    rows = await load_double_buy_from_snapshots(
+        async_session, market="kr", limit=20
+    )
+
+    assert rows is not None
+    assert [r["symbol"] for r in rows] == ["011000"]
+    assert rows[0]["change_rate"] == pytest.approx(20.0)
+    assert rows[0]["double_buy"] is True
+    assert rows[0]["_screener_snapshot_state"] in {"fresh", "stale"}
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_snapshots(async_session):
+    rows = await load_double_buy_from_snapshots(
+        async_session, market="kr", limit=20
+    )
+    assert rows is None
+
+
+@pytest.mark.asyncio
+async def test_excludes_non_common_stock_by_name_heuristic(async_session):
+    today = dt.date(2026, 5, 19)
+    async_session.add_all(
+        [
+            KRSymbolUniverse(symbol="999999", name="KODEX 200 ETF", is_active=True),
+        ]
+    )
+    async_session.add(
+        InvestorFlowSnapshot(
+            market="kr",
+            symbol="999999",
+            snapshot_date=today,
+            foreign_net=10,
+            institution_net=10,
+            double_buy=True,
+            double_sell=False,
+            source="naver_finance",
+        )
+    )
+    async_session.add(
+        InvestScreenerSnapshot(
+            market="kr",
+            symbol="999999",
+            snapshot_date=today,
+            latest_close=decimal.Decimal("10000"),
+            prev_close=decimal.Decimal("9000"),
+            change_rate=decimal.Decimal("11.0"),
+            daily_volume=1,
+        )
+    )
+    await async_session.commit()
+
+    rows = await load_double_buy_from_snapshots(
+        async_session, market="kr", limit=20
+    )
+    assert rows == []  # latest partition exists but ETF filtered out
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_double_buy_screener.py -v
+```
+
+Expected: 3 FAIL (ImportError).
+
+- [ ] **Step 3: helper 구현 (해석 A — Task 0 lock; B 로 전환 시 SQL 본체만 교체)**
+
+`app/services/invest_view_model/double_buy_screener.py`:
+
+```python
+"""Read-only loader for the 쌍끌이 매수 (Toss screenId=18 parity) preset.
+
+Joins the latest investor_flow_snapshots row with the latest invest_screener_snapshots
+row per symbol and applies the Toss-parity filter (Interpretation A, locked 2026-05-20
+under Task 0 safer-fallback rule — see plan Decision 1):
+    market = kr
+    foreign_net  > 0   AND institution_net  > 0   (=double_buy)  [LOCKED — Interpretation A]
+    change_rate >= 0
+    sort by change_rate desc, symbol asc
+
+If a later diagnostic A/B run (Task 4) shows Interpretation B is materially closer to
+Toss screenId=18, swap only this query block for the self-join variant documented
+below in the Step 3 fallback note. Preset metadata / freshness logic unchanged.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+
+logger = logging.getLogger(__name__)
+
+
+async def load_double_buy_from_snapshots(
+    session: AsyncSession | None, *, market: str, limit: int = 50
+) -> list[dict[str, Any]] | None:
+    """Return Toss-parity 쌍끌이 매수 rows or None when no snapshot partition exists.
+
+    None  → caller should report dataState=missing and warn that snapshots are absent.
+    []    → latest partition exists but no qualifiers (caller renders empty + stale).
+    Rows  → ordered by change_rate desc, symbol asc.
+    """
+    if session is None or market != "kr":
+        return None
+
+    latest_flow_stmt = sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+        InvestorFlowSnapshot.market == "kr"
+    )
+    latest_price_stmt = sa.select(sa.func.max(InvestScreenerSnapshot.snapshot_date)).where(
+        InvestScreenerSnapshot.market == "kr"
+    )
+    try:
+        flow_date = (await session.execute(latest_flow_stmt)).scalar_one_or_none()
+        price_date = (await session.execute(latest_price_stmt)).scalar_one_or_none()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("double_buy: latest dates lookup failed: %s", exc, exc_info=True)
+        return None
+    if flow_date is None or price_date is None:
+        return None
+
+    # --- Interpretation A (LOCKED via Task 0; swap block if diagnostic later picks B) ---
+    candidate_stmt = (
+        sa.select(
+            InvestorFlowSnapshot.symbol,
+            InvestorFlowSnapshot.foreign_net,
+            InvestorFlowSnapshot.institution_net,
+            InvestorFlowSnapshot.individual_net,
+            InvestorFlowSnapshot.double_buy,
+            InvestorFlowSnapshot.foreign_consecutive_buy_days,
+            InvestorFlowSnapshot.institution_consecutive_buy_days,
+            InvestScreenerSnapshot.latest_close,
+            InvestScreenerSnapshot.prev_close,
+            InvestScreenerSnapshot.change_rate,
+            InvestScreenerSnapshot.daily_volume,
+            InvestScreenerSnapshot.snapshot_date.label("price_snapshot_date"),
+            InvestorFlowSnapshot.snapshot_date.label("flow_snapshot_date"),
+        )
+        .join(
+            InvestScreenerSnapshot,
+            sa.and_(
+                InvestScreenerSnapshot.market == InvestorFlowSnapshot.market,
+                InvestScreenerSnapshot.symbol == InvestorFlowSnapshot.symbol,
+                InvestScreenerSnapshot.snapshot_date == price_date,
+            ),
+        )
+        .where(
+            InvestorFlowSnapshot.market == "kr",
+            InvestorFlowSnapshot.snapshot_date == flow_date,
+            InvestorFlowSnapshot.foreign_net > 0,
+            InvestorFlowSnapshot.institution_net > 0,
+            sa.func.coalesce(InvestScreenerSnapshot.change_rate, 0) >= 0,
+        )
+        .order_by(
+            InvestScreenerSnapshot.change_rate.desc().nullslast(),
+            InvestorFlowSnapshot.symbol.asc(),
+        )
+        .limit(max(limit * 4, limit + 40))
+    )
+    try:
+        result = await session.execute(candidate_stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("double_buy: candidate query failed: %s", exc, exc_info=True)
+        return None
+    candidate_rows = list(result.mappings().all())
+
+    # Common-stock guard via KR universe name
+    symbols = [r["symbol"] for r in candidate_rows]
+    name_map: dict[str, str] = {}
+    if symbols:
+        try:
+            names = await session.execute(
+                sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                    KRSymbolUniverse.symbol.in_(symbols),
+                    KRSymbolUniverse.is_active.is_(True),
+                )
+            )
+            name_map = {row.symbol: row.name for row in names.all()}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("double_buy: name lookup failed: %s", exc, exc_info=True)
+
+    from app.services.invest_view_model.screener_service import _is_kr_toss_common_stock
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for r in candidate_rows:
+        sym = r["symbol"]
+        if sym in seen:
+            continue
+        name = name_map.get(sym)
+        if not _is_kr_toss_common_stock(sym, name):
+            continue
+        seen.add(sym)
+        state = "fresh" if r["price_snapshot_date"] == r["flow_snapshot_date"] else "stale"
+        rows.append(
+            {
+                "symbol": sym,
+                "market": "kr",
+                "name": name,
+                "latest_close": float(r["latest_close"]) if r["latest_close"] is not None else None,
+                "prev_close": float(r["prev_close"]) if r["prev_close"] is not None else None,
+                "change_rate": float(r["change_rate"]) if r["change_rate"] is not None else None,
+                "volume": r["daily_volume"],
+                "foreign_net": r["foreign_net"],
+                "institution_net": r["institution_net"],
+                "individual_net": r["individual_net"],
+                "double_buy": r["double_buy"],
+                "foreign_consecutive_buy_days": r["foreign_consecutive_buy_days"],
+                "institution_consecutive_buy_days": r["institution_consecutive_buy_days"],
+                "snapshot_date": r["price_snapshot_date"],
+                "_screener_snapshot_state": state,
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+```
+
+> **If Task 0 locks Interpretation B**, replace the `--- Interpretation A ---` block with a self-join on `investor_flow_snapshots` for current vs previous trading day:
+>
+> ```python
+> prev_date_stmt = (
+>     sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date))
+>     .where(
+>         InvestorFlowSnapshot.market == "kr",
+>         InvestorFlowSnapshot.snapshot_date < flow_date,
+>     )
+> )
+> prev_date = (await session.execute(prev_date_stmt)).scalar_one_or_none()
+> if prev_date is None:
+>     return None  # cannot compute delta; treat as missing
+> Prev = sa.orm.aliased(InvestorFlowSnapshot)
+> candidate_stmt = (
+>     sa.select(InvestorFlowSnapshot, Prev, InvestScreenerSnapshot)
+>     .join(Prev, sa.and_(Prev.market == "kr", Prev.symbol == InvestorFlowSnapshot.symbol, Prev.snapshot_date == prev_date))
+>     .join(InvestScreenerSnapshot, sa.and_(
+>         InvestScreenerSnapshot.market == "kr",
+>         InvestScreenerSnapshot.symbol == InvestorFlowSnapshot.symbol,
+>         InvestScreenerSnapshot.snapshot_date == price_date,
+>     ))
+>     .where(
+>         InvestorFlowSnapshot.market == "kr",
+>         InvestorFlowSnapshot.snapshot_date == flow_date,
+>         (InvestorFlowSnapshot.foreign_net - Prev.foreign_net) > 0,
+>         (InvestorFlowSnapshot.institution_net - Prev.institution_net) > 0,
+>         sa.func.coalesce(InvestScreenerSnapshot.change_rate, 0) >= 0,
+>     )
+>     .order_by(InvestScreenerSnapshot.change_rate.desc().nullslast(), InvestorFlowSnapshot.symbol.asc())
+>     .limit(max(limit * 4, limit + 40))
+> )
+> ```
+>
+> 그 외 row 변환은 동일. `prev_date is None` 이면 "previous snapshot missing" 으로 caller 에 신호 (`return []` + state override 는 Task 3 에서 처리).
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_double_buy_screener.py -v
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/invest_view_model/double_buy_screener.py tests/test_invest_view_model_double_buy_screener.py
+git commit -m "$(cat <<'EOF'
+feat(rob-276): add double_buy snapshot loader for Toss screenId=18 parity
+
+- read-only join of investor_flow_snapshots + invest_screener_snapshots
+- common-stock guard via _is_kr_toss_common_stock
+- returns None when partition absent, [] when partition exists but empty
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `screener_service.py` 분기 연결 + Freshness 분리
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py:670-681, 1220-1266, 1314-1325`
+- Test: `tests/test_invest_view_model_screener_service.py` (신규 케이스 추가)
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+`tests/test_invest_view_model_screener_service.py` 에 다음 케이스 추가 (위치: 기존 `investor_flow_momentum` 테스트 근처):
+
+```python
+@pytest.mark.asyncio
+async def test_double_buy_preset_returns_snapshot_filtered_rows(async_session, ...):
+    # given: today partition with 2 double_buy True symbols, 1 with negative change_rate
+    # when: build_screener_results(preset_id="double_buy", market="kr", session=async_session)
+    # then: only the positive-change symbol returned, ordered by change_rate desc
+    ...
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_missing_snapshot_reports_missing_state(
+    async_session_no_snapshots,
+):
+    response = await build_screener_results(
+        preset_id="double_buy", market="kr", session=async_session_no_snapshots, ...
+    )
+    assert response.freshness.dataState == "missing"
+    assert any("스냅샷" in w for w in response.warnings)
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_stale_when_price_snapshot_older_than_flow(
+    async_session_stale_price,
+):
+    response = await build_screener_results(
+        preset_id="double_buy", market="kr", session=async_session_stale_price, ...
+    )
+    assert response.freshness.dataState in {"stale", "fallback"}
+    assert any(
+        "시세 스냅샷" in w or "price" in w.lower() for w in response.warnings
+    )
+
+
+def test_double_buy_in_metric_field_map():
+    from app.services.invest_view_model.screener_service import _METRIC_FIELD
+    assert _METRIC_FIELD["double_buy"] == "change_rate"
+```
+
+(테스트 시그니처는 기존 fixture 패턴에 맞춰 조정.)
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v -k double_buy
+```
+
+Expected: 4 FAIL.
+
+- [ ] **Step 3: `_METRIC_FIELD` 업데이트**
+
+`screener_service.py` L670-681:
+
+```python
+_METRIC_FIELD: dict[str, str] = {
+    "consecutive_gainers": "week_change_rate",
+    "cheap_value": "per",
+    "steady_dividend": "dividend_yield",
+    "oversold_recovery": "rsi",
+    "kr_high_volume_surge": "volume",   # was "high_volume_momentum"
+    "growth_expectation": "change_rate",
+    "investor_flow_momentum": "foreign_net",
+    "double_buy": "change_rate",        # NEW
+    "crypto_high_volume": "trade_amount_24h",
+    "crypto_oversold": "rsi",
+    "crypto_momentum": "change_rate",
+}
+```
+
+- [ ] **Step 4: snapshot-first 분기에 double_buy 추가**
+
+`screener_service.py` L1220-1266 의 분기 체인에 추가 (`investor_flow_momentum` 분기 다음, `crypto` 분기 앞):
+
+```python
+elif preset_id == "double_buy":
+    from app.services.invest_view_model.double_buy_screener import (
+        load_double_buy_from_snapshots,
+    )
+    _snapshot_check_result = await load_double_buy_from_snapshots(
+        session,
+        market=requested_market,
+        limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+    )
+    _snapshot_empty_warning = (
+        "최신 수급/시세 스냅샷에서 쌍끌이 매수 조건에 맞는 종목이 없습니다."
+    )
+```
+
+`investor_flow_momentum` 의 안전망 패턴(L1257-1265)과 동일하게 `double_buy` 도 추가:
+
+```python
+if preset_id == "double_buy" and _snapshot_check_result is None:
+    _snapshot_check_result = []
+    _snapshot_state_override = "missing"
+    _snapshot_empty_warning = (
+        "수급 또는 시세 스냅샷이 아직 적재되지 않아 쌍끌이 매수 후보를 표시할 수 없습니다."
+    )
+```
+
+- [ ] **Step 5: Freshness 다중 의존성 분리 (KST trading-date 기반)**
+
+`screener_service.py` 의 `_load_double_buy_from_snapshots` 호출 직후 / state 결정 직전에, 시세 vs 수급 스냅샷 일자를 비교해 warning 을 분리한다. 기존 `today_trading_date` 사용 (이미 `app/services/invest_screener_snapshots/freshness.py:17` 에 존재 → KST 기반).
+
+`screener_service.py` 안에 helper 추가 (예: L1325 근처 또는 별도 함수):
+
+```python
+def _double_buy_dependency_warnings(
+    *, snapshot_rows: list[dict[str, Any]] | None, now_market_date: dt.date
+) -> tuple[list[str], str | None]:
+    """Return (warnings, state_override) for double_buy by dependency.
+
+    Distinguishes: price stale vs flow stale vs both fresh.  Used only when the
+    snapshot loader returns rows; pure missing partitions are handled above.
+    """
+    if not snapshot_rows:
+        return [], None
+    flow_dates = {r.get("snapshot_date") for r in snapshot_rows}
+    price_states = {r.get("_screener_snapshot_state") for r in snapshot_rows}
+    warnings: list[str] = []
+    if "stale" in price_states:
+        warnings.append("시세 스냅샷이 직전 영업일 기준이라 일부 데이터가 1일 지연되었습니다.")
+    if all(d is not None and d < now_market_date for d in flow_dates):
+        warnings.append("수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다.")
+    state = "stale" if warnings else None
+    return warnings, state
+```
+
+이 결과를 `_aggregated_data_state` 와 `upstream_warnings` 에 머지. (정확한 머지 위치는 기존 `investor_flow_momentum` 의 stale 처리 패턴을 따른다.)
+
+- [ ] **Step 6: `_KR_ONLY_PRESET_IDS` 가 service 분기에서 일관됨 확인**
+
+`get_preset` 이 `requested_market="kr"` 일 때만 `double_buy` 를 노출하는지 확인. preset_definitions 분기를 통과하면 OK.
+
+- [ ] **Step 7: 테스트 통과 확인**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v -k double_buy
+uv run pytest tests/test_invest_view_model_screener_service.py -v
+```
+
+Expected: 신규 4 + 기존 모두 PASS.
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py
+git commit -m "$(cat <<'EOF'
+feat(rob-276): wire double_buy preset into screener view-model with split freshness
+
+- snapshot-first branch in build_screener_results
+- separate warnings for stale price vs stale investor-flow snapshots
+- missing partition → dataState=missing with explicit warning
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Diagnostic 확장 — A/B Interpretation 비교 모드
+
+**Files:**
+- Modify: `scripts/diagnose_invest_screener_toss_parity.py:34-50, 그리고 main 함수`
+- Test: `tests/test_invest_screener_toss_parity_diagnostics.py` (신규 케이스 추가)
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+```python
+def test_double_buy_supported_and_emits_ab_comparison(monkeypatch, capsys, tmp_path):
+    # given: toss_symbols file + seeded DB partitions with known A/B differing sets
+    # when: run --preset double_buy --interpretation both
+    # then: stdout JSON includes a_overlap, b_overlap, a_only, b_only, ref_missing_a, ref_missing_b
+    ...
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+```bash
+uv run pytest tests/test_invest_screener_toss_parity_diagnostics.py -v -k double_buy
+```
+
+Expected: 1 FAIL.
+
+- [ ] **Step 3: Diagnostic 본체 변경**
+
+`scripts/diagnose_invest_screener_toss_parity.py`:
+
+- L34 `_SUPPORTED_PRESETS = {"consecutive_gainers", "double_buy"}` 로 확장.
+- argparse 에 `--interpretation` 추가: `choices=("a", "b", "both"), default="both"`.
+- `double_buy` 분기에서:
+  - 해석 A 후보 set = `load_double_buy_from_snapshots(... interpretation="a")` 또는 inline SQL.
+  - 해석 B 후보 set = inline SQL (current vs prev investor_flow self-join).
+  - reference set 은 기존 `--toss-symbols-file` 로 받음.
+  - 출력 JSON 에 다음 필드 포함:
+
+    ```python
+    {
+      "preset": "double_buy",
+      "current_date": "...",
+      "prev_date": "...",
+      "interpretation_a": {
+          "count": N_a, "overlap": ..., "extra": ..., "missing": ...,
+      },
+      "interpretation_b": {
+          "count": N_b, "overlap": ..., "extra": ..., "missing": ...,
+      },
+      "ref_size": ref_n,
+      "note": "Toss data captured manually; never fetched at runtime.",
+    }
+    ```
+
+- 어떤 경우에도 Toss 에 HTTP 요청 금지 — 모든 reference 는 file path 에서 옴.
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+```bash
+uv run pytest tests/test_invest_screener_toss_parity_diagnostics.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add scripts/diagnose_invest_screener_toss_parity.py tests/test_invest_screener_toss_parity_diagnostics.py
+git commit -m "$(cat <<'EOF'
+feat(rob-276): extend toss parity diagnostic with double_buy A/B comparison
+
+- --interpretation {a,b,both} flag, default both
+- emits per-interpretation overlap/extra/missing counts
+- Toss data still file-only; no runtime scraping
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Frontend rendering 확인 + freshness sub-warning
+
+**Files:**
+- Modify (선택적): `frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx`, `ScreenerFreshnessLine.tsx`
+- Modify: `frontend/invest/src/types/screener.ts` (필요 시 preset id 상수만)
+- Test (선택적): `frontend/invest/src/desktop/screener/__tests__/*.test.tsx` 에 신규 preset snapshot
+
+- [ ] **Step 1: 백엔드 응답 수동 확인 (서버 기동 후)**
+
+```bash
+make dev &
+sleep 4
+curl -s "http://localhost:8000/invest/api/screener/presets?market=kr" | jq '.presets[] | select(.id=="double_buy" or .id=="kr_high_volume_surge" or .id=="investor_flow_momentum") | {id,name,description}'
+curl -s "http://localhost:8000/invest/api/screener/results?preset=double_buy&market=kr" | jq '{title, description, freshness, resultCount: (.results|length), warnings}'
+```
+
+Expected:
+- `double_buy` preset 의 name = `쌍끌이 매수`.
+- results 응답이 200 + freshness.dataState 는 데이터 상태에 따라 fresh/stale/missing.
+- 잘못된 generic provider fallback 으로 인한 "데이터 준비중" 메시지가 뜨지 않음.
+
+- [ ] **Step 2: 프론트엔드 화면 수동 확인**
+
+`frontend/invest` dev 서버 기동 후 브라우저로 `/invest/screener` 열어서:
+
+- 신규 `쌍끌이 매수` 카드가 거래량 카드와 별도로 보임.
+- `수급 모멘텀` 카드 카피에 `쌍끌이` 표현 없음.
+- 결과 row 에 종목명/현재가/1D 등락률/`쌍끌이 매수` 칩(`tone=double_buy`) 표시.
+- stale 상태일 때 freshness 안내 문구가 "시세 스냅샷 1일 지연" 또는 "수급 스냅샷 1일 지연" 으로 구분.
+
+각 화면 스크린샷을 PR description 에 첨부.
+
+- [ ] **Step 3: 깨진 케이스가 있으면 컴포넌트 보정**
+
+`ScreenerResultsTable.tsx` 가 `latest_close`/`change_rate`/`investor_flow_chip` 필드를 모두 렌더링하는지 확인. 누락이 있으면 type/render 추가. column 시그니처는 기존과 호환 유지.
+
+`ScreenerFreshnessLine.tsx` 는 `warnings` 배열을 그대로 렌더하므로 추가 작업 보통 불필요.
+
+- [ ] **Step 4: frontend 테스트 (있는 경우) 실행**
+
+```bash
+cd frontend/invest && pnpm test
+```
+
+- [ ] **Step 5: 커밋 (변경이 있으면)**
+
+```bash
+git add frontend/invest/
+git commit -m "$(cat <<'EOF'
+feat(rob-276): ensure /invest/screener renders double_buy preset rows correctly
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Runbook 업데이트
+
+**Files:**
+- Modify: `docs/runbooks/invest-screener-snapshots.md`
+
+- [ ] **Step 1: ROB-276 섹션 추가**
+
+내용:
+
+```markdown
+## ROB-276 — 쌍끌이 매수 (Toss screenId=18 parity)
+
+- **Preset**: `double_buy` (KR only, snapshot-only, read-only)
+- **Filter**: <Task 0 결과로 lock>
+  - Interpretation A (locked): `investor_flow_snapshots.foreign_net > 0 AND institution_net > 0` AND `invest_screener_snapshots.change_rate >= 0`, sort `change_rate DESC`
+  - (or) Interpretation B (locked): `(foreign_net - prev) > 0 AND (institution_net - prev) > 0` AND `change_rate >= 0`
+- **Lock 근거**: Toss reference (`YYYY-MM-DD` 캡처, N=___) 와 비교 시 A overlap=__, B overlap=__. <safer fallback 선택했다면 이유>.
+- **Removed**: 기존 `high_volume_momentum` preset 폐기. 후속 거래량 프리셋은 `kr_high_volume_surge` 로 이전. 구 ID 호환 안 함.
+- **Freshness**:
+  - 시세 스냅샷 stale → "시세 스냅샷 1일 지연" warning
+  - 수급 스냅샷 stale → "수급 스냅샷 1일 지연" warning
+  - 둘 다 missing → `dataState=missing` + 명시 warning
+- **Diagnostic**:
+  - `uv run python -m scripts.diagnose_invest_screener_toss_parity --preset double_buy --toss-symbols-file path/to/toss_ref.json --interpretation both`
+  - Toss 데이터는 항상 파일 기반, runtime fetch 없음.
+- **Scope guard**: no migration, no ingestion job, no scheduler activation, no broker/order mutation, no Toss runtime scraping.
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add docs/runbooks/invest-screener-snapshots.md
+git commit -m "$(cat <<'EOF'
+docs(rob-276): document double_buy preset, lock decision, and freshness behavior
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: 통합 검증 + PR
+
+- [ ] **Step 1: 전체 관련 테스트 실행**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py \
+              tests/test_invest_view_model_screener_presets.py \
+              tests/test_invest_view_model_double_buy_screener.py \
+              tests/test_invest_screener_toss_parity_diagnostics.py -v
+```
+
+Expected: 모두 PASS.
+
+- [ ] **Step 2: lint/format/typecheck**
+
+```bash
+make lint
+make typecheck
+```
+
+- [ ] **Step 3: API 샘플 캡처**
+
+```bash
+curl -s "http://localhost:8000/invest/api/screener/presets?market=kr" | jq '.presets[] | {id, name}' > /tmp/rob276_presets.json
+curl -s "http://localhost:8000/invest/api/screener/results?preset=double_buy&market=kr" | jq '.' > /tmp/rob276_results.json
+```
+
+→ PR description 에 첨부.
+
+- [ ] **Step 4: PR 생성**
+
+```bash
+git push -u origin rob-276
+gh pr create --base main --title "feat(rob-276): invest screener 쌍끌이 매수 Toss screenId=18 parity" --body "$(cat <<'EOF'
+## Summary
+
+- 새 preset `double_buy` (쌍끌이 매수) 추가 — Toss screenId=18 parity (snapshot-only, read-only)
+- 기존 `high_volume_momentum` → `kr_high_volume_surge` 로 clean-cut rename (구 ID 폐기)
+- `investor_flow_momentum` 카피에서 "쌍끌이" 표현 제거 — 사용자 입장에서 카드 구분 명확화
+- Freshness 가 price snapshot / flow snapshot 의존성을 분리해서 warning
+
+## Locked decisions (plan top)
+
+- Decision 1: Toss `외국인_순매수_비교` 해석은 **<A or B>** 로 lock. Reference (`<YYYY-MM-DD>`, N=__) 와의 overlap A=__, B=__.
+- Decision 2: `high_volume_momentum` clean cut (`kr_high_volume_surge` 로 ID 자체 변경). 구 ID 사용 URL/북마크는 unknown preset 응답.
+- Decision 3: `수급 모멘텀` 카피 정리 (description/chip 에서 "쌍끌이" 제거), 내부 ID/쿼리는 유지.
+
+## Scope guardrails (kept)
+
+- No DB migrations
+- No new ingestion job / scheduler / TaskIQ task / Prefect deployment
+- No broker / order / watch mutation
+- No Toss runtime scraping — diagnostic 만 파일 기반 reference 사용
+
+## Tests run
+
+- backend pytest: <붙여넣기>
+- diagnostic: `uv run python -m scripts.diagnose_invest_screener_toss_parity --preset double_buy --interpretation both --toss-symbols-file ...` 결과 첨부
+
+## Local API samples
+
+- `/invest/api/screener/presets?market=kr` — attached
+- `/invest/api/screener/results?preset=double_buy&market=kr` — attached
+
+## Toss parity gap (if any)
+
+- <남은 차이 명시: 캡처 일자, ETF/preferred 제외 한계, 등>
+
+## Deployment notes
+
+- 마이그레이션 없음
+- 스케줄러 활성화 없음
+- 배포 전 `model_rate_limit:*` 등 무관 인프라 점검 불필요
+- 구 `high_volume_momentum` URL 호출은 unknown preset 응답으로 빠짐 — frontend preset list 가 신규 ID 를 보장하므로 영향 작음
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Linear 상태 전환**
+
+ROB-276 status: `Backlog` → `In Progress`. PR 머지 후 → `In Review` → `Done`.
+
+---
+
+## Self-Review Checklist
+
+- [x] Spec coverage: Toss parity preset, freshness split, copy fix, scope guards, diagnostic, frontend — 모두 task 매핑됨
+- [x] No placeholders — Task 0 결과로 lock 할 SQL/criteria 모두 명시
+- [x] Type consistency — `load_double_buy_from_snapshots` 함수명 / 인자 / 반환 형태 task 간 일관
+- [x] Scope guards 명시
+- [x] Decision 1 lock 절차가 plan 상단에 명시되고 verification task 가 가장 먼저 실행됨
+- [x] 모든 task 마다 commit step 존재 (TDD: fail → impl → pass → commit)

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -27,10 +27,23 @@ const PRESETS = {
     },
     {
       id: "investor_flow_momentum", name: "수급 모멘텀",
-      description: "외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+      description: "외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)",
       badges: ["MVP"],
-      filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 또는 쌍끌이" }],
+      filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 연속 순매수" }],
       metricLabel: "외국인 순매수", market: "kr" as const,
+    },
+    {
+      id: "double_buy", name: "쌍끌이 매수",
+      description: "기관과 외국인이 동시에 매수하는 종목",
+      badges: ["NEW"],
+      filterChips: [
+        { label: "국내", detail: null },
+        { label: "외국인", detail: "순매수" },
+        { label: "기관", detail: "순매수" },
+        { label: "주가등락률", detail: "1일 ≥ 0%" },
+        { label: "데이터", detail: "지연 스냅샷 기반" },
+      ],
+      metricLabel: "주가등락률", market: "kr" as const,
     },
   ],
   selectedPresetId: "consecutive_gainers",
@@ -72,9 +85,9 @@ const RESULTS_VALUE = {
 const RESULTS_INVESTOR_FLOW = {
   ...RESULTS_GAINERS,
   presetId: "investor_flow_momentum", title: "수급 모멘텀",
-  description: "외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+  description: "외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)",
   metricLabel: "외국인 순매수",
-  filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 또는 쌍끌이" }],
+  filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 연속 순매수" }],
   results: [{
     ...ROW,
     symbol: "403550",
@@ -215,7 +228,7 @@ test("renders the investor-flow MVP preset and result chip", async () => {
   await userEvent.click(screen.getByTestId("screener-preset-investor_flow_momentum"));
 
   await waitFor(() => expect(screen.getByText("에스케이엔펄스")).toBeInTheDocument());
-  expect(screen.getByText("외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보")).toBeInTheDocument();
+  expect(screen.getByText("외국인 연속 순매수 흐름이 강한 종목 (스냅샷 기반)")).toBeInTheDocument();
   expect(screen.getByText("외국인 4일 순매수")).toBeInTheDocument();
   expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("investor_flow_momentum", "kr");
 });

--- a/scripts/diagnose_invest_screener_toss_parity.py
+++ b/scripts/diagnose_invest_screener_toss_parity.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SUPPORTED_PRESETS = {"consecutive_gainers"}
+_SUPPORTED_PRESETS = {"consecutive_gainers", "double_buy"}
 _SENSITIVE_HEADER_RE = re.compile(
     r"(cookie|authorization|x[-_]?csrf|token|secret|password|session)", re.I
 )
@@ -296,6 +296,225 @@ async def load_auto_trader_rows(
     return rows
 
 
+async def load_double_buy_rows_interpretation_a(
+    session: AsyncSession, *, market: str, limit: int
+) -> list[dict[str, Any]]:
+    """Toss screenId=18 parity, Interpretation A (absolute net buy > 0).
+
+    Mirrors the production loader at
+    app/services/invest_view_model/double_buy_screener.py so diagnostic output
+    is guaranteed to track the live serving path.
+    """
+    from app.services.invest_view_model.double_buy_screener import (
+        load_double_buy_from_snapshots,
+    )
+
+    rows = await load_double_buy_from_snapshots(session, market=market, limit=limit)
+    return rows or []
+
+
+async def load_double_buy_rows_interpretation_b(
+    session: AsyncSession, *, market: str, limit: int
+) -> list[dict[str, Any]]:
+    """Toss screenId=18 parity, Interpretation B (delta vs previous day > 0).
+
+    Implemented ONLY in the diagnostic for verification purposes. Not wired into
+    the production helper because Decision 1 locked the production rule to
+    Interpretation A under the safer-fallback policy.
+    """
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+    from app.services.invest_view_model.screener_service import (
+        _is_kr_toss_common_stock,
+    )
+
+    if market != "kr":
+        return []
+
+    latest_flow_stmt = sa.select(
+        sa.func.max(InvestorFlowSnapshot.snapshot_date)
+    ).where(InvestorFlowSnapshot.market == "kr")
+    flow_date = (await session.execute(latest_flow_stmt)).scalar_one_or_none()
+    if flow_date is None:
+        return []
+
+    prev_flow_stmt = sa.select(
+        sa.func.max(InvestorFlowSnapshot.snapshot_date)
+    ).where(
+        InvestorFlowSnapshot.market == "kr",
+        InvestorFlowSnapshot.snapshot_date < flow_date,
+    )
+    prev_flow_date = (await session.execute(prev_flow_stmt)).scalar_one_or_none()
+    if prev_flow_date is None:
+        return []
+
+    latest_price_stmt = sa.select(
+        sa.func.max(InvestScreenerSnapshot.snapshot_date)
+    ).where(InvestScreenerSnapshot.market == "kr")
+    price_date = (await session.execute(latest_price_stmt)).scalar_one_or_none()
+    if price_date is None:
+        return []
+
+    Prev = sa.orm.aliased(InvestorFlowSnapshot)
+    candidate_stmt = (
+        sa.select(
+            InvestorFlowSnapshot.symbol,
+            (InvestorFlowSnapshot.foreign_net - Prev.foreign_net).label(
+                "foreign_delta"
+            ),
+            (
+                InvestorFlowSnapshot.institution_net - Prev.institution_net
+            ).label("institution_delta"),
+            InvestScreenerSnapshot.change_rate,
+            InvestScreenerSnapshot.snapshot_date.label("price_snapshot_date"),
+            InvestorFlowSnapshot.snapshot_date.label("flow_snapshot_date"),
+        )
+        .join(
+            Prev,
+            sa.and_(
+                Prev.market == "kr",
+                Prev.symbol == InvestorFlowSnapshot.symbol,
+                Prev.snapshot_date == prev_flow_date,
+            ),
+        )
+        .join(
+            InvestScreenerSnapshot,
+            sa.and_(
+                InvestScreenerSnapshot.market == "kr",
+                InvestScreenerSnapshot.symbol == InvestorFlowSnapshot.symbol,
+                InvestScreenerSnapshot.snapshot_date == price_date,
+            ),
+        )
+        .where(
+            InvestorFlowSnapshot.market == "kr",
+            InvestorFlowSnapshot.snapshot_date == flow_date,
+            (InvestorFlowSnapshot.foreign_net - Prev.foreign_net) > 0,
+            (InvestorFlowSnapshot.institution_net - Prev.institution_net) > 0,
+            sa.func.coalesce(InvestScreenerSnapshot.change_rate, 0) >= 0,
+        )
+        .order_by(
+            InvestScreenerSnapshot.change_rate.desc().nullslast(),
+            InvestorFlowSnapshot.symbol.asc(),
+            InvestorFlowSnapshot.source.asc(),
+        )
+        .limit(max(limit * 4, limit + 40))
+    )
+    result = await session.execute(candidate_stmt)
+    candidate_rows = list(result.mappings().all())
+
+    symbols = [r["symbol"] for r in candidate_rows]
+    name_map: dict[str, str] = {}
+    if symbols:
+        names = await session.execute(
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                KRSymbolUniverse.symbol.in_(symbols),
+                KRSymbolUniverse.is_active.is_(True),
+            )
+        )
+        name_map = {row.symbol: row.name for row in names.all()}
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for r in candidate_rows:
+        sym = r["symbol"]
+        if sym in seen:
+            continue
+        if not _is_kr_toss_common_stock(sym, name_map.get(sym)):
+            continue
+        seen.add(sym)
+        rows.append(
+            {
+                "symbol": sym,
+                "foreign_delta": int(r["foreign_delta"])
+                if r["foreign_delta"] is not None
+                else None,
+                "institution_delta": int(r["institution_delta"])
+                if r["institution_delta"] is not None
+                else None,
+                "change_rate": float(r["change_rate"])
+                if r["change_rate"] is not None
+                else None,
+                "price_snapshot_date": r["price_snapshot_date"].isoformat()
+                if r["price_snapshot_date"]
+                else None,
+                "flow_snapshot_date": r["flow_snapshot_date"].isoformat()
+                if r["flow_snapshot_date"]
+                else None,
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
+def build_double_buy_parity_report(
+    *,
+    a_rows: list[dict[str, Any]] | None,
+    b_rows: list[dict[str, Any]] | None,
+    toss_rows: list[dict[str, Any]],
+    limit: int,
+    interpretation: str,
+    current_date: str | None,
+    prev_date: str | None,
+) -> dict[str, Any]:
+    """Compare Interpretation A and B against the Toss reference symbol set.
+
+    Parameters
+    ----------
+    a_rows / b_rows:
+        Loader output for each interpretation. Pass ``None`` for an
+        interpretation that was not requested — the corresponding block in the
+        report will be ``None`` so the JSON shape remains stable.
+    interpretation:
+        One of ``"a"``, ``"b"``, ``"both"``. Controls which blocks are
+        populated regardless of whether non-empty rows were supplied; this
+        keeps consumers' parsing logic predictable.
+    """
+    toss_symbols = {row["symbol"] for row in toss_rows}
+    toss_rank = {
+        row["symbol"]: int(row.get("rank") or idx)
+        for idx, row in enumerate(toss_rows, start=1)
+    }
+
+    def _block(rows: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+        if rows is None:
+            return None
+        auto_symbols = {r["symbol"] for r in rows}
+        auto_rank = {r["symbol"]: idx for idx, r in enumerate(rows, start=1)}
+        overlap = sorted(auto_symbols & toss_symbols, key=lambda s: toss_rank[s])
+        missing = sorted(toss_symbols - auto_symbols, key=lambda s: toss_rank[s])
+        extra = sorted(auto_symbols - toss_symbols, key=lambda s: auto_rank[s])
+        return {
+            "count": len(rows),
+            "overlapCount": len(overlap),
+            "missingFromAutoTrader": [
+                {"symbol": s, "tossRank": toss_rank[s]} for s in missing
+            ],
+            "extraInAutoTrader": [
+                {"symbol": s, "autoTraderRank": auto_rank[s]} for s in extra
+            ],
+        }
+
+    return {
+        "preset": "double_buy",
+        "limit": limit,
+        "interpretation": interpretation,
+        "currentSnapshotDate": current_date,
+        "previousSnapshotDate": prev_date,
+        "tossCount": len(toss_rows),
+        "interpretationA": _block(a_rows) if interpretation in {"a", "both"} else None,
+        "interpretationB": _block(b_rows) if interpretation in {"b", "both"} else None,
+        "lockedInterpretation": "A",
+        "note": (
+            "Decision 1 locked to Interpretation A under safer-fallback rule "
+            "(see plan Decision 1). Both interpretations always emitted to "
+            "support live verification; if B materially outperforms A on a "
+            "richer Toss reference set, switch the production helper body."
+        ),
+    }
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Read-only Toss parity diagnostic for /invest screener."
@@ -304,6 +523,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--preset", choices=sorted(_SUPPORTED_PRESETS), default="consecutive_gainers")
     parser.add_argument("--toss-symbols-file", type=Path, required=True)
     parser.add_argument("--limit", type=int, default=80)
+    parser.add_argument(
+        "--interpretation",
+        choices=("a", "b", "both"),
+        default="both",
+        help=(
+            "double_buy preset only. Selects which interpretation(s) to evaluate. "
+            "A = absolute net buy > 0 (locked production rule); "
+            "B = delta vs previous trading day > 0 (diagnostic only)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -319,11 +548,58 @@ async def main(argv: list[str] | None = None) -> int:
 
     try:
         toss_rows = load_toss_symbols(args.toss_symbols_file)
-        async with AsyncSessionLocal() as session:
-            auto_rows = await load_auto_trader_rows(
-                session, market=args.market, limit=args.limit
+        if args.preset == "consecutive_gainers":
+            async with AsyncSessionLocal() as session:
+                auto_rows = await load_auto_trader_rows(
+                    session, market=args.market, limit=args.limit
+                )
+            report = build_parity_report(auto_rows, toss_rows, limit=args.limit)
+        elif args.preset == "double_buy":
+            from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+
+            async with AsyncSessionLocal() as session:
+                # Resolve current/previous flow snapshot dates for report context.
+                current_date_value = (
+                    await session.execute(
+                        sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+                            InvestorFlowSnapshot.market == args.market
+                        )
+                    )
+                ).scalar_one_or_none()
+                prev_date_value = None
+                if current_date_value is not None:
+                    prev_date_value = (
+                        await session.execute(
+                            sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+                                InvestorFlowSnapshot.market == args.market,
+                                InvestorFlowSnapshot.snapshot_date < current_date_value,
+                            )
+                        )
+                    ).scalar_one_or_none()
+
+                a_rows: list[dict[str, Any]] | None = None
+                b_rows: list[dict[str, Any]] | None = None
+                if args.interpretation in {"a", "both"}:
+                    a_rows = await load_double_buy_rows_interpretation_a(
+                        session, market=args.market, limit=args.limit
+                    )
+                if args.interpretation in {"b", "both"}:
+                    b_rows = await load_double_buy_rows_interpretation_b(
+                        session, market=args.market, limit=args.limit
+                    )
+            report = build_double_buy_parity_report(
+                a_rows=a_rows,
+                b_rows=b_rows,
+                toss_rows=toss_rows,
+                limit=args.limit,
+                interpretation=args.interpretation,
+                current_date=current_date_value.isoformat()
+                if current_date_value
+                else None,
+                prev_date=prev_date_value.isoformat() if prev_date_value else None,
             )
-        report = build_parity_report(auto_rows, toss_rows, limit=args.limit)
+        else:  # pragma: no cover - argparse choices guard this branch
+            raise ValueError(f"Unsupported preset: {args.preset}")
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
         return 0
     except Exception as exc:  # noqa: BLE001

--- a/scripts/diagnose_invest_screener_toss_parity.py
+++ b/scripts/diagnose_invest_screener_toss_parity.py
@@ -12,6 +12,7 @@ Example:
       --toss-symbols-file /path/to/toss_symbols.csv \
       --limit 80
 """
+
 from __future__ import annotations
 
 import argparse
@@ -67,7 +68,9 @@ def _reject_if_sensitive(label: str, value: Any) -> None:
         )
 
 
-def _normalize_toss_row(raw: dict[str, Any], fallback_rank: int) -> dict[str, Any] | None:
+def _normalize_toss_row(
+    raw: dict[str, Any], fallback_rank: int
+) -> dict[str, Any] | None:
     for key, value in raw.items():
         _reject_if_sensitive(key, value)
 
@@ -128,11 +131,18 @@ def load_toss_symbols(path: Path) -> list[dict[str, Any]]:
     if path.suffix.lower() == ".json":
         parsed = json.loads(raw_text)
         if isinstance(parsed, dict):
-            rows = parsed.get("results") or parsed.get("rows") or parsed.get("symbols") or []
+            rows = (
+                parsed.get("results")
+                or parsed.get("rows")
+                or parsed.get("symbols")
+                or []
+            )
         else:
             rows = parsed
         if not isinstance(rows, list):
-            raise ValueError("JSON Toss export must be a list or contain rows/results/symbols")
+            raise ValueError(
+                "JSON Toss export must be a list or contain rows/results/symbols"
+            )
         raw_rows = [r if isinstance(r, dict) else {"symbol": r} for r in rows]
     else:
         lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
@@ -166,7 +176,10 @@ def build_parity_report(
     auto_rows: list[dict[str, Any]], toss_rows: list[dict[str, Any]], *, limit: int
 ) -> dict[str, Any]:
     auto_rank = {row["symbol"]: idx for idx, row in enumerate(auto_rows, start=1)}
-    toss_rank = {row["symbol"]: int(row.get("rank") or idx) for idx, row in enumerate(toss_rows, start=1)}
+    toss_rank = {
+        row["symbol"]: int(row.get("rank") or idx)
+        for idx, row in enumerate(toss_rows, start=1)
+    }
     auto_symbols = set(auto_rank)
     toss_symbols = set(toss_rank)
 
@@ -332,16 +345,14 @@ async def load_double_buy_rows_interpretation_b(
     if market != "kr":
         return []
 
-    latest_flow_stmt = sa.select(
-        sa.func.max(InvestorFlowSnapshot.snapshot_date)
-    ).where(InvestorFlowSnapshot.market == "kr")
+    latest_flow_stmt = sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+        InvestorFlowSnapshot.market == "kr"
+    )
     flow_date = (await session.execute(latest_flow_stmt)).scalar_one_or_none()
     if flow_date is None:
         return []
 
-    prev_flow_stmt = sa.select(
-        sa.func.max(InvestorFlowSnapshot.snapshot_date)
-    ).where(
+    prev_flow_stmt = sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
         InvestorFlowSnapshot.market == "kr",
         InvestorFlowSnapshot.snapshot_date < flow_date,
     )
@@ -363,9 +374,9 @@ async def load_double_buy_rows_interpretation_b(
             (InvestorFlowSnapshot.foreign_net - Prev.foreign_net).label(
                 "foreign_delta"
             ),
-            (
-                InvestorFlowSnapshot.institution_net - Prev.institution_net
-            ).label("institution_delta"),
+            (InvestorFlowSnapshot.institution_net - Prev.institution_net).label(
+                "institution_delta"
+            ),
             InvestScreenerSnapshot.change_rate,
             InvestScreenerSnapshot.snapshot_date.label("price_snapshot_date"),
             InvestorFlowSnapshot.snapshot_date.label("flow_snapshot_date"),
@@ -520,7 +531,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Read-only Toss parity diagnostic for /invest screener."
     )
     parser.add_argument("--market", choices=["kr"], default="kr")
-    parser.add_argument("--preset", choices=sorted(_SUPPORTED_PRESETS), default="consecutive_gainers")
+    parser.add_argument(
+        "--preset", choices=sorted(_SUPPORTED_PRESETS), default="consecutive_gainers"
+    )
     parser.add_argument("--toss-symbols-file", type=Path, required=True)
     parser.add_argument("--limit", type=int, default=80)
     parser.add_argument(
@@ -561,16 +574,18 @@ async def main(argv: list[str] | None = None) -> int:
                 # Resolve current/previous flow snapshot dates for report context.
                 current_date_value = (
                     await session.execute(
-                        sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
-                            InvestorFlowSnapshot.market == args.market
-                        )
+                        sa.select(
+                            sa.func.max(InvestorFlowSnapshot.snapshot_date)
+                        ).where(InvestorFlowSnapshot.market == args.market)
                     )
                 ).scalar_one_or_none()
                 prev_date_value = None
                 if current_date_value is not None:
                     prev_date_value = (
                         await session.execute(
-                            sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+                            sa.select(
+                                sa.func.max(InvestorFlowSnapshot.snapshot_date)
+                            ).where(
                                 InvestorFlowSnapshot.market == args.market,
                                 InvestorFlowSnapshot.snapshot_date < current_date_value,
                             )

--- a/tests/test_invest_screener_toss_parity_diagnostics.py
+++ b/tests/test_invest_screener_toss_parity_diagnostics.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from scripts.diagnose_invest_screener_toss_parity import (
+    build_double_buy_parity_report,
     build_parity_report,
     load_toss_symbols,
 )
@@ -129,3 +132,289 @@ def test_load_toss_symbols_rejects_sensitive_exports(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="must not contain"):
         load_toss_symbols(path)
+
+
+@pytest.mark.unit
+def test_build_double_buy_parity_report_emits_ab_blocks_with_overlap_counts() -> None:
+    toss_rows = [
+        {"rank": 1, "symbol": "011000"},
+        {"rank": 2, "symbol": "439960"},
+        {"rank": 3, "symbol": "083500"},
+    ]
+    a_rows = [
+        {"symbol": "011000"},
+        {"symbol": "439960"},
+        {"symbol": "EXTRA01"},
+    ]
+    b_rows = [
+        {"symbol": "011000"},
+        {"symbol": "083500"},
+        {"symbol": "EXTRA02"},
+        {"symbol": "EXTRA03"},
+    ]
+
+    report = build_double_buy_parity_report(
+        a_rows=a_rows,
+        b_rows=b_rows,
+        toss_rows=toss_rows,
+        limit=50,
+        interpretation="both",
+        current_date="2026-05-19",
+        prev_date="2026-05-18",
+    )
+
+    assert report["preset"] == "double_buy"
+    assert report["interpretation"] == "both"
+    assert report["limit"] == 50
+    assert report["currentSnapshotDate"] == "2026-05-19"
+    assert report["previousSnapshotDate"] == "2026-05-18"
+    assert report["tossCount"] == 3
+    assert report["lockedInterpretation"] == "A"
+    assert "Decision 1" in report["note"]
+
+    block_a = report["interpretationA"]
+    assert block_a["count"] == 3
+    assert block_a["overlapCount"] == 2  # 011000, 439960
+    assert block_a["missingFromAutoTrader"] == [{"symbol": "083500", "tossRank": 3}]
+    assert block_a["extraInAutoTrader"] == [
+        {"symbol": "EXTRA01", "autoTraderRank": 3},
+    ]
+
+    block_b = report["interpretationB"]
+    assert block_b["count"] == 4
+    assert block_b["overlapCount"] == 2  # 011000, 083500
+    assert block_b["missingFromAutoTrader"] == [{"symbol": "439960", "tossRank": 2}]
+    assert [item["symbol"] for item in block_b["extraInAutoTrader"]] == [
+        "EXTRA02",
+        "EXTRA03",
+    ]
+
+
+@pytest.mark.unit
+def test_build_double_buy_parity_report_a_only_leaves_b_block_null() -> None:
+    report = build_double_buy_parity_report(
+        a_rows=[{"symbol": "011000"}],
+        b_rows=None,
+        toss_rows=[{"rank": 1, "symbol": "011000"}],
+        limit=10,
+        interpretation="a",
+        current_date=None,
+        prev_date=None,
+    )
+    assert report["interpretation"] == "a"
+    assert report["interpretationA"] is not None
+    assert report["interpretationA"]["overlapCount"] == 1
+    assert report["interpretationB"] is None
+    assert report["lockedInterpretation"] == "A"
+
+
+@pytest.mark.unit
+def test_build_double_buy_parity_report_b_only_leaves_a_block_null() -> None:
+    report = build_double_buy_parity_report(
+        a_rows=None,
+        b_rows=[{"symbol": "011000"}],
+        toss_rows=[{"rank": 1, "symbol": "011000"}],
+        limit=10,
+        interpretation="b",
+        current_date=None,
+        prev_date=None,
+    )
+    assert report["interpretation"] == "b"
+    assert report["interpretationA"] is None
+    assert report["interpretationB"] is not None
+    assert report["interpretationB"]["overlapCount"] == 1
+
+
+@pytest.mark.unit
+def test_double_buy_supported_and_emits_ab_comparison_blocks(
+    monkeypatch, capsys, tmp_path
+) -> None:
+    """End-to-end main() exercises double_buy preset with both interpretations.
+
+    Loader and session plumbing are patched so the test is independent of DB
+    state — only the dispatch + report-building path is exercised here.
+    """
+    toss_path = tmp_path / "toss_ref.json"
+    toss_path.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {"symbol": "011000", "rank": 1},
+                    {"symbol": "439960", "rank": 2},
+                    {"symbol": "083500", "rank": 3},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_a_rows = [
+        {"symbol": "011000"},
+        {"symbol": "439960"},
+        {"symbol": "EXTRA01"},
+    ]
+    fake_b_rows = [
+        {"symbol": "011000"},
+        {"symbol": "083500"},
+        {"symbol": "EXTRA02"},
+        {"symbol": "EXTRA03"},
+    ]
+
+    a_calls: list[str] = []
+    b_calls: list[str] = []
+
+    async def _fake_a(session, *, market, limit):
+        a_calls.append(market)
+        return fake_a_rows
+
+    async def _fake_b(session, *, market, limit):
+        b_calls.append(market)
+        return fake_b_rows
+
+    # Patch session execute to return canned current/prev snapshot dates.
+    from datetime import date
+
+    async def _fake_execute(stmt):
+        result = MagicMock()
+        # Cycle through current_date then prev_date for the two scalar lookups.
+        if not hasattr(_fake_execute, "_calls"):
+            _fake_execute._calls = 0
+        _fake_execute._calls += 1
+        if _fake_execute._calls == 1:
+            result.scalar_one_or_none.return_value = date(2026, 5, 19)
+        elif _fake_execute._calls == 2:
+            result.scalar_one_or_none.return_value = date(2026, 5, 18)
+        else:
+            result.scalar_one_or_none.return_value = None
+        return result
+
+    fake_session = MagicMock()
+    fake_session.execute = _fake_execute
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__.return_value = fake_session
+    fake_ctx.__aexit__.return_value = False
+
+    monkeypatch.setattr(
+        "scripts.diagnose_invest_screener_toss_parity.load_double_buy_rows_interpretation_a",
+        _fake_a,
+    )
+    monkeypatch.setattr(
+        "scripts.diagnose_invest_screener_toss_parity.load_double_buy_rows_interpretation_b",
+        _fake_b,
+    )
+
+    # Patch AsyncSessionLocal at its source so the dynamic import inside main()
+    # picks up the fake.
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: fake_ctx)
+    # Avoid sentry/logging side-effects in the test.
+    monkeypatch.setattr(
+        "app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None
+    )
+
+    from scripts import diagnose_invest_screener_toss_parity as mod
+
+    exit_code = asyncio.run(
+        mod.main(
+            [
+                "--market",
+                "kr",
+                "--preset",
+                "double_buy",
+                "--toss-symbols-file",
+                str(toss_path),
+                "--interpretation",
+                "both",
+                "--limit",
+                "50",
+            ]
+        )
+    )
+    assert exit_code == 0
+    assert a_calls == ["kr"]
+    assert b_calls == ["kr"]
+
+    output = capsys.readouterr().out
+    report = json.loads(output)
+    assert report["preset"] == "double_buy"
+    assert report["interpretation"] == "both"
+    assert report["currentSnapshotDate"] == "2026-05-19"
+    assert report["previousSnapshotDate"] == "2026-05-18"
+    assert report["interpretationA"]["count"] == 3
+    assert report["interpretationA"]["overlapCount"] == 2  # 011000, 439960
+    assert report["interpretationB"]["count"] == 4
+    assert report["interpretationB"]["overlapCount"] == 2  # 011000, 083500
+    assert report["lockedInterpretation"] == "A"
+
+
+@pytest.mark.unit
+def test_double_buy_interpretation_a_skips_b_loader(
+    monkeypatch, capsys, tmp_path
+) -> None:
+    """--interpretation a must NOT invoke the B loader (and vice versa)."""
+    toss_path = tmp_path / "toss_ref.json"
+    toss_path.write_text(json.dumps([{"symbol": "011000", "rank": 1}]), encoding="utf-8")
+
+    a_calls: list[str] = []
+    b_calls: list[str] = []
+
+    async def _fake_a(session, *, market, limit):
+        a_calls.append(market)
+        return [{"symbol": "011000"}]
+
+    async def _fake_b(session, *, market, limit):
+        b_calls.append(market)
+        return [{"symbol": "SHOULD_NOT_BE_CALLED"}]
+
+    from datetime import date
+
+    async def _fake_execute(stmt):
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = date(2026, 5, 19)
+        return result
+
+    fake_session = MagicMock()
+    fake_session.execute = _fake_execute
+    fake_ctx = AsyncMock()
+    fake_ctx.__aenter__.return_value = fake_session
+    fake_ctx.__aexit__.return_value = False
+
+    monkeypatch.setattr(
+        "scripts.diagnose_invest_screener_toss_parity.load_double_buy_rows_interpretation_a",
+        _fake_a,
+    )
+    monkeypatch.setattr(
+        "scripts.diagnose_invest_screener_toss_parity.load_double_buy_rows_interpretation_b",
+        _fake_b,
+    )
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: fake_ctx)
+    monkeypatch.setattr(
+        "app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None
+    )
+
+    from scripts import diagnose_invest_screener_toss_parity as mod
+
+    exit_code = asyncio.run(
+        mod.main(
+            [
+                "--market",
+                "kr",
+                "--preset",
+                "double_buy",
+                "--toss-symbols-file",
+                str(toss_path),
+                "--interpretation",
+                "a",
+                "--limit",
+                "10",
+            ]
+        )
+    )
+    assert exit_code == 0
+    assert a_calls == ["kr"]
+    assert b_calls == []
+
+    output = capsys.readouterr().out
+    report = json.loads(output)
+    assert report["interpretation"] == "a"
+    assert report["interpretationA"] is not None
+    assert report["interpretationB"] is None

--- a/tests/test_invest_screener_toss_parity_diagnostics.py
+++ b/tests/test_invest_screener_toss_parity_diagnostics.py
@@ -307,9 +307,7 @@ def test_double_buy_supported_and_emits_ab_comparison_blocks(
     # picks up the fake.
     monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: fake_ctx)
     # Avoid sentry/logging side-effects in the test.
-    monkeypatch.setattr(
-        "app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None
-    )
+    monkeypatch.setattr("app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None)
 
     from scripts import diagnose_invest_screener_toss_parity as mod
 
@@ -352,7 +350,9 @@ def test_double_buy_interpretation_a_skips_b_loader(
 ) -> None:
     """--interpretation a must NOT invoke the B loader (and vice versa)."""
     toss_path = tmp_path / "toss_ref.json"
-    toss_path.write_text(json.dumps([{"symbol": "011000", "rank": 1}]), encoding="utf-8")
+    toss_path.write_text(
+        json.dumps([{"symbol": "011000", "rank": 1}]), encoding="utf-8"
+    )
 
     a_calls: list[str] = []
     b_calls: list[str] = []
@@ -387,9 +387,7 @@ def test_double_buy_interpretation_a_skips_b_loader(
         _fake_b,
     )
     monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: fake_ctx)
-    monkeypatch.setattr(
-        "app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None
-    )
+    monkeypatch.setattr("app.core.cli.setup_logging_and_sentry", lambda *a, **kw: None)
 
     from scripts import diagnose_invest_screener_toss_parity as mod
 

--- a/tests/test_invest_view_model_double_buy_screener.py
+++ b/tests/test_invest_view_model_double_buy_screener.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.invest_view_model.double_buy_screener import (
+    load_double_buy_from_snapshots,
+)
+
+# Test symbols use a 9-prefix range to stay isolated from real KR symbols and
+# from sibling tests that already claim "900xxx" ranges.
+_TEST_SYMBOLS = ["911000", "910001", "919999"]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_double_buy_test_rows(db_session):
+    """Wipe just the rows this test owns before and after each test.
+
+    The persistent test DB is shared with other suites, so we never TRUNCATE —
+    we only delete rows scoped to the synthetic symbols below.
+    """
+
+    async def _purge() -> None:
+        await db_session.execute(
+            sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(_TEST_SYMBOLS)
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    yield
+    await _purge()
+
+
+@pytest.mark.asyncio
+async def test_returns_rows_filtered_by_double_buy_and_positive_change_rate(
+    db_session,
+):
+    # Use a far-future date to ensure our rows form the latest partition in
+    # the shared persistent test DB (other suites seed dates as late as 2099).
+    today = dt.date(2099, 12, 31)
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol="911000",
+                name="진원생명과학",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="910001",
+                name="제외종목ETF",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol="911000",
+                snapshot_date=today,
+                foreign_net=1_000_000,
+                institution_net=2_000_000,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            ),
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol="910001",
+                snapshot_date=today,
+                foreign_net=-1,
+                institution_net=-1,
+                double_buy=False,
+                double_sell=True,
+                source="naver_finance",
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol="911000",
+                snapshot_date=today,
+                latest_close=decimal.Decimal("12000"),
+                prev_close=decimal.Decimal("10000"),
+                change_rate=decimal.Decimal("20.0"),
+                daily_volume=100_000,
+                closes_window=[10000, 12000],
+                source="kis",
+            ),
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol="910001",
+                snapshot_date=today,
+                latest_close=decimal.Decimal("900"),
+                prev_close=decimal.Decimal("1000"),
+                change_rate=decimal.Decimal("-10.0"),
+                daily_volume=50_000,
+                closes_window=[1000, 900],
+                source="kis",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    rows = await load_double_buy_from_snapshots(db_session, market="kr", limit=20)
+
+    assert rows is not None
+    # Cross-test contamination guard: if other test data exists in the same
+    # snapshot date partition, we still expect 911000 to be present and
+    # 910001 (negative change_rate) to be filtered out.
+    symbols = [r["symbol"] for r in rows]
+    assert "911000" in symbols
+    assert "910001" not in symbols
+    target = next(r for r in rows if r["symbol"] == "911000")
+    assert target["change_rate"] == pytest.approx(20.0)
+    assert target["double_buy"] is True
+    assert target["_screener_snapshot_state"] in {"fresh", "stale"}
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_snapshots():
+    """When the latest-date lookup yields NULL, helper must signal `missing`.
+
+    Uses a mocked AsyncSession because the shared test DB has rows owned by
+    other suites that we must not delete to satisfy this case.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    null_scalar = MagicMock()
+    null_scalar.scalar_one_or_none.return_value = None
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=null_scalar)
+
+    rows = await load_double_buy_from_snapshots(session, market="kr", limit=20)
+    assert rows is None
+
+
+@pytest.mark.asyncio
+async def test_excludes_non_common_stock_by_name_heuristic(db_session):
+    # Use a far-future date to ensure our rows form the latest partition in
+    # the shared persistent test DB (other suites seed dates as late as 2099).
+    today = dt.date(2099, 12, 31)
+    db_session.add(
+        KRSymbolUniverse(
+            symbol="919999",
+            name="KODEX 200 ETF",
+            exchange="KOSPI",
+            is_active=True,
+        )
+    )
+    db_session.add(
+        InvestorFlowSnapshot(
+            market="kr",
+            symbol="919999",
+            snapshot_date=today,
+            foreign_net=10,
+            institution_net=10,
+            double_buy=True,
+            double_sell=False,
+            source="naver_finance",
+        )
+    )
+    db_session.add(
+        InvestScreenerSnapshot(
+            market="kr",
+            symbol="919999",
+            snapshot_date=today,
+            latest_close=decimal.Decimal("10000"),
+            prev_close=decimal.Decimal("9000"),
+            change_rate=decimal.Decimal("11.0"),
+            daily_volume=1,
+            closes_window=[9000, 10000],
+            source="kis",
+        )
+    )
+    await db_session.commit()
+
+    rows = await load_double_buy_from_snapshots(db_session, market="kr", limit=20)
+    assert rows is not None
+    # ETF must not appear; other symbols already in the DB are allowed but
+    # 919999 must be excluded by the name heuristic.
+    assert all(r["symbol"] != "919999" for r in rows)

--- a/tests/test_invest_view_model_double_buy_screener.py
+++ b/tests/test_invest_view_model_double_buy_screener.py
@@ -16,7 +16,7 @@ from app.services.invest_view_model.double_buy_screener import (
 
 # Test symbols use a 9-prefix range to stay isolated from real KR symbols and
 # from sibling tests that already claim "900xxx" ranges.
-_TEST_SYMBOLS = ["911000", "910001", "919999"]
+_TEST_SYMBOLS = ["911000", "910001", "919999", "912000"]
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -204,3 +204,63 @@ async def test_excludes_non_common_stock_by_name_heuristic(db_session):
     # ETF must not appear; other symbols already in the DB are allowed but
     # 919999 must be excluded by the name heuristic.
     assert all(r["symbol"] != "919999" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_market_is_not_kr(db_session):
+    # No DB hit expected — short-circuits at the market guard
+    rows = await load_double_buy_from_snapshots(
+        db_session, market="us", limit=20
+    )
+    assert rows is None
+
+
+@pytest.mark.asyncio
+async def test_state_is_stale_when_price_snapshot_date_differs_from_flow_snapshot_date(
+    db_session,
+):
+    # Construct a scenario where flow_snapshot_date < price_snapshot_date so the
+    # latest-partition lookups return different dates → row should be tagged "stale".
+    flow_date = dt.date(2099, 12, 30)  # earlier
+    price_date = dt.date(2099, 12, 31)  # later (latest price partition)
+    symbol = "912000"
+
+    db_session.add(
+        KRSymbolUniverse(symbol=symbol, name="테스트종목", is_active=True, exchange="KOSPI")
+    )
+    db_session.add(
+        InvestorFlowSnapshot(
+            market="kr",
+            symbol=symbol,
+            snapshot_date=flow_date,
+            foreign_net=1,
+            institution_net=1,
+            double_buy=True,
+            double_sell=False,
+            source="naver_finance",
+        )
+    )
+    db_session.add(
+        InvestScreenerSnapshot(
+            market="kr",
+            symbol=symbol,
+            snapshot_date=price_date,
+            latest_close=decimal.Decimal("10000"),
+            prev_close=decimal.Decimal("9000"),
+            change_rate=decimal.Decimal("11.0"),
+            daily_volume=1,
+            closes_window=[9000, 9500, 9800, 9900, 10000],
+            source="kis",
+        )
+    )
+    await db_session.commit()
+
+    rows = await load_double_buy_from_snapshots(
+        db_session, market="kr", limit=20
+    )
+
+    assert rows is not None
+    # find our test symbol (shared DB may have other rows)
+    target = next((r for r in rows if r["symbol"] == symbol), None)
+    assert target is not None, f"expected {symbol} in results, got {[r['symbol'] for r in rows]}"
+    assert target["_screener_snapshot_state"] == "stale"

--- a/tests/test_invest_view_model_double_buy_screener.py
+++ b/tests/test_invest_view_model_double_buy_screener.py
@@ -209,9 +209,7 @@ async def test_excludes_non_common_stock_by_name_heuristic(db_session):
 @pytest.mark.asyncio
 async def test_returns_none_when_market_is_not_kr(db_session):
     # No DB hit expected — short-circuits at the market guard
-    rows = await load_double_buy_from_snapshots(
-        db_session, market="us", limit=20
-    )
+    rows = await load_double_buy_from_snapshots(db_session, market="us", limit=20)
     assert rows is None
 
 
@@ -226,7 +224,9 @@ async def test_state_is_stale_when_price_snapshot_date_differs_from_flow_snapsho
     symbol = "912000"
 
     db_session.add(
-        KRSymbolUniverse(symbol=symbol, name="테스트종목", is_active=True, exchange="KOSPI")
+        KRSymbolUniverse(
+            symbol=symbol, name="테스트종목", is_active=True, exchange="KOSPI"
+        )
     )
     db_session.add(
         InvestorFlowSnapshot(
@@ -255,12 +255,12 @@ async def test_state_is_stale_when_price_snapshot_date_differs_from_flow_snapsho
     )
     await db_session.commit()
 
-    rows = await load_double_buy_from_snapshots(
-        db_session, market="kr", limit=20
-    )
+    rows = await load_double_buy_from_snapshots(db_session, market="kr", limit=20)
 
     assert rows is not None
     # find our test symbol (shared DB may have other rows)
     target = next((r for r in rows if r["symbol"] == symbol), None)
-    assert target is not None, f"expected {symbol} in results, got {[r['symbol'] for r in rows]}"
+    assert target is not None, (
+        f"expected {symbol} in results, got {[r['symbol'] for r in rows]}"
+    )
     assert target["_screener_snapshot_state"] == "stale"

--- a/tests/test_invest_view_model_screener_presets.py
+++ b/tests/test_invest_view_model_screener_presets.py
@@ -27,8 +27,8 @@ def test_double_buy_preset_present_and_kr_only():
     assert "double_buy" in _KR_ONLY_PRESET_IDS
     chip_labels = {c.label for c in db.filterChips}
     assert "국내" in chip_labels
-    assert "외국인" in chip_labels   # independent
-    assert "기관" in chip_labels     # independent
+    assert "외국인" in chip_labels  # independent
+    assert "기관" in chip_labels  # independent
 
 
 def test_investor_flow_momentum_copy_no_double_buy_wording():
@@ -51,6 +51,7 @@ def test_double_buy_screening_filters_lookup_is_kr_only_snapshot():
 
 def test_every_preset_id_is_in_metric_field_map():
     from app.services.invest_view_model.screener_service import _METRIC_FIELD
+
     preset_ids = {p.id for p in SCREENER_PRESETS}
     metric_ids = set(_METRIC_FIELD.keys())
     missing = preset_ids - metric_ids

--- a/tests/test_invest_view_model_screener_presets.py
+++ b/tests/test_invest_view_model_screener_presets.py
@@ -25,9 +25,10 @@ def test_double_buy_preset_present_and_kr_only():
     assert db.name == "쌍끌이 매수"
     assert db.market == "kr"
     assert "double_buy" in _KR_ONLY_PRESET_IDS
-    chips = {c.label for c in db.filterChips}
-    assert "국내" in chips
-    assert any("외국인" in c.label or "기관" in c.label for c in db.filterChips)
+    chip_labels = {c.label for c in db.filterChips}
+    assert "국내" in chip_labels
+    assert "외국인" in chip_labels   # independent
+    assert "기관" in chip_labels     # independent
 
 
 def test_investor_flow_momentum_copy_no_double_buy_wording():
@@ -41,4 +42,16 @@ def test_investor_flow_momentum_copy_no_double_buy_wording():
 def test_double_buy_screening_filters_lookup_is_kr_only_snapshot():
     filters = screening_filters_for("double_buy", "kr")
     assert filters["market"] == "kr"
-    assert filters.get("sort_by") != "volume"
+    assert filters["sort_by"] == "change_rate"
+    assert filters["sort_order"] == "desc"
+    assert filters["min_change_rate"] == 0.0
+    assert filters["include_double_buy"] is True
+    assert filters["limit"] == 50
+
+
+def test_every_preset_id_is_in_metric_field_map():
+    from app.services.invest_view_model.screener_service import _METRIC_FIELD
+    preset_ids = {p.id for p in SCREENER_PRESETS}
+    metric_ids = set(_METRIC_FIELD.keys())
+    missing = preset_ids - metric_ids
+    assert not missing, f"presets missing from _METRIC_FIELD: {missing}"

--- a/tests/test_invest_view_model_screener_presets.py
+++ b/tests/test_invest_view_model_screener_presets.py
@@ -1,0 +1,44 @@
+"""ROB-276 — preset registry consistency tests for double_buy / kr_high_volume_surge rename."""
+
+from __future__ import annotations
+
+from app.services.invest_view_model.screener_presets import (
+    _KR_ONLY_PRESET_IDS,
+    SCREENER_PRESETS,
+    screening_filters_for,
+)
+
+
+def test_high_volume_momentum_removed_and_volume_preset_renamed():
+    ids = {p.id for p in SCREENER_PRESETS}
+    assert "high_volume_momentum" not in ids
+    assert "kr_high_volume_surge" in ids
+    surge = next(p for p in SCREENER_PRESETS if p.id == "kr_high_volume_surge")
+    assert surge.name == "거래량 급증"
+    assert surge.market == "kr"
+
+
+def test_double_buy_preset_present_and_kr_only():
+    ids = {p.id for p in SCREENER_PRESETS}
+    assert "double_buy" in ids
+    db = next(p for p in SCREENER_PRESETS if p.id == "double_buy")
+    assert db.name == "쌍끌이 매수"
+    assert db.market == "kr"
+    assert "double_buy" in _KR_ONLY_PRESET_IDS
+    chips = {c.label for c in db.filterChips}
+    assert "국내" in chips
+    assert any("외국인" in c.label or "기관" in c.label for c in db.filterChips)
+
+
+def test_investor_flow_momentum_copy_no_double_buy_wording():
+    ifm = next(p for p in SCREENER_PRESETS if p.id == "investor_flow_momentum")
+    assert "쌍끌이" not in ifm.description
+    for chip in ifm.filterChips:
+        detail = chip.detail or ""
+        assert "쌍끌이" not in detail
+
+
+def test_double_buy_screening_filters_lookup_is_kr_only_snapshot():
+    filters = screening_filters_for("double_buy", "kr")
+    assert filters["market"] == "kr"
+    assert filters.get("sort_by") != "volume"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1512,7 +1512,7 @@ async def test_build_screener_results_warns_and_does_not_fallback_when_latest_pa
 # ---------------------------------------------------------------------------
 
 
-_DOUBLE_BUY_TEST_SYMBOLS = ["921100", "921200", "921300", "922100"]
+_DOUBLE_BUY_TEST_SYMBOLS = ["921100", "921200", "921300", "922100", "923000"]
 
 
 @pytest.mark.unit
@@ -1822,5 +1822,117 @@ async def test_double_buy_preset_stale_when_price_snapshot_older_than_flow(
         assert any("시세 스냅샷" in w and "1일 지연" in w for w in resp.warnings), (
             f"expected price-side stale warning in {resp.warnings}"
         )
+    finally:
+        await _purge()
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
+    db_session,
+) -> None:
+    """Flow-stale branch fires even when price/flow dates match but pre-date today.
+
+    The loader tags _screener_snapshot_state="fresh" because price==flow, so the
+    price-side warning must NOT appear. But because the flow snapshot date is
+    strictly older than today's market date, the flow-side "1일 지연" warning
+    must fire — proving the helper is keying off flow_snapshot_date and not
+    accidentally reusing the price snapshot date.
+    """
+    import datetime as _dt
+    import decimal as _dec
+
+    import sqlalchemy as _sa
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    past_dt = _dt.date(2099, 12, 30)  # snapshot dates (both partitions)
+    # today's market date will be 2099-12-31 (Thursday) — see now() below.
+    symbol = "923000"
+
+    async def _purge() -> None:
+        await db_session.execute(
+            _sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    try:
+        db_session.add(
+            KRSymbolUniverse(
+                symbol=symbol,
+                name="플로우스테일테스트",
+                exchange="KOSPI",
+                is_active=True,
+            )
+        )
+        db_session.add(
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=past_dt,
+                foreign_net=1,
+                institution_net=1,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            )
+        )
+        db_session.add(
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=past_dt,
+                latest_close=_dec.Decimal("10000"),
+                prev_close=_dec.Decimal("9000"),
+                change_rate=_dec.Decimal("11.0"),
+                daily_volume=1,
+                closes_window=[9000, 9500, 9800, 9900, 10000],
+                source="kis",
+            )
+        )
+        await db_session.commit()
+
+        fake_screening = type(
+            "ScreenerService",
+            (_FakeProductionScreening,),
+            {"__module__": "app.services.screener_service"},
+        )()
+
+        # now() at 2099-12-31 06:00 UTC = 15:00 KST → today_trading_date("kr") = 2099-12-31
+        # Flow/price snapshot dates are 2099-12-30 → strictly < market date.
+        resp = await build_screener_results(
+            preset_id="double_buy",
+            screening_service=fake_screening,
+            resolver=_FakeResolver(watched=set()),
+            session=db_session,
+            now=lambda: datetime(2099, 12, 31, 6, 0, tzinfo=UTC),
+        )
+
+        fake_screening.list_screening.assert_not_called()
+        flow_warning = "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+        assert flow_warning in resp.warnings, (
+            f"expected flow-side stale warning in {resp.warnings}"
+        )
+        # price==flow ⇒ loader tagged _screener_snapshot_state="fresh", so the
+        # price-side warning must NOT appear.
+        assert not any("시세 스냅샷" in w for w in resp.warnings), (
+            f"price-stale warning must not appear when price==flow date: {resp.warnings}"
+        )
+        # state_override from helper bumps fresh → stale.
+        assert resp.freshness.dataState in {"stale", "fallback"}
     finally:
         await _purge()

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1923,7 +1923,9 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
         )
 
         fake_screening.list_screening.assert_not_called()
-        flow_warning = "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+        flow_warning = (
+            "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+        )
         assert flow_warning in resp.warnings, (
             f"expected flow-side stale warning in {resp.warnings}"
         )

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1059,7 +1059,7 @@ async def test_build_screener_results_warns_when_only_market_cap_fallback_is_abs
         ("cheap_value", "per", 8.25, "8.2"),
         ("steady_dividend", "dividend_yield", 3.456, "3.46%"),
         ("oversold_recovery", "rsi", 29.94, "29.9"),
-        ("high_volume_momentum", "volume", 1_234_567, "1,234,567"),
+        ("kr_high_volume_surge", "volume", 1_234_567, "1,234,567"),
     ],
 )
 async def test_build_screener_results_formats_preset_metrics(

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1505,3 +1505,322 @@ async def test_build_screener_results_warns_and_does_not_fallback_when_latest_pa
     assert resp.results == []
     assert any("스크리너 스냅샷 업데이트" in w for w in resp.warnings)
     assert resp.freshness.dataState == "stale"
+
+
+# ---------------------------------------------------------------------------
+# ROB-276: double_buy preset wiring (Task 3)
+# ---------------------------------------------------------------------------
+
+
+_DOUBLE_BUY_TEST_SYMBOLS = ["921100", "921200", "921300", "922100"]
+
+
+@pytest.mark.unit
+def test_double_buy_in_metric_field_map() -> None:
+    """Task 1 placeholder must remain present so the snapshot row renders a metric."""
+    from app.services.invest_view_model.screener_service import _METRIC_FIELD
+
+    assert _METRIC_FIELD["double_buy"] == "change_rate"
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_missing_snapshot_reports_missing_state() -> None:
+    """When neither snapshot partition exists, dataState must report missing.
+
+    The loader returns None when MAX(snapshot_date) is NULL, and the safety net
+    in build_screener_results pins dataState to "missing" with a warning. A
+    MagicMock session whose .execute returns scalar_one_or_none()==None covers
+    this without touching the shared DB.
+    """
+    null_scalar = MagicMock()
+    null_scalar.scalar_one_or_none.return_value = None
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=null_scalar)
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    resp = await build_screener_results(
+        preset_id="double_buy",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=session,
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results == []
+    assert resp.freshness.dataState == "missing"
+    assert any("스냅샷" in w for w in resp.warnings)
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_returns_snapshot_filtered_rows(db_session) -> None:
+    """Seed flow+price snapshots; build_screener_results must surface qualifiers.
+
+    Uses the same persistent-DB pattern as
+    tests/test_invest_view_model_double_buy_screener.py with a synthetic
+    92xxxx symbol range so other suites are not affected.
+    """
+    import datetime as _dt
+    import decimal as _dec
+
+    import sqlalchemy as _sa
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    # Far-future date wins the latest-partition lookup against shared test data.
+    today = _dt.date(2099, 12, 30)
+
+    async def _purge() -> None:
+        await db_session.execute(
+            _sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    try:
+        db_session.add_all(
+            [
+                KRSymbolUniverse(
+                    symbol="921100",
+                    name="더블바이주A",
+                    exchange="KOSPI",
+                    is_active=True,
+                ),
+                KRSymbolUniverse(
+                    symbol="921200",
+                    name="더블바이주B",
+                    exchange="KOSPI",
+                    is_active=True,
+                ),
+                KRSymbolUniverse(
+                    symbol="921300",
+                    name="더블셀주",
+                    exchange="KOSPI",
+                    is_active=True,
+                ),
+            ]
+        )
+        db_session.add_all(
+            [
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol="921100",
+                    snapshot_date=today,
+                    foreign_net=1_000_000,
+                    institution_net=2_000_000,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol="921200",
+                    snapshot_date=today,
+                    foreign_net=500_000,
+                    institution_net=600_000,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol="921300",
+                    snapshot_date=today,
+                    foreign_net=-1,
+                    institution_net=-1,
+                    double_buy=False,
+                    double_sell=True,
+                    source="naver_finance",
+                ),
+            ]
+        )
+        db_session.add_all(
+            [
+                InvestScreenerSnapshot(
+                    market="kr",
+                    symbol="921100",
+                    snapshot_date=today,
+                    latest_close=_dec.Decimal("12000"),
+                    prev_close=_dec.Decimal("10000"),
+                    change_rate=_dec.Decimal("20.0"),
+                    daily_volume=100_000,
+                    closes_window=[10000, 12000],
+                    source="kis",
+                ),
+                InvestScreenerSnapshot(
+                    market="kr",
+                    symbol="921200",
+                    snapshot_date=today,
+                    latest_close=_dec.Decimal("11000"),
+                    prev_close=_dec.Decimal("10000"),
+                    change_rate=_dec.Decimal("10.0"),
+                    daily_volume=80_000,
+                    closes_window=[10000, 11000],
+                    source="kis",
+                ),
+                InvestScreenerSnapshot(
+                    market="kr",
+                    symbol="921300",
+                    snapshot_date=today,
+                    latest_close=_dec.Decimal("900"),
+                    prev_close=_dec.Decimal("1000"),
+                    change_rate=_dec.Decimal("-10.0"),
+                    daily_volume=50_000,
+                    closes_window=[1000, 900],
+                    source="kis",
+                ),
+            ]
+        )
+        await db_session.commit()
+
+        fake_screening = type(
+            "ScreenerService",
+            (_FakeProductionScreening,),
+            {"__module__": "app.services.screener_service"},
+        )()
+
+        resp = await build_screener_results(
+            preset_id="double_buy",
+            screening_service=fake_screening,
+            resolver=_FakeResolver(watched=set()),
+            session=db_session,
+            now=lambda: datetime(2099, 12, 30, 6, 0, tzinfo=UTC),
+        )
+
+        fake_screening.list_screening.assert_not_called()
+        symbols = [row.symbol for row in resp.results]
+        # Both double_buy positives must appear; double_sell must not.
+        assert "921100" in symbols
+        assert "921200" in symbols
+        assert "921300" not in symbols
+        # SQL ORDER BY change_rate DESC — 921100 (20%) must outrank 921200 (10%).
+        assert symbols.index("921100") < symbols.index("921200")
+        # change_rate metric should render with a + sign for positive rows.
+        target = next(r for r in resp.results if r.symbol == "921100")
+        assert target.metricValueLabel == "+20.00%"
+    finally:
+        await _purge()
+
+
+@pytest.mark.asyncio
+async def test_double_buy_preset_stale_when_price_snapshot_older_than_flow(
+    db_session,
+) -> None:
+    """When price snapshot lags the flow snapshot, dataState must downshift to stale.
+
+    The loader tags the row's _screener_snapshot_state="stale" when
+    price_snapshot_date != flow_snapshot_date; the view-model split-freshness
+    helper turns that into a user-visible "1일 지연" warning and a stale state.
+    """
+    import datetime as _dt
+    import decimal as _dec
+
+    import sqlalchemy as _sa
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    flow_date = _dt.date(2099, 12, 29)
+    price_date = _dt.date(2099, 12, 30)  # latest partition is the price side
+    symbol = "922100"
+
+    async def _purge() -> None:
+        await db_session.execute(
+            _sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    try:
+        db_session.add(
+            KRSymbolUniverse(
+                symbol=symbol,
+                name="지연테스트주",
+                exchange="KOSPI",
+                is_active=True,
+            )
+        )
+        db_session.add(
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=flow_date,
+                foreign_net=1,
+                institution_net=1,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            )
+        )
+        db_session.add(
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=price_date,
+                latest_close=_dec.Decimal("10500"),
+                prev_close=_dec.Decimal("10000"),
+                change_rate=_dec.Decimal("5.0"),
+                daily_volume=1,
+                closes_window=[9000, 9500, 9800, 9900, 10500],
+                source="kis",
+            )
+        )
+        await db_session.commit()
+
+        fake_screening = type(
+            "ScreenerService",
+            (_FakeProductionScreening,),
+            {"__module__": "app.services.screener_service"},
+        )()
+
+        resp = await build_screener_results(
+            preset_id="double_buy",
+            screening_service=fake_screening,
+            resolver=_FakeResolver(watched=set()),
+            session=db_session,
+            # `now` set to the price date so today_trading_date returns 12-30 KST.
+            now=lambda: datetime(2099, 12, 30, 6, 0, tzinfo=UTC),
+        )
+
+        fake_screening.list_screening.assert_not_called()
+        assert any(r.symbol == symbol for r in resp.results), (
+            "the symbol must still appear; staleness lives on freshness/warning"
+        )
+        assert resp.freshness.dataState in {"stale", "fallback"}
+        # Split warning: price snapshot stale message
+        assert any("시세 스냅샷" in w and "1일 지연" in w for w in resp.warnings), (
+            f"expected price-side stale warning in {resp.warnings}"
+        )
+    finally:
+        await _purge()


### PR DESCRIPTION
## Summary

- 새 preset `double_buy` (쌍끌이 매수) 추가 — Toss screenId=18 parity (snapshot-only, read-only)
- 기존 `high_volume_momentum` → `kr_high_volume_surge` 로 clean-cut rename (구 ID 폐기, name `거래량 급증`)
- `investor_flow_momentum` 카피에서 "쌍끌이" 표현 제거 — 사용자 입장에서 카드 구분 명확화
- Freshness 가 price snapshot / flow snapshot 의존성을 분리해서 warning
- Diagnostic 에 A/B 비교 모드 추가 (`--interpretation {a,b,both}`)

## Locked Decisions (plan top)

- **Decision 1**: Toss `외국인_순매수_비교` 해석은 **Interpretation A (절대값)** 로 lock — Task 0 의 safer-fallback rule 적용. Live DB 검증은 환경 제약 (docker/colima 미사용) 으로 수행 불가, Toss reference 캡처도 5개로 부족 (< 50% coverage 의미). Diagnostic `--interpretation both` 가 production DB 확보 후의 verification surface.
- **Decision 2**: `high_volume_momentum` clean cut — ID 자체를 `kr_high_volume_surge` 로 변경. 구 ID URL/북마크는 unknown preset 응답으로 빠짐 (frontend preset list 진입이 주된 경로라 영향 작음).
- **Decision 3**: `수급 모멘텀` 카피 정리 — description/chip detail 에서 "쌍끌이" 표현 제거, 내부 ID/쿼리는 유지.

## Scope guardrails (kept)

- No DB migrations
- No new ingestion job / scheduler / TaskIQ task / Prefect deployment
- No broker / order / watch mutation
- No Toss runtime scraping — diagnostic 도 파일 기반 reference만 사용
- Snapshot-only routing — generic provider fallback 없음

## Tests run

- `uv run pytest tests/test_invest_view_model_screener_service.py tests/test_invest_view_model_screener_presets.py tests/test_invest_view_model_double_buy_screener.py tests/test_invest_screener_toss_parity_diagnostics.py -v` → **67 passed**
- `cd frontend/invest && pnpm vitest run src/__tests__/DesktopScreenerPage.test.tsx` → **6 passed**
- Backend lint (`ruff check`): clean on all touched files
- Backend typecheck (`ty check`): clean on all touched ROB-276 files
- Frontend typecheck: clean

## Local reviewer verification

- `uv run ruff format --check` / `ruff check` on touched backend files: clean on latest head.
- Owner explicitly approved treating SonarCloud as advisory/non-blocking; non-advisory CI gates are green on latest head.

## Visual / API verification

Dev server 실행 환경이 PR 작성 시점에는 없어 다음은 reviewer 가 로컬에서 확인 필요:

- `GET /trading/api/invest/screener/presets?market=kr` 응답에 `double_buy` (쌍끌이 매수), `kr_high_volume_surge` (거래량 급증), `investor_flow_momentum` (수급 모멘텀) 가 모두 보이고 카피가 정확한지.
- `GET /trading/api/invest/screener/results?preset=double_buy&market=kr` 응답이 200, freshness/warnings 가 데이터 상태에 맞게 표시되고, generic provider fallback 으로 인한 "데이터 준비중" 이 뜨지 않는지.
- `/invest/screener` 화면에서 `쌍끌이 매수` 카드가 거래량 카드와 분리되어 보이고, `수급 모멘텀` 카피에 "쌍끌이" 표현이 사라졌는지.
- stale 상태에서 "시세 스냅샷 1일 지연" 과 "수급 스냅샷 1일 지연" 이 구분되어 보이는지.

## Toss parity gap

- Decision 1 lock 은 구조적 (safer-fallback) — live overlap 수치로 empirically 검증되지 않았습니다.
- 후속 verification 경로:

```bash
uv run python -m scripts.diagnose_invest_screener_toss_parity \
  --market kr --preset double_buy --interpretation both \
  --toss-symbols-file path/to/toss_ref.json --limit 80
```

Toss reference 가 충분히 커진 상태에서 위 명령으로 A/B overlap 을 비교 후, 필요 시 follow-up PR 에서 production helper 본체를 Interpretation B 로 교체. preset metadata/freshness 로직은 유지.

## Deployment notes

- 마이그레이션 없음
- 스케줄러/ingestion 변경 없음
- 구 `high_volume_momentum` URL 호출은 unknown preset 응답으로 빠짐 — frontend preset list 가 신규 ID 를 보장하므로 영향 작음
- 운영 활성화 절차는 `docs/runbooks/invest-screener-snapshots.md` §9 참고.

Generated with Claude Code (https://claude.com/claude-code)