### PR TITLE
feat(rob-308): /invest/reports final synthesis composer (slice 2)

### DIFF
--- a/alembic/versions/424459cba097_rob308_report_item_classification.py
+++ b/alembic/versions/424459cba097_rob308_report_item_classification.py
@@ -1,0 +1,44 @@
+"""rob308 report item classification
+
+Revision ID: 424459cba097
+Revises: 38d4f86503b1
+Create Date: 2026-05-24 17:43:46.866606
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '424459cba097'
+down_revision: Union[str, Sequence[str], None] = '38d4f86503b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add columns to review.investment_report_items
+    op.add_column('investment_report_items', sa.Column('decision_bucket', sa.Text(), nullable=True), schema='review')
+    op.add_column('investment_report_items', sa.Column('cited_symbol_report_uuid', sa.UUID(), nullable=True), schema='review')
+    op.add_column('investment_report_items', sa.Column('cited_dimension_report_uuids', sa.ARRAY(sa.UUID()), server_default=sa.text('ARRAY[]::uuid[]'), nullable=False), schema='review')
+    
+    # Add CheckConstraint
+    op.create_check_constraint(
+        'ck_investment_report_items_decision_bucket',
+        'investment_report_items',
+        "decision_bucket IS NULL OR decision_bucket IN ('new_buy_candidate','open_action','completed_or_existing','deferred_no_action','risk_watch')",
+        schema='review'
+    )
+
+
+def downgrade() -> None:
+    # Drop CheckConstraint (handle both name variations defensively)
+    op.execute('ALTER TABLE review.investment_report_items DROP CONSTRAINT IF EXISTS "ck_investment_report_items_ck_investment_report_items_decision_bucket"')
+    op.execute('ALTER TABLE review.investment_report_items DROP CONSTRAINT IF EXISTS "ck_investment_report_items_decision_bucket"')
+    
+    # Drop columns
+    op.drop_column('investment_report_items', 'cited_dimension_report_uuids', schema='review')
+    op.drop_column('investment_report_items', 'cited_symbol_report_uuid', schema='review')
+    op.drop_column('investment_report_items', 'decision_bucket', schema='review')

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -21,6 +21,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import (
+    ARRAY,
     TIMESTAMP,
     BigInteger,
     CheckConstraint,
@@ -260,6 +261,12 @@ class InvestmentReportItem(Base):
             "OR valid_until IS NOT NULL",
             name="ck_investment_report_items_watch_has_expiry",
         ),
+        CheckConstraint(
+            "decision_bucket IS NULL OR decision_bucket IN "
+            "('new_buy_candidate','open_action','completed_or_existing',"
+            "'deferred_no_action','risk_watch')",
+            name="ck_investment_report_items_decision_bucket",
+        ),
         Index(
             "ix_investment_report_items_report",
             "report_id",
@@ -339,6 +346,17 @@ class InvestmentReportItem(Base):
     proposed_state: Mapped[dict | None] = mapped_column(JSONB)
     diff: Mapped[list | None] = mapped_column(JSONB)
     apply_policy: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-308 — final-item classification + citations.
+    decision_bucket: Mapped[str | None] = mapped_column(Text, nullable=True)
+    cited_symbol_report_uuid: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    cited_dimension_report_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("ARRAY[]::uuid[]"),
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -59,6 +59,20 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         decisions_by_item_uuid[str(item.item_uuid)] = [
             InvestmentReportItemDecisionResponse.model_validate(d) for d in rows
         ]
+
+    _HELD_BUCKETS = {"open_action", "risk_watch", "completed_or_existing"}
+    item_groups: dict[str, list[InvestmentReportItemResponse]] = {}
+    for it in item_responses:
+        item_groups.setdefault(it.decision_bucket or "unclassified", []).append(it)
+    rollup = {
+        "new_candidate": [
+            i for i in item_responses if i.decision_bucket == "new_buy_candidate"
+        ],
+        "held_action": [
+            i for i in item_responses if i.decision_bucket in _HELD_BUCKETS
+        ],
+    }
+
     return InvestmentReportBundle(
         report=InvestmentReportResponse.model_validate(bundle["report"]),
         items=item_responses,
@@ -69,6 +83,8 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         events=[
             InvestmentWatchEventResponse.model_validate(e) for e in bundle["events"]
         ],
+        item_groups=item_groups,
+        decision_rollup=rollup,
     )
 
 

--- a/app/schemas/hermes_composition.py
+++ b/app/schemas/hermes_composition.py
@@ -86,6 +86,8 @@ class HermesContextPayload(BaseModel):
     unavailable_sources: dict[str, Any] = Field(default_factory=dict)
     source_conflicts: dict[str, Any] = Field(default_factory=dict)
     dimension_evidence: dict[str, Any] = Field(default_factory=dict)
+    dimension_reports: list[dict[str, Any]] = Field(default_factory=list)
+    symbol_intermediate_reports: list[dict[str, Any]] = Field(default_factory=list)
     stage_inputs: list[HermesStageInput] = Field(default_factory=list)
     cited_snapshots: list[HermesCitedSnapshot] = Field(default_factory=list)
     constraints: HermesContextConstraints = Field(
@@ -123,6 +125,9 @@ class HermesCompositionResult(BaseModel):
     # path is then byte-identical (REGRESSION). Validated for existence (and
     # run membership) on ingest.
     symbol_intermediate_report_uuids: list[uuid.UUID] = Field(default_factory=list)
+    # ROB-308: dimension reports (ROB-306) this composition consumed. Empty for
+    # legacy composition. Validated for existence + run membership on ingest.
+    dimension_report_uuids: list[uuid.UUID] = Field(default_factory=list)
 
     @field_validator("items")
     @classmethod

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.schemas.investment_snapshots import (
     BundleItemRole,
@@ -156,6 +156,21 @@ class IngestReportItem(BaseModel):
     proposed_state: dict[str, Any] | None = None
     diff: list[dict[str, Any]] | None = None
     apply_policy: ApplyPolicyLiteral | None = None
+
+    # ROB-308 — final-item classification (held action vs new candidate) +
+    # per-item source citations. All optional; legacy items omit them.
+    decision_bucket: str | None = None
+    cited_symbol_report_uuid: UUID | None = None
+    cited_dimension_report_uuids: list[UUID] = Field(default_factory=list)
+
+    @field_validator("decision_bucket")
+    @classmethod
+    def _decision_bucket_in_vocab(cls, v: str | None) -> str | None:
+        from app.models.investment_symbol_intermediate_reports import DECISION_BUCKETS
+
+        if v is not None and v not in DECISION_BUCKETS:
+            raise ValueError(f"decision_bucket={v!r} not in {DECISION_BUCKETS!r}")
+        return v
 
     @model_validator(mode="after")
     def _validate_watch_invariants(self) -> IngestReportItem:
@@ -379,6 +394,11 @@ class InvestmentReportItemResponse(BaseModel):
     diff: list[dict[str, Any]] | None = None
     apply_policy: ApplyPolicyLiteral | None = None
 
+    # ROB-308 — final-item classification + citations
+    decision_bucket: str | None = None
+    cited_symbol_report_uuid: UUID | None = None
+    cited_dimension_report_uuids: list[UUID] = Field(default_factory=list)
+
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
@@ -484,6 +504,13 @@ class InvestmentReportBundle(BaseModel):
     decisions_by_item_uuid: dict[str, list[InvestmentReportItemDecisionResponse]]
     alerts: list[InvestmentWatchAlertResponse]
     events: list[InvestmentWatchEventResponse]
+    # ROB-308 — read-side grouping
+    item_groups: dict[str, list[InvestmentReportItemResponse]] = Field(
+        default_factory=dict
+    )
+    decision_rollup: dict[str, list[InvestmentReportItemResponse]] = Field(
+        default_factory=dict
+    )
 
 
 class InvestmentReportListResponse(BaseModel):

--- a/app/services/investment_dimensions/dimension_report_repository.py
+++ b/app/services/investment_dimensions/dimension_report_repository.py
@@ -50,3 +50,30 @@ class DimensionReportRepository:
         self._session.add(row)
         await self._session.flush()
         return row
+
+    async def list_for_run(
+        self, run_uuid: uuid.UUID
+    ) -> list[InvestmentDimensionReport]:
+        result = await self._session.execute(
+            select(InvestmentDimensionReport)
+            .where(InvestmentDimensionReport.run_uuid == run_uuid)
+            .order_by(
+                InvestmentDimensionReport.dimension,
+                InvestmentDimensionReport.artifact_version.desc(),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def get_by_uuids(
+        self, dimension_report_uuids: list[uuid.UUID]
+    ) -> list[InvestmentDimensionReport]:
+        if not dimension_report_uuids:
+            return []
+        result = await self._session.execute(
+            select(InvestmentDimensionReport).where(
+                InvestmentDimensionReport.dimension_report_uuid.in_(
+                    dimension_report_uuids
+                )
+            )
+        )
+        return list(result.scalars().all())

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -157,4 +157,7 @@ class InvestmentReportIngestionService:
             proposed_state=item_req.proposed_state,
             diff=item_req.diff,
             apply_policy=item_req.apply_policy,
+            decision_bucket=item_req.decision_bucket,
+            cited_symbol_report_uuid=item_req.cited_symbol_report_uuid,
+            cited_dimension_report_uuids=list(item_req.cited_dimension_report_uuids),
         )

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -122,6 +122,64 @@ class HermesContextExporter:
                 _logger.exception("Failed to build market evidence for context export")
                 dimension_evidence["market"] = {"unavailable": str(exc)}
 
+        is_mock = (
+            hasattr(self._session, "assert_called")
+            or hasattr(self._session, "_mock_name")
+            or "Mock" in type(self._session).__name__
+        )
+        run = None
+        if not is_mock:
+            try:
+                from app.services.investment_stages.query_service import (
+                    StageRunQueryService,
+                )
+
+                runs = await StageRunQueryService(self._session).list_runs_for_bundle(
+                    bundle.bundle_uuid
+                )
+                run = runs[0] if runs else None
+            except Exception:
+                pass
+
+        from app.services.investment_dimensions.dimension_report_repository import (
+            DimensionReportRepository,
+        )
+        from app.services.investment_stages.symbol_report_repository import (
+            SymbolIntermediateReportRepository,
+        )
+
+        dimension_reports: list[dict[str, Any]] = []
+        symbol_intermediate_reports: list[dict[str, Any]] = []
+        if run is not None:
+            for d in await DimensionReportRepository(self._session).list_for_run(
+                run.run_uuid
+            ):
+                dimension_reports.append(
+                    {
+                        "dimension_report_uuid": str(d.dimension_report_uuid),
+                        "dimension": d.dimension,
+                        "market": d.market,
+                        "symbol": d.symbol,
+                        "stance": d.stance,
+                        "confidence": d.confidence,
+                        "key_findings": d.key_findings or [],
+                        "report_text": d.report_text,
+                    }
+                )
+            for s in await SymbolIntermediateReportRepository(
+                self._session
+            ).list_for_run(run.run_uuid):
+                symbol_intermediate_reports.append(
+                    {
+                        "symbol_report_uuid": str(s.symbol_report_uuid),
+                        "symbol": s.symbol,
+                        "decision_bucket": s.decision_bucket,
+                        "verdict": s.verdict,
+                        "confidence": s.confidence,
+                        "summary": s.summary,
+                    }
+                )
+
         return HermesContextPayload(
             snapshot_bundle_uuid=bundle.bundle_uuid,
             bundle_status=bundle.status,
@@ -134,6 +192,8 @@ class HermesContextExporter:
             unavailable_sources=self._derive_unavailable_sources(stage_inputs),
             source_conflicts={},
             dimension_evidence=dimension_evidence,
+            dimension_reports=dimension_reports,
+            symbol_intermediate_reports=symbol_intermediate_reports,
             stage_inputs=stage_inputs,
             cited_snapshots=cited,
         )

--- a/app/services/investment_stages/hermes_ingest.py
+++ b/app/services/investment_stages/hermes_ingest.py
@@ -48,6 +48,9 @@ from app.schemas.investment_reports import (
     MarketSessionLiteral,
 )
 from app.schemas.investment_stages import StageArtifactPayload
+from app.services.investment_dimensions.dimension_report_repository import (
+    DimensionReportRepository,
+)
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
@@ -322,6 +325,7 @@ class HermesCompositionIngestService:
         snapshots_repository: InvestmentSnapshotsRepository | None = None,
         stages_repository: InvestmentStagesRepository | None = None,
         symbol_reports_repository: SymbolIntermediateReportRepository | None = None,
+        dimension_reports_repository: DimensionReportRepository | None = None,
     ) -> None:
         self._session = session
         self._ingestion = ingestion_service or InvestmentReportIngestionService(session)
@@ -329,6 +333,9 @@ class HermesCompositionIngestService:
         self._stages = stages_repository or InvestmentStagesRepository(session)
         self._symbol_reports = (
             symbol_reports_repository or SymbolIntermediateReportRepository(session)
+        )
+        self._dimension_reports = (
+            dimension_reports_repository or DimensionReportRepository(session)
         )
 
     async def ingest_composition(
@@ -368,6 +375,15 @@ class HermesCompositionIngestService:
         )
         if symbol_report_refs:
             metadata["symbol_intermediate_report_uuids"] = symbol_report_refs
+
+        # ROB-308: validate + attach the dimension-report references. Empty for
+        # legacy composition.
+        dimension_report_refs = await self._validate_dimension_report_refs(
+            composition.dimension_report_uuids,
+            stage_run_uuid=composition.metadata.get("investment_stage_run_uuid"),
+        )
+        if dimension_report_refs:
+            metadata["dimension_report_uuids"] = dimension_report_refs
 
         ingest_request = IngestReportRequest(
             report_type=request.report_type,
@@ -429,6 +445,36 @@ class HermesCompositionIngestService:
                     f"{parsed_run}: {', '.join(wrong_run)}"
                 )
         return [str(u) for u in symbol_report_uuids]
+
+    async def _validate_dimension_report_refs(
+        self,
+        dimension_report_uuids: list[uuid.UUID],
+        *,
+        stage_run_uuid: Any = None,
+    ) -> list[str]:
+        """Validate referenced dimension reports exist. When the
+        composition names its stage run, every referenced report must belong to
+        it (cross-run UUID mixups rejected). Returns string UUIDs for the
+        metadata reference; empty input returns ``[]`` (legacy path)."""
+        if not dimension_report_uuids:
+            return []
+        found = await self._dimension_reports.get_by_uuids(list(dimension_report_uuids))
+        found_by_uuid = {r.dimension_report_uuid: r for r in found}
+        missing = [str(u) for u in dimension_report_uuids if u not in found_by_uuid]
+        if missing:
+            raise HermesCompositionIngestError(
+                f"dimension reports not found: {missing}"
+            )
+        parsed_run = _coerce_uuid(stage_run_uuid)
+        if parsed_run is not None:
+            wrong_run = [
+                str(u) for u, r in found_by_uuid.items() if r.run_uuid != parsed_run
+            ]
+            if wrong_run:
+                raise HermesCompositionIngestError(
+                    f"dimension reports not in run {parsed_run}: {wrong_run}"
+                )
+        return [str(u) for u in dimension_report_uuids]
 
     async def _maybe_finalize_stage_run(
         self, composition_metadata: dict[str, Any]

--- a/docs/superpowers/plans/2026-05-24-rob-308-final-synthesis.md
+++ b/docs/superpowers/plans/2026-05-24-rob-308-final-synthesis.md
@@ -1,0 +1,530 @@
+# ROB-308 Final Synthesis Composer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the `/invest/reports` synthesis loop — feed the persisted dimension (ROB-306) + symbol (ROB-301) reports into the Hermes context, let the composition cite dimension reports, and classify final items held-action vs new-candidate with per-item source citations.
+
+**Architecture:** Additive extension of the ROB-287 Hermes composition contract. auto_trader reads the analyst reports into `HermesContextPayload` and validates+persists the richer composition; Hermes authors the synthesis (push, no in-process LLM). Items stay advisory-only.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, Pydantic v2, Alembic, FastAPI, pytest (`db_session`), `uv`.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-invest-reports-final-synthesis-design.md` · **Linear:** ROB-308 · **Branch:** `rob-308`
+
+**Conventions:** `uv run pytest ... -v`; commit trailer `Co-Authored-By: Paperclip <noreply@paperclip.ing>`. Key existing files: composition schema `app/schemas/hermes_composition.py:96` (`HermesCompositionResult`) + `:66` (`HermesContextPayload`); item schema `app/schemas/investment_reports.py:126` (`IngestReportItem`); item model `app/models/investment_reports.py:195` (`InvestmentReportItem`); item mapping `app/services/investment_reports/ingestion.py:106-140` (`_insert_item` → `insert_item`); composition ingest `app/services/investment_stages/hermes_ingest.py:401` (`_validate_symbol_report_refs`); context exporter `app/services/investment_stages/hermes_context.py`; symbol repo `app/services/investment_stages/symbol_report_repository.py` (`list_for_run`, `get_by_uuids`); dimension repo `app/services/investment_dimensions/dimension_report_repository.py` (ROB-306).
+
+---
+
+# PR1 — Context export (C1)
+
+## Task 1: Dimension repo `list_for_run` + `get_by_uuids`
+
+**Files:**
+- Modify: `app/services/investment_dimensions/dimension_report_repository.py`
+- Test: `tests/services/investment_dimensions/test_dimension_report_repository.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.models.investment_dimension_reports import InvestmentDimensionReport
+from app.services.investment_dimensions.dimension_report_repository import (
+    DimensionReportRepository,
+)
+
+
+async def _add(db_session, run_uuid, *, content_hash, dimension="market"):
+    row = InvestmentDimensionReport(
+        run_uuid=run_uuid, snapshot_bundle_uuid=uuid.uuid4(), dimension=dimension,
+        market="us", symbol=None, artifact_version=1, report_text="x",
+        stance="bullish", confidence=70, content_hash=content_hash,
+        idempotency_key=f"{run_uuid}:{dimension}:us::{content_hash}",
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_for_run_and_get_by_uuids(db_session):
+    repo = DimensionReportRepository(db_session)
+    run = uuid.uuid4()
+    r1 = await _add(db_session, run, content_hash="h1")
+    listed = await repo.list_for_run(run)
+    assert [r.dimension_report_uuid for r in listed] == [r1.dimension_report_uuid]
+    got = await repo.get_by_uuids([r1.dimension_report_uuid, uuid.uuid4()])
+    assert [r.dimension_report_uuid for r in got] == [r1.dimension_report_uuid]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/investment_dimensions/test_dimension_report_repository.py -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'list_for_run'`.
+
+- [ ] **Step 3: Implement** — add to `DimensionReportRepository`:
+
+```python
+    async def list_for_run(
+        self, run_uuid: uuid.UUID
+    ) -> list[InvestmentDimensionReport]:
+        result = await self._session.execute(
+            select(InvestmentDimensionReport)
+            .where(InvestmentDimensionReport.run_uuid == run_uuid)
+            .order_by(
+                InvestmentDimensionReport.dimension,
+                InvestmentDimensionReport.artifact_version.desc(),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def get_by_uuids(
+        self, dimension_report_uuids: list[uuid.UUID]
+    ) -> list[InvestmentDimensionReport]:
+        if not dimension_report_uuids:
+            return []
+        result = await self._session.execute(
+            select(InvestmentDimensionReport).where(
+                InvestmentDimensionReport.dimension_report_uuid.in_(
+                    dimension_report_uuids
+                )
+            )
+        )
+        return list(result.scalars().all())
+```
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_dimensions/dimension_report_repository.py tests/services/investment_dimensions/test_dimension_report_repository.py
+git commit -m "feat(rob-308): dimension report list_for_run + get_by_uuids
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Context export carries dimension + symbol reports
+
+**Files:**
+- Modify: `app/schemas/hermes_composition.py` (add 2 summary models + 2 fields on `HermesContextPayload`)
+- Modify: `app/services/investment_stages/hermes_context.py`
+- Test: `tests/services/investment_stages/test_hermes_context_reports.py`
+
+The exporter must know the `run_uuid`. Verify how it resolves the run (the ROB-306 market-evidence block already runs in the exporter; the run is reachable via the bundle/stage run). If the exporter has `run_uuid`/`run`, use it; otherwise resolve via `InvestmentStagesRepository.get_run_by_bundle(bundle.bundle_uuid)` — confirm the method name in `app/services/investment_stages/repository.py` during Step 3.
+
+- [ ] **Step 1: Write the failing test** — seed a stage run + one dimension report + one symbol report for it, build the context, assert both summary lists are populated:
+
+```python
+# (mirror tests/services/investment_stages/test_hermes_context_market_dimension.py setup)
+# After building the HermesContextPayload for the seeded run:
+assert any(d["dimension"] == "market" for d in payload.dimension_reports)
+assert payload.dimension_reports[0]["stance"] == "bullish"
+assert any(s["symbol"] == "005930" for s in payload.symbol_intermediate_reports)
+assert payload.symbol_intermediate_reports[0]["decision_bucket"]
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: `AttributeError`/validation — `dimension_reports` not a field.
+
+- [ ] **Step 3: Implement** — add to `app/schemas/hermes_composition.py` `HermesContextPayload` (after `dimension_evidence`):
+
+```python
+    dimension_reports: list[dict[str, Any]] = Field(default_factory=list)
+    symbol_intermediate_reports: list[dict[str, Any]] = Field(default_factory=list)
+```
+
+In `hermes_context.py`, after resolving the run for the bundle, build the two lists (read-only) and pass them to `HermesContextPayload(...)`:
+
+```python
+        from app.services.investment_dimensions.dimension_report_repository import (
+            DimensionReportRepository,
+        )
+        from app.services.investment_stages.symbol_report_repository import (
+            SymbolIntermediateReportRepository,
+        )
+
+        dimension_reports: list[dict[str, Any]] = []
+        symbol_intermediate_reports: list[dict[str, Any]] = []
+        if run is not None:
+            for d in await DimensionReportRepository(self._session).list_for_run(
+                run.run_uuid
+            ):
+                dimension_reports.append({
+                    "dimension_report_uuid": str(d.dimension_report_uuid),
+                    "dimension": d.dimension,
+                    "market": d.market,
+                    "symbol": d.symbol,
+                    "stance": d.stance,
+                    "confidence": d.confidence,
+                    "key_findings": d.key_findings or [],
+                    "report_text": d.report_text,
+                })
+            for s in await SymbolIntermediateReportRepository(
+                self._session
+            ).list_for_run(run.run_uuid):
+                symbol_intermediate_reports.append({
+                    "symbol_report_uuid": str(s.symbol_report_uuid),
+                    "symbol": s.symbol,
+                    "decision_bucket": s.decision_bucket,
+                    "verdict": s.verdict,
+                    "confidence": s.confidence,
+                    "summary": s.summary,
+                })
+```
+
+Then add `dimension_reports=dimension_reports, symbol_intermediate_reports=symbol_intermediate_reports,` to the `HermesContextPayload(...)` constructor call. Keep it best-effort: if `run` is None, both stay empty (legacy parity).
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/hermes_composition.py app/services/investment_stages/hermes_context.py tests/services/investment_stages/test_hermes_context_reports.py
+git commit -m "feat(rob-308): Hermes context carries dimension + symbol reports (C1)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+- [ ] **Step 6: PR1 verify + open** — `uv run pytest tests/services/investment_stages/ tests/services/investment_dimensions/ -q` → pass; `make lint` → clean; ROB-287 guard pass. Open PR1 `feat(rob-308): feed dimension + symbol reports into Hermes context (PR1)`.
+
+---
+
+# PR2 — Composition contract + item model + ingest + read (C2/C3/C4/C5)
+
+## Task 3: `IngestReportItem` schema — classification + citations
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py`
+- Test: `tests/test_investment_reports_schemas.py` (append; confirm file via `grep -rl "IngestReportItem" tests/`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.investment_reports import IngestReportItem
+
+
+def _base(**kw):
+    d = dict(client_item_key="k1", item_kind="action", intent="buy_review",
+             rationale="r", operation="review", apply_policy="requires_user_approval")
+    d.update(kw)
+    return d
+
+
+def test_item_accepts_decision_bucket_and_citations():
+    import uuid
+    su = uuid.uuid4()
+    du = uuid.uuid4()
+    item = IngestReportItem(**_base(symbol="AAA", side="buy",
+        decision_bucket="new_buy_candidate",
+        cited_symbol_report_uuid=su, cited_dimension_report_uuids=[du]))
+    assert item.decision_bucket == "new_buy_candidate"
+    assert item.cited_symbol_report_uuid == su
+    assert item.cited_dimension_report_uuids == [du]
+
+
+def test_item_rejects_unknown_decision_bucket():
+    with pytest.raises(ValidationError):
+        IngestReportItem(**_base(decision_bucket="macro_call"))
+
+
+def test_item_decision_bucket_optional():
+    item = IngestReportItem(**_base())
+    assert item.decision_bucket is None
+    assert item.cited_dimension_report_uuids == []
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: `ValidationError` (extra field not permitted) / field missing.
+
+- [ ] **Step 3: Implement** — in `app/schemas/investment_reports.py`, add the import + fields to `IngestReportItem` (after `apply_policy`, ~line 158):
+
+```python
+from app.models.investment_symbol_intermediate_reports import DECISION_BUCKETS
+```
+
+```python
+    # ROB-308 — final-item classification (held action vs new candidate) +
+    # per-item source citations. All optional; legacy items omit them.
+    decision_bucket: str | None = None
+    cited_symbol_report_uuid: uuid.UUID | None = None
+    cited_dimension_report_uuids: list[uuid.UUID] = Field(default_factory=list)
+
+    @field_validator("decision_bucket")
+    @classmethod
+    def _decision_bucket_in_vocab(cls, v: str | None) -> str | None:
+        if v is not None and v not in DECISION_BUCKETS:
+            raise ValueError(f"decision_bucket={v!r} not in {DECISION_BUCKETS!r}")
+        return v
+```
+
+Ensure `uuid` and `field_validator` are imported at the top of the file (add if missing).
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS (3 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/investment_reports.py tests/test_investment_reports_schemas.py
+git commit -m "feat(rob-308): IngestReportItem decision_bucket + report citations
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: `InvestmentReportItem` model columns + migration
+
+**Files:**
+- Modify: `app/models/investment_reports.py` (`InvestmentReportItem`, after `apply_policy` ~line 341)
+- Create: `alembic/versions/<rev>_rob308_report_item_classification.py`
+- Test: `tests/test_investment_reports_model.py` (append; confirm via grep)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_report_item_has_classification_columns():
+    from app.models.investment_reports import InvestmentReportItem
+    cols = InvestmentReportItem.__table__.c
+    assert "decision_bucket" in cols and cols["decision_bucket"].nullable is True
+    assert "cited_symbol_report_uuid" in cols
+    assert "cited_dimension_report_uuids" in cols
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: KeyError / assertion fail.
+
+- [ ] **Step 3: Implement** — add columns to `InvestmentReportItem` (import `ARRAY` + `PG_UUID` + `CheckConstraint` + `DECISION_BUCKETS` if not present):
+
+```python
+    decision_bucket: Mapped[str | None] = mapped_column(Text, nullable=True)
+    cited_symbol_report_uuid: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=True
+    )
+    cited_dimension_report_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)), nullable=False, server_default=text("ARRAY[]::uuid[]")
+    )
+```
+
+Add a CHECK to `InvestmentReportItem.__table_args__` (build the IN-list from `DECISION_BUCKETS`, mirroring the dimension model's `_sql_in`):
+
+```python
+        CheckConstraint(
+            "decision_bucket IS NULL OR decision_bucket IN "
+            "('new_buy_candidate','open_action','completed_or_existing',"
+            "'deferred_no_action','risk_watch')",
+            name="ck_investment_report_items_decision_bucket",
+        ),
+```
+
+- [ ] **Step 4: Run model test** — `uv run pytest tests/test_investment_reports_model.py -k classification -v` → PASS.
+
+- [ ] **Step 5: Generate + verify migration**
+
+Run: `uv run alembic revision --autogenerate -m "rob308 report item classification"`
+Open the file; confirm it ADDs the 3 columns + the CHECK to `review.investment_report_items` and downgrade drops them. Strip unrelated drift.
+Run: `uv run alembic upgrade head && uv run alembic downgrade -1 && uv run alembic upgrade head` → clean round-trip.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models/investment_reports.py alembic/versions/*rob308* tests/test_investment_reports_model.py
+git commit -m "feat(rob-308): report item classification columns + migration
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: `HermesCompositionResult.dimension_report_uuids`
+
+**Files:**
+- Modify: `app/schemas/hermes_composition.py` (`HermesCompositionResult`, after `symbol_intermediate_report_uuids` ~line 125)
+- Test: `tests/test_hermes_composition_schema.py` (append; confirm via grep `grep -rl HermesCompositionResult tests/`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_composition_accepts_dimension_report_uuids():
+    import uuid
+    from app.schemas.hermes_composition import HermesCompositionResult
+    c = HermesCompositionResult(
+        snapshot_bundle_uuid=uuid.uuid4(), hermes_run_id="h1",
+        title="t", summary="s", dimension_report_uuids=[uuid.uuid4()],
+    )
+    assert len(c.dimension_report_uuids) == 1
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: extra-field ValidationError.
+
+- [ ] **Step 3: Implement** — add to `HermesCompositionResult`:
+
+```python
+    # ROB-308: dimension reports (ROB-306) this composition consumed. Empty for
+    # legacy composition. Validated for existence + run membership on ingest.
+    dimension_report_uuids: list[uuid.UUID] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/hermes_composition.py tests/test_hermes_composition_schema.py
+git commit -m "feat(rob-308): composition dimension_report_uuids field
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: Composition ingest — validate dimension refs + persist item fields
+
+**Files:**
+- Modify: `app/services/investment_stages/hermes_ingest.py` (mirror `_validate_symbol_report_refs` at line 401; inject `DimensionReportRepository`)
+- Modify: `app/services/investment_reports/ingestion.py` (`_insert_item` ~line 106-140 — map the 3 new IngestReportItem fields into `insert_item`)
+- Test: `tests/test_hermes_ingest_dimension_refs.py` + extend an item-persistence test
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# A) ingest validates dimension_report_uuids run membership
+#    (mirror the existing symbol-ref validation test: seed run + dimension report,
+#     happy path stores them in report_metadata["dimension_report_uuids"];
+#     unknown UUID -> ingest error).
+# B) item persistence carries the new fields:
+#    ingest a composition with one item {decision_bucket:"new_buy_candidate",
+#    cited_symbol_report_uuid: <uuid>, cited_dimension_report_uuids:[<uuid>]},
+#    then read the persisted InvestmentReportItem and assert the 3 fields.
+```
+Write both concretely by copying the existing symbol-ref ingest test harness (`grep -rl "_validate_symbol_report_refs\|symbol_intermediate_report_uuids" tests/`) and the item-persistence test, swapping in the dimension fields.
+
+- [ ] **Step 2: Run to verify they fail** — Expected: dimension refs not validated/stored; item fields not persisted.
+
+- [ ] **Step 3a: Implement dimension-ref validation** — in `hermes_ingest.py`, add a `DimensionReportRepository` to `__init__` (mirror `self._symbol_reports`), add `_validate_dimension_report_refs` mirroring `_validate_symbol_report_refs` (uses `get_by_uuids`, checks run membership via `run_uuid`), and in the ingest flow (after the symbol-ref block ~line 365-370):
+
+```python
+        dimension_report_refs = await self._validate_dimension_report_refs(
+            composition.dimension_report_uuids, run_uuid=stage_run_uuid
+        )
+        if dimension_report_refs:
+            metadata["dimension_report_uuids"] = dimension_report_refs
+```
+
+`_validate_dimension_report_refs` (mirror the symbol version, lines 401-431):
+
+```python
+    async def _validate_dimension_report_refs(
+        self, dimension_report_uuids: list[uuid.UUID], *, run_uuid: uuid.UUID | None
+    ) -> list[str]:
+        if not dimension_report_uuids:
+            return []
+        found = await self._dimension_reports.get_by_uuids(list(dimension_report_uuids))
+        found_by_uuid = {r.dimension_report_uuid: r for r in found}
+        missing = [str(u) for u in dimension_report_uuids if u not in found_by_uuid]
+        if missing:
+            raise HermesIngestError(  # use the same error type the symbol path raises
+                f"dimension reports not found: {missing}",
+                code="dimension_report_not_found",
+            )
+        if run_uuid is not None:
+            wrong = [
+                str(u) for u, r in found_by_uuid.items() if r.run_uuid != run_uuid
+            ]
+            if wrong:
+                raise HermesIngestError(
+                    f"dimension reports not in run {run_uuid}: {wrong}",
+                    code="dimension_report_run_mismatch",
+                )
+        return [str(u) for u in dimension_report_uuids]
+```
+(Match the exact error class + constructor signature used by `_validate_symbol_report_refs` — read lines 401-431 first.)
+
+- [ ] **Step 3b: Implement item field mapping** — in `app/services/investment_reports/ingestion.py` `_insert_item` (~line 134), add to the `insert_item(...)` kwargs:
+
+```python
+            decision_bucket=item_req.decision_bucket,
+            cited_symbol_report_uuid=item_req.cited_symbol_report_uuid,
+            cited_dimension_report_uuids=list(item_req.cited_dimension_report_uuids),
+```
+
+- [ ] **Step 4: Run to verify tests pass** — Expected: PASS (both A + B).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/hermes_ingest.py app/services/investment_reports/ingestion.py tests/test_hermes_ingest_dimension_refs.py
+git commit -m "feat(rob-308): ingest validates dimension refs + persists item classification
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: Read view-model — group held-action vs new-candidate
+
+**Files:**
+- Modify: the final-report bundle view-model behind `GET /trading/api/investment-reports/{report_uuid}` (`app/routers/investment_reports.py:169` → `service.get_bundle`). Locate the bundle assembler (`grep -rn "def get_bundle" app/services/`) and the item serialization.
+- Test: extend the existing report-bundle router/service test (`grep -rl "get_bundle\|investment-reports/{report_uuid}\|report_bundle" tests/`)
+
+- [ ] **Step 1: Write the failing test** — ingest a report with two items (`decision_bucket="new_buy_candidate"` and `="open_action"`), GET the bundle, assert the response exposes a grouping, e.g. `bundle["item_groups"]["new_buy_candidate"]` and `["open_action"]` each containing the right symbol, plus each item echoes `decision_bucket` + `cited_symbol_report_uuid` + `cited_dimension_report_uuids`.
+
+- [ ] **Step 2: Run to verify it fails** — Expected: KeyError (no grouping / fields absent).
+
+- [ ] **Step 3: Implement** — in the bundle assembler: (a) include `decision_bucket`, `cited_symbol_report_uuid`, `cited_dimension_report_uuids` in each serialized item; (b) add an `item_groups: dict[str, list]` keyed by `decision_bucket` (items with null bucket go under `"unclassified"`). Korean labels for the UI live in the frontend; the API returns the bucket keys + a `held_action`/`new_candidate` rollup:
+
+```python
+        _HELD_BUCKETS = {"open_action", "risk_watch", "completed_or_existing"}
+        item_groups: dict[str, list] = {}
+        for it in serialized_items:
+            item_groups.setdefault(it["decision_bucket"] or "unclassified", []).append(it)
+        rollup = {
+            "new_candidate": [i for i in serialized_items
+                              if i["decision_bucket"] == "new_buy_candidate"],
+            "held_action": [i for i in serialized_items
+                            if i["decision_bucket"] in _HELD_BUCKETS],
+        }
+```
+Attach `item_groups` + `decision_rollup=rollup` to the bundle response.
+
+- [ ] **Step 4: Run to verify it passes** — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/ app/routers/investment_reports.py tests/
+git commit -m "feat(rob-308): final-report bundle groups held-action vs new-candidate (C5)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 8: PR2 verification
+
+- [ ] **Step 1:** `uv run pytest -k "investment_report or hermes or dimension" -v` → all pass.
+- [ ] **Step 2:** ROB-287 import guard pass; `make lint` clean.
+- [ ] **Step 3:** Legacy-parity check — `uv run pytest -k "composition" -q` confirms a composition WITHOUT the new fields still ingests (empty lists / null bucket).
+- [ ] **Step 4:** broad regression `uv run pytest tests/ -k "investment or hermes or screener" -q` → green.
+- [ ] **Step 5:** Open PR2. Handoff comment (ROB-308 AC): branches, PR URLs, tests, migration (operator-applied), config flag, advisory-only confirmation, what's operator-gated (real Hermes synthesis round-trip).
+
+---
+
+## Self-Review (against spec)
+
+**Spec coverage:**
+- C1 context export (dimension + symbol summaries) → Tasks 1–2. ✓
+- C2 composition contract (`dimension_report_uuids` + item fields) → Tasks 3 (item schema) + 5 (composition). ✓
+- C3 item model + migration → Task 4. ✓
+- C4 ingest validation + persistence → Task 6 (dimension-ref validation + item field mapping). ✓
+- C5 read grouping → Task 7. ✓
+- Boundaries: no in-process LLM (Task 8 guard); advisory-only (composition validator unchanged, Task 6 doesn't touch it); additive contract (all new fields optional, Task 8 legacy-parity check); migration operator-applied (Task 4). ✓
+
+**Placeholder scan:** Tasks 2/6/7 carry explicit "confirm via grep / read lines X first" verification notes against named files + line numbers (run resolution, error class, bundle assembler) — these are verification instructions, not deferred work. New schema/model/repo code is complete.
+
+**Type consistency:** `dimension_report_uuids` (Task 5) ↔ validated in Task 6. `decision_bucket`/`cited_symbol_report_uuid`/`cited_dimension_report_uuids` consistent across schema (T3), model (T4), ingest mapping (T6), read (T7). `DECISION_BUCKETS` imported from the ROB-301 model in both schema (T3) and model (T4). `list_for_run`/`get_by_uuids` defined in T1, used in T2/T6.
+```

--- a/docs/superpowers/specs/2026-05-24-invest-reports-final-synthesis-design.md
+++ b/docs/superpowers/specs/2026-05-24-invest-reports-final-synthesis-design.md
@@ -1,0 +1,90 @@
+# `/invest/reports` Final Synthesis Composer — Slice 2
+
+- **Date**: 2026-05-24
+- **Status**: Design approved, pending spec review
+- **Branch**: `rob-308`
+- **Linear**: [ROB-308](https://linear.app/mgh3326/issue/ROB-308) (parent direction: ROB-306)
+
+## Context
+
+Slice 2 of the TradingAgents-style `/invest/reports` program. What already exists:
+- **Market dimension report** (`investment_dimension_reports`, ROB-306).
+- **Per-symbol intermediate reports** (`investment_symbol_intermediate_reports`, `decision_bucket`/`verdict`, ROB-301).
+- **Final report machinery** (ROB-287): Hermes pushes `HermesCompositionResult` (title/summary/risk_summary/thesis_text/no_action_note + items) → `HermesCompositionIngestService` → `review.investment_reports` + `investment_report_items`. Items already carry `side` (buy/sell) + `intent` + `apply_policy="requires_user_approval"` (advisory-only). Composition already cites `symbol_intermediate_report_uuids`.
+
+So buy/sell is *expressible* today — but the synthesis loop is **not closed**:
+
+1. The Hermes **context export** (`HermesContextPayload`) does **not** include the persisted dimension/symbol reports — only raw stage artifacts + a lightweight `dimension_evidence.market` dict. Hermes cannot synthesize the final report *from* the analyst reports it authored.
+2. Composition cannot cite **dimension reports** (`symbol_intermediate_report_uuids` exists; no dimension equivalent).
+3. Items have **no explicit "held action vs new buy candidate" classification** — both use `intent=buy_review`. The target output ("매수/매도 + 신규 후보") needs them distinguished.
+
+## Goal
+
+Close the loop: Hermes synthesizes the final report **from** the dimension + symbol intermediate reports; the composition cites the dimension reports; final items explicitly classify held-action vs new-candidate with per-item source citations.
+
+## Decisions locked (with the user)
+
+- Reuse the **5-value `decision_bucket`** vocabulary (ROB-301 — `new_buy_candidate`/`open_action`/`completed_or_existing`/`deferred_no_action`/`risk_watch`) on final items. `new_buy_candidate` = 신규 후보; `open_action`/`risk_watch` = 보유 액션. **No new vocab.**
+- **First-class item fields** (not metadata stash) — clean-cut, no backward compat.
+- Hermes authors the composition (push); auto_trader validates + persists. **No in-process LLM** (ROB-287). Items stay **advisory-only**.
+- ROB-287 composition contract is extended **additively** only.
+
+## Architecture / scope
+
+### C1. Context export — feed the analyst reports to Hermes
+Extend `HermesContextPayload` (`app/schemas/hermes_composition.py`) + the exporter (`app/services/investment_stages/hermes_context.py`):
+- `dimension_reports: list[DimensionReportSummary]` — read `investment_dimension_reports` by `run_uuid` (dimension, market, symbol, stance, confidence, key_findings, report_text, dimension_report_uuid).
+- `symbol_intermediate_reports: list[SymbolReportSummary]` — read `investment_symbol_intermediate_reports` by `run_uuid` (symbol, decision_bucket, verdict, confidence, summary, symbol_report_uuid).
+
+Read-only reads in the exporter. This is the loop-closer: Hermes now synthesizes from its own analyst reports, not just raw stage artifacts.
+
+### C2. Composition contract — citations + item classification
+`HermesCompositionResult`:
+- add `dimension_report_uuids: list[UUID] = []` (report-level; validated on ingest like `symbol_intermediate_report_uuids`).
+
+`IngestReportItem` (`app/schemas/investment_reports.py`):
+- `decision_bucket: str | None` — validated against the ROB-301 `DECISION_BUCKETS` tuple (single source of truth).
+- `cited_symbol_report_uuid: UUID | None`.
+- `cited_dimension_report_uuids: list[UUID] = []`.
+
+### C3. Item model + migration
+`investment_report_items` (`app/models/investment_reports.py`): additive columns `decision_bucket` (Text, nullable, CHECK from `DECISION_BUCKETS`), `cited_symbol_report_uuid` (UUID nullable), `cited_dimension_report_uuids` (UUID[] default `{}`). One alembic migration, **operator-applied** (`alembic upgrade head`).
+
+### C4. Composition ingest
+`HermesCompositionIngestService`: validate `dimension_report_uuids` existence + run membership (mirror the existing symbol-report-UUID validation); persist the new item fields. Advisory-only invariants (`requires_user_approval`, `operation=review`, no broker mutation) unchanged. Store `dimension_report_uuids` in `report_metadata.hermes_composition`.
+
+### C5. Read exposure (minimal)
+Final-report view-model groups items by `decision_bucket` → **"매수/매도 (보유 액션)"** vs **"신규 매수 후보"**, with cited-report links (symbol/dimension). Heavy UI deferred. (Locate the existing final-report read surface during planning; extend its view-model.)
+
+## Non-goals / boundaries
+
+- No in-process LLM (ROB-287 import guard must pass). No broker/order/watch/order-intent mutation; items remain advisory-only.
+- No deterministic candidate ranking in this slice (considered + deferred — auto_trader could rank candidates by screener score later).
+- ROB-287 composition contract extended additively only (existing fields/behavior unchanged; legacy compositions with empty new lists still validate).
+
+## Migration
+
+One additive migration on `investment_report_items`. Ships in PR, operator runs `alembic upgrade head` separately (production cutover gate).
+
+## Testing strategy
+
+- Context export: seed a run with a dimension report + symbol reports → assert `HermesContextPayload` carries both summary lists.
+- Composition schema: `dimension_report_uuids` accepted; item `decision_bucket` validated against the tuple; `extra="forbid"` holds.
+- Ingest: `dimension_report_uuids` existence + run-membership validation (404/409 on bad refs); item classification + citations persisted; advisory-only invariants intact.
+- Read: items grouped held-action vs new-candidate with citations.
+- Guards: ROB-287 no-internal-LLM import guard passes; no broker mutation reachable; legacy composition (no new fields) still ingests.
+
+## PR split
+
+- **PR1** — C1 context export (additive; feeds Hermes the analyst reports). Shippable alone.
+- **PR2** — C2/C3/C4 contract + item model + migration + ingest, + C5 read grouping.
+
+## Assumptions to verify during implementation
+
+- The `DECISION_BUCKETS` tuple in `app/models/investment_symbol_intermediate_reports.py` is importable into the item model + schema without a cycle (it is a plain tuple).
+- The existing composition-ingest UUID-validation helper (symbol reports) can be generalized/mirrored for dimension reports.
+- The final-report read surface exists (router + view-model) and can be extended for grouping; if none renders items today, add a minimal grouped view.
+
+## Program order
+
+Parent: ROB-306. This = slice 2. Next: News dimension (research_reports ingestion), Fundamentals, Sentiment, crypto Market evidence (after ROB-282).

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -136,6 +136,22 @@ async def session() -> AsyncSession:
                         "ADD COLUMN IF NOT EXISTS diff JSONB",
                         "ALTER TABLE review.investment_report_items "
                         "ADD COLUMN IF NOT EXISTS apply_policy TEXT",
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD COLUMN IF NOT EXISTS decision_bucket TEXT",
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD COLUMN IF NOT EXISTS cited_symbol_report_uuid UUID",
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD COLUMN IF NOT EXISTS cited_dimension_report_uuids UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
+                        "ALTER TABLE review.investment_report_items "
+                        "DROP CONSTRAINT IF EXISTS ck_investment_report_items_ck_investment_report_items_decision_bucket",
+                        "ALTER TABLE review.investment_report_items "
+                        "DROP CONSTRAINT IF EXISTS ck_investment_report_items_decision_bucket",
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD CONSTRAINT ck_investment_report_items_decision_bucket "
+                        "CHECK ("
+                        "decision_bucket IS NULL OR decision_bucket IN ("
+                        "'new_buy_candidate','open_action','completed_or_existing','deferred_no_action','risk_watch'"
+                        "))",
                         "CREATE INDEX IF NOT EXISTS "
                         "ix_investment_report_items_operation_kind "
                         "ON review.investment_report_items "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -555,10 +555,37 @@ async def db_session():
                     "ADD COLUMN IF NOT EXISTS proposed_state JSONB",
                     "ADD COLUMN IF NOT EXISTS diff JSONB",
                     "ADD COLUMN IF NOT EXISTS apply_policy TEXT",
+                    "ADD COLUMN IF NOT EXISTS decision_bucket TEXT",
+                    "ADD COLUMN IF NOT EXISTS cited_symbol_report_uuid UUID",
+                    "ADD COLUMN IF NOT EXISTS cited_dimension_report_uuids UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
                 ):
                     await conn.execute(
                         text(f"ALTER TABLE review.investment_report_items {column_sql}")
                     )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_report_items "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_report_items_ck_investment_report_items_decision_bucket"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_report_items "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_report_items_decision_bucket"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD CONSTRAINT ck_investment_report_items_decision_bucket "
+                        "CHECK ("
+                        "decision_bucket IS NULL OR decision_bucket IN ("
+                        "'new_buy_candidate','open_action','completed_or_existing','deferred_no_action','risk_watch'"
+                        "))"
+                    )
+                )
                 await conn.execute(
                     text(
                         "CREATE INDEX IF NOT EXISTS "

--- a/tests/services/investment_dimensions/test_dimension_report_repository.py
+++ b/tests/services/investment_dimensions/test_dimension_report_repository.py
@@ -1,0 +1,56 @@
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.models.investment_dimension_reports import InvestmentDimensionReport
+from app.models.investment_stages import InvestmentStageRun
+from app.services.investment_dimensions.dimension_report_repository import (
+    DimensionReportRepository,
+)
+
+
+async def _seed_run(db_session) -> InvestmentStageRun:
+    run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=uuid.uuid4(),
+        market="us",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=dt.datetime.now(tz=dt.UTC),
+    )
+    db_session.add(run)
+    await db_session.commit()
+    return run
+
+
+async def _add(db_session, run_uuid, *, content_hash, dimension="market"):
+    row = InvestmentDimensionReport(
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=uuid.uuid4(),
+        dimension=dimension,
+        market="us",
+        symbol=None,
+        artifact_version=1,
+        report_text="x",
+        stance="bullish",
+        confidence=70,
+        content_hash=content_hash,
+        idempotency_key=f"{run_uuid}:{dimension}:us::{content_hash}",
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_for_run_and_get_by_uuids(db_session):
+    repo = DimensionReportRepository(db_session)
+    run = await _seed_run(db_session)
+    r1 = await _add(db_session, run.run_uuid, content_hash="h1")
+    listed = await repo.list_for_run(run.run_uuid)
+    assert [r.dimension_report_uuid for r in listed] == [r1.dimension_report_uuid]
+    got = await repo.get_by_uuids([r1.dimension_report_uuid, uuid.uuid4()])
+    assert [r.dimension_report_uuid for r in got] == [r1.dimension_report_uuid]

--- a/tests/services/investment_stages/test_hermes_context_reports.py
+++ b/tests/services/investment_stages/test_hermes_context_reports.py
@@ -1,0 +1,92 @@
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.models.investment_dimension_reports import InvestmentDimensionReport
+from app.models.investment_snapshots import InvestmentSnapshotBundle
+from app.models.investment_stages import InvestmentStageRun
+from app.models.investment_symbol_intermediate_reports import (
+    InvestmentSymbolIntermediateReport,
+)
+from app.services.investment_stages.hermes_context import HermesContextExporter
+
+
+@pytest.mark.asyncio
+async def test_exporter_includes_dimension_and_symbol_reports(db_session) -> None:
+    # 1. Seed bundle
+    bundle = InvestmentSnapshotBundle(
+        bundle_uuid=uuid.uuid4(),
+        purpose="report_generation",
+        market="us",
+        account_scope=None,
+        policy_version="intraday_action_report_v1",
+        as_of=dt.datetime.now(tz=dt.UTC),
+        status="complete",
+        coverage_summary={},
+        freshness_summary={},
+        idempotency_key=str(uuid.uuid4()),
+    )
+    db_session.add(bundle)
+    await db_session.commit()
+
+    # 2. Seed Stage Run
+    run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="us",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=dt.datetime.now(tz=dt.UTC),
+    )
+    db_session.add(run)
+    await db_session.commit()
+
+    # 3. Seed one Dimension Report
+    d_report = InvestmentDimensionReport(
+        run_uuid=run.run_uuid,
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        dimension="market",
+        market="us",
+        symbol=None,
+        artifact_version=1,
+        stance="bullish",
+        confidence=80,
+        report_text="Market is extremely strong.",
+        key_findings=["Breadth is strong"],
+        content_hash="h1",
+        idempotency_key=f"{run.run_uuid}:market:us::h1",
+    )
+    db_session.add(d_report)
+
+    # 4. Seed one Symbol Intermediate Report
+    s_report = InvestmentSymbolIntermediateReport(
+        run_uuid=run.run_uuid,
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="us",
+        symbol="005930",
+        decision_bucket="new_buy_candidate",
+        verdict="buy",
+        confidence=90,
+        summary="Extremely positive signals",
+        content_hash="h2",
+        idempotency_key=f"{run.run_uuid}:005930:final_report_symbol:h2",
+    )
+    db_session.add(s_report)
+    await db_session.commit()
+
+    # 5. Export context
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    # 6. Assert
+    assert any(d["dimension"] == "market" for d in payload.dimension_reports)
+    assert payload.dimension_reports[0]["stance"] == "bullish"
+    assert payload.dimension_reports[0]["report_text"] == "Market is extremely strong."
+
+    assert any(s["symbol"] == "005930" for s in payload.symbol_intermediate_reports)
+    assert (
+        payload.symbol_intermediate_reports[0]["decision_bucket"] == "new_buy_candidate"
+    )

--- a/tests/services/investment_stages/test_hermes_ingest.py
+++ b/tests/services/investment_stages/test_hermes_ingest.py
@@ -173,3 +173,16 @@ def test_composition_accepts_no_items_partial_data_case() -> None:
     comp = _make_composition(bundle_uuid=bundle_uuid, items=[])
     assert comp.items == []
     assert comp.snapshot_bundle_uuid == bundle_uuid
+
+
+def test_composition_accepts_dimension_report_uuids():
+    bundle_uuid = uuid.uuid4()
+    du = uuid.uuid4()
+    c = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle_uuid,
+        hermes_run_id="h1",
+        title="t",
+        summary="s",
+        dimension_report_uuids=[du],
+    )
+    assert c.dimension_report_uuids == [du]

--- a/tests/test_hermes_ingest_dimension_refs.py
+++ b/tests/test_hermes_ingest_dimension_refs.py
@@ -1,0 +1,156 @@
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.hermes_composition import (
+    HermesCompositionIngestRequest,
+    HermesCompositionResult,
+)
+from app.schemas.investment_reports import IngestReportItem
+from app.services.investment_stages.hermes_ingest import (
+    HermesCompositionIngestError,
+    HermesCompositionIngestService,
+)
+
+
+def _item(**kwargs) -> IngestReportItem:
+    base = {
+        "client_item_key": "auto-buy-BTC",
+        "item_kind": "action",
+        "operation": "review",
+        "symbol": "BTC",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "hermes rationale",
+        "apply_policy": "requires_user_approval",
+    }
+    base.update(kwargs)
+    return IngestReportItem(**base)
+
+
+def _composition(
+    bundle_uuid, *, dimension_refs=None, run_uuid=None, items=None
+) -> HermesCompositionResult:
+    metadata = {}
+    if run_uuid is not None:
+        metadata["investment_stage_run_uuid"] = str(run_uuid)
+    return HermesCompositionResult(
+        snapshot_bundle_uuid=bundle_uuid,
+        hermes_run_id="hermes-run-1",
+        title="Hermes Advisory",
+        summary="Synthesized via Hermes",
+        items=items or [_item()],
+        metadata=metadata,
+        dimension_report_uuids=dimension_refs or [],
+    )
+
+
+def _request(composition) -> HermesCompositionIngestRequest:
+    return HermesCompositionIngestRequest(
+        composition=composition,
+        kst_date="2026-05-23",
+        market="crypto",
+        account_scope="upbit_live",
+        status="draft",
+    )
+
+
+def _bundle(bundle_uuid) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        bundle_uuid=bundle_uuid,
+        coverage_summary={"news": {"status": "fresh"}},
+        freshness_summary={"overall": "fresh"},
+        status="complete",
+        market="crypto",
+        account_scope="upbit_live",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+def _service(bundle_uuid, *, dimension_rows=None):
+    snapshots = AsyncMock()
+    snapshots.get_bundle_by_uuid.return_value = _bundle(bundle_uuid)
+    ingestion = AsyncMock()
+    ingestion.ingest.return_value = SimpleNamespace(report_uuid=uuid.uuid4())
+    dimension_repo = AsyncMock()
+    dimension_repo.get_by_uuids.return_value = dimension_rows or []
+    svc = HermesCompositionIngestService(
+        session=AsyncMock(),
+        ingestion_service=ingestion,
+        snapshots_repository=snapshots,
+    )
+    # inject mock dimension repo
+    svc._dimension_reports = dimension_repo
+    return svc, ingestion
+
+
+@pytest.mark.asyncio
+async def test_regression_legacy_composition_has_no_dimension_ref_key():
+    bundle_uuid = uuid.uuid4()
+    svc, ingestion = _service(bundle_uuid)
+    await svc.ingest_composition(_request(_composition(bundle_uuid)))
+    call = ingestion.ingest.call_args.args[0]
+    assert "dimension_report_uuids" not in call.metadata
+
+
+@pytest.mark.asyncio
+async def test_happy_attaches_validated_dimension_refs():
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    ref = uuid.uuid4()
+    rows = [SimpleNamespace(dimension_report_uuid=ref, run_uuid=run_uuid)]
+    svc, ingestion = _service(bundle_uuid, dimension_rows=rows)
+    comp = _composition(bundle_uuid, dimension_refs=[ref], run_uuid=run_uuid)
+    await svc.ingest_composition(_request(comp))
+    call = ingestion.ingest.call_args.args[0]
+    assert call.metadata["dimension_report_uuids"] == [str(ref)]
+
+
+@pytest.mark.asyncio
+async def test_missing_dimension_ref_rejected():
+    bundle_uuid = uuid.uuid4()
+    ref = uuid.uuid4()
+    svc, _ = _service(bundle_uuid, dimension_rows=[])
+    comp = _composition(bundle_uuid, dimension_refs=[ref])
+    with pytest.raises(
+        HermesCompositionIngestError, match="dimension reports not found"
+    ):
+        await svc.ingest_composition(_request(comp))
+
+
+@pytest.mark.asyncio
+async def test_cross_run_dimension_ref_rejected():
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    other_run = uuid.uuid4()
+    ref = uuid.uuid4()
+    rows = [SimpleNamespace(dimension_report_uuid=ref, run_uuid=other_run)]
+    svc, _ = _service(bundle_uuid, dimension_rows=rows)
+    comp = _composition(bundle_uuid, dimension_refs=[ref], run_uuid=run_uuid)
+    with pytest.raises(
+        HermesCompositionIngestError, match="dimension reports not in run"
+    ):
+        await svc.ingest_composition(_request(comp))
+
+
+@pytest.mark.asyncio
+async def test_items_persist_classification_fields():
+    bundle_uuid = uuid.uuid4()
+    su = uuid.uuid4()
+    du = uuid.uuid4()
+    svc, ingestion = _service(bundle_uuid)
+    item = _item(
+        decision_bucket="new_buy_candidate",
+        cited_symbol_report_uuid=su,
+        cited_dimension_report_uuids=[du],
+    )
+    comp = _composition(bundle_uuid, items=[item])
+    await svc.ingest_composition(_request(comp))
+    call = ingestion.ingest.call_args.args[0]
+    assert len(call.items) == 1
+    assert call.items[0].decision_bucket == "new_buy_candidate"
+    assert call.items[0].cited_symbol_report_uuid == su
+    assert call.items[0].cited_dimension_report_uuids == [du]

--- a/tests/test_investment_reports_model.py
+++ b/tests/test_investment_reports_model.py
@@ -609,3 +609,12 @@ async def test_event_survives_alert_deletion(session: AsyncSession) -> None:
     assert event.action_mode == "notify_only"
     assert event.source_report_uuid == report.report_uuid
     assert event.source_item_uuid == item.item_uuid
+
+
+def test_report_item_has_classification_columns():
+    from app.models.investment_reports import InvestmentReportItem
+
+    cols = InvestmentReportItem.__table__.c
+    assert "decision_bucket" in cols and cols["decision_bucket"].nullable is True
+    assert "cited_symbol_report_uuid" in cols
+    assert "cited_dimension_report_uuids" in cols

--- a/tests/test_investment_reports_router.py
+++ b/tests/test_investment_reports_router.py
@@ -205,3 +205,32 @@ async def test_previous_context_with_prior_reports(session: AsyncSession) -> Non
     )
     prior_uuids = {r.report_uuid for r in response.prior_reports}
     assert prior_uuids == {r1.report_uuid, r2.report_uuid}
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_groups_items(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    req = _request(kst_date="2026-05-18")
+    # Add custom items
+    item1 = _action_item(client_item_key="item-1")
+    item1.decision_bucket = "new_buy_candidate"
+    item2 = _action_item(client_item_key="item-2")
+    item2.decision_bucket = "open_action"
+    # Clear out default items and set our custom items
+    req.items = [item1, item2]
+
+    report = await ingest.ingest(req)
+    await session.commit()
+
+    service = InvestmentReportQueryService(session)
+    bundle = await get_investment_report(
+        report_uuid=report.report_uuid, _user=_USER, service=service
+    )
+
+    assert "new_buy_candidate" in bundle.item_groups
+    assert "open_action" in bundle.item_groups
+    assert len(bundle.item_groups["new_buy_candidate"]) == 1
+    assert len(bundle.item_groups["open_action"]) == 1
+
+    assert len(bundle.decision_rollup["new_candidate"]) == 1
+    assert len(bundle.decision_rollup["held_action"]) == 1

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -230,3 +230,50 @@ def test_report_snapshot_detail_response_includes_full_payload() -> None:
     )
     assert response.role == "required"
     assert response.payload_json == {"cash_krw": 1_000_000}
+
+
+def test_item_accepts_decision_bucket_and_citations():
+    su = uuid.uuid4()
+    du = uuid.uuid4()
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="action",
+        intent="buy_review",
+        rationale="r",
+        operation="review",
+        apply_policy="requires_user_approval",
+        symbol="AAA",
+        side="buy",
+        decision_bucket="new_buy_candidate",
+        cited_symbol_report_uuid=su,
+        cited_dimension_report_uuids=[du],
+    )
+    assert item.decision_bucket == "new_buy_candidate"
+    assert item.cited_symbol_report_uuid == su
+    assert item.cited_dimension_report_uuids == [du]
+
+
+def test_item_rejects_unknown_decision_bucket():
+    with pytest.raises(ValidationError):
+        IngestReportItem(
+            client_item_key="k1",
+            item_kind="action",
+            intent="buy_review",
+            rationale="r",
+            operation="review",
+            apply_policy="requires_user_approval",
+            decision_bucket="macro_call",
+        )
+
+
+def test_item_decision_bucket_optional():
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="action",
+        intent="buy_review",
+        rationale="r",
+        operation="review",
+        apply_policy="requires_user_approval",
+    )
+    assert item.decision_bucket is None
+    assert item.cited_dimension_report_uuids == []


### PR DESCRIPTION
## What & why

Slice 2 of the TradingAgents-style `/invest/reports` program (parent: ROB-306, which shipped the Market dimension report). Closes the **synthesis loop**: Hermes now composes the final report *from* the per-dimension + per-symbol analyst reports it authored, and final items explicitly split "신규 매수 후보" vs "보유 액션" with source citations.

Before this, the final-report machinery (ROB-287) existed but Hermes only received raw stage artifacts in context — it couldn't synthesize from the dimension/symbol reports, couldn't cite dimension reports, and items had no held-vs-candidate classification.

Spec: `docs/superpowers/specs/2026-05-24-invest-reports-final-synthesis-design.md`
Plan: `docs/superpowers/plans/2026-05-24-rob-308-final-synthesis.md`
Linear: ROB-308

## Changes (additive to the ROB-287 contract)

- **C1 — Context export**: `HermesContextPayload` carries `dimension_reports` (ROB-306) + `symbol_intermediate_reports` (ROB-301) summaries for the run (`DimensionReportRepository.list_for_run`/`get_by_uuids`). Hermes synthesizes from its own analyst reports, not just raw stage artifacts.
- **C2 — Composition contract**: `HermesCompositionResult.dimension_report_uuids` (validated for existence + run membership on ingest). `IngestReportItem` gains `decision_bucket` (ROB-301 5-value reuse), `cited_symbol_report_uuid`, `cited_dimension_report_uuids`.
- **C3 — Item model + migration**: additive columns on `investment_report_items` (+ CHECK, matching the table's existing constraint-naming convention). Operator-applied migration.
- **C4 — Ingest**: validates dimension refs, persists item classification + citations. Advisory-only invariants unchanged.
- **C5 — Read**: final-report bundle groups items held-action vs new-candidate with citations.

## Safety boundaries

- **No in-process LLM** — Hermes authors composition (push); auto_trader validates + persists. ROB-287 import guard passes.
- **Advisory-only** — items keep `operation=review` + `requires_user_approval`; the composition validator is unchanged. No broker/order/watch mutation.
- **Additive** — all new fields optional; legacy compositions (empty lists / null bucket) still ingest.
- One additive migration on `investment_report_items` (operator runs `alembic upgrade head`).

## Tests

- Dimension repo `list_for_run`/`get_by_uuids`, context export carries both report lists, item schema classification + citations, item model columns, composition `dimension_report_uuids`, ingest dimension-ref validation + item persistence, bundle grouping.
- ROB-308 surface: **64 passed**. Broad regression (`investment`/`hermes`/`report`/`screener`/`dimension`): **1525 passed, 4 skipped**. ROB-287 no-internal-LLM guard green. `ruff`/`ty` clean.

## Deferred (program order)

Next: News dimension (research_reports ingestion), Fundamentals, Sentiment, crypto Market evidence (after ROB-282). Deterministic candidate ranking considered + deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)