### PR TITLE
feat(rob-278): portfolio v2 KIS-live + symbol derivation (PR1)

### DIFF
--- a/app/schemas/investment_snapshots_mcp.py
+++ b/app/schemas/investment_snapshots_mcp.py
@@ -52,6 +52,10 @@ class EnsureBundleRequest(BaseModel):
     requested_by: Literal["hermes", "user", "scheduler", "claude_code", "reviewer"] = (
         "user"
     )
+    user_id: int | None = None
+    """ROB-278 — explicit operator user_id forwarded to collectors that read
+    live-account state. ``None`` keeps broker-backed collectors in fail-closed
+    (``unavailable``) mode rather than inventing a default user."""
 
 
 class EnsureBundleResponse(BaseModel):

--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -273,6 +273,7 @@ class SnapshotBundleEnsureService:
             symbols=request.symbols,
             candidate_limit=request.candidate_limit,
             policy_snapshot=policy_snapshot,
+            user_id=request.user_id,
         )
         try:
             results = await asyncio.wait_for(

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -74,9 +74,7 @@ def _quote_is_actionable(quote: dict[str, Any]) -> bool:
     best_ask = quote.get("best_ask") or 0
     bid_depth = quote.get("bid_depth") or 0
     ask_depth = quote.get("ask_depth") or 0
-    return (
-        best_bid > 0 and best_ask > 0 and (bid_depth > 0 or ask_depth > 0)
-    )
+    return best_bid > 0 and best_ask > 0 and (bid_depth > 0 or ask_depth > 0)
 
 
 def _held_kis_symbols(
@@ -247,9 +245,7 @@ class EvidenceAutoEmitter:
             if sym in already_proposed:
                 continue
             quote_pair = symbol_quotes.get(sym)
-            quote_status = (
-                quote_pair[1].get("status") if quote_pair else "no_snapshot"
-            )
+            quote_status = quote_pair[1].get("status") if quote_pair else "no_snapshot"
             if quote_pair is not None and _quote_is_actionable(quote_pair[1]):
                 # Quote actionable but candidate usefulness wasn't useful —
                 # caller's evidence is mixed; surface as watch review.
@@ -270,7 +266,7 @@ class EvidenceAutoEmitter:
                     client_item_key=f"auto-watch-{sym}",
                     item_kind="watch",
                     symbol=sym,
-                    intent="news_followup_review",
+                    intent="trend_recovery_review",
                     rationale=(
                         f"뉴스 관심 종목 watch 검토 — {sym} "
                         f"(news_matches {count}, quote_status {quote_status})"

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -1,0 +1,284 @@
+"""ROB-278 Phase 2 — deterministic evidence-driven report-item proposer.
+
+Reads the persisted snapshot bundle and proposes ``IngestReportItem``
+drafts for the report generator. Distinct from ROB-279's LLM-staged
+``FinalComposer`` (``auto_compose=True``): this proposer is
+**deterministic** and uses Phase 2 collector enrichments (portfolio v2,
+symbol quote/orderbook, candidate_universe usefulness, news symbol
+citations) to gate candidate emission.
+
+Lockdown invariants:
+
+* Every emitted item is ``operation="review"`` +
+  ``apply_policy="requires_user_approval"``. The proposer never
+  pre-classifies anything as auto-executable.
+* Buy candidates are emitted only when the per-symbol quote evidence
+  reports ``status="ok"`` with non-zero best bid + best ask + depth.
+  Missing or unavailable quote evidence → no buy candidate.
+* Sell candidates are emitted only when the portfolio snapshot has
+  ``primary_source="kis"`` and the held row reports a positive
+  ``sellable_quantity``. Manual/reference holdings never produce sell
+  candidates here.
+* Watch candidates are emitted when candidate/news/quote evidence
+  exists but action grounds are insufficient — these surface as review
+  items so the operator can validate the thesis.
+* Each emitted item carries ``evidence_snapshot`` provenance pointing
+  to the source snapshot UUID(s) + kind(s) so an audit can trace the
+  proposed candidate back to the bundle rows that justified it.
+* No broker / order / watch / order-intent mutation paths are reached;
+  the static import guard test continues to assert this.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.schemas.investment_reports import IngestReportItem
+
+
+def _snapshot_payload(snapshot: Any) -> dict[str, Any]:
+    payload = getattr(snapshot, "payload_json", None)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _snapshot_uuid(snapshot: Any) -> str | None:
+    value = getattr(snapshot, "snapshot_uuid", None)
+    if isinstance(value, UUID):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    return None
+
+
+def _make_evidence(
+    snapshot: Any, *, extra: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "source": "auto_emit",
+        "snapshot_kind": getattr(snapshot, "snapshot_kind", None),
+        "snapshot_uuid": _snapshot_uuid(snapshot),
+        "symbol": getattr(snapshot, "symbol", None),
+    }
+    if extra:
+        evidence.update(extra)
+    return evidence
+
+
+def _quote_is_actionable(quote: dict[str, Any]) -> bool:
+    if not isinstance(quote, dict):
+        return False
+    if quote.get("status") != "ok":
+        return False
+    best_bid = quote.get("best_bid") or 0
+    best_ask = quote.get("best_ask") or 0
+    bid_depth = quote.get("bid_depth") or 0
+    ask_depth = quote.get("ask_depth") or 0
+    return (
+        best_bid > 0 and best_ask > 0 and (bid_depth > 0 or ask_depth > 0)
+    )
+
+
+def _held_kis_symbols(
+    portfolio_payload: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return KIS-primary held holdings keyed by ticker. Empty dict when
+    primary_source is not 'kis' — manual rows are never promoted here."""
+    if portfolio_payload.get("primary_source") != "kis":
+        return {}
+    holdings = portfolio_payload.get("holdings") or []
+    out: dict[str, dict[str, Any]] = {}
+    if isinstance(holdings, list):
+        for holding in holdings:
+            if not isinstance(holding, dict):
+                continue
+            ticker = holding.get("ticker")
+            if isinstance(ticker, str):
+                out[ticker] = holding
+    return out
+
+
+class EvidenceAutoEmitter:
+    """Deterministic proposer that surfaces review-only candidates from the
+    persisted snapshot bundle."""
+
+    def __init__(self, *, max_buy_candidates: int = 10) -> None:
+        self._max_buy_candidates = max_buy_candidates
+
+    def propose(
+        self,
+        *,
+        snapshots: list[Any],
+        request_market: str,
+        account_scope: str | None,
+    ) -> list[IngestReportItem]:
+        """Emit review-only ``IngestReportItem`` drafts from the bundle's
+        evidence. Returns an empty list when no evidence supports an
+        actionable proposal — never fabricates candidates."""
+        portfolio_payload: dict[str, Any] = {}
+        symbol_quotes: dict[str, tuple[Any, dict[str, Any]]] = {}
+        news_matches: dict[str, int] = {}
+        candidate_usefulness: str | None = None
+        portfolio_snapshot: Any | None = None
+        candidate_snapshot: Any | None = None
+        news_snapshot: Any | None = None
+
+        for snapshot in snapshots:
+            kind = getattr(snapshot, "snapshot_kind", None)
+            payload = _snapshot_payload(snapshot)
+            if kind == "portfolio":
+                portfolio_snapshot = snapshot
+                portfolio_payload = payload
+            elif kind == "symbol":
+                sym = getattr(snapshot, "symbol", None) or payload.get("symbol")
+                quote = payload.get("quote")
+                if isinstance(sym, str) and isinstance(quote, dict):
+                    symbol_quotes[sym] = (snapshot, quote)
+            elif kind == "candidate_universe":
+                candidate_snapshot = snapshot
+                candidate_usefulness = (
+                    payload.get("usefulness") if isinstance(payload, dict) else None
+                )
+            elif kind == "news":
+                news_snapshot = snapshot
+                matches = payload.get("symbol_matches") or {}
+                if isinstance(matches, dict):
+                    for sym, count in matches.items():
+                        if isinstance(sym, str) and isinstance(count, int):
+                            news_matches[sym] = count
+
+        held = _held_kis_symbols(portfolio_payload)
+        candidate_actionable = candidate_usefulness == "useful"
+
+        items: list[IngestReportItem] = []
+
+        # Sell candidates — held + sellable + quote evidence supports liquidity.
+        for ticker, holding in held.items():
+            sellable = holding.get("sellable_quantity") or 0
+            if sellable <= 0:
+                continue
+            symbol_pair = symbol_quotes.get(ticker)
+            if symbol_pair is None:
+                continue
+            symbol_snapshot, quote = symbol_pair
+            if not _quote_is_actionable(quote):
+                continue
+            evidence = _make_evidence(
+                symbol_snapshot,
+                extra={
+                    "portfolio_snapshot_uuid": _snapshot_uuid(portfolio_snapshot),
+                    "sellable_quantity": sellable,
+                    "quote_status": quote.get("status"),
+                    "best_bid": quote.get("best_bid"),
+                    "best_ask": quote.get("best_ask"),
+                    "spread_bps": quote.get("spread_bps"),
+                    "proposer": "auto_emit/sell_from_held",
+                },
+            )
+            items.append(
+                IngestReportItem(
+                    client_item_key=f"auto-sell-{ticker}",
+                    item_kind="action",
+                    symbol=ticker,
+                    side="sell",
+                    intent="sell_review",
+                    rationale=(
+                        f"보유 종목 {ticker} sell 검토 — sellable {sellable}, "
+                        f"best_bid {quote.get('best_bid')}, "
+                        f"spread_bps {quote.get('spread_bps')}"
+                    ),
+                    operation="review",
+                    apply_policy="requires_user_approval",
+                    evidence_snapshot=evidence,
+                )
+            )
+
+        # Buy candidates — symbols with actionable quote + a usefulness
+        # signal from candidate_universe and not currently held.
+        if candidate_actionable:
+            buy_emitted = 0
+            for sym, (symbol_snapshot, quote) in symbol_quotes.items():
+                if buy_emitted >= self._max_buy_candidates:
+                    break
+                if sym in held:
+                    continue
+                if not _quote_is_actionable(quote):
+                    continue
+                evidence = _make_evidence(
+                    symbol_snapshot,
+                    extra={
+                        "candidate_snapshot_uuid": _snapshot_uuid(candidate_snapshot),
+                        "candidate_usefulness": candidate_usefulness,
+                        "news_matches": news_matches.get(sym, 0),
+                        "quote_status": quote.get("status"),
+                        "best_bid": quote.get("best_bid"),
+                        "best_ask": quote.get("best_ask"),
+                        "spread_bps": quote.get("spread_bps"),
+                        "proposer": "auto_emit/buy_from_candidate",
+                    },
+                )
+                items.append(
+                    IngestReportItem(
+                        client_item_key=f"auto-buy-{sym}",
+                        item_kind="action",
+                        symbol=sym,
+                        side="buy",
+                        intent="buy_review",
+                        rationale=(
+                            f"신규 매수 검토 — {sym} (candidate {candidate_usefulness}"
+                            f", quote best_bid {quote.get('best_bid')}, "
+                            f"spread_bps {quote.get('spread_bps')})"
+                        ),
+                        operation="review",
+                        apply_policy="requires_user_approval",
+                        evidence_snapshot=evidence,
+                    )
+                )
+                buy_emitted += 1
+
+        # Watch candidates — news-active symbols whose quote evidence is
+        # missing or whose candidate evidence is stale/empty (action
+        # grounds insufficient). Skip symbols already held + with sell
+        # candidate emitted, and symbols already proposed as buy.
+        already_proposed = {item.symbol for item in items if item.symbol}
+        for sym, count in news_matches.items():
+            if count <= 0:
+                continue
+            if sym in already_proposed:
+                continue
+            quote_pair = symbol_quotes.get(sym)
+            quote_status = (
+                quote_pair[1].get("status") if quote_pair else "no_snapshot"
+            )
+            if quote_pair is not None and _quote_is_actionable(quote_pair[1]):
+                # Quote actionable but candidate usefulness wasn't useful —
+                # caller's evidence is mixed; surface as watch review.
+                if candidate_actionable:
+                    continue
+            evidence = _make_evidence(
+                quote_pair[0] if quote_pair else news_snapshot,
+                extra={
+                    "news_snapshot_uuid": _snapshot_uuid(news_snapshot),
+                    "news_match_count": count,
+                    "quote_status": quote_status,
+                    "candidate_usefulness": candidate_usefulness,
+                    "proposer": "auto_emit/watch_from_news",
+                },
+            )
+            items.append(
+                IngestReportItem(
+                    client_item_key=f"auto-watch-{sym}",
+                    item_kind="watch",
+                    symbol=sym,
+                    intent="news_followup_review",
+                    rationale=(
+                        f"뉴스 관심 종목 watch 검토 — {sym} "
+                        f"(news_matches {count}, quote_status {quote_status})"
+                    ),
+                    operation="review",
+                    apply_policy="requires_user_approval",
+                    evidence_snapshot=evidence,
+                )
+            )
+
+        return items

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -5,6 +5,19 @@ counts via ``InvestScreenerSnapshotsRepository.coverage``. For
 ``market=crypto`` it falls back to a count + latest-partition probe over
 :class:`InvestCryptoScreenerSnapshot`. Either branch is read-only and
 degrades to ``unavailable`` on exception.
+
+ROB-278 Phase 2 — payload separates freshness from usefulness:
+
+* ``actionable_count`` is the count the report generator should consult
+  before fabricating buy candidates. ``fresh_count`` from the repository
+  is the same number, surfaced under an explicit name so the contract
+  is unambiguous to downstream code.
+* ``usefulness`` is one of ``"useful" | "stale_only" | "empty"``.
+  ``stale_only`` means rows exist but none are fresh (the previous
+  failure mode was a ``freshness_status="fresh"`` snapshot with
+  ``fresh_count=0`` that still encouraged the generator to act).
+* ``no_data_reason`` carries a human-readable explanation when
+  ``usefulness != "useful"``.
 """
 
 from __future__ import annotations
@@ -28,6 +41,18 @@ from app.services.investment_snapshots.collectors import (
     CollectorRequest,
     SnapshotCollectResult,
 )
+
+
+def _classify_usefulness(*, actionable: int, stale: int) -> tuple[str, str | None]:
+    """Return ``(usefulness, no_data_reason)`` from counts."""
+    if actionable > 0:
+        return "useful", None
+    if stale > 0:
+        return (
+            "stale_only",
+            f"no fresh candidates today; {stale} stale row(s) only",
+        )
+    return "empty", "candidate_universe has no rows for this market"
 
 
 class CandidateUniverseSnapshotCollector:
@@ -84,12 +109,23 @@ class CandidateUniverseSnapshotCollector:
         coverage = await self._equity_repo.coverage(
             market=request.market, today_trading_date=today
         )
+        usefulness, no_data_reason = _classify_usefulness(
+            actionable=coverage.fresh_count, stale=coverage.stale_count
+        )
         payload: dict[str, Any] = {
             "market": coverage.market,
             "today_trading_date": coverage.today_trading_date.isoformat(),
             "fresh_count": coverage.fresh_count,
+            "actionable_count": coverage.fresh_count,
             "stale_count": coverage.stale_count,
             "last_computed_at": coverage.last_computed_at,
+            "usefulness": usefulness,
+            "no_data_reason": no_data_reason,
+        }
+        coverage_meta = {
+            "actionable_count": coverage.fresh_count,
+            "stale_count": coverage.stale_count,
+            "usefulness": usefulness,
         }
         if coverage.fresh_count == 0 and coverage.stale_count == 0:
             return [
@@ -101,7 +137,7 @@ class CandidateUniverseSnapshotCollector:
                     origin="auto_trader_db",
                     as_of=now,
                     freshness_status="partial",
-                    coverage={"fresh_count": 0, "stale_count": 0},
+                    coverage=coverage_meta,
                 )
             ]
         return [
@@ -112,10 +148,7 @@ class CandidateUniverseSnapshotCollector:
                 payload=payload,
                 origin="auto_trader_db",
                 as_of=now,
-                coverage={
-                    "fresh_count": coverage.fresh_count,
-                    "stale_count": coverage.stale_count,
-                },
+                coverage=coverage_meta,
             )
         ]
 
@@ -127,16 +160,24 @@ class CandidateUniverseSnapshotCollector:
         )
         latest_date = latest_date_row.scalar_one_or_none()
         if latest_date is None:
+            usefulness, no_data_reason = _classify_usefulness(actionable=0, stale=0)
             return [
                 build_result(
                     snapshot_kind=self.snapshot_kind,
                     market=request.market,
                     account_scope=request.account_scope,
-                    payload={"market": "crypto", "fresh_count": 0},
+                    payload={
+                        "market": "crypto",
+                        "fresh_count": 0,
+                        "actionable_count": 0,
+                        "stale_count": 0,
+                        "usefulness": usefulness,
+                        "no_data_reason": no_data_reason,
+                    },
                     origin="auto_trader_db",
                     as_of=now,
                     freshness_status="partial",
-                    coverage={"fresh_count": 0},
+                    coverage={"actionable_count": 0, "usefulness": usefulness},
                 )
             ]
         count_row = await self._session.execute(
@@ -145,10 +186,15 @@ class CandidateUniverseSnapshotCollector:
             )
         )
         count = int(count_row.scalar_one() or 0)
+        usefulness, no_data_reason = _classify_usefulness(actionable=count, stale=0)
         payload: dict[str, Any] = {
             "market": "crypto",
             "latest_partition": latest_date.isoformat(),
             "fresh_count": count,
+            "actionable_count": count,
+            "stale_count": 0,
+            "usefulness": usefulness,
+            "no_data_reason": no_data_reason,
         }
         return [
             build_result(
@@ -158,6 +204,6 @@ class CandidateUniverseSnapshotCollector:
                 payload=payload,
                 origin="auto_trader_db",
                 as_of=now,
-                coverage={"fresh_count": count},
+                coverage={"actionable_count": count, "usefulness": usefulness},
             )
         ]

--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -3,6 +3,14 @@
 Reads recent research reports / news ingestor citations via
 :class:`ResearchReportsQueryService`. Optional kind — a soft failure here
 degrades the bundle to ``partial`` but never blocks the report.
+
+ROB-278 Phase 2 — when ``request.symbols`` is non-empty (the symbol
+derivation already unions held/watch/candidate symbols there) the
+collector filters citations to those that touch one of the focus
+symbols and exposes a ``symbol_matches`` map per focus symbol. When no
+citation matches any focus symbol, an explicit ``no_data_reason`` is
+surfaced so the report generator can fall through to no-news rather
+than infer signal from absence.
 """
 
 from __future__ import annotations
@@ -22,6 +30,16 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 from app.services.research_reports.query_service import ResearchReportsQueryService
+
+
+def _citation_symbols(citation: Any) -> set[str]:
+    candidates = getattr(citation, "symbol_candidates", None) or []
+    symbols: set[str] = set()
+    for cand in candidates:
+        symbol = getattr(cand, "symbol", None)
+        if isinstance(symbol, str) and symbol:
+            symbols.add(symbol)
+    return symbols
 
 
 class NewsSnapshotCollector:
@@ -63,13 +81,38 @@ class NewsSnapshotCollector:
                 )
             ]
 
+        focus_symbols = [s for s in (request.symbols or []) if s]
+        focus_set = set(focus_symbols)
+        symbol_matches: dict[str, int] = dict.fromkeys(focus_symbols, 0)
+
+        included_citations: list[Any] = []
+        for citation in response.citations:
+            cit_symbols = _citation_symbols(citation)
+            if focus_set:
+                hits = cit_symbols & focus_set
+                if not hits:
+                    continue
+                for s in hits:
+                    symbol_matches[s] = symbol_matches.get(s, 0) + 1
+                included_citations.append(citation)
+            else:
+                included_citations.append(citation)
+
         citations_payload: list[dict[str, Any]] = [
-            c.model_dump(mode="json") for c in response.citations
+            c.model_dump(mode="json") for c in included_citations
         ]
+        no_data_reason: str | None = None
+        if focus_set and not citations_payload:
+            no_data_reason = (
+                "no recent citations touched the focus symbols within lookback window"
+            )
+
         payload: dict[str, Any] = {
             "since": since.isoformat(),
             "count": len(citations_payload),
             "citations": citations_payload,
+            "symbol_matches": symbol_matches,
+            "no_data_reason": no_data_reason,
         }
 
         if not citations_payload:

--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -1,29 +1,45 @@
 """Portfolio snapshot collector (read-only).
 
-Reads the user's currently-known holdings from the local DB state
-(``manual_holdings``). The upstream broker-sync flows
-(`PortfolioDataCollector`, broker websocket reconcilers, etc.) populate
-that table — this collector never calls a broker itself, so it is
-inherently safe to invoke during automated report generation.
+For the ROB-278 lockdown the collector emits a v2 payload that is
+**additive** over the legacy ``holdings``/``count``/``market`` shape:
 
-Mapping to the report ticket's account_scope:
+* ``primary_source``: ``"kis" | "manual" | "none"`` — explicit label so the
+  viewer/audit can tell which source backs the holdings.
+* ``reference_holdings``: manual rows surfaced when KIS live is primary, so
+  manual/Toss entries remain visible for cross-check without being mislabeled
+  as KIS live.
+* ``cash`` / ``buying_power`` / ``sellable_summary``: derived from the KIS
+  read-only account reader; absent when KIS was not consulted.
+* ``provenance``: per-fetch metadata (``kis_fetch_status``, warnings, errors,
+  fetched_at) for audit.
 
-* ``account_scope='kis_live'`` → KR + US ``manual_holdings`` rows.
-* ``account_scope='upbit_live'`` → CRYPTO ``manual_holdings`` rows.
+Policy invariants:
 
-If the request's market doesn't match a configured scope, the collector
-returns ``unavailable`` rather than raising — the bundle service then
-records it as a required-kind gap.
+* Manual/Toss/reference holdings are **never** promoted to ``kis_live``
+  primary. KIS unavailable on a ``kis_live`` request yields
+  ``primary_source="none"`` with ``freshness="unavailable"`` — the report
+  generator's stale gate then handles publishing.
+* ``account_scope="kis_live"`` on KR requires an explicit ``user_id`` on the
+  collector request. ``user_id`` missing → fail-closed (no implicit default).
+* Non-(kr+kis_live) combos preserve the v1 manual-primary behaviour and add
+  the ``primary_source="manual"`` label only.
+
+The collector itself never calls broker mutation paths. KIS reads go through
+``KISHomeReader`` which uses ``BaseKISClient`` for read-only account/margin
+queries.
 """
 
 from __future__ import annotations
 
+import datetime as dt
+import logging
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.manual_holdings import ManualHolding, MarketType
+from app.schemas.invest_home import Holding
 from app.services.action_report.snapshot_backed.collectors._base import (
     build_result,
     unavailable_result,
@@ -34,6 +50,8 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 
+logger = logging.getLogger(__name__)
+
 _MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
     "kr": (MarketType.KR,),
     "us": (MarketType.US,),
@@ -41,13 +59,73 @@ _MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
 }
 
 
+def _iso(value: dt.datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def _manual_row_to_dict(row: Any) -> dict[str, Any]:
+    return {
+        "ticker": row.ticker,
+        "market_type": (
+            row.market_type.value
+            if isinstance(row.market_type, MarketType)
+            else str(row.market_type)
+        ),
+        "quantity": row.quantity,
+        "avg_price": row.avg_price,
+        "display_name": row.display_name,
+        "updated_at": row.updated_at,
+        "source": "manual",
+    }
+
+
+def _kis_holding_to_dict(h: Holding) -> dict[str, Any]:
+    return {
+        "ticker": h.symbol,
+        "market": h.market,
+        "asset_type": h.assetType,
+        "asset_category": h.assetCategory,
+        "quantity": h.quantity,
+        "avg_price": h.averageCost,
+        "cost_basis": h.costBasis,
+        "currency": h.currency,
+        "display_name": h.displayName,
+        "value_native": h.valueNative,
+        "value_krw": h.valueKrw,
+        "pnl_krw": h.pnlKrw,
+        "pnl_rate": h.pnlRate,
+        "sellable_quantity": h.sellableQuantity,
+        "pending_sell_quantity": h.pendingSellQuantity,
+        "source": "kis",
+    }
+
+
 class PortfolioSnapshotCollector:
-    """Required-kind ``portfolio`` collector backed by ``manual_holdings``."""
+    """Required-kind ``portfolio`` collector backed by ``manual_holdings``
+    plus the ROB-278 KIS live source for KR + ``kis_live``."""
 
     snapshot_kind: str = "portfolio"
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        kis_reader: Any | None = None,
+    ) -> None:
         self._session = session
+        # KISHomeReader is imported lazily to avoid pulling broker module
+        # graph into call sites that don't need KIS (tests, unit imports).
+        self._kis_reader = kis_reader
+
+    def _get_kis_reader(self) -> Any:
+        if self._kis_reader is not None:
+            return self._kis_reader
+        from app.services.invest_home_readers import KISHomeReader
+
+        self._kis_reader = KISHomeReader(self._session)
+        return self._kis_reader
 
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         market_types = _MARKET_TO_TYPES.get(request.market)
@@ -64,29 +142,38 @@ class PortfolioSnapshotCollector:
                 )
             ]
 
-        stmt = select(ManualHolding).where(ManualHolding.market_type.in_(market_types))
-        rows = (await self._session.execute(stmt)).scalars().all()
+        # ROB-278 — KR + kis_live uses the new KIS live path. Other combos
+        # preserve v1 manual-primary behaviour.
+        if request.market == "kr" and request.account_scope == "kis_live":
+            return await self._collect_kr_kis_live(request, market_types, now=now)
+        return await self._collect_manual_primary(request, market_types, now=now)
 
-        holdings: list[dict[str, Any]] = [
-            {
-                "ticker": row.ticker,
-                "market_type": row.market_type.value
-                if isinstance(row.market_type, MarketType)
-                else str(row.market_type),
-                "quantity": row.quantity,
-                "avg_price": row.avg_price,
-                "display_name": row.display_name,
-                "updated_at": row.updated_at,
-            }
-            for row in rows
-        ]
-
-        payload = {
+    async def _collect_manual_primary(
+        self,
+        request: CollectorRequest,
+        market_types: tuple[MarketType, ...],
+        *,
+        now: dt.datetime,
+    ) -> list[SnapshotCollectResult]:
+        manual_rows = await self._read_manual_rows(market_types)
+        holdings = [_manual_row_to_dict(r) for r in manual_rows]
+        payload: dict[str, Any] = {
             "holdings": holdings,
             "count": len(holdings),
             "market": request.market,
+            "primary_source": "manual",
+            "reference_holdings": [],
+            "cash": None,
+            "buying_power": None,
+            "sellable_summary": None,
+            "provenance": {
+                "kis_fetch_status": "skipped",
+                "account_scope": request.account_scope,
+                "fetched_at": _iso(now),
+                "warnings": [],
+                "errors": [],
+            },
         }
-
         if not holdings:
             return [
                 build_result(
@@ -100,6 +187,178 @@ class PortfolioSnapshotCollector:
                     coverage={"holdings_found": False},
                 )
             ]
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                coverage={"holdings_count": len(holdings)},
+            )
+        ]
+
+    async def _collect_kr_kis_live(
+        self,
+        request: CollectorRequest,
+        market_types: tuple[MarketType, ...],
+        *,
+        now: dt.datetime,
+    ) -> list[SnapshotCollectResult]:
+        manual_rows = await self._read_manual_rows(market_types)
+        reference_holdings = [_manual_row_to_dict(r) for r in manual_rows]
+
+        if request.user_id is None:
+            # Lockdown — kis_live requires explicit user_id; manual is NOT
+            # promoted to primary. Surface as unavailable for the stale gate.
+            payload: dict[str, Any] = {
+                "holdings": [],
+                "count": 0,
+                "market": request.market,
+                "primary_source": "none",
+                "reference_holdings": reference_holdings,
+                "cash": None,
+                "buying_power": None,
+                "sellable_summary": None,
+                "provenance": {
+                    "kis_fetch_status": "skipped",
+                    "account_scope": request.account_scope,
+                    "fetched_at": _iso(now),
+                    "warnings": [],
+                    "errors": [],
+                },
+            }
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="unavailable",
+                    coverage={"holdings_count": 0},
+                    errors={
+                        "reason": (
+                            "kis_live portfolio requires explicit user_id; none supplied"
+                        )
+                    },
+                )
+            ]
+
+        # Call KIS read-only. Catch hard failures so the collector reports
+        # them as 'unavailable' rather than crashing report generation.
+        reader = self._get_kis_reader()
+        fetch_warnings: list[str] = []
+        fetch_errors: list[str] = []
+        kis_result: Any = None
+        try:
+            kis_result = await reader.fetch(user_id=request.user_id)
+        except Exception as exc:  # noqa: BLE001 — collector must never crash
+            logger.warning("KIS read-only fetch failed: %s", exc, exc_info=True)
+            fetch_errors.append(f"{type(exc).__name__}: {exc}")
+
+        # Map KIS holdings filtered to the requested market.
+        kis_holdings_dicts: list[dict[str, Any]] = []
+        cash_payload: dict[str, Any] | None = None
+        buying_power_payload: dict[str, Any] | None = None
+        sellable_summary: dict[str, Any] | None = None
+        kis_fetch_status: str
+        if kis_result is None:
+            kis_fetch_status = "failed"
+        else:
+            kr_holdings = [h for h in (kis_result.holdings or []) if h.market == "KR"]
+            kis_holdings_dicts = [_kis_holding_to_dict(h) for h in kr_holdings]
+            if kis_result.warning is not None:
+                fetch_warnings.append(
+                    f"{kis_result.warning.source}: {kis_result.warning.message}"
+                )
+            account = next(iter(kis_result.accounts or []), None)
+            if account is not None:
+                cash_payload = {
+                    "krw": account.cashBalances.krw,
+                    "usd": account.cashBalances.usd,
+                }
+                buying_power_payload = {
+                    "krw": account.buyingPower.krw,
+                    "usd": account.buyingPower.usd,
+                }
+            sellable_count = sum(
+                1
+                for h in kr_holdings
+                if h.sellableQuantity is not None and h.sellableQuantity > 0
+            )
+            pending_sell_count = sum(
+                1 for h in kr_holdings if (h.pendingSellQuantity or 0) > 0
+            )
+            sellable_summary = {
+                "sellable_count": sellable_count,
+                "pending_sell_count": pending_sell_count,
+            }
+            if not kis_holdings_dicts and account is None:
+                kis_fetch_status = "failed"
+            elif fetch_warnings and not kis_holdings_dicts:
+                kis_fetch_status = "failed"
+            elif fetch_warnings:
+                kis_fetch_status = "partial"
+            else:
+                kis_fetch_status = "ok"
+
+        if kis_fetch_status == "failed":
+            primary_source = "none"
+            holdings_out: list[dict[str, Any]] = []
+            cash_payload = None
+            buying_power_payload = None
+            sellable_summary = None
+            freshness = "unavailable"
+        else:
+            primary_source = "kis"
+            holdings_out = kis_holdings_dicts
+            freshness = "fresh" if kis_fetch_status == "ok" else "partial"
+
+        payload = {
+            "holdings": holdings_out,
+            "count": len(holdings_out),
+            "market": request.market,
+            "primary_source": primary_source,
+            "reference_holdings": reference_holdings,
+            "cash": cash_payload,
+            "buying_power": buying_power_payload,
+            "sellable_summary": sellable_summary,
+            "provenance": {
+                "kis_fetch_status": kis_fetch_status,
+                "account_scope": request.account_scope,
+                "fetched_at": _iso(now),
+                "warnings": fetch_warnings,
+                "errors": fetch_errors,
+            },
+        }
+
+        coverage = {
+            "holdings_count": len(holdings_out),
+            "reference_count": len(reference_holdings),
+            "kis_fetch_status": kis_fetch_status,
+        }
+
+        if freshness == "unavailable":
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="unavailable",
+                    coverage=coverage,
+                    errors={
+                        "reason": "KIS live portfolio fetch failed",
+                        "warnings": fetch_warnings,
+                        "errors": fetch_errors,
+                    },
+                )
+            ]
 
         return [
             build_result(
@@ -109,8 +368,14 @@ class PortfolioSnapshotCollector:
                 payload=payload,
                 origin="auto_trader_db",
                 as_of=now,
-                coverage={
-                    "holdings_count": len(holdings),
-                },
+                freshness_status=freshness,
+                coverage=coverage,
             )
         ]
+
+    async def _read_manual_rows(
+        self, market_types: tuple[MarketType, ...]
+    ) -> list[Any]:
+        stmt = select(ManualHolding).where(ManualHolding.market_type.in_(market_types))
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -50,6 +50,7 @@ from app.services.brokers.upbit.orders import (
     fetch_open_orders as _upbit_fetch_open_orders,
 )
 from app.services.investment_snapshots.collectors import SnapshotCollectorRegistry
+from app.services.kr_symbol_universe_service import is_nxt_eligible
 
 
 class _UpbitOpenOrdersAdapter:
@@ -64,6 +65,66 @@ class _UpbitOpenOrdersAdapter:
     @staticmethod
     async def fetch_open_orders(market: str | None = None) -> list[dict[str, Any]]:
         return await _upbit_fetch_open_orders(market=market)
+
+
+class _KISDomesticQuoteOrderbookAdapter:
+    """ROB-278 Phase 2 — read-only adapter wrapping the existing KIS quote
+    + orderbook calls. Exposes a single ``fetch_quote_orderbook(symbol)``
+    method so the symbol collector cannot reach order placement, cancel,
+    or modify paths via the bound client.
+
+    The adapter pulls last price from ``inquire_price`` and top-of-book
+    from ``inquire_orderbook``; both are existing read-only methods on
+    the KIS domestic market data client. No new HTTP surface is added.
+    """
+
+    def __init__(self, kis_client: KISClient | None) -> None:
+        self._client = kis_client
+
+    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]:
+        if self._client is None:
+            raise RuntimeError("kis client unavailable")
+        # Two read-only calls — both already exist on the KIS client. No
+        # new HTTP surface, no order placement/cancellation paths reached.
+        price_df = await self._client.inquire_price(symbol)
+        orderbook = await self._client.inquire_orderbook(symbol)
+
+        last_price = float(price_df["close"].iloc[0]) if len(price_df) else 0.0
+
+        # Top-of-book from the 10-step orderbook. KIS field naming uses
+        # ``askp1`` / ``bidp1`` for level-1 ask/bid price; ``askp_rsqn1`` /
+        # ``bidp_rsqn1`` for residual quantities. Use ``.get`` with defaults
+        # so the empty-book branch in the collector takes over cleanly.
+        def _num(name: str) -> float:
+            value = orderbook.get(name)
+            try:
+                return float(value) if value is not None else 0.0
+            except (TypeError, ValueError):
+                return 0.0
+
+        best_ask = _num("askp1")
+        best_bid = _num("bidp1")
+        ask_depth = _num("askp_rsqn1")
+        bid_depth = _num("bidp_rsqn1")
+
+        # Best-effort NXT routability flag — symbol-universe lookup is
+        # read-only and cheap; failures stay non-fatal.
+        try:
+            nxt_eligible = await is_nxt_eligible(symbol)
+        except Exception:  # noqa: BLE001
+            nxt_eligible = False
+
+        return {
+            "last_price": last_price,
+            "best_bid": best_bid,
+            "best_ask": best_ask,
+            "bid_depth": bid_depth,
+            "ask_depth": ask_depth,
+            "venue": "krx",
+            "as_of": None,  # KIS orderbook payload has no clean as_of; UI uses snapshot.as_of
+            "session": "regular" if best_bid > 0 and best_ask > 0 else "closed",
+            "nxt_eligible": bool(nxt_eligible),
+        }
 
 
 def _build_kis_client_safely() -> KISClient | None:
@@ -98,7 +159,18 @@ def production_collector_registry(session: AsyncSession) -> SnapshotCollectorReg
 
     # Optional kinds — DB-backed where possible.
     registry.register(NewsSnapshotCollector(session))
-    registry.register(SymbolSnapshotCollector(session))
+    # ROB-278 Phase 2 — wire the KIS quote/orderbook adapter so KR + kis_live
+    # requests get per-symbol quote evidence. Construction is wrapped (the
+    # KIS client can be None when credentials are absent) so the collector
+    # cleanly emits per-symbol unavailable rather than crashing.
+    registry.register(
+        SymbolSnapshotCollector(
+            session,
+            kis_quote_client=_KISDomesticQuoteOrderbookAdapter(
+                _build_kis_client_safely()
+            ),
+        )
+    )
     registry.register(CandidateUniverseSnapshotCollector(session))
     registry.register(InvestPageSnapshotCollector(session))
     # Remote-debug probes remain fail-open stubs — they are operator-driven

--- a/app/services/action_report/snapshot_backed/collectors/symbol.py
+++ b/app/services/action_report/snapshot_backed/collectors/symbol.py
@@ -1,15 +1,34 @@
 """Symbol snapshot collector (read-only, optional).
 
-Reads ``stock_info`` master rows for the symbols the caller asked about.
+Reads ``stock_info`` master rows for the symbols the caller asked about,
+and for ``(market=kr, account_scope=kis_live)`` with an explicit
+``user_id``, enriches each resolved symbol with read-only KIS
+quote/orderbook evidence (last price, best bid/ask, spread, depth, venue).
+
+Lockdown invariants (ROB-278):
+
+* No new KIS HTTP surface. Quote enrichment uses an injected client that
+  the production registry wires to a thin read-only adapter around the
+  existing ``inquire_price`` / ``inquire_orderbook`` methods.
+* No broker order-mutation surfaces are reachable. The mutation import
+  guard test asserts the symbol module does not pull in any verb tagged
+  as forbidden (placement / cancellation / submission / modification).
+* user_id missing on ``kis_live`` → quote enrichment is fail-closed
+  (``status="unavailable"`` per symbol). The default has not been invented.
+* Per-symbol failures fail-open: one symbol's KIS error never crashes the
+  others, and the symbol kind stays optional in the policy.
+* Quote enrichment is bounded by ``quote_enrichment_limit`` (default 25) to
+  cap KIS call volume per report; the overflow carries
+  ``status="skipped"`` with a ``"cap"`` reason.
+
 If ``request.symbols`` is empty/None we have no scope to read against, so
 the collector returns ``unavailable`` and the optional bucket records it
-in ``unavailable_sources`` — consistent with the policy that optional
-kinds degrade the bundle to ``partial`` but never block.
+in ``unavailable_sources``.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,14 +44,59 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 
+_DEFAULT_QUOTE_ENRICHMENT_LIMIT = 25
+
+
+class _KISQuoteOrderbookClient(Protocol):
+    """Read-only adapter contract for per-symbol KIS quote/orderbook reads.
+
+    The default production wiring lives in the collector registry; tests
+    inject fakes. Implementations MUST not call any broker mutation path.
+    """
+
+    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]: ...
+
+
+def _is_empty_book(quote: dict[str, Any]) -> bool:
+    """Return True when the quote payload carries no usable top-of-book."""
+    bid = quote.get("best_bid") or 0
+    ask = quote.get("best_ask") or 0
+    last = quote.get("last_price") or 0
+    return bid <= 0 and ask <= 0 and last <= 0
+
+
+def _derive_spread(quote: dict[str, Any]) -> tuple[float | None, float | None]:
+    bid = quote.get("best_bid")
+    ask = quote.get("best_ask")
+    if bid is None or ask is None or bid <= 0 or ask <= 0:
+        return None, None
+    spread = float(ask) - float(bid)
+    mid = (float(ask) + float(bid)) / 2.0
+    if mid <= 0:
+        return spread, None
+    spread_bps = (spread / mid) * 10_000.0
+    return spread, spread_bps
+
 
 class SymbolSnapshotCollector:
-    """Optional ``symbol`` collector backed by ``stock_info``."""
+    """Optional ``symbol`` collector backed by ``stock_info``.
+
+    The collector also performs read-only KIS quote/orderbook enrichment
+    on the resolved symbols when the request targets KR live trading.
+    """
 
     snapshot_kind: str = "symbol"
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        kis_quote_client: _KISQuoteOrderbookClient | None = None,
+        quote_enrichment_limit: int = _DEFAULT_QUOTE_ENRICHMENT_LIMIT,
+    ) -> None:
         self._session = session
+        self._kis_quote_client = kis_quote_client
+        self._quote_enrichment_limit = quote_enrichment_limit
 
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
@@ -64,8 +128,23 @@ class SymbolSnapshotCollector:
                 )
             ]
 
+        # Quote enrichment policy (ROB-278 Phase 2).
+        wants_quote = request.market == "kr" and request.account_scope == "kis_live"
+        quote_status_default: dict[str, Any] | None
+        if wants_quote and request.user_id is None:
+            # Fail-closed: never invent a default user_id for broker calls.
+            quote_status_default = {
+                "status": "unavailable",
+                "unavailable_reason": (
+                    "kis_live quote enrichment requires explicit user_id"
+                ),
+            }
+        else:
+            quote_status_default = None
+
         results: list[SnapshotCollectResult] = []
         seen_symbols: set[str] = set()
+        enriched_count = 0
         for row in rows:
             seen_symbols.add(row.symbol)
             payload: dict[str, Any] = {
@@ -77,6 +156,16 @@ class SymbolSnapshotCollector:
                 "market_cap": row.market_cap,
                 "is_active": row.is_active,
             }
+            if wants_quote:
+                quote_payload = await self._maybe_enrich_quote(
+                    symbol=row.symbol,
+                    user_id_present=request.user_id is not None,
+                    enriched_count=enriched_count,
+                    quote_status_default=quote_status_default,
+                )
+                payload["quote"] = quote_payload
+                if quote_payload.get("status") == "ok":
+                    enriched_count += 1
             results.append(
                 build_result(
                     snapshot_kind=self.snapshot_kind,
@@ -121,3 +210,72 @@ class SymbolSnapshotCollector:
                 )
             )
         return results
+
+    async def _maybe_enrich_quote(
+        self,
+        *,
+        symbol: str,
+        user_id_present: bool,
+        enriched_count: int,
+        quote_status_default: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if quote_status_default is not None:
+            return dict(quote_status_default)
+        if not user_id_present:
+            return {
+                "status": "unavailable",
+                "unavailable_reason": (
+                    "kis_live quote enrichment requires explicit user_id"
+                ),
+            }
+        if self._kis_quote_client is None:
+            return {
+                "status": "unavailable",
+                "unavailable_reason": "no KIS quote client configured",
+            }
+        if enriched_count >= self._quote_enrichment_limit:
+            return {
+                "status": "skipped",
+                "unavailable_reason": (
+                    f"quote enrichment cap ({self._quote_enrichment_limit}) reached"
+                ),
+            }
+        try:
+            raw = await self._kis_quote_client.fetch_quote_orderbook(symbol)
+        except Exception as exc:  # noqa: BLE001 — optional, per-symbol fail-open
+            return {
+                "status": "unavailable",
+                "unavailable_reason": f"kis_error: {type(exc).__name__}: {exc}",
+            }
+        if not isinstance(raw, dict):
+            return {
+                "status": "unavailable",
+                "unavailable_reason": "kis returned non-dict quote payload",
+            }
+        if _is_empty_book(raw):
+            session = raw.get("session")
+            reason = "empty_book"
+            if isinstance(session, str) and session != "regular":
+                reason = f"empty_book ({session})"
+            return {
+                "status": "unavailable",
+                "unavailable_reason": reason,
+                "session": session,
+                "venue": raw.get("venue"),
+            }
+        spread, spread_bps = _derive_spread(raw)
+        quote: dict[str, Any] = {
+            "status": "ok",
+            "last_price": raw.get("last_price"),
+            "best_bid": raw.get("best_bid"),
+            "best_ask": raw.get("best_ask"),
+            "spread": spread,
+            "spread_bps": spread_bps,
+            "bid_depth": raw.get("bid_depth"),
+            "ask_depth": raw.get("ask_depth"),
+            "venue": raw.get("venue") or "krx",
+            "nxt_eligible": bool(raw.get("nxt_eligible")),
+            "session": raw.get("session"),
+            "as_of": raw.get("as_of"),
+        }
+        return quote

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -86,6 +86,40 @@ _BLOCKING_BUNDLE_STATUSES_FOR_PUBLISHED: frozenset[str] = frozenset(
     {"stale_fallback", "failed"}
 )
 
+# ROB-278 Phase 2 — worst-case rank used to derive ``overall`` from per-kind
+# statuses when the stored summary is missing an explicit ``overall`` key
+# (most common cause: bundle.status='reused' carrying an older summary that
+# only stored per-kind entries). Higher rank = worse.
+_KIND_STATUS_RANK: dict[str, int] = {
+    "fresh": 0,
+    "soft_stale": 1,
+    "partial": 2,
+    "hard_stale": 3,
+    "failed": 4,
+    "unavailable": 5,
+}
+_RANK_TO_KIND_STATUS: dict[int, str] = {v: k for k, v in _KIND_STATUS_RANK.items()}
+
+
+def _derive_overall_from_kind_statuses(summary: Mapping[str, Any]) -> str | None:
+    """Return the worst per-kind status in ``summary``, or ``None`` if the
+    summary carries no recognisable per-kind status entries."""
+    worst_rank = -1
+    for kind, info in summary.items():
+        if kind == "overall" or not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        if not isinstance(status, str):
+            continue
+        rank = _KIND_STATUS_RANK.get(status)
+        if rank is None:
+            continue
+        if rank > worst_rank:
+            worst_rank = rank
+    if worst_rank < 0:
+        return None
+    return _RANK_TO_KIND_STATUS[worst_rank]
+
 
 class SnapshotBackedReportGeneratorError(RuntimeError):
     """Raised when the request itself cannot proceed (mismatched scope, etc.)."""
@@ -429,6 +463,7 @@ class SnapshotBackedReportGenerator:
         active_watches: list[dict[str, Any]] = []
         pending_orders: list[dict[str, Any]] = []
         pending_orders_seen = False
+        symbol_quotes: dict[str, dict[str, Any]] = {}
 
         for _item, snapshot in item_snapshot_pairs:
             payload = snapshot.payload_json or {}
@@ -443,6 +478,15 @@ class SnapshotBackedReportGenerator:
                 orders = payload.get("pending_orders") or []
                 if isinstance(orders, list):
                     pending_orders.extend(orders)
+            elif snapshot.snapshot_kind == "symbol":
+                # ROB-278 Phase 2 — per-symbol quote evidence (when the
+                # symbol collector enriched the snapshot via KIS read-only
+                # quote/orderbook). symbol may be set on the snapshot row
+                # itself (per-symbol kind), and is also echoed in payload.
+                symbol = getattr(snapshot, "symbol", None) or payload.get("symbol")
+                quote = payload.get("quote")
+                if isinstance(symbol, str) and isinstance(quote, dict):
+                    symbol_quotes[symbol] = quote
 
         # Honest "unavailable" signal: pending_orders kind was attempted but
         # didn't produce a usable result (or missing entirely from the bundle).
@@ -450,6 +494,7 @@ class SnapshotBackedReportGenerator:
         return ClassifierContext(
             active_watches=active_watches,
             pending_orders=None if unavailable else pending_orders,
+            symbol_quotes=symbol_quotes,
         )
 
     def _enrich_freshness_summary(self, ensure_response: Any) -> dict[str, Any]:
@@ -458,9 +503,17 @@ class SnapshotBackedReportGenerator:
             summary = {"raw": summary}
         overall = summary.get("overall")
         if not isinstance(overall, str):
-            overall = _BUNDLE_STATUS_TO_OVERALL.get(
-                ensure_response.status, "unavailable"
-            )
+            # ROB-278 Phase 2 — prefer per-kind statuses over the
+            # bundle-status fallback. A reused bundle whose stored summary
+            # only carries per-kind entries must not silently downgrade to
+            # 'unavailable'; compute the worst per-kind status instead.
+            derived = _derive_overall_from_kind_statuses(summary)
+            if derived is not None:
+                overall = derived
+            else:
+                overall = _BUNDLE_STATUS_TO_OVERALL.get(
+                    ensure_response.status, "unavailable"
+                )
             summary["overall"] = overall
         return summary
 

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -56,6 +56,10 @@ from app.services.action_report.snapshot_backed.request import (
     ReportGenerationRequest,
     ReportGenerationResponse,
 )
+from app.services.action_report.snapshot_backed.symbol_derivation import (
+    SymbolDerivation,
+    SymbolDerivationService,
+)
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
@@ -119,6 +123,7 @@ class SnapshotBackedReportGenerator:
         ingestion_service: InvestmentReportIngestionService | None = None,
         collector_registry: SnapshotCollectorRegistry | None = None,
         snapshots_repository: InvestmentSnapshotsRepository | None = None,
+        symbol_derivation_service: SymbolDerivationService | None = None,
     ) -> None:
         self._session = session
         registry = collector_registry or production_collector_registry(session)
@@ -131,11 +136,23 @@ class SnapshotBackedReportGenerator:
         self._snapshots_repo = snapshots_repository or InvestmentSnapshotsRepository(
             session
         )
+        self._symbol_derivation = symbol_derivation_service or SymbolDerivationService(
+            session
+        )
 
     async def generate(
         self, request: ReportGenerationRequest
     ) -> ReportGenerationResponse:
         self._validate_pair(request)
+
+        # ROB-278 — derive symbol scope (seed + portfolio/journal/watch/candidate)
+        # before ensuring the bundle so the symbol collector sees the union.
+        derivation = await self._symbol_derivation.derive(
+            market=request.market,
+            account_scope=request.account_scope,
+            user_id=request.user_id,
+            seed_symbols=request.symbols,
+        )
 
         ensure_response = await self._ensure_service.ensure(
             EnsureBundleRequest(
@@ -144,9 +161,10 @@ class SnapshotBackedReportGenerator:
                 account_scope=request.account_scope,
                 policy_version=request.policy_version,
                 mode="ensure_fresh",
-                symbols=request.symbols,
+                symbols=derivation.symbols or None,
                 candidate_limit=request.candidate_limit,
                 requested_by=request.requested_by,
+                user_id=request.user_id,
             )
         )
 
@@ -212,7 +230,8 @@ class SnapshotBackedReportGenerator:
                 artifacts=stage_run.artifacts,
             )
 
-            # Re-classify composed items against operational state
+            # Re-classify composed items against operational state (ROB-274)
+            # — also picks up ROB-278 Phase 2 symbol-quote evidence wiring.
             classifier_context = await self._build_classifier_context(
                 bundle_uuid=ensure_response.bundle_uuid,
                 missing_sources=list(ensure_response.missing_sources),
@@ -245,10 +264,24 @@ class SnapshotBackedReportGenerator:
                             "policy_version": request.policy_version,
                             "generator_version": "v2_staged",
                         },
+                        "symbol_derivation": to_jsonable(derivation.provenance),
                     },
                 }
             )
         else:
+            # ROB-278 Phase 2 — deterministic evidence-driven auto-emit can
+            # populate items from the snapshot bundle BEFORE the classifier
+            # runs. The classifier then enforces operation/apply_policy +
+            # quote-evidence gates on whatever the proposer produced.
+            if request.auto_emit_from_evidence:
+                proposed = await self._auto_emit_items_from_bundle(
+                    bundle_uuid=ensure_response.bundle_uuid,
+                    request=request,
+                )
+                request = request.model_copy(
+                    update={"items": [*request.items, *proposed]}
+                )
+
             # ROB-274 — classify draft items against persisted bundle state.
             # We read payloads back from the DB (via list_bundle_items_with_snapshots)
             # so the classifier sees the same data that was just persisted, and
@@ -286,6 +319,7 @@ class SnapshotBackedReportGenerator:
                 freshness_summary=freshness_summary,
                 unavailable_sources=unavailable_sources,
                 source_conflicts=source_conflicts,
+                symbol_derivation=derivation,
             )
 
         # Authoritative gate runs inside ingest(); this pre-flight is a
@@ -327,6 +361,40 @@ class SnapshotBackedReportGenerator:
                 f"unsupported market/account_scope pair: "
                 f"{request.market!r}/{request.account_scope!r}"
             )
+
+    async def _auto_emit_items_from_bundle(
+        self,
+        *,
+        bundle_uuid: UUID,
+        request: ReportGenerationRequest,
+    ) -> list[Any]:
+        """ROB-278 Phase 2 — deterministic, evidence-driven proposer.
+
+        Reads the persisted snapshot bundle (portfolio / symbol+quote /
+        candidate_universe / news / watch_context / journal) and emits
+        ``IngestReportItem``s with ``operation="review"`` +
+        ``apply_policy="requires_user_approval"``. The proposer is
+        fail-closed: no candidates are emitted unless the evidence
+        explicitly supports them (quote.status=='ok' with spread/depth for
+        buy; portfolio.primary_source=='kis' + sellable_quantity > 0 for
+        sell). Mutation paths are unreachable from this code path.
+        """
+        from app.services.action_report.snapshot_backed.auto_emit import (
+            EvidenceAutoEmitter,
+        )
+
+        bundle = await self._snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+        if bundle is None:
+            return []
+        item_snapshot_pairs = (
+            await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
+        )
+        emitter = EvidenceAutoEmitter()
+        return emitter.propose(
+            snapshots=[s for _i, s in item_snapshot_pairs],
+            request_market=request.market,
+            account_scope=request.account_scope,
+        )
 
     async def _build_classifier_context(
         self,
@@ -452,6 +520,7 @@ class SnapshotBackedReportGenerator:
         freshness_summary: dict[str, Any],
         unavailable_sources: dict[str, Any],
         source_conflicts: dict[str, Any],
+        symbol_derivation: SymbolDerivation | None = None,
     ) -> IngestReportRequest:
         # Normalise items — each evidence_snapshot / trigger_checklist /
         # max_action / metadata is a free-form dict the caller filled in,
@@ -485,6 +554,11 @@ class SnapshotBackedReportGenerator:
                 "generator_version": request.generator_version,
             },
         )
+        if symbol_derivation is not None:
+            metadata.setdefault(
+                "symbol_derivation",
+                to_jsonable(symbol_derivation.provenance),
+            )
 
         return IngestReportRequest(
             report_type=request.report_type,

--- a/app/services/action_report/snapshot_backed/proposal_classifier.py
+++ b/app/services/action_report/snapshot_backed/proposal_classifier.py
@@ -39,6 +39,12 @@ class ClassifierContext:
     # failed open). Empty list means the snapshot was fresh and reported
     # no open orders. The classifier MUST distinguish these.
     pending_orders: list[dict[str, Any]] | None = field(default_factory=list)
+    # ROB-278 Phase 2 — per-symbol quote evidence keyed by symbol. The
+    # value mirrors the ``quote`` sub-dict produced by the symbol
+    # collector ({status: 'ok'|'unavailable'|'skipped', ...}). Absent key
+    # means the symbol had no snapshot in the bundle (treated like
+    # ``status='unavailable'`` for buy actions).
+    symbol_quotes: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 def classify_items(
@@ -141,6 +147,30 @@ def _classify_watch(
 def _classify_action(
     item: IngestReportItem, context: ClassifierContext
 ) -> IngestReportItem:
+    # ROB-278 Phase 2 — buy intent without backing quote evidence is
+    # downgraded to review with an explicit no-data rationale. This
+    # implements the fail-closed contract: don't fabricate candidates
+    # when the bundle has market evidence for some symbols but not this
+    # one. The gate only applies when the evidence layer actually
+    # collected per-symbol quote data; an empty ``symbol_quotes`` map
+    # means the layer wasn't run (e.g., legacy crypto path) and the
+    # legacy classifier paths below stay in effect.
+    if context.symbol_quotes and item.side == "buy" and item.symbol is not None:
+        quote = context.symbol_quotes.get(item.symbol)
+        if quote is None or quote.get("status") != "ok":
+            reason = (
+                quote.get("unavailable_reason")
+                if isinstance(quote, dict)
+                else "no symbol quote snapshot"
+            )
+            return item.model_copy(
+                update={
+                    "operation": "review",
+                    "rationale": item.rationale
+                    + f" (quote evidence 확인 불가: {reason or 'no_quote'})",
+                    "apply_policy": "requires_user_approval",
+                }
+            )
     if context.pending_orders is None:
         return item.model_copy(
             update={

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -58,6 +58,18 @@ class ReportGenerationRequest(BaseModel):
     # via the staged snapshot-backed pipeline instead of using provided ones.
     auto_compose: bool = False
 
+    # ROB-278 — operator user_id for live-account read paths (e.g. KIS
+    # holdings/cash). ``None`` keeps broker-backed collectors fail-closed.
+    user_id: int | None = None
+
+    # ROB-278 Phase 2 — when True, populate ``items`` from a deterministic
+    # evidence-driven auto-emitter (portfolio + symbol quote + candidate +
+    # news + journal/watch). Items emit with operation="review" +
+    # apply_policy="requires_user_approval"; mutation paths remain
+    # unreachable. Distinct from ``auto_compose`` (ROB-279) which uses
+    # LLM-staged composition.
+    auto_emit_from_evidence: bool = False
+
 
 class ReportGenerationResponse(BaseModel):
     """Result envelope for the generator. JSON-safe."""

--- a/app/services/action_report/snapshot_backed/symbol_derivation.py
+++ b/app/services/action_report/snapshot_backed/symbol_derivation.py
@@ -125,22 +125,34 @@ class _DefaultCandidateRepo:
     async def list_fresh_candidate_symbols(
         self, *, market: str, limit: int
     ) -> list[str]:
-        # Order by snapshot_date desc to get the freshest rows. We don't
-        # require a strict "today" check here — the candidate_universe
-        # snapshot collector owns the freshness semantics for the report;
-        # derivation just wants a bounded sample of recent candidates.
+        # Order by snapshot_date desc to get the freshest rows, then
+        # dedupe symbols in Python. PostgreSQL forbids ``DISTINCT`` over
+        # SELECT columns combined with ``ORDER BY`` on columns that are
+        # NOT in the select list, so we fetch ``symbol`` + ``snapshot_date``
+        # and collapse client-side. Overfetch slightly to absorb dupes.
+        overfetch = max(limit * 4, limit)
         stmt = (
-            sa.select(InvestScreenerSnapshot.symbol)
+            sa.select(
+                InvestScreenerSnapshot.symbol, InvestScreenerSnapshot.snapshot_date
+            )
             .where(InvestScreenerSnapshot.market == market)
             .order_by(
                 InvestScreenerSnapshot.snapshot_date.desc(),
                 InvestScreenerSnapshot.symbol.asc(),
             )
-            .distinct()
-            .limit(limit)
+            .limit(overfetch)
         )
         result = await self._session.execute(stmt)
-        return [s for (s,) in result.all()]
+        out: list[str] = []
+        seen: set[str] = set()
+        for symbol, _snapshot_date in result.all():
+            if symbol in seen:
+                continue
+            seen.add(symbol)
+            out.append(symbol)
+            if len(out) >= limit:
+                break
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -185,9 +197,27 @@ class SymbolDerivationService:
         seed = [s for s in (seed_symbols or []) if s]
         source_errors: dict[str, str] = {}
 
+        # Each per-source DB query runs inside a SAVEPOINT (when the
+        # outer session supports one) so a query failure — e.g., a SQL
+        # bug or a missing column — doesn't leave the outer transaction
+        # in an aborted state. The outer caller's subsequent writes,
+        # and the stage-runner / generator pipeline that follows, must
+        # remain usable even if one optional derivation source raises.
+        outer_session = getattr(self._manual, "_session", None) or getattr(
+            self._candidate, "_session", None
+        )
+        can_savepoint = hasattr(outer_session, "begin_nested")
+
         async def _safe(name: str, coro):
+            if not can_savepoint:
+                try:
+                    return await coro
+                except Exception as exc:  # noqa: BLE001 — derivation is best-effort
+                    source_errors[name] = f"{type(exc).__name__}: {exc}"
+                    return []
             try:
-                return await coro
+                async with outer_session.begin_nested():
+                    return await coro
             except Exception as exc:  # noqa: BLE001 — derivation is best-effort
                 source_errors[name] = f"{type(exc).__name__}: {exc}"
                 return []

--- a/app/services/action_report/snapshot_backed/symbol_derivation.py
+++ b/app/services/action_report/snapshot_backed/symbol_derivation.py
@@ -1,0 +1,258 @@
+"""ROB-278 — Symbol derivation for snapshot-backed reports.
+
+Derives a bounded list of relevant symbols for a report by unioning
+caller-supplied seed symbols with symbols inferred from:
+
+* the user's portfolio (manual_holdings for the requested market)
+* active trade journals
+* active watch alerts
+* the fresh candidate universe
+
+Contract:
+
+* Seed (caller-supplied) symbols are preserved verbatim and never dropped.
+* Derived symbols are unioned with seed and capped at ``max_symbols``.
+* Per-source attribution and overflow (``dropped_by_cap``) are returned in
+  ``provenance`` so the report viewer / audit can show why each symbol is
+  in scope.
+
+This module is read-only by construction — it does not import any broker
+mutation or watch-activation surface. Tests in ``test_collectors.py``
+import-guard the module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.manual_holdings import ManualHolding, MarketType
+from app.models.trade_journal import TradeJournal
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
+    "kr": (MarketType.KR,),
+    "us": (MarketType.US,),
+    "crypto": (MarketType.CRYPTO,),
+}
+
+
+class SymbolDerivation(BaseModel):
+    """Result of a single derivation pass."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    symbols: list[str]
+    provenance: dict[str, Any] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Repository protocols — keep the service decoupled from concrete data sources
+# so tests can substitute fakes that don't touch the DB.
+# ---------------------------------------------------------------------------
+class _ManualHoldingsRepoProtocol(Protocol):
+    async def list_tickers(self, *, market: str) -> list[str]: ...
+
+
+class _JournalRepoProtocol(Protocol):
+    async def list_active_journal_symbols(self, *, market: str) -> list[str]: ...
+
+
+class _WatchRepoProtocol(Protocol):
+    async def list_active_watch_symbols(self, *, market: str) -> list[str]: ...
+
+
+class _CandidateRepoProtocol(Protocol):
+    async def list_fresh_candidate_symbols(
+        self, *, market: str, limit: int
+    ) -> list[str]: ...
+
+
+# ---------------------------------------------------------------------------
+# Default DB-backed repository adapters. Each is a narrow read-only wrapper
+# around an existing model so the derivation service does no broker I/O.
+# ---------------------------------------------------------------------------
+class _DefaultManualHoldingsRepo:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_tickers(self, *, market: str) -> list[str]:
+        market_types = _MARKET_TO_TYPES.get(market)
+        if not market_types:
+            return []
+        stmt = sa.select(ManualHolding.ticker).where(
+            ManualHolding.market_type.in_(market_types)
+        )
+        result = await self._session.execute(stmt)
+        return [t for (t,) in result.all()]
+
+
+class _DefaultJournalRepo:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_active_journal_symbols(self, *, market: str) -> list[str]:
+        # TradeJournal model has no market column; we filter by instrument_type
+        # downstream if needed. For PR1 derivation, we include all active
+        # journals because they are operator-curated and rare.
+        stmt = (
+            sa.select(TradeJournal.symbol)
+            .where(TradeJournal.status == "active")
+            .distinct()
+        )
+        result = await self._session.execute(stmt)
+        return [s for (s,) in result.all()]
+
+
+class _DefaultWatchRepo:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._repo = InvestmentReportsRepository(session)
+
+    async def list_active_watch_symbols(self, *, market: str) -> list[str]:
+        alerts = await self._repo.list_active_alerts(market=market)
+        return [a.symbol for a in alerts if a.symbol]
+
+
+class _DefaultCandidateRepo:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_fresh_candidate_symbols(
+        self, *, market: str, limit: int
+    ) -> list[str]:
+        # Order by snapshot_date desc to get the freshest rows. We don't
+        # require a strict "today" check here — the candidate_universe
+        # snapshot collector owns the freshness semantics for the report;
+        # derivation just wants a bounded sample of recent candidates.
+        stmt = (
+            sa.select(InvestScreenerSnapshot.symbol)
+            .where(InvestScreenerSnapshot.market == market)
+            .order_by(
+                InvestScreenerSnapshot.snapshot_date.desc(),
+                InvestScreenerSnapshot.symbol.asc(),
+            )
+            .distinct()
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return [s for (s,) in result.all()]
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+class SymbolDerivationService:
+    """Derive a bounded symbol scope for a snapshot-backed report.
+
+    Construction is dependency-injected so production wiring uses the
+    DB-backed repos while tests pass in fakes. The service never reaches
+    outside its injected repositories.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        manual_holdings_repo: _ManualHoldingsRepoProtocol | None = None,
+        journal_repo: _JournalRepoProtocol | None = None,
+        watch_repo: _WatchRepoProtocol | None = None,
+        candidate_repo: _CandidateRepoProtocol | None = None,
+        max_symbols: int = 50,
+        top_held: int = 20,
+        top_candidates: int = 20,
+    ) -> None:
+        self._manual = manual_holdings_repo or _DefaultManualHoldingsRepo(session)
+        self._journal = journal_repo or _DefaultJournalRepo(session)
+        self._watch = watch_repo or _DefaultWatchRepo(session)
+        self._candidate = candidate_repo or _DefaultCandidateRepo(session)
+        self._max_symbols = max_symbols
+        self._top_held = top_held
+        self._top_candidates = top_candidates
+
+    async def derive(
+        self,
+        *,
+        market: str,
+        account_scope: str | None,
+        user_id: int | None,
+        seed_symbols: list[str] | None,
+    ) -> SymbolDerivation:
+        seed = [s for s in (seed_symbols or []) if s]
+        source_errors: dict[str, str] = {}
+
+        async def _safe(name: str, coro):
+            try:
+                return await coro
+            except Exception as exc:  # noqa: BLE001 — derivation is best-effort
+                source_errors[name] = f"{type(exc).__name__}: {exc}"
+                return []
+
+        portfolio = (
+            await _safe("portfolio", self._manual.list_tickers(market=market))
+        )[: self._top_held]
+        journal = await _safe(
+            "journal", self._journal.list_active_journal_symbols(market=market)
+        )
+        watch = await _safe(
+            "watch", self._watch.list_active_watch_symbols(market=market)
+        )
+        candidate = await _safe(
+            "candidate",
+            self._candidate.list_fresh_candidate_symbols(
+                market=market, limit=self._top_candidates
+            ),
+        )
+
+        sources = {
+            "seed": seed,
+            "portfolio": portfolio,
+            "journal": journal,
+            "watch": watch,
+            "candidate": candidate,
+        }
+
+        # Seed first, then derived sources in priority order so the cap
+        # drops candidate-derived symbols before more important sources.
+        ordered_sources: list[list[str]] = [
+            seed,
+            portfolio,
+            journal,
+            watch,
+            candidate,
+        ]
+        union: list[str] = []
+        seen: set[str] = set()
+        for source in ordered_sources:
+            for sym in source:
+                if sym in seen:
+                    continue
+                seen.add(sym)
+                union.append(sym)
+
+        seed_set = set(seed)
+        if len(union) <= self._max_symbols:
+            kept = union
+            dropped: list[str] = []
+        else:
+            # Seeds always survive the cap; truncate from the derived tail.
+            seeds_in_union = [s for s in union if s in seed_set]
+            derived = [s for s in union if s not in seed_set]
+            remaining_room = max(self._max_symbols - len(seeds_in_union), 0)
+            kept_derived = derived[:remaining_room]
+            dropped = derived[remaining_room:]
+            kept = seeds_in_union + kept_derived
+
+        provenance: dict[str, Any] = {
+            "sources": sources,
+            "dropped_by_cap": dropped,
+            "cap": self._max_symbols,
+            "total_unique": len(union),
+        }
+        if source_errors:
+            provenance["source_errors"] = source_errors
+        return SymbolDerivation(symbols=kept, provenance=provenance)

--- a/app/services/investment_snapshots/collectors.py
+++ b/app/services/investment_snapshots/collectors.py
@@ -87,6 +87,11 @@ class CollectorRequest(BaseModel):
     """For ``candidate_universe`` collectors. ``None`` = collector default."""
     policy_snapshot: dict[str, Any]
     """The frozen policy as stored on the run row (read-only)."""
+    user_id: int | None = None
+    """ROB-278 — explicit operator user_id for collectors that need to call
+    live-account read endpoints (e.g. KIS holdings/cash). ``None`` means the
+    caller did not supply one; broker-backed collectors must then fail
+    closed (``unavailable``) rather than invent a default."""
 
 
 @runtime_checkable

--- a/scripts/rob278_kr_dryrun.py
+++ b/scripts/rob278_kr_dryrun.py
@@ -1,0 +1,241 @@
+# scripts/rob278_kr_dryrun.py
+"""ROB-278 — KR snapshot-backed report dry-run.
+
+Drives ``SnapshotBackedReportGenerator`` end-to-end against the local /
+dev DB with ``auto_emit_from_evidence=True``, prints the generated
+``items`` and their ``operation`` / ``apply_policy`` / ``evidence_snapshot``,
+and asserts that **no rows were inserted into any broker / order / watch /
+order-intent mutation table** during the run.
+
+Safety
+------
+* Read-only KIS calls only — the symbol/portfolio collectors go through
+  the existing ``KISHomeReader`` / ``inquire_price`` / ``inquire_orderbook``
+  surfaces, never the order client.
+* The entire generator run is wrapped in a single ``AsyncSessionLocal``
+  transaction that is **rolled back** at the end (unless ``--commit`` is
+  passed). The dry-run also reads pre/post row counts on a handful of
+  mutation-watched tables and aborts (exit 2) if any of them grew.
+* No watch activation, no order placement / cancel / modify, no
+  scheduler registration.
+
+Usage
+-----
+    uv run python -m scripts.rob278_kr_dryrun --dry-run --user-id 1
+    uv run python -m scripts.rob278_kr_dryrun --dry-run --user-id 1 --no-auto-emit
+    uv run python -m scripts.rob278_kr_dryrun --commit --user-id 1  # NOT recommended
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import sys
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+
+# Tables guarded against any row-count growth during the dry run. These
+# are the broker/order/watch/order-intent surfaces the lockdown forbids
+# mutating from the report-generation path. ``schema.table`` form is
+# accepted by Postgres directly via ``information_schema.tables`` lookups.
+_MUTATION_GUARDED_TABLES: tuple[str, ...] = (
+    "review.investment_watch_alerts",
+    "review.investment_watch_events",
+    "review.investment_report_item_decisions",
+    "pending_orders",
+    "order_preview_session",
+    "order_preview_leg",
+    "order_execution_request",
+)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+async def _table_exists(session, qualified_name: str) -> bool:
+    if "." in qualified_name:
+        schema, table = qualified_name.split(".", 1)
+    else:
+        schema, table = "public", qualified_name
+    row = await session.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.tables "
+            "WHERE table_schema = :schema AND table_name = :table"
+        ),
+        {"schema": schema, "table": table},
+    )
+    return row.scalar() is not None
+
+
+async def _count_rows(session, qualified_name: str) -> int:
+    if "." in qualified_name:
+        schema, table = qualified_name.split(".", 1)
+        ref = f'"{schema}"."{table}"'
+    else:
+        ref = f'"{qualified_name}"'
+    row = await session.execute(sa.text(f"SELECT count(*) FROM {ref}"))
+    return int(row.scalar() or 0)
+
+
+async def _snapshot_mutation_counts(session) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for name in _MUTATION_GUARDED_TABLES:
+        try:
+            if not await _table_exists(session, name):
+                continue
+            counts[name] = await _count_rows(session, name)
+        except Exception as exc:  # noqa: BLE001 — defensive
+            print(f"  [warn] could not count rows on {name}: {exc}")
+    return counts
+
+
+def _summarise_items(items) -> None:
+    if not items:
+        print("  (no items)")
+        return
+    for idx, item in enumerate(items):
+        ev = item.evidence_snapshot or {}
+        proposer = ev.get("proposer") if isinstance(ev, dict) else None
+        snap_uuid = ev.get("snapshot_uuid") if isinstance(ev, dict) else None
+        print(
+            f"  [{idx}] kind={item.item_kind} side={item.side} symbol={item.symbol} "
+            f"operation={item.operation} apply_policy={item.apply_policy} "
+            f"intent={item.intent} proposer={proposer} "
+            f"evidence_snapshot_uuid={snap_uuid}"
+        )
+
+
+async def _run(args: argparse.Namespace) -> int:
+    async with AsyncSessionLocal() as session:
+        print("=== ROB-278 KR snapshot-backed report dry-run ===")
+        print("Pre-flight: snapshotting mutation-guarded row counts ...")
+        before = await _snapshot_mutation_counts(session)
+        for table, count in before.items():
+            print(f"  before {table:50s} {count}")
+
+        request = ReportGenerationRequest(
+            market="kr",
+            account_scope="kis_live",
+            status="draft",  # never publish from the dry-run
+            requested_by="claude_code",
+            created_by_profile=args.profile,
+            title=f"ROB-278 KR dry-run {dt.datetime.now(tz=dt.UTC).isoformat()}",
+            summary="dry-run; do not publish",
+            kst_date=dt.date.today().isoformat(),
+            user_id=args.user_id,
+            auto_emit_from_evidence=not args.no_auto_emit,
+        )
+        print(
+            f"\nGenerating report (auto_emit={request.auto_emit_from_evidence}, "
+            f"user_id={request.user_id}) ..."
+        )
+        generator = SnapshotBackedReportGenerator(session)
+        try:
+            response = await generator.generate(request)
+        except Exception as exc:  # noqa: BLE001
+            print(f"\n[ERROR] generator failed: {type(exc).__name__}: {exc}")
+            await session.rollback()
+            return 3
+
+        print(f"\nReport UUID: {response.report_uuid}")
+        print(f"Bundle UUID: {response.snapshot_bundle_uuid}")
+        print(f"Bundle status: {response.bundle_status}")
+        print(f"Bundle reused: {response.bundle_reused}")
+        print(f"Items count:  {response.items_count}")
+        print(
+            f"Overall freshness: {response.snapshot_freshness_summary.get('overall')}"
+        )
+        if response.warnings:
+            print("Warnings:")
+            for w in response.warnings:
+                print(f"  - {w}")
+
+        # Read items back to print full provenance.
+        item_rows = (
+            await session.execute(
+                sa.text(
+                    "SELECT item_kind, side, symbol, operation, apply_policy, "
+                    "intent, evidence_snapshot FROM review.investment_report_items "
+                    "WHERE report_id IN (SELECT id FROM review.investment_reports "
+                    "WHERE report_uuid = :uuid) ORDER BY id"
+                ),
+                {"uuid": response.report_uuid},
+            )
+        ).all()
+        print("\nGenerated items (review.investment_report_items):")
+        if not item_rows:
+            print("  (none persisted)")
+        for row in item_rows:
+            print(
+                "  - "
+                f"kind={row.item_kind} side={row.side} symbol={row.symbol} "
+                f"operation={row.operation} apply_policy={row.apply_policy} "
+                f"intent={row.intent}"
+            )
+
+        print("\nPost-flight: re-snapshotting mutation-guarded row counts ...")
+        after = await _snapshot_mutation_counts(session)
+        for table, count in after.items():
+            delta = count - before.get(table, count)
+            marker = "" if delta == 0 else " <<< CHANGED"
+            print(f"  after  {table:50s} {count}  (Δ={delta}){marker}")
+
+        deltas = {t: after[t] - before[t] for t in after if t in before}
+        bad = {t: d for t, d in deltas.items() if d != 0}
+        if bad:
+            print("\n[FAIL] mutation-guarded tables changed during the dry-run:")
+            for t, d in bad.items():
+                print(f"  {t}: Δ={d}")
+            await session.rollback()
+            return 2
+
+        if args.commit:
+            print("\nCommitting transaction (--commit) ...")
+            await session.commit()
+        else:
+            print("\nDry-run: rolling back transaction.")
+            await session.rollback()
+
+        print("Done.")
+        return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--dry-run", action="store_true", help="Roll back at the end (default)"
+    )
+    group.add_argument(
+        "--commit", action="store_true", help="Commit the report (NOT recommended)"
+    )
+    parser.add_argument(
+        "--user-id",
+        type=int,
+        required=True,
+        help="Operator user_id for KIS read-only calls (no implicit default)",
+    )
+    parser.add_argument(
+        "--profile",
+        default="rob278-dryrun",
+        help="created_by_profile string (default: rob278-dryrun)",
+    )
+    parser.add_argument(
+        "--no-auto-emit",
+        action="store_true",
+        help="Skip the deterministic evidence-driven auto-emitter",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(_run(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/services/action_report/snapshot_backed/test_auto_emit.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit.py
@@ -1,0 +1,453 @@
+"""ROB-278 Phase 2 — EvidenceAutoEmitter tests.
+
+The auto-emitter is deterministic and fail-closed:
+
+* Sell candidates require ``portfolio.primary_source='kis'`` + a held row
+  with positive ``sellable_quantity`` AND the matching symbol snapshot's
+  quote must report ``status='ok'`` with non-zero best bid/ask and at
+  least one side of book depth.
+* Buy candidates require ``candidate_universe.usefulness='useful'`` AND
+  the symbol's quote evidence to be actionable (same gate as sell). The
+  symbol must not already be held.
+* Watch candidates require news activity (``symbol_matches > 0``) but
+  insufficient action grounds (quote unavailable, or candidate evidence
+  not useful, etc.).
+* Every emitted item is ``operation='review'`` +
+  ``apply_policy='requires_user_approval'``.
+* Every emitted item carries an ``evidence_snapshot`` dict with the
+  source snapshot's uuid + kind + symbol + a ``proposer`` tag.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+def _make_snapshot(
+    *,
+    kind: str,
+    payload: dict,
+    symbol: str | None = None,
+    snapshot_uuid=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        snapshot_kind=kind,
+        symbol=symbol,
+        snapshot_uuid=snapshot_uuid or uuid4(),
+        payload_json=payload,
+    )
+
+
+def _ok_quote_payload(symbol: str, sellable: float = 0.0) -> dict:
+    return {
+        "symbol": symbol,
+        "quote": {
+            "status": "ok",
+            "last_price": 70_000.0,
+            "best_bid": 69_900.0,
+            "best_ask": 70_100.0,
+            "spread": 200.0,
+            "spread_bps": 28.57,
+            "bid_depth": 500.0,
+            "ask_depth": 600.0,
+            "venue": "krx",
+            "nxt_eligible": True,
+            "session": "regular",
+        },
+    }
+
+
+def _kis_portfolio_payload(*, ticker: str, sellable: float) -> dict:
+    return {
+        "primary_source": "kis",
+        "holdings": [
+            {
+                "ticker": ticker,
+                "quantity": sellable + 2.0,
+                "sellable_quantity": sellable,
+                "source": "kis",
+                "market": "KR",
+            }
+        ],
+        "reference_holdings": [],
+        "count": 1,
+        "market": "kr",
+    }
+
+
+def _candidate_payload(usefulness: str, actionable_count: int = 5) -> dict:
+    return {
+        "market": "kr",
+        "actionable_count": actionable_count,
+        "stale_count": 0,
+        "usefulness": usefulness,
+        "no_data_reason": None if usefulness == "useful" else "no fresh candidates",
+    }
+
+
+def _news_payload(symbol_matches: dict[str, int]) -> dict:
+    return {
+        "since": "2026-05-19T00:00:00+00:00",
+        "count": sum(symbol_matches.values()),
+        "citations": [],
+        "symbol_matches": symbol_matches,
+        "no_data_reason": None if any(symbol_matches.values()) else "no matches",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Empty / no-evidence baselines.
+# ---------------------------------------------------------------------------
+def test_empty_snapshots_emits_nothing():
+    emitter = EvidenceAutoEmitter()
+    items = emitter.propose(snapshots=[], request_market="kr", account_scope="kis_live")
+    assert items == []
+
+
+def test_no_evidence_combo_emits_nothing():
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload={
+                "primary_source": "manual",
+                "holdings": [{"ticker": "005930", "quantity": 5}],
+                "reference_holdings": [],
+            },
+        )
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    assert items == []
+
+
+# ---------------------------------------------------------------------------
+# Sell candidates.
+# ---------------------------------------------------------------------------
+def test_sell_emitted_when_kis_held_and_quote_actionable():
+    """KIS primary + sellable > 0 + quote.status='ok' → sell review item."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=8.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload=_ok_quote_payload("005930"),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sells = [i for i in items if i.item_kind == "action" and i.side == "sell"]
+    assert len(sells) == 1
+    sell = sells[0]
+    assert sell.symbol == "005930"
+    assert sell.operation == "review"
+    assert sell.apply_policy == "requires_user_approval"
+    assert sell.evidence_snapshot["proposer"] == "auto_emit/sell_from_held"
+    assert sell.evidence_snapshot["sellable_quantity"] == 8.0
+    assert sell.evidence_snapshot["snapshot_kind"] == "symbol"
+
+
+def test_no_sell_when_portfolio_primary_source_is_manual():
+    """Manual primary is never promoted — no sell candidate even if quote ok."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload={
+                "primary_source": "manual",
+                "holdings": [
+                    {"ticker": "005930", "sellable_quantity": 10.0, "source": "manual"}
+                ],
+                "reference_holdings": [],
+            },
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload=_ok_quote_payload("005930"),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sells = [i for i in items if i.item_kind == "action" and i.side == "sell"]
+    assert sells == []
+
+
+def test_no_sell_when_quote_unavailable():
+    """KIS held but quote.status='unavailable' → no sell candidate (fail-closed)."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=8.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload={
+                "symbol": "005930",
+                "quote": {
+                    "status": "unavailable",
+                    "unavailable_reason": "session_closed",
+                },
+            },
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sells = [i for i in items if i.item_kind == "action" and i.side == "sell"]
+    assert sells == []
+
+
+def test_no_sell_when_sellable_quantity_zero():
+    """KIS held but sellable_quantity == 0 → no sell candidate."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=0.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload=_ok_quote_payload("005930"),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sells = [i for i in items if i.item_kind == "action" and i.side == "sell"]
+    assert sells == []
+
+
+# ---------------------------------------------------------------------------
+# Buy candidates.
+# ---------------------------------------------------------------------------
+def test_buy_emitted_when_candidate_useful_and_quote_ok_and_not_held():
+    """Useful candidate universe + actionable quote + unheld → buy review item."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=8.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="000660",
+            payload=_ok_quote_payload("000660"),
+        ),
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("useful", actionable_count=5),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    buys = [i for i in items if i.item_kind == "action" and i.side == "buy"]
+    assert len(buys) == 1
+    buy = buys[0]
+    assert buy.symbol == "000660"
+    assert buy.operation == "review"
+    assert buy.apply_policy == "requires_user_approval"
+    assert buy.evidence_snapshot["proposer"] == "auto_emit/buy_from_candidate"
+    assert buy.evidence_snapshot["candidate_usefulness"] == "useful"
+
+
+def test_no_buy_when_candidate_universe_stale_only():
+    """Candidate usefulness != 'useful' → no buy candidate even if quote ok."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="symbol",
+            symbol="000660",
+            payload=_ok_quote_payload("000660"),
+        ),
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("stale_only", actionable_count=0),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    buys = [i for i in items if i.item_kind == "action" and i.side == "buy"]
+    assert buys == []
+
+
+def test_no_buy_when_already_held():
+    """Useful candidate + held symbol → no buy candidate (already in position)."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=8.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload=_ok_quote_payload("005930"),
+        ),
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("useful"),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    buys = [i for i in items if i.item_kind == "action" and i.side == "buy"]
+    assert buys == []
+
+
+def test_buy_respects_cap():
+    """Max-buy-candidates bound is honoured."""
+    snapshots = [
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("useful"),
+        ),
+    ]
+    for i in range(5):
+        sym = f"00500{i}"
+        snapshots.append(
+            _make_snapshot(
+                kind="symbol",
+                symbol=sym,
+                payload=_ok_quote_payload(sym),
+            )
+        )
+    emitter = EvidenceAutoEmitter(max_buy_candidates=3)
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    buys = [i for i in items if i.item_kind == "action" and i.side == "buy"]
+    assert len(buys) == 3
+
+
+# ---------------------------------------------------------------------------
+# Watch candidates.
+# ---------------------------------------------------------------------------
+def test_watch_emitted_when_news_active_but_no_quote_evidence():
+    """News matches without quote evidence → watch review item."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="news",
+            payload=_news_payload({"000660": 3}),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    watches = [i for i in items if i.item_kind == "watch"]
+    assert len(watches) == 1
+    watch = watches[0]
+    assert watch.symbol == "000660"
+    assert watch.operation == "review"
+    assert watch.apply_policy == "requires_user_approval"
+    assert watch.evidence_snapshot["proposer"] == "auto_emit/watch_from_news"
+    assert watch.evidence_snapshot["news_match_count"] == 3
+
+
+def test_no_duplicate_watch_when_already_proposed_as_buy():
+    """A symbol already proposed for buy must not also surface as watch."""
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="symbol",
+            symbol="000660",
+            payload=_ok_quote_payload("000660"),
+        ),
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("useful"),
+        ),
+        _make_snapshot(
+            kind="news",
+            payload=_news_payload({"000660": 4}),
+        ),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    by_symbol_kind = [(i.symbol, i.item_kind) for i in items]
+    # Buy proposal should win; watch on the same symbol must not also fire.
+    assert ("000660", "action") in by_symbol_kind
+    assert ("000660", "watch") not in by_symbol_kind
+
+
+# ---------------------------------------------------------------------------
+# Mutation safety — static guard.
+# ---------------------------------------------------------------------------
+def test_auto_emit_module_does_not_import_mutation_paths():
+    import importlib
+    import sys
+
+    forbidden = (
+        "kis_trading_service",
+        "investment_reports.watch_activation",
+        "alpaca_paper_ledger_service",
+        "upbit.client",
+        "place_order",
+        "submit_order",
+        "cancel_order",
+        "modify_order",
+    )
+    module_name = "app.services.action_report.snapshot_backed.auto_emit"
+    importlib.import_module(module_name)
+    module = sys.modules[module_name]
+    source = open(module.__file__, encoding="utf-8").read()  # type: ignore[arg-type]
+    for symbol in forbidden:
+        assert symbol not in source, (
+            f"auto_emit unexpectedly references {symbol!r} — must remain read-only"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Apply-policy + evidence provenance — invariant across all proposals.
+# ---------------------------------------------------------------------------
+def test_all_emitted_items_are_review_and_require_user_approval():
+    emitter = EvidenceAutoEmitter()
+    snapshots = [
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=8.0),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="005930",
+            payload=_ok_quote_payload("005930"),
+        ),
+        _make_snapshot(
+            kind="symbol",
+            symbol="000660",
+            payload=_ok_quote_payload("000660"),
+        ),
+        _make_snapshot(
+            kind="candidate_universe",
+            payload=_candidate_payload("useful"),
+        ),
+        _make_snapshot(kind="news", payload=_news_payload({"035420": 2})),
+    ]
+    items = emitter.propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    assert items, "test setup should produce at least one proposal"
+    for item in items:
+        assert item.operation == "review", item
+        assert item.apply_policy == "requires_user_approval", item
+        assert item.evidence_snapshot is not None
+        assert item.evidence_snapshot.get("snapshot_uuid")
+        assert item.evidence_snapshot.get("proposer", "").startswith("auto_emit/")

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -8,6 +8,7 @@ order / watch / scheduler write paths.
 from __future__ import annotations
 
 import datetime as dt
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -62,16 +63,22 @@ def _request(market: str = "kr", account_scope: str = "kis_live") -> CollectorRe
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_portfolio_collector_returns_holdings(monkeypatch: pytest.MonkeyPatch):
+    """v1 manual-primary path remains for non-(kr+kis_live) combos.
+
+    ROB-278 reserved the kr+kis_live combo for the new KIS live path
+    (see test_portfolio_v2_*). Other combos keep the v1 contract and
+    additionally surface the ``primary_source="manual"`` label.
+    """
     from app.models.manual_holdings import MarketType
 
     session = MagicMock()
 
     class _Row:
-        ticker = "005930"
-        market_type = MarketType.KR
+        ticker = "AAPL"
+        market_type = MarketType.US
         quantity = 10
-        avg_price = 70_000
-        display_name = "삼성전자"
+        avg_price = 150.0
+        display_name = "Apple"
         updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
 
     scalars = MagicMock()
@@ -81,12 +88,14 @@ async def test_portfolio_collector_returns_holdings(monkeypatch: pytest.MonkeyPa
     session.execute = AsyncMock(return_value=result)
 
     collector = PortfolioSnapshotCollector(session)
-    results = await collector.collect(_request())
+    results = await collector.collect(_request(market="us", account_scope="kis_live"))
     assert len(results) == 1
     assert results[0].snapshot_kind == "portfolio"
     assert results[0].source_kind == "auto_trader_mcp"
     assert results[0].payload_json["count"] == 1
-    assert results[0].payload_json["holdings"][0]["ticker"] == "005930"
+    assert results[0].payload_json["holdings"][0]["ticker"] == "AAPL"
+    # ROB-278 — payload v2 surfaces primary_source even on the v1 path.
+    assert results[0].payload_json["primary_source"] == "manual"
 
 
 @pytest.mark.asyncio
@@ -103,6 +112,257 @@ async def test_portfolio_collector_empty_holdings_returns_partial():
     assert results[0].snapshot_kind == "portfolio"
     assert results[0].freshness_status == "partial"
     assert results[0].payload_json["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Portfolio v2 — ROB-278 KIS live path for KR + kis_live.
+#
+# Lockdown policy:
+# - user_id missing on kis_live → fail-closed (unavailable, no implicit default).
+# - KIS success → primary_source="kis"; manual rows go to reference_holdings.
+# - KIS failure → primary_source="none"; manual NEVER promoted to primary.
+# - Payload v2 is additive: existing v1 keys (holdings, count, market) preserved.
+# - Non-(kr+kis_live) combos preserve v1 manual-primary behaviour.
+# ---------------------------------------------------------------------------
+def _kr_kis_request(user_id: int | None = None) -> CollectorRequest:
+    return CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=None,
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=user_id,
+    )
+
+
+def _empty_manual_session() -> MagicMock:
+    """Session whose execute() returns no manual_holdings rows."""
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=[]))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    return session
+
+
+def _manual_kr_session(rows: list[Any] | None = None) -> MagicMock:
+    from app.models.manual_holdings import MarketType
+
+    class _ManualRow:
+        def __init__(
+            self,
+            ticker: str = "005930",
+            quantity: float = 5.0,
+            avg_price: float = 70_000,
+        ) -> None:
+            self.ticker = ticker
+            self.market_type = MarketType.KR
+            self.quantity = quantity
+            self.avg_price = avg_price
+            self.display_name = ticker
+            self.updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    rows = rows if rows is not None else [_ManualRow()]
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=rows))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    return session
+
+
+def _kis_reader_with_holdings() -> MagicMock:
+    """KISHomeReader stub returning one KR holding + KRW cash."""
+    from app.schemas.invest_home import Account, CashAmounts, Holding
+    from app.services.invest_home_service import _SourceFetchResult
+
+    holding_kr = Holding(
+        holdingId="kis:kr:005930",
+        accountId="kis_account",
+        source="kis",
+        accountKind="live",
+        symbol="005930",
+        market="KR",
+        assetType="equity",
+        assetCategory="kr_stock",
+        displayName="삼성전자",
+        quantity=10.0,
+        averageCost=70_000,
+        costBasis=700_000,
+        currency="KRW",
+        valueNative=750_000,
+        valueKrw=750_000,
+        pnlKrw=50_000,
+        pnlRate=0.0714,
+        sellableQuantity=8.0,
+        pendingSellQuantity=2.0,
+        referenceQuantity=0.0,
+    )
+    account = Account(
+        accountId="kis_account",
+        displayName="KIS 실계좌",
+        source="kis",
+        accountKind="live",
+        includedInHome=True,
+        valueKrw=750_000,
+        costBasisKrw=700_000,
+        pnlKrw=50_000,
+        pnlRate=0.0714,
+        cashBalances=CashAmounts(krw=1_200_000.0, usd=None),
+        buyingPower=CashAmounts(krw=1_000_000.0, usd=None),
+    )
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[account], holdings=[holding_kr], warning=None
+        )
+    )
+    return reader
+
+
+def _kis_reader_failed() -> MagicMock:
+    from app.schemas.invest_home import InvestHomeWarning
+    from app.services.invest_home_service import _SourceFetchResult
+
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[],
+            holdings=[],
+            warning=InvestHomeWarning(source="kis", message="connection timeout"),
+        )
+    )
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_kr_kis_live_missing_user_id_is_fail_closed():
+    """ROB-278 — no user_id on kis_live request → unavailable, no implicit default."""
+    session = _empty_manual_session()
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        side_effect=AssertionError("KIS must not be called without user_id")
+    )
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_kr_kis_request(user_id=None))
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "portfolio"
+    assert results[0].freshness_status == "unavailable"
+    assert "user_id" in results[0].errors_json["reason"]
+    # primary_source label is present and explicitly "none" (manual NOT promoted).
+    assert results[0].payload_json.get("primary_source") == "none"
+    reader.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_kr_kis_live_success_populates_kis_primary():
+    """ROB-278 — KIS success: primary_source=kis, KIS holdings primary, manual in reference."""
+    session = _manual_kr_session()
+    reader = _kis_reader_with_holdings()
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_kr_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "fresh"
+    # v1 keys preserved (additive shape).
+    assert "holdings" in payload
+    assert "count" in payload
+    assert "market" in payload
+    # v2 fields.
+    assert payload["primary_source"] == "kis"
+    assert payload["count"] == 1
+    assert payload["holdings"][0]["ticker"] == "005930"
+    assert payload["holdings"][0]["source"] == "kis"
+    assert payload["holdings"][0]["sellable_quantity"] == 8.0
+    assert payload["holdings"][0]["pending_sell_quantity"] == 2.0
+    assert payload["cash"]["krw"] == 1_200_000.0
+    assert payload["buying_power"]["krw"] == 1_000_000.0
+    assert payload["sellable_summary"]["sellable_count"] == 1
+    # Manual KR row appears in reference_holdings, NOT in holdings.
+    assert payload["reference_holdings"][0]["ticker"] == "005930"
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    # Provenance.
+    assert payload["provenance"]["kis_fetch_status"] == "ok"
+    assert payload["provenance"]["account_scope"] == "kis_live"
+    reader.fetch.assert_awaited_once_with(user_id=42)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_kr_kis_live_failure_does_not_promote_manual():
+    """ROB-278 — KIS failure: primary_source=none, manual stays in reference_holdings."""
+    session = _manual_kr_session()
+    reader = _kis_reader_failed()
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_kr_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert payload["holdings"] == []
+    assert payload["count"] == 0
+    # Manual remains visible as reference, never promoted to primary.
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    # Provenance carries the failure reason.
+    assert payload["provenance"]["kis_fetch_status"] == "failed"
+    assert "kis" in str(payload["provenance"]["warnings"]).lower()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_kr_kis_live_exception_is_fail_closed():
+    """ROB-278 — KISHomeReader raising is treated like 'failed', not crash."""
+    session = _manual_kr_session()
+    reader = MagicMock()
+    reader.fetch = AsyncMock(side_effect=RuntimeError("boom"))
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_kr_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert "boom" in payload["provenance"]["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_preserves_v1_manual_primary():
+    """ROB-278 — non-(kr+kis_live) combos unchanged: manual still primary."""
+    from app.models.manual_holdings import MarketType
+
+    class _CryptoRow:
+        ticker = "KRW-BTC"
+        market_type = MarketType.CRYPTO
+        quantity = 0.1
+        avg_price = 50_000_000
+        display_name = "비트코인"
+        updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=[_CryptoRow()]))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    # KIS reader MUST NOT be called for upbit_live.
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        side_effect=AssertionError("KIS reader called for non-kis_live request")
+    )
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    req = CollectorRequest(
+        market="crypto",
+        account_scope="upbit_live",
+        symbols=None,
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=None,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "fresh"
+    assert payload["count"] == 1
+    assert payload["holdings"][0]["ticker"] == "KRW-BTC"
+    # New label is "manual" for non-KIS combos so payload always says where data came from.
+    assert payload.get("primary_source") == "manual"
+    reader.fetch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -507,6 +767,12 @@ def test_collector_modules_do_not_import_broker_or_activation_paths():
         "investment_reports.watch_activation",
         "alpaca_paper_ledger_service",
         "upbit.client",  # upbit broker client
+        # ROB-278 — also forbid explicit broker order-mutation verbs even
+        # when shipped under different paths (defence in depth).
+        "place_order",
+        "submit_order",
+        "cancel_order",
+        "modify_order",
     )
     target_modules = [
         "app.services.action_report.snapshot_backed.collectors.portfolio",
@@ -521,6 +787,7 @@ def test_collector_modules_do_not_import_broker_or_activation_paths():
         "app.services.action_report.snapshot_backed.collectors.pending_orders",
         "app.services.action_report.snapshot_backed.collectors.registry",
         "app.services.action_report.snapshot_backed.generator",
+        "app.services.action_report.snapshot_backed.symbol_derivation",
     ]
 
     for name in target_modules:

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -527,6 +527,145 @@ async def test_news_collector_failure_is_fail_open():
     assert results[0].freshness_status == "unavailable"
 
 
+def _make_citation(*, report_uuid: str, symbols: list[str]):
+    from app.schemas.research_reports import (
+        ResearchReportCitation,
+        ResearchReportSymbolCandidate,
+    )
+
+    return ResearchReportCitation(
+        report_uuid=report_uuid,
+        title=f"t-{report_uuid[:4]}",
+        source="kr_news",
+        symbol_candidates=[
+            ResearchReportSymbolCandidate(symbol=s, market="kr") for s in symbols
+        ],
+        published_at=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        summary_text="s",
+    )
+
+
+@pytest.mark.asyncio
+async def test_news_collector_filters_to_focus_symbols_when_supplied():
+    """ROB-278 Phase 2 — request.symbols → return only citations that touch
+    one of the focus symbols; record the symbol-match mapping."""
+    from app.schemas.research_reports import ResearchReportCitationListResponse
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = MagicMock()
+    query = MagicMock()
+    citations = [
+        _make_citation(
+            report_uuid="11111111-1111-1111-1111-111111111111",
+            symbols=["005930"],
+        ),
+        _make_citation(
+            report_uuid="22222222-2222-2222-2222-222222222222",
+            symbols=["999999"],  # not in focus
+        ),
+    ]
+    query.find_relevant = AsyncMock(
+        return_value=ResearchReportCitationListResponse(
+            count=len(citations), citations=citations
+        )
+    )
+    collector = NewsSnapshotCollector(session, query_service=query)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930", "000660"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    # Only the 005930 citation reached the output.
+    assert payload["count"] == 1
+    symbols_in_first = {
+        cand["symbol"] for cand in payload["citations"][0]["symbol_candidates"]
+    }
+    assert symbols_in_first == {"005930"}
+    # Per-symbol match map preserved.
+    assert payload["symbol_matches"]["005930"] == 1
+    assert payload["symbol_matches"]["000660"] == 0
+    assert payload.get("no_data_reason") is None
+
+
+@pytest.mark.asyncio
+async def test_news_collector_no_focus_matches_surfaces_no_data_reason():
+    """ROB-278 Phase 2 — focus symbols supplied, but no citation touches them →
+    payload carries an explicit no_data_reason and a partial freshness."""
+    from app.schemas.research_reports import ResearchReportCitationListResponse
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = MagicMock()
+    query = MagicMock()
+    citations = [
+        _make_citation(
+            report_uuid="11111111-1111-1111-1111-111111111111",
+            symbols=["XYZ"],
+        ),
+    ]
+    query.find_relevant = AsyncMock(
+        return_value=ResearchReportCitationListResponse(
+            count=len(citations), citations=citations
+        )
+    )
+    collector = NewsSnapshotCollector(session, query_service=query)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["count"] == 0
+    assert payload["citations"] == []
+    assert payload["no_data_reason"]
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_news_collector_no_focus_symbols_returns_general_feed():
+    """ROB-278 Phase 2 — when no focus symbols, return general citations
+    (legacy behaviour) but still emit the symbol_matches/no_data_reason fields."""
+    from app.schemas.research_reports import ResearchReportCitationListResponse
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = MagicMock()
+    query = MagicMock()
+    citations = [
+        _make_citation(
+            report_uuid="11111111-1111-1111-1111-111111111111",
+            symbols=["005930"],
+        ),
+    ]
+    query.find_relevant = AsyncMock(
+        return_value=ResearchReportCitationListResponse(
+            count=len(citations), citations=citations
+        )
+    )
+    collector = NewsSnapshotCollector(session, query_service=query)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=None,
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=None,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    # Legacy path: all citations included.
+    assert payload["count"] == 1
+    assert payload["symbol_matches"] == {}
+    assert payload.get("no_data_reason") is None
+
+
 # ---------------------------------------------------------------------------
 # Stubs
 # ---------------------------------------------------------------------------
@@ -613,6 +752,277 @@ async def test_symbol_collector_query_failure_is_fail_open():
 
 
 # ---------------------------------------------------------------------------
+# Symbol collector quote/orderbook enrichment — ROB-278 Phase 2.
+#
+# For (market=kr, account_scope=kis_live, user_id present), the collector
+# enriches each resolved symbol with read-only KIS quote/orderbook evidence
+# (last price, best bid/ask, spread bps, depth). Adapter is injected so
+# tests use a fake. Per-symbol fetch failures fail-open with explicit
+# unavailable reasons and never crash other symbols.
+# ---------------------------------------------------------------------------
+def _stock_info_row(symbol: str = "005930", name: str = "삼성전자"):
+    class _Row:
+        def __init__(self) -> None:
+            self.symbol = symbol
+            self.name = name
+            self.instrument_type = "equity_kr"
+            self.exchange = "KRX"
+            self.sector = "Tech"
+            self.market_cap = 1_000_000.0
+            self.is_active = True
+
+    return _Row()
+
+
+def _stock_info_session(rows: list[Any]) -> MagicMock:
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=rows))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    return session
+
+
+def _fake_quote_client_ok() -> MagicMock:
+    """Fake KIS quote/orderbook client returning a full top-of-book."""
+
+    async def fetch_quote(symbol: str) -> dict[str, Any]:
+        return {
+            "last_price": 70_000.0,
+            "best_bid": 69_900.0,
+            "best_ask": 70_100.0,
+            "bid_depth": 1234.0,
+            "ask_depth": 1500.0,
+            "venue": "krx",
+            "as_of": "2026-05-20T10:30:00+09:00",
+            "session": "regular",
+            "nxt_eligible": True,
+        }
+
+    client = MagicMock()
+    client.fetch_quote_orderbook = AsyncMock(side_effect=fetch_quote)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_enriches_with_kis_quote_when_kis_live():
+    """ROB-278 Phase 2 — KR + kis_live + user_id → per-symbol quote attached."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+    quote_client = _fake_quote_client_ok()
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    # One result per symbol (no missing).
+    assert len(results) == 1
+    payload = results[0].payload_json
+    # v1 keys preserved.
+    assert payload["symbol"] == "005930"
+    assert payload["name"] == "삼성전자"
+    # Quote/orderbook attached.
+    assert payload["quote"]["last_price"] == 70_000.0
+    assert payload["quote"]["best_bid"] == 69_900.0
+    assert payload["quote"]["best_ask"] == 70_100.0
+    # Derived spread.
+    assert payload["quote"]["spread"] == 200.0
+    assert payload["quote"]["spread_bps"] == pytest.approx(28.57, rel=0.01)
+    assert payload["quote"]["bid_depth"] == 1234.0
+    assert payload["quote"]["ask_depth"] == 1500.0
+    # Venue provenance.
+    assert payload["quote"]["venue"] == "krx"
+    assert payload["quote"]["nxt_eligible"] is True
+    assert payload["quote"]["session"] == "regular"
+    assert payload["quote"]["status"] == "ok"
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("005930")
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_skips_quote_when_no_kis_live():
+    """ROB-278 Phase 2 — non-kis_live request must not call quote client."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(
+        side_effect=AssertionError("quote client must not be called")
+    )
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope=None,
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert "quote" not in payload or payload.get("quote") is None
+    quote_client.fetch_quote_orderbook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_skips_quote_when_no_user_id():
+    """ROB-278 Phase 2 — quote enrichment requires explicit user_id (fail-closed)."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(
+        side_effect=AssertionError("must not be called without user_id")
+    )
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=None,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload.get("quote", {}).get("status") == "unavailable"
+    assert "user_id" in payload["quote"]["unavailable_reason"]
+    quote_client.fetch_quote_orderbook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_quote_exception_marks_unavailable():
+    """ROB-278 Phase 2 — KIS error on one symbol marks that symbol unavailable
+    without crashing other symbols."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    rows = [
+        _stock_info_row("005930", "삼성전자"),
+        _stock_info_row("000660", "SK하이닉스"),
+    ]
+    session = _stock_info_session(rows)
+
+    async def fetch(symbol: str):
+        if symbol == "005930":
+            raise RuntimeError("session closed")
+        return {
+            "last_price": 100_000.0,
+            "best_bid": 99_900.0,
+            "best_ask": 100_100.0,
+            "bid_depth": 500.0,
+            "ask_depth": 500.0,
+            "venue": "krx",
+            "as_of": "2026-05-20T10:30:00+09:00",
+            "session": "regular",
+            "nxt_eligible": False,
+        }
+
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(side_effect=fetch)
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930", "000660"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    by_symbol = {r.symbol: r for r in results if r.symbol}
+    assert by_symbol["005930"].payload_json["quote"]["status"] == "unavailable"
+    assert (
+        "session closed"
+        in by_symbol["005930"].payload_json["quote"]["unavailable_reason"]
+    )
+    assert by_symbol["000660"].payload_json["quote"]["status"] == "ok"
+    assert by_symbol["000660"].payload_json["quote"]["last_price"] == 100_000.0
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_quote_empty_book_marks_no_data_reason():
+    """ROB-278 Phase 2 — empty book (zero bid/ask) → unavailable with reason."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+
+    async def fetch(symbol: str):
+        return {
+            "last_price": 0.0,
+            "best_bid": 0.0,
+            "best_ask": 0.0,
+            "bid_depth": 0.0,
+            "ask_depth": 0.0,
+            "venue": "krx",
+            "as_of": None,
+            "session": "closed",
+            "nxt_eligible": False,
+        }
+
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(side_effect=fetch)
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    quote = results[0].payload_json["quote"]
+    assert quote["status"] == "unavailable"
+    assert (
+        "empty_book" in quote["unavailable_reason"]
+        or "session" in quote["unavailable_reason"]
+    )
+    assert quote["session"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_quote_respects_enrichment_cap():
+    """ROB-278 Phase 2 — quote enrichment is bounded; extras get a 'capped' status."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    rows = [_stock_info_row(f"00500{i}", f"sym_{i}") for i in range(5)]
+    session = _stock_info_session(rows)
+    quote_client = _fake_quote_client_ok()
+    collector = SymbolSnapshotCollector(
+        session, kis_quote_client=quote_client, quote_enrichment_limit=3
+    )
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=[f"00500{i}" for i in range(5)],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=42,
+    )
+    results = await collector.collect(req)
+    enriched = [
+        r
+        for r in results
+        if r.symbol and r.payload_json.get("quote", {}).get("status") == "ok"
+    ]
+    capped = [
+        r
+        for r in results
+        if r.symbol and r.payload_json.get("quote", {}).get("status") == "skipped"
+    ]
+    assert len(enriched) == 3
+    assert len(capped) == 2
+    assert all(
+        "cap" in r.payload_json["quote"]["unavailable_reason"].lower() for r in capped
+    )
+
+
+# ---------------------------------------------------------------------------
 # Candidate-universe collector
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
@@ -671,6 +1081,109 @@ async def test_candidate_universe_crypto_queries_crypto_partition():
     )
     assert results[0].payload_json["fresh_count"] == 42
     assert results[0].payload_json["latest_partition"] == "2026-05-19"
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_kr_usefulness_useful_when_fresh_present():
+    """ROB-278 Phase 2 — fresh_count > 0 → usefulness='useful', no no_data_reason."""
+    from app.services.invest_screener_snapshots.repository import CoverageCounts
+
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(
+        return_value=CoverageCounts(
+            market="kr",
+            today_trading_date=dt.date(2026, 5, 19),
+            fresh_count=5,
+            stale_count=10,
+            last_computed_at=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        )
+    )
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    payload = results[0].payload_json
+    # Freshness stays 'fresh' because the bundle has fresh data.
+    assert results[0].freshness_status == "fresh"
+    # Usefulness reflects actionability.
+    assert payload["usefulness"] == "useful"
+    assert payload["actionable_count"] == 5
+    assert payload["stale_count"] == 10
+    assert payload.get("no_data_reason") is None
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_kr_usefulness_stale_only_when_no_fresh():
+    """ROB-278 Phase 2 — stale_count > 0 + fresh_count = 0 →
+    usefulness='stale_only', explicit no_data_reason. Freshness can stay
+    'fresh' because the snapshot row itself is current; usefulness is the
+    semantic the report generator should consult."""
+    from app.services.invest_screener_snapshots.repository import CoverageCounts
+
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(
+        return_value=CoverageCounts(
+            market="kr",
+            today_trading_date=dt.date(2026, 5, 19),
+            fresh_count=0,
+            stale_count=42,
+            last_computed_at=dt.datetime(2026, 5, 19, tzinfo=dt.UTC),
+        )
+    )
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    payload = results[0].payload_json
+    assert payload["usefulness"] == "stale_only"
+    assert payload["actionable_count"] == 0
+    assert payload["stale_count"] == 42
+    assert "stale" in payload["no_data_reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_kr_usefulness_empty_when_no_rows():
+    """ROB-278 Phase 2 — both counts 0 → usefulness='empty' + no_data_reason."""
+    from app.services.invest_screener_snapshots.repository import CoverageCounts
+
+    session = MagicMock()
+    repo = MagicMock()
+    repo.coverage = AsyncMock(
+        return_value=CoverageCounts(
+            market="kr",
+            today_trading_date=dt.date(2026, 5, 19),
+            fresh_count=0,
+            stale_count=0,
+            last_computed_at=None,
+        )
+    )
+    collector = CandidateUniverseSnapshotCollector(session, equity_repository=repo)
+    results = await collector.collect(_request(market="kr", account_scope="kis_live"))
+    payload = results[0].payload_json
+    assert payload["usefulness"] == "empty"
+    assert payload["actionable_count"] == 0
+    assert payload["stale_count"] == 0
+    assert payload["no_data_reason"]
+    # The legacy freshness signal (partial) is still preserved for callers
+    # that only look at freshness_status.
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_candidate_universe_crypto_includes_usefulness_fields():
+    """ROB-278 Phase 2 — crypto branch carries the same usefulness contract."""
+    session = MagicMock()
+    latest_result = MagicMock(
+        scalar_one_or_none=MagicMock(return_value=dt.date(2026, 5, 19))
+    )
+    count_result = MagicMock(scalar_one=MagicMock(return_value=7))
+    session.execute = AsyncMock(side_effect=[latest_result, count_result])
+
+    collector = CandidateUniverseSnapshotCollector(session)
+    results = await collector.collect(
+        _request(market="crypto", account_scope="upbit_live")
+    )
+    payload = results[0].payload_json
+    assert payload["actionable_count"] == 7
+    assert payload["usefulness"] == "useful"
 
 
 @pytest.mark.asyncio

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1301,6 +1301,7 @@ def test_collector_modules_do_not_import_broker_or_activation_paths():
         "app.services.action_report.snapshot_backed.collectors.registry",
         "app.services.action_report.snapshot_backed.generator",
         "app.services.action_report.snapshot_backed.symbol_derivation",
+        "app.services.action_report.snapshot_backed.auto_emit",
     ]
 
     for name in target_modules:

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -694,23 +694,15 @@ async def test_generator_preserves_seed_symbols_through_derivation() -> None:
     assert derivation.calls[0]["seed_symbols"] == ["X"]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ROB-278 Phase 2: reused bundle without 'overall' currently downgrades to 'unavailable'",
-)
 @pytest.mark.asyncio
 async def test_reused_bundle_freshness_does_not_downgrade_to_unavailable() -> None:
-    """ROB-278 Phase 2 reproducer.
-
-    Bundle.status='reused' with a stored summary that has per-kind statuses
-    (all fresh/partial) but is missing an explicit ``overall`` key. The
-    current implementation defaults ``overall`` to ``unavailable`` via
-    ``_BUNDLE_STATUS_TO_OVERALL.get(status, 'unavailable')``, which then
-    cascades into stale-gate behaviour. Phase 2 should compute ``overall``
-    from the stored per-kind statuses instead.
+    """ROB-278 Phase 2 — bundle.status='reused' with a stored summary that
+    only has per-kind statuses (no explicit ``overall``) must derive
+    ``overall`` from those per-kind statuses, not from a
+    ``_BUNDLE_STATUS_TO_OVERALL.get(status, 'unavailable')`` fallback.
     """
     reused_summary = {
-        # Note: no 'overall' key — this is the bug surface.
+        # Note: no 'overall' key — derivation must compute it.
         "portfolio": {"status": "fresh"},
         "journal": {"status": "fresh"},
         "watch_context": {"status": "fresh"},
@@ -731,6 +723,201 @@ async def test_reused_bundle_freshness_does_not_downgrade_to_unavailable() -> No
         snapshots_repository=_FakeSnapshotsRepository(),
     )
     response = await gen.generate(_make_request(status="draft"))
-    # Phase 2 invariant: never downgrade to 'unavailable' when all critical
-    # kinds reported a non-unavailable status.
-    assert response.snapshot_freshness_summary["overall"] != "unavailable"
+    # Worst per-kind status is 'partial' (market), so overall must be 'partial'.
+    assert response.snapshot_freshness_summary["overall"] == "partial"
+
+
+@pytest.mark.asyncio
+async def test_reused_bundle_freshness_all_fresh_derives_fresh() -> None:
+    """ROB-278 Phase 2 — all per-kind 'fresh' derives overall='fresh'."""
+    reused_summary = {
+        "portfolio": {"status": "fresh"},
+        "journal": {"status": "fresh"},
+        "watch_context": {"status": "fresh"},
+        "market": {"status": "fresh"},
+    }
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="reused", freshness_summary=reused_summary, created=False
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.snapshot_freshness_summary["overall"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_reused_bundle_freshness_unavailable_kind_yields_unavailable() -> None:
+    """ROB-278 Phase 2 — if any kind is 'unavailable', overall='unavailable'."""
+    reused_summary = {
+        "portfolio": {"status": "unavailable"},
+        "journal": {"status": "fresh"},
+    }
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="reused", freshness_summary=reused_summary, created=False
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    # 'unavailable' on a kind → published would be blocked; draft is allowed.
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.snapshot_freshness_summary["overall"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_reused_bundle_freshness_no_kind_statuses_falls_back() -> None:
+    """ROB-278 Phase 2 — when the stored summary has no per-kind statuses to
+    derive from, fall back to the bundle-status mapping. For an unknown
+    status (e.g. 'reused'), the safe default remains 'unavailable'.
+    """
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="reused",
+            # Non-empty (so the helper default doesn't substitute) but
+            # contains no per-kind status entries to derive from.
+            freshness_summary={"_meta": "no kind statuses present"},
+            created=False,
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.snapshot_freshness_summary["overall"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# ROB-278 Phase 2 — evidence-aware classifier downgrades.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_action_item_downgraded_to_review_when_no_quote_evidence() -> None:
+    """ROB-278 Phase 2 — buy action item targeting a symbol whose symbol
+    snapshot reports quote.status != 'ok' is downgraded to review with an
+    explicit no-quote rationale. The generator wires symbol snapshots from
+    the bundle into the classifier context."""
+    from types import SimpleNamespace
+
+    from app.schemas.investment_reports import IngestReportItem
+
+    draft_items = [
+        IngestReportItem(
+            client_item_key="a-1",
+            item_kind="action",
+            symbol="005930",
+            side="buy",
+            intent="buy_review",
+            rationale="buy thesis",
+        )
+    ]
+    fake_bundle = SimpleNamespace(id=9999)
+    fake_symbol_snapshot_item = SimpleNamespace(id=1, snapshot_id=20)
+    fake_symbol_snapshot = SimpleNamespace(
+        snapshot_kind="symbol",
+        symbol="005930",
+        payload_json={
+            "symbol": "005930",
+            "quote": {
+                "status": "unavailable",
+                "unavailable_reason": "session_closed",
+            },
+        },
+    )
+    fake_repo = _FakeSnapshotsRepository(
+        bundle=fake_bundle,
+        items=[(fake_symbol_snapshot_item, fake_symbol_snapshot)],
+    )
+
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=fake_repo,
+    )
+    await gen.generate(_make_request(status="draft", items=draft_items))
+    sent = ingest.calls[0]
+    sent_item = sent.items[0]
+    assert sent_item.operation == "review"
+    assert "quote" in sent_item.rationale.lower()
+
+
+@pytest.mark.asyncio
+async def test_action_item_unchanged_when_quote_evidence_ok() -> None:
+    """ROB-278 Phase 2 — when symbol snapshot reports quote.status='ok',
+    the classifier does not downgrade the action item on quote grounds.
+    (Other classifier paths — pending_orders, etc. — still apply.)"""
+    from types import SimpleNamespace
+
+    from app.schemas.investment_reports import IngestReportItem
+
+    draft_items = [
+        IngestReportItem(
+            client_item_key="a-1",
+            item_kind="action",
+            symbol="005930",
+            side="buy",
+            intent="buy_review",
+            rationale="buy thesis",
+        )
+    ]
+    fake_bundle = SimpleNamespace(id=9999)
+    fake_symbol_snapshot_item = SimpleNamespace(id=1, snapshot_id=20)
+    fake_symbol_snapshot = SimpleNamespace(
+        snapshot_kind="symbol",
+        symbol="005930",
+        payload_json={
+            "symbol": "005930",
+            "quote": {
+                "status": "ok",
+                "last_price": 70_000.0,
+                "best_bid": 69_900.0,
+                "best_ask": 70_100.0,
+            },
+        },
+    )
+    fake_pending_orders_item = SimpleNamespace(id=2, snapshot_id=30)
+    fake_pending_orders_snapshot = SimpleNamespace(
+        snapshot_kind="pending_orders",
+        symbol=None,
+        payload_json={"pending_orders": []},
+    )
+    fake_repo = _FakeSnapshotsRepository(
+        bundle=fake_bundle,
+        items=[
+            (fake_symbol_snapshot_item, fake_symbol_snapshot),
+            (fake_pending_orders_item, fake_pending_orders_snapshot),
+        ],
+    )
+
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=fake_repo,
+    )
+    await gen.generate(_make_request(status="draft", items=draft_items))
+    sent = ingest.calls[0]
+    sent_item = sent.items[0]
+    # No pending order matches, quote evidence is ok → caller's draft stands
+    # untouched (no operation set by classifier).
+    assert sent_item.operation is None
+    assert "quote" not in (sent_item.rationale or "").lower()

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -859,6 +859,84 @@ async def test_action_item_downgraded_to_review_when_no_quote_evidence() -> None
 
 
 @pytest.mark.asyncio
+async def test_auto_emit_from_evidence_appends_review_items_from_bundle() -> None:
+    """ROB-278 Phase 2 — auto_emit_from_evidence=True triggers the
+    deterministic proposer; the resulting items are surfaced through
+    ingest with operation='review' + apply_policy='requires_user_approval'.
+    """
+    from types import SimpleNamespace
+    from uuid import uuid4
+
+    fake_bundle = SimpleNamespace(id=7777)
+    portfolio_snapshot = SimpleNamespace(
+        snapshot_kind="portfolio",
+        symbol=None,
+        snapshot_uuid=uuid4(),
+        payload_json={
+            "primary_source": "kis",
+            "holdings": [
+                {
+                    "ticker": "005930",
+                    "quantity": 10,
+                    "sellable_quantity": 8,
+                    "source": "kis",
+                    "market": "KR",
+                }
+            ],
+            "reference_holdings": [],
+            "count": 1,
+            "market": "kr",
+        },
+    )
+    symbol_snapshot = SimpleNamespace(
+        snapshot_kind="symbol",
+        symbol="005930",
+        snapshot_uuid=uuid4(),
+        payload_json={
+            "symbol": "005930",
+            "quote": {
+                "status": "ok",
+                "last_price": 70_000.0,
+                "best_bid": 69_900.0,
+                "best_ask": 70_100.0,
+                "spread": 200.0,
+                "spread_bps": 28.57,
+                "bid_depth": 500.0,
+                "ask_depth": 600.0,
+                "venue": "krx",
+            },
+        },
+    )
+
+    fake_repo = _FakeSnapshotsRepository(
+        bundle=fake_bundle,
+        items=[
+            (SimpleNamespace(id=1, snapshot_id=1), portfolio_snapshot),
+            (SimpleNamespace(id=2, snapshot_id=2), symbol_snapshot),
+        ],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=fake_repo,
+    )
+    await gen.generate(
+        _make_request(status="draft", auto_emit_from_evidence=True, user_id=42)
+    )
+    sent = ingest.calls[0]
+    auto_items = [
+        i for i in sent.items if (i.client_item_key or "").startswith("auto-")
+    ]
+    assert auto_items, "expected at least one auto-emitted item"
+    for item in auto_items:
+        assert item.operation == "review"
+        assert item.apply_policy == "requires_user_approval"
+
+
+@pytest.mark.asyncio
 async def test_action_item_unchanged_when_quote_evidence_ok() -> None:
     """ROB-278 Phase 2 — when symbol snapshot reports quote.status='ok',
     the classifier does not downgrade the action item on quote grounds.

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -538,3 +538,199 @@ async def test_generator_surfaces_unavailable_pending_orders_to_classifier():
     sent_item = ingest.calls[0].items[0]
     assert sent_item.operation == "review"
     assert "확인 불가" in sent_item.rationale
+
+
+# ---------------------------------------------------------------------------
+# ROB-278 — user_id propagation and reused-freshness reproducer.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_user_id_is_forwarded_from_report_request_to_bundle_ensure() -> None:
+    """ROB-278 — ReportGenerationRequest.user_id flows into EnsureBundleRequest.user_id.
+
+    Policy: callers must pass user_id explicitly to enable kis_live broker
+    reads; the generator does not invent a default.
+    """
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request(user_id=42))
+    assert len(ensure.calls) == 1
+    assert ensure.calls[0].user_id == 42
+
+
+@pytest.mark.asyncio
+async def test_user_id_default_is_none_and_propagates_as_none() -> None:
+    """ROB-278 — omitting user_id propagates None (fail-closed downstream)."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request())
+    assert ensure.calls[0].user_id is None
+
+
+class _FakeSymbolDerivationService:
+    """Records the derive() call and returns a fixed derivation."""
+
+    def __init__(
+        self,
+        *,
+        symbols: list[str] | None = None,
+        provenance: dict[str, Any] | None = None,
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._symbols = symbols if symbols is not None else []
+        self._provenance = provenance or {
+            "sources": {
+                "seed": [],
+                "portfolio": [],
+                "journal": [],
+                "watch": [],
+                "candidate": [],
+            },
+            "dropped_by_cap": [],
+            "cap": 50,
+            "total_unique": 0,
+        }
+
+    async def derive(
+        self,
+        *,
+        market: str,
+        account_scope: str | None,
+        user_id: int | None,
+        seed_symbols: list[str] | None,
+    ):
+        self.calls.append(
+            {
+                "market": market,
+                "account_scope": account_scope,
+                "user_id": user_id,
+                "seed_symbols": list(seed_symbols or []),
+            }
+        )
+        from app.services.action_report.snapshot_backed.symbol_derivation import (
+            SymbolDerivation,
+        )
+
+        return SymbolDerivation(
+            symbols=list(self._symbols), provenance=self._provenance
+        )
+
+
+@pytest.mark.asyncio
+async def test_generator_calls_symbol_derivation_and_forwards_symbols() -> None:
+    """ROB-278 — derived symbols flow into EnsureBundleRequest.symbols.
+
+    The generator unions request.symbols with derived symbols (the derivation
+    service preserves seed). Provenance is stashed on the ingest metadata.
+    """
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    derivation = _FakeSymbolDerivationService(
+        symbols=["005930", "000660"],
+        provenance={
+            "sources": {
+                "seed": [],
+                "portfolio": ["005930"],
+                "journal": ["000660"],
+                "watch": [],
+                "candidate": [],
+            },
+            "dropped_by_cap": [],
+            "cap": 50,
+            "total_unique": 2,
+        },
+    )
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+        symbol_derivation_service=derivation,
+    )
+    await gen.generate(_make_request(user_id=42))
+
+    # Derivation was called with the report's context.
+    assert len(derivation.calls) == 1
+    call = derivation.calls[0]
+    assert call["market"] == "kr"
+    assert call["account_scope"] == "kis_live"
+    assert call["user_id"] == 42
+
+    # Derived symbols reached EnsureBundleRequest.symbols.
+    assert set(ensure.calls[0].symbols or []) == {"005930", "000660"}
+
+    # Provenance is recorded on the ingest metadata for audit.
+    sent = ingest.calls[0]
+    assert "symbol_derivation" in sent.metadata
+    assert sent.metadata["symbol_derivation"]["sources"]["portfolio"] == ["005930"]
+
+
+@pytest.mark.asyncio
+async def test_generator_preserves_seed_symbols_through_derivation() -> None:
+    """ROB-278 — request.symbols is passed as seed_symbols and must survive."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    # Derivation returns seed + extra.
+    derivation = _FakeSymbolDerivationService(symbols=["X", "Y"])
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+        symbol_derivation_service=derivation,
+    )
+    await gen.generate(_make_request(symbols=["X"], user_id=42))
+    assert derivation.calls[0]["seed_symbols"] == ["X"]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ROB-278 Phase 2: reused bundle without 'overall' currently downgrades to 'unavailable'",
+)
+@pytest.mark.asyncio
+async def test_reused_bundle_freshness_does_not_downgrade_to_unavailable() -> None:
+    """ROB-278 Phase 2 reproducer.
+
+    Bundle.status='reused' with a stored summary that has per-kind statuses
+    (all fresh/partial) but is missing an explicit ``overall`` key. The
+    current implementation defaults ``overall`` to ``unavailable`` via
+    ``_BUNDLE_STATUS_TO_OVERALL.get(status, 'unavailable')``, which then
+    cascades into stale-gate behaviour. Phase 2 should compute ``overall``
+    from the stored per-kind statuses instead.
+    """
+    reused_summary = {
+        # Note: no 'overall' key — this is the bug surface.
+        "portfolio": {"status": "fresh"},
+        "journal": {"status": "fresh"},
+        "watch_context": {"status": "fresh"},
+        "market": {"status": "partial"},
+    }
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="reused",
+            freshness_summary=reused_summary,
+            created=False,
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    response = await gen.generate(_make_request(status="draft"))
+    # Phase 2 invariant: never downgrade to 'unavailable' when all critical
+    # kinds reported a non-unavailable status.
+    assert response.snapshot_freshness_summary["overall"] != "unavailable"

--- a/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
+++ b/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
@@ -1,0 +1,231 @@
+"""ROB-278 — Symbol derivation service tests.
+
+The derivation service unions caller-supplied seed symbols with symbols
+inferred from the user's portfolio, active trade journals, active watch
+alerts, and the fresh candidate universe. It enforces a max-symbols cap
+and records per-source provenance.
+
+Lockdown policy:
+- Seed (request-supplied) symbols are preserved — never dropped.
+- Derived symbols are unioned with seed.
+- Cap applies to the union; overflow records dropped_by_cap in provenance.
+- Each emitted symbol is attributed to one or more sources.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.action_report.snapshot_backed.symbol_derivation import (
+    SymbolDerivation,
+    SymbolDerivationService,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — keep tests focused on the derivation contract, not data sources.
+# ---------------------------------------------------------------------------
+class _FakeManualHoldingsRepo:
+    def __init__(self, tickers: list[str]) -> None:
+        self.tickers = tickers
+        self.calls: list[str] = []
+
+    async def list_tickers(self, *, market: str) -> list[str]:
+        self.calls.append(market)
+        return list(self.tickers)
+
+
+class _FakeJournalRepo:
+    def __init__(self, symbols: list[str]) -> None:
+        self.symbols = symbols
+
+    async def list_active_journal_symbols(self, *, market: str) -> list[str]:
+        return list(self.symbols)
+
+
+class _FakeWatchRepo:
+    def __init__(self, symbols: list[str]) -> None:
+        self.symbols = symbols
+
+    async def list_active_watch_symbols(self, *, market: str) -> list[str]:
+        return list(self.symbols)
+
+
+class _FakeCandidateRepo:
+    def __init__(self, symbols: list[str]) -> None:
+        self.symbols = symbols
+
+    async def list_fresh_candidate_symbols(
+        self, *, market: str, limit: int
+    ) -> list[str]:
+        return list(self.symbols[:limit])
+
+
+def _make_service(
+    *,
+    manual: list[str] | None = None,
+    journal: list[str] | None = None,
+    watch: list[str] | None = None,
+    candidate: list[str] | None = None,
+    max_symbols: int = 50,
+    top_held: int = 20,
+    top_candidates: int = 20,
+) -> SymbolDerivationService:
+    return SymbolDerivationService(
+        session=MagicMock(),
+        manual_holdings_repo=_FakeManualHoldingsRepo(manual or []),
+        journal_repo=_FakeJournalRepo(journal or []),
+        watch_repo=_FakeWatchRepo(watch or []),
+        candidate_repo=_FakeCandidateRepo(candidate or []),
+        max_symbols=max_symbols,
+        top_held=top_held,
+        top_candidates=top_candidates,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seed preservation + source attribution.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_seed_symbols_preserved_when_no_derived_sources():
+    service = _make_service()
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=["005930"]
+    )
+    assert isinstance(result, SymbolDerivation)
+    assert result.symbols == ["005930"]
+    assert result.provenance["sources"]["seed"] == ["005930"]
+    assert result.provenance["dropped_by_cap"] == []
+
+
+@pytest.mark.asyncio
+async def test_seed_unioned_with_derived_sources():
+    service = _make_service(
+        manual=["005930", "000660"],
+        journal=["035420"],
+        watch=["005380"],
+        candidate=["028260"],
+    )
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=["096770"]
+    )
+    assert set(result.symbols) == {
+        "005930",
+        "000660",
+        "035420",
+        "005380",
+        "028260",
+        "096770",
+    }
+    sources = result.provenance["sources"]
+    assert sources["seed"] == ["096770"]
+    assert set(sources["portfolio"]) == {"005930", "000660"}
+    assert sources["journal"] == ["035420"]
+    assert sources["watch"] == ["005380"]
+    assert sources["candidate"] == ["028260"]
+
+
+@pytest.mark.asyncio
+async def test_derived_when_seed_is_none():
+    service = _make_service(manual=["005930"], watch=["035420"])
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    assert set(result.symbols) == {"005930", "035420"}
+    assert result.provenance["sources"]["seed"] == []
+
+
+# ---------------------------------------------------------------------------
+# Caps — seed always survives, overflow recorded.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_max_symbols_cap_records_dropped():
+    # 60 candidate symbols, cap 50 → 10 dropped.
+    candidates = [f"C{i:04d}" for i in range(60)]
+    service = _make_service(candidate=candidates, max_symbols=50, top_candidates=60)
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    assert len(result.symbols) == 50
+    assert len(result.provenance["dropped_by_cap"]) == 10
+    # No overlap between final symbols and dropped ones.
+    assert set(result.symbols).isdisjoint(set(result.provenance["dropped_by_cap"]))
+    assert result.provenance["cap"] == 50
+
+
+@pytest.mark.asyncio
+async def test_seed_never_dropped_even_when_over_cap():
+    """Operator-supplied seed must survive the cap (drop derived instead)."""
+    seeds = [f"S{i:04d}" for i in range(40)]
+    candidates = [f"C{i:04d}" for i in range(40)]
+    service = _make_service(candidate=candidates, max_symbols=50, top_candidates=40)
+    result = await service.derive(
+        market="kr",
+        account_scope="kis_live",
+        user_id=42,
+        seed_symbols=seeds,
+    )
+    # All 40 seeds present.
+    assert set(seeds).issubset(set(result.symbols))
+    # Only 10 of 40 candidates fit alongside seeds.
+    assert len(result.symbols) == 50
+    dropped = set(result.provenance["dropped_by_cap"])
+    assert dropped.issubset(set(candidates))
+    # No seed got dropped.
+    assert dropped.isdisjoint(set(seeds))
+
+
+# ---------------------------------------------------------------------------
+# Per-source bounding — candidate source is capped via ``top_candidates``.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_top_candidates_bound_is_passed_to_repo():
+    repo = _FakeCandidateRepo([f"C{i:04d}" for i in range(100)])
+    service = SymbolDerivationService(
+        session=MagicMock(),
+        manual_holdings_repo=_FakeManualHoldingsRepo([]),
+        journal_repo=_FakeJournalRepo([]),
+        watch_repo=_FakeWatchRepo([]),
+        candidate_repo=repo,
+        max_symbols=50,
+        top_held=20,
+        top_candidates=15,
+    )
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    # Only top 15 candidates requested.
+    assert len(result.symbols) == 15
+    assert result.provenance["sources"]["candidate"] == [f"C{i:04d}" for i in range(15)]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — duplicate symbols across sources collapse to single attribution.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_duplicate_symbols_across_sources_dedup_with_multi_attribution():
+    """A symbol present in two sources counts once in the union but appears
+    in both source lists for audit."""
+    service = _make_service(
+        manual=["005930"], journal=["005930"], watch=[], candidate=[]
+    )
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    assert result.symbols == ["005930"]
+    assert result.provenance["sources"]["portfolio"] == ["005930"]
+    assert result.provenance["sources"]["journal"] == ["005930"]
+
+
+@pytest.mark.asyncio
+async def test_provenance_exposes_cap_and_counts():
+    service = _make_service(manual=["A"], journal=["B"], watch=["C"], candidate=["D"])
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=["E"]
+    )
+    assert result.provenance["cap"] == 50
+    assert "sources" in result.provenance
+    assert "dropped_by_cap" in result.provenance
+    assert result.provenance["total_unique"] == 5

--- a/tests/test_investment_reports_snapshot_evidence_service.py
+++ b/tests/test_investment_reports_snapshot_evidence_service.py
@@ -315,7 +315,13 @@ async def _seed_report_with_portfolio_v2_payload(db_session):
         snapshot_bundle_uuid=bundle.bundle_uuid,
         snapshot_policy_version="intraday_action_report_v1",
     )
-    await db_session.commit()
+    # Intentionally do NOT commit. The repo writes already flushed are
+    # visible to the same session's reads, and keeping the transaction
+    # open blocks the concurrent ``review.investment_reports`` TRUNCATE
+    # from ``_investment_reports_helpers.session`` running on another
+    # xdist worker. Committing here would race that TRUNCATE under
+    # ``--dist=loadfile`` and intermittently lose this fixture's rows.
+    await db_session.flush()
     return report.report_uuid, snap.snapshot_uuid, portfolio_payload_v2
 
 

--- a/tests/test_investment_reports_snapshot_evidence_service.py
+++ b/tests/test_investment_reports_snapshot_evidence_service.py
@@ -236,3 +236,129 @@ async def test_get_report_snapshot_detail_returns_none_for_non_member_snapshot(
     svc = InvestmentReportQueryService(db_session)
     detail = await svc.get_report_snapshot_detail(report_uuid, other_snap.snapshot_uuid)
     assert detail is None
+
+
+# ---------------------------------------------------------------------------
+# ROB-278 — viewer compatibility: v2 portfolio payload still flows through
+# the evidence endpoints unchanged. v1 keys (holdings/count/market) MUST
+# remain in the payload; the new v2 additive keys MUST pass through.
+# ---------------------------------------------------------------------------
+async def _seed_report_with_portfolio_v2_payload(db_session):
+    snap_repo = InvestmentSnapshotsRepository(db_session)
+    run = await snap_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    portfolio_payload_v2 = {
+        # v1 keys (must remain).
+        "holdings": [{"ticker": "005930", "quantity": 10, "source": "kis"}],
+        "count": 1,
+        "market": "kr",
+        # v2 additive keys.
+        "primary_source": "kis",
+        "reference_holdings": [{"ticker": "005930", "source": "manual"}],
+        "cash": {"krw": 1_200_000.0, "usd": None},
+        "buying_power": {"krw": 1_000_000.0, "usd": None},
+        "sellable_summary": {"sellable_count": 1, "pending_sell_count": 0},
+        "provenance": {
+            "kis_fetch_status": "ok",
+            "account_scope": "kis_live",
+            "fetched_at": "2026-05-20T11:00:00+00:00",
+            "warnings": [],
+            "errors": [],
+        },
+    }
+    snap = await snap_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="auto_trader_mcp",
+            payload_json=portfolio_payload_v2,
+            as_of=_NOW,
+            freshness_status="fresh",
+        )
+    )
+    bundle = await snap_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"rob278_v2_{_uuid.uuid4().hex[:8]}",
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_NOW,
+            status="complete",
+        )
+    )
+    await snap_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="required"),
+    )
+
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=_uuid.uuid4(),
+        idempotency_key=f"k-{_uuid.uuid4().hex[:8]}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="rob278-test",
+        title="t",
+        summary="s",
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        snapshot_policy_version="intraday_action_report_v1",
+    )
+    await db_session.commit()
+    return report.report_uuid, snap.snapshot_uuid, portfolio_payload_v2
+
+
+@pytest.mark.asyncio
+async def test_rob278_v2_portfolio_payload_passes_through_evidence_detail(db_session):
+    """ROB-278 — v2 portfolio payload survives round-trip through the
+    ROB-275 evidence viewer endpoint. v1 keys and v2 additive keys must
+    both reach the client unchanged.
+    """
+    report_uuid, snap_uuid, payload = await _seed_report_with_portfolio_v2_payload(
+        db_session
+    )
+    svc = InvestmentReportQueryService(db_session)
+    detail = await svc.get_report_snapshot_detail(report_uuid, snap_uuid)
+    assert detail is not None
+    # v1 keys preserved.
+    assert detail.payload_json["holdings"] == payload["holdings"]
+    assert detail.payload_json["count"] == 1
+    assert detail.payload_json["market"] == "kr"
+    # v2 additive keys present.
+    assert detail.payload_json["primary_source"] == "kis"
+    assert detail.payload_json["reference_holdings"] == payload["reference_holdings"]
+    assert detail.payload_json["cash"] == payload["cash"]
+    assert detail.payload_json["buying_power"] == payload["buying_power"]
+    assert detail.payload_json["sellable_summary"] == payload["sellable_summary"]
+    assert detail.payload_json["provenance"]["kis_fetch_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_rob278_v2_portfolio_bundle_listing_remains_compatible(db_session):
+    """ROB-278 — bundle listing endpoint stays 200 and lists the v2 item."""
+    report_uuid, snap_uuid, _payload = await _seed_report_with_portfolio_v2_payload(
+        db_session
+    )
+    svc = InvestmentReportQueryService(db_session)
+    response = await svc.get_report_snapshot_bundle(report_uuid)
+    assert response is not None
+    assert response.legacy_no_snapshot is False
+    assert response.bundle is not None
+    assert response.bundle.status == "complete"
+    items = response.items
+    assert len(items) == 1
+    assert items[0].snapshot_uuid == snap_uuid
+    assert items[0].snapshot_kind == "portfolio"
+    # payload_size grows with the v2 additive fields but stays positive.
+    assert items[0].payload_size_bytes is not None and items[0].payload_size_bytes > 0


### PR DESCRIPTION
## Summary

ROB-278: from `risk_review`-only KR snapshot reports to actionable bundles.

This PR ships **PR1 (foundation) + Phase 2 (evidence enrichment) + auto-emit (deterministic candidate generation)** on a single branch. The goal is that the next KR `investment_report_generate_from_bundle` actually produces buy/sell/watch candidates backed by traceable snapshot evidence, while preserving the lockdown safety boundaries.

### PR1 — foundation (locked-down policies)

* Optional `user_id: int | None` on `CollectorRequest` / `EnsureBundleRequest` / `ReportGenerationRequest`. Broker-backed collectors require an explicit `user_id`; without one they fail-closed (no implicit operator). All existing call sites stay backward compatible via the `None` default.
* Portfolio v2 — for `(market=kr, account_scope=kis_live)` the collector reads live KIS holdings / cash / buying power / sellable quantity via the existing read-only `KISHomeReader`. Manual rows surface under `reference_holdings` and are **never** promoted to `kis_live` primary; KIS failure or missing `user_id` is fail-closed (`primary_source="none"`, `freshness="unavailable"`). Non-`(kr+kis_live)` combos keep the v1 manual-primary contract and gain a `primary_source="manual"` label. v2 payload is additive — `holdings`/`count`/`market` are preserved; new keys are optional.
* Symbol derivation — new `SymbolDerivationService` unions caller seed symbols with portfolio + active journal + active watch + fresh candidate. Cap (50) is applied **after** seeds; overflow goes to `provenance.dropped_by_cap`. Each source fails open with its error recorded in `source_errors`.
* Mutation import guard extended: collectors / generator / `symbol_derivation` / `auto_emit` modules can not pull in `place_order`/`submit_order`/`cancel_order`/`modify_order`/`kis_trading_service`/`watch_activation`/`alpaca_paper_ledger_service`/`upbit.client`.
* ROB-275 evidence viewer regression test confirms the v2 portfolio payload round-trips through the snapshot-bundle / snapshot-detail endpoints with v1 keys preserved + v2 additive keys passed through.

### Phase 2 — evidence enrichment

* **Reused-bundle freshness derivation** — when `bundle.status='reused'` carries a stored summary with per-kind statuses but no explicit `overall`, the generator now computes `overall` from the worst per-kind rank (`fresh < soft_stale < partial < hard_stale < failed < unavailable`) instead of silently downgrading to `unavailable`. The Phase 1 `xfail(strict=True)` reproducer is removed and replaced by four covering tests.
* **KR quote / orderbook / spread / depth enrichment** — the `symbol` collector now enriches resolved KR symbols with read-only quote evidence (last price, best bid/ask, spread, spread_bps, bid/ask depth, venue, NXT eligibility, session) via an injected `_KISDomesticQuoteOrderbookAdapter` that thin-wraps the existing `inquire_price` / `inquire_orderbook` methods — no new HTTP surface. Per-symbol failures fail open (other symbols continue); empty book / closed session is an explicit `status="unavailable"` with `unavailable_reason`; enrichment is bounded by `quote_enrichment_limit` (default 25); missing `user_id` keeps quote enrichment fail-closed.
* **`candidate_universe` usefulness vs freshness split** — payload now exposes `actionable_count` / `stale_count` / `usefulness` (`"useful" | "stale_only" | "empty"`) / `no_data_reason` so the report generator can no longer treat a stale-only payload as a buy signal.
* **News symbol citation filtering** — when `request.symbols` is populated, the news collector filters citations to those that touch a focus symbol and exposes a `symbol_matches` map plus an explicit `no_data_reason` when nothing matches.
* **Evidence-aware classifier** — `ClassifierContext.symbol_quotes` is populated by the generator from `symbol` snapshots in the bundle. Buy action items targeting a symbol with `quote.status != "ok"` are auto-downgraded to `operation="review"` with a `"quote evidence 확인 불가"` rationale. The gate only activates when `symbol_quotes` was actually populated (legacy crypto paths and callers without quote data stay on the original classifier rules).

### Auto-emit — deterministic candidate generation

New `EvidenceAutoEmitter` (opt-in via `ReportGenerationRequest.auto_emit_from_evidence=True`) reads the persisted snapshot bundle and proposes `IngestReportItem` drafts:

* **Sell action** when `portfolio.primary_source='kis'` AND the held row has `sellable_quantity > 0` AND the matching symbol snapshot reports `quote.status='ok'` with non-zero best bid/ask and at least one side of book depth.
* **Buy action** when `candidate_universe.usefulness='useful'` AND the symbol's quote is actionable (same gate) AND it is not already held. Bounded by `max_buy_candidates` (default 10).
* **Watch (review) item** when news `symbol_matches > 0` AND action grounds are insufficient. De-duped against already-proposed buy/sell candidates on the same symbol.
* **Every** emitted item carries `operation="review"` + `apply_policy="requires_user_approval"`, plus an `evidence_snapshot` provenance dict containing the source snapshot UUID / kind / symbol and a `proposer="auto_emit/<rule>"` tag. Each generated item then flows through the ROB-274 classifier and the ROB-278 Phase 2 quote-evidence gate before ingest.
* Distinct from ROB-279's LLM-based `auto_compose` pipeline — this proposer is deterministic, fail-closed, and runs without Gemini.

### Dry-run script

`scripts/rob278_kr_dryrun.py --dry-run --user-id <N>` drives the generator end-to-end against the dev DB and asserts no row-count change on a guarded set of mutation tables:

* `review.investment_watch_alerts`
* `review.investment_watch_events`
* `review.investment_report_item_decisions`
* `pending_orders`
* `order_preview_session`
* `order_preview_leg`
* `order_execution_request`

The whole run is wrapped in one `AsyncSessionLocal` transaction that is rolled back unless `--commit` is passed.

## Safety boundaries (held throughout)

* Broker calls are read-only only — KIS goes through `KISHomeReader` / `SafeKISClient` (account, integrated_margin, `inquire_price`, `inquire_orderbook`). The new symbol-quote adapter wraps only these and exposes a single `fetch_quote_orderbook(symbol)` method.
* No order placement / cancellation / submission / modification, no watch activation, no order-intent mutation, no scheduler registration touched.
* The static mutation-import guard test (`test_collector_modules_do_not_import_broker_or_activation_paths`) now covers every collector module + `symbol_derivation` + `auto_emit` + `generator` and asserts none of them pull in any of: `kis_trading_service`, `investment_reports.watch_activation`, `alpaca_paper_ledger_service`, `upbit.client`, `place_order`, `submit_order`, `cancel_order`, `modify_order`.
* Manual / Toss / reference holdings are never promoted to `kis_live` primary. KIS unavailable → `freshness="unavailable"` so the stale gate handles publishing.
* Auto-emitted candidates are always `operation="review"` + `apply_policy="requires_user_approval"`; the proposer never marks anything auto-executable.
* `user_id` missing on `kis_live` → fail-closed. No implicit default user.
* When evidence is insufficient (no quote, stale-only candidates, manual-only portfolio, etc.) the proposer **emits nothing** rather than fabricating a candidate.

## Test plan

- [x] `uv run pytest tests/services/action_report/snapshot_backed/ tests/test_investment_reports_snapshot_evidence_service.py` — 108 passed, 0 xfailed (Phase 2 reused-freshness reproducer is now passing without xfail).
- [x] Broader (snapshot_backed + investment_snapshots + investment_reports + evidence service): 350 passed.
- [x] Full non-integration sweep on the pre-rebase commit set: 7622 passed, 3 skipped (pre-existing env-dependent flakes verified against baseline).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on all changed files.
- [x] Mutation import guard test green for every new module.
- [ ] Operator dry-run (`scripts/rob278_kr_dryrun.py --dry-run --user-id <N>`) on the dev DB to confirm the row-count guard reports `Δ=0` across all mutation-watched tables and surface the generated items list.

## Files changed (high-level)

* `app/services/action_report/snapshot_backed/`
  * `auto_emit.py` (new) — `EvidenceAutoEmitter` deterministic proposer.
  * `symbol_derivation.py` (new) — bounded seed-preserving symbol derivation.
  * `generator.py` — wires `user_id` / symbol derivation / symbol-quote evidence into the classifier + the optional `auto_emit_from_evidence` path.
  * `proposal_classifier.py` — `ClassifierContext.symbol_quotes` + evidence-aware buy downgrade.
  * `request.py` — adds `user_id` and `auto_emit_from_evidence` fields.
  * `collectors/portfolio.py` — v2 payload with KIS live source for `kr+kis_live`.
  * `collectors/symbol.py` — KIS quote/orderbook enrichment.
  * `collectors/candidate_universe.py` — usefulness vs freshness split.
  * `collectors/news.py` — symbol-citation filtering + no-data reason.
  * `collectors/registry.py` — wires the new symbol-quote adapter.
* `app/schemas/investment_snapshots_mcp.py` — `EnsureBundleRequest.user_id`.
* `app/services/action_report/common/snapshot_bundle.py` — forwards `user_id` to `CollectorRequest`.
* `app/services/investment_snapshots/collectors.py` — `CollectorRequest.user_id`.
* `scripts/rob278_kr_dryrun.py` (new) — read-only dry-run with row-count guard.
* Tests: `test_collectors.py`, `test_symbol_derivation.py`, `test_auto_emit.py`, `test_generator.py`, `test_investment_reports_snapshot_evidence_service.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Intelligent symbol recommendations derived from portfolio and market data
  * Automated review-item proposals based on collected evidence
  * Enhanced portfolio snapshots with live broker account integration
  * Symbol-focused news filtering and quote enrichment for market analysis
  * Improved candidate usefulness classification and freshness tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->