### PR TITLE
feat(rob-287): Hermes JSON-over-wire round-trip smoke (Plan B Phase C)

### DIFF
--- a/docs/runbooks/hermes-report-generation.md
+++ b/docs/runbooks/hermes-report-generation.md
@@ -135,3 +135,76 @@ redeploy is required.
 | Hermes never sees a fresh bundle | Either the flow is disabled, the deployment is paused, or the cadence is too sparse for Hermes' poll interval. | Manually run the flow once and check `created=true` in the return. |
 
 The middleware token branches are at `app/middleware/auth.py`. The flow body is at `app/flows/hermes_bundle_preparation_flow.py`. The service layer that all four endpoints share is at `app/services/investment_stages/hermes_context.py` + `hermes_ingest.py`.
+
+---
+
+## 7. Phase C smoke — operator round-trip verification (ROB-287)
+
+After the activation steps in §3 / §4 land but **before** flipping ROB-287 to Done, the operator drives a single Hermes-shaped round-trip to confirm the wire contract end-to-end. The fixtures + CLI for this live in this repo and are pinned in lock-step with the contract tests so the smoke does not double as fixture-syntax validation.
+
+### 7.1 Pre-conditions
+
+- `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true` on the target auto_trader app.
+- `HERMES_INGEST_TOKEN` configured on the target app, value known to the operator.
+- One existing `InvestmentSnapshotBundle` row (use the prep flow once or seed manually). The smoke does NOT call `/prepare-bundle` — that's a separate concern.
+
+### 7.2 CLI usage
+
+```bash
+HERMES_INGEST_TOKEN="<value>" \
+uv run python -m scripts.hermes_roundtrip_smoke \
+  --base-url https://<auto_trader-host> \
+  --bundle-uuid <existing-bundle-uuid>
+```
+
+Optional flags:
+
+- `--token <value>` — bypass the env var (the env var is the default; never log either).
+- `--token-header <header>` — when the deployment uses a non-default header name.
+- `--run-uuid <uuid>` — fix the `run_uuid` for replay; default is a fresh UUID4 per invocation.
+- `--verbose` — full response bodies per step.
+
+### 7.3 Steps the CLI drives
+
+The CLI loads Hermes-shaped payloads from `tests/fixtures/hermes/*.json` and substitutes the two placeholder UUIDs (`{{run_uuid}}`, `{{snapshot_bundle_uuid}}`) at runtime:
+
+1. `POST /trading/api/investment-reports/hermes/context` — returns `HermesContextPayload` (5 deterministic stages render; missing snapshots surface as UNAVAILABLE without aborting).
+2. `POST /trading/api/investment-reports/hermes/stage-artifacts` — append-only ingest of 5 stage artifacts under one `run_uuid`. Re-running the same CLI invocation returns 200 OK with `idempotent_existing=true` on every artifact.
+3. `POST /trading/api/investment-reports/hermes/composition` — final composition + auto-finalize the stage run. The Investment­Report row lands with `metadata.hermes_composition.hermes_run_id="hermes-smoke-001"`.
+
+### 7.4 Expected output
+
+```
+... INFO base_url: https://<host>
+... INFO bundle_uuid: <uuid>
+... INFO run_uuid: <uuid>
+... INFO --- step 1/3: context export ---
+... INFO POST .../context → 200  (keys: bundle_status, constraints, ...)
+... INFO --- step 2/3: stage-artifacts ingest ---
+... INFO POST .../stage-artifacts → 200  (keys: ...)
+... INFO   artifacts: 5 (idempotent reuse: 0) run_status: running
+... INFO --- step 3/3: composition ingest ---
+... INFO POST .../composition → 200  (keys: ...)
+... INFO   report_uuid: <uuid>  items: 2  status: draft
+... INFO --- round-trip OK ---
+```
+
+Exit code 0 = full chain succeeded. Exit code 1 = some step returned a 4xx/5xx; stderr carries the body for triage. Re-runnable: stage-artifacts ingest is idempotent on `(run_uuid, stage_type)`, so an aborted run can be safely retried with the same `--run-uuid`.
+
+### 7.5 Hard invariants the smoke is allowed to assume
+
+- No external LLM is called — Hermes payloads come from the JSON fixtures.
+- No broker / order / watch / order-intent mutation reachable from any endpoint the smoke hits.
+- Token is never logged or printed; only its presence/absence is surfaced via `_redact_token`.
+- The CLI refuses to invent bundle UUIDs (`--bundle-uuid` is required).
+
+### 7.6 Closing ROB-287
+
+Done transition is approved after:
+
+- The smoke exits 0 against the production auto_trader instance with a fresh bundle UUID,
+- The InvestmentReport row is visible in the prod DB with the expected `hermes_composition` metadata,
+- The InvestmentStageRun row is `status='completed'` (auto-finalized by the composition step),
+- No anomalies in Sentry from `app/services/investment_stages/` for one trading session.
+
+Until those are signed off, ROB-287 stays In Progress.

--- a/scripts/hermes_roundtrip_smoke.py
+++ b/scripts/hermes_roundtrip_smoke.py
@@ -1,0 +1,242 @@
+"""ROB-287 Phase C — operator-runnable Hermes round-trip smoke CLI.
+
+Drives the four Hermes HTTP endpoints in sequence against a target
+auto_trader instance and reports per-step status. Loads the same
+Hermes-produced JSON fixtures the round-trip test uses, so the CLI
+contract stays in lock-step with the test contract.
+
+Usage::
+
+    uv run python -m scripts.hermes_roundtrip_smoke \\
+        --base-url https://<auto_trader-host> \\
+        --token "<HERMES_INGEST_TOKEN value>" \\
+        --bundle-uuid <existing-bundle-uuid>
+
+Exit codes::
+
+    0 — full chain succeeded (context + stage-artifacts + composition).
+    1 — at least one step failed; stderr carries the response body for
+        diagnosis. Re-runnable: the stage-artifacts ingest is
+        idempotent so a partial run can be resumed safely.
+
+Hard invariants:
+
+* No external LLM is called. Hermes payloads come from the JSON
+  fixtures, not from any LLM.
+* No broker / order / watch / order-intent mutation reachable.
+* Default ``--bundle-uuid`` is required — the CLI refuses to invent
+  bundle UUIDs to keep behaviour predictable for the operator.
+* ``--token`` is never logged or printed; only its presence/absence
+  is surfaced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+_FIXTURE_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "hermes"
+
+logger = logging.getLogger("hermes_roundtrip_smoke")
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    text = (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+    parsed = json.loads(text)
+    parsed.pop("_comment", None)
+    return parsed
+
+
+def _substitute_placeholders(
+    payload: dict[str, Any], *, run_uuid: uuid.UUID, snapshot_bundle_uuid: uuid.UUID
+) -> dict[str, Any]:
+    raw = json.dumps(payload)
+    raw = raw.replace("{{run_uuid}}", str(run_uuid))
+    raw = raw.replace("{{snapshot_bundle_uuid}}", str(snapshot_bundle_uuid))
+    return json.loads(raw)
+
+
+def _redact_token(token: str | None) -> str:
+    if not token:
+        return "(empty)"
+    if len(token) <= 8:
+        return "***"
+    return f"{token[:4]}…(len={len(token)})"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Hermes ↔ auto_trader round-trip smoke (ROB-287 Phase C)."
+    )
+    parser.add_argument(
+        "--base-url",
+        required=True,
+        help=(
+            "Target auto_trader base URL, e.g. https://<host> "
+            "(no trailing slash; the CLI prefixes /trading/api/...)."
+        ),
+    )
+    parser.add_argument(
+        "--bundle-uuid",
+        required=True,
+        type=uuid.UUID,
+        help="Existing snapshot_bundle_uuid the smoke will operate on.",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("HERMES_INGEST_TOKEN", ""),
+        help=(
+            "HERMES_INGEST_TOKEN value. Defaults to the env var with "
+            "the same name. Never logged."
+        ),
+    )
+    parser.add_argument(
+        "--token-header",
+        default=os.environ.get("HERMES_INGEST_TOKEN_HEADER", "X-Hermes-Ingest-Token"),
+        help="Header name the auto_trader server expects the token on.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Per-request HTTP timeout in seconds. Default 30.",
+    )
+    parser.add_argument(
+        "--run-uuid",
+        type=uuid.UUID,
+        default=None,
+        help=(
+            "Optional Hermes-side run_uuid. If omitted, the CLI generates "
+            "a fresh UUID4 for this run (recommended)."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print full response bodies for each step.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _post(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    verbose: bool,
+) -> dict[str, Any]:
+    resp = await client.post(path, json=body, headers=headers)
+    if resp.status_code >= 400:
+        logger.error(
+            "POST %s → %s\n  body: %s",
+            path,
+            resp.status_code,
+            resp.text[:1000],
+        )
+        raise SystemExit(1)
+    parsed = resp.json()
+    if verbose:
+        logger.info(
+            "POST %s → 200\n  body: %s", path, json.dumps(parsed, indent=2)[:1500]
+        )
+    else:
+        keys = ", ".join(sorted(parsed.keys())) if isinstance(parsed, dict) else "?"
+        logger.info("POST %s → 200  (keys: %s)", path, keys)
+    return parsed
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if not args.token:
+        logger.error("HERMES_INGEST_TOKEN is empty; provide via --token or env var.")
+        return 1
+    logger.info("token: %s  header: %s", _redact_token(args.token), args.token_header)
+
+    run_uuid = args.run_uuid or uuid.uuid4()
+    headers = {args.token_header: args.token, "Content-Type": "application/json"}
+
+    base_url = args.base_url.rstrip("/")
+    logger.info("base_url: %s", base_url)
+    logger.info("bundle_uuid: %s", args.bundle_uuid)
+    logger.info("run_uuid: %s", run_uuid)
+
+    async with httpx.AsyncClient(timeout=args.timeout) as client:
+        # 1. context export
+        logger.info("--- step 1/3: context export ---")
+        await _post(
+            client,
+            f"{base_url}/trading/api/investment-reports/hermes/context",
+            body={"snapshot_bundle_uuid": str(args.bundle_uuid)},
+            headers=headers,
+            verbose=args.verbose,
+        )
+
+        # 2. stage-artifacts ingest
+        logger.info("--- step 2/3: stage-artifacts ingest ---")
+        stage_payload = _substitute_placeholders(
+            _load_fixture("stage_artifacts_request.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=args.bundle_uuid,
+        )
+        stage_resp = await _post(
+            client,
+            f"{base_url}/trading/api/investment-reports/hermes/stage-artifacts",
+            body=stage_payload,
+            headers=headers,
+            verbose=args.verbose,
+        )
+        n_artifacts = len(stage_resp.get("artifacts", []))
+        n_idempotent = sum(
+            1 for a in stage_resp.get("artifacts", []) if a.get("idempotent_existing")
+        )
+        logger.info(
+            "  artifacts: %d (idempotent reuse: %d) run_status: %s",
+            n_artifacts,
+            n_idempotent,
+            stage_resp.get("run_status"),
+        )
+
+        # 3. composition ingest
+        logger.info("--- step 3/3: composition ingest ---")
+        composition_payload = _substitute_placeholders(
+            _load_fixture("composition_request.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=args.bundle_uuid,
+        )
+        comp_resp = await _post(
+            client,
+            f"{base_url}/trading/api/investment-reports/hermes/composition",
+            body=composition_payload,
+            headers=headers,
+            verbose=args.verbose,
+        )
+        logger.info(
+            "  report_uuid: %s  items: %s  status: %s",
+            comp_resp.get("report_uuid"),
+            comp_resp.get("items_count"),
+            comp_resp.get("status"),
+        )
+
+    logger.info("--- round-trip OK ---")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+    args = _parse_args(argv)
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/hermes/__init__.py
+++ b/tests/fixtures/hermes/__init__.py
@@ -1,0 +1,1 @@
+"""ROB-287 Phase C — Hermes-produced JSON fixtures for round-trip smoke."""

--- a/tests/fixtures/hermes/composition_request.json
+++ b/tests/fixtures/hermes/composition_request.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "ROB-287 Phase C — sample Hermes-produced composition ingest payload. metadata.investment_stage_run_uuid links back to the stage run for auto-finalize (§D4). {{...}} placeholders are substituted by the round-trip smoke at runtime.",
+  "composition": {
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "hermes_run_id": "hermes-smoke-001",
+    "title": "Hermes Advisory — KR intraday (smoke round-trip)",
+    "summary": "Hold-and-trim bias on single-name concentration. Market regime modest bull, but portfolio concentration overrides aggressive entries.",
+    "risk_summary": "Concentration: 70% NAV in one name. Recommend trim to <50% NAV before adding new positions.",
+    "thesis_text": "Bull case from market + foreign-flow stages does not outweigh portfolio concentration risk. Defer new entries; consider scaling out existing single-name position.",
+    "no_action_note": null,
+    "items": [
+      {
+        "client_item_key": "smoke-risk-concentration-001",
+        "item_kind": "risk",
+        "operation": "review",
+        "intent": "risk_review",
+        "rationale": "Single-name exposure breach: 005930 at 70% NAV. Review before any new entry.",
+        "apply_policy": "requires_user_approval"
+      },
+      {
+        "client_item_key": "smoke-watch-005930-trim-001",
+        "item_kind": "watch",
+        "operation": "review",
+        "symbol": "005930",
+        "intent": "trend_recovery_review",
+        "rationale": "Watch for scale-out opportunity once price reclaims short-term resistance.",
+        "apply_policy": "requires_user_approval"
+      }
+    ],
+    "metadata": {
+      "investment_stage_run_uuid": "{{run_uuid}}",
+      "hermes_composition_version": "hermes-composition.v1",
+      "hermes_run_id": "hermes-smoke-001"
+    },
+    "cited_snapshot_uuids": []
+  },
+  "kst_date": "2026-05-21",
+  "market": "kr",
+  "market_session": "regular",
+  "account_scope": "kis_live",
+  "report_type": "snapshot_backed_advisory_v1",
+  "generator_version": "hermes-composition.v1",
+  "policy_version": "intraday_action_report_v1",
+  "status": "draft",
+  "created_by_profile": "HERMES_ADVISOR"
+}

--- a/tests/fixtures/hermes/stage_artifacts_request.json
+++ b/tests/fixtures/hermes/stage_artifacts_request.json
@@ -1,0 +1,110 @@
+{
+  "_comment": "ROB-287 Phase C — sample Hermes-produced stage-artifacts ingest payload. The {{run_uuid}} / {{snapshot_bundle_uuid}} placeholders are substituted by the round-trip smoke test/script at runtime.",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "kr",
+    "market_session": "regular",
+    "account_scope": "kis_live",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-001"
+  },
+  "artifacts": [
+    {
+      "stage_type": "market",
+      "verdict": "bull",
+      "confidence": 62,
+      "summary": "KOSPI +0.78%, breadth net-positive; risk-on bias on KRW pairs.",
+      "key_points": [
+        "KOSPI 2,540 (+0.78%)",
+        "adv/dec 612/238",
+        "foreign net-buy ₩280B"
+      ],
+      "buy_evidence": [
+        "KOSPI 5d MA reclaimed",
+        "foreign net-buy 3rd consecutive session"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-kr-market-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "news",
+      "verdict": "neutral",
+      "confidence": 45,
+      "summary": "Mixed news flow; no dominant catalyst.",
+      "key_points": [
+        "Samsung HBM3e shipment update — modest positive",
+        "BoK rate decision unchanged (consensus)"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-kr-news-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "portfolio_journal",
+      "verdict": "neutral",
+      "confidence": 50,
+      "summary": "Buying power 8% NAV; one open thesis (005930).",
+      "key_points": [
+        "NAV ₩50M, BP ₩4M",
+        "open thesis: 005930 long, +2.3% unrealized"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Concentration: 70% NAV in single name"
+      ],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-kr-portfolio-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "bull_reducer",
+      "verdict": "bull",
+      "confidence": 58,
+      "summary": "Market regime + news mild positive; no single catalyst.",
+      "key_points": [
+        "Regime: risk-on",
+        "Foreign flow constructive"
+      ],
+      "buy_evidence": [
+        "KOSPI breadth",
+        "Foreign net-buy streak"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-bull-reducer-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "risk_review",
+      "verdict": "neutral",
+      "confidence": 40,
+      "summary": "Concentration risk overrides modest bull case; recommend hold-and-trim.",
+      "key_points": [
+        "Concentration: 70% single name"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Single-name exposure breach (>50% NAV)"
+      ],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-risk-review-v1",
+      "prompt_version": "v1"
+    }
+  ]
+}

--- a/tests/scripts/test_hermes_roundtrip_smoke_cli.py
+++ b/tests/scripts/test_hermes_roundtrip_smoke_cli.py
@@ -1,0 +1,107 @@
+"""ROB-287 Phase C — Hermes round-trip smoke CLI unit tests.
+
+The CLI is exercised against a live auto_trader instance by operators
+(see ``docs/runbooks/hermes-report-generation.md`` §Phase C smoke).
+These tests stay unit-shaped: they cover the wire-shape glue (fixture
+loading, placeholder substitution, token redaction, argparse defaults)
+without spawning a real server.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from scripts.hermes_roundtrip_smoke import (
+    _load_fixture,
+    _parse_args,
+    _redact_token,
+    _substitute_placeholders,
+)
+
+
+def test_load_fixture_strips_comment() -> None:
+    """Fixtures carry an ``_comment`` for operator readability; the
+    CLI strips it before sending so the wire payload matches the
+    Pydantic schema exactly."""
+    parsed = _load_fixture("stage_artifacts_request.json")
+    assert "_comment" not in parsed
+    assert parsed["run_envelope"]["market"] == "kr"
+
+
+def test_substitute_placeholders_replaces_uuids() -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    payload = _substitute_placeholders(
+        _load_fixture("stage_artifacts_request.json"),
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle_uuid,
+    )
+    assert payload["run_envelope"]["run_uuid"] == str(run_uuid)
+    assert payload["run_envelope"]["snapshot_bundle_uuid"] == str(bundle_uuid)
+    # The fixture must not leave behind raw braces after substitution.
+    serialised = json.dumps(payload)
+    assert "{{" not in serialised
+    assert "}}" not in serialised
+
+
+def test_substitute_placeholders_works_on_composition() -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    payload = _substitute_placeholders(
+        _load_fixture("composition_request.json"),
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle_uuid,
+    )
+    assert payload["composition"]["snapshot_bundle_uuid"] == str(bundle_uuid)
+    # The composition metadata must reference the stage run for §D4
+    # auto-finalize to kick in.
+    assert payload["composition"]["metadata"]["investment_stage_run_uuid"] == str(
+        run_uuid
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_substr"),
+    [
+        ("", "(empty)"),
+        ("abcdef", "***"),  # length <= 8 → fully redacted
+        ("abcdefghij", "abcd"),  # length > 8 → prefix shown, length disclosed
+    ],
+)
+def test_redact_token_never_prints_full_value(raw: str, expected_substr: str) -> None:
+    redacted = _redact_token(raw)
+    if raw:
+        # Full token must not appear in the redaction output.
+        assert raw not in redacted, f"redact leaked the token: {redacted}"
+    assert expected_substr in redacted
+
+
+def test_parse_args_uses_env_token_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator-friendly default: pull HERMES_INGEST_TOKEN from env so
+    the smoke command line stays free of the secret."""
+    monkeypatch.setenv("HERMES_INGEST_TOKEN", "env-secret-zzz")
+    bundle = uuid.uuid4()
+    args = _parse_args(
+        [
+            "--base-url",
+            "https://example",
+            "--bundle-uuid",
+            str(bundle),
+        ]
+    )
+    assert args.token == "env-secret-zzz"
+    assert args.token_header == "X-Hermes-Ingest-Token"
+    assert args.bundle_uuid == bundle
+    assert args.base_url == "https://example"
+
+
+def test_parse_args_rejects_missing_required_args() -> None:
+    """``--base-url`` and ``--bundle-uuid`` are required so the CLI
+    never invents bundle UUIDs to keep behaviour predictable."""
+    with pytest.raises(SystemExit):
+        _parse_args(["--base-url", "https://example"])
+    with pytest.raises(SystemExit):
+        _parse_args(["--bundle-uuid", str(uuid.uuid4())])

--- a/tests/test_hermes_roundtrip_smoke.py
+++ b/tests/test_hermes_roundtrip_smoke.py
@@ -1,0 +1,400 @@
+"""ROB-287 Phase C — Hermes ↔ auto_trader JSON-over-wire round-trip smoke.
+
+End-to-end exercise of the four Hermes endpoints in the order Hermes
+would actually drive them in production:
+
+    1. ``POST /hermes/context``         → frozen HermesContextPayload
+    2. ``POST /hermes/stage-artifacts`` → append-only stage rows
+    3. ``POST /hermes/composition``     → InvestmentReport row +
+                                          auto-finalize the stage run
+    4. (idempotency) repeat step 2 with identical payload → 200 OK
+                     idempotent reroute
+
+Uses the real ``db_session`` fixture so the AppendOnly + UNIQUE
+constraints are exercised, with an in-process ASGI client driving
+the HTTP router. AuthMiddleware is wired in to validate the token
+gate on at least one request; the rest of the chain runs with the
+token already approved.
+
+The snapshot bundle is seeded directly in the test DB; the
+``/prepare-bundle`` step is exercised as a separate dedicated test
+with a mocked ensure service (because in-process bundle preparation
+requires the full collector registry, which is out of scope for a
+contract round-trip).
+
+No external LLM is called. The artifacts + composition payloads are
+loaded from ``tests/fixtures/hermes/*.json`` and represent the shape
+Hermes is expected to produce.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import re
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.core.db import get_db
+from app.middleware.auth import AuthMiddleware
+from app.models.investment_reports import InvestmentReport
+from app.models.investment_snapshots import InvestmentSnapshotBundle
+from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+from app.routers.investment_hermes_http import router as hermes_router
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "hermes"
+_TOKEN = "hermes-smoke-secret-1234"
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    text = (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+    parsed = json.loads(text)
+    parsed.pop("_comment", None)
+    return parsed
+
+
+def _substitute_placeholders(
+    payload: dict[str, Any], *, run_uuid: uuid.UUID, snapshot_bundle_uuid: uuid.UUID
+) -> dict[str, Any]:
+    """Recursive string substitution for ``{{run_uuid}}`` and
+    ``{{snapshot_bundle_uuid}}`` placeholders inside the fixture."""
+    raw = json.dumps(payload)
+    raw = raw.replace("{{run_uuid}}", str(run_uuid))
+    raw = raw.replace("{{snapshot_bundle_uuid}}", str(snapshot_bundle_uuid))
+    return json.loads(raw)
+
+
+def _make_unique_for_test_db(
+    payload: dict[str, Any], *, run_uuid: uuid.UUID
+) -> dict[str, Any]:
+    """Tweak the composition envelope so the report-idempotency key
+    (``report_type + market + market_session + account_scope +
+    execution_mode + kst_date + generator_version``) is unique per
+    test invocation. The shared ``db_session`` fixture does not roll
+    back between tests, so two tests reading the same fixture would
+    otherwise share an idempotency-reused ``InvestmentReport`` row and
+    fail downstream assertions about ``snapshot_bundle_uuid`` linkage.
+
+    Mutates only ``generator_version`` (suffix with the run_uuid's
+    short hex) — leaves the wire shape intact for fidelity to what
+    Hermes would actually send."""
+    payload = json.loads(json.dumps(payload))
+    suffix = run_uuid.hex[:8]
+    payload["generator_version"] = f"hermes-composition.v1-test-{suffix}"
+    return payload
+
+
+def _build_app(db_session) -> FastAPI:
+    app = FastAPI()
+    app.include_router(hermes_router)
+    app.add_middleware(AuthMiddleware)
+
+    async def _db_override() -> AsyncIterator[object]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db_override
+    return app
+
+
+@pytest.fixture
+def _enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True, raising=False
+    )
+    monkeypatch.setattr(settings, "HERMES_INGEST_TOKEN", _TOKEN, raising=False)
+    monkeypatch.setattr(
+        settings,
+        "HERMES_INGEST_TOKEN_HEADER",
+        "X-Hermes-Ingest-Token",
+        raising=False,
+    )
+
+
+@pytest_asyncio.fixture
+async def _seeded_bundle(db_session) -> InvestmentSnapshotBundle:
+    """Insert a minimal InvestmentSnapshotBundle row so the Hermes
+    endpoints find it on bundle-UUID lookup. No items linked — the
+    context exporter handles the empty-items case by emitting
+    UNAVAILABLE stages, which is fine for the round-trip shape check.
+    """
+    bundle = InvestmentSnapshotBundle(
+        bundle_uuid=uuid.uuid4(),
+        purpose="hermes_report_generation",
+        market="kr",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        status="complete",
+        as_of=dt.datetime.now(tz=dt.UTC),
+        coverage_summary={"required": {"portfolio": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        idempotency_key=f"smoke-{uuid.uuid4().hex[:12]}",
+    )
+    db_session.add(bundle)
+    await db_session.flush()
+    await db_session.refresh(bundle)
+    return bundle
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"X-Hermes-Ingest-Token": _TOKEN}
+
+
+# ---------------------------------------------------------------------------
+# Round-trip happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_context_artifacts_composition(
+    db_session, _enabled, _seeded_bundle
+) -> None:
+    """Drive the full chain: context → stage-artifacts → composition.
+
+    Asserts:
+    * /context returns a HermesContextPayload referencing the seeded bundle.
+    * /stage-artifacts creates a stage run + 5 artifact rows.
+    * /composition creates an InvestmentReport row and auto-finalises
+      the stage run to ``status='completed'`` (§D4).
+    """
+    bundle = _seeded_bundle
+    run_uuid = uuid.uuid4()
+
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        # --- 1. context export ---
+        ctx_resp = await client.post(
+            "/trading/api/investment-reports/hermes/context",
+            headers=_auth_headers(),
+            json={"snapshot_bundle_uuid": str(bundle.bundle_uuid)},
+        )
+        assert ctx_resp.status_code == 200, ctx_resp.text
+        ctx_body = ctx_resp.json()
+        assert ctx_body["success"] is True
+        assert ctx_body["context_version"] == "hermes-context.v1"
+        assert ctx_body["snapshot_bundle_uuid"] == str(bundle.bundle_uuid)
+        assert ctx_body["constraints"]["advisory_only"] is True
+        # 5 deterministic stages render even with no snapshots (they
+        # surface as UNAVAILABLE).
+        stage_types = {entry["stage_type"] for entry in ctx_body["stage_inputs"]}
+        assert {
+            "market",
+            "news",
+            "portfolio_journal",
+            "watch_context",
+            "candidate_universe",
+        }.issubset(stage_types)
+
+        # --- 2. stage-artifacts ingest ---
+        stage_payload = _substitute_placeholders(
+            _load_fixture("stage_artifacts_request.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        stage_resp = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=stage_payload,
+        )
+        assert stage_resp.status_code == 200, stage_resp.text
+        stage_body = stage_resp.json()
+        assert stage_body["success"] is True
+        assert stage_body["run_uuid"] == str(run_uuid)
+        assert stage_body["run_status"] == "running"
+        assert len(stage_body["artifacts"]) == 5
+        assert all(not r["idempotent_existing"] for r in stage_body["artifacts"])
+
+        # --- 3. composition ingest ---
+        composition_payload = _make_unique_for_test_db(
+            _substitute_placeholders(
+                _load_fixture("composition_request.json"),
+                run_uuid=run_uuid,
+                snapshot_bundle_uuid=bundle.bundle_uuid,
+            ),
+            run_uuid=run_uuid,
+        )
+        comp_resp = await client.post(
+            "/trading/api/investment-reports/hermes/composition",
+            headers=_auth_headers(),
+            json=composition_payload,
+        )
+        assert comp_resp.status_code == 200, comp_resp.text
+        comp_body = comp_resp.json()
+        assert comp_body["success"] is True
+        assert comp_body["status"] == "draft"
+        assert comp_body["items_count"] == 2
+
+        # --- Assertions on persisted state ---
+        from sqlalchemy import select
+
+        # Stage run finalised to ``completed`` (§D4 auto-finalize).
+        run_row = await db_session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        assert run_row is not None, "stage run should exist"
+        assert run_row.status == "completed", (
+            f"composition ingest should auto-finalise the run; "
+            f"got status={run_row.status!r}"
+        )
+        assert run_row.completed_at is not None
+
+        # 5 stage artifacts persisted.
+        artifact_rows = (
+            await db_session.scalars(
+                select(InvestmentStageArtifact).where(
+                    InvestmentStageArtifact.run_uuid == run_uuid
+                )
+            )
+        ).all()
+        assert len(list(artifact_rows)) == 5
+
+        # InvestmentReport row exists and references the bundle.
+        report_uuid_str = comp_body["report_uuid"]
+        report_uuid = uuid.UUID(report_uuid_str)
+        report_row = await db_session.scalar(
+            select(InvestmentReport).where(InvestmentReport.report_uuid == report_uuid)
+        )
+        assert report_row is not None
+        assert report_row.snapshot_bundle_uuid == bundle.bundle_uuid
+        # Stage-run linkage is preserved in metadata.
+        hermes_meta = report_row.report_metadata.get("hermes_composition", {})
+        assert hermes_meta.get("hermes_run_id") == "hermes-smoke-001"
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_stage_artifacts_idempotent_reingest(
+    db_session, _enabled, _seeded_bundle
+) -> None:
+    """Hermes re-posts an identical stage-artifacts payload → 200 OK
+    with ``idempotent_existing=True`` for every artifact, no new
+    rows."""
+    bundle = _seeded_bundle
+    run_uuid = uuid.uuid4()
+
+    app = _build_app(db_session)
+    payload = _substitute_placeholders(
+        _load_fixture("stage_artifacts_request.json"),
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        first = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=payload,
+        )
+        second = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=payload,
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    first_body = first.json()
+    second_body = second.json()
+    assert all(not r["idempotent_existing"] for r in first_body["artifacts"])
+    assert all(r["idempotent_existing"] for r in second_body["artifacts"])
+    # Same artifact UUIDs returned on the second ingest.
+    first_uuids = {r["artifact_uuid"] for r in first_body["artifacts"]}
+    second_uuids = {r["artifact_uuid"] for r in second_body["artifacts"]}
+    assert first_uuids == second_uuids
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_stage_artifacts_content_conflict_rejected(
+    db_session, _enabled, _seeded_bundle
+) -> None:
+    """Hermes re-posts a stage-artifacts payload with the SAME
+    ``(run_uuid, stage_type)`` but different content → 409 with
+    ``error='artifact_content_conflict'``."""
+    bundle = _seeded_bundle
+    run_uuid = uuid.uuid4()
+
+    app = _build_app(db_session)
+    base_payload = _substitute_placeholders(
+        _load_fixture("stage_artifacts_request.json"),
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+    )
+
+    # Subset: only the first artifact.
+    first_payload = {
+        "run_envelope": base_payload["run_envelope"],
+        "artifacts": [base_payload["artifacts"][0]],
+    }
+    # Mutate verdict + confidence on the same stage_type.
+    mutated_payload = json.loads(json.dumps(first_payload))
+    mutated_payload["artifacts"][0]["verdict"] = "bear"
+    mutated_payload["artifacts"][0]["confidence"] = 25
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        first = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=first_payload,
+        )
+        conflict = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=mutated_payload,
+        )
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["error"] == "artifact_content_conflict"
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_token_gate_blocks_unauthenticated(
+    db_session, _enabled, _seeded_bundle
+) -> None:
+    """No token header → 401 even with valid body. Confirms the wire
+    contract enforces token-auth before reaching the handler."""
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(
+            "/trading/api/investment-reports/hermes/context",
+            json={"snapshot_bundle_uuid": str(_seeded_bundle.bundle_uuid)},
+        )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Fixture sanity
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_files_exist_and_are_well_formed() -> None:
+    """Belt-and-braces: the smoke test depends on the fixture files
+    being valid JSON with the expected placeholder shape so the round
+    trip itself doesn't double as fixture-syntax validation."""
+    for name in ("stage_artifacts_request.json", "composition_request.json"):
+        path = _FIXTURE_DIR / name
+        assert path.exists(), f"missing fixture: {path}"
+        text = path.read_text(encoding="utf-8")
+        parsed = json.loads(text)
+        assert "_comment" in parsed, f"{name}: missing operator-facing _comment"
+        # Both placeholders must appear in each fixture.
+        assert re.search(r"\{\{snapshot_bundle_uuid\}\}", text), (
+            f"{name}: missing {{snapshot_bundle_uuid}} placeholder"
+        )
+        assert re.search(r"\{\{run_uuid\}\}", text), (
+            f"{name}: missing {{run_uuid}} placeholder"
+        )


### PR DESCRIPTION
## Summary

End-to-end JSON-over-wire verification surface for the four Hermes endpoints landed in Phase A + Phase B. Ships fixtures + integration test + operator-runnable smoke CLI + runbook section.

Phase B PR #908 merge commit: `4d269518322b6fec3549b24d503f81489cd81fe8`.

## Phase C goal

Exercise the contract Hermes will actually drive in production:

1. `POST /hermes/context` → frozen `HermesContextPayload`
2. `POST /hermes/stage-artifacts` → append-only stage rows
3. `POST /hermes/composition` → `InvestmentReport` row + auto-finalize the matching stage run (§D4)

## Round-trip path used in this PR

- **Surface**: HTTP (most representative of Hermes' production path; MCP shares the service layer, covered by existing tests).
- **Mode**: fixture/mock-driven (Hermes-shaped JSON loaded from `tests/fixtures/hermes/*.json`). No external LLM. No real Hermes service.
- **DB**: real `db_session` fixture; seeds one `InvestmentSnapshotBundle` row per test invocation.
- **Auth**: real `AuthMiddleware` wired in so the wire calls include token-gate enforcement.

## Files changed

- `tests/fixtures/hermes/` (new) — `stage_artifacts_request.json`, `composition_request.json`, `__init__.py`. Both fixtures carry `_comment` for operator readability + `{{run_uuid}}` / `{{snapshot_bundle_uuid}}` placeholders substituted at runtime.
- `tests/test_hermes_roundtrip_smoke.py` (new, 5 tests) — full chain + idempotency + content-conflict + token-gate + fixture-syntax sanity.
- `scripts/hermes_roundtrip_smoke.py` (new) — operator CLI. Loads same fixtures, substitutes placeholders, drives three POSTs against `--base-url`. Token from `--token` or `HERMES_INGEST_TOKEN` env. Exit 0 on success.
- `tests/scripts/test_hermes_roundtrip_smoke_cli.py` (new, 8 tests) — fixture loading, placeholder substitution, token redaction, argparse defaults.
- `docs/runbooks/hermes-report-generation.md` — new §7 Phase C smoke section with CLI usage, expected output, hard invariants, and the explicit ROB-287 → Done approval criteria.

## Tests run (local; Claude Code did NOT watch GitHub Actions)

```bash
uv run ruff check scripts/hermes_roundtrip_smoke.py \
                  tests/test_hermes_roundtrip_smoke.py \
                  tests/scripts/test_hermes_roundtrip_smoke_cli.py        # ✓ clean
uv run ruff format --check (same)                                          # ✓ clean
uv run ty check scripts/hermes_roundtrip_smoke.py --error-on-warning       # ✓ clean
uv run pytest tests/test_hermes_roundtrip_smoke.py \
              tests/scripts/test_hermes_roundtrip_smoke_cli.py             # ✓ 13 passed
uv run pytest tests/test_hermes_roundtrip_smoke.py \
              tests/scripts/test_hermes_roundtrip_smoke_cli.py \
              tests/test_hermes_bundle_preparation_flow.py \
              tests/routers/test_investment_hermes_http*.py \
              tests/services/investment_stages/ \
              tests/mcp_server/test_investment_hermes_tools.py             # ✓ 107 passed (regression)
```

## Actual smoke evidence (in-process)

The full round-trip test (`test_roundtrip_context_artifacts_composition`) drives the wire end-to-end and asserts:

- `/context` returns a `HermesContextPayload` with `context_version="hermes-context.v1"`, the seeded `snapshot_bundle_uuid`, and the 5 deterministic stage types in `stage_inputs`.
- `/stage-artifacts` returns `success=True`, `run_status="running"`, 5 artifacts persisted with `idempotent_existing=False`.
- `/composition` returns `success=True`, `status="draft"`, `items_count=2`.
- DB: 1 `InvestmentStageRun` row with `status='completed'` (§D4 auto-finalize fired), 5 `InvestmentStageArtifact` rows, 1 `InvestmentReport` row with `snapshot_bundle_uuid` matching the seeded bundle and `report_metadata.hermes_composition.hermes_run_id == "hermes-smoke-001"`.

## CI watching

**Claude Code did NOT watch GitHub Actions for this PR** per the operator's directive. Verification above is local + targeted. Post-merge main CI is a separate operator/Hermes verification step.

## Not performed / approval required

- **Production env / secret** — NOT applied. Values stay in the operator's secret store. Runbook §7.1 documents what the operator stages.
- **Production deploy** — NOT executed.
- **Prefect deployment registration / unpause** — NOT executed. Registration lives in `robin-prefect-automations`.
- **Actual production Hermes JSON-over-wire round-trip** — NOT executed. That's the operator-driven smoke that closes ROB-287; this PR ships the CLI + fixtures + contract test the operator runs.
- **External LLM call** — NOT executed. Hermes payloads come from JSON fixtures, not from any LLM.
- **Broker / order / watch / order-intent mutation** — NOT reachable. Static guard from PR #898 automatically re-scans new modules.
- **ROB-287 → Done transition** — NOT performed. Runbook §7.6 lists the explicit Done criteria.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check`
- [x] New unit tests pass (13)
- [x] Adjacent regression sweep passes (107)
- [x] Round-trip integration test asserts persisted state end-to-end
- [x] Runbook updated with Phase C smoke section
- [ ] (operator) Production Hermes round-trip per runbook §7
- [ ] (operator) ROB-287 → Done after smoke + report row + run finalize + clean trading session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI tool for Hermes round-trip smoke testing with configurable base URL, bundle UUID, token authentication, and verbose logging options.

* **Documentation**
  * Added smoke test operator playbook section detailing procedures, pre-conditions, and completion checks.

* **Tests**
  * Added comprehensive smoke test coverage for end-to-end round-trip scenarios and CLI functionality validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->