### PR TITLE
feat(rob-311): /invest/reports Fundamentals dimension evidence (slice 4)

### DIFF
--- a/app/services/investment_dimensions/fundamentals_evidence.py
+++ b/app/services/investment_dimensions/fundamentals_evidence.py
@@ -1,0 +1,80 @@
+"""Deterministic Fundamentals dimension evidence bundle (ROB-311).
+
+Assembles per-symbol valuation (PER/PBR/ROE/dividend/market_cap/52w from
+``market_valuation_snapshots``) + sector (``stock_info``) into a market+symbol
+bundle, mirroring ``market_evidence``/``news_evidence``. DB-ONLY — never calls a
+live broker API. ``market_valuation_snapshots`` is empty until ingestion is
+enabled (operator gate); this degrades to ``unavailable``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Set
+from decimal import Decimal
+from typing import Any
+
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
+
+FRESH_WINDOW_DAYS = 7
+
+
+def _f(value: Decimal | None) -> float | None:
+    return float(value) if value is not None else None
+
+
+async def build_fundamentals_evidence(
+    valuation_repo: MarketValuationSnapshotsRepository,
+    stock_info_service: StockInfoService,
+    *,
+    market: str,
+    symbols: Set[str],
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    now_dt = now or dt.datetime.now(tz=dt.UTC)
+    requested = len(symbols)
+    rows = await valuation_repo.latest_for_symbols(market=market, symbols=set(symbols))
+
+    per_symbol: list[dict[str, Any]] = []
+    latest_date: dt.date | None = None
+    for row in rows:
+        info = await stock_info_service.get_stock_info_by_symbol(row.symbol)
+        per_symbol.append(
+            {
+                "symbol": row.symbol,
+                "sector": getattr(info, "sector", None),
+                "per": _f(row.per),
+                "pbr": _f(row.pbr),
+                "roe": _f(row.roe),
+                "dividend_yield": _f(row.dividend_yield),
+                "market_cap": _f(row.market_cap),
+                "high_52w": _f(row.high_52w),
+                "low_52w": _f(row.low_52w),
+            }
+        )
+        if latest_date is None or row.snapshot_date > latest_date:
+            latest_date = row.snapshot_date
+
+    if not per_symbol:
+        status = "unavailable"
+    elif (
+        latest_date is not None
+        and latest_date >= (now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS))
+    ):
+        status = "fresh"
+    else:
+        status = "stale"
+
+    return {
+        "market": market,
+        "per_symbol": per_symbol,
+        "covered_count": len(per_symbol),
+        "freshness": {
+            "status": status,
+            "latest_snapshot_date": latest_date.isoformat() if latest_date else None,
+        },
+        "data_health": {"requested": requested, "covered": len(per_symbol)},
+    }

--- a/app/services/investment_dimensions/fundamentals_evidence.py
+++ b/app/services/investment_dimensions/fundamentals_evidence.py
@@ -60,9 +60,8 @@ async def build_fundamentals_evidence(
 
     if not per_symbol:
         status = "unavailable"
-    elif (
-        latest_date is not None
-        and latest_date >= (now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS))
+    elif latest_date is not None and latest_date >= (
+        now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS)
     ):
         status = "fresh"
     else:

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -46,6 +46,13 @@ from app.services.investment_stages.stages.base import (
 )
 from app.services.investment_stages.stages.registry import get_default_v1_stages
 from app.services.research_reports.query_service import ResearchReportsQueryService
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
 
 _logger = logging.getLogger(__name__)
 
@@ -132,6 +139,33 @@ class HermesContextExporter:
             except Exception as exc:  # noqa: BLE001 — best-effort, like market
                 _logger.exception("Failed to build news evidence for context export")
                 dimension_evidence["news"] = {"unavailable": str(exc)}
+
+            try:
+                fundamentals_symbols: set[str] = set()
+                for snap in snapshots_by_kind.get("portfolio", []):
+                    for h in (snap.payload_json or {}).get("holdings", []):
+                        ticker = h.get("ticker")
+                        if ticker:
+                            fundamentals_symbols.add(ticker)
+                market_dim = dimension_evidence.get("market")
+                if isinstance(market_dim, dict):
+                    for mover in market_dim.get("top_movers", []):
+                        sym = mover.get("symbol")
+                        if sym:
+                            fundamentals_symbols.add(sym)
+                fundamentals_evidence = await build_fundamentals_evidence(
+                    MarketValuationSnapshotsRepository(self._session),
+                    StockInfoService(self._session),
+                    market=bundle.market,
+                    symbols=fundamentals_symbols,
+                )
+                dimension_evidence["fundamentals"] = fundamentals_evidence
+            except Exception as exc:  # noqa: BLE001 — best-effort, like market/news
+                _logger.exception(
+                    "Failed to build fundamentals evidence for context export"
+                )
+                dimension_evidence["fundamentals"] = {"unavailable": str(exc)}
+
 
         is_mock = (
             hasattr(self._session, "assert_called")

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -34,6 +34,9 @@ from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
 from app.services.invest_screener_snapshots.repository import (
     InvestScreenerSnapshotsRepository,
 )
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
 from app.services.investment_dimensions.market_evidence import build_market_evidence
 from app.services.investment_dimensions.news_evidence import build_news_evidence
 from app.services.investment_snapshots.repository import (
@@ -45,13 +48,10 @@ from app.services.investment_stages.stages.base import (
     UnavailableStageError,
 )
 from app.services.investment_stages.stages.registry import get_default_v1_stages
-from app.services.research_reports.query_service import ResearchReportsQueryService
-from app.services.investment_dimensions.fundamentals_evidence import (
-    build_fundamentals_evidence,
-)
 from app.services.market_valuation_snapshots.repository import (
     MarketValuationSnapshotsRepository,
 )
+from app.services.research_reports.query_service import ResearchReportsQueryService
 from app.services.stock_info_service import StockInfoService
 
 _logger = logging.getLogger(__name__)
@@ -165,7 +165,6 @@ class HermesContextExporter:
                     "Failed to build fundamentals evidence for context export"
                 )
                 dimension_evidence["fundamentals"] = {"unavailable": str(exc)}
-
 
         is_mock = (
             hasattr(self._session, "assert_called")

--- a/app/services/market_valuation_snapshots/repository.py
+++ b/app/services/market_valuation_snapshots/repository.py
@@ -145,7 +145,7 @@ class MarketValuationSnapshotsRepository:
         return {(r.market, r.symbol, r.snapshot_date, r.source) for r in result.all()}
 
     async def latest_for_symbols(
-        self, *, market: str, symbols: "set[str]"
+        self, *, market: str, symbols: set[str]
     ) -> list[MarketValuationSnapshot]:
         if not symbols:
             return []
@@ -166,4 +166,3 @@ class MarketValuationSnapshotsRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
-

--- a/app/services/market_valuation_snapshots/repository.py
+++ b/app/services/market_valuation_snapshots/repository.py
@@ -143,3 +143,27 @@ class MarketValuationSnapshotsRepository:
             ).where(sa.or_(*conditions))
         )
         return {(r.market, r.symbol, r.snapshot_date, r.source) for r in result.all()}
+
+    async def latest_for_symbols(
+        self, *, market: str, symbols: "set[str]"
+    ) -> list[MarketValuationSnapshot]:
+        if not symbols:
+            return []
+        norm_market = market.strip().lower()
+        norm_symbols = {s.strip().upper() for s in symbols}
+        stmt = (
+            select(MarketValuationSnapshot)
+            .where(
+                MarketValuationSnapshot.market == norm_market,
+                MarketValuationSnapshot.symbol.in_(norm_symbols),
+            )
+            .order_by(
+                MarketValuationSnapshot.symbol.asc(),
+                MarketValuationSnapshot.snapshot_date.desc(),
+                MarketValuationSnapshot.computed_at.desc(),
+            )
+            .distinct(MarketValuationSnapshot.symbol)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+

--- a/docs/superpowers/plans/2026-05-25-rob-311-fundamentals-dimension.md
+++ b/docs/superpowers/plans/2026-05-25-rob-311-fundamentals-dimension.md
@@ -1,0 +1,424 @@
+# ROB-311 Fundamentals Dimension Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, DB-only per-symbol Fundamentals evidence bundle (`fundamentals_evidence.py`, reading `market_valuation_snapshots` + `stock_info` sector) and wire it into the Hermes context export, so Hermes can write a Fundamentals dimension report — reusing the generic ROB-306/308 dimension contract (no new table/endpoint/migration).
+
+**Architecture:** Mirror `news_evidence`/`market_evidence`. A new repo method `latest_for_symbols` returns the latest valuation row per symbol; `build_fundamentals_evidence` joins it with `stock_info` sector into a JSON-able per-symbol bundle; the context exporter attaches it under `dimension_evidence["fundamentals"]` (best-effort, kr/us). **DB-only — no live KIS/Yahoo fetch.** `market_valuation_snapshots` is empty until ingestion is enabled (operator gate); the assembler degrades to `unavailable`.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, Pydantic v2, pytest (`db_session`), `uv`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-invest-reports-fundamentals-dimension-design.md` · **Linear:** ROB-311 · **Branch:** `rob-311`
+
+**Conventions:** `uv run pytest ... -v`; commit trailer `Co-Authored-By: Paperclip <noreply@paperclip.ing>`. Mirror targets: `app/services/investment_dimensions/news_evidence.py`, `tests/services/investment_dimensions/test_news_evidence.py`; the `dimension_evidence["news"]` block at `app/services/investment_stages/hermes_context.py` ~line 127-134. Repo: `app/services/market_valuation_snapshots/repository.py` (`MarketValuationSnapshotsRepository`, `MarketValuationSnapshot` cols `market/symbol/snapshot_date/source/per/pbr/roe/dividend_yield/market_cap/high_52w/low_52w/computed_at`). Sector: `app/services/stock_info_service.py` `StockInfoService(db).get_stock_info_by_symbol(symbol) -> StockInfo|None` (`.sector` nullable).
+
+---
+
+## File Structure
+- Modify: `app/services/market_valuation_snapshots/repository.py` — add `latest_for_symbols`.
+- Create: `app/services/investment_dimensions/fundamentals_evidence.py`
+- Create: `tests/services/investment_dimensions/test_fundamentals_evidence.py`
+- Modify: `app/services/investment_stages/hermes_context.py` — add `dimension_evidence["fundamentals"]`.
+- Test: `tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py`
+
+---
+
+## Task 1: `latest_for_symbols` repository method
+
+**Files:**
+- Modify: `app/services/market_valuation_snapshots/repository.py`
+- Test: `tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py`
+
+Returns the latest-`snapshot_date` row per symbol for a market (across sources). Source precedence on tie: newest `snapshot_date`, then `computed_at` desc — deterministic via `DISTINCT ON (symbol)` ordered by `symbol, snapshot_date DESC, computed_at DESC`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
+    await db_session.commit()
+
+
+def _row(symbol, *, snapshot_date, per, source="yahoo", market="us"):
+    return MarketValuationSnapshot(
+        market=market, symbol=symbol, snapshot_date=snapshot_date, source=source,
+        per=Decimal(per), pbr=Decimal("1.2"), roe=Decimal("0.15"),
+        dividend_yield=Decimal("0.02"), market_cap=Decimal("1000000"),
+        high_52w=Decimal("200"), low_52w=Decimal("100"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_returns_newest_per_symbol(db_session):
+    await _clear(db_session)
+    db_session.add_all([
+        _row("AAPL", snapshot_date=dt.date(2026, 5, 20), per="10"),
+        _row("AAPL", snapshot_date=dt.date(2026, 5, 23), per="12"),  # newest
+        _row("MSFT", snapshot_date=dt.date(2026, 5, 23), per="30"),
+    ])
+    await db_session.commit()
+
+    repo = MarketValuationSnapshotsRepository(db_session)
+    rows = await repo.latest_for_symbols(market="us", symbols={"AAPL", "MSFT", "TSLA"})
+    by_symbol = {r.symbol: r for r in rows}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # TSLA absent
+    assert by_symbol["AAPL"].per == Decimal("12")  # newest snapshot_date
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_empty_input(db_session):
+    repo = MarketValuationSnapshotsRepository(db_session)
+    assert await repo.latest_for_symbols(market="us", symbols=set()) == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py -v`
+Expected: FAIL — `AttributeError: ... 'latest_for_symbols'`.
+
+- [ ] **Step 3: Implement** — add to `MarketValuationSnapshotsRepository` (uses `Set` import + existing `select`):
+
+```python
+    async def latest_for_symbols(
+        self, *, market: str, symbols: "set[str]"
+    ) -> list[MarketValuationSnapshot]:
+        if not symbols:
+            return []
+        norm_market = market.strip().lower()
+        norm_symbols = {s.strip().upper() for s in symbols}
+        stmt = (
+            select(MarketValuationSnapshot)
+            .where(
+                MarketValuationSnapshot.market == norm_market,
+                MarketValuationSnapshot.symbol.in_(norm_symbols),
+            )
+            .order_by(
+                MarketValuationSnapshot.symbol.asc(),
+                MarketValuationSnapshot.snapshot_date.desc(),
+                MarketValuationSnapshot.computed_at.desc(),
+            )
+            .distinct(MarketValuationSnapshot.symbol)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+```
+
+(`.distinct(col)` renders Postgres `DISTINCT ON (symbol)`; the leading `ORDER BY symbol, snapshot_date DESC, computed_at DESC` makes it pick the newest per symbol deterministically.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py -v`
+Expected: PASS (2 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_valuation_snapshots/repository.py tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
+git commit -m "feat(rob-311): valuation repo latest_for_symbols (DISTINCT ON newest per symbol)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Fundamentals evidence assembler
+
+**Files:**
+- Create: `app/services/investment_dimensions/fundamentals_evidence.py`
+- Test: `tests/services/investment_dimensions/test_fundamentals_evidence.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.analysis import StockInfo
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
+    await db_session.execute(text("DELETE FROM stock_info WHERE symbol IN ('AAPL','MSFT')"))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_build_fundamentals_evidence_covered(db_session):
+    await _clear(db_session)
+    db_session.add(MarketValuationSnapshot(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 5, 23), source="yahoo",
+        per=Decimal("28.5"), pbr=Decimal("45"), roe=Decimal("1.5"),
+        dividend_yield=Decimal("0.005"), market_cap=Decimal("3000000000000"),
+        high_52w=Decimal("260"), low_52w=Decimal("164"),
+    ))
+    db_session.add(StockInfo(symbol="AAPL", name="Apple", instrument_type="equity_us",
+                             sector="Technology", is_active=True))
+    await db_session.commit()
+
+    bundle = await build_fundamentals_evidence(
+        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
+        market="us", symbols={"AAPL", "MSFT"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "us"
+    assert bundle["data_health"] == {"requested": 2, "covered": 1}
+    assert bundle["covered_count"] == 1
+    row = bundle["per_symbol"][0]
+    assert row["symbol"] == "AAPL"
+    assert row["sector"] == "Technology"
+    assert row["per"] == 28.5
+    assert row["dividend_yield"] == 0.005
+    assert bundle["freshness"]["status"] in {"fresh", "stale"}
+    assert bundle["freshness"]["latest_snapshot_date"] == "2026-05-23"
+
+
+@pytest.mark.asyncio
+async def test_build_fundamentals_evidence_empty_is_unavailable(db_session):
+    await _clear(db_session)
+    bundle = await build_fundamentals_evidence(
+        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
+        market="us", symbols={"AAPL"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["covered_count"] == 0
+    assert bundle["per_symbol"] == []
+    assert bundle["freshness"]["status"] == "unavailable"
+    assert bundle["data_health"] == {"requested": 1, "covered": 0}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/investment_dimensions/test_fundamentals_evidence.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** `app/services/investment_dimensions/fundamentals_evidence.py`:
+
+```python
+"""Deterministic Fundamentals dimension evidence bundle (ROB-311).
+
+Assembles per-symbol valuation (PER/PBR/ROE/dividend/market_cap/52w from
+``market_valuation_snapshots``) + sector (``stock_info``) into a market+symbol
+bundle, mirroring ``market_evidence``/``news_evidence``. DB-ONLY — never calls a
+live broker API. ``market_valuation_snapshots`` is empty until ingestion is
+enabled (operator gate); this degrades to ``unavailable``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Set
+from decimal import Decimal
+from typing import Any
+
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
+
+FRESH_WINDOW_DAYS = 7
+
+
+def _f(value: Decimal | None) -> float | None:
+    return float(value) if value is not None else None
+
+
+async def build_fundamentals_evidence(
+    valuation_repo: MarketValuationSnapshotsRepository,
+    stock_info_service: StockInfoService,
+    *,
+    market: str,
+    symbols: Set[str],
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    now_dt = now or dt.datetime.now(tz=dt.UTC)
+    requested = len(symbols)
+    rows = await valuation_repo.latest_for_symbols(market=market, symbols=set(symbols))
+
+    per_symbol: list[dict[str, Any]] = []
+    latest_date: dt.date | None = None
+    for row in rows:
+        info = await stock_info_service.get_stock_info_by_symbol(row.symbol)
+        per_symbol.append(
+            {
+                "symbol": row.symbol,
+                "sector": getattr(info, "sector", None),
+                "per": _f(row.per),
+                "pbr": _f(row.pbr),
+                "roe": _f(row.roe),
+                "dividend_yield": _f(row.dividend_yield),
+                "market_cap": _f(row.market_cap),
+                "high_52w": _f(row.high_52w),
+                "low_52w": _f(row.low_52w),
+            }
+        )
+        if latest_date is None or row.snapshot_date > latest_date:
+            latest_date = row.snapshot_date
+
+    if not per_symbol:
+        status = "unavailable"
+    elif (
+        latest_date is not None
+        and latest_date >= (now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS))
+    ):
+        status = "fresh"
+    else:
+        status = "stale"
+
+    return {
+        "market": market,
+        "per_symbol": per_symbol,
+        "covered_count": len(per_symbol),
+        "freshness": {
+            "status": status,
+            "latest_snapshot_date": latest_date.isoformat() if latest_date else None,
+        },
+        "data_health": {"requested": requested, "covered": len(per_symbol)},
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/services/investment_dimensions/test_fundamentals_evidence.py -v`
+Expected: PASS (2 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_dimensions/fundamentals_evidence.py tests/services/investment_dimensions/test_fundamentals_evidence.py
+git commit -m "feat(rob-311): deterministic Fundamentals dimension evidence (DB-only)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Wire Fundamentals evidence into the Hermes context export
+
+**Files:**
+- Modify: `app/services/investment_stages/hermes_context.py`
+- Test: `tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py`
+
+`symbols` = portfolio holdings (gathered from `snapshots_by_kind["portfolio"]`) ∪ market-dimension top movers (from the `dimension_evidence["market"]` dict if it was built successfully this call).
+
+- [ ] **Step 1: Write the failing test** — mirror `test_hermes_context_news_dimension.py` (`grep -rl "dimension_evidence\[.news.\]\|test_hermes_context_news" tests/`). Seed a `market_valuation_snapshots` row + matching `stock_info` for a symbol that is held (in the portfolio snapshot) for a `kr` (or `us`) bundle, build the context, and assert:
+
+```python
+assert "fundamentals" in payload.dimension_evidence
+fund = payload.dimension_evidence["fundamentals"]
+assert fund["market"] in ("kr", "us")
+assert fund["data_health"]["requested"] >= 1
+# the seeded held symbol appears (covered) when its valuation row exists
+assert any(r["symbol"] == SEEDED_SYMBOL for r in fund["per_symbol"])
+```
+
+Copy the bundle/run/portfolio-snapshot setup verbatim from the news/market context test; add the valuation + stock_info rows for the held symbol before `export`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py -v`
+Expected: FAIL — `"fundamentals" not in dimension_evidence`.
+
+- [ ] **Step 3: Implement** — in `hermes_context.py`, add imports near the news import:
+
+```python
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
+```
+
+Inside the `if bundle.market in ("kr", "us"):` block, immediately after the `dimension_evidence["news"]` try/except, add:
+
+```python
+            try:
+                fundamentals_symbols: set[str] = set()
+                for snap in snapshots_by_kind.get("portfolio", []):
+                    for h in (snap.payload_json or {}).get("holdings", []):
+                        ticker = h.get("ticker")
+                        if ticker:
+                            fundamentals_symbols.add(ticker)
+                market_dim = dimension_evidence.get("market")
+                if isinstance(market_dim, dict):
+                    for mover in market_dim.get("top_movers", []):
+                        sym = mover.get("symbol")
+                        if sym:
+                            fundamentals_symbols.add(sym)
+                fundamentals_evidence = await build_fundamentals_evidence(
+                    MarketValuationSnapshotsRepository(self._session),
+                    StockInfoService(self._session),
+                    market=bundle.market,
+                    symbols=fundamentals_symbols,
+                )
+                dimension_evidence["fundamentals"] = fundamentals_evidence
+            except Exception as exc:  # noqa: BLE001 — best-effort, like market/news
+                _logger.exception(
+                    "Failed to build fundamentals evidence for context export"
+                )
+                dimension_evidence["fundamentals"] = {"unavailable": str(exc)}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/hermes_context.py tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py
+git commit -m "feat(rob-311): attach Fundamentals evidence to Hermes context export
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: Verification
+
+- [ ] **Step 1:** `uv run pytest tests/services/investment_dimensions/ tests/services/investment_stages/ tests/services/market_valuation_snapshots/ -q` → all pass (Fundamentals + existing Market/News/dimension/valuation).
+- [ ] **Step 2:** ROB-287 guard: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -q` → pass. Also confirm the assembler imports no broker client: `grep -nE "kis|yahoo|broker|fetch_fundamental" app/services/investment_dimensions/fundamentals_evidence.py` → no matches.
+- [ ] **Step 3:** `make lint` → clean.
+- [ ] **Step 4:** broad regression: `uv run pytest tests/ -k "hermes or dimension or valuation or fundamental" -q` → green.
+- [ ] **Step 5:** Open PR. Handoff: branch, PR URL, tests; note `market_valuation_snapshots` ingestion enablement remains an operator gate (data deferred), earnings deferred, and the Fundamentals report prose is produced by Hermes via the existing `/hermes/dimension-reports` (dimension="fundamentals").
+
+---
+
+## Self-Review (against spec)
+
+**Spec coverage:**
+- F1 `build_fundamentals_evidence` (per-symbol valuation+sector, DB-only, soft-fail, coverage) → Task 2. ✓
+- F1b `latest_for_symbols` (newest per symbol, deterministic, empty→[]) → Task 1. ✓
+- F2 context wiring `dimension_evidence["fundamentals"]` (kr/us, holdings ∪ top_movers, soft-fail) → Task 3. ✓
+- F3 tests (covered/empty/partial assembler + context export) → Tasks 1-3. ✓
+- Boundaries: no live broker (Task 4 grep guard + DB-only assembler); no LLM (Task 4 guard); no table/endpoint/migration (none added); ingestion deferred (none enabled); per-symbol only. ✓
+
+**Placeholder scan:** Task 3 Step 1 says "mirror the news context test, grep to find it" — explicit instruction against a named pattern, not deferred work. Assembler + repo (Tasks 1-2) are complete code.
+
+**Type consistency:** `latest_for_symbols(*, market, symbols: set[str]) -> list[MarketValuationSnapshot]` (Task 1) ↔ called in Task 2. `build_fundamentals_evidence(valuation_repo, stock_info_service, *, market, symbols, now)` identical in Task 2 (def+tests) and Task 3 (call). Return keys `{market, per_symbol, covered_count, freshness:{status, latest_snapshot_date}, data_health:{requested, covered}}` asserted consistently. `_f` Decimal→float helper used for all numeric fields.
+```

--- a/docs/superpowers/specs/2026-05-25-invest-reports-fundamentals-dimension-design.md
+++ b/docs/superpowers/specs/2026-05-25-invest-reports-fundamentals-dimension-design.md
@@ -1,0 +1,85 @@
+# `/invest/reports` Fundamentals Dimension Evidence — Slice 4
+
+- **Date**: 2026-05-25
+- **Status**: Design approved, pending spec review
+- **Branch**: `rob-311`
+- **Linear**: [ROB-311](https://linear.app/mgh3326/issue/ROB-311) (parent: ROB-306; ROB-308 loop; ROB-310 News)
+
+## Context
+
+Slice 4 of the TradingAgents-style `/invest/reports` program. The dimension machinery is generic — `investment_dimension_reports` already supports `dimension="fundamentals"` (table + `/hermes/dimension-reports` ingest + read), and the context export carries `dimension_reports` (ROB-308). So Fundamentals needs **no new table, endpoint, migration, or schema** — only a deterministic per-symbol valuation evidence assembler + context wiring, mirroring `market_evidence` (ROB-306) / `news_evidence` (ROB-310).
+
+DB-backed source: **`market_valuation_snapshots`** (`MarketValuationSnapshotsRepository`) carries per-symbol `per / pbr / roe / dividend_yield / market_cap / high_52w / low_52w` (source `naver_finance` for KR, `yahoo` for US), built by `scripts/build_market_valuation_snapshots.py`. Sector comes from `stock_info` (`StockInfoService.get_stock_info_by_symbol(...).sector`). **Both are empty/sparse — ingestion is manual/unscheduled** (operator gate, like research_reports / crypto). Build the path + fixture-test it; ingestion enablement deferred.
+
+**Critical:** KIS/Yahoo `fetch_fundamental_info` is **live-API-only (never persisted)** and must NOT be called in the deterministic context-export path. The assembler reads `market_valuation_snapshots` (DB) only.
+
+## Decisions locked (with the user)
+
+- **Per-symbol** (per-company) — PER/PBR/ROE are company metrics; the report focuses on the symbols it acts on (held holdings ∪ candidate top movers).
+- **Assembler-only + fixture-tested.** Ingestion enablement deferred (operator gate).
+- Deterministic, **DB-only (no live broker calls)**; Hermes authors the Fundamentals report prose via existing `/hermes/dimension-reports` (dimension="fundamentals"). No in-process LLM (ROB-287). Read-only; no broker mutation.
+- **Earnings (`market_events`) excluded from v1** (empty; follow-up). v1 = valuation + sector.
+
+## Architecture / scope
+
+### F1. `app/services/investment_dimensions/fundamentals_evidence.py` (deterministic, DB-only)
+
+```python
+async def build_fundamentals_evidence(
+    valuation_repo: MarketValuationSnapshotsRepository,
+    stock_info_service: StockInfoService,
+    *, market: str, symbols: Set[str], now: dt.datetime | None = None,
+) -> dict[str, Any]
+```
+
+For each requested symbol: latest `market_valuation_snapshots` row (PER/PBR/ROE/dividend_yield/market_cap/52w) + `stock_info` sector. Returns:
+
+```python
+{
+  "market": "kr" | "us",
+  "per_symbol": [{"symbol", "sector", "per", "pbr", "roe", "dividend_yield",
+                  "market_cap", "high_52w", "low_52w"}],
+  "covered_count": int,
+  "freshness": {"status": "fresh|stale|unavailable", "latest_snapshot_date": str | None},
+  "data_health": {"requested": int, "covered": int},
+}
+```
+
+Soft-fail: zero coverage → `covered_count: 0`, `freshness.status: "unavailable"` (never raises). Numeric Decimals serialized to float/str JSON-safely. No prose.
+
+### F1b. `MarketValuationSnapshotsRepository.latest_for_symbols(market, symbols)`
+
+Add a read-only method (mirrors `coverage_counts` query style): for the given `market` + `symbols`, return the latest-`snapshot_date` row per symbol (across sources; prefer the newest). Returns `list[MarketValuationSnapshot]` (or a small DTO). Empty `symbols` → `[]`.
+
+### F2. Context wiring (`app/services/investment_stages/hermes_context.py`)
+
+Add a `dimension_evidence["fundamentals"]` block immediately after the `["news"]` block, `kr`/`us` only, best-effort `try/except` (mirror). `symbols` = portfolio holdings (already gathered for the market block's `held` set) ∪ market-dimension `top_movers` symbols (reuse the `market_evidence` result if available, else gather from `held` only). Construct `MarketValuationSnapshotsRepository` + `StockInfoService` from `self._session`.
+
+### F3. Tests
+
+- `fundamentals_evidence` assembler: fixture-seed `market_valuation_snapshots` (+ `stock_info` sector) → assert `per_symbol` rows / `covered_count` / `freshness`; empty → graceful `unavailable`; partial coverage (some symbols missing) → `data_health.requested > covered`.
+- Context export: a kr/us run yields `dimension_evidence["fundamentals"]` with expected keys; soft-fail path.
+
+## What's free (no implementation)
+
+Fundamentals dimension **report** (prose, stance, confidence): Hermes writes it via existing `POST /hermes/dimension-reports` with `dimension="fundamentals"`. Persistence, read surface, and composition citation all work via the ROB-306/308 generic contract — untouched here.
+
+## Non-goals / boundaries
+
+- No new table / endpoint / migration / schema. **No live KIS/Yahoo fundamental fetch in the assembler** (DB only). No in-process LLM. No broker/order/watch/order-intent mutation.
+- No `market_valuation_snapshots` ingestion enablement (separate operator gate; data deferred). No earnings/`market_events` in v1.
+- Market-wide fundamentals not produced (per-symbol only).
+
+## Testing strategy
+
+Fixture-based only (no live ingestion, no broker API): seed `market_valuation_snapshots` + `stock_info` rows via repository/model in `db_session`. Confirm ROB-287 no-internal-LLM import guard still passes and that the assembler imports no broker client (only the valuation repo + stock_info service).
+
+## Assumptions to verify during implementation
+
+- `StockInfoService.get_stock_info_by_symbol` returns a row with `.sector` (nullable) — confirmed at `app/services/stock_info_service.py`.
+- `latest_for_symbols` source-precedence: if a symbol has both `naver_finance` and `yahoo` rows on the same latest date, pick deterministically (e.g. by `computed_at` desc, then source asc) — lock in the plan.
+- The context exporter can reach the market-dimension `top_movers` symbols (reuse the already-built `market_evidence` dict in the same `export` scope) without re-querying.
+
+## Program order
+
+Parent: ROB-306. Slice 4 (Fundamentals, valuation+sector). Next: Sentiment (#5), crypto Market evidence (after ROB-282), earnings-in-Fundamentals follow-up. Loop-validation tooling = ROB-309 (done).

--- a/tests/services/investment_dimensions/test_fundamentals_evidence.py
+++ b/tests/services/investment_dimensions/test_fundamentals_evidence.py
@@ -5,38 +5,59 @@ import pytest
 
 from app.models.analysis import StockInfo
 from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
 from app.services.market_valuation_snapshots.repository import (
     MarketValuationSnapshotsRepository,
 )
 from app.services.stock_info_service import StockInfoService
-from app.services.investment_dimensions.fundamentals_evidence import (
-    build_fundamentals_evidence,
-)
 
 
 async def _clear(db_session):
     from sqlalchemy import text
+
     await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
-    await db_session.execute(text("DELETE FROM stock_info WHERE symbol IN ('AAPL','MSFT')"))
+    await db_session.execute(
+        text("DELETE FROM stock_info WHERE symbol IN ('AAPL','MSFT')")
+    )
     await db_session.commit()
 
 
 @pytest.mark.asyncio
 async def test_build_fundamentals_evidence_covered(db_session):
     await _clear(db_session)
-    db_session.add(MarketValuationSnapshot(
-        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 5, 23), source="yahoo",
-        per=Decimal("28.5"), pbr=Decimal("45"), roe=Decimal("1.5"),
-        dividend_yield=Decimal("0.005"), market_cap=Decimal("3000000000000"),
-        high_52w=Decimal("260"), low_52w=Decimal("164"),
-    ))
-    db_session.add(StockInfo(symbol="AAPL", name="Apple", instrument_type="equity_us",
-                             sector="Technology", is_active=True))
+    db_session.add(
+        MarketValuationSnapshot(
+            market="us",
+            symbol="AAPL",
+            snapshot_date=dt.date(2026, 5, 23),
+            source="yahoo",
+            per=Decimal("28.5"),
+            pbr=Decimal("45"),
+            roe=Decimal("1.5"),
+            dividend_yield=Decimal("0.005"),
+            market_cap=Decimal("3000000000000"),
+            high_52w=Decimal("260"),
+            low_52w=Decimal("164"),
+        )
+    )
+    db_session.add(
+        StockInfo(
+            symbol="AAPL",
+            name="Apple",
+            instrument_type="equity_us",
+            sector="Technology",
+            is_active=True,
+        )
+    )
     await db_session.commit()
 
     bundle = await build_fundamentals_evidence(
-        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
-        market="us", symbols={"AAPL", "MSFT"},
+        MarketValuationSnapshotsRepository(db_session),
+        StockInfoService(db_session),
+        market="us",
+        symbols={"AAPL", "MSFT"},
         now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
     )
     assert bundle["market"] == "us"
@@ -55,8 +76,10 @@ async def test_build_fundamentals_evidence_covered(db_session):
 async def test_build_fundamentals_evidence_empty_is_unavailable(db_session):
     await _clear(db_session)
     bundle = await build_fundamentals_evidence(
-        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
-        market="us", symbols={"AAPL"},
+        MarketValuationSnapshotsRepository(db_session),
+        StockInfoService(db_session),
+        market="us",
+        symbols={"AAPL"},
         now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
     )
     assert bundle["covered_count"] == 0

--- a/tests/services/investment_dimensions/test_fundamentals_evidence.py
+++ b/tests/services/investment_dimensions/test_fundamentals_evidence.py
@@ -1,0 +1,65 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.analysis import StockInfo
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+from app.services.stock_info_service import StockInfoService
+from app.services.investment_dimensions.fundamentals_evidence import (
+    build_fundamentals_evidence,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
+    await db_session.execute(text("DELETE FROM stock_info WHERE symbol IN ('AAPL','MSFT')"))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_build_fundamentals_evidence_covered(db_session):
+    await _clear(db_session)
+    db_session.add(MarketValuationSnapshot(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 5, 23), source="yahoo",
+        per=Decimal("28.5"), pbr=Decimal("45"), roe=Decimal("1.5"),
+        dividend_yield=Decimal("0.005"), market_cap=Decimal("3000000000000"),
+        high_52w=Decimal("260"), low_52w=Decimal("164"),
+    ))
+    db_session.add(StockInfo(symbol="AAPL", name="Apple", instrument_type="equity_us",
+                             sector="Technology", is_active=True))
+    await db_session.commit()
+
+    bundle = await build_fundamentals_evidence(
+        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
+        market="us", symbols={"AAPL", "MSFT"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "us"
+    assert bundle["data_health"] == {"requested": 2, "covered": 1}
+    assert bundle["covered_count"] == 1
+    row = bundle["per_symbol"][0]
+    assert row["symbol"] == "AAPL"
+    assert row["sector"] == "Technology"
+    assert row["per"] == 28.5
+    assert row["dividend_yield"] == 0.005
+    assert bundle["freshness"]["status"] in {"fresh", "stale"}
+    assert bundle["freshness"]["latest_snapshot_date"] == "2026-05-23"
+
+
+@pytest.mark.asyncio
+async def test_build_fundamentals_evidence_empty_is_unavailable(db_session):
+    await _clear(db_session)
+    bundle = await build_fundamentals_evidence(
+        MarketValuationSnapshotsRepository(db_session), StockInfoService(db_session),
+        market="us", symbols={"AAPL"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["covered_count"] == 0
+    assert bundle["per_symbol"] == []
+    assert bundle["freshness"]["status"] == "unavailable"
+    assert bundle["data_health"] == {"requested": 1, "covered": 0}

--- a/tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py
@@ -1,24 +1,25 @@
 import datetime as dt
-from decimal import Decimal
 import uuid
+from decimal import Decimal
 
 import pytest
 
 from app.models.analysis import StockInfo
-from app.models.market_valuation_snapshot import MarketValuationSnapshot
 from app.models.investment_stages import InvestmentStageRun
-from app.services.investment_stages.hermes_context import HermesContextExporter
-from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
 from app.schemas.investment_snapshots import (
-    SnapshotRunCreate,
-    SnapshotCreate,
     BundleCreate,
     BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
 )
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_stages.hermes_context import HermesContextExporter
 
 
 async def _clear(db_session):
     from sqlalchemy import text
+
     await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
     await db_session.execute(text("DELETE FROM stock_info WHERE symbol = 'AAPL'"))
     await db_session.commit()
@@ -31,7 +32,7 @@ async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> Non
     # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding AAPL)
     snapshots_repo = InvestmentSnapshotsRepository(db_session)
     now = dt.datetime.now(tz=dt.UTC)
-    
+
     run_obj = await snapshots_repo.insert_run(
         SnapshotRunCreate(
             purpose="report_generation",
@@ -41,7 +42,7 @@ async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> Non
             policy_version="intraday_action_report_v1",
         )
     )
-    
+
     portfolio_snap = await snapshots_repo.insert_snapshot(
         SnapshotCreate(
             run_uuid=run_obj.run_uuid,
@@ -68,7 +69,7 @@ async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> Non
             freshness_status="fresh",
         )
     )
-    
+
     bundle = await snapshots_repo.insert_bundle(
         BundleCreate(
             purpose=f"fundamentals_test_{uuid.uuid4().hex[:8]}",
@@ -79,10 +80,12 @@ async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> Non
             status="complete",
         )
     )
-    
+
     await snapshots_repo.link_bundle_item(
         bundle_uuid=bundle.bundle_uuid,
-        item=BundleItemCreate(snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"),
+        item=BundleItemCreate(
+            snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"
+        ),
     )
 
     # 2. Seed a MarketValuationSnapshot for AAPL
@@ -138,10 +141,9 @@ async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> Non
     assert fund["data_health"]["requested"] >= 1
     assert fund["data_health"]["covered"] >= 1
     assert fund["covered_count"] >= 1
-    
+
     aapl_row = next(r for r in fund["per_symbol"] if r["symbol"] == "AAPL")
     assert aapl_row["sector"] == "Technology"
     assert aapl_row["per"] == 28.5
     assert aapl_row["dividend_yield"] == 0.005
     assert fund["freshness"]["status"] == "fresh"
-

--- a/tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py
@@ -1,0 +1,147 @@
+import datetime as dt
+from decimal import Decimal
+import uuid
+
+import pytest
+
+from app.models.analysis import StockInfo
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.investment_stages import InvestmentStageRun
+from app.services.investment_stages.hermes_context import HermesContextExporter
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.schemas.investment_snapshots import (
+    SnapshotRunCreate,
+    SnapshotCreate,
+    BundleCreate,
+    BundleItemCreate,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
+    await db_session.execute(text("DELETE FROM stock_info WHERE symbol = 'AAPL'"))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_exporter_attaches_fundamentals_evidence_bundle(db_session) -> None:
+    await _clear(db_session)
+
+    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding AAPL)
+    snapshots_repo = InvestmentSnapshotsRepository(db_session)
+    now = dt.datetime.now(tz=dt.UTC)
+    
+    run_obj = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    
+    portfolio_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run_obj.run_uuid,
+            snapshot_kind="portfolio",
+            market="us",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={
+                "primary_source": "kis",
+                "holdings": [
+                    {
+                        "ticker": "AAPL",
+                        "quantity": 10,
+                        "sellable_quantity": 10,
+                        "source": "kis",
+                        "market": "us",
+                    }
+                ],
+                "reference_holdings": [],
+                "count": 1,
+                "market": "us",
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"fundamentals_test_{uuid.uuid4().hex[:8]}",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    
+    await snapshots_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"),
+    )
+
+    # 2. Seed a MarketValuationSnapshot for AAPL
+    db_session.add(
+        MarketValuationSnapshot(
+            market="us",
+            symbol="AAPL",
+            snapshot_date=now.date(),
+            source="yahoo",
+            per=Decimal("28.5"),
+            pbr=Decimal("45"),
+            roe=Decimal("1.5"),
+            dividend_yield=Decimal("0.005"),
+            market_cap=Decimal("3000000000000"),
+            high_52w=Decimal("260"),
+            low_52w=Decimal("164"),
+        )
+    )
+
+    # 3. Seed StockInfo for AAPL
+    db_session.add(
+        StockInfo(
+            symbol="AAPL",
+            name="Apple Inc.",
+            instrument_type="equity_us",
+            sector="Technology",
+            is_active=True,
+        )
+    )
+    await db_session.commit()
+
+    # 4. Seed an InvestmentStageRun associated with the bundle
+    stage_run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="us",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=now,
+    )
+    db_session.add(stage_run)
+    await db_session.commit()
+
+    # 5. Export Hermes Context
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    assert "fundamentals" in payload.dimension_evidence
+    fund = payload.dimension_evidence["fundamentals"]
+    assert fund["market"] == "us"
+    assert fund["data_health"]["requested"] >= 1
+    assert fund["data_health"]["covered"] >= 1
+    assert fund["covered_count"] >= 1
+    
+    aapl_row = next(r for r in fund["per_symbol"] if r["symbol"] == "AAPL")
+    assert aapl_row["sector"] == "Technology"
+    assert aapl_row["per"] == 28.5
+    assert aapl_row["dividend_yield"] == 0.005
+    assert fund["freshness"]["status"] == "fresh"
+

--- a/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
+++ b/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
@@ -11,27 +11,37 @@ from app.services.market_valuation_snapshots.repository import (
 
 async def _clear(db_session):
     from sqlalchemy import text
+
     await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
     await db_session.commit()
 
 
 def _row(symbol, *, snapshot_date, per, source="yahoo", market="us"):
     return MarketValuationSnapshot(
-        market=market, symbol=symbol, snapshot_date=snapshot_date, source=source,
-        per=Decimal(per), pbr=Decimal("1.2"), roe=Decimal("0.15"),
-        dividend_yield=Decimal("0.02"), market_cap=Decimal("1000000"),
-        high_52w=Decimal("200"), low_52w=Decimal("100"),
+        market=market,
+        symbol=symbol,
+        snapshot_date=snapshot_date,
+        source=source,
+        per=Decimal(per),
+        pbr=Decimal("1.2"),
+        roe=Decimal("0.15"),
+        dividend_yield=Decimal("0.02"),
+        market_cap=Decimal("1000000"),
+        high_52w=Decimal("200"),
+        low_52w=Decimal("100"),
     )
 
 
 @pytest.mark.asyncio
 async def test_latest_for_symbols_returns_newest_per_symbol(db_session):
     await _clear(db_session)
-    db_session.add_all([
-        _row("AAPL", snapshot_date=dt.date(2026, 5, 20), per="10"),
-        _row("AAPL", snapshot_date=dt.date(2026, 5, 23), per="12"),  # newest
-        _row("MSFT", snapshot_date=dt.date(2026, 5, 23), per="30"),
-    ])
+    db_session.add_all(
+        [
+            _row("AAPL", snapshot_date=dt.date(2026, 5, 20), per="10"),
+            _row("AAPL", snapshot_date=dt.date(2026, 5, 23), per="12"),  # newest
+            _row("MSFT", snapshot_date=dt.date(2026, 5, 23), per="30"),
+        ]
+    )
     await db_session.commit()
 
     repo = MarketValuationSnapshotsRepository(db_session)

--- a/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
+++ b/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
@@ -1,0 +1,47 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM market_valuation_snapshots"))
+    await db_session.commit()
+
+
+def _row(symbol, *, snapshot_date, per, source="yahoo", market="us"):
+    return MarketValuationSnapshot(
+        market=market, symbol=symbol, snapshot_date=snapshot_date, source=source,
+        per=Decimal(per), pbr=Decimal("1.2"), roe=Decimal("0.15"),
+        dividend_yield=Decimal("0.02"), market_cap=Decimal("1000000"),
+        high_52w=Decimal("200"), low_52w=Decimal("100"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_returns_newest_per_symbol(db_session):
+    await _clear(db_session)
+    db_session.add_all([
+        _row("AAPL", snapshot_date=dt.date(2026, 5, 20), per="10"),
+        _row("AAPL", snapshot_date=dt.date(2026, 5, 23), per="12"),  # newest
+        _row("MSFT", snapshot_date=dt.date(2026, 5, 23), per="30"),
+    ])
+    await db_session.commit()
+
+    repo = MarketValuationSnapshotsRepository(db_session)
+    rows = await repo.latest_for_symbols(market="us", symbols={"AAPL", "MSFT", "TSLA"})
+    by_symbol = {r.symbol: r for r in rows}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # TSLA absent
+    assert by_symbol["AAPL"].per == Decimal("12")  # newest snapshot_date
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_empty_input(db_session):
+    repo = MarketValuationSnapshotsRepository(db_session)
+    assert await repo.latest_for_symbols(market="us", symbols=set()) == []


### PR DESCRIPTION
## What & why

Slice 4 of the TradingAgents-style `/invest/reports` program (parent: ROB-306 Market; ROB-308 synthesis loop; ROB-310 News). Adds the **Fundamentals dimension** evidence so Hermes can write a Fundamentals analyst report.

The dimension machinery is generic — `investment_dimension_reports` already supports `dimension="fundamentals"` (table + `/hermes/dimension-reports` ingest + read), and the context export carries `dimension_reports` (ROB-308). So Fundamentals needs **no new table, endpoint, migration, or schema** — just a deterministic per-symbol evidence assembler + one context block.

Linear: ROB-311 (related: ROB-306, ROB-308, ROB-310).

## Changes

- **`MarketValuationSnapshotsRepository.latest_for_symbols(market, symbols)`** — read-only, `DISTINCT ON (symbol)` newest-per-symbol (snapshot_date desc, computed_at desc). Empty input → [].
- **`app/services/investment_dimensions/fundamentals_evidence.py`** — `build_fundamentals_evidence(valuation_repo, stock_info_service, *, market, symbols, now=None)`, mirroring `market_evidence`/`news_evidence`. Per symbol: latest `market_valuation_snapshots` (PER/PBR/ROE/dividend_yield/market_cap/52w) + `stock_info` sector. Returns `per_symbol` + `covered_count` + `freshness` + `data_health{requested,covered}`. Soft-fails to `unavailable` when empty; reflects partial coverage. **DB-only — no live KIS/Yahoo.**
- **`hermes_context.py`** — `dimension_evidence["fundamentals"]` block (kr/us, best-effort), symbols = portfolio holdings ∪ market-dimension top movers.

## Boundaries

- **DB-only** — assembler imports only the valuation repo + stock_info service (verified: no broker/live-fetch import). Live KIS/Yahoo `fetch_fundamental_info` is never called in the context-export path.
- Deterministic; Hermes authors the Fundamentals report prose via existing `POST /hermes/dimension-reports` (dimension="fundamentals"). **No in-process LLM** (ROB-287 guard passes). Read-only; no broker mutation.
- **No new table/endpoint/migration/schema.** Per-symbol (market-wide deferred); earnings (market_events) excluded from v1.
- **`market_valuation_snapshots` ingestion enablement is a separate operator gate** (manual/unscheduled) — data deferred like crypto/News; path is complete + fixture-tested.

## Tests

Repo `latest_for_symbols` (newest-per-symbol / empty) + assembler (covered / empty-unavailable / partial coverage) + context export carries `dimension_evidence["fundamentals"]`. ROB-311 surface + investment_stages + guard: **109 passed**. Broad (`hermes`/`dimension`/`valuation`/`fundamental`): **423 passed**. `ruff`/`ty` clean. No `app/` schema/migration.

## Deferred (program order)

Next: Sentiment (#5), crypto Market evidence (after ROB-282), earnings-in-Fundamentals follow-up. Loop-validation tooling = ROB-309 (done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fundamentals dimension for investment reports, displaying per-symbol valuation metrics (PER, PBR, ROE, dividend yield, market cap, 52-week range) with sector information.
  * Integrated freshness status indicators to track data recency (fresh/stale/unavailable based on 7-day window).

* **Documentation**
  * Added design specification and implementation plan for the fundamentals feature.

* **Tests**
  * Added comprehensive test coverage for the new functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->