### PR TITLE
fix(rob-278): avoid snapshot future-skew during collection

### DIFF
--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -173,8 +173,15 @@ class SnapshotBundleEnsureService:
             kind_statuses: list[str] = []
             last_as_of: dt.datetime | None = None
             for result in results:
+                # Collectors run after ``now`` is captured for the reuse gate.
+                # Live collectors can legitimately stamp results a few seconds
+                # after the ensure started, so classify against the post-collect
+                # clock instead of treating long collection time as future data.
+                classification_now = self._clock()
                 computed_status: FreshnessStatus = classify_freshness(
-                    as_of=result.as_of, now=now, policy=kind_policy.freshness
+                    as_of=result.as_of,
+                    now=classification_now,
+                    policy=kind_policy.freshness,
                 )
                 # Caller-supplied status (e.g. 'partial' or 'unavailable') can
                 # downgrade but never upgrade past the policy-classified one.
@@ -195,7 +202,7 @@ class SnapshotBundleEnsureService:
                         coverage_json=result.coverage_json,
                         errors_json=result.errors_json,
                         as_of=result.as_of,
-                        valid_until=now + kind_policy.freshness.hard_ttl,
+                        valid_until=classification_now + kind_policy.freshness.hard_ttl,
                         freshness_status=effective_status,
                     )
                 )

--- a/tests/services/investment_snapshots/test_bundle_ensure_service.py
+++ b/tests/services/investment_snapshots/test_bundle_ensure_service.py
@@ -302,3 +302,66 @@ async def test_ensure_fresh_uses_collector_registry_when_no_manual(db_session):
 
     assert response.status == "complete"
     assert response.coverage_summary["required"]["portfolio"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_classifies_collector_results_against_post_collect_clock(
+    db_session,
+):
+    """Collector results can be stamped after ensure() starts.
+
+    A live collector may spend several seconds reading KIS before returning a
+    SnapshotCollectResult. Freshness classification must compare that result to
+    the post-collection clock, not to the start-of-ensure reuse-gate timestamp.
+    """
+
+    collected_as_of = _FIXED_NOW + dt.timedelta(seconds=6)
+
+    class _DelayedPortfolioCollector:
+        snapshot_kind = "portfolio"
+
+        async def collect(self, request: CollectorRequest):
+            return [
+                SnapshotCollectResult(
+                    snapshot_kind="portfolio",
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    source_kind="manual",
+                    payload_json={"cash_krw": 1_000_000, "u": str(uuid.uuid4())},
+                    as_of=collected_as_of,
+                    freshness_status="fresh",
+                )
+            ]
+
+    calls = 0
+
+    def clock():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _FIXED_NOW
+        return collected_as_of
+
+    registry = SnapshotCollectorRegistry()
+    registry.register(_DelayedPortfolioCollector())
+
+    manual = _all_required_manual_snapshots()
+    del manual["portfolio"]
+
+    svc = SnapshotBundleEnsureService(db_session, collectors=registry, clock=clock)
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("post_collect_clock"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=manual,  # type: ignore[arg-type]
+        )
+    )
+    await db_session.commit()
+
+    assert response.status == "complete"
+    assert response.coverage_summary["required"]["portfolio"] == "fresh"
+    assert (
+        response.freshness_summary["portfolio"]["as_of"] == collected_as_of.isoformat()
+    )


### PR DESCRIPTION
## Summary
- classify snapshot collector results against a post-collection clock instead of the ensure-start timestamp
- keep `valid_until` aligned with the classification clock
- add regression coverage for collector results stamped after ensure starts

## Verification
- `uv run ruff check app/services/action_report/common/snapshot_bundle.py tests/services/investment_snapshots/test_bundle_ensure_service.py`
- `uv run ruff format --check app/services/action_report/common/snapshot_bundle.py tests/services/investment_snapshots/test_bundle_ensure_service.py`
- `uv run pytest tests/services/investment_snapshots/test_bundle_ensure_service.py tests/services/action_report/snapshot_backed/test_auto_emit.py tests/services/action_report/snapshot_backed/test_generator.py -q`

## Safety
Read-only snapshot freshness fix. No broker/order/watch mutation paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot freshness evaluation to use the actual post-collection timestamp instead of the pre-collection request time, ensuring more accurate freshness classification.

* **Tests**
  * Added test coverage for post-collection freshness classification behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->