### PR TITLE
feat(rob-281): KR/US /invest/screener scheduled refresh + market-aware freshness

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -317,6 +317,13 @@ class Settings(BaseSettings):
     # ROB-204 — Prefect/manual US screener snapshot writes stay dry-run unless explicitly enabled.
     invest_screener_snapshots_commit_enabled: bool = False
 
+    # ROB-281 — Gates cron registration for KR/US screener snapshot scheduled refreshes.
+    # When False, scheduled tasks remain defined as broker tasks (so operators can still
+    # kick them manually via ``taskiq kick``) but no cron entries are registered. Pairs
+    # with ``invest_screener_snapshots_commit_enabled`` (the DB write gate) so the
+    # production rollout can move schedule → dry-run-on-cron → commit-on-cron in stages.
+    invest_screener_schedule_enabled: bool = False
+
     # ROB-222 — Naver momentum/theme event snapshot writes stay dry-run unless explicitly enabled.
     invest_momentum_events_commit_enabled: bool = False
     invest_momentum_events_scheduler_enabled: bool = False

--- a/app/jobs/invest_screener_snapshots.py
+++ b/app/jobs/invest_screener_snapshots.py
@@ -10,12 +10,16 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import sqlalchemy as sa
 
 from app.core.db import AsyncSessionLocal
 from app.services.invest_screener_snapshots.builder import build_snapshots_for_market
+from app.services.invest_screener_snapshots.guards import (
+    assert_dominant_partition,
+    assert_min_row_count,
+)
 from app.services.invest_screener_snapshots.repository import (
     InvestScreenerSnapshotsRepository,
     SnapshotUpsert,
@@ -276,3 +280,39 @@ async def run_snapshot_build(request: SnapshotBuildRequest) -> SnapshotBuildResu
         samples=tuple(samples),
         warnings=tuple(warnings),
     )
+
+
+async def run_snapshot_build_guarded(
+    request: SnapshotBuildRequest,
+) -> SnapshotBuildResult:
+    """ROB-281 Stage 5: dry-run → guards → commit wrapper.
+
+    Two-pass behavior: always runs :func:`run_snapshot_build` first with
+    ``commit=False`` to obtain ``snapshot_date_distribution`` and
+    ``snapshots_built``, then applies the guards from
+    :mod:`app.services.invest_screener_snapshots.guards`.
+
+    * Guards pass + ``request.commit=True`` → re-runs ``run_snapshot_build``
+      with the original commit flag (performs the actual DB writes).
+    * Guards pass + ``request.commit=False`` → returns the dry-run result.
+    * Guard violation → raises
+      :class:`~app.services.invest_screener_snapshots.guards.SuspiciousDistributionError`
+      or
+      :class:`~app.services.invest_screener_snapshots.guards.InsufficientRowsError`.
+      The dry-run distribution is preserved in the exception message so
+      callers (Stage 6 Discord alerts) can surface it.
+
+    Trade-off note: the 2× external-fetch cost is acceptable here because
+    schedule cadence is at most 4 KR + 1 US runs per weekday. A truly
+    transactional single-pass would require refactoring the per-batch commit
+    boundary in :func:`run_snapshot_build` — out of scope for ROB-281.
+    """
+    dry_run_request = replace(request, commit=False)
+    dry_run_result = await run_snapshot_build(dry_run_request)
+
+    assert_dominant_partition(dry_run_result.snapshot_date_distribution)
+    assert_min_row_count(dry_run_result.snapshots_built, dry_run_result.market)
+
+    if not request.commit:
+        return dry_run_result
+    return await run_snapshot_build(request)

--- a/app/jobs/invest_screener_snapshots.py
+++ b/app/jobs/invest_screener_snapshots.py
@@ -17,6 +17,8 @@ import sqlalchemy as sa
 from app.core.db import AsyncSessionLocal
 from app.services.invest_screener_snapshots.builder import build_snapshots_for_market
 from app.services.invest_screener_snapshots.guards import (
+    InsufficientRowsError,
+    SuspiciousDistributionError,
     assert_dominant_partition,
     assert_min_row_count,
 )
@@ -310,8 +312,14 @@ async def run_snapshot_build_guarded(
     dry_run_request = replace(request, commit=False)
     dry_run_result = await run_snapshot_build(dry_run_request)
 
-    assert_dominant_partition(dry_run_result.snapshot_date_distribution)
-    assert_min_row_count(dry_run_result.snapshots_built, dry_run_result.market)
+    try:
+        assert_dominant_partition(dry_run_result.snapshot_date_distribution)
+        assert_min_row_count(dry_run_result.snapshots_built, dry_run_result.market)
+    except (SuspiciousDistributionError, InsufficientRowsError) as exc:
+        # Enrich the exception with the full dry-run distribution so Stage 6
+        # Discord alerts can render the offending context.
+        exc.distribution = dict(dry_run_result.snapshot_date_distribution)
+        raise
 
     if not request.commit:
         return dry_run_result

--- a/app/services/invest_screener_snapshots/alerts.py
+++ b/app/services/invest_screener_snapshots/alerts.py
@@ -1,0 +1,111 @@
+"""ROB-281 Stage 6 — Discord operational alerts for screener refresh jobs.
+
+Routes failure / suspicious-distribution / schedule-miss alerts to
+``settings.discord_webhook_alerts`` (D3 lock-in — Hermes is the review-trigger
+notification contract and is NOT used for ops alerts).
+
+Contract:
+
+* Never invoked on success (``assert_never_called_on_success`` belt-and-braces
+  test in :mod:`tests.services.invest_screener_snapshots.test_alerts`).
+* Never raises. Alert-delivery failures must not mask the underlying task
+  failure that triggered the alert; we log and return ``False`` instead.
+* Noop (returns ``False``) when ``settings.discord_webhook_alerts`` is unset.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+from app.monitoring.trade_notifier.transports import send_discord_embed_single
+
+logger = logging.getLogger(__name__)
+
+_EMBED_COLOR_FAILURE = 0xE74C3C  # red, matches existing Discord alert convention
+_MESSAGE_TRUNCATE = 1024  # Discord embed field value limit
+
+
+def _format_distribution_preview(distribution: Mapping[str, int] | None) -> str:
+    if not distribution:
+        return "n/a"
+    top = sorted(distribution.items(), key=lambda kv: kv[1], reverse=True)[:3]
+    return ", ".join(f"{date}={count}" for date, count in top)
+
+
+async def send_screener_refresh_alert(
+    *,
+    slot: str,
+    market: str,
+    exception: BaseException,
+    distribution: Mapping[str, int] | None = None,
+    commit_status: str = "skipped",
+    http_client: httpx.AsyncClient | None = None,
+) -> bool:
+    """Post a failure / guard-violation embed to ``discord_webhook_alerts``.
+
+    Returns ``True`` if the embed was successfully posted, ``False`` otherwise
+    (webhook unset, transport error, or unexpected exception during send).
+    The caller should re-raise the original ``exception`` after this call so
+    TaskIQ records the underlying failure.
+
+    When ``http_client`` is not provided, a short-lived client is created and
+    closed inside this function — convenient for one-shot alerts from
+    scheduled task bodies.
+    """
+    webhook = settings.discord_webhook_alerts
+    if not webhook:
+        logger.info(
+            "screener refresh alert noop (discord_webhook_alerts unset): "
+            "slot=%s market=%s exc=%s",
+            slot,
+            market,
+            exception.__class__.__name__,
+        )
+        return False
+
+    exc_class = exception.__class__.__name__
+    exc_msg = str(exception)
+    if len(exc_msg) > _MESSAGE_TRUNCATE:
+        exc_msg = exc_msg[: _MESSAGE_TRUNCATE - 1] + "…"
+
+    embed: dict[str, Any] = {
+        "title": f"screener refresh failure — {market} / {slot}",
+        "color": _EMBED_COLOR_FAILURE,
+        "fields": [
+            {"name": "slot", "value": slot, "inline": True},
+            {"name": "market", "value": market, "inline": True},
+            {"name": "commit", "value": commit_status, "inline": True},
+            {"name": "exception", "value": f"`{exc_class}`", "inline": True},
+            {
+                "name": "snapshot_date distribution (top 3)",
+                "value": _format_distribution_preview(distribution),
+                "inline": False,
+            },
+            {"name": "message", "value": f"```\n{exc_msg}\n```", "inline": False},
+        ],
+    }
+
+    own_client = http_client is None
+    if own_client:
+        http_client = httpx.AsyncClient(timeout=10.0)
+    try:
+        return await send_discord_embed_single(
+            http_client=http_client,
+            webhook_url=webhook,
+            embed=embed,
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "screener refresh alert send failed: slot=%s market=%s",
+            slot,
+            market,
+        )
+        return False
+    finally:
+        if own_client and http_client is not None:
+            await http_client.aclose()

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -138,6 +138,101 @@ def kr_session_label_for_partition(
     return None
 
 
+# ROB-281: US session-aware helpers using exchange-calendars (XNYS).
+# These are imported lazily inside the functions to avoid pulling exchange_calendars
+# + pandas into every importer of this module; the cost is non-trivial at startup.
+
+_ET = ZoneInfo("America/New_York")
+_US_POST_CLOSE_THRESHOLD = (17, 20)  # hour, minute in America/New_York
+
+
+def expected_us_baseline_date(now: dt.datetime) -> dt.date:
+    """The US trading date for which a snapshot is EXPECTED to exist at ``now``.
+
+    Boundary semantics (all in ``America/New_York``):
+
+    * Today is a US trading session AND ``now >= 17:20 ET`` → today.
+    * Today is a US trading session but ``now < 17:20 ET`` → prior session.
+    * Today is a weekend or NYSE holiday → most recent session before today.
+
+    Half-days (e.g., Black Friday with 13:00 ET close) are still sessions and
+    are treated identically — 17:20 ET is post-close on any session date, so
+    no half-day-specific branch is needed.
+
+    Uses :mod:`exchange_calendars` (XNYS) for holiday and half-day awareness,
+    matching the project convention established in ``us_candles_sync_service``.
+    Naive ``now`` is treated as UTC and converted to ET.
+    """
+    import exchange_calendars as xcals
+    import pandas as pd
+
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    now_et = now.astimezone(_ET)
+    today_et = now_et.date()
+    cal = xcals.get_calendar("XNYS")
+    today_ts = pd.Timestamp(today_et)
+    is_today_session = bool(cal.is_session(today_ts))
+    hm = (now_et.hour, now_et.minute)
+    if is_today_session and hm >= _US_POST_CLOSE_THRESHOLD:
+        return today_et
+    # Most recent session strictly before today. A 10-day lookback covers
+    # the worst-case US holiday gap (e.g., Thanksgiving Wed → following Mon).
+    start_ts = pd.Timestamp(today_et - dt.timedelta(days=10))
+    sessions = cal.sessions_in_range(start_ts, today_ts)
+    prior_sessions = [s.date() for s in sessions if s.date() < today_et]
+    if prior_sessions:
+        return prior_sessions[-1]
+    # Pathological fallback (should be unreachable in practice).
+    prior = today_et - dt.timedelta(days=1)
+    while prior.weekday() >= 5:
+        prior -= dt.timedelta(days=1)
+    return prior
+
+
+def last_completed_us_session_close(now: dt.datetime) -> dt.datetime | None:
+    """UTC datetime of the most recent US session close at-or-before ``now``.
+
+    Returns ``None`` only in pathological cases where no session can be found
+    in the 10-day lookback window. Half-day closes (13:00 ET) are surfaced
+    correctly because :mod:`exchange_calendars` returns the actual close time
+    per session.
+    """
+    import exchange_calendars as xcals
+    import pandas as pd
+
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    cal = xcals.get_calendar("XNYS")
+    today_et_date = now.astimezone(_ET).date()
+    start_ts = pd.Timestamp(today_et_date - dt.timedelta(days=10))
+    end_ts = pd.Timestamp(today_et_date)
+    sessions = cal.sessions_in_range(start_ts, end_ts)
+    for session in reversed(list(sessions)):
+        close = cal.session_close(session)
+        close_dt = close.to_pydatetime()
+        if close_dt.tzinfo is None:
+            close_dt = close_dt.replace(tzinfo=dt.UTC)
+        if close_dt <= now:
+            return close_dt
+    return None
+
+
+def us_session_label_for_partition(
+    partition_computed_at: dt.datetime | None,
+) -> str | None:
+    """User-facing US session label for a snapshot.
+
+    Always ``"US post-close"`` when ``partition_computed_at`` is present.
+    Unlike KR (which has KRX-preliminary vs NXT-final granularity), the US
+    schedule has a single post-close slot, so the label is constant.
+    Returns ``None`` only when ``partition_computed_at`` is ``None``.
+    """
+    if partition_computed_at is None:
+        return None
+    return "US post-close"
+
+
 def classify_state(
     *,
     snapshot_date: dt.date,

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -240,9 +240,7 @@ def us_session_label_for_partition(
 # ---------------------------------------------------------------------------
 
 
-def expected_baseline_date(
-    market: str, *, now: dt.datetime | None = None
-) -> dt.date:
+def expected_baseline_date(market: str, *, now: dt.datetime | None = None) -> dt.date:
     """Session-aware variant of :func:`today_trading_date`.
 
     Dispatches to ``expected_kr_baseline_date`` for ``"kr"`` and

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -8,7 +8,14 @@ from app.services.market_events.freshness_service import STALE_AFTER_HOURS
 
 DataState = Literal["fresh", "partial", "stale", "missing", "fallback"]
 
-_TZ_BY_MARKET = {"kr": ZoneInfo("Asia/Seoul"), "us": ZoneInfo("America/New_York")}
+# ROB-281: KR schedule slot taxonomy.
+# pre_market_repair fires at 07:40 KST and targets the prior day's NXT-final
+# (it does not produce same-day data). krx_preliminary fires at 16:20 KST after
+# KRX regular session, nxt_final at 20:20 KST after NXT after-market.
+KRSessionSlot = Literal["pre_market_repair", "krx_preliminary", "nxt_final"]
+
+_KST = ZoneInfo("Asia/Seoul")
+_TZ_BY_MARKET = {"kr": _KST, "us": ZoneInfo("America/New_York")}
 _PARTIAL_MAX_LEN = (
     5  # closes_window length < 5 → partial (week_change_rate not computable)
 )
@@ -27,6 +34,108 @@ def today_trading_date(market: str, *, now: dt.datetime | None = None) -> dt.dat
     while candidate.weekday() >= 5:
         candidate -= dt.timedelta(days=1)
     return candidate
+
+
+def _prior_weekday(d: dt.date) -> dt.date:
+    prior = d - dt.timedelta(days=1)
+    while prior.weekday() >= 5:
+        prior -= dt.timedelta(days=1)
+    return prior
+
+
+def classify_kr_session_slot(now: dt.datetime) -> KRSessionSlot:
+    """Return the KR schedule slot most recently fired at-or-before ``now``.
+
+    Slot boundaries (KST, both endpoints inclusive on the start):
+
+    ====================  ==========================================
+    KST window            slot
+    ====================  ==========================================
+    00:00 – 07:39         ``nxt_final`` (prior day's slot still authoritative)
+    07:40 – 16:19         ``pre_market_repair``
+    16:20 – 20:19         ``krx_preliminary``
+    20:20 – 23:59         ``nxt_final``
+    ====================  ==========================================
+
+    Weekends and KR holidays are out of scope here; callers should gate
+    actionable use on ``exchange_calendars.get_calendar("XKRX").is_session``.
+    Naive ``now`` is treated as UTC and converted to KST.
+    """
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    kst = now.astimezone(_KST)
+    hm = (kst.hour, kst.minute)
+    if hm >= (20, 20):
+        return "nxt_final"
+    if hm >= (16, 20):
+        return "krx_preliminary"
+    if hm >= (7, 40):
+        return "pre_market_repair"
+    return "nxt_final"
+
+
+def expected_kr_baseline_date(now: dt.datetime) -> dt.date:
+    """The KR trading date for which a snapshot is EXPECTED to exist at ``now``.
+
+    Critically, in the 07:40 – 16:19 KST window (pre-market repair, before
+    today's 16:20 KRX preliminary has fired), the expected baseline is the
+    PRIOR trading day — not today. Using raw :func:`today_trading_date` here
+    would mark a fresh prior-day partition as stale just because the clock
+    rolled past midnight, surfacing a misleading "1일 지연" label even when
+    the previous NXT-final ran successfully.
+
+    Resolution:
+
+    * Before 16:20 KST → prior trading weekday.
+    * 16:20 KST or later → today (rolled back to weekday).
+
+    Holidays are not consulted here for the same reasons as
+    :func:`today_trading_date`; daily candles upstream already collapse KR
+    public holidays into the prior trading day close.
+    """
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=dt.UTC)
+    kst = now.astimezone(_KST)
+    today_kst = kst.date()
+    while today_kst.weekday() >= 5:
+        today_kst -= dt.timedelta(days=1)
+    if (kst.hour, kst.minute) >= (16, 20):
+        return today_kst
+    return _prior_weekday(today_kst)
+
+
+def kr_session_label_for_partition(
+    partition_computed_at: dt.datetime | None,
+) -> str | None:
+    """User-facing KR session label for a snapshot's ``computed_at``.
+
+    Maps the KST time-of-day at which the partition was computed to a token:
+
+    * ``16:20 – 20:19 KST`` → ``"KRX preliminary"``
+    * ``20:20 – 23:59 KST`` → ``"NXT final"``
+    * ``00:00 – 06:59 KST`` → ``"NXT final"`` (overnight tail of prior day's run)
+    * ``07:40 – 16:19 KST`` → ``"NXT final"`` (repair window targets prior NXT-final)
+
+    Returns ``None`` for the rare 07:00 – 07:39 KST gap (between overnight
+    rollover and the pre-market repair slot) or when ``partition_computed_at``
+    is ``None``. Callers in that case fall back to the existing
+    :func:`format_kst_as_of_label` without appending a session token.
+    """
+    if partition_computed_at is None:
+        return None
+    if partition_computed_at.tzinfo is None:
+        partition_computed_at = partition_computed_at.replace(tzinfo=dt.UTC)
+    kst = partition_computed_at.astimezone(_KST)
+    hm = (kst.hour, kst.minute)
+    if (16, 20) <= hm < (20, 20):
+        return "KRX preliminary"
+    if hm >= (20, 20):
+        return "NXT final"
+    if hm < (7, 0):
+        return "NXT final"
+    if (7, 40) <= hm < (16, 20):
+        return "NXT final"
+    return None
 
 
 def classify_state(

--- a/app/services/invest_screener_snapshots/freshness.py
+++ b/app/services/invest_screener_snapshots/freshness.py
@@ -74,7 +74,7 @@ def classify_kr_session_slot(now: dt.datetime) -> KRSessionSlot:
     return "nxt_final"
 
 
-def expected_kr_baseline_date(now: dt.datetime) -> dt.date:
+def expected_kr_baseline_date(now: dt.datetime | None = None) -> dt.date:
     """The KR trading date for which a snapshot is EXPECTED to exist at ``now``.
 
     Critically, in the 07:40 – 16:19 KST window (pre-market repair, before
@@ -93,9 +93,10 @@ def expected_kr_baseline_date(now: dt.datetime) -> dt.date:
     :func:`today_trading_date`; daily candles upstream already collapse KR
     public holidays into the prior trading day close.
     """
-    if now.tzinfo is None:
-        now = now.replace(tzinfo=dt.UTC)
-    kst = now.astimezone(_KST)
+    moment = now if now is not None else dt.datetime.now(dt.UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=dt.UTC)
+    kst = moment.astimezone(_KST)
     today_kst = kst.date()
     while today_kst.weekday() >= 5:
         today_kst -= dt.timedelta(days=1)
@@ -146,7 +147,7 @@ _ET = ZoneInfo("America/New_York")
 _US_POST_CLOSE_THRESHOLD = (17, 20)  # hour, minute in America/New_York
 
 
-def expected_us_baseline_date(now: dt.datetime) -> dt.date:
+def expected_us_baseline_date(now: dt.datetime | None = None) -> dt.date:
     """The US trading date for which a snapshot is EXPECTED to exist at ``now``.
 
     Boundary semantics (all in ``America/New_York``):
@@ -166,9 +167,10 @@ def expected_us_baseline_date(now: dt.datetime) -> dt.date:
     import exchange_calendars as xcals
     import pandas as pd
 
-    if now.tzinfo is None:
-        now = now.replace(tzinfo=dt.UTC)
-    now_et = now.astimezone(_ET)
+    moment = now if now is not None else dt.datetime.now(dt.UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=dt.UTC)
+    now_et = moment.astimezone(_ET)
     today_et = now_et.date()
     cal = xcals.get_calendar("XNYS")
     today_ts = pd.Timestamp(today_et)
@@ -231,6 +233,51 @@ def us_session_label_for_partition(
     if partition_computed_at is None:
         return None
     return "US post-close"
+
+
+# ---------------------------------------------------------------------------
+# ROB-281 — Market-aware dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+def expected_baseline_date(
+    market: str, *, now: dt.datetime | None = None
+) -> dt.date:
+    """Session-aware variant of :func:`today_trading_date`.
+
+    Dispatches to ``expected_kr_baseline_date`` for ``"kr"`` and
+    ``expected_us_baseline_date`` for ``"us"``. For any other market value
+    falls back to :func:`today_trading_date` so existing non-KR/US callers
+    (e.g., crypto, future markets) are not silently broken.
+
+    Use this in place of :func:`today_trading_date` whenever the caller is
+    classifying an ``invest_screener_snapshots`` partition — it correctly
+    expects the prior trading day during the KR ``07:40–16:19`` pre-market
+    window and the US pre-17:20 ET window, preventing the "fresh prior-day
+    partition labeled stale" regression after KST/ET midnight rollover.
+    """
+    if market == "kr":
+        return expected_kr_baseline_date(now)
+    if market == "us":
+        return expected_us_baseline_date(now)
+    return today_trading_date(market, now=now)
+
+
+def session_label_for_partition(
+    market: str, partition_computed_at: dt.datetime | None
+) -> str | None:
+    """Return the user-facing session label for a partition.
+
+    Dispatches to :func:`kr_session_label_for_partition` /
+    :func:`us_session_label_for_partition` based on ``market``. Returns
+    ``None`` for unknown markets so callers can safely default to the
+    existing ``format_kst_as_of_label`` output.
+    """
+    if market == "kr":
+        return kr_session_label_for_partition(partition_computed_at)
+    if market == "us":
+        return us_session_label_for_partition(partition_computed_at)
+    return None
 
 
 def classify_state(

--- a/app/services/invest_screener_snapshots/guards.py
+++ b/app/services/invest_screener_snapshots/guards.py
@@ -1,0 +1,92 @@
+"""ROB-281 Stage 5 — Commit-time guards for invest screener snapshot builds.
+
+Guards run on the dry-run distribution before any commit. They protect against:
+
+* Mixed-partition distributions (e.g., 90% today + 10% yesterday from a builder
+  bug, where committing would create an authoritative-looking minority
+  partition that is actually noise).
+* Suspiciously small builds (e.g., the data source returned 50 rows instead
+  of the expected ~3000 because of a partial upstream outage).
+
+A failed guard raises a typed exception that the caller is expected to route
+to Stage 6 Discord alerts before re-raising to TaskIQ.
+
+Thresholds are locked in this module so a future implementer or reviewer can
+see them at a glance:
+
+* Dominant partition: at least 70% of rows in a single ``snapshot_date``.
+* Min row count: KR ≥ 2500 (observed 3867 on 2026-05-19), US ≥ 3500
+  (observed 5116 on 2026-05-19).
+
+Adjusting these floors should be a separate PR with telemetry-backed
+justification — do not silently soften during implementation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal
+
+
+class SuspiciousDistributionError(RuntimeError):
+    """Raised when no single ``snapshot_date`` holds the dominant majority."""
+
+
+class InsufficientRowsError(RuntimeError):
+    """Raised when ``snapshots_built`` is below the market's row-count floor."""
+
+
+_DOMINANT_PARTITION_THRESHOLD = 0.70
+
+_MIN_ROW_THRESHOLD: dict[str, int] = {"kr": 2500, "us": 3500}
+
+
+def assert_dominant_partition(
+    distribution: Mapping[str, int],
+    *,
+    threshold: float = _DOMINANT_PARTITION_THRESHOLD,
+) -> str:
+    """Validate that the distribution has a dominant ``snapshot_date``.
+
+    A dominant partition holds at least ``threshold`` fraction (default 70%)
+    of all rows. Otherwise the distribution is treated as suspicious and the
+    caller refuses to commit.
+
+    Returns the dominant date on success. Raises
+    :class:`SuspiciousDistributionError` on violation, with the full
+    distribution embedded in the message for operator triage.
+    """
+    if not distribution:
+        raise SuspiciousDistributionError("empty snapshot_date distribution")
+    total = sum(distribution.values())
+    if total <= 0:
+        raise SuspiciousDistributionError(
+            f"non-positive total row count: {total}"
+        )
+    dominant_date, dominant_count = max(
+        distribution.items(), key=lambda kv: kv[1]
+    )
+    ratio = dominant_count / total
+    if ratio < threshold:
+        raise SuspiciousDistributionError(
+            f"no dominant partition: top={dominant_date} "
+            f"({dominant_count}/{total} = {ratio:.2%}) below "
+            f"{threshold:.0%} threshold; distribution={dict(distribution)}"
+        )
+    return dominant_date
+
+
+def assert_min_row_count(count: int, market: Literal["kr", "us"]) -> None:
+    """Validate ``snapshots_built`` meets the per-market floor.
+
+    Raises :class:`InsufficientRowsError` when ``count`` is below the
+    locked floor for ``market``. Locked floors live in
+    :data:`_MIN_ROW_THRESHOLD`; revising them requires a separate PR.
+    """
+    floor = _MIN_ROW_THRESHOLD.get(market)
+    if floor is None:
+        raise ValueError(f"unknown market for min-row guard: {market}")
+    if count < floor:
+        raise InsufficientRowsError(
+            f"{market} snapshots_built={count} below floor={floor}"
+        )

--- a/app/services/invest_screener_snapshots/guards.py
+++ b/app/services/invest_screener_snapshots/guards.py
@@ -97,12 +97,8 @@ def assert_dominant_partition(
         raise SuspiciousDistributionError("empty snapshot_date distribution")
     total = sum(distribution.values())
     if total <= 0:
-        raise SuspiciousDistributionError(
-            f"non-positive total row count: {total}"
-        )
-    dominant_date, dominant_count = max(
-        distribution.items(), key=lambda kv: kv[1]
-    )
+        raise SuspiciousDistributionError(f"non-positive total row count: {total}")
+    dominant_date, dominant_count = max(distribution.items(), key=lambda kv: kv[1])
     ratio = dominant_count / total
     if ratio < threshold:
         raise SuspiciousDistributionError(

--- a/app/services/invest_screener_snapshots/guards.py
+++ b/app/services/invest_screener_snapshots/guards.py
@@ -29,11 +29,48 @@ from typing import Literal
 
 
 class SuspiciousDistributionError(RuntimeError):
-    """Raised when no single ``snapshot_date`` holds the dominant majority."""
+    """Raised when no single ``snapshot_date`` holds the dominant majority.
+
+    Carries the offending distribution as ``distribution`` for downstream
+    alerting (Stage 6 Discord embed).
+    """
+
+    distribution: dict[str, int]
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        distribution: dict[str, int] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.distribution = dict(distribution or {})
 
 
 class InsufficientRowsError(RuntimeError):
-    """Raised when ``snapshots_built`` is below the market's row-count floor."""
+    """Raised when ``snapshots_built`` is below the market's row-count floor.
+
+    Carries ``count``, ``market``, and (after enrichment by the guarded
+    wrapper) the dry-run ``distribution`` so Stage 6 alerts can surface the
+    full context to operators.
+    """
+
+    distribution: dict[str, int]
+    count: int | None
+    market: str | None
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        distribution: dict[str, int] | None = None,
+        count: int | None = None,
+        market: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.distribution = dict(distribution or {})
+        self.count = count
+        self.market = market
 
 
 _DOMINANT_PARTITION_THRESHOLD = 0.70
@@ -71,7 +108,8 @@ def assert_dominant_partition(
         raise SuspiciousDistributionError(
             f"no dominant partition: top={dominant_date} "
             f"({dominant_count}/{total} = {ratio:.2%}) below "
-            f"{threshold:.0%} threshold; distribution={dict(distribution)}"
+            f"{threshold:.0%} threshold; distribution={dict(distribution)}",
+            distribution=dict(distribution),
         )
     return dominant_date
 
@@ -88,5 +126,7 @@ def assert_min_row_count(count: int, market: Literal["kr", "us"]) -> None:
         raise ValueError(f"unknown market for min-row guard: {market}")
     if count < floor:
         raise InsufficientRowsError(
-            f"{market} snapshots_built={count} below floor={floor}"
+            f"{market} snapshots_built={count} below floor={floor}",
+            count=count,
+            market=market,
         )

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -406,10 +406,14 @@ async def _load_consecutive_gainers_from_snapshots(
     from app.models.invest_screener_snapshot import InvestScreenerSnapshot
     from app.services.invest_screener_snapshots.freshness import (
         classify_state,
-        today_trading_date,
+        expected_baseline_date,
     )
 
-    today = today_trading_date(market)
+    # ROB-281: session-aware baseline. In the KR 07:40–16:19 KST pre-market
+    # window (or US pre-17:20 ET window), the expected baseline is the prior
+    # trading session, not today — fixes the regression where a fresh
+    # prior-day partition is labeled stale after KST/ET midnight rollover.
+    today = expected_baseline_date(market)
 
     # Step 1: resolve the latest snapshot partition date.
     # This prevents older qualifying partitions from leaking into current results
@@ -1288,6 +1292,7 @@ def _build_freshness(
     from app.services.invest_screener_snapshots.freshness import (
         compute_overall_state,
         format_kst_as_of_label,
+        session_label_for_partition,
     )
 
     now_utc = now()
@@ -1347,16 +1352,28 @@ def _build_freshness(
     # Build primary object
     primary: ScreenerFreshnessPrimary | None = None
     if primary_kind == "screener_snapshot" and primary_snapshot_date is not None:
+        # ROB-281: append session token (KRX preliminary / NXT final / US
+        # post-close) to the data-基準 label so the UI can disambiguate which
+        # KR/US scheduled slot produced this partition. Token is omitted when
+        # session_label_for_partition returns None (unknown market or rare
+        # 07:00–07:39 KST gap) — preserves ROB-277 served vs data-as-of split.
+        base_as_of_label = format_kst_as_of_label(
+            snapshot_date=primary_snapshot_date,
+            computed_at=primary_computed_at,
+        )
+        session_token = session_label_for_partition(market, primary_computed_at)
+        as_of_label = (
+            f"{base_as_of_label} ({session_token})"
+            if session_token
+            else base_as_of_label
+        )
         primary = ScreenerFreshnessPrimary(
             kind="screener_snapshot",
             snapshotDate=primary_snapshot_date.isoformat(),
             computedAt=primary_computed_at.astimezone(UTC).isoformat()
             if primary_computed_at is not None
             else None,
-            asOfLabel=format_kst_as_of_label(
-                snapshot_date=primary_snapshot_date,
-                computed_at=primary_computed_at,
-            ),
+            asOfLabel=as_of_label,
             dataState=dataState,  # type: ignore[arg-type]
             source=primary_source,
         )

--- a/app/tasks/invest_screener_snapshot_tasks.py
+++ b/app/tasks/invest_screener_snapshot_tasks.py
@@ -1,19 +1,201 @@
 """TaskIQ wrappers for invest screener snapshot activation.
 
-No recurring schedule is attached intentionally. Operators can enqueue these tasks
-manually after dry-run evidence/reviewer approval, or run them in dry-run mode to
-produce an approval packet. Persisting rows requires commit=True.
+Includes both the manual entry point (``build_invest_screener_snapshots``,
+dry-run by default) and the ROB-281 scheduled wrappers for KR/US.
+
+ROB-281 recurring activation is double-gated for safety:
+
+* ``invest_screener_schedule_enabled`` registers the cron schedule.
+* ``invest_screener_snapshots_commit_enabled`` allows DB writes.
+
+When the schedule flag is False the cron entries are not registered (manual
+``taskiq kick`` still works). When the schedule flag is True but the commit
+flag is False, scheduled tasks run on cron and produce dry-run output without
+touching the database — this is the "dry-run-on-schedule" rollout state.
+
+Locked decisions (see ``docs/plans/2026-05-20-ROB-281-...-plan.md``):
+
+* D1 — KR pre-market repair runs at 07:40 KST (20-minute buffer to NXT
+  pre-market 08:00). This slot does NOT prepare same-day data; it repairs
+  the prior day's 20:20 KST NXT-final if that run failed or lagged.
+* D2 — KR holiday gate via ``exchange_calendars`` XKRX; US via XNYS. US
+  cron runs in ``America/New_York`` to avoid DST drift.
+* D3 — Failure / suspicious-distribution alerts route to
+  ``discord_webhook_alerts`` (Stage 6 wiring in this PR).
 """
 
 from __future__ import annotations
 
+import datetime as dt
+import logging
 from typing import Any, Literal
+from zoneinfo import ZoneInfo
 
+from app.core.config import settings
 from app.core.taskiq_broker import broker
 from app.jobs.invest_screener_snapshots import (
     SnapshotBuildRequest,
     run_snapshot_build,
 )
+
+logger = logging.getLogger(__name__)
+
+_KST_LABEL = "Asia/Seoul"
+_ET_LABEL = "America/New_York"
+
+KRSlot = Literal["pre_market_repair", "krx_preliminary", "nxt_final"]
+USSlot = Literal["post_close"]
+
+
+# ---------------------------------------------------------------------------
+# Schedule registration helpers
+# ---------------------------------------------------------------------------
+
+
+def _kr_schedule(cron: str) -> list[dict[str, str]]:
+    if not settings.invest_screener_schedule_enabled:
+        return []
+    return [{"cron": cron, "cron_offset": _KST_LABEL}]
+
+
+def _us_schedule(cron: str) -> list[dict[str, str]]:
+    if not settings.invest_screener_schedule_enabled:
+        return []
+    return [{"cron": cron, "cron_offset": _ET_LABEL}]
+
+
+def _scheduled_kr_pre_market_repair_labels() -> list[dict[str, str]]:
+    # 07:40 KST Mon–Fri. XKRX holiday filter applied at task entry.
+    return _kr_schedule("40 7 * * 1-5")
+
+
+def _scheduled_kr_krx_preliminary_labels() -> list[dict[str, str]]:
+    # 16:20 KST Mon–Fri.
+    return _kr_schedule("20 16 * * 1-5")
+
+
+def _scheduled_kr_nxt_final_labels() -> list[dict[str, str]]:
+    # 20:20 KST Mon–Fri.
+    return _kr_schedule("20 20 * * 1-5")
+
+
+def _scheduled_us_post_close_labels() -> list[dict[str, str]]:
+    # 17:20 America/New_York Mon–Fri. XNYS holiday filter applied at task entry.
+    return _us_schedule("20 17 * * 1-5")
+
+
+# ---------------------------------------------------------------------------
+# Session-day holiday gate (XKRX / XNYS)
+# ---------------------------------------------------------------------------
+
+
+def is_market_session_today(
+    market: Literal["kr", "us"], *, now: dt.datetime | None = None
+) -> bool:
+    """Return whether today (in the market's tz) is a trading session.
+
+    Uses :mod:`exchange_calendars` XKRX for KR and XNYS for US (ROB-281 D2).
+    Pulling the calendar is the only expensive op here; imports are lazy to
+    keep startup snappy for non-scheduled importers.
+    """
+    import exchange_calendars as xcals
+    import pandas as pd
+
+    if market == "kr":
+        cal = xcals.get_calendar("XKRX")
+        tz = ZoneInfo("Asia/Seoul")
+    else:
+        cal = xcals.get_calendar("XNYS")
+        tz = ZoneInfo("America/New_York")
+    moment = now or dt.datetime.now(dt.UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=dt.UTC)
+    today_local = moment.astimezone(tz).date()
+    return bool(cal.is_session(pd.Timestamp(today_local)))
+
+
+# ---------------------------------------------------------------------------
+# Scheduled task body — shared across KR/US slots
+# ---------------------------------------------------------------------------
+
+
+async def _run_scheduled_build(
+    *,
+    market: Literal["kr", "us"],
+    slot: str,
+) -> dict[str, Any]:
+    """Common body for scheduled refresh tasks.
+
+    * Skips the run on XKRX/XNYS holidays (returns a structured skipped result;
+      no Discord alert — holidays are expected).
+    * Honors ``invest_screener_snapshots_commit_enabled`` for commit gating.
+    * US uses ``common_stocks_only=True`` to match the ROB-204 production path.
+    * Stage 5 (commit-time guards) and Stage 6 (Discord alerts) hook in here
+      when those stages land in this PR.
+
+    Returns a JSON-serializable result dict suitable for TaskIQ result backend.
+    """
+    if not is_market_session_today(market):
+        logger.info(
+            "scheduled invest screener slot skipped (non-session day): "
+            "market=%s slot=%s",
+            market,
+            slot,
+        )
+        return {
+            "market": market,
+            "slot": slot,
+            "skipped": "non_session_day",
+            "committed": False,
+        }
+
+    commit = settings.invest_screener_snapshots_commit_enabled
+    common_stocks_only = market == "us"
+
+    request = SnapshotBuildRequest(
+        market=market,
+        all_symbols=True,
+        commit=commit,
+        batch_size=200,
+        concurrency=4,
+        common_stocks_only=common_stocks_only,
+    )
+
+    logger.info(
+        "scheduled invest screener build starting: market=%s slot=%s commit=%s",
+        market,
+        slot,
+        commit,
+    )
+    result = await run_snapshot_build(request)
+
+    logger.info(
+        "scheduled invest screener build finished: market=%s slot=%s "
+        "snapshots_built=%d committed=%s distribution=%s",
+        market,
+        slot,
+        result.snapshots_built,
+        result.committed,
+        result.snapshot_date_distribution,
+    )
+
+    return {
+        "market": market,
+        "slot": slot,
+        "committed": result.committed,
+        "symbolsResolved": result.symbols_resolved,
+        "snapshotsBuilt": result.snapshots_built,
+        "skipped": result.skipped,
+        "snapshotDateDistribution": result.snapshot_date_distribution,
+        "startedAt": result.started_at.isoformat(),
+        "finishedAt": result.finished_at.isoformat(),
+        "warnings": list(result.warnings),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Existing manual entry point (kept dry-run-by-default, unchanged behavior)
+# ---------------------------------------------------------------------------
 
 
 @broker.task(task_name="build_invest_screener_snapshots")
@@ -67,3 +249,70 @@ async def build_invest_screener_snapshots(
         ],
         "warnings": list(result.warnings),
     }
+
+
+# ---------------------------------------------------------------------------
+# ROB-281 — KR scheduled wrappers
+# ---------------------------------------------------------------------------
+
+
+@broker.task(
+    task_name="invest_screener_snapshots.kr_pre_market_repair",
+    schedule=_scheduled_kr_pre_market_repair_labels(),
+)
+async def scheduled_kr_pre_market_repair() -> dict[str, Any]:
+    """KR pre-market repair at 07:40 KST on KR trading days.
+
+    Per ROB-281 D1, this slot does NOT prepare same-day data — same-day data
+    arrives at 16:20 (KRX preliminary) and 20:20 (NXT final). The 07:40 KST
+    run exists solely to repair the prior trading day's 20:20 NXT-final if
+    that run failed or upstream data was delayed overnight. The 20-minute
+    buffer to NXT pre-market open (08:00 KST) allows transient-failure retry.
+    """
+    return await _run_scheduled_build(market="kr", slot="pre_market_repair")
+
+
+@broker.task(
+    task_name="invest_screener_snapshots.kr_krx_preliminary",
+    schedule=_scheduled_kr_krx_preliminary_labels(),
+)
+async def scheduled_kr_krx_preliminary() -> dict[str, Any]:
+    """KR KRX regular-session preliminary refresh at 16:20 KST.
+
+    Surfaced in the UI as ``KRX preliminary`` (ROB-281 Stage 7 wiring) to
+    distinguish it from the later 20:20 KST NXT-final result.
+    """
+    return await _run_scheduled_build(market="kr", slot="krx_preliminary")
+
+
+@broker.task(
+    task_name="invest_screener_snapshots.kr_nxt_final",
+    schedule=_scheduled_kr_nxt_final_labels(),
+)
+async def scheduled_kr_nxt_final() -> dict[str, Any]:
+    """KR NXT after-market final refresh at 20:20 KST.
+
+    Surfaced in the UI as ``NXT final`` and is the authoritative end-of-day
+    KR snapshot under the post-NXT trading-hours regime.
+    """
+    return await _run_scheduled_build(market="kr", slot="nxt_final")
+
+
+# ---------------------------------------------------------------------------
+# ROB-281 — US scheduled wrapper
+# ---------------------------------------------------------------------------
+
+
+@broker.task(
+    task_name="invest_screener_snapshots.us_post_close",
+    schedule=_scheduled_us_post_close_labels(),
+)
+async def scheduled_us_post_close() -> dict[str, Any]:
+    """US post-close refresh at 17:20 America/New_York on US trading days.
+
+    Per ROB-281 D2, cron is registered in ``America/New_York`` (not KST) to
+    avoid DST drift. Half-days (e.g., Black Friday 13:00 ET close) require
+    no special case — 17:20 ET is post-close on any session date. Holiday
+    skip uses XNYS via :func:`is_market_session_today`.
+    """
+    return await _run_scheduled_build(market="us", slot="post_close")

--- a/app/tasks/invest_screener_snapshot_tasks.py
+++ b/app/tasks/invest_screener_snapshot_tasks.py
@@ -36,6 +36,7 @@ from app.core.taskiq_broker import broker
 from app.jobs.invest_screener_snapshots import (
     SnapshotBuildRequest,
     run_snapshot_build,
+    run_snapshot_build_guarded,
 )
 
 logger = logging.getLogger(__name__)
@@ -167,7 +168,11 @@ async def _run_scheduled_build(
         slot,
         commit,
     )
-    result = await run_snapshot_build(request)
+    # Stage 5: dry-run → guards (dominant partition, min row count) → commit.
+    # Guard violations raise; Stage 6 catches and emits Discord alerts before
+    # re-raising to TaskIQ. Holiday gate above already filtered non-session
+    # days, so any guard violation here is a real data-quality signal.
+    result = await run_snapshot_build_guarded(request)
 
     logger.info(
         "scheduled invest screener build finished: market=%s slot=%s "

--- a/app/tasks/invest_screener_snapshot_tasks.py
+++ b/app/tasks/invest_screener_snapshot_tasks.py
@@ -38,6 +38,13 @@ from app.jobs.invest_screener_snapshots import (
     run_snapshot_build,
     run_snapshot_build_guarded,
 )
+from app.services.invest_screener_snapshots.alerts import (
+    send_screener_refresh_alert,
+)
+from app.services.invest_screener_snapshots.guards import (
+    InsufficientRowsError,
+    SuspiciousDistributionError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -168,11 +175,30 @@ async def _run_scheduled_build(
         slot,
         commit,
     )
-    # Stage 5: dry-run → guards (dominant partition, min row count) → commit.
-    # Guard violations raise; Stage 6 catches and emits Discord alerts before
-    # re-raising to TaskIQ. Holiday gate above already filtered non-session
-    # days, so any guard violation here is a real data-quality signal.
-    result = await run_snapshot_build_guarded(request)
+    # Stage 5/6: dry-run → guards → commit, with Discord alerts on failure.
+    # Holiday gate above already filtered non-session days, so any exception
+    # reaching here is a real data-quality / system signal. Alerts go to
+    # discord_webhook_alerts (D3); Hermes is intentionally NOT used for ops.
+    try:
+        result = await run_snapshot_build_guarded(request)
+    except (SuspiciousDistributionError, InsufficientRowsError) as exc:
+        await send_screener_refresh_alert(
+            slot=slot,
+            market=market,
+            exception=exc,
+            distribution=exc.distribution,
+            commit_status="skipped",
+        )
+        raise
+    except Exception as exc:
+        await send_screener_refresh_alert(
+            slot=slot,
+            market=market,
+            exception=exc,
+            distribution=None,
+            commit_status="failed",
+        )
+        raise
 
     logger.info(
         "scheduled invest screener build finished: market=%s slot=%s "

--- a/docs/plans/2026-05-20-ROB-281-kr-us-screener-scheduled-refresh-implementation-plan.md
+++ b/docs/plans/2026-05-20-ROB-281-kr-us-screener-scheduled-refresh-implementation-plan.md
@@ -1,0 +1,238 @@
+# ROB-281 — KR/US `/invest/screener` Scheduled Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add scheduled TaskIQ refreshes + market-aware freshness labeling + commit-time guardrails to `invest_screener_snapshots` so KR and US screeners do not drift stale silently. KR-first then US-second within this PR (or two sub-PRs of the same branch if size warrants).
+
+**Architecture:** Extend the existing `app/tasks/invest_screener_snapshot_tasks.py` (currently dry-run-only, no schedule) with TaskIQ `LabelScheduleSource` cron labels per session slot. Extend `app/services/invest_screener_snapshots/freshness.py` with session-aware slot classification reusing `today_trading_date` + `classify_state` from ROB-277. Add a guard layer (dominant-partition, min-row, suspicious-distribution) in `app/jobs/invest_screener_snapshots.py`. Wire failure/suspicious-distribution-only alerts to `discord_webhook_alerts`. Surface new UI label tokens (`KRX preliminary`, `NXT final`, `US post-close`) in `app/services/invest_view_model/screener_service.py` without regressing ROB-277 served-time vs data-as-of split.
+
+**Tech Stack:** TaskIQ (broker: `app/core/taskiq_broker.py`, scheduler: `app/core/scheduler.py` with `LabelScheduleSource`). `exchange-calendars>=4.7,<5.0` (already a dep) for KR `XKRX` and US `XNYS` session/holiday/half-day handling. Async SQLAlchemy, pytest + `pytest-asyncio`, UV-managed deps.
+
+**Parent / sibling issues:**
+
+- Parent policy: ROB-280
+- Sibling (crypto 24/7): ROB-282 — **out of scope here**
+- Sibling (investor_flow recurring): ROB-205 — **out of scope here**, dependency reference only
+- Predecessor (served-time vs data-as-of split): ROB-277 — **preserve, do not regress**
+
+---
+
+## Locked Decisions (do not re-debate during implementation)
+
+These were agreed in the ROB-280 review thread on 2026-05-20 and locked here per ROB-281 acceptance criteria. Any deviation requires explicit reviewer sign-off **before** code changes.
+
+### D1. KR pre-market repair time: `07:40 KST`
+
+**Decision:** Schedule the KR pre-market catch-up/repair at `07:40 KST` on KR trading days (Mon–Fri minus XKRX holidays).
+
+**Rationale:**
+
+- NXT pre-market opens at `08:00 KST`. `07:40 KST` gives a **20-minute buffer** before NXT pre-market activity could interfere with the repair run.
+- Purpose is **repair of the prior day's `20:20 KST` NXT-final run** (e.g. provider outage, partial data, schedule miss), not preparation of new same-day data — same-day data is fetched at the `16:20` / `20:20` slots.
+- `07:50 KST` was considered. Rejected as starting point because the 10-min buffer to NXT 08:00 is too tight for retry/backoff on transient failures.
+- If `07:40 KST` later proves to be **before** upstream overnight data is reliably available (provider lag), shift to `07:50 KST` is a one-line cron change in a follow-up; the slot's purpose and label do not change.
+
+**Recorded in code/runbook:**
+
+- `app/tasks/invest_screener_snapshot_tasks.py` — docstring on the KR pre-market task explicitly states "repair of prior day's `20:20 KST` NXT-final, NOT same-day data prep".
+- Runbook update (TBD path) — note `07:40 KST` choice + escalation path to `07:50 KST` if upstream lag observed.
+
+### D2. US trading calendar source: `exchange-calendars` (`XNYS` + `XKRX`)
+
+**Decision:** Use `exchange-calendars` (already a project dependency at `>=4.7,<5.0`) for both US (`XNYS`) and KR (`XKRX`) holiday and half-day handling. Do **not** introduce `pandas-market-calendars`.
+
+**Rationale:**
+
+- Already a direct dependency in `pyproject.toml` and used in 8+ files including `app/jobs/watch_market_data.py`, `app/services/us_candles_sync_service.py`, `app/services/kr_candles_sync_service.py`, `app/services/kis_ohlcv_cache.py`, `app/services/yahoo_ohlcv_cache.py`, `app/mcp_server/tooling/market_data_indicators.py`. Convention is firmly established.
+- `pandas-market-calendars` would add a parallel calendar source with overlapping responsibility — wrong direction.
+- Holiday + half-day data quality on `XNYS` in `exchange-calendars` is sufficient for our scheduling needs (skip on holiday, allow normal 17:20 ET on half-days since half-day closes at 13:00 ET — 17:20 ET is post-close regardless).
+
+**Behavior:**
+
+- At task entry, the KR-side tasks check `xcals.get_calendar("XKRX").is_session(today_kst)`. Holiday → fail-closed early-return + alert (suspicious-distribution category? No — holiday is expected. Just info-log, no alert.).
+- The US-side task checks `xcals.get_calendar("XNYS").is_session(today_ny)`. Holiday → early-return.
+- Half-day: US post-close `17:20 America/New_York` still runs (market closes 13:00 ET on half-days, so 17:20 ET is well after close). No special-case code needed.
+
+### D3. Operational alert channel: `discord_webhook_alerts`
+
+**Decision:** Route failure / suspicious-distribution / schedule-miss alerts to `settings.discord_webhook_alerts` (existing config in `app/core/config.py:239–242`). Do **not** route through Hermes.
+
+**Rationale:**
+
+- Hermes is a **product-level review-trigger contract** (`HERMES_WEBHOOK_URL = http://localhost:18790/hooks/review-trigger`, config in `app/core/config.py:370–376`). Sending ops alerts through Hermes would muddy that contract.
+- `discord_webhook_alerts` already exists alongside `discord_webhook_us`, `discord_webhook_kr`, `discord_webhook_crypto`, configured in `app/main.py:260–263` and lifecycle-managed there.
+- An existing Discord helper (`send_discord_content_single` / `send_discord_embed_single` in `app/monitoring/trade_notifier/transports.py`) already abstracts the HTTP call. Reuse, do not re-implement.
+
+**Behavior:**
+
+- Success: **no alert** (acceptance: success-only spam forbidden).
+- Failure or suspicious-distribution / guard rejection or schedule miss: **single Discord embed** to `discord_webhook_alerts` with: slot name (`kr_pre_market_repair` etc.), market, exception class + message (truncated), snapshot_date_distribution (if available), commit status (`skipped`/`failed`).
+- If `discord_webhook_alerts` is unset (`None`), the alert call is a no-op (info-log only). Tests cover both branches.
+
+---
+
+## Hard Boundaries (preserve throughout implementation)
+
+These come from ROB-281 issue body and the user's confirmation. **Do not relax** without explicit reviewer sign-off.
+
+- No broker / order / watch / order-intent mutations.
+- No Toss / Naver browser scraping as a production source.
+- No buy / sell recommendation logic changes.
+- No `investor_flow_snapshots` recurring / backfill / scheduler / partition repair changes — that is **ROB-205 scope**. ROB-281 only references investor_flow as a read-only freshness dependency.
+- No crypto recurring refresh — that is **ROB-282 scope**.
+- Preserve **ROB-277** served-time vs data-as-of semantics. `방금 갱신` is the **served** label only; snapshot data 기준일 surfaces via `primary.asOfLabel` + the new session label tokens.
+
+---
+
+## Implementation Stages
+
+Stages 1–2 can be developed in parallel (both extend `freshness.py` but in distinct functions). Stages 3–4 are sequential (KR-first → US-second) per the user-confirmed order. Stage 5 is independent and can land alongside any prior stage. Stages 6–7 land after 3–5. Stages 8–9 close out.
+
+### Stage 1 — KR session-aware freshness extension
+
+File: `app/services/invest_screener_snapshots/freshness.py`
+
+- [ ] Add type alias `KRSessionSlot = Literal["pre_market_repair", "krx_preliminary", "nxt_final"]`.
+- [ ] Add `classify_kr_session_slot(now_kst: datetime) -> KRSessionSlot` — returns which schedule slot most recently fired at-or-before `now_kst` on the current KR trading day, with fallback to the prior trading day's `nxt_final` for early-morning hours (before `07:40`).
+- [ ] Add `kr_session_slot_to_label_token(slot) -> str | None` — `"krx_preliminary" → "KRX preliminary"`, `"nxt_final" → "NXT final"`, `"pre_market_repair" → None` (repair has no user-facing label; surfaced as the prior NXT-final label).
+- [ ] Unit tests: `tests/services/invest_screener_snapshots/test_freshness_kr_session.py` — table-driven assertions for boundary times `07:39`, `07:40`, `16:19`, `16:20`, `20:19`, `20:20`, `23:59`, `00:10`, KR holiday + weekend behavior.
+
+### Stage 2 — US session-aware freshness extension
+
+File: `app/services/invest_screener_snapshots/freshness.py`
+
+- [ ] Add `last_completed_us_session_close(now: datetime) -> datetime | None` — uses `xcals.get_calendar("XNYS")` to find the most recent session close at-or-before `now`. Returns `None` if no recent session (extremely defensive — should never happen in practice).
+- [ ] Add `is_us_post_close_window(now: datetime) -> bool` — `True` when `now` is after that session's close, i.e. the `US post-close` slot label applies.
+- [ ] Add `us_session_label_token(now: datetime) -> str` — `"US post-close"` when in post-close window, else absent (fallback to prior session's post-close label).
+- [ ] Unit tests: `tests/services/invest_screener_snapshots/test_freshness_us_session.py` — Mon 17:20 ET, Fri 17:20 ET, holiday (Thanksgiving) skip, half-day (Black Friday 13:00 ET close, 17:20 ET still post-close), DST spring-forward boundary (verify `America/New_York` resolves correctly, no UTC ambiguity).
+
+### Stage 3 — KR TaskIQ scheduled wrappers
+
+File: `app/tasks/invest_screener_snapshot_tasks.py`
+
+- [ ] Keep existing `build_invest_screener_snapshots` task unchanged (it's the manual / dry-run entry point).
+- [ ] Add `scheduled_build_invest_screener_snapshots_kr_pre_market_repair` (cron label: `40 7 * * 1-5` in `Asia/Seoul`).
+- [ ] Add `scheduled_build_invest_screener_snapshots_kr_krx_preliminary` (cron label: `20 16 * * 1-5` in `Asia/Seoul`).
+- [ ] Add `scheduled_build_invest_screener_snapshots_kr_nxt_final` (cron label: `20 20 * * 1-5` in `Asia/Seoul`).
+- [ ] Each wrapper:
+  1. Checks `XKRX.is_session(today_kst)`. If holiday → info-log + return early (no alert).
+  2. Checks `settings.INVEST_SCREENER_SCHEDULE_ENABLED` env gate (NEW config flag, default `False` → dry-run only).
+  3. Calls `build_invest_screener_snapshots(market="kr", all_symbols=True, commit=settings.INVEST_SCREENER_SCHEDULE_ENABLED)`.
+  4. Passes a `slot: KRSessionSlot` tag through into the build result for observability.
+  5. On exception → send Discord alert (Stage 6) → re-raise so TaskIQ records failure.
+- [ ] Docstring on the `pre_market_repair` task explicitly states the D1 decision (repair of prior `20:20 KST` run, not same-day prep).
+- [ ] Verify TaskIQ `LabelScheduleSource` honors `tz` keyword in cron labels; if not, fall back to UTC cron with KST offset and document the conversion in the docstring.
+
+### Stage 4 — US TaskIQ scheduled wrapper
+
+File: `app/tasks/invest_screener_snapshot_tasks.py`
+
+- [ ] Add `scheduled_build_invest_screener_snapshots_us_post_close` (cron label: `20 17 * * 1-5` in `America/New_York`).
+- [ ] Wrapper:
+  1. Checks `XNYS.is_session(today_ny)`. Holiday → info-log + return.
+  2. Env gate (same `INVEST_SCREENER_SCHEDULE_ENABLED`).
+  3. `build_invest_screener_snapshots(market="us", all_symbols=True, common_stocks_only=True, commit=...)`.
+  4. On exception → Stage 6 Discord alert.
+- [ ] Half-day handling: no special case needed (verified in D2 rationale).
+- [ ] Docstring notes the `America/New_York` timezone choice (D2) and the DST safety this provides.
+
+### Stage 5 — Commit-time guards
+
+File: `app/jobs/invest_screener_snapshots.py` (extend `run_snapshot_build` or add a guard layer before commit)
+
+- [ ] Add `_assert_dominant_partition(distribution: Mapping[date, int], threshold: float = 0.70) -> date` — raises `SuspiciousDistributionError` if no single `snapshot_date` holds ≥ 70% of rows. Returns the dominant date on success.
+- [ ] Add `_assert_min_row_count(count: int, market: Literal["kr", "us"]) -> None` — KR threshold `2500` (observed: 3867), US threshold `3500` (observed: 5116). Raises `InsufficientRowsError` if violated. **Threshold values locked here; if scrutinized in review, adjust before merge — do not silently soften during implementation.**
+- [ ] Both guards run **after** the dry-run pass produces `snapshot_date_distribution`, **before** any commit. On `commit=False` (manual dry-run), guards log + report but do **not** raise (so operators can still see dry-run output on a degraded day).
+- [ ] Guards on scheduled (`commit=True`) path: raise → caller catches → Discord alert → no commit.
+- [ ] Tests: `tests/jobs/test_invest_screener_snapshots_guards.py` — dominant-partition pass/fail, min-row pass/fail, dry-run-vs-commit different behaviors.
+
+### Stage 6 — Discord ops alert path
+
+New file: `app/services/invest_screener_snapshots/alerts.py`
+
+- [ ] `async def send_screener_refresh_alert(slot: str, market: str, exception: BaseException | None, distribution: Mapping[date, int] | None, *, settings) -> None` — formats Discord embed and posts to `settings.discord_webhook_alerts` via existing `send_discord_embed_single`. No-op when webhook unconfigured.
+- [ ] Embed fields: `slot`, `market`, `error_class`, `error_message` (truncated to 1024 chars), `snapshot_date_distribution` (top 3 dates by row count), `commit_status` (`skipped` / `failed`).
+- [ ] **Never call on success** — function contract documented + tested.
+- [ ] Tests: `tests/services/invest_screener_snapshots/test_alerts.py` — unconfigured webhook → no-op (asserted via mock); configured + exception → expected payload format; success path must never invoke (asserted via grep + integration test).
+
+### Stage 7 — UI label tokens in view-model
+
+File: `app/services/invest_view_model/screener_service.py`
+
+- [ ] When constructing `primary.asOfLabel` for snapshot-backed screener results, append the session label token (`KRX preliminary` / `NXT final` / `US post-close`) derived from `partition_computed_at` via Stage 1 / Stage 2 classifiers.
+- [ ] Token appears in `asOfLabel` (existing field) without breaking ROB-277 contract — do not introduce a new top-level field unless needed. Format example: `"2026.05.20 16:20 KST 기준 (KRX preliminary)"`.
+- [ ] If `partition_computed_at` is `None` or session classification returns no token (pre_market_repair, early morning fallback), omit the parenthetical and keep prior ROB-277 behavior.
+- [ ] Frontend smoke: visit `/invest/screener?market=kr` and `?market=us`, verify label appears once per snapshot-backed result and disappears on stale/missing dataState.
+- [ ] Tests: extend `tests/services/invest_view_model/test_screener_service.py` (or matching test file) — label token presence per slot, ROB-277 regression check (`servedAt` / `servedRelativeLabel` unchanged).
+
+### Stage 8 — Test & smoke completeness
+
+- [ ] Unit tests: Stages 1, 2, 5, 6, 7 each have dedicated test modules per above.
+- [ ] Integration test: `tests/tasks/test_invest_screener_snapshot_tasks_scheduled.py` — dry-run path (`INVEST_SCREENER_SCHEDULE_ENABLED=False`) yields expected dry-run result; commit path (env var True) hits the guard layer; holiday path returns early.
+- [ ] Read-only smoke commands documented in plan footer (see Production rollout below).
+- [ ] `make test` passes locally. Skip slow / integration markers per project conventions if necessary.
+
+### Stage 9 — Production rollout
+
+Strictly dry-run-first.
+
+- [ ] **Step A (code merge):** PR merges with `INVEST_SCREENER_SCHEDULE_ENABLED=False` default → scheduled tasks run on cron but only emit dry-run output. Discord alerts only on actual failure / suspicious distribution.
+- [ ] **Step B (dry-run evidence):** Capture 2 KR trading days + 1 US trading day of dry-run logs. Confirm: schedule fires at expected wall-clock times (KST + ET), dominant-partition + min-row guards pass, snapshot_date_distribution looks sane, no Discord alerts spammed.
+- [ ] **Step C (alert smoke):** Force one intentional failure (e.g. set min-row threshold absurdly high in a feature-flagged test env) → verify Discord alert lands in `discord_webhook_alerts` exactly once.
+- [ ] **Step D (commit enable):** Set `INVEST_SCREENER_SCHEDULE_ENABLED=True` in production env. Monitor first 24h KR cycle + first 1 US cycle for unexpected guard failures. Read-only smoke:
+  - `curl -sS "$BASE/trading/api/invest/screener/results?market=kr&preset=consecutive_gainers" | jq '.freshness'`
+  - `curl -sS "$BASE/trading/api/invest/screener/results?market=us&preset=consecutive_gainers" | jq '.freshness'`
+  - `curl -sS "$BASE/trading/api/invest/screener/presets" | jq '.'`
+  - Verify `primary.asOfLabel` contains the expected session token, `servedRelativeLabel` shows fresh served-time (ROB-277 preserved).
+- [ ] **Step E (rollback procedure):** If a guard triggers a sustained alert storm, flip `INVEST_SCREENER_SCHEDULE_ENABLED=False` (reverts to dry-run only, no DB writes). No code revert needed.
+
+---
+
+## Out of Scope (cross-references)
+
+- **Crypto 24/7 refresh** — ROB-282. Do not touch `app/jobs/invest_crypto_screener_snapshots.py`, `app/services/invest_crypto_screener_snapshots/freshness.py`, or the crypto label `crypto computed_at 기준`.
+- **investor_flow recurring / backfill / scheduler / partition repair** — ROB-205. Read-only reference only. Do not modify `app/tasks/investor_flow_snapshot_tasks.py` or `app/jobs/investor_flow_snapshots.py`.
+- **ROB-277 served-time vs data-as-of split** — preserve unchanged. New session label tokens append to `asOfLabel`; `servedAt` / `servedRelativeLabel` untouched.
+
+---
+
+## Open Follow-ups (not in this PR)
+
+- `07:40 KST` vs `07:50 KST` empirical re-evaluation after first 2 weeks of production data. Document in runbook escalation section.
+- Half-day post-close behavior for US: if early-close (13:00 ET) ever causes data-quality issues at 17:20 ET, consider adding a `13:30 ET` half-day variant slot. Currently expected unnecessary.
+- Min-row guard thresholds (`2500` KR, `3500` US) may need tuning after first month. Track row-count distribution and revise via separate PR.
+- Long-term: split `app/tasks/invest_screener_snapshot_tasks.py` if it grows beyond ~300 LOC into `manual.py` + `scheduled.py`. Not needed now.
+
+---
+
+## File Change Inventory (estimate)
+
+**Modified:**
+
+- `app/services/invest_screener_snapshots/freshness.py` — KR/US session classifiers + label tokens.
+- `app/tasks/invest_screener_snapshot_tasks.py` — 4 new scheduled task wrappers.
+- `app/jobs/invest_screener_snapshots.py` — 2 commit-time guards + threshold constants.
+- `app/services/invest_view_model/screener_service.py` — session label token in `asOfLabel`.
+- `app/core/config.py` — `INVEST_SCREENER_SCHEDULE_ENABLED` env flag (default `False`).
+
+**Added:**
+
+- `app/services/invest_screener_snapshots/alerts.py` — Discord webhook helper.
+- `tests/services/invest_screener_snapshots/test_freshness_kr_session.py`
+- `tests/services/invest_screener_snapshots/test_freshness_us_session.py`
+- `tests/services/invest_screener_snapshots/test_alerts.py`
+- `tests/jobs/test_invest_screener_snapshots_guards.py`
+- `tests/tasks/test_invest_screener_snapshot_tasks_scheduled.py`
+
+**Read-only references (do not modify in this PR):**
+
+- `app/tasks/investor_flow_snapshot_tasks.py`, `app/jobs/investor_flow_snapshots.py` — ROB-205 scope.
+- `app/models/invest_screener_snapshot.py` — schema unchanged; ROB-204 activated.
+
+---
+
+## Estimated effort
+
+Stages 1–2: ~0.5 day (freshness extension, table-driven tests). Stages 3–4: ~1 day (TaskIQ wrappers + cron + env gate). Stage 5: ~0.5 day (guards + threshold validation). Stage 6: ~0.5 day (Discord helper + unit tests). Stage 7: ~0.5 day (label token in view-model + frontend smoke). Stages 8–9: ~1 day (test consolidation + dry-run rollout).
+
+Total: **~4 day** code + **~2 trading day** dry-run observation before enabling commit.

--- a/tests/services/invest_screener_snapshots/test_alerts.py
+++ b/tests/services/invest_screener_snapshots/test_alerts.py
@@ -7,7 +7,7 @@ distribution preview / truncated message.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -19,7 +19,6 @@ from app.services.invest_screener_snapshots.guards import (
     InsufficientRowsError,
     SuspiciousDistributionError,
 )
-
 
 # --- Noop when webhook unset -------------------------------------------------
 
@@ -161,14 +160,10 @@ async def test_alert_message_truncated_when_exception_text_too_long(
 
     huge_message = "x" * 5000
     exc = RuntimeError(huge_message)
-    await send_screener_refresh_alert(
-        slot="post_close", market="us", exception=exc
-    )
+    await send_screener_refresh_alert(slot="post_close", market="us", exception=exc)
 
     embed = mock_send.await_args.kwargs["embed"]
-    message_field = next(
-        f for f in embed["fields"] if f["name"] == "message"
-    )
+    message_field = next(f for f in embed["fields"] if f["name"] == "message")
     # 1024 char limit; allow some slack for the ```\n…\n``` wrap.
     assert len(message_field["value"]) <= 1024 + 20
     assert message_field["value"].endswith("…\n```")

--- a/tests/services/invest_screener_snapshots/test_alerts.py
+++ b/tests/services/invest_screener_snapshots/test_alerts.py
@@ -1,0 +1,200 @@
+"""ROB-281 Stage 6 — Discord ops alert unit tests.
+
+Validates the contract: never on success, no-op when webhook unset, never
+raises on transport failure, embeds carry slot / market / exception class /
+distribution preview / truncated message.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.invest_screener_snapshots import alerts as alerts_module
+from app.services.invest_screener_snapshots.alerts import (
+    send_screener_refresh_alert,
+)
+from app.services.invest_screener_snapshots.guards import (
+    InsufficientRowsError,
+    SuspiciousDistributionError,
+)
+
+
+# --- Noop when webhook unset -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alert_returns_false_when_webhook_unset(mocker) -> None:
+    mocker.patch.object(alerts_module.settings, "discord_webhook_alerts", None)
+    mock_send = mocker.patch.object(
+        alerts_module, "send_discord_embed_single", new=AsyncMock()
+    )
+
+    result = await send_screener_refresh_alert(
+        slot="krx_preliminary",
+        market="kr",
+        exception=SuspiciousDistributionError("test"),
+    )
+
+    assert result is False
+    mock_send.assert_not_awaited()  # transport never called
+
+
+@pytest.mark.asyncio
+async def test_alert_returns_false_when_webhook_empty_string(mocker) -> None:
+    """Empty string is falsy and must be treated as unset (no spurious posts)."""
+    mocker.patch.object(alerts_module.settings, "discord_webhook_alerts", "")
+    mock_send = mocker.patch.object(
+        alerts_module, "send_discord_embed_single", new=AsyncMock()
+    )
+
+    result = await send_screener_refresh_alert(
+        slot="nxt_final", market="kr", exception=RuntimeError("test")
+    )
+
+    assert result is False
+    mock_send.assert_not_awaited()
+
+
+# --- Happy path embed shape --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alert_embed_carries_slot_market_distribution_and_exception(
+    mocker,
+) -> None:
+    mocker.patch.object(
+        alerts_module.settings,
+        "discord_webhook_alerts",
+        "https://discord.com/api/webhooks/x/y",
+    )
+    mock_send = mocker.patch.object(
+        alerts_module,
+        "send_discord_embed_single",
+        new=AsyncMock(return_value=True),
+    )
+
+    exc = SuspiciousDistributionError(
+        "no dominant partition: top=2026-05-20",
+        distribution={"2026-05-20": 1800, "2026-05-19": 1200},
+    )
+    result = await send_screener_refresh_alert(
+        slot="krx_preliminary",
+        market="kr",
+        exception=exc,
+        distribution=exc.distribution,
+        commit_status="skipped",
+    )
+
+    assert result is True
+    assert mock_send.await_count == 1
+    kwargs = mock_send.await_args.kwargs
+    assert kwargs["webhook_url"] == "https://discord.com/api/webhooks/x/y"
+    embed = kwargs["embed"]
+    assert "kr / krx_preliminary" in embed["title"]
+    field_values = {f["name"]: f["value"] for f in embed["fields"]}
+    assert field_values["slot"] == "krx_preliminary"
+    assert field_values["market"] == "kr"
+    assert field_values["commit"] == "skipped"
+    assert "SuspiciousDistributionError" in field_values["exception"]
+    # Top-3 distribution preview includes both dates (sorted desc by count).
+    dist_value = field_values["snapshot_date distribution (top 3)"]
+    assert "2026-05-20=1800" in dist_value
+    assert "2026-05-19=1200" in dist_value
+    # 2026-05-20 should appear first because it has the higher count.
+    assert dist_value.index("2026-05-20") < dist_value.index("2026-05-19")
+    assert "no dominant partition" in field_values["message"]
+
+
+@pytest.mark.asyncio
+async def test_alert_embed_handles_insufficient_rows_without_distribution(
+    mocker,
+) -> None:
+    mocker.patch.object(
+        alerts_module.settings,
+        "discord_webhook_alerts",
+        "https://discord.com/api/webhooks/x/y",
+    )
+    mock_send = mocker.patch.object(
+        alerts_module,
+        "send_discord_embed_single",
+        new=AsyncMock(return_value=True),
+    )
+
+    exc = InsufficientRowsError(
+        "kr snapshots_built=50 below floor=2500",
+        count=50,
+        market="kr",
+    )
+    result = await send_screener_refresh_alert(
+        slot="nxt_final",
+        market="kr",
+        exception=exc,
+        distribution=None,  # caller signals no distribution available
+    )
+
+    assert result is True
+    embed = mock_send.await_args.kwargs["embed"]
+    field_values = {f["name"]: f["value"] for f in embed["fields"]}
+    assert "InsufficientRowsError" in field_values["exception"]
+    assert field_values["snapshot_date distribution (top 3)"] == "n/a"
+
+
+# --- Message truncation ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alert_message_truncated_when_exception_text_too_long(
+    mocker,
+) -> None:
+    mocker.patch.object(
+        alerts_module.settings,
+        "discord_webhook_alerts",
+        "https://discord.com/api/webhooks/x/y",
+    )
+    mock_send = mocker.patch.object(
+        alerts_module,
+        "send_discord_embed_single",
+        new=AsyncMock(return_value=True),
+    )
+
+    huge_message = "x" * 5000
+    exc = RuntimeError(huge_message)
+    await send_screener_refresh_alert(
+        slot="post_close", market="us", exception=exc
+    )
+
+    embed = mock_send.await_args.kwargs["embed"]
+    message_field = next(
+        f for f in embed["fields"] if f["name"] == "message"
+    )
+    # 1024 char limit; allow some slack for the ```\n…\n``` wrap.
+    assert len(message_field["value"]) <= 1024 + 20
+    assert message_field["value"].endswith("…\n```")
+
+
+# --- Resilience: transport failure must not raise ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_alert_returns_false_on_transport_exception(mocker) -> None:
+    mocker.patch.object(
+        alerts_module.settings,
+        "discord_webhook_alerts",
+        "https://discord.com/api/webhooks/x/y",
+    )
+    mocker.patch.object(
+        alerts_module,
+        "send_discord_embed_single",
+        new=AsyncMock(side_effect=RuntimeError("network broken")),
+    )
+
+    # MUST NOT raise — alert delivery failures cannot mask the underlying task
+    # failure that triggered the alert.
+    result = await send_screener_refresh_alert(
+        slot="krx_preliminary",
+        market="kr",
+        exception=SuspiciousDistributionError("test"),
+    )
+    assert result is False

--- a/tests/services/invest_screener_snapshots/test_freshness_dispatch.py
+++ b/tests/services/invest_screener_snapshots/test_freshness_dispatch.py
@@ -1,0 +1,216 @@
+"""ROB-281 Stage 7 — Market-aware dispatch helpers + view-model wiring tests.
+
+Covers the public dispatch surface used by ``screener_service``:
+
+* ``expected_baseline_date(market)`` routes KR/US to session-aware helpers
+  and falls back to ``today_trading_date`` for unknown markets.
+* ``session_label_for_partition(market, computed_at)`` routes KR/US to the
+  per-market label helpers and returns None for unknown markets.
+
+Plus a focused integration test on ``_build_freshness`` proving that
+``asOfLabel`` for a screener-snapshot result carries the parenthetical
+session token (KRX preliminary / NXT final / US post-close), without
+breaking ROB-277 served-time vs data-as-of semantics.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+from app.services.invest_screener_snapshots.freshness import (
+    expected_baseline_date,
+    session_label_for_partition,
+    today_trading_date,
+)
+from app.services.invest_view_model.screener_service import _build_freshness
+
+_KST = ZoneInfo("Asia/Seoul")
+_ET = ZoneInfo("America/New_York")
+
+
+def _kst(year: int, month: int, day: int, hour: int, minute: int) -> dt.datetime:
+    return dt.datetime(year, month, day, hour, minute, tzinfo=_KST)
+
+
+def _et(year: int, month: int, day: int, hour: int, minute: int) -> dt.datetime:
+    return dt.datetime(year, month, day, hour, minute, tzinfo=_ET)
+
+
+# --- expected_baseline_date dispatch ----------------------------------------
+
+
+def test_expected_baseline_date_kr_in_pre_market_window_returns_prior_day() -> None:
+    """The whole point of Stage 7 wiring: KR 07:40 KST → prior trading day."""
+    assert expected_baseline_date("kr", now=_kst(2026, 5, 20, 7, 40)) == dt.date(
+        2026, 5, 19
+    )
+
+
+def test_expected_baseline_date_kr_after_krx_preliminary_returns_today() -> None:
+    assert expected_baseline_date("kr", now=_kst(2026, 5, 20, 16, 20)) == dt.date(
+        2026, 5, 20
+    )
+
+
+def test_expected_baseline_date_us_post_close_returns_today() -> None:
+    assert expected_baseline_date("us", now=_et(2025, 6, 9, 17, 20)) == dt.date(
+        2025, 6, 9
+    )
+
+
+def test_expected_baseline_date_us_before_post_close_returns_prior() -> None:
+    assert expected_baseline_date("us", now=_et(2025, 6, 9, 17, 19)) == dt.date(
+        2025, 6, 6
+    )
+
+
+def test_expected_baseline_date_unknown_market_falls_back_to_today_trading_date() -> (
+    None
+):
+    """Crypto / future markets must not crash — degrade to today_trading_date."""
+    now = dt.datetime(2026, 5, 20, 14, 0, tzinfo=dt.UTC)
+    assert expected_baseline_date("crypto", now=now) == today_trading_date(
+        "crypto", now=now
+    )
+
+
+# --- session_label_for_partition dispatch -----------------------------------
+
+
+def test_session_label_for_partition_kr_krx_preliminary() -> None:
+    assert (
+        session_label_for_partition("kr", _kst(2026, 5, 20, 16, 25))
+        == "KRX preliminary"
+    )
+
+
+def test_session_label_for_partition_kr_nxt_final() -> None:
+    assert (
+        session_label_for_partition("kr", _kst(2026, 5, 20, 20, 30))
+        == "NXT final"
+    )
+
+
+def test_session_label_for_partition_us_post_close() -> None:
+    assert (
+        session_label_for_partition("us", _et(2025, 6, 9, 17, 30))
+        == "US post-close"
+    )
+
+
+def test_session_label_for_partition_none_input() -> None:
+    assert session_label_for_partition("kr", None) is None
+    assert session_label_for_partition("us", None) is None
+
+
+def test_session_label_for_partition_unknown_market_returns_none() -> None:
+    assert session_label_for_partition("crypto", _kst(2026, 5, 20, 16, 30)) is None
+
+
+# --- _build_freshness asOfLabel composition ---------------------------------
+
+
+def _now_factory(value: dt.datetime):
+    return lambda: value
+
+
+def test_build_freshness_kr_krx_preliminary_appends_label_to_as_of() -> None:
+    """ROB-281 + ROB-277 contract: asOfLabel ends with `(KRX preliminary)`."""
+    served_now = dt.datetime(2026, 5, 20, 16, 30, tzinfo=dt.UTC)
+    computed_at = _kst(2026, 5, 20, 16, 20)
+    freshness = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=True,
+        market="kr",
+        now=_now_factory(served_now),
+        dataState="fresh",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2026, 5, 20),
+        primary_computed_at=computed_at,
+        primary_source="invest_screener_snapshots",
+    )
+    assert freshness.primary is not None
+    assert freshness.primary.asOfLabel.endswith("(KRX preliminary)")
+    # ROB-277: served vs data-as-of remain distinct.
+    assert freshness.servedAt is not None
+    assert freshness.primary.asOfLabel != freshness.servedRelativeLabel
+
+
+def test_build_freshness_kr_nxt_final_appends_label() -> None:
+    served_now = dt.datetime(2026, 5, 20, 11, 30, tzinfo=dt.UTC)  # 20:30 KST
+    computed_at = _kst(2026, 5, 20, 20, 20)
+    freshness = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=True,
+        market="kr",
+        now=_now_factory(served_now),
+        dataState="fresh",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2026, 5, 20),
+        primary_computed_at=computed_at,
+        primary_source="invest_screener_snapshots",
+    )
+    assert freshness.primary is not None
+    assert freshness.primary.asOfLabel.endswith("(NXT final)")
+
+
+def test_build_freshness_us_appends_post_close_label() -> None:
+    served_now = dt.datetime(2025, 6, 9, 22, 30, tzinfo=dt.UTC)
+    computed_at = _et(2025, 6, 9, 17, 20)
+    freshness = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=True,
+        market="us",
+        now=_now_factory(served_now),
+        dataState="fresh",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2025, 6, 9),
+        primary_computed_at=computed_at,
+        primary_source="invest_screener_snapshots",
+    )
+    assert freshness.primary is not None
+    assert freshness.primary.asOfLabel.endswith("(US post-close)")
+
+
+def test_build_freshness_live_kind_does_not_get_session_token() -> None:
+    """Live (non-snapshot) results have no session label — preserves ROB-277."""
+    served_now = dt.datetime(2026, 5, 20, 11, 30, tzinfo=dt.UTC)
+    freshness = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=False,
+        market="kr",
+        now=_now_factory(served_now),
+        dataState="fresh",
+        primary_kind="live",
+        primary_snapshot_date=None,
+        primary_computed_at=None,
+        primary_source="kr_live_screener",
+    )
+    assert freshness.primary is not None
+    # live kind uses data_basis_kst format, no parenthetical session token.
+    assert "KRX" not in freshness.primary.asOfLabel
+    assert "NXT" not in freshness.primary.asOfLabel
+    assert "post-close" not in freshness.primary.asOfLabel
+
+
+def test_build_freshness_screener_snapshot_with_no_computed_at_omits_token() -> (
+    None
+):
+    """Without computed_at, session classification falls through — no token."""
+    served_now = dt.datetime(2026, 5, 20, 11, 30, tzinfo=dt.UTC)
+    freshness = _build_freshness(
+        raw_timestamp=None,
+        cache_hit=True,
+        market="kr",
+        now=_now_factory(served_now),
+        dataState="fresh",
+        primary_kind="screener_snapshot",
+        primary_snapshot_date=dt.date(2026, 5, 20),
+        primary_computed_at=None,  # no computed_at → no session token
+        primary_source="invest_screener_snapshots",
+    )
+    assert freshness.primary is not None
+    # asOfLabel falls back to "장마감 기준" (per format_kst_as_of_label) with no
+    # parenthetical session token appended.
+    assert "(" not in freshness.primary.asOfLabel

--- a/tests/services/invest_screener_snapshots/test_freshness_dispatch.py
+++ b/tests/services/invest_screener_snapshots/test_freshness_dispatch.py
@@ -86,17 +86,11 @@ def test_session_label_for_partition_kr_krx_preliminary() -> None:
 
 
 def test_session_label_for_partition_kr_nxt_final() -> None:
-    assert (
-        session_label_for_partition("kr", _kst(2026, 5, 20, 20, 30))
-        == "NXT final"
-    )
+    assert session_label_for_partition("kr", _kst(2026, 5, 20, 20, 30)) == "NXT final"
 
 
 def test_session_label_for_partition_us_post_close() -> None:
-    assert (
-        session_label_for_partition("us", _et(2025, 6, 9, 17, 30))
-        == "US post-close"
-    )
+    assert session_label_for_partition("us", _et(2025, 6, 9, 17, 30)) == "US post-close"
 
 
 def test_session_label_for_partition_none_input() -> None:
@@ -194,9 +188,7 @@ def test_build_freshness_live_kind_does_not_get_session_token() -> None:
     assert "post-close" not in freshness.primary.asOfLabel
 
 
-def test_build_freshness_screener_snapshot_with_no_computed_at_omits_token() -> (
-    None
-):
+def test_build_freshness_screener_snapshot_with_no_computed_at_omits_token() -> None:
     """Without computed_at, session classification falls through — no token."""
     served_now = dt.datetime(2026, 5, 20, 11, 30, tzinfo=dt.UTC)
     freshness = _build_freshness(

--- a/tests/services/invest_screener_snapshots/test_freshness_kr_session.py
+++ b/tests/services/invest_screener_snapshots/test_freshness_kr_session.py
@@ -1,0 +1,168 @@
+"""ROB-281 Stage 1 — KR session-aware freshness primitives.
+
+Covers ``classify_kr_session_slot``, ``expected_kr_baseline_date``, and
+``kr_session_label_for_partition``. The most important regression these tests
+guard is the 07:40 – 16:19 KST window: at that time of day no same-day KRX
+preliminary has run yet, so the expected baseline is the PRIOR trading day —
+NOT today. Without this guard, ``/invest/screener`` would mark a fresh prior-day
+partition stale right after KST midnight rollover.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.invest_screener_snapshots.freshness import (
+    classify_kr_session_slot,
+    expected_kr_baseline_date,
+    kr_session_label_for_partition,
+)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _kst(year: int, month: int, day: int, hour: int, minute: int) -> dt.datetime:
+    return dt.datetime(year, month, day, hour, minute, tzinfo=_KST)
+
+
+# --- classify_kr_session_slot ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hour, minute, expected_slot",
+    [
+        (0, 0, "nxt_final"),
+        (3, 30, "nxt_final"),
+        (7, 39, "nxt_final"),
+        (7, 40, "pre_market_repair"),
+        (10, 0, "pre_market_repair"),
+        (16, 19, "pre_market_repair"),
+        (16, 20, "krx_preliminary"),
+        (18, 0, "krx_preliminary"),
+        (20, 19, "krx_preliminary"),
+        (20, 20, "nxt_final"),
+        (22, 30, "nxt_final"),
+        (23, 59, "nxt_final"),
+    ],
+)
+def test_classify_kr_session_slot_boundaries(
+    hour: int, minute: int, expected_slot: str
+) -> None:
+    # 2026-05-20 is a Wednesday, an arbitrary KR trading day.
+    now = _kst(2026, 5, 20, hour, minute)
+    assert classify_kr_session_slot(now) == expected_slot
+
+
+def test_classify_kr_session_slot_treats_naive_input_as_utc() -> None:
+    # 2026-05-20 22:40 UTC == 2026-05-21 07:40 KST → pre_market_repair.
+    naive_utc = dt.datetime(2026, 5, 20, 22, 40)
+    assert classify_kr_session_slot(naive_utc) == "pre_market_repair"
+
+
+# --- expected_kr_baseline_date ----------------------------------------------
+
+
+def test_expected_kr_baseline_pre_market_repair_window_returns_prior_day() -> None:
+    """CRITICAL: 07:40 – 16:19 KST window must yield prior trading day.
+
+    Before today's 16:20 KRX preliminary has fired, the only legitimately
+    populated snapshot is the prior day's 20:20 NXT-final (or its 07:40 repair
+    re-run). The expected baseline MUST be the prior trading day; otherwise a
+    fresh prior-day partition would be misclassified as stale.
+    """
+    # Wednesday 2026-05-20 07:40 KST → expected baseline = Tuesday 2026-05-19.
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 7, 40)) == dt.date(2026, 5, 19)
+    # Wednesday 2026-05-20 12:00 KST → still prior day.
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 12, 0)) == dt.date(2026, 5, 19)
+    # Wednesday 2026-05-20 16:19 KST → still prior day (one minute before boundary).
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 16, 19)) == dt.date(2026, 5, 19)
+
+
+def test_expected_kr_baseline_after_krx_preliminary_returns_today() -> None:
+    # Wednesday 16:20 KST or later → today.
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 16, 20)) == dt.date(2026, 5, 20)
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 18, 30)) == dt.date(2026, 5, 20)
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 20, 20)) == dt.date(2026, 5, 20)
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 23, 59)) == dt.date(2026, 5, 20)
+
+
+def test_expected_kr_baseline_overnight_before_repair_returns_prior_day() -> None:
+    # Wednesday 03:00 KST → prior trading day = Tuesday.
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 3, 0)) == dt.date(2026, 5, 19)
+    # Wednesday 07:39 KST → still prior day (one minute before repair boundary).
+    assert expected_kr_baseline_date(_kst(2026, 5, 20, 7, 39)) == dt.date(2026, 5, 19)
+
+
+def test_expected_kr_baseline_monday_morning_rolls_back_to_friday() -> None:
+    """Mon 07:40 ~ 16:19 KST → expected baseline = Friday, not Saturday."""
+    # 2026-05-18 is Monday; the prior trading weekday is Friday 2026-05-15.
+    assert expected_kr_baseline_date(_kst(2026, 5, 18, 7, 40)) == dt.date(2026, 5, 15)
+    assert expected_kr_baseline_date(_kst(2026, 5, 18, 12, 0)) == dt.date(2026, 5, 15)
+    # Mon 00:30 KST → still prior trading day (Friday).
+    assert expected_kr_baseline_date(_kst(2026, 5, 18, 0, 30)) == dt.date(2026, 5, 15)
+
+
+def test_expected_kr_baseline_weekend_today_rolls_back_then_prior() -> None:
+    # Saturday → "today" rolls back to Friday → before 16:20 → prior = Thursday.
+    # 2026-05-23 is Saturday; "today" rolls to Fri 2026-05-22; prior weekday = Thu 2026-05-21.
+    assert expected_kr_baseline_date(_kst(2026, 5, 23, 9, 0)) == dt.date(2026, 5, 21)
+    # Sunday 23:00 KST → "today" rolls to Fri 2026-05-22; before 16:20 → Thu 2026-05-21.
+    # (Sun 23:00 KST is after Sat 16:20, but the weekend rollback in today_kst
+    # makes the time comparison happen against the rolled-back Friday's clock.
+    # We still compare hm against 16:20; 23:00 >= 16:20 → today (Fri).)
+    assert expected_kr_baseline_date(_kst(2026, 5, 24, 23, 0)) == dt.date(2026, 5, 22)
+
+
+def test_expected_kr_baseline_naive_input_treated_as_utc() -> None:
+    # 2026-05-20 22:40 UTC == 2026-05-21 07:40 KST → expected = prior weekday of Thu = Wed.
+    naive_utc = dt.datetime(2026, 5, 20, 22, 40)
+    # 2026-05-21 is Thursday; prior weekday = Wednesday 2026-05-20.
+    assert expected_kr_baseline_date(naive_utc) == dt.date(2026, 5, 20)
+
+
+# --- kr_session_label_for_partition -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hour, minute, expected_label",
+    [
+        (16, 20, "KRX preliminary"),
+        (17, 0, "KRX preliminary"),
+        (20, 19, "KRX preliminary"),
+        (20, 20, "NXT final"),
+        (22, 30, "NXT final"),
+        (23, 59, "NXT final"),
+        (0, 30, "NXT final"),  # overnight tail
+        (6, 59, "NXT final"),  # overnight tail upper edge
+        (7, 40, "NXT final"),  # 07:40 repair window targets prior NXT-final
+        (10, 0, "NXT final"),  # repair window middle
+        (16, 19, "NXT final"),  # repair window upper edge
+    ],
+)
+def test_kr_session_label_for_partition_known_windows(
+    hour: int, minute: int, expected_label: str
+) -> None:
+    computed_at = _kst(2026, 5, 20, hour, minute)
+    assert kr_session_label_for_partition(computed_at) == expected_label
+
+
+@pytest.mark.parametrize("hour, minute", [(7, 0), (7, 20), (7, 39)])
+def test_kr_session_label_for_partition_gap_returns_none(
+    hour: int, minute: int
+) -> None:
+    """The 07:00 – 07:39 KST gap has no scheduled slot — return None."""
+    computed_at = _kst(2026, 5, 20, hour, minute)
+    assert kr_session_label_for_partition(computed_at) is None
+
+
+def test_kr_session_label_for_partition_none_input_returns_none() -> None:
+    assert kr_session_label_for_partition(None) is None
+
+
+def test_kr_session_label_for_partition_naive_input_treated_as_utc() -> None:
+    # 2026-05-20 07:20 UTC == 2026-05-20 16:20 KST → "KRX preliminary".
+    naive_utc = dt.datetime(2026, 5, 20, 7, 20)
+    assert kr_session_label_for_partition(naive_utc) == "KRX preliminary"

--- a/tests/services/invest_screener_snapshots/test_freshness_us_session.py
+++ b/tests/services/invest_screener_snapshots/test_freshness_us_session.py
@@ -1,0 +1,154 @@
+"""ROB-281 Stage 2 — US session-aware freshness primitives.
+
+Covers ``expected_us_baseline_date``, ``last_completed_us_session_close``, and
+``us_session_label_for_partition``. Validates that the XNYS calendar via
+``exchange_calendars`` correctly distinguishes regular trading days, NYSE
+holidays, half-days (e.g., Black Friday 13:00 ET close), and DST boundary
+behavior. The 17:20 ET cutoff is the chosen US post-close slot per ROB-281 D2.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+from app.services.invest_screener_snapshots.freshness import (
+    expected_us_baseline_date,
+    last_completed_us_session_close,
+    us_session_label_for_partition,
+)
+
+_ET = ZoneInfo("America/New_York")
+_UTC = dt.UTC
+
+
+def _et(year: int, month: int, day: int, hour: int, minute: int) -> dt.datetime:
+    return dt.datetime(year, month, day, hour, minute, tzinfo=_ET)
+
+
+# --- expected_us_baseline_date ----------------------------------------------
+
+
+def test_expected_us_baseline_regular_day_post_close_returns_today() -> None:
+    # 2025-06-09 is a regular Monday; 17:20 ET is post-close.
+    assert expected_us_baseline_date(_et(2025, 6, 9, 17, 20)) == dt.date(2025, 6, 9)
+    # 18:00 ET same day — still today.
+    assert expected_us_baseline_date(_et(2025, 6, 9, 18, 0)) == dt.date(2025, 6, 9)
+
+
+def test_expected_us_baseline_regular_day_before_post_close_returns_prior() -> None:
+    # 17:19 ET on a session day — one minute before the post-close threshold.
+    # Prior session for Mon 2025-06-09 is Fri 2025-06-06.
+    assert expected_us_baseline_date(_et(2025, 6, 9, 17, 19)) == dt.date(2025, 6, 6)
+    # Morning of the same session — still prior.
+    assert expected_us_baseline_date(_et(2025, 6, 9, 9, 30)) == dt.date(2025, 6, 6)
+
+
+def test_expected_us_baseline_weekend_returns_prior_friday() -> None:
+    # Sat 2025-06-14 → prior session = Fri 2025-06-13.
+    assert expected_us_baseline_date(_et(2025, 6, 14, 12, 0)) == dt.date(2025, 6, 13)
+    # Sun 2025-06-15 → still Fri 2025-06-13.
+    assert expected_us_baseline_date(_et(2025, 6, 15, 23, 0)) == dt.date(2025, 6, 13)
+
+
+def test_expected_us_baseline_holiday_skips_to_prior_session() -> None:
+    """2025-07-04 is Independence Day (Friday) — NYSE closed.
+
+    Prior trading session is Thu 2025-07-03 (regular session).
+    """
+    assert expected_us_baseline_date(_et(2025, 7, 4, 18, 0)) == dt.date(2025, 7, 3)
+    # Morning of the same holiday → still Thu.
+    assert expected_us_baseline_date(_et(2025, 7, 4, 9, 0)) == dt.date(2025, 7, 3)
+
+
+def test_expected_us_baseline_thanksgiving_weekend() -> None:
+    """Thanksgiving 2025: Thu Nov 27 (closed), Fri Nov 28 (half-day).
+
+    Half-day Friday is still a SESSION — 17:20 ET on Nov 28 → today (Nov 28),
+    not Wed Nov 26. This validates that half-day handling does not require
+    special-casing.
+    """
+    # Thu 2025-11-27 (holiday) at 18:00 ET → prior = Wed 2025-11-26.
+    assert expected_us_baseline_date(_et(2025, 11, 27, 18, 0)) == dt.date(2025, 11, 26)
+    # Fri 2025-11-28 (half-day) at 17:20 ET → today (Fri Nov 28).
+    assert expected_us_baseline_date(_et(2025, 11, 28, 17, 20)) == dt.date(2025, 11, 28)
+    # Fri 2025-11-28 (half-day) at 14:00 ET → before 17:20 cutoff → prior = Wed Nov 26.
+    assert expected_us_baseline_date(_et(2025, 11, 28, 14, 0)) == dt.date(2025, 11, 26)
+
+
+def test_expected_us_baseline_dst_spring_forward_boundary() -> None:
+    """DST starts second Sunday of March (2026-03-08).
+
+    Sun itself is a non-session day. The first post-DST trading day is
+    Mon 2026-03-09; 17:20 ET on that Monday → today (Mon).
+    """
+    # Sun 2026-03-08 (DST transition day) at noon ET → prior Fri 2026-03-06.
+    assert expected_us_baseline_date(_et(2026, 3, 8, 12, 0)) == dt.date(2026, 3, 6)
+    # Mon 2026-03-09 at 17:20 ET (post-DST) → today.
+    assert expected_us_baseline_date(_et(2026, 3, 9, 17, 20)) == dt.date(2026, 3, 9)
+
+
+def test_expected_us_baseline_naive_input_treated_as_utc() -> None:
+    # 2025-06-09 21:20 UTC == 2025-06-09 17:20 EDT (DST active in June).
+    naive_utc = dt.datetime(2025, 6, 9, 21, 20)
+    assert expected_us_baseline_date(naive_utc) == dt.date(2025, 6, 9)
+    # 2025-06-09 21:19 UTC == 2025-06-09 17:19 EDT — one minute before cutoff.
+    naive_utc_before = dt.datetime(2025, 6, 9, 21, 19)
+    assert expected_us_baseline_date(naive_utc_before) == dt.date(2025, 6, 6)
+
+
+# --- last_completed_us_session_close ----------------------------------------
+
+
+def test_last_completed_us_session_close_after_regular_close() -> None:
+    """Regular NYSE close is 16:00 ET. At 17:20 ET Monday, last close = today 16:00 ET."""
+    # 17:20 EDT == 21:20 UTC; expected close = 20:00 UTC (16:00 EDT).
+    close = last_completed_us_session_close(_et(2025, 6, 9, 17, 20))
+    assert close is not None
+    assert close.astimezone(_ET).date() == dt.date(2025, 6, 9)
+    assert close.astimezone(_ET).hour == 16  # regular close
+
+
+def test_last_completed_us_session_close_before_today_close_returns_prior() -> None:
+    """At 12:00 ET Monday, today's close hasn't happened yet → prior Friday's close."""
+    close = last_completed_us_session_close(_et(2025, 6, 9, 12, 0))
+    assert close is not None
+    assert close.astimezone(_ET).date() == dt.date(2025, 6, 6)
+
+
+def test_last_completed_us_session_close_half_day_returns_early_close() -> None:
+    """Black Friday 2025-11-28 closes at 13:00 ET (half-day).
+
+    At 14:00 ET (after early close), last close = 13:00 ET today.
+    """
+    close = last_completed_us_session_close(_et(2025, 11, 28, 14, 0))
+    assert close is not None
+    close_et = close.astimezone(_ET)
+    assert close_et.date() == dt.date(2025, 11, 28)
+    assert close_et.hour == 13  # half-day early close
+
+
+# --- us_session_label_for_partition -----------------------------------------
+
+
+def test_us_session_label_for_partition_returns_post_close_for_any_datetime() -> None:
+    assert (
+        us_session_label_for_partition(_et(2025, 6, 9, 17, 20)) == "US post-close"
+    )
+    assert (
+        us_session_label_for_partition(_et(2025, 11, 28, 13, 5)) == "US post-close"
+    )
+    # Even at unusual hours, the label is constant — the partition's existence
+    # is what matters, not which time-of-day it was computed.
+    assert (
+        us_session_label_for_partition(_et(2025, 6, 9, 9, 30)) == "US post-close"
+    )
+
+
+def test_us_session_label_for_partition_none_input_returns_none() -> None:
+    assert us_session_label_for_partition(None) is None
+
+
+def test_us_session_label_for_partition_accepts_naive_utc() -> None:
+    naive_utc = dt.datetime(2025, 6, 9, 21, 20)
+    assert us_session_label_for_partition(naive_utc) == "US post-close"

--- a/tests/services/invest_screener_snapshots/test_freshness_us_session.py
+++ b/tests/services/invest_screener_snapshots/test_freshness_us_session.py
@@ -132,17 +132,11 @@ def test_last_completed_us_session_close_half_day_returns_early_close() -> None:
 
 
 def test_us_session_label_for_partition_returns_post_close_for_any_datetime() -> None:
-    assert (
-        us_session_label_for_partition(_et(2025, 6, 9, 17, 20)) == "US post-close"
-    )
-    assert (
-        us_session_label_for_partition(_et(2025, 11, 28, 13, 5)) == "US post-close"
-    )
+    assert us_session_label_for_partition(_et(2025, 6, 9, 17, 20)) == "US post-close"
+    assert us_session_label_for_partition(_et(2025, 11, 28, 13, 5)) == "US post-close"
     # Even at unusual hours, the label is constant — the partition's existence
     # is what matters, not which time-of-day it was computed.
-    assert (
-        us_session_label_for_partition(_et(2025, 6, 9, 9, 30)) == "US post-close"
-    )
+    assert us_session_label_for_partition(_et(2025, 6, 9, 9, 30)) == "US post-close"
 
 
 def test_us_session_label_for_partition_none_input_returns_none() -> None:

--- a/tests/services/invest_screener_snapshots/test_guards.py
+++ b/tests/services/invest_screener_snapshots/test_guards.py
@@ -25,7 +25,6 @@ from app.services.invest_screener_snapshots.guards import (
     assert_min_row_count,
 )
 
-
 # --- assert_dominant_partition ----------------------------------------------
 
 
@@ -153,9 +152,7 @@ async def test_guarded_wrapper_passes_runs_commit_pass_when_request_commit_true(
         committed=True,
     )
     mock = AsyncMock(side_effect=[dry_run, commit_run])
-    with patch(
-        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
-    ):
+    with patch("app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock):
         result = await run_snapshot_build_guarded(
             SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)
         )
@@ -178,9 +175,7 @@ async def test_guarded_wrapper_passes_skips_commit_pass_when_request_commit_fals
         committed=False,
     )
     mock = AsyncMock(return_value=dry_run)
-    with patch(
-        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
-    ):
+    with patch("app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock):
         result = await run_snapshot_build_guarded(
             SnapshotBuildRequest(market="kr", all_symbols=True, commit=False)
         )
@@ -201,9 +196,7 @@ async def test_guarded_wrapper_raises_on_suspicious_distribution_without_commit_
         committed=False,
     )
     mock = AsyncMock(return_value=dry_run)
-    with patch(
-        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
-    ):
+    with patch("app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock):
         with pytest.raises(SuspiciousDistributionError):
             await run_snapshot_build_guarded(
                 SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)
@@ -223,9 +216,7 @@ async def test_guarded_wrapper_raises_on_insufficient_rows_without_commit_pass()
         committed=False,
     )
     mock = AsyncMock(return_value=dry_run)
-    with patch(
-        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
-    ):
+    with patch("app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock):
         with pytest.raises(InsufficientRowsError):
             await run_snapshot_build_guarded(
                 SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)

--- a/tests/services/invest_screener_snapshots/test_guards.py
+++ b/tests/services/invest_screener_snapshots/test_guards.py
@@ -1,0 +1,233 @@
+"""ROB-281 Stage 5 — commit-time guard unit tests.
+
+Validates ``assert_dominant_partition`` (≥70% rule) and ``assert_min_row_count``
+(KR 2500 / US 3500 locked floors). Also exercises the 2-pass
+:func:`run_snapshot_build_guarded` wrapper to ensure it short-circuits commits
+on guard violations without re-fetching.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.jobs.invest_screener_snapshots import (
+    SnapshotBuildRequest,
+    SnapshotBuildResult,
+    run_snapshot_build_guarded,
+)
+from app.services.invest_screener_snapshots.guards import (
+    InsufficientRowsError,
+    SuspiciousDistributionError,
+    assert_dominant_partition,
+    assert_min_row_count,
+)
+
+
+# --- assert_dominant_partition ----------------------------------------------
+
+
+def test_assert_dominant_partition_clean_majority_passes() -> None:
+    dist = {"2026-05-20": 950, "2026-05-19": 50}  # 95%
+    assert assert_dominant_partition(dist) == "2026-05-20"
+
+
+def test_assert_dominant_partition_exactly_at_threshold_passes() -> None:
+    # 70% exactly — must be inclusive at the threshold.
+    dist = {"2026-05-20": 700, "2026-05-19": 300}
+    assert assert_dominant_partition(dist) == "2026-05-20"
+
+
+def test_assert_dominant_partition_below_threshold_raises() -> None:
+    # 69% — just below 70% threshold.
+    dist = {"2026-05-20": 690, "2026-05-19": 310}
+    with pytest.raises(SuspiciousDistributionError) as excinfo:
+        assert_dominant_partition(dist)
+    msg = str(excinfo.value)
+    assert "2026-05-20" in msg
+    assert "69" in msg  # ratio percentage surfaced
+    assert "2026-05-19" in msg  # full distribution surfaced for triage
+
+
+def test_assert_dominant_partition_empty_distribution_raises() -> None:
+    with pytest.raises(SuspiciousDistributionError, match="empty"):
+        assert_dominant_partition({})
+
+
+def test_assert_dominant_partition_zero_total_raises() -> None:
+    with pytest.raises(SuspiciousDistributionError, match="non-positive"):
+        assert_dominant_partition({"2026-05-20": 0, "2026-05-19": 0})
+
+
+def test_assert_dominant_partition_custom_threshold() -> None:
+    dist = {"2026-05-20": 600, "2026-05-19": 400}  # 60%
+    # Default 70% → fails; custom 50% → passes.
+    with pytest.raises(SuspiciousDistributionError):
+        assert_dominant_partition(dist)
+    assert assert_dominant_partition(dist, threshold=0.50) == "2026-05-20"
+
+
+def test_assert_dominant_partition_single_partition_passes() -> None:
+    dist = {"2026-05-20": 3867}  # all in one date
+    assert assert_dominant_partition(dist) == "2026-05-20"
+
+
+# --- assert_min_row_count ----------------------------------------------------
+
+
+def test_assert_min_row_count_kr_at_floor_passes() -> None:
+    assert_min_row_count(2500, "kr")  # exactly at floor
+
+
+def test_assert_min_row_count_kr_above_floor_passes() -> None:
+    assert_min_row_count(3867, "kr")  # observed 2026-05-19 KR count
+
+
+def test_assert_min_row_count_kr_below_floor_raises() -> None:
+    with pytest.raises(InsufficientRowsError, match=r"kr snapshots_built=2499"):
+        assert_min_row_count(2499, "kr")
+
+
+def test_assert_min_row_count_us_at_floor_passes() -> None:
+    assert_min_row_count(3500, "us")
+
+
+def test_assert_min_row_count_us_above_floor_passes() -> None:
+    assert_min_row_count(5116, "us")  # observed 2026-05-19 US count
+
+
+def test_assert_min_row_count_us_below_floor_raises() -> None:
+    with pytest.raises(InsufficientRowsError, match=r"us snapshots_built=3499"):
+        assert_min_row_count(3499, "us")
+
+
+def test_assert_min_row_count_unknown_market_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unknown market"):
+        assert_min_row_count(1000, "crypto")  # type: ignore[arg-type]
+
+
+# --- run_snapshot_build_guarded ---------------------------------------------
+
+
+def _build_result(
+    market: str,
+    *,
+    snapshots_built: int,
+    distribution: dict[str, int],
+    committed: bool,
+) -> SnapshotBuildResult:
+    started = dt.datetime(2026, 5, 20, 7, 40, tzinfo=dt.UTC)
+    finished = dt.datetime(2026, 5, 20, 7, 41, tzinfo=dt.UTC)
+    return SnapshotBuildResult(
+        market=market,
+        symbols_resolved=snapshots_built,
+        snapshots_built=snapshots_built,
+        skipped=0,
+        committed=committed,
+        batches=1,
+        started_at=started,
+        finished_at=finished,
+        snapshot_date_distribution=distribution,
+        samples=(),
+        warnings=(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_guarded_wrapper_passes_runs_commit_pass_when_request_commit_true() -> (
+    None
+):
+    """Both passes execute when request.commit=True and guards pass."""
+    dry_run = _build_result(
+        "kr",
+        snapshots_built=3000,
+        distribution={"2026-05-20": 3000},
+        committed=False,
+    )
+    commit_run = _build_result(
+        "kr",
+        snapshots_built=3000,
+        distribution={"2026-05-20": 3000},
+        committed=True,
+    )
+    mock = AsyncMock(side_effect=[dry_run, commit_run])
+    with patch(
+        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
+    ):
+        result = await run_snapshot_build_guarded(
+            SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)
+        )
+    assert mock.await_count == 2  # dry-run + commit
+    # First call had commit=False (dry-run), second had commit=True.
+    assert mock.call_args_list[0].args[0].commit is False
+    assert mock.call_args_list[1].args[0].commit is True
+    assert result.committed is True
+
+
+@pytest.mark.asyncio
+async def test_guarded_wrapper_passes_skips_commit_pass_when_request_commit_false() -> (
+    None
+):
+    """Only the dry-run pass executes when request.commit=False."""
+    dry_run = _build_result(
+        "kr",
+        snapshots_built=3000,
+        distribution={"2026-05-20": 3000},
+        committed=False,
+    )
+    mock = AsyncMock(return_value=dry_run)
+    with patch(
+        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
+    ):
+        result = await run_snapshot_build_guarded(
+            SnapshotBuildRequest(market="kr", all_symbols=True, commit=False)
+        )
+    assert mock.await_count == 1  # dry-run only
+    assert result.committed is False
+
+
+@pytest.mark.asyncio
+async def test_guarded_wrapper_raises_on_suspicious_distribution_without_commit_pass() -> (
+    None
+):
+    """Suspicious distribution short-circuits before commit (no second fetch)."""
+    dry_run = _build_result(
+        "kr",
+        snapshots_built=3000,
+        # 60% / 40% split — below 70% threshold.
+        distribution={"2026-05-20": 1800, "2026-05-19": 1200},
+        committed=False,
+    )
+    mock = AsyncMock(return_value=dry_run)
+    with patch(
+        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
+    ):
+        with pytest.raises(SuspiciousDistributionError):
+            await run_snapshot_build_guarded(
+                SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)
+            )
+    assert mock.await_count == 1  # dry-run only — commit pass skipped
+
+
+@pytest.mark.asyncio
+async def test_guarded_wrapper_raises_on_insufficient_rows_without_commit_pass() -> (
+    None
+):
+    """Too-few rows short-circuit before commit."""
+    dry_run = _build_result(
+        "kr",
+        snapshots_built=50,  # well below KR floor 2500
+        distribution={"2026-05-20": 50},
+        committed=False,
+    )
+    mock = AsyncMock(return_value=dry_run)
+    with patch(
+        "app.jobs.invest_screener_snapshots.run_snapshot_build", new=mock
+    ):
+        with pytest.raises(InsufficientRowsError):
+            await run_snapshot_build_guarded(
+                SnapshotBuildRequest(market="kr", all_symbols=True, commit=True)
+            )
+    assert mock.await_count == 1

--- a/tests/test_invest_screener_snapshot_tasks_scheduled.py
+++ b/tests/test_invest_screener_snapshot_tasks_scheduled.py
@@ -152,7 +152,7 @@ async def test_run_scheduled_build_kr_session_day_constructs_request_without_com
     mock_run = AsyncMock(return_value=fake_result)
     with (
         patch.object(task_module, "is_market_session_today", return_value=True),
-        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
         patch.object(
             task_module.settings,
             "invest_screener_snapshots_commit_enabled",
@@ -181,7 +181,7 @@ async def test_run_scheduled_build_us_session_day_uses_common_stocks_filter() ->
     mock_run = AsyncMock(return_value=fake_result)
     with (
         patch.object(task_module, "is_market_session_today", return_value=True),
-        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
         patch.object(
             task_module.settings,
             "invest_screener_snapshots_commit_enabled",
@@ -202,7 +202,7 @@ async def test_run_scheduled_build_commit_gate_passes_through() -> None:
     mock_run = AsyncMock(return_value=fake_result)
     with (
         patch.object(task_module, "is_market_session_today", return_value=True),
-        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
         patch.object(
             task_module.settings,
             "invest_screener_snapshots_commit_enabled",

--- a/tests/test_invest_screener_snapshot_tasks_scheduled.py
+++ b/tests/test_invest_screener_snapshot_tasks_scheduled.py
@@ -1,0 +1,218 @@
+"""ROB-281 Stage 3/4 — TaskIQ scheduled wrapper unit tests.
+
+Covers:
+
+* Schedule-registration helpers respect ``invest_screener_schedule_enabled``.
+* KR cron labels carry ``cron_offset=Asia/Seoul``; US cron carries
+  ``cron_offset=America/New_York`` (ROB-281 D2 DST safety).
+* ``is_market_session_today`` correctly skips XKRX weekends, XNYS holidays,
+  and Black Friday half-days are recognized as US sessions.
+* ``_run_scheduled_build`` skips on non-session days and constructs
+  ``SnapshotBuildRequest`` with the right market / commit gate /
+  ``common_stocks_only`` selection.
+
+The actual ``run_snapshot_build`` is mocked — these tests do not hit the
+database or external screener data sources.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.jobs.invest_screener_snapshots import (
+    SnapshotBuildRequest,
+    SnapshotBuildResult,
+)
+from app.tasks import invest_screener_snapshot_tasks as task_module
+
+
+def _fake_build_result(market: str, *, committed: bool = False) -> SnapshotBuildResult:
+    started = dt.datetime(2026, 5, 20, 7, 40, tzinfo=dt.UTC)
+    finished = dt.datetime(2026, 5, 20, 7, 41, tzinfo=dt.UTC)
+    return SnapshotBuildResult(
+        market=market,
+        symbols_resolved=10,
+        snapshots_built=10,
+        skipped=0,
+        committed=committed,
+        batches=1,
+        started_at=started,
+        finished_at=finished,
+        snapshot_date_distribution={"2026-05-20": 10},
+        samples=(),
+        warnings=(),
+    )
+
+
+# --- Schedule-registration helpers ------------------------------------------
+
+
+def test_kr_schedule_labels_empty_when_schedule_disabled() -> None:
+    with patch.object(
+        task_module.settings, "invest_screener_schedule_enabled", False
+    ):
+        assert task_module._scheduled_kr_pre_market_repair_labels() == []
+        assert task_module._scheduled_kr_krx_preliminary_labels() == []
+        assert task_module._scheduled_kr_nxt_final_labels() == []
+
+
+def test_us_schedule_labels_empty_when_schedule_disabled() -> None:
+    with patch.object(
+        task_module.settings, "invest_screener_schedule_enabled", False
+    ):
+        assert task_module._scheduled_us_post_close_labels() == []
+
+
+def test_kr_schedule_labels_carry_kst_offset_when_enabled() -> None:
+    with patch.object(
+        task_module.settings, "invest_screener_schedule_enabled", True
+    ):
+        assert task_module._scheduled_kr_pre_market_repair_labels() == [
+            {"cron": "40 7 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]
+        assert task_module._scheduled_kr_krx_preliminary_labels() == [
+            {"cron": "20 16 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]
+        assert task_module._scheduled_kr_nxt_final_labels() == [
+            {"cron": "20 20 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]
+
+
+def test_us_schedule_label_carries_et_offset_when_enabled() -> None:
+    """ROB-281 D2: US cron runs in America/New_York to avoid DST drift."""
+    with patch.object(
+        task_module.settings, "invest_screener_schedule_enabled", True
+    ):
+        assert task_module._scheduled_us_post_close_labels() == [
+            {"cron": "20 17 * * 1-5", "cron_offset": "America/New_York"}
+        ]
+
+
+# --- is_market_session_today (XKRX / XNYS) ----------------------------------
+
+
+def test_is_market_session_today_kr_regular_weekday() -> None:
+    # 2026-05-20 Wed at 14:00 UTC = 23:00 KST — regular KR trading day.
+    now = dt.datetime(2026, 5, 20, 14, 0, tzinfo=dt.UTC)
+    assert task_module.is_market_session_today("kr", now=now) is True
+
+
+def test_is_market_session_today_kr_weekend() -> None:
+    # 2026-05-23 Sat → not a KR session day.
+    now = dt.datetime(2026, 5, 23, 5, 0, tzinfo=dt.UTC)
+    assert task_module.is_market_session_today("kr", now=now) is False
+
+
+def test_is_market_session_today_us_independence_day_is_holiday() -> None:
+    """2025-07-04 Fri — NYSE closed for Independence Day."""
+    # 18:00 UTC == 14:00 EDT on July 4.
+    now = dt.datetime(2025, 7, 4, 18, 0, tzinfo=dt.UTC)
+    assert task_module.is_market_session_today("us", now=now) is False
+
+
+def test_is_market_session_today_us_black_friday_is_session() -> None:
+    """Half-day Black Friday 2025-11-28 is still a US session."""
+    # 18:00 UTC == 13:00 EST on 2025-11-28.
+    now = dt.datetime(2025, 11, 28, 18, 0, tzinfo=dt.UTC)
+    assert task_module.is_market_session_today("us", now=now) is True
+
+
+def test_is_market_session_today_christmas_closed_for_both_markets() -> None:
+    # 2025-12-25 Thu — closed for both KRX and NYSE.
+    now = dt.datetime(2025, 12, 25, 12, 0, tzinfo=dt.UTC)
+    assert task_module.is_market_session_today("kr", now=now) is False
+    assert task_module.is_market_session_today("us", now=now) is False
+
+
+# --- _run_scheduled_build ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_skips_on_non_session_day() -> None:
+    with patch.object(task_module, "is_market_session_today", return_value=False):
+        result = await task_module._run_scheduled_build(
+            market="kr", slot="krx_preliminary"
+        )
+    assert result == {
+        "market": "kr",
+        "slot": "krx_preliminary",
+        "skipped": "non_session_day",
+        "committed": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_kr_session_day_constructs_request_without_common_stocks() -> (
+    None
+):
+    fake_result = _fake_build_result("kr", committed=False)
+    mock_run = AsyncMock(return_value=fake_result)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(
+            task_module.settings,
+            "invest_screener_snapshots_commit_enabled",
+            False,
+        ),
+    ):
+        result = await task_module._run_scheduled_build(
+            market="kr", slot="nxt_final"
+        )
+
+    assert mock_run.await_count == 1
+    request: SnapshotBuildRequest = mock_run.call_args.args[0]
+    assert request.market == "kr"
+    assert request.all_symbols is True
+    assert request.common_stocks_only is False  # KR does NOT use the US filter
+    assert request.commit is False  # commit gate respected
+    assert result["market"] == "kr"
+    assert result["slot"] == "nxt_final"
+    assert result["snapshotsBuilt"] == 10
+    assert result["snapshotDateDistribution"] == {"2026-05-20": 10}
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_us_session_day_uses_common_stocks_filter() -> None:
+    fake_result = _fake_build_result("us", committed=False)
+    mock_run = AsyncMock(return_value=fake_result)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(
+            task_module.settings,
+            "invest_screener_snapshots_commit_enabled",
+            False,
+        ),
+    ):
+        await task_module._run_scheduled_build(market="us", slot="post_close")
+
+    request: SnapshotBuildRequest = mock_run.call_args.args[0]
+    assert request.market == "us"
+    assert request.common_stocks_only is True  # US uses common-stocks filter
+    assert request.all_symbols is True
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_commit_gate_passes_through() -> None:
+    fake_result = _fake_build_result("kr", committed=True)
+    mock_run = AsyncMock(return_value=fake_result)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build", new=mock_run),
+        patch.object(
+            task_module.settings,
+            "invest_screener_snapshots_commit_enabled",
+            True,
+        ),
+    ):
+        result = await task_module._run_scheduled_build(
+            market="kr", slot="nxt_final"
+        )
+
+    request: SnapshotBuildRequest = mock_run.call_args.args[0]
+    assert request.commit is True  # commit gate True → request.commit True
+    assert result["committed"] is True

--- a/tests/test_invest_screener_snapshot_tasks_scheduled.py
+++ b/tests/test_invest_screener_snapshot_tasks_scheduled.py
@@ -216,3 +216,122 @@ async def test_run_scheduled_build_commit_gate_passes_through() -> None:
     request: SnapshotBuildRequest = mock_run.call_args.args[0]
     assert request.commit is True  # commit gate True → request.commit True
     assert result["committed"] is True
+
+
+# --- Alert wiring (Stage 6) -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_does_not_alert_on_success() -> None:
+    """CRITICAL contract: success path must NEVER fire an ops alert."""
+    fake_result = _fake_build_result("kr", committed=True)
+    mock_run = AsyncMock(return_value=fake_result)
+    mock_alert = AsyncMock()
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
+        patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
+    ):
+        await task_module._run_scheduled_build(market="kr", slot="nxt_final")
+
+    mock_alert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_fires_alert_on_suspicious_distribution() -> (
+    None
+):
+    from app.services.invest_screener_snapshots.guards import (
+        SuspiciousDistributionError,
+    )
+
+    exc = SuspiciousDistributionError(
+        "no dominant partition: top=2026-05-20",
+        distribution={"2026-05-20": 1800, "2026-05-19": 1200},
+    )
+    mock_run = AsyncMock(side_effect=exc)
+    mock_alert = AsyncMock(return_value=True)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
+        patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
+    ):
+        with pytest.raises(SuspiciousDistributionError):
+            await task_module._run_scheduled_build(
+                market="kr", slot="krx_preliminary"
+            )
+
+    mock_alert.assert_awaited_once()
+    alert_kwargs = mock_alert.await_args.kwargs
+    assert alert_kwargs["slot"] == "krx_preliminary"
+    assert alert_kwargs["market"] == "kr"
+    assert alert_kwargs["exception"] is exc
+    assert alert_kwargs["distribution"] == {
+        "2026-05-20": 1800,
+        "2026-05-19": 1200,
+    }
+    assert alert_kwargs["commit_status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_fires_alert_on_insufficient_rows() -> None:
+    from app.services.invest_screener_snapshots.guards import (
+        InsufficientRowsError,
+    )
+
+    exc = InsufficientRowsError(
+        "kr snapshots_built=50 below floor=2500",
+        count=50,
+        market="kr",
+        distribution={"2026-05-20": 50},
+    )
+    mock_run = AsyncMock(side_effect=exc)
+    mock_alert = AsyncMock(return_value=True)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
+        patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
+    ):
+        with pytest.raises(InsufficientRowsError):
+            await task_module._run_scheduled_build(market="kr", slot="nxt_final")
+
+    alert_kwargs = mock_alert.await_args.kwargs
+    assert alert_kwargs["distribution"] == {"2026-05-20": 50}
+    assert alert_kwargs["commit_status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_fires_alert_on_generic_failure() -> None:
+    """Generic exceptions (network, DB, etc.) also alert, with commit=failed."""
+    exc = RuntimeError("upstream timeout")
+    mock_run = AsyncMock(side_effect=exc)
+    mock_alert = AsyncMock(return_value=True)
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=True),
+        patch.object(task_module, "run_snapshot_build_guarded", new=mock_run),
+        patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
+    ):
+        with pytest.raises(RuntimeError, match="upstream timeout"):
+            await task_module._run_scheduled_build(market="us", slot="post_close")
+
+    alert_kwargs = mock_alert.await_args.kwargs
+    assert alert_kwargs["slot"] == "post_close"
+    assert alert_kwargs["market"] == "us"
+    assert alert_kwargs["exception"] is exc
+    assert alert_kwargs["commit_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_build_holiday_skip_does_not_alert() -> None:
+    """Holiday skips are expected — must NOT fire an alert."""
+    mock_alert = AsyncMock()
+    with (
+        patch.object(task_module, "is_market_session_today", return_value=False),
+        patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
+    ):
+        result = await task_module._run_scheduled_build(
+            market="kr", slot="nxt_final"
+        )
+
+    assert result["skipped"] == "non_session_day"
+    mock_alert.assert_not_awaited()

--- a/tests/test_invest_screener_snapshot_tasks_scheduled.py
+++ b/tests/test_invest_screener_snapshot_tasks_scheduled.py
@@ -51,25 +51,19 @@ def _fake_build_result(market: str, *, committed: bool = False) -> SnapshotBuild
 
 
 def test_kr_schedule_labels_empty_when_schedule_disabled() -> None:
-    with patch.object(
-        task_module.settings, "invest_screener_schedule_enabled", False
-    ):
+    with patch.object(task_module.settings, "invest_screener_schedule_enabled", False):
         assert task_module._scheduled_kr_pre_market_repair_labels() == []
         assert task_module._scheduled_kr_krx_preliminary_labels() == []
         assert task_module._scheduled_kr_nxt_final_labels() == []
 
 
 def test_us_schedule_labels_empty_when_schedule_disabled() -> None:
-    with patch.object(
-        task_module.settings, "invest_screener_schedule_enabled", False
-    ):
+    with patch.object(task_module.settings, "invest_screener_schedule_enabled", False):
         assert task_module._scheduled_us_post_close_labels() == []
 
 
 def test_kr_schedule_labels_carry_kst_offset_when_enabled() -> None:
-    with patch.object(
-        task_module.settings, "invest_screener_schedule_enabled", True
-    ):
+    with patch.object(task_module.settings, "invest_screener_schedule_enabled", True):
         assert task_module._scheduled_kr_pre_market_repair_labels() == [
             {"cron": "40 7 * * 1-5", "cron_offset": "Asia/Seoul"}
         ]
@@ -83,9 +77,7 @@ def test_kr_schedule_labels_carry_kst_offset_when_enabled() -> None:
 
 def test_us_schedule_label_carries_et_offset_when_enabled() -> None:
     """ROB-281 D2: US cron runs in America/New_York to avoid DST drift."""
-    with patch.object(
-        task_module.settings, "invest_screener_schedule_enabled", True
-    ):
+    with patch.object(task_module.settings, "invest_screener_schedule_enabled", True):
         assert task_module._scheduled_us_post_close_labels() == [
             {"cron": "20 17 * * 1-5", "cron_offset": "America/New_York"}
         ]
@@ -159,9 +151,7 @@ async def test_run_scheduled_build_kr_session_day_constructs_request_without_com
             False,
         ),
     ):
-        result = await task_module._run_scheduled_build(
-            market="kr", slot="nxt_final"
-        )
+        result = await task_module._run_scheduled_build(market="kr", slot="nxt_final")
 
     assert mock_run.await_count == 1
     request: SnapshotBuildRequest = mock_run.call_args.args[0]
@@ -209,9 +199,7 @@ async def test_run_scheduled_build_commit_gate_passes_through() -> None:
             True,
         ),
     ):
-        result = await task_module._run_scheduled_build(
-            market="kr", slot="nxt_final"
-        )
+        result = await task_module._run_scheduled_build(market="kr", slot="nxt_final")
 
     request: SnapshotBuildRequest = mock_run.call_args.args[0]
     assert request.commit is True  # commit gate True → request.commit True
@@ -238,9 +226,7 @@ async def test_run_scheduled_build_does_not_alert_on_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_scheduled_build_fires_alert_on_suspicious_distribution() -> (
-    None
-):
+async def test_run_scheduled_build_fires_alert_on_suspicious_distribution() -> None:
     from app.services.invest_screener_snapshots.guards import (
         SuspiciousDistributionError,
     )
@@ -257,9 +243,7 @@ async def test_run_scheduled_build_fires_alert_on_suspicious_distribution() -> (
         patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
     ):
         with pytest.raises(SuspiciousDistributionError):
-            await task_module._run_scheduled_build(
-                market="kr", slot="krx_preliminary"
-            )
+            await task_module._run_scheduled_build(market="kr", slot="krx_preliminary")
 
     mock_alert.assert_awaited_once()
     alert_kwargs = mock_alert.await_args.kwargs
@@ -329,9 +313,7 @@ async def test_run_scheduled_build_holiday_skip_does_not_alert() -> None:
         patch.object(task_module, "is_market_session_today", return_value=False),
         patch.object(task_module, "send_screener_refresh_alert", new=mock_alert),
     ):
-        result = await task_module._run_scheduled_build(
-            market="kr", slot="nxt_final"
-        )
+        result = await task_module._run_scheduled_build(market="kr", slot="nxt_final")
 
     assert result["skipped"] == "non_session_day"
     mock_alert.assert_not_awaited()


### PR DESCRIPTION
## Summary

Implements ROB-281: scheduled TaskIQ refresh + market-aware freshness labeling + commit-time guardrails for KR/US `invest_screener_snapshots`. Parent policy issue is ROB-280; sibling ROB-282 (crypto) ships separately. Predecessor ROB-277 (served-time vs data-as-of split) is preserved.

8 stage-level commits, ~1700 LOC, **187 targeted tests passing** (100 new + 87 existing regression-checked). No production schedule activated — `INVEST_SCREENER_SCHEDULE_ENABLED` defaults `False`, dry-run only after merge.

## Locked decisions (ROB-280 review → ROB-281 plan §D1–D3)

**D1. KR pre-market repair time = `07:40 KST`.** NXT pre-market opens at 08:00 KST; 07:40 gives a 20-minute buffer (vs 10-minute for 07:50). The slot does NOT prep same-day data — it repairs the prior trading day's 20:20 KST NXT-final if that run failed or lagged overnight. If upstream lag is observed in production, `07:50` is a one-line cron change in a follow-up; slot purpose and label do not change.

**D2. US/KR trading calendar = `exchange-calendars` (XNYS + XKRX).** Already a direct dependency at `>=4.7,<5.0` and used across 8+ files (`watch_market_data`, `us_candles_sync_service`, `kr_candles_sync_service`, `kis_ohlcv_cache`, `yahoo_ohlcv_cache`, `market_data_indicators`, etc.). `pandas-market-calendars` was rejected — would only add a parallel library with overlapping responsibility. US cron runs in `America/New_York` (cron_offset) to avoid DST drift; half-day Black Fridays (13:00 ET close) require no special case since 17:20 ET is post-close on any session date.

**D3. Operational alerts = `discord_webhook_alerts`.** Hermes is the product-level review-trigger contract (`HERMES_WEBHOOK_URL=.../hooks/review-trigger`); routing ops alerts through Hermes would muddy that contract. `discord_webhook_alerts` already exists alongside the KR/US/crypto webhooks in `app/core/config.py:239–242` and is lifecycle-managed in `app/main.py:260`. Reuses the existing `send_discord_embed_single` transport from `app/monitoring/trade_notifier/transports.py`. Never fires on success.

## Hard boundaries (preserved throughout)

- No broker / order / watch / order-intent mutations.
- No Toss / Naver browser scraping as a production source.
- No buy / sell recommendation logic changes.
- No `investor_flow_snapshots` recurring / backfill / scheduler / partition repair — **ROB-205 scope**. Read-only dependency reference only.
- No crypto recurring refresh — **ROB-282 scope**.
- ROB-277 served-time vs data-as-of split preserved. `방금 갱신` remains the served label only; data 기준 surfaces via `primary.asOfLabel` + new session label tokens.

## Implementation by stage

1. **KR session-aware freshness primitives** (`freshness.py`) — `classify_kr_session_slot`, `expected_kr_baseline_date`, `kr_session_label_for_partition`. Critical: 07:40–16:19 KST → expected baseline = prior trading day (fixes the user-flagged regression where `today_trading_date` would mark a fresh prior-day partition as stale after KST midnight).
2. **US session-aware freshness primitives** — `expected_us_baseline_date`, `last_completed_us_session_close`, `us_session_label_for_partition` using `exchange_calendars` XNYS. Holiday/half-day/DST coverage.
3. **KR scheduled TaskIQ wrappers** — `scheduled_kr_pre_market_repair` (07:40 KST), `scheduled_kr_krx_preliminary` (16:20 KST), `scheduled_kr_nxt_final` (20:20 KST), all with `cron_offset=Asia/Seoul`.
4. **US scheduled TaskIQ wrapper** — `scheduled_us_post_close` at `20 17 * * 1-5` with `cron_offset=America/New_York` (D2 DST safety).
5. **Commit-time guards** — `assert_dominant_partition` (≥70% rule), `assert_min_row_count` (KR 2500 / US 3500), 2-pass `run_snapshot_build_guarded` wrapper that short-circuits commit on violation.
6. **Discord ops alert path** — `send_screener_refresh_alert` routes failure / guard-violation embeds to `discord_webhook_alerts`. Contract: never on success, never raises, no-op when webhook unset.
7. **UI label tokens in view-model** — `expected_baseline_date` / `session_label_for_partition` dispatch helpers. `screener_service.py` switches the screener primary classifier to session-aware baseline and appends `(KRX preliminary)` / `(NXT final)` / `(US post-close)` to `primary.asOfLabel`. Investor-flow classifier path untouched (ROB-205 scope).
8. Lint/format fixups.

## Env gates (double-gated rollout)

| Setting | Default | Effect when True |
|---|---|---|
| `invest_screener_schedule_enabled` | **`False`** | Registers KR (3) + US (1) cron entries |
| `invest_screener_snapshots_commit_enabled` (existing, ROB-204) | **`False`** | Scheduled tasks commit to DB (otherwise dry-run output only) |

Production rollout sequence (post-merge, **out of scope for this PR per ROB-281 plan §Stage 9**): set `schedule_enabled=True` for 2 KR + 1 US trading day of dry-run-on-cron observation, then `commit_enabled=True` after dry-run evidence is reviewed and approved. Rollback = flip `schedule_enabled=False`.

## Test plan

- [x] **187 targeted tests passing** across 100 new + 87 regression-checked existing suites:
  - `tests/services/invest_screener_snapshots/test_freshness_kr_session.py` — 35 tests (slot boundaries, prior-day expectation regression, weekend rollback, overnight gaps, naive-UTC input).
  - `tests/services/invest_screener_snapshots/test_freshness_us_session.py` — 13 tests (regular days, July 4 holiday, Thanksgiving half-day, DST spring-forward).
  - `tests/services/invest_screener_snapshots/test_guards.py` — 15 tests (both guards + 2-pass wrapper short-circuit).
  - `tests/services/invest_screener_snapshots/test_alerts.py` — 6 tests (never-on-success contract, no-op, transport-error resilience, embed shape, message truncation).
  - `tests/services/invest_screener_snapshots/test_freshness_dispatch.py` — 13 tests (dispatch + `_build_freshness` integration).
  - `tests/test_invest_screener_snapshot_tasks_scheduled.py` — 18 tests (schedule flag gating, KST/ET cron offsets, XKRX/XNYS holiday detection, alert wiring on each failure mode, success-silent contract).
  - 87 existing tests across `test_screener_service.py`, `test_screener_service_investor_flow_chip.py`, `test_invest_screener_snapshots_freshness.py`, `test_invest_screener_snapshots_repository.py`, `test_invest_screener_snapshots_job.py`, `test_invest_screener_week_change_filter.py` — no regressions.
- [x] `ruff format` + `ruff check` clean across all touched files.
- [ ] Post-merge smoke (NOT in this PR — runbook only):
  - `curl -sS "$BASE/trading/api/invest/screener/results?market=kr&preset=consecutive_gainers" | jq '.freshness'`
  - `curl -sS "$BASE/trading/api/invest/screener/results?market=us&preset=consecutive_gainers" | jq '.freshness'`
  - Verify `primary.asOfLabel` contains the session token and `servedRelativeLabel` shows fresh served-time (ROB-277 preserved).
- [ ] Stage 9 production rollout (NOT in this PR): separate approval after dry-run-on-cron evidence is reviewed.

## Files

**Added:** `app/services/invest_screener_snapshots/guards.py`, `app/services/invest_screener_snapshots/alerts.py`, 6 test files, 1 plan doc.

**Modified:** `app/services/invest_screener_snapshots/freshness.py` (KR/US session helpers + dispatch), `app/jobs/invest_screener_snapshots.py` (guarded wrapper), `app/tasks/invest_screener_snapshot_tasks.py` (4 scheduled wrappers + alert wiring), `app/services/invest_view_model/screener_service.py` (session-aware baseline + asOfLabel token), `app/core/config.py` (`invest_screener_schedule_enabled` flag).

**Untouched (intentional):**
- `app/tasks/investor_flow_snapshot_tasks.py`, `app/jobs/investor_flow_snapshots.py` — ROB-205 scope.
- `app/services/invest_crypto_screener_snapshots/*` — ROB-282 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated scheduled refreshes for screener snapshots across Korea (3 market sessions) and US (post-close) with market-session awareness.
  * Introduced validation guards to prevent commits of suspicious or insufficient snapshot data.
  * Added Discord alerts for snapshot refresh issues and anomalies.
  * Enhanced snapshot freshness labels with session identifiers for clearer data provenance.
  * New configuration flag to enable/disable scheduled snapshot refreshes.

* **Documentation**
  * Added implementation plan for scheduled screener refresh feature.

* **Tests**
  * Comprehensive test coverage for validation guards, session scheduling, alerts, and freshness labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->