### PR TITLE
feat(rob-287): MCP wiring for Hermes-initiated composition contract

### DIFF
--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -20,12 +20,14 @@ from importlib import import_module
 from typing import Any
 
 __all__ = [
+    "INVESTMENT_HERMES_TOOL_NAMES",
     "INVESTMENT_SNAPSHOTS_TOOL_NAMES",
     "MARKET_REPORT_TOOL_NAMES",
     "TRADE_PROFILE_TOOL_NAMES",
     "NEWS_TOOL_NAMES",
     "TRADE_JOURNAL_TOOL_NAMES",
     "register_all_tools",
+    "register_investment_hermes_tools",
     "register_investment_snapshots_tools",
     "register_market_report_tools",
     "register_trade_journal_tools",
@@ -34,6 +36,14 @@ __all__ = [
 ]
 
 _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "INVESTMENT_HERMES_TOOL_NAMES": (
+        "app.mcp_server.tooling.investment_hermes_handlers",
+        "INVESTMENT_HERMES_TOOL_NAMES",
+    ),
+    "register_investment_hermes_tools": (
+        "app.mcp_server.tooling.investment_hermes_handlers",
+        "register_investment_hermes_tools",
+    ),
     "INVESTMENT_SNAPSHOTS_TOOL_NAMES": (
         "app.mcp_server.tooling.investment_snapshots_registration",
         "INVESTMENT_SNAPSHOTS_TOOL_NAMES",

--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -1,0 +1,295 @@
+"""ROB-287 — MCP wiring for the Hermes-initiated composition contract.
+
+Three tools expose the existing service layer from PR #898 directly to
+Hermes:
+
+* ``investment_report_prepare_bundle`` — ensure (reuse or create) the
+  snapshot bundle Hermes will compose against. Deterministic bundle
+  preparation; no in-process LLM, no broker / order / watch /
+  order-intent side effect.
+* ``investment_report_get_hermes_context`` — return a frozen
+  :class:`HermesContextPayload` derived from a persisted bundle. Pure
+  read.
+* ``investment_report_create_from_hermes_composition`` — validate a
+  Hermes-produced :class:`HermesCompositionResult` and persist through
+  the existing :class:`InvestmentReportIngestionService` so idempotency
+  + stale gate + bundle linkage stay authoritative.
+
+All three are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+— the same flag the existing ``investment_report_generate_from_bundle``
+tool uses. No new env flag, no HTTP route, no token auth, no
+operational activation/Prefect wiring (those are explicit follow-ups).
+The fourth tool from the Linear locked decision —
+``investment_stage_artifacts_ingest_from_hermes`` — is intentionally
+deferred until the stage-artifact external-ingest contract is
+specified (stage_run identity, idempotency, partial-stage semantics,
+UI exposure).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.schemas.hermes_composition import (
+    HermesCompositionIngestRequest,
+    HermesCompositionResult,
+)
+from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+from app.services.action_report.common.snapshot_bundle import (
+    SnapshotBundleEnsureService,
+)
+from app.services.investment_stages.hermes_context import (
+    HermesContextExporter,
+    HermesContextExportError,
+)
+from app.services.investment_stages.hermes_ingest import (
+    HermesCompositionIngestError,
+    HermesCompositionIngestService,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+INVESTMENT_HERMES_TOOL_NAMES: set[str] = {
+    "investment_report_prepare_bundle",
+    "investment_report_get_hermes_context",
+    "investment_report_create_from_hermes_composition",
+}
+
+
+_DISABLED_PAYLOAD: dict[str, Any] = {
+    "success": False,
+    "error": "snapshot_backed_report_generator_disabled",
+    "hint": (
+        "Set SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true on the MCP "
+        "host to enable the Hermes composition contract."
+    ),
+}
+
+
+def _disabled_check() -> dict[str, Any] | None:
+    if not settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED:
+        return dict(_DISABLED_PAYLOAD)
+    return None
+
+
+def _parse_bundle_uuid(raw: str) -> uuid.UUID | dict[str, Any]:
+    try:
+        return uuid.UUID(raw)
+    except ValueError:
+        return {
+            "success": False,
+            "error": "invalid_uuid",
+            "snapshot_bundle_uuid": raw,
+        }
+
+
+# ---------------------------------------------------------------------------
+# investment_report_prepare_bundle
+# ---------------------------------------------------------------------------
+async def investment_report_prepare_bundle_impl(
+    market: str,
+    account_scope: str | None = None,
+    policy_version: str = "intraday_action_report_v1",
+    mode: str = "ensure_fresh",
+    symbols: list[str] | None = None,
+    candidate_limit: int | None = None,
+    requested_by: str = "hermes",
+    purpose: str = "report_generation",
+) -> dict[str, Any]:
+    """Ensure a snapshot bundle exists for Hermes to compose against.
+
+    Deterministic bundle preparation — reuses a fresh bundle when one
+    exists, otherwise asks the ensure service to materialise a new run
+    + bundle from the read-only collector registry. No in-process LLM
+    is invoked. No broker / order / watch / order-intent state is
+    touched. The returned ``bundle_uuid`` is the handle Hermes passes
+    to ``investment_report_get_hermes_context`` next.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    request = EnsureBundleRequest(
+        purpose=purpose,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        policy_version=policy_version,
+        mode=mode,  # type: ignore[arg-type]
+        symbols=symbols,
+        candidate_limit=candidate_limit,
+        requested_by=requested_by,  # type: ignore[arg-type]
+    )
+    async with AsyncSessionLocal() as db:
+        svc = SnapshotBundleEnsureService(db)
+        response = await svc.ensure(request)
+        await db.commit()
+    return {"success": True, **response.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# investment_report_get_hermes_context
+# ---------------------------------------------------------------------------
+async def investment_report_get_hermes_context_impl(
+    snapshot_bundle_uuid: str,
+) -> dict[str, Any]:
+    """Return the frozen Hermes context packet for a persisted bundle.
+
+    Runs the deterministic stage set against bundle snapshots already
+    in memory and returns a :class:`HermesContextPayload` Hermes can
+    use as the sole input to its out-of-process composition. Read-only:
+    no stage_run / artifact rows are persisted, no provider is
+    instantiated.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    parsed = _parse_bundle_uuid(snapshot_bundle_uuid)
+    if isinstance(parsed, dict):
+        return parsed
+
+    async with AsyncSessionLocal() as db:
+        exporter = HermesContextExporter(db)
+        try:
+            payload = await exporter.export(snapshot_bundle_uuid=parsed)
+        except HermesContextExportError as exc:
+            return {
+                "success": False,
+                "error": "snapshot_bundle_not_found",
+                "snapshot_bundle_uuid": snapshot_bundle_uuid,
+                "detail": str(exc),
+            }
+    return {"success": True, **payload.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# investment_report_create_from_hermes_composition
+# ---------------------------------------------------------------------------
+async def investment_report_create_from_hermes_composition_impl(
+    composition: dict[str, Any],
+    kst_date: str,
+    market: str,
+    market_session: str | None = None,
+    account_scope: str | None = None,
+    report_type: str = "snapshot_backed_advisory_v1",
+    generator_version: str = "hermes-composition.v1",
+    policy_version: str = "intraday_action_report_v1",
+    status: str = "draft",
+    created_by_profile: str = "HERMES_ADVISOR",
+) -> dict[str, Any]:
+    """Validate a Hermes-produced composition and ingest it as a report.
+
+    The composition body is validated via
+    :class:`HermesCompositionResult` — items that violate the
+    advisory-only invariants
+    (``operation`` ∈ {review, cancel, keep},
+    ``apply_policy='requires_user_approval'``) are rejected up front.
+    The envelope is then routed through
+    :class:`HermesCompositionIngestService` which threads the request
+    through the existing
+    :class:`InvestmentReportIngestionService` so idempotency keys,
+    stale gate, and bundle linkage stay authoritative.
+
+    Reingest of the same Hermes composition (matching ``report_type``
+    + ``market`` + ``market_session`` + ``account_scope`` +
+    ``execution_mode`` + ``kst_date`` + ``generator_version``) is
+    idempotent — the existing report row is returned untouched.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    try:
+        composition_obj = HermesCompositionResult.model_validate(composition)
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "success": False,
+            "error": "invalid_hermes_composition",
+            "detail": str(exc),
+        }
+
+    request = HermesCompositionIngestRequest(
+        composition=composition_obj,
+        kst_date=kst_date,
+        market=market,
+        market_session=market_session,
+        account_scope=account_scope,
+        report_type=report_type,
+        generator_version=generator_version,
+        policy_version=policy_version,
+        status=status,  # type: ignore[arg-type]
+        created_by_profile=created_by_profile,
+    )
+
+    async with AsyncSessionLocal() as db:
+        svc = HermesCompositionIngestService(db)
+        try:
+            report = await svc.ingest_composition(request)
+        except HermesCompositionIngestError as exc:
+            return {
+                "success": False,
+                "error": "snapshot_bundle_not_found",
+                "snapshot_bundle_uuid": str(composition_obj.snapshot_bundle_uuid),
+                "detail": str(exc),
+            }
+        await db.commit()
+
+    return {
+        "success": True,
+        "report_uuid": str(report.report_uuid),
+        "idempotency_key": report.idempotency_key,
+        "snapshot_bundle_uuid": str(composition_obj.snapshot_bundle_uuid),
+        "status": report.status,
+        "items_count": len(composition_obj.items),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+def register_investment_hermes_tools(mcp: FastMCP) -> None:
+    mcp.tool(
+        name="investment_report_prepare_bundle",
+        description=(
+            "ROB-287 — ensure a snapshot bundle exists for Hermes to compose "
+            "against. Deterministic bundle preparation; no in-process LLM, "
+            "no broker / order / watch / order-intent side effect. Gated by "
+            "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_prepare_bundle_impl)
+    mcp.tool(
+        name="investment_report_get_hermes_context",
+        description=(
+            "ROB-287 — return the frozen HermesContextPayload for a "
+            "persisted bundle. Read-only; runs the deterministic v1 stage "
+            "set in-process and returns stage_inputs + cited snapshot UUIDs "
+            "+ advisory-only constraint set. Gated by "
+            "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_get_hermes_context_impl)
+    mcp.tool(
+        name="investment_report_create_from_hermes_composition",
+        description=(
+            "ROB-287 — validate a HermesCompositionResult and ingest it as "
+            "an investment_report. Items must obey "
+            "operation∈{review,cancel,keep} + "
+            "apply_policy='requires_user_approval'; the envelope is routed "
+            "through the existing InvestmentReportIngestionService so "
+            "idempotency + stale gate + bundle linkage stay authoritative. "
+            "Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_create_from_hermes_composition_impl)
+
+
+__all__ = [
+    "INVESTMENT_HERMES_TOOL_NAMES",
+    "investment_report_create_from_hermes_composition_impl",
+    "investment_report_get_hermes_context_impl",
+    "investment_report_prepare_bundle_impl",
+    "register_investment_hermes_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -38,6 +38,9 @@ from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
 )
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.investment_hermes_handlers import (
+    register_investment_hermes_tools,
+)
 from app.mcp_server.tooling.investment_reports_handlers import (
     register_investment_report_tools,
 )
@@ -94,6 +97,12 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_fundamentals_tools(mcp)
     register_analysis_tools(mcp)
     register_investment_report_tools(mcp)
+    # ROB-287 — Hermes-initiated composition contract. The three tools
+    # short-circuit with ``success=False, error='snapshot_backed_report_generator_disabled'``
+    # when ``SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`` is off, so they're
+    # safe to register unconditionally alongside the report-generation
+    # surface.
+    register_investment_hermes_tools(mcp)
     register_trade_profile_tools(mcp)
     register_market_report_tools(mcp)
     register_user_settings_tools(mcp)

--- a/tests/mcp_server/test_investment_hermes_tools.py
+++ b/tests/mcp_server/test_investment_hermes_tools.py
@@ -1,0 +1,546 @@
+"""ROB-287 — Hermes MCP wiring round-trip tests.
+
+Covers the three tools introduced in this PR:
+
+* ``investment_report_prepare_bundle``
+* ``investment_report_get_hermes_context``
+* ``investment_report_create_from_hermes_composition``
+
+All three tools are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+— the gate-off path returns a structured ``success=False`` envelope. Gate-on
+paths exercise the existing service layer (``HermesContextExporter`` /
+``HermesCompositionIngestService``) via patched async sessions / repos so the
+suite stays unit-shaped (no DB required).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.mcp_server.tooling.investment_hermes_handlers import (
+    INVESTMENT_HERMES_TOOL_NAMES,
+    investment_report_create_from_hermes_composition_impl,
+    investment_report_get_hermes_context_impl,
+    investment_report_prepare_bundle_impl,
+    register_investment_hermes_tools,
+)
+
+
+@dataclass
+class _RecordedTool:
+    name: str
+    description: str
+    func: Any
+
+
+@dataclass
+class _RecorderMcp:
+    """Stand-in for ``FastMCP`` that captures ``mcp.tool(...)`` registrations."""
+
+    registered: list[_RecordedTool] = field(default_factory=list)
+
+    def tool(self, *, name: str, description: str):
+        def _decorator(func):
+            self.registered.append(
+                _RecordedTool(name=name, description=description, func=func)
+            )
+            return func
+
+        return _decorator
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_register_investment_hermes_tools_adds_expected_names() -> None:
+    mcp = _RecorderMcp()
+    register_investment_hermes_tools(mcp)
+    assert {t.name for t in mcp.registered} == INVESTMENT_HERMES_TOOL_NAMES
+
+
+def test_investment_hermes_tool_names_lock() -> None:
+    # Locked surface — adding/renaming a tool here should be a deliberate change.
+    assert INVESTMENT_HERMES_TOOL_NAMES == {
+        "investment_report_prepare_bundle",
+        "investment_report_get_hermes_context",
+        "investment_report_create_from_hermes_composition",
+    }
+
+
+def test_tool_descriptions_advertise_no_internal_llm_or_mutation() -> None:
+    """The advertised tool descriptions must call out the safety boundary."""
+    mcp = _RecorderMcp()
+    register_investment_hermes_tools(mcp)
+    by_name = {t.name: t.description for t in mcp.registered}
+    assert "no in-process LLM" in by_name["investment_report_prepare_bundle"]
+    assert (
+        "no broker / order / watch / order-intent side effect"
+        in by_name["investment_report_prepare_bundle"]
+    )
+    assert (
+        "Read-only" in by_name["investment_report_get_hermes_context"]
+        or "read-only" in by_name["investment_report_get_hermes_context"]
+    )
+    assert (
+        "requires_user_approval"
+        in by_name["investment_report_create_from_hermes_composition"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate-off envelopes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prepare_bundle_disabled_without_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
+    )
+    result = await investment_report_prepare_bundle_impl(
+        market="crypto",
+        account_scope="upbit_live",
+    )
+    assert result["success"] is False
+    assert result["error"] == "snapshot_backed_report_generator_disabled"
+    assert "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED" in result["hint"]
+
+
+@pytest.mark.asyncio
+async def test_get_hermes_context_disabled_without_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
+    )
+    result = await investment_report_get_hermes_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+    )
+    assert result["success"] is False
+    assert result["error"] == "snapshot_backed_report_generator_disabled"
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_disabled_without_flag(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
+    )
+    result = await investment_report_create_from_hermes_composition_impl(
+        composition={
+            "snapshot_bundle_uuid": str(uuid.uuid4()),
+            "hermes_run_id": "x",
+            "title": "t",
+            "summary": "s",
+            "items": [],
+        },
+        kst_date="2026-05-21",
+        market="crypto",
+    )
+    assert result["success"] is False
+    assert result["error"] == "snapshot_backed_report_generator_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Gate-on round-trip — patched services
+# ---------------------------------------------------------------------------
+
+
+def _make_bundle(bundle_uuid: uuid.UUID) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        bundle_uuid=bundle_uuid,
+        coverage_summary={"news": {"status": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        status="complete",
+        market="crypto",
+        account_scope="upbit_live",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+def _make_advisory_item(*, key: str = "auto-buy-BTC") -> dict[str, Any]:
+    return {
+        "client_item_key": key,
+        "item_kind": "action",
+        "operation": "review",
+        "symbol": "BTC",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "hermes-produced rationale",
+        "apply_policy": "requires_user_approval",
+    }
+
+
+@pytest.fixture
+def _flag_on(monkeypatch):
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+
+
+class _FakeAsyncSession:
+    """Minimal async context manager that yields itself."""
+
+    async def __aenter__(self) -> _FakeAsyncSession:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        return None
+
+    async def commit(self) -> None:
+        return None
+
+
+def _patched_session_local():
+    return _FakeAsyncSession()
+
+
+@pytest.mark.asyncio
+async def test_prepare_bundle_routes_through_ensure_service(_flag_on) -> None:
+    bundle_uuid = uuid.uuid4()
+    ensure_response = SimpleNamespace(
+        bundle_uuid=bundle_uuid,
+        status="complete",
+        coverage_summary={"news": {"status": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        missing_sources=[],
+        warnings=[],
+        created=False,
+    )
+    ensure_response.model_dump = lambda mode="json": {
+        "bundle_uuid": str(bundle_uuid),
+        "status": "complete",
+        "coverage_summary": {"news": {"status": "fresh"}},
+        "freshness_summary": {"overall": "fresh"},
+        "missing_sources": [],
+        "warnings": [],
+        "created": False,
+    }
+
+    ensure_svc = AsyncMock()
+    ensure_svc.ensure = AsyncMock(return_value=ensure_response)
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.SnapshotBundleEnsureService",
+            return_value=ensure_svc,
+        ),
+    ):
+        result = await investment_report_prepare_bundle_impl(
+            market="crypto",
+            account_scope="upbit_live",
+        )
+
+    assert result["success"] is True
+    assert result["bundle_uuid"] == str(bundle_uuid)
+    assert result["status"] == "complete"
+    ensure_svc.ensure.assert_awaited_once()
+    called_request = ensure_svc.ensure.call_args.args[0]
+    assert called_request.purpose == "report_generation"
+    assert called_request.market == "crypto"
+    assert called_request.account_scope == "upbit_live"
+    assert called_request.requested_by == "hermes"
+
+
+@pytest.mark.asyncio
+async def test_get_hermes_context_invalid_uuid(_flag_on) -> None:
+    result = await investment_report_get_hermes_context_impl(
+        snapshot_bundle_uuid="not-a-uuid"
+    )
+    assert result == {
+        "success": False,
+        "error": "invalid_uuid",
+        "snapshot_bundle_uuid": "not-a-uuid",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_hermes_context_missing_bundle(_flag_on) -> None:
+    from app.services.investment_stages.hermes_context import (
+        HermesContextExportError,
+    )
+
+    bundle_uuid = uuid.uuid4()
+    exporter = AsyncMock()
+    exporter.export = AsyncMock(side_effect=HermesContextExportError("missing"))
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesContextExporter",
+            return_value=exporter,
+        ),
+    ):
+        result = await investment_report_get_hermes_context_impl(
+            snapshot_bundle_uuid=str(bundle_uuid)
+        )
+
+    assert result["success"] is False
+    assert result["error"] == "snapshot_bundle_not_found"
+    assert result["snapshot_bundle_uuid"] == str(bundle_uuid)
+
+
+@pytest.mark.asyncio
+async def test_get_hermes_context_returns_payload_on_success(_flag_on) -> None:
+    from app.schemas.hermes_composition import HermesContextPayload
+
+    bundle_uuid = uuid.uuid4()
+    payload = HermesContextPayload(
+        snapshot_bundle_uuid=bundle_uuid,
+        bundle_status="complete",
+        market="crypto",
+        account_scope="upbit_live",
+        policy_version="intraday_action_report_v1",
+    )
+
+    exporter = AsyncMock()
+    exporter.export = AsyncMock(return_value=payload)
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesContextExporter",
+            return_value=exporter,
+        ),
+    ):
+        result = await investment_report_get_hermes_context_impl(
+            snapshot_bundle_uuid=str(bundle_uuid)
+        )
+
+    assert result["success"] is True
+    assert result["context_version"] == "hermes-context.v1"
+    assert result["snapshot_bundle_uuid"] == str(bundle_uuid)
+    assert result["bundle_status"] == "complete"
+    assert result["constraints"]["advisory_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_rejects_invalid_envelope(
+    _flag_on,
+) -> None:
+    """Composition validator rejects items that violate advisory-only invariants."""
+    result = await investment_report_create_from_hermes_composition_impl(
+        composition={
+            "snapshot_bundle_uuid": str(uuid.uuid4()),
+            "hermes_run_id": "run-1",
+            "title": "Bad",
+            "summary": "Bad",
+            "items": [
+                {
+                    "client_item_key": "bad-op",
+                    "item_kind": "action",
+                    "operation": "create",
+                    "intent": "buy_review",
+                    "symbol": "BTC",
+                    "side": "buy",
+                    "rationale": "x",
+                    "apply_policy": "requires_user_approval",
+                }
+            ],
+        },
+        kst_date="2026-05-21",
+        market="crypto",
+    )
+    assert result["success"] is False
+    assert result["error"] == "invalid_hermes_composition"
+    assert "advisory-only" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_missing_bundle(_flag_on) -> None:
+    from app.services.investment_stages.hermes_ingest import (
+        HermesCompositionIngestError,
+    )
+
+    bundle_uuid = uuid.uuid4()
+    svc = AsyncMock()
+    svc.ingest_composition = AsyncMock(
+        side_effect=HermesCompositionIngestError("missing bundle")
+    )
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesCompositionIngestService",
+            return_value=svc,
+        ),
+    ):
+        result = await investment_report_create_from_hermes_composition_impl(
+            composition={
+                "snapshot_bundle_uuid": str(bundle_uuid),
+                "hermes_run_id": "run-1",
+                "title": "t",
+                "summary": "s",
+                "items": [_make_advisory_item()],
+            },
+            kst_date="2026-05-21",
+            market="crypto",
+            account_scope="upbit_live",
+        )
+
+    assert result["success"] is False
+    assert result["error"] == "snapshot_bundle_not_found"
+    assert result["snapshot_bundle_uuid"] == str(bundle_uuid)
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_happy_path(_flag_on) -> None:
+    bundle_uuid = uuid.uuid4()
+    report_uuid = uuid.uuid4()
+    report = SimpleNamespace(
+        report_uuid=report_uuid,
+        idempotency_key="idem-1",
+        status="draft",
+    )
+    svc = AsyncMock()
+    svc.ingest_composition = AsyncMock(return_value=report)
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesCompositionIngestService",
+            return_value=svc,
+        ),
+    ):
+        result = await investment_report_create_from_hermes_composition_impl(
+            composition={
+                "snapshot_bundle_uuid": str(bundle_uuid),
+                "hermes_run_id": "run-1",
+                "title": "Hermes Advisory",
+                "summary": "Synth",
+                "items": [_make_advisory_item()],
+            },
+            kst_date="2026-05-21",
+            market="crypto",
+            account_scope="upbit_live",
+        )
+
+    assert result["success"] is True
+    assert result["report_uuid"] == str(report_uuid)
+    assert result["idempotency_key"] == "idem-1"
+    assert result["snapshot_bundle_uuid"] == str(bundle_uuid)
+    assert result["status"] == "draft"
+    assert result["items_count"] == 1
+    svc.ingest_composition.assert_awaited_once()
+    envelope = svc.ingest_composition.call_args.args[0]
+    assert envelope.composition.snapshot_bundle_uuid == bundle_uuid
+    assert envelope.market == "crypto"
+    assert envelope.generator_version == "hermes-composition.v1"
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_idempotency_reroutes_existing(
+    _flag_on,
+) -> None:
+    """Two invocations with the same envelope return the same report; the
+    ingest service is responsible for the actual idempotency-key check via
+    InvestmentReportIngestionService."""
+    bundle_uuid = uuid.uuid4()
+    report_uuid = uuid.uuid4()
+    report = SimpleNamespace(
+        report_uuid=report_uuid,
+        idempotency_key="idem-1",
+        status="draft",
+    )
+    svc = AsyncMock()
+    svc.ingest_composition = AsyncMock(return_value=report)
+
+    composition_payload = {
+        "snapshot_bundle_uuid": str(bundle_uuid),
+        "hermes_run_id": "run-1",
+        "title": "Hermes Advisory",
+        "summary": "Synth",
+        "items": [_make_advisory_item()],
+    }
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesCompositionIngestService",
+            return_value=svc,
+        ),
+    ):
+        first = await investment_report_create_from_hermes_composition_impl(
+            composition=composition_payload,
+            kst_date="2026-05-21",
+            market="crypto",
+            account_scope="upbit_live",
+        )
+        second = await investment_report_create_from_hermes_composition_impl(
+            composition=composition_payload,
+            kst_date="2026-05-21",
+            market="crypto",
+            account_scope="upbit_live",
+        )
+
+    assert first == second
+    assert first["report_uuid"] == str(report_uuid)
+    assert svc.ingest_composition.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_from_hermes_composition_zero_items_partial_data(_flag_on) -> None:
+    """Partial data: Hermes may legitimately return zero items when the
+    bundle is too thin. The MCP tool must accept and persist that envelope."""
+    bundle_uuid = uuid.uuid4()
+    report = SimpleNamespace(
+        report_uuid=uuid.uuid4(),
+        idempotency_key="idem-partial",
+        status="draft",
+    )
+    svc = AsyncMock()
+    svc.ingest_composition = AsyncMock(return_value=report)
+
+    with (
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.AsyncSessionLocal",
+            _patched_session_local,
+        ),
+        patch(
+            "app.mcp_server.tooling.investment_hermes_handlers.HermesCompositionIngestService",
+            return_value=svc,
+        ),
+    ):
+        result = await investment_report_create_from_hermes_composition_impl(
+            composition={
+                "snapshot_bundle_uuid": str(bundle_uuid),
+                "hermes_run_id": "thin-bundle",
+                "title": "Hermes Advisory",
+                "summary": "Nothing actionable",
+                "items": [],
+            },
+            kst_date="2026-05-21",
+            market="crypto",
+            account_scope="upbit_live",
+        )
+
+    assert result["success"] is True
+    assert result["items_count"] == 0


### PR DESCRIPTION
## Summary

Exposes the service layer landed in PR #898 to Hermes via three MCP
tools. Service-layer-only wiring — no HTTP route, no token auth, no
operational activation/Prefect, no deploy/smoke. Scope intentionally
narrowed to what maps 1:1 to the existing services.

Tools added (all gated by `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`,
the same flag the existing `investment_report_generate_from_bundle`
uses — **no new env flag**):

- `investment_report_prepare_bundle` — ensure (reuse or create) the
  snapshot bundle Hermes will compose against. Deterministic bundle
  preparation; no in-process LLM, no broker / order / watch /
  order-intent side effect.
- `investment_report_get_hermes_context` — return the frozen
  `HermesContextPayload` for a persisted bundle. Read-only; runs the
  deterministic v1 stage set in-process.
- `investment_report_create_from_hermes_composition` — validate a
  Hermes-produced `HermesCompositionResult` and persist through the
  existing `InvestmentReportIngestionService` so idempotency keys,
  stale gate, and bundle linkage stay authoritative.

## Files changed

- `app/mcp_server/tooling/investment_hermes_handlers.py` (new) — 3
  tool implementations + `register_investment_hermes_tools`.
- `app/mcp_server/tooling/registry.py` — registers the new module
  alongside `register_investment_report_tools`. Registration is
  unconditional because the gate is enforced inside each tool body.
- `app/mcp_server/tooling/__init__.py` — lazy-export the new
  `INVESTMENT_HERMES_TOOL_NAMES` + `register_investment_hermes_tools`.
- `tests/mcp_server/test_investment_hermes_tools.py` (new) — 15 unit
  tests, see below.

## Deferred to follow-up PRs

Per the ROB-287 locked decisions §2 and the user's MCP-only directive:

- `investment_stage_artifacts_ingest_from_hermes` — needs the
  stage-artifact external-ingest contract first
  (stage_run identity, artifact kind/schema/version, idempotency key,
  partial-stage semantics, ordering, provenance, UI exposure). No
  placeholder shipped here to avoid a no-op tool in the catalog.
- HTTP route + `HERMES_INGEST_TOKEN` token auth.
- Operational env flag / Prefect activation.
- deploy/smoke (production cutover).

## Gating policy

All three tools short-circuit with
`{success: false, error: 'snapshot_backed_report_generator_disabled', hint: ...}`
when `settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED` is `False`.
Registration is unconditional alongside the existing
`investment_report_*` surface — the gate is enforced inside each tool
body, mirroring how `investment_report_generate_from_bundle` already
behaves.

## Tests

`tests/mcp_server/test_investment_hermes_tools.py` (15 tests):

1. Registration surface: name-set lock + `INVESTMENT_HERMES_TOOL_NAMES`
   matches what's registered.
2. Tool descriptions advertise the safety boundary
   (`no in-process LLM`, `no broker / order / watch / order-intent
   side effect`, `requires_user_approval`).
3. Gate-off envelopes for all 3 tools.
4. `prepare_bundle` routes the request through `SnapshotBundleEnsureService.ensure(...)`
   with `purpose='report_generation'`, `requested_by='hermes'`.
5. `get_hermes_context` rejects invalid UUID, surfaces
   `HermesContextExportError` as `snapshot_bundle_not_found`, and on
   success returns `context_version='hermes-context.v1'` +
   advisory-only constraints pinned.
6. `create_from_hermes_composition` rejects items violating
   `operation∈{review,cancel,keep}` / `apply_policy='requires_user_approval'`
   at the schema validator boundary; surfaces missing-bundle as a
   structured error; happy path returns `report_uuid` +
   `idempotency_key`; idempotency reroute (two identical envelopes
   produce identical responses); partial-data case (zero items).
7. The existing ROB-287 static import guard
   (`tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py`)
   continues to scan the new handler module — passes, confirming no
   provider/composer/budget imports were re-introduced.

## Verification

```bash
uv run ruff check app/ tests/                                            # ✓
uv run ruff format --check app/mcp_server/tooling/investment_hermes_handlers.py \
                          app/mcp_server/tooling/registry.py \
                          app/mcp_server/tooling/__init__.py \
                          tests/mcp_server/test_investment_hermes_tools.py # ✓
uv run ty check app/mcp_server/tooling/investment_hermes_handlers.py \
                --error-on-warning                                       # ✓
uv run pytest tests/mcp_server/test_investment_hermes_tools.py           # ✓ 15 passed
uv run pytest tests/mcp_server/ \
              tests/services/investment_stages/ \
              tests/services/action_report/snapshot_backed/              # ✓ 301 passed
```

## Side-effect non-actions

- No DB migration. No new env flag. No new HTTP endpoint.
- No broker / order / watch / order-intent / scheduler code touched.
- No in-process LLM provider re-introduced (the existing ROB-287
  static import guard verifies the new module).
- `auto_emit_from_evidence` path is **unchanged** — it remains the
  deterministic, explicit-flag-only proposer and is never
  co-mingled with the Hermes composition path against the same
  bundle.
- Linear ROB-287 stays **In Progress** — this PR is a scoped
  follow-up; further ROB-287 follow-ups (4th tool + HTTP/token +
  operational activation) ship separately.

## Caveats / unverified

- No real Hermes service was exercised end-to-end; the validator,
  shape contracts, and ingest routing are unit-tested via patched
  services. The first real Hermes call in any environment will be
  the first JSON-over-the-wire exercise of these contracts.
- Concurrency: `prepare_bundle` and `create_from_hermes_composition`
  each commit their own session — same pattern as the rest of
  `investment_report_*` and `investment_snapshot_*`. No new
  transactional semantics introduced.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check`
- [x] New unit tests pass
- [x] Adjacent suites pass without regression (301 tests)
- [x] Static import guard still passes
- [ ] (out of scope) Hermes real-service round trip
- [ ] (out of scope) MCP transport / fastmcp registration smoke
- [ ] (deferred PR) `investment_stage_artifacts_ingest_from_hermes`
- [ ] (deferred PR) HTTP route + token auth
- [ ] (deferred PR) operational activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new tools for investment report composition are now available through Hermes integration: snapshot bundle preparation, context data retrieval for compositions, and report generation from Hermes-composed content. All tools include built-in safety measures and informative error handling when the feature flag is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->