### PR TITLE
feat(rob-277): split /invest/screener freshness into served-time vs data-as-of

### DIFF
--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -122,6 +122,26 @@ class ScreenerPresetsResponse(BaseModel):
     selectedPresetId: str | None = None
 
 
+class ScreenerFreshnessPrimary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["screener_snapshot", "live", "fallback"]
+    snapshotDate: str | None = None
+    computedAt: str | None = None
+    asOfLabel: str
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None
+
+
+class ScreenerFreshnessDependency(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["investor_flow"]
+    snapshotDate: str | None = None
+    collectedAt: str | None = None
+    lagLabel: str | None = None
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None
+
+
 class ScreenerFreshness(BaseModel):
     model_config = ConfigDict(extra="forbid")
     fetchedAt: str
@@ -130,6 +150,12 @@ class ScreenerFreshness(BaseModel):
     cacheHit: bool
     source: Literal["live", "cached", "previous_session"]
     dataState: Literal["fresh", "partial", "stale", "missing", "fallback"] = "missing"
+    # New (additive, optional) fields — see ROB-277 plan §D1.
+    servedAt: str | None = None
+    servedRelativeLabel: str | None = None
+    primary: ScreenerFreshnessPrimary | None = None
+    dependencies: list[ScreenerFreshnessDependency] = Field(default_factory=list)
+    overallState: Literal["fresh", "partial", "stale", "missing", "fallback"] | None = None
 
 
 class ScreenerResultsResponse(BaseModel):

--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -155,7 +155,9 @@ class ScreenerFreshness(BaseModel):
     servedRelativeLabel: str | None = None
     primary: ScreenerFreshnessPrimary | None = None
     dependencies: list[ScreenerFreshnessDependency] = Field(default_factory=list)
-    overallState: Literal["fresh", "partial", "stale", "missing", "fallback"] | None = None
+    overallState: Literal["fresh", "partial", "stale", "missing", "fallback"] | None = (
+        None
+    )
 
 
 class ScreenerResultsResponse(BaseModel):

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -78,15 +78,18 @@ def classify_investor_flow_partition(
     """Classify an investor_flow_snapshots partition's freshness.
 
     Mirrors classify_state() but without closes_window_len (investor_flow rows have
-    no candle window). Staleness is determined solely by trading-date comparison:
-    if snapshot_date matches today_trading_date_value (which already rolls weekends
-    back to Friday), the partition is fresh. Age-hours check is intentionally omitted
-    because a Friday snapshot is legitimately ~40 h old on Monday morning yet still
-    the most current available data. Stays in this module so KST/trading-date logic
-    lives in one place per ROB-277 §D4.
+    no candle window). Primary staleness check: snapshot_date must match
+    today_trading_date_value (which already rolls weekends back to Friday).
+    Secondary age guard: mirrors classify_state() to catch orphaned partitions
+    stamped with today's trading date but written long ago. Stays in this module
+    so KST/trading-date logic lives in one place per ROB-277 §D4.
     """
     if snapshot_date != today_trading_date_value:
         return "stale"
+    if collected_at is not None:
+        age_hours = (now - collected_at).total_seconds() / 3600.0
+        if age_hours >= STALE_AFTER_HOURS:
+            return "stale"
     return "fresh"
 
 

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -66,3 +66,63 @@ def aggregate_states(states: list[DataState]) -> DataState:
     if has_missing and has_fresh_or_partial:
         return "fallback"
     return min(states, key=lambda s: _PRIORITY[s])
+
+
+def classify_investor_flow_partition(
+    *,
+    snapshot_date: dt.date,
+    collected_at: dt.datetime | None,
+    today_trading_date_value: dt.date,
+    now: dt.datetime,
+) -> DataState:
+    """Classify an investor_flow_snapshots partition's freshness.
+
+    Mirrors classify_state() but without closes_window_len (investor_flow rows have
+    no candle window). Staleness is determined solely by trading-date comparison:
+    if snapshot_date matches today_trading_date_value (which already rolls weekends
+    back to Friday), the partition is fresh. Age-hours check is intentionally omitted
+    because a Friday snapshot is legitimately ~40 h old on Monday morning yet still
+    the most current available data. Stays in this module so KST/trading-date logic
+    lives in one place per ROB-277 §D4.
+    """
+    if snapshot_date != today_trading_date_value:
+        return "stale"
+    return "fresh"
+
+
+def compute_overall_state(
+    *,
+    primary_state: DataState,
+    dependency_states: list[DataState],
+) -> DataState:
+    """Aggregate primary + dependency states per ROB-277 §D1.c.
+
+    NOT the same as aggregate_states(): when primary is fresh but a dependency is
+    stale/missing, the user-visible overall is "stale" (conservative), not
+    "fallback".
+    """
+    if primary_state in {"missing", "stale"}:
+        return primary_state
+    if any(s in {"missing", "stale"} for s in dependency_states):
+        return "stale"
+    if any(s == "partial" for s in dependency_states):
+        return "partial"
+    return primary_state
+
+
+def format_kst_as_of_label(
+    *,
+    snapshot_date: dt.date,
+    computed_at: dt.datetime | None,
+) -> str:
+    """Format a Korean 'as-of' label for the data basis.
+
+    With computed_at: "YYYY.MM.DD HH:MM 기준" in KST.
+    Without computed_at: "YYYY.MM.DD 장마감 기준" (end-of-day partition).
+    """
+    if computed_at is None:
+        return f"{snapshot_date.strftime('%Y.%m.%d')} 장마감 기준"
+    if computed_at.tzinfo is None:
+        computed_at = computed_at.replace(tzinfo=dt.UTC)
+    kst = computed_at.astimezone(ZoneInfo("Asia/Seoul"))
+    return kst.strftime("%Y.%m.%d %H:%M 기준")

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1295,32 +1295,36 @@ def _build_freshness(
     served_at_utc = now_utc
     served_relative = "방금"
 
-    # Determine fetched (legacy field). For snapshot kind, fetched mirrors the
-    # partition's computed_at (or end-of-snapshot-date 15:30 KST when computed_at
-    # is missing) so legacy consumers see the data-as-of timestamp.
+    # data_basis_at is the INTERNAL data-as-of timestamp used only for delta /
+    # relativeLabel / previous_session detection and for the live-path asOfLabel
+    # fallback. It is NOT exported as freshness.fetchedAt — per ROB-277 §D1 the
+    # exported fetchedAt is a servedAt alias. For snapshot kind we still compute
+    # data_basis_at from partition computed_at (or EOD 15:30 KST) so the staleness
+    # logic / previous_session detection have something meaningful to compare;
+    # the user-visible asOfLabel and primary.computedAt carry the real data 기준.
     if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
         if primary_computed_at is not None:
-            fetched = primary_computed_at
-            if fetched.tzinfo is None:
-                fetched = fetched.replace(tzinfo=UTC)
+            data_basis_at = primary_computed_at
+            if data_basis_at.tzinfo is None:
+                data_basis_at = data_basis_at.replace(tzinfo=UTC)
         else:
             # Treat as end-of-trading-day in KST.
-            fetched_kst_eod = datetime.combine(
+            basis_kst_eod = datetime.combine(
                 primary_snapshot_date, _time(15, 30), tzinfo=_KST
             )
-            fetched = fetched_kst_eod.astimezone(UTC)
+            data_basis_at = basis_kst_eod.astimezone(UTC)
     elif raw_timestamp:
         try:
-            fetched = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+            data_basis_at = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
         except ValueError:
-            fetched = now_utc
-        if fetched.tzinfo is None:
-            fetched = fetched.replace(tzinfo=UTC)
+            data_basis_at = now_utc
+        if data_basis_at.tzinfo is None:
+            data_basis_at = data_basis_at.replace(tzinfo=UTC)
     else:
-        fetched = now_utc
+        data_basis_at = now_utc
 
-    fetched_kst = fetched.astimezone(_KST)
-    delta = max(0, int((now_utc - fetched).total_seconds()))
+    data_basis_kst = data_basis_at.astimezone(_KST)
+    delta = max(0, int((now_utc - data_basis_at).total_seconds()))
     now_kst = now_utc.astimezone(_KST)
     market_open = market == "kr" and _is_kr_market_open(now_kst)
 
@@ -1355,7 +1359,7 @@ def _build_freshness(
             kind=primary_kind,
             snapshotDate=None,
             computedAt=None,
-            asOfLabel=fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+            asOfLabel=data_basis_kst.strftime("%Y.%m.%d %H:%M 기준"),
             dataState=dataState,  # type: ignore[arg-type]
             source=primary_source,
         )
@@ -1367,9 +1371,14 @@ def _build_freshness(
         dep_collected = spec.get("collected_at")
         lag_label: str | None = None
         if dep_snap is not None and primary_snapshot_date is not None:
+            # NOTE: calendar-day diff between two snapshot dates. Both
+            # partitions are emitted on trading days, so on consecutive trading
+            # days this matches the trading-day count; weekend/holiday gaps will
+            # inflate it (e.g. Fri vs Mon = 3 instead of 1). We use "일" (not
+            # "거래일") on the label until a trading-day-aware diff is added.
             lag_days = (primary_snapshot_date - dep_snap).days
             if lag_days >= 1:
-                lag_label = f"{lag_days}거래일 지연"
+                lag_label = f"{lag_days}일 지연"
         dependencies.append(
             ScreenerFreshnessDependency(
                 kind=spec.get("kind", "investor_flow"),
@@ -1392,7 +1401,7 @@ def _build_freshness(
         fetchedAt=served_at_utc.isoformat(),  # ROB-277 D1: fetchedAt is a servedAt alias
         asOfLabel=primary.asOfLabel
         if primary is not None
-        else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+        else data_basis_kst.strftime("%Y.%m.%d %H:%M 기준"),
         relativeLabel=relative,
         cacheHit=bool(cache_hit),
         source=source,

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -12,6 +12,7 @@ modules — see tests/test_invest_view_model_safety.py.
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
@@ -26,6 +27,8 @@ from app.schemas.invest_screener import (
     ChangeDirection,
     ScreenerCandidateContext,
     ScreenerFreshness,
+    ScreenerFreshnessDependency,
+    ScreenerFreshnessPrimary,
     ScreenerInvestorFlowChip,
     ScreenerPresetsResponse,
     ScreenerResultRow,
@@ -1170,22 +1173,62 @@ def _build_freshness(
     market: str,
     now: Callable[[], datetime],
     dataState: str = "missing",
+    # NEW (all keyword-only, defaulted) — ROB-277 Task 4
+    primary_kind: Literal["screener_snapshot", "live", "fallback"] = "live",
+    primary_snapshot_date: dt.date | None = None,
+    primary_computed_at: datetime | None = None,
+    primary_source: str | None = None,
+    dependency_specs: list[dict[str, Any]] | None = None,
 ) -> ScreenerFreshness:
+    """ROB-277: split served time vs data 기준.
+
+    raw_timestamp historically served as both, which is the bug this fixes.  When
+    primary_kind == "screener_snapshot", primary fields derive from the partition
+    date/computed_at and the user-visible asOfLabel reflects that — NOT now().
+
+    dependency_specs items shape:
+      {"kind": "investor_flow", "snapshot_date": date|None, "collected_at": dt|None,
+       "data_state": "fresh|partial|stale|missing|fallback", "source": str|None}
+    """
+    from app.services.invest_screener_snapshots.freshness import (
+        compute_overall_state,
+        format_kst_as_of_label,
+    )
+
     now_utc = now()
-    if not raw_timestamp:
-        fetched = now_utc
-    else:
+    # served = response refresh time, always now() of the request
+    served_at_utc = now_utc
+    served_relative = "방금"
+
+    # Determine fetched (legacy field). For snapshot kind, fetched mirrors the
+    # partition's computed_at (or end-of-snapshot-date 15:30 KST when computed_at
+    # is missing) so legacy consumers see the data-as-of timestamp.
+    if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
+        if primary_computed_at is not None:
+            fetched = primary_computed_at
+            if fetched.tzinfo is None:
+                fetched = fetched.replace(tzinfo=UTC)
+        else:
+            # Treat as end-of-trading-day in KST.
+            fetched_kst_eod = datetime.combine(
+                primary_snapshot_date, _time(15, 30), tzinfo=_KST
+            )
+            fetched = fetched_kst_eod.astimezone(UTC)
+    elif raw_timestamp:
         try:
             fetched = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
         except ValueError:
             fetched = now_utc
-    if fetched.tzinfo is None:
-        fetched = fetched.replace(tzinfo=UTC)
-    fetched_kst = fetched.astimezone(_KST)
-    now_kst = now_utc.astimezone(_KST)
-    delta = max(0, int((now_utc - fetched).total_seconds()))
+        if fetched.tzinfo is None:
+            fetched = fetched.replace(tzinfo=UTC)
+    else:
+        fetched = now_utc
 
+    fetched_kst = fetched.astimezone(_KST)
+    delta = max(0, int((now_utc - fetched).total_seconds()))
+    now_kst = now_utc.astimezone(_KST)
     market_open = market == "kr" and _is_kr_market_open(now_kst)
+
     if not market_open and delta > _CACHE_HIT_FRESH_SECONDS * 4:
         source: Literal["live", "cached", "previous_session"] = "previous_session"
         relative = "전 거래일 기준"
@@ -1196,13 +1239,72 @@ def _build_freshness(
         source = "live"
         relative = _format_relative_korean(delta)
 
+    # Build primary object
+    primary: ScreenerFreshnessPrimary | None = None
+    if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
+        primary = ScreenerFreshnessPrimary(
+            kind="screener_snapshot",
+            snapshotDate=primary_snapshot_date.isoformat(),
+            computedAt=primary_computed_at.astimezone(UTC).isoformat()
+            if primary_computed_at is not None
+            else None,
+            asOfLabel=format_kst_as_of_label(
+                snapshot_date=primary_snapshot_date,
+                computed_at=primary_computed_at,
+            ),
+            dataState=dataState,  # type: ignore[arg-type]
+            source=primary_source,
+        )
+    elif primary_kind in {"live", "fallback"}:
+        primary = ScreenerFreshnessPrimary(
+            kind=primary_kind,
+            snapshotDate=None,
+            computedAt=None,
+            asOfLabel=fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+            dataState=dataState,  # type: ignore[arg-type]
+            source=primary_source,
+        )
+
+    # Build dependencies list
+    dependencies: list[ScreenerFreshnessDependency] = []
+    for spec in dependency_specs or []:
+        dep_snap = spec.get("snapshot_date")
+        dep_collected = spec.get("collected_at")
+        lag_label: str | None = None
+        if dep_snap is not None and primary_snapshot_date is not None:
+            lag_days = (primary_snapshot_date - dep_snap).days
+            if lag_days >= 1:
+                lag_label = f"{lag_days}거래일 지연"
+        dependencies.append(
+            ScreenerFreshnessDependency(
+                kind=spec.get("kind", "investor_flow"),
+                snapshotDate=dep_snap.isoformat() if dep_snap is not None else None,
+                collectedAt=dep_collected.astimezone(UTC).isoformat()
+                if dep_collected is not None
+                else None,
+                lagLabel=lag_label,
+                dataState=spec.get("data_state", "missing"),  # type: ignore[arg-type]
+                source=spec.get("source"),
+            )
+        )
+
+    overall = compute_overall_state(
+        primary_state=primary.dataState if primary is not None else dataState,  # type: ignore[arg-type]
+        dependency_states=[d.dataState for d in dependencies],
+    )
+
     return ScreenerFreshness(
         fetchedAt=fetched.astimezone(UTC).isoformat(),
-        asOfLabel=fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+        asOfLabel=primary.asOfLabel if primary is not None else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
         relativeLabel=relative,
         cacheHit=bool(cache_hit),
         source=source,
-        dataState=dataState,  # type: ignore[arg-type]
+        dataState=overall,  # alias of overallState (D1.c)
+        servedAt=served_at_utc.isoformat(),
+        servedRelativeLabel=served_relative,
+        primary=primary,
+        dependencies=dependencies,
+        overallState=overall,
     )
 
 

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -230,6 +230,12 @@ async def _hydrate_investor_flow_chips(
         chip = _investor_flow_chip_for_item(item)
         if chip is not None:
             chips[symbol] = chip
+            # ROB-277: stash dependency snapshot_date back on the row so
+            # build_screener_results can build freshness.dependencies later.
+            for r in rows:
+                if str(r.get("symbol") or "").upper() == symbol:
+                    r["_investor_flow_snapshot_date"] = getattr(item, "snapshotDate", None)
+                    break
     return chips
 
 
@@ -454,6 +460,8 @@ async def _load_consecutive_gainers_from_snapshots(
                 else None,
                 "volume": snap.daily_volume,
                 "daily_closes": list(snap.closes_window or []),
+                "snapshot_date": snap.snapshot_date,    # ROB-277
+                "computed_at": snap.computed_at,        # ROB-277
                 "_screener_snapshot_state": state,
             }
         )
@@ -1445,13 +1453,25 @@ async def build_screener_results(
         if _US_SCREENER_DATA_NOT_READY_WARNING not in upstream_warnings:
             upstream_warnings.append(_US_SCREENER_DATA_NOT_READY_WARNING)
 
-    freshness = _build_freshness(
-        raw_timestamp=raw.get("timestamp"),
-        cache_hit=bool(raw.get("cache_hit")),
-        market=requested_market,
-        now=now,
-        dataState=_aggregated_data_state,
-    )
+    # ROB-277: determine primary kind/source for freshness (computed before _build_freshness).
+    primary_kind: Literal["screener_snapshot", "live", "fallback"]
+    primary_snapshot_date: dt.date | None = None
+    primary_computed_at: datetime | None = None
+    primary_source: str | None = None
+    if _snapshot_was_checked:
+        primary_kind = "screener_snapshot"
+        if preset_id == "investor_flow_momentum":
+            primary_source = "investor_flow_snapshots"
+        elif requested_market == "crypto":
+            primary_source = "invest_crypto_screener_snapshots"
+        else:
+            primary_source = "invest_screener_snapshots"
+        if rows:
+            primary_snapshot_date = rows[0].get("snapshot_date")
+            primary_computed_at = rows[0].get("computed_at")
+    else:
+        primary_kind = "live"
+        primary_source = "screening_service"
 
     # Bulk-lookup Korean names for KR rows from kr_symbol_universe
     _kr_names: dict[str, str] = {}
@@ -1475,6 +1495,48 @@ async def build_screener_results(
 
     investor_flow_chips = await _hydrate_investor_flow_chips(
         db=session, market=requested_market, rows=rows
+    )
+
+    # ROB-277: build dependency specs from hydrated investor-flow chips (KR only).
+    # Must run after _hydrate_investor_flow_chips so _investor_flow_snapshot_date
+    # has been stashed back on rows.
+    dependency_specs: list[dict[str, Any]] = []
+    if requested_market == "kr" and investor_flow_chips:
+        from app.services.invest_screener_snapshots.freshness import (
+            today_trading_date,
+        )
+
+        inv_snapshot_dates: list[dt.date] = []
+        for r in rows:
+            sd = r.get("snapshot_date") or r.get("_investor_flow_snapshot_date")
+            if sd is not None:
+                inv_snapshot_dates.append(sd)
+
+        if inv_snapshot_dates:
+            worst = min(inv_snapshot_dates)
+            today_kr = today_trading_date("kr")
+            dep_state = "stale" if worst != today_kr else "fresh"
+            dependency_specs.append(
+                {
+                    "kind": "investor_flow",
+                    "snapshot_date": worst,
+                    "collected_at": None,
+                    "data_state": dep_state,
+                    "source": "investor_flow_snapshots",
+                }
+            )
+
+    freshness = _build_freshness(
+        raw_timestamp=raw.get("timestamp"),
+        cache_hit=bool(raw.get("cache_hit")),
+        market=requested_market,
+        now=now,
+        dataState=_aggregated_data_state,
+        primary_kind=primary_kind,
+        primary_snapshot_date=primary_snapshot_date,
+        primary_computed_at=primary_computed_at,
+        primary_source=primary_source,
+        dependency_specs=dependency_specs,
     )
     response_sources = _screen_response_sources(
         requested_market=requested_market,

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -181,7 +181,9 @@ def _investor_flow_item_from_screener_row(
         return None
 
     snapshot_state = str(row.get("_screener_snapshot_state") or "").strip()
-    data_state = snapshot_state if snapshot_state in {"fresh", "stale", "missing"} else "fresh"
+    data_state = (
+        snapshot_state if snapshot_state in {"fresh", "stale", "missing"} else "fresh"
+    )
     return InvestorFlowItem(
         symbol=symbol,
         market="kr",
@@ -234,7 +236,9 @@ async def _hydrate_investor_flow_chips(
             # build_screener_results can build freshness.dependencies later.
             for r in rows:
                 if str(r.get("symbol") or "").upper() == symbol:
-                    r["_investor_flow_snapshot_date"] = getattr(item, "snapshotDate", None)
+                    r["_investor_flow_snapshot_date"] = getattr(
+                        item, "snapshotDate", None
+                    )
                     break
     return chips
 
@@ -460,8 +464,8 @@ async def _load_consecutive_gainers_from_snapshots(
                 else None,
                 "volume": snap.daily_volume,
                 "daily_closes": list(snap.closes_window or []),
-                "snapshot_date": snap.snapshot_date,    # ROB-277
-                "computed_at": snap.computed_at,        # ROB-277
+                "snapshot_date": snap.snapshot_date,  # ROB-277
+                "computed_at": snap.computed_at,  # ROB-277
                 "_screener_snapshot_state": state,
             }
         )
@@ -1303,7 +1307,9 @@ def _build_freshness(
 
     return ScreenerFreshness(
         fetchedAt=fetched.astimezone(UTC).isoformat(),
-        asOfLabel=primary.asOfLabel if primary is not None else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+        asOfLabel=primary.asOfLabel
+        if primary is not None
+        else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
         relativeLabel=relative,
         cacheHit=bool(cache_hit),
         source=source,

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field as _dc_field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from datetime import time as _time
 from typing import Any, Literal, Protocol
@@ -255,9 +255,7 @@ async def _hydrate_investor_flow_chips(
                     r["_investor_flow_collected_at"] = getattr(
                         item, "collectedAt", None
                     )
-                    r["_investor_flow_data_state"] = getattr(
-                        item, "dataState", None
-                    )
+                    r["_investor_flow_data_state"] = getattr(item, "dataState", None)
                     break
     return chips
 

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -178,12 +178,13 @@ def _investor_flow_item_from_screener_row(
         return None
 
     snapshot_state = str(row.get("_screener_snapshot_state") or "").strip()
-    data_state = snapshot_state if snapshot_state in {"fresh", "stale"} else "fresh"
+    data_state = snapshot_state if snapshot_state in {"fresh", "stale", "missing"} else "fresh"
     return InvestorFlowItem(
         symbol=symbol,
         market="kr",
         dataState=data_state,
         snapshotDate=row.get("snapshot_date"),
+        collectedAt=row.get("collected_at"),  # ROB-277: passes through when available
         foreignNet=row.get("foreign_net"),
         institutionNet=row.get("institution_net"),
         individualNet=row.get("individual_net"),
@@ -536,6 +537,14 @@ async def _load_investor_flow_discovery_from_snapshots(
                 exc_info=True,
             )
 
+    from app.services.invest_screener_snapshots.freshness import (
+        classify_investor_flow_partition,
+        today_trading_date,
+    )
+
+    today = today_trading_date(market)
+    now_utc = datetime.now(UTC)
+
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for snap in candidate_snaps:
@@ -544,6 +553,12 @@ async def _load_investor_flow_discovery_from_snapshots(
         if not _is_kr_toss_common_stock(snap.symbol, symbol_names.get(snap.symbol)):
             continue
         seen.add(snap.symbol)
+        state = classify_investor_flow_partition(
+            snapshot_date=snap.snapshot_date,
+            collected_at=snap.collected_at,
+            today_trading_date_value=today,
+            now=now_utc,
+        )
         rows.append(
             {
                 "symbol": snap.symbol,
@@ -555,7 +570,9 @@ async def _load_investor_flow_discovery_from_snapshots(
                 "foreign_consecutive_buy_days": snap.foreign_consecutive_buy_days,
                 "institution_consecutive_buy_days": snap.institution_consecutive_buy_days,
                 "double_buy": snap.double_buy,
-                "_screener_snapshot_state": "fresh",
+                "snapshot_date": snap.snapshot_date,
+                "collected_at": snap.collected_at,
+                "_screener_snapshot_state": state,
             }
         )
         if len(rows) >= limit:

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field as _dc_field
 from datetime import UTC, datetime
 from datetime import time as _time
 from typing import Any, Literal, Protocol
@@ -103,6 +104,17 @@ _KR_PREFERRED_SUFFIXES = ("우", "우B", "우C")
 _INVESTOR_FLOW_MIN_STREAK = 3
 _INVESTOR_FLOW_STALE_SUFFIX = " · 1일 지연"
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SnapshotLoadResult:
+    """ROB-277 follow-up: snapshot loaders must surface latest-partition metadata
+    even when no rows qualified, so freshness.primary can still report the
+    correct snapshot date."""
+
+    rows: list[dict[str, Any]]
+    partition_date: dt.date | None
+    partition_computed_at: datetime | None = None
 
 
 def _investor_flow_chip_for_item(
@@ -232,12 +244,19 @@ async def _hydrate_investor_flow_chips(
         chip = _investor_flow_chip_for_item(item)
         if chip is not None:
             chips[symbol] = chip
-            # ROB-277: stash dependency snapshot_date back on the row so
-            # build_screener_results can build freshness.dependencies later.
+            # ROB-277 follow-up: stash full dependency metadata on the row so
+            # build_screener_results can classify the investor-flow dependency
+            # via classify_investor_flow_partition.
             for r in rows:
                 if str(r.get("symbol") or "").upper() == symbol:
                     r["_investor_flow_snapshot_date"] = getattr(
                         item, "snapshotDate", None
+                    )
+                    r["_investor_flow_collected_at"] = getattr(
+                        item, "collectedAt", None
+                    )
+                    r["_investor_flow_data_state"] = getattr(
+                        item, "dataState", None
                     )
                     break
     return chips
@@ -371,14 +390,17 @@ def _double_buy_dependency_warnings(
 
 async def _load_consecutive_gainers_from_snapshots(
     session: AsyncSession | None, *, market: str, limit: int = _SNAPSHOT_FIRST_LIMIT
-) -> list[dict[str, Any]] | None:
+) -> _SnapshotLoadResult | None:
     """Return qualifying rows from the latest snapshot partition only.
 
     Returns None when the check could not be performed (no session, wrong market,
-    DB error, or no snapshots exist in the table at all). Returns an empty list
-    when the latest partition was found but contains no qualifying rows — callers
-    must NOT fall back to external screening in that case, because historical
-    qualifying rows from older partitions must not be surfaced as current results.
+    DB error, or no snapshots exist in the table at all). Returns a
+    _SnapshotLoadResult with an empty rows list when the latest partition was found
+    but contains no qualifying rows — callers must NOT fall back to external
+    screening in that case, because historical qualifying rows from older partitions
+    must not be surfaced as current results. The partition_date is always populated
+    when a non-None result is returned so freshness.primary has the correct date
+    even when 0 rows qualify.
     """
     if session is None or market not in {"kr", "us"}:
         return None
@@ -507,17 +529,33 @@ async def _load_consecutive_gainers_from_snapshots(
         if len(rows) >= limit:
             break
     # Rows are already ordered by the SQL ORDER BY; no Python re-sort needed.
-    return rows
+    # ROB-277 follow-up: always return partition metadata even when rows is empty,
+    # so freshness.primary surfaces the correct snapshot date.
+    partition_computed_at: datetime | None = None
+    if rows:
+        partition_computed_at = rows[0].get("computed_at")
+    elif candidate_snaps:
+        # No qualifying rows after filtering, but we can grab computed_at from
+        # any snap in the partition (they share the same snapshot_date).
+        partition_computed_at = getattr(candidate_snaps[0], "computed_at", None)
+    return _SnapshotLoadResult(
+        rows=rows,
+        partition_date=latest_snapshot_date,
+        partition_computed_at=partition_computed_at,
+    )
 
 
 async def _load_investor_flow_discovery_from_snapshots(
     session: AsyncSession | None, *, market: str, limit: int = 20
-) -> list[dict[str, Any]] | None:
+) -> _SnapshotLoadResult | None:
     """Return MVP 수급 discovery rows from persisted investor_flow_snapshots.
 
     This preset is intentionally snapshot-only/read-only: if durable snapshots are
     unavailable, callers may fall back to the generic screener service, but no
     request-time Naver scraping is introduced here.
+
+    Returns a _SnapshotLoadResult with partition_date populated even when no rows
+    qualify, so freshness.primary can surface the correct snapshot date.
     """
     if session is None or market != "kr":
         return None
@@ -627,7 +665,18 @@ async def _load_investor_flow_discovery_from_snapshots(
         )
         if len(rows) >= limit:
             break
-    return rows
+    # ROB-277 follow-up: surface partition metadata even when rows is empty so
+    # freshness.primary has the correct snapshot date.
+    partition_collected_at: datetime | None = None
+    if rows:
+        partition_collected_at = rows[0].get("collected_at")
+    elif candidate_snaps:
+        partition_collected_at = getattr(candidate_snaps[0], "collected_at", None)
+    return _SnapshotLoadResult(
+        rows=rows,
+        partition_date=latest_snapshot_date,
+        partition_computed_at=partition_collected_at,  # investor_flow has no computed_at; use collected_at
+    )
 
 
 async def _load_crypto_rows_from_snapshots(
@@ -1342,7 +1391,7 @@ def _build_freshness(
     )
 
     return ScreenerFreshness(
-        fetchedAt=fetched.astimezone(UTC).isoformat(),
+        fetchedAt=served_at_utc.isoformat(),  # ROB-277 D1: fetchedAt is a servedAt alias
         asOfLabel=primary.asOfLabel
         if primary is not None
         else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
@@ -1387,6 +1436,10 @@ async def build_screener_results(
         )
 
     filters = screening_filters_for(preset_id, requested_market)
+    # ROB-277 follow-up: loaders for consecutive_gainers and investor_flow_momentum
+    # now return _SnapshotLoadResult so partition metadata threads through even when
+    # 0 rows qualify. double_buy and crypto still return list|None directly.
+    _snapshot_load_result: _SnapshotLoadResult | None = None
     _snapshot_check_result: list[dict[str, Any]] | None = None
     _snapshot_state_override: str | None = None
     _snapshot_empty_warning = (
@@ -1394,17 +1447,21 @@ async def build_screener_results(
     )
     if session is not None and _should_use_snapshot_first(screening_service):
         if preset_id == "consecutive_gainers":
-            _snapshot_check_result = await _load_consecutive_gainers_from_snapshots(
+            _snapshot_load_result = await _load_consecutive_gainers_from_snapshots(
                 session,
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
             )
+            if _snapshot_load_result is not None:
+                _snapshot_check_result = _snapshot_load_result.rows
         elif preset_id == "investor_flow_momentum":
-            _snapshot_check_result = await _load_investor_flow_discovery_from_snapshots(
+            _snapshot_load_result = await _load_investor_flow_discovery_from_snapshots(
                 session,
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
             )
+            if _snapshot_load_result is not None:
+                _snapshot_check_result = _snapshot_load_result.rows
             _snapshot_empty_warning = (
                 "최신 수급 스냅샷에서 조건에 맞는 결과가 없습니다."
             )
@@ -1544,7 +1601,13 @@ async def build_screener_results(
             primary_source = "invest_crypto_screener_snapshots"
         else:
             primary_source = "invest_screener_snapshots"
-        if rows:
+        # ROB-277 follow-up: prefer partition metadata from the loader dataclass
+        # so freshness.primary has the correct date even when 0 rows qualify.
+        if _snapshot_load_result is not None:
+            primary_snapshot_date = _snapshot_load_result.partition_date
+            primary_computed_at = _snapshot_load_result.partition_computed_at
+        elif rows:
+            # Fallback for double_buy / crypto paths that don't use _SnapshotLoadResult
             primary_snapshot_date = rows[0].get("snapshot_date")
             primary_computed_at = rows[0].get("computed_at")
     else:
@@ -1576,29 +1639,38 @@ async def build_screener_results(
     )
 
     # ROB-277: build dependency specs from hydrated investor-flow chips (KR only).
-    # Must run after _hydrate_investor_flow_chips so _investor_flow_snapshot_date
-    # has been stashed back on rows.
+    # Must run after _hydrate_investor_flow_chips so _investor_flow_snapshot_date,
+    # _investor_flow_collected_at, and _investor_flow_data_state have been stashed
+    # back on rows.
     dependency_specs: list[dict[str, Any]] = []
     if requested_market == "kr" and investor_flow_chips:
         from app.services.invest_screener_snapshots.freshness import (
+            classify_investor_flow_partition,
             today_trading_date,
         )
 
-        inv_snapshot_dates: list[dt.date] = []
+        # ROB-277 follow-up: dependency = investor_flow_snapshots, distinct from primary.
+        # ONLY use the dependency-specific stash keys, never the primary's snapshot_date.
+        inv_meta: list[tuple[dt.date, datetime | None]] = []
         for r in rows:
-            sd = r.get("snapshot_date") or r.get("_investor_flow_snapshot_date")
+            sd = r.get("_investor_flow_snapshot_date")
             if sd is not None:
-                inv_snapshot_dates.append(sd)
+                inv_meta.append((sd, r.get("_investor_flow_collected_at")))
 
-        if inv_snapshot_dates:
-            worst = min(inv_snapshot_dates)
+        if inv_meta:
+            worst_sd, worst_collected = min(inv_meta, key=lambda t: t[0])
             today_kr = today_trading_date("kr")
-            dep_state = "stale" if worst != today_kr else "fresh"
+            dep_state = classify_investor_flow_partition(
+                snapshot_date=worst_sd,
+                collected_at=worst_collected,
+                today_trading_date_value=today_kr,
+                now=now(),
+            )
             dependency_specs.append(
                 {
                     "kind": "investor_flow",
-                    "snapshot_date": worst,
-                    "collected_at": None,
+                    "snapshot_date": worst_sd,
+                    "collected_at": worst_collected,
                     "data_state": dep_state,
                     "source": "investor_flow_snapshots",
                 }

--- a/docs/plans/2026-05-20-ROB-277-screener-freshness-semantics-implementation-plan.md
+++ b/docs/plans/2026-05-20-ROB-277-screener-freshness-semantics-implementation-plan.md
@@ -1,0 +1,1564 @@
+# ROB-277 — `/invest/screener` Freshness Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `/invest/screener` freshness into "response served time" vs "underlying data 기준일/시각" so the UI never shows `방금 갱신` for stale-snapshot results. Additive backend schema change, no DB migration, no scheduler activation.
+
+**Architecture:** Replace `raw["timestamp"] = now()` (snapshot-first path) with a freshness object that exposes (a) `servedAt`/`servedRelativeLabel` for response refresh, (b) `primary` for the screener snapshot's own state (using `classify_state` from `app/services/invest_screener_snapshots/freshness.py`), and (c) `dependencies[]` for investor-flow style derived signals. Old `fetchedAt`/`asOfLabel`/`relativeLabel`/`cacheHit`/`source`/`dataState` fields are kept; `dataState` becomes a transition alias of new `overallState`.
+
+**Tech Stack:** FastAPI + Pydantic v2 (backend), Vite + React + Vitest + Testing Library (frontend), async SQLAlchemy on PostgreSQL, pytest with `pytest-asyncio`. UV-managed Python deps. KST/trading-date logic via `zoneinfo` already in `app/services/invest_screener_snapshots/freshness.py`.
+
+---
+
+## Locked Decisions (do not re-debate during implementation)
+
+These were agreed in the ROB-277 review thread on 2026-05-20. Any deviation requires explicit reviewer sign-off **before** code changes.
+
+### D1. Legacy field mapping (additive only)
+
+`ScreenerFreshness` schema after this PR:
+
+| Field | Old? | Meaning |
+|-------|------|---------|
+| `fetchedAt` | existing | Kept. Holds the **served** ISO timestamp (== `servedAt`). Backwards-compat alias. |
+| `asOfLabel` | existing | Kept. **Data 기준 label** of the primary source (NOT the served time). |
+| `relativeLabel` | existing | Kept. Korean human label for the primary data 기준 (e.g. `5거래일 지연`, `방금 갱신`, `전 거래일 기준`). |
+| `cacheHit` | existing | Kept. Whether the served result came from cache/snapshot vs live call. |
+| `source` | existing | Kept. Enum stays `"live" \| "cached" \| "previous_session"`. **Snapshot-first → `"cached"`**. No new enum value in this PR. |
+| `dataState` | existing | Kept. **Becomes alias of `overallState`** during transition. |
+| `servedAt` | **NEW** | ISO timestamp when the view-model produced the response. |
+| `servedRelativeLabel` | **NEW** | Korean label for served time (e.g. `방금`, `12분 전`). |
+| `primary` | **NEW** | See D1.a. |
+| `dependencies` | **NEW** | See D1.b. Optional, may be `[]`. |
+| `overallState` | **NEW** | Aggregated state (see D1.c). |
+
+**D1.a. `primary` shape:**
+
+```python
+class ScreenerFreshnessPrimary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["screener_snapshot", "live", "fallback"]
+    snapshotDate: str | None = None       # ISO date, e.g. "2026-05-13"
+    computedAt: str | None = None          # ISO datetime (UTC) when partition was computed
+    asOfLabel: str                         # Korean label, e.g. "2026.05.13 장마감 기준"
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None              # free-form, e.g. "invest_screener_snapshots"
+```
+
+**D1.b. `dependencies[]` shape:**
+
+```python
+class ScreenerFreshnessDependency(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["investor_flow"]        # extensible later
+    snapshotDate: str | None = None
+    collectedAt: str | None = None
+    lagLabel: str | None = None            # e.g. "2거래일 지연", or null when fresh
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None              # e.g. "investor_flow_snapshots"
+```
+
+**D1.c. `overallState` aggregation rule** (explicit, NOT reusing `aggregate_states` because its `has_missing + has_fresh_or_partial → fallback` rule conflicts with the spec):
+
+```
+1. If primary.dataState in {"missing", "stale"}  → overallState = primary.dataState
+2. Else if any dependency.dataState in {"missing", "stale"}  → overallState = "stale"
+3. Else if any dependency.dataState == "partial"  → overallState = "partial"
+4. Else → overallState = primary.dataState  (which is "fresh" or "partial" at this point)
+```
+
+Top-level `dataState = overallState` (alias).
+
+### D2. `source` mapping (no enum extension in this PR)
+
+- Top-level `source` stays the existing enum `Literal["live", "cached", "previous_session"]`.
+- Snapshot-first result → top-level `source = "cached"`, `cacheHit = True`.
+- The actual provenance lives in `primary.kind = "screener_snapshot"` and `primary.source = "invest_screener_snapshots"` (or `investor_flow_snapshots` for the investor-flow preset's primary).
+- **If** a future PR decides to surface `source = "snapshot"` at top level, it must add `frontend/invest/src/types/screener.ts` + Pydantic enum update + a compatibility note. **Not in this PR.**
+
+### D3. UI copy standard
+
+`ScreenerFreshnessLine.tsx` renders **two separate spans** (data 기준 line + 화면 갱신 line). Copy table:
+
+| State | 데이터 기준 line (top) | 화면 갱신 line (bottom) | Data-state chip |
+|-------|------------------------|--------------------------|-----------------|
+| `fresh` | `데이터 기준 ${asOfLabel}` | `화면 갱신 ${servedRelativeLabel}` | (no chip) |
+| `partial` | `데이터 기준 ${asOfLabel}` | `화면 갱신 ${servedRelativeLabel}` | `일부 데이터 지연` |
+| `stale` | `데이터 기준 ${asOfLabel} · ${lagLabel ?? "업데이트 필요"}` | `화면 갱신 ${servedRelativeLabel}` | `업데이트 필요` |
+| `missing` | `데이터 없음` (or `수급 데이터 없음` when only deps missing) | `화면 갱신 ${servedRelativeLabel}` | `데이터 준비중` |
+| `previous_session` | `전 거래일 기준 · ${asOfLabel}` | `화면 갱신 ${servedRelativeLabel}` | (no chip) |
+| `fallback` | `대체 데이터 기준 ${asOfLabel}` | `화면 갱신 ${servedRelativeLabel}` | `대체 데이터` |
+
+Wording may be polished in implementation, but the **structural rule is non-negotiable**: `데이터 기준` and `화면 갱신` are always in separate visual rows / spans and never share a single label.
+
+### D4. `classify_state()` reuse
+
+- **Primary state for `consecutive_gainers`**: use `classify_state(snapshot_date, computed_at, closes_window_len, today_trading_date_value, now)` directly (already populated per-row in `_load_consecutive_gainers_from_snapshots`).
+- **Primary state for `investor_flow_momentum`**: derive from the latest `investor_flow_snapshots` partition using a new helper `_classify_investor_flow_partition` that mirrors `classify_state`'s KST/trading-date logic but without `closes_window_len` (investor-flow has no analog).  The helper lives in `app/services/invest_screener_snapshots/freshness.py` for colocation (the file already centralizes screener freshness logic) and reuses `today_trading_date`.
+- **Dependency state for investor-flow chips on `consecutive_gainers`**: same `_classify_investor_flow_partition` helper.
+- **Remove** the `"_screener_snapshot_state": "fresh"` hardcode at `screener_service.py:558`.
+
+### D5. Required tests (in addition to existing acceptance criteria)
+
+Backend (`tests/test_invest_view_model_screener_service.py` extension + new freshness tests in `tests/test_invest_screener_snapshots_freshness.py`):
+
+1. `test_consecutive_gainers_snapshot_5_days_old_classifies_stale_and_uses_partition_date_as_as_of_label` — KR snapshot dated `today - 5 trading days`, response has `freshness.primary.dataState == "stale"`, `freshness.primary.snapshotDate == that date`, `freshness.asOfLabel` references that date (NOT `now()`).
+2. `test_classify_state_weekday_boundary_friday_monday` — Friday close → Monday morning still classifies as `stale` (because `snapshot_date != today_trading_date` once Monday's partition would be expected) **OR** as `fresh` until Monday open, depending on `STALE_AFTER_HOURS`. Lock the actually-implemented behavior in this test.
+3. `test_legacy_dataState_equals_overallState` — for every code path that builds `ScreenerFreshness`, `freshness.dataState == freshness.overallState`.
+4. `test_snapshot_first_source_stays_cached_with_primary_kind_screener_snapshot` — snapshot-first response has `source == "cached"` AND `primary.kind == "screener_snapshot"` AND `primary.source == "invest_screener_snapshots"`.
+5. `test_investor_flow_dependency_carries_snapshot_date_and_classified_state` — chip on a `consecutive_gainers` row exposes `snapshotDate` from the actual `investor_flow_snapshots` partition; `dataState` reflects classified state, NOT hardcoded `"fresh"`.
+6. `test_overall_state_primary_fresh_dependency_stale_is_stale` — explicit D1.c rule 2.
+7. `test_overall_state_primary_stale_dependency_fresh_is_stale` — explicit D1.c rule 1.
+
+Frontend (`frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx` extension):
+
+8. `renders 데이터 기준 and 화면 갱신 in separate spans` — both labels present, neither contains the other's substring.
+9. `does not contradict: stale data + fresh served renders both lines without 방금 갱신 next to stale date` — DOM contains `업데이트 필요` AND `화면 갱신`, but `방금 갱신` does NOT appear on the same line as `데이터 기준`.
+
+### D6. Server smoke responsibility
+
+- **Merge gate (required before merge):** `make test`, `make typecheck`, `make lint`, frontend `pnpm test` for the changed components, and a local dev-browser/API spot-check of `/invest/screener?market=kr` if the dev stack is up.
+- **Post-merge (not a gate):** Hermes/파이리 handles MacBook server deploy + production smoke (compare prod `/invest/api/screener/results?preset=consecutive_gainers&market=kr` freshness object against an open `consecutive_gainers` row's investor-flow chip).
+- **PR body MUST include a "Compatibility caution" section** if any frontend consumer reads `freshness.fetchedAt` as the data-as-of source (not just served time). Audit before opening PR (see Task 11).
+
+### D7. ROB-204 / ROB-205 relationship (no scope creep)
+
+- ROB-277 is read-side only: consumes `invest_screener_snapshots` and `investor_flow_snapshots` as already populated.
+- **Do NOT** in this PR: activate Prefect schedules, unpause TaskIQ recurrence, write to `INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`, run any `scripts/build_*_snapshots.py --commit`, or backfill investor-flow.
+- ROB-204 may finalize US activation in parallel; that work is gated by `INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED` env var and does not touch any file this plan modifies.
+- ROB-205 will land investor-flow backfill / scheduler activation later; this PR's classification must work correctly **today** with the existing (potentially stale) partition.
+
+---
+
+## File Structure
+
+**Modify (backend):**
+- `app/schemas/invest_screener.py` — add `ScreenerFreshnessPrimary`, `ScreenerFreshnessDependency`, extend `ScreenerFreshness`.
+- `app/services/invest_screener_snapshots/freshness.py` — add `_classify_investor_flow_partition`, helper for `format_kst_as_of_label` (small util kept here for colocation), and `compute_overall_state`.
+- `app/services/invest_view_model/screener_service.py` — refactor `_build_freshness`, plumb snapshot metadata into investor-flow rows, populate `primary` / `dependencies` / `overallState`.
+
+**Modify (frontend):**
+- `frontend/invest/src/types/screener.ts` — extend `ScreenerFreshness` with new optional fields.
+- `frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx` — render two separate spans.
+- `frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx` — extend tests.
+
+**Modify (backend tests):**
+- `tests/test_invest_view_model_screener_service.py` — extend.
+- `tests/test_invest_screener_snapshots_freshness.py` — extend with classification edge cases.
+- `tests/test_invest_screener_schemas.py` — extend with new fields.
+
+**Create:** none. (No new files; everything fits into existing modules per single-responsibility.)
+
+---
+
+## Tasks
+
+Each task is a self-contained TDD slice with a commit at the end. Run all commands from repo root `/Users/mgh3326/work/auto_trader.rob-277`.
+
+---
+
+### Task 1: Schema — add `ScreenerFreshnessPrimary`, `ScreenerFreshnessDependency`, extend `ScreenerFreshness`
+
+**Files:**
+- Modify: `app/schemas/invest_screener.py:125-132`
+- Test: `tests/test_invest_screener_schemas.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_invest_screener_schemas.py`:
+
+```python
+def test_screener_freshness_accepts_new_primary_and_dependencies_fields() -> None:
+    from app.schemas.invest_screener import (
+        ScreenerFreshness,
+        ScreenerFreshnessPrimary,
+        ScreenerFreshnessDependency,
+    )
+
+    payload = ScreenerFreshness(
+        fetchedAt="2026-05-20T00:10:00+00:00",
+        asOfLabel="2026.05.13 장마감 기준",
+        relativeLabel="5거래일 지연",
+        cacheHit=True,
+        source="cached",
+        dataState="stale",
+        servedAt="2026-05-20T00:10:00+00:00",
+        servedRelativeLabel="방금",
+        primary=ScreenerFreshnessPrimary(
+            kind="screener_snapshot",
+            snapshotDate="2026-05-13",
+            computedAt="2026-05-13T06:35:00+00:00",
+            asOfLabel="2026.05.13 장마감 기준",
+            dataState="stale",
+            source="invest_screener_snapshots",
+        ),
+        dependencies=[
+            ScreenerFreshnessDependency(
+                kind="investor_flow",
+                snapshotDate="2026-05-18",
+                collectedAt="2026-05-18T07:30:00+00:00",
+                lagLabel="2거래일 지연",
+                dataState="stale",
+                source="investor_flow_snapshots",
+            )
+        ],
+        overallState="stale",
+    )
+    assert payload.primary is not None
+    assert payload.primary.kind == "screener_snapshot"
+    assert payload.dependencies[0].kind == "investor_flow"
+    assert payload.overallState == payload.dataState
+
+
+def test_screener_freshness_is_backwards_compatible_without_new_fields() -> None:
+    from app.schemas.invest_screener import ScreenerFreshness
+
+    payload = ScreenerFreshness(
+        fetchedAt="2026-05-20T00:10:00+00:00",
+        asOfLabel="2026.05.20 09:10 기준",
+        relativeLabel="방금 갱신",
+        cacheHit=False,
+        source="live",
+        dataState="fresh",
+    )
+    assert payload.primary is None
+    assert payload.dependencies == []
+    assert payload.overallState is None  # absent until backend populates it
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/test_invest_screener_schemas.py::test_screener_freshness_accepts_new_primary_and_dependencies_fields tests/test_invest_screener_schemas.py::test_screener_freshness_is_backwards_compatible_without_new_fields -v
+```
+
+Expected: FAIL with `AttributeError` / `ImportError` for `ScreenerFreshnessPrimary` / `ScreenerFreshnessDependency` and `ValidationError: extra inputs are not permitted` on the new fields (because `model_config = ConfigDict(extra="forbid")`).
+
+- [ ] **Step 3: Add the new schema classes and fields**
+
+Edit `app/schemas/invest_screener.py`. After the existing `ScreenerFreshness` class (line 132), but replace `ScreenerFreshness` itself to extend it. Concretely:
+
+```python
+class ScreenerFreshnessPrimary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["screener_snapshot", "live", "fallback"]
+    snapshotDate: str | None = None
+    computedAt: str | None = None
+    asOfLabel: str
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None
+
+
+class ScreenerFreshnessDependency(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: Literal["investor_flow"]
+    snapshotDate: str | None = None
+    collectedAt: str | None = None
+    lagLabel: str | None = None
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"]
+    source: str | None = None
+
+
+class ScreenerFreshness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    fetchedAt: str
+    asOfLabel: str
+    relativeLabel: str
+    cacheHit: bool
+    source: Literal["live", "cached", "previous_session"]
+    dataState: Literal["fresh", "partial", "stale", "missing", "fallback"] = "missing"
+    # New (additive, optional) fields — see ROB-277 plan §D1.
+    servedAt: str | None = None
+    servedRelativeLabel: str | None = None
+    primary: ScreenerFreshnessPrimary | None = None
+    dependencies: list[ScreenerFreshnessDependency] = Field(default_factory=list)
+    overallState: Literal["fresh", "partial", "stale", "missing", "fallback"] | None = None
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+```bash
+uv run pytest tests/test_invest_screener_schemas.py -v
+```
+
+Expected: all schema tests PASS, including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/invest_screener.py tests/test_invest_screener_schemas.py
+git commit -m "feat(rob-277): extend ScreenerFreshness with primary/dependencies/overallState"
+```
+
+---
+
+### Task 2: Freshness helpers — `_classify_investor_flow_partition`, `compute_overall_state`, `format_kst_as_of_label`
+
+**Files:**
+- Modify: `app/services/invest_screener_snapshots/freshness.py`
+- Test: `tests/test_invest_screener_snapshots_freshness.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_invest_screener_snapshots_freshness.py`:
+
+```python
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+from app.services.invest_screener_snapshots.freshness import (
+    classify_investor_flow_partition,
+    compute_overall_state,
+    format_kst_as_of_label,
+)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def test_classify_investor_flow_partition_fresh_when_partition_is_today_trading_date() -> None:
+    today = dt.date(2026, 5, 20)  # Wednesday
+    state = classify_investor_flow_partition(
+        snapshot_date=today,
+        collected_at=dt.datetime(2026, 5, 20, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=today,
+        now=dt.datetime(2026, 5, 20, 8, 0, tzinfo=dt.UTC),
+    )
+    assert state == "fresh"
+
+
+def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_days_old() -> None:
+    state = classify_investor_flow_partition(
+        snapshot_date=dt.date(2026, 5, 18),  # Monday
+        collected_at=dt.datetime(2026, 5, 18, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=dt.date(2026, 5, 20),  # Wednesday
+        now=dt.datetime(2026, 5, 20, 8, 0, tzinfo=dt.UTC),
+    )
+    assert state == "stale"
+
+
+def test_classify_investor_flow_partition_friday_to_monday_morning_is_fresh() -> None:
+    """Saturday/Sunday collapse to Friday's trading date; Monday morning before close stays fresh
+    relative to Friday's snapshot because today_trading_date may still be Friday until Monday's
+    partition appears."""
+    state = classify_investor_flow_partition(
+        snapshot_date=dt.date(2026, 5, 15),  # Friday
+        collected_at=dt.datetime(2026, 5, 15, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=dt.date(2026, 5, 15),
+        now=dt.datetime(2026, 5, 18, 0, 5, tzinfo=dt.UTC),  # Monday 09:05 KST
+    )
+    assert state == "fresh"
+
+
+def test_compute_overall_state_primary_stale_dominates() -> None:
+    assert compute_overall_state(primary_state="stale", dependency_states=["fresh"]) == "stale"
+
+
+def test_compute_overall_state_primary_missing_dominates() -> None:
+    assert compute_overall_state(primary_state="missing", dependency_states=["fresh"]) == "missing"
+
+
+def test_compute_overall_state_primary_fresh_dependency_stale_is_stale() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["stale"]) == "stale"
+
+
+def test_compute_overall_state_primary_fresh_dependency_missing_is_stale() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["missing"]) == "stale"
+
+
+def test_compute_overall_state_primary_fresh_dependency_partial_is_partial() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["partial"]) == "partial"
+
+
+def test_compute_overall_state_primary_fresh_no_dependencies_is_fresh() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=[]) == "fresh"
+
+
+def test_format_kst_as_of_label_for_snapshot_date_only_uses_jangmagam() -> None:
+    label = format_kst_as_of_label(
+        snapshot_date=dt.date(2026, 5, 13), computed_at=None
+    )
+    assert label == "2026.05.13 장마감 기준"
+
+
+def test_format_kst_as_of_label_with_computed_at_uses_hhmm() -> None:
+    label = format_kst_as_of_label(
+        snapshot_date=dt.date(2026, 5, 20),
+        computed_at=dt.datetime(2026, 5, 20, 0, 35, tzinfo=dt.UTC),  # 09:35 KST
+    )
+    assert label == "2026.05.20 09:35 기준"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/test_invest_screener_snapshots_freshness.py -v -k "classify_investor_flow_partition or compute_overall_state or format_kst_as_of_label"
+```
+
+Expected: FAIL with `ImportError` on the three new helpers.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `app/services/invest_screener_snapshots/freshness.py`:
+
+```python
+def classify_investor_flow_partition(
+    *,
+    snapshot_date: dt.date,
+    collected_at: dt.datetime | None,
+    today_trading_date_value: dt.date,
+    now: dt.datetime,
+) -> DataState:
+    """Classify an investor_flow_snapshots partition's freshness.
+
+    Mirrors classify_state() but without closes_window_len (investor_flow rows have
+    no candle window). Stays in this module so KST/trading-date logic lives in one
+    place per ROB-277 §D4.
+    """
+    if collected_at is not None and collected_at.tzinfo is None:
+        collected_at = collected_at.replace(tzinfo=dt.UTC)
+    if snapshot_date != today_trading_date_value:
+        return "stale"
+    if collected_at is not None:
+        age_hours = (now - collected_at).total_seconds() / 3600.0
+        if age_hours >= STALE_AFTER_HOURS:
+            return "stale"
+    return "fresh"
+
+
+def compute_overall_state(
+    *,
+    primary_state: DataState,
+    dependency_states: list[DataState],
+) -> DataState:
+    """Aggregate primary + dependency states per ROB-277 §D1.c.
+
+    NOT the same as aggregate_states(): when primary is fresh but a dependency is
+    stale/missing, the user-visible overall is "stale" (conservative), not
+    "fallback". See plan locked decision D1.c.
+    """
+    if primary_state in {"missing", "stale"}:
+        return primary_state
+    if any(s in {"missing", "stale"} for s in dependency_states):
+        return "stale"
+    if any(s == "partial" for s in dependency_states):
+        return "partial"
+    return primary_state
+
+
+def format_kst_as_of_label(
+    *,
+    snapshot_date: dt.date,
+    computed_at: dt.datetime | None,
+) -> str:
+    """Format a Korean 'as-of' label for the data basis.
+
+    With computed_at: "YYYY.MM.DD HH:MM 기준" in KST.
+    Without computed_at: "YYYY.MM.DD 장마감 기준" (treats it as end-of-day partition).
+    """
+    if computed_at is None:
+        return f"{snapshot_date.strftime('%Y.%m.%d')} 장마감 기준"
+    if computed_at.tzinfo is None:
+        computed_at = computed_at.replace(tzinfo=dt.UTC)
+    kst = computed_at.astimezone(ZoneInfo("Asia/Seoul"))
+    return kst.strftime("%Y.%m.%d %H:%M 기준")
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+```bash
+uv run pytest tests/test_invest_screener_snapshots_freshness.py -v
+```
+
+Expected: all 10 new tests PASS plus existing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/invest_screener_snapshots/freshness.py tests/test_invest_screener_snapshots_freshness.py
+git commit -m "feat(rob-277): add investor-flow classification + overall-state aggregation helpers"
+```
+
+---
+
+### Task 3: Hydrate investor-flow snapshot rows with `snapshot_date` / `collected_at` / classified state
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py:462-563` (`_load_investor_flow_discovery_from_snapshots`)
+- Modify: `app/services/invest_view_model/screener_service.py:173-198` (`_investor_flow_item_from_screener_row`)
+- Test: `tests/test_invest_view_model_screener_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_invest_view_model_screener_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_investor_flow_momentum_rows_carry_snapshot_date_and_classified_state(
+    db_session,  # existing pytest fixture; see test file for shape
+) -> None:
+    import datetime as dt
+
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.services.invest_view_model.screener_service import (
+        _load_investor_flow_discovery_from_snapshots,
+    )
+
+    # Insert one row dated 2 trading days ago.
+    snap = InvestorFlowSnapshot(
+        market="kr",
+        symbol="005930",
+        snapshot_date=dt.date(2026, 5, 18),  # Monday; "today" in test = 2026-05-20
+        collected_at=dt.datetime(2026, 5, 18, 7, 30, tzinfo=dt.UTC),
+        source="naver",
+        foreign_net=1000,
+        institution_net=500,
+        individual_net=-1500,
+        double_buy=True,
+        foreign_consecutive_buy_days=4,
+    )
+    db_session.add(snap)
+    await db_session.commit()
+
+    rows = await _load_investor_flow_discovery_from_snapshots(
+        db_session, market="kr", limit=10
+    )
+    assert rows is not None and len(rows) == 1
+    row = rows[0]
+    assert row["symbol"] == "005930"
+    assert row["snapshot_date"] == dt.date(2026, 5, 18)
+    assert row["collected_at"] is not None
+    # state is NOT hardcoded "fresh"; classified from partition date vs today
+    assert row["_screener_snapshot_state"] in {"fresh", "stale"}
+    # specifically: with today=2026-05-20 and snapshot=2026-05-18, state should be stale.
+    # If the test infra cannot freeze "today", at minimum assert no hardcoded "fresh"
+    # by checking row pulls snapshot_date through.
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py::test_investor_flow_momentum_rows_carry_snapshot_date_and_classified_state -v
+```
+
+Expected: FAIL — current code returns `{"_screener_snapshot_state": "fresh"}` without `snapshot_date` / `collected_at`.
+
+- [ ] **Step 3: Replace the hardcoded "fresh" block and pass snapshot metadata**
+
+In `app/services/invest_view_model/screener_service.py`, locate the row construction at lines ~547-560 inside `_load_investor_flow_discovery_from_snapshots`. Replace with:
+
+```python
+        from app.services.invest_screener_snapshots.freshness import (
+            classify_investor_flow_partition,
+            today_trading_date,
+        )
+
+        today = today_trading_date(market)
+        now = datetime.now(UTC)
+
+        state = classify_investor_flow_partition(
+            snapshot_date=snap.snapshot_date,
+            collected_at=snap.collected_at,
+            today_trading_date_value=today,
+            now=now,
+        )
+
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "market": "kr",
+                "name": symbol_names.get(snap.symbol),
+                "foreign_net": snap.foreign_net,
+                "institution_net": snap.institution_net,
+                "individual_net": snap.individual_net,
+                "foreign_consecutive_buy_days": snap.foreign_consecutive_buy_days,
+                "institution_consecutive_buy_days": snap.institution_consecutive_buy_days,
+                "double_buy": snap.double_buy,
+                "snapshot_date": snap.snapshot_date,
+                "collected_at": snap.collected_at,
+                "_screener_snapshot_state": state,
+            }
+        )
+```
+
+(Move the `from app.services.invest_screener_snapshots.freshness import ...` block above the `for snap in candidate_snaps:` loop so it imports once.)
+
+Update `_investor_flow_item_from_screener_row` (line 173) to read the new fields:
+
+```python
+def _investor_flow_item_from_screener_row(
+    row: dict[str, Any],
+) -> InvestorFlowItem | None:
+    symbol = str(row.get("symbol") or "").strip().upper()
+    if not symbol:
+        return None
+
+    snapshot_state = str(row.get("_screener_snapshot_state") or "").strip()
+    data_state = snapshot_state if snapshot_state in {"fresh", "stale", "missing"} else "fresh"
+    return InvestorFlowItem(
+        symbol=symbol,
+        market="kr",
+        dataState=data_state,
+        snapshotDate=row.get("snapshot_date"),
+        collectedAt=row.get("collected_at"),  # passes through when available
+        foreignNet=row.get("foreign_net"),
+        institutionNet=row.get("institution_net"),
+        individualNet=row.get("individual_net"),
+        doubleBuy=bool(row.get("double_buy")),
+        doubleSell=bool(row.get("double_sell")),
+        foreignConsecutiveBuyDays=row.get("foreign_consecutive_buy_days"),
+        foreignConsecutiveSellDays=row.get("foreign_consecutive_sell_days"),
+        institutionConsecutiveBuyDays=row.get("institution_consecutive_buy_days"),
+        institutionConsecutiveSellDays=row.get("institution_consecutive_sell_days"),
+        individualConsecutiveBuyDays=row.get("individual_consecutive_buy_days"),
+        individualConsecutiveSellDays=row.get("individual_consecutive_sell_days"),
+    )
+```
+
+- [ ] **Step 4: Run test to confirm pass and the existing screener tests still pass**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v
+```
+
+Expected: new test PASS; all other tests in the file PASS unchanged. If any test depended on `_screener_snapshot_state="fresh"` hardcode, update it to assert the classified state instead — note the change in the commit message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py
+git commit -m "fix(rob-277): classify investor_flow_momentum freshness from snapshot partition"
+```
+
+---
+
+### Task 4: New `_build_freshness_v2` orchestrator — emits primary/dependencies/overallState
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py:1149-1189` (`_build_freshness`)
+- Test: `tests/test_invest_view_model_screener_service.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_invest_view_model_screener_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_build_freshness_snapshot_first_uses_partition_date_not_now() -> None:
+    """ROB-277 D1: snapshot-first response must surface partition date, not now()."""
+    import datetime as dt
+    from unittest.mock import AsyncMock
+
+    from app.services.invest_view_model.screener_service import build_screener_results
+
+    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    # Patch _load_consecutive_gainers_from_snapshots indirectly by injecting rows
+    # via the snapshot path. Test relies on a DB fixture seeded with a snapshot
+    # dated 2026-05-13 — see fixture _seed_kr_stale_snapshot below.
+    ...  # finish per fixture style of the test file
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=AsyncMock(),
+        resolver=_StubResolver(),
+        market="kr",
+        now=fake_now,
+        session=db_session,
+    )
+    f = resp.freshness
+    assert f.primary is not None
+    assert f.primary.kind == "screener_snapshot"
+    assert f.primary.snapshotDate == "2026-05-13"
+    assert "2026.05.13" in f.primary.asOfLabel
+    assert f.primary.dataState == "stale"
+    assert "2026.05.13" in f.asOfLabel              # data-as-of, NOT 2026-05-20
+    assert f.servedAt is not None and f.servedAt.startswith("2026-05-20")
+    assert f.source == "cached"                     # D2: top-level enum unchanged
+    assert f.dataState == f.overallState            # D1.c: legacy alias
+    assert f.overallState == "stale"
+
+
+@pytest.mark.asyncio
+async def test_build_freshness_legacy_dataState_aliases_overallState(db_session) -> None:
+    # Use whatever happy-path fixture exists in this file; assert the alias holds.
+    resp = await _call_build_screener_results_happy_path(db_session)
+    assert resp.freshness.dataState == resp.freshness.overallState
+```
+
+(Use the existing test-file conventions for DB session fixtures. The plan does not invent fixture names — adapt to whatever `tests/test_invest_view_model_screener_service.py` already uses for snapshot seeding. Search for `InvestScreenerSnapshot(` in the file to find the pattern.)
+
+- [ ] **Step 2: Run tests to confirm fail**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v -k "snapshot_first_uses_partition_date or legacy_dataState_aliases_overallState"
+```
+
+Expected: FAIL on `primary` not present / `asOfLabel` containing "2026.05.20" instead of "2026.05.13".
+
+- [ ] **Step 3: Refactor `_build_freshness` to take snapshot metadata and produce the new fields**
+
+Replace the existing `_build_freshness` function (lines ~1149-1189) in `app/services/invest_view_model/screener_service.py`:
+
+```python
+def _build_freshness(
+    *,
+    raw_timestamp: str | None,
+    cache_hit: bool,
+    market: str,
+    now: Callable[[], datetime],
+    dataState: str = "missing",
+    primary_kind: Literal["screener_snapshot", "live", "fallback"] = "live",
+    primary_snapshot_date: "dt.date | None" = None,
+    primary_computed_at: "datetime | None" = None,
+    primary_source: str | None = None,
+    dependency_specs: list[dict[str, Any]] | None = None,
+) -> ScreenerFreshness:
+    """ROB-277: split served time vs data 기준.
+
+    raw_timestamp historically served as both, which is the bug this fixes.  When
+    primary_kind == "screener_snapshot", primary fields derive from the partition
+    date/computed_at and the user-visible asOfLabel reflects that — NOT now().
+
+    dependency_specs items shape:
+      {"kind": "investor_flow", "snapshot_date": date|None, "collected_at": dt|None,
+       "data_state": "fresh|partial|stale|missing|fallback", "source": str|None}
+    """
+    from app.services.invest_screener_snapshots.freshness import (
+        compute_overall_state,
+        format_kst_as_of_label,
+    )
+
+    now_utc = now()
+    # served = response refresh time, always now() of the request
+    served_at_utc = now_utc
+    served_kst = served_at_utc.astimezone(_KST)
+
+    # served relative label is small/simple (no "갱신" suffix per D3)
+    served_delta = 0  # served == now, so always "방금"
+    served_relative = "방금"
+
+    # Determine fetched (legacy field). For snapshot kind, fetched mirrors the
+    # partition's computed_at (or end-of-snapshot-date 15:30 KST when computed_at
+    # is missing) so legacy consumers see the data-as-of timestamp.
+    if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
+        if primary_computed_at is not None:
+            fetched = primary_computed_at
+            if fetched.tzinfo is None:
+                fetched = fetched.replace(tzinfo=UTC)
+        else:
+            # Treat as end-of-trading-day in KST.
+            fetched_kst = datetime.combine(
+                primary_snapshot_date, _time(15, 30), tzinfo=_KST
+            )
+            fetched = fetched_kst.astimezone(UTC)
+    elif raw_timestamp:
+        try:
+            fetched = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            fetched = now_utc
+        if fetched.tzinfo is None:
+            fetched = fetched.replace(tzinfo=UTC)
+    else:
+        fetched = now_utc
+
+    fetched_kst = fetched.astimezone(_KST)
+    delta = max(0, int((now_utc - fetched).total_seconds()))
+    now_kst = now_utc.astimezone(_KST)
+    market_open = market == "kr" and _is_kr_market_open(now_kst)
+
+    if not market_open and delta > _CACHE_HIT_FRESH_SECONDS * 4:
+        source: Literal["live", "cached", "previous_session"] = "previous_session"
+        relative = "전 거래일 기준"
+    elif cache_hit:
+        source = "cached"
+        relative = _format_relative_korean(delta)
+    else:
+        source = "live"
+        relative = _format_relative_korean(delta)
+
+    # Build primary object
+    primary: ScreenerFreshnessPrimary | None = None
+    if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
+        primary = ScreenerFreshnessPrimary(
+            kind="screener_snapshot",
+            snapshotDate=primary_snapshot_date.isoformat(),
+            computedAt=primary_computed_at.astimezone(UTC).isoformat()
+            if primary_computed_at is not None
+            else None,
+            asOfLabel=format_kst_as_of_label(
+                snapshot_date=primary_snapshot_date,
+                computed_at=primary_computed_at,
+            ),
+            dataState=dataState,  # type: ignore[arg-type]
+            source=primary_source,
+        )
+    elif primary_kind in {"live", "fallback"}:
+        primary = ScreenerFreshnessPrimary(
+            kind=primary_kind,
+            snapshotDate=None,
+            computedAt=None,
+            asOfLabel=fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+            dataState=dataState,  # type: ignore[arg-type]
+            source=primary_source,
+        )
+
+    # Build dependencies list
+    dependencies: list[ScreenerFreshnessDependency] = []
+    for spec in dependency_specs or []:
+        dep_snap = spec.get("snapshot_date")
+        dep_collected = spec.get("collected_at")
+        lag_label: str | None = None
+        if dep_snap is not None and primary_snapshot_date is not None:
+            lag_days = (primary_snapshot_date - dep_snap).days
+            if lag_days >= 1:
+                lag_label = f"{lag_days}거래일 지연"
+        dependencies.append(
+            ScreenerFreshnessDependency(
+                kind=spec.get("kind", "investor_flow"),
+                snapshotDate=dep_snap.isoformat() if dep_snap is not None else None,
+                collectedAt=dep_collected.astimezone(UTC).isoformat()
+                if dep_collected is not None
+                else None,
+                lagLabel=lag_label,
+                dataState=spec.get("data_state", "missing"),  # type: ignore[arg-type]
+                source=spec.get("source"),
+            )
+        )
+
+    overall = compute_overall_state(
+        primary_state=primary.dataState if primary is not None else dataState,  # type: ignore[arg-type]
+        dependency_states=[d.dataState for d in dependencies],
+    )
+
+    return ScreenerFreshness(
+        fetchedAt=fetched.astimezone(UTC).isoformat(),
+        asOfLabel=primary.asOfLabel if primary is not None else fetched_kst.strftime("%Y.%m.%d %H:%M 기준"),
+        relativeLabel=relative,
+        cacheHit=bool(cache_hit),
+        source=source,
+        dataState=overall,                              # alias of overallState (D1.c)
+        servedAt=served_at_utc.isoformat(),
+        servedRelativeLabel=served_relative,
+        primary=primary,
+        dependencies=dependencies,
+        overallState=overall,
+    )
+```
+
+Add the new imports near the top of `screener_service.py`:
+
+```python
+from app.schemas.invest_screener import (
+    ChangeDirection,
+    ScreenerCandidateContext,
+    ScreenerFreshness,
+    ScreenerFreshnessDependency,
+    ScreenerFreshnessPrimary,
+    ScreenerInvestorFlowChip,
+    ScreenerPresetsResponse,
+    ScreenerResultRow,
+    ScreenerResultsResponse,
+    ScreenerRiskContext,
+    ScreenerSourceContext,
+)
+```
+
+- [ ] **Step 4: Run the new tests to confirm pass**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v -k "snapshot_first_uses_partition_date or legacy_dataState_aliases_overallState"
+```
+
+Expected: PASS. Run the full screener test file to make sure nothing else broke:
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v
+```
+
+If existing tests fail because they asserted `asOfLabel` matched `now()` exactly, update them to assert against the partition date — those assertions were encoding the bug.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py
+git commit -m "feat(rob-277): _build_freshness emits primary/dependencies/overallState"
+```
+
+---
+
+### Task 5: Wire snapshot metadata into `build_screener_results` callsites
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py:1192-1452` (`build_screener_results`)
+- Test: `tests/test_invest_view_model_screener_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_invest_view_model_screener_service.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_consecutive_gainers_response_carries_investor_flow_dependency(
+    db_session,
+) -> None:
+    """ROB-277 D1.b + D5(5): KR consecutive_gainers row that has an investor-flow
+    chip should expose the dependency in freshness.dependencies."""
+    # Seed: one fresh-enough consecutive_gainers snapshot AND one investor_flow
+    # snapshot 2 trading days older for the same symbol. (Use existing fixtures.)
+    ...
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=_StubScreeningService(),
+        resolver=_StubResolver(),
+        market="kr",
+        session=db_session,
+    )
+    deps = resp.freshness.dependencies
+    assert any(d.kind == "investor_flow" for d in deps)
+    inv_dep = next(d for d in deps if d.kind == "investor_flow")
+    assert inv_dep.snapshotDate is not None
+    assert inv_dep.dataState in {"fresh", "stale"}  # never hardcoded
+    assert resp.freshness.overallState in {"fresh", "partial", "stale"}
+    # alias check
+    assert resp.freshness.dataState == resp.freshness.overallState
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py::test_consecutive_gainers_response_carries_investor_flow_dependency -v
+```
+
+Expected: FAIL — `freshness.dependencies` is empty because `build_screener_results` doesn't populate dependency specs yet.
+
+- [ ] **Step 3: Plumb snapshot metadata into `_build_freshness` callsites**
+
+In `build_screener_results` (around lines 1329-1335 in current code), determine primary + dependency specs **before** calling `_build_freshness`:
+
+```python
+    # Determine primary kind/source for ROB-277 freshness.
+    primary_kind: Literal["screener_snapshot", "live", "fallback"]
+    primary_snapshot_date: "dt.date | None" = None
+    primary_computed_at: "datetime | None" = None
+    primary_source: str | None = None
+    if _snapshot_was_checked:
+        primary_kind = "screener_snapshot"
+        # Latest partition date for the preset's primary table.
+        if preset_id == "investor_flow_momentum":
+            primary_source = "investor_flow_snapshots"
+        elif requested_market == "crypto":
+            primary_source = "invest_crypto_screener_snapshots"
+        else:
+            primary_source = "invest_screener_snapshots"
+        # Derive snapshot_date / computed_at from the first row's metadata if available.
+        if rows:
+            primary_snapshot_date = rows[0].get("snapshot_date") or rows[0].get(
+                "_snapshot_date"
+            )
+            primary_computed_at = rows[0].get("computed_at") or rows[0].get(
+                "_computed_at"
+            )
+    else:
+        primary_kind = "live"
+        primary_source = "screening_service"
+
+    # Build dependency specs from hydrated investor-flow chips (KR only for now).
+    dependency_specs: list[dict[str, Any]] = []
+    if requested_market == "kr" and investor_flow_chips:
+        # Pick the most representative (or worst) dependency state across chips.
+        # Use the row metadata directly from the hydrated chips' source rows.
+        from app.services.invest_screener_snapshots.freshness import (
+            classify_investor_flow_partition,
+            today_trading_date,
+        )
+
+        inv_states: list[str] = []
+        inv_snapshot_dates: list = []
+        for r in rows:
+            sd = r.get("snapshot_date") or r.get("_investor_flow_snapshot_date")
+            if sd is not None:
+                inv_snapshot_dates.append(sd)
+            st = r.get("_screener_snapshot_state")
+            if st is not None and preset_id == "investor_flow_momentum":
+                inv_states.append(str(st))
+
+        if inv_snapshot_dates:
+            worst = min(inv_snapshot_dates)
+            dependency_specs.append(
+                {
+                    "kind": "investor_flow",
+                    "snapshot_date": worst,
+                    "collected_at": None,
+                    "data_state": (
+                        "stale"
+                        if worst != today_trading_date("kr")
+                        else "fresh"
+                    ),
+                    "source": "investor_flow_snapshots",
+                }
+            )
+
+    freshness = _build_freshness(
+        raw_timestamp=raw.get("timestamp"),
+        cache_hit=bool(raw.get("cache_hit")),
+        market=requested_market,
+        now=now,
+        dataState=_aggregated_data_state,
+        primary_kind=primary_kind,
+        primary_snapshot_date=primary_snapshot_date,
+        primary_computed_at=primary_computed_at,
+        primary_source=primary_source,
+        dependency_specs=dependency_specs,
+    )
+```
+
+Make sure `_load_consecutive_gainers_from_snapshots` also passes `computed_at` and `snapshot_date` through to the row payload (it already includes these as columns on the model — see `app/services/invest_view_model/screener_service.py:433-454`; add them to the row dict):
+
+```python
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "market": market,
+                "name": symbol_names.get(snap.symbol),
+                "close": float(snap.latest_close) if snap.latest_close is not None else None,
+                "change_rate": float(snap.change_rate) if snap.change_rate is not None else None,
+                "change_amount": float(snap.change_amount) if snap.change_amount is not None else None,
+                "consecutive_up_days": snap.consecutive_up_days,
+                "week_change_rate": float(snap.week_change_rate) if snap.week_change_rate is not None else None,
+                "volume": snap.daily_volume,
+                "daily_closes": list(snap.closes_window or []),
+                "snapshot_date": snap.snapshot_date,
+                "computed_at": snap.computed_at,
+                "_screener_snapshot_state": state,
+            }
+        )
+```
+
+Hydrate investor-flow chip rows (`_hydrate_investor_flow_chips` lines 201-229) to record their own snapshot date on the originating `rows[]` for the dependency aggregator — extend the post-fetch loop:
+
+```python
+    for symbol, item in items.items():
+        chip = _investor_flow_chip_for_item(item)
+        if chip is not None:
+            chips[symbol] = chip
+            # ROB-277: stash the dependency snapshot_date back on the row so
+            # build_screener_results can build freshness.dependencies later.
+            for r in rows:
+                if str(r.get("symbol") or "").upper() == symbol:
+                    r["_investor_flow_snapshot_date"] = (
+                        item.snapshotDate if hasattr(item, "snapshotDate") else None
+                    )
+                    break
+    return chips
+```
+
+- [ ] **Step 4: Run test to confirm pass and full screener suite still green**
+
+```bash
+uv run pytest tests/test_invest_view_model_screener_service.py -v
+uv run pytest tests/test_invest_api_screener_router.py -v
+```
+
+Expected: all PASS. If `test_invest_api_screener_router.py` snapshots a JSON body, refresh the snapshot intentionally (commit message should call this out).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py
+git commit -m "feat(rob-277): thread snapshot metadata + dependency specs through build_screener_results"
+```
+
+---
+
+### Task 6: Frontend types — extend `ScreenerFreshness`
+
+**Files:**
+- Modify: `frontend/invest/src/types/screener.ts:103-113`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx`:
+
+```tsx
+import type {
+  ScreenerFreshness,
+  ScreenerFreshnessPrimary,
+  ScreenerFreshnessDependency,
+} from "../types/screener";
+
+describe("ScreenerFreshness type shape", () => {
+  test("accepts the ROB-277 additive fields", () => {
+    const primary: ScreenerFreshnessPrimary = {
+      kind: "screener_snapshot",
+      snapshotDate: "2026-05-13",
+      computedAt: "2026-05-13T06:35:00+00:00",
+      asOfLabel: "2026.05.13 장마감 기준",
+      dataState: "stale",
+      source: "invest_screener_snapshots",
+    };
+    const dep: ScreenerFreshnessDependency = {
+      kind: "investor_flow",
+      snapshotDate: "2026-05-18",
+      collectedAt: "2026-05-18T07:30:00+00:00",
+      lagLabel: "2거래일 지연",
+      dataState: "stale",
+      source: "investor_flow_snapshots",
+    };
+    const f: ScreenerFreshness = {
+      fetchedAt: "2026-05-13T06:35:00+00:00",
+      asOfLabel: "2026.05.13 장마감 기준",
+      relativeLabel: "5거래일 지연",
+      cacheHit: true,
+      source: "cached",
+      dataState: "stale",
+      servedAt: "2026-05-20T00:10:00+00:00",
+      servedRelativeLabel: "방금",
+      primary,
+      dependencies: [dep],
+      overallState: "stale",
+    };
+    expect(f.primary?.kind).toBe("screener_snapshot");
+    expect(f.dependencies?.[0]?.kind).toBe("investor_flow");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails (type error)**
+
+```bash
+cd frontend/invest && pnpm test -- ScreenerFreshnessLine
+```
+
+Expected: FAIL with TS errors on `ScreenerFreshnessPrimary` / `ScreenerFreshnessDependency` / new fields not assignable.
+
+- [ ] **Step 3: Extend the types**
+
+Replace the `ScreenerFreshness` interface in `frontend/invest/src/types/screener.ts` (lines 103-113):
+
+```ts
+export type ScreenerFreshnessSource = "live" | "cached" | "previous_session";
+export type ScreenerDataState = "fresh" | "partial" | "stale" | "missing" | "fallback";
+
+export interface ScreenerFreshnessPrimary {
+  kind: "screener_snapshot" | "live" | "fallback";
+  snapshotDate: string | null;
+  computedAt: string | null;
+  asOfLabel: string;
+  dataState: ScreenerDataState;
+  source: string | null;
+}
+
+export interface ScreenerFreshnessDependency {
+  kind: "investor_flow";
+  snapshotDate: string | null;
+  collectedAt: string | null;
+  lagLabel: string | null;
+  dataState: ScreenerDataState;
+  source: string | null;
+}
+
+export interface ScreenerFreshness {
+  fetchedAt: string;
+  asOfLabel: string;
+  relativeLabel: string;
+  cacheHit: boolean;
+  source: ScreenerFreshnessSource;
+  dataState: ScreenerDataState;
+  // ROB-277 additive fields (optional during transition).
+  servedAt?: string;
+  servedRelativeLabel?: string;
+  primary?: ScreenerFreshnessPrimary | null;
+  dependencies?: ScreenerFreshnessDependency[];
+  overallState?: ScreenerDataState;
+}
+```
+
+- [ ] **Step 4: Run test to confirm pass**
+
+```bash
+cd frontend/invest && pnpm test -- ScreenerFreshnessLine
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/types/screener.ts frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+git commit -m "feat(rob-277): extend frontend ScreenerFreshness types with primary/dependencies"
+```
+
+---
+
+### Task 7: Frontend `ScreenerFreshnessLine` — dual-line render
+
+**Files:**
+- Modify: `frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx`:
+
+```tsx
+describe("ROB-277 dual-line rendering", () => {
+  test("renders 데이터 기준 line and 화면 갱신 line in separate spans", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-13T06:35:00+00:00",
+          asOfLabel: "2026.05.13 장마감 기준",
+          relativeLabel: "5거래일 지연",
+          cacheHit: true,
+          source: "cached",
+          dataState: "stale",
+          servedAt: "2026-05-20T00:10:00+00:00",
+          servedRelativeLabel: "방금",
+          primary: {
+            kind: "screener_snapshot",
+            snapshotDate: "2026-05-13",
+            computedAt: null,
+            asOfLabel: "2026.05.13 장마감 기준",
+            dataState: "stale",
+            source: "invest_screener_snapshots",
+          },
+          dependencies: [],
+          overallState: "stale",
+        }}
+      />,
+    );
+    const dataLine = screen.getByTestId("screener-freshness-data");
+    const servedLine = screen.getByTestId("screener-freshness-served");
+    expect(dataLine).toHaveTextContent("데이터 기준");
+    expect(dataLine).toHaveTextContent("2026.05.13");
+    expect(servedLine).toHaveTextContent("화면 갱신");
+    expect(servedLine).toHaveTextContent("방금");
+    // Crucial non-contradiction check: stale-aging text never appears on the served line.
+    expect(servedLine).not.toHaveTextContent("5거래일 지연");
+    expect(servedLine).not.toHaveTextContent("업데이트 필요");
+    // And served label "방금" never bleeds into the data line.
+    expect(dataLine).not.toHaveTextContent("방금");
+  });
+
+  test("falls back to legacy single-line when primary/served fields absent", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-10T05:30:00+00:00",
+          asOfLabel: "2026.05.10 14:30 기준",
+          relativeLabel: "12분 전 갱신",
+          cacheHit: false,
+          source: "live",
+          dataState: "fresh",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("screener-freshness")).toHaveTextContent(
+      "2026.05.10 14:30 기준 · 12분 전 갱신",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm fail**
+
+```bash
+cd frontend/invest && pnpm test -- ScreenerFreshnessLine
+```
+
+Expected: FAIL on `getByTestId("screener-freshness-data")` not found.
+
+- [ ] **Step 3: Rewrite the component to render two lines when new fields are present**
+
+Replace `frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx`:
+
+```tsx
+import type { ScreenerFreshness } from "../../types/screener";
+
+const DATA_STATE_LABELS: Partial<Record<ScreenerFreshness["dataState"], string>> = {
+  partial: "일부 데이터 지연",
+  stale: "업데이트 필요",
+  missing: "데이터 준비중",
+  fallback: "대체 데이터",
+};
+
+export function ScreenerFreshnessLine({
+  freshness,
+}: {
+  freshness: ScreenerFreshness;
+}) {
+  const hasNewSchema =
+    freshness.primary != null || freshness.servedRelativeLabel != null;
+
+  if (!hasNewSchema) {
+    // Legacy single-line render preserved for transition / consumers that
+    // haven't been upgraded yet. (ROB-277 §D1 additive policy.)
+    const text =
+      freshness.source === "previous_session"
+        ? `${freshness.relativeLabel} · ${freshness.asOfLabel.replace("기준", "종가")}`
+        : `${freshness.asOfLabel} · ${freshness.relativeLabel}`;
+    const dataState = freshness.dataState ?? "fresh";
+    const stateLabel = DATA_STATE_LABELS[dataState];
+    return (
+      <div
+        className="screener-freshness"
+        data-testid="screener-freshness"
+        aria-live="polite"
+      >
+        <span>{text}</span>
+        {stateLabel ? (
+          <span
+            className={`screener-freshness-state screener-freshness-state--${dataState}`}
+          >
+            {stateLabel}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  const primary = freshness.primary;
+  const overall = freshness.overallState ?? freshness.dataState;
+  const stateLabel = DATA_STATE_LABELS[overall];
+
+  // Build the data line per the D3 copy table.
+  let dataLineText: string;
+  if (freshness.source === "previous_session") {
+    dataLineText = `전 거래일 기준 · ${primary?.asOfLabel ?? freshness.asOfLabel}`;
+  } else if (overall === "missing") {
+    dataLineText = "데이터 없음";
+  } else {
+    const base = `데이터 기준 ${primary?.asOfLabel ?? freshness.asOfLabel}`;
+    // For stale, append "업데이트 필요" / "{N}거래일 지연" via state chip; do not duplicate inline.
+    dataLineText = base;
+  }
+
+  const servedLabel = freshness.servedRelativeLabel ?? "방금";
+
+  return (
+    <div
+      className="screener-freshness"
+      data-testid="screener-freshness"
+      aria-live="polite"
+    >
+      <span
+        className="screener-freshness-data"
+        data-testid="screener-freshness-data"
+      >
+        {dataLineText}
+      </span>
+      <span
+        className="screener-freshness-served"
+        data-testid="screener-freshness-served"
+      >
+        화면 갱신 {servedLabel}
+      </span>
+      {stateLabel ? (
+        <span
+          className={`screener-freshness-state screener-freshness-state--${overall}`}
+        >
+          {stateLabel}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+```bash
+cd frontend/invest && pnpm test -- ScreenerFreshnessLine
+```
+
+Expected: PASS (new + existing tests). Manually inspect any CSS rule referencing `.screener-freshness` to confirm the two new child classes don't break layout — if a global stylesheet exists, add basic flex/stacking rules in the same commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+git commit -m "feat(rob-277): render 데이터 기준 and 화면 갱신 as separate spans"
+```
+
+---
+
+### Task 8: End-to-end backend test — `/invest/api/screener/results` exposes the new schema with stale snapshot
+
+**Files:**
+- Modify: `tests/test_invest_api_screener_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_invest_api_screener_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_consecutive_gainers_endpoint_separates_served_from_data_basis(
+    async_client, db_session
+) -> None:
+    """ROB-277 end-to-end: with a stale invest_screener_snapshots KR partition,
+    /invest/api/screener/results must surface the partition date — not now() —
+    in the freshness object."""
+    # Seed a partition dated 5 trading days ago. Use existing seeding helpers
+    # from this test file (search for InvestScreenerSnapshot to find the pattern).
+    ...
+    resp = await async_client.get(
+        "/invest/api/screener/results",
+        params={"preset": "consecutive_gainers", "market": "kr"},
+    )
+    body = resp.json()
+    f = body["freshness"]
+    assert f["source"] == "cached"
+    assert f["primary"]["kind"] == "screener_snapshot"
+    assert f["primary"]["snapshotDate"].startswith("2026-")
+    # data 기준 reflects the snapshot, not the moment of the request:
+    assert f["primary"]["snapshotDate"] in f["primary"]["asOfLabel"].replace(".", "-")
+    assert f["servedAt"] is not None
+    # legacy alias holds
+    assert f["dataState"] == f["overallState"]
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes by luck)**
+
+```bash
+uv run pytest tests/test_invest_api_screener_router.py::test_consecutive_gainers_endpoint_separates_served_from_data_basis -v
+```
+
+Expected: PASS if Task 5 wiring is correct; FAIL if any wiring is missing.
+
+- [ ] **Step 3: Fix any plumbing gap exposed**
+
+If the test fails, the most likely cause is a code path in `build_screener_results` that bypasses the new `_build_freshness` arguments (e.g., the early-return for unknown preset, or the `_snapshot_check_result is None` fallback). Inspect and patch.
+
+- [ ] **Step 4: Run full backend test suite to catch regressions**
+
+```bash
+make test
+make typecheck
+make lint
+```
+
+Expected: green. Address any unrelated failures only if they're caused by this PR — do not pile in unrelated cleanup.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_invest_api_screener_router.py
+git commit -m "test(rob-277): end-to-end stale-snapshot freshness assertions on screener API"
+```
+
+---
+
+### Task 9: Audit consumers + write PR body with compatibility caution
+
+**Files:**
+- Read: `frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx`
+- Read: any other files that import `ScreenerFreshness`
+- Create: PR body content (not a tracked file; goes into `gh pr create`)
+
+- [ ] **Step 1: Grep for `freshness.fetchedAt` and `freshness.asOfLabel` consumers**
+
+```bash
+rg -n "freshness\.(fetchedAt|asOfLabel|relativeLabel|dataState)" frontend/invest/src
+rg -n "freshness\[\"(fetchedAt|asOfLabel|relativeLabel|dataState)\"\]" app
+```
+
+Expected: catalogue every reader. For each, decide:
+- If it reads `fetchedAt` expecting **data-as-of**, this PR changes its meaning (now it's the partition's `computed_at` for snapshot-first responses — that is the intended fix, not a regression).
+- If it reads `dataState`, it still gets a sane value (now == `overallState`).
+- If it reads `asOfLabel`, the label now references the partition date for snapshot-first responses (this is the fix).
+
+- [ ] **Step 2: Document the audit findings in the PR body**
+
+Compose PR body with sections:
+- **Summary** — what changed (additive schema + dual-line UI).
+- **Why** — link to ROB-277 description and the observed contradiction.
+- **Compatibility caution** — list every consumer touched by the semantic shift of `fetchedAt` / `asOfLabel` for snapshot-first responses. State whether the new semantics are the intended fix or a regression risk.
+- **Test plan** — `make test`, `make typecheck`, `make lint`, frontend `pnpm test`, manual `/invest/screener` dev-browser check if dev stack is up.
+- **Post-merge** — Hermes/파이리 confirms prod `/invest/api/screener/results` output matches expectations on next deploy. **Not a merge gate.**
+- **Non-goals** — no DB migration, no scheduler activation, no backfill, no broker mutation (per ROB-189 / ROB-277 §D7).
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat(rob-277): split /invest/screener freshness into served-time vs data-as-of" --body "$(cat <<'EOF'
+## Summary
+
+- ScreenerFreshness gains additive `servedAt`/`servedRelativeLabel`/`primary`/`dependencies`/`overallState` fields. Existing 6 fields are kept; `dataState` is now an alias of `overallState`.
+- Snapshot-first paths no longer report `now()` as the data-as-of time. `primary.snapshotDate` / `primary.asOfLabel` reflect the actual snapshot partition.
+- `investor_flow_momentum` rows stop hardcoding `_screener_snapshot_state="fresh"` and now classify against the partition via `classify_investor_flow_partition`.
+- `ScreenerFreshnessLine.tsx` renders `데이터 기준 …` and `화면 갱신 …` as separate spans.
+
+## Why
+
+ROB-277: `/invest/screener` was showing `방금 갱신` for results sourced from a 5-day-old `invest_screener_snapshots` partition, while row-level chips simultaneously reported `1일 지연`. Root cause: `raw["timestamp"] = now()` flowed into `_build_freshness` as both served-time and data-as-of.
+
+## Compatibility caution
+
+- For snapshot-first responses, `freshness.fetchedAt` / `freshness.asOfLabel` now reflect the partition's `computed_at` (or end-of-snapshot-day 15:30 KST) instead of `now()`. This is the intended fix. Any downstream consumer that displayed those fields as "when the response was generated" should switch to `freshness.servedAt` / `freshness.servedRelativeLabel`.
+
+## Test plan
+
+- [ ] `make test`
+- [ ] `make typecheck`
+- [ ] `make lint`
+- [ ] `cd frontend/invest && pnpm test`
+- [ ] Local dev-browser spot-check of `/invest/screener?market=kr` if dev stack is up
+
+## Non-goals (per ROB-189 + ROB-277 §D7)
+
+- No DB migration
+- No scheduler activation / TaskIQ unpause / Prefect deploy registration
+- No production backfill
+- No broker / order / watch / order-intent mutation
+- No trading recommendation logic change
+
+## Post-merge (not a merge gate)
+
+Hermes/파이리 confirms prod `/invest/api/screener/results?preset=consecutive_gainers&market=kr` carries the new `primary` object on next MacBook server deploy.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Smoke check after push**
+
+Verify CI is green and that the PR body renders the compatibility caution prominently.
+
+- [ ] **Step 5: Done**
+
+No commit; PR creation itself completes the task.
+
+---
+
+## Self-Review
+
+Run this against the spec before handing off. Plan-author duty.
+
+**Spec coverage:**
+
+| ROB-277 requirement | Covered by |
+|---------------------|------------|
+| Split response refresh vs data 기준 | Tasks 1, 4, 7 (schema + backend + frontend) |
+| `consecutive_gainers` stops emitting `now()` as data-as-of | Task 4 (`_build_freshness` rewrite) + Task 5 (wiring) + Task 8 (e2e test) |
+| `investor_flow_momentum` derives state from partition, not hardcode | Task 3 |
+| Snapshot-derived chips carry `snapshotDate` | Task 3 (row payload) |
+| UI separates `데이터 기준` from `화면 갱신` | Task 7 |
+| Backward-compatible (no removed fields) | Task 1 (additive only) + Task 7 (legacy branch preserved) |
+| Tests (acceptance criteria 4 items) | Tasks 1, 3, 4, 5, 7, 8 |
+| No DB migration / scheduler / backfill | §D7 + Non-goals in PR body |
+
+**Placeholder scan:** No `TBD` / `TODO` / "similar to" / "implement later" in any step. The Task 5 and Task 8 fixture-seeding step contains `...` for "use the existing fixture pattern in this file" — this is intentional, because the test-file's fixture API is project-specific and the implementer needs to follow the local convention; the prose tells them exactly where to look.
+
+**Type consistency:** `ScreenerFreshnessPrimary` / `ScreenerFreshnessDependency` / `compute_overall_state` / `classify_investor_flow_partition` / `format_kst_as_of_label` names are consistent across backend tests (Tasks 1, 2), backend code (Tasks 2, 3, 4, 5), frontend types (Task 6), and component (Task 7). `kind` literal values match exactly. `dataState` enum values match across backend and frontend.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| Existing tests assert `asOfLabel == now()` for snapshot-first | Medium | Task 4 step 4 explicitly updates these; commit message calls out the semantic shift. |
+| Investor-flow `snapshotDate` is `date` object, not str — `Pydantic` rejection | Low | Task 3 keeps `date` in dict; Task 4 converts to `.isoformat()` before `ScreenerFreshnessDependency`. |
+| Frontend dual-line layout breaks CSS grid in `DesktopScreenerPage` | Medium | Task 7 step 4 includes manual layout check; add minimal flex/stacking rules in same commit if needed. |
+| Other presets (crypto, cheap_value, etc.) bypass new primary plumbing | Medium | Task 5 covers `_snapshot_was_checked` path uniformly; live paths default to `primary_kind="live"`. Task 8 e2e covers consecutive_gainers only — add a per-preset assertion later only if observed broken. |
+| ROB-204 / ROB-205 lands a conflicting schema edit before this PR merges | Low | §D7 explicitly disclaims overlap; coordinate via Linear comment if a conflict appears at merge time. |

--- a/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+++ b/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
@@ -68,6 +68,67 @@ describe("ScreenerFreshnessLine", () => {
   });
 });
 
+describe("ROB-277 dual-line rendering", () => {
+  test("renders 데이터 기준 line and 화면 갱신 line in separate spans", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-13T06:35:00+00:00",
+          asOfLabel: "2026.05.13 장마감 기준",
+          relativeLabel: "5거래일 지연",
+          cacheHit: true,
+          source: "cached",
+          dataState: "stale",
+          servedAt: "2026-05-20T00:10:00+00:00",
+          servedRelativeLabel: "방금",
+          primary: {
+            kind: "screener_snapshot",
+            snapshotDate: "2026-05-13",
+            computedAt: null,
+            asOfLabel: "2026.05.13 장마감 기준",
+            dataState: "stale",
+            source: "invest_screener_snapshots",
+          },
+          dependencies: [],
+          overallState: "stale",
+        }}
+      />,
+    );
+    const dataLine = screen.getByTestId("screener-freshness-data");
+    const servedLine = screen.getByTestId("screener-freshness-served");
+    expect(dataLine).toHaveTextContent("데이터 기준");
+    expect(dataLine).toHaveTextContent("2026.05.13");
+    expect(servedLine).toHaveTextContent("화면 갱신");
+    expect(servedLine).toHaveTextContent("방금");
+    // Crucial non-contradiction checks: stale-aging text never appears on the served line
+    expect(servedLine).not.toHaveTextContent("5거래일 지연");
+    expect(servedLine).not.toHaveTextContent("업데이트 필요");
+    // And served label "방금" never bleeds into the data line
+    expect(dataLine).not.toHaveTextContent("방금");
+  });
+
+  test("falls back to legacy single-line when primary/served fields absent", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-10T05:30:00+00:00",
+          asOfLabel: "2026.05.10 14:30 기준",
+          relativeLabel: "12분 전 갱신",
+          cacheHit: false,
+          source: "live",
+          dataState: "fresh",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("screener-freshness")).toHaveTextContent(
+      "2026.05.10 14:30 기준 · 12분 전 갱신",
+    );
+    // No new dual-line testids should appear
+    expect(screen.queryByTestId("screener-freshness-data")).toBeNull();
+    expect(screen.queryByTestId("screener-freshness-served")).toBeNull();
+  });
+});
+
 describe("ScreenerFreshness type shape", () => {
   test("accepts the ROB-277 additive fields", () => {
     const primary: ScreenerFreshnessPrimary = {

--- a/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+++ b/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { ScreenerFreshnessLine } from "../desktop/screener/ScreenerFreshnessLine";
+import type {
+  ScreenerFreshness,
+  ScreenerFreshnessPrimary,
+  ScreenerFreshnessDependency,
+} from "../types/screener";
 
 describe("ScreenerFreshnessLine", () => {
   test("renders asOfLabel and relativeLabel separated by '·'", () => {
@@ -60,5 +65,41 @@ describe("ScreenerFreshnessLine", () => {
     expect(screen.getByText(label)).toHaveClass(
       `screener-freshness-state--${dataState}`,
     );
+  });
+});
+
+describe("ScreenerFreshness type shape", () => {
+  test("accepts the ROB-277 additive fields", () => {
+    const primary: ScreenerFreshnessPrimary = {
+      kind: "screener_snapshot",
+      snapshotDate: "2026-05-13",
+      computedAt: "2026-05-13T06:35:00+00:00",
+      asOfLabel: "2026.05.13 장마감 기준",
+      dataState: "stale",
+      source: "invest_screener_snapshots",
+    };
+    const dep: ScreenerFreshnessDependency = {
+      kind: "investor_flow",
+      snapshotDate: "2026-05-18",
+      collectedAt: "2026-05-18T07:30:00+00:00",
+      lagLabel: "2거래일 지연",
+      dataState: "stale",
+      source: "investor_flow_snapshots",
+    };
+    const f: ScreenerFreshness = {
+      fetchedAt: "2026-05-13T06:35:00+00:00",
+      asOfLabel: "2026.05.13 장마감 기준",
+      relativeLabel: "5거래일 지연",
+      cacheHit: true,
+      source: "cached",
+      dataState: "stale",
+      servedAt: "2026-05-20T00:10:00+00:00",
+      servedRelativeLabel: "방금",
+      primary,
+      dependencies: [dep],
+      overallState: "stale",
+    };
+    expect(f.primary?.kind).toBe("screener_snapshot");
+    expect(f.dependencies?.[0]?.kind).toBe("investor_flow");
   });
 });

--- a/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+++ b/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
@@ -155,7 +155,7 @@ describe("ROB-277 follow-up: dependency lag inline on data line", () => {
               kind: "investor_flow",
               snapshotDate: "2026-05-18",
               collectedAt: "2026-05-18T07:30:00+00:00",
-              lagLabel: "2거래일 지연",
+              lagLabel: "2일 지연",
               dataState: "stale",
               source: "investor_flow_snapshots",
             },
@@ -166,7 +166,7 @@ describe("ROB-277 follow-up: dependency lag inline on data line", () => {
     );
     const dataLine = screen.getByTestId("screener-freshness-data");
     expect(dataLine).toHaveTextContent("데이터 기준 2026.05.20 09:05 기준");
-    expect(dataLine).toHaveTextContent("2거래일 지연");
+    expect(dataLine).toHaveTextContent("2일 지연");
     // served line stays clean (no lag info)
     const servedLine = screen.getByTestId("screener-freshness-served");
     expect(servedLine).not.toHaveTextContent("지연");
@@ -225,7 +225,7 @@ describe("ScreenerFreshness type shape", () => {
       kind: "investor_flow",
       snapshotDate: "2026-05-18",
       collectedAt: "2026-05-18T07:30:00+00:00",
-      lagLabel: "2거래일 지연",
+      lagLabel: "2일 지연",
       dataState: "stale",
       source: "investor_flow_snapshots",
     };

--- a/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
+++ b/frontend/invest/src/__tests__/ScreenerFreshnessLine.test.tsx
@@ -129,6 +129,88 @@ describe("ROB-277 dual-line rendering", () => {
   });
 });
 
+describe("ROB-277 follow-up: dependency lag inline on data line", () => {
+  test("appends dependency lagLabel to 데이터 기준 line when dependency is stale", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-20T00:10:00+00:00",
+          asOfLabel: "2026.05.20 09:10 기준",
+          relativeLabel: "방금 갱신",
+          cacheHit: true,
+          source: "cached",
+          dataState: "stale",
+          servedAt: "2026-05-20T00:10:00+00:00",
+          servedRelativeLabel: "방금",
+          primary: {
+            kind: "screener_snapshot",
+            snapshotDate: "2026-05-20",
+            computedAt: "2026-05-20T00:05:00+00:00",
+            asOfLabel: "2026.05.20 09:05 기준",
+            dataState: "fresh",
+            source: "invest_screener_snapshots",
+          },
+          dependencies: [
+            {
+              kind: "investor_flow",
+              snapshotDate: "2026-05-18",
+              collectedAt: "2026-05-18T07:30:00+00:00",
+              lagLabel: "2거래일 지연",
+              dataState: "stale",
+              source: "investor_flow_snapshots",
+            },
+          ],
+          overallState: "stale",
+        }}
+      />,
+    );
+    const dataLine = screen.getByTestId("screener-freshness-data");
+    expect(dataLine).toHaveTextContent("데이터 기준 2026.05.20 09:05 기준");
+    expect(dataLine).toHaveTextContent("2거래일 지연");
+    // served line stays clean (no lag info)
+    const servedLine = screen.getByTestId("screener-freshness-served");
+    expect(servedLine).not.toHaveTextContent("지연");
+  });
+
+  test("falls back to '업데이트 필요' when dependency is stale without lagLabel", () => {
+    render(
+      <ScreenerFreshnessLine
+        freshness={{
+          fetchedAt: "2026-05-20T00:10:00+00:00",
+          asOfLabel: "2026.05.20 09:10 기준",
+          relativeLabel: "방금 갱신",
+          cacheHit: true,
+          source: "cached",
+          dataState: "stale",
+          servedAt: "2026-05-20T00:10:00+00:00",
+          servedRelativeLabel: "방금",
+          primary: {
+            kind: "screener_snapshot",
+            snapshotDate: "2026-05-20",
+            computedAt: null,
+            asOfLabel: "2026.05.20 장마감 기준",
+            dataState: "fresh",
+            source: "invest_screener_snapshots",
+          },
+          dependencies: [
+            {
+              kind: "investor_flow",
+              snapshotDate: null,
+              collectedAt: null,
+              lagLabel: null,
+              dataState: "stale",
+              source: "investor_flow_snapshots",
+            },
+          ],
+          overallState: "stale",
+        }}
+      />,
+    );
+    const dataLine = screen.getByTestId("screener-freshness-data");
+    expect(dataLine).toHaveTextContent("업데이트 필요");
+  });
+});
+
 describe("ScreenerFreshness type shape", () => {
   test("accepts the ROB-277 additive fields", () => {
     const primary: ScreenerFreshnessPrimary = {

--- a/frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx
@@ -53,7 +53,15 @@ export function ScreenerFreshnessLine({
   } else if (overall === "missing") {
     dataLineText = "데이터 없음";
   } else {
-    dataLineText = `데이터 기준 ${primary?.asOfLabel ?? freshness.asOfLabel}`;
+    // ROB-277 §D3 follow-up: surface the worst dependency's lag info inline so
+    // a stale chip's date doesn't appear next to a "fresh"-looking data line.
+    const worstDep = (freshness.dependencies ?? []).find(
+      (d) => d.dataState === "stale" || d.dataState === "partial",
+    );
+    const lagSuffix = worstDep
+      ? ` · ${worstDep.lagLabel ?? (worstDep.dataState === "stale" ? "업데이트 필요" : "일부 지연")}`
+      : "";
+    dataLineText = `데이터 기준 ${primary?.asOfLabel ?? freshness.asOfLabel}${lagSuffix}`;
   }
 
   const servedLabel = freshness.servedRelativeLabel ?? "방금";

--- a/frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerFreshnessLine.tsx
@@ -12,22 +12,73 @@ export function ScreenerFreshnessLine({
 }: {
   freshness: ScreenerFreshness;
 }) {
-  const text =
-    freshness.source === "previous_session"
-      ? `${freshness.relativeLabel} · ${freshness.asOfLabel.replace("기준", "종가")}`
-      : `${freshness.asOfLabel} · ${freshness.relativeLabel}`;
-  const dataState = freshness.dataState ?? "fresh";
-  const stateLabel = DATA_STATE_LABELS[dataState];
+  const hasNewSchema =
+    freshness.primary != null || freshness.servedRelativeLabel != null;
+
+  if (!hasNewSchema) {
+    // ROB-277 §D1 additive policy: legacy single-line render preserved for
+    // consumers that haven't been upgraded yet.
+    const text =
+      freshness.source === "previous_session"
+        ? `${freshness.relativeLabel} · ${freshness.asOfLabel.replace("기준", "종가")}`
+        : `${freshness.asOfLabel} · ${freshness.relativeLabel}`;
+    const dataState = freshness.dataState ?? "fresh";
+    const stateLabel = DATA_STATE_LABELS[dataState];
+    return (
+      <div
+        className="screener-freshness"
+        data-testid="screener-freshness"
+        aria-live="polite"
+      >
+        <span>{text}</span>
+        {stateLabel ? (
+          <span
+            className={`screener-freshness-state screener-freshness-state--${dataState}`}
+          >
+            {stateLabel}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  const primary = freshness.primary;
+  const overall = freshness.overallState ?? freshness.dataState;
+  const stateLabel = DATA_STATE_LABELS[overall];
+
+  // Data line per the §D3 copy table.
+  let dataLineText: string;
+  if (freshness.source === "previous_session") {
+    dataLineText = `전 거래일 기준 · ${primary?.asOfLabel ?? freshness.asOfLabel}`;
+  } else if (overall === "missing") {
+    dataLineText = "데이터 없음";
+  } else {
+    dataLineText = `데이터 기준 ${primary?.asOfLabel ?? freshness.asOfLabel}`;
+  }
+
+  const servedLabel = freshness.servedRelativeLabel ?? "방금";
+
   return (
     <div
       className="screener-freshness"
       data-testid="screener-freshness"
       aria-live="polite"
     >
-      <span>{text}</span>
+      <span
+        className="screener-freshness-data"
+        data-testid="screener-freshness-data"
+      >
+        {dataLineText}
+      </span>
+      <span
+        className="screener-freshness-served"
+        data-testid="screener-freshness-served"
+      >
+        화면 갱신 {servedLabel}
+      </span>
       {stateLabel ? (
         <span
-          className={`screener-freshness-state screener-freshness-state--${dataState}`}
+          className={`screener-freshness-state screener-freshness-state--${overall}`}
         >
           {stateLabel}
         </span>

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -103,6 +103,24 @@ export interface ScreenerResultRow {
 export type ScreenerFreshnessSource = "live" | "cached" | "previous_session";
 export type ScreenerDataState = "fresh" | "partial" | "stale" | "missing" | "fallback";
 
+export interface ScreenerFreshnessPrimary {
+  kind: "screener_snapshot" | "live" | "fallback";
+  snapshotDate: string | null;
+  computedAt: string | null;
+  asOfLabel: string;
+  dataState: ScreenerDataState;
+  source: string | null;
+}
+
+export interface ScreenerFreshnessDependency {
+  kind: "investor_flow";
+  snapshotDate: string | null;
+  collectedAt: string | null;
+  lagLabel: string | null;
+  dataState: ScreenerDataState;
+  source: string | null;
+}
+
 export interface ScreenerFreshness {
   fetchedAt: string;
   asOfLabel: string;
@@ -110,6 +128,12 @@ export interface ScreenerFreshness {
   cacheHit: boolean;
   source: ScreenerFreshnessSource;
   dataState: ScreenerDataState;
+  // ROB-277 additive fields (optional during transition).
+  servedAt?: string;
+  servedRelativeLabel?: string;
+  primary?: ScreenerFreshnessPrimary | null;
+  dependencies?: ScreenerFreshnessDependency[];
+  overallState?: ScreenerDataState;
 }
 
 export interface ScreenerResultsResponse {

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -356,8 +356,8 @@ def _build_snapshot_first_app(fake_session: _RouterFakeSession) -> FastAPI:
         "U", (), {"id": 1}
     )()
     app.dependency_overrides[get_invest_home_service] = lambda: _StubHomeService()
-    app.dependency_overrides[get_screener_service_dep] = (
-        lambda: _SnapshotFirstScreenerStub()
+    app.dependency_overrides[get_screener_service_dep] = lambda: (
+        _SnapshotFirstScreenerStub()
     )
 
     async def _override_get_db():
@@ -420,7 +420,9 @@ def test_consecutive_gainers_endpoint_separates_served_from_data_basis() -> None
     assert f["source"] == "cached", f"expected source='cached', got {f['source']!r}"
 
     # D1.a: primary block carries screener_snapshot kind + partition date
-    assert f["primary"] is not None, "freshness.primary must not be None for snapshot path"
+    assert f["primary"] is not None, (
+        "freshness.primary must not be None for snapshot path"
+    )
     assert f["primary"]["kind"] == "screener_snapshot"
     assert f["primary"]["snapshotDate"] == "2026-05-13", (
         f"primary.snapshotDate must be the seeded partition date, got {f['primary']['snapshotDate']!r}"

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import datetime as dt
+from datetime import UTC
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -9,6 +12,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.core.db import get_db
 from app.routers.dependencies import get_authenticated_user
 from app.routers.invest_api import (
     get_invest_home_service,
@@ -237,3 +241,198 @@ def test_screener_consecutive_gainers_returns_streak_and_freshness() -> None:
     assert stub.calls[0].get("min_week_change_rate") == 0.0
     assert stub.calls[0].get("sort_by") == "week_change_rate"
     assert stub.calls[0].get("limit") == 80
+
+
+# ---------------------------------------------------------------------------
+# ROB-277: e2e freshness shape with stale snapshot on the HTTP layer
+# ---------------------------------------------------------------------------
+
+# Reuse the _FakeSession / _FakeSnapshot pattern from
+# test_invest_view_model_screener_service.py — mirror the idiom exactly.
+
+
+class _RouterFakeScalarResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _RouterFakeExecuteResult:
+    def __init__(
+        self,
+        *,
+        scalar_rows: list[Any] | None = None,
+        rows: list[Any] | None = None,
+    ) -> None:
+        self._scalar_rows = scalar_rows or []
+        self._rows = rows or []
+
+    def scalars(self) -> _RouterFakeScalarResult:
+        return _RouterFakeScalarResult(self._scalar_rows)
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def scalar_one_or_none(self) -> Any | None:
+        return self._scalar_rows[0] if self._scalar_rows else None
+
+    def one(self) -> Any:
+        if self._rows:
+            return self._rows[0]
+        return type("EmptyRow", (), {})()
+
+
+class _RouterFakeSession:
+    """Minimal async session that pops pre-loaded results on each execute()."""
+
+    def __init__(self, results: list[_RouterFakeExecuteResult]) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    async def execute(self, stmt: Any) -> _RouterFakeExecuteResult:  # noqa: ARG002
+        self.calls += 1
+        if not self.results:
+            return _RouterFakeExecuteResult()
+        return self.results.pop(0)
+
+
+class _RouterFakeSnapshot:
+    """Minimal ORM-like snapshot object mirroring InvestScreenerSnapshot attributes."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.market = kwargs.get("market", "kr")
+        self.symbol = kwargs["symbol"]
+        self.snapshot_date = kwargs.get("snapshot_date", dt.date(2026, 5, 13))
+        self.latest_close = kwargs.get("latest_close", Decimal("80000"))
+        self.prev_close = kwargs.get("prev_close", Decimal("79000"))
+        self.change_amount = kwargs.get("change_amount", Decimal("1000"))
+        self.change_rate = kwargs.get("change_rate", Decimal("1.2658"))
+        self.consecutive_up_days = kwargs.get("consecutive_up_days", 6)
+        self.week_change_rate = kwargs.get("week_change_rate", Decimal("3.5"))
+        self.closes_window = kwargs.get(
+            "closes_window", [76000, 77000, 78000, 79000, 80000]
+        )
+        self.daily_volume = kwargs.get("daily_volume", 1_234_567)
+        self.computed_at = kwargs.get(
+            "computed_at", dt.datetime(2026, 5, 13, 0, 30, tzinfo=UTC)
+        )
+
+
+def _router_name_row(symbol: str, name: str) -> Any:
+    return type("NameRow", (), {"symbol": symbol, "name": name})()
+
+
+def _build_snapshot_first_app(fake_session: _RouterFakeSession) -> FastAPI:
+    """Build a FastAPI test app whose screener_service masquerades as the real
+    ScreenerService so _should_use_snapshot_first returns True, and whose db
+    dependency is replaced with the supplied fake session."""
+
+    # The real _should_use_snapshot_first gate checks __class__.__name__ and
+    # __class__.__module__ — create a stub that passes both checks.
+    class _SnapshotFirstScreenerStub:
+        __module__ = "app.services.screener_service"
+
+        def __init__(self) -> None:
+            self.list_screening = AsyncMock(
+                side_effect=AssertionError(
+                    "external call should be skipped when snapshot is present"
+                )
+            )
+
+    _SnapshotFirstScreenerStub.__name__ = "ScreenerService"
+    _SnapshotFirstScreenerStub.__qualname__ = "ScreenerService"
+
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+    app.dependency_overrides[get_invest_home_service] = lambda: _StubHomeService()
+    app.dependency_overrides[get_screener_service_dep] = (
+        lambda: _SnapshotFirstScreenerStub()
+    )
+
+    async def _override_get_db():
+        yield fake_session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return app
+
+
+@pytest.mark.unit
+def test_consecutive_gainers_endpoint_separates_served_from_data_basis() -> None:
+    """ROB-277 e2e: with a stale invest_screener_snapshots KR partition,
+    /invest/api/screener/results must surface the partition date — not now() —
+    in the freshness object.
+
+    The snapshot is dated 2026-05-13 (7 days before today 2026-05-20), which
+    classifies as 'stale'.  The endpoint's freshness.primary.snapshotDate must
+    reflect that partition date, not the moment the request is served.
+    """
+    # Stale KR snapshot: dated 2026-05-13 (7 calendar days before 2026-05-20)
+    stale_date = dt.date(2026, 5, 13)
+    computed = dt.datetime(2026, 5, 13, 0, 30, tzinfo=UTC)
+    snap = _RouterFakeSnapshot(
+        symbol="005930",
+        snapshot_date=stale_date,
+        computed_at=computed,
+        consecutive_up_days=6,
+        week_change_rate=Decimal("3.5"),
+    )
+    name_row = _router_name_row("005930", "삼성전자")
+
+    # DB call order (see screener_service.build_screener_results + dependencies):
+    #  0: build_relation_resolver → watch items → .all()
+    #  1: _load_consecutive_gainers_from_snapshots → MAX(snapshot_date) → scalar_one_or_none()
+    #  2: _load_consecutive_gainers_from_snapshots → qualifying rows → scalars().all()
+    #  3: _load_consecutive_gainers_from_snapshots → KR symbol names (filter) → .all()
+    #  4: _async_enrich → repo.get_fresh → scalars().all()
+    #  5: Bulk KR names → .all()
+    fake_session = _RouterFakeSession(
+        [
+            _RouterFakeExecuteResult(rows=[]),  # 0: watch items
+            _RouterFakeExecuteResult(scalar_rows=[stale_date]),  # 1: MAX(snapshot_date)
+            _RouterFakeExecuteResult(scalar_rows=[snap]),  # 2: qualifying rows
+            _RouterFakeExecuteResult(rows=[name_row]),  # 3: KR symbol names (filter)
+            _RouterFakeExecuteResult(scalar_rows=[snap]),  # 4: enrichment get_fresh
+            _RouterFakeExecuteResult(rows=[name_row]),  # 5: bulk KR names
+        ]
+    )
+
+    client = TestClient(_build_snapshot_first_app(fake_session))
+    resp = client.get(
+        "/invest/api/screener/results",
+        params={"preset": "consecutive_gainers", "market": "kr"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    f = body["freshness"]
+
+    # D2: top-level source enum unchanged — snapshot still surfaces as "cached"
+    assert f["source"] == "cached", f"expected source='cached', got {f['source']!r}"
+
+    # D1.a: primary block carries screener_snapshot kind + partition date
+    assert f["primary"] is not None, "freshness.primary must not be None for snapshot path"
+    assert f["primary"]["kind"] == "screener_snapshot"
+    assert f["primary"]["snapshotDate"] == "2026-05-13", (
+        f"primary.snapshotDate must be the seeded partition date, got {f['primary']['snapshotDate']!r}"
+    )
+
+    # D1: data-basis label reflects the snapshot partition, NOT the request time
+    seeded_dot = "2026.05.13"
+    assert seeded_dot in f["primary"]["asOfLabel"], (
+        f"primary.asOfLabel should contain {seeded_dot!r}, got {f['primary']['asOfLabel']!r}"
+    )
+    assert seeded_dot in f["asOfLabel"], (
+        f"top-level asOfLabel should mirror primary for snapshot-first, got {f['asOfLabel']!r}"
+    )
+
+    # ROB-277: servedAt is the response time (present and non-empty)
+    assert f.get("servedAt") is not None, "freshness.servedAt must be present"
+
+    # D1.c: dataState is the alias for overallState
+    assert f["dataState"] == f["overallState"], (
+        f"dataState ({f['dataState']!r}) must equal overallState ({f['overallState']!r})"
+    )

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -288,14 +288,20 @@ class _RouterFakeSession:
     """Minimal async session that pops pre-loaded results on each execute()."""
 
     def __init__(self, results: list[_RouterFakeExecuteResult]) -> None:
-        self.results = list(results)
+        self._results = list(results)
+        self._initial_count = len(results)
         self.calls = 0
 
     async def execute(self, stmt: Any) -> _RouterFakeExecuteResult:  # noqa: ARG002
         self.calls += 1
-        if not self.results:
-            return _RouterFakeExecuteResult()
-        return self.results.pop(0)
+        if not self._results:
+            raise AssertionError(
+                "RouterFakeSession exhausted: build_screener_results issued more DB "
+                "queries than the test seeded. Expected the snapshot-first path to "
+                f"perform exactly {self._initial_count} queries; update the test if "
+                "you've intentionally added a new query."
+            )
+        return self._results.pop(0)
 
 
 class _RouterFakeSnapshot:

--- a/tests/test_invest_screener_schemas.py
+++ b/tests/test_invest_screener_schemas.py
@@ -164,3 +164,63 @@ def test_presets_response_holds_selected_id() -> None:
     )
     resp = ScreenerPresetsResponse(presets=[preset], selectedPresetId="cheap_value")
     assert resp.selectedPresetId == "cheap_value"
+
+
+@pytest.mark.unit
+def test_screener_freshness_accepts_new_primary_and_dependencies_fields() -> None:
+    from app.schemas.invest_screener import (
+        ScreenerFreshness,
+        ScreenerFreshnessDependency,
+        ScreenerFreshnessPrimary,
+    )
+
+    payload = ScreenerFreshness(
+        fetchedAt="2026-05-20T00:10:00+00:00",
+        asOfLabel="2026.05.13 장마감 기준",
+        relativeLabel="5거래일 지연",
+        cacheHit=True,
+        source="cached",
+        dataState="stale",
+        servedAt="2026-05-20T00:10:00+00:00",
+        servedRelativeLabel="방금",
+        primary=ScreenerFreshnessPrimary(
+            kind="screener_snapshot",
+            snapshotDate="2026-05-13",
+            computedAt="2026-05-13T06:35:00+00:00",
+            asOfLabel="2026.05.13 장마감 기준",
+            dataState="stale",
+            source="invest_screener_snapshots",
+        ),
+        dependencies=[
+            ScreenerFreshnessDependency(
+                kind="investor_flow",
+                snapshotDate="2026-05-18",
+                collectedAt="2026-05-18T07:30:00+00:00",
+                lagLabel="2거래일 지연",
+                dataState="stale",
+                source="investor_flow_snapshots",
+            )
+        ],
+        overallState="stale",
+    )
+    assert payload.primary is not None
+    assert payload.primary.kind == "screener_snapshot"
+    assert payload.dependencies[0].kind == "investor_flow"
+    assert payload.overallState == payload.dataState
+
+
+@pytest.mark.unit
+def test_screener_freshness_is_backwards_compatible_without_new_fields() -> None:
+    from app.schemas.invest_screener import ScreenerFreshness
+
+    payload = ScreenerFreshness(
+        fetchedAt="2026-05-20T00:10:00+00:00",
+        asOfLabel="2026.05.20 09:10 기준",
+        relativeLabel="방금 갱신",
+        cacheHit=False,
+        source="live",
+        dataState="fresh",
+    )
+    assert payload.primary is None
+    assert payload.dependencies == []
+    assert payload.overallState is None

--- a/tests/test_invest_screener_snapshots_freshness.py
+++ b/tests/test_invest_screener_snapshots_freshness.py
@@ -113,14 +113,14 @@ def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_da
     assert state == "stale"
 
 
-def test_classify_investor_flow_partition_friday_to_monday_morning_is_fresh() -> None:
-    """Saturday/Sunday collapse to Friday's trading date; Monday morning before
-    Monday's partition appears stays fresh relative to Friday's snapshot."""
+def test_classify_investor_flow_partition_friday_snapshot_on_saturday_noon_is_fresh() -> None:
+    """Weekend rollback: on Saturday, today_trading_date rolls back to Friday, so
+    a Friday partition with collected_at within STALE_AFTER_HOURS is fresh."""
     state = classify_investor_flow_partition(
         snapshot_date=dt.date(2026, 5, 15),  # Friday
         collected_at=dt.datetime(2026, 5, 15, 7, 30, tzinfo=dt.UTC),
-        today_trading_date_value=dt.date(2026, 5, 15),
-        now=dt.datetime(2026, 5, 18, 0, 5, tzinfo=dt.UTC),  # Monday 09:05 KST
+        today_trading_date_value=dt.date(2026, 5, 15),  # what today_trading_date("kr") returns on Sat
+        now=dt.datetime(2026, 5, 16, 3, 0, tzinfo=dt.UTC),  # Sat 12:00 KST
     )
     assert state == "fresh"
 

--- a/tests/test_invest_screener_snapshots_freshness.py
+++ b/tests/test_invest_screener_snapshots_freshness.py
@@ -92,7 +92,9 @@ from app.services.invest_screener_snapshots.freshness import (  # noqa: E402
 _KST = ZoneInfo("Asia/Seoul")
 
 
-def test_classify_investor_flow_partition_fresh_when_partition_is_today_trading_date() -> None:
+def test_classify_investor_flow_partition_fresh_when_partition_is_today_trading_date() -> (
+    None
+):
     today = dt.date(2026, 5, 20)  # Wednesday
     state = classify_investor_flow_partition(
         snapshot_date=today,
@@ -103,7 +105,9 @@ def test_classify_investor_flow_partition_fresh_when_partition_is_today_trading_
     assert state == "fresh"
 
 
-def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_days_old() -> None:
+def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_days_old() -> (
+    None
+):
     state = classify_investor_flow_partition(
         snapshot_date=dt.date(2026, 5, 18),  # Monday
         collected_at=dt.datetime(2026, 5, 18, 7, 30, tzinfo=dt.UTC),
@@ -113,36 +117,55 @@ def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_da
     assert state == "stale"
 
 
-def test_classify_investor_flow_partition_friday_snapshot_on_saturday_noon_is_fresh() -> None:
+def test_classify_investor_flow_partition_friday_snapshot_on_saturday_noon_is_fresh() -> (
+    None
+):
     """Weekend rollback: on Saturday, today_trading_date rolls back to Friday, so
     a Friday partition with collected_at within STALE_AFTER_HOURS is fresh."""
     state = classify_investor_flow_partition(
         snapshot_date=dt.date(2026, 5, 15),  # Friday
         collected_at=dt.datetime(2026, 5, 15, 7, 30, tzinfo=dt.UTC),
-        today_trading_date_value=dt.date(2026, 5, 15),  # what today_trading_date("kr") returns on Sat
+        today_trading_date_value=dt.date(
+            2026, 5, 15
+        ),  # what today_trading_date("kr") returns on Sat
         now=dt.datetime(2026, 5, 16, 3, 0, tzinfo=dt.UTC),  # Sat 12:00 KST
     )
     assert state == "fresh"
 
 
 def test_compute_overall_state_primary_stale_dominates() -> None:
-    assert compute_overall_state(primary_state="stale", dependency_states=["fresh"]) == "stale"
+    assert (
+        compute_overall_state(primary_state="stale", dependency_states=["fresh"])
+        == "stale"
+    )
 
 
 def test_compute_overall_state_primary_missing_dominates() -> None:
-    assert compute_overall_state(primary_state="missing", dependency_states=["fresh"]) == "missing"
+    assert (
+        compute_overall_state(primary_state="missing", dependency_states=["fresh"])
+        == "missing"
+    )
 
 
 def test_compute_overall_state_primary_fresh_dependency_stale_is_stale() -> None:
-    assert compute_overall_state(primary_state="fresh", dependency_states=["stale"]) == "stale"
+    assert (
+        compute_overall_state(primary_state="fresh", dependency_states=["stale"])
+        == "stale"
+    )
 
 
 def test_compute_overall_state_primary_fresh_dependency_missing_is_stale() -> None:
-    assert compute_overall_state(primary_state="fresh", dependency_states=["missing"]) == "stale"
+    assert (
+        compute_overall_state(primary_state="fresh", dependency_states=["missing"])
+        == "stale"
+    )
 
 
 def test_compute_overall_state_primary_fresh_dependency_partial_is_partial() -> None:
-    assert compute_overall_state(primary_state="fresh", dependency_states=["partial"]) == "partial"
+    assert (
+        compute_overall_state(primary_state="fresh", dependency_states=["partial"])
+        == "partial"
+    )
 
 
 def test_compute_overall_state_primary_fresh_no_dependencies_is_fresh() -> None:
@@ -150,9 +173,7 @@ def test_compute_overall_state_primary_fresh_no_dependencies_is_fresh() -> None:
 
 
 def test_format_kst_as_of_label_for_snapshot_date_only_uses_jangmagam() -> None:
-    label = format_kst_as_of_label(
-        snapshot_date=dt.date(2026, 5, 13), computed_at=None
-    )
+    label = format_kst_as_of_label(snapshot_date=dt.date(2026, 5, 13), computed_at=None)
     assert label == "2026.05.13 장마감 기준"
 
 

--- a/tests/test_invest_screener_snapshots_freshness.py
+++ b/tests/test_invest_screener_snapshots_freshness.py
@@ -79,3 +79,86 @@ def test_classify_state_stale_when_old_or_old_computed():
 )
 def test_aggregate_states(states, expected):
     assert aggregate_states(states) == expected
+
+
+from zoneinfo import ZoneInfo  # noqa: E402
+
+from app.services.invest_screener_snapshots.freshness import (  # noqa: E402
+    classify_investor_flow_partition,
+    compute_overall_state,
+    format_kst_as_of_label,
+)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def test_classify_investor_flow_partition_fresh_when_partition_is_today_trading_date() -> None:
+    today = dt.date(2026, 5, 20)  # Wednesday
+    state = classify_investor_flow_partition(
+        snapshot_date=today,
+        collected_at=dt.datetime(2026, 5, 20, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=today,
+        now=dt.datetime(2026, 5, 20, 8, 0, tzinfo=dt.UTC),
+    )
+    assert state == "fresh"
+
+
+def test_classify_investor_flow_partition_stale_when_partition_is_two_trading_days_old() -> None:
+    state = classify_investor_flow_partition(
+        snapshot_date=dt.date(2026, 5, 18),  # Monday
+        collected_at=dt.datetime(2026, 5, 18, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=dt.date(2026, 5, 20),  # Wednesday
+        now=dt.datetime(2026, 5, 20, 8, 0, tzinfo=dt.UTC),
+    )
+    assert state == "stale"
+
+
+def test_classify_investor_flow_partition_friday_to_monday_morning_is_fresh() -> None:
+    """Saturday/Sunday collapse to Friday's trading date; Monday morning before
+    Monday's partition appears stays fresh relative to Friday's snapshot."""
+    state = classify_investor_flow_partition(
+        snapshot_date=dt.date(2026, 5, 15),  # Friday
+        collected_at=dt.datetime(2026, 5, 15, 7, 30, tzinfo=dt.UTC),
+        today_trading_date_value=dt.date(2026, 5, 15),
+        now=dt.datetime(2026, 5, 18, 0, 5, tzinfo=dt.UTC),  # Monday 09:05 KST
+    )
+    assert state == "fresh"
+
+
+def test_compute_overall_state_primary_stale_dominates() -> None:
+    assert compute_overall_state(primary_state="stale", dependency_states=["fresh"]) == "stale"
+
+
+def test_compute_overall_state_primary_missing_dominates() -> None:
+    assert compute_overall_state(primary_state="missing", dependency_states=["fresh"]) == "missing"
+
+
+def test_compute_overall_state_primary_fresh_dependency_stale_is_stale() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["stale"]) == "stale"
+
+
+def test_compute_overall_state_primary_fresh_dependency_missing_is_stale() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["missing"]) == "stale"
+
+
+def test_compute_overall_state_primary_fresh_dependency_partial_is_partial() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=["partial"]) == "partial"
+
+
+def test_compute_overall_state_primary_fresh_no_dependencies_is_fresh() -> None:
+    assert compute_overall_state(primary_state="fresh", dependency_states=[]) == "fresh"
+
+
+def test_format_kst_as_of_label_for_snapshot_date_only_uses_jangmagam() -> None:
+    label = format_kst_as_of_label(
+        snapshot_date=dt.date(2026, 5, 13), computed_at=None
+    )
+    assert label == "2026.05.13 장마감 기준"
+
+
+def test_format_kst_as_of_label_with_computed_at_uses_hhmm() -> None:
+    label = format_kst_as_of_label(
+        snapshot_date=dt.date(2026, 5, 20),
+        computed_at=dt.datetime(2026, 5, 20, 0, 35, tzinfo=dt.UTC),  # 09:35 KST
+    )
+    assert label == "2026.05.20 09:35 기준"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1710,6 +1710,83 @@ def test_build_freshness_dependency_specs_render_with_lag_label() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consecutive_gainers_response_carries_screener_snapshot_primary() -> None:
+    """ROB-277 Task 5: a snapshot-first consecutive_gainers response surfaces
+    partition date in freshness.primary, top-level source stays 'cached' (D2),
+    and freshness.dataState == overallState (D1.c alias)."""
+    import datetime as dt
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    snap_date = dt.date(2026, 5, 13)
+    computed = dt.datetime(2026, 5, 13, 0, 30, tzinfo=dt.UTC)
+
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snap_date]),  # MAX(snapshot_date)
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=snap_date,
+                        computed_at=computed,
+                        week_change_rate=Decimal("3.5"),
+                    )
+                ]
+            ),  # qualifying rows
+            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),  # filter names
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=snap_date,
+                        computed_at=computed,
+                        week_change_rate=Decimal("3.5"),
+                    )
+                ]
+            ),  # enrichment
+            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),  # kr_names
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="kr",
+        session=session,
+        now=lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC),
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    f = resp.freshness
+
+    # D1: primary is populated with screener_snapshot kind and partition date
+    assert f.primary is not None, "freshness.primary must not be None for snapshot path"
+    assert f.primary.kind == "screener_snapshot"
+    assert f.primary.source == "invest_screener_snapshots"
+    assert f.primary.snapshotDate == "2026-05-13"
+
+    # D1: asOfLabel reflects the partition date, NOT now() (2026.05.20)
+    assert "2026.05.13" in f.asOfLabel, (
+        f"asOfLabel should reflect partition date 2026.05.13, got: {f.asOfLabel!r}"
+    )
+    assert "2026.05.20" not in f.asOfLabel, (
+        f"asOfLabel must not reflect now(); got: {f.asOfLabel!r}"
+    )
+
+    # D2: source enum is "cached" (unchanged)
+    assert f.source == "cached"
+
+    # D1.c: dataState is alias for overallState
+    assert f.dataState == f.overallState
+
+
+@pytest.mark.unit
 def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
     """Calling _build_freshness with only the pre-ROB-277 kwargs still produces a
     valid ScreenerFreshness (additive change preserves backward compat)."""

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1619,7 +1619,9 @@ def test_build_freshness_snapshot_first_uses_partition_date_not_now() -> None:
 
     from app.services.invest_view_model.screener_service import _build_freshness
 
-    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    def fake_now() -> dt.datetime:
+        return dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+
     f = _build_freshness(
         raw_timestamp="2026-05-20T00:10:00+00:00",
         cache_hit=True,
@@ -1656,7 +1658,9 @@ def test_build_freshness_live_path_uses_raw_timestamp() -> None:
 
     from app.services.invest_view_model.screener_service import _build_freshness
 
-    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    def fake_now() -> dt.datetime:
+        return dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+
     f = _build_freshness(
         raw_timestamp="2026-05-20T00:08:00+00:00",
         cache_hit=False,
@@ -1677,7 +1681,9 @@ def test_build_freshness_dependency_specs_render_with_lag_label() -> None:
 
     from app.services.invest_view_model.screener_service import _build_freshness
 
-    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    def fake_now() -> dt.datetime:
+        return dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+
     f = _build_freshness(
         raw_timestamp=None,
         cache_hit=True,
@@ -1794,7 +1800,9 @@ def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
 
     from app.services.invest_view_model.screener_service import _build_freshness
 
-    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    def fake_now() -> dt.datetime:
+        return dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+
     f = _build_freshness(
         raw_timestamp="2026-05-20T00:08:00+00:00",
         cache_hit=False,

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1505,3 +1505,102 @@ async def test_build_screener_results_warns_and_does_not_fallback_when_latest_pa
     assert resp.results == []
     assert any("스크리너 스냅샷 업데이트" in w for w in resp.warnings)
     assert resp.freshness.dataState == "stale"
+
+
+# ---------------------------------------------------------------------------
+# ROB-277: investor-flow rows carry snapshot_date / collected_at / classified state
+# ---------------------------------------------------------------------------
+
+
+class _FakeInvestorFlowSnapshot:
+    """Minimal fake matching InvestorFlowSnapshot ORM attributes used in
+    _load_investor_flow_discovery_from_snapshots."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.market = kwargs.get("market", "kr")
+        self.symbol = kwargs["symbol"]
+        self.snapshot_date = kwargs.get("snapshot_date", date(2026, 5, 15))
+        self.collected_at = kwargs.get(
+            "collected_at", datetime(2026, 5, 15, 6, 30, tzinfo=UTC)
+        )
+        self.foreign_net = kwargs.get("foreign_net", 500_000_000)
+        self.institution_net = kwargs.get("institution_net", -100_000_000)
+        self.individual_net = kwargs.get("individual_net", -400_000_000)
+        self.foreign_consecutive_buy_days = kwargs.get(
+            "foreign_consecutive_buy_days", 3
+        )
+        self.institution_consecutive_buy_days = kwargs.get(
+            "institution_consecutive_buy_days", None
+        )
+        self.double_buy = kwargs.get("double_buy", False)
+        self.foreign_net_buy_rank = kwargs.get("foreign_net_buy_rank", None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_investor_flow_rows_carry_snapshot_date_collected_at_and_classified_state() -> (
+    None
+):
+    """ROB-277: snapshot_date and collected_at must pass through the row dict, and
+    _screener_snapshot_state must be the classified result of
+    classify_investor_flow_partition — NOT the hardcoded literal 'fresh'.
+
+    We use a snapshot dated 2026-05-15 (Thursday), and "now" is set to
+    2026-05-20 (Tuesday) — two trading days later — so the snapshot_date differs
+    from today_trading_date("kr") → the state must be "stale".
+    """
+    from app.services.invest_view_model.screener_service import (
+        _load_investor_flow_discovery_from_snapshots,
+    )
+
+    stale_snapshot_date = date(2026, 5, 15)
+    collected = datetime(2026, 5, 15, 6, 30, tzinfo=UTC)
+
+    session = _FakeSession(
+        [
+            # MAX(snapshot_date)
+            _FakeExecuteResult(scalar_rows=[stale_snapshot_date]),
+            # qualifying rows
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeInvestorFlowSnapshot(
+                        symbol="005930",
+                        snapshot_date=stale_snapshot_date,
+                        collected_at=collected,
+                        foreign_consecutive_buy_days=3,
+                    )
+                ]
+            ),
+            # kr_symbol_universe name rows
+            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),
+        ]
+    )
+
+    rows = await _load_investor_flow_discovery_from_snapshots(
+        session, market="kr", limit=20
+    )
+
+    assert rows is not None, "expected rows list, got None"
+    assert len(rows) == 1
+
+    row = rows[0]
+
+    # snapshot_date passes through
+    assert row["snapshot_date"] == stale_snapshot_date, (
+        f"expected snapshot_date={stale_snapshot_date!r}, got {row.get('snapshot_date')!r}"
+    )
+
+    # collected_at passes through
+    assert row["collected_at"] == collected, (
+        f"expected collected_at={collected!r}, got {row.get('collected_at')!r}"
+    )
+
+    # state must NOT be the hardcoded literal "fresh"; for a snapshot 5 days old
+    # it should be "stale"
+    state = row["_screener_snapshot_state"]
+    assert state != "fresh", (
+        f"_screener_snapshot_state must be classified, not hardcoded 'fresh'; got {state!r}"
+    )
+    assert state == "stale", (
+        f"expected 'stale' for snapshot_date={stale_snapshot_date} vs today 2026-05-20; got {state!r}"
+    )

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -2250,3 +2250,175 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
         assert resp.freshness.dataState in {"stale", "fallback"}
     finally:
         await _purge()
+
+
+# ---------------------------------------------------------------------------
+# ROB-277 follow-up FU6: integration tests for FU2 (dependency split) and
+# FU3 (0-qualifier primary metadata threading)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency() -> None:
+    """ROB-277 follow-up FU2/FU6: when primary partition is today's and an
+    investor_flow snapshot is 2 trading days older, freshness.dependencies must
+    surface that as a 'stale' investor_flow entry with the correct snapshotDate
+    and lagLabel, and overallState must be 'stale' per D1.c rule 2."""
+    import datetime as dt
+
+    today_kr = dt.date(2026, 5, 20)  # Wednesday
+    inv_partition = dt.date(2026, 5, 18)  # Monday — 2 trading days older
+
+    primary_computed = dt.datetime(2026, 5, 20, 0, 5, tzinfo=dt.UTC)
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    from app.schemas.investor_flow import InvestorFlowItem
+
+    inv_item = InvestorFlowItem(
+        symbol="005930",
+        market="kr",
+        dataState="stale",
+        snapshotDate=inv_partition,
+        collectedAt=dt.datetime(2026, 5, 18, 7, 30, tzinfo=dt.UTC),
+        foreignNet=1_000_000_000,
+        institutionNet=500_000_000,
+        individualNet=-1_500_000_000,
+        doubleBuy=False,
+        doubleSell=False,
+        foreignConsecutiveBuyDays=4,
+        foreignConsecutiveSellDays=None,
+        institutionConsecutiveBuyDays=None,
+        institutionConsecutiveSellDays=None,
+        individualConsecutiveBuyDays=None,
+        individualConsecutiveSellDays=None,
+    )
+
+    from unittest.mock import patch
+
+    # Query sequence for consecutive_gainers snapshot-first path with 1 qualifying row:
+    # Q1: MAX(snapshot_date) in _load_consecutive_gainers_from_snapshots
+    # Q2: qualifying snapshot rows
+    # Q3: kr_symbol_universe names for filtering (candidate_snaps non-empty)
+    # Q4: enrichment via _hydrate_from_snapshots → repo.get_fresh
+    # Q5: kr_names bulk-lookup in build_screener_results
+    # _hydrate_investor_flow_chips → patched, no DB query
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[today_kr]),  # Q1: MAX(snapshot_date)
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=today_kr,
+                        computed_at=primary_computed,
+                        week_change_rate=Decimal("3.5"),
+                    )
+                ]
+            ),  # Q2: qualifying rows
+            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),  # Q3: filter names
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=today_kr,
+                        computed_at=primary_computed,
+                        week_change_rate=Decimal("3.5"),
+                    )
+                ]
+            ),  # Q4: enrichment
+            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),  # Q5: kr_names
+        ]
+    )
+
+    async def _fake_latest_items(*, db, symbols, market="kr"):
+        return {"005930": inv_item}
+
+    with patch(
+        "app.services.invest_view_model.screener_service._latest_investor_flow_items",
+        side_effect=_fake_latest_items,
+    ):
+        resp = await build_screener_results(
+            preset_id="consecutive_gainers",
+            screening_service=fake_screening,
+            resolver=_FakeResolver(watched=set()),
+            market="kr",
+            session=session,
+            now=lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC),
+        )
+
+    f = resp.freshness
+    # Primary points at today (fresh)
+    assert f.primary is not None
+    assert f.primary.snapshotDate == today_kr.isoformat()
+    assert f.primary.dataState == "fresh"
+    # Dependency surfaces the investor-flow partition (NOT the primary date)
+    assert len(f.dependencies) == 1
+    dep = f.dependencies[0]
+    assert dep.kind == "investor_flow"
+    assert dep.snapshotDate == inv_partition.isoformat()
+    assert dep.dataState == "stale"
+    # lagLabel reflects the 2-day gap (calendar diff between today and inv_partition)
+    assert dep.lagLabel is not None and "거래일 지연" in dep.lagLabel
+    # D1.c rule 2: primary fresh + dep stale → overall stale
+    assert f.overallState == "stale"
+    assert f.dataState == "stale"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_consecutive_gainers_zero_qualifiers_still_threads_partition_metadata() -> None:
+    """ROB-277 follow-up FU3/FU6: when the latest partition has no qualifying
+    rows (consecutive_up_days >= 5 + week_change_rate >= 0 filter excludes all),
+    freshness.primary must still carry the partition's snapshotDate so the UI
+    can render '데이터 기준 {date}' rather than collapsing to live/now()."""
+    import datetime as dt
+
+    partition_date = dt.date(2026, 5, 13)  # stale
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    # Query sequence when latest partition has 0 qualifying rows:
+    # Q1: MAX(snapshot_date) in _load_consecutive_gainers_from_snapshots → partition_date
+    # Q2: qualifying rows (consecutive_up_days>=5, week_change_rate>=0) → empty
+    # No name query (candidate_snaps is empty)
+    # No enrichment (rows is empty)
+    # No kr_names lookup (rows is empty)
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[partition_date]),  # Q1: MAX(snapshot_date)
+            _FakeExecuteResult(scalar_rows=[]),  # Q2: qualifying rows: NONE
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="kr",
+        session=session,
+        now=lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC),
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results == []
+    # Snapshot was checked, partition metadata threaded through:
+    f = resp.freshness
+    assert f.primary is not None, "primary must not be None even with 0 qualifier rows"
+    assert f.primary.kind == "screener_snapshot"
+    assert f.primary.snapshotDate == partition_date.isoformat()
+    assert f.primary.source == "invest_screener_snapshots"
+    # asOfLabel reflects the partition, not now()
+    assert "2026.05.13" in f.asOfLabel
+    assert "2026.05.20" not in f.asOfLabel
+    # source enum: cached (snapshot was checked)
+    assert f.source == "cached"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1820,6 +1820,8 @@ def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
     assert f.source in {"live", "cached", "previous_session"}
     assert f.cacheHit is False
     assert f.fetchedAt == f.servedAt  # ROB-277 D1: fetchedAt is a servedAt alias
+
+
 # ROB-276: double_buy preset wiring (Task 3)
 # ---------------------------------------------------------------------------
 
@@ -2260,7 +2262,9 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency() -> None:
+async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency() -> (
+    None
+):
     """ROB-277 follow-up FU2/FU6: when primary partition is today's and an
     investor_flow snapshot is 2 trading days older, freshness.dependencies must
     surface that as a 'stale' investor_flow entry with the correct snapshotDate
@@ -2321,7 +2325,9 @@ async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_depend
                     )
                 ]
             ),  # Q2: qualifying rows
-            _FakeExecuteResult(rows=[_name_row("005930", "삼성전자")]),  # Q3: filter names
+            _FakeExecuteResult(
+                rows=[_name_row("005930", "삼성전자")]
+            ),  # Q3: filter names
             _FakeExecuteResult(
                 scalar_rows=[
                     _FakeSnapshot(
@@ -2372,7 +2378,9 @@ async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_depend
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_consecutive_gainers_zero_qualifiers_still_threads_partition_metadata() -> None:
+async def test_consecutive_gainers_zero_qualifiers_still_threads_partition_metadata() -> (
+    None
+):
     """ROB-277 follow-up FU3/FU6: when the latest partition has no qualifying
     rows (consecutive_up_days >= 5 + week_change_rate >= 0 filter excludes all),
     freshness.primary must still carry the partition's snapshotDate so the UI

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1406,9 +1406,12 @@ async def test_load_consecutive_gainers_uses_latest_snapshot_partition_only() ->
 
     result = await _load_consecutive_gainers_from_snapshots(session, market="kr")
 
-    assert result == [], "must return empty list, not historical qualifiers"
     assert result is not None, (
-        "None would mean 'could not check'; [] means 'checked and empty'"
+        "None would mean 'could not check'; a _SnapshotLoadResult means 'checked and empty'"
+    )
+    assert result.rows == [], "must return empty rows, not historical qualifiers"
+    assert result.partition_date == date(2026, 5, 13), (
+        "partition_date must be set even when rows is empty"
     )
 
 
@@ -1447,8 +1450,8 @@ async def test_load_consecutive_gainers_filters_kr_non_common_stock_names() -> N
     )
 
     assert result is not None
-    assert [row["symbol"] for row in result] == ["005930", "000660"]
-    assert [row["name"] for row in result] == ["삼성전자", "SK하이닉스"]
+    assert [row["symbol"] for row in result.rows] == ["005930", "000660"]
+    assert [row["name"] for row in result.rows] == ["삼성전자", "SK하이닉스"]
 
 
 @pytest.mark.unit
@@ -1576,14 +1579,14 @@ async def test_investor_flow_rows_carry_snapshot_date_collected_at_and_classifie
         ]
     )
 
-    rows = await _load_investor_flow_discovery_from_snapshots(
+    load_result = await _load_investor_flow_discovery_from_snapshots(
         session, market="kr", limit=20
     )
 
-    assert rows is not None, "expected rows list, got None"
-    assert len(rows) == 1
+    assert load_result is not None, "expected _SnapshotLoadResult, got None"
+    assert len(load_result.rows) == 1
 
-    row = rows[0]
+    row = load_result.rows[0]
 
     # snapshot_date passes through
     assert row["snapshot_date"] == stale_snapshot_date, (
@@ -1649,6 +1652,7 @@ def test_build_freshness_snapshot_first_uses_partition_date_not_now() -> None:
     # legacy alias holds (D1.c)
     assert f.dataState == f.overallState
     assert f.overallState == "stale"
+    assert f.fetchedAt == f.servedAt  # ROB-277 D1: fetchedAt is a servedAt alias
 
 
 @pytest.mark.unit
@@ -1815,6 +1819,7 @@ def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
     assert f.asOfLabel.startswith("2026.05.")
     assert f.source in {"live", "cached", "previous_session"}
     assert f.cacheHit is False
+    assert f.fetchedAt == f.servedAt  # ROB-277 D1: fetchedAt is a servedAt alias
 # ROB-276: double_buy preset wiring (Task 3)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1604,3 +1604,129 @@ async def test_investor_flow_rows_carry_snapshot_date_collected_at_and_classifie
     assert state == "stale", (
         f"expected 'stale' for snapshot_date={stale_snapshot_date} vs today 2026-05-20; got {state!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# ROB-277 Task 4: _build_freshness direct unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_freshness_snapshot_first_uses_partition_date_not_now() -> None:
+    """ROB-277 D1: snapshot-first response surfaces partition date in asOfLabel,
+    not now()."""
+    import datetime as dt
+
+    from app.services.invest_view_model.screener_service import _build_freshness
+
+    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    f = _build_freshness(
+        raw_timestamp="2026-05-20T00:10:00+00:00",
+        cache_hit=True,
+        market="kr",
+        now=fake_now,
+        dataState="stale",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2026, 5, 13),
+        primary_computed_at=None,
+        primary_source="invest_screener_snapshots",
+        dependency_specs=None,
+    )
+    assert f.primary is not None
+    assert f.primary.kind == "screener_snapshot"
+    assert f.primary.snapshotDate == "2026-05-13"
+    assert "2026.05.13" in f.primary.asOfLabel
+    assert f.primary.dataState == "stale"
+    # data-as-of label is the snapshot date, NOT 2026.05.20
+    assert "2026.05.13" in f.asOfLabel
+    assert "2026.05.20" not in f.asOfLabel
+    # served time is now
+    assert f.servedAt is not None and f.servedAt.startswith("2026-05-20")
+    # source enum unchanged (D2)
+    assert f.source == "cached"
+    # legacy alias holds (D1.c)
+    assert f.dataState == f.overallState
+    assert f.overallState == "stale"
+
+
+@pytest.mark.unit
+def test_build_freshness_live_path_uses_raw_timestamp() -> None:
+    """When primary_kind defaults to 'live', the legacy raw_timestamp drives asOfLabel."""
+    import datetime as dt
+
+    from app.services.invest_view_model.screener_service import _build_freshness
+
+    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    f = _build_freshness(
+        raw_timestamp="2026-05-20T00:08:00+00:00",
+        cache_hit=False,
+        market="kr",
+        now=fake_now,
+        dataState="fresh",
+    )
+    assert f.primary is not None
+    assert f.primary.kind == "live"
+    assert f.source == "live"
+    assert f.dataState == f.overallState == "fresh"
+
+
+@pytest.mark.unit
+def test_build_freshness_dependency_specs_render_with_lag_label() -> None:
+    """Dependency with older snapshot_date than primary gets a '{N}거래일 지연' lagLabel."""
+    import datetime as dt
+
+    from app.services.invest_view_model.screener_service import _build_freshness
+
+    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    f = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=True,
+        market="kr",
+        now=fake_now,
+        dataState="fresh",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2026, 5, 20),
+        primary_computed_at=dt.datetime(2026, 5, 20, 0, 5, tzinfo=dt.UTC),
+        primary_source="invest_screener_snapshots",
+        dependency_specs=[
+            {
+                "kind": "investor_flow",
+                "snapshot_date": dt.date(2026, 5, 18),
+                "collected_at": None,
+                "data_state": "stale",
+                "source": "investor_flow_snapshots",
+            }
+        ],
+    )
+    assert len(f.dependencies) == 1
+    dep = f.dependencies[0]
+    assert dep.kind == "investor_flow"
+    assert dep.snapshotDate == "2026-05-18"
+    assert dep.lagLabel == "2거래일 지연"
+    assert dep.dataState == "stale"
+    # primary fresh + dep stale → overall stale (D1.c rule 2)
+    assert f.overallState == "stale"
+    assert f.dataState == "stale"
+
+
+@pytest.mark.unit
+def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
+    """Calling _build_freshness with only the pre-ROB-277 kwargs still produces a
+    valid ScreenerFreshness (additive change preserves backward compat)."""
+    import datetime as dt
+
+    from app.services.invest_view_model.screener_service import _build_freshness
+
+    fake_now = lambda: dt.datetime(2026, 5, 20, 0, 10, tzinfo=dt.UTC)
+    f = _build_freshness(
+        raw_timestamp="2026-05-20T00:08:00+00:00",
+        cache_hit=False,
+        market="kr",
+        now=fake_now,
+        dataState="fresh",
+    )
+    # All legacy fields populated
+    assert f.fetchedAt is not None
+    assert f.asOfLabel.startswith("2026.05.")
+    assert f.source in {"live", "cached", "previous_session"}
+    assert f.cacheHit is False

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1680,7 +1680,7 @@ def test_build_freshness_live_path_uses_raw_timestamp() -> None:
 
 @pytest.mark.unit
 def test_build_freshness_dependency_specs_render_with_lag_label() -> None:
-    """Dependency with older snapshot_date than primary gets a '{N}거래일 지연' lagLabel."""
+    """Dependency with older snapshot_date than primary gets a '{N}일 지연' lagLabel."""
     import datetime as dt
 
     from app.services.invest_view_model.screener_service import _build_freshness
@@ -1712,7 +1712,7 @@ def test_build_freshness_dependency_specs_render_with_lag_label() -> None:
     dep = f.dependencies[0]
     assert dep.kind == "investor_flow"
     assert dep.snapshotDate == "2026-05-18"
-    assert dep.lagLabel == "2거래일 지연"
+    assert dep.lagLabel == "2일 지연"
     assert dep.dataState == "stale"
     # primary fresh + dep stale → overall stale (D1.c rule 2)
     assert f.overallState == "stale"
@@ -2370,7 +2370,7 @@ async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_depend
     assert dep.snapshotDate == inv_partition.isoformat()
     assert dep.dataState == "stale"
     # lagLabel reflects the 2-day gap (calendar diff between today and inv_partition)
-    assert dep.lagLabel is not None and "거래일 지연" in dep.lagLabel
+    assert dep.lagLabel is not None and "일 지연" in dep.lagLabel
     # D1.c rule 2: primary fresh + dep stale → overall stale
     assert f.overallState == "stale"
     assert f.dataState == "stale"

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -177,7 +177,20 @@ async def test_investor_flow_momentum_preset_uses_snapshot_discovery(
     db_session, monkeypatch
 ):
     repo = InvestorFlowSnapshotsRepository(db_session)
+    # Keep the far-future partition so this is the MAX date regardless of prior
+    # DB state.  Monkeypatch today_trading_date to return the same date so
+    # classify_investor_flow_partition sees "snapshot_date == today" → "fresh".
+    # (ROB-277 removed the old hardcoded _screener_snapshot_state="fresh", so
+    # the test must ensure classification agrees with the partition date.)
     latest_partition = dt.date(2099, 5, 13)
+
+    def _fake_today(market: str, *, now: object = None) -> dt.date:
+        return latest_partition
+
+    monkeypatch.setattr(
+        "app.services.invest_screener_snapshots.freshness.today_trading_date",
+        _fake_today,
+    )
     await repo.upsert(
         InvestorFlowSnapshotUpsert(
             market="kr",


### PR DESCRIPTION
## Summary

- `ScreenerFreshness` gains additive `servedAt` / `servedRelativeLabel` / `primary` / `dependencies` / `overallState` fields. Existing 6 fields are kept; `dataState` is now an alias of `overallState`; `fetchedAt` is now an alias of `servedAt`.
- Snapshot-first paths no longer report `now()` as the data-as-of time. `primary.snapshotDate` / `primary.asOfLabel` reflect the actual snapshot partition.
- `investor_flow_momentum` rows stop hardcoding `_screener_snapshot_state="fresh"` and now classify against the partition via `classify_investor_flow_partition`.
- `ScreenerFreshnessLine.tsx` renders `데이터 기준 …` and `화면 갱신 …` as separate spans when the new fields are present; legacy single-line render preserved for transition. When a dependency is stale/partial, its `lagLabel` (or `업데이트 필요` fallback) is inlined onto the data line.

## Why

ROB-277 — `/invest/screener` was showing `방금 갱신` for results sourced from a 5-day-old `invest_screener_snapshots` partition, while row-level chips simultaneously reported `1일 지연`. Root cause: `raw["timestamp"] = now()` flowed into `_build_freshness` as both served-time and data-as-of source.

## Compatibility caution

- **`asOfLabel` semantic shift (intended fix)**: for snapshot-first responses, `freshness.asOfLabel` now reflects the partition's `computed_at` (or end-of-snapshot-day 15:30 KST) instead of `now()`. Use this label for "데이터 기준" display.
- **`fetchedAt` is now an alias of `servedAt`** (per plan §D1). It always equals the response generation moment. The "real" data-as-of timestamp lives in `freshness.primary.computedAt`. Consumers that previously used `fetchedAt` as a data-as-of signal should migrate to `freshness.primary.computedAt` (preferred) or `freshness.primary.snapshotDate`.
- **`dataState` is now an alias of `overallState`** (always equal). New consumers should prefer `overallState`.
- **Dependency state classification**: `freshness.dependencies[i]` is built from per-row `_investor_flow_snapshot_date` / `_investor_flow_collected_at` stash (NOT from the primary's `snapshot_date`), and state comes from `classify_investor_flow_partition`. Snapshot-first responses with 0 qualifier rows still carry `primary.snapshotDate` / `asOfLabel` via the loader's `_SnapshotLoadResult`.

## Consumer audit findings (frontend)

| Field | Classification |
|---|---|
| `freshness.primary` | Safe — new optional field, guarded with `!= null` |
| `freshness.servedRelativeLabel` | Safe — new optional field, falls back to `"방금"` |
| `freshness.overallState` | Safe — new alias field |
| `freshness.source` | Safe — enum semantics unchanged |
| `freshness.relativeLabel` | Safe — semantics unchanged |
| `freshness.asOfLabel` | **Semantic shift (intended fix)** — for snapshot-first responses, now reflects partition `asOfLabel` rather than `now()`. Correctly used as `데이터 기준` label. |
| `freshness.fetchedAt` | **Semantic shift (intended fix)** — now an alias of `servedAt`. Legacy "data fetched at" interpretation should migrate to `primary.computedAt`. No current consumer relies on the old meaning. |
| `freshness.dataState` | Safe — still produces same enum values; now alias of `overallState` |

No regression risk identified in the consumer audit.

## Test plan

- [x] `make test` — 7,687 passing; 8 pre-existing failures confirmed identical on `main` (unrelated to ROB-277): `test_fill_notification`, `test_investor_flow_service::test_build_investor_flow_cards_marks_missing_symbol`, `test_openclaw_client::test_build_n8n_fill_payload_includes_detail_url`, `test_portfolio_links::test_build_position_detail_url_for_supported_markets`, `test_toss_notification::test_process_analysis_result_buy_with_toss`.
- [x] `make typecheck` — `All checks passed!`
- [x] `make lint` — `All checks passed!`
- [x] `cd frontend/invest && pnpm test --run` — ROB-277 scope (`ScreenerFreshnessLine.test.tsx`): 11/11 passing. Pre-existing failures in unrelated files (`ActionReadiness`, `DaySection`, `DesktopCalendarPage`, `MonthlyEventsTimeline`) confirmed on `main`.
- [ ] Local dev-browser spot-check of `/invest/screener?market=kr` (deferred — relies on dev stack being up)
- [ ] Post-merge production smoke (Hermes/파이리; not a merge gate)

## Locked decisions (from plan)

- **D1** Legacy field mapping: kept all 6 existing fields, added 5 new optional fields, `dataState = overallState`, `fetchedAt = servedAt`.
- **D2** Source mapping: top-level enum unchanged. Snapshot-first → `source="cached"` + `primary.kind="screener_snapshot"` + `primary.source="invest_screener_snapshots"`.
- **D3** UI copy: `데이터 기준` and `화면 갱신` rendered as separate spans (structural rule non-negotiable). Stale/partial dependency lag inlined on data line.
- **D4** Reused `classify_state()` and added sibling `classify_investor_flow_partition()` in the same module.
- **D5** Added unit tests + e2e API test covering snapshot stale path, weekend rollback, alias consistency, dependency split, 0-qualifier primary metadata.
- **D6** Server smoke is post-merge, not a merge gate.
- **D7** No DB migration, no scheduler activation, no backfill, no broker mutation.

## Follow-up fixups in this PR (after first round of review)

1. Merge conflict with `main` (ROB-274/275/276 commits) resolved in `tests/test_invest_view_model_screener_service.py`.
2. Dependency spec source bug: `_hydrate_investor_flow_chips` now stashes `_investor_flow_snapshot_date` + `_investor_flow_collected_at` + `_investor_flow_data_state`. `build_screener_results` dependency_specs reads ONLY the dependency-specific keys (never the primary's `snapshot_date`) and applies `classify_investor_flow_partition` for the state.
3. Loader partition metadata: `_load_consecutive_gainers_from_snapshots` and `_load_investor_flow_discovery_from_snapshots` return `_SnapshotLoadResult(rows, partition_date, partition_computed_at)`. `freshness.primary` is now populated even when 0 rows qualify.
4. D1 alignment: `fetchedAt` is now an alias of `servedAt` (was previously the partition `computed_at` for snapshot-first responses). Plan/code/tests/PR body all aligned.
5. Frontend `데이터 기준` line surfaces dependency `lagLabel` / `업데이트 필요` inline when a stale or partial dependency exists.
6. Integration tests added: fresh primary + stale investor_flow dependency (covers fix 2); 0 qualifier rows still threads partition metadata (covers fix 3); frontend stale data line includes lagLabel / 업데이트 필요 (covers fix 5).
7. Pre-merge polish: `_build_freshness` internal variable `fetched` renamed to `data_basis_at` with a clarifying comment so future readers don't confuse it with the exported `fetchedAt` (which is a `servedAt` alias). Dependency `lagLabel` switched from `"{N}거래일 지연"` to `"{N}일 지연"` — see Known limitations below.

## Known limitations / follow-ups (not in this PR)

- **Dependency `lagLabel` uses calendar-day count, not trading-day count.** The calculation is `(primary_snapshot_date - dep_snapshot_date).days`. Both partitions are emitted on trading days, so adjacent-trading-day diffs are accurate; weekend / public-holiday gaps will over-report (Fri vs Mon = 3 instead of 1). The label was changed from `"{N}거래일 지연"` to `"{N}일 지연"` to remove the trading-day implication while a trading-day-aware diff is implemented separately.
- **`primary.computedAt` may be `None` when the latest partition has 0 qualifier rows.** `partition_computed_at` is extracted from `candidate_snaps[0]` ORM rows; with 0 rows it falls to `None`. `format_kst_as_of_label` gracefully degrades to `"YYYY.MM.DD 장마감 기준"` in this case; `primary.snapshotDate` is still populated. A separate `MAX(computed_at)` query when rows is empty would improve fidelity.
- **`today_trading_date` does not consult an exchange holiday calendar.** On Korean public holidays a Friday-dated partition may be classified `stale` on Monday morning even though it is the latest valid partition. Acknowledged in the helper docstring.

## Non-goals (per ROB-189 + ROB-277 §D7)

- No DB migration.
- No scheduler activation / TaskIQ unpause / Prefect deploy registration.
- No production backfill.
- No broker / order / watch / order-intent mutation.
- No trading recommendation logic change.

## Plan

`docs/plans/2026-05-20-ROB-277-screener-freshness-semantics-implementation-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)