### PR TITLE
fix(rob-314): portfolio_journal derives NAV/buying_power from nested collector payload

### DIFF
--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -13,6 +13,55 @@ from app.services.investment_stages.stages.base import (
 )
 
 
+def _nested_krw(value: object) -> float | None:
+    """Return the KRW amount from a nested ``{"krw": x, "usd": y}`` block.
+
+    The production portfolio collector emits cash / buying power as nested
+    per-currency dicts (``payload["cash"] = {"krw": ..., "usd": ...}``). Returns
+    ``None`` when the block is absent or carries no KRW figure so callers can
+    fall back to the legacy flat key.
+    """
+    if isinstance(value, dict):
+        krw = value.get("krw")
+        if krw is not None:
+            return float(krw)
+    return None
+
+
+def _portfolio_totals(payload: dict) -> tuple[float, float, float]:
+    """Derive ``(nav_krw, buying_power_krw, cash_krw)`` from a portfolio payload.
+
+    ROB-314: the production collector's payload is nested (``cash.krw``,
+    ``buying_power.krw``, ``holdings[].value_krw``) and carries no canonical
+    total, so NAV is derived as ``sum(holdings value_krw) + cash.krw``. Legacy
+    flat keys (``nav_krw`` / ``buying_power_krw`` / ``cash_krw``) are honoured as
+    a fallback so older fixtures and manual snapshots keep working.
+    """
+    cash_krw = _nested_krw(payload.get("cash"))
+    if cash_krw is None:
+        cash_krw = float(payload.get("cash_krw") or 0.0)
+
+    buying_power_krw = _nested_krw(payload.get("buying_power"))
+    if buying_power_krw is None:
+        buying_power_krw = float(payload.get("buying_power_krw") or 0.0)
+
+    # Prefer an explicit total when present (legacy/flat), otherwise derive it
+    # from the holdings evaluation sum plus cash.
+    explicit_nav = payload.get("nav_krw")
+    if explicit_nav is None:
+        explicit_nav = payload.get("total_evaluation_krw")
+    if explicit_nav is not None:
+        nav_krw = float(explicit_nav)
+    else:
+        holdings = payload.get("holdings") or []
+        holdings_value_krw = sum(
+            float(h.get("value_krw") or 0.0) for h in holdings if isinstance(h, dict)
+        )
+        nav_krw = holdings_value_krw + cash_krw
+
+    return nav_krw, buying_power_krw, cash_krw
+
+
 class PortfolioJournalStage:
     stage_type = "portfolio_journal"
 
@@ -23,10 +72,7 @@ class PortfolioJournalStage:
         portfolio = portfolio_snaps[0]
         journal_snaps = context.snapshots_for("journal")
 
-        nav = float((portfolio.payload_json or {}).get("nav_krw", 0.0))
-        buying_power = float(
-            (portfolio.payload_json or {}).get("buying_power_krw", 0.0)
-        )
+        nav, buying_power, _cash_krw = _portfolio_totals(portfolio.payload_json or {})
         bp_ratio = (buying_power / nav) if nav > 0 else 0.0
 
         entries = []
@@ -37,7 +83,7 @@ class PortfolioJournalStage:
             StageCitation(
                 snapshot_uuid=portfolio.snapshot_uuid,
                 snapshot_kind="portfolio",
-                payload_path="$.buying_power_krw",
+                payload_path="$.buying_power.krw",
             )
         ]
         for snap in journal_snaps:

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -46,3 +46,44 @@ async def test_portfolio_journal_emits_neutral_with_buying_power():
     assert payload.verdict == StageVerdict.NEUTRAL
     assert "035420" in (payload.summary or "")
     assert len(payload.cited_snapshots) >= 1
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_derives_totals_from_nested_kis_payload():
+    """ROB-314 follow-up: the production portfolio collector emits a *nested*
+    payload (``cash.krw``, ``buying_power.krw``, ``holdings[].value_krw``), not
+    the legacy flat ``nav_krw`` / ``buying_power_krw`` keys. The stage must
+    derive non-zero NAV / buying power from the nested shape instead of
+    defaulting to 0 and reporting an empty portfolio for a real account."""
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap(
+                    "portfolio",
+                    {
+                        "count": 2,
+                        "primary_source": "kis",
+                        "cash": {"krw": 3_308_957.0, "usd": None},
+                        "buying_power": {"krw": 3_292_494.5274, "usd": None},
+                        "holdings": [
+                            {"symbol": "035420", "value_krw": 4_000_000.0},
+                            {"symbol": "035720", "value_krw": 2_000_000.0},
+                        ],
+                    },
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+
+    # NAV = holdings value sum (6,000,000) + cash (3,308,957) = 9,308,957
+    assert "NAV=9,308,957" in (payload.summary or "")
+    assert "buying_power_krw=3,292,495" in (payload.summary or "")
+    assert "NAV=0," not in (payload.summary or "")
+    assert "buying_power_krw=0 " not in (payload.summary or "")
+    # buying power ~35% of NAV → healthy → NEUTRAL, confidence 60
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence == 60
+    assert any(c.snapshot_kind == "portfolio" for c in payload.cited_snapshots)


### PR DESCRIPTION
## What & why

Follow-up to #947. The operator's live KR/`kis_live` smoke confirmed #947 fixed the wiring (`status=partial`, `missing_sources=[]`, journal/watch/market `fresh`), but surfaced the **next** blocker: a portfolio payload schema mismatch.

The production portfolio collector emits a **nested** payload:
- `cash.krw`, `buying_power.krw` (per-currency dicts, or `None`)
- `holdings[].value_krw`
- no canonical total field

…but the `portfolio_journal` stage read **flat** keys (`nav_krw`, `buying_power_krw`) and defaulted to `0.0`. So a real account (holdings_count=19, cash≈3.3M KRW, buying_power≈3.29M KRW, `primary_source="kis"`) produced `NAV=0, buying_power_krw=0` in the generated stage.

## Fix

`app/services/investment_stages/stages/portfolio_journal.py` — new `_portfolio_totals()` derives:
- `buying_power_krw` ← `payload.buying_power.krw`
- `cash_krw` ← `payload.cash.krw`
- `nav_krw` ← `sum(holdings[].value_krw) + cash.krw` (no canonical total exists)

Legacy flat keys (`nav_krw` / `buying_power_krw` / `cash_krw`) are honoured as a fallback so existing fixtures and manual snapshots keep working. Citation path corrected to `$.buying_power.krw`.

Verified `hermes_context.py` does **not** independently compute portfolio totals (it only reads `holdings[].ticker` for held-symbol derivation — key confirmed present), so the stage is the sole normalizer. No `ticker`/`symbol` mismatch.

## Tests

`tests/services/investment_stages/stages/test_portfolio_journal.py`:
- **New** `test_portfolio_journal_derives_totals_from_nested_kis_payload` — nested KIS payload with holdings must yield non-zero NAV/buying_power in the summary and cite the portfolio snapshot. (Verified RED first: previously produced `NAV=0, buying_power_krw=0`.)
- Existing flat-key test still green (fallback path).
- Full `tests/services/investment_stages/` + Hermes round-trip smoke: **79 passed**. `make lint` clean.

## Safety

No broker/order/watch mutation; deterministic stage only; no migration; no new LLM. No feature-flag change.

## Operator rerun (post-merge/deploy)

Once merged + deployed (or running the fixed branch), rerun the same localhost `prepare-bundle` + Hermes-context smoke (user_id=1, symbols=["035420","035720"]) and confirm the `portfolio_journal` stage now reports non-zero NAV/buying_power instead of 0. No further user lookup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)