### PR TITLE
feat(rob-307): default-OFF scalping scheduler scaffold (PR4)

### DIFF
--- a/app/jobs/binance_demo_scalping_runner.py
+++ b/app/jobs/binance_demo_scalping_runner.py
@@ -1,0 +1,128 @@
+"""ROB-307 PR4 — env-wired entrypoint for the Demo scalping scheduler tick.
+
+Scheduler-agnostic runner (TaskIQ task today; a Prefect deployment could
+call the same entrypoint). **Default-OFF, two-key gate:**
+
+* ``BINANCE_DEMO_SCALPING_ENABLED`` — the feature gate (shared with the
+  observe/execute paths), AND
+* ``BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED`` — the scheduler kill switch.
+
+Both must be truthy or the tick is a no-op that builds zero clients and
+touches no DB. Even when both are on, real orders are placed only if
+``BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM`` is also truthy; otherwise the
+tick runs the signals + risk re-checks but every ``execute_bracket`` is a
+dry-run (zero broker mutation).
+
+No schedule is registered anywhere — production recurrence + activation
+is a separate operator gate (see the runbook).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import os
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping.contract import DEFAULT_ALLOWLIST
+
+logger = logging.getLogger(__name__)
+
+_BASE_ENV = "BINANCE_DEMO_SCALPING_ENABLED"
+_SCHED_ENV = "BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED"
+_CONFIRM_ENV = "BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM"
+_PRODUCTS = ("spot", "usdm_futures")
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+async def run_demo_scalping_tick(*, now: dt.datetime | None = None) -> dict[str, Any]:
+    """Run one scheduler tick if both gates are on; else a no-op."""
+    base = _truthy(os.environ.get(_BASE_ENV))
+    scheduler = _truthy(os.environ.get(_SCHED_ENV))
+    if not (base and scheduler):
+        logger.info(
+            "demo scalping scheduler gate off (%s=%s, %s=%s) — no-op tick",
+            _BASE_ENV,
+            base,
+            _SCHED_ENV,
+            scheduler,
+        )
+        return {
+            "status": "disabled",
+            "base_enabled": base,
+            "scheduler_enabled": scheduler,
+        }
+
+    confirm = _truthy(os.environ.get(_CONFIRM_ENV))
+    now = now or dt.datetime.now(dt.UTC)
+    symbols = sorted(DEFAULT_ALLOWLIST)
+
+    # Lazy imports so the disabled path triggers zero engine/credential setup.
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+    from app.services.brokers.binance.demo_scalping_exec.executor import (
+        DemoScalpingExecutor,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.reference import (
+        DemoReferenceData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.scheduler import (
+        run_scalping_tick,
+    )
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+    from app.services.brokers.binance.spot_demo.execution_client import (
+        BinanceSpotDemoExecutionClient,
+    )
+
+    spot_client = BinanceSpotDemoExecutionClient.from_env()
+    futures_client = BinanceFuturesDemoExecutionClient.from_env()
+    market_data = DemoScalpingMarketData()
+    reference = DemoReferenceData()
+    try:
+        async with AsyncSessionLocal() as session:
+            executors = {
+                "spot": DemoScalpingExecutor(
+                    product="spot",
+                    client=spot_client,
+                    session=session,
+                    reference=reference,
+                    now=now,
+                ),
+                "usdm_futures": DemoScalpingExecutor(
+                    product="usdm_futures",
+                    client=futures_client,
+                    session=session,
+                    reference=reference,
+                    now=now,
+                ),
+            }
+            summary = await run_scalping_tick(
+                executors=executors,
+                market_data=market_data,
+                ledger=BinanceDemoLedgerService(session),
+                symbols=symbols,
+                products=list(_PRODUCTS),
+                now=now,
+                confirm=confirm,
+                enabled=True,
+            )
+            await session.commit()
+    finally:
+        await market_data.aclose()
+        await reference.aclose()
+        for client in (spot_client, futures_client):
+            aclose = getattr(client, "aclose", None)
+            if aclose is not None:
+                await aclose()
+
+    return {"status": "ran", "confirm": confirm, **summary.to_evidence_dict()}

--- a/app/services/brokers/binance/demo/ledger/repository.py
+++ b/app/services/brokers/binance/demo/ledger/repository.py
@@ -149,6 +149,20 @@ class BinanceDemoLedgerRepository:
             )
         )
 
+    async def list_held_bracketed(self) -> list[tuple[str, str]]:
+        """``(client_order_id, product)`` for rows currently ``filled``.
+
+        A ``filled`` Demo lifecycle that was not closed in-run is a held
+        bracketed position (``execute_bracket`` leaves the parent at
+        ``filled`` with exits resting). The scheduler reconciles these.
+        """
+        stmt = select(
+            BinanceDemoOrderLedger.client_order_id,
+            BinanceDemoOrderLedger.product,
+        ).where(BinanceDemoOrderLedger.lifecycle_state == "filled")
+        result = await self._session.execute(stmt)
+        return [(row[0], row[1]) for row in result.all()]
+
     async def closed_rows_since(
         self, *, since: dt.datetime
     ) -> list[BinanceDemoOrderLedger]:

--- a/app/services/brokers/binance/demo/ledger/service.py
+++ b/app/services/brokers/binance/demo/ledger/service.py
@@ -105,6 +105,9 @@ class BinanceDemoLedgerService:
     ) -> list[BinanceDemoOrderLedger]:
         return await self._repo.closed_rows_since(since=since)
 
+    async def list_held_bracketed(self) -> list[tuple[str, str]]:
+        return await self._repo.list_held_bracketed()
+
     async def record_planned(
         self,
         *,

--- a/app/services/brokers/binance/demo_scalping_exec/scheduler.py
+++ b/app/services/brokers/binance/demo_scalping_exec/scheduler.py
@@ -1,0 +1,141 @@
+"""ROB-307 PR4 — default-OFF Demo scalping tick orchestration.
+
+One tick: (1) reconcile every held bracketed position via the executor's
+``reconcile_bracket``; (2) run the deterministic signal per allowlisted
+symbol and place a broker-side bracket (``execute_bracket``) on entries.
+The executor's own live-ledger risk re-check enforces capacity (one open
+lifecycle per product+symbol, global/daily caps), so the tick never needs
+its own capacity bookkeeping.
+
+Kill switch: ``enabled=False`` → no-op. Failure-only alerting: per-item
+errors are collected (the tick never crashes mid-loop) and logged at
+ERROR; a clean tick logs nothing alarming. No schedule is registered here
+— this is a manually-invokable scaffold (see the TaskIQ task), and
+activation is a separate operator gate.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    Product,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.order_intent import build_order_intent
+from app.services.brokers.binance.demo_scalping.signal import (
+    SignalConfig,
+    evaluate_signal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TickSummary:
+    status: str  # "disabled" | "ran"
+    reconciled: list[tuple[str, str]] = field(default_factory=list)
+    entered: list[tuple[str, str, str]] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def to_evidence_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "reconciled_count": len(self.reconciled),
+            "entered_count": len(self.entered),
+            "error_count": len(self.errors),
+            "reconciled": [list(r) for r in self.reconciled],
+            "entered": [list(e) for e in self.entered],
+            "errors": list(self.errors),
+        }
+
+
+async def run_scalping_tick(
+    *,
+    executors: Mapping[str, Any],
+    market_data: Any,
+    ledger: Any,
+    symbols: Sequence[str],
+    products: Sequence[Product],
+    now: dt.datetime,
+    limits: ScalpingRiskLimits | None = None,
+    confirm: bool = False,
+    enabled: bool = True,
+    signal_config_for: Callable[[str], SignalConfig] | None = None,
+    interval: str = "1m",
+    limit: int = 50,
+) -> TickSummary:
+    """Run one scalping tick. ``enabled=False`` is the kill switch (no-op)."""
+    if not enabled:
+        logger.info("demo scalping scheduler disabled — no-op tick")
+        return TickSummary(status="disabled")
+
+    limits = limits or ScalpingRiskLimits()
+    reconciled: list[tuple[str, str]] = []
+    entered: list[tuple[str, str, str]] = []
+    errors: list[str] = []
+
+    # Phase 1 — reconcile held bracketed positions (cleanup before entering).
+    try:
+        held = await ledger.list_held_bracketed()
+    except Exception as exc:  # noqa: BLE001 — collect, never crash the tick
+        held = []
+        errors.append(f"list_held_bracketed: {exc}")
+    for cid, product in held:
+        executor = executors.get(product)
+        if executor is None:
+            errors.append(f"reconcile {cid}: no executor for product {product!r}")
+            continue
+        try:
+            result = await executor.reconcile_bracket(open_client_order_id=cid)
+            reconciled.append((cid, result.status))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"reconcile {cid}: {exc}")
+
+    # Phase 2 — signal-driven bracketed entries (capacity enforced by the
+    # executor's live-ledger risk re-check).
+    for product in products:
+        executor = executors.get(product)
+        if executor is None:
+            errors.append(f"enter {product}: no executor")
+            continue
+        for symbol in symbols:
+            try:
+                candles = await market_data.fetch_klines(
+                    product, symbol, interval=interval, limit=limit
+                )
+                config = (
+                    signal_config_for(product)
+                    if signal_config_for is not None
+                    else SignalConfig(allow_short=product == "usdm_futures")
+                )
+                signal = evaluate_signal(candles, config)
+                if not signal.has_entry:
+                    continue
+                intent = build_order_intent(
+                    signal,
+                    product=product,
+                    symbol=symbol,
+                    limits=limits,
+                    source_candle_close_time_ms=candles[-1].close_time_ms,
+                    evaluated_at_ms=int(now.timestamp() * 1000),
+                )
+                if intent is None:
+                    continue
+                result = await executor.execute_bracket(intent, confirm=confirm)
+                entered.append((product, symbol, result.status))
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"enter {product}/{symbol}: {exc}")
+
+    if errors:
+        # Failure-only signal — a clean tick stays quiet.
+        logger.error(
+            "demo scalping tick completed with %d error(s): %s", len(errors), errors
+        )
+    return TickSummary(
+        status="ran", reconciled=reconciled, entered=entered, errors=errors
+    )

--- a/app/tasks/binance_demo_scalping_tasks.py
+++ b/app/tasks/binance_demo_scalping_tasks.py
@@ -1,0 +1,21 @@
+"""ROB-307 PR4 — TaskIQ task for the Demo scalping scheduler tick.
+
+Registered with **no ``schedule=``** — a manual entry point only (e.g.
+``taskiq kick``), never auto-scheduled. Production recurrence + activation
+is a separate operator gate handled outside this repo (see
+``docs/runbooks/binance-demo-scalping.md``). The runner is default-OFF
+behind a two-key flag gate, so even invoking this task is a no-op until
+the operator opts in.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.taskiq_broker import broker
+from app.jobs.binance_demo_scalping_runner import run_demo_scalping_tick
+
+
+@broker.task(task_name="binance.demo_scalping.tick")
+async def binance_demo_scalping_tick() -> dict[str, Any]:
+    return await run_demo_scalping_tick()

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -222,9 +222,55 @@ DB:
 4. Capture redacted evidence (order ids, leg statuses, final flat /
    open-orders-0).
 
-## Not in PR3 (later phases)
+## Scheduler scaffold (PR4) — default-OFF, no activation
 
-- Scheduler scaffold + kill switch (PR4) — TaskIQ default-OFF that drives
-  `execute_bracket` on a signal and `reconcile_bracket` on held positions
-  each tick; any Prefect deployment lives in `robin-prefect-automations`
-  and activation is a separate operator gate.
+PR4 adds the scheduler **scaffold**: one tick reconciles held bracketed
+positions then runs the signal per allowlisted symbol and places brackets
+on entries. It is **registered with no schedule** (a manual entry point
+only) and **default-OFF** behind a two-key flag gate.
+
+| Surface | Added |
+|---|---|
+| `app/services/.../demo_scalping_exec/scheduler.py` | `run_scalping_tick` — reconcile held + signal-driven bracket entries; `enabled=False` kill switch; per-item error collection (failure-only) |
+| `app/jobs/binance_demo_scalping_runner.py` | `run_demo_scalping_tick` — env-wired, two-key gate |
+| `app/tasks/binance_demo_scalping_tasks.py` | `@broker.task("binance.demo_scalping.tick")` — **no `schedule=`** |
+| ledger service | `list_held_bracketed` (rows in `filled` = held) |
+
+### Flags (all default-OFF)
+
+| Env var | Effect |
+|---|---|
+| `BINANCE_DEMO_SCALPING_ENABLED` | shared feature gate |
+| `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED` | scheduler **kill switch** |
+| `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM` | second key — without it the tick runs signals + risk re-checks but every `execute_bracket` is a **dry-run** (zero broker mutation) |
+
+Both `*_ENABLED` flags must be truthy or the tick builds zero clients,
+touches no DB, and returns `{"status": "disabled"}`. **The kill switch is:
+unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED`** (or set it false) — the
+next tick is an immediate no-op.
+
+### Manual invocation (no schedule registered)
+
+```bash
+# Dry-run tick (signals + risk, zero orders): scheduler on, confirm off
+BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED=true \
+  uv run taskiq kick app.core.taskiq_broker:broker binance.demo_scalping.tick
+
+# Real tick (places brackets): add the second key + product gates + creds,
+# and run against a CLEAN demo ledger DB
+BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED=true \
+BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM=true \
+BINANCE_SPOT_DEMO_ENABLED=true BINANCE_FUTURES_DEMO_ENABLED=true \
+  uv run taskiq kick app.core.taskiq_broker:broker binance.demo_scalping.tick
+```
+
+### Activation — separate operator gate
+
+No recurring schedule is registered by this repo. Production recurrence
+(`paused=false`) is an operations decision: TaskIQ cron or a Prefect
+deployment in `robin-prefect-automations`. **Do not activate** without
+the §"Hard safety boundaries" gates satisfied + explicit operator
+approval. Failure-only alerting wires onto the tick's error log
+(`logger.error` / the `TickSummary.errors` list); a clean tick is quiet.
+Rollback = unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED` (kill switch)
+and pause/disable the schedule in the ops repo.

--- a/tests/services/brokers/binance/demo_scalping/test_ledger_state.py
+++ b/tests/services/brokers/binance/demo_scalping/test_ledger_state.py
@@ -179,3 +179,17 @@ async def test_fresh_service_instance_reads_committed_state(
         fresh_service, product="spot", symbol="EEEUSDT", now=_NOW
     )
     assert snap.has_open_lifecycle_for_symbol is True
+
+
+@pytest.mark.asyncio
+async def test_list_held_bracketed_includes_filled_row(service, db_session) -> None:
+    iid = await _instrument_id(db_session, "HELDUSDT")
+    await _plan(service, instrument_id=iid, coid="held-row")
+    await service.record_previewed(client_order_id="held-row", now=_NOW)
+    await service.record_validated(client_order_id="held-row", now=_NOW)
+    await service.record_submitted(
+        client_order_id="held-row", broker_order_id="b", now=_NOW
+    )
+    await service.record_filled(client_order_id="held-row", now=_NOW)
+    held = await service.list_held_bracketed()
+    assert ("held-row", "spot") in held

--- a/tests/services/brokers/binance/demo_scalping_exec/test_runner_from_env.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_runner_from_env.py
@@ -1,0 +1,52 @@
+"""ROB-307 PR4 — tests for the env-wired runner + the TaskIQ task gate.
+
+The two-key gate must no-op (building zero clients, touching no DB) unless
+BOTH BINANCE_DEMO_SCALPING_ENABLED and BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED
+are truthy. Verified without creds/DB/network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.jobs.binance_demo_scalping_runner import run_demo_scalping_tick
+
+
+def _no_client(monkeypatch) -> None:
+    import httpx
+
+    def _boom(*a, **k):
+        raise AssertionError("disabled gate must not construct an httpx client")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _boom)
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_scheduler_flag_off(monkeypatch) -> None:
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED", raising=False)
+    _no_client(monkeypatch)
+    result = await run_demo_scalping_tick()
+    assert result["status"] == "disabled"
+    assert result["scheduler_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_base_flag_off(monkeypatch) -> None:
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_ENABLED", raising=False)
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED", "true")
+    _no_client(monkeypatch)
+    result = await run_demo_scalping_tick()
+    assert result["status"] == "disabled"
+    assert result["base_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_taskiq_task_is_unscheduled_manual_entrypoint(monkeypatch) -> None:
+    # Importable + callable; invoking it on the disabled gate is a safe no-op.
+    from app.tasks.binance_demo_scalping_tasks import binance_demo_scalping_tick
+
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED", raising=False)
+    _no_client(monkeypatch)
+    result = await binance_demo_scalping_tick()
+    assert result["status"] == "disabled"

--- a/tests/services/brokers/binance/demo_scalping_exec/test_scheduler.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_scheduler.py
@@ -1,0 +1,193 @@
+"""ROB-307 PR4 — tests for the default-OFF scalping tick orchestration.
+
+One tick = reconcile held bracketed positions, then run the deterministic
+signal per allowlisted symbol and place a bracket on entries. Kill-switch
+(``enabled=False`` → no-op), failure-only alerting (errors collected, tick
+continues). All broker/ledger I/O is faked; no network, no real orders.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.demo_scalping_exec.scheduler import (
+    run_scalping_tick,
+)
+
+_NOW = dt.datetime(2026, 5, 24, 12, 0, 0, tzinfo=dt.UTC)
+_NOW_MS = int(_NOW.timestamp() * 1000)
+
+
+def _uptrend() -> list[Candle]:
+    closes = list(range(100, 130))
+    n = len(closes)
+    return [
+        Candle(
+            open_time_ms=_NOW_MS - (n - 1 - i) * 60_000 - 59_999,
+            open=Decimal(c),
+            high=Decimal(c),
+            low=Decimal(c),
+            close=Decimal(c),
+            close_time_ms=_NOW_MS - (n - 1 - i) * 60_000,
+        )
+        for i, c in enumerate(closes)
+    ]
+
+
+def _flat() -> list[Candle]:
+    return [
+        Candle(
+            open_time_ms=_NOW_MS - (29 - i) * 60_000 - 59_999,
+            open=Decimal(100),
+            high=Decimal(100),
+            low=Decimal(100),
+            close=Decimal(100),
+            close_time_ms=_NOW_MS - (29 - i) * 60_000,
+        )
+        for i in range(30)
+    ]
+
+
+class _Result:
+    def __init__(self, status):
+        self.status = status
+
+
+class _FakeExecutor:
+    def __init__(self, *, entry_status="bracketed", raise_on_entry=False):
+        self.reconciled: list[str] = []
+        self.entered: list[str] = []
+        self._entry_status = entry_status
+        self._raise_on_entry = raise_on_entry
+
+    async def reconcile_bracket(self, *, open_client_order_id):
+        self.reconciled.append(open_client_order_id)
+        return _Result("reconciled")
+
+    async def execute_bracket(self, intent, *, confirm):
+        if self._raise_on_entry:
+            raise RuntimeError("boom")
+        self.entered.append(intent.symbol)
+        return _Result(self._entry_status)
+
+
+class _FakeMarketData:
+    def __init__(self, candles):
+        self._candles = candles
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        return self._candles
+
+
+class _FakeLedger:
+    def __init__(self, held):
+        self._held = held
+
+    async def list_held_bracketed(self):
+        return list(self._held)
+
+
+def _executors(spot, fut):
+    return {"spot": spot, "usdm_futures": fut}
+
+
+@pytest.mark.asyncio
+async def test_disabled_is_noop() -> None:
+    spot, fut = _FakeExecutor(), _FakeExecutor()
+    summary = await run_scalping_tick(
+        executors=_executors(spot, fut),
+        market_data=_FakeMarketData(_uptrend()),
+        ledger=_FakeLedger([]),
+        symbols=["XRPUSDT"],
+        products=["spot"],
+        now=_NOW,
+        confirm=True,
+        enabled=False,
+    )
+    assert summary.status == "disabled"
+    assert spot.entered == [] and spot.reconciled == []
+
+
+@pytest.mark.asyncio
+async def test_reconciles_held_then_enters_on_signal() -> None:
+    spot, fut = _FakeExecutor(), _FakeExecutor()
+    summary = await run_scalping_tick(
+        executors=_executors(spot, fut),
+        market_data=_FakeMarketData(_uptrend()),
+        ledger=_FakeLedger([("held-1", "usdm_futures")]),
+        symbols=["XRPUSDT"],
+        products=["spot", "usdm_futures"],
+        now=_NOW,
+        limits=ScalpingRiskLimits(),
+        confirm=True,
+        enabled=True,
+    )
+    assert summary.status == "ran"
+    assert fut.reconciled == ["held-1"]
+    assert spot.entered == ["XRPUSDT"]  # uptrend -> long entry placed
+    assert fut.entered == ["XRPUSDT"]
+    assert summary.errors == []
+
+
+@pytest.mark.asyncio
+async def test_no_entry_when_flat() -> None:
+    spot, fut = _FakeExecutor(), _FakeExecutor()
+    summary = await run_scalping_tick(
+        executors=_executors(spot, fut),
+        market_data=_FakeMarketData(_flat()),
+        ledger=_FakeLedger([]),
+        symbols=["XRPUSDT"],
+        products=["spot"],
+        now=_NOW,
+        confirm=True,
+        enabled=True,
+    )
+    assert summary.status == "ran"
+    assert spot.entered == []
+
+
+@pytest.mark.asyncio
+async def test_entry_error_is_collected_and_tick_continues() -> None:
+    spot = _FakeExecutor(raise_on_entry=True)
+    fut = _FakeExecutor()
+    summary = await run_scalping_tick(
+        executors=_executors(spot, fut),
+        market_data=_FakeMarketData(_uptrend()),
+        ledger=_FakeLedger([]),
+        symbols=["XRPUSDT", "DOGEUSDT"],
+        products=["spot"],
+        now=_NOW,
+        confirm=True,
+        enabled=True,
+    )
+    assert summary.status == "ran"
+    assert len(summary.errors) == 2  # both symbols errored, tick did not crash
+    assert all("enter spot" in e for e in summary.errors)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_threads_confirm_false() -> None:
+    captured = {}
+
+    class _Spy(_FakeExecutor):
+        async def execute_bracket(self, intent, *, confirm):
+            captured["confirm"] = confirm
+            return _Result("dry_run")
+
+    spy = _Spy()
+    await run_scalping_tick(
+        executors=_executors(spy, _FakeExecutor()),
+        market_data=_FakeMarketData(_uptrend()),
+        ledger=_FakeLedger([]),
+        symbols=["XRPUSDT"],
+        products=["spot"],
+        now=_NOW,
+        confirm=False,
+        enabled=True,
+    )
+    assert captured["confirm"] is False

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -71,6 +71,13 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # binance_testnet_order_ledger.py file was deleted in ROB-298.
         "app/models/binance_demo_order_ledger.py",
         "app/models/__init__.py",
+        # ROB-307 PR4 — Demo scalping scheduler orchestration. These
+        # *orchestrate* the in-package Demo adapters (executor/clients) and
+        # perform no signed HTTP themselves (the HMAC chokepoints stay inside
+        # spot_demo/ + futures_demo/). They reference "Binance" only via
+        # imports + the BINANCE_DEMO_SCALPING_* env-flag names.
+        "app/jobs/binance_demo_scalping_runner.py",
+        "app/tasks/binance_demo_scalping_tasks.py",
     }
 )
 


### PR DESCRIPTION
ROB-307 **PR4 of 4** — the default-OFF scheduler scaffold (final phase). **Stacked on PR3 (#939)**: base is `rob-307-pr3`; retarget down the stack as PR1–PR3 merge.

Per §1 the canonical path is **TaskIQ** (prefect is not an auto_trader dependency). This ships a **manually-invokable, default-OFF** task — **no schedule registered**, no activation.

## What this PR adds
| Surface | Added |
|---|---|
| `demo_scalping_exec/scheduler.py` | `run_scalping_tick` — reconcile held bracketed positions, then signal→`execute_bracket` per allowlist symbol; `enabled=False` kill switch; per-item error collection |
| `app/jobs/binance_demo_scalping_runner.py` | `run_demo_scalping_tick` — env-wired two-key gate |
| `app/tasks/binance_demo_scalping_tasks.py` | `@broker.task("binance.demo_scalping.tick")` — **no `schedule=`** |
| ledger service | `list_held_bracketed` (rows in `filled` = held) |
| runbook | flags, kill switch, manual invocation, **activation = separate operator gate** |

## Safety: a two-key gate + no activation
- **Both** `BINANCE_DEMO_SCALPING_ENABLED` **and** `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED` must be truthy or the tick builds **zero clients, touches no DB**, returns `{"status":"disabled"}`. → **kill switch = unset the scheduler flag.**
- A **third** key `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM`: without it the tick runs signals + risk re-checks but every `execute_bracket` is a **dry-run** (zero broker mutation).
- **No `schedule=`** on the task → never auto-runs; manual `taskiq kick` only. Production recurrence/activation lives in the ops repo and is a **separate operator approval** (Hard safety boundaries).
- Capacity (one open lifecycle/symbol, global/daily caps) is enforced by the executor's live-ledger risk re-check — the tick adds none of its own.
- **Failure-only alerting**: per-item errors collected; a clean tick logs nothing alarming (`logger.error` / `TickSummary.errors` is the alert hook).

## ✅ Tests passed
- 9 new tests: `run_scalping_tick` (disabled no-op, reconcile-then-enter, no-entry-when-flat, error-collection-continues, dry-run threads confirm=False), env-runner two-key gate (3), `list_held_bracketed`.
- Full `tests/services/brokers/binance/` tree: **442 passed**. `ruff` clean.
- ROB-285 audit allowlist extended for the two orchestration files (justified: no signed HTTP; they orchestrate in-package adapters).

## Scheduler state
**Off / not activated.** No `schedule=`, default-OFF gate. No recurring run registered by this repo.

## Not performed / later (operator)
- Activation (recurrence + `paused=false`) — separate operator approval; TaskIQ cron or a Prefect deployment in `robin-prefect-automations`.
- Clean-env live evidence: PR2 open+close, PR3 bracket trigger-firing, and a real default-OFF→confirmed scheduler tick reconciling/entering against a clean demo ledger DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
