### PR TITLE
feat(rob-317): Binance Demo WebSocket scalping daemon (4-slice, default-disabled)

### DIFF
--- a/app/services/brokers/binance/demo_scalping_exec/ws_bridge.py
+++ b/app/services/brokers/binance/demo_scalping_exec/ws_bridge.py
@@ -43,6 +43,7 @@ TradeRunner = Callable[
     [OrderIntent, MarketConditions, bool, dt.datetime], Awaitable[Any]
 ]
 Clock = Callable[[], dt.datetime]
+SessionFactory = Callable[[], Any]
 
 
 def _default_clock() -> dt.datetime:
@@ -125,3 +126,97 @@ class WsExecutionBridge:
         finally:
             self._inflight.discard(symbol)
             self._global_inflight -= 1
+
+
+def make_demo_futures_trade_runner(
+    *,
+    client: Any,
+    market_data: Any,
+    reference: Any,
+    session_factory: SessionFactory,
+    limits: ScalpingRiskLimits,
+    executor_cls: Any | None = None,
+) -> TradeRunner:
+    """Build a TradeRunner that opens a per-trade session + executor.
+
+    ``executor_cls`` is injectable for tests; production uses the real
+    DemoScalpingExecutor (imported lazily so the disabled path never touches
+    broker/DB modules). Mirrors app/jobs/binance_demo_scalping_runner.py.
+    """
+    if executor_cls is None:
+        from app.services.brokers.binance.demo_scalping_exec.executor import (
+            DemoScalpingExecutor,
+        )
+
+        executor_cls = DemoScalpingExecutor
+
+    async def _run(
+        intent: OrderIntent,
+        market: MarketConditions,
+        confirm: bool,
+        now: dt.datetime,
+    ) -> Any:
+        async with session_factory() as session:
+            executor = executor_cls(
+                product="usdm_futures",
+                client=client,
+                session=session,
+                reference=reference,
+                now=now,
+                market_data=market_data,
+                limits=limits,
+            )
+            result = await executor.execute_monitored(
+                intent, confirm=confirm, market=market
+            )
+            await session.commit()
+            return result
+
+    return _run
+
+
+async def build_ws_execution_bridge_from_env(
+    *,
+    confirm: bool,
+    clock: Clock = _default_clock,
+    limits: ScalpingRiskLimits | None = None,
+) -> tuple[WsExecutionBridge, Callable[[], Awaitable[None]]]:
+    """Construct a futures Demo bridge from env + its async cleanup.
+
+    Lazy imports keep the disabled CLI path free of broker/DB setup. Futures
+    only; demo-fapi only (host-guarded at the client transport).
+    """
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.reference import (
+        DemoReferenceData,
+    )
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+
+    resolved_limits = limits or ScalpingRiskLimits()
+    client = BinanceFuturesDemoExecutionClient.from_env()
+    market_data = DemoScalpingMarketData()
+    reference = DemoReferenceData()
+    runner = make_demo_futures_trade_runner(
+        client=client,
+        market_data=market_data,
+        reference=reference,
+        session_factory=AsyncSessionLocal,
+        limits=resolved_limits,
+    )
+    bridge = WsExecutionBridge(
+        trade_runner=runner, limits=resolved_limits, confirm=confirm, clock=clock
+    )
+
+    async def _aclose() -> None:
+        await market_data.aclose()
+        await reference.aclose()
+        aclose = getattr(client, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+    return bridge, _aclose

--- a/app/services/brokers/binance/demo_scalping_exec/ws_bridge.py
+++ b/app/services/brokers/binance/demo_scalping_exec/ws_bridge.py
@@ -1,0 +1,127 @@
+"""ROB-317 — WS trigger → Demo executor bridge (the only mutation path).
+
+The supervisor (read-only package) emits TriggerEvents; this exec-side
+callback turns an allowed, confirmed trigger into a real Demo order via the
+existing DemoScalpingExecutor. The executor owns the authoritative
+ledger-backed risk re-check and analytics — this bridge adds only the
+in-process concurrency guard the executor lacks, builds the order intent +
+market snapshot, and passes the confirm flag through.
+
+Concurrency: on_trigger is awaited sequentially by the supervisor; with a
+global open-lifecycle cap of 1 at most one position exists at a time. The
+guard uses synchronous counters (race-free in single-threaded asyncio) so a
+second trigger for the same symbol — or any symbol once the global cap is
+reached — is skipped rather than double-entered. See ROB-317 design §6.2.
+
+No live host, no order placed unless ``confirm=True`` (which the client/
+executor layer enforces and tests).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Awaitable, Callable
+from decimal import Decimal
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.order_intent import (
+    OrderIntent,
+    build_order_intent,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
+
+logger = logging.getLogger("rob317.ws_bridge")
+
+# (intent, market, confirm, now) -> execution result
+TradeRunner = Callable[
+    [OrderIntent, MarketConditions, bool, dt.datetime], Awaitable[Any]
+]
+Clock = Callable[[], dt.datetime]
+
+
+def _default_clock() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+def _spread_bps(bid: Decimal | None, ask: Decimal | None) -> Decimal:
+    """Best-bid/ask spread in bps; 0 when a side is missing (preflight will
+    re-evaluate against the executor's own snapshot too)."""
+    if bid is None or ask is None or bid <= 0 or ask <= 0:
+        return Decimal("0")
+    mid = (bid + ask) / Decimal("2")
+    return (ask - bid) / mid * Decimal("10000")
+
+
+class WsExecutionBridge:
+    """Trigger → confirm-gated, concurrency-guarded Demo executor call."""
+
+    def __init__(
+        self,
+        *,
+        trade_runner: TradeRunner,
+        limits: ScalpingRiskLimits | None = None,
+        confirm: bool = False,
+        clock: Clock = _default_clock,
+    ) -> None:
+        self._trade_runner = trade_runner
+        self._limits = limits or ScalpingRiskLimits()
+        self._confirm = confirm
+        self._clock = clock
+        self._global_cap = self._limits.global_open_lifecycle_cap
+        self._inflight: set[str] = set()
+        self._global_inflight = 0
+
+    async def __call__(self, trigger: TriggerEvent) -> None:
+        symbol = trigger.symbol
+        # Synchronous guard checks + reservation: no await between check and
+        # reserve, so this is race-free under single-threaded asyncio.
+        if symbol in self._inflight:
+            logger.info(
+                "ws_bridge skip symbol=%s reason=%s",
+                symbol,
+                ReasonCode.OPEN_LIFECYCLE_EXISTS,
+            )
+            return
+        if self._global_inflight >= self._global_cap:
+            logger.info(
+                "ws_bridge skip symbol=%s reason=%s",
+                symbol,
+                ReasonCode.GLOBAL_LIFECYCLE_CAP_REACHED,
+            )
+            return
+        self._inflight.add(symbol)
+        self._global_inflight += 1
+        try:
+            now = self._clock()
+            intent = build_order_intent(
+                trigger.decision,
+                product=trigger.product,
+                symbol=symbol,
+                limits=self._limits,
+                source_candle_close_time_ms=trigger.source_candle_close_time_ms,
+                evaluated_at_ms=int(now.timestamp() * 1000),
+            )
+            if intent is None:
+                return
+            market = MarketConditions(
+                spread_bps=_spread_bps(trigger.bid_price, trigger.ask_price),
+                data_age_seconds=trigger.data_age_seconds or 0.0,
+                spot_free_base_qty=Decimal("0"),
+            )
+            result = await self._trade_runner(intent, market, self._confirm, now)
+            logger.info(
+                "ws_bridge executed symbol=%s side=%s confirm=%s status=%s",
+                symbol,
+                trigger.side,
+                self._confirm,
+                getattr(result, "status", None),
+            )
+        finally:
+            self._inflight.discard(symbol)
+            self._global_inflight -= 1

--- a/app/services/brokers/binance/demo_scalping_ws/__init__.py
+++ b/app/services/brokers/binance/demo_scalping_ws/__init__.py
@@ -1,0 +1,10 @@
+"""ROB-317 — Binance Demo WebSocket scalping daemon (read-only hot path).
+
+This package holds the read-only hot-path units: market-data stream
+decoding, in-memory state, and the event-driven trigger. It MUST NOT import
+any signed execution client, the demo_scalping_exec package, or the demo
+ledger writer — that boundary is AST-enforced by
+``tests/services/brokers/binance/demo/test_no_testnet_imports.py``. Only the
+exec-side ws_bridge (slice 4) may reach mutation layers. See ROB-317 design
+§3.
+"""

--- a/app/services/brokers/binance/demo_scalping_ws/config.py
+++ b/app/services/brokers/binance/demo_scalping_ws/config.py
@@ -1,0 +1,55 @@
+"""ROB-317 — WS scalping daemon gate configuration (default-disabled).
+
+Three independent gates, all default false:
+
+* ``BINANCE_DEMO_SCALPING_ENABLED``     — master capability (shared)
+* ``BINANCE_DEMO_SCALPING_WS_ENABLED``  — long-running WS daemon gate
+* ``BINANCE_DEMO_SCALPING_WS_CONFIRM``  — real Demo order-mutation gate
+
+The daemon does NOT reuse the scheduler confirm flag
+(``BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM``). Daemon and scheduler are gated
+independently so enabling one never silently enables the other.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_BASE_ENV = "BINANCE_DEMO_SCALPING_ENABLED"
+_WS_ENV = "BINANCE_DEMO_SCALPING_WS_ENABLED"
+_WS_CONFIRM_ENV = "BINANCE_DEMO_SCALPING_WS_CONFIRM"
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class WsDaemonGates:
+    """Resolved daemon gate state. Defaults to fully disabled."""
+
+    base_enabled: bool
+    ws_enabled: bool
+    ws_confirm: bool
+
+    @property
+    def daemon_active(self) -> bool:
+        """True only when the daemon may subscribe and evaluate triggers."""
+        return self.base_enabled and self.ws_enabled
+
+    @property
+    def mutation_allowed(self) -> bool:
+        """True only when real Demo order mutation is permitted (all three on)."""
+        return self.base_enabled and self.ws_enabled and self.ws_confirm
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "WsDaemonGates":
+        source = dict(os.environ) if env is None else env
+        return cls(
+            base_enabled=_truthy(source.get(_BASE_ENV)),
+            ws_enabled=_truthy(source.get(_WS_ENV)),
+            ws_confirm=_truthy(source.get(_WS_CONFIRM_ENV)),
+        )

--- a/app/services/brokers/binance/demo_scalping_ws/config.py
+++ b/app/services/brokers/binance/demo_scalping_ws/config.py
@@ -46,7 +46,7 @@ class WsDaemonGates:
         return self.base_enabled and self.ws_enabled and self.ws_confirm
 
     @classmethod
-    def from_env(cls, env: dict[str, str] | None = None) -> "WsDaemonGates":
+    def from_env(cls, env: dict[str, str] | None = None) -> WsDaemonGates:
         source = dict(os.environ) if env is None else env
         return cls(
             base_enabled=_truthy(source.get(_BASE_ENV)),

--- a/app/services/brokers/binance/demo_scalping_ws/events.py
+++ b/app/services/brokers/binance/demo_scalping_ws/events.py
@@ -1,0 +1,48 @@
+"""ROB-317 — event → state mutation + kline → Candle mapping (pure).
+
+``apply_event`` updates quote/trade fields + freshness timestamps from
+bookTicker/aggTrade events. Freshness is stamped from each event's OWN
+receipt/trade time (design §5: "last event received"), not a wall clock, so
+the supervisor's trigger-time clock measures true staleness against it.
+Closed klines deliberately do NOT update quote freshness (a dead bookTicker
+stream must still trip STALE_DATA); klines are routed to the signal buffer
+by the supervisor instead.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    FuturesWsEvent,
+)
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+
+def apply_event(state: MarketState, event: FuturesWsEvent) -> None:
+    """Mutate ``state`` from a market event. Klines are a no-op here.
+
+    Freshness timestamps come from the event itself (``received_at`` for
+    bookTicker, ``trade_time`` for aggTrade).
+    """
+    if isinstance(event, BookTickerEvent):
+        state.bid_price = event.bid_price
+        state.ask_price = event.ask_price
+        state.book_ticker_at = event.received_at
+    elif isinstance(event, AggTradeEvent):
+        state.last_trade_price = event.price
+        state.agg_trade_at = event.trade_time
+    # KlineEvent: intentionally no state mutation (routed to the signal buffer).
+
+
+def kline_to_candle(event: KlineEvent) -> Candle:
+    """Map a closed-kline event to the signal's Candle value object."""
+    return Candle(
+        open_time_ms=int(event.open_time.timestamp() * 1000),
+        open=event.open,
+        high=event.high,
+        low=event.low,
+        close=event.close,
+        close_time_ms=int(event.close_time.timestamp() * 1000),
+    )

--- a/app/services/brokers/binance/demo_scalping_ws/health.py
+++ b/app/services/brokers/binance/demo_scalping_ws/health.py
@@ -1,0 +1,55 @@
+"""ROB-317 — daemon health/heartbeat snapshot (pure data + JSON).
+
+Emitted for Hermes/Prefect liveness polling. Contains only operational
+status — never credentials or order payloads. See ROB-317 design §8.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolHealth:
+    """Per-symbol freshness view for the health snapshot."""
+
+    symbol: str
+    fresh: bool
+    last_event_at: dt.datetime | None
+    age_seconds: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonHealthSnapshot:
+    """Point-in-time daemon liveness snapshot."""
+
+    generated_at: dt.datetime
+    connected: bool
+    daemon_active: bool
+    mutation_allowed: bool
+    symbols: tuple[SymbolHealth, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "connected": self.connected,
+            "daemon_active": self.daemon_active,
+            "mutation_allowed": self.mutation_allowed,
+            "symbols": [
+                {
+                    "symbol": s.symbol,
+                    "fresh": s.fresh,
+                    "last_event_at": (
+                        s.last_event_at.isoformat() if s.last_event_at else None
+                    ),
+                    "age_seconds": s.age_seconds,
+                }
+                for s in self.symbols
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)

--- a/app/services/brokers/binance/demo_scalping_ws/market_stream.py
+++ b/app/services/brokers/binance/demo_scalping_ws/market_stream.py
@@ -1,0 +1,155 @@
+"""ROB-317 — futures public market stream (read-only, fstream).
+
+Parses the USD-M futures combined-stream payloads the daemon consumes:
+aggTrade (momentum/freshness), bookTicker (spread/freshness), and closed
+kline_1m (signal). Unsigned, read-only. Host is guarded against the
+read-only PUBLIC_FUTURES_STREAM_HOSTS allowlist — never a signed mutation
+host. See ROB-317 design §2, §4.
+
+This module intentionally does NOT reuse BinancePublicWSClient's parser:
+the futures payload shape differs (bookTicker carries "e":"bookTicker";
+aggTrade is a stream the spot parser does not handle). It reuses only the
+pure backoff helpers (compute_backoff_delay / is_unhealthy).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import urllib.parse
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import websockets
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.host_allowlist import (
+    PUBLIC_FUTURES_STREAM_HOSTS,
+)
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+_DEFAULT_BASE_URL = "wss://fstream.binance.com"
+
+
+@dataclass(frozen=True, slots=True)
+class AggTradeEvent:
+    symbol: str
+    price: Decimal
+    qty: Decimal
+    trade_time: dt.datetime
+    is_buyer_maker: bool
+
+
+FuturesWsEvent = KlineEvent | BookTickerEvent | AggTradeEvent
+
+
+def parse_futures_message(raw: str, *, now: dt.datetime) -> FuturesWsEvent | None:
+    """Parse one combined-stream message into a normalized event, or None.
+
+    Returns None for malformed JSON, in-progress klines (``x: False``), and
+    stream types the daemon does not consume. ``now`` is the receipt time
+    used for bookTicker freshness (injected for deterministic tests).
+    """
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    data = msg.get("data") if isinstance(msg, dict) and "data" in msg else msg
+    if not isinstance(data, dict):
+        return None
+    etype = data.get("e")
+    if etype == "kline":
+        k = data.get("k") or {}
+        if not k.get("x"):
+            return None
+        return KlineEvent(
+            symbol=k["s"],
+            interval=k["i"],
+            open_time=dt.datetime.fromtimestamp(k["t"] / 1000.0, tz=dt.UTC),
+            close_time=dt.datetime.fromtimestamp(k["T"] / 1000.0, tz=dt.UTC),
+            open=Decimal(k["o"]),
+            high=Decimal(k["h"]),
+            low=Decimal(k["l"]),
+            close=Decimal(k["c"]),
+            base_volume=Decimal(k["v"]),
+            quote_volume=Decimal(k["q"]),
+            trade_count=int(k["n"]),
+            is_closed=True,
+        )
+    if etype == "bookTicker":
+        return BookTickerEvent(
+            symbol=data["s"],
+            bid_price=Decimal(data["b"]),
+            bid_qty=Decimal(data["B"]),
+            ask_price=Decimal(data["a"]),
+            ask_qty=Decimal(data["A"]),
+            received_at=now,
+        )
+    if etype == "aggTrade":
+        return AggTradeEvent(
+            symbol=data["s"],
+            price=Decimal(data["p"]),
+            qty=Decimal(data["q"]),
+            trade_time=dt.datetime.fromtimestamp(data["T"] / 1000.0, tz=dt.UTC),
+            is_buyer_maker=bool(data["m"]),
+        )
+    return None
+
+
+def _assert_host_allowed(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    # Local test override mirrors ROB-285: 127.0.0.1 over plain ws is the
+    # websockets.serve fixture; production is always wss to fstream.
+    if host == "127.0.0.1" and parsed.scheme == "ws":
+        return
+    if host not in PUBLIC_FUTURES_STREAM_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Futures stream host blocked: {host!r} not in "
+            f"{sorted(PUBLIC_FUTURES_STREAM_HOSTS)}"
+        )
+
+
+def build_futures_stream_url(
+    symbols: Sequence[str],
+    *,
+    streams: Sequence[str],
+    base_url: str = _DEFAULT_BASE_URL,
+) -> str:
+    """Build a combined-stream URL for ``symbols`` × ``streams``, host-guarded."""
+    _assert_host_allowed(base_url)
+    parts = [f"{s.lower()}@{stream}" for s in symbols for stream in streams]
+    return f"{base_url.rstrip('/')}/stream?streams=" + "/".join(parts)
+
+
+class FuturesMarketStream:
+    """Read-only futures combined-stream subscriber (host-guarded)."""
+
+    def __init__(self, *, url: str) -> None:
+        _assert_host_allowed(url)
+        self._url = url
+        self._ws: Any = None
+
+    async def __aenter__(self) -> FuturesMarketStream:
+        self._ws = await websockets.connect(self._url, ping_interval=20)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+
+    async def events(
+        self, *, stop_after: int | None = None
+    ) -> AsyncIterator[FuturesWsEvent]:
+        assert self._ws is not None, "FuturesMarketStream not connected"
+        emitted = 0
+        async for raw in self._ws:
+            ev = parse_futures_message(raw, now=dt.datetime.now(tz=dt.UTC))
+            if ev is None:
+                continue
+            yield ev
+            emitted += 1
+            if stop_after is not None and emitted >= stop_after:
+                return

--- a/app/services/brokers/binance/demo_scalping_ws/signal.py
+++ b/app/services/brokers/binance/demo_scalping_ws/signal.py
@@ -1,0 +1,50 @@
+"""ROB-317 — event-driven scalping signal.
+
+Wraps the pure, candle-based ``demo_scalping.signal.evaluate_signal`` with a
+bounded rolling buffer. On each closed kline the buffer is appended and the
+signal re-evaluated — reacting at candle close rather than on a 5-minute
+timer. The strategy/thresholds are reused verbatim; only the feed cadence
+changes. See ROB-317 design §1, §3.2.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from app.services.brokers.binance.demo_scalping.contract import Product
+from app.services.brokers.binance.demo_scalping.signal import (
+    Candle,
+    SignalConfig,
+    SignalDecision,
+    evaluate_signal,
+)
+from app.services.brokers.binance.demo_scalping_ws.events import kline_to_candle
+from app.services.brokers.binance.ws_client import KlineEvent
+
+
+class EventDrivenSignal:
+    """Per-symbol rolling-buffer adapter over ``evaluate_signal``."""
+
+    def __init__(
+        self,
+        *,
+        product: Product,
+        symbol: str,
+        config: SignalConfig | None = None,
+        max_candles: int = 200,
+    ) -> None:
+        self._product = product
+        self._symbol = symbol
+        # Spot is long-only; futures may take the mirror short (same default
+        # as demo_scalping.runner.evaluate_symbol).
+        self._config = config or SignalConfig(allow_short=product == "usdm_futures")
+        self._candles: deque[Candle] = deque(maxlen=max_candles)
+
+    @property
+    def candle_count(self) -> int:
+        return len(self._candles)
+
+    def ingest_kline(self, event: KlineEvent) -> SignalDecision:
+        """Append the closed candle and re-evaluate the signal."""
+        self._candles.append(kline_to_candle(event))
+        return evaluate_signal(list(self._candles), self._config)

--- a/app/services/brokers/binance/demo_scalping_ws/state.py
+++ b/app/services/brokers/binance/demo_scalping_ws/state.py
@@ -36,3 +36,16 @@ class MarketState:
         if last is None:
             return True
         return (now - last).total_seconds() > max_age_seconds
+
+    def book_data_age_seconds(self, *, now: dt.datetime) -> float | None:
+        """Seconds since the last bookTicker quote, or ``None`` if none yet.
+
+        Execution gates on this — the spread guard needs a live best bid/ask.
+        aggTrade freshness is momentum context only and must NOT substitute for
+        a current quote, so it is deliberately excluded here (unlike
+        ``last_event_at``/``is_stale``, which span all streams). See ROB-317
+        design §5.
+        """
+        if self.book_ticker_at is None:
+            return None
+        return (now - self.book_ticker_at).total_seconds()

--- a/app/services/brokers/binance/demo_scalping_ws/state.py
+++ b/app/services/brokers/binance/demo_scalping_ws/state.py
@@ -1,0 +1,38 @@
+"""ROB-317 — per-symbol in-memory market state + freshness.
+
+Pure data structures: no network, no broker, no DB. The supervisor (slice 3)
+mutates these from decoded WS events; the trigger (slice 3) reads them.
+Freshness is measured from the last event RECEIVED — a half-dead socket can
+stay "open" while delivering nothing, so connection liveness is not a
+freshness signal. See ROB-317 design §5.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(slots=True)
+class MarketState:
+    """Latest quote/trade for one symbol, with per-stream receipt timestamps."""
+
+    symbol: str
+    bid_price: Decimal | None = None
+    ask_price: Decimal | None = None
+    last_trade_price: Decimal | None = None
+    book_ticker_at: dt.datetime | None = None
+    agg_trade_at: dt.datetime | None = None
+
+    def last_event_at(self) -> dt.datetime | None:
+        """Most recent receipt across all streams, or None if no data yet."""
+        stamps = [t for t in (self.book_ticker_at, self.agg_trade_at) if t is not None]
+        return max(stamps) if stamps else None
+
+    def is_stale(self, *, now: dt.datetime, max_age_seconds: float) -> bool:
+        """True when no event arrived within ``max_age_seconds`` (or ever)."""
+        last = self.last_event_at()
+        if last is None:
+            return True
+        return (now - last).total_seconds() > max_age_seconds

--- a/app/services/brokers/binance/demo_scalping_ws/supervisor.py
+++ b/app/services/brokers/binance/demo_scalping_ws/supervisor.py
@@ -1,0 +1,207 @@
+"""ROB-317 — asyncio scalping daemon supervisor.
+
+Consumes an injectable event source (real fstream client in production, a
+fake async iterator in tests). Routes closed klines to the per-symbol
+signal; on an entry, emits a TriggerEvent only when the symbol's quote/trade
+data is fresh and the per-symbol debounce window has elapsed. bookTicker/
+aggTrade events refresh state. Reconnect/backoff is added in Task 5.
+
+This slice performs NO risk re-check and NO broker mutation: ``on_trigger``
+is a caller-supplied coroutine (slice 4 wires it to the executor bridge;
+this slice logs structured JSON). See ROB-317 design §6.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    Product,
+    ReasonCode,
+    ScalpingRiskLimits,
+    Side,
+)
+from app.services.brokers.binance.demo_scalping.signal import (
+    SignalConfig,
+    SignalDecision,
+)
+from app.services.brokers.binance.demo_scalping_ws.events import apply_event
+from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
+from app.services.brokers.binance.demo_scalping_ws.signal import EventDrivenSignal
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+from app.services.brokers.binance.ws_client import (
+    KlineEvent,
+    compute_backoff_delay,
+    is_unhealthy,
+)
+
+logger = logging.getLogger("rob317.demo_scalping_ws")
+
+SourceFactory = Callable[[], AsyncIterator[FuturesWsEvent]]
+OnTrigger = Callable[["TriggerEvent"], Awaitable[None]]
+Clock = Callable[[], dt.datetime]
+Sleep = Callable[[float], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerEvent:
+    """An event-driven entry candidate, pre-risk-check (slice 4 consumes it)."""
+
+    product: Product
+    symbol: str
+    side: Side
+    decision: SignalDecision
+    source_candle_close_time_ms: int
+    bid_price: Decimal | None
+    ask_price: Decimal | None
+    data_age_seconds: float | None
+    emitted_at: dt.datetime
+
+
+def _default_clock() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+class ScalpingDaemonSupervisor:
+    """Per-symbol event router with freshness + debounce gates."""
+
+    def __init__(
+        self,
+        *,
+        symbols: list[str],
+        product: Product = "usdm_futures",
+        limits: ScalpingRiskLimits | None = None,
+        signal_config: SignalConfig | None = None,
+        debounce_seconds: float = 300.0,
+        clock: Clock = _default_clock,
+    ) -> None:
+        self._product = product
+        self._limits = limits or ScalpingRiskLimits()
+        self._debounce_seconds = debounce_seconds
+        self._clock = clock
+        self._state: dict[str, MarketState] = {
+            s: MarketState(symbol=s) for s in symbols
+        }
+        self._signals: dict[str, EventDrivenSignal] = {
+            s: EventDrivenSignal(product=product, symbol=s, config=signal_config)
+            for s in symbols
+        }
+        self._last_trigger_at: dict[str, dt.datetime] = {}
+
+    async def run(
+        self,
+        source_factory: SourceFactory,
+        *,
+        on_trigger: OnTrigger,
+        stop_after: int | None = None,
+    ) -> None:
+        """Consume one source to exhaustion (single pass; reconnect: Task 5)."""
+        consumed = 0
+        source = source_factory()
+        async for event in source:
+            trigger = self._handle_event(event)
+            if trigger is not None:
+                await on_trigger(trigger)
+            consumed += 1
+            if stop_after is not None and consumed >= stop_after:
+                return
+
+    def _handle_event(self, event: FuturesWsEvent) -> TriggerEvent | None:
+        now = self._clock()
+        symbol = event.symbol
+        state = self._state.get(symbol)
+        if state is None:
+            return None  # not an allowlisted/subscribed symbol
+        if not isinstance(event, KlineEvent):
+            apply_event(state, event)
+            return None
+        decision = self._signals[symbol].ingest_kline(event)
+        if not decision.has_entry or decision.side is None:
+            return None
+        return self._gate_and_build(
+            symbol,
+            state,
+            decision,
+            now,
+            source_candle_close_time_ms=int(event.close_time.timestamp() * 1000),
+        )
+
+    def _gate_and_build(
+        self,
+        symbol: str,
+        state: MarketState,
+        decision: SignalDecision,
+        now: dt.datetime,
+        *,
+        source_candle_close_time_ms: int,
+    ) -> TriggerEvent | None:
+        if state.is_stale(now=now, max_age_seconds=self._limits.max_data_age_seconds):
+            logger.info(
+                "trigger suppressed symbol=%s reason=%s",
+                symbol,
+                ReasonCode.STALE_DATA,
+            )
+            return None
+        last = self._last_trigger_at.get(symbol)
+        if last is not None and (now - last).total_seconds() < self._debounce_seconds:
+            logger.info("trigger suppressed symbol=%s reason=debounce", symbol)
+            return None
+        self._last_trigger_at[symbol] = now
+        last_event = state.last_event_at()
+        age = None if last_event is None else (now - last_event).total_seconds()
+        logger.info(
+            "trigger symbol=%s side=%s reasons=%s",
+            symbol,
+            decision.side,
+            decision.reason_codes,
+        )
+        return TriggerEvent(
+            product=self._product,
+            symbol=symbol,
+            side=decision.side,
+            decision=decision,
+            source_candle_close_time_ms=source_candle_close_time_ms,
+            bid_price=state.bid_price,
+            ask_price=state.ask_price,
+            data_age_seconds=age,
+            emitted_at=now,
+        )
+
+    async def run_with_reconnect(
+        self,
+        source_factory: SourceFactory,
+        *,
+        on_trigger: OnTrigger,
+        sleep: Sleep = asyncio.sleep,
+    ) -> None:
+        """Run with reconnect: back off on connection errors until unhealthy.
+
+        Clean source exhaustion ends the loop. A connection error backs off
+        (ROB-285 jittered exponential) and re-invokes the factory; once
+        consecutive failures reach the unhealthy threshold the error is
+        re-raised for the operator/supervisor above to handle.
+        """
+        consecutive_failures = 0
+        while True:
+            try:
+                await self.run(source_factory, on_trigger=on_trigger)
+                return
+            except (ConnectionError, OSError) as exc:
+                consecutive_failures += 1
+                if is_unhealthy(consecutive_failures):
+                    logger.error(
+                        "WS daemon unhealthy after %d consecutive failures: %s",
+                        consecutive_failures,
+                        exc,
+                    )
+                    raise
+                delay = compute_backoff_delay(consecutive_failures - 1)
+                logger.warning(
+                    "WS stream error (%s); reconnecting in %.2fs", exc, delay
+                )
+                await sleep(delay)

--- a/app/services/brokers/binance/demo_scalping_ws/supervisor.py
+++ b/app/services/brokers/binance/demo_scalping_ws/supervisor.py
@@ -1,14 +1,16 @@
 """ROB-317 — asyncio scalping daemon supervisor.
 
 Consumes an injectable event source (real fstream client in production, a
-fake async iterator in tests). Routes closed klines to the per-symbol
-signal; on an entry, emits a TriggerEvent only when the symbol's quote/trade
-data is fresh and the per-symbol debounce window has elapsed. bookTicker/
-aggTrade events refresh state. Reconnect/backoff is added in Task 5.
+fake async iterator in tests). Routes closed klines to the per-symbol signal;
+on an entry, emits a TriggerEvent only when the symbol has a fresh bookTicker
+quote (best bid/ask present and within the freshness window) and the
+per-symbol debounce window has elapsed. bookTicker/aggTrade events refresh
+state; aggTrade is momentum context only and never substitutes for a live
+quote. ``run_with_reconnect`` backs off on stream drops.
 
-This slice performs NO risk re-check and NO broker mutation: ``on_trigger``
-is a caller-supplied coroutine (slice 4 wires it to the executor bridge;
-this slice logs structured JSON). See ROB-317 design §6.
+The supervisor performs NO risk re-check and NO broker mutation: ``on_trigger``
+is a caller-supplied coroutine (the WsExecutionBridge wires the confirm-gated
+executor; the executor owns the ledger risk re-check). See ROB-317 design §6.
 """
 
 from __future__ import annotations
@@ -19,6 +21,8 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from decimal import Decimal
+
+from websockets.exceptions import ConnectionClosed
 
 from app.services.brokers.binance.demo_scalping.contract import (
     Product,
@@ -140,7 +144,18 @@ class ScalpingDaemonSupervisor:
         *,
         source_candle_close_time_ms: int,
     ) -> TriggerEvent | None:
-        if state.is_stale(now=now, max_age_seconds=self._limits.max_data_age_seconds):
+        # Execution requires a live quote: a fresh bookTicker with both sides
+        # present. A fresh aggTrade alone does NOT qualify — without a current
+        # best bid/ask the spread guard would receive spread=0 and pass, which
+        # could place a confirmed order with no valid spread check. aggTrade
+        # freshness stays momentum/trigger context only.
+        book_age = state.book_data_age_seconds(now=now)
+        if (
+            state.bid_price is None
+            or state.ask_price is None
+            or book_age is None
+            or book_age > self._limits.max_data_age_seconds
+        ):
             logger.info(
                 "trigger suppressed symbol=%s reason=%s",
                 symbol,
@@ -152,8 +167,6 @@ class ScalpingDaemonSupervisor:
             logger.info("trigger suppressed symbol=%s reason=debounce", symbol)
             return None
         self._last_trigger_at[symbol] = now
-        last_event = state.last_event_at()
-        age = None if last_event is None else (now - last_event).total_seconds()
         logger.info(
             "trigger symbol=%s side=%s reasons=%s",
             symbol,
@@ -168,7 +181,9 @@ class ScalpingDaemonSupervisor:
             source_candle_close_time_ms=source_candle_close_time_ms,
             bid_price=state.bid_price,
             ask_price=state.ask_price,
-            data_age_seconds=age,
+            # bookTicker age feeds the execution/spread guard, not the (possibly
+            # newer) aggTrade timestamp.
+            data_age_seconds=book_age,
             emitted_at=now,
         )
 
@@ -185,13 +200,18 @@ class ScalpingDaemonSupervisor:
         (ROB-285 jittered exponential) and re-invokes the factory; once
         consecutive failures reach the unhealthy threshold the error is
         re-raised for the operator/supervisor above to handle.
+
+        ``websockets.exceptions.ConnectionClosed`` (incl. ConnectionClosedOK/
+        ConnectionClosedError) is caught explicitly — it is NOT a subclass of
+        ConnectionError/OSError, so a real socket close would otherwise crash
+        the daemon instead of reconnecting.
         """
         consecutive_failures = 0
         while True:
             try:
                 await self.run(source_factory, on_trigger=on_trigger)
                 return
-            except (ConnectionError, OSError) as exc:
+            except (ConnectionError, OSError, ConnectionClosed) as exc:
                 consecutive_failures += 1
                 if is_unhealthy(consecutive_failures):
                     logger.error(

--- a/app/services/brokers/binance/host_allowlist.py
+++ b/app/services/brokers/binance/host_allowlist.py
@@ -33,3 +33,28 @@ def assert_allowed_host(host: str) -> None:
             f"Host {host!r} is not in PUBLIC_HOSTS. "
             "Allowed: " + ", ".join(sorted(PUBLIC_HOSTS))
         )
+
+
+# ROB-317 — read-only public USD-M futures WS stream host. Unsigned market
+# data only. Intentionally ABSENT from every signed mutation allowlist
+# (FUTURES_DEMO_HOSTS / SPOT_DEMO_HOSTS): fstream is read-allowed here but the
+# futures-demo signed transport still rejects it (it is in that transport's
+# _LIVE_FUTURES_HOSTS deny path). See ROB-317 design §2.
+PUBLIC_FUTURES_STREAM_HOSTS: frozenset[str] = frozenset(
+    {
+        "fstream.binance.com",
+    }
+)
+
+
+def assert_public_futures_stream_host(host: str) -> None:
+    """Raise BinanceLiveHostBlocked if host is not the public futures stream host.
+
+    Strict equality match — no suffix/wildcard, so subdomain spoofs like
+    ``fstream.binance.com.evil.example`` are rejected.
+    """
+    if host not in PUBLIC_FUTURES_STREAM_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Public futures stream host blocked: {host!r} not in "
+            f"{sorted(PUBLIC_FUTURES_STREAM_HOSTS)}"
+        )

--- a/docs/plans/ROB-317-binance-demo-websocket-scalping-daemon.md
+++ b/docs/plans/ROB-317-binance-demo-websocket-scalping-daemon.md
@@ -165,16 +165,21 @@ daemon does not introduce a second symbol source.
 
 **Streams per symbol:**
 
-* `@aggTrade` — trade prints for momentum and **trigger freshness** (the primary
-  scalping signal driver).
-* `@bookTicker` — best bid/ask for **spread guard** and freshness.
-* `@kline_1m` *(optional)* — closed-candle state, to reuse the existing
-  candle-based signal where safe.
+* `@kline_1m` — closed-candle state. **This is the signal driver:** the trigger
+  fires when a 1m candle closes, reusing the existing candle-based
+  `evaluate_signal` (SMA + breakout) verbatim. Reacting at candle close (vs. up
+  to 5 min later) is the improvement over polling — not sub-second ticks.
+* `@bookTicker` — best bid/ask. Feeds the **spread guard** and the **required
+  quote-freshness gate** (a trigger is emitted only with a fresh bid/ask).
+* `@aggTrade` — trade prints; **momentum/liveness context only**. It does NOT
+  drive the current signal and never substitutes for a bookTicker quote.
 
-> Note: the ROB-285 `BinancePublicWSClient` emits **closed** klines only
-> (`x: True`); in-progress candles are dropped. Tick-level scalping therefore
-> rides `aggTrade`/`bookTicker`, not 1m candle closes. A **futures aggTrade
-> parser** is added (the existing client parses kline + bookTicker only).
+> Note: the current signal is **closed-1m-kline based**, not tick-level. A true
+> tick-level signal would consume `aggTrade`/in-progress klines, but the
+> ROB-285 `BinancePublicWSClient` emits **closed** klines only (`x: True`), and
+> redefining the strategy is out of scope (issue: "reuse existing signal logic
+> where safe"). A **futures aggTrade parser** is added for freshness/liveness
+> (the existing client parses kline + bookTicker only).
 
 ---
 

--- a/docs/plans/ROB-317-binance-demo-websocket-scalping-daemon.md
+++ b/docs/plans/ROB-317-binance-demo-websocket-scalping-daemon.md
@@ -1,0 +1,426 @@
+# Binance Demo WebSocket Scalping Daemon (ROB-317) — Design + Runbook
+
+**Status.** Design / slice 1. No daemon code ships with this document; the
+module skeleton, CLI, bridge, and tests land in later slices (see §13).
+
+**Scope.** Design and operator runbook for a long-running, WebSocket-driven
+scalping **daemon** that replaces the 5-minute Prefect polling tick as the
+*true* scalping hot path for the Binance **Futures Demo** lane
+(`demo-fapi.binance.com`). The daemon consumes live public futures market
+streams read-only, evaluates triggers event-by-event, and routes confirmed
+entries through the **existing** demo scalping risk → executor → ledger →
+analytics → review layers. Order mutation never leaves `demo-fapi.binance.com`.
+
+This document satisfies ROB-317 Scope §1 (design first) and the design/runbook
+acceptance criteria. Related work: ROB-307 (demo scalping MVP), ROB-313/ROB-315
+(cost-capture + analytics + review loop), ROB-285 (public market data WS,
+read-only), ROB-298 (demo execution clients + unified ledger).
+
+---
+
+## 1. Why the 5-minute Prefect flow is polling, not scalping
+
+Today's path:
+
+```text
+Prefect every 5 min
+  -> python -m scripts.binance_demo_scalping_tick
+  -> REST polling: 1m kline / bookTicker  (demo-fapi, via DemoScalpingMarketData)
+  -> deterministic signal (demo_scalping/signal.py)
+  -> DemoScalpingExecutor (demo_scalping_exec/)
+  -> binance_demo_order_ledger / scalp_trade_analytics / scalping_daily_reviews
+```
+
+A 5-minute REST tick is a **low-frequency intraday/day-trading** cadence. By the
+time a tick fires, a scalp-sized move (seconds to low minutes) has already come
+and gone. The cadence is bounded by the scheduler interval, not by market
+events. This is fine for observation, smoke validation, and reconciliation —
+but it is structurally incapable of *true scalping*, which must react to market
+events the moment they occur.
+
+**This flow is retained, not deleted.** It is reclassified as **polling
+intraday / compatibility / smoke path**. The WS daemon is the true scalping hot
+path. Pausing the Prefect tick is an operator decision deferred until the daemon
+is validated (see §11.6).
+
+Target path:
+
+```text
+launchd/native (dev) | container/systemd (prod) long-running service
+  -> live public futures WS streams (fstream.binance.com, read-only, unsigned)
+  -> in-memory per-symbol MarketState + per-symbol event queues
+  -> event-driven trigger (reuses demo_scalping signal + risk contract)
+  -> async concurrency guard (per-symbol lock + global semaphore)
+  -> ws_bridge -> existing DemoScalpingExecutor (demo-fapi, confirm-gated)
+  -> binance_demo_order_ledger / scalp_trade_analytics / scalping_daily_reviews
+```
+
+---
+
+## 2. Lane boundaries — market data vs order mutation
+
+The daemon deliberately splits the **read-only market-data host** from the
+**signed order-mutation host**. These are different hosts and different
+allowlists, and they must never be conflated.
+
+| Lane | Host | Auth | Used by daemon for | Status |
+|---|---|---|---|---|
+| **Public futures stream (read)** | **`fstream.binance.com`** | unsigned | aggTrade / bookTicker / kline market data | **New read-only WS allowlist (this issue)** |
+| **Futures Demo (mutate)** | **`demo-fapi.binance.com`** | signed (`BINANCE_FUTURES_DEMO_*`) | order submit / cancel / reconcile | Existing (ROB-298 PR 2) |
+| Spot Demo | `demo-api.binance.com` | signed | — (not used by this daemon) | Existing |
+| Live futures (signed) | `fapi.binance.com`, `fstream.binance.com` | signed | **never** | Refused fail-closed (signed deny-list) |
+| Futures testnet | `testnet.binancefuture.com` | — | **never** | Refused fail-closed (deprecated) |
+
+### 2.1 Why market data rides a live public host (locked decision)
+
+There is **no demo-only futures market WS host**. `demo-fapi.binance.com` serves
+signed order/account REST; it does not expose a public market stream. The only
+public futures WS is the live `fstream.binance.com`.
+
+**Decision (ROB-317): read-only live public futures WS for market data; orders
+stay demo-only.** Rationale:
+
+* The stream is **unsigned, read-only public market data** — the same feed every
+  client reads. No credentials, no mutation, no account exposure.
+* It reuses the ROB-285 `BinancePublicWSClient` pattern instead of inventing a
+  parallel client.
+
+**Accepted tradeoff — price-source mismatch.** The signal is evaluated on the
+**live** public book while fills land on the **demo** book, which can diverge
+(thin/synthetic demo liquidity). This is acceptable because the demo lane's
+purpose is to validate the *execution plumbing and safety contract*, not PnL
+fidelity. This tradeoff is stated here so it is not mistaken for a bug later.
+
+### 2.2 Hard invariants
+
+* A **new** `PUBLIC_FUTURES_STREAM_HOSTS = {"fstream.binance.com"}` allowlist
+  gates the daemon's WS client. It is **read-only/unsigned** and physically
+  separate from the futures-demo signed transport.
+* `fstream.binance.com` **remains in the futures-demo signed-transport
+  deny-list.** A signed request to `fstream` still raises
+  `BinanceFuturesDemoCrossAllowlistViolation` / `BinanceLiveHostBlocked`. The
+  read-only WS allowlist (`{fstream.binance.com}`) and the signed mutation
+  allowlist (`FUTURES_DEMO_HOSTS = {demo-fapi.binance.com}`) are **disjoint** —
+  no host is both read-allowed *and* signed-allowed. Tests assert (a) that
+  disjointness and (b) that the signed transport still rejects `fstream` even
+  though the read path permits it.
+* Order mutation only ever signs against `FUTURES_DEMO_HOSTS =
+  {"demo-fapi.binance.com"}` — unchanged from ROB-298.
+* No live order path, no live signed host, no testnet host. Ever.
+
+---
+
+## 3. Module boundary & package layout
+
+The existing **read-only signal package** vs **mutation execution package** split
+(ROB-307, AST-guarded) is preserved and extended. The daemon's read-only hot
+path is a new package; the trigger→executor bridge lives on the **exec** side.
+
+```text
+app/services/brokers/binance/demo_scalping_ws/        # NEW — read-only, no signed clients
+  market_stream.py   # futures WS subscriber; wraps/extends BinancePublicWSClient;
+                     #   reconnect + exponential backoff; aggTrade + bookTicker (+ kline_1m)
+  state.py           # per-symbol MarketState: last bid/ask/trade/kline + per-stream recv ts
+  signal.py          # event-driven trigger; reuses demo_scalping/signal.py + contract.py (pure)
+  supervisor.py      # asyncio event loop, per-symbol queues, lifecycle, heartbeat, debounce
+  health.py          # status snapshot (JSON) + stale-data checks
+
+app/services/brokers/binance/demo_scalping_exec/      # EXISTING — mutation side
+  ws_bridge.py       # NEW — trigger -> live ledger risk re-check -> DemoScalpingExecutor
+
+scripts/
+  binance_demo_scalping_ws_daemon.py                  # NEW — default-disabled CLI entrypoint
+```
+
+### 3.1 Import-guard contract
+
+`tests/services/brokers/binance/demo/test_no_testnet_imports.py` gains an
+assertion: **`demo_scalping_ws/` may not import** any of
+`*_demo/execution_client`, `demo_scalping_exec/`, or `demo/ledger/`. The daemon's
+read-only package can compute triggers but cannot reach a signed client or the
+ledger writer directly — only `ws_bridge.py` (on the exec side) may. This keeps
+the read-only boundary AST-verifiable, exactly as ROB-307 established.
+
+### 3.2 Reuse map (do not reinvent)
+
+| Concern | Reused component | New code |
+|---|---|---|
+| Signal logic | `demo_scalping/signal.py` (`evaluate_signal`) | event-driven adapter only |
+| Risk contract | `demo_scalping/contract.py` (`ScalpingRiskLimits`, `evaluate_risk`, `ReasonCode`) | none |
+| Ledger state | `demo_scalping/ledger_state.py` (`LedgerSnapshot`) | none |
+| Execution | `demo_scalping_exec/executor.py` (`DemoScalpingExecutor`) | `ws_bridge.py` caller |
+| Ledger writes | `demo/ledger/service.py` (`BinanceDemoLedgerService`) | none |
+| Analytics | `demo_scalping_exec/analytics.py` (`ScalpTradeAnalyticsService`) | none |
+| Daily review | `scalping_reviews` + `ScalpingReviewService` (ROB-315) | none |
+| Public WS | `ws_client.py` (`BinancePublicWSClient`, ROB-285) | futures host + aggTrade parser |
+
+---
+
+## 4. Streams, symbols, and the market-data feed
+
+**Symbols (conservative, demo-only, unchanged from ROB-307 §5):** `XRPUSDT`,
+`DOGEUSDT`, `SOLUSDT`. `BTCUSDT` excluded (MIN_NOTIONAL > 10 USDT cap). The
+existing `ScalpingRiskLimits.allowlist`/`excluded` remain authoritative; the
+daemon does not introduce a second symbol source.
+
+**Streams per symbol:**
+
+* `@aggTrade` — trade prints for momentum and **trigger freshness** (the primary
+  scalping signal driver).
+* `@bookTicker` — best bid/ask for **spread guard** and freshness.
+* `@kline_1m` *(optional)* — closed-candle state, to reuse the existing
+  candle-based signal where safe.
+
+> Note: the ROB-285 `BinancePublicWSClient` emits **closed** klines only
+> (`x: True`); in-progress candles are dropped. Tick-level scalping therefore
+> rides `aggTrade`/`bookTicker`, not 1m candle closes. A **futures aggTrade
+> parser** is added (the existing client parses kline + bookTicker only).
+
+---
+
+## 5. In-memory state & data-freshness model
+
+`state.py` holds a per-symbol `MarketState`: latest bid/ask/qty, latest trade
+price/qty, optional latest closed kline, and a **`last_event_at` timestamp per
+stream**.
+
+**"Connection alive ≠ data fresh."** A silently half-dead socket can keep the
+connection object open while delivering nothing. Freshness is therefore measured
+from **last event received**, not from connection state:
+
+* Trigger evaluation blocks with `ReasonCode.STALE_DATA` when
+  `now - last_event_at > max_data_age_seconds` (existing 120s = 2×1m candle).
+* The heartbeat (§8) surfaces per-symbol/per-stream staleness for external
+  liveness checks.
+* Reconnect/backoff (§6) repairs the socket; freshness guard protects trades in
+  the meantime.
+
+---
+
+## 6. Trigger, concurrency, and reconnect model
+
+### 6.1 Event-driven trigger
+
+The supervisor runs one consumer task per symbol over a per-symbol event queue.
+On each relevant event it: updates `MarketState`, checks freshness, then
+evaluates the (pure, deterministic) trigger. No fixed timer. Repeated triggers
+within a per-symbol **debounce** window are suppressed to absorb event bursts.
+
+### 6.2 Concurrency — two-layer guard (closes the async race)
+
+The DB ledger reflects only *committed* state. Between "submit entry" and
+"ledger reconcile," an event-driven daemon could fire a second entry for the
+same symbol — a race the sequential 5-minute tick never had. Defense:
+
+1. **In-process asyncio guards (new):** a per-symbol lock + a global semaphore
+   with capacity matching `global_open_lifecycle_cap` (1). The symbol is locked
+   **before** the bridge call and released only after reconcile. This covers the
+   in-flight window the DB cannot see yet.
+2. **DB ledger re-check (existing):** `ws_bridge.py` re-loads the live
+   `LedgerSnapshot` and re-runs `evaluate_risk` immediately before any executor
+   call — the durable backstop, unchanged from ROB-307.
+3. **Debounce (new):** per-symbol minimum interval between triggers.
+
+Trigger evaluation stays sync/pure; only the bridge call is awaited and
+serialized through the guards.
+
+### 6.3 Reconnect / backoff / heartbeat
+
+`market_stream.py` reconnects with exponential backoff + jitter on socket
+drop/error and re-subscribes the symbol set. A heartbeat records last successful
+event time per stream. If reconnect/backoff is not fully implemented in an early
+slice, it ships as an explicit stub with `TODO` + a test asserting the stub's
+contract (per acceptance criteria).
+
+---
+
+## 7. Safety gates & environment (3-layer)
+
+```text
+BINANCE_DEMO_SCALPING_ENABLED=false        # existing master capability (signal/exec/scheduler)
+BINANCE_DEMO_SCALPING_WS_ENABLED=false     # NEW: long-running WS daemon gate (default false)
+BINANCE_DEMO_SCALPING_WS_CONFIRM=false     # NEW: real Demo order-mutation gate (default false)
+```
+
+* **All three true** is required for any broker mutation.
+* The daemon does **not** reuse the scheduler's confirm flag
+  (`BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM`). Daemon and scheduler are
+  independently gated so enabling one never silently enables the other.
+* Signed credentials resolve via the existing `BINANCE_FUTURES_DEMO_*` /
+  canonical `BINANCE_DEMO_*` chain (ROB-302). The daemon reads no new secrets and
+  prints none.
+
+**Gate behavior:**
+
+| State | Subscribe? | Trigger/risk runs? | Broker mutation? |
+|---|---|---|---|
+| `WS_ENABLED=false` (or master off) | No | No | No |
+| `WS_ENABLED=true`, `WS_CONFIRM=false` | Yes | Yes (preview/dry-run) | **No** — executor dry-run only |
+| all three true | Yes | Yes | Yes (`demo-fapi`, demo-only) |
+
+**Retained risk contract (unchanged):** symbol allowlist + `BTCUSDT` exclusion,
+max notional 10 USDT, daily order cap 10, daily loss budget 5 USDT, cooldown
+300s, spread guard 20bps, data-freshness guard, one-open-lifecycle/global cap.
+Risk-blocked paths log the accumulated `ReasonCode`s and place no order.
+
+**Fail-closed** when credentials, stream host, DB, or ledger state is
+unavailable: the daemon refuses to trigger rather than trading blind.
+
+---
+
+## 8. Operational integration (inert in the code PR)
+
+* **CLI:** `python -m scripts.binance_demo_scalping_ws_daemon` — default-disabled;
+  with all gates off it parses config, reports disabled, and exits without
+  subscribing.
+* **launchd plist:** a **template** lives in this runbook (§11.7) only. It is
+  **not** loaded/unloaded/enabled by tests or migrations. launchd is a local-Mac
+  dev convenience; the **production** runtime target is a Linux container /
+  systemd unit (this repo deploys via Docker — see `DEPLOYMENT.md`), so ops
+  activation is not left hanging on a macOS-only artifact.
+* **Health/heartbeat:** `health.py` emits a JSON snapshot — per-symbol freshness,
+  connection state, last trigger reason, last outcome — for Hermes/Prefect to
+  poll for liveness.
+* **Structured logs:** symbol, trigger reason, risk reason code, outcome. No
+  secrets.
+
+**Prefect's role going forward** (it is **not** the hot-path trigger): daemon
+health checks, reconciliation sweeps, daily review draft generation,
+failure-only notifications, operator reports. The existing 5-minute deployment
+is **not removed** here; an ops note recommends renaming/treating it as polling
+intraday and pausing it only after the daemon is validated.
+
+---
+
+## 9. Non-goals / prohibited side effects
+
+* No Binance live trading, no live endpoint routing, no real/live orders.
+* No production `confirm=true` daemon run as part of tests.
+* No editing or printing of secrets/credentials.
+* No cron-based recurrence; no TaskIQ scheduling of the hot-path daemon.
+* No deletion/rewrite of existing ledger/analytics/review tables.
+* No marking related Linear issues Done; no mutating production
+  scheduler/launchd/Prefect state without explicit operator approval.
+
+---
+
+## 10. Testing plan (fakes only — no network, no real orders)
+
+Fake stream client + fake execution/risk client. Required coverage:
+
+* websocket event → state update → signal trigger path;
+* disabled gate blocks all subscription and execution;
+* `confirm=false` blocks all broker mutation;
+* stale stream/data guard blocks the trigger;
+* risk-gate-blocked path logs reason codes, places no order;
+* one-open-lifecycle / duplicate-trigger guard, **including the in-flight race**
+  (second event during an unreconciled entry);
+* reconnect/backoff or stream-failure handling;
+* CLI config parsing + default-disabled behavior;
+* **new:** `PUBLIC_FUTURES_STREAM_HOSTS` is read-only and the futures-demo signed
+  transport still rejects `fstream.binance.com`.
+
+---
+
+## 11. Runbook
+
+### 11.1 Preconditions
+- `BINANCE_FUTURES_DEMO_*` (or canonical `BINANCE_DEMO_*`) credentials present in
+  the operator env (never committed).
+- DB reachable; `binance_demo_order_ledger` migrated.
+
+### 11.2 Default-disabled startup (safe smoke)
+```bash
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+# All gates off -> prints "disabled", subscribes to nothing, exits 0.
+```
+
+### 11.3 Dry-run (stream + trigger + risk, NO orders)
+```bash
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_CONFIRM=false \
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+# Subscribes fstream (read-only), evaluates triggers, runs risk + executor preview.
+# Broker mutation is never reached. Watch structured logs for trigger/risk reasons.
+```
+
+### 11.4 Confirm-gated Demo startup (real demo-fapi orders)
+```bash
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_CONFIRM=true \
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+# Places real DEMO orders on demo-fapi.binance.com only. Still subject to every
+# risk gate. Verify via the ledger after the first round-trip.
+```
+
+### 11.5 Health check
+```bash
+# Poll the health snapshot (path/transport finalized in the code slice).
+# Confirm: connection=connected, each symbol fresh (age < 120s), last outcome sane.
+```
+
+### 11.6 Stop / rollback
+- Stop the process (Ctrl-C / `launchctl unload` / container stop).
+- To disable without stopping config plumbing: set `BINANCE_DEMO_SCALPING_WS_ENABLED=false` and restart.
+- Open positions: reconcile via the existing demo futures reconcile path / smoke CLI; the daemon does not leave positions it cannot account for (one-open-lifecycle + reconcile gate).
+- The 5-minute Prefect tick is unaffected and remains the fallback observation path.
+
+### 11.7 launchd template (dev only — do NOT auto-load)
+```xml
+<!-- ~/Library/LaunchAgents/dev.robin.binance-demo-scalping-ws.plist (template) -->
+<!-- Operator loads manually; never loaded/enabled by tests or migrations. -->
+<!-- Prod runtime target is a Linux container/systemd unit, not launchd. -->
+```
+(Full plist finalized with the code slice; this section is the placement note.)
+
+### 11.8 Failure categories
+| Category | Symptom | Daemon behavior |
+|---|---|---|
+| Stream disconnect | socket drop/error | reconnect w/ backoff; freshness guard blocks trades until fresh |
+| Stale data | events stop, socket "open" | `STALE_DATA` blocks trigger; heartbeat flags it |
+| Risk block | cap/cooldown/spread hit | log reason codes, no order |
+| Credential/DB/ledger unavailable | startup or runtime | fail closed, refuse to trade |
+| Confirm off | dry-run | preview only, no mutation |
+
+---
+
+## 12. Acceptance-criteria mapping
+
+| Acceptance item | Where addressed |
+|---|---|
+| Polling-vs-scalping distinction + final architecture | §1 |
+| Runbook: disabled/dry-run/confirm/health/stop/failure | §11 |
+| 5-min tick documented as polling intraday/smoke | §1, §8 |
+| Default-disabled WS entrypoint | §3, §7, §11.2 |
+| Demo/testnet-safe streams for allowlisted symbols | §2, §4 |
+| In-memory state + freshness/stale guards | §5 |
+| Event-driven trigger -> risk/executor bridge | §3, §6 |
+| confirm=false never mutates; disabled never subscribes | §7 |
+| Risk-blocked logs reason codes, no order | §6.2, §7 |
+| One-open-lifecycle / concurrency guard | §6.2 |
+| Reconnect/backoff + heartbeat (or stubbed + tested) | §6.3 |
+| Test list | §10 |
+
+---
+
+## 13. Slicing (per ROB-307 4-PR precedent)
+
+1. **This doc** — design/runbook (Scope §1). *(current slice)*
+2. Skeleton (`demo_scalping_ws/` modules) + CLI + new read-only allowlist +
+   import-guard assertion + disabled-path tests.
+3. Stream → state → trigger + freshness + reconnect/backoff (fake stream tests).
+4. `ws_bridge.py` → live ledger risk re-check → `DemoScalpingExecutor` +
+   two-layer concurrency guard + confirm gate + analytics/review wiring +
+   dedicated `docs/runbooks/` entry.
+
+---
+
+## 14. Handoff checklist (final PR series)
+
+Per ROB-317 "Verification / handoff": branch + PR URLs; files changed; tests run
++ results; migrations (none expected — reuses existing tables); exact env flags
+for dry-run vs confirm; explicit statement that no live orders / no production
+scheduler mutation / no secret logging occurred; recommended Hermes post-merge
+checks (health poll + ledger spot-check after first confirmed round-trip).

--- a/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice2-implementation-plan.md
+++ b/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice2-implementation-plan.md
@@ -1,0 +1,936 @@
+# Binance Demo WS Scalping Daemon — Slice 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the default-disabled foundation of the ROB-317 WebSocket scalping daemon — the read-only public-futures host allowlist, the 3-layer gate config, the pure in-memory market-state + freshness model, the health snapshot, a default-disabled CLI, and the AST import-guard for the new read-only package.
+
+**Architecture:** This is slice 2 of 4 (slice 1 = the design doc `docs/plans/ROB-317-binance-demo-websocket-scalping-daemon.md`). It ships only complete, fully-tested, **inert** units — no WS streaming, no signal trigger, no broker bridge (those are slices 3–4). Everything here is pure/deterministic or gate-gated, so it is independently shippable and provably safe: with gates off the CLI subscribes to nothing and mutates nothing.
+
+**Tech Stack:** Python 3.13, `uv`, `pytest`, `ruff`, stdlib `dataclasses`/`datetime`/`decimal`/`ast`. No new third-party deps. Mirrors existing ROB-298/ROB-307 patterns (`host_allowlist.py`, `_truthy` env gating, the `test_no_testnet_imports.py` AST guard).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `app/services/brokers/binance/host_allowlist.py` (modify) | Add read-only `PUBLIC_FUTURES_STREAM_HOSTS` + `assert_public_futures_stream_host()` |
+| `app/services/brokers/binance/demo_scalping_ws/__init__.py` (create) | New read-only hot-path package marker |
+| `app/services/brokers/binance/demo_scalping_ws/config.py` (create) | `WsDaemonGates` — 3-layer env gating |
+| `app/services/brokers/binance/demo_scalping_ws/state.py` (create) | `MarketState` — per-symbol price/quote + freshness |
+| `app/services/brokers/binance/demo_scalping_ws/health.py` (create) | `DaemonHealthSnapshot` — liveness JSON |
+| `scripts/binance_demo_scalping_ws_daemon.py` (create) | Default-disabled CLI entrypoint |
+| `tests/services/brokers/binance/test_public_futures_stream_allowlist.py` (create) | Allowlist + disjointness + signed-reject |
+| `tests/services/brokers/binance/demo_scalping_ws/test_config.py` (create) | Gate parsing |
+| `tests/services/brokers/binance/demo_scalping_ws/test_state.py` (create) | State + freshness |
+| `tests/services/brokers/binance/demo_scalping_ws/test_health.py` (create) | Health snapshot JSON |
+| `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py` (create) | CLI default-disabled behavior |
+| `tests/services/brokers/binance/demo/test_no_testnet_imports.py` (modify) | Add `demo_scalping_ws/` boundary assertion |
+
+**Deferred to later slices (do NOT create here):** `market_stream.py`, `signal.py`, `supervisor.py` (slice 3); `demo_scalping_exec/ws_bridge.py` + concurrency guard + confirm-gated executor wiring (slice 4).
+
+---
+
+### Task 1: Read-only public futures stream allowlist
+
+`fstream.binance.com` is the only public futures WS host. It is read-only/unsigned and must be **disjoint from every signed mutation allowlist**; the futures-demo signed transport must still reject it (it already lives in that transport's `_LIVE_FUTURES_HOSTS` deny path). See design §2.
+
+**Files:**
+- Modify: `app/services/brokers/binance/host_allowlist.py`
+- Test: `tests/services/brokers/binance/test_public_futures_stream_allowlist.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/test_public_futures_stream_allowlist.py`:
+
+```python
+"""ROB-317 — read-only public futures stream allowlist.
+
+fstream.binance.com is read-allowed (unsigned market data) but
+signed-blocked (the futures-demo signed transport rejects it). The two
+purposes never share a host with any signed mutation allowlist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.futures_demo.host_allowlist import (
+    FUTURES_DEMO_HOSTS,
+    assert_futures_demo_host,
+)
+from app.services.brokers.binance.host_allowlist import (
+    PUBLIC_FUTURES_STREAM_HOSTS,
+    PUBLIC_HOSTS,
+    assert_public_futures_stream_host,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import SPOT_DEMO_HOSTS
+
+
+def test_only_fstream() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS == frozenset({"fstream.binance.com"})
+
+
+def test_disjoint_from_signed_mutation_allowlists() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(FUTURES_DEMO_HOSTS)
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(SPOT_DEMO_HOSTS)
+
+
+def test_disjoint_from_public_spot_stream_allowlist() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(PUBLIC_HOSTS)
+
+
+def test_signed_futures_transport_still_rejects_fstream() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        assert_futures_demo_host("fstream.binance.com")
+
+
+def test_assert_accepts_fstream() -> None:
+    assert_public_futures_stream_host("fstream.binance.com")  # no raise
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "fapi.binance.com",  # live signed futures
+        "demo-fapi.binance.com",  # demo signed futures (mutation lane)
+        "stream.binance.com",  # spot public stream
+        "fstream.binance.com.evil.example",  # spoofed subdomain
+    ],
+)
+def test_assert_rejects_non_fstream(host: str) -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        assert_public_futures_stream_host(host)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/test_public_futures_stream_allowlist.py -v`
+Expected: FAIL — `ImportError: cannot import name 'PUBLIC_FUTURES_STREAM_HOSTS'`.
+
+- [ ] **Step 3: Add the allowlist to `host_allowlist.py`**
+
+Append to `app/services/brokers/binance/host_allowlist.py` (after the existing `assert_allowed_host`):
+
+```python
+# ROB-317 — read-only public USD-M futures WS stream host. Unsigned market
+# data only. Intentionally ABSENT from every signed mutation allowlist
+# (FUTURES_DEMO_HOSTS / SPOT_DEMO_HOSTS): fstream is read-allowed here but the
+# futures-demo signed transport still rejects it (it is in that transport's
+# _LIVE_FUTURES_HOSTS deny path). See ROB-317 design §2.
+PUBLIC_FUTURES_STREAM_HOSTS: frozenset[str] = frozenset(
+    {
+        "fstream.binance.com",
+    }
+)
+
+
+def assert_public_futures_stream_host(host: str) -> None:
+    """Raise BinanceLiveHostBlocked if host is not the public futures stream host.
+
+    Strict equality match — no suffix/wildcard, so subdomain spoofs like
+    ``fstream.binance.com.evil.example`` are rejected.
+    """
+    if host not in PUBLIC_FUTURES_STREAM_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Public futures stream host blocked: {host!r} not in "
+            f"{sorted(PUBLIC_FUTURES_STREAM_HOSTS)}"
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/test_public_futures_stream_allowlist.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/host_allowlist.py \
+        tests/services/brokers/binance/test_public_futures_stream_allowlist.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): read-only public futures stream allowlist (fstream)
+
+Slice 2. Adds PUBLIC_FUTURES_STREAM_HOSTS + assert_public_futures_stream_host
+for the WS daemon's read-only market data. Disjoint from every signed
+mutation allowlist; the futures-demo signed transport still rejects fstream.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: WS daemon gate config (`WsDaemonGates`)
+
+Three independent gates, all default false. The daemon does NOT reuse the scheduler's confirm flag. `mutation_allowed` requires `daemon_active`, so `WS_CONFIRM=true` alone (without `WS_ENABLED`) can never enable mutation. See design §7.
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/__init__.py`
+- Create: `app/services/brokers/binance/demo_scalping_ws/config.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/__init__.py` (empty file) and `tests/services/brokers/binance/demo_scalping_ws/test_config.py`:
+
+```python
+"""ROB-317 — WS daemon gate config (default-disabled)."""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def test_empty_env_is_fully_disabled() -> None:
+    gates = WsDaemonGates.from_env({})
+    assert gates.base_enabled is False
+    assert gates.ws_enabled is False
+    assert gates.ws_confirm is False
+    assert gates.daemon_active is False
+    assert gates.mutation_allowed is False
+
+
+def test_daemon_active_requires_both_base_and_ws() -> None:
+    assert WsDaemonGates.from_env(
+        {"BINANCE_DEMO_SCALPING_ENABLED": "true"}
+    ).daemon_active is False
+    assert WsDaemonGates.from_env(
+        {"BINANCE_DEMO_SCALPING_WS_ENABLED": "true"}
+    ).daemon_active is False
+    assert WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+        }
+    ).daemon_active is True
+
+
+def test_confirm_alone_never_enables_mutation() -> None:
+    # Confirm true but ws_enabled false -> no mutation.
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_CONFIRM": "true",
+        }
+    )
+    assert gates.mutation_allowed is False
+
+
+def test_mutation_allowed_requires_all_three() -> None:
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_CONFIRM": "true",
+        }
+    )
+    assert gates.mutation_allowed is True
+
+
+def test_does_not_read_scheduler_confirm_flag() -> None:
+    # The scheduler's confirm flag must not enable the daemon's mutation.
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM": "true",
+        }
+    )
+    assert gates.ws_confirm is False
+    assert gates.mutation_allowed is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_config.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.brokers.binance.demo_scalping_ws'`.
+
+- [ ] **Step 3: Create the package and config**
+
+Create `app/services/brokers/binance/demo_scalping_ws/__init__.py`:
+
+```python
+"""ROB-317 — Binance Demo WebSocket scalping daemon (read-only hot path).
+
+This package holds the read-only hot-path units: market-data stream
+decoding, in-memory state, and the event-driven trigger. It MUST NOT import
+any signed execution client, the demo_scalping_exec package, or the demo
+ledger writer — that boundary is AST-enforced by
+``tests/services/brokers/binance/demo/test_no_testnet_imports.py``. Only the
+exec-side ws_bridge (slice 4) may reach mutation layers. See ROB-317 design
+§3.
+"""
+```
+
+Create `app/services/brokers/binance/demo_scalping_ws/config.py`:
+
+```python
+"""ROB-317 — WS scalping daemon gate configuration (default-disabled).
+
+Three independent gates, all default false:
+
+* ``BINANCE_DEMO_SCALPING_ENABLED``     — master capability (shared)
+* ``BINANCE_DEMO_SCALPING_WS_ENABLED``  — long-running WS daemon gate
+* ``BINANCE_DEMO_SCALPING_WS_CONFIRM``  — real Demo order-mutation gate
+
+The daemon does NOT reuse the scheduler confirm flag
+(``BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM``). Daemon and scheduler are gated
+independently so enabling one never silently enables the other.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_BASE_ENV = "BINANCE_DEMO_SCALPING_ENABLED"
+_WS_ENV = "BINANCE_DEMO_SCALPING_WS_ENABLED"
+_WS_CONFIRM_ENV = "BINANCE_DEMO_SCALPING_WS_CONFIRM"
+
+
+def _truthy(value: str | None) -> bool:
+    if not value:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True, slots=True)
+class WsDaemonGates:
+    """Resolved daemon gate state. Defaults to fully disabled."""
+
+    base_enabled: bool
+    ws_enabled: bool
+    ws_confirm: bool
+
+    @property
+    def daemon_active(self) -> bool:
+        """True only when the daemon may subscribe and evaluate triggers."""
+        return self.base_enabled and self.ws_enabled
+
+    @property
+    def mutation_allowed(self) -> bool:
+        """True only when real Demo order mutation is permitted (all three on)."""
+        return self.base_enabled and self.ws_enabled and self.ws_confirm
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "WsDaemonGates":
+        source = dict(os.environ) if env is None else env
+        return cls(
+            base_enabled=_truthy(source.get(_BASE_ENV)),
+            ws_enabled=_truthy(source.get(_WS_ENV)),
+            ws_confirm=_truthy(source.get(_WS_CONFIRM_ENV)),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_config.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/__init__.py \
+        app/services/brokers/binance/demo_scalping_ws/config.py \
+        tests/services/brokers/binance/demo_scalping_ws/__init__.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_config.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): WS daemon 3-layer gate config (default-disabled)
+
+Slice 2. WsDaemonGates with daemon_active (base+ws) and mutation_allowed
+(base+ws+confirm). Does not read the scheduler confirm flag; confirm alone
+never enables mutation.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Per-symbol market state + freshness
+
+Pure in-memory state. No network/broker/DB. Freshness is measured from the last event **received**, not from socket liveness ("connection alive != data fresh"). See design §5.
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/state.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_state.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_state.py`:
+
+```python
+"""ROB-317 — per-symbol market state + freshness guard."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_new_state_has_no_events_and_is_stale() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    assert state.last_event_at() is None
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is True
+
+
+def test_last_event_at_is_max_across_streams() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    state.book_ticker_at = _NOW - dt.timedelta(seconds=10)
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=3)
+    assert state.last_event_at() == _NOW - dt.timedelta(seconds=3)
+
+
+def test_fresh_within_max_age() -> None:
+    state = MarketState(symbol="XRPUSDT", bid_price=Decimal("0.5"))
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=30)
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is False
+
+
+def test_stale_beyond_max_age() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=200)
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_state.py -v`
+Expected: FAIL — `ImportError: cannot import name 'MarketState'`.
+
+- [ ] **Step 3: Create `state.py`**
+
+```python
+"""ROB-317 — per-symbol in-memory market state + freshness.
+
+Pure data structures: no network, no broker, no DB. The supervisor (slice 3)
+mutates these from decoded WS events; the trigger (slice 3) reads them.
+Freshness is measured from the last event RECEIVED — a half-dead socket can
+stay "open" while delivering nothing, so connection liveness is not a
+freshness signal. See ROB-317 design §5.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+
+
+@dataclass(slots=True)
+class MarketState:
+    """Latest quote/trade for one symbol, with per-stream receipt timestamps."""
+
+    symbol: str
+    bid_price: Decimal | None = None
+    ask_price: Decimal | None = None
+    last_trade_price: Decimal | None = None
+    book_ticker_at: dt.datetime | None = None
+    agg_trade_at: dt.datetime | None = None
+
+    def last_event_at(self) -> dt.datetime | None:
+        """Most recent receipt across all streams, or None if no data yet."""
+        stamps = [t for t in (self.book_ticker_at, self.agg_trade_at) if t is not None]
+        return max(stamps) if stamps else None
+
+    def is_stale(self, *, now: dt.datetime, max_age_seconds: float) -> bool:
+        """True when no event arrived within ``max_age_seconds`` (or ever)."""
+        last = self.last_event_at()
+        if last is None:
+            return True
+        return (now - last).total_seconds() > max_age_seconds
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_state.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/state.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_state.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): per-symbol MarketState + last-event freshness guard
+
+Slice 2. Pure in-memory state; freshness measured from last event received,
+not socket liveness.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Daemon health snapshot
+
+Pure data + JSON for Hermes/Prefect liveness polling. No secrets. See design §8.
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/health.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_health.py`:
+
+```python
+"""ROB-317 — daemon health snapshot JSON."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+from app.services.brokers.binance.demo_scalping_ws.health import (
+    DaemonHealthSnapshot,
+    SymbolHealth,
+)
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_snapshot_serializes_to_json() -> None:
+    snap = DaemonHealthSnapshot(
+        generated_at=_NOW,
+        connected=True,
+        daemon_active=True,
+        mutation_allowed=False,
+        symbols=(
+            SymbolHealth(
+                symbol="XRPUSDT",
+                fresh=True,
+                last_event_at=_NOW - dt.timedelta(seconds=2),
+                age_seconds=2.0,
+            ),
+        ),
+    )
+    payload = json.loads(snap.to_json())
+    assert payload["connected"] is True
+    assert payload["mutation_allowed"] is False
+    assert payload["symbols"][0]["symbol"] == "XRPUSDT"
+    assert payload["symbols"][0]["fresh"] is True
+    assert payload["symbols"][0]["age_seconds"] == 2.0
+
+
+def test_snapshot_handles_symbol_with_no_events() -> None:
+    snap = DaemonHealthSnapshot(
+        generated_at=_NOW,
+        connected=False,
+        daemon_active=False,
+        mutation_allowed=False,
+        symbols=(
+            SymbolHealth(
+                symbol="DOGEUSDT", fresh=False, last_event_at=None, age_seconds=None
+            ),
+        ),
+    )
+    payload = json.loads(snap.to_json())
+    assert payload["symbols"][0]["last_event_at"] is None
+    assert payload["symbols"][0]["age_seconds"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_health.py -v`
+Expected: FAIL — `ImportError: cannot import name 'DaemonHealthSnapshot'`.
+
+- [ ] **Step 3: Create `health.py`**
+
+```python
+"""ROB-317 — daemon health/heartbeat snapshot (pure data + JSON).
+
+Emitted for Hermes/Prefect liveness polling. Contains only operational
+status — never credentials or order payloads. See ROB-317 design §8.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolHealth:
+    """Per-symbol freshness view for the health snapshot."""
+
+    symbol: str
+    fresh: bool
+    last_event_at: dt.datetime | None
+    age_seconds: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class DaemonHealthSnapshot:
+    """Point-in-time daemon liveness snapshot."""
+
+    generated_at: dt.datetime
+    connected: bool
+    daemon_active: bool
+    mutation_allowed: bool
+    symbols: tuple[SymbolHealth, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at.isoformat(),
+            "connected": self.connected,
+            "daemon_active": self.daemon_active,
+            "mutation_allowed": self.mutation_allowed,
+            "symbols": [
+                {
+                    "symbol": s.symbol,
+                    "fresh": s.fresh,
+                    "last_event_at": (
+                        s.last_event_at.isoformat() if s.last_event_at else None
+                    ),
+                    "age_seconds": s.age_seconds,
+                }
+                for s in self.symbols
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_health.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/health.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_health.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): daemon health snapshot JSON (no secrets)
+
+Slice 2. DaemonHealthSnapshot/SymbolHealth for Hermes/Prefect liveness polling.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Default-disabled CLI entrypoint
+
+With gates off, the CLI subscribes to nothing and exits 0. With gates on, slice 2 has no supervisor yet, so it reports `pending_supervisor` and exits 0 **without subscribing** (no network). This satisfies the "disabled path never subscribes" criterion while staying honest about slice scope. See design §11.2.
+
+**Files:**
+- Create: `scripts/binance_demo_scalping_ws_daemon.py`
+- Test: `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`:
+
+```python
+"""ROB-317 — WS daemon CLI default-disabled behavior."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.binance_demo_scalping_ws_daemon import build_summary, main
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def test_summary_disabled_when_gates_off() -> None:
+    gates = WsDaemonGates(base_enabled=False, ws_enabled=False, ws_confirm=False)
+    summary = build_summary(gates)
+    assert summary["status"] == "disabled"
+    assert summary["subscribed"] is False
+
+
+def test_summary_pending_supervisor_when_gates_on() -> None:
+    gates = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=False)
+    summary = build_summary(gates)
+    assert summary["status"] == "pending_supervisor"
+    assert summary["subscribed"] is False
+    assert summary["mutation_allowed"] is False
+
+
+def test_main_disabled_exits_zero_and_prints_json(capsys, monkeypatch) -> None:
+    for key in (
+        "BINANCE_DEMO_SCALPING_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_CONFIRM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    rc = main([])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "disabled"
+    assert out["subscribed"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.binance_demo_scalping_ws_daemon'`.
+
+- [ ] **Step 3: Create the CLI**
+
+Create `scripts/binance_demo_scalping_ws_daemon.py`:
+
+```python
+"""ROB-317 — operator CLI for the Binance Demo WebSocket scalping daemon.
+
+Default-disabled. Behaviour is entirely env-gated (see WsDaemonGates):
+
+* ``BINANCE_DEMO_SCALPING_ENABLED`` + ``BINANCE_DEMO_SCALPING_WS_ENABLED`` —
+  both must be truthy for the daemon to subscribe/evaluate.
+* ``BINANCE_DEMO_SCALPING_WS_CONFIRM`` — only when also truthy may real Demo
+  orders be placed (slice 4 wires the bridge; this slice never mutates).
+
+Slice 2 ships the gate plumbing only: with gates off it prints a disabled
+summary and exits 0 without subscribing; with gates on it reports
+``pending_supervisor`` (the streaming supervisor lands in slice 3) and still
+does not open any socket. Demo hosts only; no live/testnet path; no secrets
+printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def build_summary(gates: WsDaemonGates) -> dict[str, Any]:
+    """Map resolved gates to a single-line JSON-able summary.
+
+    ``subscribed`` is always False in slice 2 — no socket is ever opened here.
+    """
+    if not gates.daemon_active:
+        return {
+            "status": "disabled",
+            "base_enabled": gates.base_enabled,
+            "ws_enabled": gates.ws_enabled,
+            "subscribed": False,
+        }
+    return {
+        "status": "pending_supervisor",
+        "base_enabled": gates.base_enabled,
+        "ws_enabled": gates.ws_enabled,
+        "mutation_allowed": gates.mutation_allowed,
+        "subscribed": False,
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ROB-317 Binance Demo WebSocket scalping daemon. Default-disabled "
+            "(zero side effects). Set BINANCE_DEMO_SCALPING_ENABLED=true and "
+            "BINANCE_DEMO_SCALPING_WS_ENABLED=true to activate."
+        )
+    )
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level)
+    gates = WsDaemonGates.from_env()
+    summary = build_summary(gates)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/binance_demo_scalping_ws_daemon.py \
+        tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): default-disabled WS daemon CLI entrypoint
+
+Slice 2. Gates off -> disabled summary, exit 0, no subscribe. Gates on ->
+pending_supervisor (streaming lands in slice 3), still no socket, no mutation.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: AST import-guard for the read-only `demo_scalping_ws/` package
+
+Extend the existing static guard so the read-only hot-path package can never import a signed execution client, the `demo_scalping_exec` package, or the demo ledger writer. Only the exec-side `ws_bridge` (slice 4) may reach those. See design §3.1.
+
+**Files:**
+- Modify: `tests/services/brokers/binance/demo/test_no_testnet_imports.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/brokers/binance/demo/test_no_testnet_imports.py`:
+
+```python
+def test_demo_scalping_ws_does_not_import_mutation_layers() -> None:
+    """ROB-317 — demo_scalping_ws/ is the read-only scalping hot path.
+
+    It computes triggers from public market data but must NOT import any
+    signed execution client, the demo_scalping_exec/ package, or the demo
+    ledger writer. Only the exec-side ws_bridge (slice 4) may reach those.
+    Keeps the read-only boundary AST-verifiable (cf. ROB-307 signal/exec
+    split).
+    """
+    ws_root = pathlib.Path("app/services/brokers/binance/demo_scalping_ws")
+    banned_substrings = (
+        "execution_client",
+        "binance.demo_scalping_exec",
+        "binance.demo.ledger",
+    )
+    offenders: list[str] = []
+    for py in ws_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if any(b in node.module for b in banned_substrings):
+                    offenders.append(f"{py}: from {node.module} import ...")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if any(b in alias.name for b in banned_substrings):
+                        offenders.append(f"{py}: import {alias.name}")
+    assert not offenders, (
+        "demo_scalping_ws/ (read-only hot path) must not import mutation "
+        "layers (execution clients / demo_scalping_exec / demo.ledger). "
+        "Offenders:\n" + "\n".join(offenders)
+    )
+```
+
+- [ ] **Step 2: Run test to verify it passes (guard holds on current tree)**
+
+The slice-2 package (`__init__.py`, `config.py`, `state.py`, `health.py`) imports none of the banned layers, so the guard passes immediately — it locks the boundary for slices 3–4.
+
+Run: `uv run pytest tests/services/brokers/binance/demo/test_no_testnet_imports.py::test_demo_scalping_ws_does_not_import_mutation_layers -v`
+Expected: PASS.
+
+- [ ] **Step 3: Verify the guard actually bites (temporary negative check)**
+
+Temporarily add `from app.services.brokers.binance.demo.ledger.service import BinanceDemoLedgerService  # noqa` to `app/services/brokers/binance/demo_scalping_ws/state.py`, re-run the test, and confirm it now FAILS listing `state.py` as an offender. Then **remove** the temporary import and confirm the test PASSES again. (Do not commit the temporary import.)
+
+Run: `uv run pytest tests/services/brokers/binance/demo/test_no_testnet_imports.py::test_demo_scalping_ws_does_not_import_mutation_layers -v`
+Expected: FAIL with the temporary import present; PASS after removal.
+
+- [ ] **Step 4: Run the full guard module**
+
+Run: `uv run pytest tests/services/brokers/binance/demo/test_no_testnet_imports.py -v`
+Expected: PASS (all existing guards + the new one).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/services/brokers/binance/demo/test_no_testnet_imports.py
+git commit -m "$(cat <<'EOF'
+test(rob-317): AST guard — demo_scalping_ws read-only boundary
+
+Slice 2. Read-only hot path may not import signed execution clients,
+demo_scalping_exec, or the demo ledger writer. Only the slice-4 exec-side
+ws_bridge may.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Slice-wide verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all slice-2 tests**
+
+Run:
+```bash
+uv run pytest \
+  tests/services/brokers/binance/test_public_futures_stream_allowlist.py \
+  tests/services/brokers/binance/demo_scalping_ws/ \
+  tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py \
+  tests/services/brokers/binance/demo/test_no_testnet_imports.py -v
+```
+Expected: PASS (all).
+
+- [ ] **Step 2: Lint changed surfaces**
+
+Run:
+```bash
+uv run ruff check \
+  app/services/brokers/binance/host_allowlist.py \
+  app/services/brokers/binance/demo_scalping_ws/ \
+  scripts/binance_demo_scalping_ws_daemon.py \
+  tests/services/brokers/binance/ tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+```
+Expected: no errors. If ruff reports fixable issues, run `uv run ruff format` on the same paths and re-run check, then amend the relevant commit.
+
+- [ ] **Step 3: Confirm the CLI is genuinely inert by default**
+
+Run: `uv run python -m scripts.binance_demo_scalping_ws_daemon`
+Expected (sort_keys output): `{"base_enabled": false, "status": "disabled", "subscribed": false, "ws_enabled": false}`, exit 0. No network, no credential read, no order.
+
+- [ ] **Step 4: Full import-guard + targeted regression sweep**
+
+Run: `uv run pytest tests/services/brokers/binance/ -q`
+Expected: PASS (slice-2 additions plus existing binance broker tests unaffected).
+
+---
+
+## Self-Review
+
+**Spec coverage (slice-2 scope of design §13 item 2):**
+- New read-only allowlist (design §2.2) → Task 1 ✓
+- 3-layer env gates, confirm separate from scheduler (design §7) → Task 2 ✓
+- In-memory state + freshness-from-last-event (design §5) → Task 3 ✓
+- Health snapshot JSON (design §8) → Task 4 ✓
+- Default-disabled CLI, never subscribes when off (design §7, §11.2) → Task 5 ✓
+- AST import-guard for read-only package (design §3.1) → Task 6 ✓
+- Disjointness + signed-reject test (design §2.2, test list) → Task 1 ✓
+- CLI default-disabled test (test list) → Task 5 ✓
+
+Deferred by design (NOT slice-2 gaps): WS event→state→trigger, stale-data trigger block, risk-gate path, one-open-lifecycle/duplicate-trigger, reconnect/backoff (slices 3–4, design §13). The slice-3/4 plans will cover these test-list items.
+
+**Placeholder scan:** No "TBD"/"implement later"/vague-error steps. Every code step ships complete code. Task 6 Step 3 is an explicit (temporary, uncommitted) negative check, not a placeholder.
+
+**Type consistency:** `WsDaemonGates(base_enabled, ws_enabled, ws_confirm)` + `.daemon_active`/`.mutation_allowed`/`.from_env` used identically in Tasks 2 and 5. `MarketState` fields/`is_stale`/`last_event_at` consistent (Task 3). `DaemonHealthSnapshot`/`SymbolHealth` field names consistent in Task 4. `build_summary` keys (`status`/`subscribed`/`mutation_allowed`) match the CLI test assertions in Task 5. `PUBLIC_FUTURES_STREAM_HOSTS`/`assert_public_futures_stream_host` consistent in Task 1.
+
+---
+
+## Next slices (separate plans, written when their turn comes)
+
+- **Slice 3:** `market_stream.py` (reuse/extend `BinancePublicWSClient` for `fstream` + aggTrade parser, reconnect/backoff), `signal.py` (event-driven trigger reusing `demo_scalping/signal.py`), `supervisor.py` (asyncio queues, debounce, heartbeat). Fake-stream tests: event→state→trigger, stale-data block, reconnect/backoff.
+- **Slice 4:** `demo_scalping_exec/ws_bridge.py` (live ledger risk re-check → `DemoScalpingExecutor`), two-layer concurrency guard (per-symbol lock + global semaphore), confirm gate wiring, analytics/review wiring, dedicated `docs/runbooks/` entry. Tests: confirm=false blocks mutation, risk-gate block, one-open-lifecycle/in-flight duplicate guard.

--- a/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice3-implementation-plan.md
+++ b/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice3-implementation-plan.md
@@ -1,0 +1,1464 @@
+# Binance Demo WS Scalping Daemon — Slice 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the event-driven trigger pipeline for the ROB-317 daemon — futures stream parsing (`fstream` aggTrade/bookTicker/closed-kline), per-symbol state updates, a candle-buffer signal that reuses `evaluate_signal` unchanged, and an asyncio supervisor that turns closed-kline events into freshness-gated, debounced `TriggerEvent`s with reconnect/backoff. **No broker mutation and no risk re-check yet — that is slice 4.**
+
+**Architecture:** Slice 3 of 4 (slice 1 = design doc, slice 2 = inert foundation, both landed). The trigger fires on **closed 1m kline** events over a rolling candle buffer (reacting at candle close instead of up to 5 min later), while bookTicker/aggTrade feed quote/trade **freshness** that gates the trigger. The signal logic (`demo_scalping/signal.evaluate_signal`) and risk contract are reused verbatim. The supervisor consumes an **injectable event source**, so every test uses a fake async stream — no network, no orders. The real `fstream` client is thin glue over the injectable seam. When the daemon is active, `on_trigger` only logs structured JSON in this slice; slice 4 replaces that callback with the executor bridge.
+
+**Tech Stack:** Python 3.13, `uv`, `pytest`, `pytest-asyncio`, `ruff`, `websockets`, stdlib `asyncio`/`collections.deque`/`datetime`/`decimal`/`json`. Reuses ROB-285 `compute_backoff_delay`/`is_unhealthy` and the `127.0.0.1` ws test override pattern.
+
+---
+
+## Boundary & reuse notes (read before starting)
+
+- `demo_scalping_ws/` stays **read-only**: it may import `app.services.brokers.binance.ws_client` (KlineEvent/BookTickerEvent + backoff helpers), `demo_scalping.signal` (`Candle`, `SignalConfig`, `evaluate_signal`, `SignalDecision`), `demo_scalping.contract` (`ReasonCode`, `Side`, `Product`), and `host_allowlist`. It must **NOT** import any execution client, `demo_scalping_exec`, or `demo.ledger` — the AST guard from slice 2 enforces this and must stay green.
+- `evaluate_signal(candles, config)` needs `max(sma_slow=25, breakout_lookback+1=21) = 25` candles; fewer returns `INSUFFICIENT_HISTORY`. The buffer keeps `maxlen=200`.
+- `MarketState` (slice 2) is **not modified**. Freshness uses its existing `book_ticker_at`/`agg_trade_at` + `is_stale`. Closed-kline receipt does **not** refresh quote freshness on purpose: a dead bookTicker stream must still trip `STALE_DATA` even while klines arrive.
+- The futures combined-stream payload differs from spot: futures `bookTicker` carries `"e":"bookTicker"` and there is an `aggTrade` stream the ROB-285 spot parser does not handle — hence a dedicated futures parser here rather than editing the shared client.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `app/services/brokers/binance/demo_scalping_ws/market_stream.py` (create) | `AggTradeEvent`, `parse_futures_message`, `build_futures_stream_url`, `FuturesMarketStream` (host-guarded WS client) |
+| `app/services/brokers/binance/demo_scalping_ws/events.py` (create) | `apply_event` (event → `MarketState` mutation) + `kline_to_candle` |
+| `app/services/brokers/binance/demo_scalping_ws/signal.py` (create) | `EventDrivenSignal` — rolling candle buffer + `evaluate_signal` |
+| `app/services/brokers/binance/demo_scalping_ws/supervisor.py` (create) | `TriggerEvent`, `ScalpingDaemonSupervisor` — asyncio loop, freshness gate, debounce, reconnect/backoff |
+| `scripts/binance_demo_scalping_ws_daemon.py` (modify) | Active path builds supervisor + real stream; `on_trigger` logs structured JSON (no mutation) |
+| `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py` (create) | parser + url builder + host guard |
+| `tests/services/brokers/binance/demo_scalping_ws/test_events.py` (create) | `apply_event` + `kline_to_candle` |
+| `tests/services/brokers/binance/demo_scalping_ws/test_signal.py` (create) | `EventDrivenSignal` |
+| `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py` (create) | trigger / freshness / debounce / reconnect (fake source) |
+| `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py` (create) | `FuturesMarketStream` round-trip via local `websockets.serve` |
+
+**Deferred to slice 4 (do NOT create here):** `demo_scalping_exec/ws_bridge.py`, risk re-check wiring, concurrency guard, confirm-gated executor call, analytics/review wiring, dedicated runbook.
+
+---
+
+### Task 1: Futures stream parsing + URL builder + host guard
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/market_stream.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py`:
+
+```python
+"""ROB-317 — futures stream parsing + URL builder + host guard."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    build_futures_stream_url,
+    parse_futures_message,
+)
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _wrap(stream: str, data: dict) -> str:
+    return json.dumps({"stream": stream, "data": data})
+
+
+def test_parse_agg_trade() -> None:
+    raw = _wrap(
+        "xrpusdt@aggTrade",
+        {"e": "aggTrade", "s": "XRPUSDT", "p": "0.5123", "q": "100",
+         "T": 1716724800000, "m": True},
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, AggTradeEvent)
+    assert ev.symbol == "XRPUSDT"
+    assert ev.price == Decimal("0.5123")
+    assert ev.is_buyer_maker is True
+
+
+def test_parse_book_ticker_futures_has_e_field() -> None:
+    raw = _wrap(
+        "xrpusdt@bookTicker",
+        {"e": "bookTicker", "u": 400900217, "s": "XRPUSDT",
+         "b": "0.5120", "B": "31.2", "a": "0.5125", "A": "40.6"},
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, BookTickerEvent)
+    assert ev.bid_price == Decimal("0.5120")
+    assert ev.ask_price == Decimal("0.5125")
+    assert ev.received_at == _NOW
+
+
+def test_parse_closed_kline() -> None:
+    raw = _wrap(
+        "xrpusdt@kline_1m",
+        {"e": "kline", "s": "XRPUSDT", "k": {
+            "t": 1716724740000, "T": 1716724799999, "s": "XRPUSDT", "i": "1m",
+            "o": "0.50", "h": "0.52", "l": "0.49", "c": "0.515",
+            "v": "1000", "q": "515", "n": 42, "x": True}},
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, KlineEvent)
+    assert ev.is_closed is True
+    assert ev.close == Decimal("0.515")
+
+
+def test_parse_drops_in_progress_kline() -> None:
+    raw = _wrap(
+        "xrpusdt@kline_1m",
+        {"e": "kline", "s": "XRPUSDT", "k": {
+            "t": 1716724740000, "T": 1716724799999, "s": "XRPUSDT", "i": "1m",
+            "o": "0.50", "h": "0.52", "l": "0.49", "c": "0.515",
+            "v": "1000", "q": "515", "n": 42, "x": False}},
+    )
+    assert parse_futures_message(raw, now=_NOW) is None
+
+
+def test_parse_ignores_garbage_and_unknown() -> None:
+    assert parse_futures_message("not json", now=_NOW) is None
+    assert parse_futures_message(_wrap("x@depth", {"e": "depthUpdate"}), now=_NOW) is None
+
+
+def test_build_url_combines_streams_for_allowlisted_host() -> None:
+    url = build_futures_stream_url(
+        ["XRPUSDT", "DOGEUSDT"],
+        streams=("aggTrade", "bookTicker", "kline_1m"),
+        base_url="wss://fstream.binance.com",
+    )
+    assert url.startswith("wss://fstream.binance.com/stream?streams=")
+    assert "xrpusdt@aggTrade" in url
+    assert "dogeusdt@kline_1m" in url
+
+
+def test_build_url_rejects_non_fstream_host() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_futures_stream_url(
+            ["XRPUSDT"], streams=("aggTrade",), base_url="wss://fapi.binance.com"
+        )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... market_stream`.
+
+- [ ] **Step 3: Create `market_stream.py`**
+
+```python
+"""ROB-317 — futures public market stream (read-only, fstream).
+
+Parses the USD-M futures combined-stream payloads the daemon consumes:
+aggTrade (momentum/freshness), bookTicker (spread/freshness), and closed
+kline_1m (signal). Unsigned, read-only. Host is guarded against the
+read-only PUBLIC_FUTURES_STREAM_HOSTS allowlist — never a signed mutation
+host. See ROB-317 design §2, §4.
+
+This module intentionally does NOT reuse BinancePublicWSClient's parser:
+the futures payload shape differs (bookTicker carries "e":"bookTicker";
+aggTrade is a stream the spot parser does not handle). It reuses only the
+pure backoff helpers (compute_backoff_delay / is_unhealthy).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import urllib.parse
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import websockets
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.host_allowlist import (
+    PUBLIC_FUTURES_STREAM_HOSTS,
+)
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+_DEFAULT_BASE_URL = "wss://fstream.binance.com"
+
+
+@dataclass(frozen=True, slots=True)
+class AggTradeEvent:
+    symbol: str
+    price: Decimal
+    qty: Decimal
+    trade_time: dt.datetime
+    is_buyer_maker: bool
+
+
+FuturesWsEvent = KlineEvent | BookTickerEvent | AggTradeEvent
+
+
+def parse_futures_message(raw: str, *, now: dt.datetime) -> FuturesWsEvent | None:
+    """Parse one combined-stream message into a normalized event, or None.
+
+    Returns None for malformed JSON, in-progress klines (``x: False``), and
+    stream types the daemon does not consume. ``now`` is the receipt time
+    used for bookTicker freshness (injected for deterministic tests).
+    """
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    data = msg.get("data") if isinstance(msg, dict) and "data" in msg else msg
+    if not isinstance(data, dict):
+        return None
+    etype = data.get("e")
+    if etype == "kline":
+        k = data.get("k") or {}
+        if not k.get("x"):
+            return None
+        return KlineEvent(
+            symbol=k["s"],
+            interval=k["i"],
+            open_time=dt.datetime.fromtimestamp(k["t"] / 1000.0, tz=dt.UTC),
+            close_time=dt.datetime.fromtimestamp(k["T"] / 1000.0, tz=dt.UTC),
+            open=Decimal(k["o"]),
+            high=Decimal(k["h"]),
+            low=Decimal(k["l"]),
+            close=Decimal(k["c"]),
+            base_volume=Decimal(k["v"]),
+            quote_volume=Decimal(k["q"]),
+            trade_count=int(k["n"]),
+            is_closed=True,
+        )
+    if etype == "bookTicker":
+        return BookTickerEvent(
+            symbol=data["s"],
+            bid_price=Decimal(data["b"]),
+            bid_qty=Decimal(data["B"]),
+            ask_price=Decimal(data["a"]),
+            ask_qty=Decimal(data["A"]),
+            received_at=now,
+        )
+    if etype == "aggTrade":
+        return AggTradeEvent(
+            symbol=data["s"],
+            price=Decimal(data["p"]),
+            qty=Decimal(data["q"]),
+            trade_time=dt.datetime.fromtimestamp(data["T"] / 1000.0, tz=dt.UTC),
+            is_buyer_maker=bool(data["m"]),
+        )
+    return None
+
+
+def _assert_host_allowed(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    # Local test override mirrors ROB-285: 127.0.0.1 over plain ws is the
+    # websockets.serve fixture; production is always wss to fstream.
+    if host == "127.0.0.1" and parsed.scheme == "ws":
+        return
+    if host not in PUBLIC_FUTURES_STREAM_HOSTS:
+        raise BinanceLiveHostBlocked(
+            f"Futures stream host blocked: {host!r} not in "
+            f"{sorted(PUBLIC_FUTURES_STREAM_HOSTS)}"
+        )
+
+
+def build_futures_stream_url(
+    symbols: Sequence[str],
+    *,
+    streams: Sequence[str],
+    base_url: str = _DEFAULT_BASE_URL,
+) -> str:
+    """Build a combined-stream URL for ``symbols`` × ``streams``, host-guarded."""
+    _assert_host_allowed(base_url)
+    parts = [f"{s.lower()}@{stream}" for s in symbols for stream in streams]
+    return f"{base_url.rstrip('/')}/stream?streams=" + "/".join(parts)
+
+
+class FuturesMarketStream:
+    """Read-only futures combined-stream subscriber (host-guarded)."""
+
+    def __init__(self, *, url: str) -> None:
+        _assert_host_allowed(url)
+        self._url = url
+        self._ws: Any = None
+
+    async def __aenter__(self) -> "FuturesMarketStream":
+        self._ws = await websockets.connect(self._url, ping_interval=20)
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+
+    async def events(
+        self, *, stop_after: int | None = None
+    ) -> AsyncIterator[FuturesWsEvent]:
+        assert self._ws is not None, "FuturesMarketStream not connected"
+        emitted = 0
+        async for raw in self._ws:
+            ev = parse_futures_message(raw, now=dt.datetime.now(tz=dt.UTC))
+            if ev is None:
+                continue
+            yield ev
+            emitted += 1
+            if stop_after is not None and emitted >= stop_after:
+                return
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/market_stream.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): futures stream parser + url builder + host guard
+
+Slice 3. parse_futures_message (aggTrade/bookTicker/closed-kline; drops
+in-progress klines + garbage), build_futures_stream_url (host-guarded to
+fstream), FuturesMarketStream client. Read-only; no signed host.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Event → state updater + kline → candle mapping
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/events.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_events.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_events.py`:
+
+```python
+"""ROB-317 — event → MarketState updater + kline → Candle mapping."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.events import (
+    apply_event,
+    kline_to_candle,
+)
+from app.services.brokers.binance.demo_scalping_ws.market_stream import AggTradeEvent
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _kline(close: str = "0.515") -> KlineEvent:
+    return KlineEvent(
+        symbol="XRPUSDT", interval="1m",
+        open_time=dt.datetime(2026, 5, 26, 11, 59, tzinfo=dt.UTC),
+        close_time=dt.datetime(2026, 5, 26, 11, 59, 59, tzinfo=dt.UTC),
+        open=Decimal("0.50"), high=Decimal("0.52"), low=Decimal("0.49"),
+        close=Decimal(close), base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"), trade_count=42, is_closed=True,
+    )
+
+
+def test_apply_book_ticker_updates_quote_and_freshness() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    ev = BookTickerEvent(
+        symbol="XRPUSDT", bid_price=Decimal("0.512"), bid_qty=Decimal("1"),
+        ask_price=Decimal("0.513"), ask_qty=Decimal("1"), received_at=_NOW,
+    )
+    apply_event(state, ev)
+    assert state.bid_price == Decimal("0.512")
+    assert state.ask_price == Decimal("0.513")
+    # Freshness comes from the event's own receipt time, not a wall clock.
+    assert state.book_ticker_at == _NOW
+
+
+def test_apply_agg_trade_updates_trade_and_freshness() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    ev = AggTradeEvent(
+        symbol="XRPUSDT", price=Decimal("0.5125"), qty=Decimal("10"),
+        trade_time=_NOW, is_buyer_maker=False,
+    )
+    apply_event(state, ev)
+    assert state.last_trade_price == Decimal("0.5125")
+    assert state.agg_trade_at == _NOW
+
+
+def test_apply_kline_does_not_touch_quote_freshness() -> None:
+    # A closed kline must NOT mask a dead bookTicker/aggTrade stream.
+    state = MarketState(symbol="XRPUSDT")
+    apply_event(state, _kline())
+    assert state.book_ticker_at is None
+    assert state.agg_trade_at is None
+
+
+def test_kline_to_candle_maps_fields() -> None:
+    candle = kline_to_candle(_kline(close="0.515"))
+    assert candle.close == Decimal("0.515")
+    assert candle.high == Decimal("0.52")
+    assert candle.close_time_ms == int(
+        dt.datetime(2026, 5, 26, 11, 59, 59, tzinfo=dt.UTC).timestamp() * 1000
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_events.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... events`.
+
+- [ ] **Step 3: Create `events.py`**
+
+```python
+"""ROB-317 — event → state mutation + kline → Candle mapping (pure).
+
+``apply_event`` updates quote/trade fields + freshness timestamps from
+bookTicker/aggTrade events. Freshness is stamped from each event's OWN
+receipt/trade time (design §5: "last event received"), not a wall clock, so
+the supervisor's trigger-time clock measures true staleness against it.
+Closed klines deliberately do NOT update quote freshness (a dead bookTicker
+stream must still trip STALE_DATA); klines are routed to the signal buffer
+by the supervisor instead.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    FuturesWsEvent,
+)
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+
+
+def apply_event(state: MarketState, event: FuturesWsEvent) -> None:
+    """Mutate ``state`` from a market event. Klines are a no-op here.
+
+    Freshness timestamps come from the event itself (``received_at`` for
+    bookTicker, ``trade_time`` for aggTrade).
+    """
+    if isinstance(event, BookTickerEvent):
+        state.bid_price = event.bid_price
+        state.ask_price = event.ask_price
+        state.book_ticker_at = event.received_at
+    elif isinstance(event, AggTradeEvent):
+        state.last_trade_price = event.price
+        state.agg_trade_at = event.trade_time
+    # KlineEvent: intentionally no state mutation (routed to the signal buffer).
+
+
+def kline_to_candle(event: KlineEvent) -> Candle:
+    """Map a closed-kline event to the signal's Candle value object."""
+    return Candle(
+        open_time_ms=int(event.open_time.timestamp() * 1000),
+        open=event.open,
+        high=event.high,
+        low=event.low,
+        close=event.close,
+        close_time_ms=int(event.close_time.timestamp() * 1000),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_events.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/events.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_events.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): event->state updater + kline->candle mapping
+
+Slice 3. apply_event refreshes quote/trade + freshness from bookTicker/
+aggTrade; closed klines do not touch quote freshness (dead quote stream
+still trips STALE_DATA). kline_to_candle bridges to the signal Candle.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Event-driven signal (rolling candle buffer)
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/signal.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_signal.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_signal.py`:
+
+```python
+"""ROB-317 — event-driven signal over a rolling candle buffer."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping.contract import ReasonCode
+from app.services.brokers.binance.ws_client import KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.signal import EventDrivenSignal
+
+
+def _kline(close: str, *, high: str | None = None, low: str | None = None,
+           minute: int = 0) -> KlineEvent:
+    base = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC) + dt.timedelta(minutes=minute)
+    c = Decimal(close)
+    return KlineEvent(
+        symbol="XRPUSDT", interval="1m", open_time=base,
+        close_time=base + dt.timedelta(seconds=59), open=c,
+        high=Decimal(high) if high else c, low=Decimal(low) if low else c,
+        close=c, base_volume=Decimal("1000"), quote_volume=Decimal("515"),
+        trade_count=42, is_closed=True,
+    )
+
+
+def test_insufficient_history_until_buffer_fills() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT")
+    decision = sig.ingest_kline(_kline("0.50", minute=0))
+    assert decision.has_entry is False
+    assert ReasonCode.INSUFFICIENT_HISTORY in decision.reason_codes
+
+
+def test_long_breakout_fires_after_enough_candles() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT")
+    # 24 flat candles at 0.50 (range 0.49-0.51), then a breakout close above
+    # the prior 20-bar high with a rising fast SMA.
+    last = None
+    for m in range(24):
+        last = sig.ingest_kline(_kline("0.50", high="0.51", low="0.49", minute=m))
+    assert last.has_entry is False  # 24 < 25 needed
+    fill = sig.ingest_kline(_kline("0.50", high="0.51", low="0.49", minute=24))
+    assert fill.has_entry is False  # 25th: flat, no breakout
+    breakout = sig.ingest_kline(_kline("0.60", high="0.60", low="0.50", minute=25))
+    assert breakout.has_entry is True
+    assert breakout.side == "BUY"
+    assert ReasonCode.ENTER_LONG_BREAKOUT in breakout.reason_codes
+
+
+def test_buffer_is_bounded() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT", max_candles=30)
+    for m in range(100):
+        sig.ingest_kline(_kline("0.50", minute=m))
+    assert sig.candle_count == 30
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_signal.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... signal` (the demo_scalping_ws one).
+
+- [ ] **Step 3: Create `signal.py`**
+
+```python
+"""ROB-317 — event-driven scalping signal.
+
+Wraps the pure, candle-based ``demo_scalping.signal.evaluate_signal`` with a
+bounded rolling buffer. On each closed kline the buffer is appended and the
+signal re-evaluated — reacting at candle close rather than on a 5-minute
+timer. The strategy/thresholds are reused verbatim; only the feed cadence
+changes. See ROB-317 design §1, §3.2.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from app.services.brokers.binance.demo_scalping.contract import Product
+from app.services.brokers.binance.demo_scalping.signal import (
+    Candle,
+    SignalConfig,
+    SignalDecision,
+    evaluate_signal,
+)
+from app.services.brokers.binance.ws_client import KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.events import kline_to_candle
+
+
+class EventDrivenSignal:
+    """Per-symbol rolling-buffer adapter over ``evaluate_signal``."""
+
+    def __init__(
+        self,
+        *,
+        product: Product,
+        symbol: str,
+        config: SignalConfig | None = None,
+        max_candles: int = 200,
+    ) -> None:
+        self._product = product
+        self._symbol = symbol
+        # Spot is long-only; futures may take the mirror short (same default
+        # as demo_scalping.runner.evaluate_symbol).
+        self._config = config or SignalConfig(allow_short=product == "usdm_futures")
+        self._candles: deque[Candle] = deque(maxlen=max_candles)
+
+    @property
+    def candle_count(self) -> int:
+        return len(self._candles)
+
+    def ingest_kline(self, event: KlineEvent) -> SignalDecision:
+        """Append the closed candle and re-evaluate the signal."""
+        self._candles.append(kline_to_candle(event))
+        return evaluate_signal(list(self._candles), self._config)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_signal.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/signal.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_signal.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): event-driven signal over rolling candle buffer
+
+Slice 3. EventDrivenSignal appends each closed kline to a bounded buffer and
+re-runs the unchanged evaluate_signal — fires at candle close, not on a timer.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Supervisor — trigger, freshness gate, debounce (fake source)
+
+The supervisor consumes an injectable event source. On a closed kline it routes to the per-symbol signal; if `has_entry`, it emits a `TriggerEvent` **only** when (a) the symbol's quote/trade data is fresh and (b) the per-symbol debounce window has elapsed. `now` and `sleep` are injected for deterministic tests. Reconnect is added in Task 5.
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_ws/supervisor.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`:
+
+```python
+"""ROB-317 — supervisor trigger / freshness / debounce (fake source)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    FuturesWsEvent,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import (
+    ScalpingDaemonSupervisor,
+    TriggerEvent,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _book(now_offset: int = 0) -> BookTickerEvent:
+    return BookTickerEvent(
+        symbol="XRPUSDT", bid_price=Decimal("0.50"), bid_qty=Decimal("1"),
+        ask_price=Decimal("0.5001"), ask_qty=Decimal("1"),
+        received_at=_T0 + dt.timedelta(seconds=now_offset),
+    )
+
+
+def _kline(close: str, *, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol="XRPUSDT", interval="1m", open_time=base,
+        close_time=base + dt.timedelta(seconds=59), open=Decimal(close),
+        high=Decimal(high), low=Decimal(low), close=Decimal(close),
+        base_volume=Decimal("1000"), quote_volume=Decimal("515"),
+        trade_count=42, is_closed=True,
+    )
+
+
+def _breakout_sequence() -> list[FuturesWsEvent]:
+    events: list[FuturesWsEvent] = [_book()]
+    for m in range(25):
+        events.append(_kline("0.50", high="0.51", low="0.49", minute=m))
+    events.append(_kline("0.60", high="0.60", low="0.50", minute=25))
+    return events
+
+
+async def _source_from(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
+    for ev in events:
+        yield ev
+
+
+class _Clock:
+    def __init__(self, start: dt.datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> dt.datetime:
+        return self.now
+
+
+async def test_fresh_breakout_emits_trigger() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))  # within 120s of the book event
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert len(captured) == 1
+    assert captured[0].symbol == "XRPUSDT"
+    assert captured[0].side == "BUY"
+
+
+async def test_stale_quote_blocks_trigger() -> None:
+    # Clock far past the single book event -> STALE_DATA, no trigger.
+    clock = _Clock(_T0 + dt.timedelta(seconds=600))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert captured == []
+
+
+async def test_debounce_suppresses_second_trigger() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(
+        symbols=["XRPUSDT"], clock=clock, debounce_seconds=300
+    )
+    seq = _breakout_sequence()
+    seq.append(_kline("0.70", high="0.70", low="0.60", minute=26))  # 2nd breakout
+    captured: list[TriggerEvent] = []
+    await sup.run(lambda: _source_from(seq), on_trigger=_async_appender(captured))
+    assert len(captured) == 1  # second suppressed by debounce
+
+
+def _async_appender(sink: list):
+    async def _append(trigger) -> None:
+        sink.append(trigger)
+    return _append
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... supervisor`.
+
+- [ ] **Step 3: Create `supervisor.py`**
+
+```python
+"""ROB-317 — asyncio scalping daemon supervisor.
+
+Consumes an injectable event source (real fstream client in production, a
+fake async iterator in tests). Routes closed klines to the per-symbol
+signal; on an entry, emits a TriggerEvent only when the symbol's quote/trade
+data is fresh and the per-symbol debounce window has elapsed. bookTicker/
+aggTrade events refresh state. Reconnect/backoff is added in Task 5.
+
+This slice performs NO risk re-check and NO broker mutation: ``on_trigger``
+is a caller-supplied coroutine (slice 4 wires it to the executor bridge;
+this slice logs structured JSON). See ROB-317 design §6.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    Product,
+    ReasonCode,
+    ScalpingRiskLimits,
+    Side,
+)
+from app.services.brokers.binance.demo_scalping.signal import (
+    SignalConfig,
+    SignalDecision,
+)
+from app.services.brokers.binance.ws_client import KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.events import apply_event
+from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
+from app.services.brokers.binance.demo_scalping_ws.signal import EventDrivenSignal
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+
+logger = logging.getLogger("rob317.demo_scalping_ws")
+
+SourceFactory = Callable[[], AsyncIterator[FuturesWsEvent]]
+OnTrigger = Callable[["TriggerEvent"], Awaitable[None]]
+Clock = Callable[[], dt.datetime]
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerEvent:
+    """An event-driven entry candidate, pre-risk-check (slice 4 consumes it)."""
+
+    product: Product
+    symbol: str
+    side: Side
+    decision: SignalDecision
+    bid_price: Decimal | None
+    ask_price: Decimal | None
+    data_age_seconds: float | None
+    emitted_at: dt.datetime
+
+
+def _default_clock() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+class ScalpingDaemonSupervisor:
+    """Per-symbol event router with freshness + debounce gates."""
+
+    def __init__(
+        self,
+        *,
+        symbols: list[str],
+        product: Product = "usdm_futures",
+        limits: ScalpingRiskLimits | None = None,
+        signal_config: SignalConfig | None = None,
+        debounce_seconds: float = 300.0,
+        clock: Clock = _default_clock,
+    ) -> None:
+        self._product = product
+        self._limits = limits or ScalpingRiskLimits()
+        self._debounce_seconds = debounce_seconds
+        self._clock = clock
+        self._state: dict[str, MarketState] = {
+            s: MarketState(symbol=s) for s in symbols
+        }
+        self._signals: dict[str, EventDrivenSignal] = {
+            s: EventDrivenSignal(
+                product=product, symbol=s, config=signal_config
+            )
+            for s in symbols
+        }
+        self._last_trigger_at: dict[str, dt.datetime] = {}
+
+    async def run(
+        self,
+        source_factory: SourceFactory,
+        *,
+        on_trigger: OnTrigger,
+        stop_after: int | None = None,
+    ) -> None:
+        """Consume one source to exhaustion (single pass; reconnect: Task 5)."""
+        consumed = 0
+        source = source_factory()
+        async for event in source:
+            trigger = self._handle_event(event)
+            if trigger is not None:
+                await on_trigger(trigger)
+            consumed += 1
+            if stop_after is not None and consumed >= stop_after:
+                return
+
+    def _handle_event(self, event: FuturesWsEvent) -> TriggerEvent | None:
+        now = self._clock()
+        symbol = event.symbol
+        state = self._state.get(symbol)
+        if state is None:
+            return None  # not an allowlisted/subscribed symbol
+        if not isinstance(event, KlineEvent):
+            apply_event(state, event)
+            return None
+        decision = self._signals[symbol].ingest_kline(event)
+        if not decision.has_entry or decision.side is None:
+            return None
+        return self._gate_and_build(symbol, state, decision, now)
+
+    def _gate_and_build(
+        self,
+        symbol: str,
+        state: MarketState,
+        decision: SignalDecision,
+        now: dt.datetime,
+    ) -> TriggerEvent | None:
+        if state.is_stale(now=now, max_age_seconds=self._limits.max_data_age_seconds):
+            logger.info(
+                "trigger suppressed symbol=%s reason=%s",
+                symbol,
+                ReasonCode.STALE_DATA,
+            )
+            return None
+        last = self._last_trigger_at.get(symbol)
+        if last is not None and (now - last).total_seconds() < self._debounce_seconds:
+            logger.info("trigger suppressed symbol=%s reason=debounce", symbol)
+            return None
+        self._last_trigger_at[symbol] = now
+        last_event = state.last_event_at()
+        age = None if last_event is None else (now - last_event).total_seconds()
+        logger.info(
+            "trigger symbol=%s side=%s reasons=%s",
+            symbol,
+            decision.side,
+            decision.reason_codes,
+        )
+        return TriggerEvent(
+            product=self._product,
+            symbol=symbol,
+            side=decision.side,
+            decision=decision,
+            bid_price=state.bid_price,
+            ask_price=state.ask_price,
+            data_age_seconds=age,
+            emitted_at=now,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -v`
+Expected: PASS (3 tests). If `pytest.mark.asyncio` is unrecognized, confirm `pytest-asyncio` is installed (`uv run python -c "import pytest_asyncio"`) and that `asyncio_mode = auto` or the marker is configured in `pyproject.toml`; otherwise add `@pytest.mark.asyncio` per test (already applied via `pytestmark`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/supervisor.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): supervisor trigger pipeline + freshness + debounce
+
+Slice 3. ScalpingDaemonSupervisor routes events: kline->signal->TriggerEvent,
+gated by quote/trade freshness (STALE_DATA) and per-symbol debounce. Injectable
+clock + source. No risk re-check, no mutation (slice 4).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Reconnect / backoff loop
+
+Wrap the single-pass consume in a reconnect loop reusing ROB-285 `compute_backoff_delay`/`is_unhealthy`. `sleep` is injected so tests assert delays without waiting. On clean source exhaustion the loop ends; on a connection error it backs off and re-invokes the factory until the unhealthy threshold, then re-raises.
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_ws/supervisor.py`
+- Test: append to `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`:
+
+```python
+async def test_run_with_reconnect_recovers_after_transient_error() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    slept: list[float] = []
+
+    calls = {"n": 0}
+
+    def factory() -> AsyncIterator[FuturesWsEvent]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _raises_after_book()
+        return _source_from(_breakout_sequence())
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    await sup.run_with_reconnect(
+        factory,
+        on_trigger=_async_appender(captured),
+        sleep=fake_sleep,
+    )
+    assert len(captured) == 1  # recovered on the 2nd connection
+    assert len(slept) == 1  # backed off once between attempts
+
+
+async def test_run_with_reconnect_raises_when_unhealthy() -> None:
+    clock = _Clock(_T0)
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    def always_fails() -> AsyncIterator[FuturesWsEvent]:
+        return _raises_immediately()
+
+    with pytest.raises(ConnectionError):
+        await sup.run_with_reconnect(
+            always_fails, on_trigger=_async_appender([]), sleep=fake_sleep
+        )
+    assert len(slept) == 2  # 2 backoffs before the 3rd failure trips unhealthy
+
+
+async def _raises_after_book() -> AsyncIterator[FuturesWsEvent]:
+    yield _book()
+    raise ConnectionError("socket dropped")
+
+
+async def _raises_immediately() -> AsyncIterator[FuturesWsEvent]:
+    raise ConnectionError("cannot connect")
+    yield  # pragma: no cover - makes this an async generator
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -k reconnect -v`
+Expected: FAIL — `AttributeError: 'ScalpingDaemonSupervisor' object has no attribute 'run_with_reconnect'`.
+
+- [ ] **Step 3: Add `run_with_reconnect` to `supervisor.py`**
+
+Add these imports near the top of `supervisor.py` (merge with existing import lines):
+
+```python
+import asyncio
+
+from app.services.brokers.binance.ws_client import (
+    compute_backoff_delay,
+    is_unhealthy,
+)
+```
+
+Add a module-level type alias next to the others:
+
+```python
+Sleep = Callable[[float], Awaitable[None]]
+```
+
+Add this method to `ScalpingDaemonSupervisor` (below `run`):
+
+```python
+    async def run_with_reconnect(
+        self,
+        source_factory: SourceFactory,
+        *,
+        on_trigger: OnTrigger,
+        sleep: Sleep = asyncio.sleep,
+    ) -> None:
+        """Run with reconnect: back off on connection errors until unhealthy.
+
+        Clean source exhaustion ends the loop. A connection error backs off
+        (ROB-285 jittered exponential) and re-invokes the factory; once
+        consecutive failures reach the unhealthy threshold the error is
+        re-raised for the operator/supervisor above to handle.
+        """
+        consecutive_failures = 0
+        while True:
+            try:
+                await self.run(source_factory, on_trigger=on_trigger)
+                return
+            except (ConnectionError, OSError) as exc:
+                consecutive_failures += 1
+                if is_unhealthy(consecutive_failures):
+                    logger.error(
+                        "WS daemon unhealthy after %d consecutive failures: %s",
+                        consecutive_failures,
+                        exc,
+                    )
+                    raise
+                delay = compute_backoff_delay(consecutive_failures - 1)
+                logger.warning(
+                    "WS stream error (%s); reconnecting in %.2fs", exc, delay
+                )
+                await sleep(delay)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -v`
+Expected: PASS (5 tests total). Confirm `is_unhealthy(3)` is the threshold: failures 1 and 2 sleep, failure 3 trips unhealthy → 2 sleeps then raise.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/supervisor.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): supervisor reconnect/backoff loop
+
+Slice 3. run_with_reconnect reuses ROB-285 jittered backoff + unhealthy
+threshold; injectable sleep. Recovers across a transient drop; re-raises once
+consecutive failures hit the unhealthy threshold.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: `FuturesMarketStream` live round-trip (local websockets server)
+
+Proves the real client connects, decodes, and yields against a local `websockets.serve` fixture (the `127.0.0.1` ws host override added in Task 1). No external network.
+
+**Files:**
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py`:
+
+```python
+"""ROB-317 — FuturesMarketStream round-trip over a local websockets server."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+
+import pytest
+import websockets
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.ws_client import KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    FuturesMarketStream,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_stream_yields_parsed_events_from_local_server() -> None:
+    messages = [
+        json.dumps({"stream": "xrpusdt@aggTrade", "data": {
+            "e": "aggTrade", "s": "XRPUSDT", "p": "0.51", "q": "1",
+            "T": 1716724800000, "m": False}}),
+        json.dumps({"stream": "xrpusdt@kline_1m", "data": {
+            "e": "kline", "s": "XRPUSDT", "k": {
+                "t": 1716724740000, "T": 1716724799999, "s": "XRPUSDT",
+                "i": "1m", "o": "0.50", "h": "0.52", "l": "0.49", "c": "0.515",
+                "v": "1000", "q": "515", "n": 42, "x": True}}}),
+    ]
+
+    async def handler(ws) -> None:
+        for m in messages:
+            await ws.send(m)
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        url = f"ws://127.0.0.1:{port}/stream?streams=xrpusdt@aggTrade"
+        out = []
+        async with FuturesMarketStream(url=url) as stream:
+            async for ev in stream.events(stop_after=2):
+                out.append(ev)
+
+    assert isinstance(out[0], AggTradeEvent)
+    assert out[0].price == Decimal("0.51")
+    assert isinstance(out[1], KlineEvent)
+    assert out[1].close == Decimal("0.515")
+
+
+async def test_stream_rejects_non_fstream_host() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        FuturesMarketStream(url="wss://fapi.binance.com/stream?streams=xrpusdt@aggTrade")
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py -v`
+Expected: PASS (2 tests). `FuturesMarketStream` and the host guard already exist from Task 1, so this validates the connect/iterate path. If it fails on connection, confirm `websockets.serve(..., port=0)` picks a free port and the `127.0.0.1`+`ws` override in `_assert_host_allowed` is present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py
+git commit -m "$(cat <<'EOF'
+test(rob-317): FuturesMarketStream local websockets round-trip
+
+Slice 3. Proves connect/decode/yield + host rejection against a local
+websockets.serve fixture (127.0.0.1 ws override). No external network.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Wire the CLI active path to the supervisor (logging sink, no mutation)
+
+When `daemon_active` is true, the CLI builds the supervisor + real fstream source and runs `run_with_reconnect` with an `on_trigger` that **only logs structured JSON**. No bridge, no risk re-check, no order — slice 4 swaps the sink. To keep tests network-free, the runnable loop accepts an injectable `source_factory`.
+
+**Files:**
+- Modify: `scripts/binance_demo_scalping_ws_daemon.py`
+- Test: append to `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`:
+
+```python
+import datetime as dt
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
+from scripts.binance_demo_scalping_ws_daemon import run_daemon
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _seq() -> list[FuturesWsEvent]:
+    out: list[FuturesWsEvent] = [
+        BookTickerEvent(
+            symbol="XRPUSDT", bid_price=Decimal("0.50"), bid_qty=Decimal("1"),
+            ask_price=Decimal("0.5001"), ask_qty=Decimal("1"), received_at=_T0,
+        )
+    ]
+    for m in range(25):
+        out.append(_cli_kline("0.50", "0.51", "0.49", m))
+    out.append(_cli_kline("0.60", "0.60", "0.50", 25))
+    return out
+
+
+def _cli_kline(close: str, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol="XRPUSDT", interval="1m", open_time=base,
+        close_time=base + dt.timedelta(seconds=59), open=Decimal(close),
+        high=Decimal(high), low=Decimal(low), close=Decimal(close),
+        base_volume=Decimal("1000"), quote_volume=Decimal("515"),
+        trade_count=42, is_closed=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_logs_triggers_without_mutation(caplog) -> None:
+    triggers = await run_daemon(
+        symbols=["XRPUSDT"],
+        source_factory=lambda: _source(_seq()),
+        clock=lambda: _T0 + dt.timedelta(seconds=5),
+    )
+    assert triggers == 1  # one BUY breakout, logged only
+
+
+async def _source(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
+    for ev in events:
+        yield ev
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -k run_daemon -v`
+Expected: FAIL — `ImportError: cannot import name 'run_daemon'`.
+
+- [ ] **Step 3: Add `run_daemon` and wire `main`**
+
+Add to `scripts/binance_demo_scalping_ws_daemon.py` (new imports + function; keep `build_summary`/`_parse_args` from slice 2):
+
+```python
+import asyncio
+import datetime as dt
+from collections.abc import AsyncIterator, Callable
+
+from app.services.brokers.binance.demo_scalping.contract import DEFAULT_ALLOWLIST
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    FuturesWsEvent,
+    FuturesMarketStream,
+    build_futures_stream_url,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import (
+    ScalpingDaemonSupervisor,
+    TriggerEvent,
+)
+
+logger = logging.getLogger("rob317.demo_scalping_ws_daemon")
+
+_STREAMS = ("aggTrade", "bookTicker", "kline_1m")
+
+
+def _real_source_factory(symbols: list[str]) -> Callable[[], AsyncIterator[FuturesWsEvent]]:
+    url = build_futures_stream_url(symbols, streams=_STREAMS)
+
+    async def _factory() -> AsyncIterator[FuturesWsEvent]:
+        async with FuturesMarketStream(url=url) as stream:
+            async for ev in stream.events():
+                yield ev
+
+    return _factory
+
+
+async def run_daemon(
+    *,
+    symbols: list[str],
+    source_factory: Callable[[], AsyncIterator[FuturesWsEvent]] | None = None,
+    clock: Callable[[], dt.datetime] | None = None,
+) -> int:
+    """Run the trigger pipeline; on_trigger only logs (slice 3, no mutation).
+
+    Returns the number of triggers emitted. ``source_factory`` is injectable
+    so tests never open a socket; the default connects to fstream.
+    """
+    factory = source_factory or _real_source_factory(symbols)
+    sup = ScalpingDaemonSupervisor(
+        symbols=symbols, **({"clock": clock} if clock else {})
+    )
+    count = 0
+
+    async def on_trigger(trigger: TriggerEvent) -> None:
+        nonlocal count
+        count += 1
+        logger.info(
+            "TRIGGER (log-only, no mutation) %s",
+            json.dumps(
+                {
+                    "symbol": trigger.symbol,
+                    "side": trigger.side,
+                    "reasons": list(trigger.decision.reason_codes),
+                    "data_age_seconds": trigger.data_age_seconds,
+                    "emitted_at": trigger.emitted_at.isoformat(),
+                },
+                sort_keys=True,
+            ),
+        )
+
+    await sup.run_with_reconnect(factory, on_trigger=on_trigger)
+    return count
+```
+
+Then replace the `pending_supervisor` early-return in `main` so the active path actually runs (keep the disabled path exactly as-is):
+
+```python
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level)
+    gates = WsDaemonGates.from_env()
+    summary = build_summary(gates)
+    print(json.dumps(summary, sort_keys=True))
+    if not gates.daemon_active:
+        return 0
+    symbols = sorted(DEFAULT_ALLOWLIST)
+    logger.info(
+        "WS daemon active (mutation_allowed=%s) — slice 3 logs triggers only, "
+        "no broker mutation",
+        gates.mutation_allowed,
+    )
+    asyncio.run(run_daemon(symbols=symbols))
+    return 0
+```
+
+Update `build_summary`'s active-branch `status` from `"pending_supervisor"` to `"running"` and adjust the slice-2 test `test_summary_pending_supervisor_when_gates_on` to assert `"running"` (rename it to `test_summary_running_when_gates_on`). The `subscribed` key stays in the summary but is now informational; keep it `False` since the summary prints before the socket opens.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -v`
+Expected: PASS (disabled-path tests + the new `run_daemon` test + the renamed running-status test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/binance_demo_scalping_ws_daemon.py \
+        tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): CLI active path runs supervisor (log-only triggers)
+
+Slice 3. daemon_active builds the fstream source + supervisor and runs
+run_with_reconnect; on_trigger logs structured JSON only — no risk re-check,
+no broker mutation (slice 4). Injectable source keeps tests network-free.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Slice-wide verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all demo_scalping_ws + CLI + guard tests**
+
+Run:
+```bash
+uv run pytest \
+  tests/services/brokers/binance/demo_scalping_ws/ \
+  tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py \
+  tests/services/brokers/binance/demo/test_no_testnet_imports.py -v
+```
+Expected: PASS (all). The import-guard must stay green — `demo_scalping_ws/` imports only `ws_client`, `demo_scalping.signal`/`contract`, `host_allowlist`, none of the banned mutation layers.
+
+- [ ] **Step 2: Lint changed surfaces**
+
+Run:
+```bash
+uv run ruff check \
+  app/services/brokers/binance/demo_scalping_ws/ \
+  scripts/binance_demo_scalping_ws_daemon.py \
+  tests/services/brokers/binance/demo_scalping_ws/ \
+  tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+```
+Expected: no errors. If ruff flags fixables, run `uv run ruff format` on the same paths, re-check, and amend the relevant commit.
+
+- [ ] **Step 3: Confirm the CLI is still inert by default**
+
+Run: `env -u BINANCE_DEMO_SCALPING_ENABLED -u BINANCE_DEMO_SCALPING_WS_ENABLED -u BINANCE_DEMO_SCALPING_WS_CONFIRM uv run python -m scripts.binance_demo_scalping_ws_daemon`
+Expected: `{"base_enabled": false, "status": "disabled", "subscribed": false, "ws_enabled": false}`, exit 0, no socket opened.
+
+- [ ] **Step 4: Targeted regression sweep on the binance broker surface**
+
+Run: `uv run pytest tests/services/brokers/binance/ -q`
+Expected: PASS — slice-3 additions plus existing ROB-285/298/307 broker tests unaffected (the shared `ws_client.py` was not modified).
+
+---
+
+## Self-Review
+
+**Spec coverage (design §13 slice-3 scope + relevant §10 test-list items):**
+- `market_stream.py`: fstream client + aggTrade parser + host guard (design §3.2, §4) → Task 1, Task 6 ✓
+- Event → state update + freshness-from-last-event (design §5) → Task 2 ✓
+- Event-driven trigger reusing `evaluate_signal` (design §3.2, §6.1) → Task 3, Task 4 ✓
+- Supervisor asyncio loop + debounce + heartbeat-style structured logs (design §6) → Task 4, Task 7 ✓
+- Stale-data guard blocks trigger (design §5; test-list "stale stream/data guard") → Task 4 ✓
+- Reconnect/backoff (design §6.3; test-list "reconnect/backoff") → Task 5 ✓
+- "websocket event → state update → signal trigger path" (test-list) → Task 4 ✓
+- Read-only import boundary stays green (design §3.1) → Task 8 ✓
+
+**Deferred to slice 4 (NOT slice-3 gaps):** risk-gate re-check + reason-code path, `confirm=false` blocks mutation, one-open-lifecycle/in-flight duplicate guard, concurrency semaphore, executor bridge. These need the ledger + executor and are explicitly slice 4 (design §13).
+
+**Placeholder scan:** No "TBD"/"implement later". Every code step ships complete code. The `_raises_immediately` async generator in Task 5 keeps its unreachable `yield` (marked `# pragma: no cover`) — that is the idiomatic way to make a `raise`-only coroutine an async generator, not a placeholder.
+
+**Type consistency:**
+- `parse_futures_message(raw, *, now)` returns `FuturesWsEvent | None`; `AggTradeEvent` fields (`symbol`, `price`, `qty`, `trade_time`, `is_buyer_maker`) consistent across Tasks 1, 2, 6.
+- `apply_event(state, event)` (freshness from the event's own timestamp) and `kline_to_candle(event)` signatures consistent across Tasks 2, 4.
+- `EventDrivenSignal(product=, symbol=, config=, max_candles=)` + `.ingest_kline()` + `.candle_count` consistent across Tasks 3, 4.
+- `ScalpingDaemonSupervisor(symbols=, product=, limits=, signal_config=, debounce_seconds=, clock=)`, `.run(source_factory, *, on_trigger, stop_after)`, `.run_with_reconnect(source_factory, *, on_trigger, sleep)`, and `TriggerEvent(product, symbol, side, decision, bid_price, ask_price, data_age_seconds, emitted_at)` consistent across Tasks 4, 5, 7.
+- `run_daemon(*, symbols, source_factory, clock)` returns trigger count; matches its test (Task 7).
+- `build_summary` status string changes from `"pending_supervisor"` (slice 2) to `"running"`, with the slice-2 test updated in the same task (Task 7 Step 3) — no stale assertion left behind.
+
+---
+
+## Next slice (separate plan)
+
+- **Slice 4:** `demo_scalping_exec/ws_bridge.py` — `on_trigger` that (1) re-loads the live `LedgerSnapshot` via `ledger_state`, (2) builds `MarketConditions` (spread from `TriggerEvent.bid_price`/`ask_price`, data age, spot base qty), (3) calls `evaluate_risk`, (4) only if allowed AND `WS_CONFIRM` true, acquires the per-symbol lock + global semaphore and calls `DemoScalpingExecutor`, (5) records analytics. Tests: `confirm=false` blocks mutation, risk-gate block logs reason codes, one-open-lifecycle/in-flight duplicate guard, semaphore caps concurrency. Plus the dedicated `docs/runbooks/binance-demo-ws-scalping.md` entry and the final handoff checklist (design §14).

--- a/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice4-implementation-plan.md
+++ b/docs/plans/ROB-317-binance-demo-ws-scalping-daemon-slice4-implementation-plan.md
@@ -1,0 +1,912 @@
+# Binance Demo WS Scalping Daemon — Slice 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the loop — turn the slice-3 `TriggerEvent` stream into confirm-gated, concurrency-guarded **real Demo orders** via the existing `DemoScalpingExecutor`, wire it into the daemon CLI, and ship the operator runbook. This is the **only slice that can place orders** (demo-fapi, behind all three gates).
+
+**Architecture:** The executor already owns the authoritative ledger-backed risk re-check (`_preflight`) and analytics — slice 4 does **not** re-implement them. The new `demo_scalping_exec/ws_bridge.py` is a thin `on_trigger` callback that: (1) applies an **in-process concurrency guard** the executor lacks (per-symbol in-flight + global cap), (2) builds an `OrderIntent` + `MarketConditions` from the trigger, (3) calls `execute_monitored(intent, confirm=mutation_allowed, market=...)`. The bridge lives on the **exec** side (it may import the executor/ledger); the read-only `demo_scalping_ws/` package still must not import the bridge — the AST guard stays green because the dependency direction is exec→ws (the bridge imports `TriggerEvent`), never ws→exec.
+
+**Concurrency model (decision):** `on_trigger` is **awaited sequentially** by the supervisor. Because the global open-lifecycle cap is **1**, at most one position exists at a time, so sequential execution misses no tradeable opportunity (a second entry would be ledger-blocked anyway). The in-process guard is therefore enforced with **synchronous counters** (race-free in single-threaded asyncio) and is proven by invoking `on_trigger` concurrently in tests. Known tradeoff: while a bounded monitor runs (≤ `max_runtime_s`), the supervisor pauses consuming events; on resume the freshness gate blocks until quotes are fresh again. If true multi-symbol concurrent trading is ever wanted (global cap > 1), the bridge would move to background-task dispatch — out of scope here.
+
+**Tech Stack:** Python 3.13, `uv`, `pytest`, `pytest-asyncio`, `ruff`, stdlib `asyncio`/`datetime`/`decimal`. Reuses `DemoScalpingExecutor`, `build_order_intent`, `MarketConditions`, `BinanceFuturesDemoExecutionClient`, `DemoScalpingMarketData`, `DemoReferenceData`, `AsyncSessionLocal`.
+
+---
+
+## Boundary & reuse notes (read before starting)
+
+- `ws_bridge.py` goes in `app/services/brokers/binance/demo_scalping_exec/` (the **mutation** package), NOT `demo_scalping_ws/`. It imports `TriggerEvent` from `demo_scalping_ws.supervisor` (exec→ws, allowed) and the executor/intent/clients (same package / contract).
+- The executor's `execute_monitored(intent, *, confirm=False, market=None, ...)` performs the live-ledger risk re-check in `_preflight` and writes analytics in `_finalize_analytics`. **Do not duplicate** risk or analytics in the bridge.
+- `confirm=False` ⇒ the executor/client place **no** orders (dry-run); this is already enforced and tested at the client/executor layer. The bridge's job is to pass `confirm=gates.mutation_allowed` faithfully.
+- `build_order_intent(decision, *, product, symbol, limits, source_candle_close_time_ms, evaluated_at_ms)` needs the source candle's close time — slice 3's `TriggerEvent` does not carry it, so **Task 1 adds that field**.
+- The daemon trades **futures only** (`product="usdm_futures"`); the symbol allowlist + caps come from `ScalpingRiskLimits` (unchanged).
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `app/services/brokers/binance/demo_scalping_ws/supervisor.py` (modify) | Add `source_candle_close_time_ms` to `TriggerEvent`; populate it from the closing kline |
+| `app/services/brokers/binance/demo_scalping_exec/ws_bridge.py` (create) | `WsExecutionBridge` (guard + intent + confirm passthrough), `make_demo_futures_trade_runner`, `build_ws_execution_bridge_from_env` |
+| `scripts/binance_demo_scalping_ws_daemon.py` (modify) | Active path uses the bridge as `on_trigger` (confirm=`mutation_allowed`); injectable for tests |
+| `docs/runbooks/binance-demo-ws-scalping.md` (create) | Operator runbook (startup/dry-run/confirm/health/stop/rollback/failures) |
+| `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py` (modify) | Assert `source_candle_close_time_ms` on the emitted trigger |
+| `tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py` (create) | confirm passthrough, concurrency guard, release on success/exception, intent-None |
+| `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py` (modify) | Active path wires the bridge; injected `on_trigger` |
+
+---
+
+### Task 1: Carry the source candle close time on `TriggerEvent`
+
+`build_order_intent` requires `source_candle_close_time_ms`. Propagate it from the closing kline through the trigger.
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_ws/supervisor.py`
+- Test: `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py`:
+
+```python
+async def test_trigger_carries_source_candle_close_time() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert len(captured) == 1
+    # The breakout candle is minute=25; its close_time is open+59s.
+    expected_close = _T0 + dt.timedelta(minutes=25, seconds=59)
+    assert captured[0].source_candle_close_time_ms == int(
+        expected_close.timestamp() * 1000
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -k source_candle -v`
+Expected: FAIL — `AttributeError: 'TriggerEvent' object has no attribute 'source_candle_close_time_ms'`.
+
+- [ ] **Step 3: Add the field and populate it**
+
+In `supervisor.py`, add the field to `TriggerEvent` (after `decision`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class TriggerEvent:
+    """An event-driven entry candidate, pre-risk-check (slice 4 consumes it)."""
+
+    product: Product
+    symbol: str
+    side: Side
+    decision: SignalDecision
+    source_candle_close_time_ms: int
+    bid_price: Decimal | None
+    ask_price: Decimal | None
+    data_age_seconds: float | None
+    emitted_at: dt.datetime
+```
+
+Thread the closing kline's close time from `_handle_event` into `_gate_and_build`. In `_handle_event`, change the kline branch:
+
+```python
+        decision = self._signals[symbol].ingest_kline(event)
+        if not decision.has_entry or decision.side is None:
+            return None
+        return self._gate_and_build(
+            symbol,
+            state,
+            decision,
+            now,
+            source_candle_close_time_ms=int(event.close_time.timestamp() * 1000),
+        )
+```
+
+Update `_gate_and_build`'s signature and the `TriggerEvent(...)` construction:
+
+```python
+    def _gate_and_build(
+        self,
+        symbol: str,
+        state: MarketState,
+        decision: SignalDecision,
+        now: dt.datetime,
+        *,
+        source_candle_close_time_ms: int,
+    ) -> TriggerEvent | None:
+        # ... freshness + debounce gates unchanged ...
+        return TriggerEvent(
+            product=self._product,
+            symbol=symbol,
+            side=decision.side,
+            decision=decision,
+            source_candle_close_time_ms=source_candle_close_time_ms,
+            bid_price=state.bid_price,
+            ask_price=state.ask_price,
+            data_age_seconds=age,
+            emitted_at=now,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py -v`
+Expected: PASS (all prior supervisor tests + the new one). The existing tests assert `.symbol`/`.side` and trigger counts, which are unaffected by the added field.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_ws/supervisor.py \
+        tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): carry source candle close time on TriggerEvent
+
+Slice 4. build_order_intent needs source_candle_close_time_ms; propagate it
+from the closing kline through the trigger.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: `WsExecutionBridge` — guard + intent + confirm passthrough
+
+The bridge is the `on_trigger` callback. It enforces the in-process concurrency guard (per-symbol in-flight + global cap) that the executor lacks, builds the intent + market snapshot, and delegates the trade to an injectable `trade_runner` (the real one is Task 3; tests pass a fake). Risk re-check and analytics live inside the runner's executor — not here.
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_exec/ws_bridge.py`
+- Test: `tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/binance/demo_scalping_exec/__init__.py` (empty if absent) and `tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py`:
+
+```python
+"""ROB-317 — WsExecutionBridge guard + confirm passthrough."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.signal import SignalDecision
+from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
+from app.services.brokers.binance.demo_scalping_exec.ws_bridge import WsExecutionBridge
+
+pytestmark = pytest.mark.asyncio
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _trigger(symbol: str = "XRPUSDT", side: str = "BUY") -> TriggerEvent:
+    decision = SignalDecision(
+        has_entry=True, side=side, entry_price=Decimal("0.60"),
+        tp_price=Decimal("0.62"), sl_price=Decimal("0.59"),
+        confidence=Decimal("0.8"), reason_codes=("enter_long_breakout",),
+    )
+    return TriggerEvent(
+        product="usdm_futures", symbol=symbol, side=side, decision=decision,
+        source_candle_close_time_ms=1716724799999,
+        bid_price=Decimal("0.5999"), ask_price=Decimal("0.6001"),
+        data_age_seconds=3.0, emitted_at=_T0,
+    )
+
+
+class _RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bool]] = []
+
+    async def __call__(self, intent, market, confirm, now) -> object:
+        self.calls.append((intent.symbol, confirm))
+        return SimpleNamespace(status="filled")
+
+
+def _bridge(runner, *, confirm: bool, global_cap: int = 1) -> WsExecutionBridge:
+    return WsExecutionBridge(
+        trade_runner=runner,
+        limits=ScalpingRiskLimits(global_open_lifecycle_cap=global_cap),
+        confirm=confirm,
+        clock=lambda: _T0,
+    )
+
+
+async def test_confirm_true_passes_through() -> None:
+    runner = _RecordingRunner()
+    await _bridge(runner, confirm=True)(_trigger())
+    assert runner.calls == [("XRPUSDT", True)]
+
+
+async def test_confirm_false_passes_through_no_mutation_flag() -> None:
+    runner = _RecordingRunner()
+    await _bridge(runner, confirm=False)(_trigger())
+    assert runner.calls == [("XRPUSDT", False)]
+
+
+async def test_same_symbol_inflight_is_skipped() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _Blocking:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls.append(intent.symbol)
+            started.set()
+            await release.wait()
+            return SimpleNamespace(status="filled")
+
+    runner = _Blocking()
+    bridge = _bridge(runner, confirm=True)
+    t1 = asyncio.create_task(bridge(_trigger("XRPUSDT")))
+    await started.wait()  # t1 has entered the runner and holds the guard
+    await bridge(_trigger("XRPUSDT"))  # second same-symbol call: skipped immediately
+    release.set()
+    await t1
+    assert runner.calls == ["XRPUSDT"]  # only one entry ran
+
+
+async def test_global_cap_blocks_other_symbol() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _Blocking:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls.append(intent.symbol)
+            started.set()
+            await release.wait()
+            return SimpleNamespace(status="filled")
+
+    runner = _Blocking()
+    bridge = _bridge(runner, confirm=True, global_cap=1)
+    t1 = asyncio.create_task(bridge(_trigger("XRPUSDT")))
+    await started.wait()
+    await bridge(_trigger("DOGEUSDT"))  # different symbol, but global cap=1 -> skip
+    release.set()
+    await t1
+    assert runner.calls == ["XRPUSDT"]
+
+
+async def test_guard_released_after_completion() -> None:
+    runner = _RecordingRunner()
+    bridge = _bridge(runner, confirm=True)
+    await bridge(_trigger("XRPUSDT"))
+    await bridge(_trigger("XRPUSDT"))  # guard freed -> second runs
+    assert runner.calls == [("XRPUSDT", True), ("XRPUSDT", True)]
+
+
+async def test_guard_released_on_runner_exception() -> None:
+    class _Boom:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls += 1
+            raise RuntimeError("executor blew up")
+
+    runner = _Boom()
+    bridge = _bridge(runner, confirm=True)
+    with pytest.raises(RuntimeError):
+        await bridge(_trigger("XRPUSDT"))
+    with pytest.raises(RuntimeError):
+        await bridge(_trigger("XRPUSDT"))  # guard not leaked
+    assert runner.calls == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py -v`
+Expected: FAIL — `ModuleNotFoundError: ... ws_bridge`.
+
+- [ ] **Step 3: Create `ws_bridge.py` (bridge + guard only)**
+
+```python
+"""ROB-317 — WS trigger → Demo executor bridge (the only mutation path).
+
+The supervisor (read-only package) emits TriggerEvents; this exec-side
+callback turns an allowed, confirmed trigger into a real Demo order via the
+existing DemoScalpingExecutor. The executor owns the authoritative
+ledger-backed risk re-check and analytics — this bridge adds only the
+in-process concurrency guard the executor lacks, builds the order intent +
+market snapshot, and passes the confirm flag through.
+
+Concurrency: on_trigger is awaited sequentially by the supervisor; with a
+global open-lifecycle cap of 1 at most one position exists at a time. The
+guard uses synchronous counters (race-free in single-threaded asyncio) so a
+second trigger for the same symbol — or any symbol once the global cap is
+reached — is skipped rather than double-entered. See ROB-317 design §6.2.
+
+No live host, no order placed unless ``confirm=True`` (which the client/
+executor layer enforces and tests).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Awaitable, Callable
+from decimal import Decimal
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.order_intent import (
+    OrderIntent,
+    build_order_intent,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
+
+logger = logging.getLogger("rob317.ws_bridge")
+
+# (intent, market, confirm, now) -> execution result
+TradeRunner = Callable[
+    [OrderIntent, MarketConditions, bool, dt.datetime], Awaitable[Any]
+]
+Clock = Callable[[], dt.datetime]
+
+
+def _default_clock() -> dt.datetime:
+    return dt.datetime.now(tz=dt.UTC)
+
+
+def _spread_bps(bid: Decimal | None, ask: Decimal | None) -> Decimal:
+    """Best-bid/ask spread in bps; 0 when a side is missing (preflight will
+    re-evaluate against the executor's own snapshot too)."""
+    if bid is None or ask is None or bid <= 0 or ask <= 0:
+        return Decimal("0")
+    mid = (bid + ask) / Decimal("2")
+    return (ask - bid) / mid * Decimal("10000")
+
+
+class WsExecutionBridge:
+    """Trigger → confirm-gated, concurrency-guarded Demo executor call."""
+
+    def __init__(
+        self,
+        *,
+        trade_runner: TradeRunner,
+        limits: ScalpingRiskLimits | None = None,
+        confirm: bool = False,
+        clock: Clock = _default_clock,
+    ) -> None:
+        self._trade_runner = trade_runner
+        self._limits = limits or ScalpingRiskLimits()
+        self._confirm = confirm
+        self._clock = clock
+        self._global_cap = self._limits.global_open_lifecycle_cap
+        self._inflight: set[str] = set()
+        self._global_inflight = 0
+
+    async def __call__(self, trigger: TriggerEvent) -> None:
+        symbol = trigger.symbol
+        # Synchronous guard checks + reservation: no await between check and
+        # reserve, so this is race-free under single-threaded asyncio.
+        if symbol in self._inflight:
+            logger.info(
+                "ws_bridge skip symbol=%s reason=%s",
+                symbol,
+                ReasonCode.OPEN_LIFECYCLE_EXISTS,
+            )
+            return
+        if self._global_inflight >= self._global_cap:
+            logger.info(
+                "ws_bridge skip symbol=%s reason=%s",
+                symbol,
+                ReasonCode.GLOBAL_LIFECYCLE_CAP_REACHED,
+            )
+            return
+        self._inflight.add(symbol)
+        self._global_inflight += 1
+        try:
+            now = self._clock()
+            intent = build_order_intent(
+                trigger.decision,
+                product=trigger.product,
+                symbol=symbol,
+                limits=self._limits,
+                source_candle_close_time_ms=trigger.source_candle_close_time_ms,
+                evaluated_at_ms=int(now.timestamp() * 1000),
+            )
+            if intent is None:
+                return
+            market = MarketConditions(
+                spread_bps=_spread_bps(trigger.bid_price, trigger.ask_price),
+                data_age_seconds=trigger.data_age_seconds or 0.0,
+                spot_free_base_qty=Decimal("0"),
+            )
+            result = await self._trade_runner(intent, market, self._confirm, now)
+            logger.info(
+                "ws_bridge executed symbol=%s side=%s confirm=%s status=%s",
+                symbol,
+                trigger.side,
+                self._confirm,
+                getattr(result, "status", None),
+            )
+        finally:
+            self._inflight.discard(symbol)
+            self._global_inflight -= 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_exec/ws_bridge.py \
+        tests/services/brokers/binance/demo_scalping_exec/__init__.py \
+        tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): WsExecutionBridge — concurrency guard + confirm passthrough
+
+Slice 4. on_trigger callback adds the in-process per-symbol + global-cap guard
+(synchronous counters, race-free) the executor lacks, builds intent + market,
+and passes confirm through to an injectable trade_runner. Risk re-check +
+analytics stay in the executor. Guard released on success and exception.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Real trade runner + env factory
+
+The real `trade_runner` constructs a per-trade DB session + executor and calls `execute_monitored`, mirroring `app/jobs/binance_demo_scalping_runner.py`. The env factory builds the futures client + market data + reference and wires a ready bridge.
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_exec/ws_bridge.py`
+- Test: append to `tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py`:
+
+```python
+async def test_make_demo_futures_trade_runner_calls_execute_monitored() -> None:
+    seen: dict[str, object] = {}
+
+    class _FakeSession:
+        async def __aenter__(self) -> "_FakeSession":
+            return self
+
+        async def __aexit__(self, *exc) -> None:
+            return None
+
+        async def commit(self) -> None:
+            seen["committed"] = True
+
+    class _FakeExecutor:
+        def __init__(self, **kwargs) -> None:
+            seen["product"] = kwargs["product"]
+            seen["now"] = kwargs["now"]
+
+        async def execute_monitored(self, intent, *, confirm, market) -> object:
+            seen["confirm"] = confirm
+            seen["symbol"] = intent.symbol
+            return SimpleNamespace(status="filled")
+
+    from app.services.brokers.binance.demo_scalping_exec import ws_bridge as mod
+
+    runner = mod.make_demo_futures_trade_runner(
+        client=object(),
+        market_data=object(),
+        reference=object(),
+        session_factory=lambda: _FakeSession(),
+        limits=ScalpingRiskLimits(),
+        executor_cls=_FakeExecutor,
+    )
+    intent = build_order_intent(
+        _trigger().decision, product="usdm_futures", symbol="XRPUSDT",
+        limits=ScalpingRiskLimits(), source_candle_close_time_ms=1, evaluated_at_ms=2,
+    )
+    result = await runner(intent, _market(), True, _T0)
+    assert seen == {
+        "product": "usdm_futures", "now": _T0, "confirm": True,
+        "symbol": "XRPUSDT", "committed": True,
+    }
+    assert result.status == "filled"
+
+
+def _market() -> object:
+    from app.services.brokers.binance.demo_scalping.contract import MarketConditions
+    return MarketConditions(
+        spread_bps=Decimal("1"), data_age_seconds=2.0, spot_free_base_qty=Decimal("0")
+    )
+```
+
+Add this import near the top of the test file:
+
+```python
+from app.services.brokers.binance.demo_scalping.order_intent import build_order_intent
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py -k trade_runner -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'make_demo_futures_trade_runner'`.
+
+- [ ] **Step 3: Add the runner + env factory to `ws_bridge.py`**
+
+Add a session-factory type alias near the other aliases (`Callable`/`Any` are already imported from Task 2 — add no new imports):
+
+```python
+SessionFactory = Callable[[], Any]
+```
+
+Append to `ws_bridge.py`:
+
+```python
+def make_demo_futures_trade_runner(
+    *,
+    client: Any,
+    market_data: Any,
+    reference: Any,
+    session_factory: SessionFactory,
+    limits: ScalpingRiskLimits,
+    executor_cls: Any | None = None,
+) -> TradeRunner:
+    """Build a TradeRunner that opens a per-trade session + executor.
+
+    ``executor_cls`` is injectable for tests; production uses the real
+    DemoScalpingExecutor (imported lazily so the disabled path never touches
+    broker/DB modules). Mirrors app/jobs/binance_demo_scalping_runner.py.
+    """
+    if executor_cls is None:
+        from app.services.brokers.binance.demo_scalping_exec.executor import (
+            DemoScalpingExecutor,
+        )
+
+        executor_cls = DemoScalpingExecutor
+
+    async def _run(
+        intent: OrderIntent,
+        market: MarketConditions,
+        confirm: bool,
+        now: dt.datetime,
+    ) -> Any:
+        async with session_factory() as session:
+            executor = executor_cls(
+                product="usdm_futures",
+                client=client,
+                session=session,
+                reference=reference,
+                now=now,
+                market_data=market_data,
+                limits=limits,
+            )
+            result = await executor.execute_monitored(
+                intent, confirm=confirm, market=market
+            )
+            await session.commit()
+            return result
+
+    return _run
+
+
+async def build_ws_execution_bridge_from_env(
+    *,
+    confirm: bool,
+    clock: Clock = _default_clock,
+    limits: ScalpingRiskLimits | None = None,
+) -> tuple["WsExecutionBridge", Callable[[], Awaitable[None]]]:
+    """Construct a futures Demo bridge from env + its async cleanup.
+
+    Lazy imports keep the disabled CLI path free of broker/DB setup. Futures
+    only; demo-fapi only (host-guarded at the client transport).
+    """
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.reference import (
+        DemoReferenceData,
+    )
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+
+    resolved_limits = limits or ScalpingRiskLimits()
+    client = BinanceFuturesDemoExecutionClient.from_env()
+    market_data = DemoScalpingMarketData()
+    reference = DemoReferenceData()
+    runner = make_demo_futures_trade_runner(
+        client=client,
+        market_data=market_data,
+        reference=reference,
+        session_factory=AsyncSessionLocal,
+        limits=resolved_limits,
+    )
+    bridge = WsExecutionBridge(
+        trade_runner=runner, limits=resolved_limits, confirm=confirm, clock=clock
+    )
+
+    async def _aclose() -> None:
+        await market_data.aclose()
+        await reference.aclose()
+        aclose = getattr(client, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+    return bridge, _aclose
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_exec/ws_bridge.py \
+        tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): real futures trade runner + env-built bridge factory
+
+Slice 4. make_demo_futures_trade_runner opens a per-trade session + executor
+and calls execute_monitored (mirrors the scheduler runner). build_ws_execution
+_bridge_from_env wires futures client + market data + reference + cleanup; lazy
+imports keep the disabled path broker/DB-free.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Wire the CLI active path to the bridge
+
+Replace the slice-3 log-only sink: when `daemon_active`, build the bridge from env with `confirm=gates.mutation_allowed` and use it as `on_trigger`. Keep `on_trigger` injectable so tests stay network/DB-free.
+
+**Files:**
+- Modify: `scripts/binance_demo_scalping_ws_daemon.py`
+- Test: `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the slice-3 `test_run_daemon_logs_triggers_without_mutation` test with an injected-`on_trigger` version, and add a wiring assertion. In `tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_run_daemon_routes_triggers_to_injected_on_trigger() -> None:
+    seen: list[str] = []
+
+    async def fake_on_trigger(trigger) -> None:
+        seen.append(trigger.symbol)
+
+    await run_daemon(
+        symbols=["XRPUSDT"],
+        source_factory=lambda: _source(_seq()),
+        on_trigger=fake_on_trigger,
+        clock=lambda: _T0 + dt.timedelta(seconds=5),
+    )
+    assert seen == ["XRPUSDT"]  # one BUY breakout routed to the sink
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -k routes_triggers -v`
+Expected: FAIL — `TypeError: run_daemon() got an unexpected keyword argument 'on_trigger'` (slice 3 had no `on_trigger` param).
+
+- [ ] **Step 3: Update `run_daemon` to accept an injectable `on_trigger` and default to the bridge**
+
+Replace the slice-3 `run_daemon` body (and its imports) in `scripts/binance_demo_scalping_ws_daemon.py`:
+
+```python
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+from app.services.brokers.binance.demo_scalping_ws.supervisor import (
+    ScalpingDaemonSupervisor,
+    TriggerEvent,
+)
+
+OnTrigger = Callable[[TriggerEvent], Awaitable[None]]
+
+
+async def run_daemon(
+    *,
+    symbols: list[str],
+    source_factory: Callable[[], AsyncIterator[FuturesWsEvent]] | None = None,
+    on_trigger: OnTrigger | None = None,
+    confirm: bool = False,
+    clock: Callable[[], dt.datetime] | None = None,
+) -> None:
+    """Run the trigger pipeline.
+
+    Production: ``on_trigger`` defaults to the env-built WsExecutionBridge
+    (confirm passed in from gates). Tests inject ``source_factory`` +
+    ``on_trigger`` to stay network/DB-free.
+    """
+    factory = source_factory or _real_source_factory(symbols)
+    sup = ScalpingDaemonSupervisor(
+        symbols=symbols, **({"clock": clock} if clock else {})
+    )
+    aclose: Callable[[], Awaitable[None]] | None = None
+    if on_trigger is None:
+        from app.services.brokers.binance.demo_scalping_exec.ws_bridge import (
+            build_ws_execution_bridge_from_env,
+        )
+
+        bridge, aclose = await build_ws_execution_bridge_from_env(confirm=confirm)
+        on_trigger = bridge
+    try:
+        await sup.run_with_reconnect(factory, on_trigger=on_trigger)
+    finally:
+        if aclose is not None:
+            await aclose()
+```
+
+Update `main` so the active path passes `confirm=gates.mutation_allowed` (the disabled path is unchanged):
+
+```python
+    asyncio.run(run_daemon(symbols=symbols, confirm=gates.mutation_allowed))
+```
+
+Remove the now-unused slice-3 trigger-counting `on_trigger` closure and the `count`/`return count` from `run_daemon` (it no longer returns a count). If any slice-3 test asserted a return count, it was replaced in Step 1.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py -v`
+Expected: PASS (disabled-path tests + `running` status test + the new injected-`on_trigger` test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/binance_demo_scalping_ws_daemon.py \
+        tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+git commit -m "$(cat <<'EOF'
+feat(rob-317): CLI active path executes via WsExecutionBridge
+
+Slice 4. daemon_active builds the env bridge with confirm=mutation_allowed and
+routes triggers to it; confirm=false runs the executor in dry-run (no order).
+on_trigger stays injectable for network/DB-free tests.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Operator runbook
+
+**Files:**
+- Create: `docs/runbooks/binance-demo-ws-scalping.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/runbooks/binance-demo-ws-scalping.md` with these sections (prose, mirroring `docs/runbooks/binance-futures-demo-smoke.md` house style):
+
+1. **Scope & lane boundaries** — read-only market data on `fstream.binance.com`; order mutation demo-only on `demo-fapi.binance.com`; live/testnet refused fail-closed. Reference the design doc.
+2. **Preconditions** — `BINANCE_FUTURES_DEMO_*` / canonical `BINANCE_DEMO_*` creds present; DB reachable; ledger migrated.
+3. **Three gates** — `BINANCE_DEMO_SCALPING_ENABLED`, `BINANCE_DEMO_SCALPING_WS_ENABLED`, `BINANCE_DEMO_SCALPING_WS_CONFIRM`; the gate-behavior table (disabled / dry-run / confirmed).
+4. **Default-disabled startup** — `uv run python -m scripts.binance_demo_scalping_ws_daemon` → `{"status":"disabled",...}`, exit 0, no subscribe.
+5. **Dry-run** — `ENABLED=true WS_ENABLED=true WS_CONFIRM=false` → subscribes fstream, evaluates triggers, runs the executor in dry-run (zero broker mutation). Watch structured `ws_bridge`/`trigger` logs.
+6. **Confirmed Demo startup** — all three true → real Demo orders on demo-fapi only; every order still subject to risk gates + the in-process concurrency guard (one open lifecycle). Verify via the ledger after the first round-trip.
+7. **Health check** — poll the `health.py` snapshot; confirm connected + per-symbol freshness < 120s + last outcome sane.
+8. **Stop / rollback** — stop the process; set `WS_ENABLED=false` to disable without removing config; reconcile any open position via the futures-demo smoke CLI; the 5-min Prefect tick remains the fallback observation path.
+9. **Failure categories** — stream disconnect (reconnect/backoff), stale data (`STALE_DATA` blocks), risk block (reason codes logged, no order), concurrency skip (`OPEN_LIFECYCLE_EXISTS`/`GLOBAL_LIFECYCLE_CAP_REACHED`), credential/DB unavailable (fail closed), confirm off (dry-run).
+10. **Relationship to the 5-min Prefect tick** — reclassified as polling intraday / smoke; pausing it is a deferred operator decision.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/binance-demo-ws-scalping.md
+git commit -m "$(cat <<'EOF'
+docs(rob-317): operator runbook for the WS scalping daemon
+
+Slice 4. Startup (disabled/dry-run/confirmed), health, stop/rollback, failure
+categories, lane boundaries, and the relationship to the 5-min Prefect tick.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Slice-wide verification + handoff
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run all ROB-317 daemon tests + the import guard**
+
+Run:
+```bash
+uv run pytest \
+  tests/services/brokers/binance/demo_scalping_ws/ \
+  tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py \
+  tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py \
+  tests/services/brokers/binance/demo/test_no_testnet_imports.py -v
+```
+Expected: PASS (all). The import guard must stay green: `ws_bridge.py` is in `demo_scalping_exec/` (allowed to import the executor), and `demo_scalping_ws/` still imports nothing from the exec side — the dependency is exec→ws (`ws_bridge` imports `TriggerEvent`), never ws→exec.
+
+- [ ] **Step 2: Lint changed surfaces**
+
+Run:
+```bash
+uv run ruff check \
+  app/services/brokers/binance/demo_scalping_ws/supervisor.py \
+  app/services/brokers/binance/demo_scalping_exec/ws_bridge.py \
+  scripts/binance_demo_scalping_ws_daemon.py \
+  tests/services/brokers/binance/demo_scalping_exec/ \
+  tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py \
+  tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+```
+Expected: no errors. Run `uv run ruff format` on the same paths if needed, then amend.
+
+- [ ] **Step 3: Confirm the disabled path is still fully inert (no broker/DB import reached)**
+
+Run: `env -u BINANCE_DEMO_SCALPING_ENABLED -u BINANCE_DEMO_SCALPING_WS_ENABLED -u BINANCE_DEMO_SCALPING_WS_CONFIRM uv run python -m scripts.binance_demo_scalping_ws_daemon`
+Expected: `{"base_enabled": false, "status": "disabled", "subscribed": false, "ws_enabled": false}`, exit 0. (The bridge/executor are lazily imported only on the active path, so the disabled run touches no broker/DB module.)
+
+- [ ] **Step 4: Full broker regression sweep**
+
+Run: `uv run pytest tests/services/brokers/binance/ -q`
+Expected: PASS — slice-4 additions plus all existing ROB-285/298/307/313/315 broker tests green.
+
+- [ ] **Step 5: Run the full repo import guards + targeted lint (pre-merge gate)**
+
+Run:
+```bash
+uv run ruff check app/ tests/ scripts/
+uv run pytest tests/services/brokers/binance/demo/test_no_testnet_imports.py -q
+```
+Expected: clean. (Per the project's pre-merge full-CI gate: branch protection does not gate lint/test, so confirm these before any merge.)
+
+---
+
+## Self-Review
+
+**Spec coverage (design §13 slice-4 scope + §10 remaining test-list items):**
+- `ws_bridge.py`: trigger → confirm-gated executor (design §13) → Task 2, Task 3 ✓
+- Live ledger risk re-check before executor call (design §6.2) → delegated to the executor's `_preflight` (reused, not duplicated); the bridge adds the in-process guard → Task 2 ✓
+- Two-layer concurrency guard / one-open-lifecycle / in-flight duplicate (design §6.2; test-list) → Task 2 (in-process counters + concurrent-call tests) + executor `_preflight` (durable DB backstop) ✓
+- `confirm=false` blocks mutation (test-list) → Task 2 (passthrough) + Task 4 (CLI confirm=mutation_allowed); enforced at the client/executor layer ✓
+- Risk-gate-blocked path logs reason codes, no order (test-list) → executor `_preflight` (existing coverage); bridge logs concurrency-skip reason codes ✓
+- Analytics/review wiring (design §13) → executor `_finalize_analytics` (reused) ✓
+- Dedicated runbook (design §13, §14) → Task 5 ✓
+- Handoff checklist (design §14) → Task 6 + the handoff note below ✓
+
+**Placeholder scan:** No "TBD"/"implement later". Every code step ships complete code. Task 5 (runbook) is a prose-section list because the runbook is documentation, not code — each section is specified concretely.
+
+**Type consistency:**
+- `TriggerEvent` gains `source_candle_close_time_ms: int` (Task 1) and the bridge reads it (Task 2) — consistent.
+- `TradeRunner = (OrderIntent, MarketConditions, bool, dt.datetime) -> Awaitable[Any]` used identically by `WsExecutionBridge.__call__`, `make_demo_futures_trade_runner`, and the bridge tests (Tasks 2, 3).
+- `WsExecutionBridge(trade_runner=, limits=, confirm=, clock=)` consistent across Tasks 2, 3, 4.
+- `build_ws_execution_bridge_from_env(*, confirm, clock=, limits=) -> (bridge, aclose)` consistent (Task 3) with its CLI call site (Task 4).
+- `run_daemon(*, symbols, source_factory=, on_trigger=, confirm=, clock=)` consistent between Task 4's implementation and tests; the slice-3 trigger-count return is removed and its test replaced in the same task — no stale assertion.
+
+**Cross-slice note:** Task 1 modifies the slice-3 `supervisor.py`/`test_supervisor.py` (adds a field) and Task 4 modifies the slice-3 CLI + test (swaps the log-only sink). Both are additive/explicit and update their tests in the same task.
+
+---
+
+## Handoff (per design §14, fill in at PR time)
+
+- Branch `rob-317`; PR URL: _(to add)_.
+- Files changed: `supervisor.py`, `ws_bridge.py` (new), `binance_demo_scalping_ws_daemon.py`, `binance-demo-ws-scalping.md` (new) + tests.
+- Tests run + results: the Task 6 commands and their pass counts.
+- Migrations: **none** — reuses `binance_demo_order_ledger` + `scalp_trade_analytics` (no schema change).
+- Env flags: dry-run = `BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_DEMO_SCALPING_WS_ENABLED=true` (confirm unset); confirmed = add `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`.
+- Explicit statement: no live orders, no production scheduler/launchd mutation, no secret logging performed.
+- Recommended Hermes post-merge checks: poll the health snapshot for liveness; after the first confirmed round-trip, spot-check the `binance_demo_order_ledger` + `scalp_trade_analytics` rows.
+- This completes the ROB-317 daemon (slices 1–4). The 5-min Prefect tick remains; pausing it is a deferred operator decision.

--- a/docs/runbooks/binance-demo-ws-scalping.md
+++ b/docs/runbooks/binance-demo-ws-scalping.md
@@ -1,0 +1,148 @@
+# Binance Demo WebSocket Scalping Daemon — Runbook
+
+**Scope.** Operator runbook for the Binance Demo WebSocket Scalping Daemon (`scripts/binance_demo_scalping_ws_daemon.py`). This daemon consumes real-time market data to identify breakout scalping opportunities on Binance USD-M Perpetual Futures, and places confirm-gated, concurrency-guarded mock orders on the USD-M Futures Demo lane (`demo-fapi.binance.com`).
+
+---
+
+## 1. Lane boundaries and Scope
+
+* **Public Market Data:** Real-time best-bid/ask quotes and closed 1-minute klines are read-only from the public stream host `fstream.binance.com`. No credentials or subscriptions are required to ingest these public streams.
+* **Order Mutation:** Order placement and positions are restricted exclusively to the **Demo Futures** environment (`demo-fapi.binance.com`).
+* **Mainnet & Testnet Safe:** Hard fail-closed guards at the client transport layer prevent signed requests from reaching production mainnet (`fapi.binance.com`) or deprecated futures testnet (`testnet.binancefuture.com`).
+
+---
+
+## 2. Preconditions
+
+Before starting the daemon, ensure the following requirements are met:
+
+1. **Credentials Present:** Either the Futures-specific credentials (`BINANCE_FUTURES_DEMO_API_KEY` / `BINANCE_FUTURES_DEMO_API_SECRET`) or the canonical shared Demo credentials (`BINANCE_DEMO_API_KEY` / `BINANCE_DEMO_API_SECRET`) must be resolved.
+2. **Database Reachable:** The local or production PostgreSQL instance must be running, and the database URL (`DATABASE_URL`) must be configured.
+3. **Database Ledger Migrated:** Ensure all database migrations are applied:
+   ```bash
+   uv run alembic upgrade head
+   ```
+   (Reuses the existing `binance_demo_order_ledger` and `scalp_trade_analytics` tables.)
+
+---
+
+## 3. The Three Gates
+
+The behavior of the WebSocket daemon is strictly gated by three environment variables:
+
+| Gate | Type | Description |
+|---|---|---|
+| `BINANCE_DEMO_SCALPING_ENABLED` | Boolean | Central master kill-switch for all Binance demo scalping systems. |
+| `BINANCE_DEMO_SCALPING_WS_ENABLED` | Boolean | Activates the WebSocket-driven daemon lane specifically. |
+| `BINANCE_DEMO_SCALPING_WS_CONFIRM` | Boolean | Master confirmation switch for order placement. If `false`, the daemon operates in Dry-Run mode. |
+
+### Gate Behavior Matrix
+
+| `BINANCE_DEMO_SCALPING_ENABLED` | `BINANCE_DEMO_SCALPING_WS_ENABLED` | `BINANCE_DEMO_SCALPING_WS_CONFIRM` | Resulting Behavior |
+|:---:|:---:|:---:|---|
+| `false` / unset | (any) | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
+| `true` | `false` / unset | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
+| `true` | `true` | `false` / unset | **Dry-Run**. Subscribes to websocket streams, runs signal generation, but passes `confirm=False` to the executor (zero broker mutation). |
+| `true` | `true` | `true` | **Confirmed Demo Mode**. Real mock orders are placed on `demo-fapi.binance.com`. |
+
+---
+
+## 4. Operational Modes
+
+### 4.1. Default-Disabled Startup (Inert)
+
+With no environment variables set, the daemon runs in a completely inert state, printing its status and exiting with `0`:
+
+```bash
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+```
+
+Output:
+```json
+{"base_enabled": false, "status": "disabled", "subscribed": false, "ws_enabled": false}
+```
+
+### 4.2. Dry-Run Mode (Observation)
+
+To verify connection stability, signal generation, and data freshness without mutating your account balance:
+
+```bash
+export BINANCE_DEMO_SCALPING_ENABLED=true
+export BINANCE_DEMO_SCALPING_WS_ENABLED=true
+export BINANCE_DEMO_SCALPING_WS_CONFIRM=false
+
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+```
+
+**What to expect in Dry-Run:**
+* Prints `{"status": "running", "subscribed": false, ...}` to stdout.
+* Connects to `wss://fstream.binance.com` for allowed symbols (e.g. `XRPUSDT`).
+* Computes breakout signals in memory.
+* When a trigger is hit, runs the `WsExecutionBridge` and `DemoScalpingExecutor` with `confirm=False`.
+* Logs trigger events with `confirm=False status=None` or `status=dry_run`.
+
+### 4.3. Confirmed Demo Mode (Active Trading)
+
+To engage active trading on the Demo backend, add `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`:
+
+```bash
+export BINANCE_DEMO_SCALPING_ENABLED=true
+export BINANCE_DEMO_SCALPING_WS_ENABLED=true
+export BINANCE_DEMO_SCALPING_WS_CONFIRM=true
+
+uv run python -m scripts.binance_demo_scalping_ws_daemon
+```
+
+**Risk Safeguards:**
+* Real orders are executed against the Demo endpoint `demo-fapi.binance.com`.
+* Subject to **authoritative live-ledger risk checks** (`_preflight`) inside the executor.
+* Guided by an **in-process concurrency lock** (max `1` global position open at any time) to prevent race conditions or duplicate entries under fast websocket updates.
+* Writes full order histories to `binance_demo_order_ledger` and telemetry to `scalp_trade_analytics`.
+
+---
+
+## 5. Monitoring and Health Checks
+
+The daemon exposes health snapshots that can be polled or verified via standard logs.
+
+1. **Staleness Tracking:** Ensure `data_age_seconds` logged in triggers remains low (< 5 seconds). If a quote or kline is older than the limits permit (e.g. 120s), the supervisor automatically drops the trigger with `reason=STALE_DATA`.
+2. **Freshness Monitoring:** Look for periodic state updates and kline ingestion logs in stdout.
+3. **Database Spot-Checking:** Verify ledger records:
+   ```sql
+   SELECT * FROM binance_demo_order_ledger ORDER BY created_at DESC LIMIT 5;
+   ```
+
+---
+
+## 6. Stop and Rollback Procedures
+
+### 6.1. Stopping the Daemon
+Simply send a `SIGINT` (`Ctrl+C`) or `SIGTERM` to the process. The supervisor will close all streaming websocket connections and clean up any in-memory state cleanly.
+
+### 6.2. Rollback or Deactivation
+To deactivate the WebSocket daemon lane without deleting config files, set the specific enable gate to false:
+```bash
+export BINANCE_DEMO_SCALPING_WS_ENABLED=false
+```
+
+### 6.3. Manual Reconciliation
+If the daemon is terminated while a position is open, or if you need to manually reconcile/close a stale position:
+1. Reconcile or smoke-test via the USD-M Futures smoke CLI using the `reduceOnly` mode:
+   ```bash
+   uv run python -m scripts.binance_futures_demo_smoke --close-position --symbol XRPUSDT --confirm
+   ```
+
+---
+
+## 7. Failure Recovery and Troubleshooting
+
+* **Stream Disconnection:** The daemon implements automatic reconnects using jittered exponential backoff (per ROB-285). It attempts to reconnect continuously; however, if the consecutive failure threshold is breached, the supervisor will bubble up the exception and exit `1` so an external orchestrator (like systemd or Kubernetes) can restart it.
+* **Stale Quote block:** If you see `trigger suppressed symbol=XRPUSDT reason=STALE_DATA`, it means the WebSocket stream received a kline but the best-bid/ask quote ticker hasn't updated recently. This is a safety feature. Check if the WebSocket connection is laggy or if the market is illiquid.
+* **Concurrency Skip:** If you see `ws_bridge skip symbol=XRPUSDT reason=OPEN_LIFECYCLE_EXISTS`, it means a trade is already in progress for that symbol. If the global cap is hit, it logs `GLOBAL_LIFECYCLE_CAP_REACHED`. This is a desired safety behavior ensuring we do not double-enter.
+* **Database/Credentials Unavailable:** If PostgreSQL or the credentials fail, the daemon fails closed immediately and logs the error before subscribing.
+
+---
+
+## 8. Relationship to the 5-Minute Polling Tick
+
+The pre-existing 5-minute polling tick (run via TaskIQ / Prefect / scheduler) remains completely active and untouched by the WebSocket daemon. The 5-minute tick is now reclassified as a **polling intraday / smoke observation path**. Pausing the 5-minute polling scheduler is a deferred operator decision and is not required for the WebSocket daemon to run safely.

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -17,12 +17,28 @@ printed.
 from __future__ import annotations
 
 import argparse
+import asyncio
+import datetime as dt
 import json
 import logging
 import sys
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
+from app.services.brokers.binance.demo_scalping.contract import DEFAULT_ALLOWLIST
 from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    FuturesMarketStream,
+    FuturesWsEvent,
+    build_futures_stream_url,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import (
+    ScalpingDaemonSupervisor,
+    TriggerEvent,
+)
+
+
+OnTrigger = Callable[[TriggerEvent], Awaitable[None]]
 
 
 def build_summary(gates: WsDaemonGates) -> dict[str, Any]:
@@ -38,7 +54,7 @@ def build_summary(gates: WsDaemonGates) -> dict[str, Any]:
             "subscribed": False,
         }
     return {
-        "status": "pending_supervisor",
+        "status": "running",
         "base_enabled": gates.base_enabled,
         "ws_enabled": gates.ws_enabled,
         "mutation_allowed": gates.mutation_allowed,
@@ -58,12 +74,71 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+logger = logging.getLogger("rob317.demo_scalping_ws_daemon")
+
+_STREAMS = ("aggTrade", "bookTicker", "kline_1m")
+
+
+def _real_source_factory(
+    symbols: list[str],
+) -> Callable[[], AsyncIterator[FuturesWsEvent]]:
+    url = build_futures_stream_url(symbols, streams=_STREAMS)
+
+    async def _factory() -> AsyncIterator[FuturesWsEvent]:
+        async with FuturesMarketStream(url=url) as stream:
+            async for ev in stream.events():
+                yield ev
+
+    return _factory
+
+
+async def run_daemon(
+    *,
+    symbols: list[str],
+    source_factory: Callable[[], AsyncIterator[FuturesWsEvent]] | None = None,
+    on_trigger: OnTrigger | None = None,
+    confirm: bool = False,
+    clock: Callable[[], dt.datetime] | None = None,
+) -> None:
+    """Run the trigger pipeline.
+
+    Production: ``on_trigger`` defaults to the env-built WsExecutionBridge
+    (confirm passed in from gates). Tests inject ``source_factory`` +
+    ``on_trigger`` to stay network/DB-free.
+    """
+    factory = source_factory or _real_source_factory(symbols)
+    sup = ScalpingDaemonSupervisor(
+        symbols=symbols, **({"clock": clock} if clock else {})
+    )
+    aclose: Callable[[], Awaitable[None]] | None = None
+    if on_trigger is None:
+        from app.services.brokers.binance.demo_scalping_exec.ws_bridge import (
+            build_ws_execution_bridge_from_env,
+        )
+
+        bridge, aclose = await build_ws_execution_bridge_from_env(confirm=confirm)
+        on_trigger = bridge
+    try:
+        await sup.run_with_reconnect(factory, on_trigger=on_trigger)
+    finally:
+        if aclose is not None:
+            await aclose()
+
+
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     logging.basicConfig(level=args.log_level)
     gates = WsDaemonGates.from_env()
     summary = build_summary(gates)
     print(json.dumps(summary, sort_keys=True))
+    if not gates.daemon_active:
+        return 0
+    symbols = sorted(DEFAULT_ALLOWLIST)
+    logger.info(
+        "WS daemon active (mutation_allowed=%s) — turning triggers into real Demo orders",
+        gates.mutation_allowed,
+    )
+    asyncio.run(run_daemon(symbols=symbols, confirm=gates.mutation_allowed))
     return 0
 
 

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -3,15 +3,15 @@
 Default-disabled. Behaviour is entirely env-gated (see WsDaemonGates):
 
 * ``BINANCE_DEMO_SCALPING_ENABLED`` + ``BINANCE_DEMO_SCALPING_WS_ENABLED`` —
-  both must be truthy for the daemon to subscribe/evaluate.
+  both must be truthy for the daemon to subscribe + evaluate triggers.
 * ``BINANCE_DEMO_SCALPING_WS_CONFIRM`` — only when also truthy may real Demo
-  orders be placed (slice 4 wires the bridge; this slice never mutates).
+  orders be placed; otherwise the executor runs in dry-run (no mutation).
 
-Slice 2 ships the gate plumbing only: with gates off it prints a disabled
-summary and exits 0 without subscribing; with gates on it reports
-``pending_supervisor`` (the streaming supervisor lands in slice 3) and still
-does not open any socket. Demo hosts only; no live/testnet path; no secrets
-printed.
+With the gates off it prints a ``disabled`` summary and exits 0 without
+opening a socket. With the gates on it prints a ``running`` summary, subscribes
+to the read-only fstream futures streams, and routes triggers to the
+confirm-gated WsExecutionBridge. Demo hosts only; no live/testnet path; no
+secrets printed.
 """
 
 from __future__ import annotations
@@ -41,9 +41,11 @@ OnTrigger = Callable[[TriggerEvent], Awaitable[None]]
 
 
 def build_summary(gates: WsDaemonGates) -> dict[str, Any]:
-    """Map resolved gates to a single-line JSON-able summary.
+    """Map resolved gates to a single-line startup summary.
 
-    ``subscribed`` is always False in slice 2 — no socket is ever opened here.
+    Printed once before the run loop, so ``subscribed`` is the pre-run snapshot
+    (always False at print time); on the active path the socket is opened right
+    after this line.
     """
     if not gates.daemon_active:
         return {

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -37,7 +37,6 @@ from app.services.brokers.binance.demo_scalping_ws.supervisor import (
     TriggerEvent,
 )
 
-
 OnTrigger = Callable[[TriggerEvent], Awaitable[None]]
 
 

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -1,0 +1,71 @@
+"""ROB-317 — operator CLI for the Binance Demo WebSocket scalping daemon.
+
+Default-disabled. Behaviour is entirely env-gated (see WsDaemonGates):
+
+* ``BINANCE_DEMO_SCALPING_ENABLED`` + ``BINANCE_DEMO_SCALPING_WS_ENABLED`` —
+  both must be truthy for the daemon to subscribe/evaluate.
+* ``BINANCE_DEMO_SCALPING_WS_CONFIRM`` — only when also truthy may real Demo
+  orders be placed (slice 4 wires the bridge; this slice never mutates).
+
+Slice 2 ships the gate plumbing only: with gates off it prints a disabled
+summary and exits 0 without subscribing; with gates on it reports
+``pending_supervisor`` (the streaming supervisor lands in slice 3) and still
+does not open any socket. Demo hosts only; no live/testnet path; no secrets
+printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any
+
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def build_summary(gates: WsDaemonGates) -> dict[str, Any]:
+    """Map resolved gates to a single-line JSON-able summary.
+
+    ``subscribed`` is always False in slice 2 — no socket is ever opened here.
+    """
+    if not gates.daemon_active:
+        return {
+            "status": "disabled",
+            "base_enabled": gates.base_enabled,
+            "ws_enabled": gates.ws_enabled,
+            "subscribed": False,
+        }
+    return {
+        "status": "pending_supervisor",
+        "base_enabled": gates.base_enabled,
+        "ws_enabled": gates.ws_enabled,
+        "mutation_allowed": gates.mutation_allowed,
+        "subscribed": False,
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "ROB-317 Binance Demo WebSocket scalping daemon. Default-disabled "
+            "(zero side effects). Set BINANCE_DEMO_SCALPING_ENABLED=true and "
+            "BINANCE_DEMO_SCALPING_WS_ENABLED=true to activate."
+        )
+    )
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level)
+    gates = WsDaemonGates.from_env()
+    summary = build_summary(gates)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+++ b/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 
-from scripts.binance_demo_scalping_ws_daemon import build_summary, main
 from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+from scripts.binance_demo_scalping_ws_daemon import build_summary, main
 
 
 def test_summary_disabled_when_gates_off() -> None:

--- a/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+++ b/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
@@ -1,0 +1,37 @@
+"""ROB-317 — WS daemon CLI default-disabled behavior."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.binance_demo_scalping_ws_daemon import build_summary, main
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def test_summary_disabled_when_gates_off() -> None:
+    gates = WsDaemonGates(base_enabled=False, ws_enabled=False, ws_confirm=False)
+    summary = build_summary(gates)
+    assert summary["status"] == "disabled"
+    assert summary["subscribed"] is False
+
+
+def test_summary_pending_supervisor_when_gates_on() -> None:
+    gates = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=False)
+    summary = build_summary(gates)
+    assert summary["status"] == "pending_supervisor"
+    assert summary["subscribed"] is False
+    assert summary["mutation_allowed"] is False
+
+
+def test_main_disabled_exits_zero_and_prints_json(capsys, monkeypatch) -> None:
+    for key in (
+        "BINANCE_DEMO_SCALPING_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_CONFIRM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    rc = main([])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["status"] == "disabled"
+    assert out["subscribed"] is False

--- a/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+++ b/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
@@ -2,10 +2,54 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
 
 from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
-from scripts.binance_demo_scalping_ws_daemon import build_summary, main
+from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+from scripts.binance_demo_scalping_ws_daemon import build_summary, main, run_daemon
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _seq() -> list[FuturesWsEvent]:
+    out: list[FuturesWsEvent] = [
+        BookTickerEvent(
+            symbol="XRPUSDT",
+            bid_price=Decimal("0.50"),
+            bid_qty=Decimal("1"),
+            ask_price=Decimal("0.5001"),
+            ask_qty=Decimal("1"),
+            received_at=_T0,
+        )
+    ]
+    for m in range(25):
+        out.append(_cli_kline("0.50", "0.51", "0.49", m))
+    out.append(_cli_kline("0.60", "0.60", "0.50", 25))
+    return out
+
+
+def _cli_kline(close: str, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol="XRPUSDT",
+        interval="1m",
+        open_time=base,
+        close_time=base + dt.timedelta(seconds=59),
+        open=Decimal(close),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
 
 
 def test_summary_disabled_when_gates_off() -> None:
@@ -15,10 +59,10 @@ def test_summary_disabled_when_gates_off() -> None:
     assert summary["subscribed"] is False
 
 
-def test_summary_pending_supervisor_when_gates_on() -> None:
+def test_summary_running_when_gates_on() -> None:
     gates = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=False)
     summary = build_summary(gates)
-    assert summary["status"] == "pending_supervisor"
+    assert summary["status"] == "running"
     assert summary["subscribed"] is False
     assert summary["mutation_allowed"] is False
 
@@ -35,3 +79,24 @@ def test_main_disabled_exits_zero_and_prints_json(capsys, monkeypatch) -> None:
     out = json.loads(capsys.readouterr().out.strip())
     assert out["status"] == "disabled"
     assert out["subscribed"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_routes_triggers_to_injected_on_trigger() -> None:
+    seen: list[str] = []
+
+    async def fake_on_trigger(trigger) -> None:
+        seen.append(trigger.symbol)
+
+    await run_daemon(
+        symbols=["XRPUSDT"],
+        source_factory=lambda: _source(_seq()),
+        on_trigger=fake_on_trigger,
+        clock=lambda: _T0 + dt.timedelta(seconds=5),
+    )
+    assert seen == ["XRPUSDT"]  # one BUY breakout routed to the sink
+
+
+async def _source(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
+    for ev in events:
+        yield ev

--- a/tests/services/brokers/binance/demo/test_no_testnet_imports.py
+++ b/tests/services/brokers/binance/demo/test_no_testnet_imports.py
@@ -142,3 +142,39 @@ def test_spot_demo_does_not_import_futures_demo() -> None:
         "spot_demo must not import from futures_demo. Offenders:\n"
         + "\n".join(offenders)
     )
+
+
+def test_demo_scalping_ws_does_not_import_mutation_layers() -> None:
+    """ROB-317 — demo_scalping_ws/ is the read-only scalping hot path.
+
+    It computes triggers from public market data but must NOT import any
+    signed execution client, the demo_scalping_exec/ package, or the demo
+    ledger writer. Only the exec-side ws_bridge (slice 4) may reach those.
+    Keeps the read-only boundary AST-verifiable (cf. ROB-307 signal/exec
+    split).
+    """
+    ws_root = pathlib.Path("app/services/brokers/binance/demo_scalping_ws")
+    banned_substrings = (
+        "execution_client",
+        "binance.demo_scalping_exec",
+        "binance.demo.ledger",
+    )
+    offenders: list[str] = []
+    for py in ws_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if any(b in node.module for b in banned_substrings):
+                    offenders.append(f"{py}: from {node.module} import ...")
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if any(b in alias.name for b in banned_substrings):
+                        offenders.append(f"{py}: import {alias.name}")
+    assert not offenders, (
+        "demo_scalping_ws/ (read-only hot path) must not import mutation "
+        "layers (execution clients / demo_scalping_exec / demo.ledger). "
+        "Offenders:\n" + "\n".join(offenders)
+    )

--- a/tests/services/brokers/binance/demo_scalping_exec/__init__.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/__init__.py
@@ -1,0 +1,1 @@
+# Package initialization for demo_scalping_exec tests

--- a/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
@@ -11,8 +11,8 @@ import pytest
 
 from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
 from app.services.brokers.binance.demo_scalping.signal import SignalDecision
-from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
 from app.services.brokers.binance.demo_scalping_exec.ws_bridge import WsExecutionBridge
+from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
 
 pytestmark = pytest.mark.asyncio
 
@@ -21,15 +21,24 @@ _T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
 
 def _trigger(symbol: str = "XRPUSDT", side: str = "BUY") -> TriggerEvent:
     decision = SignalDecision(
-        has_entry=True, side=side, entry_price=Decimal("0.60"),
-        tp_price=Decimal("0.62"), sl_price=Decimal("0.59"),
-        confidence=Decimal("0.8"), reason_codes=("enter_long_breakout",),
+        has_entry=True,
+        side=side,
+        entry_price=Decimal("0.60"),
+        tp_price=Decimal("0.62"),
+        sl_price=Decimal("0.59"),
+        confidence=Decimal("0.8"),
+        reason_codes=("enter_long_breakout",),
     )
     return TriggerEvent(
-        product="usdm_futures", symbol=symbol, side=side, decision=decision,
+        product="usdm_futures",
+        symbol=symbol,
+        side=side,
+        decision=decision,
         source_candle_close_time_ms=1716724799999,
-        bid_price=Decimal("0.5999"), ask_price=Decimal("0.6001"),
-        data_age_seconds=3.0, emitted_at=_T0,
+        bid_price=Decimal("0.5999"),
+        ask_price=Decimal("0.6001"),
+        data_age_seconds=3.0,
+        emitted_at=_T0,
     )
 
 
@@ -141,7 +150,7 @@ async def test_make_demo_futures_trade_runner_calls_execute_monitored() -> None:
     seen: dict[str, object] = {}
 
     class _FakeSession:
-        async def __aenter__(self) -> "_FakeSession":
+        async def __aenter__(self) -> _FakeSession:
             return self
 
         async def __aexit__(self, *exc) -> None:
@@ -160,7 +169,9 @@ async def test_make_demo_futures_trade_runner_calls_execute_monitored() -> None:
             seen["symbol"] = intent.symbol
             return SimpleNamespace(status="filled")
 
-    from app.services.brokers.binance.demo_scalping.order_intent import build_order_intent
+    from app.services.brokers.binance.demo_scalping.order_intent import (
+        build_order_intent,
+    )
     from app.services.brokers.binance.demo_scalping_exec import ws_bridge as mod
 
     runner = mod.make_demo_futures_trade_runner(
@@ -172,19 +183,27 @@ async def test_make_demo_futures_trade_runner_calls_execute_monitored() -> None:
         executor_cls=_FakeExecutor,
     )
     intent = build_order_intent(
-        _trigger().decision, product="usdm_futures", symbol="XRPUSDT",
-        limits=ScalpingRiskLimits(), source_candle_close_time_ms=1, evaluated_at_ms=2,
+        _trigger().decision,
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        limits=ScalpingRiskLimits(),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
     )
     result = await runner(intent, _market(), True, _T0)
     assert seen == {
-        "product": "usdm_futures", "now": _T0, "confirm": True,
-        "symbol": "XRPUSDT", "committed": True,
+        "product": "usdm_futures",
+        "now": _T0,
+        "confirm": True,
+        "symbol": "XRPUSDT",
+        "committed": True,
     }
     assert result.status == "filled"
 
 
 def _market() -> object:
     from app.services.brokers.binance.demo_scalping.contract import MarketConditions
+
     return MarketConditions(
         spread_bps=Decimal("1"), data_age_seconds=2.0, spot_free_base_qty=Decimal("0")
     )

--- a/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
@@ -1,0 +1,137 @@
+"""ROB-317 — WsExecutionBridge guard + confirm passthrough."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.signal import SignalDecision
+from app.services.brokers.binance.demo_scalping_ws.supervisor import TriggerEvent
+from app.services.brokers.binance.demo_scalping_exec.ws_bridge import WsExecutionBridge
+
+pytestmark = pytest.mark.asyncio
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _trigger(symbol: str = "XRPUSDT", side: str = "BUY") -> TriggerEvent:
+    decision = SignalDecision(
+        has_entry=True, side=side, entry_price=Decimal("0.60"),
+        tp_price=Decimal("0.62"), sl_price=Decimal("0.59"),
+        confidence=Decimal("0.8"), reason_codes=("enter_long_breakout",),
+    )
+    return TriggerEvent(
+        product="usdm_futures", symbol=symbol, side=side, decision=decision,
+        source_candle_close_time_ms=1716724799999,
+        bid_price=Decimal("0.5999"), ask_price=Decimal("0.6001"),
+        data_age_seconds=3.0, emitted_at=_T0,
+    )
+
+
+class _RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bool]] = []
+
+    async def __call__(self, intent, market, confirm, now) -> object:
+        self.calls.append((intent.symbol, confirm))
+        return SimpleNamespace(status="filled")
+
+
+def _bridge(runner, *, confirm: bool, global_cap: int = 1) -> WsExecutionBridge:
+    return WsExecutionBridge(
+        trade_runner=runner,
+        limits=ScalpingRiskLimits(global_open_lifecycle_cap=global_cap),
+        confirm=confirm,
+        clock=lambda: _T0,
+    )
+
+
+async def test_confirm_true_passes_through() -> None:
+    runner = _RecordingRunner()
+    await _bridge(runner, confirm=True)(_trigger())
+    assert runner.calls == [("XRPUSDT", True)]
+
+
+async def test_confirm_false_passes_through_no_mutation_flag() -> None:
+    runner = _RecordingRunner()
+    await _bridge(runner, confirm=False)(_trigger())
+    assert runner.calls == [("XRPUSDT", False)]
+
+
+async def test_same_symbol_inflight_is_skipped() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _Blocking:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls.append(intent.symbol)
+            started.set()
+            await release.wait()
+            return SimpleNamespace(status="filled")
+
+    runner = _Blocking()
+    bridge = _bridge(runner, confirm=True)
+    t1 = asyncio.create_task(bridge(_trigger("XRPUSDT")))
+    await started.wait()  # t1 has entered the runner and holds the guard
+    await bridge(_trigger("XRPUSDT"))  # second same-symbol call: skipped immediately
+    release.set()
+    await t1
+    assert runner.calls == ["XRPUSDT"]  # only one entry ran
+
+
+async def test_global_cap_blocks_other_symbol() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _Blocking:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls.append(intent.symbol)
+            started.set()
+            await release.wait()
+            return SimpleNamespace(status="filled")
+
+    runner = _Blocking()
+    bridge = _bridge(runner, confirm=True, global_cap=1)
+    t1 = asyncio.create_task(bridge(_trigger("XRPUSDT")))
+    await started.wait()
+    await bridge(_trigger("DOGEUSDT"))  # different symbol, but global cap=1 -> skip
+    release.set()
+    await t1
+    assert runner.calls == ["XRPUSDT"]
+
+
+async def test_guard_released_after_completion() -> None:
+    runner = _RecordingRunner()
+    bridge = _bridge(runner, confirm=True)
+    await bridge(_trigger("XRPUSDT"))
+    await bridge(_trigger("XRPUSDT"))  # guard freed -> second runs
+    assert runner.calls == [("XRPUSDT", True), ("XRPUSDT", True)]
+
+
+async def test_guard_released_on_runner_exception() -> None:
+    class _Boom:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def __call__(self, intent, market, confirm, now) -> object:
+            self.calls += 1
+            raise RuntimeError("executor blew up")
+
+    runner = _Boom()
+    bridge = _bridge(runner, confirm=True)
+    with pytest.raises(RuntimeError):
+        await bridge(_trigger("XRPUSDT"))
+    with pytest.raises(RuntimeError):
+        await bridge(_trigger("XRPUSDT"))  # guard not leaked
+    assert runner.calls == 2

--- a/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_ws_bridge.py
@@ -135,3 +135,56 @@ async def test_guard_released_on_runner_exception() -> None:
     with pytest.raises(RuntimeError):
         await bridge(_trigger("XRPUSDT"))  # guard not leaked
     assert runner.calls == 2
+
+
+async def test_make_demo_futures_trade_runner_calls_execute_monitored() -> None:
+    seen: dict[str, object] = {}
+
+    class _FakeSession:
+        async def __aenter__(self) -> "_FakeSession":
+            return self
+
+        async def __aexit__(self, *exc) -> None:
+            return None
+
+        async def commit(self) -> None:
+            seen["committed"] = True
+
+    class _FakeExecutor:
+        def __init__(self, **kwargs) -> None:
+            seen["product"] = kwargs["product"]
+            seen["now"] = kwargs["now"]
+
+        async def execute_monitored(self, intent, *, confirm, market) -> object:
+            seen["confirm"] = confirm
+            seen["symbol"] = intent.symbol
+            return SimpleNamespace(status="filled")
+
+    from app.services.brokers.binance.demo_scalping.order_intent import build_order_intent
+    from app.services.brokers.binance.demo_scalping_exec import ws_bridge as mod
+
+    runner = mod.make_demo_futures_trade_runner(
+        client=object(),
+        market_data=object(),
+        reference=object(),
+        session_factory=lambda: _FakeSession(),
+        limits=ScalpingRiskLimits(),
+        executor_cls=_FakeExecutor,
+    )
+    intent = build_order_intent(
+        _trigger().decision, product="usdm_futures", symbol="XRPUSDT",
+        limits=ScalpingRiskLimits(), source_candle_close_time_ms=1, evaluated_at_ms=2,
+    )
+    result = await runner(intent, _market(), True, _T0)
+    assert seen == {
+        "product": "usdm_futures", "now": _T0, "confirm": True,
+        "symbol": "XRPUSDT", "committed": True,
+    }
+    assert result.status == "filled"
+
+
+def _market() -> object:
+    from app.services.brokers.binance.demo_scalping.contract import MarketConditions
+    return MarketConditions(
+        spread_bps=Decimal("1"), data_age_seconds=2.0, spot_free_base_qty=Decimal("0")
+    )

--- a/tests/services/brokers/binance/demo_scalping_ws/__init__.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/tests/services/brokers/binance/demo_scalping_ws/test_config.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_config.py
@@ -1,0 +1,64 @@
+"""ROB-317 — WS daemon gate config (default-disabled)."""
+
+from __future__ import annotations
+
+from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
+
+
+def test_empty_env_is_fully_disabled() -> None:
+    gates = WsDaemonGates.from_env({})
+    assert gates.base_enabled is False
+    assert gates.ws_enabled is False
+    assert gates.ws_confirm is False
+    assert gates.daemon_active is False
+    assert gates.mutation_allowed is False
+
+
+def test_daemon_active_requires_both_base_and_ws() -> None:
+    assert WsDaemonGates.from_env(
+        {"BINANCE_DEMO_SCALPING_ENABLED": "true"}
+    ).daemon_active is False
+    assert WsDaemonGates.from_env(
+        {"BINANCE_DEMO_SCALPING_WS_ENABLED": "true"}
+    ).daemon_active is False
+    assert WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+        }
+    ).daemon_active is True
+
+
+def test_confirm_alone_never_enables_mutation() -> None:
+    # Confirm true but ws_enabled false -> no mutation.
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_CONFIRM": "true",
+        }
+    )
+    assert gates.mutation_allowed is False
+
+
+def test_mutation_allowed_requires_all_three() -> None:
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_CONFIRM": "true",
+        }
+    )
+    assert gates.mutation_allowed is True
+
+
+def test_does_not_read_scheduler_confirm_flag() -> None:
+    # The scheduler's confirm flag must not enable the daemon's mutation.
+    gates = WsDaemonGates.from_env(
+        {
+            "BINANCE_DEMO_SCALPING_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+            "BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM": "true",
+        }
+    )
+    assert gates.ws_confirm is False
+    assert gates.mutation_allowed is False

--- a/tests/services/brokers/binance/demo_scalping_ws/test_config.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_config.py
@@ -15,18 +15,25 @@ def test_empty_env_is_fully_disabled() -> None:
 
 
 def test_daemon_active_requires_both_base_and_ws() -> None:
-    assert WsDaemonGates.from_env(
-        {"BINANCE_DEMO_SCALPING_ENABLED": "true"}
-    ).daemon_active is False
-    assert WsDaemonGates.from_env(
-        {"BINANCE_DEMO_SCALPING_WS_ENABLED": "true"}
-    ).daemon_active is False
-    assert WsDaemonGates.from_env(
-        {
-            "BINANCE_DEMO_SCALPING_ENABLED": "true",
-            "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
-        }
-    ).daemon_active is True
+    assert (
+        WsDaemonGates.from_env({"BINANCE_DEMO_SCALPING_ENABLED": "true"}).daemon_active
+        is False
+    )
+    assert (
+        WsDaemonGates.from_env(
+            {"BINANCE_DEMO_SCALPING_WS_ENABLED": "true"}
+        ).daemon_active
+        is False
+    )
+    assert (
+        WsDaemonGates.from_env(
+            {
+                "BINANCE_DEMO_SCALPING_ENABLED": "true",
+                "BINANCE_DEMO_SCALPING_WS_ENABLED": "true",
+            }
+        ).daemon_active
+        is True
+    )
 
 
 def test_confirm_alone_never_enables_mutation() -> None:

--- a/tests/services/brokers/binance/demo_scalping_ws/test_events.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_events.py
@@ -1,0 +1,81 @@
+"""ROB-317 — event → MarketState updater + kline → Candle mapping."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping_ws.events import (
+    apply_event,
+    kline_to_candle,
+)
+from app.services.brokers.binance.demo_scalping_ws.market_stream import AggTradeEvent
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _kline(close: str = "0.515") -> KlineEvent:
+    return KlineEvent(
+        symbol="XRPUSDT",
+        interval="1m",
+        open_time=dt.datetime(2026, 5, 26, 11, 59, tzinfo=dt.UTC),
+        close_time=dt.datetime(2026, 5, 26, 11, 59, 59, tzinfo=dt.UTC),
+        open=Decimal("0.50"),
+        high=Decimal("0.52"),
+        low=Decimal("0.49"),
+        close=Decimal(close),
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
+
+
+def test_apply_book_ticker_updates_quote_and_freshness() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    ev = BookTickerEvent(
+        symbol="XRPUSDT",
+        bid_price=Decimal("0.512"),
+        bid_qty=Decimal("1"),
+        ask_price=Decimal("0.513"),
+        ask_qty=Decimal("1"),
+        received_at=_NOW,
+    )
+    apply_event(state, ev)
+    assert state.bid_price == Decimal("0.512")
+    assert state.ask_price == Decimal("0.513")
+    # Freshness comes from the event's own receipt time, not a wall clock.
+    assert state.book_ticker_at == _NOW
+
+
+def test_apply_agg_trade_updates_trade_and_freshness() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    ev = AggTradeEvent(
+        symbol="XRPUSDT",
+        price=Decimal("0.5125"),
+        qty=Decimal("10"),
+        trade_time=_NOW,
+        is_buyer_maker=False,
+    )
+    apply_event(state, ev)
+    assert state.last_trade_price == Decimal("0.5125")
+    assert state.agg_trade_at == _NOW
+
+
+def test_apply_kline_does_not_touch_quote_freshness() -> None:
+    # A closed kline must NOT mask a dead bookTicker/aggTrade stream.
+    state = MarketState(symbol="XRPUSDT")
+    apply_event(state, _kline())
+    assert state.book_ticker_at is None
+    assert state.agg_trade_at is None
+
+
+def test_kline_to_candle_maps_fields() -> None:
+    candle = kline_to_candle(_kline(close="0.515"))
+    assert candle.close == Decimal("0.515")
+    assert candle.high == Decimal("0.52")
+    assert candle.close_time_ms == int(
+        dt.datetime(2026, 5, 26, 11, 59, 59, tzinfo=dt.UTC).timestamp() * 1000
+    )

--- a/tests/services/brokers/binance/demo_scalping_ws/test_health.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_health.py
@@ -1,0 +1,53 @@
+"""ROB-317 — daemon health snapshot JSON."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+from app.services.brokers.binance.demo_scalping_ws.health import (
+    DaemonHealthSnapshot,
+    SymbolHealth,
+)
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_snapshot_serializes_to_json() -> None:
+    snap = DaemonHealthSnapshot(
+        generated_at=_NOW,
+        connected=True,
+        daemon_active=True,
+        mutation_allowed=False,
+        symbols=(
+            SymbolHealth(
+                symbol="XRPUSDT",
+                fresh=True,
+                last_event_at=_NOW - dt.timedelta(seconds=2),
+                age_seconds=2.0,
+            ),
+        ),
+    )
+    payload = json.loads(snap.to_json())
+    assert payload["connected"] is True
+    assert payload["mutation_allowed"] is False
+    assert payload["symbols"][0]["symbol"] == "XRPUSDT"
+    assert payload["symbols"][0]["fresh"] is True
+    assert payload["symbols"][0]["age_seconds"] == 2.0
+
+
+def test_snapshot_handles_symbol_with_no_events() -> None:
+    snap = DaemonHealthSnapshot(
+        generated_at=_NOW,
+        connected=False,
+        daemon_active=False,
+        mutation_allowed=False,
+        symbols=(
+            SymbolHealth(
+                symbol="DOGEUSDT", fresh=False, last_event_at=None, age_seconds=None
+            ),
+        ),
+    )
+    payload = json.loads(snap.to_json())
+    assert payload["symbols"][0]["last_event_at"] is None
+    assert payload["symbols"][0]["age_seconds"] is None

--- a/tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_market_stream_live_fixture.py
@@ -1,0 +1,83 @@
+"""ROB-317 — FuturesMarketStream round-trip over a local websockets server."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+
+import pytest
+import websockets
+
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    FuturesMarketStream,
+)
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.ws_client import KlineEvent
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_stream_yields_parsed_events_from_local_server() -> None:
+    messages = [
+        json.dumps(
+            {
+                "stream": "xrpusdt@aggTrade",
+                "data": {
+                    "e": "aggTrade",
+                    "s": "XRPUSDT",
+                    "p": "0.51",
+                    "q": "1",
+                    "T": 1716724800000,
+                    "m": False,
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "stream": "xrpusdt@kline_1m",
+                "data": {
+                    "e": "kline",
+                    "s": "XRPUSDT",
+                    "k": {
+                        "t": 1716724740000,
+                        "T": 1716724799999,
+                        "s": "XRPUSDT",
+                        "i": "1m",
+                        "o": "0.50",
+                        "h": "0.52",
+                        "l": "0.49",
+                        "c": "0.515",
+                        "v": "1000",
+                        "q": "515",
+                        "n": 42,
+                        "x": True,
+                    },
+                },
+            }
+        ),
+    ]
+
+    async def handler(ws) -> None:
+        for m in messages:
+            await ws.send(m)
+
+    async with websockets.serve(handler, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        url = f"ws://127.0.0.1:{port}/stream?streams=xrpusdt@aggTrade"
+        out = []
+        async with FuturesMarketStream(url=url) as stream:
+            async for ev in stream.events(stop_after=2):
+                out.append(ev)
+
+    assert isinstance(out[0], AggTradeEvent)
+    assert out[0].price == Decimal("0.51")
+    assert isinstance(out[1], KlineEvent)
+    assert out[1].close == Decimal("0.515")
+
+
+async def test_stream_rejects_non_fstream_host() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        FuturesMarketStream(
+            url="wss://fapi.binance.com/stream?streams=xrpusdt@aggTrade"
+        )

--- a/tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_market_stream_parse.py
@@ -1,0 +1,140 @@
+"""ROB-317 — futures stream parsing + URL builder + host guard."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
+    build_futures_stream_url,
+    parse_futures_message,
+)
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def _wrap(stream: str, data: dict) -> str:
+    return json.dumps({"stream": stream, "data": data})
+
+
+def test_parse_agg_trade() -> None:
+    raw = _wrap(
+        "xrpusdt@aggTrade",
+        {
+            "e": "aggTrade",
+            "s": "XRPUSDT",
+            "p": "0.5123",
+            "q": "100",
+            "T": 1716724800000,
+            "m": True,
+        },
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, AggTradeEvent)
+    assert ev.symbol == "XRPUSDT"
+    assert ev.price == Decimal("0.5123")
+    assert ev.is_buyer_maker is True
+
+
+def test_parse_book_ticker_futures_has_e_field() -> None:
+    raw = _wrap(
+        "xrpusdt@bookTicker",
+        {
+            "e": "bookTicker",
+            "u": 400900217,
+            "s": "XRPUSDT",
+            "b": "0.5120",
+            "B": "31.2",
+            "a": "0.5125",
+            "A": "40.6",
+        },
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, BookTickerEvent)
+    assert ev.bid_price == Decimal("0.5120")
+    assert ev.ask_price == Decimal("0.5125")
+    assert ev.received_at == _NOW
+
+
+def test_parse_closed_kline() -> None:
+    raw = _wrap(
+        "xrpusdt@kline_1m",
+        {
+            "e": "kline",
+            "s": "XRPUSDT",
+            "k": {
+                "t": 1716724740000,
+                "T": 1716724799999,
+                "s": "XRPUSDT",
+                "i": "1m",
+                "o": "0.50",
+                "h": "0.52",
+                "l": "0.49",
+                "c": "0.515",
+                "v": "1000",
+                "q": "515",
+                "n": 42,
+                "x": True,
+            },
+        },
+    )
+    ev = parse_futures_message(raw, now=_NOW)
+    assert isinstance(ev, KlineEvent)
+    assert ev.is_closed is True
+    assert ev.close == Decimal("0.515")
+
+
+def test_parse_drops_in_progress_kline() -> None:
+    raw = _wrap(
+        "xrpusdt@kline_1m",
+        {
+            "e": "kline",
+            "s": "XRPUSDT",
+            "k": {
+                "t": 1716724740000,
+                "T": 1716724799999,
+                "s": "XRPUSDT",
+                "i": "1m",
+                "o": "0.50",
+                "h": "0.52",
+                "l": "0.49",
+                "c": "0.515",
+                "v": "1000",
+                "q": "515",
+                "n": 42,
+                "x": False,
+            },
+        },
+    )
+    assert parse_futures_message(raw, now=_NOW) is None
+
+
+def test_parse_ignores_garbage_and_unknown() -> None:
+    assert parse_futures_message("not json", now=_NOW) is None
+    assert (
+        parse_futures_message(_wrap("x@depth", {"e": "depthUpdate"}), now=_NOW) is None
+    )
+
+
+def test_build_url_combines_streams_for_allowlisted_host() -> None:
+    url = build_futures_stream_url(
+        ["XRPUSDT", "DOGEUSDT"],
+        streams=("aggTrade", "bookTicker", "kline_1m"),
+        base_url="wss://fstream.binance.com",
+    )
+    assert url.startswith("wss://fstream.binance.com/stream?streams=")
+    assert "xrpusdt@aggTrade" in url
+    assert "dogeusdt@kline_1m" in url
+
+
+def test_build_url_rejects_non_fstream_host() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        build_futures_stream_url(
+            ["XRPUSDT"], streams=("aggTrade",), base_url="wss://fapi.binance.com"
+        )

--- a/tests/services/brokers/binance/demo_scalping_ws/test_signal.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_signal.py
@@ -1,0 +1,61 @@
+"""ROB-317 — event-driven signal over a rolling candle buffer."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping.contract import ReasonCode
+from app.services.brokers.binance.demo_scalping_ws.signal import EventDrivenSignal
+from app.services.brokers.binance.ws_client import KlineEvent
+
+
+def _kline(
+    close: str, *, high: str | None = None, low: str | None = None, minute: int = 0
+) -> KlineEvent:
+    base = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC) + dt.timedelta(minutes=minute)
+    c = Decimal(close)
+    return KlineEvent(
+        symbol="XRPUSDT",
+        interval="1m",
+        open_time=base,
+        close_time=base + dt.timedelta(seconds=59),
+        open=c,
+        high=Decimal(high) if high else c,
+        low=Decimal(low) if low else c,
+        close=c,
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
+
+
+def test_insufficient_history_until_buffer_fills() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT")
+    decision = sig.ingest_kline(_kline("0.50", minute=0))
+    assert decision.has_entry is False
+    assert ReasonCode.INSUFFICIENT_HISTORY in decision.reason_codes
+
+
+def test_long_breakout_fires_after_enough_candles() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT")
+    # 24 flat candles at 0.50 (range 0.49-0.51), then a breakout close above
+    # the prior 20-bar high with a rising fast SMA.
+    last = None
+    for m in range(24):
+        last = sig.ingest_kline(_kline("0.50", high="0.51", low="0.49", minute=m))
+    assert last.has_entry is False  # 24 < 25 needed
+    fill = sig.ingest_kline(_kline("0.50", high="0.51", low="0.49", minute=24))
+    assert fill.has_entry is False  # 25th: flat, no breakout
+    breakout = sig.ingest_kline(_kline("0.60", high="0.60", low="0.50", minute=25))
+    assert breakout.has_entry is True
+    assert breakout.side == "BUY"
+    assert ReasonCode.ENTER_LONG_BREAKOUT in breakout.reason_codes
+
+
+def test_buffer_is_bounded() -> None:
+    sig = EventDrivenSignal(product="usdm_futures", symbol="XRPUSDT", max_candles=30)
+    for m in range(100):
+        sig.ingest_kline(_kline("0.50", minute=m))
+    assert sig.candle_count == 30

--- a/tests/services/brokers/binance/demo_scalping_ws/test_state.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_state.py
@@ -1,0 +1,35 @@
+"""ROB-317 — per-symbol market state + freshness guard."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.services.brokers.binance.demo_scalping_ws.state import MarketState
+
+_NOW = dt.datetime(2026, 5, 26, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_new_state_has_no_events_and_is_stale() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    assert state.last_event_at() is None
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is True
+
+
+def test_last_event_at_is_max_across_streams() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    state.book_ticker_at = _NOW - dt.timedelta(seconds=10)
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=3)
+    assert state.last_event_at() == _NOW - dt.timedelta(seconds=3)
+
+
+def test_fresh_within_max_age() -> None:
+    state = MarketState(symbol="XRPUSDT", bid_price=Decimal("0.5"))
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=30)
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is False
+
+
+def test_stale_beyond_max_age() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=200)
+    assert state.is_stale(now=_NOW, max_age_seconds=120) is True

--- a/tests/services/brokers/binance/demo_scalping_ws/test_state.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_state.py
@@ -33,3 +33,21 @@ def test_stale_beyond_max_age() -> None:
     state = MarketState(symbol="XRPUSDT")
     state.agg_trade_at = _NOW - dt.timedelta(seconds=200)
     assert state.is_stale(now=_NOW, max_age_seconds=120) is True
+
+
+def test_book_data_age_none_without_bookticker() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    assert state.book_data_age_seconds(now=_NOW) is None
+
+
+def test_book_data_age_ignores_aggtrade() -> None:
+    # A fresh aggTrade must NOT make bookTicker look fresh.
+    state = MarketState(symbol="XRPUSDT")
+    state.agg_trade_at = _NOW - dt.timedelta(seconds=2)
+    assert state.book_data_age_seconds(now=_NOW) is None
+
+
+def test_book_data_age_from_bookticker() -> None:
+    state = MarketState(symbol="XRPUSDT")
+    state.book_ticker_at = _NOW - dt.timedelta(seconds=10)
+    assert state.book_data_age_seconds(now=_NOW) == 10.0

--- a/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
@@ -7,8 +7,10 @@ from collections.abc import AsyncIterator
 from decimal import Decimal
 
 import pytest
+from websockets.exceptions import ConnectionClosedError
 
 from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    AggTradeEvent,
     FuturesWsEvent,
 )
 from app.services.brokers.binance.demo_scalping_ws.supervisor import (
@@ -31,6 +33,25 @@ def _book(now_offset: int = 0) -> BookTickerEvent:
         ask_qty=Decimal("1"),
         received_at=_T0 + dt.timedelta(seconds=now_offset),
     )
+
+
+def _agg(now_offset: int = 0) -> AggTradeEvent:
+    return AggTradeEvent(
+        symbol="XRPUSDT",
+        price=Decimal("0.50"),
+        qty=Decimal("1"),
+        trade_time=_T0 + dt.timedelta(seconds=now_offset),
+        is_buyer_maker=False,
+    )
+
+
+def _klines_then_breakout() -> list[FuturesWsEvent]:
+    """25 flat 1m candles then a breakout close (no quote events)."""
+    out: list[FuturesWsEvent] = []
+    for m in range(25):
+        out.append(_kline("0.50", high="0.51", low="0.49", minute=m))
+    out.append(_kline("0.60", high="0.60", low="0.50", minute=25))
+    return out
 
 
 def _kline(close: str, *, high: str, low: str, minute: int) -> KlineEvent:
@@ -97,6 +118,46 @@ async def test_stale_quote_blocks_trigger() -> None:
     assert captured == []
 
 
+async def test_fresh_aggtrade_without_bookticker_blocks_trigger() -> None:
+    # (a) A fresh aggTrade must NOT satisfy the quote-freshness gate: without a
+    # bookTicker there is no bid/ask, so the spread guard would be bypassed.
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    events: list[FuturesWsEvent] = [_agg(now_offset=0), *_klines_then_breakout()]
+    await sup.run(lambda: _source_from(events), on_trigger=_async_appender(captured))
+    assert captured == []
+
+
+async def test_fresh_aggtrade_with_stale_bookticker_blocks_trigger() -> None:
+    # (b) A fresh aggTrade cannot rescue a stale bookTicker: the quote is what
+    # the spread guard depends on, so a stale quote blocks the trigger.
+    clock = _Clock(_T0 + dt.timedelta(seconds=300))  # book is 300s old (> 120)
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    events: list[FuturesWsEvent] = [
+        _book(now_offset=0),  # stale quote at T0
+        _agg(now_offset=290),  # fresh trade at T0+290s
+        *_klines_then_breakout(),
+    ]
+    await sup.run(lambda: _source_from(events), on_trigger=_async_appender(captured))
+    assert captured == []
+
+
+async def test_fresh_bookticker_emits_trigger_with_book_age() -> None:
+    # (c) A fresh bookTicker carries bid/ask and a valid book age into the
+    # trigger, so the downstream spread/freshness guard gets real values.
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    events: list[FuturesWsEvent] = [_book(now_offset=0), *_klines_then_breakout()]
+    await sup.run(lambda: _source_from(events), on_trigger=_async_appender(captured))
+    assert len(captured) == 1
+    assert captured[0].bid_price is not None
+    assert captured[0].ask_price is not None
+    assert captured[0].data_age_seconds == 5.0  # bookTicker age, not aggTrade
+
+
 async def test_debounce_suppresses_second_trigger() -> None:
     clock = _Clock(_T0 + dt.timedelta(seconds=5))
     sup = ScalpingDaemonSupervisor(
@@ -160,9 +221,40 @@ async def test_run_with_reconnect_raises_when_unhealthy() -> None:
     assert len(slept) == 2  # 2 backoffs before the 3rd failure trips unhealthy
 
 
+async def test_run_with_reconnect_recovers_after_websocket_close() -> None:
+    # websockets.exceptions.ConnectionClosed is NOT a ConnectionError/OSError
+    # subclass — the reconnect loop must catch it explicitly or a real socket
+    # close would crash the daemon instead of reconnecting.
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    slept: list[float] = []
+    calls = {"n": 0}
+
+    def factory() -> AsyncIterator[FuturesWsEvent]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _raises_connection_closed()
+        return _source_from(_breakout_sequence())
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    await sup.run_with_reconnect(
+        factory, on_trigger=_async_appender(captured), sleep=fake_sleep
+    )
+    assert len(captured) == 1  # recovered on the 2nd connection after a WS close
+    assert len(slept) == 1
+
+
 async def _raises_after_book() -> AsyncIterator[FuturesWsEvent]:
     yield _book()
     raise ConnectionError("socket dropped")
+
+
+async def _raises_connection_closed() -> AsyncIterator[FuturesWsEvent]:
+    yield _book()
+    raise ConnectionClosedError(None, None)
 
 
 async def _raises_immediately() -> AsyncIterator[FuturesWsEvent]:

--- a/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
@@ -1,0 +1,186 @@
+"""ROB-317 — supervisor trigger / freshness / debounce (fake source)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping_ws.market_stream import (
+    FuturesWsEvent,
+)
+from app.services.brokers.binance.demo_scalping_ws.supervisor import (
+    ScalpingDaemonSupervisor,
+    TriggerEvent,
+)
+from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
+
+pytestmark = pytest.mark.asyncio
+
+_T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
+
+
+def _book(now_offset: int = 0) -> BookTickerEvent:
+    return BookTickerEvent(
+        symbol="XRPUSDT",
+        bid_price=Decimal("0.50"),
+        bid_qty=Decimal("1"),
+        ask_price=Decimal("0.5001"),
+        ask_qty=Decimal("1"),
+        received_at=_T0 + dt.timedelta(seconds=now_offset),
+    )
+
+
+def _kline(close: str, *, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol="XRPUSDT",
+        interval="1m",
+        open_time=base,
+        close_time=base + dt.timedelta(seconds=59),
+        open=Decimal(close),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
+
+
+def _breakout_sequence() -> list[FuturesWsEvent]:
+    events: list[FuturesWsEvent] = [_book()]
+    for m in range(25):
+        events.append(_kline("0.50", high="0.51", low="0.49", minute=m))
+    events.append(_kline("0.60", high="0.60", low="0.50", minute=25))
+    return events
+
+
+async def _source_from(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
+    for ev in events:
+        yield ev
+
+
+class _Clock:
+    def __init__(self, start: dt.datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> dt.datetime:
+        return self.now
+
+
+async def test_fresh_breakout_emits_trigger() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))  # within 120s of the book event
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert len(captured) == 1
+    assert captured[0].symbol == "XRPUSDT"
+    assert captured[0].side == "BUY"
+
+
+async def test_stale_quote_blocks_trigger() -> None:
+    # Clock far past the single book event -> STALE_DATA, no trigger.
+    clock = _Clock(_T0 + dt.timedelta(seconds=600))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert captured == []
+
+
+async def test_debounce_suppresses_second_trigger() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(
+        symbols=["XRPUSDT"], clock=clock, debounce_seconds=300
+    )
+    seq = _breakout_sequence()
+    seq.append(_kline("0.70", high="0.70", low="0.60", minute=26))  # 2nd breakout
+    captured: list[TriggerEvent] = []
+    await sup.run(lambda: _source_from(seq), on_trigger=_async_appender(captured))
+    assert len(captured) == 1  # second suppressed by debounce
+
+
+def _async_appender(sink: list):
+    async def _append(trigger) -> None:
+        sink.append(trigger)
+
+    return _append
+
+
+async def test_run_with_reconnect_recovers_after_transient_error() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    slept: list[float] = []
+
+    calls = {"n": 0}
+
+    def factory() -> AsyncIterator[FuturesWsEvent]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _raises_after_book()
+        return _source_from(_breakout_sequence())
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    await sup.run_with_reconnect(
+        factory,
+        on_trigger=_async_appender(captured),
+        sleep=fake_sleep,
+    )
+    assert len(captured) == 1  # recovered on the 2nd connection
+    assert len(slept) == 1  # backed off once between attempts
+
+
+async def test_run_with_reconnect_raises_when_unhealthy() -> None:
+    clock = _Clock(_T0)
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    slept: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        slept.append(delay)
+
+    def always_fails() -> AsyncIterator[FuturesWsEvent]:
+        return _raises_immediately()
+
+    with pytest.raises(ConnectionError):
+        await sup.run_with_reconnect(
+            always_fails, on_trigger=_async_appender([]), sleep=fake_sleep
+        )
+    assert len(slept) == 2  # 2 backoffs before the 3rd failure trips unhealthy
+
+
+async def _raises_after_book() -> AsyncIterator[FuturesWsEvent]:
+    yield _book()
+    raise ConnectionError("socket dropped")
+
+
+async def _raises_immediately() -> AsyncIterator[FuturesWsEvent]:
+    raise ConnectionError("cannot connect")
+    yield  # pragma: no cover - makes this an async generator
+
+
+async def test_trigger_carries_source_candle_close_time() -> None:
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock)
+    captured: list[TriggerEvent] = []
+    await sup.run(
+        lambda: _source_from(_breakout_sequence()),
+        on_trigger=_async_appender(captured),
+    )
+    assert len(captured) == 1
+    # The breakout candle is minute=25; its close_time is open+59s.
+    expected_close = _T0 + dt.timedelta(minutes=25, seconds=59)
+    assert captured[0].source_candle_close_time_ms == int(
+        expected_close.timestamp() * 1000
+    )

--- a/tests/services/brokers/binance/test_public_futures_stream_allowlist.py
+++ b/tests/services/brokers/binance/test_public_futures_stream_allowlist.py
@@ -1,0 +1,58 @@
+"""ROB-317 — read-only public futures stream allowlist.
+
+fstream.binance.com is read-allowed (unsigned market data) but
+signed-blocked (the futures-demo signed transport rejects it). The two
+purposes never share a host with any signed mutation allowlist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.binance.errors import BinanceLiveHostBlocked
+from app.services.brokers.binance.futures_demo.host_allowlist import (
+    FUTURES_DEMO_HOSTS,
+    assert_futures_demo_host,
+)
+from app.services.brokers.binance.host_allowlist import (
+    PUBLIC_FUTURES_STREAM_HOSTS,
+    PUBLIC_HOSTS,
+    assert_public_futures_stream_host,
+)
+from app.services.brokers.binance.spot_demo.host_allowlist import SPOT_DEMO_HOSTS
+
+
+def test_only_fstream() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS == frozenset({"fstream.binance.com"})
+
+
+def test_disjoint_from_signed_mutation_allowlists() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(FUTURES_DEMO_HOSTS)
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(SPOT_DEMO_HOSTS)
+
+
+def test_disjoint_from_public_spot_stream_allowlist() -> None:
+    assert PUBLIC_FUTURES_STREAM_HOSTS.isdisjoint(PUBLIC_HOSTS)
+
+
+def test_signed_futures_transport_still_rejects_fstream() -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        assert_futures_demo_host("fstream.binance.com")
+
+
+def test_assert_accepts_fstream() -> None:
+    assert_public_futures_stream_host("fstream.binance.com")  # no raise
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "fapi.binance.com",  # live signed futures
+        "demo-fapi.binance.com",  # demo signed futures (mutation lane)
+        "stream.binance.com",  # spot public stream
+        "fstream.binance.com.evil.example",  # spoofed subdomain
+    ],
+)
+def test_assert_rejects_non_fstream(host: str) -> None:
+    with pytest.raises(BinanceLiveHostBlocked):
+        assert_public_futures_stream_host(host)


### PR DESCRIPTION
## ROB-317 — Binance Demo WebSocket scalping daemon

Replaces the 5-min Prefect REST polling tick as the **scalping hot path**: a long-running, WebSocket-driven daemon that reacts at candle close (instead of up to 5 min later), routing confirmed entries through the existing Demo executor → ledger → analytics layers. Default-disabled; demo-only.

Linear: ROB-317. Built design-first across 4 slices (docs under `docs/plans/`).

### What's in this PR

| Slice | Content |
|---|---|
| 1 | Design + runbook doc (`docs/plans/ROB-317-...-daemon.md`) |
| 2 | Inert foundation: read-only `fstream` allowlist, 3-layer gate config, `MarketState`+freshness, health snapshot, default-disabled CLI, AST import-guard |
| 3 | Event-driven trigger pipeline: futures stream parser (aggTrade/bookTicker/closed-kline), event→state updater, `EventDrivenSignal` (rolling buffer reusing `evaluate_signal`), supervisor (freshness gate + debounce + reconnect/backoff) |
| 4 | `WsExecutionBridge`: in-process concurrency guard + confirm passthrough → existing `DemoScalpingExecutor`; CLI active path; operator runbook |

### Signal cadence (no overclaim)
The trigger fires on **closed 1m kline** events, reusing the existing candle-based `evaluate_signal` (SMA + breakout) **unchanged**. The win over polling is reacting at candle close rather than up to 5 min later — **not** sub-second tick trading. `aggTrade`/`bookTicker` provide freshness + spread context; `aggTrade` is **not** a signal driver. A true tick-level strategy is out of scope.

### Safety boundaries
- **Market data** = live public futures WS `fstream.binance.com` (read-only, unsigned). **Order mutation** = demo-only `demo-fapi.binance.com`. No live/testnet path. New read-only `PUBLIC_FUTURES_STREAM_HOSTS` allowlist is disjoint from every signed mutation allowlist; the futures-demo signed transport still rejects `fstream`.
- **3-layer gates, all default false:** `BINANCE_DEMO_SCALPING_ENABLED` + `BINANCE_DEMO_SCALPING_WS_ENABLED` (subscribe/evaluate) + `BINANCE_DEMO_SCALPING_WS_CONFIRM` (real order). Daemon does **not** reuse the scheduler confirm flag.
- **Quote-freshness gate:** a trigger is emitted only with a **fresh bookTicker** (non-null bid/ask within the freshness window). A fresh aggTrade alone never qualifies — this prevents a spread-guard bypass (spread=0) from a missing quote.
- Read-only `demo_scalping_ws/` package is AST-guarded (no executor/ledger imports); only the exec-side `ws_bridge` mutates.
- Risk re-check (ledger-backed `_preflight`) + analytics are **reused** from the existing executor — not re-implemented. In-process per-symbol + global-cap concurrency guard (synchronous counters) closes the in-flight async race; global cap = 1.
- Reconnect loop catches `websockets.exceptions.ConnectionClosed` (not a `ConnectionError`/`OSError` subclass) so a real socket close reconnects instead of crashing.
- Reuses existing tables — **no migrations**.

### Env flags
- **dry-run:** `BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_DEMO_SCALPING_WS_ENABLED=true` (confirm unset) → subscribes, evaluates, executor runs in dry-run, **zero broker mutation**.
- **confirmed:** add `BINANCE_DEMO_SCALPING_WS_CONFIRM=true` → real Demo orders on demo-fapi only, still subject to every risk gate.

### Verification
- `ruff check app/ tests/` ✅ · `ruff format --check app/ tests/` ✅ (CI scope)
- 66 daemon/bridge/CLI tests + 512 broker-suite tests pass; AST import-guard green
- CLI inert by default: `{"status":"disabled","subscribed":false,...}`, exit 0
- No live orders placed, no production scheduler/launchd mutation, no secret logging

### Notes
- The existing 5-min Prefect tick is **not removed** — reclassified as polling intraday / smoke; pausing it is a deferred operator decision.
- All fake-stream tests — no network, no real orders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Post-merge note — ROB-316 finding (2026-05-26)

[ROB-316](https://linear.app/mgh3326/issue/ROB-316) backtested the trend micro-breakout signal this daemon executes (NautilusTrader, ~60d XRPUSDT tick data, 232 trades): **no durable edge** — net-negative at realistic fees and **gross-negative out-of-sample**; a 14-day apparent edge (incl. an ICT session filter) was overfit.

This PR remains a useful **infrastructure / harness** PR (CI-green, default-disabled), but it should **not** be read as a validated-alpha runner:
- the daemon is plumbing / observe / a harness for a **future validated signal**;
- the current micro-breakout signal must stay **disabled or observe/dry-run only**;
- `confirm=true` and recurring activation (Prefect / scheduler / launchd / TaskIQ) require a **separate validated-signal gate**.

Runbook reclassification: #956. Details: `docs/plans/ROB-316-*`.
