### PR TITLE
docs(rob-317): reclassify demo scalping surfaces as plumbing pending a validated signal (ROB-316 finding)

### DIFF
--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -6,6 +6,12 @@ ledger-backed durable state. **It never places, previews, or tests an
 order.** Later PRs add execution (PR2), TP/SL (PR3), and the default-OFF
 scheduler scaffold (PR4).
 
+> **⚠️ ROB-316 finding (2026-05-26) — the scalping signal here has no validated backtest edge.**
+>
+> ROB-316 backtested the deterministic trend micro-breakout signal (`demo_scalping/signal.py`) on ~60 days of XRPUSDT tick data (NautilusTrader): **net-negative at realistic fees and gross-negative out-of-sample** (232 trades); a 14-day apparent edge was overfit. See [ROB-316](https://linear.app/mgh3326/issue/ROB-316) and `docs/plans/ROB-316-*`.
+>
+> **Posture:** the whole demo scalping pipeline — the observe-only runner, execution (PR2+), the **5-min Prefect tick**, and the **WS daemon** (`binance-demo-ws-scalping.md`) — is **plumbing / harness for a future validated signal**, not a strategy-alpha runner. Keep the signal **disabled or observe/dry-run only**; `confirm=true` and recurring activation require a **separate validated-signal gate**.
+
 ## What PR1 ships
 
 | Module | Responsibility |

--- a/docs/runbooks/binance-demo-ws-scalping.md
+++ b/docs/runbooks/binance-demo-ws-scalping.md
@@ -2,6 +2,15 @@
 
 **Scope.** Operator runbook for the Binance Demo WebSocket Scalping Daemon (`scripts/binance_demo_scalping_ws_daemon.py`). This daemon consumes real-time market data to identify breakout scalping opportunities on Binance USD-M Perpetual Futures, and places confirm-gated, concurrency-guarded mock orders on the USD-M Futures Demo lane (`demo-fapi.binance.com`).
 
+> **⚠️ ROB-316 finding (2026-05-26) — this daemon is plumbing/harness, NOT a validated-alpha runner.**
+>
+> The trend micro-breakout signal this daemon executes has **no durable backtested edge**. Backtested on ~60 days of XRPUSDT spot tick data (232 trades, NautilusTrader, conservative fills) it is net-negative at realistic fees and **gross-negative even before fees**; widening targets (100/100) and adding an ICT session/killzone filter did not help — a 14-day apparent edge **vanished out-of-sample**. See [ROB-316](https://linear.app/mgh3326/issue/ROB-316) and `docs/plans/ROB-316-*`.
+>
+> **Operating posture until a validated signal exists:**
+> - Treat this daemon (and the 5-min Prefect tick in `binance-demo-scalping.md`) as **plumbing / observe / a harness for a future validated signal** — not a strategy-alpha runner.
+> - The current micro-breakout signal must remain **disabled or observe/dry-run only**.
+> - `confirm=true` and any recurring activation (Prefect / scheduler / launchd / TaskIQ) require a **separate validated-signal gate**. Do not enable live Demo order confirmation on this signal.
+
 ---
 
 ## 1. Lane boundaries and Scope


### PR DESCRIPTION
## What & why

Post-merge docs hygiene after [ROB-316](https://linear.app/mgh3326/issue/ROB-316). ROB-316 backtested the trend micro-breakout signal (the one the Demo scalping execution surfaces build on) and found **no durable edge**: net-negative at realistic fees and **gross-negative out-of-sample** on ~60 days of XRPUSDT tick data (232 trades, NautilusTrader). A 14-day apparent edge was overfit.

This PR adds a reclassification banner to both scalping runbooks so operators don't read these surfaces as validated-alpha runners.

## Changes (docs-only)
- `docs/runbooks/binance-demo-ws-scalping.md` (ROB-317 WS daemon)
- `docs/runbooks/binance-demo-scalping.md` (ROB-307 observe-only runner + 5-min tick)

Both now state:
- the WS daemon and the 5-min Prefect tick are **plumbing / observe / a harness for a future validated signal**, not strategy alpha;
- the current micro-breakout signal must remain **disabled or observe/dry-run only**;
- `confirm=true` and any recurring activation (Prefect / scheduler / launchd / TaskIQ) require a **separate validated-signal gate**.

## Safety — no behavior change
Documentation only. No code change, no broker/order submit/cancel/preview, no scheduler/Prefect/launchd/TaskIQ activation, no prod-DB/env/secret mutation, no Demo order confirmation enabled. The merged ROB-317 daemon remains default-disabled as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated operational runbooks with explicit warnings regarding signal validation status and limitations.
* Clarified that demo trading pipelines are experimental and require validated signals before production use.
* Added operational guardrails for signal enable/disable management.
* Specified observe/dry-run mode requirements for unvalidated signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->