### PR TITLE
feat(rob-312): /invest/reports Sentiment dimension evidence (slice 5, KR investor-flow)

### DIFF
--- a/app/services/investment_dimensions/sentiment_evidence.py
+++ b/app/services/investment_dimensions/sentiment_evidence.py
@@ -1,0 +1,89 @@
+"""Deterministic Sentiment dimension evidence bundle (ROB-312).
+
+Assembles per-symbol KR investor-flow consensus (foreign/institution net,
+double_buy/sell, consecutive-buy streaks from ``investor_flow_snapshots``) into
+a market+symbol bundle, mirroring ``fundamentals_evidence``. DB-ONLY, no LLM.
+
+KR-ONLY: investor-flow data is KR-only (``market IN ('kr')``). For non-KR
+markets the assembler returns ``unavailable`` (no query). ``investor_flow_
+snapshots`` is populated (ROB-205), unlike the other dimensions' sources.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Set
+from typing import Any
+
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+
+FRESH_WINDOW_DAYS = 5
+
+
+def _unavailable(market: str, requested: int) -> dict[str, Any]:
+    return {
+        "market": market,
+        "per_symbol": [],
+        "covered_count": 0,
+        "freshness": {"status": "unavailable", "latest_snapshot_date": None},
+        "data_health": {"requested": requested, "covered": 0},
+    }
+
+
+async def build_sentiment_evidence(
+    flow_repo: InvestorFlowSnapshotsRepository,
+    *,
+    market: str,
+    symbols: Set[str],
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    requested = len(symbols)
+    # KR-only source (investor_flow_snapshots.market IN ('kr')). Non-KR markets
+    # have no distinct DB sentiment signal yet → unavailable (no query).
+    if market.strip().lower() != "kr":
+        return _unavailable(market, requested)
+
+    now_dt = now or dt.datetime.now(tz=dt.UTC)
+    rows = await flow_repo.latest_by_symbols(market="kr", symbols=set(symbols))
+
+    per_symbol: list[dict[str, Any]] = []
+    latest_date: dt.date | None = None
+    for row in rows:
+        per_symbol.append(
+            {
+                "symbol": row.symbol,
+                "foreign_net": row.foreign_net,
+                "institution_net": row.institution_net,
+                "double_buy": bool(row.double_buy),
+                "double_sell": bool(row.double_sell),
+                "foreign_consecutive_buy_days": row.foreign_consecutive_buy_days,
+                "institution_consecutive_buy_days": (
+                    row.institution_consecutive_buy_days
+                ),
+            }
+        )
+        if latest_date is None or row.snapshot_date > latest_date:
+            latest_date = row.snapshot_date
+
+    if not per_symbol:
+        return _unavailable(market, requested)
+
+    if latest_date is not None and latest_date >= (
+        now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS)
+    ):
+        status = "fresh"
+    else:
+        status = "stale"
+
+    return {
+        "market": market,
+        "per_symbol": per_symbol,
+        "covered_count": len(per_symbol),
+        "freshness": {
+            "status": status,
+            "latest_snapshot_date": latest_date.isoformat() if latest_date else None,
+        },
+        "data_health": {"requested": requested, "covered": len(per_symbol)},
+    }

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -39,6 +39,9 @@ from app.services.investment_dimensions.fundamentals_evidence import (
 )
 from app.services.investment_dimensions.market_evidence import build_market_evidence
 from app.services.investment_dimensions.news_evidence import build_news_evidence
+from app.services.investment_dimensions.sentiment_evidence import (
+    build_sentiment_evidence,
+)
 from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
@@ -48,6 +51,9 @@ from app.services.investment_stages.stages.base import (
     UnavailableStageError,
 )
 from app.services.investment_stages.stages.registry import get_default_v1_stages
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
 from app.services.market_valuation_snapshots.repository import (
     MarketValuationSnapshotsRepository,
 )
@@ -140,24 +146,25 @@ class HermesContextExporter:
                 _logger.exception("Failed to build news evidence for context export")
                 dimension_evidence["news"] = {"unavailable": str(exc)}
 
+            dimension_symbols: set[str] = set()
+            for snap in snapshots_by_kind.get("portfolio", []):
+                for h in (snap.payload_json or {}).get("holdings", []):
+                    ticker = h.get("ticker")
+                    if ticker:
+                        dimension_symbols.add(ticker)
+            market_dim = dimension_evidence.get("market")
+            if isinstance(market_dim, dict):
+                for mover in market_dim.get("top_movers", []):
+                    sym = mover.get("symbol")
+                    if sym:
+                        dimension_symbols.add(sym)
+
             try:
-                fundamentals_symbols: set[str] = set()
-                for snap in snapshots_by_kind.get("portfolio", []):
-                    for h in (snap.payload_json or {}).get("holdings", []):
-                        ticker = h.get("ticker")
-                        if ticker:
-                            fundamentals_symbols.add(ticker)
-                market_dim = dimension_evidence.get("market")
-                if isinstance(market_dim, dict):
-                    for mover in market_dim.get("top_movers", []):
-                        sym = mover.get("symbol")
-                        if sym:
-                            fundamentals_symbols.add(sym)
                 fundamentals_evidence = await build_fundamentals_evidence(
                     MarketValuationSnapshotsRepository(self._session),
                     StockInfoService(self._session),
                     market=bundle.market,
-                    symbols=fundamentals_symbols,
+                    symbols=dimension_symbols,
                 )
                 dimension_evidence["fundamentals"] = fundamentals_evidence
             except Exception as exc:  # noqa: BLE001 — best-effort, like market/news
@@ -165,6 +172,19 @@ class HermesContextExporter:
                     "Failed to build fundamentals evidence for context export"
                 )
                 dimension_evidence["fundamentals"] = {"unavailable": str(exc)}
+
+            try:
+                sentiment_evidence = await build_sentiment_evidence(
+                    InvestorFlowSnapshotsRepository(self._session),
+                    market=bundle.market,
+                    symbols=dimension_symbols,
+                )
+                dimension_evidence["sentiment"] = sentiment_evidence
+            except Exception as exc:  # noqa: BLE001 — best-effort, like the others
+                _logger.exception(
+                    "Failed to build sentiment evidence for context export"
+                )
+                dimension_evidence["sentiment"] = {"unavailable": str(exc)}
 
         is_mock = (
             hasattr(self._session, "assert_called")

--- a/docs/superpowers/plans/2026-05-25-rob-312-sentiment-dimension.md
+++ b/docs/superpowers/plans/2026-05-25-rob-312-sentiment-dimension.md
@@ -1,0 +1,340 @@
+# ROB-312 Sentiment Dimension Evidence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, DB-only, KR-only per-symbol Sentiment evidence bundle (`sentiment_evidence.py`, reading `investor_flow_snapshots` foreign/institution flows) and wire it into the Hermes context export, so Hermes can write a Sentiment dimension report — reusing the generic ROB-306/308 dimension contract (no new table/endpoint/migration).
+
+**Architecture:** Mirror `fundamentals_evidence`. `build_sentiment_evidence` uses the existing `InvestorFlowSnapshotsRepository.latest_by_symbols` to get newest KR investor-flow per symbol, returns a JSON-able per-symbol bundle (non-KR → `unavailable`); the context exporter attaches it under `dimension_evidence["sentiment"]` (best-effort), reusing the same `holdings ∪ top_movers` symbol set the Fundamentals block uses (hoisted to one shared local). DB-only, no LLM. `investor_flow_snapshots` is already populated (ROB-205).
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, Pydantic v2, pytest (`db_session`), `uv`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-invest-reports-sentiment-dimension-design.md` · **Linear:** ROB-312 · **Branch:** `rob-312`
+
+**Conventions:** `uv run pytest ... -v`; commit trailer `Co-Authored-By: Paperclip <noreply@paperclip.ing>`. Mirror targets: `app/services/investment_dimensions/fundamentals_evidence.py`, `tests/services/investment_dimensions/test_fundamentals_evidence.py`, the `dimension_evidence["fundamentals"]` block in `app/services/investment_stages/hermes_context.py` (~line 143-168), `tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py`. Repo (existing, no new method): `app/services/investor_flow_snapshots/repository.py` `InvestorFlowSnapshotsRepository(session).latest_by_symbols(*, market, symbols, as_of=None) -> list[InvestorFlowSnapshot]`. Model: `app/models/investor_flow_snapshot.py` `InvestorFlowSnapshot` cols `market/symbol/snapshot_date/foreign_net/institution_net/double_buy/double_sell/foreign_consecutive_buy_days/institution_consecutive_buy_days/source` (KR only: `market IN ('kr')`).
+
+---
+
+## File Structure
+- Create: `app/services/investment_dimensions/sentiment_evidence.py`
+- Create: `tests/services/investment_dimensions/test_sentiment_evidence.py`
+- Modify: `app/services/investment_stages/hermes_context.py` (hoist symbol set; add `dimension_evidence["sentiment"]`)
+- Test: `tests/services/investment_stages/test_hermes_context_sentiment_dimension.py`
+
+---
+
+## Task 1: Sentiment evidence assembler
+
+**Files:**
+- Create: `app/services/investment_dimensions/sentiment_evidence.py`
+- Test: `tests/services/investment_dimensions/test_sentiment_evidence.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import datetime as dt
+
+import pytest
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+from app.services.investment_dimensions.sentiment_evidence import (
+    build_sentiment_evidence,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+    await db_session.execute(text("DELETE FROM investor_flow_snapshots"))
+    await db_session.commit()
+
+
+def _flow(symbol, *, snapshot_date, foreign_net, double_buy=False):
+    return InvestorFlowSnapshot(
+        market="kr", symbol=symbol, snapshot_date=snapshot_date,
+        foreign_net=foreign_net, institution_net=5000,
+        double_buy=double_buy, double_sell=False,
+        foreign_consecutive_buy_days=3, institution_consecutive_buy_days=2,
+        source="naver_finance",
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_kr_covered(db_session):
+    await _clear(db_session)
+    db_session.add(_flow("005930", snapshot_date=dt.date(2026, 5, 23),
+                         foreign_net=120000, double_buy=True))
+    await db_session.commit()
+
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="kr", symbols={"005930", "000660"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "kr"
+    assert bundle["data_health"] == {"requested": 2, "covered": 1}
+    assert bundle["covered_count"] == 1
+    row = bundle["per_symbol"][0]
+    assert row["symbol"] == "005930"
+    assert row["foreign_net"] == 120000
+    assert row["double_buy"] is True
+    assert row["foreign_consecutive_buy_days"] == 3
+    assert bundle["freshness"]["status"] in {"fresh", "stale"}
+    assert bundle["freshness"]["latest_snapshot_date"] == "2026-05-23"
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_non_kr_is_unavailable(db_session):
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="us", symbols={"AAPL"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "us"
+    assert bundle["per_symbol"] == []
+    assert bundle["covered_count"] == 0
+    assert bundle["freshness"]["status"] == "unavailable"
+    assert bundle["data_health"] == {"requested": 1, "covered": 0}
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_empty_kr_is_unavailable(db_session):
+    await _clear(db_session)
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="kr", symbols={"005930"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["covered_count"] == 0
+    assert bundle["freshness"]["status"] == "unavailable"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/investment_dimensions/test_sentiment_evidence.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** `app/services/investment_dimensions/sentiment_evidence.py`:
+
+```python
+"""Deterministic Sentiment dimension evidence bundle (ROB-312).
+
+Assembles per-symbol KR investor-flow consensus (foreign/institution net,
+double_buy/sell, consecutive-buy streaks from ``investor_flow_snapshots``) into
+a market+symbol bundle, mirroring ``fundamentals_evidence``. DB-ONLY, no LLM.
+
+KR-ONLY: investor-flow data is KR-only (``market IN ('kr')``). For non-KR
+markets the assembler returns ``unavailable`` (no query). ``investor_flow_
+snapshots`` is populated (ROB-205), unlike the other dimensions' sources.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Set
+from typing import Any
+
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+
+FRESH_WINDOW_DAYS = 5
+
+
+def _unavailable(market: str, requested: int) -> dict[str, Any]:
+    return {
+        "market": market,
+        "per_symbol": [],
+        "covered_count": 0,
+        "freshness": {"status": "unavailable", "latest_snapshot_date": None},
+        "data_health": {"requested": requested, "covered": 0},
+    }
+
+
+async def build_sentiment_evidence(
+    flow_repo: InvestorFlowSnapshotsRepository,
+    *,
+    market: str,
+    symbols: Set[str],
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    requested = len(symbols)
+    # KR-only source (investor_flow_snapshots.market IN ('kr')). Non-KR markets
+    # have no distinct DB sentiment signal yet → unavailable (no query).
+    if market.strip().lower() != "kr":
+        return _unavailable(market, requested)
+
+    now_dt = now or dt.datetime.now(tz=dt.UTC)
+    rows = await flow_repo.latest_by_symbols(market="kr", symbols=set(symbols))
+
+    per_symbol: list[dict[str, Any]] = []
+    latest_date: dt.date | None = None
+    for row in rows:
+        per_symbol.append(
+            {
+                "symbol": row.symbol,
+                "foreign_net": row.foreign_net,
+                "institution_net": row.institution_net,
+                "double_buy": bool(row.double_buy),
+                "double_sell": bool(row.double_sell),
+                "foreign_consecutive_buy_days": row.foreign_consecutive_buy_days,
+                "institution_consecutive_buy_days": (
+                    row.institution_consecutive_buy_days
+                ),
+            }
+        )
+        if latest_date is None or row.snapshot_date > latest_date:
+            latest_date = row.snapshot_date
+
+    if not per_symbol:
+        return _unavailable(market, requested)
+
+    if latest_date is not None and latest_date >= (
+        now_dt.date() - dt.timedelta(days=FRESH_WINDOW_DAYS)
+    ):
+        status = "fresh"
+    else:
+        status = "stale"
+
+    return {
+        "market": market,
+        "per_symbol": per_symbol,
+        "covered_count": len(per_symbol),
+        "freshness": {
+            "status": status,
+            "latest_snapshot_date": latest_date.isoformat() if latest_date else None,
+        },
+        "data_health": {"requested": requested, "covered": len(per_symbol)},
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/services/investment_dimensions/test_sentiment_evidence.py -v`
+Expected: PASS (3 cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_dimensions/sentiment_evidence.py tests/services/investment_dimensions/test_sentiment_evidence.py
+git commit -m "feat(rob-312): deterministic Sentiment dimension evidence (KR investor-flow, DB-only)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Wire Sentiment evidence into the Hermes context export
+
+**Files:**
+- Modify: `app/services/investment_stages/hermes_context.py`
+- Test: `tests/services/investment_stages/test_hermes_context_sentiment_dimension.py`
+
+To avoid drift, hoist the `holdings ∪ top_movers` symbol set (currently built inside the Fundamentals `try`) into a single local computed once, used by both the Fundamentals and Sentiment blocks.
+
+- [ ] **Step 1: Write the failing test** — mirror `test_hermes_context_fundamentals_dimension.py` (read it first for the exact bundle/run/portfolio-snapshot harness). Seed an `investor_flow_snapshots` KR row for a symbol that is held (in the portfolio snapshot) for a `kr` bundle, build the context, and assert:
+
+```python
+# (reuse the fundamentals context test harness: BundleCreate/SnapshotCreate/
+#  InvestmentStageRun + HermesContextExporter; portfolio snapshot holds SYMBOL)
+payload = await exporter.export(...)   # same invocation as the fundamentals test
+assert "sentiment" in payload.dimension_evidence
+sent = payload.dimension_evidence["sentiment"]
+assert sent["market"] == "kr"
+assert any(r["symbol"] == SEEDED_SYMBOL for r in sent["per_symbol"])
+assert sent["per_symbol"][0]["double_buy"] in (True, False)
+```
+
+Add a second test asserting a `us` bundle yields `dimension_evidence["sentiment"]["freshness"]["status"] == "unavailable"`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/services/investment_stages/test_hermes_context_sentiment_dimension.py -v`
+Expected: FAIL — `"sentiment" not in dimension_evidence`.
+
+- [ ] **Step 3a: Hoist the symbol set** — in `hermes_context.py`, the Fundamentals `try` currently builds `fundamentals_symbols`. Replace that local construction with a shared `dimension_symbols` computed once, immediately before the Fundamentals `try` block:
+
+```python
+            dimension_symbols: set[str] = set()
+            for snap in snapshots_by_kind.get("portfolio", []):
+                for h in (snap.payload_json or {}).get("holdings", []):
+                    ticker = h.get("ticker")
+                    if ticker:
+                        dimension_symbols.add(ticker)
+            market_dim = dimension_evidence.get("market")
+            if isinstance(market_dim, dict):
+                for mover in market_dim.get("top_movers", []):
+                    sym = mover.get("symbol")
+                    if sym:
+                        dimension_symbols.add(sym)
+```
+
+Then in the Fundamentals `try`, delete its inline `fundamentals_symbols` gathering and pass `symbols=dimension_symbols` to `build_fundamentals_evidence`.
+
+- [ ] **Step 3b: Add the Sentiment block** — add imports near the fundamentals import:
+
+```python
+from app.services.investment_dimensions.sentiment_evidence import (
+    build_sentiment_evidence,
+)
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+```
+
+And, immediately after the Fundamentals `try/except`, add:
+
+```python
+            try:
+                sentiment_evidence = await build_sentiment_evidence(
+                    InvestorFlowSnapshotsRepository(self._session),
+                    market=bundle.market,
+                    symbols=dimension_symbols,
+                )
+                dimension_evidence["sentiment"] = sentiment_evidence
+            except Exception as exc:  # noqa: BLE001 — best-effort, like the others
+                _logger.exception(
+                    "Failed to build sentiment evidence for context export"
+                )
+                dimension_evidence["sentiment"] = {"unavailable": str(exc)}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `uv run pytest tests/services/investment_stages/test_hermes_context_sentiment_dimension.py tests/services/investment_stages/test_hermes_context_fundamentals_dimension.py -v`
+Expected: PASS (sentiment new tests + fundamentals still green after the hoist).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_stages/hermes_context.py tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
+git commit -m "feat(rob-312): attach Sentiment evidence to Hermes context export (shared dimension symbols)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Verification
+
+- [ ] **Step 1:** `uv run pytest tests/services/investment_dimensions/ tests/services/investment_stages/ -q` → all pass (Sentiment + existing Market/News/Fundamentals/dimension; confirms the symbol-hoist didn't regress Fundamentals).
+- [ ] **Step 2:** ROB-287 guard: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -q` → pass. Confirm the assembler imports no broker/LLM: `grep -nE "kis|yahoo|broker|gemini|openai|llm" app/services/investment_dimensions/sentiment_evidence.py` → no matches.
+- [ ] **Step 3:** `make lint` → clean.
+- [ ] **Step 4:** broad regression: `uv run pytest tests/ -k "hermes or dimension or investor_flow or sentiment" -q` → green.
+- [ ] **Step 5:** Open PR. Handoff: branch, PR URL, tests; note KR-only limitation (US/crypto → unavailable), `investor_flow_snapshots` is already populated (ROB-205), and the Sentiment report prose is produced by Hermes via the existing `/hermes/dimension-reports` (dimension="sentiment").
+
+---
+
+## Self-Review (against spec)
+
+**Spec coverage:**
+- S1 `build_sentiment_evidence` (KR per-symbol investor-flow, non-KR → unavailable, soft-fail, coverage, freshness) → Task 1. ✓
+- S2 context wiring `dimension_evidence["sentiment"]` (shared holdings ∪ top_movers, soft-fail, us → unavailable) → Task 2 (incl. symbol-set hoist to avoid drift). ✓
+- S3 tests (KR covered / non-KR unavailable / empty / context export kr+us) → Tasks 1-2. ✓
+- Boundaries: no live calls / no LLM (Task 3 grep + guard); no new table/endpoint/migration; reuse existing `latest_by_symbols` (no new repo method); KR-only by design. ✓
+
+**Placeholder scan:** Task 2 Step 1 says "mirror the fundamentals context test, read it first" — explicit instruction against a named file, not deferred work. Assembler (Task 1) is complete code. The hoist (Task 3a) shows exact replacement code.
+
+**Type consistency:** `build_sentiment_evidence(flow_repo, *, market, symbols, now)` identical in Task 1 (def+tests) and Task 2 (call). Return keys `{market, per_symbol, covered_count, freshness:{status, latest_snapshot_date}, data_health:{requested, covered}}` asserted consistently. `latest_by_symbols(*, market, symbols)` matches the real signature (verified). `dimension_symbols` defined once (Task 2 3a) and used by both Fundamentals (rewired) and Sentiment (3b).
+```

--- a/docs/superpowers/specs/2026-05-25-invest-reports-sentiment-dimension-design.md
+++ b/docs/superpowers/specs/2026-05-25-invest-reports-sentiment-dimension-design.md
@@ -1,0 +1,81 @@
+# `/invest/reports` Sentiment Dimension Evidence — Slice 5
+
+- **Date**: 2026-05-25
+- **Status**: Design approved, pending spec review
+- **Branch**: `rob-312`
+- **Linear**: [ROB-312](https://linear.app/mgh3326/issue/ROB-312) (parent: ROB-306; ROB-308 loop; ROB-310 News; ROB-311 Fundamentals)
+
+## Context
+
+Slice 5 of the TradingAgents-style `/invest/reports` program. The dimension machinery is generic — `investment_dimension_reports` already supports `dimension="sentiment"` (table + `/hermes/dimension-reports` ingest + read), and the context export carries `dimension_reports`. So Sentiment needs **no new table, endpoint, migration, or schema** — only a deterministic per-symbol evidence assembler + context wiring, mirroring `fundamentals_evidence` (ROB-311).
+
+**Sentiment-source finding:** the repo has no social feed, no DB-persisted Fear&Greed, no stored analyst ratings. The only **distinct, DB-backed, populated, non-LLM** sentiment proxy is **`investor_flow_snapshots`** (ROB-205): KR foreign/institution net buy/sell flows, `double_buy`/`double_sell`, consecutive-buy streaks. (RSI/momentum would double-count Market; `NewsAnalysisResult` is LLM-derived; Fear&Greed is live-API-only — all rejected.) So Sentiment = **KR investor-flow consensus**, genuinely distinct from Market (price breadth) and News (citations). Unlike News/Fundamentals/crypto (empty pending ingestion), `investor_flow_snapshots` is **already populated** (ROB-205; used by the screener `double_buy` preset), so Sentiment can surface real data.
+
+## Decisions locked (with the user)
+
+- **KR-only** — investor-flow data is KR-only (`market IN ('kr')`). For US/crypto the assembler returns `unavailable` (graceful, empty `per_symbol`). Intended, documented limitation; multi-market sentiment awaits a social/analyst source.
+- **Per-symbol** (Fundamentals pattern) — symbols = holdings ∪ market top movers.
+- Deterministic, **DB-only (no live calls)**; Hermes authors the prose via existing `/hermes/dimension-reports` (dimension="sentiment"). No in-process LLM (ROB-287). Read-only; no broker mutation.
+
+## Architecture / scope
+
+### S1. `app/services/investment_dimensions/sentiment_evidence.py` (deterministic, DB-only)
+
+```python
+async def build_sentiment_evidence(
+    flow_repo: InvestorFlowSnapshotsRepository,
+    *, market: str, symbols: Set[str], now: dt.datetime | None = None,
+) -> dict[str, Any]
+```
+
+- Non-KR market → return `unavailable` immediately (`per_symbol: []`, `data_health.requested` reflects input, reason captured in freshness status). No query.
+- KR → `flow_repo.latest_by_symbols(market="kr", symbols=symbols)` (existing method — newest snapshot per symbol). Per symbol map: `foreign_net`, `institution_net`, `double_buy`, `double_sell`, `foreign_consecutive_buy_days`, `institution_consecutive_buy_days`.
+
+Returns:
+
+```python
+{
+  "market": market,
+  "per_symbol": [{"symbol", "foreign_net", "institution_net", "double_buy",
+                  "double_sell", "foreign_consecutive_buy_days",
+                  "institution_consecutive_buy_days"}],
+  "covered_count": int,
+  "freshness": {"status": "fresh|stale|unavailable", "latest_snapshot_date": str | None},
+  "data_health": {"requested": int, "covered": int},
+}
+```
+
+Soft-fail: empty (or non-KR) → `covered_count: 0`, `freshness.status: "unavailable"`, never raises. Freshness `fresh` when latest `snapshot_date` within a window (`FRESH_WINDOW_DAYS = 5`, KR trading-day-ish), else `stale`.
+
+### S2. Context wiring (`app/services/investment_stages/hermes_context.py`)
+
+Add a `dimension_evidence["sentiment"]` block immediately after the `["fundamentals"]` block, inside the `kr`/`us` guard, best-effort `try/except`. `symbols` = portfolio holdings ∪ market-dimension `top_movers` (reuse the exact set the Fundamentals block builds — extract that gathering into a small local or recompute identically). Construct `InvestorFlowSnapshotsRepository` from `self._session`. For a `us` bundle the assembler returns `unavailable` (no KR flow data) — that's expected and surfaced, not an error.
+
+### S3. Tests
+
+- `sentiment_evidence` assembler: fixture-seed `investor_flow_snapshots` (KR) → assert `per_symbol` (net flows, double_buy, streaks) / `covered_count` / `freshness`; empty → graceful `unavailable`; **non-KR market (`us`) → `unavailable` with empty `per_symbol`** (and no query attempted); partial coverage → `data_health.requested > covered`.
+- Context export: a `kr` run with seeded flows yields `dimension_evidence["sentiment"]` with populated `per_symbol`; a `us` run yields `unavailable`; soft-fail path.
+
+## What's free (no implementation)
+
+Sentiment dimension **report** (prose, stance, confidence): Hermes writes it via existing `POST /hermes/dimension-reports` with `dimension="sentiment"`. Persistence, read surface, and composition citation all work via the ROB-306/308 generic contract.
+
+## Non-goals / boundaries
+
+- No new table / endpoint / migration / schema. No live calls. No in-process LLM. No broker/order/watch/order-intent mutation.
+- **KR-only by design** — US/crypto sentiment deferred (no distinct DB source). No RSI/momentum (double-counts Market). No LLM news-sentiment, no Fear&Greed.
+- Reuse existing `InvestorFlowSnapshotsRepository.latest_by_symbols(*, market, symbols, as_of=None)` — no new repo method.
+
+## Testing strategy
+
+Fixture-based only: seed `investor_flow_snapshots` rows via model in `db_session`. Confirm ROB-287 no-internal-LLM import guard still passes and the assembler imports no broker client / LLM (only the investor-flow repo).
+
+## Assumptions to verify during implementation
+
+- `InvestorFlowSnapshotsRepository.latest_by_symbols(*, market, symbols, as_of=None) -> list[InvestorFlowSnapshot]` — confirmed at `app/services/investor_flow_snapshots/repository.py` (newest snapshot per symbol, KR-normalized).
+- The context exporter's Fundamentals block already builds `holdings ∪ top_movers`; reuse the same set for the Sentiment block (hoist into one local computed once, or replicate identically) to avoid drift.
+- `InvestorFlowSnapshot` columns: `foreign_net`, `institution_net`, `double_buy`, `double_sell`, `foreign_consecutive_buy_days`, `institution_consecutive_buy_days`, `snapshot_date`, `market` (kr) — confirmed at `app/models/investor_flow_snapshot.py`.
+
+## Program order
+
+Parent: ROB-306. Slice 5 (Sentiment, KR investor-flow). Remaining: crypto Market evidence (after ROB-282), earnings-in-Fundamentals follow-up, multi-market Sentiment (needs social/analyst source). Loop-validation tooling = ROB-309 (done).

--- a/tests/services/investment_dimensions/test_sentiment_evidence.py
+++ b/tests/services/investment_dimensions/test_sentiment_evidence.py
@@ -1,0 +1,92 @@
+import datetime as dt
+
+import pytest
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.services.investment_dimensions.sentiment_evidence import (
+    build_sentiment_evidence,
+)
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+
+    await db_session.execute(text("DELETE FROM investor_flow_snapshots"))
+    await db_session.commit()
+
+
+def _flow(symbol, *, snapshot_date, foreign_net, double_buy=False):
+    return InvestorFlowSnapshot(
+        market="kr",
+        symbol=symbol,
+        snapshot_date=snapshot_date,
+        foreign_net=foreign_net,
+        institution_net=5000,
+        double_buy=double_buy,
+        double_sell=False,
+        foreign_consecutive_buy_days=3,
+        institution_consecutive_buy_days=2,
+        source="naver_finance",
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_kr_covered(db_session):
+    await _clear(db_session)
+    db_session.add(
+        _flow(
+            "005930",
+            snapshot_date=dt.date(2026, 5, 23),
+            foreign_net=120000,
+            double_buy=True,
+        )
+    )
+    await db_session.commit()
+
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="kr",
+        symbols={"005930", "000660"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "kr"
+    assert bundle["data_health"] == {"requested": 2, "covered": 1}
+    assert bundle["covered_count"] == 1
+    row = bundle["per_symbol"][0]
+    assert row["symbol"] == "005930"
+    assert row["foreign_net"] == 120000
+    assert row["double_buy"] is True
+    assert row["foreign_consecutive_buy_days"] == 3
+    assert bundle["freshness"]["status"] in {"fresh", "stale"}
+    assert bundle["freshness"]["latest_snapshot_date"] == "2026-05-23"
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_non_kr_is_unavailable(db_session):
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="us",
+        symbols={"AAPL"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["market"] == "us"
+    assert bundle["per_symbol"] == []
+    assert bundle["covered_count"] == 0
+    assert bundle["freshness"]["status"] == "unavailable"
+    assert bundle["data_health"] == {"requested": 1, "covered": 0}
+
+
+@pytest.mark.asyncio
+async def test_build_sentiment_evidence_empty_kr_is_unavailable(db_session):
+    await _clear(db_session)
+    bundle = await build_sentiment_evidence(
+        InvestorFlowSnapshotsRepository(db_session),
+        market="kr",
+        symbols={"005930"},
+        now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
+    )
+    assert bundle["covered_count"] == 0
+    assert bundle["freshness"]["status"] == "unavailable"

--- a/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
@@ -1,0 +1,238 @@
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.models.analysis import StockInfo
+from app.models.investment_stages import InvestmentStageRun
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_stages.hermes_context import HermesContextExporter
+
+
+async def _clear(db_session):
+    from sqlalchemy import text
+
+    await db_session.execute(text("DELETE FROM investor_flow_snapshots"))
+    await db_session.execute(text("DELETE FROM stock_info WHERE symbol = '005930'"))
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> None:
+    await _clear(db_session)
+
+    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding 005930)
+    snapshots_repo = InvestmentSnapshotsRepository(db_session)
+    now = dt.datetime.now(tz=dt.UTC)
+
+    run_obj = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="kr",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+
+    portfolio_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run_obj.run_uuid,
+            snapshot_kind="portfolio",
+            market="kr",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={
+                "primary_source": "kis",
+                "holdings": [
+                    {
+                        "ticker": "005930",
+                        "quantity": 10,
+                        "sellable_quantity": 10,
+                        "source": "kis",
+                        "market": "kr",
+                    }
+                ],
+                "reference_holdings": [],
+                "count": 1,
+                "market": "kr",
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"sentiment_test_{uuid.uuid4().hex[:8]}",
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+
+    await snapshots_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(
+            snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"
+        ),
+    )
+
+    # 2. Seed an InvestorFlowSnapshot for 005930
+    db_session.add(
+        InvestorFlowSnapshot(
+            market="kr",
+            symbol="005930",
+            snapshot_date=now.date(),
+            foreign_net=120000,
+            institution_net=5000,
+            double_buy=True,
+            double_sell=False,
+            foreign_consecutive_buy_days=3,
+            institution_consecutive_buy_days=2,
+            source="naver_finance",
+        )
+    )
+
+    # 3. Seed StockInfo for 005930
+    db_session.add(
+        StockInfo(
+            symbol="005930",
+            name="Samsung Electronics",
+            instrument_type="equity_kr",
+            sector="Technology",
+            is_active=True,
+        )
+    )
+    await db_session.commit()
+
+    # 4. Seed an InvestmentStageRun associated with the bundle
+    stage_run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="kr",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=now,
+    )
+    db_session.add(stage_run)
+    await db_session.commit()
+
+    # 5. Export Hermes Context
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    assert "sentiment" in payload.dimension_evidence
+    sent = payload.dimension_evidence["sentiment"]
+    assert sent["market"] == "kr"
+    assert sent["data_health"]["requested"] >= 1
+    assert sent["data_health"]["covered"] >= 1
+    assert sent["covered_count"] >= 1
+
+    samsung_row = next(r for r in sent["per_symbol"] if r["symbol"] == "005930")
+    assert samsung_row["foreign_net"] == 120000
+    assert samsung_row["double_buy"] is True
+    assert samsung_row["foreign_consecutive_buy_days"] == 3
+    assert sent["freshness"]["status"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_exporter_attaches_sentiment_evidence_bundle_us_unavailable(
+    db_session,
+) -> None:
+    await _clear(db_session)
+
+    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding AAPL)
+    snapshots_repo = InvestmentSnapshotsRepository(db_session)
+    now = dt.datetime.now(tz=dt.UTC)
+
+    run_obj = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+
+    portfolio_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run_obj.run_uuid,
+            snapshot_kind="portfolio",
+            market="us",
+            account_scope="kis_live",
+            source_kind="manual",
+            payload_json={
+                "primary_source": "kis",
+                "holdings": [
+                    {
+                        "ticker": "AAPL",
+                        "quantity": 10,
+                        "sellable_quantity": 10,
+                        "source": "kis",
+                        "market": "us",
+                    }
+                ],
+                "reference_holdings": [],
+                "count": 1,
+                "market": "us",
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"sentiment_us_test_{uuid.uuid4().hex[:8]}",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+
+    await snapshots_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(
+            snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"
+        ),
+    )
+    await db_session.commit()
+
+    # 2. Seed an InvestmentStageRun associated with the bundle
+    stage_run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="us",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=now,
+    )
+    db_session.add(stage_run)
+    await db_session.commit()
+
+    # 3. Export Hermes Context
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    assert "sentiment" in payload.dimension_evidence
+    sent = payload.dimension_evidence["sentiment"]
+    assert sent["market"] == "us"
+    assert sent["freshness"]["status"] == "unavailable"
+    assert sent["per_symbol"] == []


### PR DESCRIPTION
## What & why

Slice 5 of the TradingAgents-style `/invest/reports` program (parent: ROB-306 Market; ROB-308 synthesis loop; ROB-310 News; ROB-311 Fundamentals). Adds the **Sentiment dimension** evidence so Hermes can write a Sentiment analyst report.

**Source finding:** the repo has no social feed / DB-Fear&Greed / stored analyst ratings. The only distinct, DB-backed, **populated**, non-LLM sentiment proxy is **`investor_flow_snapshots`** (ROB-205): KR foreign/institution net flows, `double_buy`/`double_sell`, consecutive-buy streaks. RSI/momentum would double-count Market; NewsAnalysisResult is LLM-derived; Fear&Greed is live-only — all rejected. So Sentiment = **KR investor-flow consensus**, distinct from Market (breadth) and News (citations). Unlike the other dimensions' sources, this one is already populated.

The dimension machinery is generic — `investment_dimension_reports` already supports `dimension="sentiment"` — so **no new table/endpoint/migration/schema**. Just an assembler + one context block.

Linear: ROB-312 (related: ROB-306/308/310/311).

## Changes

- **`app/services/investment_dimensions/sentiment_evidence.py`** — `build_sentiment_evidence(flow_repo, *, market, symbols, now=None)`, mirroring `fundamentals_evidence`. KR → per-symbol foreign/institution net, double_buy/sell, consecutive-buy streaks (via existing `InvestorFlowSnapshotsRepository.latest_by_symbols`). **Non-KR → `unavailable` (no query).** Soft-fails to `unavailable` when empty; reflects partial coverage. DB-only.
- **`hermes_context.py`** — `dimension_evidence["sentiment"]` block (best-effort), and **hoisted the `holdings ∪ top_movers` symbol set** into one shared local used by both the Fundamentals and Sentiment blocks (avoids drift).

## Boundaries

- **KR-only by design** — US/crypto sentiment deferred (no distinct DB source); assembler returns `unavailable` for them. No RSI/momentum (double-counts Market), no LLM news-sentiment, no Fear&Greed.
- **DB-only** — assembler imports only the investor-flow repo (no broker/LLM import). Deterministic; Hermes authors prose via existing `POST /hermes/dimension-reports` (dimension="sentiment"). No in-process LLM (ROB-287 guard passes). Read-only.
- **No new table/endpoint/migration/schema; no new repo method** (reuses `latest_by_symbols`).

## Tests

Assembler (KR covered / non-KR unavailable / empty) + context export (kr populated, us unavailable). ROB-312 surface + investment_stages + guard: **110 passed** (Fundamentals still green after the symbol-set hoist). `ruff`/`ty` clean. No `app/` schema/migration.

## Deferred (program order)

Remaining: crypto Market evidence (after ROB-282), earnings-in-Fundamentals follow-up, multi-market Sentiment (needs social/analyst source). Loop-validation tooling = ROB-309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)