### PR TITLE
fix: thread injected now() through screener freshness path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,27 +326,39 @@ chore/<설명>                 # 유지보수
 
 ### Worktree 운영 규칙 (필수)
 
-**루트 `/home/mgh3326/auto_trader` 는 항상 `main` 체크아웃 고정. 배포 머지 시에만 `production` 으로 일시 전환.** 루트에서 feature/fix 브랜치를 체크아웃하거나 작업하지 않습니다.
+**canonical repo `/Users/mgh3326/work/auto_trader` 는 항상 `main` 체크아웃 고정. 배포 머지 시에만 `production` 으로 일시 전환.** canonical repo에서 feature/fix 브랜치를 체크아웃하거나 작업하지 않습니다.
 
-모든 코드 변경은 worktree 에서 수행합니다:
+코드 변경은 worktree에서 수행합니다. 다만 **새 Linear 이슈/병렬 작업**과 **같은 Linear 이슈의 follow-up**을 구분합니다:
+
+- 새 Linear 이슈, 병렬 작업, 기존 worktree가 dirty인 경우, 또는 이전 diff/reference를 보존해야 하는 경우: 새 worktree를 만듭니다.
+- 같은 Linear 이슈의 follow-up이고 기존 issue worktree가 clean하며 재사용 가능하면: 기존 worktree를 재사용해도 됩니다. 물리 worktree를 매번 새로 만드는 것이 필수는 아닙니다.
+- PR이 merge된 브랜치 위에서 계속 커밋하지 않습니다. follow-up 작업은 항상 최신 `origin/main` 기준 새 branch로 시작합니다.
+- worktree 재사용 전에는 `git status --short`, 필요한 diff/reference 백업, `git fetch --prune`을 먼저 확인합니다.
 
 ```bash
-# 새 작업 시작
-cd ~/auto_trader && git switch main && git pull
-git worktree add ~/auto_trader/.worktrees/<ISSUE-ID> -b feature/<ISSUE-ID>-<desc> main
+# canonical repo 업데이트
+cd /Users/mgh3326/work/auto_trader
+git fetch --prune origin
+git switch main
+git pull --ff-only
 
-# 작업
-cd ~/auto_trader/.worktrees/<ISSUE-ID>
-# ... 커밋, 푸시, PR ...
+# 새 Linear 이슈/병렬 작업: 새 worktree 생성
+git worktree add ../auto_trader.<issue-id> -b <branch-name> origin/main
 
-# PR 머지 후 (24h 내)
-cd ~/auto_trader
-git worktree remove .worktrees/<ISSUE-ID>
-git branch -D feature/<ISSUE-ID>-<desc>
+# 같은 Linear 이슈 follow-up: 기존 worktree가 clean하면 재사용
+cd /Users/mgh3326/work/auto_trader.<issue-id>
+git status --short
+git fetch --prune origin
+git switch -c <new-followup-branch> origin/main
+
+# PR 머지 후 정리 (필요 diff/reference가 없고 clean한 상태에서)
+cd /Users/mgh3326/work/auto_trader
+git worktree remove ../auto_trader.<issue-id>
+git branch -D <branch-name>
 ```
 
-- **표준 worktree 경로**: `~/auto_trader/.worktrees/<ISSUE-ID>` (대문자 ISSUE-ID 권장)
-- 이전 경로 `.claude/worktrees/`, `~/.claude/worktrees/` 는 deprecated — 남아 있다면 표준 경로로 이관하거나 prune
+- **표준 worktree 경로**: `/Users/mgh3326/work/auto_trader.<issue-id>` (예: `/Users/mgh3326/work/auto_trader.rob-287`)
+- 이전 경로 `.claude/worktrees/`, `~/.claude/worktrees/`, `~/auto_trader/.worktrees/` 는 deprecated — 남아 있다면 표준 경로로 이관하거나 prune
 - 이관: `git worktree move <old-path> <new-path>` (dirty 없는 상태에서)
 - 삭제된 원격 브랜치(`upstream gone`) 는 주기적으로 `git fetch --prune && git branch -vv | grep ': gone\]'` 로 확인하고 정리
 

--- a/app/mcp_server/tooling/screening/enrichment.py
+++ b/app/mcp_server/tooling/screening/enrichment.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import inspect
 import logging
+from collections.abc import Callable
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,6 +72,7 @@ async def _enrich_consecutive_up_days(
     market: str,
     lookback: int = _STREAK_LOOKBACK_DEFAULT,
     session: AsyncSession | None = None,
+    now: Callable[[], dt.datetime] | None = None,
 ) -> None:
     if not rows:
         return
@@ -77,7 +80,7 @@ async def _enrich_consecutive_up_days(
     market_type = "equity_kr" if market == "kr" else "equity_us"
 
     if session is not None and market in {"kr", "us"}:
-        await _hydrate_from_snapshots(rows, market=market, session=session)
+        await _hydrate_from_snapshots(rows, market=market, session=session, now=now)
 
     sem = asyncio.Semaphore(_STREAK_CONCURRENCY)
 
@@ -114,12 +117,15 @@ async def _enrich_consecutive_up_days(
 
 
 async def _hydrate_from_snapshots(
-    rows: list[dict[str, Any]], *, market: str, session: AsyncSession
+    rows: list[dict[str, Any]],
+    *,
+    market: str,
+    session: AsyncSession,
+    now: Callable[[], dt.datetime] | None = None,
 ) -> None:
-    import datetime as dt
-
+    now_utc = now() if now is not None else dt.datetime.now(dt.UTC)
     repo = InvestScreenerSnapshotsRepository(session)
-    today = today_trading_date(market)
+    today = today_trading_date(market, now=now_utc)
     symbols = [_streak_symbol(r) for r in rows]
     fetched = await repo.get_fresh(
         market=market, symbols=[s for s in symbols if s], on_or_after=dt.date.min
@@ -136,7 +142,6 @@ async def _hydrate_from_snapshots(
         ):
             by_symbol[snapshot.symbol] = snapshot
 
-    now = dt.datetime.now(dt.UTC)
     for row in rows:
         sym = _streak_symbol(row)
         snap = by_symbol.get(sym) if sym else None
@@ -148,7 +153,7 @@ async def _hydrate_from_snapshots(
             computed_at=snap.computed_at,
             closes_window_len=len(snap.closes_window or []),
             today_trading_date_value=today,
-            now=now,
+            now=now_utc,
         )
         row["_screener_snapshot_state"] = state
         if state in {"fresh", "partial"}:

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -387,7 +387,11 @@ def _double_buy_dependency_warnings(
 
 
 async def _load_consecutive_gainers_from_snapshots(
-    session: AsyncSession | None, *, market: str, limit: int = _SNAPSHOT_FIRST_LIMIT
+    session: AsyncSession | None,
+    *,
+    market: str,
+    limit: int = _SNAPSHOT_FIRST_LIMIT,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> _SnapshotLoadResult | None:
     """Return qualifying rows from the latest snapshot partition only.
 
@@ -413,7 +417,8 @@ async def _load_consecutive_gainers_from_snapshots(
     # window (or US pre-17:20 ET window), the expected baseline is the prior
     # trading session, not today — fixes the regression where a fresh
     # prior-day partition is labeled stale after KST/ET midnight rollover.
-    today = expected_baseline_date(market)
+    now_utc = now()
+    today = expected_baseline_date(market, now=now_utc)
 
     # Step 1: resolve the latest snapshot partition date.
     # This prevents older qualifying partitions from leaking into current results
@@ -485,7 +490,6 @@ async def _load_consecutive_gainers_from_snapshots(
                 exc_info=True,
             )
 
-    now = datetime.now(UTC)
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
     for snap in candidate_snaps:
@@ -501,7 +505,7 @@ async def _load_consecutive_gainers_from_snapshots(
             computed_at=snap.computed_at,
             closes_window_len=len(snap.closes_window or []),
             today_trading_date_value=today,
-            now=now,
+            now=now_utc,
         )
         rows.append(
             {
@@ -548,7 +552,11 @@ async def _load_consecutive_gainers_from_snapshots(
 
 
 async def _load_investor_flow_discovery_from_snapshots(
-    session: AsyncSession | None, *, market: str, limit: int = 20
+    session: AsyncSession | None,
+    *,
+    market: str,
+    limit: int = 20,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> _SnapshotLoadResult | None:
     """Return MVP 수급 discovery rows from persisted investor_flow_snapshots.
 
@@ -632,8 +640,8 @@ async def _load_investor_flow_discovery_from_snapshots(
         today_trading_date,
     )
 
-    today = today_trading_date(market)
-    now_utc = datetime.now(UTC)
+    now_utc = now()
+    today = today_trading_date(market, now=now_utc)
 
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -1481,6 +1489,7 @@ async def build_screener_results(
                 session,
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                now=now,
             )
             if _snapshot_load_result is not None:
                 _snapshot_check_result = _snapshot_load_result.rows
@@ -1489,6 +1498,7 @@ async def build_screener_results(
                 session,
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                now=now,
             )
             if _snapshot_load_result is not None:
                 _snapshot_check_result = _snapshot_load_result.rows
@@ -1581,7 +1591,7 @@ async def build_screener_results(
             _enrich_consecutive_up_days as _async_enrich,
         )
 
-        await _async_enrich(rows, market=requested_market, session=session)
+        await _async_enrich(rows, market=requested_market, session=session, now=now)
 
     # Aggregate snapshot dataState from enriched rows (set by _enrich_consecutive_up_days when session provided)
     from app.services.invest_screener_snapshots.freshness import aggregate_states
@@ -1689,12 +1699,13 @@ async def build_screener_results(
 
         if inv_meta:
             worst_sd, worst_collected = min(inv_meta, key=lambda t: t[0])
-            today_kr = today_trading_date("kr")
+            now_utc = now()
+            today_kr = today_trading_date("kr", now=now_utc)
             dep_state = classify_investor_flow_partition(
                 snapshot_date=worst_sd,
                 collected_at=worst_collected,
                 today_trading_date_value=today_kr,
-                now=now(),
+                now=now_utc,
             )
             dependency_specs.append(
                 {


### PR DESCRIPTION
## Summary

- Date-dependent main CI failure on 2026-05-21:
  `tests/test_invest_view_model_screener_service.py::test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency`
  was passing while wall-clock = 2026-05-20 but flips to failure once
  wall-clock advances past the pinned `now=2026-05-20`. Failure surface:
  `assert f.primary.dataState == 'fresh'` got `'stale'`.
- Root cause: the ROB-277-follow-up freshness classifiers in the
  snapshot loaders + the equity enrichment helper read wall-clock time
  directly. `build_screener_results` already accepted an injected `now`
  for the freshness chip and the investor-flow dependency classify,
  but the per-row `_screener_snapshot_state` set in
  `_load_consecutive_gainers_from_snapshots`,
  `_load_investor_flow_discovery_from_snapshots`, and
  `_hydrate_from_snapshots` ignored it. Once any row's state went
  `stale`, `aggregate_states(...)` propagated stale up to
  `primary.dataState`.
- Fix: thread `now` from `build_screener_results` into both loaders
  and the enrichment helper, and pass it to `expected_baseline_date` /
  `today_trading_date` / `classify_state` /
  `classify_investor_flow_partition`. No behavior change when callers
  don't supply `now` — default still reads the wall clock.

## Tracked by ROB-288

This implements Option A from
https://linear.app/mgh3326/issue/ROB-288/auto-trader-time-dependent-test-failure-in-invest-view-model-screener
("fix the production code path") with the scope narrowed to the
freshness classifiers actually reached by the failing test. The
broader sweep proposed in ROB-288's acceptance criteria (e.g.
`investor_flow_service.py` wall-clock leaks at lines 89/116) is **not**
addressed here — those are not on the screener freshness path the
failing test exercises and are out of scope for the CI unblocker.
Suggested follow-up: separate ticket if those leak into a different
failing test, otherwise leave as known minor wall-clock dependency.

Cross-link: ROB-277 (#887) introduced the dual served-vs-data-as-of
freshness split this fix patches.

## Why not a policy change

I considered relaxing the freshness aggregation so an optional
investor_flow dependency staleness doesn't downgrade `overallState`
when primary is fresh, but the test's stable failure point is the
**primary** assertion (`primary.dataState == 'fresh'`). The downstream
`overallState=='stale'` and `dataState=='stale'` assertions already
pass once the primary classification is correct. Keeping the
aggregation rule unchanged means no follow-on fanout into the UI's
freshness chip semantics.

## Files changed

- `app/services/invest_view_model/screener_service.py`
  - `_load_consecutive_gainers_from_snapshots(... now=...)`
  - `_load_investor_flow_discovery_from_snapshots(... now=...)`
  - `build_screener_results` threads `now=now` into both loaders, into
    `_async_enrich`, and into the KR investor-flow dependency
    `today_trading_date("kr", now=now_utc)` call.
- `app/mcp_server/tooling/screening/enrichment.py`
  - `_enrich_consecutive_up_days(... now=...)`
  - `_hydrate_from_snapshots(... now=...)` uses the injected `now` for
    `today_trading_date` and `classify_state`.
- `CLAUDE.md` — picks up the updated Worktree 운영 규칙 wording (same-issue
  follow-up may reuse the existing worktree once cleaned and re-based
  on `origin/main`). Bundled here because the diff is tiny and was
  produced as part of this same follow-up workflow; no separate chore
  PR.

## Verification

```bash
uv run ruff check ...                                             # ✓ clean
uv run ruff format --check ...                                    # ✓ clean
uv run ty check ... --error-on-warning                            # ✓ clean
uv run pytest .../test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency  # ✓ pass
uv run pytest tests/test_invest_view_model_screener_service.py \
              tests/test_screener_service.py \
              tests/test_screener_service_investor_flow_chip.py \
              tests/test_invest_screener_snapshots_enrichment.py \
              tests/test_invest_screener_snapshots_followup_wiring.py \
              tests/test_screener_us_missing_warning.py \
              tests/test_invest_screener_week_change_filter.py \
              tests/test_tvscreener_stock_enrichment_fields.py \
              tests/test_mcp_screen_stocks_tvscreener_contract.py \
              tests/test_invest_screener_snapshots_builder.py \
              tests/test_invest_screener_snapshots_name_precedence.py \
              tests/test_invest_view_model_safety.py \
              tests/test_invest_api_screener_router.py \
              tests/test_screener_router.py                       # ✓ 167 passed
```

## Side-effect non-actions

- Read-only fix on the screener freshness view-model path. No broker,
  order, watch, scheduler, or order-intent code touched.
- No DB migration. No new endpoint. No scheduler change.
- `_load_crypto_rows_from_snapshots` already accepted `now`; behavior
  unchanged.
- `analysis_tool_handlers.py` calls `_enrich_consecutive_up_days`
  without a session, so it skips `_hydrate_from_snapshots` entirely
  — no caller-side update needed there.
- The aggregation rule (`compute_overall_state` /
  `aggregate_states`) is intentionally **unchanged**; this PR only
  fixes the leaking wall-clock that was incorrectly tipping the
  primary row state to `stale`.

## Caveats

- No new test added: the existing pinned-`now` test
  (`test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency`)
  already covers the fix surface. Adding a redundant test would be
  noise. The deeper class of bug (wall-clock leaks anywhere in the
  freshness path) is now considerably narrower; the ROB-288
  acceptance-criteria sweep over `investor_flow_service.py` lines
  89/116 is intentionally deferred (different code path; no failing
  test on it today).

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check`
- [x] Originally failing test passes
- [x] Adjacent screener/enrichment suites pass without regression
- [ ] (downstream) main CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>