### PR TITLE
fix(rob-315): restore main CI green (import-guard false positive + C408)

### DIFF
--- a/tests/services/brokers/binance/demo/test_no_testnet_imports.py
+++ b/tests/services/brokers/binance/demo/test_no_testnet_imports.py
@@ -19,6 +19,17 @@ _BANNED_PREFIXES = (
 )
 
 
+def _is_banned(module: str) -> bool:
+    """Match a banned package exactly or as a dotted-prefix submodule.
+
+    Uses ``== p`` or ``startswith(p + ".")`` rather than a bare
+    ``startswith(p)`` so a sibling package whose name merely begins with a
+    banned name is not a false positive — e.g. ``app.services.scalping_reviews``
+    (ROB-315 review layer) is NOT the deleted ``app.services.scalping`` package.
+    """
+    return any(module == p or module.startswith(p + ".") for p in _BANNED_PREFIXES)
+
+
 def _scan(roots: list[pathlib.Path]) -> list[str]:
     offenders: list[str] = []
     for root in roots:
@@ -29,13 +40,11 @@ def _scan(roots: list[pathlib.Path]) -> list[str]:
                 continue
             for node in ast.walk(tree):
                 if isinstance(node, ast.ImportFrom):
-                    if node.module and any(
-                        node.module.startswith(p) for p in _BANNED_PREFIXES
-                    ):
+                    if node.module and _is_banned(node.module):
                         offenders.append(f"{py}: from {node.module} import ...")
                 elif isinstance(node, ast.Import):
                     for alias in node.names:
-                        if any(alias.name.startswith(p) for p in _BANNED_PREFIXES):
+                        if _is_banned(alias.name):
                             offenders.append(f"{py}: import {alias.name}")
     return offenders
 

--- a/tests/services/scalping_reviews/test_rollup.py
+++ b/tests/services/scalping_reviews/test_rollup.py
@@ -9,14 +9,14 @@ from app.services.scalping_reviews.rollup import build_rollup
 
 
 def _row(**kw) -> ScalpTradeAnalytics:
-    base = dict(
-        open_client_order_id="o",
-        instrument_id=1,
-        product="usdm_futures",
-        symbol="XRPUSDT",
-        side="BUY",
-        qty=Decimal("1"),
-    )
+    base = {
+        "open_client_order_id": "o",
+        "instrument_id": 1,
+        "product": "usdm_futures",
+        "symbol": "XRPUSDT",
+        "side": "BUY",
+        "qty": Decimal("1"),
+    }
     base.update(kw)
     return ScalpTradeAnalytics(**base)
 

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -10,7 +10,6 @@ import datetime as dt
 from decimal import Decimal
 
 import pytest
-
 from sqlalchemy import select
 
 from app.models.crypto_instruments import CryptoInstrument
@@ -50,16 +49,16 @@ async def _instrument(session, symbol="RVWXRPUSDT") -> int:
 
 
 async def _analytics(session, instrument_id, *, created_at=_NOW, **kw):
-    base = dict(
-        open_client_order_id=f"o-{kw.get('tag', '0')}",
-        instrument_id=instrument_id,
-        product="usdm_futures",
-        symbol="XRPUSDT",
-        side="BUY",
-        qty=Decimal("1"),
-        created_at=created_at,
-        updated_at=created_at,
-    )
+    base = {
+        "open_client_order_id": f"o-{kw.get('tag', '0')}",
+        "instrument_id": instrument_id,
+        "product": "usdm_futures",
+        "symbol": "XRPUSDT",
+        "side": "BUY",
+        "qty": Decimal("1"),
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
     kw.pop("tag", None)
     base.update(kw)
     row = ScalpTradeAnalytics(**base)

--- a/tests/test_invest_api_scalping_router.py
+++ b/tests/test_invest_api_scalping_router.py
@@ -12,7 +12,6 @@ import datetime as dt
 import pathlib
 from decimal import Decimal
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -26,53 +25,53 @@ _NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
 
 
 def _make_review(review_id: int, **kw) -> ScalpingDailyReview:
-    base = dict(
-        id=review_id,
-        review_date=dt.date(2026, 5, 25),
-        product="usdm_futures",
-        account_scope="binance_demo",
-        session_tag="",
-        trade_count=2,
-        win_count=1,
-        loss_count=1,
-        anomaly_count=0,
-        gross_pnl_usdt=Decimal("0.0"),
-        net_pnl_usdt=Decimal("-0.2"),
-        net_return_bps=Decimal("-10"),
-        avg_slippage_bps=Decimal("3"),
-        avg_spread_bps=None,
-        avg_mae_bps=Decimal("-10"),
-        avg_mfe_bps=Decimal("40"),
-        avg_holding_seconds=15,
-        exit_reason_counts={"take_profit": 1, "stop_loss": 1},
-        observation=None,
-        root_cause=None,
-        improvement=None,
-        next_run_plan=None,
-        decision="review",
-        status="draft",
-        source_payload={"row_count": 2},
-        created_at=_NOW,
-        updated_at=_NOW,
-    )
+    base = {
+        "id": review_id,
+        "review_date": dt.date(2026, 5, 25),
+        "product": "usdm_futures",
+        "account_scope": "binance_demo",
+        "session_tag": "",
+        "trade_count": 2,
+        "win_count": 1,
+        "loss_count": 1,
+        "anomaly_count": 0,
+        "gross_pnl_usdt": Decimal("0.0"),
+        "net_pnl_usdt": Decimal("-0.2"),
+        "net_return_bps": Decimal("-10"),
+        "avg_slippage_bps": Decimal("3"),
+        "avg_spread_bps": None,
+        "avg_mae_bps": Decimal("-10"),
+        "avg_mfe_bps": Decimal("40"),
+        "avg_holding_seconds": 15,
+        "exit_reason_counts": {"take_profit": 1, "stop_loss": 1},
+        "observation": None,
+        "root_cause": None,
+        "improvement": None,
+        "next_run_plan": None,
+        "decision": "review",
+        "status": "draft",
+        "source_payload": {"row_count": 2},
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
     base.update(kw)
     return ScalpingDailyReview(**base)
 
 
 def _make_action(action_id: int, review_id: int, **kw) -> ScalpingReviewAction:
-    base = dict(
-        id=action_id,
-        review_id=review_id,
-        action_type="parameter_change",
-        title="widen TP",
-        rationale=None,
-        target_component=None,
-        proposed_change=None,
-        expected_effect=None,
-        status="open",
-        created_at=_NOW,
-        updated_at=_NOW,
-    )
+    base = {
+        "id": action_id,
+        "review_id": review_id,
+        "action_type": "parameter_change",
+        "title": "widen TP",
+        "rationale": None,
+        "target_component": None,
+        "proposed_change": None,
+        "expected_effect": None,
+        "status": "open",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
     base.update(kw)
     return ScalpingReviewAction(**base)
 
@@ -80,25 +79,25 @@ def _make_action(action_id: int, review_id: int, **kw) -> ScalpingReviewAction:
 def _make_analytics(**kw):
     from app.models.scalp_trade_analytics import ScalpTradeAnalytics
 
-    base = dict(
-        id=1,
-        open_client_order_id="o-1",
-        instrument_id=1,
-        product="usdm_futures",
-        symbol="XRPUSDT",
-        side="BUY",
-        qty=Decimal("1"),
-        entry_price=Decimal("100"),
-        exit_price=Decimal("101"),
-        entry_slippage_bps=Decimal("2"),
-        mae_bps=Decimal("-10"),
-        mfe_bps=Decimal("40"),
-        net_pnl_usdt=Decimal("0.9"),
-        holding_seconds=12,
-        exit_reason="take_profit",
-        created_at=_NOW,
-        updated_at=_NOW,
-    )
+    base = {
+        "id": 1,
+        "open_client_order_id": "o-1",
+        "instrument_id": 1,
+        "product": "usdm_futures",
+        "symbol": "XRPUSDT",
+        "side": "BUY",
+        "qty": Decimal("1"),
+        "entry_price": Decimal("100"),
+        "exit_price": Decimal("101"),
+        "entry_slippage_bps": Decimal("2"),
+        "mae_bps": Decimal("-10"),
+        "mfe_bps": Decimal("40"),
+        "net_pnl_usdt": Decimal("0.9"),
+        "holding_seconds": 12,
+        "exit_reason": "take_profit",
+        "created_at": _NOW,
+        "updated_at": _NOW,
+    }
     base.update(kw)
     return ScalpTradeAnalytics(**base)
 


### PR DESCRIPTION
Restores `main` CI green after #948.

#948 was merged via `--auto` while its full Test workflow was still pending (the PR was immediately mergeable), so two failures only surfaced on the post-merge `main` build:

1. **`test_no_testnet_imports.py` (ROB-298 guard)** flagged the new `app.services.scalping_reviews` package — the banned prefix `app.services.scalping` matched it via a bare `startswith()`. Tightened to exact-or-dotted-prefix (`== p or startswith(p + ".")`) so a sibling package whose name merely begins with a banned name is not a false positive. `scalping_reviews` is the ROB-315 review layer, not the deleted `app.services.scalping`.
2. **ruff C408** in the three new scalping test files (CI lints `tests/` too) — `dict(...)` helpers rewritten as `{...}` literals.

Verified locally: `ruff check` + `ruff format --check` clean on `app/ tests/`; guard + scalping_reviews + invest_api_scalping + binance audit suites pass (29).

Linear: ROB-315

🤖 Generated with [Claude Code](https://claude.com/claude-code)