### PR TITLE
feat(rob-315): /invest scalping review loop — DB + API + frontend (Phases 1-3)

### DIFF
--- a/alembic/versions/20260525_rob315_scalping_reviews.py
+++ b/alembic/versions/20260525_rob315_scalping_reviews.py
@@ -1,0 +1,162 @@
+"""rob315 scalping daily review loop tables
+
+Review layer on top of ``scalp_trade_analytics`` (ROB-315 Phase 1):
+``scalping_daily_reviews`` (one row per review_date/product/account_scope/
+session_tag, with the rollup metrics + operator judgment) and
+``scalping_review_actions`` (discrete follow-ups). Additive only; raw
+analytics + order-lifecycle tables are untouched.
+
+Revision ID: 20260525_rob315
+Revises: 20260525_rob313
+Create Date: 2026-05-25
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260525_rob315"
+down_revision: str | Sequence[str] | None = "20260525_rob313"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scalping_daily_reviews",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("review_date", sa.Date(), nullable=False),
+        sa.Column("product", sa.Text(), nullable=False),
+        sa.Column(
+            "account_scope",
+            sa.Text(),
+            server_default="binance_demo",
+            nullable=False,
+        ),
+        sa.Column("session_tag", sa.Text(), server_default="", nullable=False),
+        sa.Column("trade_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("win_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("loss_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("anomaly_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("gross_pnl_usdt", sa.Numeric(20, 8), nullable=True),
+        sa.Column("net_pnl_usdt", sa.Numeric(20, 8), nullable=True),
+        sa.Column("net_return_bps", sa.Numeric(12, 4), nullable=True),
+        sa.Column("avg_slippage_bps", sa.Numeric(12, 4), nullable=True),
+        sa.Column("avg_spread_bps", sa.Numeric(12, 4), nullable=True),
+        sa.Column("avg_mae_bps", sa.Numeric(12, 4), nullable=True),
+        sa.Column("avg_mfe_bps", sa.Numeric(12, 4), nullable=True),
+        sa.Column("avg_holding_seconds", sa.Integer(), nullable=True),
+        sa.Column("exit_reason_counts", postgresql.JSONB(), nullable=True),
+        sa.Column("observation", sa.Text(), nullable=True),
+        sa.Column("root_cause", sa.Text(), nullable=True),
+        sa.Column("improvement", sa.Text(), nullable=True),
+        sa.Column("next_run_plan", sa.Text(), nullable=True),
+        sa.Column("decision", sa.Text(), server_default="review", nullable=False),
+        sa.Column("status", sa.Text(), server_default="draft", nullable=False),
+        sa.Column("source_payload", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "review_date",
+            "product",
+            "account_scope",
+            "session_tag",
+            name="uq_scalping_daily_review_key",
+        ),
+        sa.CheckConstraint(
+            "product IN ('spot','usdm_futures')",
+            name="scalping_daily_review_product",
+        ),
+        sa.CheckConstraint(
+            "account_scope = 'binance_demo'",
+            name="scalping_daily_review_account_scope",
+        ),
+        sa.CheckConstraint(
+            "decision IN ('review','keep','adjust','pause','disable')",
+            name="scalping_daily_review_decision",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft','reviewed','locked')",
+            name="scalping_daily_review_status",
+        ),
+    )
+    op.create_index(
+        "ix_scalping_daily_review_date", "scalping_daily_reviews", ["review_date"]
+    )
+    op.create_index(
+        "ix_scalping_daily_review_product", "scalping_daily_reviews", ["product"]
+    )
+
+    op.create_table(
+        "scalping_review_actions",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("review_id", sa.BigInteger(), nullable=False),
+        sa.Column("action_type", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("rationale", sa.Text(), nullable=True),
+        sa.Column("target_component", sa.Text(), nullable=True),
+        sa.Column("proposed_change", sa.Text(), nullable=True),
+        sa.Column("expected_effect", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), server_default="open", nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(
+            ["review_id"],
+            ["scalping_daily_reviews.id"],
+            name="fk_scalping_review_action_review_id",
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "action_type IN ('parameter_change','investigate','pause','resume',"
+            "'add_guard','data_quality','no_change')",
+            name="scalping_review_action_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('open','applied','skipped','superseded')",
+            name="scalping_review_action_status",
+        ),
+    )
+    op.create_index(
+        "ix_scalping_review_action_review_id",
+        "scalping_review_actions",
+        ["review_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_scalping_review_action_review_id", table_name="scalping_review_actions"
+    )
+    op.drop_table("scalping_review_actions")
+    op.drop_index(
+        "ix_scalping_daily_review_product", table_name="scalping_daily_reviews"
+    )
+    op.drop_index("ix_scalping_daily_review_date", table_name="scalping_daily_reviews")
+    op.drop_table("scalping_daily_reviews")

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routers import (
     invest_api,
     invest_app_spa,
     invest_fills,
+    invest_scalping,
     invest_web_spa,
     investment_dimension_reports,
     investment_hermes_http,
@@ -185,6 +186,7 @@ def create_app() -> FastAPI:
     app.include_router(symbol_settings.router)
     app.include_router(deprecated_pages.router)
     app.include_router(invest_api.router)
+    app.include_router(invest_scalping.router)
     app.include_router(invest_fills.router)
     app.include_router(invest_app_spa.router)
     app.include_router(invest_web_spa.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -67,6 +67,7 @@ from .research_run import (
 )
 from .review import PendingSnapshot, Trade, TradeReview, TradeSnapshot
 from .scalp_trade_analytics import ScalpTradeAnalytics
+from .scalping_reviews import ScalpingDailyReview, ScalpingReviewAction
 from .sell_condition import SellCondition
 from .symbol_trade_settings import SymbolTradeSettings
 from .trade_journal import JournalStatus, TradeJournal
@@ -106,6 +107,8 @@ __all__ = [
     "Base",
     "BinanceDemoOrderLedger",
     "ScalpTradeAnalytics",
+    "ScalpingDailyReview",
+    "ScalpingReviewAction",
     "ExecutionLedger",
     "ExecutionLedgerReconcileRun",
     "CryptoCandle1d",

--- a/app/models/scalping_reviews.py
+++ b/app/models/scalping_reviews.py
@@ -1,0 +1,203 @@
+"""ROB-315 Phase 1 — daily scalping review-loop tables.
+
+The **review layer** sits on top of the raw ``scalp_trade_analytics`` rows
+(ROB-313). It is where human judgment lives: a daily rollup of the demo
+scalping round-trips plus the operator's observation → root cause →
+improvement → next-run plan, and the discrete review actions that follow.
+
+Two tables, both written only through ``ScalpingReviewService``:
+
+* ``scalping_daily_reviews`` — one row per ``(review_date, product,
+  account_scope, session_tag)``. ``source_payload`` is the immutable rollup
+  snapshot the draft was built from; the operator fields and ``decision`` /
+  ``status`` are the only mutable human inputs. Raw analytics rows are never
+  edited from here.
+* ``scalping_review_actions`` — discrete follow-ups attached to a review.
+
+Safety boundaries (ROB-315): ``account_scope`` is pinned to ``binance_demo``
+so demo scalping review state can never be conflated with KIS/Upbit live
+execution permissions. ``session_tag`` is ``NOT NULL DEFAULT ''`` so the
+uniqueness key is well-defined (Postgres treats NULL as distinct, which would
+silently break draft idempotency).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Date,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+# Fixed account scope for this workstream — demo-only, never a live scope.
+SCALPING_REVIEW_ACCOUNT_SCOPE = "binance_demo"
+
+REVIEW_DECISIONS = ("review", "keep", "adjust", "pause", "disable")
+REVIEW_STATUSES = ("draft", "reviewed", "locked")
+ACTION_TYPES = (
+    "parameter_change",
+    "investigate",
+    "pause",
+    "resume",
+    "add_guard",
+    "data_quality",
+    "no_change",
+)
+ACTION_STATUSES = ("open", "applied", "skipped", "superseded")
+
+
+class ScalpingDailyReview(Base):
+    """One daily review of the demo scalping loop for a product/session."""
+
+    __tablename__ = "scalping_daily_reviews"
+    __table_args__ = (
+        UniqueConstraint(
+            "review_date",
+            "product",
+            "account_scope",
+            "session_tag",
+            name="uq_scalping_daily_review_key",
+        ),
+        CheckConstraint(
+            "product IN ('spot','usdm_futures')",
+            name="scalping_daily_review_product",
+        ),
+        CheckConstraint(
+            "account_scope = 'binance_demo'",
+            name="scalping_daily_review_account_scope",
+        ),
+        CheckConstraint(
+            "decision IN ('review','keep','adjust','pause','disable')",
+            name="scalping_daily_review_decision",
+        ),
+        CheckConstraint(
+            "status IN ('draft','reviewed','locked')",
+            name="scalping_daily_review_status",
+        ),
+        Index("ix_scalping_daily_review_date", "review_date"),
+        Index("ix_scalping_daily_review_product", "product"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    review_date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    product: Mapped[str] = mapped_column(Text, nullable=False)
+    account_scope: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=SCALPING_REVIEW_ACCOUNT_SCOPE
+    )
+    # NOT NULL DEFAULT '' so the uniqueness key is well-defined (see module doc).
+    session_tag: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+
+    # --- Aggregate metrics (rolled up from scalp_trade_analytics) ---
+    # trade_count counts fill-proven round-trips only; anomaly_count counts
+    # rows with no derivable fill price. Avg/PnL fields are NULL ("n/a") when
+    # no row carries the value rather than a misleading 0.
+    trade_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    win_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    loss_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    anomaly_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    gross_pnl_usdt: Mapped[Decimal | None] = mapped_column(
+        Numeric(20, 8), nullable=True
+    )
+    net_pnl_usdt: Mapped[Decimal | None] = mapped_column(Numeric(20, 8), nullable=True)
+    net_return_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+    avg_slippage_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+    avg_spread_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+    avg_mae_bps: Mapped[Decimal | None] = mapped_column(Numeric(12, 4), nullable=True)
+    avg_mfe_bps: Mapped[Decimal | None] = mapped_column(Numeric(12, 4), nullable=True)
+    avg_holding_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    exit_reason_counts: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )
+
+    # --- Operator review (the only mutable human inputs) ---
+    observation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    root_cause: Mapped[str | None] = mapped_column(Text, nullable=True)
+    improvement: Mapped[str | None] = mapped_column(Text, nullable=True)
+    next_run_plan: Mapped[str | None] = mapped_column(Text, nullable=True)
+    decision: Mapped[str] = mapped_column(Text, nullable=False, server_default="review")
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="draft")
+
+    # Immutable rollup source snapshot the draft was built from.
+    source_payload: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    actions: Mapped[list[ScalpingReviewAction]] = relationship(
+        back_populates="review", cascade="all, delete-orphan"
+    )
+
+
+class ScalpingReviewAction(Base):
+    """A discrete follow-up attached to a daily review."""
+
+    __tablename__ = "scalping_review_actions"
+    __table_args__ = (
+        CheckConstraint(
+            "action_type IN ('parameter_change','investigate','pause','resume',"
+            "'add_guard','data_quality','no_change')",
+            name="scalping_review_action_type",
+        ),
+        CheckConstraint(
+            "status IN ('open','applied','skipped','superseded')",
+            name="scalping_review_action_status",
+        ),
+        Index("ix_scalping_review_action_review_id", "review_id"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    review_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "scalping_daily_reviews.id",
+            name="fk_scalping_review_action_review_id",
+            ondelete="CASCADE",
+        ),
+        nullable=False,
+    )
+    action_type: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    target_component: Mapped[str | None] = mapped_column(Text, nullable=True)
+    proposed_change: Mapped[str | None] = mapped_column(Text, nullable=True)
+    expected_effect: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="open")
+
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    review: Mapped[ScalpingDailyReview] = relationship(back_populates="actions")

--- a/app/routers/invest_scalping.py
+++ b/app/routers/invest_scalping.py
@@ -1,0 +1,201 @@
+"""ROB-315 Phase 2 — read/review `/invest/api/scalping` surface.
+
+Thin router over ``ScalpingReviewService``. It builds/reads daily review
+drafts and records operator judgment + actions. It imports **no** broker /
+order / scheduler / market-data module and reaches no mutation path on any
+venue — it only reads ``scalp_trade_analytics`` (via the service) and writes
+the two review tables. This boundary is asserted by a static import-guard test.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.scalping_reviews import ScalpingDailyReview, ScalpingReviewAction
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.invest_scalping import (
+    Product,
+    ScalpingActionCreateRequest,
+    ScalpingActionPatchRequest,
+    ScalpingDraftRequest,
+    ScalpingReviewPatchRequest,
+)
+from app.services.scalping_reviews.service import (
+    ScalpingReviewError,
+    ScalpingReviewService,
+)
+
+router = APIRouter(prefix="/invest/api/scalping", tags=["invest", "scalping"])
+
+
+def get_scalping_review_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> ScalpingReviewService:
+    return ScalpingReviewService(db)
+
+
+_SVC = Annotated[ScalpingReviewService, Depends(get_scalping_review_service)]
+_USER = Annotated[Any, Depends(get_authenticated_user)]
+
+
+def _num(value: Decimal | None) -> str | None:
+    """Serialize a Decimal as a string to preserve precision (n/a → null)."""
+    return None if value is None else str(value)
+
+
+def _iso(value: datetime | None) -> str | None:
+    return None if value is None else value.isoformat()
+
+
+def _serialize_action(action: ScalpingReviewAction) -> dict[str, Any]:
+    return {
+        "id": action.id,
+        "reviewId": action.review_id,
+        "actionType": action.action_type,
+        "title": action.title,
+        "rationale": action.rationale,
+        "targetComponent": action.target_component,
+        "proposedChange": action.proposed_change,
+        "expectedEffect": action.expected_effect,
+        "status": action.status,
+        "createdAt": _iso(action.created_at),
+        "updatedAt": _iso(action.updated_at),
+    }
+
+
+def _serialize_review(review: ScalpingDailyReview) -> dict[str, Any]:
+    return {
+        "id": review.id,
+        "reviewDate": review.review_date.isoformat(),
+        "product": review.product,
+        "accountScope": review.account_scope,
+        "sessionTag": review.session_tag,
+        "metrics": {
+            "tradeCount": review.trade_count,
+            "winCount": review.win_count,
+            "lossCount": review.loss_count,
+            "anomalyCount": review.anomaly_count,
+            "grossPnlUsdt": _num(review.gross_pnl_usdt),
+            "netPnlUsdt": _num(review.net_pnl_usdt),
+            "netReturnBps": _num(review.net_return_bps),
+            "avgSlippageBps": _num(review.avg_slippage_bps),
+            "avgSpreadBps": _num(review.avg_spread_bps),
+            "avgMaeBps": _num(review.avg_mae_bps),
+            "avgMfeBps": _num(review.avg_mfe_bps),
+            "avgHoldingSeconds": review.avg_holding_seconds,
+            "exitReasonCounts": review.exit_reason_counts or {},
+        },
+        "observation": review.observation,
+        "rootCause": review.root_cause,
+        "improvement": review.improvement,
+        "nextRunPlan": review.next_run_plan,
+        "decision": review.decision,
+        "status": review.status,
+        "sourcePayload": review.source_payload,
+        "createdAt": _iso(review.created_at),
+        "updatedAt": _iso(review.updated_at),
+    }
+
+
+@router.get("/reviews")
+async def list_reviews(
+    user: _USER,
+    service: _SVC,
+    review_date: Annotated[date | None, Query(alias="date")] = None,
+    product: Annotated[Product | None, Query()] = None,
+) -> dict[str, Any]:
+    reviews = await service.list_reviews(review_date=review_date, product=product)
+    return {"items": [_serialize_review(r) for r in reviews]}
+
+
+@router.get("/reviews/{review_id}")
+async def get_review(user: _USER, service: _SVC, review_id: int) -> dict[str, Any]:
+    review = await service.get(review_id)
+    if review is None:
+        raise HTTPException(status_code=404, detail="review not found")
+    actions = await service.list_actions(review_id)
+    return {
+        "review": _serialize_review(review),
+        "actions": [_serialize_action(a) for a in actions],
+    }
+
+
+@router.post("/reviews/draft")
+async def build_draft(
+    user: _USER, service: _SVC, body: ScalpingDraftRequest
+) -> dict[str, Any]:
+    try:
+        review = await service.build_draft(
+            review_date=body.review_date,
+            product=body.product,
+            session_tag=body.session_tag,
+            now=datetime.now(UTC),
+        )
+    except ScalpingReviewError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"review": _serialize_review(review)}
+
+
+@router.patch("/reviews/{review_id}")
+async def patch_review(
+    user: _USER,
+    service: _SVC,
+    review_id: int,
+    body: ScalpingReviewPatchRequest,
+) -> dict[str, Any]:
+    fields = body.model_dump(exclude_unset=True)
+    try:
+        review = await service.update_review(review_id, now=datetime.now(UTC), **fields)
+    except ScalpingReviewError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if review is None:
+        raise HTTPException(status_code=404, detail="review not found")
+    return {"review": _serialize_review(review)}
+
+
+@router.post("/reviews/{review_id}/actions")
+async def create_action(
+    user: _USER,
+    service: _SVC,
+    review_id: int,
+    body: ScalpingActionCreateRequest,
+) -> dict[str, Any]:
+    if await service.get(review_id) is None:
+        raise HTTPException(status_code=404, detail="review not found")
+    try:
+        action = await service.add_action(
+            review_id,
+            action_type=body.action_type,
+            title=body.title,
+            rationale=body.rationale,
+            target_component=body.target_component,
+            proposed_change=body.proposed_change,
+            expected_effect=body.expected_effect,
+            now=datetime.now(UTC),
+        )
+    except ScalpingReviewError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return {"action": _serialize_action(action)}
+
+
+@router.patch("/actions/{action_id}")
+async def patch_action(
+    user: _USER,
+    service: _SVC,
+    action_id: int,
+    body: ScalpingActionPatchRequest,
+) -> dict[str, Any]:
+    fields = body.model_dump(exclude_unset=True)
+    try:
+        action = await service.update_action(action_id, now=datetime.now(UTC), **fields)
+    except ScalpingReviewError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if action is None:
+        raise HTTPException(status_code=404, detail="action not found")
+    return {"action": _serialize_action(action)}

--- a/app/routers/invest_scalping.py
+++ b/app/routers/invest_scalping.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_db
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
 from app.models.scalping_reviews import ScalpingDailyReview, ScalpingReviewAction
 from app.routers.dependencies import get_authenticated_user
 from app.schemas.invest_scalping import (
@@ -101,6 +102,40 @@ def _serialize_review(review: ScalpingDailyReview) -> dict[str, Any]:
         "createdAt": _iso(review.created_at),
         "updatedAt": _iso(review.updated_at),
     }
+
+
+def _serialize_analytics(row: ScalpTradeAnalytics) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "openClientOrderId": row.open_client_order_id,
+        "symbol": row.symbol,
+        "side": row.side,
+        "qty": _num(row.qty),
+        "entryPrice": _num(row.entry_price),
+        "exitPrice": _num(row.exit_price),
+        "entrySlippageBps": _num(row.entry_slippage_bps),
+        "exitSlippageBps": _num(row.exit_slippage_bps),
+        "entrySpreadBps": _num(row.entry_spread_bps),
+        "exitSpreadBps": _num(row.exit_spread_bps),
+        "maeBps": _num(row.mae_bps),
+        "mfeBps": _num(row.mfe_bps),
+        "netPnlUsdt": _num(row.net_pnl_usdt),
+        "holdingSeconds": row.holding_seconds,
+        "exitReason": row.exit_reason,
+        # No derivable entry fill price → a partial/anomaly row (ROB-315 0b).
+        "isAnomaly": row.entry_price is None,
+    }
+
+
+@router.get("/analytics")
+async def list_analytics(
+    user: _USER,
+    service: _SVC,
+    review_date: Annotated[date, Query(alias="date")],
+    product: Annotated[Product, Query()],
+) -> dict[str, Any]:
+    rows = await service.list_analytics(review_date=review_date, product=product)
+    return {"items": [_serialize_analytics(r) for r in rows]}
 
 
 @router.get("/reviews")

--- a/app/schemas/invest_scalping.py
+++ b/app/schemas/invest_scalping.py
@@ -1,0 +1,60 @@
+"""ROB-315 Phase 2 — request bodies for the read/review `/invest/api/scalping`
+surface. Responses are serialized as plain dicts by the router (Decimals as
+strings); only the mutating request bodies need validation here."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel
+
+Product = Literal["spot", "usdm_futures"]
+ReviewDecision = Literal["review", "keep", "adjust", "pause", "disable"]
+ReviewStatus = Literal["draft", "reviewed", "locked"]
+ActionType = Literal[
+    "parameter_change",
+    "investigate",
+    "pause",
+    "resume",
+    "add_guard",
+    "data_quality",
+    "no_change",
+]
+ActionStatus = Literal["open", "applied", "skipped", "superseded"]
+
+
+class ScalpingDraftRequest(BaseModel):
+    review_date: date
+    product: Product
+    session_tag: str = ""
+
+
+class ScalpingReviewPatchRequest(BaseModel):
+    """Operator-editable review fields only. Unset fields are left untouched
+    (PATCH semantics via ``model_dump(exclude_unset=True)``)."""
+
+    observation: str | None = None
+    root_cause: str | None = None
+    improvement: str | None = None
+    next_run_plan: str | None = None
+    decision: ReviewDecision | None = None
+    status: ReviewStatus | None = None
+
+
+class ScalpingActionCreateRequest(BaseModel):
+    action_type: ActionType
+    title: str
+    rationale: str | None = None
+    target_component: str | None = None
+    proposed_change: str | None = None
+    expected_effect: str | None = None
+
+
+class ScalpingActionPatchRequest(BaseModel):
+    status: ActionStatus | None = None
+    title: str | None = None
+    rationale: str | None = None
+    target_component: str | None = None
+    proposed_change: str | None = None
+    expected_effect: str | None = None

--- a/app/services/scalping_reviews/rollup.py
+++ b/app/services/scalping_reviews/rollup.py
@@ -1,0 +1,134 @@
+"""ROB-315 Phase 1 — pure daily rollup of ``scalp_trade_analytics`` rows.
+
+No DB, no network. Aggregates a day's worth of demo scalping round-trip rows
+into the metrics the review draft stores. Rollup semantics (locked in the
+ROB-315 issue):
+
+* ``trade_count`` counts **fill-proven** round-trips only (``entry_price`` not
+  NULL). Rows with no derivable fill price count toward ``anomaly_count`` and
+  never into the success metrics — they are a data-quality signal, not a trade.
+* Telemetry averages are computed over non-NULL values only and reported as
+  ``None`` ("n/a") when no row carries the value — never a misleading ``0``.
+* ``net_return_bps`` is capital-weighted: ``sum(net_pnl) / sum(entry_notional)``.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Protocol
+
+_BPS = Decimal("10000")
+
+
+class _AnalyticsRow(Protocol):
+    open_client_order_id: str
+    entry_price: Decimal | None
+    entry_notional_usdt: Decimal | None
+    net_pnl_usdt: Decimal | None
+    gross_pnl_usdt: Decimal | None
+    entry_slippage_bps: Decimal | None
+    entry_spread_bps: Decimal | None
+    mae_bps: Decimal | None
+    mfe_bps: Decimal | None
+    holding_seconds: int | None
+    exit_reason: str | None
+
+
+@dataclass(frozen=True)
+class RollupResult:
+    trade_count: int = 0
+    win_count: int = 0
+    loss_count: int = 0
+    anomaly_count: int = 0
+    gross_pnl_usdt: Decimal | None = None
+    net_pnl_usdt: Decimal | None = None
+    net_return_bps: Decimal | None = None
+    avg_slippage_bps: Decimal | None = None
+    avg_spread_bps: Decimal | None = None
+    avg_mae_bps: Decimal | None = None
+    avg_mfe_bps: Decimal | None = None
+    avg_holding_seconds: int | None = None
+    exit_reason_counts: dict[str, int] = field(default_factory=dict)
+    source_payload: dict[str, Any] = field(default_factory=dict)
+
+
+def _mean(values: list[Decimal]) -> Decimal | None:
+    if not values:
+        return None
+    return sum(values, Decimal("0")) / Decimal(len(values))
+
+
+def _sum_or_none(values: list[Decimal]) -> Decimal | None:
+    if not values:
+        return None
+    return sum(values, Decimal("0"))
+
+
+def build_rollup(rows: list[_AnalyticsRow]) -> RollupResult:
+    """Aggregate one day's analytics rows into a ``RollupResult``."""
+    fill_proven = [r for r in rows if r.entry_price is not None]
+    anomaly = [r for r in rows if r.entry_price is None]
+
+    net_pnls = [r.net_pnl_usdt for r in fill_proven if r.net_pnl_usdt is not None]
+    gross_pnls = [r.gross_pnl_usdt for r in fill_proven if r.gross_pnl_usdt is not None]
+    notionals = [
+        r.entry_notional_usdt
+        for r in fill_proven
+        if r.net_pnl_usdt is not None and r.entry_notional_usdt is not None
+    ]
+
+    net_total = _sum_or_none(net_pnls)
+    notional_total = sum(notionals, Decimal("0"))
+    net_return_bps = (
+        net_total / notional_total * _BPS
+        if net_total is not None and notional_total > 0
+        else None
+    )
+
+    exit_counts: Counter[str] = Counter(
+        r.exit_reason for r in rows if r.exit_reason is not None
+    )
+
+    return RollupResult(
+        trade_count=len(fill_proven),
+        win_count=sum(1 for v in net_pnls if v > 0),
+        loss_count=sum(1 for v in net_pnls if v < 0),
+        anomaly_count=len(anomaly),
+        gross_pnl_usdt=_sum_or_none(gross_pnls),
+        net_pnl_usdt=net_total,
+        net_return_bps=net_return_bps,
+        avg_slippage_bps=_mean(
+            [
+                r.entry_slippage_bps
+                for r in fill_proven
+                if r.entry_slippage_bps is not None
+            ]
+        ),
+        avg_spread_bps=_mean(
+            [r.entry_spread_bps for r in fill_proven if r.entry_spread_bps is not None]
+        ),
+        avg_mae_bps=_mean([r.mae_bps for r in fill_proven if r.mae_bps is not None]),
+        avg_mfe_bps=_mean([r.mfe_bps for r in fill_proven if r.mfe_bps is not None]),
+        avg_holding_seconds=(
+            int(
+                _mean(
+                    [
+                        Decimal(r.holding_seconds)
+                        for r in fill_proven
+                        if r.holding_seconds is not None
+                    ]
+                )
+            )
+            if any(r.holding_seconds is not None for r in fill_proven)
+            else None
+        ),
+        exit_reason_counts=dict(exit_counts),
+        source_payload={
+            "row_count": len(rows),
+            "fill_proven_count": len(fill_proven),
+            "anomaly_count": len(anomaly),
+            "open_client_order_ids": [r.open_client_order_id for r in rows],
+        },
+    )

--- a/app/services/scalping_reviews/service.py
+++ b/app/services/scalping_reviews/service.py
@@ -119,21 +119,31 @@ class ScalpingReviewService:
             )
         )
 
-    async def _rollup_for(self, review_date: dt.date, product: str) -> RollupResult:
+    async def list_analytics(
+        self, *, review_date: dt.date, product: str
+    ) -> list[ScalpTradeAnalytics]:
+        """Raw scalp_trade_analytics round-trip rows for a day/product, oldest
+        first. Read-only — the per-trade table renders these; the review UI
+        never edits them."""
         start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
         end = start + dt.timedelta(days=1)
-        rows = (
-            await self._session.scalars(
-                select(ScalpTradeAnalytics)
-                .where(
-                    ScalpTradeAnalytics.product == product,
-                    ScalpTradeAnalytics.created_at >= start,
-                    ScalpTradeAnalytics.created_at < end,
+        return list(
+            (
+                await self._session.scalars(
+                    select(ScalpTradeAnalytics)
+                    .where(
+                        ScalpTradeAnalytics.product == product,
+                        ScalpTradeAnalytics.created_at >= start,
+                        ScalpTradeAnalytics.created_at < end,
+                    )
+                    .order_by(ScalpTradeAnalytics.created_at)
                 )
-                .order_by(ScalpTradeAnalytics.created_at)
-            )
-        ).all()
-        return build_rollup(list(rows))
+            ).all()
+        )
+
+    async def _rollup_for(self, review_date: dt.date, product: str) -> RollupResult:
+        rows = await self.list_analytics(review_date=review_date, product=product)
+        return build_rollup(rows)
 
     @staticmethod
     def _apply_rollup(review: ScalpingDailyReview, rollup: RollupResult) -> None:

--- a/app/services/scalping_reviews/service.py
+++ b/app/services/scalping_reviews/service.py
@@ -1,0 +1,278 @@
+"""ROB-315 Phase 1 — service layer for the scalping review loop.
+
+The **only** write path for ``scalping_daily_reviews`` /
+``scalping_review_actions``. It rolls a day's raw ``scalp_trade_analytics``
+rows into a draft review (idempotent per key) and lets the operator edit the
+human-judgment fields — but it never edits raw analytics rows, and never
+touches any broker / order / scheduler surface.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.models.scalping_reviews import (
+    ACTION_STATUSES,
+    ACTION_TYPES,
+    REVIEW_DECISIONS,
+    REVIEW_STATUSES,
+    SCALPING_REVIEW_ACCOUNT_SCOPE,
+    ScalpingDailyReview,
+    ScalpingReviewAction,
+)
+from app.services.scalping_reviews.rollup import RollupResult, build_rollup
+
+# Operator-editable review fields (everything else is rollup-owned).
+_REVIEW_TEXT_FIELDS = ("observation", "root_cause", "improvement", "next_run_plan")
+# Operator-editable action fields.
+_ACTION_TEXT_FIELDS = (
+    "title",
+    "rationale",
+    "target_component",
+    "proposed_change",
+    "expected_effect",
+)
+
+_UNSET: Any = object()
+
+
+class ScalpingReviewError(ValueError):
+    """Invalid review/action input (bad scope, decision, status, ...)."""
+
+
+def _require_demo_scope(account_scope: str) -> None:
+    if account_scope != SCALPING_REVIEW_ACCOUNT_SCOPE:
+        raise ScalpingReviewError(
+            f"account_scope must be {SCALPING_REVIEW_ACCOUNT_SCOPE!r} for the demo "
+            f"scalping review loop, got {account_scope!r}. Demo scalping review "
+            "state must never carry a KIS/Upbit live execution scope."
+        )
+
+
+class ScalpingReviewService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # ------------------------------------------------------------------
+    # Draft build (idempotent rollup)
+    # ------------------------------------------------------------------
+    async def build_draft(
+        self,
+        *,
+        review_date: dt.date,
+        product: str,
+        now: dt.datetime,
+        session_tag: str = "",
+        account_scope: str = SCALPING_REVIEW_ACCOUNT_SCOPE,
+    ) -> ScalpingDailyReview:
+        """Build or refresh the draft review for a key from that day's
+        ``scalp_trade_analytics`` rows. Idempotent per
+        ``(review_date, product, account_scope, session_tag)`` — re-running
+        refreshes the rollup metrics in place, preserves operator inputs, and
+        leaves a ``locked`` review untouched."""
+        _require_demo_scope(account_scope)
+        rollup = await self._rollup_for(review_date, product)
+
+        existing = await self._get_by_key(
+            review_date, product, account_scope, session_tag
+        )
+        if existing is not None:
+            if existing.status != "locked":
+                self._apply_rollup(existing, rollup)
+                existing.updated_at = now
+            return existing
+
+        review = ScalpingDailyReview(
+            review_date=review_date,
+            product=product,
+            account_scope=account_scope,
+            session_tag=session_tag,
+            decision="review",
+            status="draft",
+            created_at=now,
+            updated_at=now,
+        )
+        self._apply_rollup(review, rollup)
+        self._session.add(review)
+        await self._session.flush()
+        await self._session.refresh(review)
+        return review
+
+    async def _get_by_key(
+        self,
+        review_date: dt.date,
+        product: str,
+        account_scope: str,
+        session_tag: str,
+    ) -> ScalpingDailyReview | None:
+        return await self._session.scalar(
+            select(ScalpingDailyReview).where(
+                ScalpingDailyReview.review_date == review_date,
+                ScalpingDailyReview.product == product,
+                ScalpingDailyReview.account_scope == account_scope,
+                ScalpingDailyReview.session_tag == session_tag,
+            )
+        )
+
+    async def _rollup_for(self, review_date: dt.date, product: str) -> RollupResult:
+        start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
+        end = start + dt.timedelta(days=1)
+        rows = (
+            await self._session.scalars(
+                select(ScalpTradeAnalytics)
+                .where(
+                    ScalpTradeAnalytics.product == product,
+                    ScalpTradeAnalytics.created_at >= start,
+                    ScalpTradeAnalytics.created_at < end,
+                )
+                .order_by(ScalpTradeAnalytics.created_at)
+            )
+        ).all()
+        return build_rollup(list(rows))
+
+    @staticmethod
+    def _apply_rollup(review: ScalpingDailyReview, rollup: RollupResult) -> None:
+        review.trade_count = rollup.trade_count
+        review.win_count = rollup.win_count
+        review.loss_count = rollup.loss_count
+        review.anomaly_count = rollup.anomaly_count
+        review.gross_pnl_usdt = rollup.gross_pnl_usdt
+        review.net_pnl_usdt = rollup.net_pnl_usdt
+        review.net_return_bps = rollup.net_return_bps
+        review.avg_slippage_bps = rollup.avg_slippage_bps
+        review.avg_spread_bps = rollup.avg_spread_bps
+        review.avg_mae_bps = rollup.avg_mae_bps
+        review.avg_mfe_bps = rollup.avg_mfe_bps
+        review.avg_holding_seconds = rollup.avg_holding_seconds
+        review.exit_reason_counts = rollup.exit_reason_counts
+        review.source_payload = rollup.source_payload
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+    async def get(self, review_id: int) -> ScalpingDailyReview | None:
+        return await self._session.get(ScalpingDailyReview, review_id)
+
+    async def list_reviews(
+        self,
+        *,
+        review_date: dt.date | None = None,
+        product: str | None = None,
+    ) -> list[ScalpingDailyReview]:
+        stmt = select(ScalpingDailyReview)
+        if review_date is not None:
+            stmt = stmt.where(ScalpingDailyReview.review_date == review_date)
+        if product is not None:
+            stmt = stmt.where(ScalpingDailyReview.product == product)
+        stmt = stmt.order_by(
+            ScalpingDailyReview.review_date.desc(), ScalpingDailyReview.product
+        )
+        return list((await self._session.scalars(stmt)).all())
+
+    async def list_actions(self, review_id: int) -> list[ScalpingReviewAction]:
+        return list(
+            (
+                await self._session.scalars(
+                    select(ScalpingReviewAction)
+                    .where(ScalpingReviewAction.review_id == review_id)
+                    .order_by(ScalpingReviewAction.id)
+                )
+            ).all()
+        )
+
+    # ------------------------------------------------------------------
+    # Operator edits (review fields only — never raw analytics)
+    # ------------------------------------------------------------------
+    async def update_review(
+        self,
+        review_id: int,
+        *,
+        now: dt.datetime,
+        observation: str | None = _UNSET,
+        root_cause: str | None = _UNSET,
+        improvement: str | None = _UNSET,
+        next_run_plan: str | None = _UNSET,
+        decision: str | None = _UNSET,
+        status: str | None = _UNSET,
+    ) -> ScalpingDailyReview | None:
+        review = await self.get(review_id)
+        if review is None:
+            return None
+        local = locals()
+        for f in _REVIEW_TEXT_FIELDS:
+            if local[f] is not _UNSET:
+                setattr(review, f, local[f])
+        if decision is not _UNSET:
+            if decision not in REVIEW_DECISIONS:
+                raise ScalpingReviewError(f"invalid decision {decision!r}")
+            review.decision = decision
+        if status is not _UNSET:
+            if status not in REVIEW_STATUSES:
+                raise ScalpingReviewError(f"invalid status {status!r}")
+            review.status = status
+        review.updated_at = now
+        await self._session.flush()
+        return review
+
+    async def add_action(
+        self,
+        review_id: int,
+        *,
+        action_type: str,
+        title: str,
+        now: dt.datetime,
+        rationale: str | None = None,
+        target_component: str | None = None,
+        proposed_change: str | None = None,
+        expected_effect: str | None = None,
+    ) -> ScalpingReviewAction:
+        if action_type not in ACTION_TYPES:
+            raise ScalpingReviewError(f"invalid action_type {action_type!r}")
+        action = ScalpingReviewAction(
+            review_id=review_id,
+            action_type=action_type,
+            title=title,
+            rationale=rationale,
+            target_component=target_component,
+            proposed_change=proposed_change,
+            expected_effect=expected_effect,
+            status="open",
+            created_at=now,
+            updated_at=now,
+        )
+        self._session.add(action)
+        await self._session.flush()
+        await self._session.refresh(action)
+        return action
+
+    async def update_action(
+        self,
+        action_id: int,
+        *,
+        now: dt.datetime,
+        status: str | None = _UNSET,
+        title: str | None = _UNSET,
+        rationale: str | None = _UNSET,
+        target_component: str | None = _UNSET,
+        proposed_change: str | None = _UNSET,
+        expected_effect: str | None = _UNSET,
+    ) -> ScalpingReviewAction | None:
+        action = await self._session.get(ScalpingReviewAction, action_id)
+        if action is None:
+            return None
+        local = locals()
+        for f in _ACTION_TEXT_FIELDS:
+            if local[f] is not _UNSET:
+                setattr(action, f, local[f])
+        if status is not _UNSET:
+            if status not in ACTION_STATUSES:
+                raise ScalpingReviewError(f"invalid action status {status!r}")
+            action.status = status
+        action.updated_at = now
+        await self._session.flush()
+        return action

--- a/frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx
@@ -1,0 +1,167 @@
+import type { ReactElement } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import * as scalpingApi from "../api/scalping";
+import { ScalpingRoute } from "../pages/desktop/DesktopScalpingPage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
+import type {
+  ScalpingReview,
+  ScalpingReviewAction,
+  ScalpingTrade,
+} from "../types/scalping";
+
+const REVIEW: ScalpingReview = {
+  id: 1,
+  reviewDate: "2026-05-25",
+  product: "usdm_futures",
+  accountScope: "binance_demo",
+  sessionTag: "",
+  metrics: {
+    tradeCount: 2,
+    winCount: 1,
+    lossCount: 1,
+    anomalyCount: 1,
+    grossPnlUsdt: "0.0",
+    netPnlUsdt: "-0.2",
+    netReturnBps: "-10",
+    avgSlippageBps: "3",
+    avgSpreadBps: null, // n/a — no row carried it
+    avgMaeBps: "-10",
+    avgMfeBps: "40",
+    avgHoldingSeconds: 15,
+    exitReasonCounts: { take_profit: 1, stop_loss: 1 },
+  },
+  observation: "스프레드가 장중 확대됨",
+  rootCause: null,
+  improvement: null,
+  nextRunPlan: null,
+  decision: "adjust",
+  status: "draft",
+  sourcePayload: { row_count: 2 },
+  createdAt: "2026-05-25T12:00:00Z",
+  updatedAt: "2026-05-25T12:00:00Z",
+};
+
+const ACTION: ScalpingReviewAction = {
+  id: 10,
+  reviewId: 1,
+  actionType: "parameter_change",
+  title: "TP를 40bps로 확대",
+  rationale: "MFE가 일관되게 30bps 초과",
+  targetComponent: null,
+  proposedChange: null,
+  expectedEffect: null,
+  status: "applied",
+  createdAt: null,
+  updatedAt: null,
+};
+
+const TRADE_OK: ScalpingTrade = {
+  id: 1,
+  openClientOrderId: "o-1",
+  symbol: "XRPUSDT",
+  side: "BUY",
+  qty: "1",
+  entryPrice: "100",
+  exitPrice: "101",
+  entrySlippageBps: "2",
+  exitSlippageBps: "1",
+  entrySpreadBps: "5",
+  exitSpreadBps: "6",
+  maeBps: "-10",
+  mfeBps: "40",
+  netPnlUsdt: "0.9",
+  holdingSeconds: 12,
+  exitReason: "take_profit",
+  isAnomaly: false,
+};
+
+const TRADE_ANOMALY: ScalpingTrade = {
+  ...TRADE_OK,
+  id: 2,
+  openClientOrderId: "o-2",
+  entryPrice: null, // no derivable fill price → partial/anomaly
+  exitPrice: null,
+  entrySlippageBps: null,
+  entrySpreadBps: null,
+  maeBps: null,
+  mfeBps: null,
+  netPnlUsdt: null,
+  holdingSeconds: null,
+  exitReason: "timeout",
+  isAnomaly: true,
+};
+
+function wrap(ui: ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/scalping"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
+});
+
+test("empty state explains analytics rows are required", async () => {
+  vi.spyOn(scalpingApi, "fetchScalpingReviews").mockResolvedValue({ items: [] });
+  vi.spyOn(scalpingApi, "fetchScalpingTrades").mockResolvedValue({ items: [] });
+
+  render(wrap(<ScalpingRoute />));
+
+  await waitFor(() =>
+    expect(screen.getByText(/아직 분석 데이터가 없습니다/)).toBeInTheDocument(),
+  );
+});
+
+test("ready state renders summary, daily loop, trade table, and actions", async () => {
+  vi.spyOn(scalpingApi, "fetchScalpingReviews").mockResolvedValue({ items: [REVIEW] });
+  vi.spyOn(scalpingApi, "fetchScalpingReview").mockResolvedValue({
+    review: REVIEW,
+    actions: [ACTION],
+  });
+  vi.spyOn(scalpingApi, "fetchScalpingTrades").mockResolvedValue({
+    items: [TRADE_OK, TRADE_ANOMALY],
+  });
+
+  render(wrap(<ScalpingRoute />));
+
+  // Summary + decision label.
+  await waitFor(() => expect(screen.getByText("조정")).toBeInTheDocument());
+  // Daily loop card.
+  expect(screen.getByText(/실행 → 관측 → 원인 → 개선/)).toBeInTheDocument();
+  expect(screen.getByText("스프레드가 장중 확대됨")).toBeInTheDocument();
+  // Trade table — both symbols, anomaly badge on the partial row.
+  expect(screen.getAllByText("XRPUSDT").length).toBeGreaterThanOrEqual(2);
+  // "이상치" appears both as the anomaly-count metric label and the row badge.
+  expect(screen.getAllByText("이상치").length).toBeGreaterThanOrEqual(2);
+  // Action list with status.
+  expect(screen.getByText("TP를 40bps로 확대")).toBeInTheDocument();
+  expect(screen.getByText("적용됨")).toBeInTheDocument();
+});
+
+test("null telemetry renders n/a, never 0 or blank", async () => {
+  vi.spyOn(scalpingApi, "fetchScalpingReviews").mockResolvedValue({ items: [REVIEW] });
+  vi.spyOn(scalpingApi, "fetchScalpingReview").mockResolvedValue({
+    review: REVIEW,
+    actions: [],
+  });
+  vi.spyOn(scalpingApi, "fetchScalpingTrades").mockResolvedValue({
+    items: [TRADE_ANOMALY],
+  });
+
+  render(wrap(<ScalpingRoute />));
+
+  // The anomaly row's null entry/exit/slippage/pnl all render "n/a".
+  await waitFor(() =>
+    expect(screen.getAllByText("이상치").length).toBeGreaterThanOrEqual(1),
+  );
+  expect(screen.getAllByText("n/a").length).toBeGreaterThan(0);
+});

--- a/frontend/invest/src/api/scalping.ts
+++ b/frontend/invest/src/api/scalping.ts
@@ -1,0 +1,66 @@
+// ROB-315 Phase 3 — /invest/api/scalping client (read + review).
+import type {
+  ScalpingProduct,
+  ScalpingReviewDetailResponse,
+  ScalpingReviewListResponse,
+  ScalpingTradesResponse,
+} from "../types/scalping";
+
+const BASE = "/invest/api/scalping";
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { credentials: "include", signal });
+  if (!res.ok) {
+    throw new Error(`${url} ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchScalpingReviews(params: {
+  date?: string;
+  product?: ScalpingProduct;
+  signal?: AbortSignal;
+} = {}): Promise<ScalpingReviewListResponse> {
+  const q = new URLSearchParams();
+  if (params.date) q.set("date", params.date);
+  if (params.product) q.set("product", params.product);
+  const suffix = q.toString() ? `?${q.toString()}` : "";
+  return getJson(`${BASE}/reviews${suffix}`, params.signal);
+}
+
+export async function fetchScalpingReview(
+  reviewId: number,
+  signal?: AbortSignal,
+): Promise<ScalpingReviewDetailResponse> {
+  return getJson(`${BASE}/reviews/${reviewId}`, signal);
+}
+
+export async function fetchScalpingTrades(params: {
+  date: string;
+  product: ScalpingProduct;
+  signal?: AbortSignal;
+}): Promise<ScalpingTradesResponse> {
+  const q = new URLSearchParams({ date: params.date, product: params.product });
+  return getJson(`${BASE}/analytics?${q.toString()}`, params.signal);
+}
+
+export async function buildScalpingDraft(params: {
+  reviewDate: string;
+  product: ScalpingProduct;
+  sessionTag?: string;
+}): Promise<ScalpingReviewDetailResponse["review"]> {
+  const res = await fetch(`${BASE}/reviews/draft`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      review_date: params.reviewDate,
+      product: params.product,
+      session_tag: params.sessionTag ?? "",
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`${BASE}/reviews/draft ${res.status}`);
+  }
+  return (await res.json()).review;
+}

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -11,6 +11,7 @@ const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/market", label: "시장" },
   { to: "/coverage", label: "커버리지" },
   { to: "/screener", label: "골라보기" },
+  { to: "/scalping", label: "스캘핑 일지" },
 ];
 
 export function DesktopHeader() {

--- a/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
@@ -1,0 +1,309 @@
+// ROB-315 Phase 3 — /invest/scalping (스캘핑 일지).
+// Read-only daily review surface for the Binance Demo scalping loop. No order
+// placement, no scheduler toggle — it only builds/reads the review rollup and
+// displays the day's round-trips so the operator can decide the next small
+// improvement.
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  buildScalpingDraft,
+  fetchScalpingReview,
+  fetchScalpingReviews,
+  fetchScalpingTrades,
+} from "../../api/scalping";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { Button, Card } from "../../ds";
+import type {
+  ScalpingProduct,
+  ScalpingReview,
+  ScalpingReviewAction,
+  ScalpingTrade,
+} from "../../types/scalping";
+
+const DECISION_LABEL: Record<string, string> = {
+  review: "검토 필요",
+  keep: "유지",
+  adjust: "조정",
+  pause: "일시중지",
+  disable: "비활성화",
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "초안",
+  reviewed: "검토됨",
+  locked: "잠김",
+};
+
+const ACTION_STATUS_LABEL: Record<string, string> = {
+  open: "열림",
+  applied: "적용됨",
+  skipped: "건너뜀",
+  superseded: "대체됨",
+};
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// Render a nullable metric as "n/a" rather than 0/blank/fabricated (ROB-315:
+// deferred telemetry may be null on legacy/anomaly rows).
+function na(value: string | number | null | undefined): string {
+  return value === null || value === undefined ? "n/a" : String(value);
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{label}</div>
+      <strong style={{ fontSize: 22 }}>{value}</strong>
+    </Card>
+  );
+}
+
+function LoopRow({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "96px 1fr", gap: 12, padding: "6px 0" }}>
+      <span style={{ color: "var(--fg-3)", fontWeight: 700 }}>{label}</span>
+      <span style={{ color: value ? "var(--fg)" : "var(--fg-3)" }}>{value ?? "기록 없음"}</span>
+    </div>
+  );
+}
+
+export function ScalpingRoute() {
+  const [date, setDate] = useState<string>(today());
+  const [product, setProduct] = useState<ScalpingProduct>("usdm_futures");
+  const [review, setReview] = useState<ScalpingReview | null>(null);
+  const [actions, setActions] = useState<ScalpingReviewAction[]>([]);
+  const [trades, setTrades] = useState<ScalpingTrade[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [building, setBuilding] = useState(false);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const [reviews, tradesResp] = await Promise.all([
+        fetchScalpingReviews({ date, product, signal }),
+        fetchScalpingTrades({ date, product, signal }),
+      ]);
+      const found = reviews.items[0] ?? null;
+      setReview(found);
+      setTrades(tradesResp.items);
+      if (found) {
+        const detail = await fetchScalpingReview(found.id, signal);
+        setActions(detail.actions);
+      } else {
+        setActions([]);
+      }
+    } catch (e) {
+      if ((e as Error).name !== "AbortError") setErr((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [date, product]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const onBuildDraft = useCallback(async () => {
+    setBuilding(true);
+    try {
+      await buildScalpingDraft({ reviewDate: date, product });
+      await load();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setBuilding(false);
+    }
+  }, [date, product, load]);
+
+  const metrics = review?.metrics;
+  const isEmpty = !loading && !err && review === null && trades.length === 0;
+
+  const exitReasonSummary = useMemo(() => {
+    if (!metrics) return "";
+    return Object.entries(metrics.exitReasonCounts)
+      .map(([reason, count]) => `${reason} ${count}`)
+      .join(" · ");
+  }, [metrics]);
+
+  return (
+    <DesktopShell
+      center={
+        <div style={{ padding: "20px 28px", display: "grid", gap: 16 }}>
+          <PageSafetyNote
+            routeId="scalping"
+            heading="ROB-315 스캘핑 일지 — demo 전용"
+            tag="스캘핑"
+            items={[
+              "Binance Demo 전용 (demo-api / demo-fapi). live/mainnet 거래 없음",
+              "이 페이지에서 주문·스케줄러 토글·파라미터 자동 적용 없음",
+              "리뷰 액션은 운영자 기록일 뿐 자동 실행되지 않음",
+              "원시 분석 행은 편집 불가 — 판단/액션만 리뷰 레이어에 기록",
+            ]}
+          />
+
+          <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+            <h1 style={{ margin: 0, fontSize: 22 }}>스캘핑 일지</h1>
+            <input
+              type="date"
+              aria-label="review date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              style={{ padding: "6px 8px", borderRadius: 8, border: "1px solid var(--divider)", background: "var(--surface)", color: "var(--fg)" }}
+            />
+            <select
+              aria-label="product"
+              value={product}
+              onChange={(e) => setProduct(e.target.value as ScalpingProduct)}
+              style={{ padding: "6px 8px", borderRadius: 8, border: "1px solid var(--divider)", background: "var(--surface)", color: "var(--fg)" }}
+            >
+              <option value="usdm_futures">USD-M Futures</option>
+              <option value="spot">Spot</option>
+            </select>
+            <Button onClick={onBuildDraft} disabled={building}>
+              {building ? "생성 중…" : review ? "초안 새로고침" : "초안 만들기"}
+            </Button>
+          </div>
+
+          {loading && <Card>로딩 중…</Card>}
+          {err && (
+            <Card>
+              <span style={{ color: "#dc2626" }}>스캘핑 API 오류: {err}</span>
+            </Card>
+          )}
+
+          {isEmpty && (
+            <Card>
+              <div style={{ display: "grid", gap: 6 }}>
+                <strong>아직 분석 데이터가 없습니다</strong>
+                <span style={{ color: "var(--fg-3)" }}>
+                  일일 리뷰는 해당 날짜·상품의 <code>scalp_trade_analytics</code> 라운드트립이 있어야
+                  의미가 있습니다. Demo 스캘핑 실행 후 다시 확인하거나, 데이터가 있으면 "초안 만들기"를 누르세요.
+                </span>
+              </div>
+            </Card>
+          )}
+
+          {!loading && !err && !isEmpty && (
+            <>
+              {/* 1. Today summary */}
+              {metrics ? (
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 12 }}>
+                  <MetricCard label="라운드트립" value={String(metrics.tradeCount)} />
+                  <MetricCard label="승/패" value={`${metrics.winCount} / ${metrics.lossCount}`} />
+                  <MetricCard label="순손익 (USDT)" value={na(metrics.netPnlUsdt)} />
+                  <MetricCard label="이상치" value={String(metrics.anomalyCount)} />
+                  <MetricCard label="결정" value={DECISION_LABEL[review!.decision] ?? review!.decision} />
+                </div>
+              ) : (
+                <Card>
+                  분석 행 {trades.length}건이 있지만 아직 리뷰 초안이 없습니다. "초안 만들기"로 롤업을 생성하세요.
+                </Card>
+              )}
+
+              {/* 2. Daily loop card */}
+              {review && (
+                <Card>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+                    <h2 style={{ margin: 0, fontSize: 16 }}>실행 → 관측 → 원인 → 개선 → 다음 실행</h2>
+                    <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
+                      {STATUS_LABEL[review.status] ?? review.status}
+                      {exitReasonSummary ? ` · 종료사유: ${exitReasonSummary}` : ""}
+                    </span>
+                  </div>
+                  <LoopRow label="관측" value={review.observation} />
+                  <LoopRow label="원인" value={review.rootCause} />
+                  <LoopRow label="개선" value={review.improvement} />
+                  <LoopRow label="다음 실행" value={review.nextRunPlan} />
+                </Card>
+              )}
+
+              {/* 3. Trade analytics table */}
+              <Card>
+                <h2 style={{ margin: "0 0 12px", fontSize: 16 }}>거래 분석</h2>
+                {trades.length === 0 ? (
+                  <span style={{ color: "var(--fg-3)" }}>해당 날짜의 라운드트립이 없습니다.</span>
+                ) : (
+                  <div style={{ overflowX: "auto" }}>
+                    <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 900 }}>
+                      <thead>
+                        <tr style={{ textAlign: "left", color: "var(--fg-3)", fontSize: 12 }}>
+                          {["심볼", "방향", "진입", "청산", "슬리피지", "스프레드", "MAE/MFE", "순손익", "종료", "보유(s)"].map((h) => (
+                            <th key={h} style={{ padding: "0 10px 8px" }}>{h}</th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {trades.map((t) => (
+                          <tr
+                            key={t.id}
+                            style={{ borderTop: "1px solid var(--divider)", fontSize: 13, background: t.isAnomaly ? "rgba(220,38,38,0.06)" : undefined }}
+                          >
+                            <td style={{ padding: "8px 10px" }}>
+                              {t.symbol}
+                              {t.isAnomaly && <span title="체결가 미확보" style={{ marginLeft: 6, color: "#dc2626", fontSize: 11 }}>이상치</span>}
+                            </td>
+                            <td style={{ padding: "8px 10px" }}>{t.side}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.entryPrice)}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.exitPrice)}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.entrySlippageBps)}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.entrySpreadBps)}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.maeBps)} / {na(t.mfeBps)}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.netPnlUsdt)}</td>
+                            <td style={{ padding: "8px 10px" }}>{t.exitReason ?? "n/a"}</td>
+                            <td style={{ padding: "8px 10px" }}>{na(t.holdingSeconds)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </Card>
+
+              {/* 4. Review actions */}
+              {review && (
+                <Card>
+                  <h2 style={{ margin: "0 0 12px", fontSize: 16 }}>리뷰 액션</h2>
+                  {actions.length === 0 ? (
+                    <span style={{ color: "var(--fg-3)" }}>등록된 액션이 없습니다.</span>
+                  ) : (
+                    <div style={{ display: "grid", gap: 8 }}>
+                      {actions.map((a) => (
+                        <div
+                          key={a.id}
+                          style={{ display: "flex", gap: 10, alignItems: "baseline", flexWrap: "wrap", borderTop: "1px solid var(--divider)", paddingTop: 8 }}
+                        >
+                          <span style={{ fontWeight: 700 }}>{a.title}</span>
+                          <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{a.actionType}</span>
+                          <span style={{ fontSize: 12, fontWeight: 700, color: a.status === "applied" ? "#16a34a" : "var(--fg-3)" }}>
+                            {ACTION_STATUS_LABEL[a.status] ?? a.status}
+                          </span>
+                          {a.rationale && <span style={{ color: "var(--fg-3)", fontSize: 12 }}>· {a.rationale}</span>}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              )}
+
+              {/* 5. Safety panel */}
+              <Card>
+                <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>안전 상태</h2>
+                <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-3)", fontSize: 13, display: "grid", gap: 4 }}>
+                  <li>실행 venue: Demo 전용 (demo-api.binance.com / demo-fapi.binance.com)</li>
+                  <li>계정 범위: {review?.accountScope ?? "binance_demo"} (KIS/Upbit live와 분리)</li>
+                  <li>이 페이지에서 주문/스케줄러 변경 없음 · 리뷰 액션은 운영자 기록</li>
+                </ul>
+              </Card>
+            </>
+          )}
+        </div>
+      }
+    />
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -36,6 +36,7 @@ import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
 import { DesktopInsightsPage } from "./pages/desktop/DesktopInsightsPage";
 import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
 import { DesktopCryptoPage } from "./pages/desktop/DesktopCryptoPage";
+import { ScalpingRoute } from "./pages/desktop/DesktopScalpingPage";
 import {
   InvestmentReportBundleRoute,
   InvestmentReportsRoute,
@@ -87,6 +88,7 @@ export const router = createBrowserRouter(
     { path: "/crypto", element: <DesktopCryptoPage /> },
     { path: "/crypto/:pair", element: <CryptoPairRedirect /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
+    { path: "/scalping", element: <ScalpingRoute /> },
     { path: "/reports", element: <InvestmentReportsRoute /> },
     { path: "/reports/:reportUuid", element: <InvestmentReportBundleRoute /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },

--- a/frontend/invest/src/types/scalping.ts
+++ b/frontend/invest/src/types/scalping.ts
@@ -1,0 +1,97 @@
+// ROB-315 Phase 3 — /invest/scalping (스캘핑 일지) types.
+// Decimal-bearing fields arrive as strings (or null = "n/a") from the API so
+// precision is preserved; the UI renders them verbatim or as "n/a".
+
+export type ScalpingProduct = "spot" | "usdm_futures";
+export type ReviewDecision = "review" | "keep" | "adjust" | "pause" | "disable";
+export type ReviewStatus = "draft" | "reviewed" | "locked";
+export type ActionType =
+  | "parameter_change"
+  | "investigate"
+  | "pause"
+  | "resume"
+  | "add_guard"
+  | "data_quality"
+  | "no_change";
+export type ActionStatus = "open" | "applied" | "skipped" | "superseded";
+
+export interface ScalpingReviewMetrics {
+  tradeCount: number;
+  winCount: number;
+  lossCount: number;
+  anomalyCount: number;
+  grossPnlUsdt: string | null;
+  netPnlUsdt: string | null;
+  netReturnBps: string | null;
+  avgSlippageBps: string | null;
+  avgSpreadBps: string | null;
+  avgMaeBps: string | null;
+  avgMfeBps: string | null;
+  avgHoldingSeconds: number | null;
+  exitReasonCounts: Record<string, number>;
+}
+
+export interface ScalpingReview {
+  id: number;
+  reviewDate: string;
+  product: ScalpingProduct;
+  accountScope: string;
+  sessionTag: string;
+  metrics: ScalpingReviewMetrics;
+  observation: string | null;
+  rootCause: string | null;
+  improvement: string | null;
+  nextRunPlan: string | null;
+  decision: ReviewDecision;
+  status: ReviewStatus;
+  sourcePayload: Record<string, unknown> | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface ScalpingReviewAction {
+  id: number;
+  reviewId: number;
+  actionType: ActionType;
+  title: string;
+  rationale: string | null;
+  targetComponent: string | null;
+  proposedChange: string | null;
+  expectedEffect: string | null;
+  status: ActionStatus;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface ScalpingTrade {
+  id: number;
+  openClientOrderId: string;
+  symbol: string;
+  side: string;
+  qty: string | null;
+  entryPrice: string | null;
+  exitPrice: string | null;
+  entrySlippageBps: string | null;
+  exitSlippageBps: string | null;
+  entrySpreadBps: string | null;
+  exitSpreadBps: string | null;
+  maeBps: string | null;
+  mfeBps: string | null;
+  netPnlUsdt: string | null;
+  holdingSeconds: number | null;
+  exitReason: string | null;
+  isAnomaly: boolean;
+}
+
+export interface ScalpingReviewListResponse {
+  items: ScalpingReview[];
+}
+
+export interface ScalpingReviewDetailResponse {
+  review: ScalpingReview;
+  actions: ScalpingReviewAction[];
+}
+
+export interface ScalpingTradesResponse {
+  items: ScalpingTrade[];
+}

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -78,6 +78,10 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # binance_demo_order_ledger.py above. The model is registered in
         # app/models/__init__.py (one-line import).
         "app/models/scalp_trade_analytics.py",
+        # ROB-315 — the scalping review-loop ORM model. Analytics/review
+        # persistence only (no HTTP/WS, no signed surface); references Binance
+        # solely via the ``binance_demo`` account-scope literal + docstring.
+        "app/models/scalping_reviews.py",
         # ROB-307 PR4 — Demo scalping scheduler orchestration. These
         # *orchestrate* the in-package Demo adapters (executor/clients) and
         # perform no signed HTTP themselves (the HMAC chokepoints stay inside

--- a/tests/services/scalping_reviews/test_rollup.py
+++ b/tests/services/scalping_reviews/test_rollup.py
@@ -1,0 +1,115 @@
+"""ROB-315 Phase 1 — daily rollup of scalp_trade_analytics (pure, no DB)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.scalping_reviews.rollup import build_rollup
+
+
+def _row(**kw) -> ScalpTradeAnalytics:
+    base = dict(
+        open_client_order_id="o",
+        instrument_id=1,
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        qty=Decimal("1"),
+    )
+    base.update(kw)
+    return ScalpTradeAnalytics(**base)
+
+
+def test_empty_rows_are_all_zero_and_na() -> None:
+    r = build_rollup([])
+    assert r.trade_count == 0
+    assert r.win_count == 0
+    assert r.loss_count == 0
+    assert r.anomaly_count == 0
+    assert r.net_pnl_usdt is None  # n/a, not 0
+    assert r.avg_slippage_bps is None
+    assert r.exit_reason_counts == {}
+
+
+def test_fill_proven_rows_count_wins_losses_and_pnl() -> None:
+    rows = [
+        _row(
+            entry_price=Decimal("100"),
+            exit_price=Decimal("101"),
+            entry_notional_usdt=Decimal("100"),
+            net_pnl_usdt=Decimal("0.9"),
+            gross_pnl_usdt=Decimal("1.0"),
+            entry_slippage_bps=Decimal("2"),
+            exit_reason="take_profit",
+        ),
+        _row(
+            entry_price=Decimal("100"),
+            exit_price=Decimal("99"),
+            entry_notional_usdt=Decimal("100"),
+            net_pnl_usdt=Decimal("-1.1"),
+            gross_pnl_usdt=Decimal("-1.0"),
+            entry_slippage_bps=Decimal("4"),
+            exit_reason="stop_loss",
+        ),
+    ]
+    r = build_rollup(rows)
+    assert r.trade_count == 2
+    assert r.win_count == 1
+    assert r.loss_count == 1
+    assert r.anomaly_count == 0
+    assert r.net_pnl_usdt == Decimal("-0.2")  # 0.9 + (-1.1)
+    assert r.gross_pnl_usdt == Decimal("0.0")
+    # capital-weighted: -0.2 / 200 * 10_000 = -10 bps
+    assert r.net_return_bps == Decimal("-10")
+    assert r.avg_slippage_bps == Decimal("3")  # mean(2, 4)
+    assert r.exit_reason_counts == {"take_profit": 1, "stop_loss": 1}
+
+
+def test_no_fill_price_rows_count_as_anomaly_only() -> None:
+    rows = [
+        _row(
+            entry_price=Decimal("100"),
+            exit_price=Decimal("101"),
+            entry_notional_usdt=Decimal("100"),
+            net_pnl_usdt=Decimal("0.9"),
+            gross_pnl_usdt=Decimal("1.0"),
+            exit_reason="take_profit",
+        ),
+        # partial row: no derivable entry price → anomaly, not a trade.
+        _row(entry_price=None, exit_reason="timeout"),
+    ]
+    r = build_rollup(rows)
+    assert r.trade_count == 1  # only the fill-proven one
+    assert r.anomaly_count == 1
+    assert r.win_count == 1
+    assert r.net_pnl_usdt == Decimal("0.9")  # anomaly row contributes nothing
+    # exit_reason_counts still records every row's reason (audit trail).
+    assert r.exit_reason_counts == {"take_profit": 1, "timeout": 1}
+
+
+def test_telemetry_averages_skip_nulls_and_report_na_when_absent() -> None:
+    rows = [
+        _row(
+            entry_price=Decimal("100"),
+            net_pnl_usdt=Decimal("0.1"),
+            entry_notional_usdt=Decimal("100"),
+            mae_bps=Decimal("-10"),
+            mfe_bps=Decimal("40"),
+            holding_seconds=10,
+            # entry_spread_bps absent → excluded from avg_spread_bps
+        ),
+        _row(
+            entry_price=Decimal("100"),
+            net_pnl_usdt=Decimal("0.3"),
+            entry_notional_usdt=Decimal("100"),
+            mae_bps=Decimal("-20"),
+            mfe_bps=Decimal("60"),
+            holding_seconds=20,
+        ),
+    ]
+    r = build_rollup(rows)
+    assert r.avg_mae_bps == Decimal("-15")  # mean(-10, -20)
+    assert r.avg_mfe_bps == Decimal("50")  # mean(40, 60)
+    assert r.avg_holding_seconds == 15
+    assert r.avg_spread_bps is None  # no row carried it → n/a, not 0

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -1,0 +1,271 @@
+"""ROB-315 Phase 1 — ScalpingReviewService (rollup draft + operator edits).
+
+Uses the real test DB (db_session). Inserts raw scalp_trade_analytics rows,
+then exercises draft build / idempotency / operator-only edits / actions.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from sqlalchemy import select
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.scalping_reviews.service import (
+    ScalpingReviewError,
+    ScalpingReviewService,
+)
+
+_DATE = dt.date(2026, 5, 25)
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+
+async def _instrument(session, symbol="RVWXRPUSDT") -> int:
+    """Get-or-create — crypto_instruments persists across tests in the shared
+    test DB, so a fixed insert would collide on its unique key."""
+    existing = await session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "usdm_futures",
+            CryptoInstrument.venue_symbol == symbol,
+        )
+    )
+    if existing is not None:
+        return existing.id
+    inst = CryptoInstrument(
+        venue="binance",
+        product="usdm_futures",
+        venue_symbol=symbol,
+        base_asset="XRP",
+        quote_asset="USDT",
+        status="active",
+    )
+    session.add(inst)
+    await session.flush()
+    return inst.id
+
+
+async def _analytics(session, instrument_id, *, created_at=_NOW, **kw):
+    base = dict(
+        open_client_order_id=f"o-{kw.get('tag', '0')}",
+        instrument_id=instrument_id,
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        qty=Decimal("1"),
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    kw.pop("tag", None)
+    base.update(kw)
+    row = ScalpTradeAnalytics(**base)
+    session.add(row)
+    await session.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_build_draft_rolls_up_analytics(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session,
+        iid,
+        tag="win",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    await _analytics(
+        db_session,
+        iid,
+        tag="loss",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("99"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("-1.1"),
+        gross_pnl_usdt=Decimal("-1.0"),
+        exit_reason="stop_loss",
+    )
+
+    svc = ScalpingReviewService(db_session)
+    review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    assert review.status == "draft"
+    assert review.decision == "review"
+    assert review.account_scope == "binance_demo"
+    assert review.session_tag == ""
+    assert review.trade_count == 2
+    assert review.win_count == 1
+    assert review.loss_count == 1
+    assert review.anomaly_count == 0
+    assert review.net_pnl_usdt == Decimal("-0.2")
+    assert review.exit_reason_counts == {"take_profit": 1, "stop_loss": 1}
+    assert review.source_payload["row_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_build_draft_is_idempotent_for_default_session_tag(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session,
+        iid,
+        tag="a",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"),
+        exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    first = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    assert first.trade_count == 1
+
+    # A second analytics row, then re-draft with the SAME (default '') key:
+    # same row id (no duplicate), refreshed metrics.
+    await _analytics(
+        db_session,
+        iid,
+        tag="b",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("102"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("1.5"),
+        gross_pnl_usdt=Decimal("1.6"),
+        exit_reason="take_profit",
+    )
+    second = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    assert second.id == first.id  # idempotent — no duplicate row
+    assert second.trade_count == 2
+
+    rows = await svc.list_reviews(review_date=_DATE, product="usdm_futures")
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_draft_rejects_non_demo_scope(db_session) -> None:
+    svc = ScalpingReviewService(db_session)
+    with pytest.raises(ScalpingReviewError):
+        await svc.build_draft(
+            review_date=_DATE,
+            product="usdm_futures",
+            now=_NOW,
+            account_scope="kis_overseas_live",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_review_touches_only_operator_fields(db_session) -> None:
+    iid = await _instrument(db_session)
+    raw = await _analytics(
+        db_session,
+        iid,
+        tag="x",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+
+    updated = await svc.update_review(
+        review.id,
+        now=_NOW,
+        observation="spread widened intraday",
+        decision="adjust",
+        status="reviewed",
+    )
+    assert updated is not None
+    assert updated.observation == "spread widened intraday"
+    assert updated.decision == "adjust"
+    assert updated.status == "reviewed"
+    # Metrics untouched by an operator edit.
+    assert updated.trade_count == 1
+    assert updated.net_pnl_usdt == Decimal("0.9")
+    # Raw analytics row untouched.
+    await db_session.refresh(raw)
+    assert raw.entry_price == Decimal("100")
+    assert raw.net_pnl_usdt == Decimal("0.9")
+
+    with pytest.raises(ScalpingReviewError):
+        await svc.update_review(review.id, now=_NOW, decision="bogus")
+
+
+@pytest.mark.asyncio
+async def test_locked_review_is_not_refreshed(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session,
+        iid,
+        tag="a",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"),
+        exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    await svc.update_review(review.id, now=_NOW, status="locked")
+
+    await _analytics(
+        db_session,
+        iid,
+        tag="b",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("102"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("1.0"),
+        gross_pnl_usdt=Decimal("1.1"),
+        exit_reason="take_profit",
+    )
+    again = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    assert again.status == "locked"
+    assert again.trade_count == 1  # NOT refreshed while locked
+
+
+@pytest.mark.asyncio
+async def test_actions_crud(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session,
+        iid,
+        tag="a",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"),
+        exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+
+    action = await svc.add_action(
+        review.id,
+        action_type="parameter_change",
+        title="widen TP to 40 bps",
+        now=_NOW,
+        rationale="MFE consistently exceeds 30 bps",
+    )
+    assert action.status == "open"
+    actions = await svc.list_actions(review.id)
+    assert [a.id for a in actions] == [action.id]
+
+    updated = await svc.update_action(action.id, now=_NOW, status="applied")
+    assert updated is not None and updated.status == "applied"
+
+    with pytest.raises(ScalpingReviewError):
+        await svc.add_action(review.id, action_type="bogus", title="x", now=_NOW)
+    with pytest.raises(ScalpingReviewError):
+        await svc.update_action(action.id, now=_NOW, status="bogus")

--- a/tests/test_invest_api_scalping_router.py
+++ b/tests/test_invest_api_scalping_router.py
@@ -77,7 +77,36 @@ def _make_action(action_id: int, review_id: int, **kw) -> ScalpingReviewAction:
     return ScalpingReviewAction(**base)
 
 
+def _make_analytics(**kw):
+    from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+
+    base = dict(
+        id=1,
+        open_client_order_id="o-1",
+        instrument_id=1,
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        qty=Decimal("1"),
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_slippage_bps=Decimal("2"),
+        mae_bps=Decimal("-10"),
+        mfe_bps=Decimal("40"),
+        net_pnl_usdt=Decimal("0.9"),
+        holding_seconds=12,
+        exit_reason="take_profit",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    base.update(kw)
+    return ScalpTradeAnalytics(**base)
+
+
 class _StubService:
+    async def list_analytics(self, *, review_date, product):
+        return [_make_analytics(), _make_analytics(id=2, entry_price=None)]
+
     async def list_reviews(self, *, review_date=None, product=None):
         return [_make_review(1)]
 
@@ -136,6 +165,19 @@ def test_list_reviews_serializes_metrics() -> None:
     assert m["netPnlUsdt"] == "-0.2"  # Decimal serialized as string
     assert m["avgSpreadBps"] is None  # n/a, not 0
     assert m["exitReasonCounts"] == {"take_profit": 1, "stop_loss": 1}
+
+
+def test_list_analytics_marks_anomaly_rows() -> None:
+    resp = _client().get(
+        "/invest/api/scalping/analytics?date=2026-05-25&product=usdm_futures"
+    )
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 2
+    assert items[0]["isAnomaly"] is False
+    assert items[0]["entryPrice"] == "100"
+    assert items[1]["isAnomaly"] is True  # no derivable fill price
+    assert items[1]["entryPrice"] is None
 
 
 def test_get_review_includes_actions() -> None:

--- a/tests/test_invest_api_scalping_router.py
+++ b/tests/test_invest_api_scalping_router.py
@@ -1,0 +1,240 @@
+"""ROB-315 Phase 2 — router tests for read/review /invest/api/scalping.
+
+The service is stubbed (its DB behavior is covered by the Phase 1 service
+tests); these assert request parsing, response shape, status codes, and the
+broker/order/scheduler import boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+import datetime as dt
+import pathlib
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models.scalping_reviews import ScalpingDailyReview, ScalpingReviewAction
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_scalping import get_scalping_review_service
+from app.routers.invest_scalping import router as scalping_router
+from app.services.scalping_reviews.service import ScalpingReviewError
+
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _make_review(review_id: int, **kw) -> ScalpingDailyReview:
+    base = dict(
+        id=review_id,
+        review_date=dt.date(2026, 5, 25),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        trade_count=2,
+        win_count=1,
+        loss_count=1,
+        anomaly_count=0,
+        gross_pnl_usdt=Decimal("0.0"),
+        net_pnl_usdt=Decimal("-0.2"),
+        net_return_bps=Decimal("-10"),
+        avg_slippage_bps=Decimal("3"),
+        avg_spread_bps=None,
+        avg_mae_bps=Decimal("-10"),
+        avg_mfe_bps=Decimal("40"),
+        avg_holding_seconds=15,
+        exit_reason_counts={"take_profit": 1, "stop_loss": 1},
+        observation=None,
+        root_cause=None,
+        improvement=None,
+        next_run_plan=None,
+        decision="review",
+        status="draft",
+        source_payload={"row_count": 2},
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    base.update(kw)
+    return ScalpingDailyReview(**base)
+
+
+def _make_action(action_id: int, review_id: int, **kw) -> ScalpingReviewAction:
+    base = dict(
+        id=action_id,
+        review_id=review_id,
+        action_type="parameter_change",
+        title="widen TP",
+        rationale=None,
+        target_component=None,
+        proposed_change=None,
+        expected_effect=None,
+        status="open",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    base.update(kw)
+    return ScalpingReviewAction(**base)
+
+
+class _StubService:
+    async def list_reviews(self, *, review_date=None, product=None):
+        return [_make_review(1)]
+
+    async def get(self, review_id):
+        return _make_review(review_id) if review_id == 1 else None
+
+    async def list_actions(self, review_id):
+        return [_make_action(10, review_id)]
+
+    async def build_draft(self, *, review_date, product, session_tag, now):
+        return _make_review(
+            2, review_date=review_date, product=product, session_tag=session_tag
+        )
+
+    async def update_review(self, review_id, *, now, **fields):
+        if review_id != 1:
+            return None
+        r = _make_review(1)
+        for k, v in fields.items():
+            setattr(r, k, v)
+        return r
+
+    async def add_action(self, review_id, *, action_type, title, now, **kw):
+        return _make_action(11, review_id, action_type=action_type, title=title)
+
+    async def update_action(self, action_id, *, now, **fields):
+        if action_id != 10:
+            return None
+        a = _make_action(10, 1)
+        for k, v in fields.items():
+            setattr(a, k, v)
+        return a
+
+
+def _client(service=None) -> TestClient:
+    app = FastAPI()
+    app.include_router(scalping_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 7}
+    )()
+    app.dependency_overrides[get_scalping_review_service] = lambda: (
+        service or _StubService()
+    )
+    return TestClient(app)
+
+
+def test_list_reviews_serializes_metrics() -> None:
+    resp = _client().get(
+        "/invest/api/scalping/reviews?date=2026-05-25&product=usdm_futures"
+    )
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    m = items[0]["metrics"]
+    assert m["tradeCount"] == 2
+    assert m["netPnlUsdt"] == "-0.2"  # Decimal serialized as string
+    assert m["avgSpreadBps"] is None  # n/a, not 0
+    assert m["exitReasonCounts"] == {"take_profit": 1, "stop_loss": 1}
+
+
+def test_get_review_includes_actions() -> None:
+    resp = _client().get("/invest/api/scalping/reviews/1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["review"]["id"] == 1
+    assert body["actions"][0]["actionType"] == "parameter_change"
+
+
+def test_get_missing_review_is_404() -> None:
+    assert _client().get("/invest/api/scalping/reviews/999").status_code == 404
+
+
+def test_build_draft_echoes_request() -> None:
+    resp = _client().post(
+        "/invest/api/scalping/reviews/draft",
+        json={"review_date": "2026-05-25", "product": "usdm_futures"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["review"]["product"] == "usdm_futures"
+
+
+def test_patch_review_updates_operator_fields() -> None:
+    resp = _client().patch(
+        "/invest/api/scalping/reviews/1",
+        json={"decision": "adjust", "observation": "spread widened"},
+    )
+    assert resp.status_code == 200
+    review = resp.json()["review"]
+    assert review["decision"] == "adjust"
+    assert review["observation"] == "spread widened"
+
+
+def test_patch_review_rejects_bad_decision() -> None:
+    resp = _client().patch("/invest/api/scalping/reviews/1", json={"decision": "bogus"})
+    assert resp.status_code == 422  # pydantic Literal validation
+
+
+def test_create_action_on_missing_review_is_404() -> None:
+    resp = _client().post(
+        "/invest/api/scalping/reviews/999/actions",
+        json={"action_type": "investigate", "title": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_action_status() -> None:
+    resp = _client().patch(
+        "/invest/api/scalping/actions/10", json={"status": "applied"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["action"]["status"] == "applied"
+
+
+def test_service_error_maps_to_422() -> None:
+    class _Boom(_StubService):
+        async def build_draft(self, **kw):
+            raise ScalpingReviewError("non-demo scope")
+
+    resp = _client(_Boom()).post(
+        "/invest/api/scalping/reviews/draft",
+        json={"review_date": "2026-05-25", "product": "usdm_futures"},
+    )
+    assert resp.status_code == 422
+
+
+_FORBIDDEN_IMPORT_SUBSTRINGS = (
+    "brokers",
+    "scheduler",
+    "executor",
+    "execution_client",
+    "order_intent",
+    "demo_scalping",
+    "kis_trading",
+    "kis_holdings",
+    "upbit",
+    "alpaca",
+    "binance",
+)
+
+
+def test_router_imports_no_broker_order_scheduler_modules() -> None:
+    """The review surface must never import a broker/order/scheduler/market-data
+    mutation module (ROB-315 safety boundary)."""
+    src = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "app"
+        / "routers"
+        / "invest_scalping.py"
+    ).read_text()
+    tree = ast.parse(src)
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+    offenders = [
+        mod for mod in imported for bad in _FORBIDDEN_IMPORT_SUBSTRINGS if bad in mod
+    ]
+    assert not offenders, f"forbidden imports in invest_scalping router: {offenders}"


### PR DESCRIPTION
## Summary

The `/invest` daily scalping **review loop** (ROB-315 Phases 1–3), stacked on the foundation PR #946. Turns the raw `scalp_trade_analytics` rows into a day-by-day improve loop: **실행 → 관측 → 원인 → 개선 → 다음 실행**, using auto_trader DB/API/frontend (no external Notion).

**Stacked on #946** — base is `feature/rob-313-scalping-cost-capture-analytics`; retarget to `main` once #946 merges. This PR's own diff is Phases 1–3 only.

## Phase 1 — review-loop DB + service
- `scalping_daily_reviews` (rollup metrics + operator judgment + `source_payload`) and `scalping_review_actions`. `account_scope` pinned to `binance_demo` (CHECK); `session_tag NOT NULL DEFAULT ''` for idempotent drafts. alembic `20260525_rob315`.
- Pure rollup: `trade_count` = fill-proven only; no-fill rows → `anomaly_count`; telemetry averages over non-NULL only (`None` = "n/a", never 0); capital-weighted `net_return_bps`.
- `ScalpingReviewService`: idempotent `build_draft` (refreshes metrics, preserves operator inputs, leaves `locked` untouched), operator-only edits (raw analytics never touched), actions CRUD, non-demo scope rejected.

## Phase 2 — `/invest/api/scalping`
- Thin read/review router: `GET /reviews`, `GET /reviews/{id}` (+actions), `POST /reviews/draft`, `PATCH /reviews/{id}` (operator fields only), `POST /reviews/{id}/actions`, `PATCH /actions/{id}`, `GET /analytics` (raw per-trade rows). Decimals serialized as strings; null telemetry stays null.
- Static AST import-guard test: the router imports **no** broker/order/scheduler/market-data/venue module.

## Phase 3 — `/invest/scalping` frontend
- New React route + home nav `스캘핑 일지`. Sections: today summary, daily loop card, per-trade analytics table, review actions, demo-only safety panel.
- Empty state explains analytics rows are required; **null telemetry renders explicit "n/a"** (never 0/blank/fabricated); anomaly rows flagged. No order placement / scheduler toggle from the page.

## Safety boundaries
Demo-only; no live/mainnet; no order placement, scheduler unpause, or automatic parameter application from the UI; review actions are operator records only; `account_scope` pinned `binance_demo` (disjoint from KIS/Upbit live).

## Testing
- Backend: rollup units + service (idempotency, scope rejection, operator-only edits, locked-not-refreshed, actions) + API (wiring/serialization/status + import-guard + anomaly flagging). ruff + ty clean; app import smoke OK; alembic single head.
- Frontend: empty state, ready state, null-telemetry n/a rendering — 3 green; tsc typecheck clean.
- Pre-existing date-dependent calendar/coverage frontend test failures are unrelated (verified failing on the clean tree without these changes).

## Operator notes
`alembic upgrade head` applies `20260525_rob315` (additive) on a current DB. No Demo orders were placed; no live trading/order/scheduler mutation performed.

Linear: ROB-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a scalping diary feature allowing users to create, view, and manage daily scalping reviews and analysis.
* Users can build draft reviews, view trade analytics with anomaly detection, and track review actions with status updates.
* New navigation menu item "스캘핑 일지" provides quick access to the scalping review interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->