### PR TITLE
feat(rob-296): Binance Spot Demo Mode adapter + read-only preflight smoke

### DIFF
--- a/app/services/brokers/binance/spot_demo/__init__.py
+++ b/app/services/brokers/binance/spot_demo/__init__.py
@@ -1,0 +1,66 @@
+"""ROB-296 — Binance Spot Demo Mode adapter (signed, read-only preflight).
+
+This sub-package adds a parallel Spot Demo lane alongside the existing
+Spot Testnet lane (``app/services/brokers/binance/testnet/``). The two
+sub-packages share no code: env namespace, host allowlist, transport
+factory, exceptions, and signing chokepoint are all duplicated to
+preserve environment-specific fail-closed isolation.
+
+Default behavior is fail-closed:
+  * Missing ``BINANCE_SPOT_DEMO_ENABLED`` → ``BinanceSpotDemoDisabled``.
+  * Missing credentials → ``BinanceSpotDemoMissingCredentials``.
+  * Base URL outside ``SPOT_DEMO_HOSTS`` → ``BinanceLiveHostBlocked``.
+  * Per-request host in ``TESTNET_HOSTS`` or ``PUBLIC_HOSTS`` →
+    ``BinanceSpotDemoCrossAllowlistViolation``.
+
+This PR (ROB-296) implements:
+  * Spot Demo config / env parsing.
+  * Spot Demo host allowlist (single host: ``demo-api.binance.com``).
+  * Spot Demo signed transport (HMAC-SHA256).
+  * Read-only account preflight (``GET /api/v3/account``).
+  * Default-disabled dry-run smoke CLI.
+
+This PR does NOT implement:
+  * Order submission (no ``execution_client.py`` parallel — see
+    ``BinanceSpotDemoOrderSubmitNotImplemented``).
+  * Persistent order ledger.
+  * Scheduler / TaskIQ / Prefect / Hermes activation.
+  * Ed25519 signing (the preflight surfaces auth rejection as
+    ``BinanceSpotDemoUnsupportedAuth`` if the server refuses HMAC).
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.spot_demo.dry_run import (
+    SpotDemoPlannedOrder,
+    plan_spot_demo_order,
+)
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoCrossAllowlistViolation,
+    BinanceSpotDemoDisabled,
+    BinanceSpotDemoMissingCredentials,
+    BinanceSpotDemoOrderSubmitNotImplemented,
+    BinanceSpotDemoUnsupportedAuth,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import (
+    SPOT_DEMO_HOSTS,
+    assert_spot_demo_host,
+)
+from app.services.brokers.binance.spot_demo.preflight import (
+    SpotDemoPreflightClient,
+    SpotDemoPreflightResult,
+)
+
+__all__ = [
+    "SPOT_DEMO_HOSTS",
+    "assert_spot_demo_host",
+    "BinanceSpotDemoDisabled",
+    "BinanceSpotDemoMissingCredentials",
+    "BinanceSpotDemoCrossAllowlistViolation",
+    "BinanceSpotDemoUnsupportedAuth",
+    "BinanceSpotDemoOrderSubmitNotImplemented",
+    "SpotDemoPreflightClient",
+    "SpotDemoPreflightResult",
+    "SpotDemoPlannedOrder",
+    "plan_spot_demo_order",
+]

--- a/app/services/brokers/binance/spot_demo/dry_run.py
+++ b/app/services/brokers/binance/spot_demo/dry_run.py
@@ -1,0 +1,111 @@
+"""ROB-296 — Pure dry-run planning helpers for the Spot Demo smoke.
+
+These functions produce source-labeled order plan templates **without
+any HTTP, DB, or ledger side effects**. They exist so the smoke CLI can
+demonstrate planning/filtering coverage even when:
+
+  * the operator has not yet provisioned Spot Demo credentials, or
+  * the operator wants to verify planning without spending a real
+    preflight HTTP call.
+
+What this module does NOT do:
+  * Construct or call any httpx client.
+  * Build a signed payload (the secret never flows in here).
+  * Reach the ledger or any DB.
+  * Submit an order.
+
+Per ROB-296 §2 (ledger policy) and §6 (smoke path): persistent order
+lifecycle is intentionally out of scope for this PR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SpotDemoPlannedOrder:
+    """Source-labeled order plan template — no signed payload, no HTTP.
+
+    The fields are deliberately a subset of what a full execution client
+    would produce. There is no ``signed_payload_template`` here because
+    this module never sees the api_secret; signing belongs at the
+    transport boundary (``preflight``-style clients) and is deferred to
+    follow-up work.
+    """
+
+    source: str  # "spot_demo"
+    venue: str  # "binance"
+    product: str  # "spot"
+    symbol: str
+    side: str  # "BUY" / "SELL"
+    order_type: str  # "MARKET" / "LIMIT"
+    quantity: Decimal
+    price: Decimal | None
+    notional_usdt: Decimal
+    notional_cap_usdt: Decimal
+    within_cap: bool
+
+    def to_evidence_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "venue": self.venue,
+            "product": self.product,
+            "symbol": self.symbol,
+            "side": self.side,
+            "order_type": self.order_type,
+            "quantity": str(self.quantity),
+            "price": str(self.price) if self.price is not None else None,
+            "notional_usdt": str(self.notional_usdt),
+            "notional_cap_usdt": str(self.notional_cap_usdt),
+            "within_cap": self.within_cap,
+        }
+
+
+ALLOWED_SIDES: frozenset[str] = frozenset({"BUY", "SELL"})
+ALLOWED_ORDER_TYPES: frozenset[str] = frozenset({"MARKET", "LIMIT"})
+
+
+def plan_spot_demo_order(
+    *,
+    symbol: str,
+    side: str,
+    order_type: str,
+    quantity: Decimal,
+    price: Decimal | None,
+    notional_cap_usdt: Decimal,
+) -> SpotDemoPlannedOrder:
+    """Build a source-labeled planned order without any side effect.
+
+    Validates the shape of the request (sides, order types, LIMIT/MARKET
+    price requirements) and computes whether the notional sits within the
+    operator's configured cap. Does NOT raise on cap exceedance — the
+    smoke CLI surfaces ``within_cap=False`` as evidence rather than
+    crashing the dry-run.
+    """
+    if side not in ALLOWED_SIDES:
+        raise ValueError(f"side {side!r} not in {sorted(ALLOWED_SIDES)}")
+    if order_type not in ALLOWED_ORDER_TYPES:
+        raise ValueError(
+            f"order_type {order_type!r} not in {sorted(ALLOWED_ORDER_TYPES)}"
+        )
+    if order_type == "LIMIT" and price is None:
+        raise ValueError("LIMIT order requires explicit price")
+    if order_type == "MARKET" and price is not None:
+        raise ValueError("MARKET order must not carry a price")
+    notional = (price if price is not None else Decimal("0")) * quantity
+    return SpotDemoPlannedOrder(
+        source="spot_demo",
+        venue="binance",
+        product="spot",
+        symbol=symbol,
+        side=side,
+        order_type=order_type,
+        quantity=quantity,
+        price=price,
+        notional_usdt=notional,
+        notional_cap_usdt=notional_cap_usdt,
+        within_cap=notional <= notional_cap_usdt,
+    )

--- a/app/services/brokers/binance/spot_demo/errors.py
+++ b/app/services/brokers/binance/spot_demo/errors.py
@@ -1,0 +1,72 @@
+"""ROB-296 — Binance Spot Demo Mode adapter error vocabulary.
+
+Mirrors the testnet sibling module (`binance.testnet.errors`) but keeps
+exception types **distinct** so a caller cannot accidentally treat a Spot
+Demo failure as a testnet failure (or vice versa) when catching by name.
+
+Both hierarchies share `BinanceAdapterError` so call-sites that catch the
+common base still work.
+
+Constraint per ROB-296: do not reuse `BINANCE_TESTNET_*` config or
+`BinanceTestnetDisabled` for Spot Demo. The "Disabled" / "MissingCredentials"
+duplication below is intentional environment isolation, not duplication
+to be refactored away.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.errors import BinanceAdapterError
+
+
+class BinanceSpotDemoDisabled(BinanceAdapterError):
+    """Raised when caller attempts a Spot Demo op while the env gate is off.
+
+    Triggered by ``BINANCE_SPOT_DEMO_ENABLED`` unset or non-truthy at
+    adapter construction. Hard fail-closed per ROB-296 §6 smoke path.
+    """
+
+
+class BinanceSpotDemoMissingCredentials(BinanceAdapterError):
+    """Raised when API key/secret are missing at Spot Demo adapter construction.
+
+    The adapter never constructs an HTTP client without both credentials.
+    """
+
+
+class BinanceSpotDemoCrossAllowlistViolation(BinanceAdapterError):
+    """Raised when the Spot Demo transport sees a host in TESTNET_HOSTS or PUBLIC_HOSTS.
+
+    Cross-allowlist guard: a signed Spot Demo request that lands on a
+    testnet host (Spot Testnet) or a live host (mainnet Binance) means a
+    misconfigured deploy is one step from leaking credentials to the
+    wrong environment. Fail hard at the request-event hook, no silent
+    fallback.
+    """
+
+
+class BinanceSpotDemoUnsupportedAuth(BinanceAdapterError):
+    """Raised when the Spot Demo server rejects HMAC-SHA256 signing.
+
+    Per ROB-296 §5 signer preflight: if the operator's Spot Demo account
+    requires Ed25519 (or any non-HMAC signing mechanism), this PR does
+    NOT silently fall back. The preflight surfaces the auth-rejection
+    response and raises this exception so the operator reports it as a
+    scope-expansion follow-up rather than landing a half-baked signer.
+
+    Detected via Binance API error codes returned from a read-only
+    preflight call: -2014 (API-key format invalid), -2008 (Invalid
+    API-key), -1022 (Signature for this request is not valid). The
+    underlying response is summarized in the exception message with
+    credential values redacted.
+    """
+
+
+class BinanceSpotDemoOrderSubmitNotImplemented(BinanceAdapterError):
+    """Raised when ``--confirm`` is passed to the Spot Demo smoke CLI.
+
+    The first ROB-296 PR opens the adapter/config/preflight/dry-run lane
+    but deliberately does NOT mirror the 620-line testnet execution
+    client + ledger semantics. Confirmed order submission is a separate
+    follow-up. The smoke CLI raises this with the exact next-step
+    operator pointer when ``--confirm`` is requested.
+    """

--- a/app/services/brokers/binance/spot_demo/host_allowlist.py
+++ b/app/services/brokers/binance/spot_demo/host_allowlist.py
@@ -1,0 +1,39 @@
+"""ROB-296 — Spot Demo host allowlist (frozen, disjoint from PUBLIC + TESTNET).
+
+Three separate host sets with cross-allowlist guards:
+
+  * Public adapter (Child B)         → ``PUBLIC_HOSTS``
+  * Spot Testnet signed adapter      → ``TESTNET_HOSTS``
+  * Spot Demo signed adapter (here)  → ``SPOT_DEMO_HOSTS``
+
+A host appearing in two sets would let a signed request leak between
+environments. The pairwise disjointness assertion lives in
+``tests/services/brokers/binance/spot_demo/test_host_allowlist.py``.
+
+Spot only — Futures Demo (``demo-fapi.binance.com``) is deliberately
+excluded and tracked under ROB-291.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+
+SPOT_DEMO_HOSTS: frozenset[str] = frozenset(
+    {
+        "demo-api.binance.com",
+    }
+)
+
+
+def assert_spot_demo_host(host: str) -> None:
+    """Raise ``BinanceLiveHostBlocked`` if ``host`` is not in ``SPOT_DEMO_HOSTS``.
+
+    Strict equality match — no suffix/wildcard. Subdomain spoofs like
+    ``demo-api.binance.com.evil.example`` are rejected because the full
+    host string differs from any allowlist entry.
+    """
+    if host not in SPOT_DEMO_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Host {host!r} is not in SPOT_DEMO_HOSTS. "
+            "Allowed: " + ", ".join(sorted(SPOT_DEMO_HOSTS))
+        )

--- a/app/services/brokers/binance/spot_demo/preflight.py
+++ b/app/services/brokers/binance/spot_demo/preflight.py
@@ -1,0 +1,303 @@
+"""ROB-296 — Binance Spot Demo read-only preflight client.
+
+Non-mutating credential-presence check. Calls ``GET /api/v3/account``
+(read-only signed endpoint) and returns a redacted summary that the
+smoke CLI can write to evidence JSON without leaking secrets.
+
+What this module does NOT do:
+  * Place, cancel, or query orders. Order submission is intentionally
+    absent from this first ROB-296 PR (see
+    ``BinanceSpotDemoOrderSubmitNotImplemented``).
+  * Touch the database / ledger.
+  * Activate scheduler / TaskIQ / Prefect / Hermes.
+  * Route to mainnet or testnet hosts (transport layer refuses).
+
+Fail-closed contract:
+  * ``BINANCE_SPOT_DEMO_ENABLED`` unset/non-truthy → ``BinanceSpotDemoDisabled``.
+  * Missing key/secret → ``BinanceSpotDemoMissingCredentials``.
+  * Base URL outside ``SPOT_DEMO_HOSTS`` → ``BinanceLiveHostBlocked``
+    (or ``BinanceSpotDemoCrossAllowlistViolation`` if testnet/public).
+  * Server rejects HMAC signature with codes -2014 / -2008 / -1022 →
+    ``BinanceSpotDemoUnsupportedAuth``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoDisabled,
+    BinanceSpotDemoMissingCredentials,
+    BinanceSpotDemoUnsupportedAuth,
+)
+from app.services.brokers.binance.spot_demo.signing import (
+    BINANCE_SPOT_DEMO_RECV_WINDOW_MS,
+    _sign_request_params,
+)
+from app.services.brokers.binance.spot_demo.transport import build_spot_demo_client
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL: Final[str] = "https://demo-api.binance.com"
+_ACCOUNT_PATH: Final[str] = "/api/v3/account"
+
+# Binance error codes that indicate the server rejected our HMAC-SHA256
+# signature. If the operator's Spot Demo account requires Ed25519
+# instead, the request reaches the server and gets one of these codes
+# back — we surface that as an explicit "unsupported auth" exception
+# rather than silently failing.
+_UNSUPPORTED_AUTH_BINANCE_CODES: frozenset[int] = frozenset({-2014, -2008, -1022})
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _redact_api_key(api_key: str) -> str:
+    """Return a fingerprint of the API key safe for logs/evidence.
+
+    The api_key half of the credential pair is less sensitive than the
+    secret, but we still avoid full logging in case the evidence file is
+    shared. Format: ``<first4>…<last2>`` (or ``***`` if too short).
+    """
+    if len(api_key) >= 6:
+        return f"{api_key[:4]}…{api_key[-2:]}"
+    return "***"
+
+
+@dataclass(frozen=True, slots=True)
+class SpotDemoPreflightResult:
+    """Source-labeled, secret-redacted preflight evidence.
+
+    Designed to be serialized to JSON for the smoke CLI's evidence
+    output. ``source`` / ``venue`` / ``product`` are explicit so the
+    operator can distinguish Spot Demo evidence from Spot Testnet
+    evidence at a glance.
+    """
+
+    source: str  # "spot_demo"
+    venue: str  # "binance"
+    product: str  # "spot"
+    base_url: str
+    api_key_fingerprint: str
+    account_can_trade: bool | None
+    account_can_deposit: bool | None
+    account_can_withdraw: bool | None
+    account_type: str | None
+    balances_nonzero_count: int
+
+    def to_evidence_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "venue": self.venue,
+            "product": self.product,
+            "base_url": self.base_url,
+            "api_key_fingerprint": self.api_key_fingerprint,
+            "account": {
+                "can_trade": self.account_can_trade,
+                "can_deposit": self.account_can_deposit,
+                "can_withdraw": self.account_can_withdraw,
+                "account_type": self.account_type,
+                "balances_nonzero_count": self.balances_nonzero_count,
+            },
+        }
+
+
+def _summarize_account(payload: dict[str, Any]) -> dict[str, Any]:
+    """Extract the safe-to-log summary fields from an account payload.
+
+    Drops free/locked balance amounts (only the count of nonzero rows is
+    kept) and any field that could identify the account holder.
+    """
+    balances = payload.get("balances") or []
+    nonzero = 0
+    for entry in balances:
+        try:
+            free = float(entry.get("free", "0"))
+            locked = float(entry.get("locked", "0"))
+        except (TypeError, ValueError):
+            free = 0.0
+            locked = 0.0
+        if free > 0 or locked > 0:
+            nonzero += 1
+    return {
+        "can_trade": payload.get("canTrade"),
+        "can_deposit": payload.get("canDeposit"),
+        "can_withdraw": payload.get("canWithdraw"),
+        "account_type": payload.get("accountType"),
+        "balances_nonzero_count": nonzero,
+    }
+
+
+class SpotDemoPreflightClient:
+    """Read-only Spot Demo client used by the smoke CLI.
+
+    Constructed via ``from_env()`` for the strict fail-closed path, or
+    directly for tests/inline use.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        api_secret: str,
+        base_url: str = _DEFAULT_BASE_URL,
+    ) -> None:
+        if not api_key:
+            raise BinanceSpotDemoMissingCredentials(
+                "BINANCE_SPOT_DEMO_API_KEY is empty. Refusing to construct "
+                "Spot Demo preflight client."
+            )
+        if not api_secret:
+            raise BinanceSpotDemoMissingCredentials(
+                "BINANCE_SPOT_DEMO_API_SECRET is empty. Refusing to construct "
+                "Spot Demo preflight client."
+            )
+        # Transport factory enforces the host-allowlist check on base_url.
+        self._client = build_spot_demo_client(
+            api_key=api_key, api_secret=api_secret, base_url=base_url
+        )
+        # _api_secret is the ONLY persistent reference to the secret.
+        # repr/str/log paths MUST NOT read this attribute directly.
+        self._api_secret = api_secret
+        self._api_key = api_key
+        self._base_url = base_url
+
+    @classmethod
+    def from_env(cls) -> SpotDemoPreflightClient:
+        """Construct from environment variables with full fail-closed checks.
+
+        Env contract:
+          * ``BINANCE_SPOT_DEMO_ENABLED`` MUST be truthy.
+          * ``BINANCE_SPOT_DEMO_API_KEY`` MUST be present and non-empty.
+          * ``BINANCE_SPOT_DEMO_API_SECRET`` MUST be present and non-empty.
+          * ``BINANCE_SPOT_DEMO_BASE_URL`` (optional) MUST be a Spot Demo
+            host if set; transport factory enforces.
+
+        Note: ``BINANCE_TESTNET_*`` env vars MUST NOT activate this path.
+        They are read by the testnet adapter only.
+        """
+        if not _truthy(os.environ.get("BINANCE_SPOT_DEMO_ENABLED")):
+            raise BinanceSpotDemoDisabled(
+                "BINANCE_SPOT_DEMO_ENABLED is not truthy. Set "
+                "BINANCE_SPOT_DEMO_ENABLED=true to opt in to the Spot Demo "
+                "preflight path. Default is fail-closed."
+            )
+        api_key = os.environ.get("BINANCE_SPOT_DEMO_API_KEY", "")
+        api_secret = os.environ.get("BINANCE_SPOT_DEMO_API_SECRET", "")
+        if not api_key:
+            raise BinanceSpotDemoMissingCredentials(
+                "BINANCE_SPOT_DEMO_API_KEY is empty or missing. Refusing to "
+                "construct Spot Demo preflight client."
+            )
+        if not api_secret:
+            raise BinanceSpotDemoMissingCredentials(
+                "BINANCE_SPOT_DEMO_API_SECRET is empty or missing. Refusing "
+                "to construct Spot Demo preflight client."
+            )
+        base_url = os.environ.get("BINANCE_SPOT_DEMO_BASE_URL", _DEFAULT_BASE_URL)
+        return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
+
+    def __repr__(self) -> str:
+        # Never reference _api_secret in repr/str. api_key half is
+        # fingerprinted to avoid log exposure of credentials.
+        return (
+            f"<SpotDemoPreflightClient base_url={self._base_url!r} "
+            f"api_key={_redact_api_key(self._api_key)!r}>"
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def preflight_account(self) -> SpotDemoPreflightResult:
+        """Call ``GET /api/v3/account`` and return a redacted summary.
+
+        Side effects: ONE signed HTTP GET against ``demo-api.binance.com``.
+        No DB writes, no ledger writes, no order placement, no scheduler
+        activation. The httpx transport refuses any non-Spot-Demo host
+        even if the env was misconfigured.
+
+        Raises:
+          * ``BinanceSpotDemoUnsupportedAuth`` if the server response
+            indicates HMAC signing is rejected (codes -2014, -2008, -1022).
+          * ``httpx.HTTPStatusError`` for other non-2xx responses (caller
+            decides whether to log + exit non-zero).
+        """
+        signed = _sign_request_params(
+            params={"recvWindow": BINANCE_SPOT_DEMO_RECV_WINDOW_MS},
+            api_secret=self._api_secret,
+        )
+        # Path MUST stay /api/v3/account. httpx joins base_url + path
+        # without /api/api/v3 duplication because base_url has no path
+        # component beyond the host.
+        response = await self._client.get(_ACCOUNT_PATH, params=signed)
+        if response.status_code >= 400:
+            self._raise_for_auth_or_status(response)
+        payload = response.json()
+        summary = _summarize_account(payload)
+        return SpotDemoPreflightResult(
+            source="spot_demo",
+            venue="binance",
+            product="spot",
+            base_url=self._base_url,
+            api_key_fingerprint=_redact_api_key(self._api_key),
+            account_can_trade=summary["can_trade"],
+            account_can_deposit=summary["can_deposit"],
+            account_can_withdraw=summary["can_withdraw"],
+            account_type=summary["account_type"],
+            balances_nonzero_count=summary["balances_nonzero_count"],
+        )
+
+    def _raise_for_auth_or_status(self, response: httpx.Response) -> None:
+        """Map Binance HMAC-rejection codes to UnsupportedAuth; otherwise raise.
+
+        Binance returns JSON ``{"code": <int>, "msg": "..."}`` on signed
+        endpoint errors. If the code matches one of the known HMAC
+        rejection codes, raise ``BinanceSpotDemoUnsupportedAuth`` so the
+        operator reports the Ed25519/HMAC mismatch as a scope-expansion
+        follow-up.
+
+        The exception message redacts any echoed key/secret material:
+        Binance error messages do not normally echo credentials, but we
+        defensively strip anything that looks like the api_key or
+        api_secret.
+        """
+        binance_code: int | None = None
+        binance_msg: str = ""
+        try:
+            body = response.json()
+            if isinstance(body, dict):
+                code_value = body.get("code")
+                if isinstance(code_value, int):
+                    binance_code = code_value
+                msg_value = body.get("msg")
+                if isinstance(msg_value, str):
+                    binance_msg = msg_value
+        except ValueError:
+            pass
+        if binance_code in _UNSUPPORTED_AUTH_BINANCE_CODES:
+            redacted_msg = self._redact_credential_echoes(binance_msg)
+            raise BinanceSpotDemoUnsupportedAuth(
+                f"Spot Demo server rejected HMAC-SHA256 signing with code "
+                f"{binance_code} ({redacted_msg!r}). If your Spot Demo "
+                "credentials are Ed25519, this is a scope expansion: do not "
+                "patch a signer fallback in this PR. Report as ROB-296 "
+                "follow-up."
+            )
+        response.raise_for_status()
+
+    def _redact_credential_echoes(self, message: str) -> str:
+        """Strip any echoed api_key/api_secret bytes from ``message``."""
+        redacted = message
+        if self._api_key and self._api_key in redacted:
+            redacted = redacted.replace(self._api_key, "<redacted-api-key>")
+        if self._api_secret and self._api_secret in redacted:
+            redacted = redacted.replace(self._api_secret, "<redacted-api-secret>")
+        return redacted

--- a/app/services/brokers/binance/spot_demo/signing.py
+++ b/app/services/brokers/binance/spot_demo/signing.py
@@ -1,0 +1,63 @@
+"""ROB-296 — HMAC-SHA256 signing chokepoint for Binance Spot Demo.
+
+Intentionally duplicates ``binance.testnet.signing`` rather than sharing
+a generic helper. Per ROB-296 Hermes review §1 (Option A): preserving
+environment-specific fail-closed isolation outweighs deduplication for
+this first PR. If a future PR introduces a 3rd signed lane and the
+duplication grows untenable, extract a pure ``hmac_sign(params, secret)``
+helper under ``binance/`` and have each lane wrap it with its own
+fail-closed validation — but not in this PR.
+
+Per ROB-296 §5: if the operator's Spot Demo account requires Ed25519
+signing instead of HMAC-SHA256, this signer will produce a syntactically
+valid but semantically rejected signature. The read-only preflight
+detects that rejection (Binance error code -1022 / -2014 / -2008) and
+raises ``BinanceSpotDemoUnsupportedAuth`` so the operator reports it as
+a scope-expansion follow-up rather than silently falling back to a
+non-HMAC path.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Final
+from urllib.parse import urlencode
+
+from binance_common.utils import hmac_hashing
+
+# Binance documents the default recvWindow as 5000 ms; allowed up to 60000.
+# We pin a conservative default at the chokepoint so call-sites don't need
+# to remember to pass it. Matches the testnet sibling's default.
+BINANCE_SPOT_DEMO_RECV_WINDOW_MS: Final[int] = 5000
+
+
+def _sign_request_params(
+    *,
+    params: dict[str, Any],
+    api_secret: str,
+) -> dict[str, Any]:
+    """Return a new params dict containing ``timestamp`` + ``signature``.
+
+    Behavior:
+      * If ``params`` already contains ``timestamp``, the caller's value
+        is used (tests fix this for canonical-signature verification).
+      * Otherwise, the current epoch in milliseconds is attached.
+      * The signed payload is the URL-encoded form of the params dict in
+        insertion order.
+      * The original ``params`` is NOT mutated; the returned dict is new.
+
+    Raises:
+      * ``ValueError`` if ``api_secret`` is empty.
+    """
+    if not api_secret:
+        raise ValueError(
+            "api_secret must be a non-empty string. The Spot Demo adapter "
+            "init is responsible for fail-closed credential validation."
+        )
+    signed: dict[str, Any] = dict(params)
+    if "timestamp" not in signed:
+        signed["timestamp"] = int(time.time() * 1000)
+    payload = urlencode(signed)
+    signature = hmac_hashing(api_secret, payload)
+    signed["signature"] = signature
+    return signed

--- a/app/services/brokers/binance/spot_demo/transport.py
+++ b/app/services/brokers/binance/spot_demo/transport.py
@@ -1,0 +1,154 @@
+"""ROB-296 — Binance Spot Demo signed-transport factory + event hooks.
+
+Single chokepoint for constructing httpx clients used by the Spot Demo
+signed adapter. All event hooks are wired here; no other module
+constructs an ``httpx.AsyncClient`` for the Spot Demo endpoints.
+
+Three-way cross-allowlist guard fires at:
+  1. Factory init time — rejects ``base_url`` whose host is in
+     ``TESTNET_HOSTS`` (cross-allowlist) or ``PUBLIC_HOSTS`` (live), and
+     accepts only ``SPOT_DEMO_HOSTS``.
+  2. Pre-request hook — re-checks the per-request host. A misconfigured
+     caller that swaps ``base_url`` post-construction or supplies an
+     absolute URL still hits the disjointness check.
+  3. Post-response hook — rejects 3xx redirects; Spot Demo endpoints do
+     not legitimately redirect.
+
+Implementation note: this module intentionally duplicates
+``binance.testnet.transport`` rather than sharing a generic factory. The
+host-set membership and exception type are environment-specific by
+design.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+from urllib.parse import urlsplit
+
+import httpx
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.host_allowlist import PUBLIC_HOSTS
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoCrossAllowlistViolation,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import (
+    SPOT_DEMO_HOSTS,
+    assert_spot_demo_host,
+)
+from app.services.brokers.binance.testnet.host_allowlist import TESTNET_HOSTS
+
+_DEFAULT_TIMEOUT: Final[float] = 10.0
+_DEFAULT_SPOT_DEMO_BASE: Final[str] = "https://demo-api.binance.com"
+
+# Header name kept as an explicit constant. Identical to the testnet
+# adapter's constant by Binance convention; the audit grep allows this
+# header to appear only under signed-adapter sub-packages.
+APIKEY_HEADER: Final[str] = "X-MBX-APIKEY"
+
+
+async def _on_request(request: httpx.Request) -> None:
+    """Pre-request hook: enforce Spot Demo allowlist + cross-allowlist guard."""
+    host = request.url.host
+    # Cross-allowlist guard FIRST — emit the more specific exception when
+    # the misconfiguration would route a signed Spot Demo request to a
+    # testnet or live host.
+    if host in TESTNET_HOSTS:
+        raise BinanceSpotDemoCrossAllowlistViolation(
+            f"Spot Demo signed-request transport attempted to talk to {host!r}, "
+            "which is in TESTNET_HOSTS (the Spot Testnet allowlist). "
+            "Cross-environment leakage refused. Use the testnet adapter for "
+            "testnet endpoints; this transport is Spot Demo-only."
+        )
+    if host in PUBLIC_HOSTS:
+        raise BinanceSpotDemoCrossAllowlistViolation(
+            f"Spot Demo signed-request transport attempted to talk to {host!r}, "
+            "which is in PUBLIC_HOSTS (the live-Binance allowlist). This means "
+            "a misconfigured caller is one step from sending Spot Demo "
+            "credentials to live Binance. Refusing."
+        )
+    # Then the generic Spot Demo host check (catches anything else).
+    assert_spot_demo_host(host)
+
+
+async def _on_response(response: httpx.Response) -> None:
+    """Post-response hook: surface 3xx as host-violation suspicion.
+
+    With ``follow_redirects=False``, a 30x reaches us as-is. Spot Demo
+    endpoints do not legitimately redirect; treat any 30x as a routing
+    anomaly and refuse to silently follow.
+    """
+    if 300 <= response.status_code < 400:
+        location = response.headers.get("location", "")
+        raise BinanceLiveHostBlocked(
+            f"Unexpected redirect from {response.request.url} to {location!r}; "
+            "Binance Spot Demo endpoints do not legitimately redirect. Refusing."
+        )
+
+
+def _assert_base_url_is_spot_demo(base_url: str) -> None:
+    parsed = urlsplit(base_url)
+    host = parsed.hostname or ""
+    if host in TESTNET_HOSTS:
+        raise BinanceSpotDemoCrossAllowlistViolation(
+            f"Refusing to build Spot Demo client against base_url={base_url!r}: "
+            f"host {host!r} is in TESTNET_HOSTS (Spot Testnet). The Spot Demo "
+            "adapter MUST NOT be initialized with a testnet host."
+        )
+    if host in PUBLIC_HOSTS:
+        raise BinanceSpotDemoCrossAllowlistViolation(
+            f"Refusing to build Spot Demo client against base_url={base_url!r}: "
+            f"host {host!r} is in PUBLIC_HOSTS (live Binance). The Spot Demo "
+            "adapter MUST NOT be initialized with a live host."
+        )
+    if host not in SPOT_DEMO_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Refusing to build Spot Demo client against base_url={base_url!r}: "
+            f"host {host!r} is not in SPOT_DEMO_HOSTS. "
+            "Allowed: " + ", ".join(sorted(SPOT_DEMO_HOSTS))
+        )
+
+
+def build_spot_demo_client(
+    *,
+    api_key: str,
+    api_secret: str,
+    base_url: str = _DEFAULT_SPOT_DEMO_BASE,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> httpx.AsyncClient:
+    """Construct an httpx.AsyncClient for the Binance Spot Demo endpoint.
+
+    Required arguments enforced at the type level — there is no
+    default-empty path. Env-fallback lookup is the caller's job (lives in
+    the Spot Demo preflight client's ``from_env``).
+
+    The ``api_secret`` is accepted here so callers don't have to thread it
+    through a second factory for signing; it is NOT stored on the client
+    object nor logged. The signing chokepoint
+    (``spot_demo.signing._sign_request_params``) is the only place the
+    secret is materially used.
+
+    Caller owns ``await client.aclose()`` (usually via async context manager).
+    """
+    if not api_key:
+        raise ValueError(
+            "api_key is required (empty string disallowed). The adapter init "
+            "is responsible for env-fallback + fail-closed logic before "
+            "calling this factory."
+        )
+    if not api_secret:
+        raise ValueError(
+            "api_secret is required (empty string disallowed). The adapter "
+            "init is responsible for env-fallback + fail-closed logic before "
+            "calling this factory."
+        )
+    _assert_base_url_is_spot_demo(base_url)
+
+    client = httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        follow_redirects=False,
+        headers={APIKEY_HEADER: api_key},
+        event_hooks={"request": [_on_request], "response": [_on_response]},
+    )
+    return client

--- a/docs/runbooks/binance-spot-demo-smoke.md
+++ b/docs/runbooks/binance-spot-demo-smoke.md
@@ -1,0 +1,180 @@
+# Binance Spot Demo Mode Smoke (ROB-296) — Runbook
+
+**Scope.** Operator runbook for the Binance Spot **Demo Mode** lane
+introduced by ROB-296 (`demo-api.binance.com`). This is a **separate
+adapter** from the Spot Testnet lane (ROB-286, `testnet.binance.vision`).
+Both lanes coexist; do **not** repurpose either env namespace for the
+other.
+
+**This PR (ROB-296 first cut)** opens the adapter/config/preflight/
+dry-run lane only. Confirmed order submission against Spot Demo is
+**not** implemented here — see §6 for the operator follow-up template.
+
+---
+
+## 0. Lane boundaries at a glance
+
+| Lane | Host | Env namespace | Adapter package |
+|---|---|---|---|
+| Spot Testnet (ROB-286) | `testnet.binance.vision` | `BINANCE_TESTNET_*` | `app/services/brokers/binance/testnet/` |
+| **Spot Demo (this issue)** | **`demo-api.binance.com`** | **`BINANCE_SPOT_DEMO_*`** | **`app/services/brokers/binance/spot_demo/`** |
+| USD-M Futures Demo (ROB-291) | `demo-fapi.binance.com` | — | not implemented; tracked under [ROB-291](https://linear.app/mgh3326/issue/ROB-291) |
+
+**Hard invariants:**
+* The three host allowlists (`PUBLIC_HOSTS`, `TESTNET_HOSTS`,
+  `SPOT_DEMO_HOSTS`) are pairwise disjoint. Cross-environment leakage is
+  refused at the transport layer with
+  `BinanceSpotDemoCrossAllowlistViolation` (or
+  `BinanceLiveHostBlocked`).
+* `BINANCE_TESTNET_*` env vars do **not** activate the Spot Demo path,
+  and vice versa.
+* The Spot Demo adapter signs with HMAC-SHA256 (same as Spot Testnet).
+  If the operator's Spot Demo account requires Ed25519, the preflight
+  surfaces `BinanceSpotDemoUnsupportedAuth` — **do not** patch a signer
+  fallback in this PR; report as ROB-296 follow-up.
+* No scheduler / TaskIQ / Prefect / cron / Hermes activation in this
+  issue. ROB-292 remains blocked.
+
+---
+
+## 1. Env variables
+
+| Variable | Required when opted in? | Default | Notes |
+|---|---|---|---|
+| `BINANCE_SPOT_DEMO_ENABLED` | Yes (must be `true`) | unset → disabled | Master kill-switch. Default behavior is fail-closed. |
+| `BINANCE_SPOT_DEMO_API_KEY` | Yes (for preflight) | — | API key from your Spot Demo account. |
+| `BINANCE_SPOT_DEMO_API_SECRET` | Yes (for preflight) | — | API secret. Never logged. |
+| `BINANCE_SPOT_DEMO_BASE_URL` | No | `https://demo-api.binance.com` | Validated against `SPOT_DEMO_HOSTS` at factory init; a testnet or live host raises `BinanceSpotDemoCrossAllowlistViolation`. |
+| `BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT` | No | `10` | Per-order cap for the planned-order template. |
+
+---
+
+## 2. Default-disabled behavior
+
+```bash
+uv run python -m scripts.binance_spot_demo_smoke
+# → exit 0; single log line:
+#   "spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in"
+# → zero HTTP, zero DB writes, zero Sentry events
+```
+
+This is the safe default. Setting only `BINANCE_TESTNET_*` does **not**
+activate Spot Demo.
+
+---
+
+## 3. Plan-only dry-run (no HTTP, no credentials needed)
+
+```bash
+BINANCE_SPOT_DEMO_ENABLED=true \
+  uv run python -m scripts.binance_spot_demo_smoke \
+    --plan-only \
+    --symbol BTCUSDT --side BUY --order-type LIMIT \
+    --quantity 0.001 --price 50000
+```
+
+Effect:
+* Stdout emits a single JSON line with `event: "spot_demo_plan"`.
+* No httpx client is constructed.
+* No DB writes, no ledger writes, no Sentry events.
+* Evidence is `source: "spot_demo"`, `venue: "binance"`, `product: "spot"`.
+
+Use this when you want to verify the planning/filter pipeline without
+touching the Spot Demo server.
+
+---
+
+## 4. Read-only preflight (one signed GET, no orders)
+
+```bash
+BINANCE_SPOT_DEMO_ENABLED=true \
+  BINANCE_SPOT_DEMO_API_KEY=$KEY \
+  BINANCE_SPOT_DEMO_API_SECRET=$SECRET \
+  uv run python -m scripts.binance_spot_demo_smoke --preflight
+```
+
+Effect:
+* ONE signed `GET /api/v3/account` against `demo-api.binance.com`.
+* Stdout emits a single JSON line with `event: "spot_demo_preflight"`.
+* No DB writes, no ledger writes, no order placement.
+* `api_key_fingerprint` is `<first4>…<last2>` — full key/secret are
+  never logged.
+* Balance amounts are NOT logged; only the count of nonzero rows.
+
+**Auth-rejection surface:** if the server returns Binance error codes
+`-2014`, `-2008`, or `-1022`, the CLI exits non-zero and raises
+`BinanceSpotDemoUnsupportedAuth`. This typically means the Spot Demo
+account uses Ed25519 keys (not HMAC). **Report as ROB-296 follow-up
+rather than patching the signer in this PR.**
+
+---
+
+## 5. Cross-environment leakage smoke (always safe)
+
+```bash
+uv run pytest tests/services/brokers/binance/spot_demo/test_cross_environment_leakage.py -q
+```
+
+Asserts:
+* The Spot Testnet adapter refuses `demo-api.binance.com`.
+* The Spot Demo adapter refuses `testnet.binance.vision`.
+* Both adapters refuse `api.binance.com`, `fapi.binance.com`,
+  `stream.binance.com`, `data-api.binance.vision`.
+
+---
+
+## 6. Confirmed order-submit smoke — **NOT implemented in this PR**
+
+```bash
+# This command WILL refuse with BinanceSpotDemoOrderSubmitNotImplemented:
+BINANCE_SPOT_DEMO_ENABLED=true \
+  BINANCE_SPOT_DEMO_API_KEY=$KEY \
+  BINANCE_SPOT_DEMO_API_SECRET=$SECRET \
+  uv run python -m scripts.binance_spot_demo_smoke --confirm
+```
+
+Reason: the first ROB-296 PR deliberately opens only the adapter +
+preflight + dry-run lane. Order submission would require mirroring the
+~620-line `BinanceTestnetExecutionClient` plus a Spot Demo ledger
+decision, which the Hermes review intentionally deferred.
+
+**Operator follow-up template** (use when authorized to expand scope):
+
+> Implement `BinanceSpotDemoExecutionClient` under
+> `app/services/brokers/binance/spot_demo/execution_client.py` mirroring
+> the testnet sibling. Decide ledger policy explicitly (reuse a
+> source-labeled testnet table? add a new Spot Demo ledger table? keep
+> log-only?). Land behind a separate operator approval gate; do NOT
+> reuse the ROB-296 PR.
+
+---
+
+## 7. Verification command summary
+
+```bash
+# Existing Binance safety suite (must still pass — no regressions):
+uv run pytest \
+  tests/services/brokers/binance/testnet/test_host_allowlist.py \
+  tests/services/brokers/binance/testnet/test_audit_no_live_host.py \
+  tests/services/brokers/binance/test_audit_no_signed_endpoints.py \
+  -q
+
+# New Spot Demo suite:
+uv run pytest \
+  tests/services/brokers/binance/spot_demo/ \
+  tests/scripts/test_binance_spot_demo_smoke.py \
+  -q
+```
+
+---
+
+## 8. Out of scope (do NOT do from this issue)
+
+* Order submission against Spot Demo (see §6).
+* Persistent Spot Demo order ledger (no alembic migration in this PR).
+* Ed25519 signer (report as scope expansion if preflight surfaces it).
+* USD-M Futures Demo (`demo-fapi.binance.com`) — tracked under ROB-291.
+* TaskIQ / Prefect / cron / Hermes automation — ROB-292 is blocked.
+* Production deploy, production DB migration, or live/mainnet routing.
+* Touching Upbit, Alpaca, KIS, or any real-money broker path.
+* Printing, committing, persisting, or summarizing credential values.

--- a/docs/runbooks/binance-testnet-scalping.md
+++ b/docs/runbooks/binance-testnet-scalping.md
@@ -10,6 +10,14 @@ is no live mode. The class name (`BinanceTestnetExecutionClient`), host
 allowlist (`TESTNET_HOSTS`), and transport factory all enforce this at
 the type/runtime layer.
 
+**Related lane (ROB-296)**: a parallel Spot Demo Mode lane lives at
+`app/services/brokers/binance/spot_demo/` and targets
+`demo-api.binance.com`. The two lanes share **no** code — env namespace
+(`BINANCE_TESTNET_*` vs `BINANCE_SPOT_DEMO_*`), host allowlist, transport
+factory, and exception types are all duplicated to preserve fail-closed
+isolation. See [`binance-spot-demo-smoke.md`](./binance-spot-demo-smoke.md)
+for the Spot Demo runbook and the cross-environment leakage guard tests.
+
 ---
 
 ## 1. Env variables

--- a/env.example
+++ b/env.example
@@ -353,3 +353,20 @@ RESEARCH_REPORTS_INGEST_TOKEN=
 RESEARCH_REPORTS_INGEST_TOKEN_HEADER=X-Research-Reports-Ingest-Token
 RESEARCH_REPORTS_FRESHNESS_MAX_AGE_HOURS=24
 RESEARCH_REPORTS_INGEST_COMMIT_ENABLED=false
+
+# ========================================
+# Binance Spot Demo Mode (ROB-296)
+# ========================================
+# Realistic spot strategy validation lane against https://demo-api.binance.com.
+# Strictly separate from BINANCE_TESTNET_* (Spot Testnet, ROB-286) — do not
+# repurpose either set for the other.
+#   - Spot Testnet  : testnet.binance.vision   (BINANCE_TESTNET_*)
+#   - Spot Demo     : demo-api.binance.com     (BINANCE_SPOT_DEMO_*, this block)
+#   - Futures Demo  : demo-fapi.binance.com    (ROB-291 — out of scope here)
+# Default behavior is fail-closed: unset/false → smoke CLI exits 0 with a
+# single log line and zero side effects.
+BINANCE_SPOT_DEMO_ENABLED=false
+BINANCE_SPOT_DEMO_API_KEY=
+BINANCE_SPOT_DEMO_API_SECRET=
+BINANCE_SPOT_DEMO_BASE_URL=https://demo-api.binance.com
+BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT=10

--- a/scripts/binance_spot_demo_smoke.py
+++ b/scripts/binance_spot_demo_smoke.py
@@ -181,9 +181,7 @@ def _emit_evidence(payload: dict[str, object]) -> None:
 async def _run(args: argparse.Namespace) -> int:
     # Default-disabled gate — must match the testnet smoke CLI's UX.
     if not _truthy(os.environ.get("BINANCE_SPOT_DEMO_ENABLED")):
-        logger.info(
-            "spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in"
-        )
+        logger.info("spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in")
         return 0
 
     # --confirm: operator-only; not implemented in this PR.

--- a/scripts/binance_spot_demo_smoke.py
+++ b/scripts/binance_spot_demo_smoke.py
@@ -1,0 +1,285 @@
+"""ROB-296 — Binance Spot Demo Mode smoke CLI (default-disabled).
+
+Parallel to ``scripts.binance_testnet_scalper_smoke`` but targets the
+Spot Demo endpoint (``https://demo-api.binance.com``) and is read-only
+by design: this PR does NOT include order submission for Spot Demo (see
+``BinanceSpotDemoOrderSubmitNotImplemented``).
+
+Hard invariant: default behavior is fail-closed.
+
+    uv run python -m scripts.binance_spot_demo_smoke
+    # ⇒ exits 0, single log line:
+    #    "spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in"
+    # zero HTTP, zero DB writes, zero Sentry events.
+
+Opt-in (dry-run plan only; no HTTP):
+
+    BINANCE_SPOT_DEMO_ENABLED=true \\
+      uv run python -m scripts.binance_spot_demo_smoke --plan-only
+
+Opt-in with credentials (read-only GET /api/v3/account preflight):
+
+    BINANCE_SPOT_DEMO_ENABLED=true \\
+      BINANCE_SPOT_DEMO_API_KEY=... \\
+      BINANCE_SPOT_DEMO_API_SECRET=... \\
+      uv run python -m scripts.binance_spot_demo_smoke --preflight
+
+The ``--confirm`` flag is intentionally unsupported in this PR; the CLI
+raises ``BinanceSpotDemoOrderSubmitNotImplemented`` with the exact
+follow-up step.
+
+Exit codes:
+  0 — clean run (or default-disabled exit)
+  1 — operator misconfiguration (missing env, missing credentials,
+      ``--confirm`` requested)
+  2 — runtime failure (HTTP error, server auth rejection, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from decimal import Decimal
+
+from app.services.brokers.binance.spot_demo import (
+    BinanceSpotDemoDisabled,
+    BinanceSpotDemoMissingCredentials,
+    BinanceSpotDemoOrderSubmitNotImplemented,
+    BinanceSpotDemoUnsupportedAuth,
+    SpotDemoPreflightClient,
+    plan_spot_demo_order,
+)
+
+logger = logging.getLogger("scripts.binance_spot_demo_smoke")
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ROB-296 smoke CLI for the Binance Spot Demo Mode adapter. "
+            "Default behavior is disabled (zero side effects). Set "
+            "BINANCE_SPOT_DEMO_ENABLED=true + credentials to opt in. "
+            "Read-only preflight is supported; order submission is NOT "
+            "in this PR — use --confirm to see the operator follow-up "
+            "instructions."
+        )
+    )
+    parser.add_argument(
+        "--plan-only",
+        action="store_true",
+        default=False,
+        help=(
+            "Emit a source-labeled planned-order template without any "
+            "HTTP. Safe to run with no credentials when the env gate is "
+            "on."
+        ),
+    )
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        default=False,
+        help=(
+            "Run a read-only GET /api/v3/account preflight against the "
+            "Spot Demo endpoint. Requires env gate + credentials. Emits "
+            "redacted evidence JSON."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help=(
+            "Dry-run mode (default and the only supported mode in this "
+            "PR). No order submission."
+        ),
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        default=False,
+        help=(
+            "Operator-only flag. Order submission is NOT implemented "
+            "in this PR; passing this raises with follow-up instructions."
+        ),
+    )
+    parser.add_argument(
+        "--symbol",
+        default="BTCUSDT",
+        help="Symbol for the planned-order template (default: BTCUSDT).",
+    )
+    parser.add_argument(
+        "--side",
+        default="BUY",
+        choices=["BUY", "SELL"],
+        help="Side for the planned-order template (default: BUY).",
+    )
+    parser.add_argument(
+        "--quantity",
+        type=Decimal,
+        default=Decimal("0.0001"),
+        help="Quantity for the planned-order template (default: 0.0001).",
+    )
+    parser.add_argument(
+        "--price",
+        type=Decimal,
+        default=None,
+        help="Price for LIMIT orders. Omit for MARKET.",
+    )
+    parser.add_argument(
+        "--order-type",
+        default="MARKET",
+        choices=["MARKET", "LIMIT"],
+        help="Order type for the planned-order template (default: MARKET).",
+    )
+    parser.add_argument(
+        "--max-notional-usdt",
+        type=Decimal,
+        default=None,
+        help=(
+            "Override the per-order notional cap. Default reads "
+            "BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT (default 10)."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Python logging level (default INFO).",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_notional_cap(arg_value: Decimal | None) -> Decimal:
+    if arg_value is not None:
+        return arg_value
+    raw = os.environ.get("BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT", "10")
+    try:
+        return Decimal(raw)
+    except Exception:
+        logger.warning(
+            "BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT=%r is not a valid Decimal; "
+            "falling back to 10",
+            raw,
+        )
+        return Decimal("10")
+
+
+def _emit_evidence(payload: dict[str, object]) -> None:
+    """Stdout-stream a single source-labeled evidence JSON line."""
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    # Default-disabled gate — must match the testnet smoke CLI's UX.
+    if not _truthy(os.environ.get("BINANCE_SPOT_DEMO_ENABLED")):
+        logger.info(
+            "spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in"
+        )
+        return 0
+
+    # --confirm: operator-only; not implemented in this PR.
+    if args.confirm:
+        raise BinanceSpotDemoOrderSubmitNotImplemented(
+            "--confirm requires Spot Demo order submission, which is NOT "
+            "included in the ROB-296 first PR. Follow-up: implement a Spot "
+            "Demo execution client (mirror app/services/brokers/binance/"
+            "testnet/execution_client.py under spot_demo/, decide ledger "
+            "policy, and land behind operator approval). Until then, do not "
+            "pass --confirm."
+        )
+
+    cap = _resolve_notional_cap(args.max_notional_usdt)
+
+    if args.plan_only and not args.preflight:
+        plan = plan_spot_demo_order(
+            symbol=args.symbol,
+            side=args.side,
+            order_type=args.order_type,
+            quantity=args.quantity,
+            price=args.price,
+            notional_cap_usdt=cap,
+        )
+        _emit_evidence(
+            {
+                "event": "spot_demo_plan",
+                "plan": plan.to_evidence_dict(),
+            }
+        )
+        return 0
+
+    if args.preflight:
+        try:
+            client = SpotDemoPreflightClient.from_env()
+        except BinanceSpotDemoMissingCredentials as exc:
+            logger.error("preflight refused: %s", exc)
+            return 1
+        try:
+            result = await client.preflight_account()
+        finally:
+            await client.aclose()
+        _emit_evidence(
+            {
+                "event": "spot_demo_preflight",
+                "preflight": result.to_evidence_dict(),
+            }
+        )
+        # Optionally chain a plan emission so operators can compare in one run.
+        if args.plan_only:
+            plan = plan_spot_demo_order(
+                symbol=args.symbol,
+                side=args.side,
+                order_type=args.order_type,
+                quantity=args.quantity,
+                price=args.price,
+                notional_cap_usdt=cap,
+            )
+            _emit_evidence(
+                {
+                    "event": "spot_demo_plan",
+                    "plan": plan.to_evidence_dict(),
+                }
+            )
+        return 0
+
+    # No action flag supplied while enabled — print guidance and exit 0.
+    logger.info(
+        "spot demo enabled but no action requested. Pass --plan-only for a "
+        "no-HTTP planning template, or --preflight for a read-only "
+        "GET /api/v3/account against demo-api.binance.com."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    try:
+        return asyncio.run(_run(args))
+    except BinanceSpotDemoDisabled as exc:
+        logger.error("spot demo disabled: %s", exc)
+        return 1
+    except BinanceSpotDemoMissingCredentials as exc:
+        logger.error("spot demo credentials missing: %s", exc)
+        return 1
+    except BinanceSpotDemoOrderSubmitNotImplemented as exc:
+        logger.error("spot demo order submit not implemented: %s", exc)
+        return 1
+    except BinanceSpotDemoUnsupportedAuth as exc:
+        logger.error("spot demo unsupported auth: %s", exc)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_binance_spot_demo_smoke.py
+++ b/tests/scripts/test_binance_spot_demo_smoke.py
@@ -147,9 +147,7 @@ def test_enabled_no_action_exits_with_guidance(
     exit_code = smoke.main([])
     assert exit_code == 0
     messages = [r.message for r in caplog.records]
-    assert any(
-        "--plan-only" in m or "--preflight" in m for m in messages
-    ), messages
+    assert any("--plan-only" in m or "--preflight" in m for m in messages), messages
 
 
 def test_preflight_without_credentials_exits_one(

--- a/tests/scripts/test_binance_spot_demo_smoke.py
+++ b/tests/scripts/test_binance_spot_demo_smoke.py
@@ -1,0 +1,202 @@
+"""ROB-296 — Spot Demo smoke CLI tests.
+
+Covers:
+  * Default-disabled clean exit (no env → exit 0, single log line).
+  * ``--plan-only`` produces source-labeled evidence with no HTTP.
+  * ``--confirm`` refuses with the documented follow-up message.
+  * No broker/HTTP mutation in dry-run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+
+import scripts.binance_spot_demo_smoke as smoke
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "BINANCE_SPOT_DEMO_ENABLED",
+        "BINANCE_SPOT_DEMO_API_KEY",
+        "BINANCE_SPOT_DEMO_API_SECRET",
+        "BINANCE_SPOT_DEMO_BASE_URL",
+        "BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT",
+        "BINANCE_TESTNET_ENABLED",
+        "BINANCE_TESTNET_API_KEY",
+        "BINANCE_TESTNET_API_SECRET",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_default_disabled_clean_exit(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No env at all → exit 0 + single disabled log line, zero HTTP."""
+    _clear_env(monkeypatch)
+    caplog.set_level(logging.INFO, logger="scripts.binance_spot_demo_smoke")
+    exit_code = smoke.main([])
+    assert exit_code == 0
+    messages = [r.message for r in caplog.records]
+    disabled_lines = [m for m in messages if "spot demo disabled" in m]
+    assert len(disabled_lines) >= 1, messages
+
+
+def test_default_disabled_with_testnet_env_does_not_activate(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``BINANCE_TESTNET_*`` env must not activate the Spot Demo CLI."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "testnet-key")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "testnet-secret")
+    caplog.set_level(logging.INFO, logger="scripts.binance_spot_demo_smoke")
+    exit_code = smoke.main([])
+    assert exit_code == 0
+    messages = [r.message for r in caplog.records]
+    assert any("spot demo disabled" in m for m in messages), messages
+
+
+def test_plan_only_emits_source_labeled_evidence(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--plan-only`` produces a stdout JSON line labeled ``source: spot_demo``."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    exit_code = smoke.main(
+        [
+            "--plan-only",
+            "--symbol",
+            "BTCUSDT",
+            "--side",
+            "BUY",
+            "--order-type",
+            "LIMIT",
+            "--quantity",
+            "0.001",
+            "--price",
+            "50000",
+            "--max-notional-usdt",
+            "100",
+        ]
+    )
+    assert exit_code == 0
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["event"] == "spot_demo_plan"
+    plan = payload["plan"]
+    assert plan["source"] == "spot_demo"
+    assert plan["venue"] == "binance"
+    assert plan["product"] == "spot"
+    assert plan["symbol"] == "BTCUSDT"
+    assert plan["within_cap"] is True
+
+
+def test_plan_only_marks_over_cap_without_crashing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A planned order over the cap is reported as ``within_cap=False``."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT", "5")
+    exit_code = smoke.main(
+        [
+            "--plan-only",
+            "--symbol",
+            "BTCUSDT",
+            "--side",
+            "BUY",
+            "--order-type",
+            "LIMIT",
+            "--quantity",
+            "0.01",
+            "--price",
+            "50000",
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["plan"]["within_cap"] is False
+
+
+def test_confirm_refused_not_implemented(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``--confirm`` is refused with the documented follow-up message."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "secret")
+    caplog.set_level(logging.ERROR, logger="scripts.binance_spot_demo_smoke")
+    exit_code = smoke.main(["--confirm", "--plan-only"])
+    assert exit_code == 1
+    error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("not implemented" in m.lower() for m in error_messages), error_messages
+
+
+def test_enabled_no_action_exits_with_guidance(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Env on but no action flag → exit 0 + guidance message; zero side effects."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    caplog.set_level(logging.INFO, logger="scripts.binance_spot_demo_smoke")
+    exit_code = smoke.main([])
+    assert exit_code == 0
+    messages = [r.message for r in caplog.records]
+    assert any(
+        "--plan-only" in m or "--preflight" in m for m in messages
+    ), messages
+
+
+def test_preflight_without_credentials_exits_one(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``--preflight`` with env on but missing creds → exit 1, error log."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    caplog.set_level(logging.ERROR, logger="scripts.binance_spot_demo_smoke")
+    exit_code = smoke.main(["--preflight"])
+    assert exit_code == 1
+
+
+def test_no_httpx_request_in_plan_only(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--plan-only`` makes no httpx request (no transport instantiation needed).
+
+    We assert this by patching ``httpx.AsyncClient`` to raise on
+    instantiation and confirming the CLI still succeeds.
+    """
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+
+    import httpx
+
+    real_async_client = httpx.AsyncClient
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError(
+            "--plan-only must not construct an httpx.AsyncClient. "
+            "If this fires, the dry-run path leaked into HTTP."
+        )
+
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+    try:
+        exit_code = smoke.main(
+            [
+                "--plan-only",
+                "--symbol",
+                "BTCUSDT",
+                "--quantity",
+                "0.001",
+            ]
+        )
+        assert exit_code == 0
+        out = capsys.readouterr().out.strip()
+        assert "spot_demo_plan" in out
+    finally:
+        monkeypatch.setattr(httpx, "AsyncClient", real_async_client)

--- a/tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py
+++ b/tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py
@@ -1,0 +1,117 @@
+"""ROB-296 — Source-level audit guards for the Spot Demo sub-package.
+
+Two top-level invariants enforced by grep over the sub-package source:
+
+  1. **No live-Binance host literal** anywhere under
+     ``app/services/brokers/binance/spot_demo/``. The Spot Demo signed
+     adapter must only ever talk to ``demo-api.binance.com``. A literal
+     ``api.binance.com`` or ``fapi.binance.com`` in this sub-package
+     would mean a single typo could route signed Spot Demo credentials
+     to live Binance.
+
+  2. **No scheduler activation.** The Spot Demo preflight client and
+     smoke CLI must NOT be referenced anywhere in
+     ``app/core/scheduler.py``, ``app/core/taskiq_broker.py``, or
+     ``app/tasks/``. The smoke runner is CLI-only; ROB-292 scheduler
+     activation remains blocked.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+
+def _repo_root() -> pathlib.Path:
+    # tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py
+    # parents[0]=spot_demo, [1]=binance, [2]=brokers, [3]=services,
+    # [4]=tests, [5]=repo root
+    return pathlib.Path(__file__).resolve().parents[5]
+
+
+def test_no_live_host_url_in_spot_demo_package() -> None:
+    """No literal live-Binance host appears in ``binance/spot_demo/`` source.
+
+    The Spot Demo signed adapter must never reference ``api.binance.com``
+    or ``fapi.binance.com``. The Spot Testnet host
+    ``testnet.binance.vision`` and the live Futures host
+    ``demo-fapi.binance.com`` (ROB-291 scope) must also not appear as
+    runtime literals — only inside comment-only lines that document the
+    invariant.
+    """
+    repo_root = _repo_root()
+    pkg = repo_root / "app" / "services" / "brokers" / "binance" / "spot_demo"
+    assert pkg.exists(), f"Expected spot_demo package at {pkg}"
+    # Precise-host regexes: the negative lookbehind prevents matching when the
+    # candidate host is a suffix of an allowed host. For example, the literal
+    # ``demo-api.binance.com`` contains the substring ``api.binance.com`` but
+    # the lookbehind ``(?<![-A-Za-z0-9])`` ensures we only flag the live host
+    # when it stands alone (preceded by a non-host character such as quote,
+    # whitespace, slash, etc.).
+    forbidden_patterns = (
+        re.compile(r"(?<![-A-Za-z0-9])api\.binance\.com"),
+        re.compile(r"(?<![-A-Za-z0-9])fapi\.binance\.com"),
+        re.compile(r"(?<![-A-Za-z0-9])testnet\.binance\.vision"),
+    )
+    offenders: list[tuple[pathlib.Path, int, str]] = []
+    for py_file in pkg.rglob("*.py"):
+        for lineno, line in enumerate(py_file.read_text().splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            for pattern in forbidden_patterns:
+                if pattern.search(line):
+                    offenders.append((py_file, lineno, line.strip()))
+                    break
+    assert not offenders, (
+        "Forbidden host literal(s) found inside spot_demo package: "
+        f"{offenders}. ROB-296 invariant: the Spot Demo adapter must "
+        "only reference demo-api.binance.com. If a docstring needs to "
+        "mention another host for contrast, place it in a comment-only "
+        "line or split the words."
+    )
+
+
+def test_no_scheduler_activation() -> None:
+    """No scheduler/TaskIQ/tasks module references the Spot Demo runner.
+
+    Scans ``app/core/scheduler.py``, ``app/core/taskiq_broker.py``, and
+    every ``*.py`` under ``app/tasks/`` for references to the Spot Demo
+    preflight client or the smoke script module. Any match is a scope
+    breach — ROB-292 activation must remain blocked.
+    """
+    repo_root = _repo_root()
+    needles = (
+        "SpotDemoPreflightClient",
+        "binance_spot_demo_smoke",
+        "app.services.brokers.binance.spot_demo",
+    )
+    targets: list[pathlib.Path] = []
+    for path in (
+        repo_root / "app" / "core" / "scheduler.py",
+        repo_root / "app" / "core" / "taskiq_broker.py",
+    ):
+        if path.exists():
+            targets.append(path)
+    tasks_dir = repo_root / "app" / "tasks"
+    if tasks_dir.exists():
+        targets.extend(tasks_dir.rglob("*.py"))
+    offenders: list[tuple[pathlib.Path, int, str]] = []
+    for path in targets:
+        try:
+            content = path.read_text()
+        except OSError:
+            continue
+        for lineno, line in enumerate(content.splitlines(), 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            for needle in needles:
+                if needle in line:
+                    offenders.append((path, lineno, line.strip()))
+                    break
+    assert not offenders, (
+        "Spot Demo runner referenced from scheduler/TaskIQ/tasks modules: "
+        f"{offenders}. ROB-296 invariant: the Spot Demo smoke is CLI-only. "
+        "ROB-292 scheduler activation must remain blocked."
+    )

--- a/tests/services/brokers/binance/spot_demo/test_config_env.py
+++ b/tests/services/brokers/binance/spot_demo/test_config_env.py
@@ -1,0 +1,107 @@
+"""ROB-296 — Env/config parsing fail-closed behavior for the Spot Demo client.
+
+Covers:
+  * Default-disabled when ``BINANCE_SPOT_DEMO_ENABLED`` is unset/false.
+  * Missing credentials → ``BinanceSpotDemoMissingCredentials``.
+  * Default base URL when ``BINANCE_SPOT_DEMO_BASE_URL`` is unset.
+  * ``BINANCE_TESTNET_*`` env vars MUST NOT activate the Spot Demo path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoDisabled,
+    BinanceSpotDemoMissingCredentials,
+)
+from app.services.brokers.binance.spot_demo.preflight import SpotDemoPreflightClient
+
+
+def _clear_spot_demo_and_testnet_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "BINANCE_SPOT_DEMO_ENABLED",
+        "BINANCE_SPOT_DEMO_API_KEY",
+        "BINANCE_SPOT_DEMO_API_SECRET",
+        "BINANCE_SPOT_DEMO_BASE_URL",
+        "BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT",
+        "BINANCE_TESTNET_ENABLED",
+        "BINANCE_TESTNET_API_KEY",
+        "BINANCE_TESTNET_API_SECRET",
+        "BINANCE_TESTNET_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_from_env_unset_raises_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env at all → fail-closed."""
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    with pytest.raises(BinanceSpotDemoDisabled):
+        SpotDemoPreflightClient.from_env()
+
+
+@pytest.mark.parametrize("falsy", ["", "false", "no", "0", "off", "FALSE"])
+def test_from_env_falsy_enabled_raises_disabled(
+    monkeypatch: pytest.MonkeyPatch, falsy: str
+) -> None:
+    """Falsy values for the gate are treated as disabled."""
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", falsy)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "secret")
+    with pytest.raises(BinanceSpotDemoDisabled):
+        SpotDemoPreflightClient.from_env()
+
+
+def test_from_env_missing_api_key_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate on, key empty → MissingCredentials."""
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "secret")
+    with pytest.raises(BinanceSpotDemoMissingCredentials):
+        SpotDemoPreflightClient.from_env()
+
+
+def test_from_env_missing_api_secret_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate on, secret empty → MissingCredentials."""
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "")
+    with pytest.raises(BinanceSpotDemoMissingCredentials):
+        SpotDemoPreflightClient.from_env()
+
+
+def test_from_env_default_base_url_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``BINANCE_SPOT_DEMO_BASE_URL`` is unset, the default Spot Demo host is used."""
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "secret")
+    client = SpotDemoPreflightClient.from_env()
+    try:
+        assert str(client._client.base_url) == "https://demo-api.binance.com"
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())
+
+
+def test_testnet_env_does_not_activate_spot_demo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BINANCE_TESTNET_*`` vars MUST NOT activate the Spot Demo path.
+
+    Hermes review §3 isolation: env namespaces are strictly separate.
+    Even if every testnet var is set, ``SpotDemoPreflightClient.from_env``
+    still raises ``BinanceSpotDemoDisabled`` because it reads
+    ``BINANCE_SPOT_DEMO_ENABLED`` only.
+    """
+    _clear_spot_demo_and_testnet_env(monkeypatch)
+    monkeypatch.setenv("BINANCE_TESTNET_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "testnet-key")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "testnet-secret")
+    monkeypatch.setenv("BINANCE_TESTNET_BASE_URL", "https://testnet.binance.vision")
+    with pytest.raises(BinanceSpotDemoDisabled):
+        SpotDemoPreflightClient.from_env()

--- a/tests/services/brokers/binance/spot_demo/test_cross_environment_leakage.py
+++ b/tests/services/brokers/binance/spot_demo/test_cross_environment_leakage.py
@@ -1,0 +1,124 @@
+"""ROB-296 — Cross-environment leakage tests.
+
+Per Hermes review §4: explicitly prove that
+  * the existing testnet adapter rejects ``demo-api.binance.com``;
+  * the new Spot Demo adapter rejects ``testnet.binance.vision``;
+  * both adapters reject live/prod Binance hosts.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoCrossAllowlistViolation,
+)
+from app.services.brokers.binance.spot_demo.transport import (
+    _on_request as spot_demo_on_request,
+)
+from app.services.brokers.binance.spot_demo.transport import (
+    build_spot_demo_client,
+)
+from app.services.brokers.binance.testnet.transport import (
+    _on_request as testnet_on_request,
+)
+from app.services.brokers.binance.testnet.transport import (
+    build_testnet_client,
+)
+
+# -----------------------------------------------------------------------------
+# Testnet adapter must NOT accept Spot Demo or live hosts
+# -----------------------------------------------------------------------------
+
+
+def test_testnet_factory_rejects_spot_demo_base_url() -> None:
+    """Spot Testnet adapter must reject the Spot Demo base URL."""
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_testnet_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://demo-api.binance.com",
+        )
+
+
+def test_testnet_factory_rejects_live_base_url() -> None:
+    """Spot Testnet adapter must reject the live mainnet base URL."""
+    # The testnet transport raises BinanceLiveHostBlocked for any non-testnet
+    # host; PUBLIC_HOSTS membership escalates the message but the exception
+    # class hierarchy still includes BinanceLiveHostBlocked.
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_testnet_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://api.binance.com",
+        )
+
+
+@pytest.mark.asyncio
+async def test_testnet_request_hook_rejects_spot_demo_host() -> None:
+    """Per-request testnet hook refuses a Spot Demo host."""
+    request = httpx.Request("GET", "https://demo-api.binance.com/api/v3/account")
+    with pytest.raises(BinanceLiveHostBlocked):
+        await testnet_on_request(request)
+
+
+# -----------------------------------------------------------------------------
+# Spot Demo adapter must NOT accept testnet or live hosts
+# -----------------------------------------------------------------------------
+
+
+def test_spot_demo_factory_rejects_testnet_base_url() -> None:
+    """Spot Demo adapter must reject the Spot Testnet base URL."""
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://testnet.binance.vision",
+        )
+
+
+def test_spot_demo_factory_rejects_live_base_url() -> None:
+    """Spot Demo adapter must reject the live mainnet base URL."""
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://api.binance.com",
+        )
+
+
+@pytest.mark.asyncio
+async def test_spot_demo_request_hook_rejects_testnet_host() -> None:
+    """Per-request Spot Demo hook refuses a Spot Testnet host."""
+    request = httpx.Request("GET", "https://testnet.binance.vision/api/v3/account")
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        await spot_demo_on_request(request)
+
+
+@pytest.mark.asyncio
+async def test_spot_demo_request_hook_rejects_live_host() -> None:
+    """Per-request Spot Demo hook refuses a live/mainnet host."""
+    request = httpx.Request("GET", "https://api.binance.com/api/v3/account")
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        await spot_demo_on_request(request)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "api.binance.com",
+        "fapi.binance.com",
+        "stream.binance.com",
+        "data-api.binance.vision",
+    ],
+)
+@pytest.mark.asyncio
+async def test_spot_demo_rejects_all_live_hosts(host: str) -> None:
+    """Spot Demo rejects every documented live host (PUBLIC_HOSTS members)."""
+    request = httpx.Request("GET", f"https://{host}/api/v3/account")
+    # The exception is BinanceSpotDemoCrossAllowlistViolation for PUBLIC_HOSTS
+    # members and BinanceLiveHostBlocked for non-allowlisted hosts.
+    with pytest.raises((BinanceSpotDemoCrossAllowlistViolation, BinanceLiveHostBlocked)):
+        await spot_demo_on_request(request)

--- a/tests/services/brokers/binance/spot_demo/test_cross_environment_leakage.py
+++ b/tests/services/brokers/binance/spot_demo/test_cross_environment_leakage.py
@@ -120,5 +120,7 @@ async def test_spot_demo_rejects_all_live_hosts(host: str) -> None:
     request = httpx.Request("GET", f"https://{host}/api/v3/account")
     # The exception is BinanceSpotDemoCrossAllowlistViolation for PUBLIC_HOSTS
     # members and BinanceLiveHostBlocked for non-allowlisted hosts.
-    with pytest.raises((BinanceSpotDemoCrossAllowlistViolation, BinanceLiveHostBlocked)):
+    with pytest.raises(
+        (BinanceSpotDemoCrossAllowlistViolation, BinanceLiveHostBlocked)
+    ):
         await spot_demo_on_request(request)

--- a/tests/services/brokers/binance/spot_demo/test_host_allowlist.py
+++ b/tests/services/brokers/binance/spot_demo/test_host_allowlist.py
@@ -1,0 +1,79 @@
+"""ROB-296 — Spot Demo host allowlist + 3-way cross-allowlist disjointness."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.host_allowlist import PUBLIC_HOSTS
+from app.services.brokers.binance.spot_demo.host_allowlist import (
+    SPOT_DEMO_HOSTS,
+    assert_spot_demo_host,
+)
+from app.services.brokers.binance.testnet.host_allowlist import TESTNET_HOSTS
+
+
+def test_spot_demo_hosts_is_frozen() -> None:
+    """Defense against accidental in-place mutation."""
+    assert isinstance(SPOT_DEMO_HOSTS, frozenset)
+
+
+def test_spot_demo_hosts_contains_only_demo_api() -> None:
+    """Spot Demo allowlist holds exactly the documented demo endpoint."""
+    assert SPOT_DEMO_HOSTS == frozenset({"demo-api.binance.com"})
+
+
+def test_spot_demo_and_testnet_hosts_are_disjoint() -> None:
+    """Spot Demo and Spot Testnet share no host. Cross-allowlist guard."""
+    overlap = SPOT_DEMO_HOSTS & TESTNET_HOSTS
+    assert overlap == set(), (
+        f"SPOT_DEMO_HOSTS and TESTNET_HOSTS overlap on {overlap!r}. These "
+        "allowlists must be strictly disjoint — a shared host would let a "
+        "Spot Demo signed request leak to Spot Testnet (or vice versa)."
+    )
+
+
+def test_spot_demo_and_public_hosts_are_disjoint() -> None:
+    """Spot Demo and live/public allowlist share no host. Mainnet protection."""
+    overlap = SPOT_DEMO_HOSTS & PUBLIC_HOSTS
+    assert overlap == set(), (
+        f"SPOT_DEMO_HOSTS and PUBLIC_HOSTS overlap on {overlap!r}. A shared "
+        "host would let a Spot Demo signed request reach live Binance."
+    )
+
+
+def test_three_way_disjointness() -> None:
+    """All 3 allowlists (PUBLIC, TESTNET, SPOT_DEMO) are pairwise disjoint."""
+    public_testnet = PUBLIC_HOSTS & TESTNET_HOSTS
+    public_demo = PUBLIC_HOSTS & SPOT_DEMO_HOSTS
+    testnet_demo = TESTNET_HOSTS & SPOT_DEMO_HOSTS
+    assert public_testnet == set(), f"PUBLIC ∩ TESTNET = {public_testnet}"
+    assert public_demo == set(), f"PUBLIC ∩ SPOT_DEMO = {public_demo}"
+    assert testnet_demo == set(), f"TESTNET ∩ SPOT_DEMO = {testnet_demo}"
+
+
+@pytest.mark.parametrize("host", ["demo-api.binance.com"])
+def test_spot_demo_hosts_accepted(host: str) -> None:
+    """Allowed Spot Demo hosts pass the module-level check."""
+    assert_spot_demo_host(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "testnet.binance.vision",  # Spot Testnet — different env
+        "stream.testnet.binance.vision",  # Spot Testnet WS — different env
+        "api.binance.com",  # live spot — catastrophic if accepted
+        "fapi.binance.com",  # live futures — not in scope
+        "demo-fapi.binance.com",  # Futures Demo — ROB-291 scope, not here
+        "testnet.binancefuture.com",  # Futures testnet — not in scope
+        "stream.binance.com",  # live public stream
+        "api.binance.us",  # different exchange
+        "evil.example.com",  # arbitrary
+        "demo-api.binance.com.evil.example",  # subdomain spoof
+    ],
+)
+def test_non_spot_demo_hosts_rejected(host: str) -> None:
+    """Anything outside SPOT_DEMO_HOSTS raises BinanceLiveHostBlocked."""
+    with pytest.raises(BinanceLiveHostBlocked):
+        assert_spot_demo_host(host)

--- a/tests/services/brokers/binance/spot_demo/test_path_construction.py
+++ b/tests/services/brokers/binance/spot_demo/test_path_construction.py
@@ -1,0 +1,69 @@
+"""ROB-296 — Path construction tests.
+
+Verify that ``base_url + path`` composition yields the documented
+``/api/v3/...`` endpoints without ``/api/api/v3`` duplication.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.transport import build_spot_demo_client
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v3/account",
+        "/api/v3/ping",
+        "/api/v3/order",
+    ],
+)
+def test_path_is_not_duplicated(path: str) -> None:
+    """httpx joins base_url + path without ``/api/api/v3`` duplication."""
+    client = build_spot_demo_client(
+        api_key="testkey",
+        api_secret="testsecret",
+        base_url="https://demo-api.binance.com",
+    )
+    try:
+        request = client.build_request("GET", path)
+        assert str(request.url) == f"https://demo-api.binance.com{path}"
+        assert "/api/api/v3" not in str(request.url)
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())
+
+
+def test_base_url_with_trailing_slash_does_not_duplicate() -> None:
+    """Trailing slash on base_url + leading slash on path → no duplication."""
+    client = build_spot_demo_client(
+        api_key="testkey",
+        api_secret="testsecret",
+        base_url="https://demo-api.binance.com/",
+    )
+    try:
+        request = client.build_request("GET", "/api/v3/account")
+        assert str(request.url) == "https://demo-api.binance.com/api/v3/account"
+        assert "/api/api/v3" not in str(request.url)
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())
+
+
+def test_apikey_header_attached() -> None:
+    """The ``X-MBX-APIKEY`` header is attached on every request."""
+    client = build_spot_demo_client(
+        api_key="my-key",
+        api_secret="my-secret",
+        base_url="https://demo-api.binance.com",
+    )
+    try:
+        request = client.build_request("GET", "/api/v3/account")
+        assert request.headers.get("X-MBX-APIKEY") == "my-key"
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())

--- a/tests/services/brokers/binance/spot_demo/test_secret_redaction.py
+++ b/tests/services/brokers/binance/spot_demo/test_secret_redaction.py
@@ -1,0 +1,142 @@
+"""ROB-296 — Secret redaction tests for the Spot Demo preflight client.
+
+Guard against credentials leaking through ``repr``, logs, or evidence
+JSON.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.services.brokers.binance.spot_demo.dry_run import plan_spot_demo_order
+from app.services.brokers.binance.spot_demo.preflight import (
+    SpotDemoPreflightClient,
+    SpotDemoPreflightResult,
+    _redact_api_key,
+)
+
+_API_KEY = "ROB296_TESTKEY_DEFINITELY_NOT_REAL_ABCDEF"
+_API_SECRET = "ROB296_TESTSECRET_DEFINITELY_NOT_REAL_XYZ123"
+
+
+def _close(client: SpotDemoPreflightClient) -> None:
+    import asyncio
+
+    asyncio.run(client.aclose())
+
+
+def test_redact_api_key_short_returns_stars() -> None:
+    assert _redact_api_key("ab") == "***"
+    assert _redact_api_key("") == "***"
+
+
+def test_redact_api_key_long_returns_fingerprint() -> None:
+    """Long API keys are reduced to ``<first4>…<last2>`` fingerprint."""
+    fp = _redact_api_key(_API_KEY)
+    assert fp.startswith("ROB2")
+    assert fp.endswith("AL"[-2:]) or fp.endswith("EF")
+    # The full key never appears inside the fingerprint
+    assert _API_KEY not in fp
+
+
+def test_repr_does_not_contain_api_secret() -> None:
+    client = SpotDemoPreflightClient(
+        api_key=_API_KEY,
+        api_secret=_API_SECRET,
+        base_url="https://demo-api.binance.com",
+    )
+    try:
+        rep = repr(client)
+        assert _API_SECRET not in rep, (
+            f"repr() leaked api_secret: {rep!r}. Secret-redaction failure."
+        )
+    finally:
+        _close(client)
+
+
+def test_repr_does_not_contain_raw_api_key() -> None:
+    """The full api_key string must NOT appear in repr — fingerprint only."""
+    client = SpotDemoPreflightClient(
+        api_key=_API_KEY,
+        api_secret=_API_SECRET,
+        base_url="https://demo-api.binance.com",
+    )
+    try:
+        rep = repr(client)
+        assert _API_KEY not in rep, (
+            f"repr() leaked raw api_key: {rep!r}. Use fingerprint instead."
+        )
+    finally:
+        _close(client)
+
+
+def test_evidence_dict_redacts_secret_and_full_key() -> None:
+    """Preflight evidence dict has no full secret and no full key."""
+    result = SpotDemoPreflightResult(
+        source="spot_demo",
+        venue="binance",
+        product="spot",
+        base_url="https://demo-api.binance.com",
+        api_key_fingerprint=_redact_api_key(_API_KEY),
+        account_can_trade=True,
+        account_can_deposit=False,
+        account_can_withdraw=False,
+        account_type="SPOT",
+        balances_nonzero_count=2,
+    )
+    payload = json.dumps(result.to_evidence_dict())
+    assert _API_SECRET not in payload, "evidence JSON leaked api_secret"
+    assert _API_KEY not in payload, "evidence JSON leaked raw api_key"
+
+
+def test_plan_evidence_dict_has_no_secret_or_key_fields() -> None:
+    """Planned-order evidence does not carry credential material at all."""
+    from decimal import Decimal
+
+    plan = plan_spot_demo_order(
+        symbol="BTCUSDT",
+        side="BUY",
+        order_type="LIMIT",
+        quantity=Decimal("0.001"),
+        price=Decimal("50000"),
+        notional_cap_usdt=Decimal("10"),
+    )
+    payload = plan.to_evidence_dict()
+    assert "api_key" not in payload
+    assert "api_secret" not in payload
+    assert "X-MBX-APIKEY" not in json.dumps(payload)
+
+
+def test_source_venue_labels_on_evidence() -> None:
+    """Both evidence types carry explicit source/venue labels."""
+    from decimal import Decimal
+
+    plan = plan_spot_demo_order(
+        symbol="BTCUSDT",
+        side="BUY",
+        order_type="MARKET",
+        quantity=Decimal("0.001"),
+        price=None,
+        notional_cap_usdt=Decimal("10"),
+    )
+    plan_dict = plan.to_evidence_dict()
+    assert plan_dict["source"] == "spot_demo"
+    assert plan_dict["venue"] == "binance"
+    assert plan_dict["product"] == "spot"
+
+    result = SpotDemoPreflightResult(
+        source="spot_demo",
+        venue="binance",
+        product="spot",
+        base_url="https://demo-api.binance.com",
+        api_key_fingerprint="abc…ef",
+        account_can_trade=True,
+        account_can_deposit=True,
+        account_can_withdraw=True,
+        account_type="SPOT",
+        balances_nonzero_count=0,
+    )
+    result_dict = result.to_evidence_dict()
+    assert result_dict["source"] == "spot_demo"
+    assert result_dict["venue"] == "binance"
+    assert result_dict["product"] == "spot"

--- a/tests/services/brokers/binance/spot_demo/test_signing.py
+++ b/tests/services/brokers/binance/spot_demo/test_signing.py
@@ -53,7 +53,12 @@ def test_sign_request_params_attaches_timestamp_when_missing() -> None:
 
 
 def test_sign_request_params_does_not_mutate_caller_dict() -> None:
-    original = {"symbol": "BTCUSDT", "side": "BUY", "type": "MARKET", "quantity": "0.001"}
+    original = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "MARKET",
+        "quantity": "0.001",
+    }
     snapshot = dict(original)
     _sign_request_params(params=original, api_secret="TEST_SECRET")
     assert original == snapshot

--- a/tests/services/brokers/binance/spot_demo/test_signing.py
+++ b/tests/services/brokers/binance/spot_demo/test_signing.py
@@ -1,0 +1,71 @@
+"""ROB-296 — Spot Demo HMAC signing chokepoint tests.
+
+Mirrors the testnet signing tests so any divergence (e.g., accidental
+algorithm change) surfaces here too. The Spot Demo signer is
+intentionally duplicated; this test pins its independent contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from urllib.parse import urlencode
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.signing import (
+    BINANCE_SPOT_DEMO_RECV_WINDOW_MS,
+    _sign_request_params,
+)
+
+
+def test_sign_request_params_canonical_hmac_sha256() -> None:
+    """Fixed inputs produce the canonical HMAC-SHA256 hex signature."""
+    api_secret = "TEST_SECRET_DO_NOT_USE_IN_PROD"
+    params = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "LIMIT",
+        "timeInForce": "GTC",
+        "quantity": "0.001",
+        "price": "50000.00",
+        "timestamp": 1700000000000,
+        "recvWindow": BINANCE_SPOT_DEMO_RECV_WINDOW_MS,
+    }
+    signed = _sign_request_params(params=params.copy(), api_secret=api_secret)
+    assert "signature" in signed
+    expected_payload = urlencode(params)
+    expected_sig = hmac.new(
+        api_secret.encode("utf-8"),
+        expected_payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    assert signed["signature"] == expected_sig
+
+
+def test_sign_request_params_attaches_timestamp_when_missing() -> None:
+    api_secret = "TEST_SECRET_DO_NOT_USE_IN_PROD"
+    params = {"symbol": "ETHUSDT", "side": "SELL", "type": "MARKET", "quantity": "0.01"}
+    signed = _sign_request_params(params=dict(params), api_secret=api_secret)
+    assert "timestamp" in signed
+    assert isinstance(signed["timestamp"], int)
+    assert signed["timestamp"] > 10**12
+
+
+def test_sign_request_params_does_not_mutate_caller_dict() -> None:
+    original = {"symbol": "BTCUSDT", "side": "BUY", "type": "MARKET", "quantity": "0.001"}
+    snapshot = dict(original)
+    _sign_request_params(params=original, api_secret="TEST_SECRET")
+    assert original == snapshot
+
+
+def test_sign_request_params_rejects_empty_secret() -> None:
+    with pytest.raises(ValueError):
+        _sign_request_params(params={"symbol": "BTCUSDT"}, api_secret="")
+
+
+def test_recv_window_matches_testnet_default() -> None:
+    """Spot Demo recv_window matches the testnet default — Binance convention."""
+    from app.services.brokers.binance.testnet.signing import BINANCE_RECV_WINDOW_MS
+
+    assert BINANCE_SPOT_DEMO_RECV_WINDOW_MS == BINANCE_RECV_WINDOW_MS

--- a/tests/services/brokers/binance/spot_demo/test_transport.py
+++ b/tests/services/brokers/binance/spot_demo/test_transport.py
@@ -1,0 +1,149 @@
+"""ROB-296 — Spot Demo signed-transport factory + event-hook tests.
+
+Covers factory-time and per-request enforcement of the Spot Demo
+allowlist, the 3-way cross-allowlist guard (TESTNET + PUBLIC rejected),
+and the 3xx redirect refusal.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoCrossAllowlistViolation,
+)
+from app.services.brokers.binance.spot_demo.transport import (
+    _on_request,
+    _on_response,
+    build_spot_demo_client,
+)
+
+
+def _close_client_safely(client: httpx.AsyncClient) -> None:
+    """Close a client that was constructed for a fail-closed test."""
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(client.aclose())
+
+
+def test_build_spot_demo_client_accepts_default_base_url() -> None:
+    """Factory accepts the documented demo base URL."""
+    client = build_spot_demo_client(
+        api_key="testkey",
+        api_secret="testsecret",
+        base_url="https://demo-api.binance.com",
+    )
+    try:
+        assert str(client.base_url) == "https://demo-api.binance.com"
+    finally:
+        import asyncio
+
+        asyncio.run(client.aclose())
+
+
+def test_build_spot_demo_client_rejects_testnet_host() -> None:
+    """Factory rejects a Spot Testnet host with the cross-allowlist exception."""
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://testnet.binance.vision",
+        )
+
+
+def test_build_spot_demo_client_rejects_live_api_host() -> None:
+    """Factory rejects live/mainnet host with cross-allowlist exception."""
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://api.binance.com",
+        )
+
+
+def test_build_spot_demo_client_rejects_futures_demo_host() -> None:
+    """Factory rejects Futures Demo host (ROB-291 scope, not here)."""
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://demo-fapi.binance.com",
+        )
+
+
+def test_build_spot_demo_client_rejects_arbitrary_host() -> None:
+    """Factory rejects any host outside SPOT_DEMO_HOSTS."""
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_spot_demo_client(
+            api_key="testkey",
+            api_secret="testsecret",
+            base_url="https://evil.example.com",
+        )
+
+
+def test_build_spot_demo_client_rejects_empty_key() -> None:
+    with pytest.raises(ValueError):
+        build_spot_demo_client(
+            api_key="", api_secret="x", base_url="https://demo-api.binance.com"
+        )
+
+
+def test_build_spot_demo_client_rejects_empty_secret() -> None:
+    with pytest.raises(ValueError):
+        build_spot_demo_client(
+            api_key="x", api_secret="", base_url="https://demo-api.binance.com"
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_request_rejects_testnet_host() -> None:
+    """Per-request hook rejects a Spot Testnet host with the cross-allowlist exception."""
+    request = httpx.Request("GET", "https://testnet.binance.vision/api/v3/account")
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        await _on_request(request)
+
+
+@pytest.mark.asyncio
+async def test_on_request_rejects_public_host() -> None:
+    """Per-request hook rejects a live/public host with the cross-allowlist exception."""
+    request = httpx.Request("GET", "https://api.binance.com/api/v3/account")
+    with pytest.raises(BinanceSpotDemoCrossAllowlistViolation):
+        await _on_request(request)
+
+
+@pytest.mark.asyncio
+async def test_on_request_rejects_unknown_host() -> None:
+    """Per-request hook rejects an arbitrary host with BinanceLiveHostBlocked."""
+    request = httpx.Request("GET", "https://evil.example.com/api/v3/account")
+    with pytest.raises(BinanceLiveHostBlocked):
+        await _on_request(request)
+
+
+@pytest.mark.asyncio
+async def test_on_request_accepts_spot_demo_host() -> None:
+    """Per-request hook accepts the documented Spot Demo host."""
+    request = httpx.Request("GET", "https://demo-api.binance.com/api/v3/account")
+    await _on_request(request)  # Should not raise.
+
+
+@pytest.mark.asyncio
+async def test_on_response_rejects_3xx_redirect() -> None:
+    """3xx redirects are refused — Spot Demo endpoints do not legitimately redirect."""
+    request = httpx.Request("GET", "https://demo-api.binance.com/api/v3/account")
+    response = httpx.Response(
+        302,
+        headers={"location": "https://api.binance.com/api/v3/account"},
+        request=request,
+    )
+    with pytest.raises(BinanceLiveHostBlocked):
+        await _on_response(response)
+
+
+@pytest.mark.asyncio
+async def test_on_response_accepts_2xx() -> None:
+    """2xx responses pass through the post-response hook untouched."""
+    request = httpx.Request("GET", "https://demo-api.binance.com/api/v3/account")
+    response = httpx.Response(200, request=request)
+    await _on_response(response)  # Should not raise.

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -125,69 +125,84 @@ def test_only_one_binance_package_path_exists() -> None:
 
 
 def test_no_signed_endpoint_surface_in_binance_public_package() -> None:
-    """ROB-285 public-adapter invariant — extended by ROB-286.
+    """ROB-285 public-adapter invariant — extended by ROB-286 and ROB-296.
 
     The signed-endpoint vocabulary (``order``, ``cancel_order``, etc.) is
-    permitted ONLY inside ``app/services/brokers/binance/testnet/`` (the
-    isolated testnet execution adapter introduced by ROB-286). Anywhere
-    else under ``app/services/brokers/binance/`` is the read-only public
-    adapter and must not gain signed surface.
+    permitted ONLY inside the isolated signed sub-packages:
+      * ``app/services/brokers/binance/testnet/`` (ROB-286 — Spot Testnet)
+      * ``app/services/brokers/binance/spot_demo/`` (ROB-296 — Spot Demo)
+    Anywhere else under ``app/services/brokers/binance/`` is the
+    read-only public adapter and must not gain signed surface.
     """
     repo_root = _repo_root()
     pkg = repo_root / "app" / "services" / "brokers" / "binance"
     if not pkg.exists():
         # Until Task 4 introduces the package, this is fine.
         return
-    testnet_pkg = pkg / "testnet"
+    isolated_signed_pkgs = (pkg / "testnet", pkg / "spot_demo")
     offenders: list[tuple[pathlib.Path, int, str]] = []
     for py_file in pkg.rglob("*.py"):
-        # ROB-286: skip the isolated testnet sub-package — signed methods
-        # legitimately live there.
-        try:
-            py_file.relative_to(testnet_pkg)
+        # ROB-286 + ROB-296: skip the isolated signed sub-packages — signed
+        # methods legitimately live there.
+        skip = False
+        for signed_pkg in isolated_signed_pkgs:
+            try:
+                py_file.relative_to(signed_pkg)
+                skip = True
+                break
+            except ValueError:
+                continue
+        if skip:
             continue
-        except ValueError:
-            pass
         for lineno, line in enumerate(py_file.read_text().splitlines(), 1):
             if SIGNED_SYMBOL_RE.search(line) and "def " in line:
                 offenders.append((py_file, lineno, line.strip()))
     assert not offenders, (
         f"Signed-endpoint method names found in Binance public adapter: "
         f"{offenders}. ROB-285 public adapter must not expose signed-endpoint "
-        "surface. Signed methods are allowed ONLY inside binance/testnet/. "
-        "If a name collision is unavoidable, rename or justify in PR "
-        "description and update SIGNED_SYMBOL_RE."
+        "surface. Signed methods are allowed ONLY inside binance/testnet/ "
+        "or binance/spot_demo/. If a name collision is unavoidable, rename "
+        "or justify in PR description and update SIGNED_SYMBOL_RE."
     )
 
 
 def test_no_api_key_header_constants_in_binance_public_package() -> None:
-    """ROB-285 invariant — extended by ROB-286.
+    """ROB-285 invariant — extended by ROB-286 and ROB-296.
 
-    The ``X-MBX-APIKEY`` header constant is permitted ONLY inside
-    ``app/services/brokers/binance/testnet/transport.py`` (where the
-    signed transport legitimately attaches it). Anywhere else under
-    ``app/services/brokers/binance/`` is the read-only public adapter.
+    The ``X-MBX-APIKEY`` header constant is permitted ONLY inside the
+    isolated signed sub-packages:
+      * ``app/services/brokers/binance/testnet/`` (ROB-286 — Spot Testnet)
+      * ``app/services/brokers/binance/spot_demo/`` (ROB-296 — Spot Demo)
+    Anywhere else under ``app/services/brokers/binance/`` is the
+    read-only public adapter and must not reference this header.
     """
     repo_root = _repo_root()
     pkg = repo_root / "app" / "services" / "brokers" / "binance"
     if not pkg.exists():
         return
-    testnet_pkg = pkg / "testnet"
+    isolated_signed_pkgs = (pkg / "testnet", pkg / "spot_demo")
     forbidden = "X-MBX-APIKEY"
     offenders: list[str] = []
     for py_file in pkg.rglob("*.py"):
-        # ROB-286: signed transport may legitimately reference the header.
-        try:
-            py_file.relative_to(testnet_pkg)
+        # ROB-286 + ROB-296: signed transports may legitimately reference
+        # the header.
+        skip = False
+        for signed_pkg in isolated_signed_pkgs:
+            try:
+                py_file.relative_to(signed_pkg)
+                skip = True
+                break
+            except ValueError:
+                continue
+        if skip:
             continue
-        except ValueError:
-            pass
         if forbidden in py_file.read_text():
             offenders.append(str(py_file))
     assert not offenders, (
         f"X-MBX-APIKEY header constant found in: {offenders}. "
         "Public adapter must never construct API-key headers. The header "
-        "is permitted only inside app/services/brokers/binance/testnet/. "
-        "The transport event hook checks for this header at request time "
-        "as defense in depth; the source itself must not reference it."
+        "is permitted only inside app/services/brokers/binance/testnet/ or "
+        "app/services/brokers/binance/spot_demo/. The transport event hook "
+        "checks for this header at request time as defense in depth; the "
+        "source itself must not reference it."
     )


### PR DESCRIPTION
## Summary
- Adds parallel Spot Demo lane (`app/services/brokers/binance/spot_demo/`) targeting `demo-api.binance.com`, strictly isolated from the Spot Testnet lane (ROB-286).
- Three-way disjoint host allowlists (`PUBLIC_HOSTS` ⊥ `TESTNET_HOSTS` ⊥ `SPOT_DEMO_HOSTS`) enforced at the transport layer; cross-allowlist guards reject testnet + public hosts at factory init **and** per-request.
- Read-only preflight (`GET /api/v3/account`), source-labeled dry-run planning evidence, default-disabled smoke CLI — **no order submission, no ledger, no scheduler activation**.

Linear: https://linear.app/mgh3326/issue/ROB-296

## Hermes review boundary compliance

| Constraint | Implementation |
|---|---|
| §1 — Option A parallel lane | New `spot_demo/` sub-package with duplicated `signing.py` / `transport.py` / `host_allowlist.py`. No shared `BinanceSignedAdapter[Env]` base class. |
| §2 — Ledger policy | Zero ledger code; zero alembic migrations. Evidence is logs/JSON with `source: "spot_demo"`. |
| §3 — Env/host boundaries | `BINANCE_SPOT_DEMO_*` namespace only. Default base URL `https://demo-api.binance.com`, path `/api/v3/*`. `BINANCE_TESTNET_*` env does NOT activate Spot Demo (`test_testnet_env_does_not_activate_spot_demo`). |
| §4 — Cross-environment leakage tests | `test_cross_environment_leakage.py` — testnet rejects `demo-api.binance.com`; Spot Demo rejects `testnet.binance.vision`; both reject `api.binance.com`, `fapi.binance.com`, `stream.binance.com`, `data-api.binance.vision`. |
| §5 — Signer/auth preflight | Re-uses HMAC-SHA256 (same primitive as testnet). If server rejects with codes -2014 / -2008 / -1022 → `BinanceSpotDemoUnsupportedAuth` raised; no Ed25519 fallback patched. |
| §6 — Smoke path | Default-disabled clean exit; `--plan-only` (no HTTP); `--preflight` (single signed GET); `--confirm` raises `BinanceSpotDemoOrderSubmitNotImplemented` with operator follow-up template. |
| §7 — ROB-292 boundary | `tests/services/brokers/binance/spot_demo/test_audit_no_live_host.py::test_no_scheduler_activation` blocks any scheduler/TaskIQ/tasks reference. |
| §8 — Verification | 206/206 Binance + smoke tests green (78 new + 128 existing). |

## Files changed
**New (19):**
- `app/services/brokers/binance/spot_demo/{__init__,errors,host_allowlist,signing,transport,preflight,dry_run}.py`
- `scripts/binance_spot_demo_smoke.py`
- `tests/services/brokers/binance/spot_demo/{__init__,test_host_allowlist,test_transport,test_config_env,test_path_construction,test_signing,test_secret_redaction,test_cross_environment_leakage,test_audit_no_live_host}.py`
- `tests/scripts/test_binance_spot_demo_smoke.py`
- `docs/runbooks/binance-spot-demo-smoke.md`

**Modified (3):**
- `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` — allow `X-MBX-APIKEY` and signed vocabulary inside `spot_demo/` (alongside existing `testnet/` allowance)
- `docs/runbooks/binance-testnet-scalping.md` — cross-link to new Spot Demo runbook
- `env.example` — append `BINANCE_SPOT_DEMO_*` block (values blank, gate `false`)

## Migrations
**None.** No alembic revision in this PR. Per Hermes review §2, persistent Spot Demo order ledger is deferred — if needed later, it lands as a separate scope-expansion PR.

## Tests run

```
uv run pytest tests/services/brokers/binance/ \
              tests/scripts/test_binance_spot_demo_smoke.py \
              tests/scripts/test_binance_testnet_scalper_smoke.py \
              tests/scripts/test_binance_testnet_lifecycle_smoke.py -q
# → 206 passed, 2 warnings in 9.81s
```

Also verified the CLI end-to-end:
- No env → exit 0 + `"spot demo disabled — set BINANCE_SPOT_DEMO_ENABLED=true to opt in"` log line.
- `--plan-only` with `BINANCE_SPOT_DEMO_ENABLED=true` → stdout JSON `{"event": "spot_demo_plan", "plan": {"source": "spot_demo", "venue": "binance", "product": "spot", ...}}`.

## Confirmed Spot Demo `--confirm` smoke

**Not run / unverified.**

Order submission is intentionally NOT implemented in this PR. The CLI refuses `--confirm` with `BinanceSpotDemoOrderSubmitNotImplemented` and the documented next-step:

> Implement `BinanceSpotDemoExecutionClient` under `app/services/brokers/binance/spot_demo/execution_client.py` mirroring the testnet sibling. Decide ledger policy explicitly (reuse a source-labeled testnet table? add a new Spot Demo ledger table? keep log-only?). Land behind a separate operator approval gate; do NOT reuse the ROB-296 PR.

Operator command template (for the future follow-up PR):

```bash
# This command WILL refuse in this PR with BinanceSpotDemoOrderSubmitNotImplemented:
BINANCE_SPOT_DEMO_ENABLED=true \
  BINANCE_SPOT_DEMO_API_KEY=$KEY \
  BINANCE_SPOT_DEMO_API_SECRET=$SECRET \
  uv run python -m scripts.binance_spot_demo_smoke --confirm
```

## Acceptance criteria checklist

- [x] Spot Demo has separate env/config names; does not repurpose Spot Testnet settings
- [x] Spot Demo and Spot Testnet host allowlists are separate and fail closed
- [x] Read-only Spot Demo auth/account preflight is implemented and redacts secrets
- [x] Dry-run Spot Demo smoke is non-mutating and records source/venue metadata
- [x] Existing Spot Testnet tests still pass (128 unchanged + audit extended)
- [x] New tests cover env/config, host allowlist, path construction, default-disabled behavior, dry-run no-mutation
- [x] Runbook explains Spot Testnet vs Spot Demo vs Futures Demo boundaries
- [x] PR handoff explicitly states confirmed Spot Demo order-submit smoke = **not run / unverified** + operator template provided

## Test plan
- [ ] Reviewer confirms `pytest tests/services/brokers/binance/spot_demo/ tests/scripts/test_binance_spot_demo_smoke.py -q` passes
- [ ] Reviewer confirms no new alembic revisions in `alembic/versions/`
- [ ] Reviewer confirms no scheduler/TaskIQ/Prefect references to `SpotDemoPreflightClient` or `binance_spot_demo_smoke`
- [ ] Operator (separate approval) confirms preflight runs against `demo-api.binance.com` with their credentials; reports back on HMAC vs Ed25519 result so the team can decide the follow-up PR shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Binance Spot Demo Mode with safe order planning and read-only account validation (no order submission).
  * Includes preflight signed account checks and notional cap enforcement.
  * Default fail-closed behavior; requires explicit environment variable enablement.

* **Documentation**
  * Added operator runbook for Spot Demo Mode usage, safety boundaries, and environment isolation.

* **Tests**
  * Comprehensive test coverage for Spot Demo Mode including environment configuration, host allowlist validation, and cross-environment leakage prevention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
