### PR TITLE
fix(rob-302): Binance Futures Demo smoke — canonical credential, v2 preflight, XRPUSDT sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
 
 ## Unreleased
 
+### Fixed (ROB-302 — Binance Futures Demo smoke: credential alias, v2 preflight, XRPUSDT sizing)
+- Futures Demo preflight now calls `GET /fapi/v2/account` instead of `/fapi/v1/account`. `demo-fapi.binance.com` returns `404` for v1; v2 returns the same redacted summary fields (`canTrade`, nonzero asset/position counts) so evidence shape is unchanged.
+- `scripts/binance_futures_demo_smoke.py` now selects the requested symbol's row from the `exchangeInfo` response instead of `symbols[0]`. demo-fapi does not honor the `symbol=` query param and can lead the array with BTCUSDT, so XRPUSDT was being sized against BTCUSDT's step/precision/min-notional (cap-10 falsely blocked at `MIN_NOTIONAL=50`). The requested symbol is now matched and the helper fails closed if it is absent.
+- The submitted MARKET quantity is quantized to the symbol's `quantityPrecision` on **both** the open leg and the reduceOnly close leg. A step-floored `Decimal` carried the `exchangeInfo` step string's trailing zeros (`"0.10000000"` → `"30.00000000"`) which `format(qty, "f")` emitted verbatim, triggering Binance `-1111 Precision is over the maximum`. The close leg sizes from `abs(positionAmt)` and is now quantized identically, so a confirmed open can no longer be left with a failing close.
+- LIMIT confirm orders floor to `LOT_SIZE` while MARKET orders floor to `MARKET_LOT_SIZE`, so a coarser MARKET step no longer over-floors or blocks a LIMIT smoke order.
+
+### Added (ROB-302)
+- Canonical shared Demo credential resolution (`app/services/brokers/binance/demo/credentials.py`): set `BINANCE_DEMO_API_KEY` / `BINANCE_DEMO_API_SECRET` once and both the Spot Demo and Futures Demo lanes use it — no duplicate secret per lane. Per-product vars (`BINANCE_{SPOT,FUTURES}_DEMO_API_*`) remain optional overrides that win when set. Credential pairs resolve by source: a half-set override (key without secret, or vice versa) fails closed and is never completed from the canonical pair. Each lane's `*_ENABLED` flag still gates activation independently, and a Spot-specific override never resolves for Futures (crossing happens only through the explicit canonical pair).
+- `--readiness` evidence now reports `credential_source` (`futures_demo_env` / `shared_demo_env`) and `credential_incomplete`, so operators can confirm which credential pair would be used without any value being printed.
+
 ### Added (ROB-299 — Binance Demo smoke hardening + Futures env readiness)
 - Spot Demo `--confirm` close path is now fee-aware: the closing SELL sizes from the live free base-asset balance (step-floored, min-notional gated) instead of reusing the original BUY quantity, so a commission-reduced balance no longer triggers an insufficient-balance failure that needs manual remediation.
 - New `--readiness` mode on `scripts/binance_futures_demo_smoke.py`: a no-secret, no-HTTP report of `BINANCE_FUTURES_DEMO_{ENABLED,API_KEY,API_SECRET,BASE_URL}` presence/truthiness and host-allowlist judgment, surfacing every missing var at once. Reads only the Futures Demo namespace — Spot Demo and legacy testnet env never leak in.

--- a/app/services/brokers/binance/demo/credentials.py
+++ b/app/services/brokers/binance/demo/credentials.py
@@ -146,7 +146,9 @@ def inspect_demo_credential(
         resolved = resolve_demo_credentials(product, env)
     except BinanceDemoIncompleteCredentialOverride:
         key_env, secret_env = _PRODUCT_ENV[product]
-        key_present = bool(_clean(env.get(key_env)) or _clean(env.get(CANONICAL_KEY_ENV)))
+        key_present = bool(
+            _clean(env.get(key_env)) or _clean(env.get(CANONICAL_KEY_ENV))
+        )
         secret_present = bool(
             _clean(env.get(secret_env)) or _clean(env.get(CANONICAL_SECRET_ENV))
         )

--- a/app/services/brokers/binance/demo/credentials.py
+++ b/app/services/brokers/binance/demo/credentials.py
@@ -1,0 +1,171 @@
+"""ROB-302 — shared Binance Demo credential resolver.
+
+The Spot Demo and Futures Demo lanes share ONE Binance Demo credential. To
+avoid duplicating the same secret across two env var pairs in production, both
+lanes resolve through a canonical ``BINANCE_DEMO_API_KEY`` /
+``BINANCE_DEMO_API_SECRET`` pair. Per-product vars remain optional overrides.
+
+Resolution chain (per product, PAIR-by-source — never mixes key/secret across
+sources, per Codex review #2):
+
+    product-specific pair  ->  canonical pair  ->  MissingCredentials
+       (SPOT/FUTURES)            (BINANCE_DEMO_*)
+
+    spot:    BINANCE_SPOT_DEMO_API_{KEY,SECRET}    -> BINANCE_DEMO_API_{KEY,SECRET}
+    futures: BINANCE_FUTURES_DEMO_API_{KEY,SECRET} -> BINANCE_DEMO_API_{KEY,SECRET}
+
+Fail-closed rules:
+  * If EITHER product-specific var is set, the PAIR must come from product vars.
+    A half-set product override raises ``BinanceDemoIncompleteCredentialOverride``
+    — we never backfill the missing half from canonical (that would pair a
+    product key with a canonical secret).
+  * A half-set canonical pair also fails closed.
+  * Nothing set -> ``BinanceDemoMissingCredentials``.
+
+Isolation invariant: a Spot-specific var never resolves for Futures and vice
+versa. The only cross-lane sharing is the explicit canonical pair. This module
+does NOT read ``*_ENABLED`` flags — lane activation stays gated by each lane's
+own ``from_env`` (``BINANCE_{SPOT,FUTURES}_DEMO_ENABLED``).
+
+Secret hygiene: ``ResolvedDemoCredential`` and ``DemoCredentialInspection`` keep
+the key/secret out of ``repr``; only the source label is shown.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+from app.services.brokers.binance.demo.errors import (
+    BinanceDemoIncompleteCredentialOverride,
+    BinanceDemoMissingCredentials,
+)
+
+DemoProduct = Literal["spot", "futures"]
+
+CANONICAL_KEY_ENV: Final[str] = "BINANCE_DEMO_API_KEY"
+CANONICAL_SECRET_ENV: Final[str] = "BINANCE_DEMO_API_SECRET"
+
+_PRODUCT_ENV: Final[dict[str, tuple[str, str]]] = {
+    "spot": ("BINANCE_SPOT_DEMO_API_KEY", "BINANCE_SPOT_DEMO_API_SECRET"),
+    "futures": ("BINANCE_FUTURES_DEMO_API_KEY", "BINANCE_FUTURES_DEMO_API_SECRET"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedDemoCredential:
+    """A matched key/secret pair plus the env source it came from.
+
+    ``api_key`` / ``api_secret`` are excluded from ``repr`` so the pair never
+    leaks into logs or evidence files. Only ``credential_source`` is shown.
+    """
+
+    api_key: str = field(repr=False)
+    api_secret: str = field(repr=False)
+    credential_source: str  # "spot_demo_env" | "futures_demo_env" | "shared_demo_env"
+
+
+@dataclass(frozen=True, slots=True)
+class DemoCredentialInspection:
+    """Non-raising presence/source view for the readiness reflector.
+
+    Reports only booleans + the source label that WOULD be used. Carries no
+    secret material, so it is safe to serialize into readiness evidence.
+    """
+
+    api_key_present: bool
+    api_secret_present: bool
+    credential_source: str | None
+    incomplete: bool
+
+
+def _clean(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def resolve_demo_credentials(
+    product: DemoProduct,
+    env: Mapping[str, str],
+) -> ResolvedDemoCredential:
+    """Resolve a matched Demo credential pair for ``product``.
+
+    Raises ``BinanceDemoIncompleteCredentialOverride`` on a half-set source and
+    ``BinanceDemoMissingCredentials`` when no source is present.
+    """
+    key_env, secret_env = _PRODUCT_ENV[product]
+    product_key = _clean(env.get(key_env))
+    product_secret = _clean(env.get(secret_env))
+
+    # 1. Product-specific override: if either half is set, the PAIR must come
+    #    from product vars. No canonical backfill (Codex #2).
+    if product_key or product_secret:
+        if not (product_key and product_secret):
+            missing = secret_env if product_key else key_env
+            raise BinanceDemoIncompleteCredentialOverride(
+                f"{key_env}/{secret_env}: only one half is set (missing "
+                f"{missing}). Set BOTH product vars, or NEITHER to fall back to "
+                f"the canonical {CANONICAL_KEY_ENV}/{CANONICAL_SECRET_ENV} pair. "
+                "Refusing to pair a product key with a canonical secret."
+            )
+        return ResolvedDemoCredential(
+            api_key=product_key,
+            api_secret=product_secret,
+            credential_source=f"{product}_demo_env",
+        )
+
+    # 2. Canonical shared pair.
+    canon_key = _clean(env.get(CANONICAL_KEY_ENV))
+    canon_secret = _clean(env.get(CANONICAL_SECRET_ENV))
+    if canon_key or canon_secret:
+        if not (canon_key and canon_secret):
+            missing = CANONICAL_SECRET_ENV if canon_key else CANONICAL_KEY_ENV
+            raise BinanceDemoIncompleteCredentialOverride(
+                f"{CANONICAL_KEY_ENV}/{CANONICAL_SECRET_ENV}: only one half is "
+                f"set (missing {missing}). Set BOTH canonical vars."
+            )
+        return ResolvedDemoCredential(
+            api_key=canon_key,
+            api_secret=canon_secret,
+            credential_source="shared_demo_env",
+        )
+
+    # 3. Nothing usable.
+    raise BinanceDemoMissingCredentials(
+        f"No Demo credentials for product={product!r}. Set both {key_env}+"
+        f"{secret_env}, or both {CANONICAL_KEY_ENV}+{CANONICAL_SECRET_ENV}."
+    )
+
+
+def inspect_demo_credential(
+    product: DemoProduct,
+    env: Mapping[str, str],
+) -> DemoCredentialInspection:
+    """Non-raising presence/source inspection for readiness reporting."""
+    try:
+        resolved = resolve_demo_credentials(product, env)
+    except BinanceDemoIncompleteCredentialOverride:
+        key_env, secret_env = _PRODUCT_ENV[product]
+        key_present = bool(_clean(env.get(key_env)) or _clean(env.get(CANONICAL_KEY_ENV)))
+        secret_present = bool(
+            _clean(env.get(secret_env)) or _clean(env.get(CANONICAL_SECRET_ENV))
+        )
+        return DemoCredentialInspection(
+            api_key_present=key_present,
+            api_secret_present=secret_present,
+            credential_source=None,
+            incomplete=True,
+        )
+    except BinanceDemoMissingCredentials:
+        return DemoCredentialInspection(
+            api_key_present=False,
+            api_secret_present=False,
+            credential_source=None,
+            incomplete=False,
+        )
+    return DemoCredentialInspection(
+        api_key_present=True,
+        api_secret_present=True,
+        credential_source=resolved.credential_source,
+        incomplete=False,
+    )

--- a/app/services/brokers/binance/demo/errors.py
+++ b/app/services/brokers/binance/demo/errors.py
@@ -35,3 +35,33 @@ class BinanceDemoInvalidProduct(BinanceDemoLedgerError):
 
 class BinanceDemoDuplicateClientOrderId(BinanceDemoLedgerError):
     """Raised when an insert collides with an existing client_order_id."""
+
+
+class BinanceDemoCredentialError(Exception):
+    """Base class for shared Demo credential resolution errors (ROB-302).
+
+    Distinct from the ledger hierarchy: credential resolution applies across
+    products (spot + futures) and is read at client construction time, before
+    any HTTP/DB activity. Lane ``from_env`` methods catch these and re-raise the
+    lane-specific ``Binance{Spot,Futures}DemoMissingCredentials`` so existing
+    fail-closed contracts (and the smoke CLI's catch blocks) are preserved.
+    """
+
+
+class BinanceDemoMissingCredentials(BinanceDemoCredentialError):
+    """No usable Demo credential pair found for the requested product.
+
+    Neither the product-specific pair nor the canonical ``BINANCE_DEMO_*`` pair
+    was present.
+    """
+
+
+class BinanceDemoIncompleteCredentialOverride(BinanceDemoCredentialError):
+    """A credential source supplied only half of a key/secret pair.
+
+    Per Codex review #2: when a product-specific override sets the key XOR the
+    secret, we MUST fail closed rather than backfill the missing half from the
+    canonical pair — pairing a product key with a canonical secret would submit
+    a mismatched HMAC credential. Same guard applies to a half-set canonical
+    pair.
+    """

--- a/app/services/brokers/binance/futures_demo/execution_client.py
+++ b/app/services/brokers/binance/futures_demo/execution_client.py
@@ -49,6 +49,8 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Final
 
+from app.services.brokers.binance.demo.credentials import resolve_demo_credentials
+from app.services.brokers.binance.demo.errors import BinanceDemoCredentialError
 from app.services.brokers.binance.futures_demo.dto import (
     FuturesDemoCancelResult,
     FuturesDemoLeverageResult,
@@ -156,8 +158,10 @@ class BinanceFuturesDemoExecutionClient:
 
         Env contract:
           * ``BINANCE_FUTURES_DEMO_ENABLED`` MUST be truthy.
-          * ``BINANCE_FUTURES_DEMO_API_KEY`` MUST be present and non-empty.
-          * ``BINANCE_FUTURES_DEMO_API_SECRET`` MUST be present and non-empty.
+          * Credentials (ROB-302): the ``BINANCE_FUTURES_DEMO_API_*`` pair
+            OR the canonical ``BINANCE_DEMO_API_*`` pair MUST be present
+            (the per-product pair wins when set). A half-set pair fails
+            closed. Resolved via ``demo.credentials.resolve_demo_credentials``.
           * ``BINANCE_FUTURES_DEMO_BASE_URL`` (optional) MUST be a Futures
             Demo host if set; transport factory enforces.
 
@@ -170,20 +174,16 @@ class BinanceFuturesDemoExecutionClient:
                 "BINANCE_FUTURES_DEMO_ENABLED=true to opt in to the Futures "
                 "Demo execution path. Default is fail-closed."
             )
-        api_key = os.environ.get("BINANCE_FUTURES_DEMO_API_KEY", "")
-        api_secret = os.environ.get("BINANCE_FUTURES_DEMO_API_SECRET", "")
-        if not api_key:
-            raise BinanceFuturesDemoMissingCredentials(
-                "BINANCE_FUTURES_DEMO_API_KEY is empty or missing. Refusing "
-                "to construct Futures Demo execution client."
-            )
-        if not api_secret:
-            raise BinanceFuturesDemoMissingCredentials(
-                "BINANCE_FUTURES_DEMO_API_SECRET is empty or missing. "
-                "Refusing to construct Futures Demo execution client."
-            )
+        # ROB-302: credentials resolve through the shared canonical pair.
+        # Re-raise as the lane-specific error so fail-closed contracts hold.
+        try:
+            creds = resolve_demo_credentials("futures", os.environ)
+        except BinanceDemoCredentialError as exc:
+            raise BinanceFuturesDemoMissingCredentials(str(exc)) from exc
         base_url = os.environ.get("BINANCE_FUTURES_DEMO_BASE_URL", _DEFAULT_BASE_URL)
-        return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
+        return cls(
+            api_key=creds.api_key, api_secret=creds.api_secret, base_url=base_url
+        )
 
     def __repr__(self) -> str:
         # Never reference _api_secret in repr/str. api_key half is

--- a/app/services/brokers/binance/futures_demo/preflight.py
+++ b/app/services/brokers/binance/futures_demo/preflight.py
@@ -1,7 +1,7 @@
 """ROB-298 PR 2 — Binance Futures Demo read-only preflight client.
 
 Non-mutating credential-presence check for the USD-M Futures Demo lane.
-Calls ``GET /fapi/v1/account`` (read-only signed endpoint) and returns a
+Calls ``GET /fapi/v2/account`` (read-only signed endpoint) and returns a
 redacted summary that the smoke CLI can write to evidence JSON without
 leaking secrets.
 
@@ -39,6 +39,8 @@ from typing import Any, Final
 
 import httpx
 
+from app.services.brokers.binance.demo.credentials import resolve_demo_credentials
+from app.services.brokers.binance.demo.errors import BinanceDemoCredentialError
 from app.services.brokers.binance.futures_demo.errors import (
     BinanceFuturesDemoDisabled,
     BinanceFuturesDemoMissingCredentials,
@@ -55,7 +57,7 @@ from app.services.brokers.binance.futures_demo.transport import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL: Final[str] = "https://demo-fapi.binance.com"
-_ACCOUNT_PATH: Final[str] = "/fapi/v1/account"
+_ACCOUNT_PATH: Final[str] = "/fapi/v2/account"
 
 # Binance error codes that indicate the server rejected our HMAC-SHA256
 # signature. If the operator's Futures Demo account requires Ed25519
@@ -218,8 +220,10 @@ class FuturesDemoPreflightClient:
 
         Env contract:
           * ``BINANCE_FUTURES_DEMO_ENABLED`` MUST be truthy.
-          * ``BINANCE_FUTURES_DEMO_API_KEY`` MUST be present and non-empty.
-          * ``BINANCE_FUTURES_DEMO_API_SECRET`` MUST be present and non-empty.
+          * Credentials (ROB-302): the ``BINANCE_FUTURES_DEMO_API_*`` pair
+            OR the canonical ``BINANCE_DEMO_API_*`` pair MUST be present
+            (the per-product pair wins when set). A half-set pair fails
+            closed. Resolved via ``demo.credentials.resolve_demo_credentials``.
           * ``BINANCE_FUTURES_DEMO_BASE_URL`` (optional) MUST be a Futures
             Demo host if set; transport factory enforces.
 
@@ -232,20 +236,17 @@ class FuturesDemoPreflightClient:
                 "BINANCE_FUTURES_DEMO_ENABLED=true to opt in to the Futures "
                 "Demo preflight path. Default is fail-closed."
             )
-        api_key = os.environ.get("BINANCE_FUTURES_DEMO_API_KEY", "")
-        api_secret = os.environ.get("BINANCE_FUTURES_DEMO_API_SECRET", "")
-        if not api_key:
-            raise BinanceFuturesDemoMissingCredentials(
-                "BINANCE_FUTURES_DEMO_API_KEY is empty or missing. Refusing "
-                "to construct Futures Demo preflight client."
-            )
-        if not api_secret:
-            raise BinanceFuturesDemoMissingCredentials(
-                "BINANCE_FUTURES_DEMO_API_SECRET is empty or missing. "
-                "Refusing to construct Futures Demo preflight client."
-            )
+        # ROB-302: credentials resolve through the shared canonical pair.
+        # Re-raise as the lane-specific error so existing fail-closed contracts
+        # and the smoke CLI's catch block are preserved.
+        try:
+            creds = resolve_demo_credentials("futures", os.environ)
+        except BinanceDemoCredentialError as exc:
+            raise BinanceFuturesDemoMissingCredentials(str(exc)) from exc
         base_url = os.environ.get("BINANCE_FUTURES_DEMO_BASE_URL", _DEFAULT_BASE_URL)
-        return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
+        return cls(
+            api_key=creds.api_key, api_secret=creds.api_secret, base_url=base_url
+        )
 
     def __repr__(self) -> str:
         # Never reference _api_secret in repr/str. api_key half is
@@ -259,7 +260,7 @@ class FuturesDemoPreflightClient:
         await self._client.aclose()
 
     async def preflight_account(self) -> FuturesDemoPreflightResult:
-        """Call ``GET /fapi/v1/account`` and return a redacted summary.
+        """Call ``GET /fapi/v2/account`` and return a redacted summary.
 
         Side effects: ONE signed HTTP GET against
         ``demo-fapi.binance.com``. No DB writes, no ledger writes, no
@@ -277,7 +278,7 @@ class FuturesDemoPreflightClient:
             params={"recvWindow": BINANCE_FUTURES_DEMO_RECV_WINDOW_MS},
             api_secret=self._api_secret,
         )
-        # Path MUST stay /fapi/v1/account. httpx joins base_url + path
+        # Path MUST stay /fapi/v2/account. httpx joins base_url + path
         # without /fapi/fapi/v1 duplication because base_url has no path
         # component beyond the host.
         response = await self._client.get(_ACCOUNT_PATH, params=signed)

--- a/app/services/brokers/binance/futures_demo/readiness.py
+++ b/app/services/brokers/binance/futures_demo/readiness.py
@@ -1,9 +1,14 @@
-"""ROB-299 — Futures Demo no-secret env readiness reflector.
+"""ROB-299 / ROB-302 — Futures Demo no-secret env readiness reflector.
 
 Reports presence/absence + truthiness + host-allowlist judgment for the
-``BINANCE_FUTURES_DEMO_*`` env quartet WITHOUT raising and WITHOUT echoing
-any value. Independent from Spot Demo and legacy testnet env: this module
-reads only the four ``BINANCE_FUTURES_DEMO_*`` keys.
+Futures Demo env WITHOUT raising and WITHOUT echoing any value.
+
+Credential presence (ROB-302) is resolved through the shared resolver
+``app.services.brokers.binance.demo.credentials``: the Futures Demo lane
+accepts either the futures-specific pair (``BINANCE_FUTURES_DEMO_API_*``) or
+the canonical shared pair (``BINANCE_DEMO_API_*``). The reflector reports which
+source WOULD be used via ``credential_source`` (label only). Spot-specific vars
+are never in the futures chain, so they cannot make this lane ready.
 """
 
 from __future__ import annotations
@@ -15,6 +20,7 @@ from typing import Any
 
 import httpx
 
+from app.services.brokers.binance.demo.credentials import inspect_demo_credential
 from app.services.brokers.binance.futures_demo.host_allowlist import FUTURES_DEMO_HOSTS
 
 _DEFAULT_BASE_URL = "https://demo-fapi.binance.com"
@@ -30,11 +36,13 @@ class FuturesDemoEnvReadiness:
     base_url_present: bool
     base_url_host: str | None
     base_url_host_allowed: bool
+    credential_source: str | None = None
+    credential_incomplete: bool = False
     missing: list[str] = field(default_factory=list)
     ready: bool = False
 
     def to_evidence_dict(self) -> dict[str, Any]:
-        # Presence/judgment ONLY — never a value.
+        # Presence/judgment + source label ONLY — never a value.
         return {
             "source": "futures_demo",
             "venue": "binance",
@@ -43,6 +51,8 @@ class FuturesDemoEnvReadiness:
             "enabled_truthy": self.enabled_truthy,
             "api_key_present": self.api_key_present,
             "api_secret_present": self.api_secret_present,
+            "credential_source": self.credential_source,
+            "credential_incomplete": self.credential_incomplete,
             "base_url_present": self.base_url_present,
             "base_url_host": self.base_url_host,
             "base_url_host_allowed": self.base_url_host_allowed,
@@ -56,15 +66,15 @@ def evaluate_futures_demo_env_readiness(
 ) -> FuturesDemoEnvReadiness:
     src = env if env is not None else os.environ
     enabled_raw = src.get("BINANCE_FUTURES_DEMO_ENABLED")
-    api_key = src.get("BINANCE_FUTURES_DEMO_API_KEY") or ""
-    api_secret = src.get("BINANCE_FUTURES_DEMO_API_SECRET") or ""
     base_url_raw = src.get("BINANCE_FUTURES_DEMO_BASE_URL")
 
     enabled_present = enabled_raw is not None
     enabled_truthy = bool(enabled_raw) and enabled_raw.strip().lower() in _TRUTHY
-    api_key_present = bool(api_key)
-    api_secret_present = bool(api_secret)
     base_url_present = bool(base_url_raw)
+
+    credential = inspect_demo_credential("futures", src)
+    api_key_present = credential.api_key_present
+    api_secret_present = credential.api_secret_present
 
     effective_base = base_url_raw or _DEFAULT_BASE_URL
     host: str | None = httpx.URL(effective_base).host or None
@@ -78,7 +88,7 @@ def evaluate_futures_demo_env_readiness(
     if not api_secret_present:
         missing.append("BINANCE_FUTURES_DEMO_API_SECRET")
 
-    ready = not missing and host_allowed
+    ready = not missing and host_allowed and not credential.incomplete
     return FuturesDemoEnvReadiness(
         enabled_present=enabled_present,
         enabled_truthy=enabled_truthy,
@@ -87,6 +97,8 @@ def evaluate_futures_demo_env_readiness(
         base_url_present=base_url_present,
         base_url_host=host,
         base_url_host_allowed=host_allowed,
+        credential_source=credential.credential_source,
+        credential_incomplete=credential.incomplete,
         missing=missing,
         ready=ready,
     )

--- a/app/services/brokers/binance/spot_demo/execution_client.py
+++ b/app/services/brokers/binance/spot_demo/execution_client.py
@@ -39,6 +39,8 @@ import uuid
 from decimal import Decimal
 from typing import Any, Final
 
+from app.services.brokers.binance.demo.credentials import resolve_demo_credentials
+from app.services.brokers.binance.demo.errors import BinanceDemoCredentialError
 from app.services.brokers.binance.spot_demo.dto import (
     SpotDemoAssetBalance,
     SpotDemoCancelResult,
@@ -161,8 +163,10 @@ class BinanceSpotDemoExecutionClient:
 
         Env contract:
           * ``BINANCE_SPOT_DEMO_ENABLED`` MUST be truthy.
-          * ``BINANCE_SPOT_DEMO_API_KEY`` MUST be present and non-empty.
-          * ``BINANCE_SPOT_DEMO_API_SECRET`` MUST be present and non-empty.
+          * Credentials (ROB-302): the ``BINANCE_SPOT_DEMO_API_*`` pair
+            OR the canonical ``BINANCE_DEMO_API_*`` pair MUST be present
+            (the per-product pair wins when set). A half-set pair fails
+            closed. Resolved via ``demo.credentials.resolve_demo_credentials``.
           * ``BINANCE_SPOT_DEMO_BASE_URL`` (optional) MUST be a Spot Demo
             host if set; the transport factory enforces.
 
@@ -176,20 +180,16 @@ class BinanceSpotDemoExecutionClient:
                 "BINANCE_SPOT_DEMO_ENABLED=true to opt in to the Spot Demo "
                 "execution path. Default is fail-closed."
             )
-        api_key = os.environ.get("BINANCE_SPOT_DEMO_API_KEY", "")
-        api_secret = os.environ.get("BINANCE_SPOT_DEMO_API_SECRET", "")
-        if not api_key:
-            raise BinanceSpotDemoMissingCredentials(
-                "BINANCE_SPOT_DEMO_API_KEY is empty or missing. Refusing to "
-                "construct Spot Demo execution client."
-            )
-        if not api_secret:
-            raise BinanceSpotDemoMissingCredentials(
-                "BINANCE_SPOT_DEMO_API_SECRET is empty or missing. Refusing "
-                "to construct Spot Demo execution client."
-            )
+        # ROB-302: credentials resolve through the shared canonical pair.
+        # Additive — byte-identical when BINANCE_SPOT_DEMO_API_* is set.
+        try:
+            creds = resolve_demo_credentials("spot", os.environ)
+        except BinanceDemoCredentialError as exc:
+            raise BinanceSpotDemoMissingCredentials(str(exc)) from exc
         base_url = os.environ.get("BINANCE_SPOT_DEMO_BASE_URL", _DEFAULT_BASE_URL)
-        return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
+        return cls(
+            api_key=creds.api_key, api_secret=creds.api_secret, base_url=base_url
+        )
 
     def __repr__(self) -> str:
         # Never reference _api_secret in repr/str. api_key half is

--- a/app/services/brokers/binance/spot_demo/preflight.py
+++ b/app/services/brokers/binance/spot_demo/preflight.py
@@ -30,6 +30,8 @@ from typing import Any, Final
 
 import httpx
 
+from app.services.brokers.binance.demo.credentials import resolve_demo_credentials
+from app.services.brokers.binance.demo.errors import BinanceDemoCredentialError
 from app.services.brokers.binance.spot_demo.errors import (
     BinanceSpotDemoDisabled,
     BinanceSpotDemoMissingCredentials,
@@ -176,8 +178,10 @@ class SpotDemoPreflightClient:
 
         Env contract:
           * ``BINANCE_SPOT_DEMO_ENABLED`` MUST be truthy.
-          * ``BINANCE_SPOT_DEMO_API_KEY`` MUST be present and non-empty.
-          * ``BINANCE_SPOT_DEMO_API_SECRET`` MUST be present and non-empty.
+          * Credentials (ROB-302): the ``BINANCE_SPOT_DEMO_API_*`` pair
+            OR the canonical ``BINANCE_DEMO_API_*`` pair MUST be present
+            (the per-product pair wins when set). A half-set pair fails
+            closed. Resolved via ``demo.credentials.resolve_demo_credentials``.
           * ``BINANCE_SPOT_DEMO_BASE_URL`` (optional) MUST be a Spot Demo
             host if set; transport factory enforces.
 
@@ -190,20 +194,17 @@ class SpotDemoPreflightClient:
                 "BINANCE_SPOT_DEMO_ENABLED=true to opt in to the Spot Demo "
                 "preflight path. Default is fail-closed."
             )
-        api_key = os.environ.get("BINANCE_SPOT_DEMO_API_KEY", "")
-        api_secret = os.environ.get("BINANCE_SPOT_DEMO_API_SECRET", "")
-        if not api_key:
-            raise BinanceSpotDemoMissingCredentials(
-                "BINANCE_SPOT_DEMO_API_KEY is empty or missing. Refusing to "
-                "construct Spot Demo preflight client."
-            )
-        if not api_secret:
-            raise BinanceSpotDemoMissingCredentials(
-                "BINANCE_SPOT_DEMO_API_SECRET is empty or missing. Refusing "
-                "to construct Spot Demo preflight client."
-            )
+        # ROB-302: credentials resolve through the shared canonical pair.
+        # Additive — when BINANCE_SPOT_DEMO_API_* is set this is byte-identical
+        # to the prior contract. Re-raise as the lane-specific error.
+        try:
+            creds = resolve_demo_credentials("spot", os.environ)
+        except BinanceDemoCredentialError as exc:
+            raise BinanceSpotDemoMissingCredentials(str(exc)) from exc
         base_url = os.environ.get("BINANCE_SPOT_DEMO_BASE_URL", _DEFAULT_BASE_URL)
-        return cls(api_key=api_key, api_secret=api_secret, base_url=base_url)
+        return cls(
+            api_key=creds.api_key, api_secret=creds.api_secret, base_url=base_url
+        )
 
     def __repr__(self) -> str:
         # Never reference _api_secret in repr/str. api_key half is

--- a/docs/plans/2026-05-23-ROB-302-futures-demo-smoke-fixes-implementation-plan.md
+++ b/docs/plans/2026-05-23-ROB-302-futures-demo-smoke-fixes-implementation-plan.md
@@ -1,0 +1,239 @@
+# ROB-302 — Binance Futures Demo smoke fixes (implementation plan)
+
+**Source spec:** Linear ROB-302 (acts as design doc). Follow-up to ROB-298 PR2 / ROB-299.
+**Branch:** `rob-302`
+**Deployed main SHA blocked on:** `5786fd52`
+
+## Problem
+
+Hermes ran the Futures Demo smoke (`readiness → preflight → order-test → confirm`)
+on the MacBook native runtime and hit three blockers. `--confirm` was never run
+(no demo mutation created). Three real bugs + one ergonomics gap:
+
+1. **Credential duplication** — Futures Demo only reads `BINANCE_FUTURES_DEMO_*`;
+   operator must duplicate the Spot Demo secret into a second env var. Spot and
+   Futures Demo share the same Demo credential.
+2. **Preflight 404** — `preflight.py` calls `GET /fapi/v1/account`; `demo-fapi`
+   returns 404. `GET /fapi/v2/account` returns 200 with the same credential.
+3. **Wrong symbol filters** — `_fetch_symbol_filters()` uses `symbols[0]` from the
+   exchangeInfo response. On demo-fapi the `symbol=` query param is not honored and
+   the array can lead with BTCUSDT, so XRPUSDT sizing applies BTCUSDT's
+   stepSize/precision/min-notional → cap-10 falsely blocked (MIN_NOTIONAL=50),
+   cap-60 reaches Binance and fails `-1111 Precision is over the maximum`.
+
+## Bug → fix map (verified against code)
+
+**DECISION (user, D2):** the Demo API key/secret is ONE shared credential, not a
+"fallback". Model it as a single canonical `BINANCE_DEMO_API_KEY/SECRET` that both
+Spot and Futures Demo read, with the existing per-product vars as optional
+overrides. Drop "fallback" wording everywhere.
+
+| # | Location (verified) | Current | Fix |
+|---|---------------------|---------|-----|
+| 1 | `futures_demo/{readiness,preflight,execution_client}.py` + `spot_demo/{preflight,execution_client}.py` | each reads only its own `BINANCE_{SPOT,FUTURES}_DEMO_API_KEY/SECRET` | shared resolver: per-product var → canonical `BINANCE_DEMO_*` → error. ENABLED gate unchanged. Evidence reports `api_key_source` label only |
+| 2 | `preflight.py:58` `_ACCOUNT_PATH = "/fapi/v1/account"` | v1 → 404 on demo-fapi | `_ACCOUNT_PATH = "/fapi/v2/account"`; `_summarize_account` fields (canTrade/assets[].walletBalance/positions[].positionAmt) are identical in v2 → no shape change |
+| 3 | `scripts/binance_futures_demo_smoke.py:926` `filters = symbols[0]` | picks index 0 (may be BTCUSDT) | select row where `s["symbol"] == requested`; fail closed if absent; prefer `MARKET_LOT_SIZE.stepSize` over `LOT_SIZE.stepSize` for MARKET orders; honor `quantityPrecision` |
+
+Confirm reconciliation (`execution_client.py` positionRisk + openOrders) does NOT
+touch `/account`, so the v2 change is isolated to `preflight.py`.
+
+## Proposed implementation
+
+### Shared canonical Demo credential resolver (DRY — 5 call sites today)
+New module `app/services/brokers/binance/demo/credentials.py` (the `demo/` shared
+namespace already exists alongside `demo/ledger/`):
+
+```
+resolve_demo_credentials(product: "spot" | "futures", env) -> ResolvedDemoCredential
+  PAIR resolution by SOURCE (Codex #2 — never mix key/secret across sources):
+    1. product-specific source: if EITHER product var is set, the PAIR must come
+       from product vars. If only one of the product key/secret is set → FAIL
+       CLOSED (BinanceDemoIncompleteCredentialOverride). Never backfill the
+       missing half from canonical (that would pair a product key with a
+       canonical secret).
+    2. else canonical source: both BINANCE_DEMO_API_KEY + BINANCE_DEMO_API_SECRET,
+       or fail closed if only one present.
+    3. else → MissingCredentials.
+  source resolution per product:
+    spot:    SPOT_DEMO pair  -> DEMO pair  -> missing
+    futures: FUTURES_DEMO pair -> DEMO pair -> missing
+  returns:
+    api_key, api_secret (held privately, never logged) — always a matched pair
+    credential_source in {"futures_demo_env","spot_demo_env","shared_demo_env"}  (one label, the pair came from one source)
+```
+
+Isolation invariant (preserved):
+- product-specific overrides do NOT cross — a Spot-specific key never resolves for
+  Futures and vice-versa. Crossing happens ONLY through the explicit canonical var.
+- activation stays independently gated by each lane's `*_ENABLED` flag.
+- host allowlists (`demo-api` / `demo-fapi`) untouched, still fail-closed at transport.
+
+Call sites switch to the resolver:
+- `futures_demo/readiness.py`, `futures_demo/preflight.py::from_env`,
+  `futures_demo/execution_client.py::from_env`
+- `spot_demo/preflight.py::from_env`, `spot_demo/execution_client.py::from_env`
+
+**Spot Demo is a deployed, working lane** → the change MUST be strictly additive:
+when `BINANCE_SPOT_DEMO_API_KEY` is set, behavior is byte-identical to today
+(per-product var wins). Regression tests prove this (see test plan).
+
+- Readiness `to_evidence_dict` adds `api_key_source` / `api_secret_source`
+  (presence + source label only, never a value).
+
+### Preflight endpoint
+- `preflight.py:58` → `/fapi/v2/account`. Update docstrings (`:4`, `:262`, `:280`).
+
+### Symbol filter/sizing (smoke script)
+**DECISION (user, M1 REVERSED after Codex #6 — verified): floor is NOT enough;
+add explicit quantityPrecision formatting.**
+
+Root cause (verified, confidence 9/10): `sizing.py:88` floors via
+`int(raw/step) * step_size`. When `step_size` comes from the exchangeInfo string
+`"0.10000000"` it carries exponent -8, so floored qty = `Decimal("30.00000000")`.
+`execution_client.py:290` serializes with `format(qty, "f")` → `"30.00000000"`
+(8 decimals) → exceeds XRPUSDT `quantityPrecision=1` → **-1111 persists** even with
+the correct symbol row. Numeric value is fine; the submitted STRING is wrong.
+
+- `_fetch_symbol_filters()`:
+  - match `s for s in symbols if s["symbol"] == symbol`; `RuntimeError` if absent.
+  - read `MARKET_LOT_SIZE.stepSize` first, fall back to `LOT_SIZE.stepSize`.
+  - **also return `quantity_precision` from the symbol row.**
+  - keep MIN_NOTIONAL/NOTIONAL extraction for the matched row.
+- Smoke script quantizes `sizing.qty` to `quantity_precision`
+  (`qty.quantize(Decimal(1).scaleb(-quantity_precision), ROUND_DOWN)`) BEFORE
+  passing to `order_test` / `submit_order`, so `format(qty, "f")` emits a
+  precision-valid string. `sizing.py` and `execution_client.py` signatures
+  unchanged (fix contained at the smoke-script boundary). Codex #7: precision is
+  used for output formatting, not as the sizing increment (that stays stepSize).
+
+## Test plan (regression coverage required by acceptance criteria)
+
+- `tests/services/brokers/binance/demo/test_credentials.py` (NEW): per-product
+  resolution chain (product-specific PAIR wins; canonical PAIR used when product
+  vars absent; missing→error); **partial product override (key XOR secret) →
+  fail closed, never mixes product key with canonical secret (Codex #2)**;
+  `credential_source` label correct for each branch; no secret value in any
+  returned dataclass field / repr / evidence dict.
+- `futures_demo/test_env_readiness.py`: ready=true via canonical `BINANCE_DEMO_*`;
+  source label = `shared_demo_env`.
+- `futures_demo/test_spot_demo_env_does_not_activate_futures.py` (UPDATE): a
+  Spot-specific key alone still does NOT resolve for Futures (override isolation
+  preserved); only canonical or futures-specific does.
+- **Spot regression (CRITICAL, IRON RULE — change touches a deployed lane):**
+  spot `from_env` byte-identical when `BINANCE_SPOT_DEMO_API_KEY` set; spot resolves
+  via canonical when only `BINANCE_DEMO_*` set; spot stays disabled when
+  `BINANCE_SPOT_DEMO_ENABLED` unset regardless of creds.
+- `futures_demo/test_preflight.py`: update 5 `/fapi/v1/account` URL assertions →
+  `/fapi/v2/account`. **Do NOT assert `account_type == "FUTURES"` on v2 (Codex #4 —
+  accountType absent from v2 example; `.get()` tolerates None).**
+- `tests/scripts/test_binance_futures_demo_smoke.py`: exchangeInfo response where
+  BTCUSDT is index 0 and XRPUSDT appears later → sizing uses XRPUSDT row; missing
+  symbol → fail closed; `MARKET_LOT_SIZE` preferred over `LOT_SIZE`; **regression
+  for Codex #6: stepSize string `"0.10000000"` → submitted `quantity` STRING has
+  exactly `quantity_precision` decimals (e.g. `"30"` or `"30.0"`, NOT
+  `"30.00000000"`); min-notional correct for matched row.**
+
+## Safety boundaries (unchanged, must stay green)
+- `demo-fapi.binance.com` only; live/testnet/spot hosts fail-closed at transport.
+- `BINANCE_FUTURES_DEMO_ENABLED=true` still required (fallback does not bypass it).
+- No scheduler/TaskIQ/Prefect. `--confirm` only on explicit flag. leverage=1.
+  reduce-only close. reconcile requires open orders empty AND position flat.
+- No secret values in logs/evidence/comments.
+
+## Out of scope (carried from issue non-goals)
+- Recurring automation / scheduler activation.
+- Live Binance/KIS/Upbit behavior changes.
+- Ed25519 signer fallback (still surfaced as UnsupportedAuth).
+- `BINANCE_USDM_FUTURES_DEMO_BASE_URL` legacy alias support (default already correct).
+- `/fapi/v3/account` (v2 is the empirically verified working endpoint on demo-fapi).
+- Migrating Spot Demo to read canonical-only (existing per-product vars stay as
+  overrides; no removal).
+
+## What already exists (reuse, not rebuild)
+- `app/services/brokers/binance/demo/` shared namespace (currently holds `ledger/`,
+  `errors.py`) → natural home for the new shared `credentials.py`.
+- `demo/ledger/repository.py` has an AST import guard pattern → mirror if we want to
+  keep the resolver service-internal (optional).
+- `respx`-based HTTP mocking in `test_preflight.py` → reuse for v2 endpoint tests.
+- `_truthy()` exists (duplicated) in both `spot_demo` and `futures_demo` `from_env`;
+  consolidating into `demo/credentials.py` removes the dup (DRY win, optional).
+- Transport-layer host allowlists (`spot_demo/host_allowlist.py`,
+  `futures_demo/host_allowlist.py`) already fail-closed → untouched.
+
+## Failure modes (new/changed codepaths)
+| Codepath | Realistic prod failure | Test? | Error handling? | User-visible? |
+|----------|------------------------|-------|-----------------|---------------|
+| resolver: both vars absent | operator forgets canonical AND product var | yes (new) | `MissingCredentials` raised | clear (refuse to construct) |
+| resolver: canonical set, wrong lane enabled | operator sets canonical but not `*_ENABLED` | yes | `*Disabled` raised | clear |
+| v2 preflight | demo-fapi changes account schema | partial (summary fields) | `raise_for_status` / KeyError-safe `.get()` | clear (non-zero exit) |
+| symbol filter: requested absent | demo-fapi drops XRPUSDT from exchangeInfo | yes (new) | `RuntimeError` fail-closed | clear |
+| symbol filter: MARKET_LOT_SIZE missing | symbol exposes only LOT_SIZE | yes | falls back to LOT_SIZE.stepSize | n/a |
+
+No critical gaps: every new failure mode has a test AND fail-closed error handling
+AND surfaces a clear non-zero exit (no silent failures).
+
+## Parallelization strategy
+| Step | Modules touched | Depends on |
+|------|----------------|------------|
+| S1 shared resolver + tests | `binance/demo/credentials.py` | — |
+| S2 v2 preflight + test update | `futures_demo/preflight.py`, its tests | — (independent of S1) |
+| S3 symbol filter/sizing + tests | `scripts/binance_futures_demo_smoke.py`, its tests | — (independent) |
+| S4 wire call sites to resolver | `futures_demo/{readiness,preflight,execution_client}.py`, `spot_demo/{preflight,execution_client}.py` | S1 |
+| S5 env.example + runbook | `env.example`, `docs/runbooks/` | S1, S4 |
+
+- Lane A: S1 → S4 → S5 (sequential, share resolver contract).
+- Lane B: S2 (independent).
+- Lane C: S3 (independent).
+- Launch A, B, C in parallel. B and C touch disjoint modules from A. Merge order
+  any. S5 docs last.
+
+## Implementation Tasks
+Synthesized from this review. Each derives from a finding above.
+
+- [ ] **T1 (P1, human: ~2h / CC: ~20min)** — credentials — add shared `resolve_demo_credentials(product, env)`
+  - Surfaced by: Arch §1 (5 duplicated call sites; user D2 = canonical model)
+  - Files: `app/services/brokers/binance/demo/credentials.py`, `tests/services/brokers/binance/demo/test_credentials.py`
+  - Verify: `uv run pytest tests/services/brokers/binance/demo/test_credentials.py -v`
+- [ ] **T2 (P1, human: ~1h / CC: ~10min)** — futures/spot from_env — wire all 5 call sites to resolver, add `*_source` to readiness evidence
+  - Surfaced by: Arch §1; spot regression (IRON RULE)
+  - Files: `futures_demo/{readiness,preflight,execution_client}.py`, `spot_demo/{preflight,execution_client}.py`, their tests
+  - Verify: targeted pytest for env/readiness + spot regression tests
+- [ ] **T3 (P1, human: ~20min / CC: ~5min)** — preflight — `/fapi/v1/account` → `/fapi/v2/account`
+  - Surfaced by: Bug #2 (`preflight.py:58`)
+  - Files: `futures_demo/preflight.py`, `tests/.../test_preflight.py` (5 URL asserts)
+  - Verify: `uv run pytest tests/services/brokers/binance/futures_demo/test_preflight.py -v`
+- [ ] **T4 (P1, human: ~1.5h / CC: ~15min)** — smoke — select requested symbol row + MARKET_LOT_SIZE stepSize + quantize qty to quantityPrecision before submit
+  - Surfaced by: Bug #3 (`scripts/binance_futures_demo_smoke.py:926`) + Codex #6 (verified `-1111` via `format(qty,"f")` trailing zeros)
+  - Files: `scripts/binance_futures_demo_smoke.py`, `tests/scripts/test_binance_futures_demo_smoke.py`
+  - Verify: multi-symbol exchangeInfo regression + submitted-quantity-string precision test (stepSize `"0.10000000"` → no trailing zeros)
+- [ ] **T5 (P2, human: ~20min / CC: ~5min)** — docs — env.example canonical `BINANCE_DEMO_*` + runbook update
+  - Surfaced by: Arch §1 (operator-facing); project doc convention
+  - Files: `env.example`, `docs/runbooks/binance-futures-demo-smoke.md`
+  - Verify: manual read; ruff n/a
+- [ ] **T6 (P2, human: ~15min / CC: ~5min)** — local gates
+  - Surfaced by: acceptance criteria
+  - Verify: `uv run ruff check app/services/brokers/binance scripts/binance_futures_demo_smoke.py tests` + full futures/spot demo pytest
+
+## Cross-model review resolutions (Codex gpt-5.5, read-only)
+| Codex finding | Disposition |
+|---------------|-------------|
+| #2 resolver mixes key/secret across sources → mismatched pair | ACCEPTED (baked in): PAIR-by-source resolution, fail closed on partial product override |
+| #6 `format(qty,"f")` emits stepSize trailing zeros → -1111 persists | ACCEPTED (user reversed M1): quantize qty to quantityPrecision before submit |
+| #4 accountType absent from v2 response | ACCEPTED (baked in): tests do not assert accountType on v2 |
+| #1/#3 canonical-both weakens isolation; touching Spot is risk | REJECTED by user (D2 stands): dedup goal requires both lanes read canonical; mitigated by additive change + pair-resolution + spot regression tests + loud source label |
+| #5 exchangeInfo has no symbol param | CONFIRMS plan (symbol-row match required) |
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run (bug fix, not a product change) |
+| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 3 substantive: pair-resolution bug, -1111 string precision, isolation tension |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 4 issues (D2 cred model, M1 sizing, spot regression, v2 endpoint) |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | n/a (backend/CLI only) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | n/a |
+
+- **CODEX:** found 1 real bug Eng Review missed (independent key/secret resolution → mismatched pair) + verified `-1111` recurs via `format(qty,"f")` trailing zeros. Both accepted into plan.
+- **CROSS-MODEL:** 2 tensions surfaced to user — #6 sizing (user accepted Codex, M1 reversed); #1/#3 credential scope (user kept D2, mitigated). Resolutions table above.
+- **UNRESOLVED:** 0.
+- **VERDICT:** ENG CLEARED — ready to implement. CEO/Design not required for this bug fix.

--- a/docs/runbooks/binance-futures-demo-smoke.md
+++ b/docs/runbooks/binance-futures-demo-smoke.md
@@ -59,14 +59,26 @@ Hard invariants enforced at the transport / signer layer:
 | Variable | Required when opted in? | Default | Notes |
 |---|---|---|---|
 | `BINANCE_FUTURES_DEMO_ENABLED` | Yes (must be `true`) | unset → disabled | Master kill-switch. Default is fail-closed. |
-| `BINANCE_FUTURES_DEMO_API_KEY` | Yes (for signed modes) | — | API key from your Demo account. Never logged. |
-| `BINANCE_FUTURES_DEMO_API_SECRET` | Yes (for signed modes) | — | API secret. Never logged. |
+| `BINANCE_DEMO_API_KEY` | Yes¹ (for signed modes) | — | Canonical shared Demo key. Used by Spot AND Futures. Never logged. |
+| `BINANCE_DEMO_API_SECRET` | Yes¹ (for signed modes) | — | Canonical shared Demo secret. Never logged. |
+| `BINANCE_FUTURES_DEMO_API_KEY` | No (override) | — | Optional Futures-only override; wins over canonical when set. |
+| `BINANCE_FUTURES_DEMO_API_SECRET` | No (override) | — | Optional Futures-only override. |
 | `BINANCE_FUTURES_DEMO_BASE_URL` | No | `https://demo-fapi.binance.com` | Validated against `FUTURES_DEMO_HOSTS` at factory init; a non-demo-fapi host raises `BinanceFuturesDemoCrossAllowlistViolation`. |
 
-`env.example` carries these as a sibling block below
-`BINANCE_SPOT_DEMO_*`. The two namespaces are independent — the same
-Demo credential may auth against both `demo-api` and `demo-fapi`, but
-each namespace must be set explicitly.
+¹ Credential resolution (ROB-302): set EITHER the canonical
+`BINANCE_DEMO_API_KEY`/`BINANCE_DEMO_API_SECRET` pair (shared by both Demo
+lanes — set once, no duplication) OR the Futures-specific override pair. The
+override wins when present. A half-set pair (key without secret, or vice versa)
+fails closed — it is never completed from the canonical pair (prevents pairing a
+Futures key with a canonical secret).
+
+Resolution order for the Futures lane:
+`BINANCE_FUTURES_DEMO_API_*` → `BINANCE_DEMO_API_*` → `BinanceFuturesDemoMissingCredentials`.
+
+Isolation: a Spot-specific override (`BINANCE_SPOT_DEMO_API_*`) never resolves
+for Futures — crossing happens only through the canonical pair. `--readiness`
+evidence reports `credential_source` (`shared_demo_env` / `futures_demo_env`)
+so you can confirm which pair was used without printing any value.
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -355,20 +355,37 @@ RESEARCH_REPORTS_FRESHNESS_MAX_AGE_HOURS=24
 RESEARCH_REPORTS_INGEST_COMMIT_ENABLED=false
 
 # ========================================
-# Binance Demo (canonical mock-trading backend, ROB-298)
+# Binance Demo (canonical mock-trading backend, ROB-298 / ROB-302)
 # ========================================
 # Spot Demo:     demo-api.binance.com   (BINANCE_SPOT_DEMO_*)
-# Futures Demo:  demo-fapi.binance.com  (BINANCE_FUTURES_DEMO_*, added in PR 2)
+# Futures Demo:  demo-fapi.binance.com  (BINANCE_FUTURES_DEMO_*)
 #
 # Live/mainnet hosts (api.binance.com, fapi.binance.com) are fail-closed at the
 # transport layer; no env var can re-enable them. The legacy Binance Spot
 # Testnet path (testnet.binance.vision) was removed in ROB-298. Setting any
 # BINANCE_TESTNET_* variable here does nothing.
 #
-# Same credential may auth against both demo-api and demo-fapi, but each
-# namespace must be set independently — namespaces are not aliased.
+# Credential resolution (ROB-302): the Spot and Futures Demo lanes share ONE
+# Binance Demo credential. Set the canonical pair below ONCE and both lanes use
+# it — no need to duplicate the same secret. Per-product vars
+# (BINANCE_{SPOT,FUTURES}_DEMO_API_*) remain optional overrides; if set they win
+# for that lane. A half-set override (key without secret, or vice versa) fails
+# closed — it is never completed from the canonical pair.
+#
+# Resolution per lane:
+#   Spot:    BINANCE_SPOT_DEMO_API_*    -> BINANCE_DEMO_API_*    -> missing
+#   Futures: BINANCE_FUTURES_DEMO_API_* -> BINANCE_DEMO_API_*    -> missing
+#
+# Isolation: a Spot-specific override never resolves for Futures and vice versa;
+# crossing happens ONLY through the canonical pair. Lane activation stays gated
+# independently by BINANCE_{SPOT,FUTURES}_DEMO_ENABLED.
+
+# Canonical shared Demo credential (used by both lanes unless overridden):
+BINANCE_DEMO_API_KEY=
+BINANCE_DEMO_API_SECRET=
 
 BINANCE_SPOT_DEMO_ENABLED=false
+# Optional per-lane override; leave blank to use the canonical pair above.
 BINANCE_SPOT_DEMO_API_KEY=
 BINANCE_SPOT_DEMO_API_SECRET=
 BINANCE_SPOT_DEMO_BASE_URL=https://demo-api.binance.com
@@ -377,14 +394,11 @@ BINANCE_SPOT_DEMO_MAX_NOTIONAL_USDT=10
 # -----------------------------------------------------------------------------
 # Binance USD-M Futures Demo (canonical futures mock-trading, ROB-298 PR 2)
 # -----------------------------------------------------------------------------
-# Independent namespace from BINANCE_SPOT_DEMO_*. Same Demo credential may
-# auth against both demo-api and demo-fapi, but each namespace must be set
-# independently — they are not aliased.
-#
 # Live futures host (fapi.binance.com) and deprecated futures testnet
 # (testnet.binancefuture.com) are fail-closed at the transport layer.
 
 BINANCE_FUTURES_DEMO_ENABLED=false
+# Optional per-lane override; leave blank to use the canonical pair above.
 BINANCE_FUTURES_DEMO_API_KEY=
 BINANCE_FUTURES_DEMO_API_SECRET=
 BINANCE_FUTURES_DEMO_BASE_URL=https://demo-fapi.binance.com

--- a/scripts/binance_futures_demo_smoke.py
+++ b/scripts/binance_futures_demo_smoke.py
@@ -9,7 +9,7 @@ Five operating modes (mutually exclusive; default exits with guidance):
      exits 0, zero HTTP / DB / ledger writes.
   2. ``--plan-only`` — print a JSON plan; no HTTP, no DB, no signing.
      Rejects BTCUSDT (excluded from the futures allowlist).
-  3. ``--preflight`` — signed ``GET /fapi/v1/account``; redacted summary.
+  3. ``--preflight`` — signed ``GET /fapi/v2/account``; redacted summary.
   4. ``--order-test`` — signed ``POST /fapi/v1/order/test``; non-mutating
      server-side validation of the order shape.
   5. ``--confirm`` — full BUY (open) + reduceOnly SELL (close) round-trip
@@ -53,7 +53,7 @@ import logging
 import os
 import sys
 import uuid
-from decimal import Decimal
+from decimal import ROUND_DOWN, Decimal
 from typing import Any
 
 import httpx
@@ -153,7 +153,7 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         "--preflight",
         action="store_true",
         help=(
-            "Run a read-only GET /fapi/v1/account preflight against the "
+            "Run a read-only GET /fapi/v2/account preflight against the "
             "Futures Demo endpoint. Requires env gate + credentials."
         ),
     )
@@ -306,7 +306,7 @@ async def _run_plan_only(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Mode: --preflight — signed GET /fapi/v1/account, redacted summary.
+# Mode: --preflight — signed GET /fapi/v2/account, redacted summary.
 # ---------------------------------------------------------------------------
 async def _run_preflight(args: argparse.Namespace) -> int:
     try:
@@ -359,11 +359,18 @@ async def _run_order_test(args: argparse.Namespace) -> int:
         if isinstance(sizing, FuturesSizingBlocked):
             logger.error("order_test sizing blocked: %s", sizing.reason)
             return 1
+        # ROB-302 (Codex #6): quantize to quantityPrecision so the submitted
+        # quantity STRING has no step-string trailing zeros (avoids -1111).
+        submit_qty = _quantize_qty(
+            sizing.qty,
+            step_size=filters["step_size"],
+            quantity_precision=filters["quantity_precision"],
+        )
         result = await execution.order_test(
             symbol=symbol,
             side=args.side,
             order_type="MARKET",
-            qty=sizing.qty,
+            qty=submit_qty,
         )
         _trace(
             f"order_test_ok symbol={result.symbol} side={result.side} qty={result.qty}"
@@ -436,12 +443,13 @@ async def _run_confirm(args: argparse.Namespace) -> int:
             if args.order_type == "LIMIT"
             else await _fetch_reference_price(base_url, symbol)
         )
+        sizing_step = _step_for_order_type(filters, args.order_type)
         sizing = compute_futures_demo_order_qty(
             symbol=symbol,
             target_notional_usdt=args.cap_usdt,
             price=ref_price,
             min_notional=filters["min_notional"],
-            step_size=filters["step_size"],
+            step_size=sizing_step,
             cap_usdt=args.cap_usdt,
             symbol_allowlist_override=allowlist,
         )
@@ -449,6 +457,16 @@ async def _run_confirm(args: argparse.Namespace) -> int:
             logger.error("confirm sizing blocked: %s", sizing.reason)
             return 1
         assert isinstance(sizing, FuturesSizingResult)
+        # ROB-302 (Codex #6): quantize to quantityPrecision before submit so the
+        # outbound quantity STRING is Binance-valid (avoids -1111).
+        submit_qty = _quantize_qty(
+            sizing.qty,
+            step_size=sizing_step,
+            quantity_precision=filters["quantity_precision"],
+        )
+        # Recompute notional from the actually-submitted qty so the ledger
+        # records the real exposure, not the pre-quantize estimate (Codex).
+        submit_notional = submit_qty * ref_price
 
         async with AsyncSessionLocal() as session:
             ledger = BinanceDemoLedgerService(session)
@@ -468,10 +486,13 @@ async def _run_confirm(args: argparse.Namespace) -> int:
                 side=args.side,
                 order_type=args.order_type,
                 price=args.price,
-                qty=sizing.qty,
-                notional=sizing.notional_usdt,
+                qty=submit_qty,
+                notional=submit_notional,
                 leverage=args.leverage,
                 close_with=args.close_with,
+                # close leg (always MARKET) quantizes against MARKET step.
+                close_step_size=filters["step_size"],
+                quantity_precision=filters["quantity_precision"],
             )
     finally:
         await execution.aclose()
@@ -494,6 +515,8 @@ async def _execute_confirm_lifecycle(
     notional: Decimal,
     leverage: int,
     close_with: str,
+    close_step_size: Decimal,
+    quantity_precision: int | None,
 ) -> int:
     """Run the full planned→reconciled lifecycle. Returns exit code."""
     # 1. Position-mode check (One-way required for PR 2).
@@ -668,7 +691,14 @@ async def _execute_confirm_lifecycle(
     _trace(f"position_check symbol={symbol} amt={position_amt}")
 
     # 9. Close side — reduceOnly always true.
-    close_qty = abs(position_amt)
+    # ROB-302 (Codex): positionAmt from /positionRisk can carry a fixed scale
+    # (e.g. "30.00000000"); submitting it raw would hit -1111 on the reduceOnly
+    # close, leaving an open position. Quantize the same way as the open leg.
+    close_qty = _quantize_qty(
+        abs(position_amt),
+        step_size=close_step_size,
+        quantity_precision=quantity_precision,
+    )
     return await _close_with_reduce_only(
         execution=execution,
         ledger=ledger,
@@ -910,26 +940,35 @@ async def _reconcile(
 # Public-read helpers — used by --order-test and --confirm to pull live
 # exchangeInfo filters + a reference price. No signing needed.
 # ---------------------------------------------------------------------------
-async def _fetch_symbol_filters(base_url: str, symbol: str) -> dict[str, Decimal]:
-    """Pull ``LOT_SIZE.stepSize`` + ``MIN_NOTIONAL.notional`` for ``symbol``.
+def _parse_symbol_filters(body: dict[str, Any], symbol: str) -> dict[str, Any]:
+    """Extract sizing constraints for ``symbol`` from an exchangeInfo body.
 
-    USD-M Futures uses ``filterType == 'MIN_NOTIONAL'`` with field
-    ``notional`` (no fallback aliases needed for the demo deployment).
+    ROB-302 (Codex #5): demo-fapi does not honor the ``symbol=`` query param —
+    the response can contain many symbols led by BTCUSDT. Select the row whose
+    ``symbol`` matches the request and fail closed if it is absent (never fall
+    back to ``symbols[0]``, which applied BTCUSDT filters to XRPUSDT).
+
+    Returns ``step_size`` (MARKET_LOT_SIZE preferred over LOT_SIZE for MARKET
+    orders), ``min_notional`` (matched row, default 5), and ``quantity_precision``
+    (used to format the submitted quantity string — see ``_quantize_qty``).
     """
-    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
-        resp = await client.get(_EXCHANGE_INFO_PATH, params={"symbol": symbol})
-        resp.raise_for_status()
-        body = resp.json()
-    symbols = body.get("symbols") or []
-    if not symbols:
-        raise RuntimeError(f"exchangeInfo returned no symbols for {symbol!r}")
-    filters = symbols[0].get("filters") or []
-    step_size: Decimal | None = None
+    row: dict[str, Any] | None = None
+    for entry in body.get("symbols") or []:
+        if entry.get("symbol") == symbol:
+            row = entry
+            break
+    if row is None:
+        raise RuntimeError(f"exchangeInfo has no row for {symbol!r}")
+
+    market_step: Decimal | None = None
+    lot_step: Decimal | None = None
     min_notional: Decimal | None = None
-    for entry in filters:
+    for entry in row.get("filters") or []:
         ftype = entry.get("filterType")
-        if ftype == "LOT_SIZE":
-            step_size = Decimal(str(entry.get("stepSize", "0")))
+        if ftype == "MARKET_LOT_SIZE":
+            market_step = Decimal(str(entry.get("stepSize", "0")))
+        elif ftype == "LOT_SIZE":
+            lot_step = Decimal(str(entry.get("stepSize", "0")))
         elif ftype in ("MIN_NOTIONAL", "NOTIONAL"):
             mn = (
                 entry.get("notional")
@@ -938,13 +977,76 @@ async def _fetch_symbol_filters(base_url: str, symbol: str) -> dict[str, Decimal
             )
             if mn is not None:
                 min_notional = Decimal(str(mn))
-    if step_size is None:
-        raise RuntimeError(f"no LOT_SIZE filter in exchangeInfo for {symbol!r}")
+
+    # MARKET orders must respect MARKET_LOT_SIZE when present; LOT_SIZE otherwise.
+    # LIMIT orders use LOT_SIZE (Codex: MARKET_LOT_SIZE can be coarser than
+    # LOT_SIZE, so applying it to a LIMIT order would over-floor or block it).
+    market_usable = market_step is not None and market_step > 0
+    lot_usable = lot_step is not None and lot_step > 0
+    step_size = market_step if market_usable else lot_step
+    lot_step_size = lot_step if lot_usable else step_size
+    if step_size is None or step_size <= 0:
+        raise RuntimeError(
+            f"no usable LOT_SIZE/MARKET_LOT_SIZE step in exchangeInfo for {symbol!r}"
+        )
     if min_notional is None:
-        # Fall back to a conservative 5 USDT if the server doesn't expose
-        # the filter. XRPUSDT on demo-fapi is typically 5 USDT.
+        # Conservative default if the server omits the filter; XRPUSDT is 5 USDT.
+        # Binance enforces the real MIN_NOTIONAL server-side regardless, so this
+        # local default is a pre-check, not the authority.
         min_notional = Decimal("5")
-    return {"step_size": step_size, "min_notional": min_notional}
+
+    qp = row.get("quantityPrecision")
+    quantity_precision = int(qp) if qp is not None else None
+    return {
+        "step_size": step_size,  # MARKET step (MARKET_LOT_SIZE preferred)
+        "lot_step_size": lot_step_size,  # LOT_SIZE step for LIMIT orders
+        "min_notional": min_notional,
+        "quantity_precision": quantity_precision,
+    }
+
+
+def _step_for_order_type(filters: dict[str, Any], order_type: str) -> Decimal:
+    """Pick the LOT step appropriate to ``order_type``.
+
+    MARKET orders floor to MARKET_LOT_SIZE (``step_size``); LIMIT orders floor to
+    LOT_SIZE (``lot_step_size``).
+    """
+    if order_type == "LIMIT":
+        return filters["lot_step_size"]
+    return filters["step_size"]
+
+
+def _quantize_qty(
+    qty: Decimal,
+    *,
+    step_size: Decimal,
+    quantity_precision: int | None,
+) -> Decimal:
+    """Round ``qty`` DOWN to a Binance-submittable precision.
+
+    ROB-302 (Codex #6): the step-floored Decimal carries the exchangeInfo step
+    string's exponent (``"0.10000000"`` -> exponent -8), so ``format(qty, "f")``
+    in the execution client emits ``"30.00000000"`` and Binance rejects it with
+    ``-1111 Precision is over the maximum``. Quantizing to the symbol's
+    ``quantityPrecision`` (or, absent that, the step's normalized exponent)
+    strips the trailing zeros without changing the numeric value for a
+    step-floored quantity. ROUND_DOWN keeps us within the notional cap.
+    """
+    if quantity_precision is not None:
+        target = Decimal(1).scaleb(-quantity_precision)
+    else:
+        exponent = step_size.normalize().as_tuple().exponent
+        target = Decimal(1).scaleb(exponent) if isinstance(exponent, int) and exponent < 0 else Decimal(1)
+    return qty.quantize(target, rounding=ROUND_DOWN)
+
+
+async def _fetch_symbol_filters(base_url: str, symbol: str) -> dict[str, Any]:
+    """Fetch exchangeInfo and parse sizing constraints for ``symbol``."""
+    async with httpx.AsyncClient(base_url=base_url, timeout=10.0) as client:
+        resp = await client.get(_EXCHANGE_INFO_PATH, params={"symbol": symbol})
+        resp.raise_for_status()
+        body = resp.json()
+    return _parse_symbol_filters(body, symbol)
 
 
 async def _fetch_reference_price(base_url: str, symbol: str) -> Decimal:

--- a/scripts/binance_futures_demo_smoke.py
+++ b/scripts/binance_futures_demo_smoke.py
@@ -1036,7 +1036,11 @@ def _quantize_qty(
         target = Decimal(1).scaleb(-quantity_precision)
     else:
         exponent = step_size.normalize().as_tuple().exponent
-        target = Decimal(1).scaleb(exponent) if isinstance(exponent, int) and exponent < 0 else Decimal(1)
+        target = (
+            Decimal(1).scaleb(exponent)
+            if isinstance(exponent, int) and exponent < 0
+            else Decimal(1)
+        )
     return qty.quantize(target, rounding=ROUND_DOWN)
 
 

--- a/tests/scripts/test_binance_futures_demo_sizing.py
+++ b/tests/scripts/test_binance_futures_demo_sizing.py
@@ -1,0 +1,160 @@
+"""ROB-302 — Futures Demo smoke symbol-filter selection + quantity precision.
+
+Pure-function coverage (no HTTP) for the two ``--order-test`` / ``--confirm``
+sizing bugs:
+
+  * exchangeInfo can return many symbols and the ``symbol=`` query param is not
+    honored on demo-fapi; selecting ``symbols[0]`` applied BTCUSDT filters to
+    XRPUSDT. Fix: match the requested symbol row, fail closed if absent.
+  * Even with the right MARKET_LOT_SIZE step, ``format(qty, "f")`` emitted the
+    step string's trailing zeros (``"0.10000000"`` -> ``"30.00000000"``) and
+    Binance returned ``-1111 Precision is over the maximum``. Fix: quantize the
+    submitted quantity to the symbol's quantityPrecision (Codex review #6).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+import scripts.binance_futures_demo_smoke as smoke
+
+
+def _exchange_info_multi() -> dict:
+    """BTCUSDT first, XRPUSDT later — mirrors demo-fapi's unfiltered response."""
+    return {
+        "symbols": [
+            {
+                "symbol": "BTCUSDT",
+                "quantityPrecision": 3,
+                "filters": [
+                    {"filterType": "LOT_SIZE", "stepSize": "0.00100000"},
+                    {"filterType": "MARKET_LOT_SIZE", "stepSize": "0.00100000"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "100"},
+                ],
+            },
+            {
+                "symbol": "XRPUSDT",
+                "quantityPrecision": 1,
+                "filters": [
+                    {"filterType": "LOT_SIZE", "stepSize": "0.00100000"},
+                    {"filterType": "MARKET_LOT_SIZE", "stepSize": "0.10000000"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "5"},
+                ],
+            },
+        ]
+    }
+
+
+def test_parse_selects_requested_symbol_not_index_zero():
+    filters = smoke._parse_symbol_filters(_exchange_info_multi(), "XRPUSDT")
+    # XRPUSDT MARKET step 0.1, not BTCUSDT's 0.001; XRP min_notional 5, not 100.
+    assert filters["step_size"] == Decimal("0.10000000")
+    assert filters["min_notional"] == Decimal("5")
+    assert filters["quantity_precision"] == 1
+
+
+def test_parse_prefers_market_lot_size_over_lot_size():
+    filters = smoke._parse_symbol_filters(_exchange_info_multi(), "XRPUSDT")
+    # MARKET_LOT_SIZE (0.1) wins over LOT_SIZE (0.001) for MARKET orders.
+    assert filters["step_size"] == Decimal("0.10000000")
+
+
+def test_parse_falls_back_to_lot_size_when_no_market_lot_size():
+    body = {
+        "symbols": [
+            {
+                "symbol": "XRPUSDT",
+                "quantityPrecision": 1,
+                "filters": [
+                    {"filterType": "LOT_SIZE", "stepSize": "0.10000000"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "5"},
+                ],
+            }
+        ]
+    }
+    filters = smoke._parse_symbol_filters(body, "XRPUSDT")
+    assert filters["step_size"] == Decimal("0.10000000")
+
+
+def test_parse_missing_symbol_fails_closed():
+    body = {"symbols": [{"symbol": "BTCUSDT", "filters": []}]}
+    with pytest.raises(RuntimeError):
+        smoke._parse_symbol_filters(body, "XRPUSDT")
+
+
+def test_parse_empty_symbols_fails_closed():
+    with pytest.raises(RuntimeError):
+        smoke._parse_symbol_filters({"symbols": []}, "XRPUSDT")
+
+
+def test_quantize_strips_step_trailing_zeros():
+    """Codex #6: floored-to-step Decimal must serialize without trailing zeros."""
+    step = Decimal("0.10000000")
+    floored = Decimal("30.00000000")  # what step-floor produces
+    qty = smoke._quantize_qty(floored, step_size=step, quantity_precision=1)
+    # format(qty, "f") is how execution_client serializes the outbound quantity.
+    assert format(qty, "f") == "30.0"
+    assert format(qty, "f") != "30.00000000"
+
+
+def test_quantize_precision_zero_yields_integer_string():
+    qty = smoke._quantize_qty(
+        Decimal("30.00000000"), step_size=Decimal("1"), quantity_precision=0
+    )
+    assert format(qty, "f") == "30"
+
+
+def test_quantize_does_not_round_up():
+    qty = smoke._quantize_qty(
+        Decimal("30.19"), step_size=Decimal("0.1"), quantity_precision=1
+    )
+    assert qty == Decimal("30.1")
+
+
+def test_quantize_without_precision_uses_normalized_step_exponent():
+    qty = smoke._quantize_qty(
+        Decimal("30.00000000"), step_size=Decimal("0.10000000"), quantity_precision=None
+    )
+    assert format(qty, "f") == "30.0"
+
+
+def test_quantize_close_qty_from_position_amt_strips_trailing_zeros():
+    """Codex: reduceOnly close uses abs(positionAmt) which can carry a fixed
+    scale; it must be quantized so the close leg does not re-trigger -1111."""
+    position_amt = Decimal("-30.00000000")  # short position, fixed-scale
+    close_qty = smoke._quantize_qty(
+        abs(position_amt), step_size=Decimal("0.1"), quantity_precision=1
+    )
+    assert format(close_qty, "f") == "30.0"
+
+
+def test_parse_returns_lot_step_size_for_limit():
+    filters = smoke._parse_symbol_filters(_exchange_info_multi(), "XRPUSDT")
+    # LIMIT orders must use LOT_SIZE (0.001), not MARKET_LOT_SIZE (0.1).
+    assert filters["lot_step_size"] == Decimal("0.00100000")
+    assert filters["step_size"] == Decimal("0.10000000")
+
+
+def test_step_for_order_type_selects_correct_step():
+    filters = smoke._parse_symbol_filters(_exchange_info_multi(), "XRPUSDT")
+    assert smoke._step_for_order_type(filters, "MARKET") == Decimal("0.10000000")
+    assert smoke._step_for_order_type(filters, "LIMIT") == Decimal("0.00100000")
+
+
+def test_lot_step_falls_back_to_market_when_lot_absent():
+    body = {
+        "symbols": [
+            {
+                "symbol": "XRPUSDT",
+                "quantityPrecision": 1,
+                "filters": [
+                    {"filterType": "MARKET_LOT_SIZE", "stepSize": "0.10000000"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "5"},
+                ],
+            }
+        ]
+    }
+    filters = smoke._parse_symbol_filters(body, "XRPUSDT")
+    assert filters["lot_step_size"] == Decimal("0.10000000")

--- a/tests/services/brokers/binance/demo/test_credentials.py
+++ b/tests/services/brokers/binance/demo/test_credentials.py
@@ -1,0 +1,164 @@
+"""ROB-302 — shared Demo credential resolver.
+
+The Spot and Futures Demo lanes share ONE Binance Demo credential. To avoid
+duplicating the same secret across two env var pairs, a canonical
+``BINANCE_DEMO_API_KEY`` / ``BINANCE_DEMO_API_SECRET`` pair is read by both
+lanes. Per-product vars (``BINANCE_{SPOT,FUTURES}_DEMO_API_*``) remain optional
+overrides.
+
+Resolution rules (verified against Codex review #2 — never mix key/secret
+across sources):
+
+    1. If EITHER product-specific var is set, the PAIR must come from product
+       vars. A half-set product override fails closed (never backfills the
+       missing half from canonical).
+    2. Else the canonical pair is used (both halves, or fail closed).
+    3. Else MissingCredentials.
+
+Isolation invariant: a Spot-specific var never resolves for Futures and vice
+versa. Crossing happens ONLY through the explicit canonical var.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.demo.credentials import (
+    ResolvedDemoCredential,
+    inspect_demo_credential,
+    resolve_demo_credentials,
+)
+from app.services.brokers.binance.demo.errors import (
+    BinanceDemoIncompleteCredentialOverride,
+    BinanceDemoMissingCredentials,
+)
+
+_CANON_KEY = "BINANCE_DEMO_API_KEY"
+_CANON_SECRET = "BINANCE_DEMO_API_SECRET"
+_PRODUCT_VARS = {
+    "spot": ("BINANCE_SPOT_DEMO_API_KEY", "BINANCE_SPOT_DEMO_API_SECRET"),
+    "futures": ("BINANCE_FUTURES_DEMO_API_KEY", "BINANCE_FUTURES_DEMO_API_SECRET"),
+}
+_ALL_VARS = [
+    _CANON_KEY,
+    _CANON_SECRET,
+    *_PRODUCT_VARS["spot"],
+    *_PRODUCT_VARS["futures"],
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_demo_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _ALL_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.parametrize("product", ["spot", "futures"])
+def test_product_specific_pair_wins(monkeypatch, product):
+    key_env, secret_env = _PRODUCT_VARS[product]
+    monkeypatch.setenv(key_env, "prod-key")
+    monkeypatch.setenv(secret_env, "prod-secret")
+    # canonical also present — product override must win
+    monkeypatch.setenv(_CANON_KEY, "canon-key")
+    monkeypatch.setenv(_CANON_SECRET, "canon-secret")
+
+    resolved = resolve_demo_credentials(product, dict(__import__("os").environ))
+
+    assert resolved.api_key == "prod-key"
+    assert resolved.api_secret == "prod-secret"
+    assert resolved.credential_source == f"{product}_demo_env"
+
+
+@pytest.mark.parametrize("product", ["spot", "futures"])
+def test_canonical_pair_used_when_product_absent(monkeypatch, product):
+    monkeypatch.setenv(_CANON_KEY, "canon-key")
+    monkeypatch.setenv(_CANON_SECRET, "canon-secret")
+
+    resolved = resolve_demo_credentials(product, dict(__import__("os").environ))
+
+    assert resolved.api_key == "canon-key"
+    assert resolved.api_secret == "canon-secret"
+    assert resolved.credential_source == "shared_demo_env"
+
+
+@pytest.mark.parametrize("product", ["spot", "futures"])
+def test_missing_everything_fails_closed(monkeypatch, product):
+    with pytest.raises(BinanceDemoMissingCredentials):
+        resolve_demo_credentials(product, {})
+
+
+@pytest.mark.parametrize("product", ["spot", "futures"])
+@pytest.mark.parametrize("present_half", ["key", "secret"])
+def test_partial_product_override_fails_closed_no_canonical_backfill(
+    monkeypatch, product, present_half
+):
+    """Codex #2: a half-set product override must NOT pair with a canonical half."""
+    key_env, secret_env = _PRODUCT_VARS[product]
+    if present_half == "key":
+        monkeypatch.setenv(key_env, "prod-key")
+    else:
+        monkeypatch.setenv(secret_env, "prod-secret")
+    # canonical fully present — must NOT be used to complete the product pair
+    monkeypatch.setenv(_CANON_KEY, "canon-key")
+    monkeypatch.setenv(_CANON_SECRET, "canon-secret")
+
+    with pytest.raises(BinanceDemoIncompleteCredentialOverride):
+        resolve_demo_credentials(product, dict(__import__("os").environ))
+
+
+@pytest.mark.parametrize("present_half", ["key", "secret"])
+def test_partial_canonical_fails_closed(monkeypatch, present_half):
+    if present_half == "key":
+        monkeypatch.setenv(_CANON_KEY, "canon-key")
+    else:
+        monkeypatch.setenv(_CANON_SECRET, "canon-secret")
+    with pytest.raises(BinanceDemoIncompleteCredentialOverride):
+        resolve_demo_credentials("futures", dict(__import__("os").environ))
+
+
+def test_spot_specific_var_does_not_resolve_for_futures(monkeypatch):
+    """Isolation: spot-specific vars are not in the futures resolution chain."""
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "spot-key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "spot-secret")
+    with pytest.raises(BinanceDemoMissingCredentials):
+        resolve_demo_credentials("futures", dict(__import__("os").environ))
+
+
+def test_no_secret_value_in_repr(monkeypatch):
+    resolved = ResolvedDemoCredential(
+        api_key="SUPER_SECRET_KEY",
+        api_secret="SUPER_SECRET_SECRET",
+        credential_source="shared_demo_env",
+    )
+    blob = repr(resolved)
+    assert "SUPER_SECRET_KEY" not in blob
+    assert "SUPER_SECRET_SECRET" not in blob
+    assert "shared_demo_env" in blob
+
+
+def test_inspect_reports_presence_and_source_without_secret(monkeypatch):
+    monkeypatch.setenv(_CANON_KEY, "SUPER_SECRET_KEY")
+    monkeypatch.setenv(_CANON_SECRET, "SUPER_SECRET_SECRET")
+    inspection = inspect_demo_credential("futures", dict(__import__("os").environ))
+    blob = repr(inspection)
+    assert inspection.api_key_present is True
+    assert inspection.api_secret_present is True
+    assert inspection.credential_source == "shared_demo_env"
+    assert inspection.incomplete is False
+    assert "SUPER_SECRET_KEY" not in blob
+    assert "SUPER_SECRET_SECRET" not in blob
+
+
+def test_inspect_missing(monkeypatch):
+    inspection = inspect_demo_credential("futures", {})
+    assert inspection.api_key_present is False
+    assert inspection.api_secret_present is False
+    assert inspection.credential_source is None
+    assert inspection.incomplete is False
+
+
+def test_inspect_partial_marks_incomplete(monkeypatch):
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "prod-key")
+    inspection = inspect_demo_credential("futures", dict(__import__("os").environ))
+    assert inspection.incomplete is True
+    assert inspection.credential_source is None

--- a/tests/services/brokers/binance/futures_demo/test_canonical_credentials.py
+++ b/tests/services/brokers/binance/futures_demo/test_canonical_credentials.py
@@ -1,0 +1,78 @@
+"""ROB-302 — Futures Demo from_env resolves via the shared canonical pair."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.futures_demo.errors import (
+    BinanceFuturesDemoDisabled,
+    BinanceFuturesDemoMissingCredentials,
+)
+from app.services.brokers.binance.futures_demo.execution_client import (
+    BinanceFuturesDemoExecutionClient,
+)
+from app.services.brokers.binance.futures_demo.preflight import (
+    FuturesDemoPreflightClient,
+)
+
+_VARS = [
+    "BINANCE_FUTURES_DEMO_API_KEY",
+    "BINANCE_FUTURES_DEMO_API_SECRET",
+    "BINANCE_DEMO_API_KEY",
+    "BINANCE_DEMO_API_SECRET",
+]
+
+
+@pytest.fixture(autouse=True)
+def _enabled_no_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
+    for v in _VARS:
+        monkeypatch.delenv(v, raising=False)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [FuturesDemoPreflightClient.from_env, BinanceFuturesDemoExecutionClient.from_env],
+)
+def test_canonical_demo_pair_constructs_client(monkeypatch, factory):
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    client = factory()
+    assert client is not None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [FuturesDemoPreflightClient.from_env, BinanceFuturesDemoExecutionClient.from_env],
+)
+def test_futures_specific_pair_still_constructs(monkeypatch, factory):
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "fut-key")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_SECRET", "fut-secret")
+    client = factory()
+    assert client is not None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [FuturesDemoPreflightClient.from_env, BinanceFuturesDemoExecutionClient.from_env],
+)
+def test_partial_override_fails_closed(monkeypatch, factory):
+    """Half-set product override must fail closed (lane-specific error)."""
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "fut-key")
+    # secret missing; canonical present must NOT backfill
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    with pytest.raises(BinanceFuturesDemoMissingCredentials):
+        factory()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [FuturesDemoPreflightClient.from_env, BinanceFuturesDemoExecutionClient.from_env],
+)
+def test_canonical_does_not_bypass_enabled_gate(monkeypatch, factory):
+    monkeypatch.delenv("BINANCE_FUTURES_DEMO_ENABLED", raising=False)
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    with pytest.raises(BinanceFuturesDemoDisabled):
+        factory()

--- a/tests/services/brokers/binance/futures_demo/test_env_readiness.py
+++ b/tests/services/brokers/binance/futures_demo/test_env_readiness.py
@@ -52,6 +52,35 @@ def test_ignores_spot_and_testnet_env(monkeypatch):
     assert r.api_secret_present is False
 
 
+def test_canonical_demo_creds_make_ready(monkeypatch):
+    """ROB-302: canonical BINANCE_DEMO_* pair satisfies futures readiness."""
+    for k in (
+        "BINANCE_FUTURES_DEMO_API_KEY",
+        "BINANCE_FUTURES_DEMO_API_SECRET",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "CANON_KEY_VALUE")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "CANON_SECRET_VALUE")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_BASE_URL", "https://demo-fapi.binance.com")
+    ev = evaluate_futures_demo_env_readiness().to_evidence_dict()
+    assert ev["ready"] is True
+    assert ev["api_key_present"] is True
+    assert ev["credential_source"] == "shared_demo_env"
+    assert "CANON_KEY_VALUE" not in repr(ev)
+    assert "CANON_SECRET_VALUE" not in repr(ev)
+
+
+def test_futures_specific_creds_label_source(monkeypatch):
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_SECRET", "s")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_BASE_URL", "https://demo-fapi.binance.com")
+    ev = evaluate_futures_demo_env_readiness().to_evidence_dict()
+    assert ev["credential_source"] == "futures_demo_env"
+    assert ev["ready"] is True
+
+
 def test_host_judgment_rejects_non_demo_host_without_raising(monkeypatch):
     monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
     monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "k")

--- a/tests/services/brokers/binance/futures_demo/test_preflight.py
+++ b/tests/services/brokers/binance/futures_demo/test_preflight.py
@@ -1,4 +1,4 @@
-"""ROB-298 PR 2 — Futures Demo preflight (signed GET /fapi/v1/account).
+"""ROB-298 PR 2 — Futures Demo preflight (signed GET /fapi/v2/account).
 
 Mirrors the Spot Demo preflight contract under an independent fail-closed
 exception hierarchy. The preflight is read-only: ONE signed HTTP GET
@@ -11,7 +11,7 @@ Contract coverage:
       - API key or secret is missing → ``BinanceFuturesDemoMissingCredentials``
       - ``BINANCE_FUTURES_DEMO_BASE_URL`` resolves to a non-Futures-Demo host
         (Spot Demo / Spot Testnet / Live spot / Live futures / arbitrary)
-  * Signed GET ``/fapi/v1/account`` returns a redacted summary on 200.
+  * Signed GET ``/fapi/v2/account`` returns a redacted summary on 200.
   * Returned dataclass has expected source/venue/product = futures_demo/binance/usdm_futures.
   * Secret never appears in repr/caplog (regression sentinel).
   * ``aclose()`` shuts down the httpx client cleanly.
@@ -157,7 +157,7 @@ def test_base_url_rejects_arbitrary(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Signed GET /fapi/v1/account success path                                    #
+# Signed GET /fapi/v2/account success path                                    #
 # --------------------------------------------------------------------------- #
 
 
@@ -174,10 +174,10 @@ def client(monkeypatch: pytest.MonkeyPatch) -> FuturesDemoPreflightClient:
 async def test_preflight_account_success(
     client: FuturesDemoPreflightClient, httpx_mock
 ) -> None:
-    """``preflight_account`` hits /fapi/v1/account and returns a redacted summary."""
+    """``preflight_account`` hits /fapi/v2/account and returns a redacted summary."""
     httpx_mock.add_response(
         method="GET",
-        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/account\?.*$"),
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/account\?.*$"),
         status_code=200,
         json={
             "canTrade": True,
@@ -224,7 +224,7 @@ async def test_preflight_account_success(
     requests = httpx_mock.get_requests()
     assert len(requests) == 1
     url_str = str(requests[0].url)
-    assert "/fapi/v1/account" in url_str
+    assert "/fapi/v2/account" in url_str
     assert "signature=" in url_str
     assert "timestamp=" in url_str
 
@@ -238,7 +238,7 @@ async def test_preflight_to_evidence_dict_shape(
     """``to_evidence_dict`` is JSON-serializable and has the expected shape."""
     httpx_mock.add_response(
         method="GET",
-        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/account\?.*$"),
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/account\?.*$"),
         status_code=200,
         json={
             "canTrade": True,
@@ -278,7 +278,7 @@ async def test_preflight_account_unsupported_auth_codes(
     """Server-side HMAC rejection codes → BinanceFuturesDemoUnsupportedAuth."""
     httpx_mock.add_response(
         method="GET",
-        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/account\?.*$"),
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/account\?.*$"),
         status_code=401,
         json={"code": code, "msg": "Signature for this request is not valid."},
     )
@@ -294,7 +294,7 @@ async def test_preflight_account_other_4xx_raises_http_status_error(
     """Non-auth 4xx surfaces as ``httpx.HTTPStatusError``."""
     httpx_mock.add_response(
         method="GET",
-        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/account\?.*$"),
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/account\?.*$"),
         status_code=429,
         json={"code": -1003, "msg": "Too many requests."},
     )
@@ -341,7 +341,7 @@ async def test_secret_not_in_caplog_on_4xx(
     client = FuturesDemoPreflightClient.from_env()
     httpx_mock.add_response(
         method="GET",
-        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/account\?.*$"),
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/account\?.*$"),
         status_code=401,
         json={"code": -1022, "msg": "Signature for this request is not valid."},
     )

--- a/tests/services/brokers/binance/spot_demo/test_canonical_credentials.py
+++ b/tests/services/brokers/binance/spot_demo/test_canonical_credentials.py
@@ -1,0 +1,78 @@
+"""ROB-302 — Spot Demo from_env resolves via the shared canonical pair.
+
+Spot Demo is a deployed, working lane. These tests pin the additive contract:
+behavior is byte-identical when BINANCE_SPOT_DEMO_* is set, and the canonical
+BINANCE_DEMO_* pair is used only when the spot-specific pair is absent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.errors import (
+    BinanceSpotDemoDisabled,
+    BinanceSpotDemoMissingCredentials,
+)
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+)
+from app.services.brokers.binance.spot_demo.preflight import SpotDemoPreflightClient
+
+_VARS = [
+    "BINANCE_SPOT_DEMO_API_KEY",
+    "BINANCE_SPOT_DEMO_API_SECRET",
+    "BINANCE_DEMO_API_KEY",
+    "BINANCE_DEMO_API_SECRET",
+]
+
+
+@pytest.fixture(autouse=True)
+def _enabled_no_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    for v in _VARS:
+        monkeypatch.delenv(v, raising=False)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [SpotDemoPreflightClient.from_env, BinanceSpotDemoExecutionClient.from_env],
+)
+def test_spot_specific_pair_still_constructs(monkeypatch, factory):
+    """Regression: deployed contract unchanged when SPOT_* set."""
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "spot-key")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "spot-secret")
+    assert factory() is not None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [SpotDemoPreflightClient.from_env, BinanceSpotDemoExecutionClient.from_env],
+)
+def test_canonical_demo_pair_constructs_client(monkeypatch, factory):
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    assert factory() is not None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [SpotDemoPreflightClient.from_env, BinanceSpotDemoExecutionClient.from_env],
+)
+def test_partial_override_fails_closed(monkeypatch, factory):
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "spot-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    with pytest.raises(BinanceSpotDemoMissingCredentials):
+        factory()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [SpotDemoPreflightClient.from_env, BinanceSpotDemoExecutionClient.from_env],
+)
+def test_canonical_does_not_bypass_enabled_gate(monkeypatch, factory):
+    monkeypatch.delenv("BINANCE_SPOT_DEMO_ENABLED", raising=False)
+    monkeypatch.setenv("BINANCE_DEMO_API_KEY", "canon-key")
+    monkeypatch.setenv("BINANCE_DEMO_API_SECRET", "canon-secret")
+    with pytest.raises(BinanceSpotDemoDisabled):
+        factory()


### PR DESCRIPTION
## Summary
Fixes the Binance USD-M Futures Demo smoke blockers Hermes hit after #926, so `readiness → preflight → order-test → confirm` can complete on the MacBook native runtime. Three real bugs + a shared-credential ergonomics change.

**Credentials (canonical model, ROB-302 D2)**
- New `app/services/brokers/binance/demo/credentials.py`. Spot and Futures Demo share ONE Demo credential, so a canonical `BINANCE_DEMO_API_KEY` / `BINANCE_DEMO_API_SECRET` pair is read by both lanes — no duplicate secret. Per-product vars remain optional overrides that win when set.
- Pair-by-source resolution: a half-set override (key XOR secret) fails closed and is never completed from canonical (prevents pairing a product key with a canonical secret). Each lane's `*_ENABLED` flag still gates activation independently; a Spot-specific override never resolves for Futures.
- Wired through all five `from_env`/readiness call sites. Spot lane change is strictly additive (byte-identical when `BINANCE_SPOT_DEMO_API_*` is set).

**Preflight**
- `GET /fapi/v1/account` → `GET /fapi/v2/account` (v1 returns 404 on demo-fapi; v2 returns the same redacted summary fields).

**Sizing (`scripts/binance_futures_demo_smoke.py`)**
- Select the requested symbol's `exchangeInfo` row instead of `symbols[0]` (demo-fapi ignores `symbol=` and can lead with BTCUSDT). Fail closed if absent.
- Quantize the submitted MARKET quantity to `quantityPrecision` on **both** the open and the reduceOnly close legs — a step-floored `Decimal` carried the step string's trailing zeros (`"30.00000000"`), which `format(qty,"f")` emitted verbatim and Binance rejected with `-1111`. The close leg sizes from `abs(positionAmt)` and is now quantized identically, so a confirmed open is never left with a failing close.
- MARKET floors to `MARKET_LOT_SIZE`, LIMIT to `LOT_SIZE`.

## Test Coverage
TDD throughout (failing test first, then implementation). New tests:
- `tests/services/brokers/binance/demo/test_credentials.py` — resolution chain, partial-override fail-closed, source labels, no secret leak (17 cases)
- `tests/services/brokers/binance/{futures,spot}_demo/test_canonical_credentials.py` — canonical + override construction, ENABLED gate, partial fail-closed
- `test_env_readiness.py` (+2) — canonical readiness + `credential_source` label
- `test_preflight.py` — `/fapi/v2/account` assertions
- `tests/scripts/test_binance_futures_demo_sizing.py` — symbol-row selection, MARKET vs LOT step, quantityPrecision (open + close-leg `positionAmt`), min-notional

Full targeted suite: **510 passed** (`tests/services/brokers/binance/` + `tests/scripts/`). `ruff check` clean. Existing Spot/Futures isolation + cross-environment-leakage tests unchanged and green.

## Pre-Landing Review
Plan reviewed via `/plan-eng-review` (CLEAR) + Codex outside voice on the plan (found the independent key/secret resolution bug and the `-1111` serialization issue, both fixed). Codex adversarial review on the implemented diff found the **close-leg precision bug** (open quantized, reduceOnly close was not) — fixed in this PR with regression coverage. Remaining Codex notes dispositioned: `min_notional` default-5 kept (Binance enforces the real min server-side); readiness `missing` list does not list a var as missing once canonical is present (verified e2e).

## Verification
`--readiness` exercised end-to-end (no HTTP): canonical pair → `ready=true, credential_source="shared_demo_env"`; futures override → `credential_source="futures_demo_env"`; no secret value in output. `--preflight`/`--order-test`/`--confirm` against live Demo credentials are the MacBook-native step Hermes runs after merge/deploy.

## Safety boundaries (unchanged)
`demo-fapi.binance.com` only; live/testnet/spot hosts fail-closed at transport. `BINANCE_FUTURES_DEMO_ENABLED` still required. No scheduler. `--confirm` only on the explicit flag. leverage=1, reduce-only close, reconcile requires open orders empty AND position flat. No secret values in logs/evidence.

## Post-merge smoke (Hermes, MacBook native)
After deploy, with the canonical `BINANCE_DEMO_*` pair set:
- `--readiness`
- `--preflight --symbol XRPUSDT`
- `--order-test --symbol XRPUSDT --cap-usdt 10`
- `--confirm --symbol XRPUSDT --cap-usdt 10 --leverage 1 --close-with SELL`

Expected post-confirm: open orders `0`, position flat, no live/testnet request, no secret in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Binance Futures Demo smoke tests to use correct API endpoint for account queries.
  * Corrected order quantity precision and lot-size handling to prevent submission failures.
  * Improved symbol filtering to ensure correct market data is selected.

* **New Features**
  * Introduced unified credential management for Binance demo accounts with optional per-product overrides.
  * Enhanced readiness reporting to display credential source and validation status.

* **Documentation**
  * Updated environment variable setup with credential resolution rules and fail-safe behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->