### PR TITLE
feat(rob-307): operator tick CLI for external (Prefect) scheduler activation

### DIFF
--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -248,13 +248,35 @@ BINANCE_SPOT_DEMO_ENABLED=true BINANCE_FUTURES_DEMO_ENABLED=true \
   uv run taskiq kick app.core.taskiq_broker:broker binance.demo_scalping.tick
 ```
 
+### Scheduler entrypoint CLI (`scripts/binance_demo_scalping_tick.py`)
+
+`scripts/binance_demo_scalping_tick.py` is the operator-facing, **env-driven**
+one-tick entrypoint an external scheduler shells out to. It wraps
+`run_demo_scalping_tick`, prints a single-line JSON summary to stdout, and maps
+it to an exit code (0 = disabled/clean, 1 = ran-with-errors or runner raised).
+No flags — the same two-key gate + `_CONFIRM` env vars above apply.
+
+```bash
+# Gate OFF (default) → no-op, zero clients, exit 0
+uv run python -m scripts.binance_demo_scalping_tick
+# → {"base_enabled": false, "scheduler_enabled": false, "status": "disabled"}
+
+# Dry-run tick (signals + risk, zero orders)
+BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED=true \
+  uv run python -m scripts.binance_demo_scalping_tick
+```
+
+This is the command the (paused) Prefect deployment in `robin-prefect-automations`
+invokes; the Prefect repo owns scheduling/retry/alerting and only ever calls
+this CLI (it never imports auto_trader trading logic).
+
 ### Activation — separate operator gate
 
 No recurring schedule is registered by this repo. Production recurrence
-(`paused=false`) is an operations decision: TaskIQ cron or a Prefect
-deployment in `robin-prefect-automations`. **Do not activate** without
+(`paused=false`) lives in `robin-prefect-automations` as a **paused-by-default**
+deployment that shells out to the tick CLI above. **Do not activate** without
 the §"Hard safety boundaries" gates satisfied + explicit operator
 approval. Failure-only alerting wires onto the tick's error log
-(`logger.error` / the `TickSummary.errors` list); a clean tick is quiet.
-Rollback = unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED` (kill switch)
-and pause/disable the schedule in the ops repo.
+(`logger.error` / the `TickSummary.errors` list) and the CLI's non-zero exit; a
+clean tick is quiet. Rollback = unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED`
+(kill switch) and pause the deployment in the ops repo.

--- a/scripts/binance_demo_scalping_tick.py
+++ b/scripts/binance_demo_scalping_tick.py
@@ -1,0 +1,54 @@
+"""ROB-307 — operator CLI for one default-OFF Demo scalping scheduler tick.
+
+Thin, env-driven wrapper over
+``app.jobs.binance_demo_scalping_runner.run_demo_scalping_tick``: it runs one
+gated tick and prints a single-line JSON summary to stdout so an external
+scheduler (e.g. a *paused* Prefect deployment) can parse it. There are no
+flags — behaviour is entirely env-gated, matching the runner contract:
+
+* ``BINANCE_DEMO_SCALPING_ENABLED`` + ``BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED``
+  — both must be truthy or the tick is a no-op (builds zero clients).
+* ``BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM`` — only when truthy are real Demo
+  orders placed; otherwise every entry is a dry-run (zero broker mutation).
+
+Demo hosts only; no live/testnet path. No schedule is registered here —
+production recurrence + activation is a separate operator gate (runbook).
+
+Exit codes: 0 for a disabled (gate-off) or clean tick; 1 when the tick ran
+with per-symbol errors or the runner raised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from app.jobs.binance_demo_scalping_runner import run_demo_scalping_tick
+
+
+def exit_code_for(summary: dict[str, Any]) -> int:
+    """Map a tick summary to a process exit code.
+
+    A gate-off (``disabled``) tick is a healthy no-op (0). A tick that ``ran``
+    is a failure (1) only if it collected per-symbol errors, so an external
+    scheduler treats a partially-failed tick as a failed run.
+    """
+    if summary.get("status") == "ran" and int(summary.get("error_count", 0)) > 0:
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        summary = asyncio.run(run_demo_scalping_tick())
+    except Exception as exc:  # noqa: BLE001 - serialize any failure for the scheduler
+        print(json.dumps({"status": "error", "error": f"{type(exc).__name__}: {exc}"}))
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return exit_code_for(summary)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_binance_demo_scalping_tick.py
+++ b/tests/scripts/test_binance_demo_scalping_tick.py
@@ -1,0 +1,75 @@
+"""ROB-307 follow-up — tests for the Demo scalping tick operator CLI.
+
+The CLI is a thin, env-driven wrapper over ``run_demo_scalping_tick``: it
+runs one gated tick, prints a single-line JSON summary to stdout (for an
+external scheduler to parse), and maps the summary to an exit code. No real
+orders, no network — the tick function is faked.
+
+Exit codes: 0 for a disabled (gate-off) or clean tick; 1 when the tick ran
+with per-symbol errors or the runner raised.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import binance_demo_scalping_tick as cli
+
+
+def test_exit_code_disabled_is_zero() -> None:
+    assert cli.exit_code_for({"status": "disabled"}) == 0
+
+
+def test_exit_code_ran_clean_is_zero() -> None:
+    assert cli.exit_code_for({"status": "ran", "error_count": 0}) == 0
+
+
+def test_exit_code_ran_with_errors_is_one() -> None:
+    assert cli.exit_code_for({"status": "ran", "error_count": 2}) == 1
+
+
+def test_main_prints_summary_and_returns_zero_when_disabled(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def _fake_tick() -> dict:
+        return {"status": "disabled", "base_enabled": False, "scheduler_enabled": False}
+
+    monkeypatch.setattr(cli, "run_demo_scalping_tick", _fake_tick)
+    rc = cli.main([])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "disabled"
+
+
+def test_main_returns_one_when_tick_has_errors(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def _fake_tick() -> dict:
+        return {
+            "status": "ran",
+            "error_count": 1,
+            "errors": ["enter spot/XRPUSDT: boom"],
+        }
+
+    monkeypatch.setattr(cli, "run_demo_scalping_tick", _fake_tick)
+    rc = cli.main([])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "ran"
+    assert out["error_count"] == 1
+
+
+def test_main_returns_one_and_emits_error_json_on_exception(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def _boom() -> dict:
+        raise RuntimeError("explode")
+
+    monkeypatch.setattr(cli, "run_demo_scalping_tick", _boom)
+    rc = cli.main([])
+    assert rc == 1
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "error"
+    assert "RuntimeError" in out["error"]


### PR DESCRIPTION
ROB-307 activation prep (auto_trader side). Adds the operator-facing entrypoint the **paused** Prefect deployment in `robin-prefect-automations` will shell out to.

## What
`scripts/binance_demo_scalping_tick.py` — a thin, **env-driven** wrapper over `run_demo_scalping_tick`:
- Runs one gated scheduler tick, prints a **single-line JSON summary** to stdout, maps it to an exit code (`0` = disabled/clean, `1` = ran-with-errors or runner raised).
- **No flags.** The existing default-OFF two-key gate (`BINANCE_DEMO_SCALPING_ENABLED` + `_SCHEDULER_ENABLED`) plus `_SCHEDULER_CONFIRM` are the only control surface. Demo hosts only; no live/testnet path; no schedule registered.

This matches the repo's `scripts/`-CLI convention (mirrors `scripts.ingest_market_events`) so the Prefect flow can invoke `python -m scripts.binance_demo_scalping_tick` without importing any auto_trader trading logic.

## Why a CLI
The market-events Prefect convention requires the flow to call an auto_trader **operator CLI**, never import its business logic. `run_demo_scalping_tick` was an async function with no CLI entrypoint — this is that entrypoint.

## Verification
- 6 new tests (exit-code mapping + `main` JSON/exit for disabled / ran-with-errors / runner-raised). Tick function faked — no network, no orders.
- Gate-OFF real smoke: `python -m scripts.binance_demo_scalping_tick` → `{"base_enabled": false, "scheduler_enabled": false, "status": "disabled"}`, exit 0, zero clients built.
- ROB-285 signed-endpoint + mutation-import guards green; `ruff` + `ty` clean.
- Runbook updated (`docs/runbooks/binance-demo-scalping.md`): new "Scheduler entrypoint CLI" section + Activation section points at the paused Prefect deployment.

## Scope
No new endpoints, no broker/order mutation reachable except behind the unchanged confirm gate. Scheduler still default-OFF; **activation remains a separate operator gate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a scheduler entrypoint CLI for Binance Demo scalping that executes a single tick operation and outputs JSON-formatted results for external orchestration tools.

* **Documentation**
  * Updated the Binance Demo scalping runbook to document the new scheduler entrypoint and clarify external orchestration integration.

* **Tests**
  * Added comprehensive test coverage for the scheduler entrypoint CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->