### PR TITLE
fix(rob-303): Futures Demo confirm reconcile — v2 positionRisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ## Unreleased
 
-### Fixed (ROB-302 — Binance Futures Demo smoke: credential alias, v2 preflight, XRPUSDT sizing)
+### Fixed (ROB-303 — Futures Demo confirm reconcile: v2 positionRisk)
+- `BinanceFuturesDemoExecutionClient.get_position` now calls `GET /fapi/v2/positionRisk` instead of `/fapi/v1/positionRisk`. `demo-fapi.binance.com` rejects the v1 path with `404 {"code": -5000, "msg": "Path /fapi/v1/positionRisk, Method GET is invalid"}`, which aborted `--confirm` after a real Demo position had been opened — leaving the ledger row in `anomaly`. v2 returns the same `positionAmt` / `entryPrice` / `leverage` list shape, so parsing is unchanged. Constant, docstrings, and the position DTO doc are updated to match; the smoke runbook already documented v2.
+
+
 - Futures Demo preflight now calls `GET /fapi/v2/account` instead of `/fapi/v1/account`. `demo-fapi.binance.com` returns `404` for v1; v2 returns the same redacted summary fields (`canTrade`, nonzero asset/position counts) so evidence shape is unchanged.
 - `scripts/binance_futures_demo_smoke.py` now selects the requested symbol's row from the `exchangeInfo` response instead of `symbols[0]`. demo-fapi does not honor the `symbol=` query param and can lead the array with BTCUSDT, so XRPUSDT was being sized against BTCUSDT's step/precision/min-notional (cap-10 falsely blocked at `MIN_NOTIONAL=50`). The requested symbol is now matched and the helper fails closed if it is absent.
 - The submitted MARKET quantity is quantized to the symbol's `quantityPrecision` on **both** the open leg and the reduceOnly close leg. A step-floored `Decimal` carried the `exchangeInfo` step string's trailing zeros (`"0.10000000"` → `"30.00000000"`) which `format(qty, "f")` emitted verbatim, triggering Binance `-1111 Precision is over the maximum`. The close leg sizes from `abs(positionAmt)` and is now quantized identically, so a confirmed open can no longer be left with a failing close.

--- a/app/services/brokers/binance/futures_demo/dto.py
+++ b/app/services/brokers/binance/futures_demo/dto.py
@@ -59,7 +59,7 @@ class FuturesDemoOpenOrdersResult:
 
 @dataclass(frozen=True)
 class FuturesDemoPositionResult:
-    """Single-symbol position snapshot from ``/fapi/v1/positionRisk``."""
+    """Single-symbol position snapshot from ``/fapi/v2/positionRisk``."""
 
     symbol: str
     position_amt: Decimal  # signed; positive=long, negative=short, 0=flat

--- a/app/services/brokers/binance/futures_demo/execution_client.py
+++ b/app/services/brokers/binance/futures_demo/execution_client.py
@@ -80,7 +80,9 @@ _DEFAULT_BASE_URL: Final[str] = "https://demo-fapi.binance.com"
 _ORDER_PATH: Final[str] = "/fapi/v1/order"
 _ORDER_TEST_PATH: Final[str] = "/fapi/v1/order/test"
 _OPEN_ORDERS_PATH: Final[str] = "/fapi/v1/openOrders"
-_POSITION_RISK_PATH: Final[str] = "/fapi/v1/positionRisk"
+# ROB-303: demo-fapi rejects /fapi/v1/positionRisk with -5000 ("Path ...
+# is invalid"). v2 is the demo-fapi-supported position-reconcile source.
+_POSITION_RISK_PATH: Final[str] = "/fapi/v2/positionRisk"
 _POSITION_SIDE_DUAL_PATH: Final[str] = "/fapi/v1/positionSide/dual"
 _LEVERAGE_PATH: Final[str] = "/fapi/v1/leverage"
 
@@ -525,7 +527,7 @@ class BinanceFuturesDemoExecutionClient:
         return FuturesDemoOpenOrdersResult(orders=orders)
 
     async def get_position(self, *, symbol: str) -> FuturesDemoPositionResult:
-        """Query the current position for ``symbol`` from /fapi/v1/positionRisk.
+        """Query the current position for ``symbol`` from /fapi/v2/positionRisk.
 
         Returns the signed ``positionAmt`` (positive=long, negative=short,
         zero=flat) along with ``entryPrice`` and ``leverage``. Used by the
@@ -539,7 +541,7 @@ class BinanceFuturesDemoExecutionClient:
         resp = await self._client.get(_POSITION_RISK_PATH, params=signed)
         resp.raise_for_status()
         body = resp.json()
-        # /fapi/v1/positionRisk?symbol=... returns a list; pick the matching row.
+        # /fapi/v2/positionRisk?symbol=... returns a list; pick the matching row.
         entry: dict[str, Any] = {}
         if isinstance(body, list):
             for item in body:

--- a/tests/services/brokers/binance/futures_demo/test_execution_client_position.py
+++ b/tests/services/brokers/binance/futures_demo/test_execution_client_position.py
@@ -1,0 +1,119 @@
+"""ROB-303 — get_position() must hit /fapi/v2/positionRisk on demo-fapi.
+
+demo-fapi rejects the legacy ``GET /fapi/v1/positionRisk`` endpoint with
+``404 {"code": -5000, "msg": "Path /fapi/v1/positionRisk, Method GET is
+invalid"}``. The confirm/reconcile path depends on ``get_position()`` to
+verify a position before the reduceOnly close, so a 404 here aborts the
+smoke after a real Demo position has been opened (leaving an anomaly).
+
+These tests pin the position-reconcile source to the demo-fapi-supported
+``/fapi/v2/positionRisk`` and guard against a regression back to v1.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.futures_demo.dto import (
+    FuturesDemoPositionResult,
+)
+from app.services.brokers.binance.futures_demo.execution_client import (
+    BinanceFuturesDemoExecutionClient,
+)
+
+_FUTURES_DEMO_BASE = "https://demo-fapi.binance.com"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> BinanceFuturesDemoExecutionClient:
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "DUMMY_FUTURES_DEMO_KEY")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_SECRET", "DUMMY_FUTURES_DEMO_SECRET")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_BASE_URL", _FUTURES_DEMO_BASE)
+    return BinanceFuturesDemoExecutionClient.from_env()
+
+
+@pytest.mark.asyncio
+async def test_get_position_hits_v2_position_risk_path(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """``get_position`` dispatches GET /fapi/v2/positionRisk (not v1).
+
+    Regression guard for ROB-303: v1 is rejected by demo-fapi (-5000).
+    """
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/positionRisk\?.*$"),
+        status_code=200,
+        json=[
+            {
+                "symbol": "XRPUSDT",
+                "positionAmt": "7.4",
+                "entryPrice": "0.5000",
+                "leverage": "1",
+            }
+        ],
+    )
+    await client.get_position(symbol="XRPUSDT")
+
+    last = httpx_mock.get_request()
+    assert last is not None
+    assert last.method == "GET"
+    assert last.url.path == "/fapi/v2/positionRisk"
+    assert last.url.path != "/fapi/v1/positionRisk"
+    url_str = str(last.url)
+    assert "signature=" in url_str
+    assert "timestamp=" in url_str
+
+
+@pytest.mark.asyncio
+async def test_get_position_parses_v2_position_risk_row(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """v2 positionRisk list row parses into a signed FuturesDemoPositionResult."""
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/positionRisk\?.*$"),
+        status_code=200,
+        json=[
+            {
+                "symbol": "XRPUSDT",
+                "positionAmt": "7.4",
+                "entryPrice": "0.5000",
+                "leverage": "1",
+            }
+        ],
+    )
+    result = await client.get_position(symbol="XRPUSDT")
+    assert isinstance(result, FuturesDemoPositionResult)
+    assert result.symbol == "XRPUSDT"
+    assert result.position_amt == Decimal("7.4")
+    assert result.entry_price == Decimal("0.5000")
+    assert result.leverage == 1
+    assert result.is_flat is False
+
+
+@pytest.mark.asyncio
+async def test_get_position_flat_when_amount_zero(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    """Zero ``positionAmt`` from v2 positionRisk yields ``is_flat=True``."""
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v2/positionRisk\?.*$"),
+        status_code=200,
+        json=[
+            {
+                "symbol": "XRPUSDT",
+                "positionAmt": "0.0",
+                "entryPrice": "0.0",
+                "leverage": "1",
+            }
+        ],
+    )
+    result = await client.get_position(symbol="XRPUSDT")
+    assert result.position_amt == Decimal("0.0")
+    assert result.is_flat is True


### PR DESCRIPTION
## Summary

Production deploy of PR #928 (ROB-302) is healthy, but the post-deploy Binance **Futures Demo** confirm smoke found a remaining blocker: `--confirm` opens a real Demo position, then aborts before the reduceOnly close because `get_position()` calls an endpoint demo-fapi rejects.

```
GET /fapi/v1/positionRisk
→ 404 {"code": -5000, "msg": "Path /fapi/v1/positionRisk, Method GET is invalid"}
```

This left the prior Futures BUY ledger row stuck in `anomaly` (cleaned up manually out-of-band; not touched by this PR).

**Fix:** `BinanceFuturesDemoExecutionClient._POSITION_RISK_PATH` → `/fapi/v2/positionRisk`. v2 returns the same `positionAmt` / `entryPrice` / `leverage` list shape, so `get_position()` parsing is unchanged. The fix is validated by the issue's own manual-cleanup evidence, where `/fapi/v2/positionRisk` returned `positionAmt=0.0` successfully on demo-fapi.

Changed:
- `app/services/brokers/binance/futures_demo/execution_client.py` — path constant + docstrings/comment
- `app/services/brokers/binance/futures_demo/dto.py` — `FuturesDemoPositionResult` docstring

## Test Coverage

There was **no** test for `get_position()` / the positionRisk path before — that gap is why the v1/v2 drift slipped past ROB-302. Added `tests/services/brokers/binance/futures_demo/test_execution_client_position.py` (3 tests):

- `test_get_position_hits_v2_position_risk_path` — asserts the request path is `/fapi/v2/positionRisk` and **not** `/fapi/v1/positionRisk` (regression guard), plus signed-query presence
- `test_get_position_parses_v2_position_risk_row` — v2 list row → signed `FuturesDemoPositionResult`
- `test_get_position_flat_when_amount_zero` — `positionAmt=0` → `is_flat=True`

All new code paths covered. Tests: TDD red→green confirmed (red failed because the request went to v1).

## Pre-Landing Review

Diff is a path constant + docstrings + tests. No SQL, no LLM trust boundary, no auth surface. Existing safety boundaries preserved: demo-fapi host allowlist only, no live/testnet fallback, `--confirm` gate, 1x leverage, One-way mode, reduceOnly close. Host allowlist is unaffected (path change, not host).

## Out of scope (per ROB-303 non-goals)

- The persisted production env still needs the canonical `BINANCE_DEMO_API_KEY` / `BINANCE_DEMO_API_SECRET` pair added by an operator (secret manager task; runbook §3 already documents resolution order). Smoke validation used an ephemeral process-only alias.
- The existing `anomaly` ledger row is left untouched.
- Runbook unchanged — it already documents `/fapi/v2/positionRisk`.

## Test plan
- [x] `uv run ruff check app/ tests/ scripts/binance_futures_demo_smoke.py` — All checks passed
- [x] `uv run ruff format --check` on changed files — 3 files already formatted
- [x] `uv run pytest tests/services/brokers/binance/ tests/scripts/test_binance_futures_demo_smoke.py tests/scripts/test_binance_futures_demo_sizing.py` — **357 passed**
- [ ] Post-merge operator smoke on production: `--readiness`, `--preflight`, `--order-test`, `--confirm --symbol XRPUSDT --cap-usdt 10 --leverage 1 --close-with SELL` → open orders 0, `positionAmt=0.0`, ledger `reconciled` without anomaly

Closes ROB-303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Futures Demo position reconciliation to use the v2 endpoint instead of v1, resolving 404 errors on the demo host that were preventing successful `--confirm` operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->