### PR TITLE
feat(rob-284): crypto_instruments master + venue-aware candle schema (Child A)

### DIFF
--- a/alembic/versions/181f946296ff_migrate_crypto_candles_1d_step2_backfill.py
+++ b/alembic/versions/181f946296ff_migrate_crypto_candles_1d_step2_backfill.py
@@ -1,0 +1,91 @@
+"""migrate crypto_candles_1d step2 backfill
+
+Revision ID: 181f946296ff
+Revises: 6acbc5e7fc93
+Create Date: 2026-05-20 21:53:38.063844
+
+ROB-284 step 2 — idempotent backfill:
+  - For every distinct (market, symbol) currently in crypto_candles_1d,
+    ensure a crypto_instruments row exists. Today this is Upbit KRW pairs
+    only (market='upbit_krw', symbol like 'KRW-XXX').
+  - Populate instrument_id by JOIN on (market, symbol) -> derived
+    (venue, product, venue_symbol).
+  - Copy volume -> base_volume, value -> quote_volume.
+  - Mark all existing rows is_closed = TRUE.
+
+This step is re-runnable: the instrument seed uses ON CONFLICT DO NOTHING
+and the backfill UPDATE filters by `WHERE c.instrument_id IS NULL`.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '181f946296ff'
+down_revision: Union[str, Sequence[str], None] = '6acbc5e7fc93'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Seed crypto_instruments for every distinct (market, symbol).
+    #
+    # Today the only producer is the Upbit KRW path: market='upbit_krw',
+    # symbol like 'KRW-XXX'. Translate that into (venue='upbit',
+    # product='spot', venue_symbol=symbol, base_asset=substring after 'KRW-',
+    # quote_asset='KRW'). Idempotent via ON CONFLICT DO NOTHING.
+    op.execute(
+        """
+        INSERT INTO crypto_instruments
+            (venue, product, venue_symbol, base_asset, quote_asset, status)
+        SELECT DISTINCT
+            CASE WHEN c.market = 'upbit_krw' THEN 'upbit' ELSE c.market END
+              AS venue,
+            'spot' AS product,
+            c.symbol AS venue_symbol,
+            CASE
+                WHEN c.symbol LIKE 'KRW-%' THEN substring(c.symbol from 5)
+                ELSE c.symbol
+            END AS base_asset,
+            CASE
+                WHEN c.symbol LIKE 'KRW-%' THEN 'KRW'
+                ELSE 'UNKNOWN'
+            END AS quote_asset,
+            'active' AS status
+        FROM crypto_candles_1d c
+        ON CONFLICT (venue, product, venue_symbol) DO NOTHING
+        """
+    )
+
+    # 2. Backfill instrument_id, base_volume, quote_volume, is_closed.
+    op.execute(
+        """
+        UPDATE crypto_candles_1d c
+        SET instrument_id = i.id,
+            base_volume   = COALESCE(c.base_volume, c.volume),
+            quote_volume  = COALESCE(c.quote_volume, c.value),
+            is_closed     = COALESCE(c.is_closed, TRUE)
+        FROM crypto_instruments i
+        WHERE i.venue_symbol = c.symbol
+          AND i.venue = CASE WHEN c.market = 'upbit_krw' THEN 'upbit' ELSE c.market END
+          AND i.product = 'spot'
+          AND c.instrument_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Reverse the backfill: clear the columns we populated. The instruments
+    # themselves are kept (cheap, useful for other paths).
+    op.execute(
+        """
+        UPDATE crypto_candles_1d
+        SET instrument_id = NULL,
+            base_volume   = NULL,
+            quote_volume  = NULL,
+            is_closed     = NULL
+        """
+    )

--- a/alembic/versions/2efa08c3fb09_add_crypto_instruments.py
+++ b/alembic/versions/2efa08c3fb09_add_crypto_instruments.py
@@ -1,0 +1,89 @@
+"""add crypto_instruments
+
+Revision ID: 2efa08c3fb09
+Revises: 20260520_rob279_p1
+Create Date: 2026-05-20 21:46:30.546891
+
+ROB-284 — master/source-of-truth table for venue/product/symbol identity.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2efa08c3fb09'
+down_revision: Union[str, Sequence[str], None] = '20260520_rob279_p1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "crypto_instruments",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("venue", sa.Text(), nullable=False),
+        sa.Column("product", sa.Text(), nullable=False),
+        sa.Column("venue_symbol", sa.Text(), nullable=False),
+        sa.Column("base_asset", sa.Text(), nullable=False),
+        sa.Column("quote_asset", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+        sa.Column("precision_price", sa.Integer(), nullable=True),
+        sa.Column("precision_amount", sa.Integer(), nullable=True),
+        sa.Column("tick_size", sa.Numeric(), nullable=True),
+        sa.Column("lot_size", sa.Numeric(), nullable=True),
+        sa.Column("min_notional", sa.Numeric(), nullable=True),
+        sa.Column("listed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("delisted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "venue", "product", "venue_symbol",
+            name="uq_crypto_instruments_venue_product_symbol",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active','delisted','halted')",
+            name="ck_crypto_instruments_status",
+        ),
+    )
+    op.create_index(
+        "ix_crypto_instruments_venue_product_base",
+        "crypto_instruments",
+        ["venue", "product", "base_asset"],
+    )
+    op.create_index(
+        "ix_crypto_instruments_base_quote",
+        "crypto_instruments",
+        ["base_asset", "quote_asset"],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_crypto_instruments_base_quote", table_name="crypto_instruments"
+    )
+    op.drop_index(
+        "ix_crypto_instruments_venue_product_base",
+        table_name="crypto_instruments",
+    )
+    op.drop_table("crypto_instruments")

--- a/alembic/versions/5fa5a347d85b_migrate_crypto_candles_1d_step3_finalize.py
+++ b/alembic/versions/5fa5a347d85b_migrate_crypto_candles_1d_step3_finalize.py
@@ -1,0 +1,179 @@
+"""migrate crypto_candles_1d step3 finalize
+
+Revision ID: 5fa5a347d85b
+Revises: 181f946296ff
+Create Date: 2026-05-20 21:53:38.574675
+
+ROB-284 step 3 — destructive finalize. Operator MUST have taken the
+crypto_candles_1d_pre_rob283 backup (see docs/runbooks/daily-candles-store.md)
+before running this revision.
+
+This step fails closed if any row still has NULL instrument_id /
+base_volume / is_closed — re-run step 2 (backfill) or restore from the
+backup table before retrying.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5fa5a347d85b'
+down_revision: Union[str, Sequence[str], None] = '181f946296ff'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Safety check: refuse to drop legacy columns if any row has
+    # instrument_id NULL or base_volume NULL or is_closed NULL — the step 2
+    # backfill is incomplete.
+    connection = op.get_bind()
+    incomplete = connection.execute(
+        sa.text(
+            "SELECT count(*) FROM crypto_candles_1d "
+            "WHERE instrument_id IS NULL OR base_volume IS NULL "
+            "OR is_closed IS NULL"
+        )
+    ).scalar_one()
+    if incomplete > 0:
+        raise RuntimeError(
+            f"ROB-284 step 3 refused: {incomplete} rows in crypto_candles_1d "
+            "have NULL instrument_id / base_volume / is_closed. "
+            "Re-run step 2 backfill (or restore from "
+            "crypto_candles_1d_pre_rob283 backup) before retrying."
+        )
+
+    # Enforce NOT NULL.
+    op.alter_column("crypto_candles_1d", "instrument_id", nullable=False)
+    op.alter_column("crypto_candles_1d", "base_volume", nullable=False)
+    op.alter_column("crypto_candles_1d", "is_closed", nullable=False)
+
+    # Add FK now that instrument_id is fully populated.
+    op.create_foreign_key(
+        "fk_crypto_candles_1d_instrument",
+        "crypto_candles_1d", "crypto_instruments",
+        ["instrument_id"], ["id"],
+    )
+
+    # Drop legacy indexes/uniques first, then legacy columns.
+    op.drop_constraint(
+        "uq_crypto_candles_1d_time_symbol_market",
+        "crypto_candles_1d",
+        type_="unique",
+    )
+    op.drop_index(
+        "ix_crypto_candles_1d_symbol_market_time_desc",
+        table_name="crypto_candles_1d",
+    )
+    op.drop_column("crypto_candles_1d", "market")
+    op.drop_column("crypto_candles_1d", "symbol")
+    op.drop_column("crypto_candles_1d", "volume")
+    op.drop_column("crypto_candles_1d", "value")
+
+    # New PK = (instrument_id, time). Timescale hypertable accepts a
+    # composite PK that includes the partitioning column.
+    op.execute(
+        "ALTER TABLE crypto_candles_1d "
+        "ADD CONSTRAINT pk_crypto_candles_1d PRIMARY KEY (instrument_id, time)"
+    )
+
+    # CHECK constraints (OHLC sanity + non-negative).
+    op.create_check_constraint(
+        "ck_crypto_candles_1d_base_volume_nn",
+        "crypto_candles_1d",
+        "base_volume >= 0",
+    )
+    op.create_check_constraint(
+        "ck_crypto_candles_1d_quote_volume_nn",
+        "crypto_candles_1d",
+        "quote_volume IS NULL OR quote_volume >= 0",
+    )
+    op.create_check_constraint(
+        "ck_crypto_candles_1d_high_ge_low",
+        "crypto_candles_1d",
+        "high >= low",
+    )
+    op.create_check_constraint(
+        "ck_crypto_candles_1d_high_ge_oc",
+        "crypto_candles_1d",
+        "high >= open AND high >= close",
+    )
+    op.create_check_constraint(
+        "ck_crypto_candles_1d_low_le_oc",
+        "crypto_candles_1d",
+        "low <= open AND low <= close",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Restore legacy shape from JOIN. Requires crypto_instruments still
+    # present.
+    op.drop_constraint(
+        "ck_crypto_candles_1d_low_le_oc", "crypto_candles_1d", type_="check"
+    )
+    op.drop_constraint(
+        "ck_crypto_candles_1d_high_ge_oc", "crypto_candles_1d", type_="check"
+    )
+    op.drop_constraint(
+        "ck_crypto_candles_1d_high_ge_low", "crypto_candles_1d", type_="check"
+    )
+    op.drop_constraint(
+        "ck_crypto_candles_1d_quote_volume_nn",
+        "crypto_candles_1d",
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_crypto_candles_1d_base_volume_nn",
+        "crypto_candles_1d",
+        type_="check",
+    )
+    op.execute(
+        "ALTER TABLE crypto_candles_1d DROP CONSTRAINT pk_crypto_candles_1d"
+    )
+    op.add_column(
+        "crypto_candles_1d", sa.Column("value", sa.Numeric(), nullable=True)
+    )
+    op.add_column(
+        "crypto_candles_1d", sa.Column("volume", sa.Numeric(), nullable=True)
+    )
+    op.add_column(
+        "crypto_candles_1d", sa.Column("symbol", sa.Text(), nullable=True)
+    )
+    op.add_column(
+        "crypto_candles_1d", sa.Column("market", sa.Text(), nullable=True)
+    )
+    op.execute(
+        """
+        UPDATE crypto_candles_1d c
+        SET symbol = i.venue_symbol,
+            market = CASE WHEN i.venue = 'upbit' THEN 'upbit_krw' ELSE i.venue END,
+            volume = c.base_volume,
+            value  = c.quote_volume
+        FROM crypto_instruments i
+        WHERE i.id = c.instrument_id
+        """
+    )
+    op.alter_column("crypto_candles_1d", "symbol", nullable=False)
+    op.alter_column("crypto_candles_1d", "market", nullable=False)
+    op.alter_column("crypto_candles_1d", "volume", nullable=False)
+    op.alter_column("crypto_candles_1d", "instrument_id", nullable=True)
+    op.alter_column("crypto_candles_1d", "is_closed", nullable=True)
+    op.drop_constraint(
+        "fk_crypto_candles_1d_instrument",
+        "crypto_candles_1d",
+        type_="foreignkey",
+    )
+    op.create_index(
+        "ix_crypto_candles_1d_symbol_market_time_desc",
+        "crypto_candles_1d",
+        ["symbol", "market", sa.text("time DESC")],
+    )
+    op.create_unique_constraint(
+        "uq_crypto_candles_1d_time_symbol_market",
+        "crypto_candles_1d",
+        ["time", "symbol", "market"],
+    )

--- a/alembic/versions/5fa5a347d85b_migrate_crypto_candles_1d_step3_finalize.py
+++ b/alembic/versions/5fa5a347d85b_migrate_crypto_candles_1d_step3_finalize.py
@@ -152,7 +152,12 @@ def downgrade() -> None:
         SET symbol = i.venue_symbol,
             market = CASE WHEN i.venue = 'upbit' THEN 'upbit_krw' ELSE i.venue END,
             volume = c.base_volume,
-            value  = c.quote_volume
+            -- Original f974ac12e573 schema had value NUMERIC NOT NULL. The
+            -- new schema allows quote_volume IS NULL (sources without quote
+            -- volume), so we COALESCE to 0 here so the NOT NULL restore
+            -- below cannot fail on rows inserted after the upgrade. Operator
+            -- runbook documents the 0-default for new-schema-era rows.
+            value  = COALESCE(c.quote_volume, 0)
         FROM crypto_instruments i
         WHERE i.id = c.instrument_id
         """
@@ -160,6 +165,8 @@ def downgrade() -> None:
     op.alter_column("crypto_candles_1d", "symbol", nullable=False)
     op.alter_column("crypto_candles_1d", "market", nullable=False)
     op.alter_column("crypto_candles_1d", "volume", nullable=False)
+    # ROB-284 — restore value NOT NULL to match the f974ac12e573 schema.
+    op.alter_column("crypto_candles_1d", "value", nullable=False)
     op.alter_column("crypto_candles_1d", "instrument_id", nullable=True)
     op.alter_column("crypto_candles_1d", "is_closed", nullable=True)
     op.drop_constraint(

--- a/alembic/versions/6acbc5e7fc93_migrate_crypto_candles_1d_step1_add_.py
+++ b/alembic/versions/6acbc5e7fc93_migrate_crypto_candles_1d_step1_add_.py
@@ -1,0 +1,69 @@
+"""migrate crypto_candles_1d step1 add columns
+
+Revision ID: 6acbc5e7fc93
+Revises: e5df7fbd9803
+Create Date: 2026-05-20 21:53:37.526479
+
+ROB-284 step 1 — add new nullable columns (instrument_id, base_volume,
+quote_volume, is_closed, source_event_at) to the legacy crypto_candles_1d
+table. Reversible. The destructive cut from legacy (symbol, market) shape
+is performed in step 3 only after step 2's backfill is verified.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6acbc5e7fc93'
+down_revision: Union[str, Sequence[str], None] = 'e5df7fbd9803'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "crypto_candles_1d",
+        sa.Column("instrument_id", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "crypto_candles_1d",
+        sa.Column("base_volume", sa.Numeric(), nullable=True),
+    )
+    op.add_column(
+        "crypto_candles_1d",
+        sa.Column("quote_volume", sa.Numeric(), nullable=True),
+    )
+    op.add_column(
+        "crypto_candles_1d",
+        sa.Column(
+            "is_closed",
+            sa.Boolean(),
+            nullable=True,
+            server_default=sa.text("TRUE"),
+        ),
+    )
+    op.add_column(
+        "crypto_candles_1d",
+        sa.Column("source_event_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_crypto_candles_1d_instrument_time",
+        "crypto_candles_1d",
+        ["instrument_id", sa.text("time DESC")],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_crypto_candles_1d_instrument_time",
+        table_name="crypto_candles_1d",
+    )
+    op.drop_column("crypto_candles_1d", "source_event_at")
+    op.drop_column("crypto_candles_1d", "is_closed")
+    op.drop_column("crypto_candles_1d", "quote_volume")
+    op.drop_column("crypto_candles_1d", "base_volume")
+    op.drop_column("crypto_candles_1d", "instrument_id")

--- a/alembic/versions/e5df7fbd9803_add_crypto_candles_1m.py
+++ b/alembic/versions/e5df7fbd9803_add_crypto_candles_1m.py
@@ -1,0 +1,104 @@
+"""add crypto_candles_1m
+
+Revision ID: e5df7fbd9803
+Revises: 2efa08c3fb09
+Create Date: 2026-05-20 21:50:30.432158
+
+ROB-284 — TimescaleDB hypertable for 1-minute crypto candles. Identity is
+(instrument_id, time); instrument_id FK references crypto_instruments(id).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5df7fbd9803'
+down_revision: Union[str, Sequence[str], None] = '2efa08c3fb09'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "crypto_candles_1m",
+        sa.Column("instrument_id", sa.BigInteger(), nullable=False),
+        sa.Column("time", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("open", sa.Numeric(), nullable=False),
+        sa.Column("high", sa.Numeric(), nullable=False),
+        sa.Column("low", sa.Numeric(), nullable=False),
+        sa.Column("close", sa.Numeric(), nullable=False),
+        sa.Column("base_volume", sa.Numeric(), nullable=False),
+        sa.Column("quote_volume", sa.Numeric(), nullable=True),
+        sa.Column("trade_count", sa.Integer(), nullable=True),
+        sa.Column("vwap", sa.Numeric(), nullable=True),
+        sa.Column("taker_buy_base_volume", sa.Numeric(), nullable=True),
+        sa.Column("taker_buy_quote_volume", sa.Numeric(), nullable=True),
+        sa.Column(
+            "is_closed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("TRUE"),
+        ),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("source_event_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "ingested_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["instrument_id"],
+            ["crypto_instruments.id"],
+            name="fk_crypto_candles_1m_instrument",
+        ),
+        sa.PrimaryKeyConstraint(
+            "instrument_id", "time", name="pk_crypto_candles_1m"
+        ),
+        sa.CheckConstraint(
+            "base_volume >= 0", name="ck_crypto_candles_1m_base_volume_nn"
+        ),
+        sa.CheckConstraint(
+            "quote_volume IS NULL OR quote_volume >= 0",
+            name="ck_crypto_candles_1m_quote_volume_nn",
+        ),
+        sa.CheckConstraint(
+            "trade_count IS NULL OR trade_count >= 0",
+            name="ck_crypto_candles_1m_trade_count_nn",
+        ),
+        sa.CheckConstraint(
+            "vwap IS NULL OR vwap >= 0",
+            name="ck_crypto_candles_1m_vwap_nn",
+        ),
+        sa.CheckConstraint(
+            "high >= low", name="ck_crypto_candles_1m_high_ge_low"
+        ),
+        sa.CheckConstraint(
+            "high >= open AND high >= close",
+            name="ck_crypto_candles_1m_high_ge_oc",
+        ),
+        sa.CheckConstraint(
+            "low <= open AND low <= close",
+            name="ck_crypto_candles_1m_low_le_oc",
+        ),
+    )
+    op.execute(
+        "SELECT create_hypertable('public.crypto_candles_1m', 'time', "
+        "chunk_time_interval => INTERVAL '1 day')"
+    )
+    op.create_index(
+        "ix_crypto_candles_1m_source_time",
+        "crypto_candles_1m",
+        ["source", sa.text("time DESC")],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_crypto_candles_1m_source_time", table_name="crypto_candles_1m"
+    )
+    op.drop_table("crypto_candles_1m")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 # app/models/__init__.py
 from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
+from .crypto_candles import CryptoCandle1d, CryptoCandle1m
 from .crypto_insight_snapshot import CryptoInsightSnapshot
 from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
@@ -102,6 +103,8 @@ __all__ = [
     "Base",
     "ExecutionLedger",
     "ExecutionLedgerReconcileRun",
+    "CryptoCandle1d",
+    "CryptoCandle1m",
     "CryptoInsightSnapshot",
     "CryptoInstrument",
     "Exchange",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@
 from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
 from .crypto_insight_snapshot import CryptoInsightSnapshot
+from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
 from .invest_momentum_event_snapshot import (
@@ -102,6 +103,7 @@ __all__ = [
     "ExecutionLedger",
     "ExecutionLedgerReconcileRun",
     "CryptoInsightSnapshot",
+    "CryptoInstrument",
     "Exchange",
     "Instrument",
     "User",

--- a/app/models/crypto_candles.py
+++ b/app/models/crypto_candles.py
@@ -28,32 +28,29 @@ from app.models.base import Base
 
 class CryptoCandle1m(Base):
     __tablename__ = "crypto_candles_1m"
+    # NOTE on naming: ``Base.metadata.naming_convention['ck']`` is
+    # ``"ck_%(table_name)s_%(constraint_name)s"``, so the stem name passed
+    # here is prefixed with ``ck_crypto_candles_1m_`` by SQLAlchemy at
+    # ``create_all`` time. The alembic migration calls
+    # ``create_check_constraint`` with the same final, fully-qualified
+    # name, so both code paths produce identical constraint names on disk.
     __table_args__ = (
         PrimaryKeyConstraint("instrument_id", "time", name="pk_crypto_candles_1m"),
-        CheckConstraint(
-            "base_volume >= 0", name="ck_crypto_candles_1m_base_volume_nn"
-        ),
+        CheckConstraint("base_volume >= 0", name="base_volume_nn"),
         CheckConstraint(
             "quote_volume IS NULL OR quote_volume >= 0",
-            name="ck_crypto_candles_1m_quote_volume_nn",
+            name="quote_volume_nn",
         ),
         CheckConstraint(
             "trade_count IS NULL OR trade_count >= 0",
-            name="ck_crypto_candles_1m_trade_count_nn",
+            name="trade_count_nn",
         ),
+        CheckConstraint("vwap IS NULL OR vwap >= 0", name="vwap_nn"),
+        CheckConstraint("high >= low", name="high_ge_low"),
         CheckConstraint(
-            "vwap IS NULL OR vwap >= 0",
-            name="ck_crypto_candles_1m_vwap_nn",
+            "high >= open AND high >= close", name="high_ge_oc"
         ),
-        CheckConstraint("high >= low", name="ck_crypto_candles_1m_high_ge_low"),
-        CheckConstraint(
-            "high >= open AND high >= close",
-            name="ck_crypto_candles_1m_high_ge_oc",
-        ),
-        CheckConstraint(
-            "low <= open AND low <= close",
-            name="ck_crypto_candles_1m_low_le_oc",
-        ),
+        CheckConstraint("low <= open AND low <= close", name="low_le_oc"),
     )
 
     instrument_id: Mapped[int] = mapped_column(
@@ -100,24 +97,20 @@ class CryptoCandle1d(Base):
     """
 
     __tablename__ = "crypto_candles_1d"
+    # See CryptoCandle1m for naming-convention notes; final on-disk names
+    # are produced by ``ck_%(table_name)s_%(constraint_name)s``.
     __table_args__ = (
         PrimaryKeyConstraint("instrument_id", "time", name="pk_crypto_candles_1d"),
-        CheckConstraint(
-            "base_volume >= 0", name="ck_crypto_candles_1d_base_volume_nn"
-        ),
+        CheckConstraint("base_volume >= 0", name="base_volume_nn"),
         CheckConstraint(
             "quote_volume IS NULL OR quote_volume >= 0",
-            name="ck_crypto_candles_1d_quote_volume_nn",
+            name="quote_volume_nn",
         ),
-        CheckConstraint("high >= low", name="ck_crypto_candles_1d_high_ge_low"),
+        CheckConstraint("high >= low", name="high_ge_low"),
         CheckConstraint(
-            "high >= open AND high >= close",
-            name="ck_crypto_candles_1d_high_ge_oc",
+            "high >= open AND high >= close", name="high_ge_oc"
         ),
-        CheckConstraint(
-            "low <= open AND low <= close",
-            name="ck_crypto_candles_1d_low_le_oc",
-        ),
+        CheckConstraint("low <= open AND low <= close", name="low_le_oc"),
     )
 
     instrument_id: Mapped[int] = mapped_column(

--- a/app/models/crypto_candles.py
+++ b/app/models/crypto_candles.py
@@ -47,18 +47,14 @@ class CryptoCandle1m(Base):
         ),
         CheckConstraint("vwap IS NULL OR vwap >= 0", name="vwap_nn"),
         CheckConstraint("high >= low", name="high_ge_low"),
-        CheckConstraint(
-            "high >= open AND high >= close", name="high_ge_oc"
-        ),
+        CheckConstraint("high >= open AND high >= close", name="high_ge_oc"),
         CheckConstraint("low <= open AND low <= close", name="low_le_oc"),
     )
 
     instrument_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("crypto_instruments.id"), nullable=False
     )
-    time: Mapped[dt.datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
-    )
+    time: Mapped[dt.datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
     open: Mapped[float] = mapped_column(Numeric, nullable=False)
     high: Mapped[float] = mapped_column(Numeric, nullable=False)
     low: Mapped[float] = mapped_column(Numeric, nullable=False)
@@ -67,12 +63,8 @@ class CryptoCandle1m(Base):
     quote_volume: Mapped[float | None] = mapped_column(Numeric, nullable=True)
     trade_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     vwap: Mapped[float | None] = mapped_column(Numeric, nullable=True)
-    taker_buy_base_volume: Mapped[float | None] = mapped_column(
-        Numeric, nullable=True
-    )
-    taker_buy_quote_volume: Mapped[float | None] = mapped_column(
-        Numeric, nullable=True
-    )
+    taker_buy_base_volume: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    taker_buy_quote_volume: Mapped[float | None] = mapped_column(Numeric, nullable=True)
     is_closed: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("TRUE")
     )
@@ -107,18 +99,14 @@ class CryptoCandle1d(Base):
             name="quote_volume_nn",
         ),
         CheckConstraint("high >= low", name="high_ge_low"),
-        CheckConstraint(
-            "high >= open AND high >= close", name="high_ge_oc"
-        ),
+        CheckConstraint("high >= open AND high >= close", name="high_ge_oc"),
         CheckConstraint("low <= open AND low <= close", name="low_le_oc"),
     )
 
     instrument_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("crypto_instruments.id"), nullable=False
     )
-    time: Mapped[dt.datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
-    )
+    time: Mapped[dt.datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
     open: Mapped[float] = mapped_column(Numeric, nullable=False)
     high: Mapped[float] = mapped_column(Numeric, nullable=False)
     low: Mapped[float] = mapped_column(Numeric, nullable=False)

--- a/app/models/crypto_candles.py
+++ b/app/models/crypto_candles.py
@@ -1,0 +1,144 @@
+"""ROB-284 — crypto candle ORM models (1m + 1d).
+
+Both tables reference `crypto_instruments(id)` as the source of truth for
+venue/product/symbol identity. Identity for a row is `(instrument_id, time)`.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    ForeignKey,
+    Integer,
+    Numeric,
+    PrimaryKeyConstraint,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class CryptoCandle1m(Base):
+    __tablename__ = "crypto_candles_1m"
+    __table_args__ = (
+        PrimaryKeyConstraint("instrument_id", "time", name="pk_crypto_candles_1m"),
+        CheckConstraint(
+            "base_volume >= 0", name="ck_crypto_candles_1m_base_volume_nn"
+        ),
+        CheckConstraint(
+            "quote_volume IS NULL OR quote_volume >= 0",
+            name="ck_crypto_candles_1m_quote_volume_nn",
+        ),
+        CheckConstraint(
+            "trade_count IS NULL OR trade_count >= 0",
+            name="ck_crypto_candles_1m_trade_count_nn",
+        ),
+        CheckConstraint(
+            "vwap IS NULL OR vwap >= 0",
+            name="ck_crypto_candles_1m_vwap_nn",
+        ),
+        CheckConstraint("high >= low", name="ck_crypto_candles_1m_high_ge_low"),
+        CheckConstraint(
+            "high >= open AND high >= close",
+            name="ck_crypto_candles_1m_high_ge_oc",
+        ),
+        CheckConstraint(
+            "low <= open AND low <= close",
+            name="ck_crypto_candles_1m_low_le_oc",
+        ),
+    )
+
+    instrument_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("crypto_instruments.id"), nullable=False
+    )
+    time: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    open: Mapped[float] = mapped_column(Numeric, nullable=False)
+    high: Mapped[float] = mapped_column(Numeric, nullable=False)
+    low: Mapped[float] = mapped_column(Numeric, nullable=False)
+    close: Mapped[float] = mapped_column(Numeric, nullable=False)
+    base_volume: Mapped[float] = mapped_column(Numeric, nullable=False)
+    quote_volume: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    trade_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    vwap: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    taker_buy_base_volume: Mapped[float | None] = mapped_column(
+        Numeric, nullable=True
+    )
+    taker_buy_quote_volume: Mapped[float | None] = mapped_column(
+        Numeric, nullable=True
+    )
+    is_closed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    source_event_at: Mapped[dt.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    ingested_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+class CryptoCandle1d(Base):
+    """ROB-284 — daily crypto candle, instrument-FK shape.
+
+    The pre-ROB-284 schema (`time, symbol, market, open, high, low, close,
+    volume, value, source`) is migrated in-place by the three-step alembic
+    migrations (step 1 add nullable columns; step 2 seed instruments +
+    backfill; step 3 finalize NOT NULL + drop legacy columns). This ORM
+    model reflects the post-step-3 final shape and is what
+    `Base.metadata.create_all` (used by the test fixture) produces.
+    """
+
+    __tablename__ = "crypto_candles_1d"
+    __table_args__ = (
+        PrimaryKeyConstraint("instrument_id", "time", name="pk_crypto_candles_1d"),
+        CheckConstraint(
+            "base_volume >= 0", name="ck_crypto_candles_1d_base_volume_nn"
+        ),
+        CheckConstraint(
+            "quote_volume IS NULL OR quote_volume >= 0",
+            name="ck_crypto_candles_1d_quote_volume_nn",
+        ),
+        CheckConstraint("high >= low", name="ck_crypto_candles_1d_high_ge_low"),
+        CheckConstraint(
+            "high >= open AND high >= close",
+            name="ck_crypto_candles_1d_high_ge_oc",
+        ),
+        CheckConstraint(
+            "low <= open AND low <= close",
+            name="ck_crypto_candles_1d_low_le_oc",
+        ),
+    )
+
+    instrument_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("crypto_instruments.id"), nullable=False
+    )
+    time: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    open: Mapped[float] = mapped_column(Numeric, nullable=False)
+    high: Mapped[float] = mapped_column(Numeric, nullable=False)
+    low: Mapped[float] = mapped_column(Numeric, nullable=False)
+    close: Mapped[float] = mapped_column(Numeric, nullable=False)
+    base_volume: Mapped[float] = mapped_column(Numeric, nullable=False)
+    quote_volume: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    is_closed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    source_event_at: Mapped[dt.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    ingested_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/app/models/crypto_instruments.py
+++ b/app/models/crypto_instruments.py
@@ -1,0 +1,77 @@
+"""ROB-284 — crypto instruments ORM model.
+
+Master/source-of-truth for crypto venue/product/symbol identity. Candles
+(`crypto_candles_1d`, `crypto_candles_1m`) reference this table by
+`instrument_id` FK so identity is captured at the database layer rather
+than via free-form `(symbol, market)` strings.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class CryptoInstrument(Base):
+    __tablename__ = "crypto_instruments"
+    __table_args__ = (
+        UniqueConstraint(
+            "venue",
+            "product",
+            "venue_symbol",
+            name="uq_crypto_instruments_venue_product_symbol",
+        ),
+        CheckConstraint(
+            "status IN ('active','delisted','halted')",
+            name="ck_crypto_instruments_status",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, primary_key=True, autoincrement=True
+    )
+    venue: Mapped[str] = mapped_column(Text, nullable=False)
+    product: Mapped[str] = mapped_column(Text, nullable=False)
+    venue_symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    base_asset: Mapped[str] = mapped_column(Text, nullable=False)
+    quote_asset: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="active"
+    )
+    precision_price: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    precision_amount: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tick_size: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    lot_size: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    min_notional: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    listed_at: Mapped[dt.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    delisted_at: Mapped[dt.datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    # SQLAlchemy reserves the attribute name `metadata` on the declarative base,
+    # so the Python attribute is `extra_metadata` and is explicitly mapped to
+    # the DB column name `metadata` for parity with the migration.
+    extra_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        "metadata", JSONB, nullable=True
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/app/models/crypto_instruments.py
+++ b/app/models/crypto_instruments.py
@@ -45,17 +45,13 @@ class CryptoInstrument(Base):
         ),
     )
 
-    id: Mapped[int] = mapped_column(
-        BigInteger, primary_key=True, autoincrement=True
-    )
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     venue: Mapped[str] = mapped_column(Text, nullable=False)
     product: Mapped[str] = mapped_column(Text, nullable=False)
     venue_symbol: Mapped[str] = mapped_column(Text, nullable=False)
     base_asset: Mapped[str] = mapped_column(Text, nullable=False)
     quote_asset: Mapped[str] = mapped_column(Text, nullable=False)
-    status: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default="active"
-    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="active")
     precision_price: Mapped[int | None] = mapped_column(Integer, nullable=True)
     precision_amount: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tick_size: Mapped[float | None] = mapped_column(Numeric, nullable=True)

--- a/app/models/crypto_instruments.py
+++ b/app/models/crypto_instruments.py
@@ -28,6 +28,10 @@ from app.models.base import Base
 
 class CryptoInstrument(Base):
     __tablename__ = "crypto_instruments"
+    # Final on-disk names are produced by Base.metadata.naming_convention.
+    # The alembic migration passes the same fully-qualified names so both
+    # ORM (``create_all``) and migration produce identical constraint
+    # names. See ``app/models/base.py`` for the convention.
     __table_args__ = (
         UniqueConstraint(
             "venue",
@@ -37,7 +41,7 @@ class CryptoInstrument(Base):
         ),
         CheckConstraint(
             "status IN ('active','delisted','halted')",
-            name="ck_crypto_instruments_status",
+            name="status",
         ),
     )
 

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -26,6 +26,11 @@ class MarketKey(enum.StrEnum):
 _TABLE_CONFIGS: dict[MarketKey, SyncTableConfig] = {
     MarketKey.US: SyncTableConfig(table_name="us_candles_1d", partition_col="exchange"),
     MarketKey.KR: SyncTableConfig(table_name="kr_candles_1d", partition_col="venue"),
+    # ROB-284: crypto_candles_1d no longer has a `market`/`symbol` partition;
+    # identity is `(instrument_id, time)`. The partition_col entry is kept
+    # only so legacy KR/US-shape config consumers don't NPE — the crypto
+    # write/read paths in this class take a separate code branch and
+    # resolve `(symbol, partition)` -> `instrument_id` at the boundary.
     MarketKey.CRYPTO: SyncTableConfig(
         table_name="crypto_candles_1d", partition_col="market"
     ),
@@ -78,6 +83,12 @@ class DailyCandlesRepository:
         if not rows:
             return 0
 
+        if market == MarketKey.CRYPTO:
+            # ROB-284: crypto_candles_1d uses instrument_id FK; resolve at
+            # the boundary so callers continue to pass legacy (symbol,
+            # partition).
+            return await self._upsert_crypto_rows(rows=rows)
+
         cfg = self._config(market)
         upsert_sql = self._build_market_upsert(
             cfg, with_adj_close=self._supports_adj_close(market)
@@ -103,6 +114,84 @@ class DailyCandlesRepository:
         result = cast(
             "_RowcountResult",
             cast(object, await self._session.execute(upsert_sql, payload)),
+        )
+        return max(int(result.rowcount or 0), 0)
+
+    async def _resolve_instrument_id(
+        self, *, symbol: str, partition: str
+    ) -> int:
+        """Translate legacy (symbol, partition) -> instrument_id.
+
+        Today only Upbit KRW is producing crypto rows; (partition='upbit_krw',
+        symbol='KRW-XXX') maps to (venue='upbit', product='spot',
+        venue_symbol=symbol). Children B/C will add Binance/Alpaca mappings
+        via additional rows in crypto_instruments.
+        """
+        venue = "upbit" if partition == "upbit_krw" else partition.split("_")[0]
+        sql = text(
+            "SELECT id FROM crypto_instruments "
+            "WHERE venue = :v AND product = 'spot' AND venue_symbol = :s "
+            "LIMIT 1"
+        )
+        result = await self._session.execute(sql, {"v": venue, "s": symbol})
+        row = result.first()
+        if row is None:
+            raise LookupError(
+                f"No crypto_instruments row for venue={venue!r} symbol={symbol!r}; "
+                "seed the instrument before writing candles."
+            )
+        return int(row.id)
+
+    async def _upsert_crypto_rows(self, *, rows: list[DailyCandleRow]) -> int:
+        if not rows:
+            return 0
+        payload: list[dict[str, object]] = []
+        for row in rows:
+            iid = await self._resolve_instrument_id(
+                symbol=row.symbol, partition=row.partition
+            )
+            payload.append(
+                {
+                    "instrument_id": iid,
+                    "time": row.time_utc,
+                    "open": row.open,
+                    "high": row.high,
+                    "low": row.low,
+                    "close": row.close,
+                    "base_volume": row.volume,
+                    "quote_volume": row.value,
+                    "is_closed": True,
+                    "source": row.source,
+                }
+            )
+        sql = text(
+            """
+            INSERT INTO public.crypto_candles_1d (
+                instrument_id, time, open, high, low, close,
+                base_volume, quote_volume, is_closed, source
+            ) VALUES (
+                :instrument_id, :time, :open, :high, :low, :close,
+                :base_volume, :quote_volume, :is_closed, :source
+            )
+            ON CONFLICT (instrument_id, time) DO UPDATE
+            SET open         = EXCLUDED.open,
+                high         = EXCLUDED.high,
+                low          = EXCLUDED.low,
+                close        = EXCLUDED.close,
+                base_volume  = EXCLUDED.base_volume,
+                quote_volume = EXCLUDED.quote_volume,
+                is_closed    = EXCLUDED.is_closed,
+                source       = EXCLUDED.source,
+                ingested_at  = now()
+            WHERE
+                NOT (public.crypto_candles_1d.is_closed = TRUE
+                     AND EXCLUDED.is_closed = TRUE
+                     AND public.crypto_candles_1d.source = EXCLUDED.source)
+            """
+        )
+        result = cast(
+            "_RowcountResult",
+            cast(object, await self._session.execute(sql, payload)),
         )
         return max(int(result.rowcount or 0), 0)
 
@@ -145,6 +234,25 @@ class DailyCandlesRepository:
     async def latest_time_utc(
         self, *, market: MarketKey, symbol: str, partition: str
     ) -> datetime | None:
+        if market == MarketKey.CRYPTO:
+            # ROB-284: resolve instrument first; this avoids touching the
+            # legacy (symbol, market) shape that the table no longer has.
+            try:
+                iid = await self._resolve_instrument_id(
+                    symbol=symbol, partition=partition
+                )
+            except LookupError:
+                return None
+            sql = text(
+                "SELECT MAX(time) AS latest FROM public.crypto_candles_1d "
+                "WHERE instrument_id = :iid"
+            )
+            result = await self._session.execute(sql, {"iid": iid})
+            row = result.first()
+            if row is None or row.latest is None:
+                return None
+            return row.latest
+
         cfg = self._config(market)
         sql = text(
             f"""
@@ -164,6 +272,59 @@ class DailyCandlesRepository:
     async def fetch_recent(
         self, *, market: MarketKey, symbol: str, partition: str, count: int
     ) -> list[DailyCandleRow]:
+        if market == MarketKey.CRYPTO:
+            # ROB-284: JOIN crypto_instruments back to reconstruct the
+            # legacy (symbol, partition) shape consumers expect.
+            try:
+                iid = await self._resolve_instrument_id(
+                    symbol=symbol, partition=partition
+                )
+            except LookupError:
+                return []
+            sql = text(
+                """
+                SELECT time, :symbol AS symbol, :partition AS partition,
+                       open, high, low, close,
+                       NULL::numeric AS adj_close,
+                       base_volume AS volume, quote_volume AS value, source
+                FROM public.crypto_candles_1d
+                WHERE instrument_id = :iid
+                ORDER BY time DESC
+                LIMIT :count
+                """
+            )
+            result = await self._session.execute(
+                sql,
+                {
+                    "iid": iid,
+                    "symbol": symbol,
+                    "partition": partition,
+                    "count": int(count),
+                },
+            )
+            out: list[DailyCandleRow] = []
+            for row in result.mappings().all():
+                out.append(
+                    DailyCandleRow(
+                        time_utc=row["time"],
+                        symbol=row["symbol"],
+                        partition=row["partition"],
+                        open=float(row["open"]),
+                        high=float(row["high"]),
+                        low=float(row["low"]),
+                        close=float(row["close"]),
+                        adj_close=None,
+                        volume=float(row["volume"])
+                        if row["volume"] is not None
+                        else 0.0,
+                        value=float(row["value"])
+                        if row["value"] is not None
+                        else 0.0,
+                        source=row["source"],
+                    )
+                )
+            return list(reversed(out))
+
         cfg = self._config(market)
         adj_close_select = (
             "adj_close, " if self._supports_adj_close(market) else "NULL AS adj_close, "
@@ -181,7 +342,7 @@ class DailyCandlesRepository:
         result = await self._session.execute(
             sql, {"symbol": symbol, "partition": partition, "count": int(count)}
         )
-        out: list[DailyCandleRow] = []
+        out = []
         for row in result.mappings().all():
             out.append(
                 DailyCandleRow(

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -117,9 +117,7 @@ class DailyCandlesRepository:
         )
         return max(int(result.rowcount or 0), 0)
 
-    async def _resolve_instrument_id(
-        self, *, symbol: str, partition: str
-    ) -> int:
+    async def _resolve_instrument_id(self, *, symbol: str, partition: str) -> int:
         """Translate legacy (symbol, partition) -> instrument_id.
 
         Today only Upbit KRW is producing crypto rows; (partition='upbit_krw',
@@ -317,9 +315,7 @@ class DailyCandlesRepository:
                         volume=float(row["volume"])
                         if row["volume"] is not None
                         else 0.0,
-                        value=float(row["value"])
-                        if row["value"] is not None
-                        else 0.0,
+                        value=float(row["value"]) if row["value"] is not None else 0.0,
                         source=row["source"],
                     )
                 )

--- a/app/services/minute_candles/repository.py
+++ b/app/services/minute_candles/repository.py
@@ -1,0 +1,124 @@
+"""ROB-284 — DB boundary for crypto 1m candle store.
+
+Writes to `crypto_candles_1m` via `instrument_id`. Idempotent: a closed
+candle is never overwritten by another source's row at the same bucket.
+The upsert WHERE clause mirrors `DailyCandlesRepository`'s
+closed-candle-protection behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import TextClause
+
+
+@dataclass(frozen=True, slots=True)
+class MinuteCandleRow:
+    instrument_id: int
+    time_utc: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    base_volume: float
+    quote_volume: float | None = None
+    trade_count: int | None = None
+    vwap: float | None = None
+    taker_buy_base_volume: float | None = None
+    taker_buy_quote_volume: float | None = None
+    is_closed: bool = True
+    source: str = ""
+    source_event_at: datetime | None = None
+
+
+class _RowcountResult:
+    rowcount: int | None
+
+
+class MinuteCandlesRepository:
+    """Writes to crypto_candles_1m via instrument_id.
+
+    Idempotent: a closed candle is never overwritten by a less-trustworthy
+    source. The upsert WHERE clause mirrors DailyCandlesRepository's
+    closed-candle-protection behavior.
+    """
+
+    def __init__(self, *, session: AsyncSession) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> AsyncSession:
+        return self._session
+
+    async def upsert_rows(self, *, rows: list[MinuteCandleRow]) -> int:
+        if not rows:
+            return 0
+        sql = self._build_upsert()
+        payload = [
+            {
+                "instrument_id": r.instrument_id,
+                "time": r.time_utc,
+                "open": r.open,
+                "high": r.high,
+                "low": r.low,
+                "close": r.close,
+                "base_volume": r.base_volume,
+                "quote_volume": r.quote_volume,
+                "trade_count": r.trade_count,
+                "vwap": r.vwap,
+                "taker_buy_base_volume": r.taker_buy_base_volume,
+                "taker_buy_quote_volume": r.taker_buy_quote_volume,
+                "is_closed": r.is_closed,
+                "source": r.source,
+                "source_event_at": r.source_event_at,
+            }
+            for r in rows
+        ]
+        result = cast(
+            "_RowcountResult",
+            cast(object, await self._session.execute(sql, payload)),
+        )
+        return max(int(result.rowcount or 0), 0)
+
+    @staticmethod
+    def _build_upsert() -> TextClause:
+        return text(
+            """
+            INSERT INTO public.crypto_candles_1m (
+                instrument_id, time, open, high, low, close,
+                base_volume, quote_volume, trade_count, vwap,
+                taker_buy_base_volume, taker_buy_quote_volume,
+                is_closed, source, source_event_at
+            ) VALUES (
+                :instrument_id, :time, :open, :high, :low, :close,
+                :base_volume, :quote_volume, :trade_count, :vwap,
+                :taker_buy_base_volume, :taker_buy_quote_volume,
+                :is_closed, :source, :source_event_at
+            )
+            ON CONFLICT (instrument_id, time) DO UPDATE
+            SET open                   = EXCLUDED.open,
+                high                   = EXCLUDED.high,
+                low                    = EXCLUDED.low,
+                close                  = EXCLUDED.close,
+                base_volume            = EXCLUDED.base_volume,
+                quote_volume           = EXCLUDED.quote_volume,
+                trade_count            = EXCLUDED.trade_count,
+                vwap                   = EXCLUDED.vwap,
+                taker_buy_base_volume  = EXCLUDED.taker_buy_base_volume,
+                taker_buy_quote_volume = EXCLUDED.taker_buy_quote_volume,
+                is_closed              = EXCLUDED.is_closed,
+                source                 = EXCLUDED.source,
+                source_event_at        = EXCLUDED.source_event_at,
+                ingested_at            = now()
+            WHERE
+                -- Never overwrite a closed candle from the same source.
+                NOT (public.crypto_candles_1m.is_closed = TRUE
+                     AND EXCLUDED.is_closed = TRUE
+                     AND public.crypto_candles_1m.source = EXCLUDED.source)
+            """
+        )

--- a/docs/runbooks/daily-candles-store.md
+++ b/docs/runbooks/daily-candles-store.md
@@ -251,3 +251,50 @@ column will be NULL for all rows.
 The `_fetch_ohlcv_for_volume_profile` helper in the MCP tooling still uses
 the legacy `kis_ohlcv_cache` path for KR market data. It was not migrated to
 the durable store in this PR. Migration is a separate follow-up.
+
+---
+
+## ROB-284 pre-migration backup (one-time, before alembic upgrade)
+
+The `crypto_candles_1d` in-place migration drops legacy `symbol` / `market`
+columns. Before running `alembic upgrade head` on any environment with
+existing crypto candle data, take a backup table:
+
+```sql
+-- Run as DB superuser on the target environment.
+CREATE TABLE crypto_candles_1d_pre_rob283 AS
+SELECT * FROM crypto_candles_1d;
+
+-- Verify row count matches.
+SELECT
+  (SELECT COUNT(*) FROM crypto_candles_1d) AS live,
+  (SELECT COUNT(*) FROM crypto_candles_1d_pre_rob283) AS backup;
+```
+
+If `live != backup`, abort the migration. If they match, proceed:
+
+```bash
+uv run alembic upgrade head
+```
+
+To roll back manually after a failed migration:
+
+```sql
+DROP TABLE crypto_candles_1d;
+ALTER TABLE crypto_candles_1d_pre_rob283 RENAME TO crypto_candles_1d;
+-- Restore Timescale hypertable registration:
+SELECT create_hypertable('crypto_candles_1d', 'time',
+  chunk_time_interval => INTERVAL '90 days', migrate_data => TRUE);
+```
+
+Remove the backup table only after at least one full week of successful
+operation on the new schema:
+
+```sql
+DROP TABLE crypto_candles_1d_pre_rob283;
+```
+
+> The backup is an **operator step** in this runbook — it is NOT performed
+> automatically by the alembic migration. ROB-284's step-3 migration
+> additionally fails closed if any row still has `NULL instrument_id`,
+> `NULL base_volume`, or `NULL is_closed` after step 2 (the backfill).

--- a/docs/runbooks/daily-candles-store.md
+++ b/docs/runbooks/daily-candles-store.md
@@ -323,5 +323,30 @@ process test suite cannot exercise alembic against the test DB without
 colliding with `create_all` schema management (see
 `tests/services/daily_candles/test_migration_round_trip.py`).
 
+#### Post-downgrade schema check (operator action)
+
+After running the alembic downgrade, verify the restored schema matches
+the original `f974ac12e573_add_crypto_candles_1d` shape — in particular,
+the legacy `value` column must be `NOT NULL`:
+
+```sql
+SELECT column_name, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'crypto_candles_1d'
+  AND column_name IN ('symbol', 'market', 'volume', 'value')
+ORDER BY column_name;
+-- Expected: all four rows have is_nullable = 'NO'.
+```
+
+`value` is restored via `UPDATE ... SET value = COALESCE(quote_volume, 0)`
+inside the step-3 downgrade. Rows that were inserted under the new
+schema and had `quote_volume IS NULL` will have `value = 0` after the
+downgrade — this is a documented best-effort default because the new
+schema does not require `quote_volume`. Operators who downgrade in
+practice should additionally spot-check whether any rows show
+`value = 0` with `volume > 0` (a likely indicator of the 0-default
+substitution) and decide whether to refresh those rows from the source
+of truth before resuming production traffic.
+
 If alembic downgrade fails partway, fall back to the manual procedure
 above using `crypto_candles_1d_pre_rob283`.

--- a/docs/runbooks/daily-candles-store.md
+++ b/docs/runbooks/daily-candles-store.md
@@ -298,3 +298,30 @@ DROP TABLE crypto_candles_1d_pre_rob283;
 > automatically by the alembic migration. ROB-284's step-3 migration
 > additionally fails closed if any row still has `NULL instrument_id`,
 > `NULL base_volume`, or `NULL is_closed` after step 2 (the backfill).
+
+### Automated rollback via alembic downgrade
+
+If the issue is detected before the backup table is dropped, the cleanest
+rollback is to alembic-downgrade the three ROB-284 revisions:
+
+```bash
+# Step-by-step (verbose, recommended for production):
+uv run alembic downgrade 5fa5a347d85b   # noop if already at this rev
+uv run alembic downgrade 181f946296ff   # rolls back step 3 (finalize)
+uv run alembic downgrade 6acbc5e7fc93   # rolls back step 2 (backfill clear)
+uv run alembic downgrade e5df7fbd9803   # rolls back step 1 (drop columns)
+
+# Or in one shot (less granular control):
+uv run alembic downgrade e5df7fbd9803
+```
+
+This reverses step 3, step 2, and step 1 of the in-place migration.
+`crypto_instruments` is preserved (cheap, useful for re-running). The
+verification that the round-trip preserves row counts is performed by
+operators on a real DB before approving production cutover; the in-
+process test suite cannot exercise alembic against the test DB without
+colliding with `create_all` schema management (see
+`tests/services/daily_candles/test_migration_round_trip.py`).
+
+If alembic downgrade fails partway, fall back to the manual procedure
+above using `crypto_candles_1d_pre_rob283`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,6 +449,26 @@ async def db_session():
                         "ADD COLUMN IF NOT EXISTS is_common_stock BOOLEAN"
                     )
                 )
+                # ROB-284 — crypto_candles_1d migrates in-place from the
+                # legacy (symbol, market) shape to the (instrument_id, time)
+                # shape. The test DB picks up its schema from
+                # ``Base.metadata.create_all`` which is no-op against an
+                # existing table; if the legacy table is still present we
+                # drop it here so create_all rebuilds it from the new ORM
+                # model (``app.models.crypto_candles.CryptoCandle1d``).
+                legacy_has_symbol = (
+                    await conn.execute(
+                        text(
+                            "SELECT 1 FROM information_schema.columns "
+                            "WHERE table_name = 'crypto_candles_1d' "
+                            "AND column_name = 'symbol'"
+                        )
+                    )
+                ).first()
+                if legacy_has_symbol:
+                    await conn.execute(
+                        text("DROP TABLE IF EXISTS public.crypto_candles_1d CASCADE")
+                    )
                 # ROB-269 Phase 3 — snapshot metadata + 3-layer stale gate
                 # layer (i). create_all is no-op for already-existing tables,
                 # so we patch the six new columns + index + CHECK constraint

--- a/tests/services/daily_candles/test_audit_no_other_consumer.py
+++ b/tests/services/daily_candles/test_audit_no_other_consumer.py
@@ -12,7 +12,17 @@ import pathlib
 import subprocess
 
 
-ALLOWED = {"app/services/daily_candles/repository.py"}
+ALLOWED = {
+    # The repository is the sole production code consumer (reader/writer).
+    "app/services/daily_candles/repository.py",
+    # ORM model file declares __tablename__ = "crypto_candles_1d" and a
+    # docstring describing the table; these are definitional references,
+    # not additional consumers.
+    "app/models/crypto_candles.py",
+    # Docstring reference describing the FK relationship from
+    # crypto_instruments to crypto_candles_*.
+    "app/models/crypto_instruments.py",
+}
 
 
 def test_only_daily_candles_repository_references_crypto_candles_1d() -> None:

--- a/tests/services/daily_candles/test_audit_no_other_consumer.py
+++ b/tests/services/daily_candles/test_audit_no_other_consumer.py
@@ -1,0 +1,42 @@
+"""Locks the invariant that crypto_candles_1d has exactly one reader/writer.
+
+ROB-284 pre-implementation audit (2026-05-20): only
+app/services/daily_candles/repository.py touches the table. If this test
+fails after ROB-284 lands, a new consumer was added without migrating to
+the new instrument-FK shape — re-evaluate before merging.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+
+ALLOWED = {"app/services/daily_candles/repository.py"}
+
+
+def test_only_daily_candles_repository_references_crypto_candles_1d() -> None:
+    repo_root = pathlib.Path(__file__).resolve().parents[3]
+    result = subprocess.run(
+        [
+            "grep",
+            "-rln",
+            "crypto_candles_1d",
+            "--include=*.py",
+            "app/",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    files = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    unexpected = files - ALLOWED
+    assert not unexpected, (
+        f"Unexpected files reference crypto_candles_1d: {sorted(unexpected)}. "
+        "If you intentionally added a new consumer of crypto_candles_1d, extend "
+        "the ALLOWED set in this test and explain why in your PR description. "
+        "ROB-284 audit invariant — see "
+        "docs/plans/ROB-284-crypto-instruments-schema-implementation-plan.md "
+        "for context."
+    )

--- a/tests/services/daily_candles/test_audit_no_other_consumer.py
+++ b/tests/services/daily_candles/test_audit_no_other_consumer.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import pathlib
 import subprocess
 
-
 ALLOWED = {
     # The repository is the sole production code consumer (reader/writer).
     "app/services/daily_candles/repository.py",

--- a/tests/services/daily_candles/test_crypto_candles_1d_migration.py
+++ b/tests/services/daily_candles/test_crypto_candles_1d_migration.py
@@ -73,17 +73,13 @@ async def test_step2_backfill_populates_instrument_id_and_volumes(
     rows_with_iid = (
         await db_session.execute(
             text(
-                "SELECT count(*) FROM crypto_candles_1d "
-                "WHERE instrument_id IS NOT NULL"
+                "SELECT count(*) FROM crypto_candles_1d WHERE instrument_id IS NOT NULL"
             )
         )
     ).scalar_one()
     rows_with_base_vol = (
         await db_session.execute(
-            text(
-                "SELECT count(*) FROM crypto_candles_1d "
-                "WHERE base_volume IS NOT NULL"
-            )
+            text("SELECT count(*) FROM crypto_candles_1d WHERE base_volume IS NOT NULL")
         )
     ).scalar_one()
     rows_closed = (

--- a/tests/services/daily_candles/test_crypto_candles_1d_migration.py
+++ b/tests/services/daily_candles/test_crypto_candles_1d_migration.py
@@ -1,0 +1,218 @@
+"""ROB-284 — crypto_candles_1d in-place migration to instrument-FK shape.
+
+The test DB schema is built by ``Base.metadata.create_all`` which produces
+the post-migration (step 3) shape directly — it does not execute the three
+alembic revisions sequentially. Intermediate-state assertions (legacy
+columns still present after step 1; backfill correctness after step 2)
+are therefore marked server-only and verified against a real PG +
+TimescaleDB environment, not the in-process test DB.
+
+What this test file DOES verify against the test DB:
+- The final-shape schema produced by the ORM model
+  (``app.models.crypto_candles.CryptoCandle1d``) matches what step 3 of
+  the migration produces (column nullability, PK shape, CHECK constraints).
+- The CryptoCandle1d ORM model accepts a valid insert via the session
+  fixture.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# -----------------------------------------------------------------------------
+# Step 1 + Step 2 intermediate-state assertions — server-only.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason="blocker: server-only validation — step 1 adds columns to the "
+    "legacy table shape, but the test DB rebuilds crypto_candles_1d from "
+    "the post-step-3 ORM model via Base.metadata.create_all. Intermediate "
+    "states are validated on a real DB during the alembic upgrade run."
+)
+@pytest.mark.asyncio
+async def test_step1_adds_nullable_columns(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT column_name, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_name = 'crypto_candles_1d'"
+        )
+    )
+    cols = {row.column_name: row.is_nullable for row in result}
+    # Old columns still present at this stage:
+    assert "symbol" in cols
+    assert "market" in cols
+    # New columns added by step 1 — all nullable initially:
+    assert cols.get("instrument_id") == "YES"
+    assert cols.get("base_volume") == "YES"
+    assert cols.get("quote_volume") == "YES"
+    assert cols.get("is_closed") == "YES"
+    assert cols.get("source_event_at") == "YES"
+
+
+@pytest.mark.skip(
+    reason="blocker: server-only validation — the backfill UPDATE runs "
+    "against pre-existing legacy rows. The test DB starts the table from "
+    "the ORM model and never holds legacy rows. Backfill correctness is "
+    "validated on a real DB during the alembic upgrade run; the migration "
+    "is also re-runnable and the step 3 NULL check fails closed if the "
+    "backfill is incomplete."
+)
+@pytest.mark.asyncio
+async def test_step2_backfill_populates_instrument_id_and_volumes(
+    db_session: AsyncSession,
+) -> None:
+    rows_total = (
+        await db_session.execute(text("SELECT count(*) FROM crypto_candles_1d"))
+    ).scalar_one()
+    rows_with_iid = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM crypto_candles_1d "
+                "WHERE instrument_id IS NOT NULL"
+            )
+        )
+    ).scalar_one()
+    rows_with_base_vol = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM crypto_candles_1d "
+                "WHERE base_volume IS NOT NULL"
+            )
+        )
+    ).scalar_one()
+    rows_closed = (
+        await db_session.execute(
+            text("SELECT count(*) FROM crypto_candles_1d WHERE is_closed IS TRUE")
+        )
+    ).scalar_one()
+    assert rows_total > 0, "Test database must contain crypto candle fixture rows"
+    assert rows_with_iid == rows_total
+    assert rows_with_base_vol == rows_total
+    assert rows_closed == rows_total
+
+
+@pytest.mark.skip(
+    reason="blocker: server-only validation — depends on legacy "
+    "(market, symbol) rows being present and translated by step 2."
+)
+@pytest.mark.asyncio
+async def test_step2_creates_one_instrument_per_distinct_pair(
+    db_session: AsyncSession,
+) -> None:
+    result = await db_session.execute(
+        text("SELECT COUNT(DISTINCT instrument_id) FROM crypto_candles_1d")
+    )
+    distinct_iids = result.scalar_one()
+    result = await db_session.execute(
+        text("SELECT count(*) FROM crypto_instruments WHERE venue = 'upbit'")
+    )
+    upbit_instruments = result.scalar_one()
+    assert distinct_iids == upbit_instruments
+
+
+# -----------------------------------------------------------------------------
+# Step 3 final-shape assertions — verified against ORM-driven test DB.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_step3_final_shape(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT column_name, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_name = 'crypto_candles_1d'"
+        )
+    )
+    cols = {row.column_name: row.is_nullable for row in result}
+    # Legacy columns are gone.
+    assert "symbol" not in cols
+    assert "market" not in cols
+    assert "volume" not in cols
+    assert "value" not in cols
+    # New shape:
+    assert cols["instrument_id"] == "NO"
+    assert cols["base_volume"] == "NO"
+    assert cols["is_closed"] == "NO"
+    assert cols["quote_volume"] == "YES"
+
+
+@pytest.mark.asyncio
+async def test_step3_primary_key_is_instrument_time(
+    db_session: AsyncSession,
+) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT a.attname "
+            "FROM pg_index i JOIN pg_attribute a "
+            "  ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
+            "WHERE i.indrelid = 'public.crypto_candles_1d'::regclass "
+            "  AND i.indisprimary"
+        )
+    )
+    pk_cols = {row.attname for row in result}
+    assert pk_cols == {"instrument_id", "time"}
+
+
+@pytest.mark.asyncio
+async def test_step3_checks_present(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT conname FROM pg_constraint "
+            "WHERE conrelid = 'public.crypto_candles_1d'::regclass "
+            "  AND contype = 'c'"
+        )
+    )
+    check_names = {row.conname for row in result}
+    expected = {
+        "ck_crypto_candles_1d_base_volume_nn",
+        "ck_crypto_candles_1d_high_ge_low",
+        "ck_crypto_candles_1d_high_ge_oc",
+        "ck_crypto_candles_1d_low_le_oc",
+    }
+    assert expected <= check_names
+
+
+@pytest.mark.asyncio
+async def test_daily_candle_orm_roundtrip(db_session: AsyncSession) -> None:
+    from app.models.crypto_candles import CryptoCandle1d
+    from app.models.crypto_instruments import CryptoInstrument
+
+    inst = CryptoInstrument(
+        venue="binance",
+        product="spot",
+        venue_symbol="ETHUSDT",
+        base_asset="ETH",
+        quote_asset="USDT",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    candle = CryptoCandle1d(
+        instrument_id=inst.id,
+        time=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        open=3000,
+        high=3100,
+        low=2950,
+        close=3050,
+        base_volume=42.5,
+        quote_volume=128000,
+        is_closed=True,
+        source="test",
+    )
+    db_session.add(candle)
+    await db_session.flush()
+    fetched = await db_session.get(
+        CryptoCandle1d,
+        (inst.id, dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc)),
+    )
+    assert fetched is not None
+    assert float(fetched.close) == 3050.0

--- a/tests/services/daily_candles/test_crypto_candles_1d_migration.py
+++ b/tests/services/daily_candles/test_crypto_candles_1d_migration.py
@@ -23,7 +23,6 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
 # -----------------------------------------------------------------------------
 # Step 1 + Step 2 intermediate-state assertions — server-only.
 # -----------------------------------------------------------------------------
@@ -198,7 +197,7 @@ async def test_daily_candle_orm_roundtrip(db_session: AsyncSession) -> None:
 
     candle = CryptoCandle1d(
         instrument_id=inst.id,
-        time=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        time=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
         open=3000,
         high=3100,
         low=2950,
@@ -212,7 +211,7 @@ async def test_daily_candle_orm_roundtrip(db_session: AsyncSession) -> None:
     await db_session.flush()
     fetched = await db_session.get(
         CryptoCandle1d,
-        (inst.id, dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc)),
+        (inst.id, dt.datetime(2026, 5, 20, tzinfo=dt.UTC)),
     )
     assert fetched is not None
     assert float(fetched.close) == 3050.0

--- a/tests/services/daily_candles/test_crypto_candles_1m.py
+++ b/tests/services/daily_candles/test_crypto_candles_1m.py
@@ -1,0 +1,193 @@
+"""ROB-284 — crypto_candles_1m schema + hypertable + repository."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_table_columns(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT column_name, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_name = 'crypto_candles_1m' "
+            "ORDER BY ordinal_position"
+        )
+    )
+    cols = {row.column_name: row.is_nullable for row in result}
+    assert cols["instrument_id"] == "NO"
+    assert cols["time"] == "NO"
+    assert cols["open"] == "NO"
+    assert cols["high"] == "NO"
+    assert cols["low"] == "NO"
+    assert cols["close"] == "NO"
+    assert cols["base_volume"] == "NO"
+    assert cols["quote_volume"] == "YES"
+    assert cols["trade_count"] == "YES"
+    assert cols["vwap"] == "YES"
+    assert cols["taker_buy_base_volume"] == "YES"
+    assert cols["taker_buy_quote_volume"] == "YES"
+    assert cols["is_closed"] == "NO"
+    assert cols["source"] == "NO"
+    assert cols["source_event_at"] == "YES"
+    assert cols["ingested_at"] == "NO"
+
+
+@pytest.mark.skip(
+    reason="blocker: server-only validation — Timescale create_hypertable is "
+    "not called by Base.metadata.create_all in the test DB. Hypertable "
+    "registration is verified manually post-migration on real environments. "
+    "See migration alembic/versions/<rev_b>_add_crypto_candles_1m.py "
+    "for the create_hypertable invocation."
+)
+@pytest.mark.asyncio
+async def test_hypertable_registered(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT count(*) FROM timescaledb_information.hypertables "
+            "WHERE hypertable_name = 'crypto_candles_1m'"
+        )
+    )
+    assert result.scalar_one() == 1
+
+
+@pytest.mark.asyncio
+async def test_ohlc_check_rejects_inconsistent(db_session: AsyncSession) -> None:
+    # Pre-seed an instrument.
+    await db_session.execute(
+        text(
+            "INSERT INTO crypto_instruments "
+            "(venue, product, venue_symbol, base_asset, quote_asset, status) "
+            "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+        )
+    )
+    inst_id = (
+        await db_session.execute(
+            text("SELECT id FROM crypto_instruments WHERE venue_symbol='KRW-BTC'")
+        )
+    ).scalar_one()
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO crypto_candles_1m "
+                "(instrument_id, time, open, high, low, close, base_volume, "
+                "is_closed, source) "
+                "VALUES (:iid, '2026-05-20T00:00:00Z', 100, 50, 60, 70, 1, true, 'test')"
+            ),
+            {"iid": inst_id},
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_minute_repository_idempotent_upsert(db_session: AsyncSession) -> None:
+    from app.models.crypto_instruments import CryptoInstrument
+    from app.services.minute_candles.repository import (
+        MinuteCandleRow,
+        MinuteCandlesRepository,
+    )
+
+    inst = CryptoInstrument(
+        venue="binance",
+        product="spot",
+        venue_symbol="BTCUSDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = MinuteCandlesRepository(session=db_session)
+    row = MinuteCandleRow(
+        instrument_id=inst.id,
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        open=100,
+        high=105,
+        low=99,
+        close=103,
+        base_volume=10,
+        quote_volume=1030,
+        is_closed=True,
+        source="binance_sdk_ws",
+    )
+    await repo.upsert_rows(rows=[row])
+    await repo.upsert_rows(rows=[row])
+    # Idempotency assertion: after two upserts of an identical closed
+    # candle from the same source, the table holds exactly one row. The
+    # closed-candle-protection WHERE clause in the ON CONFLICT clause means
+    # the second insert is a no-op.
+    cnt = (
+        await db_session.execute(
+            text("SELECT count(*) FROM crypto_candles_1m WHERE instrument_id = :i"),
+            {"i": inst.id},
+        )
+    ).scalar_one()
+    assert cnt == 1
+
+
+@pytest.mark.asyncio
+async def test_cross_venue_same_bucket_coexistence(db_session: AsyncSession) -> None:
+    """ROB-284 — 4 distinct instruments at same time bucket must not collide."""
+    from app.models.crypto_instruments import CryptoInstrument
+    from app.services.minute_candles.repository import (
+        MinuteCandleRow,
+        MinuteCandlesRepository,
+    )
+
+    instruments = [
+        ("upbit", "spot", "KRW-BTC", "BTC", "KRW"),
+        ("binance", "spot", "BTCUSDT", "BTC", "USDT"),
+        ("binance", "usdm_futures", "BTCUSDT", "BTC", "USDT"),
+        ("alpaca", "paper", "BTC/USD", "BTC", "USD"),
+    ]
+    ids = []
+    for venue, product, sym, base, quote in instruments:
+        inst = CryptoInstrument(
+            venue=venue,
+            product=product,
+            venue_symbol=sym,
+            base_asset=base,
+            quote_asset=quote,
+            status="active",
+        )
+        db_session.add(inst)
+        await db_session.flush()
+        ids.append(inst.id)
+
+    repo = MinuteCandlesRepository(session=db_session)
+    t = dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc)
+    rows = [
+        MinuteCandleRow(
+            instrument_id=i,
+            time_utc=t,
+            open=100,
+            high=101,
+            low=99,
+            close=100,
+            base_volume=1,
+            is_closed=True,
+            source="test",
+        )
+        for i in ids
+    ]
+    await repo.upsert_rows(rows=rows)
+    # asyncpg executemany cannot return cumulative rowcount across the batch,
+    # so we verify by querying the table directly — the assertion is that 4
+    # rows coexist at the same bucket across distinct instrument_ids.
+    inserted = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM crypto_candles_1m "
+                "WHERE time = :t AND instrument_id = ANY(:ids)"
+            ),
+            {"t": t, "ids": ids},
+        )
+    ).scalar_one()
+    assert inserted == 4

--- a/tests/services/daily_candles/test_crypto_candles_1m.py
+++ b/tests/services/daily_candles/test_crypto_candles_1m.py
@@ -107,7 +107,7 @@ async def test_minute_repository_idempotent_upsert(db_session: AsyncSession) -> 
     repo = MinuteCandlesRepository(session=db_session)
     row = MinuteCandleRow(
         instrument_id=inst.id,
-        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
         open=100,
         high=105,
         low=99,
@@ -162,7 +162,7 @@ async def test_cross_venue_same_bucket_coexistence(db_session: AsyncSession) -> 
         ids.append(inst.id)
 
     repo = MinuteCandlesRepository(session=db_session)
-    t = dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc)
+    t = dt.datetime(2026, 5, 20, tzinfo=dt.UTC)
     rows = [
         MinuteCandleRow(
             instrument_id=i,

--- a/tests/services/daily_candles/test_crypto_instruments.py
+++ b/tests/services/daily_candles/test_crypto_instruments.py
@@ -1,0 +1,99 @@
+"""ROB-284 — crypto_instruments table contract."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_crypto_instruments_table_exists(db_session: AsyncSession) -> None:
+    result = await db_session.execute(
+        text(
+            "SELECT column_name, is_nullable, data_type "
+            "FROM information_schema.columns "
+            "WHERE table_name = 'crypto_instruments' "
+            "ORDER BY ordinal_position"
+        )
+    )
+    cols = {row.column_name: (row.is_nullable, row.data_type) for row in result}
+    assert "id" in cols
+    assert "venue" in cols and cols["venue"][0] == "NO"
+    assert "product" in cols and cols["product"][0] == "NO"
+    assert "venue_symbol" in cols and cols["venue_symbol"][0] == "NO"
+    assert "base_asset" in cols and cols["base_asset"][0] == "NO"
+    assert "quote_asset" in cols and cols["quote_asset"][0] == "NO"
+    assert "status" in cols and cols["status"][0] == "NO"
+    for opt in (
+        "precision_price",
+        "precision_amount",
+        "tick_size",
+        "lot_size",
+        "min_notional",
+        "listed_at",
+        "delisted_at",
+        "metadata",
+    ):
+        assert opt in cols, f"missing optional column {opt}"
+
+
+@pytest.mark.asyncio
+async def test_crypto_instruments_unique_constraint(db_session: AsyncSession) -> None:
+    await db_session.execute(
+        text(
+            "INSERT INTO crypto_instruments "
+            "(venue, product, venue_symbol, base_asset, quote_asset, status) "
+            "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+        )
+    )
+    await db_session.flush()
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO crypto_instruments "
+                "(venue, product, venue_symbol, base_asset, quote_asset, status) "
+                "VALUES ('upbit', 'spot', 'KRW-BTC', 'BTC', 'KRW', 'active')"
+            )
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_crypto_instruments_status_check(db_session: AsyncSession) -> None:
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO crypto_instruments "
+                "(venue, product, venue_symbol, base_asset, quote_asset, status) "
+                "VALUES ('upbit', 'spot', 'KRW-XYZ', 'XYZ', 'KRW', 'bogus_status')"
+            )
+        )
+        await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_crypto_instrument_orm_roundtrip(db_session: AsyncSession) -> None:
+    from app.models.crypto_instruments import CryptoInstrument
+
+    inst = CryptoInstrument(
+        venue="binance",
+        product="spot",
+        venue_symbol="BTCUSDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        status="active",
+        precision_price=2,
+        precision_amount=5,
+        tick_size=0.01,
+        lot_size=0.00001,
+        min_notional=10,
+    )
+    db_session.add(inst)
+    await db_session.flush()
+    assert inst.id is not None
+    fetched = await db_session.get(CryptoInstrument, inst.id)
+    assert fetched is not None
+    assert fetched.venue == "binance"
+    assert fetched.extra_metadata is None

--- a/tests/services/daily_candles/test_migration_round_trip.py
+++ b/tests/services/daily_candles/test_migration_round_trip.py
@@ -1,0 +1,49 @@
+"""ROB-284 — full migration round-trip must preserve row count.
+
+This test is **server-only**: it shells out to ``alembic downgrade -3``
+and ``alembic upgrade head``, which mutates the schema of the database
+referenced by the project's alembic config. Running it against the
+test DB collides with the create_all-driven fixture (see
+``tests/conftest.py::db_session``) which is the canonical schema source
+for the in-process test suite. Operators verify the round-trip manually
+during ROB-284 deployment per the rollback runbook
+``docs/runbooks/daily-candles-store.md``.
+
+To run on a dedicated DB:
+
+    DATABASE_URL=... uv run pytest \
+      tests/services/daily_candles/test_migration_round_trip.py \
+      -v -m slow --run-live  # plus a custom flag to opt-in
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.skip(
+    reason="blocker: server-only validation — alembic downgrade/upgrade "
+    "shells against the project DB and collides with the test DB's "
+    "create_all-driven schema. Operators verify round-trip on a real "
+    "environment per docs/runbooks/daily-candles-store.md."
+)
+@pytest.mark.slow
+@pytest.mark.asyncio
+async def test_upgrade_downgrade_upgrade_preserves_rows(
+    db_session: AsyncSession,
+) -> None:
+    before = (
+        await db_session.execute(text("SELECT count(*) FROM crypto_candles_1d"))
+    ).scalar_one()
+
+    subprocess.run(["uv", "run", "alembic", "downgrade", "-3"], check=True)
+    subprocess.run(["uv", "run", "alembic", "upgrade", "head"], check=True)
+
+    after = (
+        await db_session.execute(text("SELECT count(*) FROM crypto_candles_1d"))
+    ).scalar_one()
+    assert before == after

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -1,0 +1,181 @@
+"""ROB-284 — DailyCandlesRepository crypto path writes via instrument_id."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.services.daily_candles.repository import (
+    DailyCandleRow,
+    DailyCandlesRepository,
+    MarketKey,
+)
+
+
+@pytest.mark.asyncio
+async def test_crypto_upsert_writes_via_instrument_id(
+    db_session: AsyncSession,
+) -> None:
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-SOL",
+        base_asset="SOL",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    row = DailyCandleRow(
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        symbol="KRW-SOL",
+        partition="upbit_krw",
+        open=100,
+        high=110,
+        low=95,
+        close=105,
+        adj_close=None,
+        volume=12.5,
+        value=1300,
+        source="upbit",
+    )
+    await repo.upsert_rows(market=MarketKey.CRYPTO, rows=[row])
+
+    result = await db_session.execute(
+        text(
+            "SELECT instrument_id, base_volume, quote_volume, is_closed, source "
+            "FROM crypto_candles_1d WHERE instrument_id = :i"
+        ),
+        {"i": inst.id},
+    )
+    stored = result.one()
+    assert stored.instrument_id == inst.id
+    assert float(stored.base_volume) == 12.5
+    assert float(stored.quote_volume) == 1300
+    assert stored.is_closed is True
+    assert stored.source == "upbit"
+
+
+@pytest.mark.asyncio
+async def test_crypto_upsert_raises_for_unknown_pair(
+    db_session: AsyncSession,
+) -> None:
+    repo = DailyCandlesRepository(session=db_session)
+    row = DailyCandleRow(
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        symbol="KRW-NEWCOIN",
+        partition="upbit_krw",
+        open=1,
+        high=1,
+        low=1,
+        close=1,
+        adj_close=None,
+        volume=1,
+        value=1,
+        source="upbit",
+    )
+    with pytest.raises(LookupError):
+        await repo.upsert_rows(market=MarketKey.CRYPTO, rows=[row])
+
+
+@pytest.mark.asyncio
+async def test_crypto_latest_time_utc_resolves_via_instrument(
+    db_session: AsyncSession,
+) -> None:
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-ETH",
+        base_asset="ETH",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    rows = [
+        DailyCandleRow(
+            time_utc=dt.datetime(2026, 5, 18, tzinfo=dt.timezone.utc),
+            symbol="KRW-ETH",
+            partition="upbit_krw",
+            open=100,
+            high=101,
+            low=99,
+            close=100,
+            adj_close=None,
+            volume=1,
+            value=100,
+            source="upbit",
+        ),
+        DailyCandleRow(
+            time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+            symbol="KRW-ETH",
+            partition="upbit_krw",
+            open=100,
+            high=101,
+            low=99,
+            close=100,
+            adj_close=None,
+            volume=1,
+            value=100,
+            source="upbit",
+        ),
+    ]
+    await repo.upsert_rows(market=MarketKey.CRYPTO, rows=rows)
+
+    latest = await repo.latest_time_utc(
+        market=MarketKey.CRYPTO, symbol="KRW-ETH", partition="upbit_krw"
+    )
+    assert latest is not None
+    assert latest.date() == dt.date(2026, 5, 20)
+
+
+@pytest.mark.asyncio
+async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
+    db_session: AsyncSession,
+) -> None:
+    inst = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-XRP",
+        base_asset="XRP",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+
+    repo = DailyCandlesRepository(session=db_session)
+    rows = [
+        DailyCandleRow(
+            time_utc=dt.datetime(2026, 5, d, tzinfo=dt.timezone.utc),
+            symbol="KRW-XRP",
+            partition="upbit_krw",
+            open=100,
+            high=101,
+            low=99,
+            close=100,
+            adj_close=None,
+            volume=1,
+            value=100,
+            source="upbit",
+        )
+        for d in (18, 19, 20)
+    ]
+    await repo.upsert_rows(market=MarketKey.CRYPTO, rows=rows)
+    recent = await repo.fetch_recent(
+        market=MarketKey.CRYPTO,
+        symbol="KRW-XRP",
+        partition="upbit_krw",
+        count=10,
+    )
+    assert [r.time_utc.day for r in recent] == [18, 19, 20]
+    assert all(r.symbol == "KRW-XRP" for r in recent)
+    assert all(r.partition == "upbit_krw" for r in recent)

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -33,7 +33,7 @@ async def test_crypto_upsert_writes_via_instrument_id(
 
     repo = DailyCandlesRepository(session=db_session)
     row = DailyCandleRow(
-        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
         symbol="KRW-SOL",
         partition="upbit_krw",
         open=100,
@@ -68,7 +68,7 @@ async def test_crypto_upsert_raises_for_unknown_pair(
 ) -> None:
     repo = DailyCandlesRepository(session=db_session)
     row = DailyCandleRow(
-        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+        time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
         symbol="KRW-NEWCOIN",
         partition="upbit_krw",
         open=1,
@@ -102,7 +102,7 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
     repo = DailyCandlesRepository(session=db_session)
     rows = [
         DailyCandleRow(
-            time_utc=dt.datetime(2026, 5, 18, tzinfo=dt.timezone.utc),
+            time_utc=dt.datetime(2026, 5, 18, tzinfo=dt.UTC),
             symbol="KRW-ETH",
             partition="upbit_krw",
             open=100,
@@ -115,7 +115,7 @@ async def test_crypto_latest_time_utc_resolves_via_instrument(
             source="upbit",
         ),
         DailyCandleRow(
-            time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.timezone.utc),
+            time_utc=dt.datetime(2026, 5, 20, tzinfo=dt.UTC),
             symbol="KRW-ETH",
             partition="upbit_krw",
             open=100,
@@ -155,7 +155,7 @@ async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
     repo = DailyCandlesRepository(session=db_session)
     rows = [
         DailyCandleRow(
-            time_utc=dt.datetime(2026, 5, d, tzinfo=dt.timezone.utc),
+            time_utc=dt.datetime(2026, 5, d, tzinfo=dt.UTC),
             symbol="KRW-XRP",
             partition="upbit_krw",
             open=100,


### PR DESCRIPTION
## Summary

Child A of ROB-283 epic. Introduces `crypto_instruments` as the master/source-of-truth for venue/product/symbol identity and migrates `crypto_candles_1d` in place to instrument-FK shape; adds `crypto_candles_1m` Timescale hypertable with the same shape. Unblocks Child B (ROB-285 Binance public market data adapter) and Child C (ROB-286 testnet scalping MVP).

Plan: shipped as plan-only in PR #895 (`docs/plans/ROB-284-crypto-instruments-schema-implementation-plan.md`).

## Pre-implementation audit (locked invariant)

`grep -rln "crypto_candles_1d" --include="*.py" app/` returns:

```
app/models/crypto_candles.py             # ORM model __tablename__ + docstring
app/models/crypto_instruments.py         # docstring describing FK relationship
app/services/daily_candles/repository.py # sole production reader/writer
```

`tests/services/daily_candles/test_audit_no_other_consumer.py` locks this list as the `ALLOWED` set; if a future PR adds a new consumer without extending `ALLOWED`, the test fails with a clear message pointing to the plan doc.

## What landed (7 commits)

| Commit | Subject |
|---|---|
| `bcdedccb` | test(rob-284): lock audit invariant — crypto_candles_1d has single consumer |
| `eb7dfd78` | feat(rob-284): add crypto_instruments master table + ORM model |
| `931fbd7f` | feat(rob-284): add crypto_candles_1m hypertable + MinuteCandlesRepository |
| `a011516e` | docs(rob-284): add crypto_candles_1d pre-migration backup procedure |
| `09dfe5a8` | feat(rob-284): crypto_candles_1d 3-step in-place migration + CryptoCandle1d model |
| `bfba737f` | feat(rob-284): DailyCandlesRepository crypto path writes via instrument_id |
| `af8c4323` | test(rob-284): round-trip migration test placeholder + rollback runbook |

## Alembic revisions (chain off `20260520_rob279_p1` → new head `5fa5a347d85b`)

1. `2efa08c3fb09` — add crypto_instruments
2. `e5df7fbd9803` — add crypto_candles_1m
3. `6acbc5e7fc93` — step1 add columns
4. `181f946296ff` — step2 backfill (idempotent; seeds instruments from existing `(symbol, market)` then UPDATEs `instrument_id`/`base_volume`/`quote_volume`/`is_closed`)
5. `5fa5a347d85b` — step3 finalize (refuses to proceed if any row has NULL `instrument_id` / `base_volume` / `is_closed`; drops legacy `symbol`/`market`/`volume`/`value` columns; new PK `(instrument_id, time)`; adds OHLC sanity + non-negative CHECKs)

`uv run alembic heads` returns `5fa5a347d85b (head)`. Full history chain verified.

## Test results

```
tests/services/daily_candles/  — 17 passed, 5 skipped, 0 failed
```

Skipped tests are all explicit server-only blockers (see Blockers section). No silent passes.

ROB-282 regression: `pytest -k "screener_snapshot or invest_crypto_screener"` — **186 passed, 1 skipped** (unrelated). `app/jobs/invest_crypto_screener_snapshots.py` was not modified.

## Migration safety

- Pre-migration `crypto_candles_1d_pre_rob283` backup is documented in `docs/runbooks/daily-candles-store.md` as an **operator runbook step**, not an automatic migration step.
- Step 3 fails closed if backfill is incomplete:
  ```
  if incomplete > 0:
      raise RuntimeError(
          f\"ROB-284 step 3 refused: {incomplete} rows ... \"
          \"Re-run step 2 backfill (or restore from backup) first.\"
      )
  ```
- All three migration steps have explicit `downgrade()` implementations that restore the prior state.
- Round-trip verification (`alembic upgrade head` → `downgrade -1` → `upgrade head` row preservation) is marked as server-only because `Base.metadata.create_all`-based test schema collides with alembic-based round-trip on the same DB. Operators verify on a real DB pre-cutover.

## Blockers (server-only validation)

These items cannot be verified in the test DB because tests use `Base.metadata.create_all` + manual ALTER patches, not `alembic upgrade`:

1. **Timescale `create_hypertable` registration** — `Base.metadata.create_all` does not invoke `create_hypertable`. Verified by reading the migration code. (`test_hypertable_registered` skipped.)
2. **Step 1 + Step 2 intermediate-state assertions** — test DB rebuilds `crypto_candles_1d` from the post-step-3 ORM model via `create_all`; never holds legacy `(symbol, market)` rows for the backfill UPDATE to touch. Step 3's fail-closed check protects against incomplete backfill on real DBs. (3 tests skipped.)
3. **Alembic round-trip downgrade/upgrade** — alembic against test DB collides with `create_all`. (`test_upgrade_downgrade_upgrade_preserves_rows` skipped.)

All skip reasons explicitly include \"blocker: server-only validation\".

## Scope confirmation

- ❌ No Binance SDK added (`pyproject.toml` unchanged).
- ❌ No `app/services/brokers/binance/` package.
- ❌ No `binance_testnet_order_ledger` table or service.
- ❌ No scalping state machine.
- ❌ No scheduler/TaskIQ changes (`app/core/taskiq_broker.py`, `app/core/scheduler.py` untouched).
- ❌ No `crypto_candles_1d_view` (YAGNI per audit).
- ❌ No modification to `app/services/crypto_execution_mapping.py`.
- ❌ No modification to `app/jobs/invest_crypto_screener_snapshots.py`.
- ❌ No KR/US candle path changes.
- ❌ No broker/order/watch/order-intent mutation.
- ❌ No production-DB writes (the user's dev `auto_trader` DB on `localhost:5432` was never touched; only `test_db`).

## Notes on small plan deviations

- **`metadata` rename**: SQLAlchemy reserves `metadata` on `Base`. The `CryptoInstrument` Python attribute is `extra_metadata`, mapped to the DB column `metadata`. The plan pre-flagged this.
- **CHECK constraint naming**: `Base.metadata.naming_convention['ck']` already prefixes; CHECK names in models use stem-only (`high_ge_low`) to avoid double-prefixing on disk. Final DB names match what migrations create.
- **`MinuteCandlesRepository.upsert_rows` return value**: asyncpg executemany cannot return cumulative rowcount across the batch — same limitation as the existing `DailyCandlesRepository`. Tests verify by SELECT after upsert.
- **`tests/conftest.py` patch**: same shape as existing `is_common_stock` / ROB-269/274 patches — drops legacy `crypto_candles_1d` table if it has the old `symbol` column so `create_all` rebuilds it from the new ORM model.
- **Test directory layout**: Tests under `tests/services/daily_candles/` per plan. Project has parallel `tests/unit/services/daily_candles/` and `tests/integration/services/daily_candles/` directories. Pytest discovers both via `testpaths = [\"tests\"]`. Open to relocating if reviewer prefers.

## Operator pre-cutover checklist (production environments)

Before `alembic upgrade head` on production-like environments:

1. Take the backup:
   ```sql
   CREATE TABLE crypto_candles_1d_pre_rob283 AS SELECT * FROM crypto_candles_1d;
   ```
2. Verify row counts match (see `docs/runbooks/daily-candles-store.md`).
3. Apply migrations.
4. Verify Timescale hypertable registration on both `crypto_candles_1m` and `crypto_candles_1d`.
5. Verify round-trip: `alembic downgrade -3 && alembic upgrade head` preserves row count.
6. Drop backup table only after one week of clean operation.

## Test plan

- [ ] Reviewer confirms migration step 3's fail-closed check is sufficient guard against incomplete backfill in production.
- [ ] Reviewer confirms `tests/conftest.py` patch is acceptable (same shape as existing patches).
- [ ] Reviewer confirms audit-invariant test `ALLOWED` set + extension message are clear for future contributors.
- [ ] Reviewer confirms test directory layout — keep at `tests/services/daily_candles/` or relocate to `tests/unit/services/daily_candles/`?
- [ ] Server-side: operator runs `alembic upgrade head` + round-trip + hypertable verification on a non-prod DB before approving cutover.

Closes ROB-284. Advances ROB-283 epic (unblocks ROB-285, ROB-286).

🤖 Generated with Claude Code