### PR TITLE
test(rob-279): harden main CI isolation

### DIFF
--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -71,6 +71,18 @@ async def session() -> AsyncSession:
                         tables=INVESTMENT_REPORTS_TABLES,
                         checkfirst=True,
                     )
+                    # Start clean as well as cleaning up after the test. Global
+                    # db_session-based cross-domain tests can commit rows into
+                    # these tables, and interrupted local/CI runs can leave
+                    # stale rows behind before this fixture's first test starts.
+                    for table in reversed(INVESTMENT_REPORTS_TABLES):
+                        table_name = table.name  # type: ignore[attr-defined]
+                        await conn.execute(
+                            sa.text(
+                                f'TRUNCATE TABLE review."{table_name}" '
+                                "RESTART IDENTITY CASCADE"
+                            )
+                        )
                     # ROB-269 Phase 3 — additive snapshot metadata + CHECK.
                     # create_all with checkfirst=True skips existing tables,
                     # so persistent test DBs miss the new columns. These are

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -650,6 +650,64 @@ async def db_session():
 
 
 @pytest_asyncio.fixture
+async def investment_reports_cleanup_lock(db_session):
+    """Hold the investment-report cleanup lock for tests using ``db_session``.
+
+    Most investment-report table tests use ``tests._investment_reports_helpers.session``.
+    That fixture serializes its own body and cleanup because it truncates
+    ``review.investment_reports`` and child tables after each test.
+
+    A few cross-domain tests must use the global ``db_session`` fixture because
+    they span ``review.investment_reports`` plus snapshot/stage tables. During
+    xdist runs those tests can otherwise seed a report, commit it, and then race
+    with the helper fixture cleanup running on another worker. The symptom is a
+    flaky ``report_not_found``/``None`` read immediately after seeding.
+
+    This fixture keeps those specific tests parallel-safe without serializing
+    every global ``db_session`` user. Apply it with ``pytestmark =
+    pytest.mark.usefixtures("investment_reports_cleanup_lock")`` in files that
+    mix global ``db_session`` with investment-report rows.
+    """
+    from sqlalchemy import text
+
+    from app.core.db import engine
+    from tests._investment_reports_helpers import (
+        INVESTMENT_REPORTS_TABLES,
+        INVESTMENT_REPORTS_TEST_LOCK_ID,
+    )
+
+    async def _truncate_investment_report_tables() -> None:
+        # Keep this cleanup aligned with tests._investment_reports_helpers.session:
+        # only the investment-report table family is reset here. Snapshot/stage
+        # tables use UUID-scoped test rows and are intentionally left alone.
+        async with engine.begin() as cleanup:
+            for table in reversed(INVESTMENT_REPORTS_TABLES):
+                table_name = table.name  # type: ignore[attr-defined]
+                await cleanup.execute(
+                    text(
+                        f'TRUNCATE TABLE review."{table_name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+
+    async with engine.connect() as guard:
+        await guard.execute(
+            text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+            {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+        )
+        try:
+            await db_session.rollback()
+            await _truncate_investment_report_tables()
+            yield db_session
+            await db_session.rollback()
+            await _truncate_investment_report_tables()
+        finally:
+            await guard.execute(
+                text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+            )
+
+
+@pytest_asyncio.fixture
 async def user(db_session):
     """Create a test user."""
     from uuid import uuid4

--- a/tests/routers/test_investment_reports_snapshot_evidence_router.py
+++ b/tests/routers/test_investment_reports_snapshot_evidence_router.py
@@ -35,6 +35,8 @@ from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
 
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 _USER = SimpleNamespace(username="operator-test", id=1)
 _NOW = dt.datetime(2026, 5, 20, 11, 0, 0, tzinfo=dt.UTC)
 

--- a/tests/routers/test_investment_stage_runs.py
+++ b/tests/routers/test_investment_stage_runs.py
@@ -40,6 +40,8 @@ from app.services.investment_reports.repository import InvestmentReportsReposito
 from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
 from app.services.investment_stages.repository import InvestmentStagesRepository
 
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 # ---------------------------------------------------------------------------
 # App factory (mirrors test_investment_snapshots_router.py)
 # ---------------------------------------------------------------------------

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -22,9 +22,10 @@ SERVICE_PATH = Path(__file__).parents[2] / "app/services/kis_mock_lifecycle_serv
 
 @pytest_asyncio.fixture
 async def seeded_ledger_id(db_session: AsyncSession) -> int:
+    symbol = f"TEST-{uuid4().hex}"
     row = KISMockOrderLedger(
         trade_date=datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
-        symbol="005930",
+        symbol=symbol,
         instrument_type="equity_kr",
         side="buy",
         order_type="limit",
@@ -137,10 +138,12 @@ async def test_record_holdings_baseline(
 async def test_list_open_orders_returns_only_inflight_and_fill(
     db_session: AsyncSession, seeded_ledger_id: int
 ):
+    row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
+    assert row is not None
     # add a terminal row that should be excluded
     terminal = KISMockOrderLedger(
         trade_date=datetime(2026, 5, 3, tzinfo=UTC),
-        symbol="000660",
+        symbol=row.symbol,
         instrument_type="equity_kr",
         side="buy",
         order_type="limit",
@@ -158,7 +161,7 @@ async def test_list_open_orders_returns_only_inflight_and_fill(
     await db_session.commit()
 
     svc = KISMockLifecycleService(db_session)
-    rows = await svc.list_open_orders(limit=50)
+    rows = await svc.list_open_orders(limit=50, symbol=row.symbol)
     ids = {r.id for r in rows}
     assert seeded_ledger_id in ids
     assert terminal.id not in ids

--- a/tests/test_investment_reports_snapshot_evidence_service.py
+++ b/tests/test_investment_reports_snapshot_evidence_service.py
@@ -30,6 +30,8 @@ from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
 
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 _NOW = dt.datetime(2026, 5, 20, 11, 0, 0, tzinfo=dt.UTC)
 
 


### PR DESCRIPTION
## Summary
- serialize investment report table cleanup across helper/global-db tests with an advisory lock
- truncate investment report tables before helper fixture setup to clear stale interrupted-run data
- isolate KIS mock lifecycle open-order test by unique symbol so shared persistent test DB rows cannot crowd out the seeded row under limit ordering

## Root cause
Main CI after #889 failed in `test_get_report_snapshot_bundle_returns_bundle_and_items` because xdist workers could race: helper-based investment report tests truncate `review.investment_reports` while cross-domain global `db_session` tests are seeding/reading committed reports. Local full-suite also exposed another persistent-DB isolation issue in `test_list_open_orders_returns_only_inflight_and_fill` where old open ledger rows could fill the `limit=50` window before the seeded row.

## Verification
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run ty check app/ --error-on-warning`
- `uv run pytest tests/ -m "not live" -n auto --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml --cov-fail-under=30`
  - `7747 passed, 16 skipped, 229 warnings in 329.66s`
