### PR TITLE
feat(rob-307): broker-side bracket TP/SL exit strategy (PR3)

### DIFF
--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import logging
 import uuid
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -58,6 +59,8 @@ from app.services.brokers.binance.spot_demo.sizing import (
     compute_demo_order_qty,
 )
 
+logger = logging.getLogger(__name__)
+
 _VENUE = "binance"
 _VENUE_HOST = {
     "spot": "demo-api.binance.com",
@@ -66,6 +69,10 @@ _VENUE_HOST = {
 _TERMINAL_NONFILL = frozenset({"CANCELED", "REJECTED", "EXPIRED"})
 _FILL_POLL_MAX = 5
 _FILL_POLL_DELAY_SECONDS = 1.0
+_BPS = Decimal("10000")
+# Spot OCO stop-limit price sits a hair below the stop trigger so a SELL
+# stop-limit reliably fills once triggered.
+_SL_LIMIT_BUFFER_BPS = Decimal("5")
 
 
 def _new_cid() -> str:
@@ -74,6 +81,14 @@ def _new_cid() -> str:
 
 def _base_asset(symbol: str) -> str:
     return symbol[:-4] if symbol.endswith("USDT") else symbol
+
+
+def _align_price(price: Decimal, tick: Decimal) -> Decimal:
+    """Floor ``price`` to the exchange ``tick`` (PRICE_FILTER) so a bracket
+    stop/limit price is never rejected for tick misalignment."""
+    if tick <= 0:
+        return price
+    return (price // tick) * tick
 
 
 @dataclass(frozen=True)
@@ -88,6 +103,7 @@ class ExecutionResult:
     sized_notional_usdt: Decimal | None = None
     final_open_orders: int | None = None
     final_flat: bool | None = None
+    bracket_client_order_ids: tuple[str, ...] = field(default_factory=tuple)
 
     def to_evidence_dict(self) -> dict[str, Any]:
         return {
@@ -97,6 +113,7 @@ class ExecutionResult:
             "side": self.intent.side,
             "open_client_order_id": self.open_client_order_id,
             "close_client_order_id": self.close_client_order_id,
+            "bracket_client_order_ids": list(self.bracket_client_order_ids),
             "reason_codes": list(self.reason_codes),
             "anomaly_reason": self.anomaly_reason,
             "sized_qty": None if self.sized_qty is None else str(self.sized_qty),
@@ -260,7 +277,16 @@ class DemoScalpingExecutor:
         return False  # fail-closed: fill not proven
 
     async def _open_leg(
-        self, intent, instrument_id, qty, notional, *, reduce_only=False, role="open"
+        self,
+        intent,
+        instrument_id,
+        qty,
+        notional,
+        *,
+        reduce_only=False,
+        role="open",
+        tp_price: Decimal | None = None,
+        sl_price: Decimal | None = None,
     ) -> tuple[str, Any]:
         cid = _new_cid()
         meta = {
@@ -279,8 +305,8 @@ class DemoScalpingExecutor:
             order_type="MARKET",
             qty=qty,
             price=None,
-            tp_price=intent.tp_price,
-            sl_price=intent.sl_price,
+            tp_price=tp_price if tp_price is not None else intent.tp_price,
+            sl_price=sl_price if sl_price is not None else intent.sl_price,
             notional_usdt=notional,
             extra_metadata=meta,
             now=self.now,
@@ -305,6 +331,251 @@ class DemoScalpingExecutor:
             extra_metadata_merge={"submit_status": submit.status},
         )
         return cid, submit
+
+    # ------------------------------------------------------------------
+    # Broker-side bracket (PR3): open + place exchange-native TP/SL, hold.
+    # ------------------------------------------------------------------
+    async def execute_bracket(
+        self,
+        intent: OrderIntent,
+        *,
+        confirm: bool = False,
+        tp_bps: Decimal = Decimal("30"),
+        sl_bps: Decimal = Decimal("20"),
+    ) -> ExecutionResult:
+        """Open, place broker-side TP+SL, and **leave the protected position**.
+
+        Unlike :meth:`execute` (open + close-flat), this holds the position
+        with exchange-native exits resting (futures: STOP_MARKET +
+        TAKE_PROFIT_MARKET reduceOnly; spot: one SELL OCO). Terminal status
+        ``bracketed`` means held + protected; the position is intentionally
+        not flat. Exit detection + survivor-leg cleanup is a separate
+        reconcile step (later poll / scheduler tick).
+        """
+        snapshot = await load_ledger_snapshot(
+            self.ledger, product=intent.product, symbol=intent.symbol, now=self.now
+        )
+        risk = evaluate_risk(
+            product=intent.product,
+            symbol=intent.symbol,
+            side=intent.side,
+            target_notional_usdt=intent.target_notional_usdt,
+            limits=self.limits,
+            ledger=snapshot,
+            market=MarketConditions(
+                spread_bps=Decimal("0"),
+                data_age_seconds=0.0,
+                spot_free_base_qty=Decimal("0"),
+            ),
+        )
+        if not risk.allowed:
+            return ExecutionResult(
+                intent=intent, status="blocked", reason_codes=risk.reason_codes
+            )
+
+        ref = await self.reference.fetch(intent.product, intent.symbol)
+        sized = self._size(intent, ref)
+        if isinstance(sized, str):
+            return ExecutionResult(
+                intent=intent, status="blocked", reason_codes=(sized,)
+            )
+        qty, notional = sized
+
+        long = intent.side == "BUY"
+        if long:
+            tp = _align_price(ref.price * (Decimal("1") + tp_bps / _BPS), ref.tick_size)
+            sl = _align_price(ref.price * (Decimal("1") - sl_bps / _BPS), ref.tick_size)
+            close_side = "SELL"
+        else:
+            tp = _align_price(ref.price * (Decimal("1") - tp_bps / _BPS), ref.tick_size)
+            sl = _align_price(ref.price * (Decimal("1") + sl_bps / _BPS), ref.tick_size)
+            close_side = "BUY"
+
+        if not confirm:
+            return ExecutionResult(
+                intent=intent,
+                status="dry_run",
+                sized_qty=qty,
+                sized_notional_usdt=notional,
+            )
+
+        instrument_id = await self._resolve_or_create_instrument(intent.symbol)
+        if intent.product == "usdm_futures":
+            mode = await self.client.get_position_mode()
+            if mode.is_hedge_mode:
+                return ExecutionResult(
+                    intent=intent,
+                    status="blocked",
+                    reason_codes=("futures_hedge_mode_blocked",),
+                )
+            leverage = await self.client.set_leverage(symbol=intent.symbol, leverage=1)
+            if leverage.leverage != 1:
+                return ExecutionResult(
+                    intent=intent,
+                    status="blocked",
+                    reason_codes=("futures_leverage_mismatch",),
+                )
+
+        open_cid, submit = await self._open_leg(
+            intent, instrument_id, qty, notional, tp_price=tp, sl_price=sl
+        )
+        proven = await self._fill_proven(intent.symbol, open_cid, submit.status)
+        if not proven and intent.product == "usdm_futures":
+            position = await self.client.get_position(symbol=intent.symbol)
+            proven = not position.is_flat
+        if not proven:
+            reason = "bracket_open_fill_unproven"
+            await self.ledger.record_anomaly(
+                client_order_id=open_cid, reason=reason, now=self.now
+            )
+            return ExecutionResult(
+                intent=intent,
+                status="anomaly",
+                open_client_order_id=open_cid,
+                anomaly_reason=reason,
+                sized_qty=qty,
+                sized_notional_usdt=notional,
+            )
+
+        try:
+            bracket_info, bracket_cids = await self._place_bracket(
+                intent, ref, qty, tp=tp, sl=sl, close_side=close_side
+            )
+        except Exception as exc:  # noqa: BLE001 — failsafe: never leave unprotected
+            await self._failsafe_close(intent, qty, close_side)
+            reason = f"bracket_placement_failed_position_closed: {exc}"
+            await self.ledger.record_anomaly(
+                client_order_id=open_cid, reason=reason, now=self.now
+            )
+            return ExecutionResult(
+                intent=intent,
+                status="anomaly",
+                open_client_order_id=open_cid,
+                anomaly_reason=reason,
+                sized_qty=qty,
+                sized_notional_usdt=notional,
+                final_flat=True,
+            )
+
+        await self.ledger.record_filled(
+            client_order_id=open_cid,
+            now=self.now,
+            extra_metadata_merge={"bracket": bracket_info},
+        )
+        return ExecutionResult(
+            intent=intent,
+            status="bracketed",
+            open_client_order_id=open_cid,
+            bracket_client_order_ids=bracket_cids,
+            sized_qty=qty,
+            sized_notional_usdt=notional,
+            final_flat=False,
+        )
+
+    async def _place_bracket(
+        self, intent, ref, qty, *, tp: Decimal, sl: Decimal, close_side: str
+    ) -> tuple[dict[str, Any], tuple[str, ...]]:
+        if intent.product == "usdm_futures":
+            position = await self.client.get_position(symbol=intent.symbol)
+            close_qty = abs(position.position_amt) or qty
+            sl_cid = _new_cid()
+            tp_cid = _new_cid()
+            await self.client.submit_reduce_only_trigger(
+                symbol=intent.symbol,
+                side=close_side,
+                order_type="STOP_MARKET",
+                qty=close_qty,
+                stop_price=sl,
+                client_order_id=sl_cid,
+                confirm=True,
+            )
+            await self.client.submit_reduce_only_trigger(
+                symbol=intent.symbol,
+                side=close_side,
+                order_type="TAKE_PROFIT_MARKET",
+                qty=close_qty,
+                stop_price=tp,
+                client_order_id=tp_cid,
+                confirm=True,
+            )
+            info = {
+                "type": "futures_triggers",
+                "sl_client_order_id": sl_cid,
+                "tp_client_order_id": tp_cid,
+                "sl_price": str(sl),
+                "tp_price": str(tp),
+                "close_side": close_side,
+            }
+            return info, (sl_cid, tp_cid)
+
+        # Spot OCO on the free base balance (never the raw BUY qty).
+        balance = await self.client.get_asset_balance(asset=_base_asset(intent.symbol))
+        close = compute_close_qty(
+            free_balance=balance.free,
+            price=ref.price,
+            min_notional=ref.min_notional,
+            step_size=ref.step_size,
+        )
+        if not isinstance(close, CloseQtyResult):
+            raise RuntimeError(f"spot bracket qty not sellable: {close}")
+        sl_limit = _align_price(
+            sl * (Decimal("1") - _SL_LIMIT_BUFFER_BPS / _BPS), ref.tick_size
+        )
+        oco_cid = _new_cid()
+        oco = await self.client.submit_oco(
+            symbol=intent.symbol,
+            side="SELL",
+            quantity=close.qty,
+            tp_price=tp,
+            sl_stop_price=sl,
+            sl_limit_price=sl_limit,
+            list_client_order_id=oco_cid,
+            confirm=True,
+        )
+        info = {
+            "type": "spot_oco",
+            "order_list_id": oco.order_list_id,
+            "leg_client_order_ids": list(oco.leg_client_order_ids),
+            "tp_price": str(tp),
+            "sl_stop_price": str(sl),
+            "sl_limit_price": str(sl_limit),
+        }
+        return info, tuple(oco.leg_client_order_ids)
+
+    async def _failsafe_close(self, intent, qty, close_side) -> None:
+        """Best-effort flatten after a bracket-placement failure."""
+        try:
+            if intent.product == "usdm_futures":
+                await self.client.submit_order(
+                    symbol=intent.symbol,
+                    side=close_side,
+                    order_type="MARKET",
+                    qty=qty,
+                    client_order_id=_new_cid(),
+                    reduce_only=True,
+                    confirm=True,
+                )
+            else:
+                balance = await self.client.get_asset_balance(
+                    asset=_base_asset(intent.symbol)
+                )
+                close = compute_close_qty(
+                    free_balance=balance.free,
+                    price=Decimal("1"),
+                    min_notional=Decimal("0"),
+                    step_size=Decimal("0.00000001"),
+                )
+                if isinstance(close, CloseQtyResult):
+                    await self.client.submit_order(
+                        symbol=intent.symbol,
+                        side="SELL",
+                        order_type="MARKET",
+                        qty=close.qty,
+                        client_order_id=_new_cid(),
+                        confirm=True,
+                    )
+        except Exception:  # noqa: BLE001 — failsafe is best-effort
+            logger.exception("failsafe close failed for %s", intent.symbol)
 
     # ------------------------------------------------------------------
     # Spot lifecycle

--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -542,6 +542,101 @@ class DemoScalpingExecutor:
         }
         return info, tuple(oco.leg_client_order_ids)
 
+    async def _symbol_for_instrument(self, instrument_id: int) -> str:
+        symbol = await self.session.scalar(
+            select(CryptoInstrument.venue_symbol).where(
+                CryptoInstrument.id == instrument_id
+            )
+        )
+        if symbol is None:
+            raise RuntimeError(f"no crypto_instrument for id={instrument_id}")
+        return symbol
+
+    async def reconcile_bracket(self, *, open_client_order_id: str) -> ExecutionResult:
+        """Reconcile a held bracketed position on a later tick.
+
+        Still holding (futures non-flat / spot OCO legs resting) → no-op
+        (``still_protected``). Exit fired (futures flat / spot OCO
+        resolved) → cancel any surviving leg and drive the parent
+        ``filled → closed → reconciled``. A parent not in ``filled`` is a
+        no-op (already terminal).
+        """
+        row = await self.ledger.get_by_client_order_id(open_client_order_id)
+        if row is None:
+            raise ValueError(f"no ledger row for {open_client_order_id!r}")
+        # ``intent`` is only needed for the result envelope; rebuild a minimal one.
+        intent = OrderIntent(
+            product=row.product,  # type: ignore[arg-type]
+            symbol=await self._symbol_for_instrument(row.instrument_id),
+            side=row.side,  # type: ignore[arg-type]
+            order_type=row.order_type,
+            target_notional_usdt=row.notional_usdt or Decimal("0"),
+            entry_reference_price=None,
+            tp_price=row.tp_price,
+            sl_price=row.sl_price,
+            confidence=Decimal("0"),
+            reason_codes=(),
+            source_candle_close_time_ms=0,
+            evaluated_at_ms=0,
+        )
+        if row.lifecycle_state != "filled":
+            return ExecutionResult(
+                intent=intent, status="noop", open_client_order_id=open_client_order_id
+            )
+
+        symbol = intent.symbol
+        if row.product == "usdm_futures":
+            position = await self.client.get_position(symbol=symbol)
+            if not position.is_flat:
+                return ExecutionResult(
+                    intent=intent,
+                    status="still_protected",
+                    open_client_order_id=open_client_order_id,
+                    final_flat=False,
+                )
+            open_orders = await self.client.get_open_orders(symbol=symbol)
+            for order in open_orders.orders:
+                await self.client.cancel_order(
+                    symbol=symbol, client_order_id=order.client_order_id
+                )
+            remaining = await self.client.get_open_orders(symbol=symbol)
+            if len(remaining.orders) != 0:
+                reason = "bracket_reconcile_dirty: open orders remain after cancel"
+                await self.ledger.record_anomaly(
+                    client_order_id=open_client_order_id, reason=reason, now=self.now
+                )
+                return ExecutionResult(
+                    intent=intent,
+                    status="anomaly",
+                    open_client_order_id=open_client_order_id,
+                    anomaly_reason=reason,
+                    final_open_orders=len(remaining.orders),
+                    final_flat=True,
+                )
+        else:  # spot: OCO self-cancels its sibling, so resolved == no open orders
+            open_orders = await self.client.get_open_orders(symbol=symbol)
+            if len(open_orders.orders) != 0:
+                return ExecutionResult(
+                    intent=intent,
+                    status="still_protected",
+                    open_client_order_id=open_client_order_id,
+                    final_open_orders=len(open_orders.orders),
+                )
+
+        await self.ledger.record_closed(
+            client_order_id=open_client_order_id, now=self.now
+        )
+        await self.ledger.record_reconciled(
+            client_order_id=open_client_order_id, now=self.now
+        )
+        return ExecutionResult(
+            intent=intent,
+            status="reconciled",
+            open_client_order_id=open_client_order_id,
+            final_open_orders=0,
+            final_flat=True,
+        )
+
     async def _failsafe_close(self, intent, qty, close_side) -> None:
         """Best-effort flatten after a bracket-placement failure."""
         try:

--- a/app/services/brokers/binance/demo_scalping_exec/reference.py
+++ b/app/services/brokers/binance/demo_scalping_exec/reference.py
@@ -40,8 +40,9 @@ class ReferenceDataError(RuntimeError):
 @dataclass(frozen=True)
 class SymbolReference:
     price: Decimal
-    step_size: Decimal  # MARKET sizing step
+    step_size: Decimal  # MARKET sizing step (LOT_SIZE / MARKET_LOT_SIZE)
     min_notional: Decimal
+    tick_size: Decimal  # PRICE_FILTER tick — for tick-aligning bracket prices
 
 
 def _find_symbol_row(body: dict[str, Any], symbol: str) -> dict[str, Any]:
@@ -51,7 +52,8 @@ def _find_symbol_row(body: dict[str, Any], symbol: str) -> dict[str, Any]:
     raise ReferenceDataError(f"exchangeInfo has no row for {symbol!r}")
 
 
-def _market_step_and_min_notional(row: dict[str, Any]) -> tuple[Decimal, Decimal]:
+def _parse_filters(row: dict[str, Any]) -> tuple[Decimal, Decimal, Decimal]:
+    """Return ``(market_step, min_notional, tick_size)`` from a symbol row."""
     filters = {f.get("filterType"): f for f in row.get("filters", [])}
 
     # MARKET orders use MARKET_LOT_SIZE when present and non-zero, else LOT_SIZE.
@@ -78,7 +80,14 @@ def _market_step_and_min_notional(row: dict[str, Any]) -> tuple[Decimal, Decimal
                 break
         if min_notional > 0:
             break
-    return step, min_notional
+
+    # PRICE_FILTER tickSize — needed to tick-align bracket stop/limit prices.
+    price_filter = filters.get("PRICE_FILTER")
+    if not price_filter or Decimal(str(price_filter.get("tickSize", "0"))) <= 0:
+        raise ReferenceDataError("no usable PRICE_FILTER tickSize")
+    tick_size = Decimal(str(price_filter["tickSize"]))
+
+    return step, min_notional, tick_size
 
 
 class DemoReferenceData:
@@ -94,7 +103,7 @@ class DemoReferenceData:
             base + _EXCHANGE_INFO_PATH[product], params={"symbol": symbol}
         )
         info.raise_for_status()
-        step, min_notional = _market_step_and_min_notional(
+        step, min_notional, tick_size = _parse_filters(
             _find_symbol_row(info.json(), symbol)
         )
 
@@ -110,6 +119,7 @@ class DemoReferenceData:
             price=Decimal(str(raw_price)),
             step_size=step,
             min_notional=min_notional,
+            tick_size=tick_size,
         )
 
     async def aclose(self) -> None:

--- a/app/services/brokers/binance/futures_demo/execution_client.py
+++ b/app/services/brokers/binance/futures_demo/execution_client.py
@@ -89,6 +89,10 @@ _LEVERAGE_PATH: Final[str] = "/fapi/v1/leverage"
 
 ALLOWED_SIDES: Final[frozenset[str]] = frozenset({"BUY", "SELL"})
 ALLOWED_ORDER_TYPES: Final[frozenset[str]] = frozenset({"LIMIT", "MARKET"})
+# ROB-307 PR3 — broker-side bracket exit legs (always reduceOnly).
+TRIGGER_ORDER_TYPES: Final[frozenset[str]] = frozenset(
+    {"STOP_MARKET", "TAKE_PROFIT_MARKET"}
+)
 
 
 def _truthy(value: str | None) -> bool:
@@ -411,6 +415,75 @@ class BinanceFuturesDemoExecutionClient:
             avg_price=Decimal(str(body.get("avgPrice", "0"))),
             status=str(body.get("status", "UNKNOWN")),
             reduce_only=bool(body.get("reduceOnly", reduce_only)),
+            raw_response_redacted=_redact(body),
+        )
+
+    async def submit_reduce_only_trigger(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        order_type: str,
+        qty: Decimal,
+        stop_price: Decimal,
+        client_order_id: str | None = None,
+        confirm: bool = False,
+    ) -> FuturesDemoOrderSubmitResult | FuturesDemoDryRunResult:
+        """Operator-gated reduceOnly trigger exit (STOP_MARKET / TAKE_PROFIT_MARKET).
+
+        A broker-side bracket exit leg: MARKET-triggered at ``stop_price``
+        and **always** ``reduceOnly=true`` (these only ever close a
+        position, never open one). Dry-run with zero HTTP unless
+        ``confirm=True``; ``confirm=True`` signs the params via the HMAC
+        chokepoint and POSTs to ``demo-fapi.binance.com/fapi/v1/order``.
+        """
+        if not symbol or not symbol.strip():
+            raise ValueError("symbol must be non-empty")
+        if side not in ALLOWED_SIDES:
+            raise ValueError(f"side {side!r} not in {sorted(ALLOWED_SIDES)}")
+        if order_type not in TRIGGER_ORDER_TYPES:
+            raise ValueError(
+                f"order_type {order_type!r} not in {sorted(TRIGGER_ORDER_TYPES)}"
+            )
+        if qty <= 0:
+            raise ValueError(f"qty must be > 0, got {qty}")
+        if stop_price <= 0:
+            raise ValueError(f"stop_price must be > 0, got {stop_price}")
+        cid = client_order_id or self._new_client_order_id()
+        if not confirm:
+            return FuturesDemoDryRunResult(
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                qty=qty,
+                client_order_id=cid,
+                reduce_only=True,
+            )
+        params: dict[str, str] = {
+            "symbol": symbol,
+            "side": side,
+            "type": order_type,
+            "quantity": format(qty, "f"),
+            "stopPrice": format(stop_price, "f"),
+            "reduceOnly": "true",
+            "recvWindow": str(BINANCE_FUTURES_DEMO_RECV_WINDOW_MS),
+            "newClientOrderId": cid,
+        }
+        signed = _sign_request_params(params=params, api_secret=self._api_secret)
+        resp = await self._client.post(_ORDER_PATH, params=signed)
+        resp.raise_for_status()
+        body = resp.json()
+        return FuturesDemoOrderSubmitResult(
+            client_order_id=str(body.get("clientOrderId", cid)),
+            broker_order_id=str(body.get("orderId", "")),
+            symbol=str(body.get("symbol", symbol)),
+            side=str(body.get("side", side)),
+            order_type=str(body.get("type", order_type)),
+            qty=Decimal(str(body.get("origQty", qty))),
+            executed_qty=Decimal(str(body.get("executedQty", "0"))),
+            avg_price=Decimal(str(body.get("avgPrice", "0"))),
+            status=str(body.get("status", "UNKNOWN")),
+            reduce_only=bool(body.get("reduceOnly", True)),
             raw_response_redacted=_redact(body),
         )
 

--- a/app/services/brokers/binance/spot_demo/dto.py
+++ b/app/services/brokers/binance/spot_demo/dto.py
@@ -69,3 +69,13 @@ class SpotDemoAssetBalance:
     asset: str
     free: Decimal
     locked: Decimal
+
+
+@dataclass(frozen=True)
+class SpotDemoOcoResult:
+    """ROB-307 PR3 — a placed OCO order list (TP limit + SL stop-limit)."""
+
+    order_list_id: str
+    list_status: str
+    leg_client_order_ids: tuple[str, ...]
+    raw_response_redacted: dict[str, Any] = field(default_factory=dict)

--- a/app/services/brokers/binance/spot_demo/execution_client.py
+++ b/app/services/brokers/binance/spot_demo/execution_client.py
@@ -44,6 +44,7 @@ from app.services.brokers.binance.demo.errors import BinanceDemoCredentialError
 from app.services.brokers.binance.spot_demo.dto import (
     SpotDemoAssetBalance,
     SpotDemoCancelResult,
+    SpotDemoOcoResult,
     SpotDemoOpenOrder,
     SpotDemoOpenOrdersResult,
     SpotDemoOrderSubmitResult,
@@ -63,6 +64,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_BASE_URL: Final[str] = "https://demo-api.binance.com"
 _ORDER_PATH: Final[str] = "/api/v3/order"
+_OCO_PATH: Final[str] = "/api/v3/order/oco"
 _ORDER_TEST_PATH: Final[str] = "/api/v3/order/test"
 _OPEN_ORDERS_PATH: Final[str] = "/api/v3/openOrders"
 _ACCOUNT_PATH: Final[str] = "/api/v3/account"
@@ -351,6 +353,79 @@ class BinanceSpotDemoExecutionClient:
             executed_qty=Decimal(str(body.get("executedQty", "0"))),
             cummulative_quote_qty=Decimal(str(body.get("cummulativeQuoteQty", "0"))),
             status=body.get("status", "UNKNOWN"),
+            raw_response_redacted=_redact(body),
+        )
+
+    async def submit_oco(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        quantity: Decimal,
+        tp_price: Decimal,
+        sl_stop_price: Decimal,
+        sl_limit_price: Decimal,
+        time_in_force: str = "GTC",
+        list_client_order_id: str | None = None,
+        confirm: bool = False,
+    ) -> SpotDemoOcoResult | SpotDemoDryRunResult:
+        """Operator-gated SELL OCO bracket on a held long (TP + SL).
+
+        Spot has no reduceOnly, so the broker-side bracket is a one-cancels-
+        other pair: a LIMIT take-profit (``tp_price``, above) and a
+        STOP_LOSS_LIMIT (trigger ``sl_stop_price`` / limit ``sl_limit_price``,
+        below). Dry-run with zero HTTP unless ``confirm=True``; the signed
+        POST goes to ``demo-api.binance.com/api/v3/order/oco``.
+        """
+        if not symbol or not symbol.strip():
+            raise ValueError("symbol must be non-empty")
+        if side not in ALLOWED_SIDES:
+            raise ValueError(f"side {side!r} not in {sorted(ALLOWED_SIDES)}")
+        if quantity <= 0:
+            raise ValueError(f"quantity must be > 0, got {quantity}")
+        for label, value in (
+            ("tp_price", tp_price),
+            ("sl_stop_price", sl_stop_price),
+            ("sl_limit_price", sl_limit_price),
+        ):
+            if value <= 0:
+                raise ValueError(f"{label} must be > 0, got {value}")
+        if side == "SELL" and tp_price <= sl_stop_price:
+            raise ValueError(
+                "SELL OCO requires tp_price above sl_stop_price "
+                f"(got tp={tp_price}, sl={sl_stop_price})"
+            )
+        cid = list_client_order_id or self._new_client_order_id()
+        if not confirm:
+            return SpotDemoDryRunResult(
+                symbol=symbol,
+                side=side,
+                order_type="OCO",
+                qty=quantity,
+                client_order_id=cid,
+            )
+        params: dict[str, str] = {
+            "symbol": symbol,
+            "side": side,
+            "quantity": format(quantity, "f"),
+            "price": format(tp_price, "f"),
+            "stopPrice": format(sl_stop_price, "f"),
+            "stopLimitPrice": format(sl_limit_price, "f"),
+            "stopLimitTimeInForce": time_in_force,
+            "listClientOrderId": cid,
+            "recvWindow": str(BINANCE_SPOT_DEMO_RECV_WINDOW_MS),
+        }
+        signed = _sign_request_params(params=params, api_secret=self._api_secret)
+        resp = await self._client.post(_OCO_PATH, params=signed)
+        resp.raise_for_status()
+        body = resp.json()
+        legs = tuple(
+            str(order.get("clientOrderId", "")) for order in body.get("orders", [])
+        )
+        return SpotDemoOcoResult(
+            order_list_id=str(body.get("orderListId", "")),
+            list_status=str(body.get("listOrderStatus", "UNKNOWN")),
+            leg_client_order_ids=legs,
             raw_response_redacted=_redact(body),
         )
 

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -166,11 +166,65 @@ don't (correctly) trip the global cap. Procedure:
 5. Capture the redacted evidence line + a broker/ledger reconciliation
    check (open orders 0; futures position flat).
 
-## Not in PR2 (later phases)
+## Broker-side bracket TP/SL (PR3)
 
-- TP/SL exit strategy (PR3) — broker-side bracket preferred, else a
-  bounded app-managed monitor (§2). PR2 never leaves an unattended
-  position.
-- Scheduler scaffold + kill switch (PR4) — TaskIQ default-OFF; any
-  Prefect deployment lives in `robin-prefect-automations` and activation
-  is a separate operator gate.
+PR3 adds the §2-preferred **broker-side bracket**: after entry, place
+exchange-native exits and **hold the protected position** (it survives
+across scheduler runs — that's the point). Exit detection + cleanup is a
+separate reconcile step.
+
+| Surface | Added |
+|---|---|
+| `futures_demo` exec client | `submit_reduce_only_trigger` (STOP_MARKET / TAKE_PROFIT_MARKET, reduceOnly) |
+| `spot_demo` exec client | `submit_oco` (SELL OCO: TP limit + SL stop-limit) |
+| `demo_scalping_exec/reference.py` | `tick_size` (PRICE_FILTER) for tick-aligned bracket prices |
+| `demo_scalping_exec/executor.py` | `execute_bracket` (open + place TP/SL + hold) and `reconcile_bracket` (detect exit, cancel survivor, close+reconcile) |
+| `scripts/binance_demo_scalping_execute.py` | `--bracket` and `--reconcile OPEN_CID` modes |
+
+**Lifecycle:** `execute_bracket` → open (MARKET) → fill-resolve → place
+TP+SL (futures: two reduceOnly triggers; spot: one OCO, tick-aligned) →
+`record_filled` with the bracket leg ids in `extra_metadata` → status
+`bracketed` (parent stays `filled`, exits resting). Unproven fill →
+`anomaly` (no bracket). Bracket-placement failure → best-effort failsafe
+close + `anomaly` (never left unprotected). On a later tick,
+`reconcile_bracket` → still holding = `still_protected` (no-op); exit
+fired = cancel any surviving futures leg (spot OCO self-cancels) →
+parent `filled→closed→reconciled`.
+
+```bash
+# Open + bracket + HOLD (real; clean ledger DB + Demo creds + product gate)
+BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_FUTURES_DEMO_ENABLED=true \
+  uv run python scripts/binance_demo_scalping_execute.py \
+    --product usdm_futures --symbol XRPUSDT --bracket --confirm
+# → status=bracketed; note the open_client_order_id from the evidence line
+
+# Later: reconcile the held position by its open client_order_id
+BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_FUTURES_DEMO_ENABLED=true \
+  uv run python scripts/binance_demo_scalping_execute.py \
+    --product usdm_futures --symbol XRPUSDT --reconcile rob307-<...>
+# → still_protected (held) OR reconciled (exit fired, survivor cancelled)
+```
+
+### Live demo trigger-firing validation (operator, clean env)
+
+Unit tests cover placement + cancellation + reconcile logic with a fake
+broker; they **cannot** prove Binance Demo actually *fires* a STOP/TP
+trigger (needs real price movement). Validate live in a clean demo ledger
+DB:
+
+1. `--bracket --confirm` a tiny position; confirm both exit legs rest
+   (`GET openOrders` shows STOP_MARKET + TAKE_PROFIT_MARKET, or the OCO
+   list) and the position is held.
+2. Wait for (or nudge via a near-the-money trigger) one leg to fire;
+   confirm the position goes flat.
+3. `--reconcile <open_cid>`; confirm the surviving leg is cancelled
+   (futures), open orders = 0, and the parent ledger row reconciles.
+4. Capture redacted evidence (order ids, leg statuses, final flat /
+   open-orders-0).
+
+## Not in PR3 (later phases)
+
+- Scheduler scaffold + kill switch (PR4) — TaskIQ default-OFF that drives
+  `execute_bracket` on a signal and `reconcile_bracket` on held positions
+  each tick; any Prefect deployment lives in `robin-prefect-automations`
+  and activation is a separate operator gate.

--- a/scripts/binance_demo_scalping_execute.py
+++ b/scripts/binance_demo_scalping_execute.py
@@ -37,7 +37,15 @@ logger = logging.getLogger("rob307.demo_scalping_execute")
 
 _ENABLED_ENV = "BINANCE_DEMO_SCALPING_ENABLED"
 _VALID_PRODUCTS = ("spot", "usdm_futures")
-_EXIT_BY_STATUS = {"reconciled": 0, "dry_run": 0, "blocked": 1, "anomaly": 2}
+_EXIT_BY_STATUS = {
+    "reconciled": 0,
+    "dry_run": 0,
+    "bracketed": 0,  # opened + protected (held); success
+    "still_protected": 0,  # reconcile no-op; position still held + protected
+    "noop": 0,  # nothing to reconcile (already terminal)
+    "blocked": 1,
+    "anomaly": 2,
+}
 
 
 def _truthy(value: str | None) -> bool:
@@ -92,6 +100,22 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         action="store_true",
         help="Place real Demo orders. Without it, dry-run (no mutation).",
     )
+    parser.add_argument(
+        "--bracket",
+        action="store_true",
+        help=(
+            "Open + place broker-side TP/SL and HOLD the protected position "
+            "(vs the default open+close-flat). Reconcile later with --reconcile."
+        ),
+    )
+    parser.add_argument(
+        "--reconcile",
+        metavar="OPEN_CID",
+        help=(
+            "Reconcile a held bracketed position by its open client_order_id: "
+            "detect exit, cancel any surviving leg, close+reconcile the parent."
+        ),
+    )
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args(argv)
 
@@ -105,13 +129,6 @@ async def _run(args: argparse.Namespace) -> int:
 
     now = dt.datetime.now(dt.UTC)
     limits = ScalpingRiskLimits()
-    intent = build_manual_intent(
-        product=args.product,
-        symbol=args.symbol,
-        side=args.side,
-        now=now,
-        limits=limits,
-    )
 
     # Lazy imports so the disabled path triggers zero engine/credential setup.
     from app.core.db import AsyncSessionLocal
@@ -146,7 +163,24 @@ async def _run(args: argparse.Namespace) -> int:
                 now=now,
                 limits=limits,
             )
-            result = await executor.execute(intent, confirm=args.confirm)
+            if args.reconcile:
+                result = await executor.reconcile_bracket(
+                    open_client_order_id=args.reconcile
+                )
+            else:
+                intent = build_manual_intent(
+                    product=args.product,
+                    symbol=args.symbol,
+                    side=args.side,
+                    now=now,
+                    limits=limits,
+                )
+                if args.bracket:
+                    result = await executor.execute_bracket(
+                        intent, confirm=args.confirm
+                    )
+                else:
+                    result = await executor.execute(intent, confirm=args.confirm)
             await session.commit()
     finally:
         await reference.aclose()

--- a/tests/scripts/test_binance_demo_scalping_execute.py
+++ b/tests/scripts/test_binance_demo_scalping_execute.py
@@ -80,10 +80,11 @@ class _FakeReference:
 
 
 class _FakeResult:
-    status = "dry_run"
+    def __init__(self, status: str = "dry_run") -> None:
+        self.status = status
 
     def to_evidence_dict(self) -> dict:
-        return {"status": "dry_run"}
+        return {"status": self.status}
 
 
 class _FakeExecutor:
@@ -91,7 +92,32 @@ class _FakeExecutor:
         pass
 
     async def execute(self, intent, *, confirm: bool):
-        return _FakeResult()
+        return _FakeResult("dry_run")
+
+    async def execute_bracket(self, intent, *, confirm: bool):
+        return _FakeResult("bracketed")
+
+    async def reconcile_bracket(self, *, open_client_order_id: str):
+        return _FakeResult("reconciled")
+
+
+def _patch_wiring(monkeypatch) -> None:
+    import app.core.db as dbmod
+    import app.services.brokers.binance.demo_scalping_exec.executor as exmod
+    import app.services.brokers.binance.demo_scalping_exec.reference as refmod
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+    from app.services.brokers.binance.spot_demo.execution_client import (
+        BinanceSpotDemoExecutionClient,
+    )
+
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    for cls in (BinanceSpotDemoExecutionClient, BinanceFuturesDemoExecutionClient):
+        monkeypatch.setattr(cls, "from_env", classmethod(lambda cls: _FakeClient()))
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(refmod, "DemoReferenceData", _FakeReference)
+    monkeypatch.setattr(exmod, "DemoScalpingExecutor", _FakeExecutor)
 
 
 def test_enabled_dry_run_wiring_does_not_await_sync_from_env(
@@ -120,3 +146,21 @@ def test_enabled_dry_run_wiring_does_not_await_sync_from_env(
     rc = main(["--product", "spot", "--symbol", "DOGEUSDT"])
     assert rc == 0
     assert "dry_run" in capsys.readouterr().out
+
+
+def test_bracket_flag_routes_to_execute_bracket(monkeypatch, capsys) -> None:
+    _patch_wiring(monkeypatch)
+    rc = main(
+        ["--product", "usdm_futures", "--symbol", "XRPUSDT", "--bracket", "--confirm"]
+    )
+    assert rc == 0  # bracketed -> success
+    assert "bracketed" in capsys.readouterr().out
+
+
+def test_reconcile_flag_routes_to_reconcile_bracket(monkeypatch, capsys) -> None:
+    _patch_wiring(monkeypatch)
+    rc = main(
+        ["--product", "usdm_futures", "--symbol", "XRPUSDT", "--reconcile", "rob307-x"]
+    )
+    assert rc == 0  # reconciled -> success
+    assert "reconciled" in capsys.readouterr().out

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor.py
@@ -221,10 +221,16 @@ async def _instrument(db_session, symbol, product) -> int:
 
 
 _SPOT_REF = SymbolReference(
-    price=Decimal("1.36"), step_size=Decimal("0.1"), min_notional=Decimal("5")
+    price=Decimal("1.36"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.0001"),
 )
 _FUT_REF = SymbolReference(
-    price=Decimal("1.36"), step_size=Decimal("0.1"), min_notional=Decimal("5")
+    price=Decimal("1.36"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.0001"),
 )
 
 

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_bracket.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_bracket.py
@@ -1,0 +1,322 @@
+"""ROB-307 PR3 — tests for broker-side bracket placement (execute_bracket).
+
+Unlike PR2's open+close-flat, the bracket path opens, places exchange-
+native exits (futures: STOP_MARKET + TAKE_PROFIT_MARKET reduceOnly; spot:
+one SELL OCO), then **leaves the protected position held** (status
+``bracketed``). Broker I/O faked; ledger is the real service on the test
+DB. The position is intentionally NOT flat at the end of this run.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+from app.services.brokers.binance.demo_scalping_exec.executor import (
+    DemoScalpingExecutor,
+)
+from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
+
+_NOW = dt.datetime(2026, 5, 24, 12, 0, 0, tzinfo=dt.UTC)
+_REF = SymbolReference(
+    price=Decimal("1.36"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.0001"),
+)
+
+
+def _limits_for(symbol: str) -> ScalpingRiskLimits:
+    return ScalpingRiskLimits(
+        allowlist=frozenset({symbol}),
+        excluded=frozenset(),
+        global_open_lifecycle_cap=10_000,
+        daily_order_count_cap=10_000,
+        daily_loss_budget_usdt=Decimal("1000000"),
+    )
+
+
+def _intent(product: str, symbol: str, side: str = "BUY") -> OrderIntent:
+    return OrderIntent(
+        product=product,
+        symbol=symbol,
+        side=side,
+        order_type="MARKET",
+        target_notional_usdt=Decimal("10"),
+        entry_reference_price=Decimal("1.36"),
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+class _FakeRef:
+    async def fetch(self, product, symbol):
+        return _REF
+
+    async def aclose(self):
+        return None
+
+
+class _Order:
+    def __init__(self, status, coid, broker="b1"):
+        self.status = status
+        self.client_order_id = coid
+        self.broker_order_id = broker
+        self.executed_qty = Decimal("7.3")
+
+
+class _OpenOrders:
+    def __init__(self, orders):
+        self.orders = orders
+
+
+class _Oco:
+    order_list_id = "777"
+    list_status = "EXECUTING"
+    leg_client_order_ids = ("tp-x", "sl-x")
+
+
+class _Position:
+    def __init__(self, amt):
+        self.position_amt = amt
+        self.is_flat = amt == 0
+        self.entry_price = Decimal("1.36")
+        self.leverage = 1
+
+
+class _PosMode:
+    is_hedge_mode = False
+
+
+class _Lev:
+    leverage = 1
+
+
+class _FakeSpot:
+    def __init__(self):
+        self.submits = []
+        self.ocos = []
+        self._free = Decimal("0")
+
+    async def submit_order(
+        self,
+        *,
+        symbol,
+        side,
+        order_type,
+        qty,
+        client_order_id=None,
+        price=None,
+        time_in_force=None,
+        confirm=False,
+    ):
+        self.submits.append(side)
+        if side == "BUY":
+            self._free = Decimal("7.3")
+        return _Order("FILLED", client_order_id)
+
+    async def submit_oco(
+        self,
+        *,
+        symbol,
+        side,
+        quantity,
+        tp_price,
+        sl_stop_price,
+        sl_limit_price,
+        time_in_force="GTC",
+        list_client_order_id=None,
+        confirm=False,
+    ):
+        self.ocos.append(
+            {
+                "side": side,
+                "qty": quantity,
+                "tp": tp_price,
+                "sl": sl_stop_price,
+                "sl_limit": sl_limit_price,
+                "confirm": confirm,
+            }
+        )
+        return _Oco()
+
+    async def get_asset_balance(self, *, asset):
+        class _B:
+            free = self._free
+
+        b = _B()
+        b.free = self._free
+        return b
+
+    async def get_open_orders(self, *, symbol):
+        return _OpenOrders([])
+
+
+class _FakeFutures:
+    def __init__(self, *, open_status="FILLED"):
+        self.submits = []
+        self.triggers = []
+        self._amt = Decimal("0")
+        self._open_status = open_status
+
+    async def get_position_mode(self):
+        return _PosMode()
+
+    async def set_leverage(self, *, symbol, leverage):
+        return _Lev()
+
+    async def submit_order(
+        self,
+        *,
+        symbol,
+        side,
+        order_type,
+        qty,
+        client_order_id=None,
+        price=None,
+        time_in_force=None,
+        reduce_only=False,
+        confirm=False,
+    ):
+        self.submits.append(side)
+        self._amt = qty if side == "BUY" else -qty
+        return _Order(self._open_status, client_order_id)
+
+    async def submit_reduce_only_trigger(
+        self,
+        *,
+        symbol,
+        side,
+        order_type,
+        qty,
+        stop_price,
+        client_order_id=None,
+        confirm=False,
+    ):
+        self.triggers.append(
+            {
+                "side": side,
+                "type": order_type,
+                "qty": qty,
+                "stop_price": stop_price,
+                "confirm": confirm,
+            }
+        )
+        return _Order("NEW", client_order_id)
+
+    async def get_order(self, *, symbol, client_order_id):
+        return _Order("FILLED", client_order_id)
+
+    async def get_position(self, *, symbol):
+        return _Position(self._amt)
+
+    async def get_open_orders(self, *, symbol):
+        return _OpenOrders([])
+
+
+async def _parent_row(db_session, open_cid):
+    return await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == open_cid
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_spot_bracket_places_oco_and_holds(db_session) -> None:
+    client = _FakeSpot()
+    ex = DemoScalpingExecutor(
+        product="spot",
+        client=client,
+        session=db_session,
+        reference=_FakeRef(),
+        now=_NOW,
+        limits=_limits_for("EXEBRKSPOTUSDT"),
+    )
+    result = await ex.execute_bracket(_intent("spot", "EXEBRKSPOTUSDT"), confirm=True)
+    assert result.status == "bracketed"
+    assert list(client.submits) == ["BUY"]  # opened, NOT sold
+    assert len(client.ocos) == 1 and client.ocos[0]["side"] == "SELL"
+    row = await _parent_row(db_session, result.open_client_order_id)
+    assert row.lifecycle_state == "filled"  # held, protected (not closed)
+    assert "bracket" in (row.extra_metadata or {})
+
+
+@pytest.mark.asyncio
+async def test_futures_bracket_places_two_reduce_only_triggers(db_session) -> None:
+    client = _FakeFutures(open_status="FILLED")
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_FakeRef(),
+        now=_NOW,
+        limits=_limits_for("EXEBRKFUTUSDT"),
+    )
+    result = await ex.execute_bracket(
+        _intent("usdm_futures", "EXEBRKFUTUSDT"), confirm=True
+    )
+    assert result.status == "bracketed"
+    types = sorted(t["type"] for t in client.triggers)
+    assert types == ["STOP_MARKET", "TAKE_PROFIT_MARKET"]
+    assert all(t["side"] == "SELL" for t in client.triggers)  # close a long
+    row = await _parent_row(db_session, result.open_client_order_id)
+    assert row.lifecycle_state == "filled"
+
+
+@pytest.mark.asyncio
+async def test_bracket_dry_run_places_nothing(db_session) -> None:
+    client = _FakeSpot()
+    ex = DemoScalpingExecutor(
+        product="spot",
+        client=client,
+        session=db_session,
+        reference=_FakeRef(),
+        now=_NOW,
+        limits=_limits_for("EXEBRKDRYUSDT"),
+    )
+    result = await ex.execute_bracket(_intent("spot", "EXEBRKDRYUSDT"), confirm=False)
+    assert result.status == "dry_run"
+    assert client.submits == [] and client.ocos == []
+
+
+@pytest.mark.asyncio
+async def test_futures_bracket_unproven_fill_is_anomaly_no_bracket(db_session) -> None:
+    # Open returns NEW and position stays flat -> fill unproven -> anomaly, no bracket.
+    client = _FakeFutures(open_status="NEW")
+
+    async def _flat(*, symbol):
+        return _Position(Decimal("0"))
+
+    client.get_position = _flat  # never goes non-flat
+    client.get_order = lambda **k: _Order("NEW", k.get("client_order_id"))
+
+    async def _get_order(*, symbol, client_order_id):
+        return _Order("NEW", client_order_id)
+
+    client.get_order = _get_order
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_FakeRef(),
+        now=_NOW,
+        limits=_limits_for("EXEBRKANOMUSDT"),
+        poll_max=2,
+        poll_delay_seconds=0.0,
+    )
+    result = await ex.execute_bracket(
+        _intent("usdm_futures", "EXEBRKANOMUSDT"), confirm=True
+    )
+    assert result.status == "anomaly"
+    assert client.triggers == []  # no bracket on an unproven fill

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_bracket_reconcile.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_bracket_reconcile.py
@@ -1,0 +1,212 @@
+"""ROB-307 PR3 — tests for reconcile_bracket (detect exit, cancel survivor).
+
+A bracketed position is held (parent row 'filled', exits resting). On a
+later tick reconcile_bracket checks the venue: if still holding → no-op
+('still_protected'); if an exit fired (futures flat / spot OCO resolved)
+→ cancel any surviving leg and drive the parent filled→closed→reconciled.
+Broker faked; ledger is the real service on the test DB.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.models.crypto_instruments import CryptoInstrument
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+from app.services.brokers.binance.demo_scalping_exec.executor import (
+    DemoScalpingExecutor,
+)
+
+_NOW = dt.datetime(2026, 5, 24, 12, 0, 0, tzinfo=dt.UTC)
+
+
+class _OO:
+    def __init__(self, coid):
+        self.client_order_id = coid
+
+
+class _OpenOrders:
+    def __init__(self, orders):
+        self.orders = orders
+
+
+class _Position:
+    def __init__(self, amt):
+        self.position_amt = amt
+        self.is_flat = amt == 0
+
+
+class _FutReconClient:
+    def __init__(self, *, flat, open_orders):
+        self._flat = flat
+        self._open = list(open_orders)
+        self.cancels: list[str] = []
+
+    async def get_position(self, *, symbol):
+        return _Position(Decimal("0") if self._flat else Decimal("7.3"))
+
+    async def get_open_orders(self, *, symbol):
+        return _OpenOrders(list(self._open))
+
+    async def cancel_order(self, *, symbol, client_order_id):
+        self.cancels.append(client_order_id)
+        self._open = [o for o in self._open if o.client_order_id != client_order_id]
+        return None
+
+
+class _SpotReconClient:
+    def __init__(self, *, open_orders):
+        self._open = list(open_orders)
+
+    async def get_open_orders(self, *, symbol):
+        return _OpenOrders(list(self._open))
+
+
+async def _instrument(db_session, symbol, product) -> int:
+    existing = await db_session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == product,
+            CryptoInstrument.venue_symbol == symbol,
+        )
+    )
+    if existing is not None:
+        return existing.id
+    inst = CryptoInstrument(
+        venue="binance",
+        product=product,
+        venue_symbol=symbol,
+        base_asset=symbol.replace("USDT", ""),
+        quote_asset="USDT",
+        status="active",
+    )
+    db_session.add(inst)
+    await db_session.flush()
+    return inst.id
+
+
+async def _make_filled_parent(db_session, product, symbol) -> str:
+    svc = BinanceDemoLedgerService(db_session)
+    iid = await _instrument(db_session, symbol, product)
+    cid = f"recon-{product}-{symbol}"
+    host = "demo-api.binance.com" if product == "spot" else "demo-fapi.binance.com"
+    await svc.record_planned(
+        instrument_id=iid,
+        product=product,
+        venue_host=host,
+        client_order_id=cid,
+        side="BUY",
+        order_type="MARKET",
+        qty=Decimal("7.3"),
+        price=None,
+        extra_metadata={"bracket": {"type": "test"}},
+        now=_NOW,
+    )
+    await svc.record_previewed(client_order_id=cid, now=_NOW)
+    await svc.record_validated(client_order_id=cid, now=_NOW)
+    await svc.record_submitted(client_order_id=cid, broker_order_id="b1", now=_NOW)
+    await svc.record_filled(client_order_id=cid, now=_NOW)
+    return cid
+
+
+async def _state(db_session, cid) -> str:
+    row = await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == cid
+        )
+    )
+    return row.lifecycle_state
+
+
+@pytest.mark.asyncio
+async def test_futures_still_holding_is_noop(db_session) -> None:
+    cid = await _make_filled_parent(db_session, "usdm_futures", "RCFUTAUSDT")
+    client = _FutReconClient(flat=False, open_orders=[_OO("sl"), _OO("tp")])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=None,
+        now=_NOW,
+    )
+    result = await ex.reconcile_bracket(open_client_order_id=cid)
+    assert result.status == "still_protected"
+    assert client.cancels == []
+    assert await _state(db_session, cid) == "filled"  # still held
+
+
+@pytest.mark.asyncio
+async def test_futures_exit_fired_cancels_survivor_and_reconciles(db_session) -> None:
+    cid = await _make_filled_parent(db_session, "usdm_futures", "RCFUTBUSDT")
+    # Position went flat (TP fired); the SL leg still rests and must be cancelled.
+    client = _FutReconClient(flat=True, open_orders=[_OO("surviving-sl")])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=None,
+        now=_NOW,
+    )
+    result = await ex.reconcile_bracket(open_client_order_id=cid)
+    assert result.status == "reconciled"
+    assert result.final_flat is True
+    assert client.cancels == ["surviving-sl"]
+    assert await _state(db_session, cid) == "reconciled"
+
+
+@pytest.mark.asyncio
+async def test_spot_oco_resolved_reconciles(db_session) -> None:
+    cid = await _make_filled_parent(db_session, "spot", "RCSPOTAUSDT")
+    client = _SpotReconClient(
+        open_orders=[]
+    )  # OCO resolved (one filled, other auto-cancelled)
+    ex = DemoScalpingExecutor(
+        product="spot",
+        client=client,
+        session=db_session,
+        reference=None,
+        now=_NOW,
+    )
+    result = await ex.reconcile_bracket(open_client_order_id=cid)
+    assert result.status == "reconciled"
+    assert await _state(db_session, cid) == "reconciled"
+
+
+@pytest.mark.asyncio
+async def test_spot_oco_still_resting_is_noop(db_session) -> None:
+    cid = await _make_filled_parent(db_session, "spot", "RCSPOTBUSDT")
+    client = _SpotReconClient(open_orders=[_OO("tp"), _OO("sl")])
+    ex = DemoScalpingExecutor(
+        product="spot",
+        client=client,
+        session=db_session,
+        reference=None,
+        now=_NOW,
+    )
+    result = await ex.reconcile_bracket(open_client_order_id=cid)
+    assert result.status == "still_protected"
+    assert await _state(db_session, cid) == "filled"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_noop_when_parent_not_filled(db_session) -> None:
+    # A parent already reconciled (terminal) is a no-op, not a re-close.
+    cid = await _make_filled_parent(db_session, "spot", "RCSPOTCUSDT")
+    svc = BinanceDemoLedgerService(db_session)
+    await svc.record_closed(client_order_id=cid, now=_NOW)
+    await svc.record_reconciled(client_order_id=cid, now=_NOW)
+    client = _SpotReconClient(open_orders=[])
+    ex = DemoScalpingExecutor(
+        product="spot",
+        client=client,
+        session=db_session,
+        reference=None,
+        now=_NOW,
+    )
+    result = await ex.reconcile_bracket(open_client_order_id=cid)
+    assert result.status == "noop"

--- a/tests/services/brokers/binance/demo_scalping_exec/test_reference.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_reference.py
@@ -23,6 +23,7 @@ _SPOT_EXCHANGE_INFO = {
         {
             "symbol": "XRPUSDT",
             "filters": [
+                {"filterType": "PRICE_FILTER", "tickSize": "0.00010000"},
                 {"filterType": "LOT_SIZE", "stepSize": "0.10000000"},
                 {"filterType": "NOTIONAL", "minNotional": "5.00000000"},
             ],
@@ -35,6 +36,7 @@ _FUTURES_EXCHANGE_INFO = {
         {
             "symbol": "XRPUSDT",
             "filters": [
+                {"filterType": "PRICE_FILTER", "tickSize": "0.0001"},
                 {"filterType": "LOT_SIZE", "stepSize": "0.1"},
                 {"filterType": "MARKET_LOT_SIZE", "stepSize": "0.1"},
                 {"filterType": "MIN_NOTIONAL", "notional": "5"},
@@ -61,6 +63,7 @@ async def test_fetch_spot_reference(httpx_mock) -> None:
         price=Decimal("1.36010000"),
         step_size=Decimal("0.10000000"),
         min_notional=Decimal("5.00000000"),
+        tick_size=Decimal("0.00010000"),
     )
 
 
@@ -82,6 +85,7 @@ async def test_fetch_futures_reference_uses_demo_fapi_and_market_lot(
     assert ref.price == Decimal("1.3595")
     assert ref.step_size == Decimal("0.1")
     assert ref.min_notional == Decimal("5")
+    assert ref.tick_size == Decimal("0.0001")
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/binance/futures_demo/test_execution_client_bracket.py
+++ b/tests/services/brokers/binance/futures_demo/test_execution_client_bracket.py
@@ -1,0 +1,152 @@
+"""ROB-307 PR3 — futures reduceOnly trigger orders (STOP_MARKET / TAKE_PROFIT_MARKET).
+
+Broker-side bracket exit legs: a signed POST /fapi/v1/order carrying
+``type=STOP_MARKET`` or ``TAKE_PROFIT_MARKET``, ``stopPrice``, and
+``reduceOnly=true`` (always — these only ever close, never open). Default
+is a dry-run with zero HTTP. Demo host only; network mocked.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.futures_demo.dto import (
+    FuturesDemoOrderSubmitResult,
+)
+from app.services.brokers.binance.futures_demo.execution_client import (
+    BinanceFuturesDemoExecutionClient,
+    FuturesDemoDryRunResult,
+)
+
+_FUTURES_DEMO_BASE = "https://demo-fapi.binance.com"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> BinanceFuturesDemoExecutionClient:
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_KEY", "DUMMY_FUTURES_DEMO_KEY")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_API_SECRET", "DUMMY_FUTURES_DEMO_SECRET")
+    monkeypatch.setenv("BINANCE_FUTURES_DEMO_BASE_URL", _FUTURES_DEMO_BASE)
+    return BinanceFuturesDemoExecutionClient.from_env()
+
+
+@pytest.mark.asyncio
+async def test_stop_market_dispatches_signed_reduce_only_trigger(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/order\?.*$"),
+        json={
+            "clientOrderId": "sl-1",
+            "orderId": 999,
+            "symbol": "XRPUSDT",
+            "side": "SELL",
+            "type": "STOP_MARKET",
+            "origQty": "7.3",
+            "executedQty": "0",
+            "status": "NEW",
+            "reduceOnly": True,
+        },
+    )
+    result = await client.submit_reduce_only_trigger(
+        symbol="XRPUSDT",
+        side="SELL",
+        order_type="STOP_MARKET",
+        qty=Decimal("7.3"),
+        stop_price=Decimal("1.33"),
+        client_order_id="sl-1",
+        confirm=True,
+    )
+    assert isinstance(result, FuturesDemoOrderSubmitResult)
+    assert result.status == "NEW"
+    assert result.reduce_only is True
+    url = str(httpx_mock.get_requests()[0].url)
+    assert "type=STOP_MARKET" in url
+    assert "stopPrice=1.33" in url
+    assert "reduceOnly=true" in url
+    assert "price=" not in url  # MARKET-triggered: no limit price
+
+
+@pytest.mark.asyncio
+async def test_take_profit_market_dispatches_signed_trigger(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/order\?.*$"),
+        json={
+            "clientOrderId": "tp-1",
+            "orderId": 1000,
+            "symbol": "XRPUSDT",
+            "side": "SELL",
+            "type": "TAKE_PROFIT_MARKET",
+            "origQty": "7.3",
+            "executedQty": "0",
+            "status": "NEW",
+            "reduceOnly": True,
+        },
+    )
+    result = await client.submit_reduce_only_trigger(
+        symbol="XRPUSDT",
+        side="SELL",
+        order_type="TAKE_PROFIT_MARKET",
+        qty=Decimal("7.3"),
+        stop_price=Decimal("1.40"),
+        client_order_id="tp-1",
+        confirm=True,
+    )
+    assert isinstance(result, FuturesDemoOrderSubmitResult)
+    url = str(httpx_mock.get_requests()[0].url)
+    assert "type=TAKE_PROFIT_MARKET" in url
+    assert "stopPrice=1.40" in url
+    assert "reduceOnly=true" in url
+
+
+@pytest.mark.asyncio
+async def test_trigger_dry_run_dispatches_zero_http(
+    client: BinanceFuturesDemoExecutionClient, httpx_mock
+) -> None:
+    result = await client.submit_reduce_only_trigger(
+        symbol="XRPUSDT",
+        side="SELL",
+        order_type="STOP_MARKET",
+        qty=Decimal("7.3"),
+        stop_price=Decimal("1.33"),
+    )
+    assert isinstance(result, FuturesDemoDryRunResult)
+    assert result.reduce_only is True
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_trigger_rejects_non_trigger_order_type(
+    client: BinanceFuturesDemoExecutionClient,
+) -> None:
+    with pytest.raises(ValueError):
+        await client.submit_reduce_only_trigger(
+            symbol="XRPUSDT",
+            side="SELL",
+            order_type="MARKET",
+            qty=Decimal("7.3"),
+            stop_price=Decimal("1.33"),
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_rejects_nonpositive_stop_price(
+    client: BinanceFuturesDemoExecutionClient,
+) -> None:
+    with pytest.raises(ValueError):
+        await client.submit_reduce_only_trigger(
+            symbol="XRPUSDT",
+            side="SELL",
+            order_type="STOP_MARKET",
+            qty=Decimal("7.3"),
+            stop_price=Decimal("0"),
+            confirm=True,
+        )

--- a/tests/services/brokers/binance/spot_demo/test_execution_client_oco.py
+++ b/tests/services/brokers/binance/spot_demo/test_execution_client_oco.py
@@ -1,0 +1,116 @@
+"""ROB-307 PR3 — spot OCO bracket (TP limit + SL stop-limit).
+
+Spot has no reduceOnly, so the broker-side bracket on a held long is a
+SELL OCO: a LIMIT take-profit (above) one-cancels-other a STOP_LOSS_LIMIT
+(below). Signed POST /api/v3/order/oco; dry-run with zero HTTP by default.
+Demo host only; network mocked.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.spot_demo.dto import SpotDemoOcoResult
+from app.services.brokers.binance.spot_demo.execution_client import (
+    BinanceSpotDemoExecutionClient,
+    SpotDemoDryRunResult,
+)
+
+_SPOT_DEMO_BASE = "https://demo-api.binance.com"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> BinanceSpotDemoExecutionClient:
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_KEY", "DUMMY_SPOT_DEMO_KEY")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_API_SECRET", "DUMMY_SPOT_DEMO_SECRET")
+    monkeypatch.setenv("BINANCE_SPOT_DEMO_BASE_URL", _SPOT_DEMO_BASE)
+    return BinanceSpotDemoExecutionClient.from_env()
+
+
+@pytest.mark.asyncio
+async def test_sell_oco_dispatches_signed_two_legs(
+    client: BinanceSpotDemoExecutionClient, httpx_mock
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url=re.compile(r"^https://demo-api\.binance\.com/api/v3/order/oco\?.*$"),
+        json={
+            "orderListId": 555,
+            "listClientOrderId": "list-1",
+            "listOrderStatus": "EXECUTING",
+            "orders": [
+                {"symbol": "XRPUSDT", "orderId": 1, "clientOrderId": "tp-1"},
+                {"symbol": "XRPUSDT", "orderId": 2, "clientOrderId": "sl-1"},
+            ],
+        },
+    )
+    result = await client.submit_oco(
+        symbol="XRPUSDT",
+        side="SELL",
+        quantity=Decimal("7.3"),
+        tp_price=Decimal("1.40"),
+        sl_stop_price=Decimal("1.33"),
+        sl_limit_price=Decimal("1.32"),
+        confirm=True,
+    )
+    assert isinstance(result, SpotDemoOcoResult)
+    assert result.order_list_id == "555"
+    assert set(result.leg_client_order_ids) == {"tp-1", "sl-1"}
+    url = str(httpx_mock.get_requests()[0].url)
+    assert "price=1.40" in url  # TP limit leg
+    assert "stopPrice=1.33" in url  # SL trigger
+    assert "stopLimitPrice=1.32" in url  # SL limit
+    assert "stopLimitTimeInForce=GTC" in url
+
+
+@pytest.mark.asyncio
+async def test_oco_dry_run_dispatches_zero_http(
+    client: BinanceSpotDemoExecutionClient, httpx_mock
+) -> None:
+    result = await client.submit_oco(
+        symbol="XRPUSDT",
+        side="SELL",
+        quantity=Decimal("7.3"),
+        tp_price=Decimal("1.40"),
+        sl_stop_price=Decimal("1.33"),
+        sl_limit_price=Decimal("1.32"),
+    )
+    assert isinstance(result, SpotDemoDryRunResult)
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.asyncio
+async def test_oco_rejects_tp_not_above_sl_for_sell(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    # SELL bracket: TP must be above the SL trigger.
+    with pytest.raises(ValueError):
+        await client.submit_oco(
+            symbol="XRPUSDT",
+            side="SELL",
+            quantity=Decimal("7.3"),
+            tp_price=Decimal("1.30"),
+            sl_stop_price=Decimal("1.33"),
+            sl_limit_price=Decimal("1.32"),
+            confirm=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_oco_rejects_nonpositive_quantity(
+    client: BinanceSpotDemoExecutionClient,
+) -> None:
+    with pytest.raises(ValueError):
+        await client.submit_oco(
+            symbol="XRPUSDT",
+            side="SELL",
+            quantity=Decimal("0"),
+            tp_price=Decimal("1.40"),
+            sl_stop_price=Decimal("1.33"),
+            sl_limit_price=Decimal("1.32"),
+            confirm=True,
+        )


### PR DESCRIPTION
ROB-307 **PR3 of 4** — broker-side bracket TP/SL (the §2-**preferred** model you selected). **Stacked on PR2 (#937)**: base is `rob-307-pr2`; retarget down the stack as PR1/PR2 merge.

Demo `exchangeInfo` advertises the needed order types on both venues (probed: spot `STOP_LOSS_LIMIT`/`TAKE_PROFIT`/`ocoAllowed`; futures `STOP_MARKET`/`TAKE_PROFIT_MARKET`), so exits are exchange-held and survive across scheduler runs — true unattended protection.

## What this PR adds
| Surface | Added |
|---|---|
| futures exec client | `submit_reduce_only_trigger` — STOP_MARKET / TAKE_PROFIT_MARKET, MARKET-triggered, **always reduceOnly**, operator-gated |
| spot exec client | `submit_oco` + `SpotDemoOcoResult` — SELL OCO (TP limit + SL stop-limit) on a held long |
| `demo_scalping_exec/reference.py` | `tick_size` (PRICE_FILTER) → tick-aligned bracket prices |
| `demo_scalping_exec/executor.py` | `execute_bracket` (open + place TP/SL + **hold**) and `reconcile_bracket` (detect exit, cancel survivor, close+reconcile) |
| executor CLI | `--bracket` and `--reconcile OPEN_CID` modes |
| runbook | bracket lifecycle + operator clean-env live trigger-validation procedure |

## Lifecycle & safety
- `execute_bracket`: open (MARKET) → fill-resolve (futures `NEW`→bounded poll→non-flat positionRisk, ROB-305 §4) → place TP+SL (futures: two reduceOnly triggers; spot: one tick-aligned OCO on the free base balance) → `record_filled` with leg ids in `extra_metadata` → status **`bracketed`** (parent stays `filled`, exits resting, position intentionally held).
- **Unproven fill → `anomaly`** (no bracket placed). **Bracket-placement failure → best-effort failsafe close + `anomaly`** (never left open-unprotected).
- `reconcile_bracket` (later tick): still holding → **`still_protected`** no-op; exit fired → cancel surviving futures leg (spot OCO self-cancels) → parent `filled→closed→reconciled`; dirty → `anomaly`; already-terminal → `noop`.
- Futures 1x-pinned + one-way checked; demo hosts only; secret hygiene preserved. Read-only signal package's import guard still green (executor lives outside it).

## ✅ Tests passed
- **21 new tests**: futures triggers (5), spot OCO (4), reference tick_size, bracket placement (4: spot/futures/dry-run/unproven-anomaly), reconcile (5: still-protected/exit-fired+cancel/spot-resolved/spot-resting/noop), CLI bracket+reconcile routing (2).
- Full `tests/services/brokers/binance/` tree: **433 passed** (additive to shared exec clients — no regression). `ruff` clean.

## ⏳ Live trigger-firing evidence — pending operator run (clean env)
Unit tests (fake broker) prove placement + cancellation + reconcile logic; they **can't** prove Demo actually *fires* a STOP/TP trigger (needs real price movement). The runbook documents the clean-env procedure (place bracket → confirm legs rest → trigger fires → `--reconcile` cancels survivor & reconciles). Same clean-ledger-DB gate as PR2's live smoke.

## Scheduler state
None — **off** (PR4: a default-OFF scheduler driving `execute_bracket` on signals + `reconcile_bracket` on held positions each tick).

## Not performed / later
PR4 scheduler scaffold + kill switch. No scheduler, no live/mainnet endpoints, no secrets logged/committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
