### PR TITLE
feat(rob-297): KIS overseas (US) snapshot-backed report support

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -19,10 +19,18 @@ Policy invariants:
   primary. KIS unavailable on a ``kis_live`` request yields
   ``primary_source="none"`` with ``freshness="unavailable"`` — the report
   generator's stale gate then handles publishing.
-* ``account_scope="kis_live"`` on KR requires an explicit ``user_id`` on the
-  collector request. ``user_id`` missing → fail-closed (no implicit default).
-* Non-(kr+kis_live) combos preserve the v1 manual-primary behaviour and add
+* ``account_scope="kis_live"`` on KR or US requires an explicit ``user_id``
+  on the collector request. ``user_id`` missing → fail-closed (no implicit
+  default).
+* Non-(kis_live) combos preserve the v1 manual-primary behaviour and add
   the ``primary_source="manual"`` label only.
+
+ROB-297 — ``market="us" + account_scope="kis_live"`` is the canonical KIS
+overseas combo and takes the same KIS-live path as ``market="kr"``. The KR/US
+disambiguation lives in ``market`` per ROB-297 guardrail #2; no
+``kis_overseas_live`` alias is introduced. Toss/manual US reference quantity
+is NEVER summed into KIS-primary holdings or ``sellable_summary``
+(guardrail #3).
 
 The collector itself never calls broker mutation paths. KIS reads go through
 ``KISHomeReader`` which uses ``BaseKISClient`` for read-only account/margin
@@ -56,6 +64,15 @@ _MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
     "kr": (MarketType.KR,),
     "us": (MarketType.US,),
     "crypto": (MarketType.CRYPTO,),
+}
+
+# Maps the request's ``market`` to the value used on
+# :class:`~app.schemas.invest_home.Holding.market`. The KIS reader returns a
+# mixed list of KR + US holdings on the same account fetch; the KIS-live
+# branch filters that list by the request's market.
+_REQUEST_MARKET_TO_HOLDING_MARKET: dict[str, str] = {
+    "kr": "KR",
+    "us": "US",
 }
 
 
@@ -142,10 +159,15 @@ class PortfolioSnapshotCollector:
                 )
             ]
 
-        # ROB-278 — KR + kis_live uses the new KIS live path. Other combos
-        # preserve v1 manual-primary behaviour.
-        if request.market == "kr" and request.account_scope == "kis_live":
-            return await self._collect_kr_kis_live(request, market_types, now=now)
+        # ROB-278 / ROB-297 — (kr|us) + kis_live uses the KIS live path.
+        # Other combos preserve v1 manual-primary behaviour. KR/US disambig
+        # lives in ``market`` per ROB-297 guardrail #2; no ``kis_overseas_live``
+        # alias is introduced.
+        if request.account_scope == "kis_live" and request.market in (
+            "kr",
+            "us",
+        ):
+            return await self._collect_kis_live(request, market_types, now=now)
         return await self._collect_manual_primary(request, market_types, now=now)
 
     async def _collect_manual_primary(
@@ -199,15 +221,24 @@ class PortfolioSnapshotCollector:
             )
         ]
 
-    async def _collect_kr_kis_live(
+    async def _collect_kis_live(
         self,
         request: CollectorRequest,
         market_types: tuple[MarketType, ...],
         *,
         now: dt.datetime,
     ) -> list[SnapshotCollectResult]:
+        """KIS live path shared by ``(kr|us) + kis_live``.
+
+        ROB-278 introduced this for KR; ROB-297 extended it to US. The
+        request's ``market`` selects the holding filter on the
+        :class:`KISHomeReader` result (``"KR"`` vs ``"US"``); manual/Toss
+        rows are scoped to the matching :class:`MarketType` and surface
+        only via ``reference_holdings``.
+        """
         manual_rows = await self._read_manual_rows(market_types)
         reference_holdings = [_manual_row_to_dict(r) for r in manual_rows]
+        holding_market_filter = _REQUEST_MARKET_TO_HOLDING_MARKET[request.market]
 
         if request.user_id is None:
             # Lockdown — kis_live requires explicit user_id; manual is NOT
@@ -259,7 +290,9 @@ class PortfolioSnapshotCollector:
             logger.warning("KIS read-only fetch failed: %s", exc, exc_info=True)
             fetch_errors.append(f"{type(exc).__name__}: {exc}")
 
-        # Map KIS holdings filtered to the requested market.
+        # Map KIS holdings filtered to the requested market. KR/US live on
+        # the same KIS account fetch; the per-market filter keeps the
+        # payload scoped to ``request.market``.
         kis_holdings_dicts: list[dict[str, Any]] = []
         cash_payload: dict[str, Any] | None = None
         buying_power_payload: dict[str, Any] | None = None
@@ -268,14 +301,21 @@ class PortfolioSnapshotCollector:
         if kis_result is None:
             kis_fetch_status = "failed"
         else:
-            kr_holdings = [h for h in (kis_result.holdings or []) if h.market == "KR"]
-            kis_holdings_dicts = [_kis_holding_to_dict(h) for h in kr_holdings]
+            market_holdings = [
+                h
+                for h in (kis_result.holdings or [])
+                if h.market == holding_market_filter
+            ]
+            kis_holdings_dicts = [_kis_holding_to_dict(h) for h in market_holdings]
             if kis_result.warning is not None:
                 fetch_warnings.append(
                     f"{kis_result.warning.source}: {kis_result.warning.message}"
                 )
             account = next(iter(kis_result.accounts or []), None)
             if account is not None:
+                # Surface both currencies as-is; consumers pick the one that
+                # matches ``market``. The KIS account fetch returns USD for
+                # overseas accounts and KRW for domestic; either may be None.
                 cash_payload = {
                     "krw": account.cashBalances.krw,
                     "usd": account.cashBalances.usd,
@@ -286,11 +326,11 @@ class PortfolioSnapshotCollector:
                 }
             sellable_count = sum(
                 1
-                for h in kr_holdings
+                for h in market_holdings
                 if h.sellableQuantity is not None and h.sellableQuantity > 0
             )
             pending_sell_count = sum(
-                1 for h in kr_holdings if (h.pendingSellQuantity or 0) > 0
+                1 for h in market_holdings if (h.pendingSellQuantity or 0) > 0
             )
             sellable_summary = {
                 "sellable_count": sellable_count,

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -70,6 +70,7 @@ from app.services.investment_snapshots.repository import (
 
 _MARKET_ACCOUNT_PAIRS: dict[str, str] = {
     "kr": "kis_live",
+    "us": "kis_live",  # ROB-297 — KIS overseas (US) stock account.
     "crypto": "upbit_live",
 }
 

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from app.schemas.investment_reports import IngestReportItem
 from app.schemas.investment_snapshots import SnapshotRequestedBy
 
-GeneratorMarketLiteral = Literal["kr", "crypto"]
+GeneratorMarketLiteral = Literal["kr", "us", "crypto"]
 GeneratorAccountScopeLiteral = Literal["kis_live", "upbit_live"]
 GeneratorStatusLiteral = Literal["draft", "published"]
 
@@ -19,9 +19,15 @@ GeneratorStatusLiteral = Literal["draft", "published"]
 class ReportGenerationRequest(BaseModel):
     """Request envelope for :class:`SnapshotBackedReportGenerator.generate`.
 
-    Only ``kr / kis_live`` and ``crypto / upbit_live`` are supported in this
-    PR. The generator validates the pairing at runtime; expanding to US is
-    intentionally a follow-up.
+    Supported canonical pairs (enforced by the generator at runtime):
+
+    * ``kr / kis_live`` — KIS domestic stock account.
+    * ``us / kis_live`` — KIS overseas (US) stock account (ROB-297).
+    * ``crypto / upbit_live`` — Upbit spot.
+
+    ``account_scope`` stays a single canonical literal — KR vs US is
+    disambiguated by ``market`` per ROB-297 guardrail #2. No
+    ``kis_overseas_live`` alias is introduced.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -63,11 +63,11 @@ def _request(market: str = "kr", account_scope: str = "kis_live") -> CollectorRe
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_portfolio_collector_returns_holdings(monkeypatch: pytest.MonkeyPatch):
-    """v1 manual-primary path remains for non-(kr+kis_live) combos.
+    """v1 manual-primary path remains for non-(kis_live) combos.
 
-    ROB-278 reserved the kr+kis_live combo for the new KIS live path
-    (see test_portfolio_v2_*). Other combos keep the v1 contract and
-    additionally surface the ``primary_source="manual"`` label.
+    ROB-278 reserved kr+kis_live and ROB-297 reserved us+kis_live for the
+    KIS live path (see test_portfolio_v2_*). Other combos keep the v1
+    contract and additionally surface ``primary_source="manual"``.
     """
     from app.models.manual_holdings import MarketType
 
@@ -88,7 +88,11 @@ async def test_portfolio_collector_returns_holdings(monkeypatch: pytest.MonkeyPa
     session.execute = AsyncMock(return_value=result)
 
     collector = PortfolioSnapshotCollector(session)
-    results = await collector.collect(_request(market="us", account_scope="kis_live"))
+    # us + alpaca_paper is a non-canonical (collector-only) combo that still
+    # falls back to manual_primary — exactly the contract this test asserts.
+    results = await collector.collect(
+        _request(market="us", account_scope="alpaca_paper")
+    )
     assert len(results) == 1
     assert results[0].snapshot_kind == "portfolio"
     assert results[0].source_kind == "auto_trader_mcp"
@@ -107,7 +111,9 @@ async def test_portfolio_collector_empty_holdings_returns_partial():
     session.execute = AsyncMock(return_value=result)
 
     collector = PortfolioSnapshotCollector(session)
-    results = await collector.collect(_request(market="us", account_scope="kis_live"))
+    results = await collector.collect(
+        _request(market="us", account_scope="alpaca_paper")
+    )
     assert len(results) == 1
     assert results[0].snapshot_kind == "portfolio"
     assert results[0].freshness_status == "partial"
@@ -363,6 +369,253 @@ async def test_portfolio_v2_crypto_upbit_live_preserves_v1_manual_primary():
     # New label is "manual" for non-KIS combos so payload always says where data came from.
     assert payload.get("primary_source") == "manual"
     reader.fetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Portfolio v2 — ROB-297 KIS live path for US + kis_live.
+#
+# Guardrails (ROB-297 pre-implementation comment):
+#   - market="us" + account_scope="kis_live" is canonical KIS overseas.
+#   - Toss/manual US holdings stay reference-only — never summed into the
+#     KIS-primary ``holdings`` or ``sellable_summary``.
+#   - KIS unavailable → primary_source="none"; manual NEVER promoted.
+# ---------------------------------------------------------------------------
+def _us_kis_request(user_id: int | None = None) -> CollectorRequest:
+    return CollectorRequest(
+        market="us",
+        account_scope="kis_live",
+        symbols=None,
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=user_id,
+    )
+
+
+def _manual_us_session(rows: list[Any] | None = None) -> MagicMock:
+    """Session whose execute() returns Toss-style manual US holdings.
+
+    Default row is intentionally a different quantity from the KIS holding
+    fixture so any accidental KIS+manual sum surfaces as a test failure.
+    """
+    from app.models.manual_holdings import MarketType
+
+    class _ManualUSRow:
+        def __init__(
+            self,
+            ticker: str = "AAPL",
+            quantity: float = 5.0,
+            avg_price: float = 140.0,
+        ) -> None:
+            self.ticker = ticker
+            self.market_type = MarketType.US
+            self.quantity = quantity
+            self.avg_price = avg_price
+            self.display_name = ticker
+            self.updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    rows = rows if rows is not None else [_ManualUSRow()]
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=rows))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    return session
+
+
+def _kis_reader_with_us_holdings() -> MagicMock:
+    """KISHomeReader stub returning one US holding + USD cash.
+
+    The KIS quantity (10.0) is deliberately different from the
+    manual/Toss row default (5.0) so the Toss-no-sum invariant is
+    observable in assertions.
+    """
+    from app.schemas.invest_home import Account, CashAmounts, Holding
+    from app.services.invest_home_service import _SourceFetchResult
+
+    holding_us = Holding(
+        holdingId="kis:us:AAPL",
+        accountId="kis_overseas",
+        source="kis",
+        accountKind="live",
+        symbol="AAPL",
+        market="US",
+        assetType="equity",
+        assetCategory="us_stock",
+        displayName="Apple",
+        quantity=10.0,
+        averageCost=150.0,
+        costBasis=1_500.0,
+        currency="USD",
+        valueNative=1_700.0,
+        valueKrw=2_300_000.0,
+        pnlKrw=270_000.0,
+        pnlRate=0.1333,
+        sellableQuantity=8.0,
+        pendingSellQuantity=2.0,
+        referenceQuantity=0.0,
+    )
+    # KIS also exposes any KR-side holdings on the same account fetch;
+    # include one to verify the US branch filters by ``h.market == "US"``
+    # and does not mix domestic holdings into the US payload.
+    holding_kr_noise = Holding(
+        holdingId="kis:kr:005930",
+        accountId="kis_overseas",
+        source="kis",
+        accountKind="live",
+        symbol="005930",
+        market="KR",
+        assetType="equity",
+        assetCategory="kr_stock",
+        displayName="삼성전자",
+        quantity=99.0,
+        averageCost=70_000,
+        costBasis=6_930_000,
+        currency="KRW",
+        valueNative=7_000_000,
+        valueKrw=7_000_000,
+        pnlKrw=70_000,
+        pnlRate=0.01,
+        sellableQuantity=99.0,
+        pendingSellQuantity=0.0,
+        referenceQuantity=0.0,
+    )
+    account = Account(
+        accountId="kis_overseas",
+        displayName="KIS 해외주식",
+        source="kis",
+        accountKind="live",
+        includedInHome=True,
+        valueKrw=2_300_000.0,
+        costBasisKrw=2_000_000.0,
+        pnlKrw=300_000.0,
+        pnlRate=0.15,
+        cashBalances=CashAmounts(krw=None, usd=12_500.0),
+        buyingPower=CashAmounts(krw=None, usd=10_000.0),
+    )
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[account],
+            holdings=[holding_us, holding_kr_noise],
+            warning=None,
+        )
+    )
+    return reader
+
+
+def _kis_reader_us_failed() -> MagicMock:
+    from app.schemas.invest_home import InvestHomeWarning
+    from app.services.invest_home_service import _SourceFetchResult
+
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[],
+            holdings=[],
+            warning=InvestHomeWarning(source="kis", message="overseas auth refused"),
+        )
+    )
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_us_kis_live_missing_user_id_is_fail_closed():
+    """ROB-297 — no user_id on us+kis_live → unavailable, manual not promoted."""
+    session = _manual_us_session()
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        side_effect=AssertionError("KIS must not be called without user_id")
+    )
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_us_kis_request(user_id=None))
+    assert len(results) == 1
+    assert results[0].snapshot_kind == "portfolio"
+    assert results[0].freshness_status == "unavailable"
+    assert "user_id" in results[0].errors_json["reason"]
+    payload = results[0].payload_json
+    assert payload["primary_source"] == "none"
+    assert payload["holdings"] == []
+    # Manual US row stays visible as reference (never promoted).
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    reader.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_us_kis_live_success_populates_kis_primary_with_toss_reference():
+    """ROB-297 — KIS US success: primary_source=kis, USD cash, Toss in reference.
+
+    Toss-no-sum invariant (ROB-297 guardrail #3): manual US quantity (5)
+    must NEVER be summed into KIS US holding (10) or sellable_summary.
+    """
+    session = _manual_us_session()
+    reader = _kis_reader_with_us_holdings()
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_us_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "fresh"
+    # KIS-primary holdings filtered to market="US"; KR noise stays out.
+    assert payload["primary_source"] == "kis"
+    assert payload["count"] == 1
+    assert payload["holdings"][0]["ticker"] == "AAPL"
+    assert payload["holdings"][0]["source"] == "kis"
+    assert payload["holdings"][0]["quantity"] == 10.0  # NOT 10+5 (Toss-no-sum).
+    assert payload["holdings"][0]["sellable_quantity"] == 8.0
+    assert payload["holdings"][0]["pending_sell_quantity"] == 2.0
+    # USD cash + buying_power surfaced for US.
+    assert payload["cash"]["usd"] == 12_500.0
+    assert payload["buying_power"]["usd"] == 10_000.0
+    # Sellable summary counts KIS holdings only — NOT Toss quantity.
+    assert payload["sellable_summary"]["sellable_count"] == 1
+    # Toss/manual US row appears in reference_holdings (untouched, source="manual").
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["ticker"] == "AAPL"
+    assert payload["reference_holdings"][0]["quantity"] == 5.0
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    # Provenance.
+    assert payload["provenance"]["kis_fetch_status"] == "ok"
+    assert payload["provenance"]["account_scope"] == "kis_live"
+    reader.fetch.assert_awaited_once_with(user_id=42)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_us_kis_live_failure_does_not_promote_manual():
+    """ROB-297 — KIS US failure: primary_source=none, manual stays reference."""
+    session = _manual_us_session()
+    reader = _kis_reader_us_failed()
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_us_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert payload["holdings"] == []
+    assert payload["count"] == 0
+    # Manual remains visible as reference, never promoted to primary.
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    # Provenance carries the failure reason.
+    assert payload["provenance"]["kis_fetch_status"] == "failed"
+    assert "kis" in str(payload["provenance"]["warnings"]).lower()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_us_kis_live_exception_is_fail_closed():
+    """ROB-297 — KISHomeReader raising on US is treated like 'failed', not crash."""
+    session = _manual_us_session()
+    reader = MagicMock()
+    reader.fetch = AsyncMock(side_effect=RuntimeError("overseas endpoint down"))
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_us_kis_request(user_id=42))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert payload["holdings"] == []
+    # Manual US row remains visible.
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["provenance"]["kis_fetch_status"] == "failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -190,7 +190,11 @@ async def test_happy_path_crypto_published() -> None:
 
 @pytest.mark.asyncio
 async def test_unsupported_market_account_pair_rejected() -> None:
-    """US/kis_live or crypto/kis_live etc. are rejected at request validation."""
+    """crypto/kis_live etc. are rejected at the generator's pair validator.
+
+    Post ROB-297, ``us/kis_live`` is the canonical KIS overseas pair and
+    must NOT raise; see ``test_happy_path_us_kis_live_published``.
+    """
     ensure = _FakeEnsureService(_ensure_response())
     ingest = _FakeIngestionService()
     gen = SnapshotBackedReportGenerator(
@@ -200,6 +204,61 @@ async def test_unsupported_market_account_pair_rejected() -> None:
         snapshots_repository=_FakeSnapshotsRepository(),
     )
     req = _make_request(market="crypto", account_scope="kis_live")
+    with pytest.raises(SnapshotBackedReportGeneratorError):
+        await gen.generate(req)
+    assert ingest.calls == []
+
+
+# ---------------------------------------------------------------------------
+# ROB-297 — market="us" + account_scope="kis_live" canonical pair.
+#
+# Guardrails (see ROB-297 pre-implementation comment):
+# - market="us" is a single market; brokers are separated by account_scope.
+# - canonical KIS overseas combo is ("us", "kis_live"); no kis_overseas_live
+#   alias is introduced.
+# - the existing ("kr", "kis_live") and ("crypto", "upbit_live") paths must
+#   keep working without regression.
+# ---------------------------------------------------------------------------
+def test_request_schema_accepts_us_kis_live() -> None:
+    """ReportGenerationRequest accepts market='us' with account_scope='kis_live'."""
+    req = _make_request(market="us", account_scope="kis_live")
+    assert req.market == "us"
+    assert req.account_scope == "kis_live"
+
+
+@pytest.mark.asyncio
+async def test_happy_path_us_kis_live_published() -> None:
+    """US/kis_live published flow: validator passes, bundle ensure called with us."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    response = await gen.generate(_make_request(market="us", account_scope="kis_live"))
+
+    assert response.report_uuid == ingest.report_uuid
+    assert ensure.calls[0].market == "us"
+    assert ensure.calls[0].account_scope == "kis_live"
+    # Round-trip: ingestion service received market="us" + account_scope="kis_live".
+    assert ingest.calls[0].market == "us"
+    assert ingest.calls[0].account_scope == "kis_live"
+
+
+@pytest.mark.asyncio
+async def test_us_upbit_live_pair_rejected() -> None:
+    """us/upbit_live passes Pydantic literal check but is rejected by the validator."""
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    req = _make_request(market="us", account_scope="upbit_live")
     with pytest.raises(SnapshotBackedReportGeneratorError):
         await gen.generate(req)
     assert ingest.calls == []


### PR DESCRIPTION
## Summary

- Extends the snapshot-backed `/invest/reports` pipeline to support `market="us" + account_scope="kis_live"` as the canonical KIS overseas combo, alongside existing `kr/kis_live` and `crypto/upbit_live`.
- Aligns the legacy `ReportGenerationRequest` path with the Hermes-first US contract from ROB-287 / PR #912; KIS overseas read paths (`KISHomeReader.fetch_my_overseas_stocks`, overseas margin, overseas orders) are reused — no new broker surface.
- Toss/manual US holdings stay reference-only — never summed into KIS-primary holdings or `sellable_summary` (encoded as a test invariant).

Linear: [ROB-297](https://linear.app/mgh3326/issue/ROB-297/auto-trader-kis-live-중심-us-snapshot-backed-invest-report-지원)

## ROB-297 pre-implementation guardrails (locked before this PR)

1. **`market="us" + account_scope="kis_live"`** is the canonical KIS overseas combo. Existing `us/alpaca_paper` smoke fixtures (`hermes-smoke-us-001`, `tests/fixtures/hermes/*_us.json`) stay as ROB-295 Alpaca smoke context — NOT reskinned by this PR.
2. **`account_scope` stays a single canonical literal**. No `kis_overseas_live` alias added to DB check constraint, Pydantic enum, or validator. KR vs US is disambiguated by `market`.
3. **Toss-no-sum (hard invariant)**: Toss/manual US reference quantity NEVER summed into KIS-primary `holdings` or `sellable_summary`. `sellable_quantity` / `tradeable_quantity` / orderability derive from KIS live alone. Manual rows surface only via `reference_holdings`.
4. **KR/crypto regression**: existing `kr/kis_live` and `crypto/upbit_live` paths remain green (283 tests pass across snapshot_backed + Hermes + reports).
5. **ROB-279 v1 stage catalog inherited as-is**. No US-specific new stage / fundamentals / valuation expansion.

## Changes (5 files, +383/-24, no alembic)

| File | Change |
|------|--------|
| `app/services/action_report/snapshot_backed/request.py` | `GeneratorMarketLiteral` adds `"us"`; docstring lists 3 canonical pairs |
| `app/services/action_report/snapshot_backed/generator.py` | `_MARKET_ACCOUNT_PAIRS` registers `("us", "kis_live")` |
| `app/services/action_report/snapshot_backed/collectors/portfolio.py` | `_collect_kr_kis_live` → `_collect_kis_live` (KR/US shared); `_REQUEST_MARKET_TO_HOLDING_MARKET` filters mixed KIS holdings by request market; dispatch widened; USD cash + buying_power surfaced |
| `tests/services/action_report/snapshot_backed/test_generator.py` | 3 new ROB-297 tests; pre-existing pair-rejected docstring updated |
| `tests/services/action_report/snapshot_backed/test_collectors.py` | 4 new portfolio v2 US tests (incl. Toss-no-sum invariant); 2 pre-existing US manual-primary tests migrated to `account_scope="alpaca_paper"` to keep exercising the same code path post-dispatch widening |

**Toss-no-sum invariant test (key check):** KIS reader returns AAPL qty=10, manual session returns AAPL qty=5 — `payload["holdings"][0]["quantity"]` must equal 10, NOT 15; `sellable_summary["sellable_count"]` must equal 1, NOT 2.

## Safety boundary (re-confirmed)

- No live order submit / cancel / modify.
- No broker / order / watch / order-intent mutation.
- No recurring scheduler / Prefect / Hermes cron activation.
- No production destructive DB migration / backfill (`investment_reports.market` check constraint already allows `'us'`; `account_scope` already allows `'kis_live'` — no alembic needed).
- No secret / token / password logged.

## Test plan

- [x] `tests/services/action_report/snapshot_backed/` — 149 passed (incl. 7 new ROB-297 tests).
- [x] `tests/routers/test_investment_reports_snapshot_backed.py` + `tests/services/investment_stages/` + `tests/services/investment_reports/` — 53 passed.
- [x] Hermes client + roundtrip + HTTP + MCP suites — 81 passed.
- [x] Consolidated: **283 passed, 0 failed**.
- [x] `uv run ruff check app/services/action_report/snapshot_backed/ tests/services/action_report/snapshot_backed/` — clean.
- [x] `uv run ruff format --check` on all touched files — clean.
- [x] `uv run ty check app/services/action_report/snapshot_backed/` — clean.
- [ ] CI green on this PR.

## Out of scope (deliberately)

- Production Hermes US smoke (operator-driven; ROB-295 path).
- Discord / operator action report formatting for US holdings.
- TaskIQ / Prefect activation of any US recurring job.
- Production cutover for the Hermes Prefect deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for live US market portfolio data retrieval through KIS integration

* **Improvements**
  * Enhanced portfolio collection with proper fail-closed handling when user identification is missing
  * Implemented market-based filtering to correctly separate and categorize holdings by market type

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->