### PR TITLE
fix(rob-279): expose stage artifacts under invest api

### DIFF
--- a/app/routers/investment_stage_runs.py
+++ b/app/routers/investment_stage_runs.py
@@ -1,12 +1,13 @@
 """ROB-279 — Read-only API surface for staged snapshot-backed reports.
 
-Two endpoints:
+Two endpoint families (served under both legacy ``/trading/api`` and
+current ``/invest/api`` prefixes):
 
-* ``GET /trading/api/investment-stage-runs/{run_uuid}`` — run-scoped
+* ``GET /{prefix}/investment-stage-runs/{run_uuid}`` — run-scoped
   diagnostic; returns the stage run row + all artifacts. Useful for
   forensics when the stale gate blocks final report creation.
 
-* ``GET /trading/api/investment-reports/{report_uuid}/stage-artifacts`` —
+* ``GET /{prefix}/investment-reports/{report_uuid}/stage-artifacts`` —
   report-scoped; returns the union of all artifacts from stage runs
   linked to the report.  Resolution path:
 
@@ -117,6 +118,11 @@ def _build_reports_repository(
     response_model=StageRunWithArtifactsResponse,
     summary="Get stage run + artifacts by run UUID (ROB-279)",
 )
+@router.get(
+    "/invest/api/investment-stage-runs/{run_uuid}",
+    response_model=StageRunWithArtifactsResponse,
+    summary="Get stage run + artifacts by run UUID for /invest (ROB-279)",
+)
 async def get_stage_run(
     run_uuid: UUID,
     _user: Annotated[User, Depends(get_authenticated_user)],
@@ -140,6 +146,11 @@ async def get_stage_run(
     "/trading/api/investment-reports/{report_uuid}/stage-artifacts",
     response_model=ReportStageArtifactsResponse,
     summary="Get stage artifacts linked to an investment report (ROB-279)",
+)
+@router.get(
+    "/invest/api/investment-reports/{report_uuid}/stage-artifacts",
+    response_model=ReportStageArtifactsResponse,
+    summary="Get stage artifacts linked to an investment report for /invest (ROB-279)",
 )
 async def get_report_stage_artifacts(
     report_uuid: UUID,

--- a/tests/routers/test_investment_stage_runs.py
+++ b/tests/routers/test_investment_stage_runs.py
@@ -231,13 +231,14 @@ async def _seed_report_with_stale_metadata_run_uuid(db_session):
 # Test 1: 200 + artifact list for a valid run UUID
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_get_stage_run_returns_200_with_artifacts(db_session):
+@pytest.mark.parametrize("route_prefix", ["/trading/api", "/invest/api"])
+async def test_get_stage_run_returns_200_with_artifacts(db_session, route_prefix):
     run_uuid, artifact_uuid = await _seed_run_with_artifact(db_session)
     app = _build_app(db_session)
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
-        resp = await client.get(f"/trading/api/investment-stage-runs/{run_uuid}")
+        resp = await client.get(f"{route_prefix}/investment-stage-runs/{run_uuid}")
 
     assert resp.status_code == 200
     body = resp.json()
@@ -273,7 +274,10 @@ async def test_get_stage_run_returns_404_for_unknown_uuid(db_session):
 # Test 3: 200 + artifacts via report→run linkage through metadata field
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
-async def test_get_report_stage_artifacts_via_metadata_linkage(db_session):
+@pytest.mark.parametrize("route_prefix", ["/trading/api", "/invest/api"])
+async def test_get_report_stage_artifacts_via_metadata_linkage(
+    db_session, route_prefix
+):
     report_uuid, stage_run_uuid, artifact_uuid = await _seed_report_with_stage_run(
         db_session
     )
@@ -282,7 +286,7 @@ async def test_get_report_stage_artifacts_via_metadata_linkage(db_session):
         transport=ASGITransport(app=app), base_url="https://testserver"
     ) as client:
         resp = await client.get(
-            f"/trading/api/investment-reports/{report_uuid}/stage-artifacts"
+            f"{route_prefix}/investment-reports/{report_uuid}/stage-artifacts"
         )
 
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Expose ROB-279 stage run and report stage-artifact endpoints under the `/invest/api` prefix used by the Invest frontend.
- Keep existing `/trading/api` routes as aliases for compatibility.
- Parameterize router tests so both `/trading/api` and `/invest/api` happy paths are covered.

## Test Plan
- `uv run pytest tests/routers/test_investment_stage_runs.py -q`
- `uv run ruff check app/routers/investment_stage_runs.py tests/routers/test_investment_stage_runs.py`
- `uv run ruff format --check app/routers/investment_stage_runs.py tests/routers/test_investment_stage_runs.py`

## Safety
- Read-only router alias change only.
- No broker, order, watch, scheduler, or DB mutation path added.
