### PR TITLE
feat(rob-318): Phase 3 PR-A — deterministic report diagnostics (reason_code + why_no_action)

### DIFF
--- a/app/services/action_report/common/diagnostics.py
+++ b/app/services/action_report/common/diagnostics.py
@@ -1,0 +1,201 @@
+"""ROB-318 Phase 3 — deterministic report diagnostics.
+
+Shared, deterministic helpers that turn a snapshot bundle's freshness/coverage
+state into structured, operator-facing diagnostics. **No in-process LLM** lives
+here (PR #898 guard): this module only classifies facts. The human-readable
+narrative is composed by Hermes; the Korean strings produced here are
+deterministic fallback templates, not generated prose.
+
+Two surfaces:
+
+1. ``reason_code`` — a closed enum attached per snapshot kind so the collector,
+   the bundle assembler, the report response, and the frontend all switch on the
+   same values instead of parsing free text. Collectors emit a specific code
+   (e.g. ``user_id_missing``); otherwise the code is derived from the freshness
+   status.
+2. ``why_no_action`` — a report-level classification of *why* a report concludes
+   no-action: genuine no-action vs blocked by missing data vs blocked by stale
+   data. This is what lets ``/invest/reports`` stop showing the generic
+   "포지션 데이터 확인 불가" for every degraded source.
+
+```
+collector.errors_json{reason_code?, reason?}  +  status (fresh|hard_stale|unavailable|...)
+                 |
+                 v   reason_code_for() / sanitize_reason()
+                 |
+   freshness_summary[kind]{status, reason_code, reason}            (Slice 1)
+                 |
+                 v   classify_why_no_action(freshness_summary, bundle_status, items)
+                 |
+   why_no_action{kind, blocking_sources, reason_ko}                (Slice 2)
+```
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from app.services.action_report.common.critical_kinds import CRITICAL_SNAPSHOT_KINDS
+
+# Closed set of reason codes. Collectors emit the specific ones; the generic
+# ones are derived from a freshness/bundle status. Unknown collector reasons
+# map to ``unknown`` — never a free-form code — so the frontend can switch.
+ReasonCode = Literal[
+    "user_id_missing",  # broker collector got no user_id (ROB-278 lockdown)
+    "kis_fetch_failed",  # KIS read-only fetch raised / returned nothing
+    "stale",  # data present but past freshness TTL (soft/hard_stale)
+    "unavailable",  # source produced no usable data
+    "failed",  # bundle/source hard-failed
+    "unknown",  # degraded for a reason we didn't classify
+]
+
+_VALID_REASON_CODES: frozenset[str] = frozenset(
+    (
+        "user_id_missing",
+        "kis_fetch_failed",
+        "stale",
+        "unavailable",
+        "failed",
+        "unknown",
+    )
+)
+
+WhyNoActionKind = Literal["data_insufficient", "stale_gated", "real_no_action"]
+
+# Per-kind statuses that block action language (mirrors
+# critical_kinds.CRITICAL_KIND_DEGRADING_STATUSES, kept local to avoid a
+# circular intent: "missing data" vs "stale data" are split here).
+_MISSING_STATUSES = frozenset(("unavailable", "failed"))
+_STALE_STATUSES = frozenset(("hard_stale",))
+
+_MAX_REASON_LEN = 200
+
+# Redact token/secret-shaped substrings before a free-form collector reason is
+# surfaced to the operator. The reason_code (closed enum) is the primary signal;
+# this string is secondary context only.
+_SECRET_RE = re.compile(
+    r"(?i)(token|secret|bearer|api[_-]?key|password|authorization)"
+    r"\s*[:=]?\s*\S+"
+)
+_LONG_OPAQUE_RE = re.compile(r"\b[A-Za-z0-9_\-]{32,}\b")
+
+
+def sanitize_reason(reason: str | None) -> str | None:
+    """Bound + redact a free-form collector reason for operator display.
+
+    Returns ``None`` for empty input. Strips credential/token-shaped tokens and
+    long opaque blobs (JWT/keys), collapses whitespace, and caps length so a raw
+    upstream error cannot leak account or secret material into the report/UI.
+    """
+    if not reason:
+        return None
+    text = _SECRET_RE.sub("[REDACTED]", reason)
+    text = _LONG_OPAQUE_RE.sub("[REDACTED]", text)
+    text = " ".join(text.split())
+    if len(text) > _MAX_REASON_LEN:
+        text = text[: _MAX_REASON_LEN - 1].rstrip() + "…"
+    return text or None
+
+
+def reason_code_for(
+    status: str | None, errors_json: Mapping[str, Any] | None
+) -> ReasonCode:
+    """Resolve the closed ``ReasonCode`` for a degraded snapshot kind.
+
+    Prefers a collector-emitted ``errors_json['reason_code']`` when it is a known
+    code; otherwise derives a generic code from the freshness/bundle status.
+    """
+    if errors_json:
+        emitted = errors_json.get("reason_code")
+        if isinstance(emitted, str) and emitted in _VALID_REASON_CODES:
+            return emitted  # type: ignore[return-value]
+    if status in ("hard_stale", "soft_stale"):
+        return "stale"
+    if status == "unavailable":
+        return "unavailable"
+    if status == "failed":
+        return "failed"
+    return "unknown"
+
+
+def build_kind_diagnostic(
+    status: str | None, errors_json: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    """Return the additive diagnostic keys for ``freshness_summary[kind]``.
+
+    Always returns ``reason_code``; includes ``reason`` only when a sanitized
+    free-form reason survives. Callers merge this into the existing per-kind
+    dict, so unknown keys stay backward compatible.
+    """
+    diagnostic: dict[str, Any] = {
+        "reason_code": reason_code_for(status, errors_json),
+    }
+    reason = sanitize_reason((errors_json or {}).get("reason") if errors_json else None)
+    if reason is not None:
+        diagnostic["reason"] = reason
+    return diagnostic
+
+
+_WHY_NO_ACTION_REASON_KO: dict[WhyNoActionKind, str] = {
+    "data_insufficient": "데이터 부족 — {sources} 확인 불가로 매수/매도 권고 보류",
+    "stale_gated": "스냅샷 stale — {sources} 신선도 부족으로 매수/매도 권고 보류",
+    "real_no_action": "데이터 충분 — 현 시점 신규 액션 없음(관망)",
+}
+
+
+def classify_why_no_action(
+    *,
+    freshness_summary: Mapping[str, Any] | None,
+    bundle_status: str | None,
+    has_action_items: bool,
+) -> dict[str, Any] | None:
+    """Classify *why* a report has no actionable recommendation.
+
+    Returns ``None`` when action language is allowed AND the report carries
+    action items (i.e. there is an action — nothing to explain). Otherwise:
+
+    * ``data_insufficient`` — bundle failed, or a critical kind is
+      unavailable/failed (missing data, not merely stale).
+    * ``stale_gated`` — bundle is a stale fallback, or a critical kind is
+      hard_stale (data exists but is too old to act on).
+    * ``real_no_action`` — data is sufficient and fresh, but no action item was
+      produced (genuine "watch / hold" conclusion).
+
+    Precedence: missing > stale > genuine. ``blocking_sources`` lists the
+    critical kinds that triggered a gated classification.
+    """
+    summary = freshness_summary or {}
+    missing: list[str] = []
+    stale: list[str] = []
+    for kind in CRITICAL_SNAPSHOT_KINDS:
+        info = summary.get(kind)
+        if not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        if status in _MISSING_STATUSES:
+            missing.append(kind)
+        elif status in _STALE_STATUSES:
+            stale.append(kind)
+
+    if bundle_status == "failed":
+        return _why("data_insufficient", missing or ["bundle"])
+    if missing:
+        return _why("data_insufficient", missing)
+    if bundle_status == "stale_fallback":
+        return _why("stale_gated", stale or ["bundle"])
+    if stale:
+        return _why("stale_gated", stale)
+    if not has_action_items:
+        return _why("real_no_action", [])
+    return None
+
+
+def _why(kind: WhyNoActionKind, blocking_sources: list[str]) -> dict[str, Any]:
+    sources_label = ", ".join(blocking_sources) if blocking_sources else "전체"
+    return {
+        "kind": kind,
+        "blocking_sources": blocking_sources,
+        "reason_ko": _WHY_NO_ACTION_REASON_KO[kind].format(sources=sources_label),
+    }

--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -34,6 +34,10 @@ from app.schemas.investment_snapshots_mcp import (
     EnsureBundleRequest,
     EnsureBundleResponse,
 )
+from app.services.action_report.common.critical_kinds import (
+    CRITICAL_KIND_DEGRADING_STATUSES,
+)
+from app.services.action_report.common.diagnostics import build_kind_diagnostic
 from app.services.investment_snapshots.collectors import (
     CollectorRequest,
     SnapshotCollectorRegistry,
@@ -178,13 +182,17 @@ class SnapshotBundleEnsureService:
                 #     fall here when callers don't supply manual data.
                 if kind_policy.required or attempted:
                     coverage[bucket][kind_policy.snapshot_kind] = "unavailable"
+                    # ROB-318 Slice 1 — no collector result means no reason_code
+                    # to carry; derive a generic 'unavailable' diagnostic.
                     freshness_summary[kind_policy.snapshot_kind] = {
-                        "status": "unavailable"
+                        "status": "unavailable",
+                        **build_kind_diagnostic("unavailable", None),
                     }
                     missing_sources.append(kind_policy.snapshot_kind)
                 continue
 
             kind_statuses: list[str] = []
+            status_errors: list[tuple[str, dict[str, Any]]] = []
             last_as_of: dt.datetime | None = None
             for result in results:
                 # Collectors run after ``now`` is captured for the reuse gate.
@@ -222,15 +230,27 @@ class SnapshotBundleEnsureService:
                 )
                 linked_items.append((snap.snapshot_uuid, role))
                 kind_statuses.append(effective_status)
+                status_errors.append((effective_status, result.errors_json or {}))
                 last_as_of = result.as_of
 
             worst_status = _worst_status(kind_statuses)
             coverage[bucket][kind_policy.snapshot_kind] = worst_status
-            freshness_summary[kind_policy.snapshot_kind] = {
+            summary_entry: dict[str, Any] = {
                 "status": worst_status,
                 "as_of": last_as_of.isoformat() if last_as_of else None,
                 "result_count": str(len(results)),
             }
+            # ROB-318 Slice 1 — when the worst status is degrading, surface the
+            # collector's reason_code (+ sanitized reason) so the operator sees
+            # WHY (e.g. portfolio user_id_missing) instead of a bare status.
+            if worst_status in CRITICAL_KIND_DEGRADING_STATUSES:
+                errors_for_worst = next(
+                    (e for s, e in status_errors if s == worst_status), None
+                )
+                summary_entry.update(
+                    build_kind_diagnostic(worst_status, errors_for_worst)
+                )
+            freshness_summary[kind_policy.snapshot_kind] = summary_entry
 
         bundle_status = _derive_bundle_status(coverage)
 

--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -271,9 +271,10 @@ class PortfolioSnapshotCollector:
                     freshness_status="unavailable",
                     coverage={"holdings_count": 0},
                     errors={
+                        "reason_code": "user_id_missing",
                         "reason": (
                             "kis_live portfolio requires explicit user_id; none supplied"
-                        )
+                        ),
                     },
                 )
             ]
@@ -393,6 +394,7 @@ class PortfolioSnapshotCollector:
                     freshness_status="unavailable",
                     coverage=coverage,
                     errors={
+                        "reason_code": "kis_fetch_failed",
                         "reason": "KIS live portfolio fetch failed",
                         "warnings": fetch_warnings,
                         "errors": fetch_errors,

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -41,6 +41,7 @@ from app.services.action_report.common.critical_kinds import (
     CRITICAL_KIND_DEGRADING_STATUSES,
     CRITICAL_SNAPSHOT_KINDS,
 )
+from app.services.action_report.common.diagnostics import classify_why_no_action
 from app.services.action_report.common.jsonable import to_jsonable
 from app.services.action_report.common.snapshot_bundle import (
     SnapshotBundleEnsureService,
@@ -285,6 +286,19 @@ class SnapshotBackedReportGenerator:
 
         report = await self._ingestion_service.ingest(ingest_request)
 
+        # ROB-318 Phase 3 (PR-A) — classify why the report is no-action so the
+        # operator can tell a genuine hold from a data-blocked / stale-gated one.
+        # Deterministic; Hermes composes the prose. Action items are item_kind
+        # 'action' (watch/risk are not buy/sell actions).
+        why_no_action = classify_why_no_action(
+            freshness_summary=freshness_summary,
+            bundle_status=ensure_response.status,
+            has_action_items=any(
+                getattr(it, "item_kind", None) == "action"
+                for it in ingest_request.items
+            ),
+        )
+
         return ReportGenerationResponse(
             report_uuid=report.report_uuid,
             snapshot_bundle_uuid=ensure_response.bundle_uuid,
@@ -298,6 +312,7 @@ class SnapshotBackedReportGenerator:
             bundle_status=ensure_response.status,
             bundle_reused=not ensure_response.created,
             stale_gate=gate_result.to_metadata_summary(),
+            why_no_action=why_no_action,
         )
 
     # ------------------------------------------------------------------

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -110,3 +110,10 @@ class ReportGenerationResponse(BaseModel):
     bundle_status: str
     bundle_reused: bool
     stale_gate: dict[str, Any]
+
+    # ROB-318 Phase 3 (PR-A) — deterministic classification of why the report
+    # concludes no-action: data_insufficient | stale_gated | real_no_action,
+    # or ``None`` when an action is allowed. ``{kind, blocking_sources,
+    # reason_ko}``. Computed deterministically; Hermes owns the prose. In PR-A
+    # this is a response-only field (ephemeral); PR-B persists it.
+    why_no_action: dict[str, Any] | None = None

--- a/docs/plans/2026-05-26-ROB-318-phase3-deterministic-report-diagnostics-plan.md
+++ b/docs/plans/2026-05-26-ROB-318-phase3-deterministic-report-diagnostics-plan.md
@@ -1,0 +1,308 @@
+# ROB-318 Phase 3 — deterministic report diagnostics (eng-review plan)
+
+- **Date**: 2026-05-26 (KST)
+- **Branch**: follow-up to `rob-318` (PR #953 = Slice A + audit)
+- **Predecessor doc**: `2026-05-26-ROB-318-invest-reports-reference-audit-and-bugfix.md` §4
+- **Status**: DRAFT for eng-review
+
+## Problem
+
+After the Slice A fix, KR/kis_live reports can collect a live portfolio, but
+`/invest/reports` still surfaces only a **generic** Korean reason
+("포지션 데이터 확인 불가 — 매수/매도 권고 불가") when a required source is degraded,
+and it cannot tell the operator whether a no-action conclusion is a **real**
+no-action or a **data-insufficient / stale-gated** one. The collector already
+records a specific reason (`errors_json.reason`), but it is dropped before it
+reaches the operator-visible `freshness_summary`.
+
+## Goal (Phase 3 scope = report-level diagnostics)
+
+Deterministic, structured evidence the report can show and Hermes can compose
+from. **No in-process LLM** (ROB-287 / PR #898 guard). Narrative is Hermes;
+deterministic fallback templates are allowed.
+
+In scope (this plan):
+1. Source-specific diagnostics (per-kind `reason_code` + `reason`).
+2. Report-level `why_no_action` (real vs stale_gated vs data_insufficient).
+3. `report_quality_summary` + `data_sufficiency_by_source` rollups.
+4. Export the above to Hermes (optional fields).
+5. Frontend rendering on `/invest/reports` detail.
+
+**Deferred to Phase 3b (separate issue/PR)** — candidate/holding-level evidence
+(`new_candidate_reference_signals`, `held_strategy_change_signals`,
+`external_reference_checks`, `screener_condition_provenance`). These touch the
+candidate / journal / watch / screener / browser-reference collectors and are a
+larger surface; they consume the same deterministic-container pattern. Out of
+this plan to keep the review tight.
+
+## Architecture & data flow
+
+```
+collector (errors_json={reason_code, reason})           ← Slice 1 source
+  → snapshot_bundle.ensure(): freshness_summary[kind]    snapshot_bundle.py:181,229
+      {status, as_of, result_count, reason_code?, reason?}
+  → derive_generator_constraints()                       generator_constraints.py:44
+      → GeneratorConstraints(forced_action_mode, reason_ko)
+  → generator.generate(): build why_no_action +          generator.py:251-272
+      report_quality_summary + data_sufficiency_by_source
+  → persist on InvestmentReport (new JSONB column)        models/investment_reports.py
+  → HermesContextExporter.export(): expose to Hermes      hermes_context.py:247-263
+  → GET report detail → frontend renders                  frontend/invest/...
+```
+
+The deterministic boundary: collectors + assembler + generator produce
+**structured facts**; Hermes consumes them for prose. The only strings the
+deterministic layer emits are `reason_ko` (already exists) and enum-driven
+fallback templates.
+
+## Sub-slices (proposed ordering)
+
+### Slice 1 — per-kind `reason_code` + `reason` (no migration, no Hermes break)
+- `snapshot_bundle.py` (lines 181-184 empty-results branch; 229-233 populated
+  branch): when status ∈ {unavailable, hard_stale, failed}, copy
+  `result.errors_json.get("reason")` into `freshness_summary[kind]` and add a
+  normalized `reason_code`.
+- Collectors emit a `reason_code` enum alongside the human `reason`. Start with
+  portfolio (`portfolio.py:273`): `user_id_missing`, `kis_fetch_failed`,
+  `stale`. Other critical kinds get `unavailable`/`stale`/`failed` defaults.
+- Backward compatible: existing consumers read `freshness_summary[kind]["status"]`;
+  new keys are additive. `HermesContextPayload` re-exports freshness_summary as-is.
+- Tests: extend `test_collectors.py`, `test_generator_constraints.py`,
+  `test_stale_gate.py` fixtures with reason_code assertions.
+
+### Slice 2 — `why_no_action` (report-level, deterministic)
+- In `generator.py` after `derive_generator_constraints`, map
+  `forced_action_mode` + blocking kinds → `why_no_action`:
+  `{kind: real_no_action | stale_gated | data_insufficient,
+    blocking_sources: [kind...], reason_ko}`.
+  - `data_insufficient` = required source unavailable (e.g. portfolio
+    user_id_missing/kis_fetch_failed).
+  - `stale_gated` = required source hard_stale / bundle stale_fallback.
+  - `real_no_action` = all critical fresh, generator still emits no action.
+- Added to `ReportGenerationResponse` (request.py) and the Hermes context.
+- Tests: `test_generator.py` / `test_generator_constraints.py`.
+
+### Slice 3 — `report_quality_summary` + `data_sufficiency_by_source` (+ migration)
+- `report_quality_summary` (report-level rollup): coverage %, fresh/stale/
+  unavailable counts, grade ∈ {high_confidence, informational_only, no_action}.
+- `data_sufficiency_by_source`: per-source `{status, reason_code, as_of, origin}`
+  derived from `unavailable_sources` + `freshness_summary`.
+- **Persistence**: new nullable JSONB column `snapshot_quality_summary` on
+  `investment_reports`. Alembic migration mirrors
+  `alembic/versions/20260519_rob269_p3_add_snapshot_metadata_to_investment_reports.py`.
+  `data_sufficiency_by_source` can live inside this column (no second migration).
+- **Open question for review**: persist as a first-class column (queryable
+  "show low-quality reports") vs nest in an existing JSON metadata field
+  (no migration). Recommend first-class column for future filtering.
+- Migration is included in the PR but `alembic upgrade head` is operator-run
+  (cutover gate, per repo convention).
+
+### Slice 4 — Hermes context export (optional fields)
+- `hermes_context.py` / `app/schemas/hermes_composition.py`
+  (`HermesContextPayload`): add `data_sufficiency_by_source`, `why_no_action`,
+  `report_quality_summary` as `... | None` (graceful degradation if Hermes lags).
+- Tests: `test_hermes_*` context/roundtrip.
+
+### Slice 5 — frontend `/invest/reports` detail
+- Render: quality grade badge, per-source data-sufficiency chips with
+  reason_code, and the real-vs-stale-gated no-action distinction.
+- `external_reference_checks` remains optional/fail-open (Phase 3b) — if absent,
+  render "확인 불가", never infer.
+- Tests: frontend component tests alongside existing snapshot-evidence rendering.
+
+## Edge cases / invariants
+
+- Fail-open: missing optional reference data must never crash generation.
+- No in-process LLM anywhere in the assembler/generator path (PR #898 guard
+  must stay green — verify import guard covers new code paths).
+- `reason_code` is a closed enum; unknown collector reasons map to a generic
+  code, never a free-form code, so the frontend can switch on it.
+- Backward compat: reports generated before Phase 3 have null new fields; UI
+  degrades gracefully.
+- No broker/order/watch/order-intent mutation (side-effect guards stay green).
+
+## Test coverage plan + coverage map
+
+```
+CODE PATHS                                                  STATUS
+[+] snapshot_bundle.ensure (Slice 1)
+  ├── reason_code/reason copied when status degraded         [GAP] unit — test_collectors/test_snapshot_bundle
+  └── status fresh → no reason key (no leakage)              [GAP] unit
+[+] generator_constraints / generator (Slice 2)
+  ├── why_no_action = data_insufficient (required unavail)   [GAP] unit — classification table
+  ├── why_no_action = stale_gated (hard_stale/fallback)      [GAP] unit
+  └── why_no_action = real_no_action (all fresh, no action)  [GAP] unit
+[+] diagnostics.ReasonCode (shared enum)
+  └── unmatched reason → 'unknown', never free-form code      [GAP] unit
+[+] new column + quality grading (Slice 3)
+  ├── grade high_confidence / informational_only / no_action [GAP] unit
+  └── data_sufficiency_by_source per source                  [GAP] unit
+[+] Hermes export (Slice 4)
+  └── optional fields present when set, omitted when None     [GAP] integration — test_hermes_*
+[+] LEGACY report (null new fields) — REGRESSION  [CRITICAL]
+  ├── detail endpoint renders                                [GAP] regression
+  ├── serializer / Hermes export tolerate null               [GAP] regression
+  └── frontend renders (PR-C)                                 [GAP] regression
+[+] reason free-text sanitation
+  └── account/credential-shaped token stripped + length cap   [GAP] unit (safety)
+
+COVERAGE TARGET: 100% of new branches. Guards: no_internal_llm_imports +
+import_contracts + side-effect guards stay green.
+```
+
+- **CRITICAL regression**: legacy pre-Phase-3 reports (null diagnostics) render
+  on every surface (endpoint, serializer, Hermes export, frontend). IRON RULE —
+  in the plan, no opt-out.
+- Unit: reason_code derivation per collector; why_no_action 3-branch table;
+  quality grading; enum fallback; reason sanitation.
+- Integration: generate → (PR-B) persist → re-read → Hermes export carries fields.
+- Frontend: badge/chip per grade + reason_code; null-safety.
+
+## What already exists (reuse, do not rebuild)
+
+- `snapshot_freshness_summary[kind]` JSONB (status/as_of/result_count) — Slice 1
+  extends it; existing column, no migration.
+- `generator_constraints.derive_generator_constraints` + `reason_ko` — Slice 2
+  reuses; `why_no_action` wraps it, does not replace.
+- `HermesContextPayload` re-exports freshness_summary — Slice 4 adds optional
+  fields alongside.
+- alembic pattern `20260519_rob269_p3_*` — Slice 3 migration mirrors it.
+- `investment_stage_artifacts` (analysis-axis) + ROB-301 symbol-axis reports —
+  Phase 3 does NOT touch either; report-level only.
+
+## NOT in scope (explicitly deferred)
+
+- **Phase 3b — candidate/held-signal evidence** (`new_candidate_reference_signals`,
+  `held_strategy_change_signals`, `external_reference_checks`,
+  `screener_condition_provenance`): touches candidate/journal/watch/screener/
+  browser-reference collectors. Separate Linear issue. Rationale: bigger surface,
+  different (symbol/candidate) axis; report-level diagnostics ship value first.
+- **/invest/screener freshness semantics** → ROB-277/280/281.
+- **Crypto Upbit/Naver market-context cards + column parity** → ROB-304/280.
+- **ROB-301 symbol-intermediate-reports** → its own (already eng-reviewed) track.
+
+## Failure modes (per new codepath)
+
+| codepath | realistic failure | test? | error handling? | user sees |
+|---|---|---|---|---|
+| reason_code copy | collector emits unknown reason | unit | map → `unknown` | enum chip `unknown` (not crash) |
+| why_no_action | bundle status combos not covered | unit table | default → most-degrading | correct classification |
+| new column read | legacy report null diagnostics | **regression** | null-safe render | nothing / 확인 불가 |
+| free-text reason | raw KIS error leaks account info | unit | sanitize + cap | bounded enum-led message |
+| Hermes export | Hermes version lags new fields | integration | optional `\|None` | graceful degradation |
+
+No critical gap (silent + untested + unhandled): all failure modes above have a
+planned test AND deterministic handling.
+
+## Parallelization
+
+PR-A and PR-B share `generator.py` + `request.py` + the diagnostics module, and
+PR-B depends on PR-A's `why_no_action` computation. **Mostly sequential**:
+Lane A: PR-A → PR-B (shared generator/request). Lane B: PR-C frontend can start
+against PR-A's response shape in parallel, but final wiring waits on PR-B's
+persisted column. Net: A sequential; C can prototype in parallel, integrate after B.
+
+## Implementation Tasks
+Synthesized from this review. Checkbox as shipped.
+
+- [ ] **T1 (P1, human: ~3h / CC: ~20min)** — snapshot_bundle — thread `reason_code` + sanitized `reason` into `freshness_summary[kind]` when degraded
+  - Surfaced by: Architecture/Slice 1 — collector `errors_json.reason` dropped at `snapshot_bundle.py:181,229`
+  - Files: app/services/action_report/common/snapshot_bundle.py, app/services/action_report/common/diagnostics.py (new), app/services/action_report/snapshot_backed/collectors/portfolio.py
+  - Verify: `uv run pytest tests/services/action_report/`
+- [ ] **T2 (P1, human: ~2h / CC: ~15min)** — generator — compute `why_no_action` (3-branch) onto `ReportGenerationResponse`
+  - Surfaced by: Slice 2 / AC#5 — real vs stale_gated vs data_insufficient
+  - Files: app/services/action_report/snapshot_backed/generator.py, request.py, generator_constraints.py
+  - Verify: classification table unit test
+- [ ] **T3 (P1, human: ~4h / CC: ~30min)** — model+migration — new `snapshot_report_diagnostics` JSONB; persist quality_summary + data_sufficiency + why_no_action
+  - Surfaced by: D1 — first-class column
+  - Files: app/models/investment_reports.py, app/schemas/investment_reports.py, alembic/versions/<new>.py
+  - Verify: migration up/down + persist round-trip test
+- [ ] **T4 (P1, human: ~2h / CC: ~15min)** — hermes — add 3 optional fields to `HermesContextPayload`
+  - Surfaced by: D5 — push-only optional fields
+  - Files: app/services/investment_stages/hermes_context.py, app/schemas/hermes_composition.py
+  - Verify: `tests/test_hermes_*`
+- [ ] **T5 (P1, human: ~2h / CC: ~15min)** — tests — CRITICAL legacy null-diagnostics regression across endpoint/serializer/export/frontend
+  - Surfaced by: Test review IRON RULE + design-doc "legacy 깨지 않기"
+  - Files: tests/test_investment_reports_mcp.py, tests/routers/..., frontend tests
+  - Verify: load pre-Phase-3 report fixture, assert graceful render
+- [ ] **T6 (P2, human: ~4h / CC: ~30min)** — frontend — quality badge + data-sufficiency chips + null-safety (PR-C)
+  - Surfaced by: Slice 5 — AC render
+  - Files: frontend/invest/src/...
+  - Verify: component tests per grade/reason_code
+
+## Locked decisions (eng-review 2026-05-26)
+
+- **D1 persistence — new JSONB column.** Add one nullable JSONB column
+  `snapshot_report_diagnostics` on `investment_reports` (alembic mirrors
+  `20260519_rob269_p3_add_snapshot_metadata_to_investment_reports.py`). It holds
+  `report_quality_summary` + `data_sufficiency_by_source` + `why_no_action`
+  together. First-class column → queryable ("show blocked/low-quality reports"),
+  decoupled from per-kind `snapshot_freshness_summary`. Operator runs
+  `alembic upgrade head` (cutover gate).
+- **D3 PR slicing — A → B → C.**
+  - **PR-A (no migration)**: Slice 1 (`reason_code` in `freshness_summary[kind]`,
+    persisted in the EXISTING `snapshot_freshness_summary` column) + Slice 2
+    (`why_no_action` as a computed field on `ReportGenerationResponse`, **not**
+    persisted yet — see reconciliation below).
+  - **PR-B (migration + Hermes)**: Slice 3 (new `snapshot_report_diagnostics`
+    column + `report_quality_summary` + `data_sufficiency_by_source`, and
+    **persist** `why_no_action` into that column) + Slice 4 (Hermes export).
+  - **PR-C**: Slice 5 frontend.
+- **D4 scope — report-level only; coordinate with ROB-301.** Phase 3 stays
+  report-level. `data_sufficiency_by_source` is the canonical "structured
+  unavailable" feed the ROB-301 design doc requires. `why_no_action`
+  (report-level no-action classification) references but does not duplicate
+  ROB-301 `decision_bucket` (per-item 5-value). No fold-in.
+- **D5 Hermes contract — optional fields.** All three new fields added to
+  `HermesContextPayload` as `... | None = None`; graceful degradation if Hermes
+  lags. Push-only contract preserved ([[hermes-push-only-not-pull]]).
+
+### D1↔D3 reconciliation (why_no_action lifecycle)
+`why_no_action` needs the new column (D1) but PR-A is no-migration (D3). Resolved
+incrementally: **PR-A computes `why_no_action` and returns it on
+`ReportGenerationResponse`** (ephemeral, available to the immediate
+Hermes/operator caller, no DB write). **PR-B persists it** into
+`snapshot_report_diagnostics` and the report-detail endpoint reads it from there.
+Reversibility-friendly: PR-A delivers the signal in the API response before it
+becomes durable.
+
+## Eng-review refinements (mechanical, batched)
+
+- **`reason_code` is a shared closed enum.** Define once in
+  `app/services/action_report/common/diagnostics.py` (e.g. `ReasonCode` Literal/
+  Enum) so collector, `generator_constraints`, Hermes export, and the frontend
+  switch on the same values. DRY — no per-collector string duplication.
+  Start set: `user_id_missing`, `kis_fetch_failed`, `stale`, `unavailable`,
+  `failed`; unknown → `unknown`.
+- **Sanitize the free-form `reason`.** The collector's `errors_json.reason` is
+  free text (e.g. a raw KIS error) and is operator-visible. Surface the
+  `reason_code` (closed enum, safe) as the primary signal; bound/sanitize the
+  free `reason` string (length cap, strip account/credential-shaped tokens)
+  before it reaches the report/UI. Never infer a code from unmatched text.
+- **CRITICAL regression (IRON RULE, no opt-out).** Legacy reports generated
+  before Phase 3 have `null` new fields. The report-detail endpoint, serializer,
+  Hermes export, and frontend must render them without error. Add a regression
+  test per surface that loads a pre-Phase-3 report (null diagnostics) and asserts
+  graceful handling. Mandated by the design-doc constraint "legacy 리포트 깨지
+  않기."
+- **Frontend null-safety.** PR-C must treat all three fields as optional; absent
+  → render nothing / "확인 불가", never a crash or an inferred value.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | — |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 4 decisions locked (D1/D3/D4/D5), 1 critical regression mandated, 0 unresolved |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |
+
+- **Scope:** accepted with report-level boundary (Phase 3b deferred to a separate issue).
+- **Decisions locked:** D1 new `snapshot_report_diagnostics` JSONB column; D3 PR-A(no-migration)→PR-B(migration+Hermes)→PR-C(frontend); D4 report-level only, coordinate with ROB-301; D5 optional `|None` Hermes fields.
+- **Critical gap flagged:** 1 — legacy null-diagnostics regression (IRON RULE, mandated in plan, no opt-out).
+- **Failure modes:** 5 codepaths, all with planned test + deterministic handling; no silent+untested+unhandled gap.
+- **Outside voice:** skipped (additive plan, well-scoped; available via `/codex` if desired).
+- **Parallelization:** Lane A sequential (PR-A→PR-B, shared generator); PR-C frontend can prototype in parallel, integrate after PR-B.
+- **UNRESOLVED:** 0.
+- **VERDICT:** ENG CLEARED — ready to implement PR-A. CEO/Design reviews not required (backend diagnostics; PR-C frontend is render-only of deterministic fields).

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -1,0 +1,162 @@
+"""ROB-318 Phase 3 — unit tests for deterministic report diagnostics."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.action_report.common.diagnostics import (
+    build_kind_diagnostic,
+    classify_why_no_action,
+    reason_code_for,
+    sanitize_reason,
+)
+
+
+# --- sanitize_reason --------------------------------------------------------
+def test_sanitize_reason_none_and_empty() -> None:
+    assert sanitize_reason(None) is None
+    assert sanitize_reason("") is None
+    assert sanitize_reason("   ") is None
+
+
+def test_sanitize_reason_redacts_secret_shaped_tokens() -> None:
+    out = sanitize_reason("auth failed token=ABC123secretvalue for account")
+    assert "ABC123secretvalue" not in out
+    assert "[REDACTED]" in out
+
+
+def test_sanitize_reason_redacts_long_opaque_blob() -> None:
+    blob = "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"  # 32 chars
+    out = sanitize_reason(f"kis error context {blob} end")
+    assert blob not in out
+    assert "[REDACTED]" in out
+
+
+def test_sanitize_reason_caps_length() -> None:
+    out = sanitize_reason("x " * 400)
+    assert out is not None
+    assert len(out) <= 200
+
+
+# --- reason_code_for --------------------------------------------------------
+def test_reason_code_prefers_valid_collector_code() -> None:
+    assert (
+        reason_code_for("unavailable", {"reason_code": "user_id_missing"})
+        == "user_id_missing"
+    )
+
+
+def test_reason_code_ignores_unknown_collector_code() -> None:
+    # An unrecognized code must not pass through as a free-form code.
+    assert reason_code_for("unavailable", {"reason_code": "weird"}) == "unavailable"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("hard_stale", "stale"),
+        ("soft_stale", "stale"),
+        ("unavailable", "unavailable"),
+        ("failed", "failed"),
+        ("fresh", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_reason_code_derived_from_status(status: str | None, expected: str) -> None:
+    assert reason_code_for(status, None) == expected
+
+
+# --- build_kind_diagnostic --------------------------------------------------
+def test_build_kind_diagnostic_includes_sanitized_reason() -> None:
+    diag = build_kind_diagnostic(
+        "unavailable",
+        {
+            "reason_code": "user_id_missing",
+            "reason": "kis_live portfolio requires explicit user_id; none supplied",
+        },
+    )
+    assert diag["reason_code"] == "user_id_missing"
+    assert "user_id" in diag["reason"]
+
+
+def test_build_kind_diagnostic_omits_reason_when_absent() -> None:
+    diag = build_kind_diagnostic("unavailable", None)
+    assert diag == {"reason_code": "unavailable"}
+    assert "reason" not in diag
+
+
+# --- classify_why_no_action -------------------------------------------------
+def test_why_no_action_data_insufficient_on_missing_critical() -> None:
+    out = classify_why_no_action(
+        freshness_summary={"portfolio": {"status": "unavailable"}},
+        bundle_status="partial",
+        has_action_items=False,
+    )
+    assert out is not None
+    assert out["kind"] == "data_insufficient"
+    assert out["blocking_sources"] == ["portfolio"]
+    assert "확인 불가" in out["reason_ko"]
+
+
+def test_why_no_action_stale_gated_on_hard_stale_critical() -> None:
+    out = classify_why_no_action(
+        freshness_summary={"market": {"status": "hard_stale"}},
+        bundle_status="complete",
+        has_action_items=False,
+    )
+    assert out is not None
+    assert out["kind"] == "stale_gated"
+    assert out["blocking_sources"] == ["market"]
+
+
+def test_why_no_action_missing_precedes_stale() -> None:
+    out = classify_why_no_action(
+        freshness_summary={
+            "portfolio": {"status": "unavailable"},
+            "market": {"status": "hard_stale"},
+        },
+        bundle_status="partial",
+        has_action_items=False,
+    )
+    assert out["kind"] == "data_insufficient"
+    assert out["blocking_sources"] == ["portfolio"]
+
+
+def test_why_no_action_bundle_failed_is_data_insufficient() -> None:
+    out = classify_why_no_action(
+        freshness_summary={},
+        bundle_status="failed",
+        has_action_items=False,
+    )
+    assert out["kind"] == "data_insufficient"
+    assert out["blocking_sources"] == ["bundle"]
+
+
+def test_why_no_action_stale_fallback_bundle() -> None:
+    out = classify_why_no_action(
+        freshness_summary={},
+        bundle_status="stale_fallback",
+        has_action_items=False,
+    )
+    assert out["kind"] == "stale_gated"
+    assert out["blocking_sources"] == ["bundle"]
+
+
+def test_why_no_action_real_no_action_when_fresh_but_no_items() -> None:
+    out = classify_why_no_action(
+        freshness_summary={"portfolio": {"status": "fresh"}},
+        bundle_status="complete",
+        has_action_items=False,
+    )
+    assert out is not None
+    assert out["kind"] == "real_no_action"
+    assert out["blocking_sources"] == []
+
+
+def test_why_no_action_none_when_action_present_and_fresh() -> None:
+    out = classify_why_no_action(
+        freshness_summary={"portfolio": {"status": "fresh"}},
+        bundle_status="complete",
+        has_action_items=True,
+    )
+    assert out is None

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -255,6 +255,8 @@ async def test_portfolio_v2_kr_kis_live_missing_user_id_is_fail_closed():
     assert results[0].snapshot_kind == "portfolio"
     assert results[0].freshness_status == "unavailable"
     assert "user_id" in results[0].errors_json["reason"]
+    # ROB-318 Slice 1 — collector emits the closed reason_code for the gate.
+    assert results[0].errors_json["reason_code"] == "user_id_missing"
     # primary_source label is present and explicitly "none" (manual NOT promoted).
     assert results[0].payload_json.get("primary_source") == "none"
     reader.fetch.assert_not_called()

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -170,6 +170,52 @@ async def test_happy_path_kr_published(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_why_no_action_data_insufficient_on_unavailable_portfolio() -> None:
+    """ROB-318 PR-A — unavailable required kind → why_no_action=data_insufficient."""
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="partial",
+            freshness_summary={
+                "overall": "unavailable",
+                "portfolio": {
+                    "status": "unavailable",
+                    "reason_code": "user_id_missing",
+                },
+                "journal": {"status": "fresh"},
+                "watch_context": {"status": "fresh"},
+                "market": {"status": "fresh"},
+            },
+            missing_sources=["portfolio"],
+        )
+    )
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=_FakeIngestionService(),
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    # draft so the publish gate does not short-circuit before the response.
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.why_no_action is not None
+    assert response.why_no_action["kind"] == "data_insufficient"
+    assert response.why_no_action["blocking_sources"] == ["portfolio"]
+
+
+@pytest.mark.asyncio
+async def test_why_no_action_real_no_action_when_fresh_and_no_items() -> None:
+    """ROB-318 PR-A — all fresh, no action items → why_no_action=real_no_action."""
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=_FakeEnsureService(_ensure_response()),
+        ingestion_service=_FakeIngestionService(),
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.why_no_action is not None
+    assert response.why_no_action["kind"] == "real_no_action"
+
+
+@pytest.mark.asyncio
 async def test_happy_path_crypto_published() -> None:
     """Crypto/upbit_live pairing is also accepted."""
     ensure = _FakeEnsureService(_ensure_response())

--- a/tests/services/investment_snapshots/test_bundle_ensure_service.py
+++ b/tests/services/investment_snapshots/test_bundle_ensure_service.py
@@ -378,6 +378,59 @@ async def test_ensure_fresh_uses_collector_registry_when_no_manual(db_session):
 
 
 @pytest.mark.asyncio
+async def test_ensure_surfaces_collector_reason_code_in_freshness_summary(db_session):
+    """ROB-318 Slice 1 — a collector's reason_code/reason for a degraded kind is
+    surfaced in freshness_summary[kind] (previously only the bare status survived)."""
+
+    class _FailClosedPortfolioCollector:
+        snapshot_kind = "portfolio"
+
+        async def collect(self, request: CollectorRequest):
+            return [
+                SnapshotCollectResult(
+                    snapshot_kind="portfolio",
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    source_kind="manual",
+                    payload_json={},
+                    errors_json={
+                        "reason_code": "user_id_missing",
+                        "reason": (
+                            "kis_live portfolio requires explicit user_id; "
+                            "none supplied"
+                        ),
+                    },
+                    as_of=_FIXED_NOW,
+                    freshness_status="unavailable",
+                )
+            ]
+
+    registry = SnapshotCollectorRegistry()
+    registry.register(_FailClosedPortfolioCollector())
+    manual = _all_required_manual_snapshots()
+    del manual["portfolio"]
+
+    svc = SnapshotBundleEnsureService(
+        db_session, collectors=registry, clock=_frozen_clock()
+    )
+    response = await svc.ensure(
+        EnsureBundleRequest(
+            purpose=_unique_purpose("reason_code"),
+            market="kr",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            manual_snapshots=manual,
+        )
+    )
+    await db_session.commit()
+
+    pf = response.freshness_summary["portfolio"]
+    assert pf["status"] == "unavailable"
+    assert pf["reason_code"] == "user_id_missing"
+    assert "user_id" in pf["reason"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_classifies_collector_results_against_post_collect_clock(
     db_session,
 ):


### PR DESCRIPTION
## What

ROB-318 Phase 3, **PR-A** (the no-migration slice). Adds two deterministic, no-LLM diagnostics so `/invest/reports` can explain **why** a report is degraded instead of the generic `포지션 데이터 확인 불가 — 매수/매도 권고 불가`.

Follows the eng-reviewed plan: `docs/plans/2026-05-26-ROB-318-phase3-deterministic-report-diagnostics-plan.md` (committed here). Locked decisions: D1 new JSONB column (PR-B), **D3 PR-A = no-migration**, D4 report-level scope, D5 optional Hermes fields.

## Slice 1 — per-kind `reason_code`

- New `app/services/action_report/common/diagnostics.py`: closed `ReasonCode` enum (`user_id_missing`, `kis_fetch_failed`, `stale`, `unavailable`, `failed`, `unknown`), `reason_code_for()`, `sanitize_reason()` (redacts token/secret-shaped text + caps length), `build_kind_diagnostic()`.
- `snapshot_bundle.ensure()`: when a kind's worst status is degrading, merge `reason_code` + sanitized `reason` into `freshness_summary[kind]`. Previously only the bare status survived — the collector's specific reason was dropped. Additive keys, backward compatible; re-exported to Hermes as-is.
- Portfolio collector emits `reason_code` (`user_id_missing`, `kis_fetch_failed`).

## Slice 2 — report-level `why_no_action`

- `classify_why_no_action()`: `data_insufficient` vs `stale_gated` vs `real_no_action` (precedence missing > stale > genuine), with `blocking_sources` + `reason_ko`.
- Generator computes it from `freshness_summary` + `bundle_status` + whether any action item was produced; surfaced on `ReportGenerationResponse`.
- **Response-only in PR-A** (ephemeral). PR-B persists it in the new `snapshot_report_diagnostics` column.

## Safety / boundary

- **No in-process LLM** — `diagnostics.py` only classifies facts; narrative stays with Hermes (PR #898 `no_internal_llm_imports` guard green). `reason_ko` strings are deterministic fallback templates.
- `sanitize_reason()` redacts credential/token-shaped text and caps length so a raw upstream error can't leak account/secret material into the report/UI.
- No broker/order/watch/order-intent mutation. Additive only — legacy reports unaffected (null new fields).

## Tests

- diagnostics unit suite (21: sanitize, reason_code_for, build_kind_diagnostic, why_no_action classification table)
- collector reason_code assertion; bundle-ensure reason_code propagation into `freshness_summary`
- generator `why_no_action` (data_insufficient + real_no_action)
- `ruff check` + `ruff format --check` clean; `no_internal_llm_imports` + `import_contracts` green; 261 passed across affected dirs.

## Not in this PR

- PR-B: `snapshot_report_diagnostics` JSONB column + migration, `report_quality_summary` + `data_sufficiency_by_source`, persist `why_no_action`, Hermes export, **legacy null-diagnostics regression tests**.
- PR-C: frontend rendering.
- Phase 3b (candidate/held-signal evidence) — separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)