### PR TITLE
feat(rob-287): US narrow smoke fixtures + test + CLI flag + runbook

### DIFF
--- a/docs/runbooks/hermes-report-generation.md
+++ b/docs/runbooks/hermes-report-generation.md
@@ -208,3 +208,124 @@ Done transition is approved after:
 - No anomalies in Sentry from `app/services/investment_stages/` for one trading session.
 
 Until those are signed off, ROB-287 stays In Progress.
+
+---
+
+## 8. US narrow smoke (ROB-287 follow-up)
+
+A narrow, **non-prod** verification that the Hermes-first contract
+(four endpoints in §1) accepts a `market="us"` snapshot bundle and
+produces a **draft** `InvestmentReport` linked back to it. This is
+NOT a "US production support" milestone — it is a contract-shape
+check for the Hermes path on US-shaped payloads.
+
+### 8.1 Scope and boundaries
+
+- **In scope**: Hermes context export / stage-artifacts ingest /
+  composition ingest on a `market="us"`, `account_scope="alpaca_paper"`
+  snapshot bundle, producing a `status="draft"` report row.
+- **Out of scope** (do NOT execute as part of this smoke):
+  - Published US reports (`status="published"`) — operator review
+    required.
+  - The legacy `ReportGenerationRequest` snapshot-backed generator
+    (`/trading/api/investment-reports/snapshot-backed`) — its
+    request schema still only accepts `market` ∈ `{"kr", "crypto"}`
+    paired with `kis_live` / `upbit_live`. The Hermes-first
+    endpoints take `market` as a plain string and therefore work
+    on US bundles without that legacy validator firing.
+  - `auto_emit_from_evidence` — same legacy path, US bundles aren't
+    accepted there. The Hermes flow does not pass through that
+    proposer.
+  - Real-money broker mutation — every Hermes endpoint is
+    structurally read/persist-only on the report-database side; no
+    code path reaches `submit_order` / `cancel_order` /
+    `create_watch_intent` / order-intent shapes from any of the
+    four endpoints. The static guard from PR #898
+    auto-scans the staged path for re-introductions.
+  - Production env / secret application, Prefect registration or
+    unpause, production deploy, ROB-287 → Done reconciliation.
+
+### 8.2 Pre-conditions
+
+Same as §7.1 plus:
+
+- An existing `InvestmentSnapshotBundle` row with `market="us"` and
+  `account_scope="alpaca_paper"` in the non-prod DB. The smoke does
+  not call `/prepare-bundle`; seed the bundle row via whatever
+  out-of-band mechanism non-prod already has (or by calling the
+  `investment_snapshots_refresh_flow` once after the env var flip
+  in §3 — `purpose` field is opaque to the Hermes path).
+- Hermes will reach the endpoints from a host that has connectivity
+  to the non-prod auto_trader and a valid `HERMES_INGEST_TOKEN`
+  header. **Do not stage production tokens into a non-prod
+  environment.**
+
+### 8.3 CLI invocation (operator runs)
+
+```bash
+HERMES_INGEST_TOKEN="<value-from-non-prod-secret-manager>" \
+uv run python -m scripts.hermes_roundtrip_smoke \
+  --base-url https://<non-prod-auto_trader-host> \
+  --bundle-uuid <existing-us-bundle-uuid> \
+  --fixture-set us
+```
+
+- `--fixture-set us` switches the CLI to the US fixtures
+  (`tests/fixtures/hermes/{stage_artifacts_request_us,composition_request_us}.json`).
+  These are pinned to `market="us"`, `account_scope="alpaca_paper"`,
+  `status="draft"`, with example tickers `AAPL` + `MSFT`. The fixture
+  lock test (`test_us_fixtures_pin_alpaca_paper_and_draft_and_us_symbols`)
+  guards against scope drift.
+- Default `--fixture-set kr` matches PR #910 behaviour — operators
+  not interested in the US smoke don't need to change anything.
+
+### 8.4 Expected outcome
+
+Three POSTs in order (same chain as §7.3, but on US fixtures):
+
+1. `/context` — returns a `HermesContextPayload` with
+   `market="us"`, `account_scope="alpaca_paper"`. The 5 deterministic
+   stages render even with no items in the bundle (UNAVAILABLE).
+2. `/stage-artifacts` — 5 artifact rows persisted under one
+   `run_uuid`, `run_status="running"`.
+3. `/composition` — returns a 200 envelope with `status="draft"`,
+   `items_count=3`. The matching `InvestmentStageRun` row is
+   auto-finalised to `status="completed"` (§D4).
+
+### 8.5 DB-level invariants the operator confirms
+
+After the CLI exits 0:
+
+- `investment_stage_runs.status='completed'` for the run UUID the
+  CLI printed.
+- 5 `investment_stage_artifacts` rows linked to that `run_uuid`.
+- One `investment_reports` row with:
+  - `snapshot_bundle_uuid` = the US bundle UUID,
+  - `status='draft'` (**must not be `published`**),
+  - `market='us'`,
+  - `account_scope='alpaca_paper'`,
+  - `report_metadata.hermes_composition.hermes_run_id="hermes-smoke-us-001"`.
+
+If any of those fail, treat the smoke as failed and surface the
+exact mismatch on the ROB-287 ticket — do NOT attempt to publish or
+remediate the row.
+
+### 8.6 Closing the US narrow smoke
+
+The US narrow smoke does NOT close ROB-287. It is a contract-shape
+check that the Hermes-first endpoints round-trip on US bundles.
+ROB-287 → Done still requires the operator-driven prod-side cycle
+listed in §7.6 (and KR is the default fixture for that prod cycle
+until a separate decision approves US for production Hermes
+composition).
+
+If the US narrow smoke passes, the operator may flag the contract
+as "US-ready (advisory-only)" on the ROB-287 thread and decide
+separately whether to:
+
+- Expand `ReportGenerationRequest` to accept `market="us"` (out of
+  scope here — that's a different code change with its own
+  approval gate).
+- Schedule a US Prefect deployment (separate `robin-prefect-automations`
+  PR, separate operator approval).
+- Add US to the prod cutover checklist (operator decision).

--- a/scripts/hermes_roundtrip_smoke.py
+++ b/scripts/hermes_roundtrip_smoke.py
@@ -120,11 +120,29 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--fixture-set",
+        choices=("kr", "us"),
+        default="kr",
+        help=(
+            "Which Hermes fixture pair to send. ``kr`` uses the original "
+            "KR/KIS-paper payloads (default); ``us`` uses the US narrow "
+            "smoke payloads pinned to market='us', account_scope='alpaca_paper', "
+            "status='draft'. The operator chooses the set to match the bundle "
+            "they passed via --bundle-uuid."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Print full response bodies for each step.",
     )
     return parser.parse_args(argv)
+
+
+_FIXTURE_BY_SET: dict[str, tuple[str, str]] = {
+    "kr": ("stage_artifacts_request.json", "composition_request.json"),
+    "us": ("stage_artifacts_request_us.json", "composition_request_us.json"),
+}
 
 
 async def _post(
@@ -165,9 +183,16 @@ async def _run(args: argparse.Namespace) -> int:
     headers = {args.token_header: args.token, "Content-Type": "application/json"}
 
     base_url = args.base_url.rstrip("/")
+    stage_fixture, composition_fixture = _FIXTURE_BY_SET[args.fixture_set]
     logger.info("base_url: %s", base_url)
     logger.info("bundle_uuid: %s", args.bundle_uuid)
     logger.info("run_uuid: %s", run_uuid)
+    logger.info(
+        "fixture_set: %s (stage=%s composition=%s)",
+        args.fixture_set,
+        stage_fixture,
+        composition_fixture,
+    )
 
     async with httpx.AsyncClient(timeout=args.timeout) as client:
         # 1. context export
@@ -183,7 +208,7 @@ async def _run(args: argparse.Namespace) -> int:
         # 2. stage-artifacts ingest
         logger.info("--- step 2/3: stage-artifacts ingest ---")
         stage_payload = _substitute_placeholders(
-            _load_fixture("stage_artifacts_request.json"),
+            _load_fixture(stage_fixture),
             run_uuid=run_uuid,
             snapshot_bundle_uuid=args.bundle_uuid,
         )
@@ -208,7 +233,7 @@ async def _run(args: argparse.Namespace) -> int:
         # 3. composition ingest
         logger.info("--- step 3/3: composition ingest ---")
         composition_payload = _substitute_placeholders(
-            _load_fixture("composition_request.json"),
+            _load_fixture(composition_fixture),
             run_uuid=run_uuid,
             snapshot_bundle_uuid=args.bundle_uuid,
         )

--- a/tests/fixtures/hermes/composition_request_us.json
+++ b/tests/fixtures/hermes/composition_request_us.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "ROB-287 follow-up — US narrow smoke. Hermes-produced composition payload with market='us', account_scope='alpaca_paper'. metadata.investment_stage_run_uuid links to the matching stage run for §D4 auto-finalize. status MUST stay 'draft' for this smoke — published reports require operator review. {{...}} placeholders are substituted by the round-trip smoke at runtime. NOTE: ReportGenerationRequest (legacy snapshot-backed generator) does NOT support market='us'; this fixture exercises ONLY the Hermes-first contract path.",
+  "composition": {
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "hermes_run_id": "hermes-smoke-us-001",
+    "title": "Hermes Advisory — US intraday (smoke narrow round-trip)",
+    "summary": "Hold-and-trim bias on tech-megacap concentration. Market regime modest bull, but portfolio concentration overrides aggressive entries.",
+    "risk_summary": "Concentration: AAPL+MSFT combined >60% NAV. Recommend trim toward <50% sector exposure before adding new positions.",
+    "thesis_text": "Bull case from market + earnings stages does not outweigh sector-concentration risk on the Alpaca paper account. Defer new entries; consider scaling out partial AAPL or MSFT exposure.",
+    "no_action_note": null,
+    "items": [
+      {
+        "client_item_key": "smoke-us-risk-concentration-001",
+        "item_kind": "risk",
+        "operation": "review",
+        "intent": "risk_review",
+        "rationale": "Single-sector exposure breach: AAPL+MSFT >60% NAV on alpaca_paper account. Review before any new entry.",
+        "apply_policy": "requires_user_approval"
+      },
+      {
+        "client_item_key": "smoke-us-watch-aapl-trim-001",
+        "item_kind": "watch",
+        "operation": "review",
+        "symbol": "AAPL",
+        "intent": "trend_recovery_review",
+        "rationale": "Watch for scale-out opportunity once price tags short-term resistance; advisory only, no broker mutation.",
+        "apply_policy": "requires_user_approval"
+      },
+      {
+        "client_item_key": "smoke-us-watch-msft-trim-001",
+        "item_kind": "watch",
+        "operation": "review",
+        "symbol": "MSFT",
+        "intent": "trend_recovery_review",
+        "rationale": "Watch for partial trim if cloud guidance disappoints next quarter; advisory only, no broker mutation.",
+        "apply_policy": "requires_user_approval"
+      }
+    ],
+    "metadata": {
+      "investment_stage_run_uuid": "{{run_uuid}}",
+      "hermes_composition_version": "hermes-composition.v1",
+      "hermes_run_id": "hermes-smoke-us-001"
+    },
+    "cited_snapshot_uuids": []
+  },
+  "kst_date": "2026-05-22",
+  "market": "us",
+  "market_session": "regular",
+  "account_scope": "alpaca_paper",
+  "report_type": "snapshot_backed_advisory_v1",
+  "generator_version": "hermes-composition.v1",
+  "policy_version": "intraday_action_report_v1",
+  "status": "draft",
+  "created_by_profile": "HERMES_ADVISOR"
+}

--- a/tests/fixtures/hermes/stage_artifacts_request_us.json
+++ b/tests/fixtures/hermes/stage_artifacts_request_us.json
@@ -1,0 +1,111 @@
+{
+  "_comment": "ROB-287 follow-up — US narrow smoke. Hermes-produced stage-artifacts payload with market='us', account_scope='alpaca_paper'. Example holdings reference AAPL + MSFT. {{run_uuid}} / {{snapshot_bundle_uuid}} placeholders are substituted by the round-trip smoke test/CLI at runtime. NOTE: ReportGenerationRequest (legacy snapshot-backed generator) does NOT support market='us'; this fixture exercises ONLY the Hermes-first contract path, which accepts market as a plain string.",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "us",
+    "market_session": "regular",
+    "account_scope": "alpaca_paper",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-us-001"
+  },
+  "artifacts": [
+    {
+      "stage_type": "market",
+      "verdict": "bull",
+      "confidence": 60,
+      "summary": "S&P 500 +0.5%, breadth net-positive; risk-on bias on rate-sensitive megacaps.",
+      "key_points": [
+        "SPX 5,210 (+0.5%)",
+        "adv/dec 2.1:1",
+        "VIX 12.4 (-3%)"
+      ],
+      "buy_evidence": [
+        "SPX 20d MA reclaimed",
+        "Megacap leadership intact"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-us-market-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "news",
+      "verdict": "neutral",
+      "confidence": 42,
+      "summary": "Mixed earnings reads; no single dominant catalyst.",
+      "key_points": [
+        "AAPL services revenue mildly above consensus",
+        "MSFT cloud guide reiterated"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-us-news-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "portfolio_journal",
+      "verdict": "neutral",
+      "confidence": 50,
+      "summary": "Alpaca paper account: buying power 12% NAV; two open theses (AAPL, MSFT).",
+      "key_points": [
+        "NAV $50k, BP $6k",
+        "open: AAPL long, +1.8% unrealized",
+        "open: MSFT long, +0.6% unrealized"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Sector concentration: tech-megacap >60% NAV"
+      ],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-us-portfolio-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "bull_reducer",
+      "verdict": "bull",
+      "confidence": 55,
+      "summary": "Market regime + earnings reads mildly positive; tech-megacap leadership intact.",
+      "key_points": [
+        "Regime: risk-on",
+        "Megacap earnings stable"
+      ],
+      "buy_evidence": [
+        "SPX breadth",
+        "AAPL services upside surprise"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-bull-reducer-v1",
+      "prompt_version": "v1"
+    },
+    {
+      "stage_type": "risk_review",
+      "verdict": "neutral",
+      "confidence": 38,
+      "summary": "Tech-megacap concentration overrides modest bull case; recommend hold-and-trim.",
+      "key_points": [
+        "Concentration: AAPL+MSFT >60% NAV"
+      ],
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Single-sector exposure breach (>50% NAV)"
+      ],
+      "missing_data": [],
+      "cited_snapshots": [],
+      "model_name": "hermes-risk-review-v1",
+      "prompt_version": "v1"
+    }
+  ]
+}

--- a/tests/scripts/test_hermes_roundtrip_smoke_cli.py
+++ b/tests/scripts/test_hermes_roundtrip_smoke_cli.py
@@ -105,3 +105,65 @@ def test_parse_args_rejects_missing_required_args() -> None:
         _parse_args(["--base-url", "https://example"])
     with pytest.raises(SystemExit):
         _parse_args(["--bundle-uuid", str(uuid.uuid4())])
+
+
+def test_parse_args_defaults_fixture_set_to_kr() -> None:
+    """Backwards compatibility — operators who omit --fixture-set keep
+    getting the original KR payloads (PR #910 behaviour)."""
+    args = _parse_args(
+        [
+            "--base-url",
+            "https://example",
+            "--bundle-uuid",
+            str(uuid.uuid4()),
+        ]
+    )
+    assert args.fixture_set == "kr"
+
+
+def test_parse_args_accepts_us_fixture_set() -> None:
+    """``--fixture-set us`` switches the CLI to the US narrow smoke
+    fixtures pinned to market='us', account_scope='alpaca_paper',
+    status='draft'."""
+    args = _parse_args(
+        [
+            "--base-url",
+            "https://example",
+            "--bundle-uuid",
+            str(uuid.uuid4()),
+            "--fixture-set",
+            "us",
+        ]
+    )
+    assert args.fixture_set == "us"
+
+
+def test_parse_args_rejects_unknown_fixture_set() -> None:
+    """The fixture set is a closed enum — extending it requires a
+    code change (deliberate friction)."""
+    with pytest.raises(SystemExit):
+        _parse_args(
+            [
+                "--base-url",
+                "https://example",
+                "--bundle-uuid",
+                str(uuid.uuid4()),
+                "--fixture-set",
+                "kr_or_us_or_zz",
+            ]
+        )
+
+
+def test_fixture_by_set_map_locks_us_payload_files() -> None:
+    """Lock the fixture filenames bound to each set so an accidental
+    rename can't silently change what the CLI sends on the wire."""
+    from scripts.hermes_roundtrip_smoke import _FIXTURE_BY_SET
+
+    assert _FIXTURE_BY_SET["kr"] == (
+        "stage_artifacts_request.json",
+        "composition_request.json",
+    )
+    assert _FIXTURE_BY_SET["us"] == (
+        "stage_artifacts_request_us.json",
+        "composition_request_us.json",
+    )

--- a/tests/test_hermes_roundtrip_smoke.py
+++ b/tests/test_hermes_roundtrip_smoke.py
@@ -50,6 +50,17 @@ from app.models.investment_snapshots import InvestmentSnapshotBundle
 from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
 from app.routers.investment_hermes_http import router as hermes_router
 
+# Cross-domain ``db_session`` test that writes to ``review.investment_reports``.
+# Without this fixture, xdist sibling workers running ``investment_reports_helpers``
+# can TRUNCATE the table between our ingest and our follow-up SELECT, returning
+# ``None`` for a row we just persisted. ``investment_reports_cleanup_lock``
+# serializes the cleanup window for the lifetime of the test, mirroring
+# ``tests._investment_reports_helpers.session``'s own advisory-lock guard. The
+# fix applies to both KR and US round-trip cases — KR happened to pass on the
+# original session by timing, US flushed the race because the second smoke
+# tightens the read window.
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 _FIXTURE_DIR = Path(__file__).parent / "fixtures" / "hermes"
 _TOKEN = "hermes-smoke-secret-1234"
 

--- a/tests/test_hermes_roundtrip_smoke.py
+++ b/tests/test_hermes_roundtrip_smoke.py
@@ -118,6 +118,27 @@ def _enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+async def _seed_bundle(
+    db_session, *, market: str, account_scope: str
+) -> InvestmentSnapshotBundle:
+    bundle = InvestmentSnapshotBundle(
+        bundle_uuid=uuid.uuid4(),
+        purpose="hermes_report_generation",
+        market=market,
+        account_scope=account_scope,
+        policy_version="intraday_action_report_v1",
+        status="complete",
+        as_of=dt.datetime.now(tz=dt.UTC),
+        coverage_summary={"required": {"portfolio": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        idempotency_key=f"smoke-{uuid.uuid4().hex[:12]}",
+    )
+    db_session.add(bundle)
+    await db_session.flush()
+    await db_session.refresh(bundle)
+    return bundle
+
+
 @pytest_asyncio.fixture
 async def _seeded_bundle(db_session) -> InvestmentSnapshotBundle:
     """Insert a minimal InvestmentSnapshotBundle row so the Hermes
@@ -385,7 +406,12 @@ def test_fixture_files_exist_and_are_well_formed() -> None:
     """Belt-and-braces: the smoke test depends on the fixture files
     being valid JSON with the expected placeholder shape so the round
     trip itself doesn't double as fixture-syntax validation."""
-    for name in ("stage_artifacts_request.json", "composition_request.json"):
+    for name in (
+        "stage_artifacts_request.json",
+        "composition_request.json",
+        "stage_artifacts_request_us.json",
+        "composition_request_us.json",
+    ):
         path = _FIXTURE_DIR / name
         assert path.exists(), f"missing fixture: {path}"
         text = path.read_text(encoding="utf-8")
@@ -398,3 +424,194 @@ def test_fixture_files_exist_and_are_well_formed() -> None:
         assert re.search(r"\{\{run_uuid\}\}", text), (
             f"{name}: missing {{run_uuid}} placeholder"
         )
+
+
+# ---------------------------------------------------------------------------
+# ROB-287 follow-up — US narrow smoke
+#
+# Hermes-first contract round-trip against a ``market="us"`` /
+# ``account_scope="alpaca_paper"`` snapshot bundle. Narrow scope: this
+# verifies the four Hermes endpoints accept and persist a US-shaped
+# payload + produce a draft InvestmentReport linked to the US bundle.
+# The legacy ``ReportGenerationRequest`` (snapshot_backed generator)
+# still does NOT accept ``market="us"`` — that path is intentionally
+# out of scope and the runbook calls it out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_us_narrow_smoke(db_session, _enabled) -> None:
+    """US narrow smoke — Hermes contract on ``market='us'`` /
+    ``account_scope='alpaca_paper'``.
+
+    Asserts:
+    * Context export accepts the US bundle.
+    * Stage-artifacts ingest persists 5 rows under one ``run_uuid``.
+    * Composition ingest persists a **draft** InvestmentReport linked
+      to the US bundle, with cited stage artifact UUIDs threaded into
+      ``report_metadata.hermes_composition``.
+    * Composition ingest auto-finalises the stage run (§D4) — same
+      contract as KR.
+    * Status MUST stay ``draft`` (the smoke does not produce
+      published reports — operator review is required).
+    """
+    bundle = await _seed_bundle(db_session, market="us", account_scope="alpaca_paper")
+    run_uuid = uuid.uuid4()
+
+    app = _build_app(db_session)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        # 1. context
+        ctx_resp = await client.post(
+            "/trading/api/investment-reports/hermes/context",
+            headers=_auth_headers(),
+            json={"snapshot_bundle_uuid": str(bundle.bundle_uuid)},
+        )
+        assert ctx_resp.status_code == 200, ctx_resp.text
+        ctx_body = ctx_resp.json()
+        assert ctx_body["market"] == "us"
+        assert ctx_body["account_scope"] == "alpaca_paper"
+
+        # 2. stage-artifacts ingest (US fixture)
+        stage_payload = _substitute_placeholders(
+            _load_fixture("stage_artifacts_request_us.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        stage_resp = await client.post(
+            "/trading/api/investment-reports/hermes/stage-artifacts",
+            headers=_auth_headers(),
+            json=stage_payload,
+        )
+        assert stage_resp.status_code == 200, stage_resp.text
+        stage_body = stage_resp.json()
+        assert stage_body["success"] is True
+        assert stage_body["run_uuid"] == str(run_uuid)
+        assert stage_body["run_status"] == "running"
+        assert len(stage_body["artifacts"]) == 5
+        assert all(not r["idempotent_existing"] for r in stage_body["artifacts"])
+
+        # 3. composition ingest (US fixture) — keep status=draft and make
+        # generator_version unique so the shared db_session doesn't reuse
+        # an existing report row from a sibling test.
+        composition_payload = _make_unique_for_test_db(
+            _substitute_placeholders(
+                _load_fixture("composition_request_us.json"),
+                run_uuid=run_uuid,
+                snapshot_bundle_uuid=bundle.bundle_uuid,
+            ),
+            run_uuid=run_uuid,
+        )
+        assert composition_payload["status"] == "draft", (
+            "US narrow smoke must NOT publish — status MUST stay 'draft'"
+        )
+        assert composition_payload["market"] == "us"
+        assert composition_payload["account_scope"] == "alpaca_paper"
+
+        comp_resp = await client.post(
+            "/trading/api/investment-reports/hermes/composition",
+            headers=_auth_headers(),
+            json=composition_payload,
+        )
+        assert comp_resp.status_code == 200, comp_resp.text
+        comp_body = comp_resp.json()
+        assert comp_body["success"] is True
+        assert comp_body["status"] == "draft", (
+            "InvestmentReport row MUST be 'draft' for the US narrow smoke."
+        )
+        assert comp_body["items_count"] == 3
+
+        # --- DB-level assertions ---
+        from sqlalchemy import select
+
+        run_row = await db_session.scalar(
+            select(InvestmentStageRun).where(InvestmentStageRun.run_uuid == run_uuid)
+        )
+        assert run_row is not None
+        assert run_row.market == "us"
+        assert run_row.account_scope == "alpaca_paper"
+        assert run_row.status == "completed", (
+            "§D4: composition ingest must auto-finalize the matching stage run."
+        )
+        assert run_row.completed_at is not None
+        # Run is linked to the same US bundle.
+        assert run_row.snapshot_bundle_uuid == bundle.bundle_uuid
+
+        artifact_rows = list(
+            (
+                await db_session.scalars(
+                    select(InvestmentStageArtifact).where(
+                        InvestmentStageArtifact.run_uuid == run_uuid
+                    )
+                )
+            ).all()
+        )
+        assert len(artifact_rows) == 5
+        stage_types = {a.stage_type for a in artifact_rows}
+        assert stage_types == {
+            "market",
+            "news",
+            "portfolio_journal",
+            "bull_reducer",
+            "risk_review",
+        }
+
+        # InvestmentReport row is linked to the same US bundle and is draft.
+        report_uuid = uuid.UUID(comp_body["report_uuid"])
+        report_row = await db_session.scalar(
+            select(InvestmentReport).where(InvestmentReport.report_uuid == report_uuid)
+        )
+        assert report_row is not None
+        assert report_row.snapshot_bundle_uuid == bundle.bundle_uuid, (
+            "InvestmentReport.snapshot_bundle_uuid must match the seeded US bundle."
+        )
+        assert report_row.status == "draft", (
+            "Persisted InvestmentReport MUST stay 'draft' — published reports "
+            "are operator-gated and out of this smoke's scope."
+        )
+        assert report_row.market == "us"
+        assert report_row.account_scope == "alpaca_paper"
+        hermes_meta = report_row.report_metadata.get("hermes_composition", {})
+        assert hermes_meta.get("hermes_run_id") == "hermes-smoke-us-001"
+
+
+def test_us_fixtures_pin_alpaca_paper_and_draft_and_us_symbols() -> None:
+    """Lock the US fixture invariants in code so a careless edit
+    can't silently broaden the smoke into broker-touching territory.
+
+    Specifically:
+    * ``market`` is ``'us'`` on both fixtures and the run envelope.
+    * ``account_scope`` is ``'alpaca_paper'`` — Alpaca paper is the
+      only non-prod broker scope auto_trader supports today, and it
+      is read-only with respect to the Hermes path (no order
+      submission is reachable from any Hermes endpoint).
+    * The composition fixture ``status`` is ``'draft'`` — the smoke
+      must never publish.
+    * Symbol-bearing items reference ``AAPL`` and ``MSFT`` only —
+      stress-test ticker, not stress-test universe.
+    * No item has ``operation`` ∈ ``{create, modify}`` — Hermes
+      contract rejects those, but the fixture lock makes the
+      intent explicit.
+    """
+    stage_payload = _load_fixture("stage_artifacts_request_us.json")
+    assert stage_payload["run_envelope"]["market"] == "us"
+    assert stage_payload["run_envelope"]["account_scope"] == "alpaca_paper"
+
+    composition_payload = _load_fixture("composition_request_us.json")
+    assert composition_payload["market"] == "us"
+    assert composition_payload["account_scope"] == "alpaca_paper"
+    assert composition_payload["status"] == "draft"
+
+    items = composition_payload["composition"]["items"]
+    symbols = {it.get("symbol") for it in items if it.get("symbol")}
+    assert symbols.issubset({"AAPL", "MSFT"}), (
+        f"US smoke ticker scope locked to AAPL/MSFT; got {symbols!r}"
+    )
+    for it in items:
+        assert it["operation"] in {"review", "cancel", "keep"}, (
+            f"US smoke item {it['client_item_key']!r} has operation="
+            f"{it['operation']!r}; advisory-only contract forbids "
+            "create/modify/place/cancel-order verbs"
+        )
+        assert it["apply_policy"] == "requires_user_approval"


### PR DESCRIPTION
## Summary

ROB-287 follow-up — prepares (but does NOT execute) a **narrow US smoke** that operators run later against a non-prod auto_trader instance. Verifies the Hermes-first contract round-trips on a `market="us"` / `account_scope="alpaca_paper"` snapshot bundle.

This is **not** "US production support" — `ReportGenerationRequest` (legacy snapshot-backed generator) still does not accept `market="us"`. The Hermes-first endpoints take `market` as a plain string and therefore round-trip on US bundles without that legacy validator firing. The runbook makes this distinction explicit (§8.1).

## Files changed (6 files / +594 / −3)

- `tests/fixtures/hermes/stage_artifacts_request_us.json` (new) — Hermes-shaped stage-artifacts payload, market='us', account_scope='alpaca_paper', AAPL+MSFT example.
- `tests/fixtures/hermes/composition_request_us.json` (new) — Hermes composition, **status='draft'** (pinned), 3 advisory-only items (1 risk + 2 watch on AAPL/MSFT).
- `tests/test_hermes_roundtrip_smoke.py` — new `test_roundtrip_us_narrow_smoke` (full round-trip with DB-level assertions on a `market='us'` bundle) + new `test_us_fixtures_pin_alpaca_paper_and_draft_and_us_symbols` (fixture-lock). Existing well-formed fixture test extended.
- `scripts/hermes_roundtrip_smoke.py` — new `--fixture-set kr|us` option, default `kr` (backwards compatible).
- `tests/scripts/test_hermes_roundtrip_smoke_cli.py` — 4 new tests: default fixture set, accepts `us`, rejects unknown set, locks filename map.
- `docs/runbooks/hermes-report-generation.md` — new §8 "US narrow smoke" section: scope + boundaries, CLI invocation, expected outcome, DB-level invariants, what the smoke does and does NOT mean (in particular: does NOT close ROB-287).

## Hard invariants reaffirmed

- `ReportGenerationRequest` legacy path: `market` literal remains `Literal["kr", "crypto"]` — **NOT** modified in this PR. US bundles go through the Hermes-first contract only.
- `auto_emit_from_evidence` legacy proposer untouched; Hermes path doesn't pass through it.
- Static import guard from PR #898 auto-scans the (unchanged) staged path; no provider re-introduction possible.
- **No broker / order / watch / order-intent mutation reachable** from any Hermes endpoint. The US fixture-lock test asserts no item carries `operation` ∈ `{create, modify}`.
- US composition fixture **status pinned to `draft`**. The test refuses to proceed if the fixture is ever flipped to `published`.

## Local verification (no CI watch/polling)

```bash
uv run ruff check scripts/hermes_roundtrip_smoke.py \
                  tests/test_hermes_roundtrip_smoke.py \
                  tests/scripts/test_hermes_roundtrip_smoke_cli.py        # ✓ clean
uv run ruff format --check (same)                                          # ✓ clean
uv run ty check scripts/hermes_roundtrip_smoke.py --error-on-warning       # ✓ clean
uv run pytest tests/test_hermes_roundtrip_smoke.py \
              tests/scripts/test_hermes_roundtrip_smoke_cli.py             # ✓ 19 passed
uv run pytest <Phase A + B + C + this PR>                                  # ✓ 113 passed (regression)
```

## Side-effect non-actions

- **No real wire smoke executed** against any non-prod or production host. This PR ships the fixtures + CLI flag + test + runbook section that the operator runs later.
- **No production env / secret applied.**
- **No production deploy.** No Prefect registration / unpause.
- **No external LLM call.** Hermes payloads come from the JSON fixtures only.
- **No broker / order / watch / order-intent mutation** reachable.
- **ROB-287 status untouched**; operator-gated per runbook §7.6 (KR remains the default fixture for the prod cycle until separate approval decides otherwise).

## What this PR enables

The operator can later run, against a non-prod auto_trader instance with a US bundle seeded:

```bash
HERMES_INGEST_TOKEN="<value-from-non-prod-secret-manager>" \
uv run python -m scripts.hermes_roundtrip_smoke \
  --base-url https://<non-prod-auto_trader-host> \
  --bundle-uuid <existing-us-bundle-uuid> \
  --fixture-set us
```

If the CLI exits 0 with the documented response shapes and the DB-level invariants in runbook §8.5 hold, the operator can flag the Hermes contract as "US-ready (advisory-only)" on the ROB-287 thread.

## Test plan

- [x] `ruff check`, `ruff format --check`, `ty check`
- [x] New unit tests pass (19; 5 US smoke + 4 CLI + lock test extension + 9 existing KR)
- [x] Adjacent regression sweep passes (113)
- [x] Runbook updated with §8 US narrow smoke section
- [ ] (operator) Non-prod US wire smoke per runbook §8
- [ ] (operator) Decide whether US expansion of `ReportGenerationRequest` is in scope for a future PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added US market Hermes-first endpoint smoke test runbook.

* **Tests**
  * Extended smoke test CLI with `--fixture-set` argument for US and KR market selection.
  * Added US market end-to-end tests for Hermes composition workflow.
  * Added fixture validation to ensure US market configuration stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->