### PR TITLE
feat(rob-309): Hermes round-trip smoke exercises the full current contract (ROB-306/308 validation)

### DIFF
--- a/docs/runbooks/hermes-report-generation.md
+++ b/docs/runbooks/hermes-report-generation.md
@@ -166,36 +166,63 @@ Optional flags:
 
 ### 7.3 Steps the CLI drives
 
-The CLI loads Hermes-shaped payloads from `tests/fixtures/hermes/*.json` and substitutes the two placeholder UUIDs (`{{run_uuid}}`, `{{snapshot_bundle_uuid}}`) at runtime:
+The CLI loads Hermes-shaped payloads from `tests/fixtures/hermes/*.json` and substitutes the placeholder UUIDs (`{{run_uuid}}`, `{{snapshot_bundle_uuid}}` always; `{{symbol_report_uuid}}` / `{{dimension_report_uuid}}` are filled in from the symbol-/dimension-reports responses before the composition POST). As of ROB-309 a single run exercises the **full current contract** — ROB-287 baseline + ROB-301 symbol-reports + ROB-306 dimension-reports + ROB-308 final-synthesis fields:
 
-1. `POST /trading/api/investment-reports/hermes/context` — returns `HermesContextPayload` (5 deterministic stages render; missing snapshots surface as UNAVAILABLE without aborting).
+1. `POST /trading/api/investment-reports/hermes/context` — returns `HermesContextPayload` (5 deterministic stages render; missing snapshots surface as UNAVAILABLE without aborting). On this first pull `dimension_reports` / `symbol_intermediate_reports` are empty.
 2. `POST /trading/api/investment-reports/hermes/stage-artifacts` — append-only ingest of 5 stage artifacts under one `run_uuid`. Re-running the same CLI invocation returns 200 OK with `idempotent_existing=true` on every artifact.
-3. `POST /trading/api/investment-reports/hermes/composition` — final composition + auto-finalize the stage run. The Investment­Report row lands with `metadata.hermes_composition.hermes_run_id="hermes-smoke-001"`.
+3. `POST /trading/api/investment-reports/hermes/symbol-reports` (ROB-301) — per-symbol reductions for the same `run_uuid`. The CLI captures the first returned `symbol_report_uuid`.
+4. `POST /trading/api/investment-reports/hermes/dimension-reports` (ROB-306) — per-dimension analyst reports for the same `run_uuid`. The CLI captures the `market` dimension's `dimension_report_uuid`.
+5. `POST /trading/api/investment-reports/hermes/context` (re-pull) — the CLI asserts the response now carries **non-empty** `dimension_reports` and `symbol_intermediate_reports`, confirming the run linkage surfaces back to Hermes.
+6. `POST /trading/api/investment-reports/hermes/composition` (ROB-308) — final composition + auto-finalize the stage run. The payload threads `symbol_intermediate_report_uuids` + `dimension_report_uuids` (validated for existence + run membership) and includes one `decision_bucket="new_buy_candidate"` item with `cited_symbol_report_uuid` / `cited_dimension_report_uuids`. The Investment­Report row lands with `metadata.hermes_composition.hermes_run_id="hermes-smoke-001"` plus `metadata.symbol_intermediate_report_uuids` / `metadata.dimension_report_uuids`.
+7. `GET /trading/api/investment-reports/runs/{run_uuid}/dimension-reports?dimension=market` — read surface; the CLI asserts the market dimension report renders (stance `bullish`). **Session-authed** (see §7.4 note).
+8. `GET /trading/api/investment-reports/{report_uuid}` — final report bundle; the CLI asserts `decision_rollup.new_candidate` is non-empty and `item_groups` carries the `new_buy_candidate` group alongside the held/unclassified items (ROB-308 C5 held-action vs new-candidate split). **Session-authed.**
 
 ### 7.4 Expected output
+
+The two GET read surfaces (steps 7–8) are authenticated by the **operator session cookie**, NOT the Hermes ingest token (only the five `…/hermes/*` POSTs use the token). Supply the cookie via `--session-cookie "<cookie>"` or `HERMES_SMOKE_SESSION_COOKIE`. When the cookie is omitted the CLI runs the ingest chain (steps 1–6), logs a warning, and exits 0 without the read-surface assertions — verify the grouping manually in that case (see §7.4 note below).
 
 ```
 ... INFO base_url: https://<host>
 ... INFO bundle_uuid: <uuid>
 ... INFO run_uuid: <uuid>
-... INFO --- step 1/3: context export ---
-... INFO POST .../context → 200  (keys: bundle_status, constraints, ...)
-... INFO --- step 2/3: stage-artifacts ingest ---
+... INFO read-surface GETs: enabled (session cookie supplied)
+... INFO --- step 1/8: context export ---
+... INFO POST .../context → 200  (keys: bundle_status, constraints, dimension_reports, ...)
+... INFO --- step 2/8: stage-artifacts ingest ---
 ... INFO POST .../stage-artifacts → 200  (keys: ...)
 ... INFO   artifacts: 5 (idempotent reuse: 0) run_status: running
-... INFO --- step 3/3: composition ingest ---
+... INFO --- step 3/8: symbol-reports ingest ---
+... INFO POST .../symbol-reports → 200  (keys: ...)
+... INFO   symbol_reports: 2  first symbol_report_uuid: <uuid>
+... INFO --- step 4/8: dimension-reports ingest ---
+... INFO POST .../dimension-reports → 200  (keys: ...)
+... INFO   dimension_reports: 2  market dimension_report_uuid: <uuid>
+... INFO --- step 5/8: context re-pull (carries reports) ---
+... INFO POST .../context → 200  (keys: ...)
+... INFO   context carries dimension_reports: 2  symbol_intermediate_reports: 2
+... INFO --- step 6/8: composition ingest ---
 ... INFO POST .../composition → 200  (keys: ...)
-... INFO   report_uuid: <uuid>  items: 2  status: draft
+... INFO   report_uuid: <uuid>  items: 3  status: draft
+... INFO --- step 7/8: dimension-reports read surface ---
+... INFO GET .../runs/<uuid>/dimension-reports?dimension=market → 200  (keys: ...)
+... INFO   read-surface market reports: 1  stance: bullish
+... INFO --- step 8/8: final report bundle grouping ---
+... INFO GET .../<report_uuid> → 200  (keys: ...)
+... INFO   decision_rollup: new_candidate=1 held_action=0  groups: new_buy_candidate, unclassified
 ... INFO --- round-trip OK ---
 ```
 
-Exit code 0 = full chain succeeded. Exit code 1 = some step returned a 4xx/5xx; stderr carries the body for triage. Re-runnable: stage-artifacts ingest is idempotent on `(run_uuid, stage_type)`, so an aborted run can be safely retried with the same `--run-uuid`.
+(The US fixture set — `--fixture-set us` — drives the same 8 steps but composes 4 items and tags `hermes-smoke-us-001`.)
+
+Exit code 0 = full chain succeeded. Exit code 1 = some step returned a 4xx/5xx (or a contract assertion failed, e.g. the context re-pull did not carry the reports, or the bundle had no `new_candidate`); stderr carries the body for triage. Re-runnable: the stage-artifacts / symbol-reports / dimension-reports ingests are content-idempotent, so an aborted run can be safely retried with the same `--run-uuid`.
+
+> **Note — verifying the new legs during the real-Hermes operator run.** After the smoke exits 0, confirm in the prod DB / read API that (a) the `investment_dimension_reports` row for the `market` dimension exists for the run (or `GET …/runs/{run_uuid}/dimension-reports?dimension=market` returns it), and (b) the final bundle's `decision_rollup` splits the items correctly — the `new_buy_candidate` item lands under `new_candidate` while held/risk/completed items land under `held_action`. If you ran without `--session-cookie`, drive those two GETs by hand with an authenticated session to close the verification.
 
 ### 7.5 Hard invariants the smoke is allowed to assume
 
 - No external LLM is called — Hermes payloads come from the JSON fixtures.
-- No broker / order / watch / order-intent mutation reachable from any endpoint the smoke hits.
-- Token is never logged or printed; only its presence/absence is surfaced via `_redact_token`.
+- No broker / order / watch / order-intent mutation reachable from any endpoint the smoke hits (the symbol-/dimension-reports and composition are advisory-only; items stay `operation ∈ {review, cancel, keep}` + `apply_policy=requires_user_approval`).
+- Token is never logged or printed; only its presence/absence is surfaced via `_redact_token`. The `--session-cookie` value is likewise never logged.
 - The CLI refuses to invent bundle UUIDs (`--bundle-uuid` is required).
 
 ### 7.6 Closing ROB-287
@@ -203,7 +230,8 @@ Exit code 0 = full chain succeeded. Exit code 1 = some step returned a 4xx/5xx; 
 Done transition is approved after:
 
 - The smoke exits 0 against the production auto_trader instance with a fresh bundle UUID,
-- The InvestmentReport row is visible in the prod DB with the expected `hermes_composition` metadata,
+- The InvestmentReport row is visible in the prod DB with the expected `hermes_composition` metadata **and** the consumed `symbol_intermediate_report_uuids` / `dimension_report_uuids`,
+- The dimension report read surface returns the `market` dimension row and the final bundle splits held-action vs new-candidate (§7.4 note),
 - The InvestmentStageRun row is `status='completed'` (auto-finalized by the composition step),
 - No anomalies in Sentry from `app/services/investment_stages/` for one trading session.
 
@@ -271,7 +299,7 @@ uv run python -m scripts.hermes_roundtrip_smoke \
 ```
 
 - `--fixture-set us` switches the CLI to the US fixtures
-  (`tests/fixtures/hermes/{stage_artifacts_request_us,composition_request_us}.json`).
+  (`tests/fixtures/hermes/{stage_artifacts_request_us,symbol_reports_request_us,dimension_reports_request_us,composition_request_us}.json`).
   These are pinned to `market="us"`, `account_scope="alpaca_paper"`,
   `status="draft"`, with example tickers `AAPL` + `MSFT`. The fixture
   lock test (`test_us_fixtures_pin_alpaca_paper_and_draft_and_us_symbols`)
@@ -281,16 +309,26 @@ uv run python -m scripts.hermes_roundtrip_smoke \
 
 ### 8.4 Expected outcome
 
-Three POSTs in order (same chain as §7.3, but on US fixtures):
+Same 8-step chain as §7.3, on the US fixtures (the read-surface GETs in
+steps 7–8 still need `--session-cookie`):
 
 1. `/context` — returns a `HermesContextPayload` with
    `market="us"`, `account_scope="alpaca_paper"`. The 5 deterministic
-   stages render even with no items in the bundle (UNAVAILABLE).
+   stages render even with no items in the bundle (UNAVAILABLE);
+   `dimension_reports` / `symbol_intermediate_reports` start empty.
 2. `/stage-artifacts` — 5 artifact rows persisted under one
    `run_uuid`, `run_status="running"`.
-3. `/composition` — returns a 200 envelope with `status="draft"`,
-   `items_count=3`. The matching `InvestmentStageRun` row is
-   auto-finalised to `status="completed"` (§D4).
+3. `/symbol-reports` — 2 per-symbol reductions (AAPL/MSFT).
+4. `/dimension-reports` — 2 per-dimension reports (market/news).
+5. `/context` (re-pull) — now carries 2 `dimension_reports` + 2
+   `symbol_intermediate_reports`.
+6. `/composition` — returns a 200 envelope with `status="draft"`,
+   `items_count=4` (the extra item is the `new_buy_candidate` on AAPL).
+   The matching `InvestmentStageRun` row is auto-finalised to
+   `status="completed"` (§D4).
+7. `/runs/{run_uuid}/dimension-reports?dimension=market` — the US
+   market dimension report renders.
+8. `/{report_uuid}` — `decision_rollup.new_candidate` is non-empty.
 
 ### 8.5 DB-level invariants the operator confirms
 
@@ -299,12 +337,17 @@ After the CLI exits 0:
 - `investment_stage_runs.status='completed'` for the run UUID the
   CLI printed.
 - 5 `investment_stage_artifacts` rows linked to that `run_uuid`.
+- 2 `investment_symbol_intermediate_reports` + 2
+  `investment_dimension_reports` rows linked to that `run_uuid`.
 - One `investment_reports` row with:
   - `snapshot_bundle_uuid` = the US bundle UUID,
   - `status='draft'` (**must not be `published`**),
   - `market='us'`,
   - `account_scope='alpaca_paper'`,
-  - `report_metadata.hermes_composition.hermes_run_id="hermes-smoke-us-001"`.
+  - `report_metadata.hermes_composition.hermes_run_id="hermes-smoke-us-001"`,
+  - `report_metadata.symbol_intermediate_report_uuids` /
+    `report_metadata.dimension_report_uuids` populated with the
+    consumed report UUIDs.
 
 If any of those fail, treat the smoke as failed and surface the
 exact mismatch on the ROB-287 ticket — do NOT attempt to publish or

--- a/scripts/hermes_roundtrip_smoke.py
+++ b/scripts/hermes_roundtrip_smoke.py
@@ -1,9 +1,24 @@
-"""ROB-287 Phase C — operator-runnable Hermes round-trip smoke CLI.
+"""ROB-287 / ROB-309 — operator-runnable Hermes round-trip smoke CLI.
 
-Drives the four Hermes HTTP endpoints in sequence against a target
-auto_trader instance and reports per-step status. Loads the same
+Drives the full current Hermes HTTP contract in sequence against a
+target auto_trader instance and reports per-step status. Loads the same
 Hermes-produced JSON fixtures the round-trip test uses, so the CLI
 contract stays in lock-step with the test contract.
+
+The chain (ROB-309 extends the ROB-287 baseline of
+context → stage-artifacts → composition):
+
+    1. POST /context           — frozen context packet
+    2. POST /stage-artifacts   — append-only stage rows (5 artifacts)
+    3. POST /symbol-reports    — per-symbol reductions (ROB-301)
+    4. POST /dimension-reports — per-dimension analyst reports (ROB-306)
+    5. POST /context (re-pull)  — assert dimension_reports +
+                                  symbol_intermediate_reports now non-empty
+    6. POST /composition       — final report; threads the captured
+                                  symbol/dimension report UUIDs (ROB-308)
+    7. GET  /runs/{run}/dimension-reports?dimension=market — read surface
+    8. GET  /investment-reports/{report} — assert held-action vs
+                                  new-candidate grouping is present
 
 Usage::
 
@@ -14,10 +29,11 @@ Usage::
 
 Exit codes::
 
-    0 — full chain succeeded (context + stage-artifacts + composition).
+    0 — full chain succeeded.
     1 — at least one step failed; stderr carries the response body for
-        diagnosis. Re-runnable: the stage-artifacts ingest is
-        idempotent so a partial run can be resumed safely.
+        diagnosis. Re-runnable: the stage-artifacts / symbol-reports /
+        dimension-reports ingests are idempotent so a partial run can be
+        resumed safely with the same ``--run-uuid``.
 
 Hard invariants:
 
@@ -57,11 +73,28 @@ def _load_fixture(name: str) -> dict[str, Any]:
 
 
 def _substitute_placeholders(
-    payload: dict[str, Any], *, run_uuid: uuid.UUID, snapshot_bundle_uuid: uuid.UUID
+    payload: dict[str, Any],
+    *,
+    run_uuid: uuid.UUID,
+    snapshot_bundle_uuid: uuid.UUID,
+    symbol_report_uuid: uuid.UUID | str | None = None,
+    dimension_report_uuid: uuid.UUID | str | None = None,
 ) -> dict[str, Any]:
+    """Substitute the placeholder UUIDs inside a fixture.
+
+    ``run_uuid`` / ``snapshot_bundle_uuid`` are always available. The
+    ``symbol_report_uuid`` / ``dimension_report_uuid`` placeholders are only
+    known after the symbol-reports / dimension-reports POSTs return their
+    server-assigned UUIDs (ROB-309), so they are substituted in a second pass
+    on the composition payload.
+    """
     raw = json.dumps(payload)
     raw = raw.replace("{{run_uuid}}", str(run_uuid))
     raw = raw.replace("{{snapshot_bundle_uuid}}", str(snapshot_bundle_uuid))
+    if symbol_report_uuid is not None:
+        raw = raw.replace("{{symbol_report_uuid}}", str(symbol_report_uuid))
+    if dimension_report_uuid is not None:
+        raw = raw.replace("{{dimension_report_uuid}}", str(dimension_report_uuid))
     return json.loads(raw)
 
 
@@ -132,6 +165,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--session-cookie",
+        default=os.environ.get("HERMES_SMOKE_SESSION_COOKIE", ""),
+        help=(
+            "Operator session cookie used for the read-surface GETs "
+            "(dimension-reports + final report bundle). Those endpoints are "
+            "session-authed (NOT the Hermes ingest token). When omitted the "
+            "CLI skips the two GET assertions and logs a warning — the ingest "
+            "chain (steps 1-6) still runs and gates exit code. Never logged."
+        ),
+    )
+    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Print full response bodies for each step.",
@@ -139,9 +183,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-_FIXTURE_BY_SET: dict[str, tuple[str, str]] = {
-    "kr": ("stage_artifacts_request.json", "composition_request.json"),
-    "us": ("stage_artifacts_request_us.json", "composition_request_us.json"),
+_FIXTURE_BY_SET: dict[str, dict[str, str]] = {
+    "kr": {
+        "stage_artifacts": "stage_artifacts_request.json",
+        "symbol_reports": "symbol_reports_request.json",
+        "dimension_reports": "dimension_reports_request.json",
+        "composition": "composition_request.json",
+    },
+    "us": {
+        "stage_artifacts": "stage_artifacts_request_us.json",
+        "symbol_reports": "symbol_reports_request_us.json",
+        "dimension_reports": "dimension_reports_request_us.json",
+        "composition": "composition_request_us.json",
+    },
 }
 
 
@@ -173,6 +227,37 @@ async def _post(
     return parsed
 
 
+async def _get(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str],
+    verbose: bool,
+) -> dict[str, Any]:
+    resp = await client.get(path, headers=headers)
+    if resp.status_code >= 400:
+        logger.error(
+            "GET %s → %s\n  body: %s",
+            path,
+            resp.status_code,
+            resp.text[:1000],
+        )
+        raise SystemExit(1)
+    parsed = resp.json()
+    if verbose:
+        logger.info(
+            "GET %s → 200\n  body: %s", path, json.dumps(parsed, indent=2)[:1500]
+        )
+    else:
+        keys = ", ".join(sorted(parsed.keys())) if isinstance(parsed, dict) else "?"
+        logger.info("GET %s → 200  (keys: %s)", path, keys)
+    return parsed
+
+
+_HERMES_PREFIX = "/trading/api/investment-reports/hermes"
+_READ_PREFIX = "/trading/api/investment-reports"
+
+
 async def _run(args: argparse.Namespace) -> int:
     if not args.token:
         logger.error("HERMES_INGEST_TOKEN is empty; provide via --token or env var.")
@@ -181,40 +266,51 @@ async def _run(args: argparse.Namespace) -> int:
 
     run_uuid = args.run_uuid or uuid.uuid4()
     headers = {args.token_header: args.token, "Content-Type": "application/json"}
+    # The read-surface GETs are session-authed (NOT the Hermes ingest token).
+    read_cookie: str = args.session_cookie or ""
+    read_headers: dict[str, str] = {"Cookie": read_cookie} if read_cookie else {}
 
     base_url = args.base_url.rstrip("/")
-    stage_fixture, composition_fixture = _FIXTURE_BY_SET[args.fixture_set]
+    fixtures = _FIXTURE_BY_SET[args.fixture_set]
     logger.info("base_url: %s", base_url)
     logger.info("bundle_uuid: %s", args.bundle_uuid)
     logger.info("run_uuid: %s", run_uuid)
     logger.info(
-        "fixture_set: %s (stage=%s composition=%s)",
+        "fixture_set: %s (stage=%s symbol=%s dimension=%s composition=%s)",
         args.fixture_set,
-        stage_fixture,
-        composition_fixture,
+        fixtures["stage_artifacts"],
+        fixtures["symbol_reports"],
+        fixtures["dimension_reports"],
+        fixtures["composition"],
+    )
+    logger.info(
+        "read-surface GETs: %s",
+        "enabled (session cookie supplied)"
+        if read_cookie
+        else "SKIPPED (no --session-cookie / HERMES_SMOKE_SESSION_COOKIE)",
     )
 
     async with httpx.AsyncClient(timeout=args.timeout) as client:
         # 1. context export
-        logger.info("--- step 1/3: context export ---")
+        logger.info("--- step 1/8: context export ---")
         await _post(
             client,
-            f"{base_url}/trading/api/investment-reports/hermes/context",
+            f"{base_url}{_HERMES_PREFIX}/context",
             body={"snapshot_bundle_uuid": str(args.bundle_uuid)},
             headers=headers,
             verbose=args.verbose,
         )
 
         # 2. stage-artifacts ingest
-        logger.info("--- step 2/3: stage-artifacts ingest ---")
+        logger.info("--- step 2/8: stage-artifacts ingest ---")
         stage_payload = _substitute_placeholders(
-            _load_fixture(stage_fixture),
+            _load_fixture(fixtures["stage_artifacts"]),
             run_uuid=run_uuid,
             snapshot_bundle_uuid=args.bundle_uuid,
         )
         stage_resp = await _post(
             client,
-            f"{base_url}/trading/api/investment-reports/hermes/stage-artifacts",
+            f"{base_url}{_HERMES_PREFIX}/stage-artifacts",
             body=stage_payload,
             headers=headers,
             verbose=args.verbose,
@@ -230,25 +326,165 @@ async def _run(args: argparse.Namespace) -> int:
             stage_resp.get("run_status"),
         )
 
-        # 3. composition ingest
-        logger.info("--- step 3/3: composition ingest ---")
-        composition_payload = _substitute_placeholders(
-            _load_fixture(composition_fixture),
+        # 3. symbol-reports ingest (ROB-301) — capture a symbol_report_uuid.
+        logger.info("--- step 3/8: symbol-reports ingest ---")
+        symbol_payload = _substitute_placeholders(
+            _load_fixture(fixtures["symbol_reports"]),
             run_uuid=run_uuid,
             snapshot_bundle_uuid=args.bundle_uuid,
         )
+        symbol_resp = await _post(
+            client,
+            f"{base_url}{_HERMES_PREFIX}/symbol-reports",
+            body=symbol_payload,
+            headers=headers,
+            verbose=args.verbose,
+        )
+        symbol_reports = symbol_resp.get("symbol_reports", [])
+        if not symbol_reports:
+            logger.error("symbol-reports ingest returned no rows; aborting.")
+            raise SystemExit(1)
+        symbol_report_uuid = symbol_reports[0]["symbol_report_uuid"]
+        logger.info(
+            "  symbol_reports: %d  first symbol_report_uuid: %s",
+            len(symbol_reports),
+            symbol_report_uuid,
+        )
+
+        # 4. dimension-reports ingest (ROB-306) — capture a dimension_report_uuid.
+        logger.info("--- step 4/8: dimension-reports ingest ---")
+        dimension_payload = _substitute_placeholders(
+            _load_fixture(fixtures["dimension_reports"]),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=args.bundle_uuid,
+        )
+        dimension_resp = await _post(
+            client,
+            f"{base_url}{_HERMES_PREFIX}/dimension-reports",
+            body=dimension_payload,
+            headers=headers,
+            verbose=args.verbose,
+        )
+        dimension_reports = dimension_resp.get("dimension_reports", [])
+        if not dimension_reports:
+            logger.error("dimension-reports ingest returned no rows; aborting.")
+            raise SystemExit(1)
+        # Prefer the market-dimension row (it is what the read-surface GET filters
+        # on); fall back to the first row if absent.
+        market_dim = next(
+            (d for d in dimension_reports if d.get("dimension") == "market"),
+            dimension_reports[0],
+        )
+        dimension_report_uuid = market_dim["dimension_report_uuid"]
+        logger.info(
+            "  dimension_reports: %d  market dimension_report_uuid: %s",
+            len(dimension_reports),
+            dimension_report_uuid,
+        )
+
+        # 5. context re-pull — the freshly-ingested reports must now surface.
+        logger.info("--- step 5/8: context re-pull (carries reports) ---")
+        ctx2 = await _post(
+            client,
+            f"{base_url}{_HERMES_PREFIX}/context",
+            body={"snapshot_bundle_uuid": str(args.bundle_uuid)},
+            headers=headers,
+            verbose=args.verbose,
+        )
+        ctx_dim_reports = ctx2.get("dimension_reports", [])
+        ctx_symbol_reports = ctx2.get("symbol_intermediate_reports", [])
+        if not ctx_dim_reports or not ctx_symbol_reports:
+            logger.error(
+                "context re-pull did NOT carry the ingested reports "
+                "(dimension_reports=%d, symbol_intermediate_reports=%d); aborting.",
+                len(ctx_dim_reports),
+                len(ctx_symbol_reports),
+            )
+            raise SystemExit(1)
+        logger.info(
+            "  context carries dimension_reports: %d  symbol_intermediate_reports: %d",
+            len(ctx_dim_reports),
+            len(ctx_symbol_reports),
+        )
+
+        # 6. composition ingest — thread the captured report UUIDs into the payload.
+        logger.info("--- step 6/8: composition ingest ---")
+        composition_payload = _substitute_placeholders(
+            _load_fixture(fixtures["composition"]),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=args.bundle_uuid,
+            symbol_report_uuid=symbol_report_uuid,
+            dimension_report_uuid=dimension_report_uuid,
+        )
         comp_resp = await _post(
             client,
-            f"{base_url}/trading/api/investment-reports/hermes/composition",
+            f"{base_url}{_HERMES_PREFIX}/composition",
             body=composition_payload,
             headers=headers,
             verbose=args.verbose,
         )
+        report_uuid = comp_resp.get("report_uuid")
         logger.info(
             "  report_uuid: %s  items: %s  status: %s",
-            comp_resp.get("report_uuid"),
+            report_uuid,
             comp_resp.get("items_count"),
             comp_resp.get("status"),
+        )
+
+        # 7 + 8 — read surfaces (session-authed). Skipped when no cookie supplied.
+        if not read_cookie:
+            logger.warning(
+                "Skipping read-surface assertions (steps 7-8): no session cookie. "
+                "Re-run with --session-cookie to verify the dimension-reports "
+                "read surface + the held-action/new-candidate bundle grouping."
+            )
+            logger.info("--- ingest chain OK (read-surface GETs skipped) ---")
+            return 0
+
+        # 7. dimension-reports read surface (filtered to the market dimension).
+        logger.info("--- step 7/8: dimension-reports read surface ---")
+        dim_view = await _get(
+            client,
+            f"{base_url}{_READ_PREFIX}/runs/{run_uuid}/dimension-reports"
+            "?dimension=market",
+            headers=read_headers,
+            verbose=args.verbose,
+        )
+        view_reports = dim_view.get("reports", [])
+        if not view_reports:
+            logger.error(
+                "dimension-reports read surface returned no market reports; aborting."
+            )
+            raise SystemExit(1)
+        logger.info(
+            "  read-surface market reports: %d  stance: %s",
+            len(view_reports),
+            view_reports[0].get("stance"),
+        )
+
+        # 8. final report bundle — assert held-action vs new-candidate grouping.
+        logger.info("--- step 8/8: final report bundle grouping ---")
+        bundle = await _get(
+            client,
+            f"{base_url}{_READ_PREFIX}/{report_uuid}",
+            headers=read_headers,
+            verbose=args.verbose,
+        )
+        rollup = bundle.get("decision_rollup", {})
+        item_groups = bundle.get("item_groups", {})
+        new_candidate = rollup.get("new_candidate", [])
+        held_action = rollup.get("held_action", [])
+        if not new_candidate:
+            logger.error(
+                "final bundle decision_rollup.new_candidate is empty — the "
+                "new_buy_candidate item did not classify; aborting."
+            )
+            raise SystemExit(1)
+        logger.info(
+            "  decision_rollup: new_candidate=%d held_action=%d  groups: %s",
+            len(new_candidate),
+            len(held_action),
+            ", ".join(sorted(item_groups.keys())),
         )
 
     logger.info("--- round-trip OK ---")

--- a/tests/fixtures/hermes/composition_request.json
+++ b/tests/fixtures/hermes/composition_request.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "ROB-287 Phase C — sample Hermes-produced composition ingest payload. metadata.investment_stage_run_uuid links back to the stage run for auto-finalize (§D4). {{...}} placeholders are substituted by the round-trip smoke at runtime.",
+  "_comment": "ROB-287 Phase C + ROB-309 — sample Hermes-produced composition ingest payload. metadata.investment_stage_run_uuid links back to the stage run for auto-finalize (§D4). symbol_intermediate_report_uuids (ROB-301) + dimension_report_uuids (ROB-308) reference the per-symbol / per-dimension reports this composition consumed; the {{symbol_report_uuid}} / {{dimension_report_uuid}} placeholders are substituted from the symbol-reports / dimension-reports POST responses at runtime. One item carries decision_bucket='new_buy_candidate' + per-item citations to exercise the held-action vs new-candidate bundle grouping (ROB-308 C5). {{...}} placeholders are substituted by the round-trip smoke at runtime.",
   "composition": {
     "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
     "hermes_run_id": "hermes-smoke-001",
@@ -25,6 +25,19 @@
         "intent": "trend_recovery_review",
         "rationale": "Watch for scale-out opportunity once price reclaims short-term resistance.",
         "apply_policy": "requires_user_approval"
+      },
+      {
+        "client_item_key": "smoke-action-005930-buy-candidate-001",
+        "item_kind": "action",
+        "operation": "review",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "Fresh long candidate on foreign net-buy + breadth; advisory only, requires user approval before any entry.",
+        "apply_policy": "requires_user_approval",
+        "decision_bucket": "new_buy_candidate",
+        "cited_symbol_report_uuid": "{{symbol_report_uuid}}",
+        "cited_dimension_report_uuids": ["{{dimension_report_uuid}}"]
       }
     ],
     "metadata": {
@@ -32,7 +45,9 @@
       "hermes_composition_version": "hermes-composition.v1",
       "hermes_run_id": "hermes-smoke-001"
     },
-    "cited_snapshot_uuids": []
+    "cited_snapshot_uuids": [],
+    "symbol_intermediate_report_uuids": ["{{symbol_report_uuid}}"],
+    "dimension_report_uuids": ["{{dimension_report_uuid}}"]
   },
   "kst_date": "2026-05-21",
   "market": "kr",

--- a/tests/fixtures/hermes/composition_request_us.json
+++ b/tests/fixtures/hermes/composition_request_us.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "ROB-287 follow-up — US narrow smoke. Hermes-produced composition payload with market='us', account_scope='alpaca_paper'. metadata.investment_stage_run_uuid links to the matching stage run for §D4 auto-finalize. status MUST stay 'draft' for this smoke — published reports require operator review. {{...}} placeholders are substituted by the round-trip smoke at runtime. NOTE: ReportGenerationRequest (legacy snapshot-backed generator) does NOT support market='us'; this fixture exercises ONLY the Hermes-first contract path.",
+  "_comment": "ROB-287 follow-up + ROB-309 — US narrow smoke. Hermes-produced composition payload with market='us', account_scope='alpaca_paper'. metadata.investment_stage_run_uuid links to the matching stage run for §D4 auto-finalize. symbol_intermediate_report_uuids (ROB-301) + dimension_report_uuids (ROB-308) reference the per-symbol / per-dimension reports consumed; {{symbol_report_uuid}} / {{dimension_report_uuid}} placeholders are substituted from the symbol-reports / dimension-reports POST responses at runtime. One item carries decision_bucket='new_buy_candidate' + per-item citations (ROB-308 C5). status MUST stay 'draft' — published reports require operator review. {{...}} placeholders are substituted by the round-trip smoke at runtime. NOTE: ReportGenerationRequest (legacy snapshot-backed generator) does NOT support market='us'; this fixture exercises ONLY the Hermes-first contract path.",
   "composition": {
     "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
     "hermes_run_id": "hermes-smoke-us-001",
@@ -34,6 +34,19 @@
         "intent": "trend_recovery_review",
         "rationale": "Watch for partial trim if cloud guidance disappoints next quarter; advisory only, no broker mutation.",
         "apply_policy": "requires_user_approval"
+      },
+      {
+        "client_item_key": "smoke-us-action-aapl-buy-candidate-001",
+        "item_kind": "action",
+        "operation": "review",
+        "symbol": "AAPL",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "Fresh long candidate on services upside + megacap leadership; advisory only on alpaca_paper, requires user approval before any entry.",
+        "apply_policy": "requires_user_approval",
+        "decision_bucket": "new_buy_candidate",
+        "cited_symbol_report_uuid": "{{symbol_report_uuid}}",
+        "cited_dimension_report_uuids": ["{{dimension_report_uuid}}"]
       }
     ],
     "metadata": {
@@ -41,7 +54,9 @@
       "hermes_composition_version": "hermes-composition.v1",
       "hermes_run_id": "hermes-smoke-us-001"
     },
-    "cited_snapshot_uuids": []
+    "cited_snapshot_uuids": [],
+    "symbol_intermediate_report_uuids": ["{{symbol_report_uuid}}"],
+    "dimension_report_uuids": ["{{dimension_report_uuid}}"]
   },
   "kst_date": "2026-05-22",
   "market": "us",

--- a/tests/fixtures/hermes/dimension_reports_request.json
+++ b/tests/fixtures/hermes/dimension_reports_request.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "ROB-309 — sample Hermes-produced dimension-reports ingest payload (ROB-306 contract). Per-dimension analyst reports for the SAME stage run as the stage-artifacts. run_envelope must match the stage run (snapshot_bundle_uuid + market). confidence is capped by freshness on ingest. {{run_uuid}} / {{snapshot_bundle_uuid}} placeholders are substituted by the round-trip smoke test/CLI at runtime.",
+  "request_version": "hermes-dimension-reports.v1",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "kr",
+    "market_session": "regular",
+    "account_scope": "kis_live",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-001"
+  },
+  "dimension_reports": [
+    {
+      "dimension": "market",
+      "market": "kr",
+      "symbol": null,
+      "report_text": "KOSPI risk-on: breadth net-positive, foreign net-buy streak intact. Constructive regime for selective longs.",
+      "key_findings": [
+        "KOSPI 2,540 (+0.78%)",
+        "foreign net-buy ₩280B",
+        "adv/dec 612/238"
+      ],
+      "signals": {
+        "regime": "risk_on",
+        "breadth": "net_positive"
+      },
+      "stance": "bullish",
+      "confidence": 62,
+      "missing_data": [],
+      "freshness_summary": {
+        "status": "fresh"
+      },
+      "cited_snapshot_uuids": []
+    },
+    {
+      "dimension": "news",
+      "market": "kr",
+      "symbol": null,
+      "report_text": "Mixed news flow; no dominant catalyst. HBM3e shipment update modest positive, BoK on hold as expected.",
+      "key_findings": [
+        "Samsung HBM3e shipment update — modest positive",
+        "BoK rate decision unchanged (consensus)"
+      ],
+      "signals": {
+        "catalyst": "none_dominant"
+      },
+      "stance": "neutral",
+      "confidence": 45,
+      "missing_data": [],
+      "freshness_summary": {
+        "status": "fresh"
+      },
+      "cited_snapshot_uuids": []
+    }
+  ]
+}

--- a/tests/fixtures/hermes/dimension_reports_request_us.json
+++ b/tests/fixtures/hermes/dimension_reports_request_us.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "ROB-309 — US narrow dimension-reports ingest payload (ROB-306 contract) pinned to market='us'. Per-dimension analyst reports for the SAME US stage run. confidence is capped by freshness on ingest. {{...}} placeholders substituted by the round-trip smoke at runtime.",
+  "request_version": "hermes-dimension-reports.v1",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "us",
+    "market_session": "regular",
+    "account_scope": "alpaca_paper",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-us-001"
+  },
+  "dimension_reports": [
+    {
+      "dimension": "market",
+      "market": "us",
+      "symbol": null,
+      "report_text": "S&P 500 risk-on: breadth net-positive, megacap leadership intact, VIX subdued. Constructive regime for selective longs.",
+      "key_findings": [
+        "SPX 5,210 (+0.5%)",
+        "adv/dec 2.1:1",
+        "VIX 12.4 (-3%)"
+      ],
+      "signals": {
+        "regime": "risk_on",
+        "breadth": "net_positive"
+      },
+      "stance": "bullish",
+      "confidence": 60,
+      "missing_data": [],
+      "freshness_summary": {
+        "status": "fresh"
+      },
+      "cited_snapshot_uuids": []
+    },
+    {
+      "dimension": "news",
+      "market": "us",
+      "symbol": null,
+      "report_text": "Mixed earnings reads; no single dominant catalyst. AAPL services mildly above consensus, MSFT cloud guide reiterated.",
+      "key_findings": [
+        "AAPL services revenue mildly above consensus",
+        "MSFT cloud guide reiterated"
+      ],
+      "signals": {
+        "catalyst": "none_dominant"
+      },
+      "stance": "neutral",
+      "confidence": 42,
+      "missing_data": [],
+      "freshness_summary": {
+        "status": "fresh"
+      },
+      "cited_snapshot_uuids": []
+    }
+  ]
+}

--- a/tests/fixtures/hermes/symbol_reports_request.json
+++ b/tests/fixtures/hermes/symbol_reports_request.json
@@ -1,0 +1,54 @@
+{
+  "_comment": "ROB-309 — sample Hermes-produced symbol-reports ingest payload (ROB-301 contract). Belongs to the SAME stage run as the cross-symbol artifacts it consumes, so run_envelope must match the stage-artifacts run_envelope. verdict is NOT a field — the service derives it from (decision_bucket, side, availability). {{run_uuid}} / {{snapshot_bundle_uuid}} placeholders are substituted by the round-trip smoke test/CLI at runtime.",
+  "request_version": "hermes-symbol-reports.v1",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "kr",
+    "market_session": "regular",
+    "account_scope": "kis_live",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-001"
+  },
+  "report_kind": "final_report_symbol",
+  "symbol_reports": [
+    {
+      "symbol": "005930",
+      "symbol_name": "삼성전자",
+      "data_available": true,
+      "decision_bucket": "new_buy_candidate",
+      "side": "buy",
+      "confidence": 61,
+      "summary": "Foreign net-buy + breadth support a fresh long; entry on pullback to 5d MA.",
+      "rationale": "Market regime risk-on, foreign net-buy 3rd session, HBM3e shipment catalyst modest positive. Scale in on dip.",
+      "buy_evidence": [
+        "Foreign net-buy 3rd consecutive session",
+        "KOSPI breadth net-positive"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshot_uuids": [],
+      "source_stage_artifact_uuids": []
+    },
+    {
+      "symbol": "000660",
+      "symbol_name": "SK하이닉스",
+      "data_available": true,
+      "decision_bucket": "risk_watch",
+      "side": null,
+      "confidence": 44,
+      "summary": "Hold and watch; memory cycle read mixed, no fresh entry edge.",
+      "rationale": "No dominant catalyst; keep on watch for trend reclaim before adding.",
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Memory pricing read mixed"
+      ],
+      "missing_data": [],
+      "cited_snapshot_uuids": [],
+      "source_stage_artifact_uuids": []
+    }
+  ]
+}

--- a/tests/fixtures/hermes/symbol_reports_request_us.json
+++ b/tests/fixtures/hermes/symbol_reports_request_us.json
@@ -1,0 +1,54 @@
+{
+  "_comment": "ROB-309 — US narrow symbol-reports ingest payload (ROB-301 contract) pinned to market='us', account_scope='alpaca_paper'. Belongs to the SAME stage run as the US stage-artifacts. verdict is NOT a field — the service derives it. Symbols stay within AAPL/MSFT (stress-test ticker, not universe). {{...}} placeholders substituted by the round-trip smoke at runtime.",
+  "request_version": "hermes-symbol-reports.v1",
+  "run_envelope": {
+    "run_uuid": "{{run_uuid}}",
+    "snapshot_bundle_uuid": "{{snapshot_bundle_uuid}}",
+    "market": "us",
+    "market_session": "regular",
+    "account_scope": "alpaca_paper",
+    "policy_version": "intraday_action_report_v1",
+    "generator_version": "hermes-stage-artifacts.v1",
+    "hermes_run_id": "hermes-smoke-us-001"
+  },
+  "report_kind": "final_report_symbol",
+  "symbol_reports": [
+    {
+      "symbol": "AAPL",
+      "symbol_name": "Apple Inc.",
+      "data_available": true,
+      "decision_bucket": "new_buy_candidate",
+      "side": "buy",
+      "confidence": 58,
+      "summary": "Services upside surprise + megacap leadership support a fresh paper long.",
+      "rationale": "SPX breadth net-positive, AAPL services revenue above consensus. Advisory entry on pullback; alpaca_paper only.",
+      "buy_evidence": [
+        "AAPL services revenue above consensus",
+        "Megacap leadership intact"
+      ],
+      "sell_evidence": [],
+      "risk_evidence": [],
+      "missing_data": [],
+      "cited_snapshot_uuids": [],
+      "source_stage_artifact_uuids": []
+    },
+    {
+      "symbol": "MSFT",
+      "symbol_name": "Microsoft Corp.",
+      "data_available": true,
+      "decision_bucket": "risk_watch",
+      "side": null,
+      "confidence": 41,
+      "summary": "Hold and watch; cloud guide reiterated but no fresh entry edge.",
+      "rationale": "No dominant catalyst; watch for cloud guidance next quarter before adding.",
+      "buy_evidence": [],
+      "sell_evidence": [],
+      "risk_evidence": [
+        "Sector concentration: tech-megacap >60% NAV"
+      ],
+      "missing_data": [],
+      "cited_snapshot_uuids": [],
+      "source_stage_artifact_uuids": []
+    }
+  ]
+}

--- a/tests/scripts/test_hermes_roundtrip_smoke_cli.py
+++ b/tests/scripts/test_hermes_roundtrip_smoke_cli.py
@@ -63,6 +63,54 @@ def test_substitute_placeholders_works_on_composition() -> None:
     )
 
 
+def test_substitute_placeholders_threads_report_uuids_into_composition() -> None:
+    """ROB-309 — the composition fixture carries {{symbol_report_uuid}} +
+    {{dimension_report_uuid}} placeholders, substituted in a second pass once
+    the symbol-reports / dimension-reports POSTs return their server UUIDs."""
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    symbol_report_uuid = uuid.uuid4()
+    dimension_report_uuid = uuid.uuid4()
+    payload = _substitute_placeholders(
+        _load_fixture("composition_request.json"),
+        run_uuid=run_uuid,
+        snapshot_bundle_uuid=bundle_uuid,
+        symbol_report_uuid=symbol_report_uuid,
+        dimension_report_uuid=dimension_report_uuid,
+    )
+    composition = payload["composition"]
+    assert composition["symbol_intermediate_report_uuids"] == [str(symbol_report_uuid)]
+    assert composition["dimension_report_uuids"] == [str(dimension_report_uuid)]
+    # The classified item threads both citations.
+    candidate = next(
+        it
+        for it in composition["items"]
+        if it.get("decision_bucket") == "new_buy_candidate"
+    )
+    assert candidate["cited_symbol_report_uuid"] == str(symbol_report_uuid)
+    assert candidate["cited_dimension_report_uuids"] == [str(dimension_report_uuid)]
+    # No placeholder braces survive the full substitution.
+    serialised = json.dumps(payload)
+    assert "{{" not in serialised
+    assert "}}" not in serialised
+
+
+def test_substitute_placeholders_works_on_symbol_and_dimension_fixtures() -> None:
+    bundle_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    for name in ("symbol_reports_request.json", "dimension_reports_request.json"):
+        payload = _substitute_placeholders(
+            _load_fixture(name),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle_uuid,
+        )
+        assert payload["run_envelope"]["run_uuid"] == str(run_uuid)
+        assert payload["run_envelope"]["snapshot_bundle_uuid"] == str(bundle_uuid)
+        serialised = json.dumps(payload)
+        assert "{{" not in serialised
+        assert "}}" not in serialised
+
+
 @pytest.mark.parametrize(
     ("raw", "expected_substr"),
     [
@@ -154,16 +202,48 @@ def test_parse_args_rejects_unknown_fixture_set() -> None:
         )
 
 
-def test_fixture_by_set_map_locks_us_payload_files() -> None:
+def test_fixture_by_set_map_locks_payload_files() -> None:
     """Lock the fixture filenames bound to each set so an accidental
-    rename can't silently change what the CLI sends on the wire."""
+    rename can't silently change what the CLI sends on the wire. ROB-309
+    extends each set with the symbol-reports + dimension-reports fixtures."""
     from scripts.hermes_roundtrip_smoke import _FIXTURE_BY_SET
 
-    assert _FIXTURE_BY_SET["kr"] == (
-        "stage_artifacts_request.json",
-        "composition_request.json",
+    assert _FIXTURE_BY_SET["kr"] == {
+        "stage_artifacts": "stage_artifacts_request.json",
+        "symbol_reports": "symbol_reports_request.json",
+        "dimension_reports": "dimension_reports_request.json",
+        "composition": "composition_request.json",
+    }
+    assert _FIXTURE_BY_SET["us"] == {
+        "stage_artifacts": "stage_artifacts_request_us.json",
+        "symbol_reports": "symbol_reports_request_us.json",
+        "dimension_reports": "dimension_reports_request_us.json",
+        "composition": "composition_request_us.json",
+    }
+
+
+def test_parse_args_session_cookie_defaults_empty() -> None:
+    """The read-surface GETs need a session cookie; it defaults to empty so
+    the ingest chain still runs (read-surface assertions are then skipped)."""
+    args = _parse_args(
+        [
+            "--base-url",
+            "https://example",
+            "--bundle-uuid",
+            str(uuid.uuid4()),
+        ]
     )
-    assert _FIXTURE_BY_SET["us"] == (
-        "stage_artifacts_request_us.json",
-        "composition_request_us.json",
+    assert args.session_cookie == ""
+
+
+def test_parse_args_session_cookie_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_SMOKE_SESSION_COOKIE", "session=abc123")
+    args = _parse_args(
+        [
+            "--base-url",
+            "https://example",
+            "--bundle-uuid",
+            str(uuid.uuid4()),
+        ]
     )
+    assert args.session_cookie == "session=abc123"

--- a/tests/test_hermes_roundtrip_smoke.py
+++ b/tests/test_hermes_roundtrip_smoke.py
@@ -48,7 +48,12 @@ from app.middleware.auth import AuthMiddleware
 from app.models.investment_reports import InvestmentReport
 from app.models.investment_snapshots import InvestmentSnapshotBundle
 from app.models.investment_stages import InvestmentStageArtifact, InvestmentStageRun
+from app.routers.dependencies import get_authenticated_user
+from app.routers.investment_dimension_reports import (
+    router as dimension_reports_router,
+)
 from app.routers.investment_hermes_http import router as hermes_router
+from app.routers.investment_reports import router as investment_reports_router
 
 # Cross-domain ``db_session`` test that writes to ``review.investment_reports``.
 # Without this fixture, xdist sibling workers running ``investment_reports_helpers``
@@ -73,13 +78,28 @@ def _load_fixture(name: str) -> dict[str, Any]:
 
 
 def _substitute_placeholders(
-    payload: dict[str, Any], *, run_uuid: uuid.UUID, snapshot_bundle_uuid: uuid.UUID
+    payload: dict[str, Any],
+    *,
+    run_uuid: uuid.UUID,
+    snapshot_bundle_uuid: uuid.UUID,
+    symbol_report_uuid: uuid.UUID | str | None = None,
+    dimension_report_uuid: uuid.UUID | str | None = None,
 ) -> dict[str, Any]:
-    """Recursive string substitution for ``{{run_uuid}}`` and
-    ``{{snapshot_bundle_uuid}}`` placeholders inside the fixture."""
+    """String substitution for the placeholder UUIDs inside a fixture.
+
+    ``run_uuid`` / ``snapshot_bundle_uuid`` are always known. The
+    ``symbol_report_uuid`` / ``dimension_report_uuid`` placeholders (ROB-309)
+    are only known after the symbol-reports / dimension-reports ingests return
+    their server-assigned UUIDs, so they are substituted in a second pass on
+    the composition payload.
+    """
     raw = json.dumps(payload)
     raw = raw.replace("{{run_uuid}}", str(run_uuid))
     raw = raw.replace("{{snapshot_bundle_uuid}}", str(snapshot_bundle_uuid))
+    if symbol_report_uuid is not None:
+        raw = raw.replace("{{symbol_report_uuid}}", str(symbol_report_uuid))
+    if dimension_report_uuid is not None:
+        raw = raw.replace("{{dimension_report_uuid}}", str(dimension_report_uuid))
     return json.loads(raw)
 
 
@@ -112,6 +132,30 @@ def _build_app(db_session) -> FastAPI:
         yield db_session
 
     app.dependency_overrides[get_db] = _db_override
+    return app
+
+
+def _build_read_app(db_session) -> FastAPI:
+    """ROB-309 — read-surface app (no AuthMiddleware).
+
+    The dimension-reports read surface + the final report bundle GET are
+    session-authed in production (NOT the Hermes ingest token), so they live
+    on a separate app whose ``get_authenticated_user`` dependency is overridden
+    with a stub user, mirroring the established pattern in the other
+    ``/invest`` / ``/trading`` router tests. Shares the same ``db_session`` so
+    rows written through the ingest app are visible here.
+    """
+    from types import SimpleNamespace
+
+    app = FastAPI()
+    app.include_router(investment_reports_router)
+    app.include_router(dimension_reports_router)
+
+    async def _db_override() -> AsyncIterator[object]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = _db_override
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
     return app
 
 
@@ -188,21 +232,36 @@ def _auth_headers() -> dict[str, str]:
 async def test_roundtrip_context_artifacts_composition(
     db_session, _enabled, _seeded_bundle
 ) -> None:
-    """Drive the full chain: context → stage-artifacts → composition.
+    """Drive the FULL current contract (ROB-309): context →
+    stage-artifacts → symbol-reports → dimension-reports → context
+    re-pull → composition → read surfaces.
 
     Asserts:
     * /context returns a HermesContextPayload referencing the seeded bundle.
     * /stage-artifacts creates a stage run + 5 artifact rows.
-    * /composition creates an InvestmentReport row and auto-finalises
-      the stage run to ``status='completed'`` (§D4).
+    * /symbol-reports persists per-symbol reductions (ROB-301).
+    * /dimension-reports persists per-dimension reports (ROB-306).
+    * /context re-pull now carries non-empty ``dimension_reports`` +
+      ``symbol_intermediate_reports``.
+    * /composition stores the ``dimension_report_uuids`` +
+      ``symbol_intermediate_report_uuids`` it consumed and classifies a
+      ``new_buy_candidate`` item (ROB-308); the run auto-finalises (§D4).
+    * The dimension-reports read surface + the final report bundle render
+      the held-action vs new-candidate grouping.
     """
     bundle = _seeded_bundle
     run_uuid = uuid.uuid4()
 
     app = _build_app(db_session)
-    async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="https://test"
-    ) as client:
+    read_app = _build_read_app(db_session)
+    async with (
+        AsyncClient(
+            transport=ASGITransport(app=app), base_url="https://test"
+        ) as client,
+        AsyncClient(
+            transport=ASGITransport(app=read_app), base_url="https://test"
+        ) as read_client,
+    ):
         # --- 1. context export ---
         ctx_resp = await client.post(
             "/trading/api/investment-reports/hermes/context",
@@ -215,6 +274,9 @@ async def test_roundtrip_context_artifacts_composition(
         assert ctx_body["context_version"] == "hermes-context.v1"
         assert ctx_body["snapshot_bundle_uuid"] == str(bundle.bundle_uuid)
         assert ctx_body["constraints"]["advisory_only"] is True
+        # First pull (before any reports ingested) carries empty report lists.
+        assert ctx_body["dimension_reports"] == []
+        assert ctx_body["symbol_intermediate_reports"] == []
         # 5 deterministic stages render even with no snapshots (they
         # surface as UNAVAILABLE).
         stage_types = {entry["stage_type"] for entry in ctx_body["stage_inputs"]}
@@ -245,12 +307,69 @@ async def test_roundtrip_context_artifacts_composition(
         assert len(stage_body["artifacts"]) == 5
         assert all(not r["idempotent_existing"] for r in stage_body["artifacts"])
 
-        # --- 3. composition ingest ---
+        # --- 3. symbol-reports ingest (ROB-301) ---
+        symbol_payload = _substitute_placeholders(
+            _load_fixture("symbol_reports_request.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        sym_resp = await client.post(
+            "/trading/api/investment-reports/hermes/symbol-reports",
+            headers=_auth_headers(),
+            json=symbol_payload,
+        )
+        assert sym_resp.status_code == 200, sym_resp.text
+        sym_body = sym_resp.json()
+        assert sym_body["success"] is True
+        assert sym_body["run_uuid"] == str(run_uuid)
+        assert len(sym_body["symbol_reports"]) == 2
+        assert all(not r["idempotent_existing"] for r in sym_body["symbol_reports"])
+        symbol_report_uuid = sym_body["symbol_reports"][0]["symbol_report_uuid"]
+
+        # --- 4. dimension-reports ingest (ROB-306) ---
+        dimension_payload = _substitute_placeholders(
+            _load_fixture("dimension_reports_request.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        dim_resp = await client.post(
+            "/trading/api/investment-reports/hermes/dimension-reports",
+            headers=_auth_headers(),
+            json=dimension_payload,
+        )
+        assert dim_resp.status_code == 200, dim_resp.text
+        dim_body = dim_resp.json()
+        assert dim_body["success"] is True
+        assert dim_body["run_uuid"] == str(run_uuid)
+        assert len(dim_body["dimension_reports"]) == 2
+        market_dim = next(
+            d for d in dim_body["dimension_reports"] if d["dimension"] == "market"
+        )
+        dimension_report_uuid = market_dim["dimension_report_uuid"]
+
+        # --- 5. context re-pull carries both report families ---
+        ctx2_resp = await client.post(
+            "/trading/api/investment-reports/hermes/context",
+            headers=_auth_headers(),
+            json={"snapshot_bundle_uuid": str(bundle.bundle_uuid)},
+        )
+        assert ctx2_resp.status_code == 200, ctx2_resp.text
+        ctx2_body = ctx2_resp.json()
+        assert len(ctx2_body["dimension_reports"]) == 2, (
+            "context re-pull must surface the freshly-ingested dimension reports"
+        )
+        assert len(ctx2_body["symbol_intermediate_reports"]) == 2, (
+            "context re-pull must surface the freshly-ingested symbol reports"
+        )
+
+        # --- 6. composition ingest (threads the captured report UUIDs) ---
         composition_payload = _make_unique_for_test_db(
             _substitute_placeholders(
                 _load_fixture("composition_request.json"),
                 run_uuid=run_uuid,
                 snapshot_bundle_uuid=bundle.bundle_uuid,
+                symbol_report_uuid=symbol_report_uuid,
+                dimension_report_uuid=dimension_report_uuid,
             ),
             run_uuid=run_uuid,
         )
@@ -263,7 +382,7 @@ async def test_roundtrip_context_artifacts_composition(
         comp_body = comp_resp.json()
         assert comp_body["success"] is True
         assert comp_body["status"] == "draft"
-        assert comp_body["items_count"] == 2
+        assert comp_body["items_count"] == 3
 
         # --- Assertions on persisted state ---
         from sqlalchemy import select
@@ -300,6 +419,46 @@ async def test_roundtrip_context_artifacts_composition(
         # Stage-run linkage is preserved in metadata.
         hermes_meta = report_row.report_metadata.get("hermes_composition", {})
         assert hermes_meta.get("hermes_run_id") == "hermes-smoke-001"
+        # ROB-308/ROB-301 — the consumed report UUIDs are threaded into metadata.
+        assert report_row.report_metadata.get("symbol_intermediate_report_uuids") == [
+            symbol_report_uuid
+        ]
+        assert report_row.report_metadata.get("dimension_report_uuids") == [
+            dimension_report_uuid
+        ]
+
+        # --- 7. dimension-reports read surface (session-authed) ---
+        dim_view_resp = await read_client.get(
+            f"/trading/api/investment-reports/runs/{run_uuid}/dimension-reports",
+            params={"dimension": "market"},
+        )
+        assert dim_view_resp.status_code == 200, dim_view_resp.text
+        dim_view = dim_view_resp.json()
+        assert dim_view["dimension"] == "market"
+        assert len(dim_view["reports"]) == 1
+        assert dim_view["reports"][0]["stance"] == "bullish"
+
+        # --- 8. final report bundle grouping (held-action vs new-candidate) ---
+        bundle_resp = await read_client.get(
+            f"/trading/api/investment-reports/{report_uuid}"
+        )
+        assert bundle_resp.status_code == 200, bundle_resp.text
+        bundle_body = bundle_resp.json()
+        rollup = bundle_body["decision_rollup"]
+        assert len(rollup["new_candidate"]) == 1, (
+            "the new_buy_candidate item must classify into decision_rollup"
+        )
+        assert rollup["new_candidate"][0]["decision_bucket"] == "new_buy_candidate"
+        assert rollup["new_candidate"][0]["cited_symbol_report_uuid"] == (
+            symbol_report_uuid
+        )
+        assert rollup["new_candidate"][0]["cited_dimension_report_uuids"] == [
+            dimension_report_uuid
+        ]
+        # item_groups keys items by decision_bucket; unclassified items land
+        # under "unclassified".
+        assert "new_buy_candidate" in bundle_body["item_groups"]
+        assert "unclassified" in bundle_body["item_groups"]
 
 
 @pytest.mark.asyncio
@@ -419,8 +578,12 @@ def test_fixture_files_exist_and_are_well_formed() -> None:
     trip itself doesn't double as fixture-syntax validation."""
     for name in (
         "stage_artifacts_request.json",
+        "symbol_reports_request.json",
+        "dimension_reports_request.json",
         "composition_request.json",
         "stage_artifacts_request_us.json",
+        "symbol_reports_request_us.json",
+        "dimension_reports_request_us.json",
         "composition_request_us.json",
     ):
         path = _FIXTURE_DIR / name
@@ -434,6 +597,17 @@ def test_fixture_files_exist_and_are_well_formed() -> None:
         )
         assert re.search(r"\{\{run_uuid\}\}", text), (
             f"{name}: missing {{run_uuid}} placeholder"
+        )
+
+    # The composition fixtures additionally carry the report-UUID placeholders
+    # (ROB-309) substituted from the symbol-/dimension-reports responses.
+    for name in ("composition_request.json", "composition_request_us.json"):
+        text = (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+        assert re.search(r"\{\{symbol_report_uuid\}\}", text), (
+            f"{name}: missing {{symbol_report_uuid}} placeholder"
+        )
+        assert re.search(r"\{\{dimension_report_uuid\}\}", text), (
+            f"{name}: missing {{dimension_report_uuid}} placeholder"
         )
 
 
@@ -503,14 +677,63 @@ async def test_roundtrip_us_narrow_smoke(db_session, _enabled) -> None:
         assert len(stage_body["artifacts"]) == 5
         assert all(not r["idempotent_existing"] for r in stage_body["artifacts"])
 
-        # 3. composition ingest (US fixture) — keep status=draft and make
+        # 3. symbol-reports ingest (US fixture, ROB-301)
+        symbol_payload = _substitute_placeholders(
+            _load_fixture("symbol_reports_request_us.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        sym_resp = await client.post(
+            "/trading/api/investment-reports/hermes/symbol-reports",
+            headers=_auth_headers(),
+            json=symbol_payload,
+        )
+        assert sym_resp.status_code == 200, sym_resp.text
+        sym_body = sym_resp.json()
+        assert len(sym_body["symbol_reports"]) == 2
+        symbol_report_uuid = sym_body["symbol_reports"][0]["symbol_report_uuid"]
+
+        # 4. dimension-reports ingest (US fixture, ROB-306)
+        dimension_payload = _substitute_placeholders(
+            _load_fixture("dimension_reports_request_us.json"),
+            run_uuid=run_uuid,
+            snapshot_bundle_uuid=bundle.bundle_uuid,
+        )
+        dim_resp = await client.post(
+            "/trading/api/investment-reports/hermes/dimension-reports",
+            headers=_auth_headers(),
+            json=dimension_payload,
+        )
+        assert dim_resp.status_code == 200, dim_resp.text
+        dim_body = dim_resp.json()
+        assert len(dim_body["dimension_reports"]) == 2
+        market_dim = next(
+            d for d in dim_body["dimension_reports"] if d["dimension"] == "market"
+        )
+        dimension_report_uuid = market_dim["dimension_report_uuid"]
+
+        # 5. context re-pull carries both report families (US shape)
+        ctx2_resp = await client.post(
+            "/trading/api/investment-reports/hermes/context",
+            headers=_auth_headers(),
+            json={"snapshot_bundle_uuid": str(bundle.bundle_uuid)},
+        )
+        assert ctx2_resp.status_code == 200, ctx2_resp.text
+        ctx2_body = ctx2_resp.json()
+        assert len(ctx2_body["dimension_reports"]) == 2
+        assert len(ctx2_body["symbol_intermediate_reports"]) == 2
+
+        # 6. composition ingest (US fixture) — keep status=draft and make
         # generator_version unique so the shared db_session doesn't reuse
-        # an existing report row from a sibling test.
+        # an existing report row from a sibling test. Threads the captured
+        # symbol/dimension report UUIDs into the payload (ROB-308/ROB-301).
         composition_payload = _make_unique_for_test_db(
             _substitute_placeholders(
                 _load_fixture("composition_request_us.json"),
                 run_uuid=run_uuid,
                 snapshot_bundle_uuid=bundle.bundle_uuid,
+                symbol_report_uuid=symbol_report_uuid,
+                dimension_report_uuid=dimension_report_uuid,
             ),
             run_uuid=run_uuid,
         )
@@ -531,7 +754,7 @@ async def test_roundtrip_us_narrow_smoke(db_session, _enabled) -> None:
         assert comp_body["status"] == "draft", (
             "InvestmentReport row MUST be 'draft' for the US narrow smoke."
         )
-        assert comp_body["items_count"] == 3
+        assert comp_body["items_count"] == 4
 
         # --- DB-level assertions ---
         from sqlalchemy import select
@@ -585,6 +808,26 @@ async def test_roundtrip_us_narrow_smoke(db_session, _enabled) -> None:
         assert report_row.account_scope == "alpaca_paper"
         hermes_meta = report_row.report_metadata.get("hermes_composition", {})
         assert hermes_meta.get("hermes_run_id") == "hermes-smoke-us-001"
+        # ROB-308/ROB-301 — consumed report UUIDs threaded into metadata.
+        assert report_row.report_metadata.get("symbol_intermediate_report_uuids") == [
+            symbol_report_uuid
+        ]
+        assert report_row.report_metadata.get("dimension_report_uuids") == [
+            dimension_report_uuid
+        ]
+
+        # Read surface: the final bundle classifies the new_buy_candidate item.
+        read_app = _build_read_app(db_session)
+        async with AsyncClient(
+            transport=ASGITransport(app=read_app), base_url="https://test"
+        ) as read_client:
+            bundle_resp = await read_client.get(
+                f"/trading/api/investment-reports/{report_uuid}"
+            )
+            assert bundle_resp.status_code == 200, bundle_resp.text
+            rollup = bundle_resp.json()["decision_rollup"]
+            assert len(rollup["new_candidate"]) == 1
+            assert rollup["new_candidate"][0]["decision_bucket"] == "new_buy_candidate"
 
 
 def test_us_fixtures_pin_alpaca_paper_and_draft_and_us_symbols() -> None:


### PR DESCRIPTION
## What & why

The Hermes round-trip smoke (`scripts/hermes_roundtrip_smoke.py`, runbook §7) was the ROB-287 baseline — context → stage-artifacts → composition. It did **not** exercise the legs shipped since: ROB-301 symbol-reports, ROB-306 dimension-reports, ROB-308 final-synthesis fields. So an operator running it could not validate the Market→final loop.

This extends the smoke (+ fixtures + round-trip test + runbook) so one run exercises the **full current contract**, gating the "validate the real Hermes round-trip" step before adding more dimensions.

Linear: ROB-309 (related: ROB-306, ROB-308). **Validation tooling only — no app/ production code, no schema, no migration.**

## New smoke step sequence
1. POST `/context` (first pull)
2. POST `/stage-artifacts`
3. POST `/symbol-reports` (capture `symbol_report_uuid`)
4. POST `/dimension-reports` (capture market `dimension_report_uuid`)
5. POST `/context` re-pull → **assert non-empty `dimension_reports` + `symbol_intermediate_reports`** (gates ROB-308 C1; in the always-run, exit-code-gating chain)
6. POST `/composition` (threads captured UUIDs; classified `new_buy_candidate` item with citations)
7. GET `/runs/{run_uuid}/dimension-reports?dimension=market`
8. GET `/investment-reports/{report_uuid}` → assert `decision_rollup.new_candidate` non-empty + held/candidate `item_groups`

## Notes

- **No real LLM** — fixtures only (wire-contract validation). Real-Hermes quality run stays operator-driven; runbook §7/§8 documents verifying the new dimension report + held/candidate split.
- Read surfaces (steps 7–8) are **session-authed**, not Hermes-token-authed. The CLI adds `--session-cookie`; when omitted, the ingest chain (1–6) still runs + gates exit code, and steps 7–8 skip with a clear warning (honest narrowing, not masked success). The in-app round-trip test covers steps 7–8 via an auth-overridden app.
- Advisory-only invariants unchanged.

## Files
4 new fixtures (`symbol_reports_request{,_us}.json`, `dimension_reports_request{,_us}.json`) + 2 extended composition fixtures; `hermes_roundtrip_smoke.py` (8-step chain + UUID threading + `--session-cookie`); `tests/test_hermes_roundtrip_smoke.py` + `tests/scripts/test_hermes_roundtrip_smoke_cli.py` extended; runbook §7/§8.

## Tests
Round-trip **7 passed**, CLI **16 passed**, ROB-287 no-internal-LLM guard **36 passed** (59 total). `ruff`/`ty` clean. No `app/` code changed → no broad-regression risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)