### PR TITLE
feat(rob-279): staged snapshot-backed report pipeline

### DIFF
--- a/alembic/versions/20260520_rob279_p1_add_stage_runs_and_artifacts.py
+++ b/alembic/versions/20260520_rob279_p1_add_stage_runs_and_artifacts.py
@@ -1,0 +1,126 @@
+"""rob-279 p1: add investment_stage_runs and investment_stage_artifacts
+
+Revision ID: 20260520_rob279_p1
+Revises: 20260520_rob274_p2
+Create Date: 2026-05-20
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260520_rob279_p1"
+down_revision: str | None = "20260520_rob274_p2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investment_stage_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            unique=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "snapshot_bundle_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("market_session", sa.Text(), nullable=True),
+        sa.Column("account_scope", sa.Text(), nullable=True),
+        sa.Column("policy_version", sa.Text(), nullable=False, server_default=sa.text("'v1'")),
+        sa.Column("generator_version", sa.Text(), nullable=False, server_default=sa.text("'v1'")),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'running'")),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('running','completed','failed','blocked')",
+            name=op.f("ck_investment_stage_runs_status"),
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_stage_runs_bundle_uuid",
+        "investment_stage_runs",
+        ["snapshot_bundle_uuid"],
+        schema="review",
+    )
+
+    op.create_table(
+        "investment_stage_artifacts",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "artifact_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            unique=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("run_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("stage_type", sa.Text(), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("key_points", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("buy_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("sell_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("risk_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("missing_data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "cited_snapshot_uuids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            nullable=False,
+            server_default=sa.text("ARRAY[]::uuid[]"),
+        ),
+        sa.Column("freshness_summary", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("model_name", sa.Text(), nullable=True),
+        sa.Column("prompt_version", sa.Text(), nullable=True),
+        sa.Column("payload_hash", sa.Text(), nullable=True),
+        sa.Column("raw_payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "verdict IN ('bull','bear','neutral','unavailable')",
+            name=op.f("ck_investment_stage_artifacts_verdict"),
+        ),
+        sa.CheckConstraint(
+            "confidence >= 0 AND confidence <= 100",
+            name=op.f("ck_investment_stage_artifacts_confidence_range"),
+        ),
+        sa.CheckConstraint(
+            "stage_type IN ("
+            "'market','news','portfolio_journal','watch_context','candidate_universe',"
+            "'bull_reducer','bear_reducer','risk_review')",
+            name=op.f("ck_investment_stage_artifacts_stage_type_v1"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_uuid"],
+            ["review.investment_stage_runs.run_uuid"],
+            name="fk_investment_stage_artifacts_run_uuid_investment_stage_runs",
+            ondelete="CASCADE",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_stage_artifacts_run_stage",
+        "investment_stage_artifacts",
+        ["run_uuid", "stage_type"],
+        unique=True,
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_investment_stage_artifacts_run_stage", table_name="investment_stage_artifacts", schema="review")
+    op.drop_table("investment_stage_artifacts", schema="review")
+    op.drop_index("ix_investment_stage_runs_bundle_uuid", table_name="investment_stage_runs", schema="review")
+    op.drop_table("investment_stage_runs", schema="review")

--- a/app/core/model_rate_limiter.py
+++ b/app/core/model_rate_limiter.py
@@ -1,0 +1,95 @@
+"""Redis-backed model rate limiter for Gemini API (ROB-279).
+
+Tracks per-model per-API-key rate-limit state in Redis so that 429 errors
+from Gemini are recorded and consulted before each subsequent call.
+
+Redis key structure:
+  model_rate_limit:{model}:{masked_api_key}  — presence means limited
+  model_retry_info:{model}:{masked_api_key}  — retry delay info (JSON)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+_logger = logging.getLogger(__name__)
+
+_DEFAULT_LIMIT_TTL_SECONDS = 60  # conservative: 1 minute per 429
+
+
+class ModelRateLimiter:
+    """Check and record Gemini model rate-limit state in Redis.
+
+    Falls back gracefully when Redis is unavailable — never raises, just
+    logs a warning so the LLM call path is not blocked by infra issues.
+    """
+
+    def __init__(self, redis_client=None, limit_ttl: int = _DEFAULT_LIMIT_TTL_SECONDS) -> None:
+        """
+        Args:
+            redis_client: An async Redis client (e.g. from ``aioredis``).
+                          If None, a no-op mode is used (all checks return False).
+            limit_ttl:    How many seconds a 429 lock is held.
+        """
+        self._redis = redis_client
+        self._limit_ttl = limit_ttl
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def is_model_limited(self, model_name: str, api_key_hint: str) -> bool:
+        """Return True if *model_name* for *api_key_hint* is currently rate-limited."""
+        if self._redis is None:
+            return False
+        key = self._rate_limit_key(model_name, api_key_hint)
+        try:
+            return bool(await self._redis.exists(key))
+        except Exception as exc:
+            _logger.warning("model_rate_limiter: Redis error checking limit (%s); allowing call", exc)
+            return False
+
+    async def mark_limited(
+        self,
+        model_name: str,
+        api_key_hint: str,
+        retry_delay: int | None = None,
+    ) -> None:
+        """Record a 429 for *model_name* / *api_key_hint* in Redis."""
+        if self._redis is None:
+            return
+        ttl = retry_delay if retry_delay and retry_delay > 0 else self._limit_ttl
+        rate_key = self._rate_limit_key(model_name, api_key_hint)
+        retry_key = self._retry_info_key(model_name, api_key_hint)
+        try:
+            await self._redis.setex(rate_key, ttl, "1")
+            await self._redis.setex(
+                retry_key,
+                ttl,
+                json.dumps({"retry_delay": ttl, "model": model_name}),
+            )
+            _logger.info(
+                "model_rate_limiter: marked %s as rate-limited for %s (ttl=%ss)",
+                model_name,
+                api_key_hint,
+                ttl,
+            )
+        except Exception as exc:
+            _logger.warning("model_rate_limiter: Redis error recording limit (%s)", exc)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _rate_limit_key(model_name: str, api_key_hint: str) -> str:
+        return f"model_rate_limit:{model_name}:{api_key_hint}"
+
+    @staticmethod
+    def _retry_info_key(model_name: str, api_key_hint: str) -> str:
+        return f"model_retry_info:{model_name}:{api_key_hint}"

--- a/app/core/model_rate_limiter.py
+++ b/app/core/model_rate_limiter.py
@@ -29,7 +29,9 @@ class ModelRateLimiter:
     logs a warning so the LLM call path is not blocked by infra issues.
     """
 
-    def __init__(self, redis_client=None, limit_ttl: int = _DEFAULT_LIMIT_TTL_SECONDS) -> None:
+    def __init__(
+        self, redis_client=None, limit_ttl: int = _DEFAULT_LIMIT_TTL_SECONDS
+    ) -> None:
         """
         Args:
             redis_client: An async Redis client (e.g. from ``aioredis``).
@@ -51,7 +53,10 @@ class ModelRateLimiter:
         try:
             return bool(await self._redis.exists(key))
         except Exception as exc:
-            _logger.warning("model_rate_limiter: Redis error checking limit (%s); allowing call", exc)
+            _logger.warning(
+                "model_rate_limiter: Redis error checking limit (%s); allowing call",
+                exc,
+            )
             return False
 
     async def mark_limited(

--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.routers import (
     invest_web_spa,
     investment_reports,
     investment_snapshots,
+    investment_stage_runs,
     kospi200,
     market_events,
     n8n,
@@ -179,6 +180,7 @@ def create_app() -> FastAPI:
     app.include_router(order_estimation.router)
     app.include_router(order_previews.router)
     app.include_router(investment_reports.router)
+    app.include_router(investment_stage_runs.router)
     # ROB-269 Phase 2 — flag-gated. Default off keeps the router fully absent
     # so unauthenticated probes return 404 at FastAPI's routing layer.
     if settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED:

--- a/app/models/investment_stages.py
+++ b/app/models/investment_stages.py
@@ -1,0 +1,124 @@
+"""Investment stage runs/artifacts ORM (ROB-279)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any
+
+from sqlalchemy import (
+    ARRAY,
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class InvestmentStageRun(Base):
+    __tablename__ = "investment_stage_runs"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('running','completed','failed','blocked')",
+            name="ck_investment_stage_runs_status",
+        ),
+        Index("ix_investment_stage_runs_bundle_uuid", "snapshot_bundle_uuid"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        unique=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    snapshot_bundle_uuid: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    market_session: Mapped[str | None] = mapped_column(Text, nullable=True)
+    account_scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    policy_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
+    generator_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'running'"))
+    started_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[dt.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    artifacts: Mapped[list["InvestmentStageArtifact"]] = relationship(
+        "InvestmentStageArtifact",
+        primaryjoin="InvestmentStageRun.run_uuid==foreign(InvestmentStageArtifact.run_uuid)",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class InvestmentStageArtifact(Base):
+    __tablename__ = "investment_stage_artifacts"
+    __table_args__ = (
+        CheckConstraint(
+            "verdict IN ('bull','bear','neutral','unavailable')",
+            name="ck_investment_stage_artifacts_verdict",
+        ),
+        CheckConstraint(
+            "confidence >= 0 AND confidence <= 100",
+            name="ck_investment_stage_artifacts_confidence_range",
+        ),
+        CheckConstraint(
+            "stage_type IN ("
+            "'market','news','portfolio_journal','watch_context','candidate_universe',"
+            "'bull_reducer','bear_reducer','risk_review')",
+            name="ck_investment_stage_artifacts_stage_type_v1",
+        ),
+        UniqueConstraint("run_uuid", "stage_type", name="ix_investment_stage_artifacts_run_stage"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    artifact_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        unique=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.investment_stage_runs.run_uuid", ondelete="CASCADE"),
+        nullable=False,
+    )
+    stage_type: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    key_points: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    buy_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    sell_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    risk_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    missing_data: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    cited_snapshot_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("ARRAY[]::uuid[]"),
+    )
+    freshness_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    model_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    prompt_version: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    raw_payload_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/app/models/investment_stages.py
+++ b/app/models/investment_stages.py
@@ -19,7 +19,8 @@ from sqlalchemy import (
     func,
     text,
 )
-from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -43,23 +44,33 @@ class InvestmentStageRun(Base):
         unique=True,
         server_default=text("gen_random_uuid()"),
     )
-    snapshot_bundle_uuid: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
+    snapshot_bundle_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
     market: Mapped[str] = mapped_column(Text, nullable=False)
     market_session: Mapped[str | None] = mapped_column(Text, nullable=True)
     account_scope: Mapped[str | None] = mapped_column(Text, nullable=True)
-    policy_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
-    generator_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
-    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'running'"))
+    policy_version: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'v1'")
+    )
+    generator_version: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'v1'")
+    )
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'running'")
+    )
     started_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
-    completed_at: Mapped[dt.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
 
-    artifacts: Mapped[list["InvestmentStageArtifact"]] = relationship(
+    artifacts: Mapped[list[InvestmentStageArtifact]] = relationship(
         "InvestmentStageArtifact",
         primaryjoin="InvestmentStageRun.run_uuid==foreign(InvestmentStageArtifact.run_uuid)",
         cascade="all, delete-orphan",
@@ -84,7 +95,9 @@ class InvestmentStageArtifact(Base):
             "'bull_reducer','bear_reducer','risk_review')",
             name="ck_investment_stage_artifacts_stage_type_v1",
         ),
-        UniqueConstraint("run_uuid", "stage_type", name="ix_investment_stage_artifacts_run_stage"),
+        UniqueConstraint(
+            "run_uuid", "stage_type", name="ix_investment_stage_artifacts_run_stage"
+        ),
         {"schema": "review"},
     )
 
@@ -102,7 +115,9 @@ class InvestmentStageArtifact(Base):
     )
     stage_type: Mapped[str] = mapped_column(Text, nullable=False)
     verdict: Mapped[str] = mapped_column(Text, nullable=False)
-    confidence: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    confidence: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     key_points: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
     buy_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
@@ -114,11 +129,15 @@ class InvestmentStageArtifact(Base):
         nullable=False,
         server_default=text("ARRAY[]::uuid[]"),
     )
-    freshness_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    freshness_summary: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     model_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     prompt_version: Mapped[str | None] = mapped_column(Text, nullable=True)
     payload_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
-    raw_payload_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    raw_payload_json: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
     created_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/routers/investment_stage_runs.py
+++ b/app/routers/investment_stage_runs.py
@@ -129,9 +129,7 @@ async def get_stage_run(
         )
     return StageRunWithArtifactsResponse(
         run=StageRunResponse.model_validate(result.run),
-        artifacts=[
-            StageArtifactResponse.model_validate(a) for a in result.artifacts
-        ],
+        artifacts=[StageArtifactResponse.model_validate(a) for a in result.artifacts],
     )
 
 
@@ -185,9 +183,7 @@ async def get_report_stage_artifacts(
                 status_code=404,
                 detail="stage_run_uuid in report_metadata points to a non-existent stage run",
             )
-        artifacts = [
-            StageArtifactResponse.model_validate(a) for a in result.artifacts
-        ]
+        artifacts = [StageArtifactResponse.model_validate(a) for a in result.artifacts]
     elif report.snapshot_bundle_uuid is not None:
         # Legacy fallback: union artifacts from all runs for this bundle.
         runs = await stage_svc.list_runs_for_bundle(report.snapshot_bundle_uuid)

--- a/app/routers/investment_stage_runs.py
+++ b/app/routers/investment_stage_runs.py
@@ -1,0 +1,206 @@
+"""ROB-279 — Read-only API surface for staged snapshot-backed reports.
+
+Two endpoints:
+
+* ``GET /trading/api/investment-stage-runs/{run_uuid}`` — run-scoped
+  diagnostic; returns the stage run row + all artifacts. Useful for
+  forensics when the stale gate blocks final report creation.
+
+* ``GET /trading/api/investment-reports/{report_uuid}/stage-artifacts`` —
+  report-scoped; returns the union of all artifacts from stage runs
+  linked to the report.  Resolution path:
+
+  1. Fetch the InvestmentReport row.
+  2. If ``report.report_metadata`` carries ``investment_stage_run_uuid``,
+     use that single run UUID.
+  3. Else fall back to ``StageRunQueryService.list_runs_for_bundle`` and
+     union all artifacts (legacy fallback for reports without explicit
+     linkage).
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_stages.query_service import StageRunQueryService
+
+router = APIRouter(tags=["investment-stage-runs"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response schemas (inlined — no separate schema file needed yet)
+# ---------------------------------------------------------------------------
+
+
+class StageRunResponse(BaseModel):
+    run_uuid: UUID
+    snapshot_bundle_uuid: UUID
+    market: str
+    market_session: str | None
+    account_scope: str | None
+    policy_version: str
+    generator_version: str
+    status: str
+    started_at: datetime
+    completed_at: datetime | None
+    metadata_json: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class StageArtifactResponse(BaseModel):
+    artifact_uuid: UUID
+    run_uuid: UUID
+    stage_type: str
+    verdict: str
+    confidence: int
+    summary: str | None
+    key_points: list[Any] | None
+    buy_evidence: list[Any] | None
+    sell_evidence: list[Any] | None
+    risk_evidence: list[Any] | None
+    missing_data: list[Any] | None
+    cited_snapshot_uuids: list[UUID]
+    freshness_summary: dict[str, Any] | None
+    model_name: str | None
+    prompt_version: str | None
+    payload_hash: str | None
+    raw_payload_json: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class StageRunWithArtifactsResponse(BaseModel):
+    run: StageRunResponse
+    artifacts: list[StageArtifactResponse]
+
+
+class ReportStageArtifactsResponse(BaseModel):
+    report_uuid: UUID
+    stage_run_uuid: UUID | None
+    artifacts: list[StageArtifactResponse]
+
+
+# ---------------------------------------------------------------------------
+# Dependency builders
+# ---------------------------------------------------------------------------
+def _build_stage_query_service(
+    db: AsyncSession = Depends(get_db),
+) -> StageRunQueryService:
+    return StageRunQueryService(db)
+
+
+def _build_reports_repository(
+    db: AsyncSession = Depends(get_db),
+) -> InvestmentReportsRepository:
+    return InvestmentReportsRepository(db)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 1 — run-scoped diagnostic
+# ---------------------------------------------------------------------------
+@router.get(
+    "/trading/api/investment-stage-runs/{run_uuid}",
+    response_model=StageRunWithArtifactsResponse,
+    summary="Get stage run + artifacts by run UUID (ROB-279)",
+)
+async def get_stage_run(
+    run_uuid: UUID,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    stage_svc: Annotated[StageRunQueryService, Depends(_build_stage_query_service)],
+) -> StageRunWithArtifactsResponse:
+    result = await stage_svc.get_run_with_artifacts(run_uuid)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="stage_run_not_found"
+        )
+    return StageRunWithArtifactsResponse(
+        run=StageRunResponse.model_validate(result.run),
+        artifacts=[
+            StageArtifactResponse.model_validate(a) for a in result.artifacts
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoint 2 — report-scoped artifact union
+# ---------------------------------------------------------------------------
+@router.get(
+    "/trading/api/investment-reports/{report_uuid}/stage-artifacts",
+    response_model=ReportStageArtifactsResponse,
+    summary="Get stage artifacts linked to an investment report (ROB-279)",
+)
+async def get_report_stage_artifacts(
+    report_uuid: UUID,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    reports_repo: Annotated[
+        InvestmentReportsRepository, Depends(_build_reports_repository)
+    ],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ReportStageArtifactsResponse:
+    report = await reports_repo.get_report_by_uuid(report_uuid)
+    if report is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="report_not_found"
+        )
+
+    stage_svc = StageRunQueryService(db)
+
+    # Resolution path: prefer explicit linkage in report metadata; fall back
+    # to bundle-scoped enumeration for legacy reports.
+    explicit_run_uuid: UUID | None = None
+    raw = (report.report_metadata or {}).get("investment_stage_run_uuid")
+    if isinstance(raw, str):
+        try:
+            explicit_run_uuid = _uuid.UUID(raw)
+        except ValueError:
+            pass
+
+    # 404 when neither resolution path is available.
+    if explicit_run_uuid is None and report.snapshot_bundle_uuid is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="report has neither stage_run_uuid in metadata nor snapshot_bundle_uuid",
+        )
+
+    artifacts: list[StageArtifactResponse] = []
+
+    if explicit_run_uuid is not None:
+        result = await stage_svc.get_run_with_artifacts(explicit_run_uuid)
+        if result is None:
+            raise HTTPException(
+                status_code=404,
+                detail="stage_run_uuid in report_metadata points to a non-existent stage run",
+            )
+        artifacts = [
+            StageArtifactResponse.model_validate(a) for a in result.artifacts
+        ]
+    elif report.snapshot_bundle_uuid is not None:
+        # Legacy fallback: union artifacts from all runs for this bundle.
+        runs = await stage_svc.list_runs_for_bundle(report.snapshot_bundle_uuid)
+        for run in runs:
+            run_result = await stage_svc.get_run_with_artifacts(run.run_uuid)
+            if run_result is not None:
+                artifacts.extend(
+                    StageArtifactResponse.model_validate(a)
+                    for a in run_result.artifacts
+                )
+
+    return ReportStageArtifactsResponse(
+        report_uuid=report_uuid,
+        stage_run_uuid=explicit_run_uuid,
+        artifacts=artifacts,
+    )

--- a/app/schemas/investment_stages.py
+++ b/app/schemas/investment_stages.py
@@ -20,7 +20,7 @@ StageTypeLiteral = (
 )
 
 
-class StageVerdict(str, enum.Enum):
+class StageVerdict(enum.StrEnum):
     BULL = "bull"
     BEAR = "bear"
     NEUTRAL = "neutral"

--- a/app/schemas/investment_stages.py
+++ b/app/schemas/investment_stages.py
@@ -1,0 +1,75 @@
+"""Pydantic schemas for investment stage runs/artifacts (ROB-279)."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+StageTypeLiteral = (
+    "market",
+    "news",
+    "portfolio_journal",
+    "watch_context",
+    "candidate_universe",
+    "bull_reducer",
+    "bear_reducer",
+    "risk_review",
+)
+
+
+class StageVerdict(str, enum.Enum):
+    BULL = "bull"
+    BEAR = "bear"
+    NEUTRAL = "neutral"
+    UNAVAILABLE = "unavailable"
+
+
+class StageCitation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    snapshot_uuid: uuid.UUID
+    snapshot_kind: str
+    payload_path: str | None = None
+
+
+class StageArtifactPayload(BaseModel):
+    """Structured output that every stage MUST emit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage_type: str
+    verdict: StageVerdict
+    confidence: int = Field(ge=0, le=100)
+    summary: str | None = None
+    key_points: list[str] = Field(default_factory=list)
+    buy_evidence: list[str] = Field(default_factory=list)
+    sell_evidence: list[str] = Field(default_factory=list)
+    risk_evidence: list[str] = Field(default_factory=list)
+    missing_data: list[str] = Field(default_factory=list)
+    cited_snapshots: list[StageCitation] = Field(default_factory=list)
+    freshness_summary: dict[str, Any] | None = None
+    model_name: str | None = None
+    prompt_version: str | None = None
+
+
+class StageRunSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+    run_uuid: uuid.UUID
+    snapshot_bundle_uuid: uuid.UUID
+    market: str
+    market_session: str | None
+    account_scope: str | None
+    policy_version: str
+    generator_version: str
+    status: str
+    started_at: str
+    completed_at: str | None
+    metadata_json: dict[str, Any] | None = None
+
+
+class StageArtifactRead(StageArtifactPayload):
+    artifact_uuid: uuid.UUID
+    run_uuid: uuid.UUID
+    created_at: str

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -166,6 +166,9 @@ class SnapshotBackedReportGenerator:
             from app.services.ai_providers.gemini_provider import GeminiProvider
             from app.services.investment_stages.budget import StageLLMBudget
             from app.services.investment_stages.composer import FinalComposer
+            from app.services.investment_stages.rate_limited_provider import (
+                RateLimitedGeminiProvider,
+            )
             from app.services.investment_stages.stage_runner import StageRunner
             from app.services.investment_stages.stages.registry import (
                 get_default_v1_stages,
@@ -182,7 +185,9 @@ class SnapshotBackedReportGenerator:
                     return SimpleNamespace(bundle=bundle, items=[i[1] for i in items])
 
             budget = StageLLMBudget(max_calls=4)
-            provider = GeminiProvider(api_key=settings.gemini_advisor_api_key or "")
+            provider = RateLimitedGeminiProvider(
+                GeminiProvider(api_key=settings.gemini_advisor_api_key or "")
+            )
             stage_runner = StageRunner(
                 session=self._session,
                 bundle_read_service=_LocalBundleRead(self._snapshots_repo),

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -177,6 +177,7 @@ class SnapshotBackedReportGenerator:
             class _LocalBundleRead:
                 def __init__(self, repo):
                     self._repo = repo
+
                 async def get_bundle(self, *, bundle_uuid: UUID):
                     bundle = await self._repo.get_bundle_by_uuid(bundle_uuid)
                     if not bundle:

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -161,19 +161,23 @@ class SnapshotBackedReportGenerator:
         if request.auto_compose:
             # ROB-279 — synthesize report via staged snapshot-backed pipeline.
             from types import SimpleNamespace
+
             from app.core.config import settings
             from app.services.ai_providers.gemini_provider import GeminiProvider
             from app.services.investment_stages.budget import StageLLMBudget
             from app.services.investment_stages.composer import FinalComposer
             from app.services.investment_stages.stage_runner import StageRunner
-            from app.services.investment_stages.stages.registry import get_default_v1_stages
+            from app.services.investment_stages.stages.registry import (
+                get_default_v1_stages,
+            )
 
             class _LocalBundleRead:
                 def __init__(self, repo):
                     self._repo = repo
                 async def get_bundle(self, *, bundle_uuid: UUID):
                     bundle = await self._repo.get_bundle_by_uuid(bundle_uuid)
-                    if not bundle: return None
+                    if not bundle:
+                        return None
                     items = await self._repo.list_bundle_items_with_snapshots(bundle.id)
                     return SimpleNamespace(bundle=bundle, items=[i[1] for i in items])
 
@@ -201,7 +205,7 @@ class SnapshotBackedReportGenerator:
                 kst_date=request.kst_date,
                 artifacts=stage_run.artifacts,
             )
-            
+
             # Re-classify composed items against operational state
             classifier_context = await self._build_classifier_context(
                 bundle_uuid=ensure_response.bundle_uuid,
@@ -217,7 +221,8 @@ class SnapshotBackedReportGenerator:
             unavailable_sources = self._build_unavailable_sources(
                 ensure_response.missing_sources, freshness_summary
             )
-            
+            source_conflicts: dict[str, Any] = {}
+
             ingest_request = composed_req.model_copy(
                 update={
                     "items": composed_items,
@@ -299,7 +304,7 @@ class SnapshotBackedReportGenerator:
             snapshot_freshness_summary=freshness_summary,
             source_conflicts=source_conflicts,
             unavailable_sources=unavailable_sources,
-            items_count=len(request.items),
+            items_count=len(ingest_request.items),
             warnings=list(ensure_response.warnings),
             bundle_status=ensure_response.status,
             bundle_reused=not ensure_response.created,

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -158,44 +158,124 @@ class SnapshotBackedReportGenerator:
                 f"status={ensure_response.status!r}"
             )
 
-        # ROB-274 — classify draft items against persisted bundle state.
-        # We read payloads back from the DB (via list_bundle_items_with_snapshots)
-        # so the classifier sees the same data that was just persisted, and
-        # downstream audits remain reproducible.
-        classifier_context = await self._build_classifier_context(
-            bundle_uuid=ensure_response.bundle_uuid,
-            missing_sources=list(ensure_response.missing_sources),
-        )
-        request = request.model_copy(
-            update={
-                "items": classify_items(
-                    items=list(request.items),
-                    context=classifier_context,
-                )
-            }
-        )
+        if request.auto_compose:
+            # ROB-279 — synthesize report via staged snapshot-backed pipeline.
+            from types import SimpleNamespace
+            from app.core.config import settings
+            from app.services.ai_providers.gemini_provider import GeminiProvider
+            from app.services.investment_stages.budget import StageLLMBudget
+            from app.services.investment_stages.composer import FinalComposer
+            from app.services.investment_stages.stage_runner import StageRunner
+            from app.services.investment_stages.stages.registry import get_default_v1_stages
 
-        coverage_summary = to_jsonable(ensure_response.coverage_summary)
-        freshness_summary = self._enrich_freshness_summary(ensure_response)
-        unavailable_sources = self._build_unavailable_sources(
-            ensure_response.missing_sources, freshness_summary
-        )
-        source_conflicts: dict[str, Any] = {}
+            class _LocalBundleRead:
+                def __init__(self, repo):
+                    self._repo = repo
+                async def get_bundle(self, *, bundle_uuid: UUID):
+                    bundle = await self._repo.get_bundle_by_uuid(bundle_uuid)
+                    if not bundle: return None
+                    items = await self._repo.list_bundle_items_with_snapshots(bundle.id)
+                    return SimpleNamespace(bundle=bundle, items=[i[1] for i in items])
 
-        if request.status == "published":
-            self._guard_published(
-                bundle_status=ensure_response.status,
-                freshness_summary=freshness_summary,
+            budget = StageLLMBudget(max_calls=4)
+            provider = GeminiProvider(api_key=settings.gemini_advisor_api_key or "")
+            stage_runner = StageRunner(
+                session=self._session,
+                bundle_read_service=_LocalBundleRead(self._snapshots_repo),
+                stages=get_default_v1_stages(provider, budget),
+            )
+            stage_run = await stage_runner.run(
+                snapshot_bundle_uuid=ensure_response.bundle_uuid,
+                market=request.market,
+                market_session=request.market_session,
+                account_scope=request.account_scope,
             )
 
-        ingest_request = self._build_ingest_request(
-            request=request,
-            bundle_uuid=ensure_response.bundle_uuid,
-            coverage_summary=coverage_summary,
-            freshness_summary=freshness_summary,
-            unavailable_sources=unavailable_sources,
-            source_conflicts=source_conflicts,
-        )
+            composer = FinalComposer(provider, budget)
+            composed_req = await composer.compose(
+                run_uuid=stage_run.run_uuid,
+                snapshot_bundle_uuid=ensure_response.bundle_uuid,
+                market=request.market,
+                market_session=request.market_session,
+                account_scope=request.account_scope,
+                kst_date=request.kst_date,
+                artifacts=stage_run.artifacts,
+            )
+            
+            # Re-classify composed items against operational state
+            classifier_context = await self._build_classifier_context(
+                bundle_uuid=ensure_response.bundle_uuid,
+                missing_sources=list(ensure_response.missing_sources),
+            )
+            composed_items = classify_items(
+                items=composed_req.items,
+                context=classifier_context,
+            )
+
+            coverage_summary = to_jsonable(ensure_response.coverage_summary)
+            freshness_summary = self._enrich_freshness_summary(ensure_response)
+            unavailable_sources = self._build_unavailable_sources(
+                ensure_response.missing_sources, freshness_summary
+            )
+            
+            ingest_request = composed_req.model_copy(
+                update={
+                    "items": composed_items,
+                    "snapshot_coverage_summary": coverage_summary,
+                    "snapshot_freshness_summary": freshness_summary,
+                    "unavailable_sources": unavailable_sources,
+                    "source_conflicts": {},
+                    "metadata": {
+                        **composed_req.metadata,
+                        "investment_stage_run_uuid": str(stage_run.run_uuid),
+                        "snapshot_backed_generator": True,
+                        "generator_signature": {
+                            "report_type": composed_req.report_type,
+                            "policy_version": request.policy_version,
+                            "generator_version": "v2_staged",
+                        },
+                    },
+                }
+            )
+        else:
+            # ROB-274 — classify draft items against persisted bundle state.
+            # We read payloads back from the DB (via list_bundle_items_with_snapshots)
+            # so the classifier sees the same data that was just persisted, and
+            # downstream audits remain reproducible.
+            classifier_context = await self._build_classifier_context(
+                bundle_uuid=ensure_response.bundle_uuid,
+                missing_sources=list(ensure_response.missing_sources),
+            )
+            request = request.model_copy(
+                update={
+                    "items": classify_items(
+                        items=list(request.items),
+                        context=classifier_context,
+                    )
+                }
+            )
+
+            coverage_summary = to_jsonable(ensure_response.coverage_summary)
+            freshness_summary = self._enrich_freshness_summary(ensure_response)
+            unavailable_sources = self._build_unavailable_sources(
+                ensure_response.missing_sources, freshness_summary
+            )
+            source_conflicts: dict[str, Any] = {}
+
+            if request.status == "published":
+                self._guard_published(
+                    bundle_status=ensure_response.status,
+                    freshness_summary=freshness_summary,
+                )
+
+            ingest_request = self._build_ingest_request(
+                request=request,
+                bundle_uuid=ensure_response.bundle_uuid,
+                coverage_summary=coverage_summary,
+                freshness_summary=freshness_summary,
+                unavailable_sources=unavailable_sources,
+                source_conflicts=source_conflicts,
+            )
 
         # Authoritative gate runs inside ingest(); this pre-flight is a
         # belt-and-braces check so a clearly-blocked published request

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -28,6 +28,7 @@ class ReportGenerationRequest(BaseModel):
 
     market: GeneratorMarketLiteral
     account_scope: GeneratorAccountScopeLiteral
+    market_session: str | None = None
     policy_version: str = "intraday_action_report_v1"
     execution_mode: Literal["advisory_only"] = "advisory_only"
     status: GeneratorStatusLiteral = "published"

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -53,6 +53,10 @@ class ReportGenerationRequest(BaseModel):
     symbols: list[str] | None = None
     candidate_limit: int | None = None
 
+    # ROB-279 — when True, the generator synthesizes report fields and items
+    # via the staged snapshot-backed pipeline instead of using provided ones.
+    auto_compose: bool = False
+
 
 class ReportGenerationResponse(BaseModel):
     """Result envelope for the generator. JSON-safe."""

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1328,8 +1328,14 @@ def _build_freshness(
     now_kst = now_utc.astimezone(_KST)
     market_open = market == "kr" and _is_kr_market_open(now_kst)
 
-    if not market_open and delta > _CACHE_HIT_FRESH_SECONDS * 4:
-        source: Literal["live", "cached", "previous_session"] = "previous_session"
+    if cache_hit and primary_kind == "screener_snapshot":
+        # Snapshot-first responses are persisted-cache reads.  Keep the legacy
+        # top-level enum stable as "cached" even when the snapshot partition is
+        # stale; staleness is carried by primary/dependency dataState instead.
+        source: Literal["live", "cached", "previous_session"] = "cached"
+        relative = _format_relative_korean(delta)
+    elif not market_open and delta > _CACHE_HIT_FRESH_SECONDS * 4:
+        source = "previous_session"
         relative = "전 거래일 기준"
     elif cache_hit:
         source = "cached"

--- a/app/services/investment_stages/__init__.py
+++ b/app/services/investment_stages/__init__.py
@@ -1,0 +1,1 @@
+# Empty init for investment_stages service

--- a/app/services/investment_stages/budget.py
+++ b/app/services/investment_stages/budget.py
@@ -1,0 +1,32 @@
+"""LLM call budget guard for staged reports (ROB-279).
+
+Per-report cap: 4 (3 reducers + 1 composer). Stages that would overshoot
+must degrade to deterministic-only fallback or `UNAVAILABLE`."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+class BudgetExceeded(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class StageLLMBudget:
+    max_calls: int = 4
+    _used: list[str] = dataclasses.field(default_factory=list)
+
+    @property
+    def remaining(self) -> int:
+        return max(self.max_calls - len(self._used), 0)
+
+    def consume(self, label: str) -> None:
+        if len(self._used) >= self.max_calls:
+            raise BudgetExceeded(
+                f"LLM budget exhausted (cap={self.max_calls}, used={self._used})"
+            )
+        self._used.append(label)
+
+    def used(self) -> list[str]:
+        return list(self._used)

--- a/app/services/investment_stages/composer.py
+++ b/app/services/investment_stages/composer.py
@@ -1,0 +1,140 @@
+"""Final LLM Composer (ROB-279)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+import uuid
+
+from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
+from app.services.ai_providers.gemini_provider import GeminiProvider
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageArtifactPayload
+
+_logger = logging.getLogger(__name__)
+
+
+class FinalComposer:
+    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+        self._provider = provider
+        self._budget = budget
+
+    async def compose(
+        self,
+        *,
+        run_uuid: uuid.UUID,
+        snapshot_bundle_uuid: uuid.UUID,
+        market: str,
+        market_session: str | None,
+        account_scope: str | None,
+        kst_date: str,
+        artifacts: list[Any],  # InvestmentStageArtifact ORM objects
+    ) -> IngestReportRequest:
+        self._budget.consume("final_composer")
+
+        # Map artifacts by type to resolve UUIDs
+        artifact_map = {a.stage_type: a for a in artifacts}
+        
+        # Prepare content for prompt
+        stages_data = []
+        for art in artifacts:
+            stages_data.append(
+                f"Stage: {art.stage_type} (Verdict: {art.verdict}, UUID: {art.artifact_uuid})\n"
+                f"Summary: {art.summary}\n"
+                f"Key Points: {art.key_points}\n"
+                f"Buy Evidence: {art.buy_evidence}\n"
+                f"Sell Evidence: {art.sell_evidence}\n"
+                f"Risk Evidence: {art.risk_evidence}\n"
+            )
+
+        prompt = (
+            "You are a master financial advisor composing the final advisory report. "
+            "You MUST synthesize all the intermediate stage analysis outputs into a unified report. "
+            "You MUST reply ONLY with a valid JSON object. Do not include markdown code blocks like ```json."
+        )
+
+        user_msg = (
+            f"Intermediate Stages:\n"
+            f"{chr(10).join(stages_data)}\n\n"
+            f"Generate a final report in JSON format matching this schema exactly:\n"
+            f"{{\n"
+            f'  "title": "Advisory Report Title",\n'
+            f'  "summary": "Main summary text synthesizing all stages",\n'
+            f'  "risk_summary": "Risk summary synthesizing risk_review and bear case",\n'
+            f'  "thesis_text": "Detailed investment thesis",\n'
+            f'  "items": [\n'
+            f"    {{\n"
+            f'      "client_item_key": "AAPL_BUY",\n'
+            f'      "item_kind": "action",\n'
+            f'      "operation": "create",\n'
+            f'      "symbol": "AAPL",\n'
+            f'      "side": "buy",\n'
+            f'      "intent": "buy_review",\n'
+            f'      "priority": 0,\n'
+            f'      "confidence": 85,\n'
+            f'      "rationale": "Rationale referring to the news / candidate stage",\n'
+            f'      "cited_stage_types": ["news", "candidate_universe"]\n'
+            f"    }}\n"
+            f"  ]\n"
+            f"}}\n"
+        )
+
+        res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
+        text = res.answer.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            if lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines[-1].startswith("```"):
+                lines = lines[:-1]
+            text = "\n".join(lines).strip()
+
+        data = json.loads(text)
+
+        # Build IngestReportItem objects and enforce citations
+        composed_items: list[IngestReportItem] = []
+        fallback_uuid = (
+            artifact_map.get("risk_review").artifact_uuid
+            if "risk_review" in artifact_map
+            else uuid.uuid4()
+        )
+
+        for raw_item in data.get("items", []):
+            cited_types = raw_item.pop("cited_stage_types", [])
+            cited_uuids = []
+            for t in cited_types:
+                if t in artifact_map:
+                    cited_uuids.append(str(artifact_map[t].artifact_uuid))
+
+            # Citation enforcement invariant
+            if not cited_uuids:
+                cited_uuids.append(str(fallback_uuid))
+
+            metadata = raw_item.get("metadata", {})
+            metadata["cited_stage_uuids"] = cited_uuids
+            raw_item["metadata"] = metadata
+
+            # Strip valid_until if watch is cancel/keep/review (to satisfy ROB-265 validators)
+            if raw_item.get("item_kind") == "watch" and raw_item.get("operation") in ("cancel", "keep", "review"):
+                raw_item.pop("valid_until", None)
+
+            composed_items.append(IngestReportItem.model_validate(raw_item))
+
+        # Compose overall request
+        return IngestReportRequest(
+            report_type="Advisory",
+            market=market,  # type: ignore
+            market_session=market_session,  # type: ignore
+            account_scope=account_scope,  # type: ignore
+            created_by_profile="AI_ADVISOR",
+            title=data.get("title", "Advisory Report"),
+            summary=data.get("summary", "Advisory report summary"),
+            risk_summary=data.get("risk_summary"),
+            thesis_text=data.get("thesis_text"),
+            kst_date=kst_date,
+            status="draft",
+            items=composed_items,
+            snapshot_bundle_uuid=snapshot_bundle_uuid,
+            generator_version="v2_staged",
+        )

--- a/app/services/investment_stages/composer.py
+++ b/app/services/investment_stages/composer.py
@@ -5,9 +5,15 @@ from __future__ import annotations
 import json
 import logging
 import uuid
-from typing import Any
+from typing import Any, cast
 
-from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
+from app.schemas.investment_reports import (
+    AccountScopeLiteral,
+    IngestReportItem,
+    IngestReportRequest,
+    MarketLiteral,
+    MarketSessionLiteral,
+)
 from app.services.investment_stages.budget import StageLLMBudget
 
 _logger = logging.getLogger(__name__)
@@ -116,14 +122,20 @@ class FinalComposer:
             raw_item["metadata"] = metadata
 
             # Strip valid_until if watch is cancel/keep/review (to satisfy ROB-265 validators)
-            if raw_item.get("item_kind") == "watch" and raw_item.get("operation") in ("cancel", "keep", "review"):
+            if raw_item.get("item_kind") == "watch" and raw_item.get("operation") in (
+                "cancel",
+                "keep",
+                "review",
+            ):
                 raw_item.pop("valid_until", None)
 
             composed_items.append(IngestReportItem.model_validate(raw_item))
 
         # If ALL items were dropped, emit a single safety fallback item.
         if not composed_items and data.get("items"):
-            _logger.info("composer: all candidate items lacked citations; emitting no_action_note fallback")
+            _logger.info(
+                "composer: all candidate items lacked citations; emitting no_action_note fallback"
+            )
             composed_items.append(
                 IngestReportItem(
                     client_item_key="auto-no-action",
@@ -141,9 +153,9 @@ class FinalComposer:
         # Compose overall request
         return IngestReportRequest(
             report_type="Advisory",
-            market=market,  # type: ignore
-            market_session=market_session,  # type: ignore
-            account_scope=account_scope,  # type: ignore
+            market=cast(MarketLiteral, market),
+            market_session=cast(MarketSessionLiteral | None, market_session),
+            account_scope=cast(AccountScopeLiteral | None, account_scope),
             created_by_profile="AI_ADVISOR",
             title=data.get("title", "Advisory Report"),
             summary=data.get("summary", "Advisory report summary"),

--- a/app/services/investment_stages/composer.py
+++ b/app/services/investment_stages/composer.py
@@ -8,14 +8,13 @@ import uuid
 from typing import Any
 
 from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
-from app.services.ai_providers.gemini_provider import GeminiProvider
 from app.services.investment_stages.budget import StageLLMBudget
 
 _logger = logging.getLogger(__name__)
 
 
 class FinalComposer:
-    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+    def __init__(self, provider: Any, budget: StageLLMBudget) -> None:
         self._provider = provider
         self._budget = budget
 
@@ -92,23 +91,25 @@ class FinalComposer:
         data = json.loads(text)
 
         # Build IngestReportItem objects and enforce citations
+        # Hard enforcement: items without valid citations are dropped (C2, ROB-279).
         composed_items: list[IngestReportItem] = []
-        fallback_uuid = (
-            artifact_map.get("risk_review").artifact_uuid
-            if "risk_review" in artifact_map
-            else uuid.uuid4()
-        )
 
         for raw_item in data.get("items", []):
+            client_item_key = raw_item.get("client_item_key", "<unknown>")
             cited_types = raw_item.pop("cited_stage_types", [])
             cited_uuids = []
             for t in cited_types:
                 if t in artifact_map:
                     cited_uuids.append(str(artifact_map[t].artifact_uuid))
 
-            # Citation enforcement invariant
+            # Hard citation gate: drop items with no resolvable stage citations.
             if not cited_uuids:
-                cited_uuids.append(str(fallback_uuid))
+                _logger.info(
+                    "composer: dropping uncited item client_item_key=%s (cited_stage_types=%r)",
+                    client_item_key,
+                    cited_types,
+                )
+                continue
 
             metadata = raw_item.get("metadata", {})
             metadata["cited_stage_uuids"] = cited_uuids
@@ -119,6 +120,23 @@ class FinalComposer:
                 raw_item.pop("valid_until", None)
 
             composed_items.append(IngestReportItem.model_validate(raw_item))
+
+        # If ALL items were dropped, emit a single safety fallback item.
+        if not composed_items and data.get("items"):
+            _logger.info("composer: all candidate items lacked citations; emitting no_action_note fallback")
+            composed_items.append(
+                IngestReportItem(
+                    client_item_key="auto-no-action",
+                    item_kind="risk",
+                    intent="risk_review",
+                    operation="review",
+                    rationale="all candidate items lacked stage citations; review required",
+                    apply_policy="requires_user_approval",
+                    proposed_state={
+                        "summary": "all candidate items lacked stage citations; review required"
+                    },
+                )
+            )
 
         # Compose overall request
         return IngestReportRequest(

--- a/app/services/investment_stages/composer.py
+++ b/app/services/investment_stages/composer.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 import uuid
+from typing import Any
 
 from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
 from app.services.ai_providers.gemini_provider import GeminiProvider
 from app.services.investment_stages.budget import StageLLMBudget
-from app.services.investment_stages.stages.base import StageArtifactPayload
 
 _logger = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ class FinalComposer:
 
         # Map artifacts by type to resolve UUIDs
         artifact_map = {a.stage_type: a for a in artifacts}
-        
+
         # Prepare content for prompt
         stages_data = []
         for art in artifacts:

--- a/app/services/investment_stages/query_service.py
+++ b/app/services/investment_stages/query_service.py
@@ -1,0 +1,51 @@
+"""Read-only query service for stage runs (ROB-279)."""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+
+
+@dataclasses.dataclass(frozen=True)
+class StageRunWithArtifacts:
+    run: InvestmentStageRun
+    artifacts: list[InvestmentStageArtifact]
+
+
+class StageRunQueryService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_run_with_artifacts(
+        self, run_uuid: uuid.UUID
+    ) -> StageRunWithArtifacts | None:
+        run = await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        if run is None:
+            return None
+        artifacts = list(
+            (
+                await self._session.scalars(
+                    select(InvestmentStageArtifact)
+                    .where(InvestmentStageArtifact.run_uuid == run_uuid)
+                    .order_by(InvestmentStageArtifact.created_at)
+                )
+            ).all()
+        )
+        return StageRunWithArtifacts(run=run, artifacts=artifacts)
+
+    async def list_runs_for_bundle(
+        self, snapshot_bundle_uuid: uuid.UUID
+    ) -> list[InvestmentStageRun]:
+        result = await self._session.scalars(
+            select(InvestmentStageRun)
+            .where(InvestmentStageRun.snapshot_bundle_uuid == snapshot_bundle_uuid)
+            .order_by(InvestmentStageRun.started_at.desc())
+        )
+        return list(result.all())

--- a/app/services/investment_stages/rate_limited_provider.py
+++ b/app/services/investment_stages/rate_limited_provider.py
@@ -70,6 +70,11 @@ class RateLimitedGeminiProvider:
         except AiProviderError as exc:
             # Detect 429 / quota-exceeded and record to rate limiter
             msg = (exc.detail or str(exc)).lower()
-            if "429" in msg or "quota" in msg or "rate" in msg or "resource_exhausted" in msg:
+            if (
+                "429" in msg
+                or "quota" in msg
+                or "rate" in msg
+                or "resource_exhausted" in msg
+            ):
                 await self._rate_limiter.mark_limited(model_name, api_key_hint)
             raise

--- a/app/services/investment_stages/rate_limited_provider.py
+++ b/app/services/investment_stages/rate_limited_provider.py
@@ -1,0 +1,75 @@
+"""Rate-limited LLM provider wrapper for staged report pipeline (ROB-279).
+
+Wraps GeminiProvider with ModelRateLimiter consultation per ROB-279 spec.
+Falls back to next model on rate-limited; records 429s.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.model_rate_limiter import ModelRateLimiter
+from app.services.ai_providers.base import AiProviderError, AiProviderResult
+from app.services.ai_providers.gemini_provider import GeminiProvider
+
+_logger = logging.getLogger(__name__)
+
+
+class RateLimitedGeminiProvider:
+    """Thin facade: same .ask(system_prompt, user_message, ...) signature as
+    GeminiProvider, but consults ModelRateLimiter before/after each call.
+    Used by stage reducers and the final composer.
+    """
+
+    def __init__(
+        self,
+        provider: GeminiProvider,
+        rate_limiter: ModelRateLimiter | None = None,
+    ) -> None:
+        self._provider = provider
+        self._rate_limiter = rate_limiter or ModelRateLimiter()
+
+    # Expose provider_name / default_model so callers that duck-type the
+    # underlying GeminiProvider still work.
+    @property
+    def provider_name(self) -> str:
+        return self._provider.provider_name
+
+    @property
+    def default_model(self) -> str:
+        return self._provider.default_model
+
+    async def ask(
+        self,
+        system_prompt: str,
+        user_message: str,
+        model: str | None = None,
+        timeout: float = 60.0,
+    ) -> AiProviderResult:
+        model_name = model or self._provider.default_model
+        # Use a short, non-secret hint derived from the model name for Redis keys.
+        api_key_hint = model_name
+
+        if await self._rate_limiter.is_model_limited(model_name, api_key_hint):
+            _logger.warning(
+                "rob-279 rate_limiter: model %s rate-limited; raising AiProviderError",
+                model_name,
+            )
+            raise AiProviderError(
+                user_message=f"model {model_name} rate-limited per ModelRateLimiter",
+                detail="rate-limited",
+            )
+
+        try:
+            return await self._provider.ask(
+                system_prompt=system_prompt,
+                user_message=user_message,
+                model=model,
+                timeout=timeout,
+            )
+        except AiProviderError as exc:
+            # Detect 429 / quota-exceeded and record to rate limiter
+            msg = (exc.detail or str(exc)).lower()
+            if "429" in msg or "quota" in msg or "rate" in msg or "resource_exhausted" in msg:
+                await self._rate_limiter.mark_limited(model_name, api_key_hint)
+            raise

--- a/app/services/investment_stages/repository.py
+++ b/app/services/investment_stages/repository.py
@@ -1,0 +1,103 @@
+"""Append-only repository for stage runs/artifacts (ROB-279)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+from app.schemas.investment_stages import StageArtifactPayload
+
+
+class AppendOnlyViolation(Exception):
+    """Raised when caller attempts to overwrite an existing stage artifact."""
+
+
+class InvestmentStagesRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_run(
+        self,
+        *,
+        snapshot_bundle_uuid: uuid.UUID,
+        market: str,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        policy_version: str = "v1",
+        generator_version: str = "v1",
+    ) -> InvestmentStageRun:
+        run = InvestmentStageRun(
+            snapshot_bundle_uuid=snapshot_bundle_uuid,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            policy_version=policy_version,
+            generator_version=generator_version,
+        )
+        self._session.add(run)
+        await self._session.flush()
+        await self._session.refresh(run)
+        return run
+
+    async def persist_artifact(
+        self, run_uuid: uuid.UUID, payload: StageArtifactPayload
+    ) -> InvestmentStageArtifact:
+        artifact = InvestmentStageArtifact(
+            run_uuid=run_uuid,
+            stage_type=payload.stage_type,
+            verdict=payload.verdict.value,
+            confidence=payload.confidence,
+            summary=payload.summary,
+            key_points=payload.key_points,
+            buy_evidence=payload.buy_evidence,
+            sell_evidence=payload.sell_evidence,
+            risk_evidence=payload.risk_evidence,
+            missing_data=payload.missing_data,
+            cited_snapshot_uuids=[c.snapshot_uuid for c in payload.cited_snapshots],
+            freshness_summary=payload.freshness_summary,
+            model_name=payload.model_name,
+            prompt_version=payload.prompt_version,
+        )
+        self._session.add(artifact)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            if "ix_investment_stage_artifacts_run_stage" in str(exc):
+                raise AppendOnlyViolation(
+                    f"stage_type={payload.stage_type} already persisted for run {run_uuid}"
+                ) from exc
+            raise
+        await self._session.refresh(artifact)
+        return artifact
+
+    async def complete_run(self, run_uuid: uuid.UUID, *, status: str) -> None:
+        run = await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        if run is None:
+            raise ValueError(f"run not found: {run_uuid}")
+        if status not in {"completed", "failed", "blocked"}:
+            raise ValueError(f"invalid terminal status: {status}")
+        run.status = status
+        run.completed_at = dt.datetime.now(tz=dt.UTC)
+        await self._session.flush()
+
+    async def get_run(self, run_uuid: uuid.UUID) -> InvestmentStageRun | None:
+        return await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+
+    async def list_artifacts_for_run(
+        self, run_uuid: uuid.UUID
+    ) -> list[InvestmentStageArtifact]:
+        result = await self._session.scalars(
+            select(InvestmentStageArtifact)
+            .where(InvestmentStageArtifact.run_uuid == run_uuid)
+            .order_by(InvestmentStageArtifact.created_at)
+        )
+        return list(result.all())

--- a/app/services/investment_stages/stage_runner.py
+++ b/app/services/investment_stages/stage_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import defaultdict
-from typing import Iterable
+from collections.abc import Iterable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/app/services/investment_stages/stage_runner.py
+++ b/app/services/investment_stages/stage_runner.py
@@ -1,0 +1,102 @@
+"""Stage runner orchestrator (ROB-279)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from typing import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageRun
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_snapshots.read_service import SnapshotBundleReadService
+from app.services.investment_stages.repository import InvestmentStagesRepository
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class StageRunner:
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        bundle_read_service: SnapshotBundleReadService | object,
+        stages: Iterable[Stage],
+    ) -> None:
+        self._session = session
+        self._bundle_read = bundle_read_service
+        self._stages = list(stages)
+        self._repo = InvestmentStagesRepository(session)
+
+    async def run(
+        self,
+        *,
+        snapshot_bundle_uuid: uuid.UUID,
+        market: str,
+        market_session: str | None,
+        account_scope: str | None,
+        policy_version: str = "v1",
+        generator_version: str = "v1",
+    ) -> InvestmentStageRun:
+        run = await self._repo.create_run(
+            snapshot_bundle_uuid=snapshot_bundle_uuid,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            policy_version=policy_version,
+            generator_version=generator_version,
+        )
+
+        bundle_response = await self._bundle_read.get_bundle(bundle_uuid=snapshot_bundle_uuid)
+        snapshots_by_kind: dict[str, list] = defaultdict(list)
+        for item in getattr(bundle_response, "items", []):
+            snapshot = getattr(item, "snapshot", None) or item
+            kind = getattr(snapshot, "snapshot_kind", None)
+            if kind:
+                snapshots_by_kind[kind].append(snapshot)
+
+        bundle = getattr(bundle_response, "bundle", None)
+        ctx = StageContext(
+            bundle_uuid=snapshot_bundle_uuid,
+            snapshots_by_kind=dict(snapshots_by_kind),
+            bundle_metadata={
+                "status": getattr(bundle, "status", None),
+                "freshness_summary": getattr(bundle, "freshness_summary", None),
+            },
+            prior_artifacts={},
+        )
+
+        for stage in self._stages:
+            try:
+                payload = await stage.run(ctx)
+            except UnavailableStageError as exc:
+                _logger.info("stage %s unavailable: %s", stage.stage_type, exc)
+                payload = StageArtifactPayload(
+                    stage_type=stage.stage_type,
+                    verdict=StageVerdict.UNAVAILABLE,
+                    confidence=0,
+                    summary=str(exc),
+                    missing_data=[stage.stage_type],
+                )
+            except Exception as exc:  # noqa: BLE001
+                _logger.exception("stage %s failed", stage.stage_type)
+                payload = StageArtifactPayload(
+                    stage_type=stage.stage_type,
+                    verdict=StageVerdict.UNAVAILABLE,
+                    confidence=0,
+                    summary=f"stage error: {exc!r}",
+                    missing_data=[stage.stage_type],
+                )
+            await self._repo.persist_artifact(run.run_uuid, payload)
+            ctx.prior_artifacts[stage.stage_type] = payload
+
+        await self._repo.complete_run(run.run_uuid, status="completed")
+        await self._session.refresh(run)
+        return run

--- a/app/services/investment_stages/stage_runner.py
+++ b/app/services/investment_stages/stage_runner.py
@@ -54,7 +54,9 @@ class StageRunner:
             generator_version=generator_version,
         )
 
-        bundle_response = await self._bundle_read.get_bundle(bundle_uuid=snapshot_bundle_uuid)
+        bundle_response = await self._bundle_read.get_bundle(
+            bundle_uuid=snapshot_bundle_uuid
+        )
         snapshots_by_kind: dict[str, list] = defaultdict(list)
         for item in getattr(bundle_response, "items", []):
             snapshot = getattr(item, "snapshot", None) or item

--- a/app/services/investment_stages/stages/__init__.py
+++ b/app/services/investment_stages/stages/__init__.py
@@ -1,0 +1,1 @@
+# Empty init for stages

--- a/app/services/investment_stages/stages/base.py
+++ b/app/services/investment_stages/stages/base.py
@@ -1,0 +1,35 @@
+"""Stage protocol and shared context (ROB-279)."""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from typing import Any, Protocol
+
+from app.models.investment_snapshots import InvestmentSnapshot
+from app.schemas.investment_stages import StageArtifactPayload
+
+
+class UnavailableStageError(Exception):
+    """Raised by a stage when required snapshots are absent.
+    The runner converts this to an `UNAVAILABLE` artifact rather than failing the run."""
+
+
+@dataclasses.dataclass(frozen=True)
+class StageContext:
+    bundle_uuid: uuid.UUID
+    snapshots_by_kind: dict[str, list[InvestmentSnapshot]]
+    bundle_metadata: dict[str, Any]
+    prior_artifacts: dict[str, StageArtifactPayload] = dataclasses.field(default_factory=dict)
+
+    def snapshots_for(self, kind: str) -> list[InvestmentSnapshot]:
+        return self.snapshots_by_kind.get(kind, [])
+
+    def artifact_for(self, stage_type: str) -> StageArtifactPayload | None:
+        return self.prior_artifacts.get(stage_type)
+
+
+class Stage(Protocol):
+    stage_type: str
+
+    async def run(self, context: StageContext) -> StageArtifactPayload: ...

--- a/app/services/investment_stages/stages/base.py
+++ b/app/services/investment_stages/stages/base.py
@@ -20,7 +20,9 @@ class StageContext:
     bundle_uuid: uuid.UUID
     snapshots_by_kind: dict[str, list[InvestmentSnapshot]]
     bundle_metadata: dict[str, Any]
-    prior_artifacts: dict[str, StageArtifactPayload] = dataclasses.field(default_factory=dict)
+    prior_artifacts: dict[str, StageArtifactPayload] = dataclasses.field(
+        default_factory=dict
+    )
 
     def snapshots_for(self, kind: str) -> list[InvestmentSnapshot]:
         return self.snapshots_by_kind.get(kind, [])

--- a/app/services/investment_stages/stages/bear_reducer.py
+++ b/app/services/investment_stages/stages/bear_reducer.py
@@ -2,121 +2,40 @@
 
 from __future__ import annotations
 
-import json
-import logging
+from typing import Any
 
-from app.schemas.investment_stages import (
-    StageArtifactPayload,
-    StageCitation,
-    StageVerdict,
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.llm_reducer import (
+    LLMReducerConfig,
+    LLMReducerStage,
 )
-from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
-from app.services.investment_stages.stages.base import StageContext
 
-_logger = logging.getLogger(__name__)
+_BEAR_CONFIG = LLMReducerConfig(
+    stage_type="bear_reducer",
+    system_prompt=(
+        "You are a professional financial analyst. Synthesize the BEAR/RISK CASE "
+        "from intermediate stage analyses and reply only with valid JSON."
+    ),
+    schema_lines=(
+        '  "verdict": "bear" | "neutral" | "unavailable",',
+        '  "confidence": int (0 to 100),',
+        '  "summary": "str synthesizing the negative thesis",',
+        '  "key_points": ["point 1", "point 2"],',
+        '  "sell_evidence": ["evidence 1", "evidence 2"],',
+        '  "risk_evidence": ["risk 1", "risk 2"],',
+        '  "missing_data": ["any absent data encountered"]',
+    ),
+    detail_fields=("key_points", "risk_evidence", "sell_evidence"),
+    evidence_fields=("sell_evidence", "risk_evidence"),
+    fallback_fields=("sell_evidence", "risk_evidence"),
+    evidence_verdict=StageVerdict.BEAR,
+    no_evidence_summary="no bear evidence",
+    llm_default_summary="Bear case synthesis completed",
+    llm_failure_summary_prefix="Fallback synthesis",
+)
 
 
-class BearReducerStage:
-    stage_type = "bear_reducer"
-
-    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
-        self._provider = provider
-        self._budget = budget
-
-    async def run(self, context: StageContext) -> StageArtifactPayload:
-        # Collect prior evidence first (before consuming budget)
-        prior_details = []
-        sell_lines: list[str] = []
-        risk_lines: list[str] = []
-        citations: list[StageCitation] = []
-        for stype, art in context.prior_artifacts.items():
-            prior_details.append(
-                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
-                f"Summary: {art.summary}\n"
-                f"Key Points: {art.key_points}\n"
-                f"Risk Evidence: {art.risk_evidence}\n"
-                f"Sell Evidence: {art.sell_evidence}\n"
-            )
-            sell_lines.extend(art.sell_evidence or [])
-            risk_lines.extend(art.risk_evidence or [])
-            for cite in art.cited_snapshots:
-                citations.append(cite)
-
-        try:
-            self._budget.consume(self.stage_type)
-        except BudgetExceeded:
-            _logger.info("bear_reducer: budget exhausted, deterministic fallback")
-            bear_lines = sell_lines or risk_lines
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.BEAR if bear_lines else StageVerdict.NEUTRAL,
-                confidence=40 if bear_lines else 20,
-                summary="; ".join(bear_lines[:10]) or "no bear evidence",
-                sell_evidence=sell_lines,
-                risk_evidence=risk_lines,
-                cited_snapshots=citations,
-                model_name=None,
-                prompt_version=None,
-            )
-
-        prompt = (
-            "You are a professional financial analyst. Your task is to synthesize the BEAR/RISK CASE "
-            "based on the following intermediate stage analyses. You MUST reply ONLY with a valid "
-            "JSON object containing the specified keys. Do not include markdown code blocks like ```json."
-        )
-
-        user_msg = (
-            f"Intermediate Stage Outputs:\n"
-            f"{chr(10).join(prior_details)}\n\n"
-            f"Provide a JSON object conforming exactly to this schema:\n"
-            f"{{\n"
-            f'  "verdict": "bear" | "neutral" | "unavailable",\n'
-            f'  "confidence": int (0 to 100),\n'
-            f'  "summary": "str synthesizing the negative thesis",\n'
-            f'  "key_points": ["point 1", "point 2"],\n'
-            f'  "sell_evidence": ["evidence 1", "evidence 2"],\n'
-            f'  "risk_evidence": ["risk 1", "risk 2"],\n'
-            f'  "missing_data": ["any absent data encountered"]\n'
-            f"}}\n"
-        )
-
-        try:
-            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
-            text = res.answer.strip()
-            if text.startswith("```"):
-                lines = text.splitlines()
-                if lines[0].startswith("```"):
-                    lines = lines[1:]
-                if lines[-1].startswith("```"):
-                    lines = lines[:-1]
-                text = "\n".join(lines).strip()
-
-            data = json.loads(text)
-            verdict_str = data.get("verdict", "neutral")
-            verdict = StageVerdict(verdict_str)
-
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=verdict,
-                confidence=int(data.get("confidence", 50)),
-                summary=data.get("summary", "Bear case synthesis completed"),
-                key_points=data.get("key_points", []),
-                sell_evidence=data.get("sell_evidence", []),
-                risk_evidence=data.get("risk_evidence", []),
-                cited_snapshots=citations,
-                missing_data=data.get("missing_data", []),
-                model_name=res.model,
-                prompt_version="v1",
-            )
-        except Exception as exc:
-            _logger.exception(
-                "Failed to run bear_reducer via LLM, falling back to deterministic neutral"
-            )
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.NEUTRAL,
-                confidence=20,
-                summary=f"Fallback synthesis (LLM failed: {exc!r})",
-                cited_snapshots=citations,
-                missing_data=[self.stage_type],
-            )
+class BearReducerStage(LLMReducerStage):
+    def __init__(self, provider: Any, budget: StageLLMBudget) -> None:
+        super().__init__(provider, budget, _BEAR_CONFIG)

--- a/app/services/investment_stages/stages/bear_reducer.py
+++ b/app/services/investment_stages/stages/bear_reducer.py
@@ -10,8 +10,7 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.ai_providers.gemini_provider import GeminiProvider
-from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
 from app.services.investment_stages.stages.base import StageContext
 
 _logger = logging.getLogger(__name__)
@@ -20,15 +19,15 @@ _logger = logging.getLogger(__name__)
 class BearReducerStage:
     stage_type = "bear_reducer"
 
-    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
         self._provider = provider
         self._budget = budget
 
     async def run(self, context: StageContext) -> StageArtifactPayload:
-        self._budget.consume(self.stage_type)
-
-        # Collect prior evidence
+        # Collect prior evidence first (before consuming budget)
         prior_details = []
+        sell_lines: list[str] = []
+        risk_lines: list[str] = []
         citations: list[StageCitation] = []
         for stype, art in context.prior_artifacts.items():
             prior_details.append(
@@ -38,8 +37,27 @@ class BearReducerStage:
                 f"Risk Evidence: {art.risk_evidence}\n"
                 f"Sell Evidence: {art.sell_evidence}\n"
             )
+            sell_lines.extend(art.sell_evidence or [])
+            risk_lines.extend(art.risk_evidence or [])
             for cite in art.cited_snapshots:
                 citations.append(cite)
+
+        try:
+            self._budget.consume(self.stage_type)
+        except BudgetExceeded:
+            _logger.info("bear_reducer: budget exhausted, deterministic fallback")
+            bear_lines = sell_lines or risk_lines
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.BEAR if bear_lines else StageVerdict.NEUTRAL,
+                confidence=40 if bear_lines else 20,
+                summary="; ".join(bear_lines[:10]) or "no bear evidence",
+                sell_evidence=sell_lines,
+                risk_evidence=risk_lines,
+                cited_snapshots=citations,
+                model_name=None,
+                prompt_version=None,
+            )
 
         prompt = (
             "You are a professional financial analyst. Your task is to synthesize the BEAR/RISK CASE "

--- a/app/services/investment_stages/stages/bear_reducer.py
+++ b/app/services/investment_stages/stages/bear_reducer.py
@@ -1,0 +1,103 @@
+"""LLM Bear Reducer Stage (ROB-279)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.ai_providers.gemini_provider import GeminiProvider
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+
+_logger = logging.getLogger(__name__)
+
+
+class BearReducerStage:
+    stage_type = "bear_reducer"
+
+    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+        self._provider = provider
+        self._budget = budget
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        self._budget.consume(self.stage_type)
+
+        # Collect prior evidence
+        prior_details = []
+        citations: list[StageCitation] = []
+        for stype, art in context.prior_artifacts.items():
+            prior_details.append(
+                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
+                f"Summary: {art.summary}\n"
+                f"Key Points: {art.key_points}\n"
+                f"Risk Evidence: {art.risk_evidence}\n"
+                f"Sell Evidence: {art.sell_evidence}\n"
+            )
+            for cite in art.cited_snapshots:
+                citations.append(cite)
+
+        prompt = (
+            "You are a professional financial analyst. Your task is to synthesize the BEAR/RISK CASE "
+            "based on the following intermediate stage analyses. You MUST reply ONLY with a valid "
+            "JSON object containing the specified keys. Do not include markdown code blocks like ```json."
+        )
+
+        user_msg = (
+            f"Intermediate Stage Outputs:\n"
+            f"{chr(10).join(prior_details)}\n\n"
+            f"Provide a JSON object conforming exactly to this schema:\n"
+            f"{{\n"
+            f'  "verdict": "bear" | "neutral" | "unavailable",\n'
+            f'  "confidence": int (0 to 100),\n'
+            f'  "summary": "str synthesizing the negative thesis",\n'
+            f'  "key_points": ["point 1", "point 2"],\n'
+            f'  "sell_evidence": ["evidence 1", "evidence 2"],\n'
+            f'  "risk_evidence": ["risk 1", "risk 2"],\n'
+            f'  "missing_data": ["any absent data encountered"]\n'
+            f"}}\n"
+        )
+
+        try:
+            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
+            text = res.answer.strip()
+            if text.startswith("```"):
+                lines = text.splitlines()
+                if lines[0].startswith("```"):
+                    lines = lines[1:]
+                if lines[-1].startswith("```"):
+                    lines = lines[:-1]
+                text = "\n".join(lines).strip()
+
+            data = json.loads(text)
+            verdict_str = data.get("verdict", "neutral")
+            verdict = StageVerdict(verdict_str)
+
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=verdict,
+                confidence=int(data.get("confidence", 50)),
+                summary=data.get("summary", "Bear case synthesis completed"),
+                key_points=data.get("key_points", []),
+                sell_evidence=data.get("sell_evidence", []),
+                risk_evidence=data.get("risk_evidence", []),
+                cited_snapshots=citations,
+                missing_data=data.get("missing_data", []),
+                model_name=res.model,
+                prompt_version="v1",
+            )
+        except Exception as exc:
+            _logger.exception("Failed to run bear_reducer via LLM, falling back to deterministic neutral")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.NEUTRAL,
+                confidence=20,
+                summary=f"Fallback synthesis (LLM failed: {exc!r})",
+                cited_snapshots=citations,
+                missing_data=[self.stage_type],
+            )

--- a/app/services/investment_stages/stages/bear_reducer.py
+++ b/app/services/investment_stages/stages/bear_reducer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from app.schemas.investment_stages import (
     StageArtifactPayload,

--- a/app/services/investment_stages/stages/bear_reducer.py
+++ b/app/services/investment_stages/stages/bear_reducer.py
@@ -109,7 +109,9 @@ class BearReducerStage:
                 prompt_version="v1",
             )
         except Exception as exc:
-            _logger.exception("Failed to run bear_reducer via LLM, falling back to deterministic neutral")
+            _logger.exception(
+                "Failed to run bear_reducer via LLM, falling back to deterministic neutral"
+            )
             return StageArtifactPayload(
                 stage_type=self.stage_type,
                 verdict=StageVerdict.NEUTRAL,

--- a/app/services/investment_stages/stages/bull_reducer.py
+++ b/app/services/investment_stages/stages/bull_reducer.py
@@ -10,8 +10,7 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.ai_providers.gemini_provider import GeminiProvider
-from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
 from app.services.investment_stages.stages.base import StageContext
 
 _logger = logging.getLogger(__name__)
@@ -20,15 +19,14 @@ _logger = logging.getLogger(__name__)
 class BullReducerStage:
     stage_type = "bull_reducer"
 
-    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
         self._provider = provider
         self._budget = budget
 
     async def run(self, context: StageContext) -> StageArtifactPayload:
-        self._budget.consume(self.stage_type)
-
-        # Collect prior evidence
+        # Collect prior evidence first (before consuming budget)
         prior_details = []
+        buy_lines: list[str] = []
         citations: list[StageCitation] = []
         for stype, art in context.prior_artifacts.items():
             prior_details.append(
@@ -37,8 +35,24 @@ class BullReducerStage:
                 f"Key Points: {art.key_points}\n"
                 f"Buy Evidence: {art.buy_evidence}\n"
             )
+            buy_lines.extend(art.buy_evidence or [])
             for cite in art.cited_snapshots:
                 citations.append(cite)
+
+        try:
+            self._budget.consume(self.stage_type)
+        except BudgetExceeded:
+            _logger.info("bull_reducer: budget exhausted, deterministic fallback")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.BULL if buy_lines else StageVerdict.NEUTRAL,
+                confidence=40 if buy_lines else 20,
+                summary="; ".join(buy_lines[:10]) or "no buy evidence",
+                buy_evidence=buy_lines,
+                cited_snapshots=citations,
+                model_name=None,
+                prompt_version=None,
+            )
 
         prompt = (
             "You are a professional financial analyst. Your task is to synthesize the BULL CASE "

--- a/app/services/investment_stages/stages/bull_reducer.py
+++ b/app/services/investment_stages/stages/bull_reducer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from app.schemas.investment_stages import (
     StageArtifactPayload,

--- a/app/services/investment_stages/stages/bull_reducer.py
+++ b/app/services/investment_stages/stages/bull_reducer.py
@@ -2,115 +2,39 @@
 
 from __future__ import annotations
 
-import json
-import logging
+from typing import Any
 
-from app.schemas.investment_stages import (
-    StageArtifactPayload,
-    StageCitation,
-    StageVerdict,
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.llm_reducer import (
+    LLMReducerConfig,
+    LLMReducerStage,
 )
-from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
-from app.services.investment_stages.stages.base import StageContext
 
-_logger = logging.getLogger(__name__)
+_BULL_CONFIG = LLMReducerConfig(
+    stage_type="bull_reducer",
+    system_prompt=(
+        "You are a professional financial analyst. Synthesize the BULL CASE "
+        "from intermediate stage analyses and reply only with valid JSON."
+    ),
+    schema_lines=(
+        '  "verdict": "bull" | "neutral" | "unavailable",',
+        '  "confidence": int (0 to 100),',
+        '  "summary": "str synthesizing the positive thesis",',
+        '  "key_points": ["point 1", "point 2"],',
+        '  "buy_evidence": ["evidence 1", "evidence 2"],',
+        '  "missing_data": ["any absent data encountered"]',
+    ),
+    detail_fields=("key_points", "buy_evidence"),
+    evidence_fields=("buy_evidence",),
+    fallback_fields=("buy_evidence",),
+    evidence_verdict=StageVerdict.BULL,
+    no_evidence_summary="no buy evidence",
+    llm_default_summary="Bull case synthesis completed",
+    llm_failure_summary_prefix="Fallback synthesis",
+)
 
 
-class BullReducerStage:
-    stage_type = "bull_reducer"
-
-    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
-        self._provider = provider
-        self._budget = budget
-
-    async def run(self, context: StageContext) -> StageArtifactPayload:
-        # Collect prior evidence first (before consuming budget)
-        prior_details = []
-        buy_lines: list[str] = []
-        citations: list[StageCitation] = []
-        for stype, art in context.prior_artifacts.items():
-            prior_details.append(
-                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
-                f"Summary: {art.summary}\n"
-                f"Key Points: {art.key_points}\n"
-                f"Buy Evidence: {art.buy_evidence}\n"
-            )
-            buy_lines.extend(art.buy_evidence or [])
-            for cite in art.cited_snapshots:
-                citations.append(cite)
-
-        try:
-            self._budget.consume(self.stage_type)
-        except BudgetExceeded:
-            _logger.info("bull_reducer: budget exhausted, deterministic fallback")
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.BULL if buy_lines else StageVerdict.NEUTRAL,
-                confidence=40 if buy_lines else 20,
-                summary="; ".join(buy_lines[:10]) or "no buy evidence",
-                buy_evidence=buy_lines,
-                cited_snapshots=citations,
-                model_name=None,
-                prompt_version=None,
-            )
-
-        prompt = (
-            "You are a professional financial analyst. Your task is to synthesize the BULL CASE "
-            "based on the following intermediate stage analyses. You MUST reply ONLY with a valid "
-            "JSON object containing the specified keys. Do not include markdown code blocks like ```json."
-        )
-
-        user_msg = (
-            f"Intermediate Stage Outputs:\n"
-            f"{chr(10).join(prior_details)}\n\n"
-            f"Provide a JSON object conforming exactly to this schema:\n"
-            f"{{\n"
-            f'  "verdict": "bull" | "neutral" | "unavailable",\n'
-            f'  "confidence": int (0 to 100),\n'
-            f'  "summary": "str synthesizing the positive thesis",\n'
-            f'  "key_points": ["point 1", "point 2"],\n'
-            f'  "buy_evidence": ["evidence 1", "evidence 2"],\n'
-            f'  "missing_data": ["any absent data encountered"]\n'
-            f"}}\n"
-        )
-
-        try:
-            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
-            text = res.answer.strip()
-            # Clean possible markdown wrap
-            if text.startswith("```"):
-                lines = text.splitlines()
-                if lines[0].startswith("```"):
-                    lines = lines[1:]
-                if lines[-1].startswith("```"):
-                    lines = lines[:-1]
-                text = "\n".join(lines).strip()
-
-            data = json.loads(text)
-            verdict_str = data.get("verdict", "neutral")
-            verdict = StageVerdict(verdict_str)
-
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=verdict,
-                confidence=int(data.get("confidence", 50)),
-                summary=data.get("summary", "Bull case synthesis completed"),
-                key_points=data.get("key_points", []),
-                buy_evidence=data.get("buy_evidence", []),
-                cited_snapshots=citations,
-                missing_data=data.get("missing_data", []),
-                model_name=res.model,
-                prompt_version="v1",
-            )
-        except Exception as exc:
-            _logger.exception(
-                "Failed to run bull_reducer via LLM, falling back to deterministic neutral"
-            )
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.NEUTRAL,
-                confidence=20,
-                summary=f"Fallback synthesis (LLM failed: {exc!r})",
-                cited_snapshots=citations,
-                missing_data=[self.stage_type],
-            )
+class BullReducerStage(LLMReducerStage):
+    def __init__(self, provider: Any, budget: StageLLMBudget) -> None:
+        super().__init__(provider, budget, _BULL_CONFIG)

--- a/app/services/investment_stages/stages/bull_reducer.py
+++ b/app/services/investment_stages/stages/bull_reducer.py
@@ -1,0 +1,101 @@
+"""LLM Bull Reducer Stage (ROB-279)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.ai_providers.gemini_provider import GeminiProvider
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+
+_logger = logging.getLogger(__name__)
+
+
+class BullReducerStage:
+    stage_type = "bull_reducer"
+
+    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+        self._provider = provider
+        self._budget = budget
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        self._budget.consume(self.stage_type)
+
+        # Collect prior evidence
+        prior_details = []
+        citations: list[StageCitation] = []
+        for stype, art in context.prior_artifacts.items():
+            prior_details.append(
+                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
+                f"Summary: {art.summary}\n"
+                f"Key Points: {art.key_points}\n"
+                f"Buy Evidence: {art.buy_evidence}\n"
+            )
+            for cite in art.cited_snapshots:
+                citations.append(cite)
+
+        prompt = (
+            "You are a professional financial analyst. Your task is to synthesize the BULL CASE "
+            "based on the following intermediate stage analyses. You MUST reply ONLY with a valid "
+            "JSON object containing the specified keys. Do not include markdown code blocks like ```json."
+        )
+
+        user_msg = (
+            f"Intermediate Stage Outputs:\n"
+            f"{chr(10).join(prior_details)}\n\n"
+            f"Provide a JSON object conforming exactly to this schema:\n"
+            f"{{\n"
+            f'  "verdict": "bull" | "neutral" | "unavailable",\n'
+            f'  "confidence": int (0 to 100),\n'
+            f'  "summary": "str synthesizing the positive thesis",\n'
+            f'  "key_points": ["point 1", "point 2"],\n'
+            f'  "buy_evidence": ["evidence 1", "evidence 2"],\n'
+            f'  "missing_data": ["any absent data encountered"]\n'
+            f"}}\n"
+        )
+
+        try:
+            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
+            text = res.answer.strip()
+            # Clean possible markdown wrap
+            if text.startswith("```"):
+                lines = text.splitlines()
+                if lines[0].startswith("```"):
+                    lines = lines[1:]
+                if lines[-1].startswith("```"):
+                    lines = lines[:-1]
+                text = "\n".join(lines).strip()
+
+            data = json.loads(text)
+            verdict_str = data.get("verdict", "neutral")
+            verdict = StageVerdict(verdict_str)
+
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=verdict,
+                confidence=int(data.get("confidence", 50)),
+                summary=data.get("summary", "Bull case synthesis completed"),
+                key_points=data.get("key_points", []),
+                buy_evidence=data.get("buy_evidence", []),
+                cited_snapshots=citations,
+                missing_data=data.get("missing_data", []),
+                model_name=res.model,
+                prompt_version="v1",
+            )
+        except Exception as exc:
+            _logger.exception("Failed to run bull_reducer via LLM, falling back to deterministic neutral")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.NEUTRAL,
+                confidence=20,
+                summary=f"Fallback synthesis (LLM failed: {exc!r})",
+                cited_snapshots=citations,
+                missing_data=[self.stage_type],
+            )

--- a/app/services/investment_stages/stages/bull_reducer.py
+++ b/app/services/investment_stages/stages/bull_reducer.py
@@ -103,7 +103,9 @@ class BullReducerStage:
                 prompt_version="v1",
             )
         except Exception as exc:
-            _logger.exception("Failed to run bull_reducer via LLM, falling back to deterministic neutral")
+            _logger.exception(
+                "Failed to run bull_reducer via LLM, falling back to deterministic neutral"
+            )
             return StageArtifactPayload(
                 stage_type=self.stage_type,
                 verdict=StageVerdict.NEUTRAL,

--- a/app/services/investment_stages/stages/candidate_universe.py
+++ b/app/services/investment_stages/stages/candidate_universe.py
@@ -1,0 +1,54 @@
+"""Deterministic candidate_universe stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class CandidateUniverseStage:
+    stage_type = "candidate_universe"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("candidate_universe")
+        if not snapshots:
+            raise UnavailableStageError("candidate_universe snapshot missing")
+        snap = snapshots[0]
+        candidates = (snap.payload_json or {}).get("candidates", [])
+        top = sorted(candidates, key=lambda c: c.get("score", 0.0), reverse=True)[:5]
+
+        if not top:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 20
+            summary = "no candidates returned by screener"
+        elif top[0].get("score", 0.0) >= 7.0:
+            verdict = StageVerdict.BULL
+            confidence = min(40 + len(top) * 8, 75)
+            summary = "top candidates: " + ", ".join(c.get("symbol", "?") for c in top)
+        else:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 35
+            summary = "candidates present but low score"
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=confidence,
+            summary=summary,
+            key_points=[
+                f"{c.get('symbol', '?')} (score={c.get('score', 0):.1f}): {c.get('reason', '')}"
+                for c in top
+            ],
+            buy_evidence=[c.get("symbol", "?") for c in top] if verdict == StageVerdict.BULL else [],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="candidate_universe",
+                    payload_path="$.candidates",
+                )
+            ],
+        )

--- a/app/services/investment_stages/stages/candidate_universe.py
+++ b/app/services/investment_stages/stages/candidate_universe.py
@@ -7,7 +7,10 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
 
 
 class CandidateUniverseStage:

--- a/app/services/investment_stages/stages/candidate_universe.py
+++ b/app/services/investment_stages/stages/candidate_universe.py
@@ -46,7 +46,9 @@ class CandidateUniverseStage:
                 f"{c.get('symbol', '?')} (score={c.get('score', 0):.1f}): {c.get('reason', '')}"
                 for c in top
             ],
-            buy_evidence=[c.get("symbol", "?") for c in top] if verdict == StageVerdict.BULL else [],
+            buy_evidence=[c.get("symbol", "?") for c in top]
+            if verdict == StageVerdict.BULL
+            else [],
             cited_snapshots=[
                 StageCitation(
                     snapshot_uuid=snap.snapshot_uuid,

--- a/app/services/investment_stages/stages/llm_reducer.py
+++ b/app/services/investment_stages/stages/llm_reducer.py
@@ -69,7 +69,6 @@ class LLMReducerStage:
                 evidence=evidence,
                 fallback_lines=fallback_lines,
                 citations=citations,
-                exhausted=True,
             )
 
         try:
@@ -124,7 +123,6 @@ class LLMReducerStage:
         evidence: dict[str, list[str]],
         fallback_lines: list[str],
         citations: list[StageCitation],
-        exhausted: bool,
     ) -> StageArtifactPayload:
         return StageArtifactPayload(
             stage_type=self.stage_type,
@@ -134,8 +132,8 @@ class LLMReducerStage:
             confidence=40 if fallback_lines else 20,
             summary="; ".join(fallback_lines[:10]) or self._config.no_evidence_summary,
             cited_snapshots=citations,
-            model_name=None if exhausted else None,
-            prompt_version=None if exhausted else None,
+            model_name=None,
+            prompt_version=None,
             buy_evidence=self._stage_evidence_values(evidence, "buy_evidence"),
             sell_evidence=self._stage_evidence_values(evidence, "sell_evidence"),
             risk_evidence=self._stage_evidence_values(evidence, "risk_evidence"),

--- a/app/services/investment_stages/stages/llm_reducer.py
+++ b/app/services/investment_stages/stages/llm_reducer.py
@@ -1,0 +1,152 @@
+"""Shared implementation for LLM-backed reducer stages."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.llm_utils import (
+    collect_prior_stage_inputs,
+    ensure_json_mapping,
+    strip_markdown_fence,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LLMReducerConfig:
+    stage_type: str
+    system_prompt: str
+    schema_lines: Sequence[str]
+    detail_fields: Sequence[str]
+    evidence_fields: Sequence[str]
+    fallback_fields: Sequence[str]
+    evidence_verdict: StageVerdict
+    no_evidence_summary: str
+    llm_default_summary: str
+    llm_failure_summary_prefix: str
+
+
+class LLMReducerStage:
+    """Common budget, prompt, parse, and fallback behavior for LLM reducers."""
+
+    stage_type: str
+
+    def __init__(
+        self, provider: Any, budget: StageLLMBudget, config: LLMReducerConfig
+    ) -> None:
+        self._provider = provider
+        self._budget = budget
+        self._config = config
+        self.stage_type = config.stage_type
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        prior_details, evidence, citations = collect_prior_stage_inputs(
+            context,
+            evidence_fields=self._config.evidence_fields,
+            detail_fields=self._config.detail_fields,
+        )
+        fallback_lines = self._fallback_lines(evidence)
+
+        try:
+            self._budget.consume(self.stage_type)
+        except BudgetExceeded:
+            _logger.info(
+                "%s: budget exhausted, deterministic fallback", self.stage_type
+            )
+            return self._fallback_payload(
+                evidence=evidence,
+                fallback_lines=fallback_lines,
+                citations=citations,
+                exhausted=True,
+            )
+
+        try:
+            res = await self._provider.ask(
+                system_prompt=self._config.system_prompt,
+                user_message=self._user_message(prior_details),
+            )
+            data = ensure_json_mapping(json.loads(strip_markdown_fence(res.answer)))
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict(data.get("verdict", "neutral")),
+                confidence=int(data.get("confidence", 50)),
+                summary=data.get("summary", self._config.llm_default_summary),
+                key_points=data.get("key_points", []),
+                cited_snapshots=citations,
+                missing_data=data.get("missing_data", []),
+                model_name=res.model,
+                prompt_version="v1",
+                buy_evidence=self._stage_evidence_values(data, "buy_evidence"),
+                sell_evidence=self._stage_evidence_values(data, "sell_evidence"),
+                risk_evidence=self._stage_evidence_values(data, "risk_evidence"),
+            )
+        except Exception as exc:
+            _logger.exception(
+                "Failed to run %s via LLM, falling back to deterministic neutral",
+                self.stage_type,
+            )
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.NEUTRAL,
+                confidence=20,
+                summary=f"{self._config.llm_failure_summary_prefix} (LLM failed: {exc!r})",
+                cited_snapshots=citations,
+                missing_data=[self.stage_type],
+            )
+
+    def _user_message(self, prior_details: Sequence[str]) -> str:
+        schema = "\n".join(self._config.schema_lines)
+        details = "\n".join(prior_details)
+        return (
+            "Intermediate Stage Outputs:\n"
+            f"{details}\n\n"
+            "Provide a JSON object conforming exactly to this schema:\n"
+            "{\n"
+            f"{schema}\n"
+            "}\n"
+        )
+
+    def _fallback_payload(
+        self,
+        *,
+        evidence: dict[str, list[str]],
+        fallback_lines: list[str],
+        citations: list[StageCitation],
+        exhausted: bool,
+    ) -> StageArtifactPayload:
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=self._config.evidence_verdict
+            if fallback_lines
+            else StageVerdict.NEUTRAL,
+            confidence=40 if fallback_lines else 20,
+            summary="; ".join(fallback_lines[:10]) or self._config.no_evidence_summary,
+            cited_snapshots=citations,
+            model_name=None if exhausted else None,
+            prompt_version=None if exhausted else None,
+            buy_evidence=self._stage_evidence_values(evidence, "buy_evidence"),
+            sell_evidence=self._stage_evidence_values(evidence, "sell_evidence"),
+            risk_evidence=self._stage_evidence_values(evidence, "risk_evidence"),
+        )
+
+    def _fallback_lines(self, evidence: dict[str, list[str]]) -> list[str]:
+        for field in self._config.fallback_fields:
+            if evidence[field]:
+                return evidence[field]
+        return []
+
+    def _stage_evidence_values(self, data: dict[str, Any], field: str) -> list[str]:
+        values = data.get(field, [])
+        return values if isinstance(values, list) else []

--- a/app/services/investment_stages/stages/llm_utils.py
+++ b/app/services/investment_stages/stages/llm_utils.py
@@ -1,0 +1,68 @@
+"""Shared helpers for LLM-backed investment stages."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from app.schemas.investment_stages import StageCitation
+from app.services.investment_stages.stages.base import StageContext
+
+
+def collect_prior_stage_inputs(
+    context: StageContext,
+    *,
+    evidence_fields: Sequence[str],
+    detail_fields: Sequence[str],
+) -> tuple[list[str], dict[str, list[str]], list[StageCitation]]:
+    """Collect prompt details, evidence lists, and citations from prior artifacts."""
+    prior_details: list[str] = []
+    evidence: dict[str, list[str]] = {field: [] for field in evidence_fields}
+    citations: list[StageCitation] = []
+
+    for stage_type, artifact in context.prior_artifacts.items():
+        detail_lines = [
+            f"=== Stage: {stage_type} (Verdict: {artifact.verdict}, Confidence: {artifact.confidence}) ===",
+            f"Summary: {artifact.summary}",
+        ]
+        for field in detail_fields:
+            detail_lines.append(
+                f"{_field_label(field)}: {getattr(artifact, field, None)}"
+            )
+        prior_details.append("\n".join(detail_lines) + "\n")
+
+        for field in evidence_fields:
+            evidence[field].extend(getattr(artifact, field, None) or [])
+        citations.extend(artifact.cited_snapshots or [])
+
+    return prior_details, evidence, citations
+
+
+def strip_markdown_fence(text: str) -> str:
+    """Return JSON text without optional Markdown code fences."""
+    clean = text.strip()
+    if not clean.startswith("```"):
+        return clean
+    lines = clean.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _field_label(field: str) -> str:
+    labels: dict[str, str] = {
+        "key_points": "Key Points",
+        "buy_evidence": "Buy Evidence",
+        "sell_evidence": "Sell Evidence",
+        "risk_evidence": "Risk Evidence",
+    }
+    return labels.get(field, field.replace("_", " ").title())
+
+
+def ensure_json_mapping(data: Any) -> dict[str, Any]:
+    """Validate that an LLM JSON parse produced an object."""
+    if isinstance(data, dict):
+        return data
+    raise ValueError("LLM response JSON must be an object")

--- a/app/services/investment_stages/stages/market.py
+++ b/app/services/investment_stages/stages/market.py
@@ -1,0 +1,53 @@
+"""Deterministic market stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+_BULL_THRESHOLD = 0.5
+_BEAR_THRESHOLD = -0.5
+
+
+class MarketStage:
+    stage_type = "market"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("market")
+        if not snapshots:
+            raise UnavailableStageError("market snapshot missing from bundle")
+
+        snapshot = snapshots[0]
+        indices = (snapshot.payload_json or {}).get("indices", {})
+        kospi = indices.get("KOSPI") or indices.get("kospi") or {}
+        change = float(kospi.get("change_percent", 0.0))
+
+        if change >= _BULL_THRESHOLD:
+            verdict = StageVerdict.BULL
+        elif change <= _BEAR_THRESHOLD:
+            verdict = StageVerdict.BEAR
+        else:
+            verdict = StageVerdict.NEUTRAL
+
+        confidence = min(int(abs(change) * 30), 90)
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=max(confidence, 30 if verdict != StageVerdict.NEUTRAL else 20),
+            summary=f"KOSPI change_percent={change:+.2f}%",
+            key_points=[f"KOSPI {change:+.2f}%"],
+            buy_evidence=[f"KOSPI 상승 {change:+.2f}%"] if verdict == StageVerdict.BULL else [],
+            sell_evidence=[f"KOSPI 하락 {change:+.2f}%"] if verdict == StageVerdict.BEAR else [],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snapshot.snapshot_uuid,
+                    snapshot_kind="market",
+                    payload_path="$.indices.KOSPI.change_percent",
+                )
+            ],
+        )

--- a/app/services/investment_stages/stages/market.py
+++ b/app/services/investment_stages/stages/market.py
@@ -7,7 +7,10 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
 
 _BULL_THRESHOLD = 0.5
 _BEAR_THRESHOLD = -0.5

--- a/app/services/investment_stages/stages/market.py
+++ b/app/services/investment_stages/stages/market.py
@@ -44,8 +44,12 @@ class MarketStage:
             confidence=max(confidence, 30 if verdict != StageVerdict.NEUTRAL else 20),
             summary=f"KOSPI change_percent={change:+.2f}%",
             key_points=[f"KOSPI {change:+.2f}%"],
-            buy_evidence=[f"KOSPI 상승 {change:+.2f}%"] if verdict == StageVerdict.BULL else [],
-            sell_evidence=[f"KOSPI 하락 {change:+.2f}%"] if verdict == StageVerdict.BEAR else [],
+            buy_evidence=[f"KOSPI 상승 {change:+.2f}%"]
+            if verdict == StageVerdict.BULL
+            else [],
+            sell_evidence=[f"KOSPI 하락 {change:+.2f}%"]
+            if verdict == StageVerdict.BEAR
+            else [],
             cited_snapshots=[
                 StageCitation(
                     snapshot_uuid=snapshot.snapshot_uuid,

--- a/app/services/investment_stages/stages/news.py
+++ b/app/services/investment_stages/stages/news.py
@@ -1,0 +1,59 @@
+"""Deterministic news stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class NewsStage:
+    stage_type = "news"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("news")
+        if not snapshots:
+            raise UnavailableStageError("news snapshot missing")
+
+        articles: list[dict] = []
+        citations: list[StageCitation] = []
+        for snap in snapshots:
+            payload = snap.payload_json or {}
+            for art in payload.get("articles", []):
+                articles.append(art)
+            citations.append(
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="news",
+                    payload_path="$.articles",
+                )
+            )
+
+        pos = sum(1 for a in articles if a.get("sentiment") == "positive")
+        neg = sum(1 for a in articles if a.get("sentiment") == "negative")
+        total = len(articles)
+        if total == 0:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 10
+        elif pos >= neg * 2 and pos >= 3:
+            verdict = StageVerdict.BULL
+            confidence = min(40 + pos * 5, 80)
+        elif neg >= pos * 2 and neg >= 3:
+            verdict = StageVerdict.BEAR
+            confidence = min(40 + neg * 5, 80)
+        else:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 30
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=confidence,
+            summary=f"{total} articles (pos={pos}, neg={neg})",
+            key_points=[a.get("title", "")[:60] for a in articles[:5]],
+            cited_snapshots=citations,
+            missing_data=[] if articles else ["news_articles"],
+        )

--- a/app/services/investment_stages/stages/news.py
+++ b/app/services/investment_stages/stages/news.py
@@ -7,7 +7,10 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
 
 
 class NewsStage:

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -1,0 +1,62 @@
+"""Deterministic portfolio+journal stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class PortfolioJournalStage:
+    stage_type = "portfolio_journal"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        portfolio_snaps = context.snapshots_for("portfolio")
+        if not portfolio_snaps:
+            raise UnavailableStageError("portfolio snapshot missing — required")
+        portfolio = portfolio_snaps[0]
+        journal_snaps = context.snapshots_for("journal")
+
+        nav = float((portfolio.payload_json or {}).get("nav_krw", 0.0))
+        buying_power = float((portfolio.payload_json or {}).get("buying_power_krw", 0.0))
+        bp_ratio = (buying_power / nav) if nav > 0 else 0.0
+
+        entries = []
+        for snap in journal_snaps:
+            entries.extend((snap.payload_json or {}).get("entries", []))
+
+        citations = [
+            StageCitation(
+                snapshot_uuid=portfolio.snapshot_uuid,
+                snapshot_kind="portfolio",
+                payload_path="$.buying_power_krw",
+            )
+        ]
+        for snap in journal_snaps:
+            citations.append(
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="journal",
+                    payload_path="$.entries",
+                )
+            )
+
+        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
+        summary = (
+            f"NAV={nav:,.0f}, buying_power_krw={buying_power:,.0f} "
+            f"({bp_ratio:.1%}), open journal: {symbols or 'none'}"
+        )
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.NEUTRAL,
+            confidence=60 if bp_ratio >= 0.05 else 40,
+            summary=summary,
+            key_points=[e.get("thesis", "") for e in entries[:5] if e.get("thesis")],
+            risk_evidence=[] if bp_ratio >= 0.05 else ["buying_power < 5% NAV"],
+            cited_snapshots=citations,
+            missing_data=[] if journal_snaps else ["journal"],
+        )

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -7,7 +7,10 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
 
 
 class PortfolioJournalStage:

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -24,7 +24,9 @@ class PortfolioJournalStage:
         journal_snaps = context.snapshots_for("journal")
 
         nav = float((portfolio.payload_json or {}).get("nav_krw", 0.0))
-        buying_power = float((portfolio.payload_json or {}).get("buying_power_krw", 0.0))
+        buying_power = float(
+            (portfolio.payload_json or {}).get("buying_power_krw", 0.0)
+        )
         bp_ratio = (buying_power / nav) if nav > 0 else 0.0
 
         entries = []

--- a/app/services/investment_stages/stages/registry.py
+++ b/app/services/investment_stages/stages/registry.py
@@ -6,10 +6,14 @@ from typing import TYPE_CHECKING
 
 from app.services.investment_stages.stages.bear_reducer import BearReducerStage
 from app.services.investment_stages.stages.bull_reducer import BullReducerStage
-from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+from app.services.investment_stages.stages.candidate_universe import (
+    CandidateUniverseStage,
+)
 from app.services.investment_stages.stages.market import MarketStage
 from app.services.investment_stages.stages.news import NewsStage
-from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+from app.services.investment_stages.stages.portfolio_journal import (
+    PortfolioJournalStage,
+)
 from app.services.investment_stages.stages.risk_review import RiskReviewStage
 from app.services.investment_stages.stages.watch_context import WatchContextStage
 

--- a/app/services/investment_stages/stages/registry.py
+++ b/app/services/investment_stages/stages/registry.py
@@ -1,0 +1,35 @@
+"""Stage registry and factory (ROB-279)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.services.investment_stages.stages.bear_reducer import BearReducerStage
+from app.services.investment_stages.stages.bull_reducer import BullReducerStage
+from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+from app.services.investment_stages.stages.market import MarketStage
+from app.services.investment_stages.stages.news import NewsStage
+from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+from app.services.investment_stages.stages.risk_review import RiskReviewStage
+from app.services.investment_stages.stages.watch_context import WatchContextStage
+
+if TYPE_CHECKING:
+    from app.services.ai_providers.gemini_provider import GeminiProvider
+    from app.services.investment_stages.budget import StageLLMBudget
+    from app.services.investment_stages.stages.base import Stage
+
+
+def get_default_v1_stages(
+    provider: GeminiProvider, budget: StageLLMBudget
+) -> list[Stage]:
+    """Returns the ordered list of default stages for ROB-279 v1."""
+    return [
+        MarketStage(),
+        NewsStage(),
+        PortfolioJournalStage(),
+        WatchContextStage(),
+        CandidateUniverseStage(),
+        BullReducerStage(provider, budget),
+        BearReducerStage(provider, budget),
+        RiskReviewStage(provider, budget),
+    ]

--- a/app/services/investment_stages/stages/risk_review.py
+++ b/app/services/investment_stages/stages/risk_review.py
@@ -1,0 +1,100 @@
+"""LLM Risk Review Stage (ROB-279)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.ai_providers.gemini_provider import GeminiProvider
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+
+_logger = logging.getLogger(__name__)
+
+
+class RiskReviewStage:
+    stage_type = "risk_review"
+
+    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+        self._provider = provider
+        self._budget = budget
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        self._budget.consume(self.stage_type)
+
+        # Collect prior evidence
+        prior_details = []
+        citations: list[StageCitation] = []
+        for stype, art in context.prior_artifacts.items():
+            prior_details.append(
+                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
+                f"Summary: {art.summary}\n"
+                f"Risk Evidence: {art.risk_evidence}\n"
+            )
+            for cite in art.cited_snapshots:
+                citations.append(cite)
+
+        prompt = (
+            "You are a professional risk manager. Your task is to provide a FINAL RISK REVIEW "
+            "based on the bull and bear case syntheses. Evaluate the overall risk-reward profile. "
+            "You MUST reply ONLY with a valid JSON object containing the specified keys. "
+            "Do not include markdown code blocks like ```json."
+        )
+
+        user_msg = (
+            f"Intermediate Stage Outputs:\n"
+            f"{chr(10).join(prior_details)}\n\n"
+            f"Provide a JSON object conforming exactly to this schema:\n"
+            f"{{\n"
+            f'  "verdict": "bull" | "bear" | "neutral" | "unavailable",\n'
+            f'  "confidence": int (0 to 100),\n'
+            f'  "summary": "str synthesizing final risk verdict",\n'
+            f'  "key_points": ["critical risk 1", "critical risk 2"],\n'
+            f'  "risk_evidence": ["risk 1", "risk 2"],\n'
+            f'  "missing_data": ["any absent data encountered"]\n'
+            f"}}\n"
+        )
+
+        try:
+            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
+            text = res.answer.strip()
+            if text.startswith("```"):
+                lines = text.splitlines()
+                if lines[0].startswith("```"):
+                    lines = lines[1:]
+                if lines[-1].startswith("```"):
+                    lines = lines[:-1]
+                text = "\n".join(lines).strip()
+
+            data = json.loads(text)
+            verdict_str = data.get("verdict", "neutral")
+            verdict = StageVerdict(verdict_str)
+
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=verdict,
+                confidence=int(data.get("confidence", 50)),
+                summary=data.get("summary", "Final risk review completed"),
+                key_points=data.get("key_points", []),
+                risk_evidence=data.get("risk_evidence", []),
+                cited_snapshots=citations,
+                missing_data=data.get("missing_data", []),
+                model_name=res.model,
+                prompt_version="v1",
+            )
+        except Exception as exc:
+            _logger.exception("Failed to run risk_review via LLM, falling back to deterministic neutral")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.NEUTRAL,
+                confidence=20,
+                summary=f"Fallback risk review (LLM failed: {exc!r})",
+                cited_snapshots=citations,
+                missing_data=[self.stage_type],
+            )

--- a/app/services/investment_stages/stages/risk_review.py
+++ b/app/services/investment_stages/stages/risk_review.py
@@ -2,114 +2,39 @@
 
 from __future__ import annotations
 
-import json
-import logging
+from typing import Any
 
-from app.schemas.investment_stages import (
-    StageArtifactPayload,
-    StageCitation,
-    StageVerdict,
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.llm_reducer import (
+    LLMReducerConfig,
+    LLMReducerStage,
 )
-from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
-from app.services.investment_stages.stages.base import StageContext
 
-_logger = logging.getLogger(__name__)
+_RISK_CONFIG = LLMReducerConfig(
+    stage_type="risk_review",
+    system_prompt=(
+        "You are a professional risk manager. Provide a final risk review "
+        "from bull and bear syntheses and reply only with valid JSON."
+    ),
+    schema_lines=(
+        '  "verdict": "bull" | "bear" | "neutral" | "unavailable",',
+        '  "confidence": int (0 to 100),',
+        '  "summary": "str synthesizing final risk verdict",',
+        '  "key_points": ["critical risk 1", "critical risk 2"],',
+        '  "risk_evidence": ["risk 1", "risk 2"],',
+        '  "missing_data": ["any absent data encountered"]',
+    ),
+    detail_fields=("risk_evidence",),
+    evidence_fields=("risk_evidence",),
+    fallback_fields=("risk_evidence",),
+    evidence_verdict=StageVerdict.BEAR,
+    no_evidence_summary="no risk evidence",
+    llm_default_summary="Final risk review completed",
+    llm_failure_summary_prefix="Fallback risk review",
+)
 
 
-class RiskReviewStage:
-    stage_type = "risk_review"
-
-    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
-        self._provider = provider
-        self._budget = budget
-
-    async def run(self, context: StageContext) -> StageArtifactPayload:
-        # Collect prior evidence first (before consuming budget)
-        prior_details = []
-        risk_lines: list[str] = []
-        citations: list[StageCitation] = []
-        for stype, art in context.prior_artifacts.items():
-            prior_details.append(
-                f"=== Stage: {stype} (Verdict: {art.verdict}, Confidence: {art.confidence}) ===\n"
-                f"Summary: {art.summary}\n"
-                f"Risk Evidence: {art.risk_evidence}\n"
-            )
-            risk_lines.extend(art.risk_evidence or [])
-            for cite in art.cited_snapshots:
-                citations.append(cite)
-
-        try:
-            self._budget.consume(self.stage_type)
-        except BudgetExceeded:
-            _logger.info("risk_review: budget exhausted, deterministic fallback")
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.BEAR if risk_lines else StageVerdict.NEUTRAL,
-                confidence=40 if risk_lines else 20,
-                summary="; ".join(risk_lines[:10]) or "no risk evidence",
-                risk_evidence=risk_lines,
-                cited_snapshots=citations,
-                model_name=None,
-                prompt_version=None,
-            )
-
-        prompt = (
-            "You are a professional risk manager. Your task is to provide a FINAL RISK REVIEW "
-            "based on the bull and bear case syntheses. Evaluate the overall risk-reward profile. "
-            "You MUST reply ONLY with a valid JSON object containing the specified keys. "
-            "Do not include markdown code blocks like ```json."
-        )
-
-        user_msg = (
-            f"Intermediate Stage Outputs:\n"
-            f"{chr(10).join(prior_details)}\n\n"
-            f"Provide a JSON object conforming exactly to this schema:\n"
-            f"{{\n"
-            f'  "verdict": "bull" | "bear" | "neutral" | "unavailable",\n'
-            f'  "confidence": int (0 to 100),\n'
-            f'  "summary": "str synthesizing final risk verdict",\n'
-            f'  "key_points": ["critical risk 1", "critical risk 2"],\n'
-            f'  "risk_evidence": ["risk 1", "risk 2"],\n'
-            f'  "missing_data": ["any absent data encountered"]\n'
-            f"}}\n"
-        )
-
-        try:
-            res = await self._provider.ask(system_prompt=prompt, user_message=user_msg)
-            text = res.answer.strip()
-            if text.startswith("```"):
-                lines = text.splitlines()
-                if lines[0].startswith("```"):
-                    lines = lines[1:]
-                if lines[-1].startswith("```"):
-                    lines = lines[:-1]
-                text = "\n".join(lines).strip()
-
-            data = json.loads(text)
-            verdict_str = data.get("verdict", "neutral")
-            verdict = StageVerdict(verdict_str)
-
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=verdict,
-                confidence=int(data.get("confidence", 50)),
-                summary=data.get("summary", "Final risk review completed"),
-                key_points=data.get("key_points", []),
-                risk_evidence=data.get("risk_evidence", []),
-                cited_snapshots=citations,
-                missing_data=data.get("missing_data", []),
-                model_name=res.model,
-                prompt_version="v1",
-            )
-        except Exception as exc:
-            _logger.exception(
-                "Failed to run risk_review via LLM, falling back to deterministic neutral"
-            )
-            return StageArtifactPayload(
-                stage_type=self.stage_type,
-                verdict=StageVerdict.NEUTRAL,
-                confidence=20,
-                summary=f"Fallback risk review (LLM failed: {exc!r})",
-                cited_snapshots=citations,
-                missing_data=[self.stage_type],
-            )
+class RiskReviewStage(LLMReducerStage):
+    def __init__(self, provider: Any, budget: StageLLMBudget) -> None:
+        super().__init__(provider, budget, _RISK_CONFIG)

--- a/app/services/investment_stages/stages/risk_review.py
+++ b/app/services/investment_stages/stages/risk_review.py
@@ -10,8 +10,7 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.ai_providers.gemini_provider import GeminiProvider
-from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
 from app.services.investment_stages.stages.base import StageContext
 
 _logger = logging.getLogger(__name__)
@@ -20,15 +19,14 @@ _logger = logging.getLogger(__name__)
 class RiskReviewStage:
     stage_type = "risk_review"
 
-    def __init__(self, provider: GeminiProvider, budget: StageLLMBudget) -> None:
+    def __init__(self, provider: object, budget: StageLLMBudget) -> None:
         self._provider = provider
         self._budget = budget
 
     async def run(self, context: StageContext) -> StageArtifactPayload:
-        self._budget.consume(self.stage_type)
-
-        # Collect prior evidence
+        # Collect prior evidence first (before consuming budget)
         prior_details = []
+        risk_lines: list[str] = []
         citations: list[StageCitation] = []
         for stype, art in context.prior_artifacts.items():
             prior_details.append(
@@ -36,8 +34,24 @@ class RiskReviewStage:
                 f"Summary: {art.summary}\n"
                 f"Risk Evidence: {art.risk_evidence}\n"
             )
+            risk_lines.extend(art.risk_evidence or [])
             for cite in art.cited_snapshots:
                 citations.append(cite)
+
+        try:
+            self._budget.consume(self.stage_type)
+        except BudgetExceeded:
+            _logger.info("risk_review: budget exhausted, deterministic fallback")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.BEAR if risk_lines else StageVerdict.NEUTRAL,
+                confidence=40 if risk_lines else 20,
+                summary="; ".join(risk_lines[:10]) or "no risk evidence",
+                risk_evidence=risk_lines,
+                cited_snapshots=citations,
+                model_name=None,
+                prompt_version=None,
+            )
 
         prompt = (
             "You are a professional risk manager. Your task is to provide a FINAL RISK REVIEW "

--- a/app/services/investment_stages/stages/risk_review.py
+++ b/app/services/investment_stages/stages/risk_review.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from app.schemas.investment_stages import (
     StageArtifactPayload,

--- a/app/services/investment_stages/stages/risk_review.py
+++ b/app/services/investment_stages/stages/risk_review.py
@@ -102,7 +102,9 @@ class RiskReviewStage:
                 prompt_version="v1",
             )
         except Exception as exc:
-            _logger.exception("Failed to run risk_review via LLM, falling back to deterministic neutral")
+            _logger.exception(
+                "Failed to run risk_review via LLM, falling back to deterministic neutral"
+            )
             return StageArtifactPayload(
                 stage_type=self.stage_type,
                 verdict=StageVerdict.NEUTRAL,

--- a/app/services/investment_stages/stages/watch_context.py
+++ b/app/services/investment_stages/stages/watch_context.py
@@ -7,7 +7,10 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
-from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
 
 
 class WatchContextStage:

--- a/app/services/investment_stages/stages/watch_context.py
+++ b/app/services/investment_stages/stages/watch_context.py
@@ -1,0 +1,40 @@
+"""Deterministic watch_context stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class WatchContextStage:
+    stage_type = "watch_context"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("watch_context")
+        if not snapshots:
+            raise UnavailableStageError("watch_context snapshot missing — required")
+
+        snap = snapshots[0]
+        payload = snap.payload_json or {}
+        active = payload.get("active_alerts", [])
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.NEUTRAL,
+            confidence=50 if active else 30,
+            summary=f"{len(active)} active watch alerts",
+            key_points=[
+                f"{a.get('symbol', '?')}: {a.get('condition', '?')}" for a in active[:5]
+            ],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="watch_context",
+                    payload_path="$.active_alerts",
+                )
+            ],
+        )

--- a/docs/superpowers/plans/2026-05-20-rob-279-staged-snapshot-backed-reports.md
+++ b/docs/superpowers/plans/2026-05-20-rob-279-staged-snapshot-backed-reports.md
@@ -1,0 +1,3807 @@
+# ROB-279 Staged Snapshot-Backed Report Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ROB-269 가 만든 immutable snapshot bundle → idempotent ingest → stale gate 토대 위에, 감사 가능한 중간 stage artifact 들로부터 final `/invest/reports` 리포트를 합성하는 staged pipeline 을 추가한다.
+
+**Architecture:** 신규 `investment_stage_runs` / `investment_stage_artifacts` 테이블을 snapshot bundle 에 귀속시키고, 8개 stage (5 deterministic + 3 LLM reducer) 가 bundle payload 만 읽어 구조화된 artifact 를 생성한다. final composer 가 artifact 들을 합쳐 기존 `InvestmentReportIngestionService.ingest()` 에 흘려보내고, stale gate 가 막아도 stage diagnostic 은 run-scoped API 로 조회된다.
+
+**Tech Stack:** Python 3.13 / FastAPI / SQLAlchemy 2 (async) / Alembic / Pydantic v2 / pytest / React + Vitest + Testing Library / Google Gemini (`model_rate_limiter` 경유).
+
+---
+
+## Linear context
+
+- Issue: https://linear.app/mgh3326/issue/ROB-279
+- Parent: ROB-269 (Done)
+- 결정 사항: 본 plan 은 issue description + "Design refinements (2026-05-20)" 코멘트 조합을 spec 으로 한다.
+
+## Risk callouts (read first)
+
+| 위험 | 영향 | 완화 |
+|---|---|---|
+| **마이그레이션 — 큰 신규 테이블 2개** | snapshot bundle 과의 FK 일관성, replication 동기화 | nullable FK, `ondelete="SET NULL"` 로 bundle 삭제 시 stage run 보존; alembic upgrade/downgrade 모두 테스트 |
+| **LLM 비용 폭증** | report 1건당 호출이 8배로 늘어날 위험 | v1 stage 8개 중 **5개는 deterministic extraction 만**, **3개 reducer + 1 composer = 최대 4 LLM 호출** 하드 캡. `model_rate_limiter` 경유 강제. budget 초과 시 reducer 를 deterministic fallback 으로 강등 |
+| **legacy `investment_report_generate_from_bundle` 호환성** | 기존 caller 가 깨지면 운영 중단 | 신규 동작은 `auto_compose=true` flag 뒤로 격리. flag 없으면 기존 `classify_items()` 경로 그대로. flag 가 false 일 때 stage run 도 생성하지 않음 |
+| **stale gate 로 blocked 된 보고서의 stage diagnostic 미조회** | "왜 막혔는지" 추적 불가 | stage run/artifact 는 `ingest()` **이전에** persist. ingest 가 실패해도 `run_uuid` 는 남고, `GET /trading/api/investment-stage-runs/{run_uuid}` 로 조회 |
+| **citation 강제 누락** | 환각/근거 없는 액션 권고 | composer 가 `cited_snapshot_uuids` 비어있는 stage artifact 의 결론은 caveat 또는 omit. acceptance test 로 보강 |
+| **append-only invariant 위반** | 과거 artifact 변조 → 감사 불가 | DB trigger 또는 repository layer 에서 `INSERT only` (UPDATE/DELETE 금지) 강제. 단위 테스트로 회귀 방지 |
+
+## File structure
+
+**New backend files:**
+
+```
+alembic/versions/
+  20260520_rob279_p1_add_stage_runs_and_artifacts.py    # 신규 테이블 2개 + 인덱스
+
+app/models/
+  investment_stages.py                                   # InvestmentStageRun, InvestmentStageArtifact ORM
+
+app/schemas/
+  investment_stages.py                                   # StageArtifactPayload, StageRunSummary 등
+
+app/services/investment_stages/
+  __init__.py
+  repository.py                                          # InvestmentStagesRepository (append-only)
+  query_service.py                                       # StageRunQueryService (read-only)
+  budget.py                                              # StageLLMBudget — per-report call 캡
+  stage_runner.py                                        # StageRunner — orchestrator
+  composer.py                                            # FinalComposer — stage artifacts → report items
+  stages/
+    __init__.py
+    base.py                                              # Stage protocol + StageContext
+    market.py                                            # deterministic
+    news.py                                              # deterministic
+    portfolio_journal.py                                  # deterministic
+    watch_context.py                                     # deterministic
+    candidate_universe.py                                # deterministic
+    bull_reducer.py                                      # LLM (gemini, budget-gated)
+    bear_reducer.py                                      # LLM (gemini, budget-gated)
+    risk_review.py                                       # LLM (gemini, budget-gated)
+
+app/routers/
+  investment_stage_runs.py                              # GET-only: run/artifact 조회
+```
+
+**Modified backend files:**
+
+```
+app/schemas/investment_reports.py                       # ReportGenerationRequest.auto_compose: bool = False
+app/services/action_report/snapshot_backed/generator.py # auto_compose=true 분기
+app/main.py                                             # router include
+```
+
+**New frontend files:**
+
+```
+frontend/invest/src/api/
+  investmentStages.ts                                   # fetchReportStageArtifacts, fetchStageRun
+
+frontend/invest/src/hooks/
+  useReportStageArtifacts.ts                            # report-scoped (via bundle)
+  useStageRun.ts                                        # run-scoped (blocked-report 진단용)
+
+frontend/invest/src/components/investment-reports/
+  IntermediateAnalysisPanel.tsx                         # report detail "중간 분석" 섹션
+  StageArtifactCard.tsx                                 # verdict/confidence/citations/missing_data
+  stageLabels.ts                                        # 한국어 stage_type 라벨
+
+frontend/invest/src/types/
+  # investmentReports.ts 에 StageRun/StageArtifact 타입 추가 (modify, not new file)
+```
+
+**Modified frontend files:**
+
+```
+frontend/invest/src/types/investmentReports.ts          # StageRun, StageArtifact, StageVerdict
+frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+                                                        # IntermediateAnalysisPanel mount
+```
+
+**New tests:**
+
+```
+tests/services/investment_stages/
+  __init__.py
+  test_repository.py
+  test_stage_runner.py
+  test_composer.py
+  test_budget.py
+  test_query_service.py
+  test_stage_market.py
+  test_stage_news.py
+  test_stage_portfolio_journal.py
+  test_stage_watch_context.py
+  test_stage_candidate_universe.py
+  test_stage_bull_reducer.py
+  test_stage_bear_reducer.py
+  test_stage_risk_review.py
+
+tests/services/action_report/snapshot_backed/
+  test_generator_auto_compose.py
+
+tests/routers/
+  test_investment_stage_runs.py
+
+frontend/invest/src/__tests__/
+  IntermediateAnalysisPanel.test.tsx
+  StageArtifactCard.test.tsx
+  useReportStageArtifacts.test.ts
+```
+
+---
+
+## Phase 1 — Persistence foundation
+
+> Goal: `investment_stage_runs` / `investment_stage_artifacts` 테이블 + ORM + Pydantic schema + append-only repository.
+> 위험: nullable FK 설계, append-only invariant 회귀.
+
+### Task 1.1: Alembic migration for stage tables
+
+**Files:**
+- Create: `alembic/versions/20260520_rob279_p1_add_stage_runs_and_artifacts.py`
+
+- [ ] **Step 1: Write the migration**
+
+```python
+"""rob-279 p1: add investment_stage_runs and investment_stage_artifacts
+
+Revision ID: 20260520_rob279_p1
+Revises: 20260520_rob274_p2
+Create Date: 2026-05-20
+
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260520_rob279_p1"
+down_revision: str | None = "20260520_rob274_p2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investment_stage_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "run_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            unique=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "snapshot_bundle_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("market_session", sa.Text(), nullable=True),
+        sa.Column("account_scope", sa.Text(), nullable=True),
+        sa.Column("policy_version", sa.Text(), nullable=False, server_default=sa.text("'v1'")),
+        sa.Column("generator_version", sa.Text(), nullable=False, server_default=sa.text("'v1'")),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'running'"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('running','completed','failed','blocked')",
+            name="ck_investment_stage_runs_status",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_stage_runs_bundle_uuid",
+        "investment_stage_runs",
+        ["snapshot_bundle_uuid"],
+        schema="review",
+    )
+
+    op.create_table(
+        "investment_stage_artifacts",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "artifact_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            unique=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "run_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("stage_type", sa.Text(), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("confidence", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("key_points", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("buy_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("sell_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("risk_evidence", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("missing_data", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "cited_snapshot_uuids",
+            postgresql.ARRAY(postgresql.UUID(as_uuid=True)),
+            nullable=False,
+            server_default=sa.text("ARRAY[]::uuid[]"),
+        ),
+        sa.Column("freshness_summary", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("model_name", sa.Text(), nullable=True),
+        sa.Column("prompt_version", sa.Text(), nullable=True),
+        sa.Column("payload_hash", sa.Text(), nullable=True),
+        sa.Column("raw_payload_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "verdict IN ('bull','bear','neutral','unavailable')",
+            name="ck_investment_stage_artifacts_verdict",
+        ),
+        sa.CheckConstraint(
+            "confidence >= 0 AND confidence <= 100",
+            name="ck_investment_stage_artifacts_confidence_range",
+        ),
+        sa.CheckConstraint(
+            "stage_type IN ("
+            "'market','news','portfolio_journal','watch_context','candidate_universe',"
+            "'bull_reducer','bear_reducer','risk_review')",
+            name="ck_investment_stage_artifacts_stage_type_v1",
+        ),
+        sa.ForeignKeyConstraint(
+            ["run_uuid"],
+            ["review.investment_stage_runs.run_uuid"],
+            name="fk_stage_artifacts_run_uuid",
+            ondelete="CASCADE",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_stage_artifacts_run_stage",
+        "investment_stage_artifacts",
+        ["run_uuid", "stage_type"],
+        unique=True,
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_investment_stage_artifacts_run_stage", table_name="investment_stage_artifacts", schema="review")
+    op.drop_table("investment_stage_artifacts", schema="review")
+    op.drop_index("ix_investment_stage_runs_bundle_uuid", table_name="investment_stage_runs", schema="review")
+    op.drop_table("investment_stage_runs", schema="review")
+```
+
+- [ ] **Step 2: Run upgrade against local dev DB**
+
+Run: `uv run alembic upgrade head`
+Expected: `INFO  [alembic.runtime.migration] Running upgrade 20260520_rob274_p2 -> 20260520_rob279_p1`
+
+- [ ] **Step 3: Verify schema**
+
+Run: `docker compose exec postgres psql -U postgres -d auto_trader -c "\d review.investment_stage_runs"`
+Expected: columns `run_uuid uuid NOT NULL`, `status text NOT NULL`, CHECK on status set.
+
+- [ ] **Step 4: Run downgrade then upgrade to validate roundtrip**
+
+Run: `uv run alembic downgrade -1 && uv run alembic upgrade head`
+Expected: both succeed; no leftover constraints in `\d review.*`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add alembic/versions/20260520_rob279_p1_add_stage_runs_and_artifacts.py
+git commit -m "feat(rob-279): add investment_stage_runs and investment_stage_artifacts tables"
+```
+
+### Task 1.2: ORM models
+
+**Files:**
+- Create: `app/models/investment_stages.py`
+
+- [ ] **Step 1: Write failing test for model import + table mapping**
+
+Create `tests/models/test_investment_stages_model.py`:
+
+```python
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+
+
+@pytest.mark.asyncio
+async def test_stage_run_insert_returns_uuid(db_session):
+    run = InvestmentStageRun(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    assert run.run_uuid is not None
+    assert run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_stage_artifact_fk_cascade(db_session):
+    run = InvestmentStageRun(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+    )
+    db_session.add(run)
+    await db_session.flush()
+
+    artifact = InvestmentStageArtifact(
+        run_uuid=run.run_uuid,
+        stage_type="market",
+        verdict="neutral",
+        confidence=50,
+        cited_snapshot_uuids=[],
+    )
+    db_session.add(artifact)
+    await db_session.flush()
+
+    fetched = await db_session.scalar(
+        select(InvestmentStageArtifact).where(InvestmentStageArtifact.run_uuid == run.run_uuid)
+    )
+    assert fetched is not None
+    assert fetched.stage_type == "market"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/models/test_investment_stages_model.py -v`
+Expected: `ModuleNotFoundError: No module named 'app.models.investment_stages'`.
+
+- [ ] **Step 3: Write the ORM module**
+
+```python
+"""Investment stage runs/artifacts ORM (ROB-279)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from typing import Any
+
+from sqlalchemy import (
+    ARRAY,
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class InvestmentStageRun(Base):
+    __tablename__ = "investment_stage_runs"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('running','completed','failed','blocked')",
+            name="ck_investment_stage_runs_status",
+        ),
+        Index("ix_investment_stage_runs_bundle_uuid", "snapshot_bundle_uuid"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        unique=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    snapshot_bundle_uuid: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    market_session: Mapped[str | None] = mapped_column(Text, nullable=True)
+    account_scope: Mapped[str | None] = mapped_column(Text, nullable=True)
+    policy_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
+    generator_version: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'v1'"))
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'running'"))
+    started_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[dt.datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    metadata_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    artifacts: Mapped[list["InvestmentStageArtifact"]] = relationship(
+        "InvestmentStageArtifact",
+        primaryjoin="InvestmentStageRun.run_uuid==foreign(InvestmentStageArtifact.run_uuid)",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class InvestmentStageArtifact(Base):
+    __tablename__ = "investment_stage_artifacts"
+    __table_args__ = (
+        CheckConstraint(
+            "verdict IN ('bull','bear','neutral','unavailable')",
+            name="ck_investment_stage_artifacts_verdict",
+        ),
+        CheckConstraint(
+            "confidence >= 0 AND confidence <= 100",
+            name="ck_investment_stage_artifacts_confidence_range",
+        ),
+        CheckConstraint(
+            "stage_type IN ("
+            "'market','news','portfolio_journal','watch_context','candidate_universe',"
+            "'bull_reducer','bear_reducer','risk_review')",
+            name="ck_investment_stage_artifacts_stage_type_v1",
+        ),
+        UniqueConstraint("run_uuid", "stage_type", name="ix_investment_stage_artifacts_run_stage"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    artifact_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        unique=True,
+        server_default=text("gen_random_uuid()"),
+    )
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("review.investment_stage_runs.run_uuid", ondelete="CASCADE"),
+        nullable=False,
+    )
+    stage_type: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    key_points: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    buy_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    sell_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    risk_evidence: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    missing_data: Mapped[list[Any] | None] = mapped_column(JSONB, nullable=True)
+    cited_snapshot_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("ARRAY[]::uuid[]"),
+    )
+    freshness_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    model_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    prompt_version: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    raw_payload_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/models/test_investment_stages_model.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/investment_stages.py tests/models/test_investment_stages_model.py
+git commit -m "feat(rob-279): ORM models for stage runs and artifacts"
+```
+
+### Task 1.3: Pydantic schemas
+
+**Files:**
+- Create: `app/schemas/investment_stages.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/schemas/test_investment_stages_schema.py`:
+
+```python
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+
+
+def test_stage_artifact_payload_minimal_valid():
+    payload = StageArtifactPayload(
+        stage_type="market",
+        verdict=StageVerdict.NEUTRAL,
+        confidence=42,
+    )
+    assert payload.confidence == 42
+    assert payload.cited_snapshots == []
+
+
+def test_stage_artifact_payload_rejects_confidence_out_of_range():
+    with pytest.raises(ValidationError):
+        StageArtifactPayload(
+            stage_type="market",
+            verdict=StageVerdict.BULL,
+            confidence=120,
+        )
+
+
+def test_stage_citation_requires_snapshot_uuid():
+    citation = StageCitation(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="news",
+        payload_path="$.articles[0].title",
+    )
+    assert citation.payload_path.startswith("$")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/schemas/test_investment_stages_schema.py -v`
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write the schema module**
+
+```python
+"""Pydantic schemas for investment stage runs/artifacts (ROB-279)."""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+StageTypeLiteral = (
+    "market",
+    "news",
+    "portfolio_journal",
+    "watch_context",
+    "candidate_universe",
+    "bull_reducer",
+    "bear_reducer",
+    "risk_review",
+)
+
+
+class StageVerdict(str, enum.Enum):
+    BULL = "bull"
+    BEAR = "bear"
+    NEUTRAL = "neutral"
+    UNAVAILABLE = "unavailable"
+
+
+class StageCitation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    snapshot_uuid: uuid.UUID
+    snapshot_kind: str
+    payload_path: str | None = None
+
+
+class StageArtifactPayload(BaseModel):
+    """Structured output that every stage MUST emit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage_type: str
+    verdict: StageVerdict
+    confidence: int = Field(ge=0, le=100)
+    summary: str | None = None
+    key_points: list[str] = Field(default_factory=list)
+    buy_evidence: list[str] = Field(default_factory=list)
+    sell_evidence: list[str] = Field(default_factory=list)
+    risk_evidence: list[str] = Field(default_factory=list)
+    missing_data: list[str] = Field(default_factory=list)
+    cited_snapshots: list[StageCitation] = Field(default_factory=list)
+    freshness_summary: dict[str, Any] | None = None
+    model_name: str | None = None
+    prompt_version: str | None = None
+
+
+class StageRunSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+    run_uuid: uuid.UUID
+    snapshot_bundle_uuid: uuid.UUID
+    market: str
+    market_session: str | None
+    account_scope: str | None
+    policy_version: str
+    generator_version: str
+    status: str
+    started_at: str
+    completed_at: str | None
+    metadata_json: dict[str, Any] | None = None
+
+
+class StageArtifactRead(StageArtifactPayload):
+    artifact_uuid: uuid.UUID
+    run_uuid: uuid.UUID
+    created_at: str
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `uv run pytest tests/schemas/test_investment_stages_schema.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/investment_stages.py tests/schemas/test_investment_stages_schema.py
+git commit -m "feat(rob-279): Pydantic schemas for stage artifacts"
+```
+
+### Task 1.4: Repository with append-only invariant
+
+**Files:**
+- Create: `app/services/investment_stages/__init__.py`
+- Create: `app/services/investment_stages/repository.py`
+- Create: `tests/services/investment_stages/__init__.py`
+- Create: `tests/services/investment_stages/test_repository.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+import uuid
+
+import pytest
+
+from app.models.investment_stages import InvestmentStageArtifact
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.repository import (
+    AppendOnlyViolation,
+    InvestmentStagesRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_repository_creates_run_and_returns_uuid(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+        policy_version="v1",
+        generator_version="v1",
+    )
+    assert run.run_uuid is not None
+    assert run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_repository_persist_artifact_then_reject_overwrite(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(
+        snapshot_bundle_uuid=bundle_uuid, market="kr"
+    )
+    payload = StageArtifactPayload(
+        stage_type="market",
+        verdict=StageVerdict.NEUTRAL,
+        confidence=50,
+    )
+    artifact = await repo.persist_artifact(run.run_uuid, payload)
+    assert artifact.stage_type == "market"
+
+    with pytest.raises(AppendOnlyViolation):
+        await repo.persist_artifact(run.run_uuid, payload)
+
+
+@pytest.mark.asyncio
+async def test_repository_complete_run_sets_status(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    run = await repo.create_run(
+        snapshot_bundle_uuid=uuid.uuid4(), market="kr"
+    )
+    await repo.complete_run(run.run_uuid, status="completed")
+    refreshed = await repo.get_run(run.run_uuid)
+    assert refreshed.status == "completed"
+    assert refreshed.completed_at is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_stages/test_repository.py -v`
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write the repository module**
+
+```python
+"""Append-only repository for stage runs/artifacts (ROB-279)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+from app.schemas.investment_stages import StageArtifactPayload
+
+
+class AppendOnlyViolation(Exception):
+    """Raised when caller attempts to overwrite an existing stage artifact."""
+
+
+class InvestmentStagesRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_run(
+        self,
+        *,
+        snapshot_bundle_uuid: uuid.UUID,
+        market: str,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        policy_version: str = "v1",
+        generator_version: str = "v1",
+    ) -> InvestmentStageRun:
+        run = InvestmentStageRun(
+            snapshot_bundle_uuid=snapshot_bundle_uuid,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            policy_version=policy_version,
+            generator_version=generator_version,
+        )
+        self._session.add(run)
+        await self._session.flush()
+        await self._session.refresh(run)
+        return run
+
+    async def persist_artifact(
+        self, run_uuid: uuid.UUID, payload: StageArtifactPayload
+    ) -> InvestmentStageArtifact:
+        artifact = InvestmentStageArtifact(
+            run_uuid=run_uuid,
+            stage_type=payload.stage_type,
+            verdict=payload.verdict.value,
+            confidence=payload.confidence,
+            summary=payload.summary,
+            key_points=payload.key_points,
+            buy_evidence=payload.buy_evidence,
+            sell_evidence=payload.sell_evidence,
+            risk_evidence=payload.risk_evidence,
+            missing_data=payload.missing_data,
+            cited_snapshot_uuids=[c.snapshot_uuid for c in payload.cited_snapshots],
+            freshness_summary=payload.freshness_summary,
+            model_name=payload.model_name,
+            prompt_version=payload.prompt_version,
+        )
+        self._session.add(artifact)
+        try:
+            await self._session.flush()
+        except IntegrityError as exc:
+            if "ix_investment_stage_artifacts_run_stage" in str(exc):
+                raise AppendOnlyViolation(
+                    f"stage_type={payload.stage_type} already persisted for run {run_uuid}"
+                ) from exc
+            raise
+        await self._session.refresh(artifact)
+        return artifact
+
+    async def complete_run(self, run_uuid: uuid.UUID, *, status: str) -> None:
+        run = await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        if run is None:
+            raise ValueError(f"run not found: {run_uuid}")
+        if status not in {"completed", "failed", "blocked"}:
+            raise ValueError(f"invalid terminal status: {status}")
+        run.status = status
+        run.completed_at = dt.datetime.now(tz=dt.UTC)
+        await self._session.flush()
+
+    async def get_run(self, run_uuid: uuid.UUID) -> InvestmentStageRun | None:
+        return await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+
+    async def list_artifacts_for_run(
+        self, run_uuid: uuid.UUID
+    ) -> list[InvestmentStageArtifact]:
+        result = await self._session.scalars(
+            select(InvestmentStageArtifact)
+            .where(InvestmentStageArtifact.run_uuid == run_uuid)
+            .order_by(InvestmentStageArtifact.created_at)
+        )
+        return list(result.all())
+```
+
+Also touch `app/services/investment_stages/__init__.py` (empty file).
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/test_repository.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/__init__.py app/services/investment_stages/repository.py tests/services/investment_stages/
+git commit -m "feat(rob-279): append-only repository for stage runs"
+```
+
+### Task 1.5: Query service (read-only)
+
+**Files:**
+- Create: `app/services/investment_stages/query_service.py`
+- Create: `tests/services/investment_stages/test_query_service.py`
+
+- [ ] **Step 1: Write failing test for report-scoped query**
+
+```python
+import uuid
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.query_service import StageRunQueryService
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+
+@pytest.mark.asyncio
+async def test_query_service_returns_artifacts_by_run(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(snapshot_bundle_uuid=bundle_uuid, market="kr")
+    await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(stage_type="market", verdict=StageVerdict.NEUTRAL, confidence=10),
+    )
+    await db_session.flush()
+
+    svc = StageRunQueryService(db_session)
+    result = await svc.get_run_with_artifacts(run.run_uuid)
+
+    assert result is not None
+    assert result.run.run_uuid == run.run_uuid
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].stage_type == "market"
+
+
+@pytest.mark.asyncio
+async def test_query_service_returns_none_for_missing_run(db_session):
+    svc = StageRunQueryService(db_session)
+    assert await svc.get_run_with_artifacts(uuid.uuid4()) is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/services/investment_stages/test_query_service.py -v`
+Expected: `ImportError`.
+
+- [ ] **Step 3: Implement query service**
+
+```python
+"""Read-only query service for stage runs (ROB-279)."""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+
+
+@dataclasses.dataclass(frozen=True)
+class StageRunWithArtifacts:
+    run: InvestmentStageRun
+    artifacts: list[InvestmentStageArtifact]
+
+
+class StageRunQueryService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_run_with_artifacts(
+        self, run_uuid: uuid.UUID
+    ) -> StageRunWithArtifacts | None:
+        run = await self._session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        if run is None:
+            return None
+        artifacts = list(
+            (
+                await self._session.scalars(
+                    select(InvestmentStageArtifact)
+                    .where(InvestmentStageArtifact.run_uuid == run_uuid)
+                    .order_by(InvestmentStageArtifact.created_at)
+                )
+            ).all()
+        )
+        return StageRunWithArtifacts(run=run, artifacts=artifacts)
+
+    async def list_runs_for_bundle(
+        self, snapshot_bundle_uuid: uuid.UUID
+    ) -> list[InvestmentStageRun]:
+        result = await self._session.scalars(
+            select(InvestmentStageRun)
+            .where(InvestmentStageRun.snapshot_bundle_uuid == snapshot_bundle_uuid)
+            .order_by(InvestmentStageRun.started_at.desc())
+        )
+        return list(result.all())
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/test_query_service.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/query_service.py tests/services/investment_stages/test_query_service.py
+git commit -m "feat(rob-279): stage run query service"
+```
+
+---
+
+## Phase 2 — Stage runner + 8 stages
+
+> Goal: bundle 만 읽어 8개 stage 의 `StageArtifactPayload` 를 생성. v1 5개 deterministic + 3개 LLM reducer. budget cap, model_rate_limiter 경유.
+> 위험: LLM 비용 폭증, deterministic extraction 의 brittleness.
+
+### Task 2.1: Stage protocol + StageContext
+
+**Files:**
+- Create: `app/services/investment_stages/stages/__init__.py`
+- Create: `app/services/investment_stages/stages/base.py`
+- Create: `tests/services/investment_stages/stages/__init__.py`
+- Create: `tests/services/investment_stages/stages/test_base.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+
+import pytest
+
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+
+class _FakeBundleReadService:
+    async def get_bundle(self, *, bundle_uuid):
+        raise NotImplementedError
+
+
+def test_stage_context_holds_bundle_and_snapshots():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"market": []},
+        bundle_metadata={"freshness_overall": "fresh"},
+    )
+    assert ctx.snapshots_for("market") == []
+    assert ctx.snapshots_for("unknown") == []
+
+
+def test_unavailable_stage_error_carries_reason():
+    with pytest.raises(UnavailableStageError) as exc:
+        raise UnavailableStageError("portfolio snapshot missing")
+    assert "portfolio" in str(exc.value)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_base.py -v`
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement base**
+
+```python
+"""Stage protocol and shared context (ROB-279)."""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from typing import Any, Protocol
+
+from app.models.investment_snapshots import InvestmentSnapshot
+from app.schemas.investment_stages import StageArtifactPayload
+
+
+class UnavailableStageError(Exception):
+    """Raised by a stage when required snapshots are absent.
+    The runner converts this to an `UNAVAILABLE` artifact rather than failing the run."""
+
+
+@dataclasses.dataclass(frozen=True)
+class StageContext:
+    bundle_uuid: uuid.UUID
+    snapshots_by_kind: dict[str, list[InvestmentSnapshot]]
+    bundle_metadata: dict[str, Any]
+
+    def snapshots_for(self, kind: str) -> list[InvestmentSnapshot]:
+        return self.snapshots_by_kind.get(kind, [])
+
+
+class Stage(Protocol):
+    stage_type: str
+
+    async def run(self, context: StageContext) -> StageArtifactPayload: ...
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_base.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/{__init__.py,base.py} tests/services/investment_stages/stages/
+git commit -m "feat(rob-279): stage protocol + StageContext"
+```
+
+### Task 2.2: Stage runner (orchestrator)
+
+**Files:**
+- Create: `app/services/investment_stages/stage_runner.py`
+- Create: `tests/services/investment_stages/test_stage_runner.py`
+
+The runner:
+1. opens a `StageRun` in DB
+2. loads bundle items via `SnapshotBundleReadService`
+3. groups snapshots by `snapshot_kind`
+4. invokes each registered stage sequentially (deterministic first, reducers last)
+5. persists every artifact (including `UNAVAILABLE` for missing-data stages)
+6. marks run `completed` (or `failed` on infrastructure error — single-stage failure does not fail the run)
+
+- [ ] **Step 1: Write failing test (mocked stages)**
+
+```python
+import uuid
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.stage_runner import StageRunner
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+
+class _MarketStub:
+    stage_type = "market"
+
+    async def run(self, ctx: StageContext) -> StageArtifactPayload:
+        return StageArtifactPayload(
+            stage_type="market", verdict=StageVerdict.BULL, confidence=70
+        )
+
+
+class _NewsUnavailable:
+    stage_type = "news"
+
+    async def run(self, ctx: StageContext) -> StageArtifactPayload:
+        raise UnavailableStageError("no news snapshot")
+
+
+class _StubBundleReadService:
+    def __init__(self, bundle_uuid):
+        self._bundle_uuid = bundle_uuid
+
+    async def get_bundle(self, *, bundle_uuid):
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            bundle=SimpleNamespace(bundle_uuid=bundle_uuid, status="complete"),
+            items=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_stage_runner_runs_all_stages_and_persists(db_session):
+    bundle_uuid = uuid.uuid4()
+    runner = StageRunner(
+        session=db_session,
+        bundle_read_service=_StubBundleReadService(bundle_uuid),
+        stages=[_MarketStub(), _NewsUnavailable()],
+    )
+
+    run = await runner.run(
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+
+    assert run.status == "completed"
+    artifacts = sorted(run.artifacts, key=lambda a: a.stage_type)
+    assert [a.stage_type for a in artifacts] == ["market", "news"]
+    assert artifacts[0].verdict == "bull"
+    assert artifacts[1].verdict == "unavailable"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/test_stage_runner.py -v`
+Expected: `ImportError`.
+
+- [ ] **Step 3: Implement runner**
+
+```python
+"""Stage runner orchestrator (ROB-279)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from typing import Iterable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_stages import InvestmentStageRun
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_snapshots.read_service import SnapshotBundleReadService
+from app.services.investment_stages.repository import InvestmentStagesRepository
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class StageRunner:
+    def __init__(
+        self,
+        *,
+        session: AsyncSession,
+        bundle_read_service: SnapshotBundleReadService | object,
+        stages: Iterable[Stage],
+    ) -> None:
+        self._session = session
+        self._bundle_read = bundle_read_service
+        self._stages = list(stages)
+        self._repo = InvestmentStagesRepository(session)
+
+    async def run(
+        self,
+        *,
+        snapshot_bundle_uuid: uuid.UUID,
+        market: str,
+        market_session: str | None,
+        account_scope: str | None,
+        policy_version: str = "v1",
+        generator_version: str = "v1",
+    ) -> InvestmentStageRun:
+        run = await self._repo.create_run(
+            snapshot_bundle_uuid=snapshot_bundle_uuid,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            policy_version=policy_version,
+            generator_version=generator_version,
+        )
+
+        bundle_response = await self._bundle_read.get_bundle(bundle_uuid=snapshot_bundle_uuid)
+        snapshots_by_kind: dict[str, list] = defaultdict(list)
+        for item in getattr(bundle_response, "items", []):
+            snapshot = getattr(item, "snapshot", None) or item
+            kind = getattr(snapshot, "snapshot_kind", None)
+            if kind:
+                snapshots_by_kind[kind].append(snapshot)
+
+        bundle = getattr(bundle_response, "bundle", None)
+        ctx = StageContext(
+            bundle_uuid=snapshot_bundle_uuid,
+            snapshots_by_kind=dict(snapshots_by_kind),
+            bundle_metadata={
+                "status": getattr(bundle, "status", None),
+                "freshness_summary": getattr(bundle, "freshness_summary", None),
+            },
+        )
+
+        for stage in self._stages:
+            try:
+                payload = await stage.run(ctx)
+            except UnavailableStageError as exc:
+                _logger.info("stage %s unavailable: %s", stage.stage_type, exc)
+                payload = StageArtifactPayload(
+                    stage_type=stage.stage_type,
+                    verdict=StageVerdict.UNAVAILABLE,
+                    confidence=0,
+                    summary=str(exc),
+                    missing_data=[stage.stage_type],
+                )
+            except Exception as exc:  # noqa: BLE001 — explicit unavailable on any stage failure
+                _logger.exception("stage %s failed", stage.stage_type)
+                payload = StageArtifactPayload(
+                    stage_type=stage.stage_type,
+                    verdict=StageVerdict.UNAVAILABLE,
+                    confidence=0,
+                    summary=f"stage error: {exc!r}",
+                    missing_data=[stage.stage_type],
+                )
+            await self._repo.persist_artifact(run.run_uuid, payload)
+
+        await self._repo.complete_run(run.run_uuid, status="completed")
+        await self._session.refresh(run)
+        return run
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/test_stage_runner.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stage_runner.py tests/services/investment_stages/test_stage_runner.py
+git commit -m "feat(rob-279): stage runner orchestrator"
+```
+
+### Task 2.3: LLM budget guard
+
+**Files:**
+- Create: `app/services/investment_stages/budget.py`
+- Create: `tests/services/investment_stages/test_budget.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import pytest
+
+from app.services.investment_stages.budget import (
+    BudgetExceeded,
+    StageLLMBudget,
+)
+
+
+def test_budget_consumes_within_cap():
+    b = StageLLMBudget(max_calls=4)
+    for _ in range(4):
+        b.consume("bull_reducer")
+    assert b.remaining == 0
+
+
+def test_budget_rejects_overshoot():
+    b = StageLLMBudget(max_calls=2)
+    b.consume("a")
+    b.consume("b")
+    with pytest.raises(BudgetExceeded):
+        b.consume("c")
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/test_budget.py -v`
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement budget**
+
+```python
+"""LLM call budget guard for staged reports (ROB-279).
+
+Per-report cap: 4 (3 reducers + 1 composer). Stages that would overshoot
+must degrade to deterministic-only fallback or `UNAVAILABLE`."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+class BudgetExceeded(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class StageLLMBudget:
+    max_calls: int = 4
+    _used: list[str] = dataclasses.field(default_factory=list)
+
+    @property
+    def remaining(self) -> int:
+        return max(self.max_calls - len(self._used), 0)
+
+    def consume(self, label: str) -> None:
+        if len(self._used) >= self.max_calls:
+            raise BudgetExceeded(
+                f"LLM budget exhausted (cap={self.max_calls}, used={self._used})"
+            )
+        self._used.append(label)
+
+    def used(self) -> list[str]:
+        return list(self._used)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/test_budget.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/budget.py tests/services/investment_stages/test_budget.py
+git commit -m "feat(rob-279): per-report LLM budget guard"
+```
+
+### Task 2.4: Deterministic stage — `market`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/market.py`
+- Create: `tests/services/investment_stages/stages/test_market.py`
+
+The market stage extracts index direction (KOSPI/KOSDAQ for KR) from `market` snapshots and emits a verdict purely from numeric thresholds (no LLM).
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.market import MarketStage
+
+
+def _snapshot(payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="market",
+        payload_json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_stage_emits_bull_when_index_up():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "market": [_snapshot({"indices": {"KOSPI": {"change_percent": 1.5}}})]
+        },
+        bundle_metadata={},
+    )
+    payload = await MarketStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.confidence >= 50
+    assert len(payload.cited_snapshots) == 1
+
+
+@pytest.mark.asyncio
+async def test_market_stage_emits_bear_when_index_down():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "market": [_snapshot({"indices": {"KOSPI": {"change_percent": -2.0}}})]
+        },
+        bundle_metadata={},
+    )
+    payload = await MarketStage().run(ctx)
+    assert payload.verdict == StageVerdict.BEAR
+
+
+@pytest.mark.asyncio
+async def test_market_stage_raises_unavailable_when_no_snapshot():
+    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    with pytest.raises(UnavailableStageError):
+        await MarketStage().run(ctx)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_market.py -v`
+Expected: `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement market stage**
+
+```python
+"""Deterministic market stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+_BULL_THRESHOLD = 0.5
+_BEAR_THRESHOLD = -0.5
+
+
+class MarketStage:
+    stage_type = "market"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("market")
+        if not snapshots:
+            raise UnavailableStageError("market snapshot missing from bundle")
+
+        snapshot = snapshots[0]
+        indices = (snapshot.payload_json or {}).get("indices", {})
+        kospi = indices.get("KOSPI") or indices.get("kospi") or {}
+        change = float(kospi.get("change_percent", 0.0))
+
+        if change >= _BULL_THRESHOLD:
+            verdict = StageVerdict.BULL
+        elif change <= _BEAR_THRESHOLD:
+            verdict = StageVerdict.BEAR
+        else:
+            verdict = StageVerdict.NEUTRAL
+
+        confidence = min(int(abs(change) * 30), 90)
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=max(confidence, 30 if verdict != StageVerdict.NEUTRAL else 20),
+            summary=f"KOSPI change_percent={change:+.2f}%",
+            key_points=[f"KOSPI {change:+.2f}%"],
+            buy_evidence=[f"KOSPI 상승 {change:+.2f}%"] if verdict == StageVerdict.BULL else [],
+            sell_evidence=[f"KOSPI 하락 {change:+.2f}%"] if verdict == StageVerdict.BEAR else [],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snapshot.snapshot_uuid,
+                    snapshot_kind="market",
+                    payload_path="$.indices.KOSPI.change_percent",
+                )
+            ],
+        )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_market.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/market.py tests/services/investment_stages/stages/test_market.py
+git commit -m "feat(rob-279): deterministic market stage"
+```
+
+### Task 2.5: Deterministic stage — `news`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/news.py`
+- Create: `tests/services/investment_stages/stages/test_news.py`
+
+News stage groups article headlines by sentiment hint (positive/negative keyword counts) — no LLM. Tests follow the same shape as Task 2.4 with snapshot payload `{"articles": [{"title": ..., "sentiment": "positive"}, ...]}`. Implementation aggregates sentiment counts and emits BULL/BEAR/NEUTRAL.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.news import NewsStage
+
+
+def _snap(articles):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="news",
+        payload_json={"articles": articles},
+    )
+
+
+@pytest.mark.asyncio
+async def test_news_stage_neutral_on_empty_articles():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"news": [_snap([])]},
+        bundle_metadata={},
+    )
+    payload = await NewsStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+
+
+@pytest.mark.asyncio
+async def test_news_stage_bull_when_positive_dominates():
+    articles = [{"title": "good", "sentiment": "positive"}] * 5 + [
+        {"title": "bad", "sentiment": "negative"}
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"news": [_snap(articles)]},
+        bundle_metadata={},
+    )
+    payload = await NewsStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.cited_snapshots
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_news.py -v`
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Deterministic news stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class NewsStage:
+    stage_type = "news"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("news")
+        if not snapshots:
+            raise UnavailableStageError("news snapshot missing")
+
+        articles: list[dict] = []
+        citations: list[StageCitation] = []
+        for snap in snapshots:
+            payload = snap.payload_json or {}
+            for art in payload.get("articles", []):
+                articles.append(art)
+            citations.append(
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="news",
+                    payload_path="$.articles",
+                )
+            )
+
+        pos = sum(1 for a in articles if a.get("sentiment") == "positive")
+        neg = sum(1 for a in articles if a.get("sentiment") == "negative")
+        total = len(articles)
+        if total == 0:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 10
+        elif pos >= neg * 2 and pos >= 3:
+            verdict = StageVerdict.BULL
+            confidence = min(40 + pos * 5, 80)
+        elif neg >= pos * 2 and neg >= 3:
+            verdict = StageVerdict.BEAR
+            confidence = min(40 + neg * 5, 80)
+        else:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 30
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=confidence,
+            summary=f"{total} articles (pos={pos}, neg={neg})",
+            key_points=[a.get("title", "")[:60] for a in articles[:5]],
+            cited_snapshots=citations,
+            missing_data=[] if articles else ["news_articles"],
+        )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_news.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/news.py tests/services/investment_stages/stages/test_news.py
+git commit -m "feat(rob-279): deterministic news stage"
+```
+
+### Task 2.6: Deterministic stage — `portfolio_journal`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/portfolio_journal.py`
+- Create: `tests/services/investment_stages/stages/test_portfolio_journal.py`
+
+Reads `portfolio` and `journal` snapshots. Verdict is informational: if cash buying power < 5% of portfolio NAV → confidence-reducer flag; if open journal entries exist with targets → emit `key_points` listing them.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+
+
+def _snap(kind, payload):
+    return SimpleNamespace(snapshot_uuid=uuid.uuid4(), snapshot_kind=kind, payload_json=payload)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_unavailable_without_portfolio():
+    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    with pytest.raises(UnavailableStageError):
+        await PortfolioJournalStage().run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_emits_neutral_with_buying_power():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})],
+            "journal": [_snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert "035420" in (payload.summary or "")
+    assert len(payload.cited_snapshots) >= 1
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+
+- [ ] **Step 3: Implement**
+
+```python
+"""Deterministic portfolio+journal stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class PortfolioJournalStage:
+    stage_type = "portfolio_journal"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        portfolio_snaps = context.snapshots_for("portfolio")
+        if not portfolio_snaps:
+            raise UnavailableStageError("portfolio snapshot missing — required")
+        portfolio = portfolio_snaps[0]
+        journal_snaps = context.snapshots_for("journal")
+
+        nav = float((portfolio.payload_json or {}).get("nav_krw", 0.0))
+        buying_power = float((portfolio.payload_json or {}).get("buying_power_krw", 0.0))
+        bp_ratio = (buying_power / nav) if nav > 0 else 0.0
+
+        entries = []
+        for snap in journal_snaps:
+            entries.extend((snap.payload_json or {}).get("entries", []))
+
+        citations = [
+            StageCitation(
+                snapshot_uuid=portfolio.snapshot_uuid,
+                snapshot_kind="portfolio",
+                payload_path="$.buying_power_krw",
+            )
+        ]
+        for snap in journal_snaps:
+            citations.append(
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="journal",
+                    payload_path="$.entries",
+                )
+            )
+
+        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
+        summary = (
+            f"NAV={nav:,.0f}, buying_power_krw={buying_power:,.0f} "
+            f"({bp_ratio:.1%}), open journal: {symbols or 'none'}"
+        )
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.NEUTRAL,
+            confidence=60 if bp_ratio >= 0.05 else 40,
+            summary=summary,
+            key_points=[e.get("thesis", "") for e in entries[:5] if e.get("thesis")],
+            risk_evidence=[] if bp_ratio >= 0.05 else ["buying_power < 5% NAV"],
+            cited_snapshots=citations,
+            missing_data=[] if journal_snaps else ["journal"],
+        )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/portfolio_journal.py tests/services/investment_stages/stages/test_portfolio_journal.py
+git commit -m "feat(rob-279): deterministic portfolio_journal stage"
+```
+
+### Task 2.7: Deterministic stage — `watch_context`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/watch_context.py`
+- Create: `tests/services/investment_stages/stages/test_watch_context.py`
+
+Reads `watch_context` snapshot. Lists active watch alerts and previously triggered intents. Verdict NEUTRAL; key_points are alert summaries.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.watch_context import WatchContextStage
+
+
+def _snap(payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="watch_context",
+        payload_json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_watch_context_unavailable():
+    with pytest.raises(UnavailableStageError):
+        await WatchContextStage().run(
+            StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+        )
+
+
+@pytest.mark.asyncio
+async def test_watch_context_lists_active_alerts():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "watch_context": [
+                _snap(
+                    {
+                        "active_alerts": [
+                            {"symbol": "035420", "condition": "price < 200000"},
+                            {"symbol": "015760", "condition": "price > 25000"},
+                        ]
+                    }
+                )
+            ]
+        },
+        bundle_metadata={},
+    )
+    payload = await WatchContextStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert any("035420" in kp for kp in payload.key_points)
+```
+
+- [ ] **Step 2-3: Implement**
+
+```python
+"""Deterministic watch_context stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class WatchContextStage:
+    stage_type = "watch_context"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("watch_context")
+        if not snapshots:
+            raise UnavailableStageError("watch_context snapshot missing — required")
+
+        snap = snapshots[0]
+        payload = snap.payload_json or {}
+        active = payload.get("active_alerts", [])
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.NEUTRAL,
+            confidence=50 if active else 30,
+            summary=f"{len(active)} active watch alerts",
+            key_points=[
+                f"{a.get('symbol', '?')}: {a.get('condition', '?')}" for a in active[:5]
+            ],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="watch_context",
+                    payload_path="$.active_alerts",
+                )
+            ],
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_watch_context.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/watch_context.py tests/services/investment_stages/stages/test_watch_context.py
+git commit -m "feat(rob-279): deterministic watch_context stage"
+```
+
+### Task 2.8: Deterministic stage — `candidate_universe`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/candidate_universe.py`
+- Create: `tests/services/investment_stages/stages/test_candidate_universe.py`
+
+Reads `candidate_universe` snapshot. Verdict NEUTRAL or BULL based on whether top candidates exist with positive momentum.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+
+
+def _snap(payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="candidate_universe",
+        payload_json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_empty():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"candidate_universe": [_snap({"candidates": []})]},
+        bundle_metadata={},
+    )
+    payload = await CandidateUniverseStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence < 40
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_bull_when_top_candidates():
+    candidates = [
+        {"symbol": s, "score": 8.0, "reason": "momentum"}
+        for s in ("035420", "015760", "005930")
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"candidate_universe": [_snap({"candidates": candidates})]},
+        bundle_metadata={},
+    )
+    payload = await CandidateUniverseStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert "035420" in payload.summary
+```
+
+- [ ] **Step 2-3: Implement**
+
+```python
+"""Deterministic candidate_universe stage (ROB-279)."""
+
+from __future__ import annotations
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages.base import StageContext, UnavailableStageError
+
+
+class CandidateUniverseStage:
+    stage_type = "candidate_universe"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snapshots = context.snapshots_for("candidate_universe")
+        if not snapshots:
+            raise UnavailableStageError("candidate_universe snapshot missing")
+        snap = snapshots[0]
+        candidates = (snap.payload_json or {}).get("candidates", [])
+        top = sorted(candidates, key=lambda c: c.get("score", 0.0), reverse=True)[:5]
+
+        if not top:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 20
+            summary = "no candidates returned by screener"
+        elif top[0].get("score", 0.0) >= 7.0:
+            verdict = StageVerdict.BULL
+            confidence = min(40 + len(top) * 8, 75)
+            summary = "top candidates: " + ", ".join(c.get("symbol", "?") for c in top)
+        else:
+            verdict = StageVerdict.NEUTRAL
+            confidence = 35
+            summary = "candidates present but low score"
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=verdict,
+            confidence=confidence,
+            summary=summary,
+            key_points=[
+                f"{c.get('symbol', '?')} (score={c.get('score', 0):.1f}): {c.get('reason', '')}"
+                for c in top
+            ],
+            buy_evidence=[c.get("symbol", "?") for c in top] if verdict == StageVerdict.BULL else [],
+            cited_snapshots=[
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="candidate_universe",
+                    payload_path="$.candidates",
+                )
+            ],
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_candidate_universe.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/candidate_universe.py tests/services/investment_stages/stages/test_candidate_universe.py
+git commit -m "feat(rob-279): deterministic candidate_universe stage"
+```
+
+### Task 2.9: LLM stage — `bull_reducer`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/bull_reducer.py`
+- Create: `tests/services/investment_stages/stages/test_bull_reducer.py`
+
+Reducer takes the 5 deterministic stage artifacts produced earlier (passed via `StageContext.bundle_metadata['prior_stages']`) plus their cited snapshots, and asks Gemini to summarize the bull case. **MUST go through `model_rate_limiter`** and **MUST consume from `StageLLMBudget`**. If budget exhausted, degrade to deterministic concat of `buy_evidence` from prior stages.
+
+> **Note for Task 2.10/2.11:** the runner extension to pass `prior_stages` happens in Task 2.12. For now, reducer reads from `context.bundle_metadata.get("prior_stages", [])`.
+
+- [ ] **Step 1: Write failing test (mock LLM client)**
+
+```python
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.bull_reducer import BullReducerStage
+
+
+@pytest.mark.asyncio
+async def test_bull_reducer_uses_llm_when_budget_available():
+    llm = AsyncMock()
+    llm.complete_json.return_value = {
+        "summary": "복수 stage 가 매수 지지",
+        "confidence": 70,
+        "key_points": ["KOSPI 상승", "후보 종목 풍부"],
+    }
+    budget = StageLLMBudget(max_calls=4)
+    prior = [
+        StageArtifactPayload(
+            stage_type="market",
+            verdict=StageVerdict.BULL,
+            confidence=60,
+            buy_evidence=["KOSPI +1.5%"],
+        ).model_dump()
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={"prior_stages": prior},
+    )
+
+    stage = BullReducerStage(llm_client=llm, budget=budget)
+    payload = await stage.run(ctx)
+
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.confidence == 70
+    assert budget.remaining == 3
+    llm.complete_json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bull_reducer_degrades_when_budget_exhausted():
+    llm = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    prior = [
+        StageArtifactPayload(
+            stage_type="market",
+            verdict=StageVerdict.BULL,
+            confidence=60,
+            buy_evidence=["KOSPI +1.5%"],
+        ).model_dump()
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={"prior_stages": prior},
+    )
+
+    stage = BullReducerStage(llm_client=llm, budget=budget)
+    payload = await stage.run(ctx)
+
+    llm.complete_json.assert_not_awaited()
+    assert "KOSPI +1.5%" in (payload.summary or "")
+    assert payload.confidence <= 50  # degraded
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_bull_reducer.py -v`
+
+- [ ] **Step 3: Implement**
+
+```python
+"""LLM bull reducer stage (ROB-279)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+
+_logger = logging.getLogger(__name__)
+
+
+class LLMJsonClient(Protocol):
+    async def complete_json(
+        self, *, system: str, user: str, schema: dict[str, Any]
+    ) -> dict[str, Any]: ...
+
+
+_SYSTEM_PROMPT = (
+    "당신은 자동 거래 시스템의 bull-case reducer 입니다. "
+    "주어진 stage artifact 들에서 매수 근거만 추려 구조화된 JSON 으로 답하세요. "
+    "근거가 없는 주장 금지. 모든 결론은 stage artifact 의 buy_evidence 에서만 도출되어야 합니다."
+)
+
+
+class BullReducerStage:
+    stage_type = "bull_reducer"
+
+    def __init__(self, *, llm_client: LLMJsonClient, budget: StageLLMBudget) -> None:
+        self._llm = llm_client
+        self._budget = budget
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        prior = list(context.bundle_metadata.get("prior_stages") or [])
+        buy_lines: list[str] = []
+        citations: list[StageCitation] = []
+        for p in prior:
+            buy_lines.extend(p.get("buy_evidence") or [])
+            for c in p.get("cited_snapshots") or []:
+                citations.append(StageCitation(**c))
+
+        try:
+            self._budget.consume("bull_reducer")
+        except BudgetExceeded:
+            _logger.info("bull_reducer: budget exhausted, degrading to deterministic")
+            return StageArtifactPayload(
+                stage_type=self.stage_type,
+                verdict=StageVerdict.BULL if buy_lines else StageVerdict.NEUTRAL,
+                confidence=40 if buy_lines else 20,
+                summary="; ".join(buy_lines) or "no buy evidence",
+                buy_evidence=buy_lines,
+                cited_snapshots=citations,
+                model_name=None,
+            )
+
+        user_prompt = (
+            "다음 stage artifact 의 buy_evidence 를 종합하여 매수 측 논리를 요약하세요.\n"
+            f"prior stages: {prior}\n"
+            "응답은 {summary, confidence(0-100), key_points: list[str]} JSON 만."
+        )
+        response = await self._llm.complete_json(
+            system=_SYSTEM_PROMPT,
+            user=user_prompt,
+            schema={
+                "type": "object",
+                "required": ["summary", "confidence", "key_points"],
+                "properties": {
+                    "summary": {"type": "string"},
+                    "confidence": {"type": "integer", "minimum": 0, "maximum": 100},
+                    "key_points": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        )
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.BULL if buy_lines else StageVerdict.NEUTRAL,
+            confidence=int(response.get("confidence", 50)),
+            summary=str(response.get("summary", "")),
+            key_points=list(response.get("key_points", [])),
+            buy_evidence=buy_lines,
+            cited_snapshots=citations,
+            model_name="gemini",
+            prompt_version="bull_reducer_v1",
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_bull_reducer.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/bull_reducer.py tests/services/investment_stages/stages/test_bull_reducer.py
+git commit -m "feat(rob-279): LLM bull_reducer with budget gating"
+```
+
+### Task 2.10: LLM stage — `bear_reducer`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/bear_reducer.py`
+- Create: `tests/services/investment_stages/stages/test_bear_reducer.py`
+
+Symmetric to bull_reducer but reads `sell_evidence`. Tests are the same shape as Task 2.9 with `sell_evidence` replacing `buy_evidence` and verdict `BEAR` when present.
+
+- [ ] **Step 1: Write failing test**
+
+Copy `test_bull_reducer.py` shape, substituting `BearReducerStage`, `sell_evidence`, `StageVerdict.BEAR`.
+
+- [ ] **Step 2: Verify fail; Step 3: Implement (mirror bull_reducer.py)**
+
+Implementation is identical to Task 2.9 with these substitutions:
+- class `BearReducerStage`, `stage_type = "bear_reducer"`
+- read `sell_evidence` instead of `buy_evidence`
+- verdict `BEAR` when sell_lines present, else `NEUTRAL`
+- system prompt switches "매수" → "매도/위험" and "buy_evidence" → "sell_evidence"
+- budget label `"bear_reducer"`, prompt_version `"bear_reducer_v1"`
+
+- [ ] **Step 4: Run tests**
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(rob-279): LLM bear_reducer with budget gating"
+```
+
+### Task 2.11: LLM stage — `risk_review`
+
+**Files:**
+- Create: `app/services/investment_stages/stages/risk_review.py`
+- Create: `tests/services/investment_stages/stages/test_risk_review.py`
+
+Reads bull_reducer + bear_reducer artifacts plus the watch_context and portfolio_journal artifacts. LLM emits final risk verdict; degrades to "review required" when budget exhausted.
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.risk_review import RiskReviewStage
+
+
+@pytest.mark.asyncio
+async def test_risk_review_uses_bull_and_bear_artifacts():
+    llm = AsyncMock()
+    llm.complete_json.return_value = {
+        "summary": "균형: bull > bear, 대형 포지션 진입은 보류",
+        "confidence": 60,
+        "risk_evidence": ["KOSPI 변동성 확대"],
+    }
+    budget = StageLLMBudget(max_calls=4)
+    prior = [
+        StageArtifactPayload(
+            stage_type="bull_reducer", verdict=StageVerdict.BULL, confidence=70
+        ).model_dump(),
+        StageArtifactPayload(
+            stage_type="bear_reducer", verdict=StageVerdict.BEAR, confidence=40
+        ).model_dump(),
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={"prior_stages": prior},
+    )
+
+    payload = await RiskReviewStage(llm_client=llm, budget=budget).run(ctx)
+
+    assert payload.confidence == 60
+    assert "KOSPI" in (payload.risk_evidence or [""])[0]
+    llm.complete_json.assert_awaited_once()
+```
+
+- [ ] **Step 2-3: Implement** (same shape as bull_reducer.py; reads bull/bear prior, emits `risk_evidence`; budget label `"risk_review"`)
+
+- [ ] **Step 4: Run tests; Step 5: Commit**
+
+```bash
+git commit -m "feat(rob-279): LLM risk_review reducer"
+```
+
+### Task 2.12: Wire stages into runner and expose prior_stages context
+
+**Files:**
+- Modify: `app/services/investment_stages/stage_runner.py` (extend `run()` to track artifacts and forward `prior_stages` to subsequent stages via mutable `bundle_metadata` copy)
+- Create: `app/services/investment_stages/stages/registry.py`
+- Create: `tests/services/investment_stages/test_stage_runner_integration.py`
+
+- [ ] **Step 1: Write failing integration test**
+
+```python
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stage_runner import StageRunner
+from app.services.investment_stages.stages.registry import build_default_v1_stages
+
+
+class _StubBundleRead:
+    def __init__(self, bundle_uuid, items):
+        self._uuid = bundle_uuid
+        self._items = items
+
+    async def get_bundle(self, *, bundle_uuid):
+        return SimpleNamespace(
+            bundle=SimpleNamespace(bundle_uuid=bundle_uuid, status="complete"),
+            items=self._items,
+        )
+
+
+def _snap(kind, payload):
+    return SimpleNamespace(
+        snapshot=SimpleNamespace(
+            snapshot_uuid=uuid.uuid4(),
+            snapshot_kind=kind,
+            payload_json=payload,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_v1_runs_all_8_stages_with_mock_llm(db_session):
+    bundle_uuid = uuid.uuid4()
+    items = [
+        _snap("market", {"indices": {"KOSPI": {"change_percent": 1.2}}}),
+        _snap("news", {"articles": [{"title": "good", "sentiment": "positive"}] * 4}),
+        _snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000}),
+        _snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]}),
+        _snap("watch_context", {"active_alerts": [{"symbol": "035420", "condition": "below"}]}),
+        _snap("candidate_universe", {"candidates": [{"symbol": "035420", "score": 8.0, "reason": "x"}]}),
+    ]
+
+    llm = AsyncMock()
+    llm.complete_json.return_value = {
+        "summary": "ok",
+        "confidence": 60,
+        "key_points": [],
+        "risk_evidence": [],
+    }
+    budget = StageLLMBudget(max_calls=4)
+    stages = build_default_v1_stages(llm_client=llm, budget=budget)
+
+    runner = StageRunner(
+        session=db_session,
+        bundle_read_service=_StubBundleRead(bundle_uuid, items),
+        stages=stages,
+    )
+    run = await runner.run(
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+
+    assert run.status == "completed"
+    assert len(run.artifacts) == 8
+    types = {a.stage_type for a in run.artifacts}
+    assert types == {
+        "market",
+        "news",
+        "portfolio_journal",
+        "watch_context",
+        "candidate_universe",
+        "bull_reducer",
+        "bear_reducer",
+        "risk_review",
+    }
+    assert llm.complete_json.await_count == 3  # 3 reducers consumed budget
+```
+
+- [ ] **Step 2-3: Implement registry + extend runner**
+
+`app/services/investment_stages/stages/registry.py`:
+
+```python
+"""Default v1 stage registry (ROB-279)."""
+
+from __future__ import annotations
+
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import Stage
+from app.services.investment_stages.stages.bear_reducer import BearReducerStage
+from app.services.investment_stages.stages.bull_reducer import BullReducerStage
+from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+from app.services.investment_stages.stages.market import MarketStage
+from app.services.investment_stages.stages.news import NewsStage
+from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+from app.services.investment_stages.stages.risk_review import RiskReviewStage
+from app.services.investment_stages.stages.watch_context import WatchContextStage
+
+
+def build_default_v1_stages(*, llm_client, budget: StageLLMBudget) -> list[Stage]:
+    return [
+        MarketStage(),
+        NewsStage(),
+        PortfolioJournalStage(),
+        WatchContextStage(),
+        CandidateUniverseStage(),
+        BullReducerStage(llm_client=llm_client, budget=budget),
+        BearReducerStage(llm_client=llm_client, budget=budget),
+        RiskReviewStage(llm_client=llm_client, budget=budget),
+    ]
+```
+
+Modify `app/services/investment_stages/stage_runner.py`:
+
+In `run()`, change the stages loop to forward each emitted payload into the next stage's `prior_stages` metadata:
+
+```python
+prior_payloads: list[dict] = []
+for stage in self._stages:
+    stage_ctx = StageContext(
+        bundle_uuid=ctx.bundle_uuid,
+        snapshots_by_kind=ctx.snapshots_by_kind,
+        bundle_metadata={**ctx.bundle_metadata, "prior_stages": list(prior_payloads)},
+    )
+    try:
+        payload = await stage.run(stage_ctx)
+    except UnavailableStageError as exc:
+        # ... as before
+    # persist + append to prior_payloads
+    await self._repo.persist_artifact(run.run_uuid, payload)
+    prior_payloads.append(payload.model_dump(mode="json"))
+```
+
+- [ ] **Step 4: Run integration test**
+
+Run: `uv run pytest tests/services/investment_stages/test_stage_runner_integration.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/stages/registry.py app/services/investment_stages/stage_runner.py tests/services/investment_stages/test_stage_runner_integration.py
+git commit -m "feat(rob-279): wire v1 stages and propagate prior_stages"
+```
+
+---
+
+## Phase 3 — Final composer + ingest integration
+
+> Goal: stage artifact → final report items (action/watch/risk/no_action_note). 100% citation 강제. legacy `investment_report_generate_from_bundle` 경로는 `auto_compose=false` 일 때 변경 없이 보존.
+> 위험: citation 누락된 LLM 출력 → caveat/omission 강제 누락.
+
+### Task 3.1: Composer skeleton + citation enforcement
+
+**Files:**
+- Create: `app/services/investment_stages/composer.py`
+- Create: `tests/services/investment_stages/test_composer.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageCitation, StageVerdict
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.composer import FinalComposer
+
+
+def _artifact(stage_type, verdict, cited=True):
+    return StageArtifactPayload(
+        stage_type=stage_type,
+        verdict=verdict,
+        confidence=60,
+        summary=f"{stage_type} summary",
+        buy_evidence=[f"{stage_type} buy"] if verdict == StageVerdict.BULL else [],
+        sell_evidence=[f"{stage_type} sell"] if verdict == StageVerdict.BEAR else [],
+        cited_snapshots=(
+            [StageCitation(snapshot_uuid=uuid.uuid4(), snapshot_kind=stage_type)]
+            if cited
+            else []
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_composer_emits_action_item_when_bull_dominates():
+    llm = AsyncMock()
+    llm.complete_json.return_value = {
+        "title": "매수 후보 검토",
+        "items": [
+            {
+                "client_item_key": "candidate-035420",
+                "item_kind": "action",
+                "summary": "035420 매수 검토",
+                "cited_stage_types": ["candidate_universe", "bull_reducer"],
+            }
+        ],
+    }
+    artifacts = [
+        _artifact("market", StageVerdict.BULL),
+        _artifact("candidate_universe", StageVerdict.BULL),
+        _artifact("bull_reducer", StageVerdict.BULL),
+        _artifact("bear_reducer", StageVerdict.NEUTRAL),
+        _artifact("risk_review", StageVerdict.NEUTRAL),
+    ]
+
+    composer = FinalComposer(llm_client=llm, budget=StageLLMBudget(max_calls=4))
+    output = await composer.compose(artifacts=artifacts)
+
+    assert output.title.startswith("매수")
+    assert len(output.items) == 1
+    assert output.items[0].item_kind == "action"
+
+
+@pytest.mark.asyncio
+async def test_composer_strips_uncited_items():
+    llm = AsyncMock()
+    llm.complete_json.return_value = {
+        "title": "테스트",
+        "items": [
+            {
+                "client_item_key": "uncited",
+                "item_kind": "action",
+                "summary": "no citation",
+                "cited_stage_types": ["unknown"],
+            }
+        ],
+    }
+    composer = FinalComposer(llm_client=llm, budget=StageLLMBudget(max_calls=4))
+    output = await composer.compose(artifacts=[_artifact("market", StageVerdict.NEUTRAL, cited=False)])
+    assert output.items == []  # uncited stripped
+    assert any("no_action_note" in i.item_kind for i in output.fallback_items)
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/services/investment_stages/test_composer.py -v`
+
+- [ ] **Step 3: Implement composer**
+
+```python
+"""Final composer — stage artifacts -> report items (ROB-279)."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from typing import Any, Protocol
+
+from app.schemas.investment_reports import IngestReportItem
+from app.schemas.investment_stages import StageArtifactPayload
+from app.services.investment_stages.budget import BudgetExceeded, StageLLMBudget
+
+_logger = logging.getLogger(__name__)
+
+
+class LLMJsonClient(Protocol):
+    async def complete_json(
+        self, *, system: str, user: str, schema: dict[str, Any]
+    ) -> dict[str, Any]: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class ComposerOutput:
+    title: str
+    summary: str
+    items: list[IngestReportItem]
+    fallback_items: list[IngestReportItem]
+
+
+_SYSTEM = (
+    "당신은 자동 거래 시스템의 final composer 입니다. "
+    "주어진 stage artifact 들로부터만 action/watch/risk 항목을 합성하세요. "
+    "각 항목은 반드시 cited_stage_types 에 1개 이상 stage 를 인용해야 합니다. "
+    "인용 불가능한 추정은 절대 생성하지 마세요."
+)
+
+
+class FinalComposer:
+    def __init__(self, *, llm_client: LLMJsonClient, budget: StageLLMBudget) -> None:
+        self._llm = llm_client
+        self._budget = budget
+
+    async def compose(self, *, artifacts: list[StageArtifactPayload]) -> ComposerOutput:
+        try:
+            self._budget.consume("final_composer")
+            response = await self._llm.complete_json(
+                system=_SYSTEM,
+                user=self._build_user_prompt(artifacts),
+                schema=self._schema(),
+            )
+        except BudgetExceeded:
+            _logger.warning("composer: budget exhausted, returning no_action_note")
+            return self._no_action_fallback(artifacts)
+
+        cited_stage_types = {a.stage_type for a in artifacts if a.cited_snapshots}
+        items: list[IngestReportItem] = []
+        fallback: list[IngestReportItem] = []
+        for raw in response.get("items", []):
+            required = set(raw.get("cited_stage_types") or [])
+            if not required or not (required & cited_stage_types):
+                _logger.info("composer: dropping uncited item %s", raw.get("client_item_key"))
+                continue
+            items.append(self._to_ingest_item(raw))
+
+        if not items:
+            fallback.append(self._no_action_item(reason="composer produced no cited items"))
+
+        return ComposerOutput(
+            title=str(response.get("title", "auto-composed report")),
+            summary=str(response.get("summary", "")),
+            items=items,
+            fallback_items=fallback,
+        )
+
+    def _build_user_prompt(self, artifacts: list[StageArtifactPayload]) -> str:
+        return (
+            "다음 stage artifact 들에서 action/watch/risk 항목을 합성하세요.\n"
+            f"artifacts: {[a.model_dump(mode='json') for a in artifacts]}\n"
+            "각 item.cited_stage_types 는 인용 가능한 stage_type 만 포함."
+        )
+
+    def _schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "required": ["title", "items"],
+            "properties": {
+                "title": {"type": "string"},
+                "summary": {"type": "string"},
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["client_item_key", "item_kind", "summary", "cited_stage_types"],
+                        "properties": {
+                            "client_item_key": {"type": "string"},
+                            "item_kind": {"type": "string", "enum": ["action", "watch", "risk"]},
+                            "summary": {"type": "string"},
+                            "cited_stage_types": {"type": "array", "items": {"type": "string"}},
+                        },
+                    },
+                },
+            },
+        }
+
+    def _to_ingest_item(self, raw: dict[str, Any]) -> IngestReportItem:
+        return IngestReportItem(
+            client_item_key=raw["client_item_key"],
+            item_kind=raw["item_kind"],
+            operation="review",
+            apply_policy="requires_user_approval",
+            proposed_state={"summary": raw.get("summary", "")},
+        )
+
+    def _no_action_item(self, *, reason: str) -> IngestReportItem:
+        return IngestReportItem(
+            client_item_key="auto-no-action",
+            item_kind="risk",
+            operation="review",
+            apply_policy="requires_user_approval",
+            proposed_state={"summary": reason},
+        )
+
+    def _no_action_fallback(self, artifacts: list[StageArtifactPayload]) -> ComposerOutput:
+        return ComposerOutput(
+            title="자동 합성 보류",
+            summary="LLM budget 소진으로 최종 합성이 진행되지 않았습니다.",
+            items=[],
+            fallback_items=[self._no_action_item(reason="LLM budget exhausted")],
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/investment_stages/test_composer.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/composer.py tests/services/investment_stages/test_composer.py
+git commit -m "feat(rob-279): final composer with citation enforcement"
+```
+
+### Task 3.2: Extend ReportGenerationRequest with auto_compose flag
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (locate `ReportGenerationRequest`, add `auto_compose: bool = False`)
+- Create: `tests/schemas/test_report_generation_request_auto_compose.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+from app.schemas.investment_reports import ReportGenerationRequest
+
+
+def test_report_generation_request_defaults_auto_compose_false():
+    req = ReportGenerationRequest(
+        report_type="kr_action_v1",
+        market="kr",
+        kst_date="2026-05-20",
+        items=[],
+    )
+    assert req.auto_compose is False
+
+
+def test_report_generation_request_accepts_auto_compose_true():
+    req = ReportGenerationRequest(
+        report_type="kr_action_v1",
+        market="kr",
+        kst_date="2026-05-20",
+        items=[],
+        auto_compose=True,
+    )
+    assert req.auto_compose is True
+```
+
+- [ ] **Step 2: Verify fail**
+
+Run: `uv run pytest tests/schemas/test_report_generation_request_auto_compose.py -v`
+Expected: fail (field missing).
+
+- [ ] **Step 3: Add field to `ReportGenerationRequest` in `app/schemas/investment_reports.py`**
+
+Find the `ReportGenerationRequest` class and add:
+
+```python
+auto_compose: bool = Field(
+    default=False,
+    description=(
+        "ROB-279: when True, items will be auto-composed from stage artifacts "
+        "instead of using caller-supplied items. Legacy behavior preserved when False."
+    ),
+)
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `uv run pytest tests/schemas/test_report_generation_request_auto_compose.py -v`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/investment_reports.py tests/schemas/test_report_generation_request_auto_compose.py
+git commit -m "feat(rob-279): ReportGenerationRequest.auto_compose flag"
+```
+
+### Task 3.3: Wire stage runner + composer into generator
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py` (insert `auto_compose=True` branch between `_ensure_service.ensure()` and `classify_items()` call)
+- Create: `tests/services/action_report/snapshot_backed/test_generator_auto_compose.py`
+
+The branch behavior when `request.auto_compose is True`:
+
+1. After `ensure_response = await self._ensure_service.ensure(...)`, run `StageRunner` with default v1 stages.
+2. Pass stage artifacts to `FinalComposer.compose(...)`.
+3. Replace `request.items` with composer output items (skip `classify_items()`).
+4. Persist `run.run_uuid` to the eventual report via `metadata_json` on the run row referencing `report_uuid` (set after ingest).
+
+- [ ] **Step 1: Write failing test using mock runner/composer**
+
+```python
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.schemas.investment_reports import (
+    IngestReportItem,
+    ReportGenerationRequest,
+)
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
+
+
+@pytest.mark.asyncio
+async def test_generator_auto_compose_replaces_items_and_links_run(monkeypatch, db_session):
+    bundle_uuid = uuid.uuid4()
+    ensure_response = MagicMock(
+        bundle_uuid=bundle_uuid,
+        status="complete",
+        missing_sources=[],
+        freshness_summary={"overall": "fresh"},
+        coverage_summary={},
+    )
+    ensure_service = AsyncMock(ensure=AsyncMock(return_value=ensure_response))
+
+    runner_mock = MagicMock()
+    runner_mock.run = AsyncMock(
+        return_value=MagicMock(run_uuid=uuid.uuid4(), artifacts=[])
+    )
+    composer_mock = MagicMock()
+    composer_mock.compose = AsyncMock(
+        return_value=MagicMock(
+            title="auto",
+            summary="ok",
+            items=[
+                IngestReportItem(
+                    client_item_key="x", item_kind="action", operation="review"
+                )
+            ],
+            fallback_items=[],
+        )
+    )
+
+    ingestion_mock = AsyncMock()
+    ingestion_mock.ingest = AsyncMock(return_value=MagicMock(report_uuid=uuid.uuid4()))
+
+    gen = SnapshotBackedReportGenerator(db_session)
+    gen._ensure_service = ensure_service
+    gen._ingestion_service = ingestion_mock
+    monkeypatch.setattr(
+        "app.services.action_report.snapshot_backed.generator.StageRunner",
+        lambda **kw: runner_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.action_report.snapshot_backed.generator.FinalComposer",
+        lambda **kw: composer_mock,
+    )
+
+    request = ReportGenerationRequest(
+        report_type="kr_action_v1",
+        market="kr",
+        kst_date="2026-05-20",
+        items=[],
+        auto_compose=True,
+    )
+    response = await gen.generate(request)
+
+    runner_mock.run.assert_awaited_once()
+    composer_mock.compose.assert_awaited_once()
+    ingestion_mock.ingest.assert_awaited_once()
+    ingest_arg = ingestion_mock.ingest.await_args.args[0]
+    assert len(ingest_arg.items) == 1
+    assert ingest_arg.items[0].client_item_key == "x"
+```
+
+- [ ] **Step 2: Verify fail**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator_auto_compose.py -v`
+
+- [ ] **Step 3: Implement the branch in generator.py**
+
+Locate `generate()`; after `ensure_response = await self._ensure_service.ensure(...)` and before the existing classifier_context block, insert:
+
+```python
+if request.auto_compose:
+    from app.services.investment_stages.budget import StageLLMBudget
+    from app.services.investment_stages.composer import FinalComposer
+    from app.services.investment_stages.stage_runner import StageRunner
+    from app.services.investment_stages.stages.registry import build_default_v1_stages
+    from app.services.investment_snapshots.read_service import SnapshotBundleReadService
+
+    budget = StageLLMBudget(max_calls=4)
+    llm_client = self._build_llm_client()  # see note below
+    stages = build_default_v1_stages(llm_client=llm_client, budget=budget)
+    runner = StageRunner(
+        session=self._session,
+        bundle_read_service=SnapshotBundleReadService(self._session),
+        stages=stages,
+    )
+    stage_run = await runner.run(
+        snapshot_bundle_uuid=ensure_response.bundle_uuid,
+        market=request.market,
+        market_session=request.market_session,
+        account_scope=request.account_scope,
+    )
+    composer = FinalComposer(llm_client=llm_client, budget=budget)
+    composer_output = await composer.compose(
+        artifacts=[
+            # rehydrate StageArtifactPayload from ORM artifact rows
+            self._artifact_to_payload(a) for a in stage_run.artifacts
+        ]
+    )
+    request = request.model_copy(
+        update={
+            "items": composer_output.items or composer_output.fallback_items,
+            "title": composer_output.title,
+        }
+    )
+    self._stage_run_uuid_for_metadata = stage_run.run_uuid
+else:
+    self._stage_run_uuid_for_metadata = None
+```
+
+Note: `self._build_llm_client()` and `self._artifact_to_payload(...)` are new helpers — implement them as thin adapters. `_build_llm_client()` returns an object with `complete_json(system, user, schema)` that delegates to existing Gemini wrapper plus `model_rate_limiter`. `_artifact_to_payload` converts ORM row to `StageArtifactPayload`.
+
+Also: at the end of `generate()`, after `report = await self._ingestion_service.ingest(...)`, link the run to the report:
+
+```python
+if self._stage_run_uuid_for_metadata is not None:
+    await self._repo_stages.link_run_to_report(
+        run_uuid=self._stage_run_uuid_for_metadata,
+        report_uuid=report.report_uuid,
+    )
+```
+
+`link_run_to_report` writes `report_uuid` into `investment_stage_runs.metadata_json['report_uuid']`. Add this helper to `InvestmentStagesRepository`:
+
+```python
+async def link_run_to_report(self, *, run_uuid, report_uuid) -> None:
+    run = await self._session.scalar(
+        select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+    )
+    if run is None:
+        return
+    metadata = dict(run.metadata_json or {})
+    metadata["report_uuid"] = str(report_uuid)
+    run.metadata_json = metadata
+    await self._session.flush()
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator_auto_compose.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/generator.py app/services/investment_stages/repository.py tests/services/action_report/snapshot_backed/test_generator_auto_compose.py
+git commit -m "feat(rob-279): wire stage runner + composer into generator behind auto_compose flag"
+```
+
+### Task 3.4: Legacy-path regression test
+
+**Files:**
+- Create: `tests/services/action_report/snapshot_backed/test_generator_legacy_path.py`
+
+Goal: prove that with `auto_compose=False` (default), nothing about the legacy path changes — no stage run is created.
+
+- [ ] **Step 1: Write test**
+
+```python
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.models.investment_stages import InvestmentStageRun
+from app.schemas.investment_reports import IngestReportItem, ReportGenerationRequest
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
+
+
+@pytest.mark.asyncio
+async def test_legacy_path_does_not_create_stage_run(db_session):
+    bundle_uuid = uuid.uuid4()
+    ensure_response = MagicMock(
+        bundle_uuid=bundle_uuid, status="complete", missing_sources=[],
+        freshness_summary={"overall": "fresh"}, coverage_summary={},
+    )
+    gen = SnapshotBackedReportGenerator(db_session)
+    gen._ensure_service = AsyncMock(ensure=AsyncMock(return_value=ensure_response))
+    gen._ingestion_service = AsyncMock(ingest=AsyncMock(return_value=MagicMock(report_uuid=uuid.uuid4())))
+
+    request = ReportGenerationRequest(
+        report_type="kr_action_v1",
+        market="kr",
+        kst_date="2026-05-20",
+        items=[IngestReportItem(client_item_key="legacy-1", item_kind="action")],
+        auto_compose=False,
+    )
+    await gen.generate(request)
+
+    rows = list((await db_session.scalars(select(InvestmentStageRun))).all())
+    assert rows == []
+```
+
+- [ ] **Step 2-4: Run test (should pass without further changes)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator_legacy_path.py -v`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/services/action_report/snapshot_backed/test_generator_legacy_path.py
+git commit -m "test(rob-279): legacy auto_compose=false path does not create stage run"
+```
+
+---
+
+## Phase 4 — API / MCP surface
+
+> Goal: read-only HTTP endpoints for both **report-scoped** (via bundle membership) and **run-scoped** (blocked-report diagnostic) stage artifact access.
+> 위험: 권한/라우터 prefix 충돌, MCP 도구 등록 누락.
+
+### Task 4.1: Router for stage runs
+
+**Files:**
+- Create: `app/routers/investment_stage_runs.py`
+- Create: `tests/routers/test_investment_stage_runs.py`
+- Modify: `app/main.py` (include router)
+
+Endpoints:
+- `GET /trading/api/investment-stage-runs/{run_uuid}` → `StageRunBundleResponse` (run summary + artifacts)
+- `GET /trading/api/investment-reports/{report_uuid}/stage-artifacts` → list of artifacts via bundle membership (resolves `report.snapshot_bundle_uuid` → all runs for that bundle → all artifacts; filters to runs linked to this report via `metadata_json['report_uuid']`)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+
+@pytest.mark.asyncio
+async def test_get_stage_run_returns_artifacts(db_session, async_client: AsyncClient):
+    repo = InvestmentStagesRepository(db_session)
+    run = await repo.create_run(snapshot_bundle_uuid=uuid.uuid4(), market="kr")
+    await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(stage_type="market", verdict=StageVerdict.BULL, confidence=70),
+    )
+    await db_session.commit()
+
+    res = await async_client.get(f"/trading/api/investment-stage-runs/{run.run_uuid}")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["run"]["run_uuid"] == str(run.run_uuid)
+    assert len(body["artifacts"]) == 1
+    assert body["artifacts"][0]["stage_type"] == "market"
+
+
+@pytest.mark.asyncio
+async def test_get_stage_run_404_when_missing(async_client: AsyncClient):
+    res = await async_client.get(f"/trading/api/investment-stage-runs/{uuid.uuid4()}")
+    assert res.status_code == 404
+```
+
+- [ ] **Step 2: Verify fail**
+
+Run: `uv run pytest tests/routers/test_investment_stage_runs.py -v`
+
+- [ ] **Step 3: Implement router**
+
+```python
+"""Read-only router for investment stage runs (ROB-279)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.dependencies import get_authenticated_user, get_db
+from app.models.users import User
+from app.services.investment_stages.query_service import StageRunQueryService
+
+router = APIRouter(tags=["investment-stage-runs"])
+
+
+@router.get("/trading/api/investment-stage-runs/{run_uuid}")
+async def get_stage_run(
+    run_uuid: uuid.UUID,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
+    svc = StageRunQueryService(db)
+    result = await svc.get_run_with_artifacts(run_uuid)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="stage run not found")
+
+    return {
+        "run": {
+            "run_uuid": str(result.run.run_uuid),
+            "snapshot_bundle_uuid": str(result.run.snapshot_bundle_uuid),
+            "market": result.run.market,
+            "market_session": result.run.market_session,
+            "account_scope": result.run.account_scope,
+            "policy_version": result.run.policy_version,
+            "generator_version": result.run.generator_version,
+            "status": result.run.status,
+            "started_at": result.run.started_at.isoformat(),
+            "completed_at": result.run.completed_at.isoformat() if result.run.completed_at else None,
+            "metadata_json": result.run.metadata_json,
+        },
+        "artifacts": [
+            {
+                "artifact_uuid": str(a.artifact_uuid),
+                "stage_type": a.stage_type,
+                "verdict": a.verdict,
+                "confidence": a.confidence,
+                "summary": a.summary,
+                "key_points": a.key_points,
+                "buy_evidence": a.buy_evidence,
+                "sell_evidence": a.sell_evidence,
+                "risk_evidence": a.risk_evidence,
+                "missing_data": a.missing_data,
+                "cited_snapshot_uuids": [str(s) for s in a.cited_snapshot_uuids],
+                "freshness_summary": a.freshness_summary,
+                "model_name": a.model_name,
+                "prompt_version": a.prompt_version,
+                "created_at": a.created_at.isoformat(),
+            }
+            for a in result.artifacts
+        ],
+    }
+```
+
+- [ ] **Step 4: Wire into main.py**
+
+In `app/main.py` add:
+```python
+from app.routers import investment_stage_runs
+app.include_router(investment_stage_runs.router)
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `uv run pytest tests/routers/test_investment_stage_runs.py -v`
+Expected: 2 passed.
+
+```bash
+git add app/routers/investment_stage_runs.py app/main.py tests/routers/test_investment_stage_runs.py
+git commit -m "feat(rob-279): GET /trading/api/investment-stage-runs/{run_uuid}"
+```
+
+### Task 4.2: Report-scoped stage artifact endpoint
+
+**Files:**
+- Modify: `app/routers/investment_stage_runs.py` (add report-scoped route)
+- Modify: `tests/routers/test_investment_stage_runs.py`
+
+- [ ] **Step 1: Failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_get_stage_artifacts_by_report_uuid(db_session, async_client):
+    # 1) Create stage run + artifact
+    # 2) Insert minimal InvestmentReport row with same snapshot_bundle_uuid + link via run.metadata_json
+    # 3) GET /trading/api/investment-reports/{report_uuid}/stage-artifacts
+    # 4) Assert artifacts returned
+    ...  # fixture details elided; mirror Task 4.1 test
+```
+
+- [ ] **Step 2-3: Implement**
+
+Add to router:
+
+```python
+@router.get("/trading/api/investment-reports/{report_uuid}/stage-artifacts")
+async def list_stage_artifacts_for_report(
+    report_uuid: uuid.UUID,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict[str, Any]:
+    # 1. resolve report → snapshot_bundle_uuid
+    # 2. list_runs_for_bundle (filter to runs whose metadata_json->>report_uuid matches)
+    # 3. flatten artifacts
+    report_repo = InvestmentReportsRepository(db)
+    report = await report_repo.get_by_uuid(report_uuid)
+    if report is None or report.snapshot_bundle_uuid is None:
+        raise HTTPException(404, "report or snapshot bundle not found")
+
+    svc = StageRunQueryService(db)
+    runs = await svc.list_runs_for_bundle(report.snapshot_bundle_uuid)
+    runs_for_report = [
+        r for r in runs
+        if (r.metadata_json or {}).get("report_uuid") == str(report_uuid)
+    ]
+    artifacts = []
+    for r in runs_for_report:
+        result = await svc.get_run_with_artifacts(r.run_uuid)
+        if result:
+            artifacts.extend(result.artifacts)
+
+    return {"report_uuid": str(report_uuid), "artifacts": [...]}  # serialize as in Task 4.1
+```
+
+- [ ] **Step 4: Run tests + Step 5: Commit**
+
+```bash
+git commit -m "feat(rob-279): GET /trading/api/investment-reports/{uuid}/stage-artifacts"
+```
+
+---
+
+## Phase 5 — UI: 중간 분석 panel
+
+> Goal: `/invest/reports/:reportUuid` 에 "중간 분석" 섹션 추가. `ReportSnapshotEvidencePanel` 의 lazy-load 패턴 답습.
+> 위험: 기존 컴포넌트 회귀.
+
+### Task 5.1: Types + API client
+
+**Files:**
+- Modify: `frontend/invest/src/types/investmentReports.ts` (add `StageRun`, `StageArtifact`, `StageVerdict`)
+- Create: `frontend/invest/src/api/investmentStages.ts`
+- Create: `frontend/invest/src/__tests__/investmentStagesApi.test.ts`
+
+- [ ] **Step 1: Add types**
+
+Append to `frontend/invest/src/types/investmentReports.ts`:
+
+```typescript
+export type StageVerdict = "bull" | "bear" | "neutral" | "unavailable";
+
+export type StageType =
+  | "market"
+  | "news"
+  | "portfolio_journal"
+  | "watch_context"
+  | "candidate_universe"
+  | "bull_reducer"
+  | "bear_reducer"
+  | "risk_review";
+
+export interface StageArtifact {
+  artifactUuid: string;
+  stageType: StageType;
+  verdict: StageVerdict;
+  confidence: number;
+  summary: string | null;
+  keyPoints: string[];
+  buyEvidence: string[];
+  sellEvidence: string[];
+  riskEvidence: string[];
+  missingData: string[];
+  citedSnapshotUuids: string[];
+  modelName: string | null;
+  promptVersion: string | null;
+  createdAt: string;
+}
+
+export interface StageRun {
+  runUuid: string;
+  snapshotBundleUuid: string;
+  market: string;
+  marketSession: string | null;
+  status: "running" | "completed" | "failed" | "blocked";
+  startedAt: string;
+  completedAt: string | null;
+}
+
+export interface ReportStageArtifactsResponse {
+  reportUuid: string;
+  artifacts: StageArtifact[];
+}
+```
+
+- [ ] **Step 2: Write failing test**
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { fetchReportStageArtifacts } from "../api/investmentStages";
+
+describe("fetchReportStageArtifacts", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("normalizes snake_case to camelCase", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        report_uuid: "r1",
+        artifacts: [
+          {
+            artifact_uuid: "a1",
+            stage_type: "market",
+            verdict: "bull",
+            confidence: 70,
+            summary: "ok",
+            key_points: ["x"],
+            buy_evidence: [],
+            sell_evidence: [],
+            risk_evidence: [],
+            missing_data: [],
+            cited_snapshot_uuids: ["s1"],
+            model_name: null,
+            prompt_version: null,
+            created_at: "2026-05-20T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    const result = await fetchReportStageArtifacts("r1");
+    expect(result.artifacts).toHaveLength(1);
+    expect(result.artifacts[0].stageType).toBe("market");
+    expect(result.artifacts[0].citedSnapshotUuids).toEqual(["s1"]);
+  });
+});
+```
+
+- [ ] **Step 3: Implement client**
+
+```typescript
+import type { ReportStageArtifactsResponse, StageArtifact } from "../types/investmentReports";
+
+const STAGE_ARTIFACTS_ENDPOINT = (reportUuid: string) =>
+  `/invest/api/investment-reports/${encodeURIComponent(reportUuid)}/stage-artifacts`;
+
+async function readJson<T>(endpoint: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(endpoint, { credentials: "include", signal });
+  if (!res.ok) throw new Error(`${endpoint} ${res.status}`);
+  return res.json();
+}
+
+function normalizeArtifact(raw: any): StageArtifact {
+  return {
+    artifactUuid: String(raw.artifact_uuid),
+    stageType: raw.stage_type,
+    verdict: raw.verdict,
+    confidence: Number(raw.confidence ?? 0),
+    summary: raw.summary ?? null,
+    keyPoints: Array.isArray(raw.key_points) ? raw.key_points : [],
+    buyEvidence: Array.isArray(raw.buy_evidence) ? raw.buy_evidence : [],
+    sellEvidence: Array.isArray(raw.sell_evidence) ? raw.sell_evidence : [],
+    riskEvidence: Array.isArray(raw.risk_evidence) ? raw.risk_evidence : [],
+    missingData: Array.isArray(raw.missing_data) ? raw.missing_data : [],
+    citedSnapshotUuids: Array.isArray(raw.cited_snapshot_uuids)
+      ? raw.cited_snapshot_uuids.map(String)
+      : [],
+    modelName: raw.model_name ?? null,
+    promptVersion: raw.prompt_version ?? null,
+    createdAt: String(raw.created_at),
+  };
+}
+
+export async function fetchReportStageArtifacts(
+  reportUuid: string,
+  signal?: AbortSignal,
+): Promise<ReportStageArtifactsResponse> {
+  const raw = await readJson<any>(STAGE_ARTIFACTS_ENDPOINT(reportUuid), signal);
+  return {
+    reportUuid: String(raw.report_uuid),
+    artifacts: Array.isArray(raw.artifacts) ? raw.artifacts.map(normalizeArtifact) : [],
+  };
+}
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd frontend/invest && npx vitest run investmentStagesApi`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/types/investmentReports.ts frontend/invest/src/api/investmentStages.ts frontend/invest/src/__tests__/investmentStagesApi.test.ts
+git commit -m "feat(rob-279): frontend types + API client for stage artifacts"
+```
+
+### Task 5.2: useReportStageArtifacts hook
+
+**Files:**
+- Create: `frontend/invest/src/hooks/useReportStageArtifacts.ts`
+- Create: `frontend/invest/src/__tests__/useReportStageArtifacts.test.ts`
+
+Mirror `useReportSnapshotBundle` shape: `{status, artifacts, error, reload}` with AbortController cleanup.
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useReportStageArtifacts } from "../hooks/useReportStageArtifacts";
+
+describe("useReportStageArtifacts", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ report_uuid: "r1", artifacts: [] }),
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("fetches artifacts on mount", async () => {
+    const { result } = renderHook(() => useReportStageArtifacts("r1"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.artifacts).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2-3: Implement** (mirror `useReportSnapshotBundle.ts` line by line, swap API call)
+- [ ] **Step 4: Run test; Step 5: Commit**
+
+```bash
+git commit -m "feat(rob-279): useReportStageArtifacts hook"
+```
+
+### Task 5.3: StageArtifactCard component
+
+**Files:**
+- Create: `frontend/invest/src/components/investment-reports/StageArtifactCard.tsx`
+- Create: `frontend/invest/src/components/investment-reports/stageLabels.ts`
+- Create: `frontend/invest/src/__tests__/StageArtifactCard.test.tsx`
+
+Renders one stage: badge with verdict (colored), confidence bar, summary, key_points list, missing_data chips, cited_snapshot_uuids count.
+
+- [ ] **Step 1: Failing test**
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import { StageArtifactCard } from "../components/investment-reports/StageArtifactCard";
+
+const baseArtifact = {
+  artifactUuid: "a1",
+  stageType: "market" as const,
+  verdict: "bull" as const,
+  confidence: 72,
+  summary: "KOSPI 1.5%",
+  keyPoints: ["KOSPI +1.5%"],
+  buyEvidence: [],
+  sellEvidence: [],
+  riskEvidence: [],
+  missingData: [],
+  citedSnapshotUuids: ["s1", "s2"],
+  modelName: null,
+  promptVersion: null,
+  createdAt: "2026-05-20T00:00:00Z",
+};
+
+test("renders verdict label and confidence", () => {
+  render(<StageArtifactCard artifact={baseArtifact} />);
+  expect(screen.getByText(/매수/)).toBeInTheDocument();
+  expect(screen.getByText(/72/)).toBeInTheDocument();
+  expect(screen.getByText(/KOSPI \+1\.5%/)).toBeInTheDocument();
+  expect(screen.getByText(/스냅샷 2개/)).toBeInTheDocument();
+});
+
+test("flags missing_data", () => {
+  render(
+    <StageArtifactCard
+      artifact={{ ...baseArtifact, missingData: ["news_articles"] }}
+    />,
+  );
+  expect(screen.getByText(/누락 데이터/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2-3: Implement**
+
+`stageLabels.ts`:
+
+```typescript
+import type { StageType, StageVerdict } from "../../types/investmentReports";
+
+export const STAGE_TYPE_LABELS: Record<StageType, string> = {
+  market: "시장",
+  news: "뉴스",
+  portfolio_journal: "포트폴리오·저널",
+  watch_context: "와치 컨텍스트",
+  candidate_universe: "후보 종목",
+  bull_reducer: "매수 측 요약",
+  bear_reducer: "매도/위험 측 요약",
+  risk_review: "리스크 리뷰",
+};
+
+export const VERDICT_LABELS: Record<StageVerdict, string> = {
+  bull: "매수 측",
+  bear: "매도 측",
+  neutral: "중립",
+  unavailable: "확인 불가",
+};
+```
+
+`StageArtifactCard.tsx`:
+
+```tsx
+import type { StageArtifact } from "../../types/investmentReports";
+import { STAGE_TYPE_LABELS, VERDICT_LABELS } from "./stageLabels";
+
+const VERDICT_COLORS = {
+  bull: "#2e7d32",
+  bear: "#c62828",
+  neutral: "#5c6b73",
+  unavailable: "#9e9e9e",
+} as const;
+
+export function StageArtifactCard({ artifact }: { artifact: StageArtifact }) {
+  return (
+    <article
+      style={{
+        border: "1px solid #d0d7de",
+        borderRadius: 8,
+        padding: 14,
+        display: "grid",
+        gap: 8,
+      }}
+      data-testid={`stage-card-${artifact.stageType}`}
+    >
+      <header style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+        <strong>{STAGE_TYPE_LABELS[artifact.stageType]}</strong>
+        <span style={{ color: VERDICT_COLORS[artifact.verdict], fontWeight: 600 }}>
+          {VERDICT_LABELS[artifact.verdict]}
+        </span>
+        <span style={{ marginLeft: "auto", fontSize: 12, color: "#5c6b73" }}>
+          신뢰도 {artifact.confidence}
+        </span>
+      </header>
+      {artifact.summary ? <p style={{ margin: 0 }}>{artifact.summary}</p> : null}
+      {artifact.keyPoints.length > 0 ? (
+        <ul style={{ margin: 0, paddingLeft: 16 }}>
+          {artifact.keyPoints.map((kp, i) => (
+            <li key={i}>{kp}</li>
+          ))}
+        </ul>
+      ) : null}
+      {artifact.missingData.length > 0 ? (
+        <div style={{ fontSize: 12, color: "#9a3324" }}>
+          누락 데이터: {artifact.missingData.join(", ")}
+        </div>
+      ) : null}
+      <footer style={{ fontSize: 11, color: "#5c6b73" }}>
+        근거 스냅샷 {artifact.citedSnapshotUuids.length}개
+        {artifact.modelName ? ` · ${artifact.modelName}` : ""}
+      </footer>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 4: Run test; Step 5: Commit**
+
+```bash
+git commit -m "feat(rob-279): StageArtifactCard component"
+```
+
+### Task 5.4: IntermediateAnalysisPanel + mount
+
+**Files:**
+- Create: `frontend/invest/src/components/investment-reports/IntermediateAnalysisPanel.tsx`
+- Modify: `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx`
+- Create: `frontend/invest/src/__tests__/IntermediateAnalysisPanel.test.tsx`
+
+- [ ] **Step 1: Failing test**
+
+```typescript
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { IntermediateAnalysisPanel } from "../components/investment-reports/IntermediateAnalysisPanel";
+
+describe("IntermediateAnalysisPanel", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        report_uuid: "r1",
+        artifacts: [
+          {
+            artifact_uuid: "a1",
+            stage_type: "market",
+            verdict: "bull",
+            confidence: 70,
+            summary: "ok",
+            key_points: [],
+            buy_evidence: [],
+            sell_evidence: [],
+            risk_evidence: [],
+            missing_data: [],
+            cited_snapshot_uuids: [],
+            model_name: null,
+            prompt_version: null,
+            created_at: "2026-05-20T00:00:00Z",
+          },
+        ],
+      }),
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders all stage cards lazily after fetch", async () => {
+    render(<IntermediateAnalysisPanel reportUuid="r1" />);
+    expect(screen.getByText(/중간 분석 로드 중/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId("stage-card-market")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders empty-state when no artifacts", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ report_uuid: "r1", artifacts: [] }),
+    });
+    render(<IntermediateAnalysisPanel reportUuid="r1" />);
+    await waitFor(() =>
+      expect(screen.getByText(/중간 분석 결과가 없습니다/)).toBeInTheDocument(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2-3: Implement**
+
+```tsx
+import { useReportStageArtifacts } from "../../hooks/useReportStageArtifacts";
+import { StageArtifactCard } from "./StageArtifactCard";
+
+export function IntermediateAnalysisPanel({ reportUuid }: { reportUuid: string }) {
+  const { status, artifacts, error, reload } = useReportStageArtifacts(reportUuid);
+
+  if (status === "loading") {
+    return <div>중간 분석 로드 중…</div>;
+  }
+  if (status === "error") {
+    return (
+      <div>
+        중간 분석 조회 실패: {error}
+        <button onClick={reload}>다시 시도</button>
+      </div>
+    );
+  }
+  if (artifacts.length === 0) {
+    return (
+      <div style={{ color: "#5c6b73" }}>
+        중간 분석 결과가 없습니다 (legacy 또는 auto_compose=false 리포트).
+      </div>
+    );
+  }
+
+  return (
+    <section style={{ display: "grid", gap: 10 }}>
+      <h2 style={{ margin: 0 }}>중간 분석</h2>
+      {artifacts.map((a) => (
+        <StageArtifactCard key={a.artifactUuid} artifact={a} />
+      ))}
+    </section>
+  );
+}
+```
+
+In `InvestmentReportBundleContent.tsx`, find the section after `ReportSnapshotEvidencePanel` mount (around line 470) and add:
+
+```tsx
+<IntermediateAnalysisPanel reportUuid={bundle.report.reportUuid} />
+```
+
+Plus import: `import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";`
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend/invest && npx vitest run IntermediateAnalysisPanel`
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/investment-reports/IntermediateAnalysisPanel.tsx frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx frontend/invest/src/__tests__/IntermediateAnalysisPanel.test.tsx
+git commit -m "feat(rob-279): mount IntermediateAnalysisPanel on report detail"
+```
+
+---
+
+## Phase 6 — Integration tests + blocked-report smoke
+
+> Goal: end-to-end integration + stale-gate blocked-report diagnostic test + legacy compatibility.
+
+### Task 6.1: End-to-end happy path
+
+**Files:**
+- Create: `tests/integration/test_rob279_e2e_auto_compose.py`
+
+Spins up: real bundle (via factory) → real stage runner with mocked LLM → real composer → real ingestion. Asserts report row exists with snapshot_bundle_uuid + linked stage run.
+
+- [ ] **Step 1-3: Write + implement test**
+- [ ] **Step 4: Run integration test**
+
+Run: `uv run pytest tests/integration/test_rob279_e2e_auto_compose.py -v -m integration`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "test(rob-279): e2e auto_compose integration"
+```
+
+### Task 6.2: Blocked-report diagnostic test
+
+**Files:**
+- Create: `tests/integration/test_rob279_stale_gate_blocked.py`
+
+Setup: bundle with `freshness_summary.overall = "hard_stale"` + `auto_compose=true` + `request.status = "published"`. Expected: stale gate rejects the ingest, but `GET /trading/api/investment-stage-runs/{run_uuid}` still returns artifacts.
+
+- [ ] **Step 1-3: Write + implement**
+- [ ] **Step 4: Run test**
+
+Run: `uv run pytest tests/integration/test_rob279_stale_gate_blocked.py -v -m integration`
+Expected: 1 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "test(rob-279): blocked-report stage diagnostic remains queryable"
+```
+
+### Task 6.3: Run full backend + frontend test suite
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `make test`
+Expected: all pass; new ROB-279 tests included. Triage any pre-existing failures and document them in the PR.
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `cd frontend/invest && npm test -- --run`
+Expected: all pass.
+
+- [ ] **Step 3: Run lint**
+
+Run: `make lint`
+Expected: clean (or pre-existing only).
+
+- [ ] **Step 4: Manual UI smoke**
+
+Run: `make dev`
+Then in browser open `/invest/reports/<existing-report-uuid>` → confirm "중간 분석" section renders (empty state for legacy reports is OK).
+
+- [ ] **Step 5: Final commit + PR**
+
+```bash
+git log --oneline main..HEAD   # confirm all commits
+gh pr create --title "feat(rob-279): staged snapshot-backed report generation pipeline" --body "$(cat <<'EOF'
+## Summary
+- Adds investment_stage_runs / investment_stage_artifacts tables
+- 8 v1 stages (5 deterministic + 3 LLM reducers) + final composer behind auto_compose=true flag
+- Run-scoped diagnostic API for stale-gate blocked reports
+- /invest/reports IntermediateAnalysisPanel mount
+
+## Test plan
+- [x] Phase 1-6 unit tests pass
+- [x] e2e integration green
+- [x] stale-gate blocked-report still queryable
+- [x] legacy auto_compose=false unchanged
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**1. Spec coverage:**
+
+| Spec item | Plan task |
+|---|---|
+| `investment_stage_runs` / `_artifacts` 명명 | Task 1.1, 1.2 |
+| append-only invariant | Task 1.4 (`AppendOnlyViolation`) |
+| 8 v1 stages | Tasks 2.4–2.11 |
+| LLM budget cap (4 calls) | Task 2.3 + 2.9/2.10/2.11 + 3.1 |
+| `model_rate_limiter` 경유 | Task 3.3 `_build_llm_client()` adapter note |
+| run-scoped 진단 라우트 | Task 4.1 |
+| report-scoped artifact API | Task 4.2 |
+| stale gate blocked-report diagnostic | Task 6.2 |
+| 100% citation 강제 | Task 3.1 (composer strips uncited) |
+| legacy compat | Task 3.4 |
+| 중간 분석 UI 탭 | Tasks 5.1–5.4 |
+
+**2. Placeholder scan:** No "TODO", "TBD", "similar to Task N" references that omit code. Bear/Risk reducer tasks (2.10, 2.11) explicitly call out "mirror Task 2.9 with substitutions" — acceptable because the substitutions are listed concretely.
+
+**3. Type consistency:** `StageArtifactPayload` shape in Pydantic (Task 1.3) matches ORM `InvestmentStageArtifact` columns (Task 1.2) and frontend `StageArtifact` interface (Task 5.1). `StageVerdict` enum values (`bull|bear|neutral|unavailable`) consistent across DB CHECK, Pydantic enum, and TS literal.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-20-rob-279-staged-snapshot-backed-reports.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/frontend/invest/src/__tests__/IntermediateAnalysisPanel.test.tsx
+++ b/frontend/invest/src/__tests__/IntermediateAnalysisPanel.test.tsx
@@ -1,0 +1,170 @@
+// ROB-279 Phase 5 — IntermediateAnalysisPanel tests.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+import { IntermediateAnalysisPanel } from "../components/investment-reports/IntermediateAnalysisPanel";
+
+const originalFetch = global.fetch;
+
+interface FetchResponseInit {
+  status?: number;
+  ok?: boolean;
+  json: () => Promise<unknown>;
+}
+
+function makeResponse(payload: unknown, status: number = 200): FetchResponseInit {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => payload,
+  };
+}
+
+function makeArtifact(
+  stageType: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    artifact_uuid: `art-${stageType}`,
+    run_uuid: "run-1",
+    stage_type: stageType,
+    verdict: "bull",
+    confidence: 70,
+    summary: `Summary for ${stageType}`,
+    key_points: [],
+    buy_evidence: [],
+    sell_evidence: [],
+    risk_evidence: [],
+    missing_data: [],
+    cited_snapshot_uuids: [],
+    freshness_summary: null,
+    model_name: "gemini-2.0-flash",
+    prompt_version: "v1",
+    payload_hash: null,
+    raw_payload_json: null,
+    created_at: "2026-05-20T12:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("IntermediateAnalysisPanel", () => {
+  it("shows loading state initially", () => {
+    // Fetch that never resolves (simulate slow network)
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {})) as unknown as typeof fetch;
+
+    render(<IntermediateAnalysisPanel reportUuid="uuid-1" />);
+    expect(
+      screen.getByTestId("intermediate-analysis-panel-loading"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all stage cards after data loads", async () => {
+    const stageTypes = ["market", "news", "portfolio_journal"];
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeResponse({
+        report_uuid: "uuid-1",
+        stage_run_uuid: "run-1",
+        artifacts: stageTypes.map((t) => makeArtifact(t)),
+      }),
+    );
+
+    render(<IntermediateAnalysisPanel reportUuid="uuid-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("intermediate-analysis-panel"),
+      ).toBeInTheDocument(),
+    );
+
+    for (const stageType of stageTypes) {
+      expect(
+        screen.getByTestId(`stage-card-${stageType}`),
+      ).toBeInTheDocument();
+    }
+
+    expect(screen.getByText("중간 분석")).toBeInTheDocument();
+  });
+
+  it("shows empty state when artifacts is empty", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeResponse({
+        report_uuid: "uuid-1",
+        stage_run_uuid: null,
+        artifacts: [],
+      }),
+    );
+
+    render(<IntermediateAnalysisPanel reportUuid="uuid-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("intermediate-analysis-panel-empty"),
+      ).toBeInTheDocument(),
+    );
+
+    expect(
+      screen.getByText(
+        "중간 분석 결과가 없습니다 (legacy 또는 auto_compose=false 리포트).",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error state on fetch failure with reload button", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("network failure"))
+      .mockResolvedValue(
+        makeResponse({
+          report_uuid: "uuid-1",
+          stage_run_uuid: "run-1",
+          artifacts: [makeArtifact("market")],
+        }),
+      );
+
+    render(<IntermediateAnalysisPanel reportUuid="uuid-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("intermediate-analysis-panel-error"),
+      ).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText(/network failure/)).toBeInTheDocument();
+
+    const reloadButton = screen.getByRole("button", { name: "다시 시도" });
+    expect(reloadButton).toBeInTheDocument();
+
+    fireEvent.click(reloadButton);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("intermediate-analysis-panel"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows error state on non-OK HTTP response", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      makeResponse({}, 404),
+    );
+
+    render(<IntermediateAnalysisPanel reportUuid="uuid-missing" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("intermediate-analysis-panel-error"),
+      ).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText(/404/)).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/StageArtifactCard.test.tsx
+++ b/frontend/invest/src/__tests__/StageArtifactCard.test.tsx
@@ -1,0 +1,168 @@
+// ROB-279 Phase 5 — StageArtifactCard unit tests.
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { StageArtifactCard } from "../components/investment-reports/StageArtifactCard";
+import type { StageArtifact } from "../types/investmentReports";
+
+function makeArtifact(overrides: Partial<StageArtifact> = {}): StageArtifact {
+  return {
+    artifactUuid: "art-1",
+    runUuid: "run-1",
+    stageType: "market",
+    verdict: "bull",
+    confidence: 85,
+    summary: "Strong market conditions",
+    keyPoints: ["Momentum positive", "Volume high"],
+    buyEvidence: [],
+    sellEvidence: [],
+    riskEvidence: [],
+    missingData: [],
+    citedSnapshotUuids: ["snap-1", "snap-2", "snap-3"],
+    freshnessSummary: null,
+    modelName: "gemini-2.0-flash",
+    promptVersion: "v1",
+    payloadHash: null,
+    rawPayloadJson: null,
+    createdAt: "2026-05-20T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("StageArtifactCard", () => {
+  it("renders the stage type label in Korean", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ stageType: "market" })} />);
+    expect(screen.getByText("시장")).toBeInTheDocument();
+  });
+
+  it("renders the verdict label in Korean", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ verdict: "bull" })} />);
+    expect(screen.getByText("매수 측")).toBeInTheDocument();
+  });
+
+  it("renders bear verdict label", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ verdict: "bear" })} />);
+    expect(screen.getByText("매도 측")).toBeInTheDocument();
+  });
+
+  it("renders neutral verdict label", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ verdict: "neutral" })} />);
+    expect(screen.getByText("중립")).toBeInTheDocument();
+  });
+
+  it("renders unavailable verdict label", () => {
+    render(
+      <StageArtifactCard artifact={makeArtifact({ verdict: "unavailable" })} />,
+    );
+    expect(screen.getByText("확인 불가")).toBeInTheDocument();
+  });
+
+  it("renders confidence value", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ confidence: 85 })} />);
+    expect(screen.getByText("85")).toBeInTheDocument();
+  });
+
+  it("renders zero confidence", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ confidence: 0 })} />);
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("renders the summary text", () => {
+    render(
+      <StageArtifactCard
+        artifact={makeArtifact({ summary: "Strong market conditions" })}
+      />,
+    );
+    expect(screen.getByText("Strong market conditions")).toBeInTheDocument();
+  });
+
+  it("does not render summary section when summary is null", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ summary: null })} />);
+    expect(screen.queryByText("Strong market conditions")).not.toBeInTheDocument();
+  });
+
+  it("renders key points as a list", () => {
+    render(
+      <StageArtifactCard
+        artifact={makeArtifact({ keyPoints: ["Point A", "Point B"] })}
+      />,
+    );
+    expect(screen.getByText("Point A")).toBeInTheDocument();
+    expect(screen.getByText("Point B")).toBeInTheDocument();
+  });
+
+  it("renders missing_data chips with '누락 데이터:' prefix", () => {
+    render(
+      <StageArtifactCard
+        artifact={makeArtifact({ missingData: ["news_api", "portfolio"] })}
+      />,
+    );
+    expect(screen.getByText("누락 데이터: news_api")).toBeInTheDocument();
+    expect(screen.getByText("누락 데이터: portfolio")).toBeInTheDocument();
+  });
+
+  it("renders the citation count in the footer", () => {
+    render(
+      <StageArtifactCard
+        artifact={makeArtifact({
+          citedSnapshotUuids: ["snap-1", "snap-2", "snap-3"],
+        })}
+      />,
+    );
+    expect(screen.getByText("근거 스냅샷 3개")).toBeInTheDocument();
+  });
+
+  it("renders model name in the footer", () => {
+    render(
+      <StageArtifactCard
+        artifact={makeArtifact({ modelName: "gemini-2.0-flash" })}
+      />,
+    );
+    expect(screen.getByText("gemini-2.0-flash")).toBeInTheDocument();
+  });
+
+  it("omits model name from footer when null", () => {
+    render(<StageArtifactCard artifact={makeArtifact({ modelName: null })} />);
+    // Model name should not appear; the separator '·' should not appear either
+    expect(screen.queryByText("gemini-2.0-flash")).not.toBeInTheDocument();
+  });
+
+  it("applies the correct data-testid to the article", () => {
+    render(
+      <StageArtifactCard artifact={makeArtifact({ stageType: "risk_review" })} />,
+    );
+    expect(screen.getByTestId("stage-card-risk_review")).toBeInTheDocument();
+  });
+
+  it("renders all 8 stage type labels", () => {
+    const stages: Array<StageArtifact["stageType"]> = [
+      "market",
+      "news",
+      "portfolio_journal",
+      "watch_context",
+      "candidate_universe",
+      "bull_reducer",
+      "bear_reducer",
+      "risk_review",
+    ];
+    const expectedLabels = [
+      "시장",
+      "뉴스",
+      "포트폴리오·저널",
+      "와치 컨텍스트",
+      "후보 종목",
+      "매수 측 요약",
+      "매도/위험 측 요약",
+      "리스크 리뷰",
+    ];
+
+    for (let i = 0; i < stages.length; i++) {
+      const { unmount } = render(
+        <StageArtifactCard artifact={makeArtifact({ stageType: stages[i] })} />,
+      );
+      expect(screen.getByText(expectedLabels[i]!)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/frontend/invest/src/__tests__/investmentStagesApi.test.ts
+++ b/frontend/invest/src/__tests__/investmentStagesApi.test.ts
@@ -1,0 +1,152 @@
+// ROB-279 Phase 5 — investmentStages API client normalization tests.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchReportStageArtifacts } from "../api/investmentStages";
+
+const originalFetch = global.fetch;
+
+function mockFetchOnce(payload: unknown, status: number = 200): void {
+  global.fetch = vi.fn().mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+const SNAKE_ARTIFACT = {
+  artifact_uuid: "art-1",
+  run_uuid: "run-1",
+  stage_type: "market",
+  verdict: "bull",
+  confidence: 72,
+  summary: "Market looks positive",
+  key_points: ["Point A", "Point B"],
+  buy_evidence: ["ev1"],
+  sell_evidence: [],
+  risk_evidence: ["risk1"],
+  missing_data: [],
+  cited_snapshot_uuids: ["snap-1", "snap-2"],
+  freshness_summary: { overall: "fresh" },
+  model_name: "gemini-2.0-flash",
+  prompt_version: "v1",
+  payload_hash: "abc123",
+  raw_payload_json: { raw: true },
+  created_at: "2026-05-20T12:00:00Z",
+};
+
+describe("fetchReportStageArtifacts", () => {
+  it("normalises snake_case response to camelCase", async () => {
+    mockFetchOnce({
+      report_uuid: "uuid-1",
+      stage_run_uuid: "run-1",
+      artifacts: [SNAKE_ARTIFACT],
+    });
+
+    const result = await fetchReportStageArtifacts("uuid-1");
+
+    expect(result.reportUuid).toBe("uuid-1");
+    expect(result.stageRunUuid).toBe("run-1");
+    expect(result.artifacts).toHaveLength(1);
+
+    const art = result.artifacts[0]!;
+    expect(art.artifactUuid).toBe("art-1");
+    expect(art.runUuid).toBe("run-1");
+    expect(art.stageType).toBe("market");
+    expect(art.verdict).toBe("bull");
+    expect(art.confidence).toBe(72);
+    expect(art.summary).toBe("Market looks positive");
+    expect(art.keyPoints).toEqual(["Point A", "Point B"]);
+    expect(art.buyEvidence).toEqual(["ev1"]);
+    expect(art.sellEvidence).toEqual([]);
+    expect(art.riskEvidence).toEqual(["risk1"]);
+    expect(art.missingData).toEqual([]);
+    expect(art.citedSnapshotUuids).toEqual(["snap-1", "snap-2"]);
+    expect(art.freshnessSummary).toEqual({ overall: "fresh" });
+    expect(art.modelName).toBe("gemini-2.0-flash");
+    expect(art.promptVersion).toBe("v1");
+    expect(art.payloadHash).toBe("abc123");
+    expect(art.rawPayloadJson).toEqual({ raw: true });
+    expect(art.createdAt).toBe("2026-05-20T12:00:00Z");
+  });
+
+  it("handles null stageRunUuid gracefully", async () => {
+    mockFetchOnce({
+      report_uuid: "uuid-2",
+      stage_run_uuid: null,
+      artifacts: [],
+    });
+
+    const result = await fetchReportStageArtifacts("uuid-2");
+    expect(result.stageRunUuid).toBeNull();
+    expect(result.artifacts).toHaveLength(0);
+  });
+
+  it("handles null/missing optional fields on an artifact", async () => {
+    mockFetchOnce({
+      report_uuid: "uuid-3",
+      stage_run_uuid: null,
+      artifacts: [
+        {
+          artifact_uuid: "art-2",
+          run_uuid: "run-2",
+          stage_type: "news",
+          verdict: "neutral",
+          confidence: 0,
+          summary: null,
+          key_points: [],
+          buy_evidence: [],
+          sell_evidence: [],
+          risk_evidence: [],
+          missing_data: ["news_api"],
+          cited_snapshot_uuids: [],
+          freshness_summary: null,
+          model_name: null,
+          prompt_version: null,
+          payload_hash: null,
+          raw_payload_json: null,
+          created_at: "2026-05-20T12:00:00Z",
+        },
+      ],
+    });
+
+    const result = await fetchReportStageArtifacts("uuid-3");
+    const art = result.artifacts[0]!;
+    expect(art.summary).toBeNull();
+    expect(art.freshnessSummary).toBeNull();
+    expect(art.modelName).toBeNull();
+    expect(art.missingData).toEqual(["news_api"]);
+  });
+
+  it("URL-encodes the report_uuid", async () => {
+    mockFetchOnce({
+      report_uuid: "uuid with space",
+      stage_run_uuid: null,
+      artifacts: [],
+    });
+
+    await fetchReportStageArtifacts("uuid with space");
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("uuid%20with%20space"),
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("throws an error including the status code on non-OK response", async () => {
+    mockFetchOnce({}, 404);
+    await expect(fetchReportStageArtifacts("uuid-1")).rejects.toThrow(/404/);
+  });
+
+  it("throws an error on 500 response", async () => {
+    mockFetchOnce({ detail: "internal error" }, 500);
+    await expect(fetchReportStageArtifacts("uuid-1")).rejects.toThrow(/500/);
+  });
+});

--- a/frontend/invest/src/__tests__/useReportStageArtifacts.test.ts
+++ b/frontend/invest/src/__tests__/useReportStageArtifacts.test.ts
@@ -1,0 +1,147 @@
+// ROB-279 Phase 5 — useReportStageArtifacts hook tests.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useReportStageArtifacts } from "../hooks/useReportStageArtifacts";
+
+const originalFetch = global.fetch;
+
+function makeArtifact(overrides: Record<string, unknown> = {}) {
+  return {
+    artifact_uuid: "art-1",
+    run_uuid: "run-1",
+    stage_type: "market",
+    verdict: "bull",
+    confidence: 80,
+    summary: "Strong uptrend",
+    key_points: ["momentum"],
+    buy_evidence: [],
+    sell_evidence: [],
+    risk_evidence: [],
+    missing_data: [],
+    cited_snapshot_uuids: ["snap-1"],
+    freshness_summary: null,
+    model_name: "gemini-2.0-flash",
+    prompt_version: "v1",
+    payload_hash: null,
+    raw_payload_json: null,
+    created_at: "2026-05-20T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function mockFetch(payload: unknown, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("useReportStageArtifacts", () => {
+  it("starts with status 'loading' and no artifacts", () => {
+    mockFetch({ report_uuid: "uuid-1", stage_run_uuid: null, artifacts: [] });
+
+    const { result } = renderHook(() =>
+      useReportStageArtifacts("uuid-1"),
+    );
+
+    expect(result.current.status).toBe("loading");
+    expect(result.current.artifacts).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions to 'ready' and populates artifacts on success", async () => {
+    mockFetch({
+      report_uuid: "uuid-1",
+      stage_run_uuid: "run-1",
+      artifacts: [makeArtifact()],
+    });
+
+    const { result } = renderHook(() =>
+      useReportStageArtifacts("uuid-1"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.artifacts).toHaveLength(1);
+    expect(result.current.artifacts[0]!.artifactUuid).toBe("art-1");
+    expect(result.current.stageRunUuid).toBe("run-1");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("transitions to 'error' when fetch throws", async () => {
+    global.fetch = vi.fn().mockRejectedValue(
+      new Error("network error"),
+    ) as unknown as typeof fetch;
+
+    const { result } = renderHook(() =>
+      useReportStageArtifacts("uuid-1"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toMatch(/network error/);
+    expect(result.current.artifacts).toEqual([]);
+  });
+
+  it("transitions to 'error' when server returns non-OK", async () => {
+    mockFetch({}, 404);
+
+    const { result } = renderHook(() =>
+      useReportStageArtifacts("uuid-1"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toMatch(/404/);
+  });
+
+  it("stays 'loading' and does not fetch when reportUuid is undefined", async () => {
+    const { result } = renderHook(() =>
+      useReportStageArtifacts(undefined),
+    );
+
+    // Wait a tick to ensure no async transition happens
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(result.current.status).toBe("loading");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("reload increments call count (re-fetches)", async () => {
+    mockFetch({
+      report_uuid: "uuid-1",
+      stage_run_uuid: "run-1",
+      artifacts: [makeArtifact()],
+    });
+
+    const { result } = renderHook(() =>
+      useReportStageArtifacts("uuid-1"),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const callsBefore = fetchMock.mock.calls.length;
+
+    act(() => {
+      result.current.reload();
+    });
+
+    await waitFor(() => {
+      expect(
+        (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeGreaterThan(callsBefore);
+    });
+  });
+});

--- a/frontend/invest/src/api/investmentStages.ts
+++ b/frontend/invest/src/api/investmentStages.ts
@@ -1,0 +1,89 @@
+// ROB-279 Phase 5 — API client for the stage artifacts endpoint.
+//
+// GET /invest/api/investment-reports/{reportUuid}/stage-artifacts
+// Converts the snake_case JSON to camelCase TypeScript shapes from
+// ``../types/investmentReports``.
+
+import type {
+  ReportStageArtifactsResponse,
+  StageArtifact,
+  StageType,
+  StageVerdict,
+} from "../types/investmentReports";
+
+const STAGE_ARTIFACTS_ENDPOINT = (reportUuid: string) =>
+  `/invest/api/investment-reports/${encodeURIComponent(reportUuid)}/stage-artifacts`;
+
+type ApiArtifact = Record<string, unknown>;
+
+function asString(value: unknown, fallback: string = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asOptionalString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  return typeof value === "string" ? value : null;
+}
+
+function asNumber(value: unknown, fallback: number = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function asArray<T = unknown>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function asOptionalRecord(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function normalizeArtifact(raw: ApiArtifact): StageArtifact {
+  return {
+    artifactUuid: asString(raw.artifact_uuid),
+    runUuid: asString(raw.run_uuid),
+    stageType: asString(raw.stage_type, "market") as StageType,
+    verdict: asString(raw.verdict, "unavailable") as StageVerdict,
+    confidence: asNumber(raw.confidence),
+    summary: asOptionalString(raw.summary),
+    keyPoints: asArray(raw.key_points),
+    buyEvidence: asArray(raw.buy_evidence),
+    sellEvidence: asArray(raw.sell_evidence),
+    riskEvidence: asArray(raw.risk_evidence),
+    missingData: asArray(raw.missing_data),
+    citedSnapshotUuids: asArray<string>(raw.cited_snapshot_uuids),
+    freshnessSummary: asOptionalRecord(raw.freshness_summary),
+    modelName: asOptionalString(raw.model_name),
+    promptVersion: asOptionalString(raw.prompt_version),
+    payloadHash: asOptionalString(raw.payload_hash),
+    rawPayloadJson: asOptionalRecord(raw.raw_payload_json),
+    createdAt: asString(raw.created_at),
+  };
+}
+
+export async function fetchReportStageArtifacts(
+  reportUuid: string,
+  signal?: AbortSignal,
+): Promise<ReportStageArtifactsResponse> {
+  const endpoint = STAGE_ARTIFACTS_ENDPOINT(reportUuid);
+  const res = await fetch(endpoint, { credentials: "include", signal });
+  if (!res.ok) {
+    throw new Error(`${endpoint} ${res.status}`);
+  }
+  const raw = (await res.json()) as {
+    report_uuid?: unknown;
+    stage_run_uuid?: unknown;
+    artifacts?: ApiArtifact[];
+  };
+
+  return {
+    reportUuid: asString(raw.report_uuid),
+    stageRunUuid: asOptionalString(raw.stage_run_uuid),
+    artifacts: asArray<ApiArtifact>(raw.artifacts).map(normalizeArtifact),
+  };
+}

--- a/frontend/invest/src/components/investment-reports/IntermediateAnalysisPanel.tsx
+++ b/frontend/invest/src/components/investment-reports/IntermediateAnalysisPanel.tsx
@@ -1,0 +1,97 @@
+// ROB-279 Phase 5 — Intermediate analysis panel.
+//
+// Mounted on /invest/reports/:reportUuid below ReportSnapshotEvidencePanel.
+// Lazy-loads stage artifacts via useReportStageArtifacts; renders each
+// artifact as a StageArtifactCard.
+
+import type { JSX } from "react";
+
+import { Card } from "../../ds";
+import { useReportStageArtifacts } from "../../hooks/useReportStageArtifacts";
+import { StageArtifactCard } from "./StageArtifactCard";
+
+export interface IntermediateAnalysisPanelProps {
+  reportUuid: string;
+}
+
+export function IntermediateAnalysisPanel({
+  reportUuid,
+}: IntermediateAnalysisPanelProps): JSX.Element | null {
+  const { status, artifacts, error, reload } =
+    useReportStageArtifacts(reportUuid);
+
+  if (status === "loading") {
+    return (
+      <Card>
+        <div
+          data-testid="intermediate-analysis-panel-loading"
+          style={{ color: "var(--fg-3)", fontSize: 13 }}
+        >
+          중간 분석 로드 중…
+        </div>
+      </Card>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Card>
+        <div
+          data-testid="intermediate-analysis-panel-error"
+          style={{
+            display: "flex",
+            gap: 10,
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <span style={{ color: "var(--danger)", fontSize: 13 }}>
+            {error ?? "중간 분석을 불러오지 못했습니다."}
+          </span>
+          <button
+            type="button"
+            onClick={reload}
+            style={{
+              padding: "4px 10px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "transparent",
+              color: "var(--fg-2)",
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+          >
+            다시 시도
+          </button>
+        </div>
+      </Card>
+    );
+  }
+
+  if (artifacts.length === 0) {
+    return (
+      <Card>
+        <div
+          data-testid="intermediate-analysis-panel-empty"
+          style={{ color: "var(--fg-3)", fontSize: 13 }}
+        >
+          중간 분석 결과가 없습니다 (legacy 또는 auto_compose=false 리포트).
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div
+        data-testid="intermediate-analysis-panel"
+        style={{ display: "grid", gap: 12 }}
+      >
+        <h2 style={{ margin: 0, fontSize: 18 }}>중간 분석</h2>
+        {artifacts.map((artifact) => (
+          <StageArtifactCard key={artifact.artifactUuid} artifact={artifact} />
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -16,6 +16,7 @@ import type {
   InvestmentWatchEvent,
   SnapshotFreshnessSummary,
 } from "../../types/investmentReports";
+import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";
 import { ProposalDiffPanel } from "./ProposalDiffPanel";
 import { ReportSnapshotEvidencePanel } from "./ReportSnapshotEvidencePanel";
 import { SnapshotBundleFreshnessChip } from "./SnapshotBundleFreshnessChip";
@@ -474,6 +475,8 @@ export function InvestmentReportBundleContent({
       />
 
       <ReportSnapshotEvidencePanel reportUuid={bundle.report.reportUuid} />
+
+      <IntermediateAnalysisPanel reportUuid={bundle.report.reportUuid} />
 
       {(
         ["action", "watch", "risk"] as const

--- a/frontend/invest/src/components/investment-reports/StageArtifactCard.tsx
+++ b/frontend/invest/src/components/investment-reports/StageArtifactCard.tsx
@@ -1,0 +1,156 @@
+// ROB-279 Phase 5 — Single stage artifact card.
+//
+// Renders one StageArtifact row: stage label + verdict pill + confidence
+// (right-aligned) → summary → key_points list → missing_data chips (red
+// text) → footer with cited snapshot count and model name.
+
+import type { JSX } from "react";
+
+import type { StageArtifact, StageVerdict } from "../../types/investmentReports";
+import { STAGE_TYPE_LABELS, VERDICT_LABELS } from "./stageLabels";
+
+const VERDICT_COLORS: Record<StageVerdict, { background: string; color: string }> = {
+  bull: { background: "rgba(52,199,89,0.15)", color: "var(--success, #34c759)" },
+  bear: { background: "rgba(255,59,48,0.15)", color: "var(--danger, #ff3b30)" },
+  neutral: { background: "rgba(142,142,147,0.15)", color: "var(--fg-3, #8e8e93)" },
+  unavailable: { background: "rgba(209,209,214,0.15)", color: "var(--fg-3, #aeaeb2)" },
+};
+
+interface StageArtifactCardProps {
+  artifact: StageArtifact;
+}
+
+export function StageArtifactCard({ artifact }: StageArtifactCardProps): JSX.Element {
+  const stageLabel = STAGE_TYPE_LABELS[artifact.stageType] ?? artifact.stageType;
+  const verdictLabel = VERDICT_LABELS[artifact.verdict] ?? artifact.verdict;
+  const verdictStyle = VERDICT_COLORS[artifact.verdict] ?? VERDICT_COLORS.unavailable;
+
+  const citationCount = artifact.citedSnapshotUuids.length;
+
+  return (
+    <article
+      data-testid={`stage-card-${artifact.stageType}`}
+      style={{
+        display: "grid",
+        gap: 10,
+        padding: 14,
+        border: "1px solid var(--border)",
+        borderRadius: 12,
+        background: "rgba(255,255,255,0.015)",
+      }}
+    >
+      {/* Header row: stage label + verdict pill + confidence */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 10,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span style={{ fontWeight: 700, fontSize: 14 }}>{stageLabel}</span>
+          <span
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              padding: "2px 8px",
+              borderRadius: 100,
+              background: verdictStyle.background,
+              color: verdictStyle.color,
+            }}
+          >
+            {verdictLabel}
+          </span>
+        </div>
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 800,
+            color: "var(--fg-2)",
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {artifact.confidence}
+        </span>
+      </div>
+
+      {/* Summary */}
+      {artifact.summary ? (
+        <p
+          style={{
+            margin: 0,
+            fontSize: 13,
+            lineHeight: 1.6,
+            color: "var(--fg-2)",
+          }}
+        >
+          {artifact.summary}
+        </p>
+      ) : null}
+
+      {/* Key points */}
+      {artifact.keyPoints.length > 0 ? (
+        <ul
+          style={{
+            margin: 0,
+            paddingLeft: 18,
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          {artifact.keyPoints.map((point, idx) => (
+            <li
+              // eslint-disable-next-line react/no-array-index-key
+              key={idx}
+              style={{ fontSize: 13, color: "var(--fg-2)", lineHeight: 1.5 }}
+            >
+              {typeof point === "string" ? point : JSON.stringify(point)}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {/* Missing data chips */}
+      {artifact.missingData.length > 0 ? (
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {artifact.missingData.map((item, idx) => (
+            <span
+              // eslint-disable-next-line react/no-array-index-key
+              key={idx}
+              style={{
+                fontSize: 11,
+                color: "var(--danger, #ff3b30)",
+                background: "rgba(255,59,48,0.08)",
+                padding: "2px 8px",
+                borderRadius: 8,
+              }}
+            >
+              누락 데이터: {typeof item === "string" ? item : JSON.stringify(item)}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Footer */}
+      <div
+        style={{
+          fontSize: 11,
+          color: "var(--fg-3)",
+          display: "flex",
+          gap: 6,
+          flexWrap: "wrap",
+        }}
+      >
+        <span>근거 스냅샷 {citationCount}개</span>
+        {artifact.modelName ? (
+          <>
+            <span>·</span>
+            <span>{artifact.modelName}</span>
+          </>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/frontend/invest/src/components/investment-reports/stageLabels.ts
+++ b/frontend/invest/src/components/investment-reports/stageLabels.ts
@@ -1,0 +1,24 @@
+// ROB-279 Phase 5 — Korean labels for stage artifact types and verdicts.
+//
+// Centralised so a new StageType or StageVerdict value only needs to be
+// reflected in one place.
+
+import type { StageType, StageVerdict } from "../../types/investmentReports";
+
+export const STAGE_TYPE_LABELS: Record<StageType, string> = {
+  market: "시장",
+  news: "뉴스",
+  portfolio_journal: "포트폴리오·저널",
+  watch_context: "와치 컨텍스트",
+  candidate_universe: "후보 종목",
+  bull_reducer: "매수 측 요약",
+  bear_reducer: "매도/위험 측 요약",
+  risk_review: "리스크 리뷰",
+};
+
+export const VERDICT_LABELS: Record<StageVerdict, string> = {
+  bull: "매수 측",
+  bear: "매도 측",
+  neutral: "중립",
+  unavailable: "확인 불가",
+};

--- a/frontend/invest/src/hooks/useReportStageArtifacts.ts
+++ b/frontend/invest/src/hooks/useReportStageArtifacts.ts
@@ -1,0 +1,65 @@
+// ROB-279 Phase 5 — lazy-fetch hook for stage artifacts.
+//
+// Fires once on mount per (reportUuid). AbortController is cleaned up on
+// unmount or when reportUuid changes. A ``reload`` helper increments an
+// internal tick to re-trigger the effect.
+
+import { useEffect, useState } from "react";
+
+import { fetchReportStageArtifacts } from "../api/investmentStages";
+import type {
+  InvestmentReportRequestState,
+  StageArtifact,
+} from "../types/investmentReports";
+
+interface UseReportStageArtifactsResult {
+  status: InvestmentReportRequestState;
+  artifacts: StageArtifact[];
+  stageRunUuid: string | null;
+  error: string | null;
+  reload: () => void;
+}
+
+export function useReportStageArtifacts(
+  reportUuid: string | undefined,
+): UseReportStageArtifactsResult {
+  const [status, setStatus] =
+    useState<InvestmentReportRequestState>("loading");
+  const [artifacts, setArtifacts] = useState<StageArtifact[]>([]);
+  const [stageRunUuid, setStageRunUuid] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!reportUuid) {
+      // Keep status as "loading" while uuid is not yet resolved (e.g. params
+      // not ready). Do NOT set error — the parent component hasn't failed.
+      return;
+    }
+    const controller = new AbortController();
+    setStatus("loading");
+    setError(null);
+
+    fetchReportStageArtifacts(reportUuid, controller.signal)
+      .then((response) => {
+        setArtifacts(response.artifacts);
+        setStageRunUuid(response.stageRunUuid);
+        setStatus("ready");
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      });
+
+    return () => controller.abort();
+  }, [reportUuid, tick]);
+
+  return {
+    status,
+    artifacts,
+    stageRunUuid,
+    error,
+    reload: () => setTick((value) => value + 1),
+  };
+}

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -348,3 +348,45 @@ export interface ReportSnapshotDetail {
   errorsJson: Record<string, unknown>;
   payloadJson: Record<string, unknown>;
 }
+
+// ROB-279 Phase 5 — Stage artifact types. Mirrors the backend
+// ``app/schemas/investment_stage_runs.py`` response shapes.
+
+export type StageVerdict = "bull" | "bear" | "neutral" | "unavailable";
+
+export type StageType =
+  | "market"
+  | "news"
+  | "portfolio_journal"
+  | "watch_context"
+  | "candidate_universe"
+  | "bull_reducer"
+  | "bear_reducer"
+  | "risk_review";
+
+export interface StageArtifact {
+  artifactUuid: string;
+  runUuid: string;
+  stageType: StageType;
+  verdict: StageVerdict;
+  confidence: number;
+  summary: string | null;
+  keyPoints: unknown[];
+  buyEvidence: unknown[];
+  sellEvidence: unknown[];
+  riskEvidence: unknown[];
+  missingData: unknown[];
+  citedSnapshotUuids: string[];
+  freshnessSummary: Record<string, unknown> | null;
+  modelName: string | null;
+  promptVersion: string | null;
+  payloadHash: string | null;
+  rawPayloadJson: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface ReportStageArtifactsResponse {
+  reportUuid: string;
+  stageRunUuid: string | null;
+  artifacts: StageArtifact[];
+}

--- a/tests/integration/test_rob279_staged_pipeline_e2e.py
+++ b/tests/integration/test_rob279_staged_pipeline_e2e.py
@@ -1,0 +1,98 @@
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+
+
+@pytest.mark.asyncio
+async def test_staged_pipeline_e2e_with_mocked_llm(db_session):
+    # This integration test verifies that setting auto_compose=True
+    # triggers the StageRunner and FinalComposer.
+
+    # 1. Mock the ensure_service to return a bundle with snapshots
+    bundle_uuid = uuid.uuid4()
+    ensure_mock = AsyncMock()
+    from types import SimpleNamespace
+    ensure_mock.ensure.return_value = SimpleNamespace(
+        bundle_uuid=bundle_uuid,
+        status="complete",
+        coverage_summary={},
+        freshness_summary={"overall": "fresh"},
+        missing_sources=[],
+        warnings=[],
+        created=True,
+    )
+
+    # 2. Mock GeminiProvider.ask to return consistent JSON for stages and composer
+    with patch("app.services.ai_providers.gemini_provider.GeminiProvider.ask") as mock_ask:
+        from app.services.ai_providers.base import AiProviderResult
+
+        # We expect 4 LLM calls (bull, bear, risk, composer)
+        mock_ask.side_effect = [
+            # bull_reducer
+            AiProviderResult(answer='{"verdict": "bull", "confidence": 70, "summary": "Bull synthesis"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            # bear_reducer
+            AiProviderResult(answer='{"verdict": "bear", "confidence": 30, "summary": "Bear synthesis"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            # risk_review
+            AiProviderResult(answer='{"verdict": "bull", "confidence": 60, "summary": "Risk review"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            # final_composer
+            AiProviderResult(answer='{"title": "AI Report", "summary": "Full summary", "items": [{"client_item_key": "x", "item_kind": "action", "intent": "buy_review", "symbol": "BTC", "side": "buy", "rationale": "r", "cited_stage_types": ["bull_reducer"]}]}', provider="g", model="m", usage=None, elapsed_ms=1),
+        ]
+
+        generator = SnapshotBackedReportGenerator(
+            db_session,
+            ensure_service=ensure_mock,
+        )
+
+        request = ReportGenerationRequest(
+            market="crypto",
+            account_scope="upbit_live",
+            created_by_profile="AI_ADVISOR",
+            title="DUMMY",
+            summary="DUMMY",
+            kst_date="2026-05-20",
+            auto_compose=True,
+        )
+
+        # We need a real bundle in the DB because _LocalBundleRead fetches it
+        from app.models.investment_snapshots import InvestmentSnapshotBundle
+        bundle = InvestmentSnapshotBundle(
+            bundle_uuid=bundle_uuid,
+            purpose="report_generation",
+            market="crypto",
+            account_scope="upbit_live",
+            status="complete",
+            policy_version="v1",
+            as_of=datetime.now(tz=UTC),
+            idempotency_key=f"e2e-test-{bundle_uuid.hex[:12]}",
+        )
+        db_session.add(bundle)
+        await db_session.flush()
+
+        response = await generator.generate(request)
+
+        assert response.bundle_status == "complete"
+        assert response.items_count == 1
+
+        # Verify ingestion occurred via side effects or by checking DB
+        from sqlalchemy import select
+
+        from app.models.investment_reports import InvestmentReport
+        result = await db_session.execute(select(InvestmentReport).where(InvestmentReport.report_uuid == response.report_uuid))
+        report = result.scalar_one()
+        assert report.title == "AI Report"
+        assert "investment_stage_run_uuid" in report.report_metadata
+
+        # Verify stage run was persisted
+        from app.models.investment_stages import InvestmentStageRun
+        run_uuid = uuid.UUID(report.report_metadata["investment_stage_run_uuid"])
+        result = await db_session.execute(select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid))
+        stage_run = result.scalar_one()
+        assert stage_run.status == "completed"
+        assert len(stage_run.artifacts) == 8

--- a/tests/integration/test_rob279_staged_pipeline_e2e.py
+++ b/tests/integration/test_rob279_staged_pipeline_e2e.py
@@ -19,6 +19,7 @@ async def test_staged_pipeline_e2e_with_mocked_llm(db_session):
     bundle_uuid = uuid.uuid4()
     ensure_mock = AsyncMock()
     from types import SimpleNamespace
+
     ensure_mock.ensure.return_value = SimpleNamespace(
         bundle_uuid=bundle_uuid,
         status="complete",
@@ -30,19 +31,45 @@ async def test_staged_pipeline_e2e_with_mocked_llm(db_session):
     )
 
     # 2. Mock GeminiProvider.ask to return consistent JSON for stages and composer
-    with patch("app.services.ai_providers.gemini_provider.GeminiProvider.ask") as mock_ask:
+    with patch(
+        "app.services.ai_providers.gemini_provider.GeminiProvider.ask"
+    ) as mock_ask:
         from app.services.ai_providers.base import AiProviderResult
 
         # We expect 4 LLM calls (bull, bear, risk, composer)
         mock_ask.side_effect = [
             # bull_reducer
-            AiProviderResult(answer='{"verdict": "bull", "confidence": 70, "summary": "Bull synthesis"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            AiProviderResult(
+                answer='{"verdict": "bull", "confidence": 70, "summary": "Bull synthesis"}',
+                provider="g",
+                model="m",
+                usage=None,
+                elapsed_ms=1,
+            ),
             # bear_reducer
-            AiProviderResult(answer='{"verdict": "bear", "confidence": 30, "summary": "Bear synthesis"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            AiProviderResult(
+                answer='{"verdict": "bear", "confidence": 30, "summary": "Bear synthesis"}',
+                provider="g",
+                model="m",
+                usage=None,
+                elapsed_ms=1,
+            ),
             # risk_review
-            AiProviderResult(answer='{"verdict": "bull", "confidence": 60, "summary": "Risk review"}', provider="g", model="m", usage=None, elapsed_ms=1),
+            AiProviderResult(
+                answer='{"verdict": "bull", "confidence": 60, "summary": "Risk review"}',
+                provider="g",
+                model="m",
+                usage=None,
+                elapsed_ms=1,
+            ),
             # final_composer
-            AiProviderResult(answer='{"title": "AI Report", "summary": "Full summary", "items": [{"client_item_key": "x", "item_kind": "action", "intent": "buy_review", "symbol": "BTC", "side": "buy", "rationale": "r", "cited_stage_types": ["bull_reducer"]}]}', provider="g", model="m", usage=None, elapsed_ms=1),
+            AiProviderResult(
+                answer='{"title": "AI Report", "summary": "Full summary", "items": [{"client_item_key": "x", "item_kind": "action", "intent": "buy_review", "symbol": "BTC", "side": "buy", "rationale": "r", "cited_stage_types": ["bull_reducer"]}]}',
+                provider="g",
+                model="m",
+                usage=None,
+                elapsed_ms=1,
+            ),
         ]
 
         generator = SnapshotBackedReportGenerator(
@@ -62,6 +89,7 @@ async def test_staged_pipeline_e2e_with_mocked_llm(db_session):
 
         # We need a real bundle in the DB because _LocalBundleRead fetches it
         from app.models.investment_snapshots import InvestmentSnapshotBundle
+
         bundle = InvestmentSnapshotBundle(
             bundle_uuid=bundle_uuid,
             purpose="report_generation",
@@ -84,15 +112,23 @@ async def test_staged_pipeline_e2e_with_mocked_llm(db_session):
         from sqlalchemy import select
 
         from app.models.investment_reports import InvestmentReport
-        result = await db_session.execute(select(InvestmentReport).where(InvestmentReport.report_uuid == response.report_uuid))
+
+        result = await db_session.execute(
+            select(InvestmentReport).where(
+                InvestmentReport.report_uuid == response.report_uuid
+            )
+        )
         report = result.scalar_one()
         assert report.title == "AI Report"
         assert "investment_stage_run_uuid" in report.report_metadata
 
         # Verify stage run was persisted
         from app.models.investment_stages import InvestmentStageRun
+
         run_uuid = uuid.UUID(report.report_metadata["investment_stage_run_uuid"])
-        result = await db_session.execute(select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid))
+        result = await db_session.execute(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
         stage_run = result.scalar_one()
         assert stage_run.status == "completed"
         assert len(stage_run.artifacts) == 8

--- a/tests/integration/test_rob279_stale_gate_blocked.py
+++ b/tests/integration/test_rob279_stale_gate_blocked.py
@@ -92,9 +92,7 @@ async def test_stage_run_queryable_without_report_row(db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.get(
-            f"/trading/api/investment-stage-runs/{run.run_uuid}"
-        )
+        resp = await client.get(f"/trading/api/investment-stage-runs/{run.run_uuid}")
 
     assert resp.status_code == 200
     body = resp.json()
@@ -163,9 +161,7 @@ async def test_blocked_run_artifacts_still_queryable(db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.get(
-            f"/trading/api/investment-stage-runs/{run.run_uuid}"
-        )
+        resp = await client.get(f"/trading/api/investment-stage-runs/{run.run_uuid}")
 
     assert resp.status_code == 200
     body = resp.json()

--- a/tests/integration/test_rob279_stale_gate_blocked.py
+++ b/tests/integration/test_rob279_stale_gate_blocked.py
@@ -90,7 +90,7 @@ async def test_stage_run_queryable_without_report_row(db_session):
 
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(f"/trading/api/investment-stage-runs/{run.run_uuid}")
 
@@ -159,7 +159,7 @@ async def test_blocked_run_artifacts_still_queryable(db_session):
 
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(f"/trading/api/investment-stage-runs/{run.run_uuid}")
 

--- a/tests/integration/test_rob279_stale_gate_blocked.py
+++ b/tests/integration/test_rob279_stale_gate_blocked.py
@@ -1,0 +1,185 @@
+"""ROB-279 — Blocked-report diagnostic integration tests.
+
+Proves that even when a stale gate would block final report ingest, the
+stage run + artifacts remain queryable via the run-scoped API
+(GET /trading/api/investment-stage-runs/{run_uuid}).
+
+Two invariants tested:
+
+1. No-report diagnostic: a stage run + artifact seeded directly via
+   InvestmentStagesRepository is fully queryable even though no
+   investment_reports row exists for the run.
+
+2. Blocked-run diagnostic: a stage run whose status was explicitly set
+   to "blocked" (proxy for aborted ingest) is still returned by the
+   endpoint with status="blocked" and any pre-abort artifacts intact.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.routers.investment_stage_runs import router as stage_runs_router
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+# ---------------------------------------------------------------------------
+# App factory (mirrors tests/routers/test_investment_stage_runs.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_app(db_session) -> FastAPI:
+    app = FastAPI()
+    app.include_router(stage_runs_router)
+
+    async def _db_override() -> AsyncIterator:
+        yield db_session
+
+    async def _user_override() -> User:
+        return User(id=1, email="test@example.com", role="user")  # type: ignore[call-arg]
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_authenticated_user] = _user_override
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Test 1: stage run + artifact queryable even with no investment_reports row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stage_run_queryable_without_report_row(db_session):
+    """Forensics invariant: stage run + artifacts remain accessible even
+    when no investment_reports row exists for this run.
+
+    This is the "blocked-report still queryable" scenario — the ingest
+    was never called (stale gate blocked it upstream), but the diagnostic
+    artifacts persisted during the run are still retrievable.
+    """
+    repo = InvestmentStagesRepository(db_session)
+
+    # Seed a stage run with one artifact directly — no report row created.
+    run = await repo.create_run(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="crypto",
+        market_session=None,
+        account_scope="upbit_live",
+    )
+    artifact = await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(
+            stage_type="bull_reducer",
+            verdict=StageVerdict.BULL,
+            confidence=65,
+            summary="Bullish synthesis — no report row exists",
+        ),
+    )
+    await repo.complete_run(run.run_uuid, status="completed")
+    await db_session.flush()
+
+    # No investment_reports row is created — this is intentional.
+
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-stage-runs/{run.run_uuid}"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # Run metadata is present.
+    assert body["run"]["run_uuid"] == str(run.run_uuid)
+    assert body["run"]["status"] == "completed"
+
+    # Artifact is present and correct.
+    assert len(body["artifacts"]) == 1
+    art = body["artifacts"][0]
+    assert art["artifact_uuid"] == str(artifact.artifact_uuid)
+    assert art["stage_type"] == "bull_reducer"
+    assert art["verdict"] == "bull"
+    assert art["confidence"] == 65
+    assert art["run_uuid"] == str(run.run_uuid)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: blocked-status run still returns artifacts persisted before abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blocked_run_artifacts_still_queryable(db_session):
+    """A stage run whose status is 'blocked' (stale gate aborted the final
+    ingest) is still returned by the endpoint with all artifacts that were
+    persisted before the abort.
+
+    This confirms the diagnostic consumer can read partial-run state even
+    when the pipeline was cut short.
+    """
+    repo = InvestmentStagesRepository(db_session)
+
+    # Seed a run with two artifacts, then mark it as blocked.
+    run = await repo.create_run(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+    artifact_bull = await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(
+            stage_type="bull_reducer",
+            verdict=StageVerdict.BULL,
+            confidence=72,
+            summary="Bull evidence collected before abort",
+        ),
+    )
+    artifact_bear = await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(
+            stage_type="bear_reducer",
+            verdict=StageVerdict.BEAR,
+            confidence=28,
+            summary="Bear evidence collected before abort",
+        ),
+    )
+
+    # Simulate stale gate abort: mark run as blocked.
+    await repo.complete_run(run.run_uuid, status="blocked")
+    await db_session.flush()
+
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-stage-runs/{run.run_uuid}"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # Run is returned with blocked status.
+    assert body["run"]["run_uuid"] == str(run.run_uuid)
+    assert body["run"]["status"] == "blocked"
+    assert body["run"]["completed_at"] is not None
+
+    # Both pre-abort artifacts are present.
+    assert len(body["artifacts"]) == 2
+    artifact_uuids = {a["artifact_uuid"] for a in body["artifacts"]}
+    assert str(artifact_bull.artifact_uuid) in artifact_uuids
+    assert str(artifact_bear.artifact_uuid) in artifact_uuids
+
+    stage_types = {a["stage_type"] for a in body["artifacts"]}
+    assert stage_types == {"bull_reducer", "bear_reducer"}

--- a/tests/models/test_investment_stages_model.py
+++ b/tests/models/test_investment_stages_model.py
@@ -42,7 +42,9 @@ async def test_stage_artifact_fk_cascade(db_session):
     await db_session.flush()
 
     fetched = await db_session.scalar(
-        select(InvestmentStageArtifact).where(InvestmentStageArtifact.run_uuid == run.run_uuid)
+        select(InvestmentStageArtifact).where(
+            InvestmentStageArtifact.run_uuid == run.run_uuid
+        )
     )
     assert fetched is not None
     assert fetched.stage_type == "market"

--- a/tests/models/test_investment_stages_model.py
+++ b/tests/models/test_investment_stages_model.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+
+
+@pytest.mark.asyncio
+async def test_stage_run_insert_returns_uuid(db_session):
+    run = InvestmentStageRun(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    assert run.run_uuid is not None
+    assert run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_stage_artifact_fk_cascade(db_session):
+    run = InvestmentStageRun(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+    )
+    db_session.add(run)
+    await db_session.flush()
+
+    artifact = InvestmentStageArtifact(
+        run_uuid=run.run_uuid,
+        stage_type="market",
+        verdict="neutral",
+        confidence=50,
+        cited_snapshot_uuids=[],
+    )
+    db_session.add(artifact)
+    await db_session.flush()
+
+    fetched = await db_session.scalar(
+        select(InvestmentStageArtifact).where(InvestmentStageArtifact.run_uuid == run.run_uuid)
+    )
+    assert fetched is not None
+    assert fetched.stage_type == "market"

--- a/tests/routers/test_investment_stage_runs.py
+++ b/tests/routers/test_investment_stage_runs.py
@@ -233,7 +233,7 @@ async def test_get_stage_run_returns_200_with_artifacts(db_session):
     run_uuid, artifact_uuid = await _seed_run_with_artifact(db_session)
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(f"/trading/api/investment-stage-runs/{run_uuid}")
 
@@ -259,7 +259,7 @@ async def test_get_stage_run_returns_200_with_artifacts(db_session):
 async def test_get_stage_run_returns_404_for_unknown_uuid(db_session):
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(f"/trading/api/investment-stage-runs/{uuid.uuid4()}")
 
@@ -277,7 +277,7 @@ async def test_get_report_stage_artifacts_via_metadata_linkage(db_session):
     )
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
             f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
@@ -300,7 +300,7 @@ async def test_get_report_stage_artifacts_via_metadata_linkage(db_session):
 async def test_get_report_stage_artifacts_returns_404_for_unknown_report(db_session):
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
             f"/trading/api/investment-reports/{uuid.uuid4()}/stage-artifacts"
@@ -319,7 +319,7 @@ async def test_get_report_stage_artifacts_returns_empty_for_no_stage_run(db_sess
     report_uuid = await _seed_bundle_with_report(db_session)
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
             f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
@@ -343,7 +343,7 @@ async def test_get_report_stage_artifacts_404_when_no_bundle_and_no_metadata_run
     report_uuid = await _seed_report_no_bundle_no_metadata(db_session)
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
             f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
@@ -364,7 +364,7 @@ async def test_get_report_stage_artifacts_404_when_metadata_run_uuid_stale(
     report_uuid = await _seed_report_with_stale_metadata_run_uuid(db_session)
     app = _build_app(db_session)
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://testserver"
+        transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
             f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"

--- a/tests/routers/test_investment_stage_runs.py
+++ b/tests/routers/test_investment_stage_runs.py
@@ -44,6 +44,7 @@ from app.services.investment_stages.repository import InvestmentStagesRepository
 # App factory (mirrors test_investment_snapshots_router.py)
 # ---------------------------------------------------------------------------
 
+
 def _build_app(db_session) -> FastAPI:
     """Minimal FastAPI app for testing — uses the shared db_session fixture."""
     app = FastAPI()
@@ -67,6 +68,7 @@ def _now() -> dt.datetime:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 async def _seed_run_with_artifact(db_session):
     """Create a stage run with one artifact; return (run_uuid, artifact_uuid)."""
@@ -259,9 +261,7 @@ async def test_get_stage_run_returns_404_for_unknown_uuid(db_session):
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://testserver"
     ) as client:
-        resp = await client.get(
-            f"/trading/api/investment-stage-runs/{uuid.uuid4()}"
-        )
+        resp = await client.get(f"/trading/api/investment-stage-runs/{uuid.uuid4()}")
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "stage_run_not_found"

--- a/tests/routers/test_investment_stage_runs.py
+++ b/tests/routers/test_investment_stage_runs.py
@@ -1,0 +1,374 @@
+"""ROB-279 — Router-level tests for investment-stage-runs endpoints.
+
+Uses the AsyncClient + ASGITransport pattern (same as
+tests/routers/test_investment_snapshots_router.py) to exercise endpoints
+over ASGI without spinning the full app and SSO loop.
+
+Test coverage:
+1. 200 + artifact list for a valid run UUID
+2. 404 for unknown run UUID
+3. 200 + artifacts via report→run linkage (metadata field on report)
+4. 404 for unknown report UUID
+5. 200 + empty artifacts for a report that has a bundle but no stage run
+   (legacy fallback — bundle exists but no stage runs → empty list)
+6. 404 when report has neither snapshot_bundle_uuid nor stage_run_uuid in
+   metadata (new spec compliance — both paths absent → 404, not 200 empty)
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.routers.investment_stage_runs import router as stage_runs_router
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+# ---------------------------------------------------------------------------
+# App factory (mirrors test_investment_snapshots_router.py)
+# ---------------------------------------------------------------------------
+
+def _build_app(db_session) -> FastAPI:
+    """Minimal FastAPI app for testing — uses the shared db_session fixture."""
+    app = FastAPI()
+    app.include_router(stage_runs_router)
+
+    async def _db_override() -> AsyncIterator:
+        yield db_session
+
+    async def _user_override() -> User:
+        return User(id=1, email="test@example.com", role="user")  # type: ignore[call-arg]
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_authenticated_user] = _user_override
+    return app
+
+
+def _now() -> dt.datetime:
+    return dt.datetime(2026, 5, 20, 11, 0, 0, tzinfo=dt.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _seed_run_with_artifact(db_session):
+    """Create a stage run with one artifact; return (run_uuid, artifact_uuid)."""
+    repo = InvestmentStagesRepository(db_session)
+    run = await repo.create_run(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+    artifact = await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(
+            stage_type="market",
+            verdict=StageVerdict.BULL,
+            confidence=70,
+            summary="bullish overall",
+        ),
+    )
+    await db_session.flush()
+    return run.run_uuid, artifact.artifact_uuid
+
+
+async def _seed_report_with_stage_run(db_session):
+    """Create a report whose metadata links to a stage run.
+
+    Returns (report_uuid, stage_run_uuid, artifact_uuid).
+    """
+    stage_run_uuid, artifact_uuid = await _seed_run_with_artifact(db_session)
+
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=uuid.uuid4(),
+        idempotency_key=f"k-{uuid.uuid4().hex[:8]}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="rob279-router-test",
+        title="t",
+        summary="s",
+        report_metadata={"investment_stage_run_uuid": str(stage_run_uuid)},
+    )
+    await db_session.flush()
+    return report.report_uuid, stage_run_uuid, artifact_uuid
+
+
+async def _seed_bundle_with_report(db_session):
+    """Create a snapshot bundle and a report linked to it (no stage run).
+
+    Returns report_uuid.
+    """
+    snap_repo = InvestmentSnapshotsRepository(db_session)
+    run = await snap_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    snap = await snap_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={"cash_krw": 1_000},
+            as_of=_now(),
+            freshness_status="fresh",
+        )
+    )
+    bundle = await snap_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"rob279_bundle_{uuid.uuid4().hex[:8]}",
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_now(),
+            status="complete",
+        )
+    )
+    await snap_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="required"),
+    )
+
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=uuid.uuid4(),
+        idempotency_key=f"k-{uuid.uuid4().hex[:8]}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="rob279-router-test",
+        title="t",
+        summary="s",
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+    )
+    await db_session.flush()
+    return report.report_uuid
+
+
+async def _seed_report_no_bundle_no_metadata(db_session):
+    """Create a report with no snapshot_bundle_uuid and no stage_run_uuid metadata.
+
+    Returns report_uuid.
+    """
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=uuid.uuid4(),
+        idempotency_key=f"k-{uuid.uuid4().hex[:8]}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="rob279-router-test",
+        title="t",
+        summary="s",
+        # snapshot_bundle_uuid intentionally omitted (defaults to None)
+        # report_metadata intentionally omitted (defaults to None)
+    )
+    await db_session.flush()
+    return report.report_uuid
+
+
+async def _seed_report_with_stale_metadata_run_uuid(db_session):
+    """Create a report whose metadata references a stage run UUID that does not exist.
+
+    Returns report_uuid.
+    """
+    stale_run_uuid = uuid.uuid4()  # never inserted into stage runs
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=uuid.uuid4(),
+        idempotency_key=f"k-{uuid.uuid4().hex[:8]}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="rob279-router-test",
+        title="t",
+        summary="s",
+        report_metadata={"investment_stage_run_uuid": str(stale_run_uuid)},
+    )
+    await db_session.flush()
+    return report.report_uuid
+
+
+# ---------------------------------------------------------------------------
+# Test 1: 200 + artifact list for a valid run UUID
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_stage_run_returns_200_with_artifacts(db_session):
+    run_uuid, artifact_uuid = await _seed_run_with_artifact(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(f"/trading/api/investment-stage-runs/{run_uuid}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run"]["run_uuid"] == str(run_uuid)
+    assert len(body["artifacts"]) == 1
+    assert body["artifacts"][0]["artifact_uuid"] == str(artifact_uuid)
+    assert body["artifacts"][0]["stage_type"] == "market"
+    assert body["artifacts"][0]["verdict"] == "bull"
+    assert body["artifacts"][0]["confidence"] == 70
+    # Verify new fields are present in response
+    assert "run_uuid" in body["artifacts"][0]
+    assert "payload_hash" in body["artifacts"][0]
+    assert "raw_payload_json" in body["artifacts"][0]
+    assert "created_at" in body["run"]
+
+
+# ---------------------------------------------------------------------------
+# Test 2: 404 for unknown run UUID
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_stage_run_returns_404_for_unknown_uuid(db_session):
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-stage-runs/{uuid.uuid4()}"
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "stage_run_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: 200 + artifacts via report→run linkage through metadata field
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_report_stage_artifacts_via_metadata_linkage(db_session):
+    report_uuid, stage_run_uuid, artifact_uuid = await _seed_report_with_stage_run(
+        db_session
+    )
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["report_uuid"] == str(report_uuid)
+    assert body["stage_run_uuid"] == str(stage_run_uuid)
+    assert len(body["artifacts"]) == 1
+    assert body["artifacts"][0]["artifact_uuid"] == str(artifact_uuid)
+    # run_uuid in artifact should match the stage run
+    assert body["artifacts"][0]["run_uuid"] == str(stage_run_uuid)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: 404 for unknown report UUID
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_report_stage_artifacts_returns_404_for_unknown_report(db_session):
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-reports/{uuid.uuid4()}/stage-artifacts"
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "report_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: 200 + empty artifacts for report with bundle but no stage run
+# (legacy fallback — bundle exists but no stage runs → empty list)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_report_stage_artifacts_returns_empty_for_no_stage_run(db_session):
+    report_uuid = await _seed_bundle_with_report(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["report_uuid"] == str(report_uuid)
+    assert body["stage_run_uuid"] is None
+    assert body["artifacts"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test 6: 404 when report has neither snapshot_bundle_uuid nor stage_run_uuid
+# in metadata (spec compliance — both resolution paths absent → 404)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_report_stage_artifacts_404_when_no_bundle_and_no_metadata_run(
+    db_session,
+):
+    report_uuid = await _seed_report_no_bundle_no_metadata(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
+        )
+
+    assert resp.status_code == 404
+    assert "snapshot_bundle_uuid" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Test 7: 404 when report_metadata carries a stage_run_uuid that no longer
+# exists in the DB (stale link — deleted/migrated run)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_report_stage_artifacts_404_when_metadata_run_uuid_stale(
+    db_session,
+):
+    report_uuid = await _seed_report_with_stale_metadata_run_uuid(db_session)
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        resp = await client.get(
+            f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
+        )
+
+    assert resp.status_code == 404
+    assert "non-existent" in resp.json()["detail"]

--- a/tests/schemas/test_investment_stages_schema.py
+++ b/tests/schemas/test_investment_stages_schema.py
@@ -1,0 +1,38 @@
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+
+
+def test_stage_artifact_payload_minimal_valid():
+    payload = StageArtifactPayload(
+        stage_type="market",
+        verdict=StageVerdict.NEUTRAL,
+        confidence=42,
+    )
+    assert payload.confidence == 42
+    assert payload.cited_snapshots == []
+
+
+def test_stage_artifact_payload_rejects_confidence_out_of_range():
+    with pytest.raises(ValidationError):
+        StageArtifactPayload(
+            stage_type="market",
+            verdict=StageVerdict.BULL,
+            confidence=120,
+        )
+
+
+def test_stage_citation_requires_snapshot_uuid():
+    citation = StageCitation(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="news",
+        payload_path="$.articles[0].title",
+    )
+    assert citation.payload_path.startswith("$")

--- a/tests/services/action_report/snapshot_backed/test_generator_regression.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_regression.py
@@ -1,0 +1,43 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGenerator
+
+
+@pytest.mark.asyncio
+async def test_generator_uses_legacy_path_by_default(db_session):
+    # Ensure the ensure_service returns a simulated bundle response
+    ensure_mock = AsyncMock()
+    from types import SimpleNamespace
+    ensure_mock.ensure.return_value = SimpleNamespace(
+        bundle_uuid=None,  # Will raise early, proving it hit the main generate path before stage runner
+        status="complete",
+        coverage_summary={},
+        freshness_summary={"overall": "fresh"},
+        missing_sources=[],
+        warnings=[],
+        created=True,
+    )
+
+    generator = SnapshotBackedReportGenerator(
+        db_session,
+        ensure_service=ensure_mock,
+    )
+
+    request = ReportGenerationRequest(
+        market="kr",
+        account_scope="kis_live",
+        created_by_profile="PROFILER",
+        title="Title",
+        summary="Summary",
+        kst_date="2026-05-20",
+        auto_compose=False,  # default
+    )
+
+    from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGeneratorError
+    with pytest.raises(SnapshotBackedReportGeneratorError) as exc:
+        await generator.generate(request)
+    
+    assert "bundle ensure returned no bundle_uuid" in str(exc.value)
+    ensure_mock.ensure.assert_called_once()

--- a/tests/services/action_report/snapshot_backed/test_generator_regression.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_regression.py
@@ -1,8 +1,11 @@
-import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
+import pytest
+
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
 from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
-from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGenerator
 
 
 @pytest.mark.asyncio
@@ -10,6 +13,7 @@ async def test_generator_uses_legacy_path_by_default(db_session):
     # Ensure the ensure_service returns a simulated bundle response
     ensure_mock = AsyncMock()
     from types import SimpleNamespace
+
     ensure_mock.ensure.return_value = SimpleNamespace(
         bundle_uuid=None,  # Will raise early, proving it hit the main generate path before stage runner
         status="complete",
@@ -35,9 +39,12 @@ async def test_generator_uses_legacy_path_by_default(db_session):
         auto_compose=False,  # default
     )
 
-    from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGeneratorError
+    from app.services.action_report.snapshot_backed.generator import (
+        SnapshotBackedReportGeneratorError,
+    )
+
     with pytest.raises(SnapshotBackedReportGeneratorError) as exc:
         await generator.generate(request)
-    
+
     assert "bundle ensure returned no bundle_uuid" in str(exc.value)
     ensure_mock.ensure.assert_called_once()

--- a/tests/services/investment_stages/stages/test_base.py
+++ b/tests/services/investment_stages/stages/test_base.py
@@ -1,0 +1,30 @@
+import uuid
+
+import pytest
+
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+
+class _FakeBundleReadService:
+    async def get_bundle(self, *, bundle_uuid):
+        raise NotImplementedError
+
+
+def test_stage_context_holds_bundle_and_snapshots():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"market": []},
+        bundle_metadata={"freshness_overall": "fresh"},
+    )
+    assert ctx.snapshots_for("market") == []
+    assert ctx.snapshots_for("unknown") == []
+
+
+def test_unavailable_stage_error_carries_reason():
+    with pytest.raises(UnavailableStageError) as exc:
+        raise UnavailableStageError("portfolio snapshot missing")
+    assert "portfolio" in str(exc.value)

--- a/tests/services/investment_stages/stages/test_bear_reducer.py
+++ b/tests/services/investment_stages/stages/test_bear_reducer.py
@@ -1,0 +1,40 @@
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.ai_providers.base import AiProviderResult
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.bear_reducer import BearReducerStage
+
+
+@pytest.mark.asyncio
+async def test_bear_reducer_synthesizes_prior_artifacts():
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer='{"verdict": "bear", "confidence": 90, "summary": "Extreme volatility detected"}',
+        provider="gemini",
+        model="gemini-2.5-flash",
+        usage=None,
+        elapsed_ms=100,
+    )
+    budget = StageLLMBudget(max_calls=4)
+    stage = BearReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "market": StageArtifactPayload(
+                stage_type="market", verdict=StageVerdict.BEAR, confidence=80
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+    assert payload.verdict == StageVerdict.BEAR
+    assert payload.confidence == 90
+    assert budget.remaining == 3

--- a/tests/services/investment_stages/stages/test_bear_reducer.py
+++ b/tests/services/investment_stages/stages/test_bear_reducer.py
@@ -11,6 +11,56 @@ from app.services.investment_stages.stages.bear_reducer import BearReducerStage
 
 
 @pytest.mark.asyncio
+async def test_bear_reducer_degrades_when_budget_exhausted():
+    """C3 (ROB-279): BudgetExceeded must produce a deterministic BEAR fallback,
+    not propagate the exception, and not call the LLM provider."""
+    provider = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    stage = BearReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "market": StageArtifactPayload(
+                stage_type="market",
+                verdict=StageVerdict.BEAR,
+                confidence=80,
+                sell_evidence=["macro headwinds", "declining revenue"],
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+
+    provider.ask.assert_not_called()
+    assert payload.verdict == StageVerdict.BEAR
+    assert payload.confidence <= 40
+    assert payload.model_name is None
+    assert "macro headwinds" in (payload.summary or "")
+
+
+@pytest.mark.asyncio
+async def test_bear_reducer_degrades_to_neutral_when_budget_exhausted_and_no_evidence():
+    provider = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    stage = BearReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={},
+    )
+
+    payload = await stage.run(ctx)
+    provider.ask.assert_not_called()
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence <= 20
+
+
+@pytest.mark.asyncio
 async def test_bear_reducer_synthesizes_prior_artifacts():
     provider = AsyncMock()
     provider.ask.return_value = AiProviderResult(

--- a/tests/services/investment_stages/stages/test_bull_reducer.py
+++ b/tests/services/investment_stages/stages/test_bull_reducer.py
@@ -67,6 +67,36 @@ async def test_bull_reducer_degrades_to_neutral_when_budget_exhausted_and_no_evi
 
 
 @pytest.mark.asyncio
+async def test_bull_reducer_falls_back_when_llm_returns_non_object_json():
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer="[]",
+        provider="gemini",
+        model="gemini-2.5-flash",
+        usage=None,
+        elapsed_ms=123,
+    )
+    budget = StageLLMBudget(max_calls=4)
+    stage = BullReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={},
+    )
+
+    payload = await stage.run(ctx)
+
+    provider.ask.assert_called_once()
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence == 20
+    assert payload.missing_data == ["bull_reducer"]
+    assert payload.model_name is None
+    assert payload.prompt_version is None
+
+
+@pytest.mark.asyncio
 async def test_bull_reducer_synthesizes_prior_artifacts():
     provider = AsyncMock()
     provider.ask.return_value = AiProviderResult(

--- a/tests/services/investment_stages/stages/test_bull_reducer.py
+++ b/tests/services/investment_stages/stages/test_bull_reducer.py
@@ -11,6 +11,62 @@ from app.services.investment_stages.stages.bull_reducer import BullReducerStage
 
 
 @pytest.mark.asyncio
+async def test_bull_reducer_degrades_when_budget_exhausted():
+    """C3 (ROB-279): BudgetExceeded must produce a deterministic BULL fallback,
+    not propagate the exception, and not call the LLM provider."""
+    provider = AsyncMock()
+    # Budget already exhausted (0 remaining calls)
+    budget = StageLLMBudget(max_calls=0)
+    stage = BullReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "market": StageArtifactPayload(
+                stage_type="market",
+                verdict=StageVerdict.BULL,
+                confidence=70,
+                buy_evidence=["strong earnings", "positive guidance"],
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+
+    # LLM must NOT be called on budget exhaustion
+    provider.ask.assert_not_called()
+    # Verdict should be BULL because buy_evidence was present
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.confidence <= 40
+    assert payload.model_name is None
+    assert payload.prompt_version is None
+    # Summary should contain at least one buy evidence fragment
+    assert "strong earnings" in (payload.summary or "")
+
+
+@pytest.mark.asyncio
+async def test_bull_reducer_degrades_to_neutral_when_budget_exhausted_and_no_evidence():
+    """C3: with no buy_evidence and exhausted budget → NEUTRAL at low confidence."""
+    provider = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    stage = BullReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={},
+    )
+
+    payload = await stage.run(ctx)
+    provider.ask.assert_not_called()
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence <= 20
+
+
+@pytest.mark.asyncio
 async def test_bull_reducer_synthesizes_prior_artifacts():
     provider = AsyncMock()
     provider.ask.return_value = AiProviderResult(

--- a/tests/services/investment_stages/stages/test_bull_reducer.py
+++ b/tests/services/investment_stages/stages/test_bull_reducer.py
@@ -1,0 +1,41 @@
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.ai_providers.base import AiProviderResult
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.bull_reducer import BullReducerStage
+
+
+@pytest.mark.asyncio
+async def test_bull_reducer_synthesizes_prior_artifacts():
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer='{"verdict": "bull", "confidence": 85, "summary": "Highly positive news and market momentum"}',
+        provider="gemini",
+        model="gemini-2.5-flash",
+        usage=None,
+        elapsed_ms=123,
+    )
+    budget = StageLLMBudget(max_calls=4)
+    stage = BullReducerStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "market": StageArtifactPayload(
+                stage_type="market", verdict=StageVerdict.BULL, confidence=60
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.confidence == 85
+    assert budget.remaining == 3
+    provider.ask.assert_called_once()

--- a/tests/services/investment_stages/stages/test_candidate_universe.py
+++ b/tests/services/investment_stages/stages/test_candidate_universe.py
@@ -5,7 +5,9 @@ import pytest
 
 from app.schemas.investment_stages import StageVerdict
 from app.services.investment_stages.stages.base import StageContext
-from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+from app.services.investment_stages.stages.candidate_universe import (
+    CandidateUniverseStage,
+)
 
 
 def _snap(candidates):

--- a/tests/services/investment_stages/stages/test_candidate_universe.py
+++ b/tests/services/investment_stages/stages/test_candidate_universe.py
@@ -1,0 +1,47 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.candidate_universe import CandidateUniverseStage
+
+
+def _snap(candidates):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="candidate_universe",
+        payload_json={"candidates": candidates},
+    )
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_bull_on_high_scores():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "candidate_universe": [
+                _snap([{"symbol": "AAPL", "score": 8.5, "reason": "momentum"}])
+            ]
+        },
+        bundle_metadata={},
+    )
+    payload = await CandidateUniverseStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert "AAPL" in payload.summary
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_neutral_on_low_scores():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "candidate_universe": [
+                _snap([{"symbol": "INTC", "score": 2.0, "reason": "laggard"}])
+            ]
+        },
+        bundle_metadata={},
+    )
+    payload = await CandidateUniverseStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL

--- a/tests/services/investment_stages/stages/test_market.py
+++ b/tests/services/investment_stages/stages/test_market.py
@@ -49,6 +49,8 @@ async def test_market_stage_emits_bear_when_index_down():
 
 @pytest.mark.asyncio
 async def test_market_stage_raises_unavailable_when_no_snapshot():
-    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={}
+    )
     with pytest.raises(UnavailableStageError):
         await MarketStage().run(ctx)

--- a/tests/services/investment_stages/stages/test_market.py
+++ b/tests/services/investment_stages/stages/test_market.py
@@ -1,0 +1,54 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.market import MarketStage
+
+
+def _snapshot(payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="market",
+        payload_json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_stage_emits_bull_when_index_up():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "market": [_snapshot({"indices": {"KOSPI": {"change_percent": 2.0}}})]
+        },
+        bundle_metadata={},
+    )
+    payload = await MarketStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.confidence >= 50
+    assert len(payload.cited_snapshots) == 1
+
+
+@pytest.mark.asyncio
+async def test_market_stage_emits_bear_when_index_down():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "market": [_snapshot({"indices": {"KOSPI": {"change_percent": -2.0}}})]
+        },
+        bundle_metadata={},
+    )
+    payload = await MarketStage().run(ctx)
+    assert payload.verdict == StageVerdict.BEAR
+
+
+@pytest.mark.asyncio
+async def test_market_stage_raises_unavailable_when_no_snapshot():
+    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    with pytest.raises(UnavailableStageError):
+        await MarketStage().run(ctx)

--- a/tests/services/investment_stages/stages/test_news.py
+++ b/tests/services/investment_stages/stages/test_news.py
@@ -1,0 +1,42 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.news import NewsStage
+
+
+def _snap(articles):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="news",
+        payload_json={"articles": articles},
+    )
+
+
+@pytest.mark.asyncio
+async def test_news_stage_neutral_on_empty_articles():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"news": [_snap([])]},
+        bundle_metadata={},
+    )
+    payload = await NewsStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+
+
+@pytest.mark.asyncio
+async def test_news_stage_bull_when_positive_dominates():
+    articles = [{"title": "good", "sentiment": "positive"}] * 5 + [
+        {"title": "bad", "sentiment": "negative"}
+    ]
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={"news": [_snap(articles)]},
+        bundle_metadata={},
+    )
+    payload = await NewsStage().run(ctx)
+    assert payload.verdict == StageVerdict.BULL
+    assert payload.cited_snapshots

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -8,16 +8,22 @@ from app.services.investment_stages.stages.base import (
     StageContext,
     UnavailableStageError,
 )
-from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+from app.services.investment_stages.stages.portfolio_journal import (
+    PortfolioJournalStage,
+)
 
 
 def _snap(kind, payload):
-    return SimpleNamespace(snapshot_uuid=uuid.uuid4(), snapshot_kind=kind, payload_json=payload)
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(), snapshot_kind=kind, payload_json=payload
+    )
 
 
 @pytest.mark.asyncio
 async def test_portfolio_journal_unavailable_without_portfolio():
-    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={}
+    )
     with pytest.raises(UnavailableStageError):
         await PortfolioJournalStage().run(ctx)
 
@@ -27,8 +33,12 @@ async def test_portfolio_journal_emits_neutral_with_buying_power():
     ctx = StageContext(
         bundle_uuid=uuid.uuid4(),
         snapshots_by_kind={
-            "portfolio": [_snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})],
-            "journal": [_snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})],
+            "portfolio": [
+                _snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})
+            ],
+            "journal": [
+                _snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})
+            ],
         },
         bundle_metadata={},
     )

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -1,0 +1,38 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.portfolio_journal import PortfolioJournalStage
+
+
+def _snap(kind, payload):
+    return SimpleNamespace(snapshot_uuid=uuid.uuid4(), snapshot_kind=kind, payload_json=payload)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_unavailable_without_portfolio():
+    ctx = StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+    with pytest.raises(UnavailableStageError):
+        await PortfolioJournalStage().run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_emits_neutral_with_buying_power():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})],
+            "journal": [_snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert "035420" in (payload.summary or "")
+    assert len(payload.cited_snapshots) >= 1

--- a/tests/services/investment_stages/stages/test_risk_review.py
+++ b/tests/services/investment_stages/stages/test_risk_review.py
@@ -11,6 +11,56 @@ from app.services.investment_stages.stages.risk_review import RiskReviewStage
 
 
 @pytest.mark.asyncio
+async def test_risk_review_degrades_when_budget_exhausted():
+    """C3 (ROB-279): BudgetExceeded must produce a deterministic BEAR fallback,
+    not propagate the exception, and not call the LLM provider."""
+    provider = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    stage = RiskReviewStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "bull_reducer": StageArtifactPayload(
+                stage_type="bull_reducer",
+                verdict=StageVerdict.BULL,
+                confidence=60,
+                risk_evidence=["leverage risk", "concentration risk"],
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+
+    provider.ask.assert_not_called()
+    assert payload.verdict == StageVerdict.BEAR
+    assert payload.confidence <= 40
+    assert payload.model_name is None
+    assert "leverage risk" in (payload.summary or "")
+
+
+@pytest.mark.asyncio
+async def test_risk_review_degrades_to_neutral_when_budget_exhausted_and_no_evidence():
+    provider = AsyncMock()
+    budget = StageLLMBudget(max_calls=0)
+    stage = RiskReviewStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={},
+    )
+
+    payload = await stage.run(ctx)
+    provider.ask.assert_not_called()
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence <= 20
+
+
+@pytest.mark.asyncio
 async def test_risk_review_synthesizes_prior_artifacts():
     provider = AsyncMock()
     provider.ask.return_value = AiProviderResult(

--- a/tests/services/investment_stages/stages/test_risk_review.py
+++ b/tests/services/investment_stages/stages/test_risk_review.py
@@ -83,7 +83,7 @@ async def test_risk_review_synthesizes_prior_artifacts():
             ),
             "bear_reducer": StageArtifactPayload(
                 stage_type="bear_reducer", verdict=StageVerdict.BEAR, confidence=60
-            )
+            ),
         },
     )
 

--- a/tests/services/investment_stages/stages/test_risk_review.py
+++ b/tests/services/investment_stages/stages/test_risk_review.py
@@ -1,0 +1,43 @@
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.ai_providers.base import AiProviderResult
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.stages.base import StageContext
+from app.services.investment_stages.stages.risk_review import RiskReviewStage
+
+
+@pytest.mark.asyncio
+async def test_risk_review_synthesizes_prior_artifacts():
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer='{"verdict": "neutral", "confidence": 50, "summary": "Balanced risk-reward"}',
+        provider="gemini",
+        model="gemini-2.5-flash",
+        usage=None,
+        elapsed_ms=100,
+    )
+    budget = StageLLMBudget(max_calls=4)
+    stage = RiskReviewStage(provider, budget)
+
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={},
+        bundle_metadata={},
+        prior_artifacts={
+            "bull_reducer": StageArtifactPayload(
+                stage_type="bull_reducer", verdict=StageVerdict.BULL, confidence=60
+            ),
+            "bear_reducer": StageArtifactPayload(
+                stage_type="bear_reducer", verdict=StageVerdict.BEAR, confidence=60
+            )
+        },
+    )
+
+    payload = await stage.run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence == 50
+    assert budget.remaining == 3

--- a/tests/services/investment_stages/stages/test_stage_base.py
+++ b/tests/services/investment_stages/stages/test_stage_base.py
@@ -3,7 +3,6 @@ import uuid
 import pytest
 
 from app.services.investment_stages.stages.base import (
-    Stage,
     StageContext,
     UnavailableStageError,
 )

--- a/tests/services/investment_stages/stages/test_watch_context.py
+++ b/tests/services/investment_stages/stages/test_watch_context.py
@@ -23,7 +23,9 @@ def _snap(payload):
 async def test_watch_context_unavailable():
     with pytest.raises(UnavailableStageError):
         await WatchContextStage().run(
-            StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+            StageContext(
+                bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={}
+            )
         )
 
 

--- a/tests/services/investment_stages/stages/test_watch_context.py
+++ b/tests/services/investment_stages/stages/test_watch_context.py
@@ -1,0 +1,50 @@
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.watch_context import WatchContextStage
+
+
+def _snap(payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(),
+        snapshot_kind="watch_context",
+        payload_json=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_watch_context_unavailable():
+    with pytest.raises(UnavailableStageError):
+        await WatchContextStage().run(
+            StageContext(bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={})
+        )
+
+
+@pytest.mark.asyncio
+async def test_watch_context_lists_active_alerts():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "watch_context": [
+                _snap(
+                    {
+                        "active_alerts": [
+                            {"symbol": "035420", "condition": "price < 200000"},
+                            {"symbol": "015760", "condition": "price > 25000"},
+                        ]
+                    }
+                )
+            ]
+        },
+        bundle_metadata={},
+    )
+    payload = await WatchContextStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert any("035420" in kp for kp in payload.key_points)

--- a/tests/services/investment_stages/test_budget.py
+++ b/tests/services/investment_stages/test_budget.py
@@ -1,0 +1,21 @@
+import pytest
+
+from app.services.investment_stages.budget import (
+    BudgetExceeded,
+    StageLLMBudget,
+)
+
+
+def test_budget_consumes_within_cap():
+    b = StageLLMBudget(max_calls=4)
+    for _ in range(4):
+        b.consume("bull_reducer")
+    assert b.remaining == 0
+
+
+def test_budget_rejects_overshoot():
+    b = StageLLMBudget(max_calls=2)
+    b.consume("a")
+    b.consume("b")
+    with pytest.raises(BudgetExceeded):
+        b.consume("c")

--- a/tests/services/investment_stages/test_composer.py
+++ b/tests/services/investment_stages/test_composer.py
@@ -1,0 +1,43 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.ai_providers.base import AiProviderResult
+from app.services.investment_stages.budget import StageLLMBudget
+from app.services.investment_stages.composer import FinalComposer
+
+
+@pytest.mark.asyncio
+async def test_composer_assembles_report_and_enforces_citations():
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer='{"title": "Test Report", "summary": "Sum", "items": [{"client_item_key": "k1", "item_kind": "action", "intent": "buy_review", "symbol": "AAPL", "side": "buy", "rationale": "r", "cited_stage_types": ["market"]}]}',
+        provider="gemini",
+        model="m",
+        usage=None,
+        elapsed_ms=1,
+    )
+    budget = StageLLMBudget()
+    composer = FinalComposer(provider, budget)
+
+    market_uuid = uuid.uuid4()
+    artifacts = [
+        SimpleNamespace(stage_type="market", artifact_uuid=market_uuid, verdict="bull", summary="s", key_points=[], buy_evidence=[], sell_evidence=[], risk_evidence=[])
+    ]
+
+    req = await composer.compose(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+        kst_date="2026-05-20",
+        artifacts=artifacts,
+    )
+
+    assert req.title == "Test Report"
+    assert len(req.items) == 1
+    assert str(market_uuid) in req.items[0].metadata["cited_stage_uuids"]
+    assert budget.remaining == 3

--- a/tests/services/investment_stages/test_composer.py
+++ b/tests/services/investment_stages/test_composer.py
@@ -79,7 +79,16 @@ async def test_composer_assembles_report_and_enforces_citations():
 
     market_uuid = uuid.uuid4()
     artifacts = [
-        SimpleNamespace(stage_type="market", artifact_uuid=market_uuid, verdict="bull", summary="s", key_points=[], buy_evidence=[], sell_evidence=[], risk_evidence=[])
+        SimpleNamespace(
+            stage_type="market",
+            artifact_uuid=market_uuid,
+            verdict="bull",
+            summary="s",
+            key_points=[],
+            buy_evidence=[],
+            sell_evidence=[],
+            risk_evidence=[],
+        )
     ]
 
     req = await composer.compose(

--- a/tests/services/investment_stages/test_composer.py
+++ b/tests/services/investment_stages/test_composer.py
@@ -10,6 +10,61 @@ from app.services.investment_stages.composer import FinalComposer
 
 
 @pytest.mark.asyncio
+async def test_composer_drops_uncited_items():
+    """C2 (ROB-279): items with empty or unknown cited_stage_types must be dropped;
+    when ALL items are dropped a single no_action_note fallback is emitted."""
+    provider = AsyncMock()
+    provider.ask.return_value = AiProviderResult(
+        answer=(
+            '{"title": "T", "summary": "S", "items": ['
+            '{"client_item_key": "k_empty", "item_kind": "action", "intent": "buy_review",'
+            ' "symbol": "AAPL", "side": "buy", "rationale": "r", "cited_stage_types": []},'
+            '{"client_item_key": "k_unknown", "item_kind": "action", "intent": "buy_review",'
+            ' "symbol": "GOOG", "side": "buy", "rationale": "r2", "cited_stage_types": ["unknown_stage"]}'
+            "]}"
+        ),
+        provider="gemini",
+        model="m",
+        usage=None,
+        elapsed_ms=1,
+    )
+    budget = StageLLMBudget()
+    composer = FinalComposer(provider, budget)
+
+    market_uuid = uuid.uuid4()
+    artifacts = [
+        SimpleNamespace(
+            stage_type="market",
+            artifact_uuid=market_uuid,
+            verdict="bull",
+            summary="s",
+            key_points=[],
+            buy_evidence=[],
+            sell_evidence=[],
+            risk_evidence=[],
+        )
+    ]
+
+    req = await composer.compose(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+        kst_date="2026-05-20",
+        artifacts=artifacts,
+    )
+
+    # Both items have no valid citations — both dropped; fallback emitted
+    assert len(req.items) == 1
+    fallback = req.items[0]
+    assert fallback.client_item_key == "auto-no-action"
+    assert fallback.item_kind == "risk"
+    assert fallback.operation == "review"
+    assert "stage citations" in fallback.rationale
+
+
+@pytest.mark.asyncio
 async def test_composer_assembles_report_and_enforces_citations():
     provider = AsyncMock()
     provider.ask.return_value = AiProviderResult(

--- a/tests/services/investment_stages/test_query_service.py
+++ b/tests/services/investment_stages/test_query_service.py
@@ -14,7 +14,9 @@ async def test_query_service_returns_artifacts_by_run(db_session):
     run = await repo.create_run(snapshot_bundle_uuid=bundle_uuid, market="kr")
     await repo.persist_artifact(
         run.run_uuid,
-        StageArtifactPayload(stage_type="market", verdict=StageVerdict.NEUTRAL, confidence=10),
+        StageArtifactPayload(
+            stage_type="market", verdict=StageVerdict.NEUTRAL, confidence=10
+        ),
     )
     await db_session.flush()
 

--- a/tests/services/investment_stages/test_query_service.py
+++ b/tests/services/investment_stages/test_query_service.py
@@ -1,0 +1,33 @@
+import uuid
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.query_service import StageRunQueryService
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+
+@pytest.mark.asyncio
+async def test_query_service_returns_artifacts_by_run(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(snapshot_bundle_uuid=bundle_uuid, market="kr")
+    await repo.persist_artifact(
+        run.run_uuid,
+        StageArtifactPayload(stage_type="market", verdict=StageVerdict.NEUTRAL, confidence=10),
+    )
+    await db_session.flush()
+
+    svc = StageRunQueryService(db_session)
+    result = await svc.get_run_with_artifacts(run.run_uuid)
+
+    assert result is not None
+    assert result.run.run_uuid == run.run_uuid
+    assert len(result.artifacts) == 1
+    assert result.artifacts[0].stage_type == "market"
+
+
+@pytest.mark.asyncio
+async def test_query_service_returns_none_for_missing_run(db_session):
+    svc = StageRunQueryService(db_session)
+    assert await svc.get_run_with_artifacts(uuid.uuid4()) is None

--- a/tests/services/investment_stages/test_rate_limited_provider.py
+++ b/tests/services/investment_stages/test_rate_limited_provider.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.services.ai_providers.base import AiProviderError, AiProviderResult
-from app.services.investment_stages.rate_limited_provider import RateLimitedGeminiProvider
+from app.services.investment_stages.rate_limited_provider import (
+    RateLimitedGeminiProvider,
+)
 
 
 def _make_provider(model: str = "gemini-2.5-flash") -> MagicMock:

--- a/tests/services/investment_stages/test_rate_limited_provider.py
+++ b/tests/services/investment_stages/test_rate_limited_provider.py
@@ -1,0 +1,104 @@
+"""Tests for RateLimitedGeminiProvider (C1, ROB-279)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ai_providers.base import AiProviderError, AiProviderResult
+from app.services.investment_stages.rate_limited_provider import RateLimitedGeminiProvider
+
+
+def _make_provider(model: str = "gemini-2.5-flash") -> MagicMock:
+    provider = MagicMock()
+    provider.provider_name = "gemini"
+    provider.default_model = model
+    provider.ask = AsyncMock(
+        return_value=AiProviderResult(
+            answer="ok",
+            provider="gemini",
+            model=model,
+            usage=None,
+            elapsed_ms=10,
+        )
+    )
+    return provider
+
+
+def _make_rate_limiter(*, limited: bool = False) -> MagicMock:
+    rl = MagicMock()
+    rl.is_model_limited = AsyncMock(return_value=limited)
+    rl.mark_limited = AsyncMock()
+    return rl
+
+
+@pytest.mark.asyncio
+async def test_passes_through_when_not_limited():
+    provider = _make_provider()
+    rl = _make_rate_limiter(limited=False)
+
+    wrapped = RateLimitedGeminiProvider(provider, rl)
+    result = await wrapped.ask(system_prompt="sys", user_message="msg")
+
+    provider.ask.assert_called_once()
+    assert result.answer == "ok"
+    rl.mark_limited.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_raises_without_calling_provider_when_model_is_limited():
+    provider = _make_provider()
+    rl = _make_rate_limiter(limited=True)
+
+    wrapped = RateLimitedGeminiProvider(provider, rl)
+    with pytest.raises(AiProviderError, match="rate-limited"):
+        await wrapped.ask(system_prompt="sys", user_message="msg")
+
+    # Provider must NOT be called when rate-limited
+    provider.ask.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_records_429_to_rate_limiter():
+    provider = _make_provider()
+    provider.ask = AsyncMock(
+        side_effect=AiProviderError(
+            user_message="rate limit exceeded",
+            detail="429 quota exhausted",
+        )
+    )
+    rl = _make_rate_limiter(limited=False)
+
+    wrapped = RateLimitedGeminiProvider(provider, rl)
+    with pytest.raises(AiProviderError):
+        await wrapped.ask(system_prompt="sys", user_message="msg")
+
+    rl.mark_limited.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_does_not_record_non_429_errors():
+    provider = _make_provider()
+    provider.ask = AsyncMock(
+        side_effect=AiProviderError(
+            user_message="auth error",
+            detail="401 unauthorized",
+        )
+    )
+    rl = _make_rate_limiter(limited=False)
+
+    wrapped = RateLimitedGeminiProvider(provider, rl)
+    with pytest.raises(AiProviderError):
+        await wrapped.ask(system_prompt="sys", user_message="msg")
+
+    rl.mark_limited.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exposes_provider_name_and_default_model():
+    provider = _make_provider(model="gemini-pro")
+    rl = _make_rate_limiter()
+    wrapped = RateLimitedGeminiProvider(provider, rl)
+    assert wrapped.provider_name == "gemini"
+    assert wrapped.default_model == "gemini-pro"

--- a/tests/services/investment_stages/test_repository.py
+++ b/tests/services/investment_stages/test_repository.py
@@ -1,0 +1,57 @@
+import uuid
+
+import pytest
+
+from app.models.investment_stages import InvestmentStageArtifact
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.repository import (
+    AppendOnlyViolation,
+    InvestmentStagesRepository,
+)
+
+
+@pytest.mark.asyncio
+async def test_repository_creates_run_and_returns_uuid(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+        policy_version="v1",
+        generator_version="v1",
+    )
+    assert run.run_uuid is not None
+    assert run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_repository_persist_artifact_then_reject_overwrite(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    bundle_uuid = uuid.uuid4()
+    run = await repo.create_run(
+        snapshot_bundle_uuid=bundle_uuid, market="kr"
+    )
+    payload = StageArtifactPayload(
+        stage_type="market",
+        verdict=StageVerdict.NEUTRAL,
+        confidence=50,
+    )
+    artifact = await repo.persist_artifact(run.run_uuid, payload)
+    assert artifact.stage_type == "market"
+
+    with pytest.raises(AppendOnlyViolation):
+        await repo.persist_artifact(run.run_uuid, payload)
+
+
+@pytest.mark.asyncio
+async def test_repository_complete_run_sets_status(db_session):
+    repo = InvestmentStagesRepository(db_session)
+    run = await repo.create_run(
+        snapshot_bundle_uuid=uuid.uuid4(), market="kr"
+    )
+    await repo.complete_run(run.run_uuid, status="completed")
+    refreshed = await repo.get_run(run.run_uuid)
+    assert refreshed.status == "completed"
+    assert refreshed.completed_at is not None

--- a/tests/services/investment_stages/test_stage_repository.py
+++ b/tests/services/investment_stages/test_stage_repository.py
@@ -2,7 +2,6 @@ import uuid
 
 import pytest
 
-from app.models.investment_stages import InvestmentStageArtifact
 from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
 from app.services.investment_stages.repository import (
     AppendOnlyViolation,
@@ -30,9 +29,7 @@ async def test_repository_creates_run_and_returns_uuid(db_session):
 async def test_repository_persist_artifact_then_reject_overwrite(db_session):
     repo = InvestmentStagesRepository(db_session)
     bundle_uuid = uuid.uuid4()
-    run = await repo.create_run(
-        snapshot_bundle_uuid=bundle_uuid, market="kr"
-    )
+    run = await repo.create_run(snapshot_bundle_uuid=bundle_uuid, market="kr")
     payload = StageArtifactPayload(
         stage_type="market",
         verdict=StageVerdict.NEUTRAL,
@@ -48,9 +45,7 @@ async def test_repository_persist_artifact_then_reject_overwrite(db_session):
 @pytest.mark.asyncio
 async def test_repository_complete_run_sets_status(db_session):
     repo = InvestmentStagesRepository(db_session)
-    run = await repo.create_run(
-        snapshot_bundle_uuid=uuid.uuid4(), market="kr"
-    )
+    run = await repo.create_run(snapshot_bundle_uuid=uuid.uuid4(), market="kr")
     await repo.complete_run(run.run_uuid, status="completed")
     refreshed = await repo.get_run(run.run_uuid)
     assert refreshed.status == "completed"

--- a/tests/services/investment_stages/test_stage_runner.py
+++ b/tests/services/investment_stages/test_stage_runner.py
@@ -5,7 +5,6 @@ import pytest
 from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
 from app.services.investment_stages.stage_runner import StageRunner
 from app.services.investment_stages.stages.base import (
-    Stage,
     StageContext,
     UnavailableStageError,
 )
@@ -33,6 +32,7 @@ class _StubBundleReadService:
 
     async def get_bundle(self, *, bundle_uuid):
         from types import SimpleNamespace
+
         return SimpleNamespace(
             bundle=SimpleNamespace(bundle_uuid=bundle_uuid, status="complete"),
             items=[],

--- a/tests/services/investment_stages/test_stage_runner.py
+++ b/tests/services/investment_stages/test_stage_runner.py
@@ -1,0 +1,62 @@
+import uuid
+
+import pytest
+
+from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.investment_stages.stage_runner import StageRunner
+from app.services.investment_stages.stages.base import (
+    Stage,
+    StageContext,
+    UnavailableStageError,
+)
+
+
+class _MarketStub:
+    stage_type = "market"
+
+    async def run(self, ctx: StageContext) -> StageArtifactPayload:
+        return StageArtifactPayload(
+            stage_type="market", verdict=StageVerdict.BULL, confidence=70
+        )
+
+
+class _NewsUnavailable:
+    stage_type = "news"
+
+    async def run(self, ctx: StageContext) -> StageArtifactPayload:
+        raise UnavailableStageError("no news snapshot")
+
+
+class _StubBundleReadService:
+    def __init__(self, bundle_uuid):
+        self._bundle_uuid = bundle_uuid
+
+    async def get_bundle(self, *, bundle_uuid):
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            bundle=SimpleNamespace(bundle_uuid=bundle_uuid, status="complete"),
+            items=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_stage_runner_runs_all_stages_and_persists(db_session):
+    bundle_uuid = uuid.uuid4()
+    runner = StageRunner(
+        session=db_session,
+        bundle_read_service=_StubBundleReadService(bundle_uuid),
+        stages=[_MarketStub(), _NewsUnavailable()],
+    )
+
+    run = await runner.run(
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+
+    assert run.status == "completed"
+    artifacts = sorted(run.artifacts, key=lambda a: a.stage_type)
+    assert [a.stage_type for a in artifacts] == ["market", "news"]
+    assert artifacts[0].verdict == "bull"
+    assert artifacts[1].verdict == "unavailable"

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -396,6 +396,7 @@ def test_consecutive_gainers_endpoint_separates_served_from_data_basis() -> None
     #  3: _load_consecutive_gainers_from_snapshots → KR symbol names (filter) → .all()
     #  4: _async_enrich → repo.get_fresh → scalars().all()
     #  5: Bulk KR names → .all()
+    #  6: investor-flow chip hydration → latest_by_symbols → scalars().all()
     fake_session = _RouterFakeSession(
         [
             _RouterFakeExecuteResult(rows=[]),  # 0: watch items
@@ -404,6 +405,7 @@ def test_consecutive_gainers_endpoint_separates_served_from_data_basis() -> None
             _RouterFakeExecuteResult(rows=[name_row]),  # 3: KR symbol names (filter)
             _RouterFakeExecuteResult(scalar_rows=[snap]),  # 4: enrichment get_fresh
             _RouterFakeExecuteResult(rows=[name_row]),  # 5: bulk KR names
+            _RouterFakeExecuteResult(scalar_rows=[]),  # 6: no investor-flow chip
         ]
     )
 

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -49,15 +49,16 @@ async def test_build_investor_flow_cards_empty_symbols_returns_empty(db_session)
 
 @pytest.mark.asyncio
 async def test_build_investor_flow_cards_marks_missing_symbol(db_session):
+    missing_symbol = "989898"
     response = await build_investor_flow_cards(
         db=db_session,
-        symbols=["900193"],
+        symbols=[missing_symbol],
         market="kr",
         as_of=dt.date(2026, 5, 11),
     )
 
     assert response.dataState == "missing"
-    assert response.items[0].symbol == "900193"
+    assert response.items[0].symbol == missing_symbol
     assert response.items[0].dataState == "missing"
     assert response.items[0].source is None
 

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -76,9 +76,9 @@ def test_build_n8n_fill_payload_includes_detail_url() -> None:
         market_type="kr",
     )
     payload = _build_n8n_fill_payload(order, correlation_id="corr-123")
-    assert (
-        payload["detail_url"]
-        == "https://mgh3326.duckdns.org/portfolio/positions/kr/005930"
+    expected_base_url = settings.public_base_url.rstrip("/")
+    assert payload["detail_url"] == (
+        f"{expected_base_url}/portfolio/positions/kr/005930"
     )
     assert payload["correlation_id"] == "corr-123"
 


### PR DESCRIPTION
## Summary

ROB-269 가 만든 immutable snapshot bundle → idempotent ingest → stale gate 토대 위에, 감사 가능한 중간 stage artifact 들로부터 final `/invest/reports` 리포트를 합성하는 staged pipeline 을 추가합니다. Linear: https://linear.app/mgh3326/issue/ROB-279

### 핵심 아키텍처
- 신규 `review.investment_stage_runs` + `review.investment_stage_artifacts` (append-only, snapshot bundle 에 귀속).
- 8개 v1 stages (5 deterministic + 3 LLM reducers) + final composer. 모든 stage 는 persisted bundle payload 만 읽음.
- `auto_compose=True` flag 뒤로 격리 — legacy `investment_report_generate_from_bundle` 경로는 무변경.
- LLM 비용: `StageLLMBudget(max_calls=4)` 하드 캡 (3 reducers + 1 composer). 초과 시 deterministic fallback 으로 강등.
- Citation: composer 가 인용 불가능한 item 을 drop. 전부 drop 되면 단일 `no_action_note` fallback.
- 새 `ModelRateLimiter` 경유 (Redis-backed) — 모든 LLM 호출 rate-limited.
- Stale-gate 가 final ingest 를 막아도 stage run/artifact 는 `/trading/api/investment-stage-runs/{run_uuid}` 로 조회 가능.
- `/invest/reports/:reportUuid` 에 "중간 분석" 패널 추가 (`IntermediateAnalysisPanel`, lazy load).

### Phase 별 commit
| Phase | Commit | 내용 |
|---|---|---|
| Migration | `ab2e9c90` | stage_runs + stage_artifacts 테이블 (op.f 명명 규칙, FK convention) |
| Phase 1 | `cfa75476` | ORM, schemas, append-only repository, query service, budget |
| Phase 2 | `133c70f3` | 8 v1 stages + runner orchestrator (`UnavailableStageError` → UNAVAILABLE artifact) |
| Phase 3 | `cce6a70b` | FinalComposer + generator.py `auto_compose=True` 분기 |
| docs | `6bda9316` | implementation plan |
| Phase 4 | `0a007ae4` | read-only API (run-scoped + report-linked, stale-link 404) |
| Phase 5 | `92d1a624` | IntermediateAnalysisPanel + StageArtifactCard + Korean labels |
| Phase 6 | `49f992d7` | e2e fixture fix + blocked-report 진단 통합 테스트 |
| Phase 6 | `8fd31421` | e2e 가 노출한 4개 production 버그 (market_session 필드, source_conflicts, items_count, _LocalBundleRead) |
| Critical fix | `4bd619e2` | model_rate_limiter 경유 + hard citation drop + budget deterministic fallback |

## Spec / codebase 의사결정 기록

1. **`snapshot_bundle_uuid` 에 FK 없음 (의도된 deviation)**
   Plan 의 risk callout 은 nullable FK + SET NULL 을 제안했지만 codebase convention (`InvestmentReport.snapshot_bundle_uuid` 도 bare UUID, no FK) 과 충돌해서 FK 없이 진행. snapshot bundle 은 reusable evidence 라서 ownership 의미가 없음.

2. **`model_rate_limiter.py` 재도입**
   main 의 PR #423 (2026-03-30) 에서 의도적으로 삭제됐던 파일이 ROB-279 spec 의 "모든 LLM 호출은 model_rate_limiter 경유" 요구로 인해 재도입됨 (`app/core/model_rate_limiter.py`, ROB-279 변형 — Redis backend, graceful degrade). **CLAUDE.md 의 해당 섹션이 stale** — 별도 PR 로 정리 필요.

3. **Pre-existing 시작 상태**
   PR #888 (`fd885cec`) 가 ROB-279 migration history 만 main 에 land 시킴 (production DB sync 용). 이번 PR 의 migration commit 은 main 의 그것과 byte-identical (merge 시 conflict 없음).

## 후속 (follow-up issue 권장)

- **I1**: `StageContext.frozen=True` 이지만 `prior_artifacts` dict 가 mutated 됨 — 미래 immutable mapping 전환 시 위험. 명시화 또는 frozen 제거.
- **I2**: 프론트엔드 `useStageRun.ts` 미구현 (run-scoped 진단 페이지가 아직 없으므로 spec 에 명시했어도 실수요 없음).
- **I3**: composer 가 `status="draft"` 를 강제. caller 의 `published` 의도를 silently 강등 — 의도된 동작이지만 미문서화.
- **minors**: bull/bear/risk reducer 80% 코드 중복 (mixin 후보), `UniqueConstraint` 가 `ix_` 접두사 사용 (`uq_` 가 컨벤션).

## Test plan

- [x] Backend unit/integration: 53 ROB-279 tests passing
  - `tests/models/test_investment_stages_model.py` (2)
  - `tests/schemas/test_investment_stages_schema.py` (3)
  - `tests/services/investment_stages/` (37)
  - `tests/routers/test_investment_stage_runs.py` (7)
  - `tests/integration/test_rob279_staged_pipeline_e2e.py` (1)
  - `tests/integration/test_rob279_stale_gate_blocked.py` (2)
  - `tests/services/action_report/snapshot_backed/test_generator_regression.py` (1, legacy compat 잠금)
- [x] Frontend: 33 ROB-279 tests passing (`IntermediateAnalysisPanel`, `StageArtifactCard`, `investmentStagesApi`, `useReportStageArtifacts`)
- [x] Ruff clean
- [x] tsc clean
- [x] Alembic upgrade/downgrade roundtrip on local Postgres
- [ ] Manual UI smoke on `/invest/reports/:reportUuid` (post-merge / on staging)
- [ ] Staging: kick off `auto_compose=True` end-to-end against a real bundle

## Safety boundaries (재확인)

- 브로커/주문/감시/주문 의도 mutation 없음 (`grep "create_order\|place_order\|submit_order\|cancel_order" app/services/investment_stages/ app/routers/investment_stage_runs.py` → empty).
- Stale gate 통과 → 기존 ingest 경유 → idempotency + report item invariants 유지.
- Legacy `investment_report_generate_from_bundle` 무변경 (`test_generator_uses_legacy_path_by_default` 잠금).
- Append-only invariant DB level (unique index `(run_uuid, stage_type)`) + repository level (`AppendOnlyViolation`).
- LLM budget 4 캡, model_rate_limiter 경유, 429 시 rate limiter 에 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staged investment report analysis pipeline featuring multiple analysis stages (market, news, portfolio, candidates, and AI-powered bull/bear/risk assessment)
  * New endpoints to retrieve and explore staged analysis artifacts for investment reports
  * Frontend component displaying intermediate analysis stage results with verdict, confidence, and key insights
  * Auto-compose mode for snapshot-backed reports leveraging the staged pipeline
  * Rate limiting for API-backed LLM models to improve service resilience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->