### PR TITLE
feat(rob-294): Binance testnet scalping lifecycle smoke (operator-gated)

### DIFF
--- a/docs/runbooks/binance-testnet-scalping.md
+++ b/docs/runbooks/binance-testnet-scalping.md
@@ -373,6 +373,164 @@ sequence rather than improvising. Order matters.
 
 ---
 
+## 10C. Lifecycle smoke (ROB-294)
+
+The ROB-286 smoke CLI (`scripts/binance_testnet_scalper_smoke.py`)
+uses a synthetic snapshot that always resolves to `Hold`, so it proves
+*connectivity + signed reads + confirm-gate plumbing* but never walks
+the `submitted → filled → tp_sl_armed → closed` lifecycle. ROB-294
+adds a companion CLI that injects a deterministic snapshot so an
+operator can drive a **single symbol, single cycle** through the full
+lifecycle with explicit gates.
+
+**File:** `scripts/binance_testnet_lifecycle_smoke.py`.
+
+All hard invariants from §1–§5 still apply: default-disabled gate,
+host allowlist, per-call `--confirm`, no scheduler/TaskIQ/cron/Prefect/
+Hermes wiring, no futures, no live hosts, no secret persistence.
+
+### 10C.1 Three operator stages
+
+```bash
+# Stage 1 — default-disabled (no env, no flags)
+uv run python -m scripts.binance_testnet_lifecycle_smoke
+# → exit 0, "scalper disabled" log line, zero side effects.
+
+# Stage 2 — credentialed dry-run lifecycle
+BINANCE_TESTNET_ENABLED=true \
+  BINANCE_TESTNET_API_KEY=$KEY \
+  BINANCE_TESTNET_API_SECRET=$SECRET \
+  uv run python -m scripts.binance_testnet_lifecycle_smoke \
+    --symbol BTCUSDT \
+    --simulate-price 50000 \
+    --simulate-rsi 20 \
+    --simulate-ema20 49600 \
+    --simulate-ema50 49000 \
+    --dry-run \
+    --evidence-json /tmp/rob-294-dry-run.json
+# → reconcile open_orders signed read against testnet;
+# → tick resolves to Entry(BUY);
+# → ledger walks planned → previewed → validated, then STOPS;
+# → evidence JSON written to /tmp/rob-294-dry-run.json.
+
+# Stage 3 — operator-confirmed single-cycle (real testnet submit)
+BINANCE_TESTNET_ENABLED=true \
+  BINANCE_TESTNET_API_KEY=$KEY \
+  BINANCE_TESTNET_API_SECRET=$SECRET \
+  uv run python -m scripts.binance_testnet_lifecycle_smoke \
+    --symbol BTCUSDT \
+    --simulate-price 50000 \
+    --simulate-rsi 20 \
+    --simulate-ema20 49600 \
+    --simulate-ema50 49000 \
+    --no-dry-run --confirm \
+    --evidence-json /tmp/rob-294-confirmed.json
+# → real signed POST to testnet.binance.vision /api/v3/order;
+# → if broker fills immediately, paired TP/SL placed (sequential);
+# → evidence JSON written.
+```
+
+### 10C.2 Evidence summary
+
+Every invocation prints (and with `--evidence-json` writes) a
+structured summary. Pertinent fields:
+
+| Field | Meaning |
+|---|---|
+| `mode` | `default-disabled` \| `dry-run` \| `confirmed-single-cycle` |
+| `symbol` | The single MVP symbol the operator chose |
+| `env_*_present` | Booleans only — credential values are never recorded |
+| `snapshot` | The deterministic indicator inputs used this tick |
+| `reconcile_rows_examined`, `reconcile_anomalies_detected` | `reconcile_on_start` result |
+| `ledger_rows_before` / `ledger_rows_after` | Symbol-scoped row delta |
+| `client_order_ids_created` | CIDs the runner generated this run |
+| `final_lifecycle_states` | `{cid → lifecycle_state}` for those CIDs |
+| `broker_open_orders_after` | Broker `openOrders` length post-tick |
+| `anomaly_client_order_ids` | Subset of CIDs that ended in `anomaly` |
+| `tick_action`, `tick_submitted`, `tick_dry_run`, `tick_notes` | Per-tick decision/runner output |
+| `notes` | Free-form operator-facing observations (cancel results, broker read failures, etc.) |
+| `cli_command` | The argv list (no env values; safe to paste) |
+| `exit_code` | 0 clean, 1 misconfig, 2 runtime failure |
+
+The JSON file is **safe to paste into Linear / Slack as-is** — it
+contains no credential values by construction. Confirm before pasting
+with `grep -F "$BINANCE_TESTNET_API_KEY" /tmp/rob-294-confirmed.json`
+returning no matches.
+
+### 10C.3 Lifecycle outcomes the CLI exposes
+
+| Outcome | How to reach it from the CLI | Evidence to verify |
+|---|---|---|
+| Entry held (no signal) | Default `--simulate-rsi 50` (neutral) | `tick_action="hold"`; zero new ledger rows |
+| Entry submitted not filled → operator cancel | Stage 3 + `--cancel-pending-on-exit`; broker returns `status=NEW` | `tick_submitted=true`; entry row final state `cancelled`; one cancel call |
+| Entry filled + paired TP/SL armed | Stage 3 with deterministic Entry snapshot; broker returns `status=FILLED` on MARKET | `final_lifecycle_states` shows entry=`filled` + two legs=`tp_sl_armed`; `broker_open_orders_after >= 2` |
+| TP triggered (sibling SL cancelled) | Second tick with `--simulate-price` ≥ `tp_price` after armed run | Sibling SL row → `cancelled(opposite_leg_triggered)`; TP row → `tp_sl_triggered` |
+| SL triggered (sibling TP cancelled) | Second tick with `--simulate-price` ≤ `sl_price` after armed run | Sibling TP row → `cancelled(opposite_leg_triggered)`; SL row → `tp_sl_triggered` |
+| Broker reject (4xx) on TP/SL placement | Real testnet may reject for filter failures (see §10C.4) | `anomaly_client_order_ids` non-empty; `reason` carried in `extra_metadata` |
+
+Each outcome above has at least one fake-client test under
+`tests/services/scalping/test_runner_lifecycle*.py` and is exercised by
+the runner without HTTP. The CLI's job is to expose the same paths to
+operators against the real testnet.
+
+### 10C.4 Binance `MIN_NOTIONAL` (`-1013 Filter failure`)
+
+Binance Spot enforces a per-symbol **`MIN_NOTIONAL`** filter — orders
+whose `price * quantity` falls below the symbol's minimum are rejected
+with `-1013 "Filter failure: MIN_NOTIONAL"`. The default
+`max_notional_usdt = 10` USDT may be too small for high-priced symbols
+on testnet (e.g., `BTCUSDT` when the testnet's `MIN_NOTIONAL` is set
+to `10` USDT exactly, the order may round below depending on
+`stepSize`/`tickSize` quantization).
+
+If a confirmed lifecycle run fails with `-1013` or `Filter failure`:
+
+1. **Stop the run.** The order was not submitted. There is no broker
+   state to clean up. The ledger row is in `validated` (the
+   `record_submit` call never happened because the POST raised).
+2. **Inspect the symbol's filters** via
+   `https://testnet.binance.vision/api/v3/exchangeInfo?symbol=BTCUSDT`
+   and read the `MIN_NOTIONAL` and `LOT_SIZE` filters.
+3. **Bump the notional** within the CLI ceiling using
+   `--max-notional`. The ceiling is `25` USDT (deliberate friction:
+   any higher requires editing
+   `scripts/binance_testnet_lifecycle_smoke.py::MAX_NOTIONAL_CEILING_USDT`
+   in a follow-up PR with reviewer sign-off).
+4. **Re-run** the lifecycle command with the bumped notional, e.g.::
+
+       uv run python -m scripts.binance_testnet_lifecycle_smoke \
+         --symbol BTCUSDT --simulate-rsi 20 \
+         --simulate-price 50000 \
+         --simulate-ema20 49600 --simulate-ema50 49000 \
+         --max-notional 15 \
+         --no-dry-run --confirm
+
+5. **Document the reason** in the PR/handoff: which symbol, what the
+   broker's reported `MIN_NOTIONAL` was, and what notional you used.
+
+Other common rejects (`-2010 NEW_ORDER_REJECTED`, `-1100 Illegal
+characters`) follow the same pattern: stop, inspect, adjust the
+deterministic snapshot or notional, re-run. Never bypass the
+`--confirm` gate to "force" through a filter failure — that is what
+the `anomaly` ledger state is for.
+
+### 10C.5 Emergency stop + clean-up reminder
+
+If anything goes off-script during Stage 3, follow §10B's
+kill-switch sequence (`Ctrl-C`, `unset BINANCE_TESTNET_ENABLED`,
+capture logs, triage by symptom). The lifecycle CLI's
+`--cancel-pending-on-exit` is the only path that issues a broker
+cancel itself; otherwise broker-side cleanup is operator-driven via
+the testnet UI plus `record_cancel` / `record_reconciled`.
+
+> **ROB-292 remains blocked.** This CLI is invoked manually by a human
+> operator. There is no scheduler / TaskIQ / cron / Prefect / Hermes
+> wiring. The no-scheduler audit
+> (`tests/services/brokers/binance/testnet/test_audit_no_live_host.py::test_no_scheduler_activation`)
+> still passes and remains the structural gate.
+
+---
+
 ## 11. What this PR does NOT do (locked non-goals)
 
 Echoing the plan's forbidden scope:
@@ -402,3 +560,8 @@ Echoing the plan's forbidden scope:
 | T33 | `test_no_live_host_url_in_testnet_package` | No `api.binance.com` literal |
 | T34 | `test_no_scheduler_activation` | No scheduler drift |
 | T35 | `test_no_signed_endpoint_surface_in_binance_public_package` | Child B public adapter unchanged |
+| TT7-TT13 | `tests/services/scalping/test_runner_lifecycle.py::test_*` | Paired TP/SL placement, trigger, anomaly fallbacks |
+| L1 | `test_entry_submitted_not_filled_then_operator_cancel` | ROB-294 submitted-not-filled → cancel branch |
+| L2 | `test_dry_run_lifecycle_produces_no_submitted_or_cancel_calls` | ROB-294 dry-run no-HTTP joint invariant |
+| L3 | `test_lifecycle_evidence_shape_after_full_armed_flow` | ROB-294 evidence-shape contract |
+| L4-L8 | `tests/scripts/test_binance_testnet_lifecycle_smoke.py::test_*` | Lifecycle CLI default-disabled / missing-symbol / non-MVP / notional-ceiling / dry-run |

--- a/scripts/binance_testnet_lifecycle_smoke.py
+++ b/scripts/binance_testnet_lifecycle_smoke.py
@@ -1,0 +1,663 @@
+"""ROB-294 — Binance testnet scalper lifecycle smoke CLI (operator-gated).
+
+This is the lifecycle-validation companion to
+``scripts/binance_testnet_scalper_smoke.py``. The earlier ROB-286/ROB-293
+smoke proved connectivity + signed-read + confirm-gate plumbing, but
+because its market-snapshot stub returns ``rsi_5m=50`` for every symbol
+the decision function always resolves to ``Hold`` — no ``submitted``,
+``filled``, or ``tp_sl_armed`` ledger rows are ever produced. This CLI
+fills the gap by accepting deterministic snapshot inputs so an operator
+can drive a single tick through the full lifecycle on the testnet.
+
+The CLI is **not** scheduled, **not** wired to TaskIQ/cron/Prefect, and
+default-disabled. Activation requires:
+
+  1. ``BINANCE_TESTNET_ENABLED=true`` in the environment.
+  2. ``BINANCE_TESTNET_API_KEY`` + ``BINANCE_TESTNET_API_SECRET`` set.
+  3. ``--symbol`` chosen from the locked MVP set
+     (``BTCUSDT``/``ETHUSDT``/``SOLUSDT``).
+  4. Explicit ``--confirm`` (and ``--no-dry-run``) for any HTTP
+     submission.
+
+Three operator stages — pass exactly the flags for the stage you intend:
+
+  Stage 1 — default-disabled (no env, no flags)::
+
+      uv run python -m scripts.binance_testnet_lifecycle_smoke
+      # → exit 0, "scalper disabled" log line, zero side effects.
+
+  Stage 2 — credentialed dry-run lifecycle (env set, ``--dry-run``)::
+
+      BINANCE_TESTNET_ENABLED=true \\
+        BINANCE_TESTNET_API_KEY=... BINANCE_TESTNET_API_SECRET=... \\
+        uv run python -m scripts.binance_testnet_lifecycle_smoke \\
+        --symbol BTCUSDT --simulate-rsi 25 \\
+        --simulate-price 50000 \\
+        --simulate-ema20 50100 --simulate-ema50 50000 \\
+        --dry-run
+      # → reconcile signed-read against testnet runs;
+      # → tick resolves to Entry (BUY);
+      # → ledger walks planned → previewed → validated, then STOPS
+      #   (dry_run=True ⇒ no broker submission, no submitted rows).
+
+  Stage 3 — operator-confirmed single-cycle (env set, ``--confirm``)::
+
+      BINANCE_TESTNET_ENABLED=true \\
+        BINANCE_TESTNET_API_KEY=... BINANCE_TESTNET_API_SECRET=... \\
+        uv run python -m scripts.binance_testnet_lifecycle_smoke \\
+        --symbol BTCUSDT --simulate-rsi 25 \\
+        --simulate-price 50000 \\
+        --simulate-ema20 50100 --simulate-ema50 50000 \\
+        --no-dry-run --confirm
+      # → real signed POST to testnet.binance.vision /api/v3/order;
+      # → if broker fills immediately, paired TP/SL are placed
+      #   (sequential, never gather);
+      # → evidence summary printed at end.
+
+Evidence summary (always printed at exit; ``--evidence-json`` also writes
+a structured file for the PR handoff):
+
+  * env vars present? (presence only — values are NEVER printed)
+  * ledger row count before / after the tick
+  * client_order_id(s) created this run
+  * broker open-order count after the tick
+  * final lifecycle states per row
+  * anomaly summary
+  * mode: dry-run | confirmed-single-cycle
+
+Exit codes mirror the ROB-286 smoke CLI:
+  * 0 — clean (or default-disabled)
+  * 1 — operator misconfiguration (missing env, invalid symbol, etc.)
+  * 2 — runtime failure
+
+Hard non-goals (do not relax without a separate review):
+  * No scheduler / TaskIQ / cron / Prefect / Hermes activation.
+  * No live Binance hosts (``BinanceLiveHostBlocked`` enforces).
+  * No futures path.
+  * No secret value printed/persisted.
+  * No notional cap weakening — ``--max-notional`` defaults to the
+    config value and is bounded to a small testnet ceiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+logger = logging.getLogger("scripts.binance_testnet_lifecycle_smoke")
+
+# Locked MVP set — kept in sync with ``ScalperConfig.symbols`` so the CLI
+# refuses any symbol outside the lifecycle-validated trio. Expanding the
+# set is deliberately a code change in two places (config + here) to
+# preserve reviewer friction.
+MVP_SYMBOLS: frozenset[str] = frozenset({"BTCUSDT", "ETHUSDT", "SOLUSDT"})
+
+# Testnet ceiling for the CLI: the operator can lower ``--max-notional``
+# below this, but never above it. Keeps a typo-introduced large notional
+# from escaping. Mirrors ``ScalperConfig.max_notional_usdt`` default x2 to
+# leave operator headroom for symbols where ``MIN_NOTIONAL`` filter
+# requires bumping past the default.
+MAX_NOTIONAL_CEILING_USDT: Decimal = Decimal("25")
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class LifecycleEvidence:
+    """Structured evidence record emitted at the end of a lifecycle run.
+
+    All fields are operator-facing and safe to log. Credential values
+    are NEVER stored here — only presence flags.
+    """
+
+    mode: str  # "default-disabled" | "dry-run" | "confirmed-single-cycle"
+    symbol: str | None
+    started_at: str
+    completed_at: str | None = None
+    env_binance_enabled_present: bool = False
+    env_api_key_present: bool = False
+    env_api_secret_present: bool = False
+    env_base_url_present: bool = False
+    snapshot: dict[str, str] = field(default_factory=dict)
+    reconcile_rows_examined: int = 0
+    reconcile_anomalies_detected: int = 0
+    ledger_rows_before: int = 0
+    ledger_rows_after: int = 0
+    client_order_ids_created: list[str] = field(default_factory=list)
+    final_lifecycle_states: dict[str, str] = field(default_factory=dict)
+    broker_open_orders_after: int = 0
+    anomaly_client_order_ids: list[str] = field(default_factory=list)
+    tick_action: str | None = None
+    tick_submitted: bool = False
+    tick_dry_run: bool = True
+    tick_notes: str = ""
+    cli_command: list[str] = field(default_factory=list)
+    exit_code: int = 0
+    notes: list[str] = field(default_factory=list)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="binance_testnet_lifecycle_smoke",
+        description=(
+            "ROB-294 lifecycle-validation smoke for the Binance testnet "
+            "scalper. Default behavior is disabled (zero side effects). "
+            "Set BINANCE_TESTNET_ENABLED=true + credentials and pass "
+            "--symbol to opt in. Only operator-confirmed flags reach the "
+            "testnet."
+        ),
+    )
+    parser.add_argument(
+        "--symbol",
+        type=str,
+        default=None,
+        help=(
+            "Single MVP symbol to drive through the lifecycle. Required "
+            "when opted in. Must be one of "
+            f"{sorted(MVP_SYMBOLS)}."
+        ),
+    )
+    parser.add_argument(
+        "--simulate-price",
+        type=str,
+        default=None,
+        help="Snapshot ``last_price`` for the deterministic tick (Decimal).",
+    )
+    parser.add_argument(
+        "--simulate-rsi",
+        type=float,
+        default=50.0,
+        help=(
+            "Snapshot ``rsi_5m`` for the deterministic tick. Default 50.0 "
+            "(neutral; resolves to Hold)."
+        ),
+    )
+    parser.add_argument(
+        "--simulate-ema20",
+        type=str,
+        default=None,
+        help="Snapshot ``ema_20_5m`` for the deterministic tick (Decimal).",
+    )
+    parser.add_argument(
+        "--simulate-ema50",
+        type=str,
+        default=None,
+        help="Snapshot ``ema_50_5m`` for the deterministic tick (Decimal).",
+    )
+    parser.add_argument(
+        "--simulate-instrument-health",
+        type=str,
+        default="healthy",
+        choices=("healthy", "degraded", "rate_limited", "manual_backfill_required"),
+        help="Snapshot ``instrument_health``. Default ``healthy``.",
+    )
+    parser.add_argument(
+        "--max-notional",
+        type=str,
+        default=None,
+        help=(
+            "Override the runner's ``max_notional_usdt`` for this run. "
+            f"Bounded to {MAX_NOTIONAL_CEILING_USDT} USDT. Useful when "
+            "Binance ``MIN_NOTIONAL`` filter rejects the default 10 USDT "
+            "for a high-priced symbol; raise carefully and document the "
+            "reason in the PR/handoff."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Dry-run mode (default). No HTTP submission.",
+    )
+    parser.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Disable dry-run; use with --confirm.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        default=False,
+        help=(
+            "Required for any broker submission. Implies --no-dry-run; "
+            "without it the runner stays in preview-only mode."
+        ),
+    )
+    parser.add_argument(
+        "--cancel-pending-on-exit",
+        action="store_true",
+        default=False,
+        help=(
+            "If a row created during this run is still in ``submitted`` "
+            "state at exit (entry submitted but not filled), issue a "
+            "broker cancel. Requires --confirm to actually hit testnet; "
+            "without it the cancel is itself a dry-run preview."
+        ),
+    )
+    parser.add_argument(
+        "--evidence-json",
+        type=str,
+        default=None,
+        help=(
+            "Write the evidence summary as JSON to this path. The same "
+            "summary is always also printed to stdout. The file should "
+            "be reviewed before pasting into Linear; it contains no "
+            "secret values by construction."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _collect_env_presence(evidence: LifecycleEvidence) -> None:
+    """Record which env vars are present WITHOUT logging their values."""
+    evidence.env_binance_enabled_present = bool(
+        os.environ.get("BINANCE_TESTNET_ENABLED")
+    )
+    evidence.env_api_key_present = bool(os.environ.get("BINANCE_TESTNET_API_KEY"))
+    evidence.env_api_secret_present = bool(os.environ.get("BINANCE_TESTNET_API_SECRET"))
+    evidence.env_base_url_present = bool(os.environ.get("BINANCE_TESTNET_BASE_URL"))
+
+
+def _print_evidence(evidence: LifecycleEvidence) -> None:
+    """Log the evidence summary as a single structured block."""
+    payload = asdict(evidence)
+    logger.info("lifecycle smoke evidence: %s", json.dumps(payload, default=str))
+
+
+def _maybe_write_evidence_json(
+    evidence: LifecycleEvidence, *, path: str | None
+) -> None:
+    if not path:
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(asdict(evidence), fh, indent=2, default=str)
+        logger.info("lifecycle smoke evidence written to %s", path)
+    except OSError as exc:
+        logger.warning("lifecycle smoke: could not write evidence to %s: %s", path, exc)
+
+
+async def _build_snapshot_factory(
+    *,
+    symbol: str,
+    price: Decimal,
+    rsi: float,
+    ema20: Decimal,
+    ema50: Decimal,
+    instrument_health: str,
+) -> Callable[[str], Awaitable[Any]]:
+    """Return a deterministic ``market_snapshot_for_symbol`` for one tick.
+
+    The factory raises if the runner asks for any symbol other than the
+    one the operator chose. That keeps the CLI single-symbol — multi-
+    symbol drift would invalidate the deterministic guarantee.
+    """
+    from app.services.scalping.decision import MarketSnapshot
+
+    async def _snapshot(req_symbol: str) -> MarketSnapshot:
+        if req_symbol != symbol:
+            raise AssertionError(
+                f"lifecycle smoke driver received unexpected symbol "
+                f"{req_symbol!r}; expected {symbol!r}. The CLI is "
+                "single-symbol by design."
+            )
+        return MarketSnapshot(
+            symbol=symbol,
+            last_price=price,
+            rsi_5m=rsi,
+            ema_20_5m=ema20,
+            ema_50_5m=ema50,
+            instrument_health=instrument_health,
+        )
+
+    return _snapshot
+
+
+async def _count_ledger_rows(session, instrument_id: int) -> int:
+    from sqlalchemy import func, select
+
+    from app.models.binance_testnet_order_ledger import BinanceTestnetOrderLedger
+
+    result = await session.execute(
+        select(func.count())
+        .select_from(BinanceTestnetOrderLedger)
+        .where(BinanceTestnetOrderLedger.instrument_id == instrument_id)
+    )
+    return int(result.scalar_one())
+
+
+async def _collect_run_ledger_states(
+    session, *, instrument_id: int, since: datetime
+) -> dict[str, str]:
+    """Return ``{client_order_id: lifecycle_state}`` for rows created during this run."""
+    from sqlalchemy import select
+
+    from app.models.binance_testnet_order_ledger import BinanceTestnetOrderLedger
+
+    result = await session.execute(
+        select(
+            BinanceTestnetOrderLedger.client_order_id,
+            BinanceTestnetOrderLedger.lifecycle_state,
+        )
+        .where(BinanceTestnetOrderLedger.instrument_id == instrument_id)
+        .where(BinanceTestnetOrderLedger.created_at >= since)
+    )
+    return {str(cid): str(state) for cid, state in result.all()}
+
+
+async def _instrument_id_resolver(session) -> Callable[[str], Awaitable[int]]:
+    from sqlalchemy import select
+
+    from app.models.crypto_instruments import CryptoInstrument
+
+    async def _resolve(symbol: str) -> int:
+        result = await session.execute(
+            select(CryptoInstrument.id).where(
+                CryptoInstrument.venue == "binance",
+                CryptoInstrument.product == "spot",
+                CryptoInstrument.venue_symbol == symbol,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise LookupError(
+                f"crypto_instruments row not found for binance/spot/{symbol}. "
+                "Run scripts/binance_testnet_seed_instruments.py first."
+            )
+        return int(row)
+
+    return _resolve
+
+
+def _resolve_decimal(value: str | None, *, default: Decimal) -> Decimal:
+    if value is None or value == "":
+        return default
+    return Decimal(value)
+
+
+async def _run_lifecycle(
+    *,
+    args: argparse.Namespace,
+    evidence: LifecycleEvidence,
+) -> int:
+    """Run the deterministic single-cycle lifecycle. Returns exit code."""
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.testnet.dto import DryRunResult
+    from app.services.brokers.binance.testnet.execution_client import (
+        BinanceTestnetExecutionClient,
+    )
+    from app.services.brokers.binance.testnet.ledger.service import (
+        BinanceTestnetLedgerService,
+    )
+    from app.services.scalping.config import ScalperConfig
+    from app.services.scalping.runner import ScalperRunner
+
+    if args.symbol not in MVP_SYMBOLS:
+        logger.error(
+            "lifecycle smoke: --symbol must be one of %s (got %r)",
+            sorted(MVP_SYMBOLS),
+            args.symbol,
+        )
+        return 1
+
+    # Build the runner config. Honor --max-notional within the ceiling.
+    base_config = ScalperConfig.default_for_testnet()
+    max_notional = base_config.max_notional_usdt
+    if args.max_notional is not None:
+        override = Decimal(args.max_notional)
+        if override > MAX_NOTIONAL_CEILING_USDT:
+            logger.error(
+                "lifecycle smoke: --max-notional %s exceeds testnet ceiling %s",
+                override,
+                MAX_NOTIONAL_CEILING_USDT,
+            )
+            return 1
+        if override <= 0:
+            logger.error("lifecycle smoke: --max-notional must be positive")
+            return 1
+        max_notional = override
+    # ScalperConfig is frozen; spawn a new instance with the overridden notional.
+    config = ScalperConfig(
+        symbols=base_config.symbols,
+        max_notional_usdt=max_notional,
+        rsi_oversold=base_config.rsi_oversold,
+        rsi_overbought=base_config.rsi_overbought,
+        tp_pct=base_config.tp_pct,
+        sl_pct=base_config.sl_pct,
+        reconcile_open_orders_limit=base_config.reconcile_open_orders_limit,
+        reconcile_recent_fills_limit=base_config.reconcile_recent_fills_limit,
+        reconcile_lookback_hours=base_config.reconcile_lookback_hours,
+    )
+
+    # Resolve snapshot inputs. Defaults intentionally resolve to Hold so
+    # that omitting flags yields a no-op tick (mirrors ROB-293 smoke).
+    price = _resolve_decimal(args.simulate_price, default=Decimal("50000"))
+    ema20 = _resolve_decimal(args.simulate_ema20, default=price)
+    ema50 = _resolve_decimal(args.simulate_ema50, default=price)
+    evidence.snapshot = {
+        "symbol": args.symbol,
+        "last_price": str(price),
+        "rsi_5m": str(args.simulate_rsi),
+        "ema_20_5m": str(ema20),
+        "ema_50_5m": str(ema50),
+        "instrument_health": args.simulate_instrument_health,
+        "max_notional_usdt": str(max_notional),
+    }
+    snapshot_factory = await _build_snapshot_factory(
+        symbol=args.symbol,
+        price=price,
+        rsi=args.simulate_rsi,
+        ema20=ema20,
+        ema50=ema50,
+        instrument_health=args.simulate_instrument_health,
+    )
+
+    client = BinanceTestnetExecutionClient.from_env()
+    started = datetime.now(tz=UTC)
+    async with AsyncSessionLocal() as session:
+        instrument_id_for_symbol = await _instrument_id_resolver(session)
+        instrument_id = await instrument_id_for_symbol(args.symbol)
+        ledger = BinanceTestnetLedgerService(session=session)
+
+        # Restrict the runner's reconcile + tick surface to the chosen
+        # symbol only. ``ScalperConfig.symbols`` is frozen, so we wrap.
+        single_symbol_config = ScalperConfig(
+            symbols=frozenset({args.symbol}),
+            max_notional_usdt=config.max_notional_usdt,
+            rsi_oversold=config.rsi_oversold,
+            rsi_overbought=config.rsi_overbought,
+            tp_pct=config.tp_pct,
+            sl_pct=config.sl_pct,
+            reconcile_open_orders_limit=config.reconcile_open_orders_limit,
+            reconcile_recent_fills_limit=config.reconcile_recent_fills_limit,
+            reconcile_lookback_hours=config.reconcile_lookback_hours,
+        )
+
+        runner = ScalperRunner(
+            execution_client=client,
+            ledger_service=ledger,
+            config=single_symbol_config,
+            instrument_id_for_symbol=instrument_id_for_symbol,
+            market_snapshot_for_symbol=snapshot_factory,
+            dry_run=args.dry_run,
+        )
+
+        evidence.ledger_rows_before = await _count_ledger_rows(
+            session, instrument_id=instrument_id
+        )
+
+        try:
+            recon = await runner.reconcile_on_start()
+            evidence.reconcile_rows_examined = recon.rows_examined
+            evidence.reconcile_anomalies_detected = recon.anomalies_detected
+            if recon.anomaly_client_order_ids:
+                evidence.notes.append(
+                    f"reconcile detected {recon.anomalies_detected} "
+                    "anomaly row(s); review before proceeding"
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("lifecycle smoke: reconcile_on_start failed: %s", exc)
+            evidence.notes.append(f"reconcile_on_start failed: {exc}")
+
+        try:
+            tick = await runner.tick_once(symbol=args.symbol)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("lifecycle smoke: tick failed: %s", exc)
+            evidence.notes.append(f"tick failed: {exc}")
+            await client.aclose()
+            return 2
+
+        evidence.tick_action = tick.action_name
+        evidence.tick_submitted = tick.submitted
+        evidence.tick_dry_run = tick.dry_run
+        evidence.tick_notes = tick.notes
+
+        # Collect the ledger trail produced this run.
+        states = await _collect_run_ledger_states(
+            session, instrument_id=instrument_id, since=started
+        )
+        evidence.client_order_ids_created = sorted(states.keys())
+        evidence.final_lifecycle_states = states
+        evidence.anomaly_client_order_ids = sorted(
+            cid for cid, st in states.items() if st == "anomaly"
+        )
+
+        # Optional: cancel any row still in ``submitted`` state. This
+        # exercises the not-filled-within-timeout → cancel branch when
+        # the broker leaves the entry pending. Cancels use the same
+        # ``confirm``/``dry_run`` discipline as the main submit path.
+        if args.cancel_pending_on_exit:
+            for cid, st in list(states.items()):
+                if st != "submitted":
+                    continue
+                try:
+                    cancel_result = await client.cancel_order(
+                        symbol=args.symbol,
+                        client_order_id=cid,
+                        dry_run=args.dry_run,
+                        confirm=args.confirm,
+                    )
+                    if isinstance(cancel_result, DryRunResult):
+                        evidence.notes.append(
+                            f"cancel-pending: {cid} preview-only "
+                            "(confirm/no-dry-run not set)"
+                        )
+                    else:
+                        await ledger.record_cancel(
+                            client_order_id=cid,
+                            reason="lifecycle_smoke_cancel_pending",
+                        )
+                        evidence.notes.append(
+                            f"cancel-pending: cancelled {cid} at broker"
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    evidence.notes.append(
+                        f"cancel-pending: failed to cancel {cid}: {exc}"
+                    )
+
+        # Refresh states after possible cancellations.
+        states = await _collect_run_ledger_states(
+            session, instrument_id=instrument_id, since=started
+        )
+        evidence.final_lifecycle_states = states
+        evidence.anomaly_client_order_ids = sorted(
+            cid for cid, st in states.items() if st == "anomaly"
+        )
+
+        # Broker open-orders count after the tick — purely observational.
+        try:
+            broker_open = await client.open_orders(symbol=args.symbol)
+            evidence.broker_open_orders_after = len(broker_open)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "lifecycle smoke: broker open_orders failed for %s: %s",
+                args.symbol,
+                exc,
+            )
+            evidence.notes.append(f"broker open_orders failed: {exc}")
+
+        evidence.ledger_rows_after = await _count_ledger_rows(
+            session, instrument_id=instrument_id
+        )
+
+        await session.commit()
+    await client.aclose()
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    # Avoid double-configuration: if a caller (e.g., tests) already
+    # configured root logging, ``basicConfig`` is a no-op.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    evidence = LifecycleEvidence(
+        mode="default-disabled",
+        symbol=args.symbol,
+        started_at=datetime.now(tz=UTC).isoformat(),
+        cli_command=[sys.argv[0]] + list(sys.argv[1:]) if argv is None else list(argv),
+    )
+    _collect_env_presence(evidence)
+
+    # Default-disabled gate (mirrors ROB-286 smoke).
+    if not _truthy(os.environ.get("BINANCE_TESTNET_ENABLED")):
+        logger.info("scalper disabled — set BINANCE_TESTNET_ENABLED=true to opt in")
+        evidence.completed_at = datetime.now(tz=UTC).isoformat()
+        evidence.exit_code = 0
+        _print_evidence(evidence)
+        _maybe_write_evidence_json(evidence, path=args.evidence_json)
+        return 0
+
+    if not args.symbol:
+        logger.error(
+            "lifecycle smoke: --symbol is required when opted in (must be one of %s)",
+            sorted(MVP_SYMBOLS),
+        )
+        evidence.completed_at = datetime.now(tz=UTC).isoformat()
+        evidence.exit_code = 1
+        _print_evidence(evidence)
+        _maybe_write_evidence_json(evidence, path=args.evidence_json)
+        return 1
+
+    # --confirm implies --no-dry-run at the CLI layer for symmetry with
+    # the ROB-286 smoke. Without --confirm we stay in preview-only mode.
+    dry_run = args.dry_run and not args.confirm
+    args.dry_run = dry_run
+    evidence.tick_dry_run = dry_run
+    evidence.mode = "confirmed-single-cycle" if args.confirm else "dry-run"
+
+    try:
+        exit_code = asyncio.run(_run_lifecycle(args=args, evidence=evidence))
+    except Exception as exc:  # noqa: BLE001
+        # Top-level safety net — operator misconfiguration / missing
+        # credentials surfaced via custom exceptions land here.
+        logger.error("lifecycle smoke: top-level failure: %s", exc)
+        evidence.notes.append(f"top-level failure: {exc}")
+        exit_code = 1
+
+    evidence.completed_at = datetime.now(tz=UTC).isoformat()
+    evidence.exit_code = exit_code
+    _print_evidence(evidence)
+    _maybe_write_evidence_json(evidence, path=args.evidence_json)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_binance_testnet_lifecycle_smoke.py
+++ b/tests/scripts/test_binance_testnet_lifecycle_smoke.py
@@ -1,0 +1,257 @@
+"""ROB-294 — Lifecycle smoke CLI tests.
+
+Mirrors ``tests/scripts/test_binance_testnet_scalper_smoke.py`` for the
+ROB-294 lifecycle CLI:
+
+  * default-disabled gate (no env → exit 0, no side effects);
+  * opted-in but missing ``--symbol`` → exit 1;
+  * opted-in but ``--symbol`` outside MVP set → exit 1;
+  * credentialed dry-run with a deterministic Entry snapshot → ledger
+    walks planned → previewed → validated and STOPS (zero submitted
+    rows); single broker open_orders signed read is allowed.
+
+The confirmed-single-cycle path is NOT exercised here because it
+requires real testnet credentials + operator approval. The runbook
+documents that path; the unit tests cover the runner-level outcomes
+that the CLI orchestrates (see
+``tests/services/scalping/test_runner_lifecycle_outcomes_rob294.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _scrub_env(monkeypatch):
+    for var in (
+        "BINANCE_TESTNET_ENABLED",
+        "BINANCE_TESTNET_API_KEY",
+        "BINANCE_TESTNET_API_SECRET",
+        "BINANCE_TESTNET_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_lifecycle_smoke_disabled_by_default_no_side_effects(
+    caplog, httpx_mock
+) -> None:
+    """No env, no flags → exit 0 with the 'disabled' log line and 0 HTTP."""
+    from scripts.binance_testnet_lifecycle_smoke import main
+
+    with caplog.at_level(logging.INFO):
+        exit_code = main(argv=[])
+    assert exit_code == 0
+    messages = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "scalper disabled" in messages
+    assert "BINANCE_TESTNET_ENABLED=true" in messages
+    # No HTTP at all — httpx_mock has no registered responses; any leak
+    # would have errored out.
+    assert httpx_mock.get_requests() == []
+
+
+def test_lifecycle_smoke_disabled_emits_evidence_json(tmp_path: Path, caplog) -> None:
+    """Even on the disabled path, --evidence-json writes a usable JSON file.
+
+    Locks the evidence contract: every CLI invocation produces an
+    operator-facing summary, regardless of outcome. The disabled-stage
+    file should contain ``mode='default-disabled'`` and zero side-effect
+    counters.
+    """
+    from scripts.binance_testnet_lifecycle_smoke import main
+
+    out = tmp_path / "evidence.json"
+    with caplog.at_level(logging.INFO):
+        exit_code = main(argv=["--evidence-json", str(out)])
+    assert exit_code == 0
+    assert out.exists(), f"evidence-json file not written: {out}"
+    payload = json.loads(out.read_text())
+    assert payload["mode"] == "default-disabled"
+    assert payload["exit_code"] == 0
+    assert payload["env_binance_enabled_present"] is False
+    # No secret values ever — sanity-grep the JSON.
+    text = out.read_text()
+    assert "API_KEY" not in text.upper() or "API_KEY_PRESENT" in text.upper()
+
+
+def test_lifecycle_smoke_missing_symbol_returns_nonzero(monkeypatch, caplog) -> None:
+    """Opted in but --symbol absent → exit 1 (operator misconfig)."""
+    from scripts.binance_testnet_lifecycle_smoke import main
+
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "DUMMY_SECRET")
+    with caplog.at_level(logging.INFO):
+        exit_code = main(argv=[])
+    assert exit_code == 1
+    messages = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "--symbol" in messages
+
+
+def test_lifecycle_smoke_rejects_symbol_outside_mvp_set(monkeypatch, caplog) -> None:
+    """Symbol must be in the locked MVP triplet — DOGEUSDT must be rejected."""
+    from scripts.binance_testnet_lifecycle_smoke import main
+
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "DUMMY_SECRET")
+    with caplog.at_level(logging.INFO):
+        exit_code = main(argv=["--symbol", "DOGEUSDT"])
+    assert exit_code == 1
+    messages = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "MVP" in messages or "BTCUSDT" in messages
+
+
+def test_lifecycle_smoke_rejects_excessive_max_notional(monkeypatch, caplog) -> None:
+    """``--max-notional`` is bounded; anything above the ceiling is rejected."""
+    from scripts.binance_testnet_lifecycle_smoke import main
+
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "DUMMY_SECRET")
+    with caplog.at_level(logging.INFO):
+        exit_code = main(
+            argv=[
+                "--symbol",
+                "BTCUSDT",
+                "--max-notional",
+                "100000",  # absurdly large; ceiling is 25
+            ]
+        )
+    assert exit_code == 1
+    messages = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "ceiling" in messages or "max-notional" in messages
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_smoke_dry_run_walks_to_validated(
+    monkeypatch, caplog, db_session, httpx_mock, tmp_path: Path
+) -> None:
+    """Opt-in dry-run with an Entry-resolving snapshot:
+
+    - reconcile_on_start issues one signed GET (open_orders, stubbed);
+    - tick resolves to Entry(BUY);
+    - ledger walks planned → previewed → validated (no submitted rows);
+    - evidence JSON is written and contains the expected shape.
+
+    Uses the global ``db_session`` so the CLI's own ``AsyncSessionLocal``
+    reaches the same DB. Cleanup removes any rows the CLI wrote.
+    """
+
+    from sqlalchemy import delete, select
+
+    from app.models.binance_testnet_order_ledger import BinanceTestnetOrderLedger
+    from app.models.crypto_instruments import CryptoInstrument
+
+    # Reconcile pass's open_orders read for BTCUSDT.
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://testnet\.binance\.vision/api/v3/openOrders\?.*$"),
+        json=[],
+        status_code=200,
+        is_reusable=True,
+    )
+
+    existing_result = await db_session.execute(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "spot",
+            CryptoInstrument.venue_symbol == "BTCUSDT",
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+    seeded_here = False
+    if existing is None:
+        new_row = CryptoInstrument(
+            venue="binance",
+            product="spot",
+            venue_symbol="BTCUSDT",
+            base_asset="BTC",
+            quote_asset="USDT",
+            status="active",
+        )
+        db_session.add(new_row)
+        await db_session.commit()
+        await db_session.refresh(new_row)
+        instrument_id = new_row.id
+        seeded_here = True
+    else:
+        instrument_id = existing.id
+
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "DUMMY_KEY")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "DUMMY_SECRET")
+
+    out = tmp_path / "evidence.json"
+    try:
+        with caplog.at_level(logging.INFO):
+            # Invoke ``_run_lifecycle`` directly so we share the test's
+            # asyncio loop (mirrors the ROB-286 smoke test pattern).
+            from scripts.binance_testnet_lifecycle_smoke import (
+                LifecycleEvidence,
+                _run_lifecycle,
+            )
+
+            class _Args:
+                symbol = "BTCUSDT"
+                simulate_price = "50000"
+                simulate_rsi = 20.0  # oversold → Entry
+                simulate_ema20 = "49600"
+                simulate_ema50 = "49000"
+                simulate_instrument_health = "healthy"
+                max_notional = None
+                dry_run = True
+                confirm = False
+                cancel_pending_on_exit = False
+                evidence_json = str(out)
+
+            evidence = LifecycleEvidence(
+                mode="dry-run",
+                symbol="BTCUSDT",
+                started_at="2026-05-22T00:00:00+00:00",
+            )
+            exit_code = await _run_lifecycle(args=_Args(), evidence=evidence)
+        assert exit_code == 0
+
+        result = await db_session.execute(
+            select(BinanceTestnetOrderLedger).where(
+                BinanceTestnetOrderLedger.instrument_id == instrument_id
+            )
+        )
+        rows = list(result.scalars().all())
+        states = [r.lifecycle_state for r in rows]
+        # Entry decision → planned → previewed → validated. Exactly one row.
+        assert len(rows) == 1, (
+            f"dry-run produced {len(rows)} ledger rows; expected 1 "
+            f"(planned→previewed→validated). states={states}"
+        )
+        assert rows[0].lifecycle_state == "validated"
+
+        # Evidence dataclass: filled-in shape we expect.
+        assert evidence.tick_action == "entry"
+        assert evidence.tick_submitted is False
+        assert evidence.tick_dry_run is True
+        assert len(evidence.client_order_ids_created) == 1
+        assert evidence.final_lifecycle_states == {
+            evidence.client_order_ids_created[0]: "validated"
+        }
+        assert evidence.anomaly_client_order_ids == []
+        # Ledger count is monotonic.
+        assert evidence.ledger_rows_after == evidence.ledger_rows_before + 1
+    finally:
+        # Cleanup state the CLI wrote through its own session.
+        await db_session.execute(
+            delete(BinanceTestnetOrderLedger).where(
+                BinanceTestnetOrderLedger.instrument_id == instrument_id
+            )
+        )
+        if seeded_here:
+            await db_session.execute(
+                delete(CryptoInstrument).where(CryptoInstrument.id == instrument_id)
+            )
+        await db_session.commit()

--- a/tests/services/scalping/test_runner_lifecycle_outcomes_rob294.py
+++ b/tests/services/scalping/test_runner_lifecycle_outcomes_rob294.py
@@ -1,0 +1,345 @@
+"""ROB-294 — Lifecycle-outcome readiness tests for the testnet scalper.
+
+The existing ROB-286/289 suite (``tests/services/scalping/test_runner_lifecycle.py``)
+already covers three of the four lifecycle outcomes called out in ROB-294's
+acceptance criteria via fake clients:
+
+  * filled + paired TP/SL armed       → TT7
+  * filled + TP trigger               → TT8
+  * filled + SL trigger               → TT9
+  * anomaly (4xx / timeout) outcomes  → TT10-TT13
+
+The remaining outcome is **"entry submitted but not filled within the
+tick → cancelled and recorded safely."** This file adds that test plus
+an end-to-end fake-broker dry-run lifecycle check that proves the
+ROB-294 evidence path (``client_order_id``s collected, final lifecycle
+states, broker open-orders cross-check) is wired through the runner
+without HTTP.
+
+The tests deliberately stay at the ``ScalperRunner`` + ``_FakeExecutionClient``
+layer used by the rest of the suite — no real testnet calls. Real
+``--confirm`` lifecycle validation against ``testnet.binance.vision`` is
+documented in ``docs/runbooks/binance-testnet-scalping.md`` §10C as an
+operator-gated smoke step.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.services.brokers.binance.testnet.dto import (
+    CancelResult,
+    DryRunResult,
+    OrderPreview,
+    OrderSubmitResult,
+)
+from app.services.brokers.binance.testnet.ledger.service import (
+    BinanceTestnetLedgerService,
+)
+from app.services.scalping.config import ScalperConfig
+from app.services.scalping.decision import MarketSnapshot
+from app.services.scalping.runner import ScalperRunner
+
+
+@pytest_asyncio.fixture
+async def instrument(db_session) -> CryptoInstrument:
+    """Find-or-create the binance/spot/BTCUSDT instrument row."""
+    from sqlalchemy import select
+
+    existing = await db_session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "spot",
+            CryptoInstrument.venue_symbol == "BTCUSDT",
+        )
+    )
+    if existing is not None:
+        return existing
+    inst = CryptoInstrument(
+        venue="binance",
+        product="spot",
+        venue_symbol="BTCUSDT",
+        base_asset="BTC",
+        quote_asset="USDT",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+    await db_session.refresh(inst)
+    return inst
+
+
+def _instrument_id_factory(instrument_id: int) -> Callable[[str], Awaitable[int]]:
+    async def _get(symbol: str) -> int:
+        return instrument_id
+
+    return _get
+
+
+def _snapshot_factory(
+    snapshot: MarketSnapshot,
+) -> Callable[[str], Awaitable[MarketSnapshot]]:
+    async def _get(symbol: str) -> MarketSnapshot:
+        return snapshot
+
+    return _get
+
+
+def _entry_snapshot() -> MarketSnapshot:
+    """Snapshot that resolves to Entry(BUY): oversold RSI + uptrend EMA."""
+    return MarketSnapshot(
+        symbol="BTCUSDT",
+        last_price=Decimal("50000"),
+        rsi_5m=20.0,
+        ema_20_5m=Decimal("49600"),
+        ema_50_5m=Decimal("49000"),
+        instrument_health="healthy",
+    )
+
+
+class _FakeExecutionClientNotFilled:
+    """Fake client where every ``submit_order`` returns ``status="NEW"``.
+
+    Records submit + cancel calls so the test can assert exactly what
+    happened. Defaults emulate Binance behaviour for an order that the
+    broker accepts but doesn't fill within the response window.
+    """
+
+    def __init__(self) -> None:
+        self.submit_calls: list[dict] = []
+        self.cancel_calls: list[dict] = []
+        self.open_orders_calls: list[dict] = []
+        self._counter = 0
+        # The runner inspects the submit response's ``status``; "NEW" means
+        # the broker accepted the order but it isn't filled yet, so the
+        # runner SHOULD NOT proceed to TP/SL placement on this tick.
+        self.submit_status = "NEW"
+
+    def _next_broker_id(self) -> str:
+        self._counter += 1
+        return f"broker-{self._counter}"
+
+    def _new_client_order_id(self) -> str:
+        self._counter += 1
+        return f"cid-{self._counter}"
+
+    async def submit_order(self, **kwargs):
+        self.submit_calls.append(kwargs)
+        # Mirror the real client's operator gate: dry_run=True or
+        # confirm=False returns a DryRunResult with no broker activity.
+        if kwargs.get("dry_run", True) or not kwargs.get("confirm", False):
+            preview = OrderPreview(
+                symbol=kwargs["symbol"],
+                side=kwargs["side"],
+                order_type=kwargs["order_type"],
+                quantity=kwargs["quantity"],
+                price=kwargs.get("price"),
+                notional_usdt=kwargs.get("notional_usdt", Decimal("0")),
+                client_order_id=kwargs["client_order_id"],
+            )
+            return DryRunResult(preview=preview, reason="fake dry-run")
+        return OrderSubmitResult(
+            client_order_id=kwargs["client_order_id"],
+            broker_order_id=self._next_broker_id(),
+            symbol=kwargs["symbol"],
+            side=kwargs["side"],
+            order_type=kwargs["order_type"],
+            quantity=kwargs["quantity"],
+            price=kwargs.get("price"),
+            status=self.submit_status,
+            transact_time_ms=1700000000000,
+            raw_response={},
+        )
+
+    async def cancel_order(self, **kwargs):
+        self.cancel_calls.append(kwargs)
+        return CancelResult(
+            client_order_id=kwargs["client_order_id"],
+            broker_order_id=self._next_broker_id(),
+            symbol=kwargs["symbol"],
+            status="CANCELED",
+            raw_response={},
+        )
+
+    async def open_orders(self, *, symbol: str) -> list[dict]:
+        self.open_orders_calls.append({"symbol": symbol})
+        return []
+
+    async def aclose(self) -> None:
+        return
+
+
+@pytest.mark.asyncio
+async def test_entry_submitted_not_filled_then_operator_cancel(
+    db_session,
+    instrument: CryptoInstrument,
+) -> None:
+    """ROB-294 acceptance #1 — submitted-not-filled-cancel branch.
+
+    Flow:
+      1. Snapshot resolves to Entry(BUY).
+      2. Fake broker returns ``status="NEW"`` (accepted, not filled).
+      3. Runner records the entry row at ``submitted`` and stops there:
+         no TP/SL placement happens because ``status != "FILLED"``.
+      4. Operator (here: the test) issues a confirmed cancel via the
+         execution client; the ledger transitions to ``cancelled``.
+
+    This is the exact path the lifecycle smoke CLI's
+    ``--cancel-pending-on-exit`` flag exercises. The runner itself does
+    not poll for fills mid-tick — that is by design (no in-process retry
+    loop). Operator cancel is the deterministic recovery.
+    """
+    fake = _FakeExecutionClientNotFilled()
+    ledger = BinanceTestnetLedgerService(session=db_session)
+    config = ScalperConfig.default_for_testnet()
+    runner = ScalperRunner(
+        execution_client=fake,  # type: ignore[arg-type]
+        ledger_service=ledger,
+        config=config,
+        instrument_id_for_symbol=_instrument_id_factory(instrument.id),
+        market_snapshot_for_symbol=_snapshot_factory(_entry_snapshot()),
+        dry_run=False,
+    )
+    tick = await runner.tick_once(symbol="BTCUSDT")
+    assert tick.action_name == "entry"
+    assert tick.submitted is True
+    # No TP/SL placement happened — only the entry submit call was made.
+    assert len(fake.submit_calls) == 1
+    # cancel_calls is still empty pre-operator-action.
+    assert fake.cancel_calls == []
+    # Ledger: single entry row in ``submitted``.
+    rows = await ledger.list_by_instrument(instrument_id=instrument.id, limit=10)
+    submitted_rows = [r for r in rows if r.lifecycle_state == "submitted"]
+    assert len(submitted_rows) == 1, (
+        f"expected exactly one submitted row, got: "
+        f"{[(r.client_order_id, r.lifecycle_state) for r in rows]}"
+    )
+    entry_cid = submitted_rows[0].client_order_id
+
+    # --- Operator cancel (the recovery path) -----------------------------
+    cancel_result = await fake.cancel_order(
+        symbol="BTCUSDT",
+        client_order_id=entry_cid,
+        dry_run=False,
+        confirm=True,
+    )
+    assert isinstance(cancel_result, CancelResult)
+    assert cancel_result.status == "CANCELED"
+    # Record the cancel in the ledger — the service layer enforces the
+    # ``submitted → cancelled`` transition (illegal moves would raise
+    # ``BinanceInvalidStateTransition``).
+    cancelled_row = await ledger.record_cancel(
+        client_order_id=entry_cid,
+        reason="operator_cancel_not_filled_within_window",
+    )
+    assert cancelled_row.lifecycle_state == "cancelled"
+    assert cancelled_row.cancelled_at is not None
+    # Final lifecycle state assertion — what the smoke CLI's evidence
+    # block reports for this branch.
+    final = await ledger.get_by_client_order_id(entry_cid)
+    assert final is not None
+    assert final.lifecycle_state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_lifecycle_produces_no_submitted_or_cancel_calls(
+    db_session,
+    instrument: CryptoInstrument,
+) -> None:
+    """ROB-294 — confirmed evidence shape for the dry-run stage.
+
+    When the runner is in dry-run mode the lifecycle stops at
+    ``validated``: no submits and no cancels are issued against the
+    broker. This locks the "no HTTP in dry-run" guarantee from the
+    runner's side (the execution client's gate is already tested
+    elsewhere, but the runner could in theory bypass it; this test pins
+    the joint behaviour).
+    """
+    fake = _FakeExecutionClientNotFilled()
+    ledger = BinanceTestnetLedgerService(session=db_session)
+    config = ScalperConfig.default_for_testnet()
+    runner = ScalperRunner(
+        execution_client=fake,  # type: ignore[arg-type]
+        ledger_service=ledger,
+        config=config,
+        instrument_id_for_symbol=_instrument_id_factory(instrument.id),
+        market_snapshot_for_symbol=_snapshot_factory(_entry_snapshot()),
+        dry_run=True,
+    )
+    tick = await runner.tick_once(symbol="BTCUSDT")
+    assert tick.action_name == "entry"
+    # In dry-run the submit returns a DryRunResult, so the runner's
+    # ``submitted`` boolean stays False. We assert the contract: no
+    # broker mutation calls at all.
+    assert tick.submitted is False
+    assert tick.dry_run is True
+    # Critically — even though we called ``submit_order``, the fake
+    # records the kwargs, so we can prove the runner's ``dry_run=True``
+    # flag flowed into the client call.
+    assert len(fake.submit_calls) == 1
+    assert fake.submit_calls[0]["dry_run"] is True
+    assert fake.submit_calls[0]["confirm"] is False
+    # No cancels.
+    assert fake.cancel_calls == []
+    # Ledger: the entry row is in ``validated`` (planned → previewed →
+    # validated path, with no submit).
+    rows = await ledger.list_by_instrument(instrument_id=instrument.id, limit=10)
+    assert len(rows) == 1
+    assert rows[0].lifecycle_state == "validated"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_evidence_shape_after_full_armed_flow(
+    db_session,
+    instrument: CryptoInstrument,
+) -> None:
+    """ROB-294 — evidence snapshot for the filled+armed branch.
+
+    Verifies that after the full happy path (entry filled + paired
+    TP/SL armed) the ledger can be projected into the evidence shape
+    the lifecycle smoke CLI emits:
+
+      * client_order_ids_created (one entry + two paired legs);
+      * final lifecycle states (entry=filled, legs=tp_sl_armed);
+      * anomaly_client_order_ids empty;
+      * broker_open_orders_after (mocked here at 2 — TP + SL armed).
+
+    This locks the evidence contract so a future runner refactor can't
+    silently break the operator handoff.
+    """
+    # We reuse the canonical fake from the ROB-289 test file's TT7 path.
+    from tests.services.scalping.test_runner_lifecycle import _FakeExecutionClient
+
+    fake = _FakeExecutionClient()
+    ledger = BinanceTestnetLedgerService(session=db_session)
+    config = ScalperConfig.default_for_testnet()
+    runner = ScalperRunner(
+        execution_client=fake,  # type: ignore[arg-type]
+        ledger_service=ledger,
+        config=config,
+        instrument_id_for_symbol=_instrument_id_factory(instrument.id),
+        market_snapshot_for_symbol=_snapshot_factory(_entry_snapshot()),
+        dry_run=False,
+    )
+    tick = await runner.tick_once(symbol="BTCUSDT")
+    assert tick.action_name == "entry"
+    assert tick.submitted is True
+
+    rows = await ledger.list_by_instrument(instrument_id=instrument.id, limit=10)
+    states = {r.client_order_id: r.lifecycle_state for r in rows}
+    # Exactly one entry row in ``filled``.
+    filled = [cid for cid, st in states.items() if st == "filled"]
+    assert len(filled) == 1
+    entry_cid = filled[0]
+    # Exactly two paired legs in ``tp_sl_armed`` with matching parent CID.
+    armed = [cid for cid, st in states.items() if st == "tp_sl_armed"]
+    assert len(armed) == 2
+    assert {f"{entry_cid}-tp", f"{entry_cid}-sl"} == set(armed)
+    # No anomalies.
+    anomaly = [cid for cid, st in states.items() if st == "anomaly"]
+    assert anomaly == []


### PR DESCRIPTION
## Summary

Adds a deterministic-input companion to the ROB-286/293 smoke so an
operator can manually drive a single MVP symbol through the full
`submit → fill → tp_sl_armed → close` lifecycle on
`testnet.binance.vision`, **without enabling any scheduler / TaskIQ /
cron / Prefect / Hermes path** (ROB-292 remains blocked).

Linear: [ROB-294](https://linear.app/mgh3326/issue/ROB-294)

## Why

ROB-293's confirmed smoke was synthetic Hold-only (`action=hold`,
`submitted=False`, zero ledger mutation) — it proved credential / auth /
signed-read / confirm-gate plumbing but never exercised the
`submit → fill → TP/SL → close` lifecycle. ROB-294 closes that gap with
an operator-gated manual command + fake-client tests + runbook update.

## What changed

* **New CLI** `scripts/binance_testnet_lifecycle_smoke.py` — three
  operator stages (default-disabled, dry-run, `--confirm` single
  cycle), `--simulate-*` snapshot injection, bounded `--max-notional`
  override, `--cancel-pending-on-exit` for the not-filled branch, and
  a structured evidence summary (printed + optional `--evidence-json`).
  Credentials are never logged or recorded — only presence booleans.
* **Runner fake-client tests** (`tests/services/scalping/test_runner_lifecycle_outcomes_rob294.py`):
  submitted-not-filled → operator cancel (the missing branch),
  dry-run no-HTTP joint invariant, evidence-shape contract after a
  filled+armed flow. ROB-289's existing TT7-TT13 tests cover the other
  three outcomes (filled+TP, filled+SL, anomaly fallbacks).
* **CLI tests** (`tests/scripts/test_binance_testnet_lifecycle_smoke.py`):
  default-disabled (no env → exit 0, zero HTTP), missing-symbol /
  non-MVP / notional-ceiling misconfig exits, dry-run flow ending at
  `validated`.
* **Runbook §10C** with:
  * exact dry-run / confirmed-single-cycle command templates;
  * evidence schema + lifecycle-outcome matrix;
  * **`-1013 Filter failure` / `MIN_NOTIONAL` guidance** with the
    ceiling-bounded notional bump procedure;
  * emergency-stop reference back to §10B;
  * explicit reminder that ROB-292 scheduler activation remains blocked.

## Safety invariants preserved

- [x] `test_no_scheduler_activation` still passes — the new CLI lives
  under `scripts/` and is not imported from `app/core/scheduler.py`,
  `app/core/taskiq_broker.py`, or `app/tasks/`.
- [x] Host-allowlist + `BinanceTestnetExecutionClient.from_env` gate
  unchanged; live Binance hosts unreachable by mutation-capable code.
- [x] `--confirm` is per-call, default off; no scheduler / cron wiring.
- [x] No futures / `reduceOnly`.
- [x] No Upbit / real-money paths touched.
- [x] No secret values printed / committed / persisted.
- [x] `max_notional_usdt` ceiling bounded; default `10` USDT, CLI
  ceiling `25` USDT (raising requires a follow-up PR).
- [x] No migrations.

## Test plan

Run on a non-production DB:

- [x] `uv run pytest tests/services/brokers/binance/testnet/test_audit_no_live_host.py -q` (no-scheduler audit)
- [x] `uv run pytest tests/scripts/test_binance_testnet_scalper_smoke.py tests/scripts/test_binance_testnet_lifecycle_smoke.py tests/services/scalping/ tests/services/brokers/binance/testnet/ -q` (full lifecycle + safety suite, 99 passed)
- [x] `uv run python -m scripts.binance_testnet_lifecycle_smoke` (default-disabled manual check: exit 0, one log line, zero HTTP, evidence JSON shows `mode=default-disabled` and all env-presence booleans false)
- [x] `uv run ruff check` + `uv run ruff format --check` clean on the three new files
- [x] `uv run ty check scripts/binance_testnet_lifecycle_smoke.py` clean

## What this PR does NOT verify

- **Real testnet `--confirm` lifecycle was NOT executed** by this PR.
  The operator command template lives in runbook §10C.1 (Stage 3).
  After cutover the operator runs that command against
  `testnet.binance.vision` with small notional and captures the
  evidence JSON for Linear/handoff. Until then, end-to-end
  `submitted → filled → tp_sl_armed → closed → reconciled` is
  **unverified** on real testnet for the deterministic-snapshot path.
- ROB-292 scheduler/TaskIQ activation is **out of scope** and remains
  blocked. This PR does not modify that issue's gate.

## Files changed

* `scripts/binance_testnet_lifecycle_smoke.py` (new, 663 lines)
* `tests/scripts/test_binance_testnet_lifecycle_smoke.py` (new)
* `tests/services/scalping/test_runner_lifecycle_outcomes_rob294.py` (new)
* `docs/runbooks/binance-testnet-scalping.md` (+163 lines: §10C + matrix rows L1-L8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle smoke testing CLI tool for validating the complete scalper workflow on Binance testnet with deterministic controls (dry-run mode, confirmation gates, evidence capture).

* **Documentation**
  * Added operator runbook section documenting lifecycle smoke testing workflow, including configuration options, error handling guidance, and evidence collection.

* **Tests**
  * Added comprehensive test coverage for lifecycle smoke CLI behavior and scalper lifecycle outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->