### PR TITLE
feat(rob-287): investment_stage_artifacts_ingest_from_hermes (Plan B Phase 2)

### DIFF
--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -1,7 +1,6 @@
 """ROB-287 — MCP wiring for the Hermes-initiated composition contract.
 
-Three tools expose the existing service layer from PR #898 directly to
-Hermes:
+Four tools expose the service layer (PRs #898 + #905) directly to Hermes:
 
 * ``investment_report_prepare_bundle`` — ensure (reuse or create) the
   snapshot bundle Hermes will compose against. Deterministic bundle
@@ -10,20 +9,26 @@ Hermes:
 * ``investment_report_get_hermes_context`` — return a frozen
   :class:`HermesContextPayload` derived from a persisted bundle. Pure
   read.
+* ``investment_stage_artifacts_ingest_from_hermes`` — append-only
+  ingest of one or more Hermes-produced stage artifacts. Hermes
+  generates ``run_uuid`` client-side (§D1); auto_trader creates the
+  run row on first ingest and reuses it for subsequent calls.
+  ``(run_uuid, stage_type)`` is the idempotency key — identical
+  payload returns the stored row, differing payload is rejected
+  (§D3). Leaves ``run.status='running'`` — composition ingest is the
+  canonical finalizer (§D4).
 * ``investment_report_create_from_hermes_composition`` — validate a
   Hermes-produced :class:`HermesCompositionResult` and persist through
   the existing :class:`InvestmentReportIngestionService` so idempotency
-  + stale gate + bundle linkage stay authoritative.
+  + stale gate + bundle linkage stay authoritative. Also auto-finalises
+  any matching ``running`` Hermes stage run when
+  ``composition.metadata.investment_stage_run_uuid`` points at one.
 
-All three are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+All four are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
 — the same flag the existing ``investment_report_generate_from_bundle``
 tool uses. No new env flag, no HTTP route, no token auth, no
-operational activation/Prefect wiring (those are explicit follow-ups).
-The fourth tool from the Linear locked decision —
-``investment_stage_artifacts_ingest_from_hermes`` — is intentionally
-deferred until the stage-artifact external-ingest contract is
-specified (stage_run identity, idempotency, partial-stage semantics,
-UI exposure).
+operational activation / Prefect wiring (those are explicit follow-up
+PRs per the user's Plan B directive).
 """
 
 from __future__ import annotations

--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -36,6 +36,7 @@ from app.core.db import AsyncSessionLocal
 from app.schemas.hermes_composition import (
     HermesCompositionIngestRequest,
     HermesCompositionResult,
+    HermesStageArtifactsIngestRequest,
 )
 from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
 from app.services.action_report.common.snapshot_bundle import (
@@ -48,6 +49,8 @@ from app.services.investment_stages.hermes_context import (
 from app.services.investment_stages.hermes_ingest import (
     HermesCompositionIngestError,
     HermesCompositionIngestService,
+    HermesStageArtifactsIngestError,
+    HermesStageArtifactsIngestService,
 )
 
 if TYPE_CHECKING:
@@ -58,6 +61,7 @@ INVESTMENT_HERMES_TOOL_NAMES: set[str] = {
     "investment_report_prepare_bundle",
     "investment_report_get_hermes_context",
     "investment_report_create_from_hermes_composition",
+    "investment_stage_artifacts_ingest_from_hermes",
 }
 
 
@@ -250,6 +254,84 @@ async def investment_report_create_from_hermes_composition_impl(
 
 
 # ---------------------------------------------------------------------------
+# investment_stage_artifacts_ingest_from_hermes
+# ---------------------------------------------------------------------------
+async def investment_stage_artifacts_ingest_from_hermes_impl(
+    run_envelope: dict[str, Any],
+    artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Ingest one or more Hermes-produced stage artifacts.
+
+    Locked decisions (signed off 2026-05-21):
+
+    * §D1 — Hermes generates ``run_uuid`` client-side; auto_trader creates
+      the run row on the first ingest, reuses it on subsequent calls with
+      the same id.
+    * §D3 — Append-only idempotency on ``(run_uuid, stage_type)``. Same key
+      with identical payload returns the stored row; differing payload is
+      rejected with ``error='artifact_content_conflict'``.
+    * §D4 — This tool does NOT advance ``run.status`` to a terminal state;
+      ``investment_report_create_from_hermes_composition`` finalises a
+      ``running`` run when its composition references the same ``run_uuid``.
+    * §D5 — Artifacts may arrive in any order; auto_trader does not enforce
+      stage dependencies at the ingest layer.
+    * §D8 — Multiple artifacts allowed per call; duplicate ``stage_type``
+      values in a single call are rejected at the schema validator.
+    * §TS6 — Empty ``artifacts`` list is rejected.
+
+    Hard invariants:
+
+    * No external LLM is called.
+    * No broker / order / watch / order-intent mutation path is touched.
+    * Append-only: a successfully stored artifact is never mutated.
+
+    Gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``. When
+    the flag is off, returns a structured ``success=False`` envelope.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    try:
+        request = HermesStageArtifactsIngestRequest.model_validate(
+            {"run_envelope": run_envelope, "artifacts": artifacts}
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "success": False,
+            "error": "invalid_stage_artifacts_request",
+            "detail": str(exc),
+        }
+
+    async with AsyncSessionLocal() as db:
+        svc = HermesStageArtifactsIngestService(db)
+        try:
+            response = await svc.ingest_stage_artifacts(request)
+        except HermesStageArtifactsIngestError as exc:
+            return {
+                "success": False,
+                "error": exc.code,
+                "detail": str(exc),
+            }
+        await db.commit()
+
+    return {
+        "success": True,
+        "run_uuid": str(response.run.run_uuid),
+        "run_status": response.run.status,
+        "snapshot_bundle_uuid": str(response.run.snapshot_bundle_uuid),
+        "artifacts": [
+            {
+                "stage_type": r.stage_type,
+                "artifact_uuid": str(r.artifact.artifact_uuid),
+                "idempotent_existing": r.idempotent_existing,
+            }
+            for r in response.results
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 def register_investment_hermes_tools(mcp: FastMCP) -> None:
@@ -281,9 +363,26 @@ def register_investment_hermes_tools(mcp: FastMCP) -> None:
             "apply_policy='requires_user_approval'; the envelope is routed "
             "through the existing InvestmentReportIngestionService so "
             "idempotency + stale gate + bundle linkage stay authoritative. "
+            "Auto-finalises any matching Hermes stage run "
+            "(metadata.investment_stage_run_uuid) from 'running' to "
+            "'completed' (§D4). "
             "Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
         ),
     )(investment_report_create_from_hermes_composition_impl)
+    mcp.tool(
+        name="investment_stage_artifacts_ingest_from_hermes",
+        description=(
+            "ROB-287 — append-only ingest of Hermes-produced stage "
+            "artifacts. Hermes generates the run_uuid client-side; "
+            "auto_trader creates the run row on first ingest and reuses "
+            "it for subsequent calls. Same (run_uuid, stage_type) with "
+            "identical payload returns the stored row (idempotent); "
+            "differing payload is rejected. Does NOT finalise the run — "
+            "use investment_report_create_from_hermes_composition for "
+            "that (§D4). No broker / order / watch / order-intent side "
+            "effect. Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_stage_artifacts_ingest_from_hermes_impl)
 
 
 __all__ = [
@@ -291,5 +390,6 @@ __all__ = [
     "investment_report_create_from_hermes_composition_impl",
     "investment_report_get_hermes_context_impl",
     "investment_report_prepare_bundle_impl",
+    "investment_stage_artifacts_ingest_from_hermes_impl",
     "register_investment_hermes_tools",
 ]

--- a/app/schemas/hermes_composition.py
+++ b/app/schemas/hermes_composition.py
@@ -28,6 +28,7 @@ from app.schemas.investment_stages import StageArtifactPayload
 
 HERMES_CONTEXT_VERSION = "hermes-context.v1"
 HERMES_COMPOSITION_VERSION = "hermes-composition.v1"
+HERMES_STAGE_ARTIFACTS_VERSION = "hermes-stage-artifacts.v1"
 
 
 class HermesCitedSnapshot(BaseModel):
@@ -163,3 +164,82 @@ class HermesCompositionIngestRequest(BaseModel):
     policy_version: str = "intraday_action_report_v1"
     status: Literal["draft", "published"] = "draft"
     created_by_profile: str = "HERMES_ADVISOR"
+
+
+class HermesStageRunEnvelope(BaseModel):
+    """Run-scope metadata Hermes attaches to each stage-artifact ingest call.
+
+    Locked decisions for stage-artifacts ingest (sign-off 2026-05-21):
+
+    * **D1 — run_uuid ownership**: Hermes generates ``run_uuid`` client-side
+      (UUID v4). auto_trader creates the run row on the first ingest and
+      reuses it for subsequent calls with the same ``run_uuid``. If a
+      pre-existing run row's envelope fields differ from this one, the
+      ingest is rejected for consistency (a single ``run_uuid`` must map
+      to a single ``(bundle_uuid, market, market_session, account_scope,
+      policy_version, generator_version)`` tuple).
+    * **D4 — finalization**: stage-artifact ingest leaves ``run.status``
+      at ``running``. The downstream
+      ``HermesCompositionIngestService.ingest_composition`` auto-flips the
+      run to ``completed`` when ``composition.metadata.investment_stage_run_uuid``
+      matches an existing ``running`` run row.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_uuid: uuid.UUID
+    snapshot_bundle_uuid: uuid.UUID
+    market: str
+    market_session: str | None = None
+    account_scope: str | None = None
+    policy_version: str = "intraday_action_report_v1"
+    generator_version: str = HERMES_STAGE_ARTIFACTS_VERSION
+    hermes_run_id: str | None = None
+
+
+class HermesStageArtifactsIngestRequest(BaseModel):
+    """Top-level envelope for stage-artifacts ingest.
+
+    Locked decisions:
+
+    * **D2 — schema**: artifacts are validated as :class:`StageArtifactPayload`
+      directly. No Hermes-specific extension fields — extending the artifact
+      shape requires bumping ``HERMES_STAGE_ARTIFACTS_VERSION`` and the
+      ``stage_type`` DB CHECK.
+    * **D5 — ordering**: artifacts may arrive in any order. auto_trader does
+      NOT enforce stage dependencies at the ingest layer; Hermes orchestrates
+      its own pipeline.
+    * **D8 — batching**: multiple artifacts allowed per call.
+    * **TS6 — empty list reject**: an empty ``artifacts`` list is rejected;
+      "create a run row with no artifacts" is not a supported use case in v1.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    request_version: Literal["hermes-stage-artifacts.v1"] = (
+        HERMES_STAGE_ARTIFACTS_VERSION
+    )
+    run_envelope: HermesStageRunEnvelope
+    artifacts: list[StageArtifactPayload] = Field(min_length=1)
+
+    @field_validator("artifacts")
+    @classmethod
+    def _enforce_unique_stage_types(
+        cls, artifacts: list[StageArtifactPayload]
+    ) -> list[StageArtifactPayload]:
+        seen: set[str] = set()
+        duplicates: list[str] = []
+        for art in artifacts:
+            if art.stage_type in seen:
+                duplicates.append(art.stage_type)
+            else:
+                seen.add(art.stage_type)
+        if duplicates:
+            raise ValueError(
+                "Hermes stage-artifacts ingest cannot include duplicate "
+                f"stage_type values in a single call: {duplicates!r}. The "
+                "ledger's (run_uuid, stage_type) UNIQUE constraint forbids "
+                "two artifacts with the same key; split into separate calls "
+                "if reattempting an artifact intentionally."
+            )
+        return artifacts

--- a/app/services/investment_stages/hermes_ingest.py
+++ b/app/services/investment_stages/hermes_ingest.py
@@ -1,37 +1,45 @@
-"""Hermes composition ingest service (ROB-287).
+"""Hermes ingest services (ROB-287).
 
-Takes a Hermes-produced :class:`HermesCompositionResult`, builds an
-:class:`IngestReportRequest`, and persists through
-:class:`InvestmentReportIngestionService`. The existing
-``enforce_stale_gate_for_ingest`` + idempotency-key pipeline is the
-authoritative gate; this service only validates the Hermes-shaped
-envelope and wires bundle metadata back onto the request so provenance
-survives.
+Two Hermes-initiated write paths land here:
+
+1. :class:`HermesStageArtifactsIngestService` — Hermes ingests one or more
+   :class:`StageArtifactPayload` rows for a single ``run_uuid``. The run
+   row is auto-created on the first ingest (Hermes-generated UUID per
+   locked decision §D1) and reused on subsequent calls. Append-only
+   idempotency: re-ingesting the same ``(run_uuid, stage_type)`` with
+   identical content returns the stored row; differing content is
+   rejected (§D3).
+2. :class:`HermesCompositionIngestService` — Hermes ingests a final
+   composition (title/summary/items) that becomes an
+   ``InvestmentReport`` row via the existing
+   :class:`InvestmentReportIngestionService`. When the composition's
+   ``metadata.investment_stage_run_uuid`` matches an existing
+   ``running`` stage run, the composition ingest also flips that run
+   to ``completed`` (§D4 — composition is the canonical finalizer).
 
 Hard invariants:
 
-* No external LLM is called here. Hermes does its reasoning out of
-  process and hands a frozen JSON shape back through this contract.
-* All items must be ``operation`` ∈ ``{review, cancel, keep}`` with
-  ``apply_policy='requires_user_approval'`` — the schema validator
-  rejects anything else outright.
-* ``snapshot_bundle_uuid`` is mandatory and round-trips into the
-  ingested row's metadata, so the report stays linked to the source
-  bundle for audit.
+* No external LLM is called here.
+* No broker / order / watch / order-intent mutation reachable.
+* Stage-artifact ingest does NOT advance ``run.status`` to a terminal
+  state. Composition ingest is the only path that closes a run.
 """
 
 from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.investment_reports import InvestmentReport
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
 from app.schemas.hermes_composition import (
     HERMES_COMPOSITION_VERSION,
     HermesCompositionIngestRequest,
+    HermesStageArtifactsIngestRequest,
 )
 from app.schemas.investment_reports import (
     AccountScopeLiteral,
@@ -39,11 +47,16 @@ from app.schemas.investment_reports import (
     MarketLiteral,
     MarketSessionLiteral,
 )
+from app.schemas.investment_stages import StageArtifactPayload
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
 from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
+)
+from app.services.investment_stages.repository import (
+    AppendOnlyViolation,
+    InvestmentStagesRepository,
 )
 
 _logger = logging.getLogger(__name__)
@@ -53,8 +66,250 @@ class HermesCompositionIngestError(RuntimeError):
     """Raised when the Hermes-produced envelope cannot be ingested."""
 
 
+class HermesStageArtifactsIngestError(RuntimeError):
+    """Raised when the stage-artifacts envelope cannot be ingested.
+
+    Carries a ``code`` field so the MCP tool can serialise a structured
+    error envelope without leaking server-side internals.
+    """
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class HermesStageArtifactIngestResult:
+    """One row's outcome from the stage-artifact ingest."""
+
+    stage_type: str
+    artifact: InvestmentStageArtifact
+    idempotent_existing: bool
+
+
+@dataclass(frozen=True)
+class HermesStageArtifactsIngestResponse:
+    run: InvestmentStageRun
+    results: list[HermesStageArtifactIngestResult]
+
+
+# ---------------------------------------------------------------------------
+# Stage-artifacts ingest
+# ---------------------------------------------------------------------------
+
+
+class HermesStageArtifactsIngestService:
+    """Validate + persist Hermes-produced stage artifacts.
+
+    Locked decisions referenced by this service:
+
+    * §D1 — Hermes generates ``run_uuid`` client-side.
+    * §D3 — Content-aware idempotency on ``(run_uuid, stage_type)``.
+    * §D4 — Run stays in ``running``; composition ingest finalizes.
+    * §D5 — No ordering enforced.
+    * §D8 — Multiple artifacts per call.
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        stages_repository: InvestmentStagesRepository | None = None,
+        snapshots_repository: InvestmentSnapshotsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._stages = stages_repository or InvestmentStagesRepository(session)
+        self._snapshots = snapshots_repository or InvestmentSnapshotsRepository(session)
+
+    async def ingest_stage_artifacts(
+        self, request: HermesStageArtifactsIngestRequest
+    ) -> HermesStageArtifactsIngestResponse:
+        envelope = request.run_envelope
+
+        bundle = await self._snapshots.get_bundle_by_uuid(envelope.snapshot_bundle_uuid)
+        if bundle is None:
+            raise HermesStageArtifactsIngestError(
+                f"snapshot bundle not found: {envelope.snapshot_bundle_uuid}",
+                code="snapshot_bundle_not_found",
+            )
+
+        run = await self._find_or_create_run(envelope)
+
+        results: list[HermesStageArtifactIngestResult] = []
+        for payload in request.artifacts:
+            persisted, idempotent = await self._persist_or_reuse_artifact(
+                run_uuid=run.run_uuid, payload=payload
+            )
+            results.append(
+                HermesStageArtifactIngestResult(
+                    stage_type=payload.stage_type,
+                    artifact=persisted,
+                    idempotent_existing=idempotent,
+                )
+            )
+
+        return HermesStageArtifactsIngestResponse(run=run, results=results)
+
+    # ------------------------------------------------------------------
+    # Run helpers
+    # ------------------------------------------------------------------
+
+    async def _find_or_create_run(self, envelope: Any) -> InvestmentStageRun:
+        existing = await self._stages.get_run(envelope.run_uuid)
+        if existing is None:
+            return await self._stages.create_run(
+                run_uuid=envelope.run_uuid,
+                snapshot_bundle_uuid=envelope.snapshot_bundle_uuid,
+                market=envelope.market,
+                market_session=envelope.market_session,
+                account_scope=envelope.account_scope,
+                policy_version=envelope.policy_version,
+                generator_version=envelope.generator_version,
+            )
+
+        # Run exists — verify envelope consistency. A single run_uuid must
+        # map to a single (bundle, market, session, scope, policy, generator).
+        mismatches: list[str] = []
+        if existing.snapshot_bundle_uuid != envelope.snapshot_bundle_uuid:
+            mismatches.append(
+                f"snapshot_bundle_uuid (existing={existing.snapshot_bundle_uuid}, "
+                f"envelope={envelope.snapshot_bundle_uuid})"
+            )
+        if existing.market != envelope.market:
+            mismatches.append(
+                f"market (existing={existing.market!r}, envelope={envelope.market!r})"
+            )
+        if (existing.market_session or None) != (envelope.market_session or None):
+            mismatches.append(
+                f"market_session (existing={existing.market_session!r}, "
+                f"envelope={envelope.market_session!r})"
+            )
+        if (existing.account_scope or None) != (envelope.account_scope or None):
+            mismatches.append(
+                f"account_scope (existing={existing.account_scope!r}, "
+                f"envelope={envelope.account_scope!r})"
+            )
+        if existing.policy_version != envelope.policy_version:
+            mismatches.append(
+                f"policy_version (existing={existing.policy_version!r}, "
+                f"envelope={envelope.policy_version!r})"
+            )
+        if existing.generator_version != envelope.generator_version:
+            mismatches.append(
+                f"generator_version (existing={existing.generator_version!r}, "
+                f"envelope={envelope.generator_version!r})"
+            )
+        if mismatches:
+            raise HermesStageArtifactsIngestError(
+                "stage run envelope inconsistent with existing row for "
+                f"run_uuid={envelope.run_uuid}: " + "; ".join(mismatches),
+                code="run_envelope_mismatch",
+            )
+        return existing
+
+    # ------------------------------------------------------------------
+    # Artifact helpers
+    # ------------------------------------------------------------------
+
+    async def _persist_or_reuse_artifact(
+        self, *, run_uuid: uuid.UUID, payload: StageArtifactPayload
+    ) -> tuple[InvestmentStageArtifact, bool]:
+        """Look-before-leap idempotent persist.
+
+        ``persist_artifact`` raises ``AppendOnlyViolation`` on the
+        underlying ``IntegrityError``, but that also leaves the
+        SQLAlchemy async session in a rolled-back state — subsequent
+        reads on the same session would hit ``PendingRollbackError``.
+        Probe for an existing row first; if absent, insert. The
+        existence check + insert run in the same transaction so a true
+        concurrent insert by another worker would still surface as
+        ``AppendOnlyViolation`` (acceptable: Hermes is single-flight
+        per ``run_uuid`` in practice, and the bubbled error message
+        identifies the race window for operator triage).
+        """
+        existing = await self._fetch_existing(run_uuid, payload.stage_type)
+        if existing is not None:
+            if not _artifact_content_matches(existing, payload):
+                raise HermesStageArtifactsIngestError(
+                    f"stage artifact ({run_uuid}, {payload.stage_type}) "
+                    "already exists with different content; re-ingest with "
+                    "mutated payload is rejected (append-only contract — "
+                    "§D3).",
+                    code="artifact_content_conflict",
+                )
+            return existing, True
+
+        try:
+            persisted = await self._stages.persist_artifact(run_uuid, payload)
+        except AppendOnlyViolation as exc:
+            raise HermesStageArtifactsIngestError(
+                f"append-only race for ({run_uuid}, {payload.stage_type}): "
+                "an artifact appeared between the existence probe and the "
+                "insert. Retry the ingest.",
+                code="append_only_race",
+            ) from exc
+        return persisted, False
+
+    async def _fetch_existing(
+        self, run_uuid: uuid.UUID, stage_type: str
+    ) -> InvestmentStageArtifact | None:
+        artifacts = await self._stages.list_artifacts_for_run(run_uuid)
+        for art in artifacts:
+            if art.stage_type == stage_type:
+                return art
+        return None
+
+
+def _artifact_content_matches(
+    existing: InvestmentStageArtifact, payload: StageArtifactPayload
+) -> bool:
+    """Compare every payload-derived field on the stored artifact against
+    the incoming payload. Server-set fields (``id``, ``created_at``,
+    ``run_uuid``, ``stage_type``) are intentionally excluded — they are
+    either keys or non-payload."""
+    if existing.verdict != payload.verdict.value:
+        return False
+    if int(existing.confidence) != int(payload.confidence):
+        return False
+    if (existing.summary or "") != (payload.summary or ""):
+        return False
+    if list(existing.key_points or []) != list(payload.key_points):
+        return False
+    if list(existing.buy_evidence or []) != list(payload.buy_evidence):
+        return False
+    if list(existing.sell_evidence or []) != list(payload.sell_evidence):
+        return False
+    if list(existing.risk_evidence or []) != list(payload.risk_evidence):
+        return False
+    if list(existing.missing_data or []) != list(payload.missing_data):
+        return False
+    incoming_citations = [str(c.snapshot_uuid) for c in payload.cited_snapshots]
+    existing_citations = [str(u) for u in (existing.cited_snapshot_uuids or [])]
+    if existing_citations != incoming_citations:
+        return False
+    if dict(existing.freshness_summary or {}) != dict(payload.freshness_summary or {}):
+        return False
+    if (existing.model_name or None) != (payload.model_name or None):
+        return False
+    if (existing.prompt_version or None) != (payload.prompt_version or None):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Composition ingest
+# ---------------------------------------------------------------------------
+
+
 class HermesCompositionIngestService:
-    """Validate + persist a Hermes-composed report."""
+    """Validate + persist a Hermes-composed report.
+
+    On successful ingest, this service also auto-finalizes any Hermes
+    stage run referenced from ``composition.metadata.investment_stage_run_uuid``:
+    a matching run row in the ``running`` state is transitioned to
+    ``completed`` (§D4). Runs in any other state are left untouched and
+    a single ``info`` log line is emitted so operators can investigate.
+    """
 
     def __init__(
         self,
@@ -62,10 +317,12 @@ class HermesCompositionIngestService:
         *,
         ingestion_service: InvestmentReportIngestionService | None = None,
         snapshots_repository: InvestmentSnapshotsRepository | None = None,
+        stages_repository: InvestmentStagesRepository | None = None,
     ) -> None:
         self._session = session
         self._ingestion = ingestion_service or InvestmentReportIngestionService(session)
         self._snapshots = snapshots_repository or InvestmentSnapshotsRepository(session)
+        self._stages = stages_repository or InvestmentStagesRepository(session)
 
     async def ingest_composition(
         self, request: HermesCompositionIngestRequest
@@ -79,10 +336,6 @@ class HermesCompositionIngestService:
                 f"snapshot bundle not found: {composition.snapshot_bundle_uuid}"
             )
 
-        # ``items`` already passed the advisory-only validator in
-        # :class:`HermesCompositionResult`. We carry them through unchanged so
-        # the ingestion service's own idempotency and stale gate stay
-        # authoritative.
         metadata: dict[str, Any] = {
             **dict(composition.metadata),
             "hermes_composition": {
@@ -125,15 +378,67 @@ class HermesCompositionIngestService:
             generator_version=request.generator_version or HERMES_COMPOSITION_VERSION,
         )
 
-        return await self._ingestion.ingest(ingest_request)
+        report = await self._ingestion.ingest(ingest_request)
+        await self._maybe_finalize_stage_run(composition.metadata)
+        return report
+
+    async def _maybe_finalize_stage_run(
+        self, composition_metadata: dict[str, Any]
+    ) -> None:
+        """If composition metadata references a Hermes stage run that's
+        still ``running``, transition it to ``completed`` (§D4).
+        Best-effort: malformed UUID, missing run, or non-``running``
+        state all noop with an ``info`` log line so the composition
+        ingest itself stays the authoritative outcome."""
+        raw_uuid = composition_metadata.get("investment_stage_run_uuid")
+        if raw_uuid is None:
+            return
+        if not isinstance(raw_uuid, str | uuid.UUID):
+            _logger.info(
+                "hermes_composition: skipping stage-run finalize — "
+                "metadata.investment_stage_run_uuid is %r (expected str/UUID)",
+                type(raw_uuid).__name__,
+            )
+            return
+        try:
+            parsed = uuid.UUID(str(raw_uuid))
+        except (TypeError, ValueError):
+            _logger.info(
+                "hermes_composition: skipping stage-run finalize — invalid UUID %r",
+                raw_uuid,
+            )
+            return
+
+        run = await self._stages.get_run(parsed)
+        if run is None:
+            _logger.info(
+                "hermes_composition: stage-run finalize skipped — run %s not found",
+                parsed,
+            )
+            return
+        if run.status != "running":
+            _logger.info(
+                "hermes_composition: stage-run %s already in terminal state %r; "
+                "not re-transitioning",
+                parsed,
+                run.status,
+            )
+            return
+        await self._stages.complete_run(parsed, status="completed")
 
 
 __all__ = [
     "HermesCompositionIngestError",
     "HermesCompositionIngestService",
+    "HermesStageArtifactIngestResult",
+    "HermesStageArtifactsIngestError",
+    "HermesStageArtifactsIngestResponse",
+    "HermesStageArtifactsIngestService",
 ]
 
 
+# Backwards-compat shim — earlier code imported a no-op ``_uuid_str``
+# helper from this module. Drop only after grep across consumers shows
+# zero remaining references (none today).
 def _uuid_str(value: uuid.UUID | None) -> str | None:
-    """Internal helper, kept for symmetry with potential future usage."""
     return str(value) if value is not None else None

--- a/app/services/investment_stages/repository.py
+++ b/app/services/investment_stages/repository.py
@@ -30,15 +30,23 @@ class InvestmentStagesRepository:
         account_scope: str | None = None,
         policy_version: str = "v1",
         generator_version: str = "v1",
+        run_uuid: uuid.UUID | None = None,
     ) -> InvestmentStageRun:
-        run = InvestmentStageRun(
-            snapshot_bundle_uuid=snapshot_bundle_uuid,
-            market=market,
-            market_session=market_session,
-            account_scope=account_scope,
-            policy_version=policy_version,
-            generator_version=generator_version,
-        )
+        """Create a run row. ``run_uuid`` is optional — when omitted, the
+        DB ``gen_random_uuid()`` server default fills it in. Pass an
+        explicit UUID for the Hermes stage-artifacts ingest path where
+        Hermes generates the run id client-side (ROB-287 §D1)."""
+        kwargs: dict[str, object] = {
+            "snapshot_bundle_uuid": snapshot_bundle_uuid,
+            "market": market,
+            "market_session": market_session,
+            "account_scope": account_scope,
+            "policy_version": policy_version,
+            "generator_version": generator_version,
+        }
+        if run_uuid is not None:
+            kwargs["run_uuid"] = run_uuid
+        run = InvestmentStageRun(**kwargs)
         self._session.add(run)
         await self._session.flush()
         await self._session.refresh(run)

--- a/tests/mcp_server/test_investment_hermes_tools.py
+++ b/tests/mcp_server/test_investment_hermes_tools.py
@@ -29,6 +29,7 @@ from app.mcp_server.tooling.investment_hermes_handlers import (
     investment_report_create_from_hermes_composition_impl,
     investment_report_get_hermes_context_impl,
     investment_report_prepare_bundle_impl,
+    investment_stage_artifacts_ingest_from_hermes_impl,
     register_investment_hermes_tools,
 )
 
@@ -73,6 +74,7 @@ def test_investment_hermes_tool_names_lock() -> None:
         "investment_report_prepare_bundle",
         "investment_report_get_hermes_context",
         "investment_report_create_from_hermes_composition",
+        "investment_stage_artifacts_ingest_from_hermes",
     }
 
 
@@ -94,6 +96,10 @@ def test_tool_descriptions_advertise_no_internal_llm_or_mutation() -> None:
         "requires_user_approval"
         in by_name["investment_report_create_from_hermes_composition"]
     )
+    # New stage-artifacts ingest tool advertises append-only + no-side-effect.
+    stage_desc = by_name["investment_stage_artifacts_ingest_from_hermes"]
+    assert "append-only" in stage_desc.lower()
+    assert "no broker / order / watch / order-intent side effect" in stage_desc.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +131,56 @@ async def test_get_hermes_context_disabled_without_flag(monkeypatch) -> None:
     )
     assert result["success"] is False
     assert result["error"] == "snapshot_backed_report_generator_disabled"
+
+
+@pytest.mark.asyncio
+async def test_stage_artifacts_ingest_disabled_without_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False, raising=False
+    )
+    result = await investment_stage_artifacts_ingest_from_hermes_impl(
+        run_envelope={
+            "run_uuid": str(uuid.uuid4()),
+            "snapshot_bundle_uuid": str(uuid.uuid4()),
+            "market": "kr",
+        },
+        artifacts=[
+            {
+                "stage_type": "market",
+                "verdict": "neutral",
+                "confidence": 50,
+            }
+        ],
+    )
+    assert result["success"] is False
+    assert result["error"] == "snapshot_backed_report_generator_disabled"
+
+
+@pytest.mark.asyncio
+async def test_stage_artifacts_ingest_invalid_envelope_returns_structured_error(
+    monkeypatch,
+) -> None:
+    """TS11 — envelope/schema validation errors come back as structured
+    ``invalid_stage_artifacts_request`` envelopes, not exceptions."""
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+    # Missing required ``run_uuid`` in run_envelope.
+    result = await investment_stage_artifacts_ingest_from_hermes_impl(
+        run_envelope={
+            "snapshot_bundle_uuid": str(uuid.uuid4()),
+            "market": "kr",
+        },
+        artifacts=[
+            {
+                "stage_type": "market",
+                "verdict": "neutral",
+                "confidence": 50,
+            }
+        ],
+    )
+    assert result["success"] is False
+    assert result["error"] == "invalid_stage_artifacts_request"
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_investment_hermes_tools.py
+++ b/tests/mcp_server/test_investment_hermes_tools.py
@@ -1,16 +1,21 @@
 """ROB-287 — Hermes MCP wiring round-trip tests.
 
-Covers the three tools introduced in this PR:
+Covers all four Hermes MCP tools (PRs #901 + #905):
 
 * ``investment_report_prepare_bundle``
 * ``investment_report_get_hermes_context``
+* ``investment_stage_artifacts_ingest_from_hermes``
 * ``investment_report_create_from_hermes_composition``
 
-All three tools are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
+All four tools are gated by ``settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED``
 — the gate-off path returns a structured ``success=False`` envelope. Gate-on
-paths exercise the existing service layer (``HermesContextExporter`` /
-``HermesCompositionIngestService``) via patched async sessions / repos so the
-suite stays unit-shaped (no DB required).
+paths exercise the underlying service layer (``HermesContextExporter`` /
+``HermesCompositionIngestService`` / ``HermesStageArtifactsIngestService``)
+via patched async sessions or mocked services so the suite stays
+unit-shaped — the deep service-level append-only tests for the
+stage-artifacts ingest live in
+``tests/services/investment_stages/test_hermes_stage_artifacts_ingest.py``
+and use the real ``db_session`` fixture.
 """
 
 from __future__ import annotations

--- a/tests/services/investment_stages/test_hermes_stage_artifacts_ingest.py
+++ b/tests/services/investment_stages/test_hermes_stage_artifacts_ingest.py
@@ -1,0 +1,445 @@
+"""Unit + integration tests for ``HermesStageArtifactsIngestService``
+(ROB-287, locked decisions D1/D3/D4/D5/D8 + TS6).
+
+These tests use the real ``db_session`` fixture so the AppendOnly
+behaviour rides on the actual ``(run_uuid, stage_type)`` UNIQUE
+constraint. The snapshot-bundle repository is mocked because bundle
+creation is tangential to the stage-artifact write path; the service
+only consults it for an existence check.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.hermes_composition import (
+    HERMES_STAGE_ARTIFACTS_VERSION,
+    HermesStageArtifactsIngestRequest,
+    HermesStageRunEnvelope,
+)
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.hermes_ingest import (
+    HermesStageArtifactsIngestError,
+    HermesStageArtifactsIngestService,
+)
+from app.services.investment_stages.repository import InvestmentStagesRepository
+
+
+def _bundle_row(bundle_uuid: uuid.UUID) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        bundle_uuid=bundle_uuid,
+        coverage_summary={"news": {"status": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        status="complete",
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+def _snapshots_repo_with_bundle(bundle_uuid: uuid.UUID) -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_bundle_by_uuid = AsyncMock(return_value=_bundle_row(bundle_uuid))
+    return repo
+
+
+def _snapshots_repo_missing_bundle() -> AsyncMock:
+    repo = AsyncMock()
+    repo.get_bundle_by_uuid = AsyncMock(return_value=None)
+    return repo
+
+
+def _envelope(
+    *,
+    run_uuid: uuid.UUID,
+    bundle_uuid: uuid.UUID,
+    market: str = "kr",
+    market_session: str | None = "regular",
+    account_scope: str | None = "kis_live",
+    policy_version: str = "intraday_action_report_v1",
+    generator_version: str = HERMES_STAGE_ARTIFACTS_VERSION,
+) -> HermesStageRunEnvelope:
+    return HermesStageRunEnvelope(
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle_uuid,
+        market=market,
+        market_session=market_session,
+        account_scope=account_scope,
+        policy_version=policy_version,
+        generator_version=generator_version,
+        hermes_run_id="hermes-run-1",
+    )
+
+
+def _payload(
+    *,
+    stage_type: str,
+    verdict: StageVerdict = StageVerdict.NEUTRAL,
+    confidence: int = 55,
+    summary: str = "ok",
+    cited_snapshots: list[StageCitation] | None = None,
+) -> StageArtifactPayload:
+    return StageArtifactPayload(
+        stage_type=stage_type,
+        verdict=verdict,
+        confidence=confidence,
+        summary=summary,
+        cited_snapshots=cited_snapshots or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# TS1: happy path — multiple artifacts on a new run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts1_ingest_creates_run_and_persists_artifacts(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid)
+    )
+    request = HermesStageArtifactsIngestRequest(
+        run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+        artifacts=[
+            _payload(stage_type="market", verdict=StageVerdict.BULL, confidence=60),
+            _payload(stage_type="news", verdict=StageVerdict.NEUTRAL, confidence=40),
+        ],
+    )
+
+    response = await svc.ingest_stage_artifacts(request)
+    assert response.run.run_uuid == run_uuid
+    assert response.run.status == "running"
+    assert response.run.snapshot_bundle_uuid == bundle_uuid
+    assert [r.stage_type for r in response.results] == ["market", "news"]
+    assert all(not r.idempotent_existing for r in response.results)
+
+    repo = InvestmentStagesRepository(db_session)
+    persisted = await repo.list_artifacts_for_run(run_uuid)
+    assert {a.stage_type for a in persisted} == {"market", "news"}
+
+
+# ---------------------------------------------------------------------------
+# TS2: same key + same payload → idempotent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts2_same_key_same_payload_is_idempotent(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid)
+    )
+    artifact = _payload(stage_type="market", verdict=StageVerdict.BULL, confidence=60)
+
+    first = await svc.ingest_stage_artifacts(
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[artifact],
+        )
+    )
+    second = await svc.ingest_stage_artifacts(
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[artifact],
+        )
+    )
+
+    assert first.run.run_uuid == second.run.run_uuid
+    assert first.results[0].idempotent_existing is False
+    assert second.results[0].idempotent_existing is True
+    assert (
+        second.results[0].artifact.artifact_uuid
+        == first.results[0].artifact.artifact_uuid
+    )
+
+
+# ---------------------------------------------------------------------------
+# TS3: same key + different payload → conflict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts3_same_key_different_payload_rejected(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid)
+    )
+    await svc.ingest_stage_artifacts(
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[
+                _payload(stage_type="market", verdict=StageVerdict.BULL, confidence=60)
+            ],
+        )
+    )
+
+    with pytest.raises(HermesStageArtifactsIngestError) as excinfo:
+        await svc.ingest_stage_artifacts(
+            HermesStageArtifactsIngestRequest(
+                run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+                artifacts=[
+                    # Same stage_type, different verdict/confidence — must reject.
+                    _payload(
+                        stage_type="market",
+                        verdict=StageVerdict.BEAR,
+                        confidence=30,
+                    )
+                ],
+            )
+        )
+    assert excinfo.value.code == "artifact_content_conflict"
+
+
+# ---------------------------------------------------------------------------
+# TS4: existing run + inconsistent envelope → reject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts4_existing_run_inconsistent_envelope_rejected(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid)
+    )
+    await svc.ingest_stage_artifacts(
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(
+                run_uuid=run_uuid, bundle_uuid=bundle_uuid, market="kr"
+            ),
+            artifacts=[_payload(stage_type="market")],
+        )
+    )
+
+    with pytest.raises(HermesStageArtifactsIngestError) as excinfo:
+        await svc.ingest_stage_artifacts(
+            HermesStageArtifactsIngestRequest(
+                # Same run_uuid, different market.
+                run_envelope=_envelope(
+                    run_uuid=run_uuid, bundle_uuid=bundle_uuid, market="crypto"
+                ),
+                artifacts=[_payload(stage_type="news")],
+            )
+        )
+    assert excinfo.value.code == "run_envelope_mismatch"
+    assert "market" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# TS5: missing bundle → reject
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts5_missing_snapshot_bundle_rejected(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_missing_bundle()
+    )
+    with pytest.raises(HermesStageArtifactsIngestError) as excinfo:
+        await svc.ingest_stage_artifacts(
+            HermesStageArtifactsIngestRequest(
+                run_envelope=_envelope(run_uuid=uuid.uuid4(), bundle_uuid=bundle_uuid),
+                artifacts=[_payload(stage_type="market")],
+            )
+        )
+    assert excinfo.value.code == "snapshot_bundle_not_found"
+
+
+# ---------------------------------------------------------------------------
+# TS6: empty artifacts list → schema-level reject
+# ---------------------------------------------------------------------------
+
+
+def test_ts6_empty_artifacts_list_rejected_at_schema() -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    with pytest.raises(Exception) as excinfo:
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[],
+        )
+    # Pydantic v2 phrasing — accept any of the listed surfaces.
+    msg = str(excinfo.value)
+    assert "at least 1" in msg or "min_length" in msg or "too_short" in msg
+
+
+# ---------------------------------------------------------------------------
+# TS7: artifacts may arrive in any order (no ordering enforced)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts7_unordered_ingest_allowed(db_session) -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    svc = HermesStageArtifactsIngestService(
+        db_session, snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid)
+    )
+    # Bull reducer arrives before market — auto_trader must not enforce
+    # stage ordering at the ingest layer.
+    response = await svc.ingest_stage_artifacts(
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[
+                _payload(stage_type="bull_reducer", verdict=StageVerdict.BULL),
+                _payload(stage_type="market", verdict=StageVerdict.NEUTRAL),
+            ],
+        )
+    )
+    assert {r.stage_type for r in response.results} == {"bull_reducer", "market"}
+
+
+# ---------------------------------------------------------------------------
+# TS8: composition ingest auto-finalises the matching stage run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts8_composition_ingest_finalises_running_stage_run(db_session) -> None:
+    from app.schemas.hermes_composition import (
+        HermesCompositionIngestRequest,
+        HermesCompositionResult,
+    )
+    from app.schemas.investment_reports import IngestReportItem
+    from app.services.investment_stages.hermes_ingest import (
+        HermesCompositionIngestService,
+    )
+
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+
+    # Seed a Hermes stage run in "running" state.
+    stages_repo = InvestmentStagesRepository(db_session)
+    await stages_repo.create_run(
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle_uuid,
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+    )
+    await db_session.flush()
+
+    # Build a composition that references the same run via metadata.
+    composition = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle_uuid,
+        hermes_run_id="hermes-1",
+        title="t",
+        summary="s",
+        metadata={"investment_stage_run_uuid": str(run_uuid)},
+        items=[
+            IngestReportItem(
+                client_item_key="x",
+                item_kind="risk",
+                intent="risk_review",
+                operation="review",
+                rationale="r",
+                apply_policy="requires_user_approval",
+            )
+        ],
+    )
+
+    # Mock the report ingestion service so we don't need the report tables.
+    ingestion = AsyncMock()
+    ingestion.ingest = AsyncMock(return_value=SimpleNamespace(report_uuid=uuid.uuid4()))
+
+    svc = HermesCompositionIngestService(
+        db_session,
+        ingestion_service=ingestion,
+        snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid),
+    )
+    await svc.ingest_composition(
+        HermesCompositionIngestRequest(
+            composition=composition,
+            kst_date="2026-05-21",
+            market="kr",
+            market_session="regular",
+            account_scope="kis_live",
+        )
+    )
+
+    refreshed = await stages_repo.get_run(run_uuid)
+    assert refreshed.status == "completed"
+    assert refreshed.completed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# TS9: composition without matching run — no auto-finalisation, no error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ts9_composition_without_matching_run_does_not_break(db_session) -> None:
+    from app.schemas.hermes_composition import (
+        HermesCompositionIngestRequest,
+        HermesCompositionResult,
+    )
+    from app.services.investment_stages.hermes_ingest import (
+        HermesCompositionIngestService,
+    )
+
+    bundle_uuid = uuid.uuid4()
+    unknown_run_uuid = uuid.uuid4()
+
+    composition = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle_uuid,
+        hermes_run_id="hermes-1",
+        title="t",
+        summary="s",
+        # Run UUID referenced but no run row exists — must noop.
+        metadata={"investment_stage_run_uuid": str(unknown_run_uuid)},
+        items=[],
+    )
+
+    ingestion = AsyncMock()
+    ingestion.ingest = AsyncMock(return_value=SimpleNamespace(report_uuid=uuid.uuid4()))
+
+    svc = HermesCompositionIngestService(
+        db_session,
+        ingestion_service=ingestion,
+        snapshots_repository=_snapshots_repo_with_bundle(bundle_uuid),
+    )
+    # Must not raise.
+    await svc.ingest_composition(
+        HermesCompositionIngestRequest(
+            composition=composition,
+            kst_date="2026-05-21",
+            market="kr",
+        )
+    )
+
+    # No phantom run was created.
+    stages_repo = InvestmentStagesRepository(db_session)
+    assert await stages_repo.get_run(unknown_run_uuid) is None
+
+
+# ---------------------------------------------------------------------------
+# Schema-level: duplicate stage_type in a single call rejected
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_stage_type_in_single_call_rejected() -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    with pytest.raises(Exception) as excinfo:
+        HermesStageArtifactsIngestRequest(
+            run_envelope=_envelope(run_uuid=run_uuid, bundle_uuid=bundle_uuid),
+            artifacts=[
+                _payload(stage_type="market", verdict=StageVerdict.BULL),
+                _payload(stage_type="market", verdict=StageVerdict.BEAR),
+            ],
+        )
+    assert "duplicate" in str(excinfo.value).lower()


### PR DESCRIPTION
## Summary

Adds the **fourth** Hermes-initiated MCP contract from the ROB-287 locked-decisions list:

- `investment_stage_artifacts_ingest_from_hermes` — Hermes streams stage artifacts as it produces them; the existing `investment_report_create_from_hermes_composition` closes the run.

Plan-B scope-faithful: backend contract + service + MCP tool + tests only. **No HTTP route, no `HERMES_INGEST_TOKEN`, no env flag / Prefect activation / deploy / smoke.**

## Locked decisions adopted (signed off 2026-05-21)

| # | Decision | Adopted? |
|---|---|---|
| D1 | Hermes generates `run_uuid` client-side; auto_trader creates the run row on first ingest, reuses on subsequent. | ✓ |
| D3 | Append-only idempotency on `(run_uuid, stage_type)`. Same key + identical payload → idempotent; differing payload → `artifact_content_conflict` reject. | ✓ |
| D4 | Stage-artifact ingest leaves `run.status='running'`. The existing `HermesCompositionIngestService.ingest_composition` extended to auto-flip a matching `running` run to `completed`. | ✓ |
| D5 | No ordering enforced — artifacts may arrive in any order. | ✓ |
| D6 | Backend contract + service + MCP tool + tests only. Frontend UI is a separate follow-up. | ✓ |
| D8 | Multiple artifacts allowed per call; duplicate `stage_type` in a single call rejected at the schema validator. | ✓ |
| TS6 | Empty `artifacts` list rejected (`min_length=1`). | ✓ |

Boundaries reaffirmed: **no UI**, **no HTTP**, **no operational activation** in this PR.

## Files changed

- `app/schemas/hermes_composition.py` — new `HERMES_STAGE_ARTIFACTS_VERSION`, `HermesStageRunEnvelope`, `HermesStageArtifactsIngestRequest` (with duplicate-stage_type validator + `min_length=1`).
- `app/services/investment_stages/hermes_ingest.py` — new `HermesStageArtifactsIngestService`; `HermesCompositionIngestService.ingest_composition` extended with `_maybe_finalize_stage_run` (§D4).
- `app/services/investment_stages/repository.py` — `create_run` accepts optional `run_uuid` (Hermes-driven identity).
- `app/mcp_server/tooling/investment_hermes_handlers.py` — `investment_stage_artifacts_ingest_from_hermes_impl` MCP tool + registration.
- `tests/services/investment_stages/test_hermes_stage_artifacts_ingest.py` (new) — TS1-TS9 + schema-level duplicate-stage_type test.
- `tests/mcp_server/test_investment_hermes_tools.py` — tool-name lock extended, description guard extended, gate-off + invalid-envelope tests.

Diff: 6 files / **+1025 / −31** (deletions are mostly module-doc/structure cleanup).

## Safety boundary

| Boundary | Enforcement |
|---|---|
| append-only artifacts | Look-before-leap probe + `(run_uuid, stage_type)` UNIQUE; content-aware idempotency vs conflict. |
| no in-process LLM | PR #898 static import guard auto-scans the new service module. |
| no broker / order / watch / order-intent mutation | Service touches only `review.investment_stage_runs` / `review.investment_stage_artifacts`. |
| no HTTP / no token / no Prefect / no deploy | Out of scope per Plan B; reaffirmed in tool description and PR body. |
| Gate-off path is structured | All 4 Hermes tools (incl. new one) return `{success:false, error:'snapshot_backed_report_generator_disabled'}` when `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=false`. |

## Verification

```bash
uv run ruff check app/ tests/                                  # ✓
uv run ruff format --check app/ tests/                         # ✓
uv run ty check app/services/investment_stages/ \
                app/schemas/hermes_composition.py \
                app/mcp_server/tooling/investment_hermes_handlers.py \
                --error-on-warning                             # ✓
uv run pytest tests/services/investment_stages/test_hermes_stage_artifacts_ingest.py \
              tests/mcp_server/test_investment_hermes_tools.py # ✓ 27 passed
uv run pytest tests/services/investment_stages/ \
              tests/services/action_report/snapshot_backed/ \
              tests/mcp_server/test_investment_hermes_tools.py \
              tests/routers/test_investment_stage_runs.py      # ✓ 206 passed (regression sweep)
```

Static import guard from PR #898 (`test_no_internal_llm_imports.py`) automatically scans the modified `hermes_ingest.py` and the new MCP tool surface — passes (no provider/composer/budget imports re-introduced).

## Caveats / unverified

- No real Hermes service exercised end-to-end. Validator/shape contract + ingest routing are unit-tested via patched services + real DB transactions for the AppendOnly path.
- Race-window safety net (`code='append_only_race'`) is intentionally surfaced rather than retried — Hermes is single-flight per `run_uuid` in practice; the bubbled error gives operators a precise signal if that ever breaks.
- ROB-287 stays **In Progress** per directive. Next phases (HTTP + token, env flag / Prefect activation / deploy / smoke, real Hermes JSON-over-wire round trip) are separate PRs; ROB-287 closes only after the round trip is verified.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check`
- [x] New unit tests pass (TS1-TS9 + schema-level)
- [x] Static import guard still passes
- [x] Adjacent regression sweep (206 tests) passes
- [ ] (separate PR) HTTP route + `HERMES_INGEST_TOKEN`
- [ ] (separate PR) Operational activation gate (env flag / Prefect / dashboard)
- [ ] (deferred) Real Hermes JSON-over-wire round-trip verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>