### PR TITLE
feat(rob-318): Phase 3 PR-B — persist report diagnostics + Hermes export

### DIFF
--- a/alembic/versions/20260526_rob318_p3_add_snapshot_report_diagnostics.py
+++ b/alembic/versions/20260526_rob318_p3_add_snapshot_report_diagnostics.py
@@ -1,0 +1,48 @@
+"""rob-318 phase 3: snapshot_report_diagnostics on investment_reports (additive)
+
+Revision ID: 20260526_rob318_p3
+Revises: 20260525_rob315
+Create Date: 2026-05-26
+
+Adds 1 nullable JSONB column ``snapshot_report_diagnostics`` to
+``review.investment_reports``. Purely additive and informational: it holds the
+deterministic report-level diagnostics bundle
+``{why_no_action, data_sufficiency_by_source, report_quality_summary}``
+(ROB-318 Phase 3 PR-B). No CHECK, no index — it does not gate publishing.
+Existing rows stay readable because the column is nullable (legacy reports
+carry NULL).
+
+See: docs/plans/2026-05-26-ROB-318-phase3-deterministic-report-diagnostics-plan.md
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260526_rob318_p3"
+down_revision: str | None = "20260525_rob315"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investment_reports",
+        sa.Column(
+            "snapshot_report_diagnostics",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "investment_reports", "snapshot_report_diagnostics", schema="review"
+    )

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -188,6 +188,10 @@ class InvestmentReport(Base):
     snapshot_freshness_summary: Mapped[dict | None] = mapped_column(JSONB)
     source_conflicts: Mapped[dict | None] = mapped_column(JSONB)
     unavailable_sources: Mapped[dict | None] = mapped_column(JSONB)
+    # ROB-318 Phase 3 (PR-B) — deterministic report-level diagnostics bundle:
+    # {why_no_action, data_sufficiency_by_source, report_quality_summary}.
+    # Nullable so legacy reports stay readable.
+    snapshot_report_diagnostics: Mapped[dict | None] = mapped_column(JSONB)
 
 
 # ---------------------------------------------------------------------------

--- a/app/schemas/hermes_composition.py
+++ b/app/schemas/hermes_composition.py
@@ -85,6 +85,13 @@ class HermesContextPayload(BaseModel):
     freshness_summary: dict[str, Any] = Field(default_factory=dict)
     unavailable_sources: dict[str, Any] = Field(default_factory=dict)
     source_conflicts: dict[str, Any] = Field(default_factory=dict)
+    # ROB-318 Phase 3 (PR-B) — deterministic data-sufficiency signals Hermes
+    # reads as input. Optional (default empty / None) so a lagging Hermes
+    # version degrades gracefully. ``why_no_action`` here reflects data/stale
+    # gating only (Hermes has not produced items yet).
+    data_sufficiency_by_source: dict[str, Any] = Field(default_factory=dict)
+    report_quality_summary: dict[str, Any] | None = None
+    why_no_action: dict[str, Any] | None = None
     dimension_evidence: dict[str, Any] = Field(default_factory=dict)
     dimension_reports: list[dict[str, Any]] = Field(default_factory=list)
     symbol_intermediate_reports: list[dict[str, Any]] = Field(default_factory=list)

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -262,6 +262,9 @@ class IngestReportRequest(BaseModel):
     {fresh, soft_stale, partial}."""
     source_conflicts: dict[str, Any] | None = None
     unavailable_sources: dict[str, Any] | None = None
+    # ROB-318 Phase 3 (PR-B) — deterministic report diagnostics bundle:
+    # {why_no_action, data_sufficiency_by_source, report_quality_summary}.
+    snapshot_report_diagnostics: dict[str, Any] | None = None
 
     @model_validator(mode="after")
     def _validate_advisory_only(self) -> IngestReportRequest:
@@ -358,6 +361,9 @@ class InvestmentReportResponse(BaseModel):
     snapshot_freshness_summary: dict[str, Any] | None = None
     source_conflicts: dict[str, Any] | None = None
     unavailable_sources: dict[str, Any] | None = None
+    # ROB-318 Phase 3 (PR-B) — {why_no_action, data_sufficiency_by_source,
+    # report_quality_summary}. Null on legacy reports.
+    snapshot_report_diagnostics: dict[str, Any] | None = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 

--- a/app/services/action_report/common/diagnostics.py
+++ b/app/services/action_report/common/diagnostics.py
@@ -37,7 +37,10 @@ import re
 from collections.abc import Mapping
 from typing import Any, Literal
 
-from app.services.action_report.common.critical_kinds import CRITICAL_SNAPSHOT_KINDS
+from app.services.action_report.common.critical_kinds import (
+    CRITICAL_KIND_DEGRADING_STATUSES,
+    CRITICAL_SNAPSHOT_KINDS,
+)
 
 # Closed set of reason codes. Collectors emit the specific ones; the generic
 # ones are derived from a freshness/bundle status. Unknown collector reasons
@@ -198,4 +201,102 @@ def _why(kind: WhyNoActionKind, blocking_sources: list[str]) -> dict[str, Any]:
         "kind": kind,
         "blocking_sources": blocking_sources,
         "reason_ko": _WHY_NO_ACTION_REASON_KO[kind].format(sources=sources_label),
+    }
+
+
+# Report-level rollups (PR-B). Both are derived deterministically from the
+# bundle's freshness/coverage state — no per-symbol or LLM reasoning.
+
+ReportQualityGrade = Literal["high_confidence", "informational_only", "no_action"]
+
+
+def build_data_sufficiency_by_source(
+    freshness_summary: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Per-source data-sufficiency view: every known kind with its status and
+    (when degraded) the reason_code/reason already threaded by Slice 1.
+
+    This is the canonical "structured unavailable" feed (ROB-301 design-doc
+    constraint): the operator/Hermes can see exactly which source is missing or
+    stale and why, instead of inferring from a generic message.
+    """
+    summary = freshness_summary or {}
+    out: dict[str, Any] = {}
+    for kind, info in summary.items():
+        if kind == "overall" or not isinstance(info, Mapping):
+            continue
+        entry: dict[str, Any] = {"status": info.get("status")}
+        for key in ("reason_code", "reason", "as_of"):
+            if key in info:
+                entry[key] = info[key]
+        out[kind] = entry
+    return out
+
+
+def build_report_quality_summary(
+    *,
+    freshness_summary: Mapping[str, Any] | None,
+    bundle_status: str | None,
+) -> dict[str, Any]:
+    """Report-level quality rollup: a grade + per-status counts.
+
+    Grade:
+    * ``no_action`` — bundle failed or fell back to stale data.
+    * ``informational_only`` — a critical kind is degrading (the stale gate
+      forces advisory/no-action language).
+    * ``high_confidence`` — all critical kinds usable.
+    """
+    summary = freshness_summary or {}
+    counts: dict[str, int] = {}
+    critical_statuses: list[str | None] = []
+    for kind, info in summary.items():
+        if kind == "overall" or not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        counts[str(status)] = counts.get(str(status), 0) + 1
+        if kind in CRITICAL_SNAPSHOT_KINDS:
+            critical_statuses.append(status)
+
+    total = sum(counts.values())
+    fresh = counts.get("fresh", 0)
+    fresh_pct = round(100 * fresh / total) if total else 0
+
+    grade: ReportQualityGrade
+    if bundle_status in ("failed", "stale_fallback"):
+        grade = "no_action"
+    elif any(s in CRITICAL_KIND_DEGRADING_STATUSES for s in critical_statuses):
+        grade = "informational_only"
+    else:
+        grade = "high_confidence"
+
+    return {
+        "grade": grade,
+        "bundle_status": bundle_status,
+        "freshness_overall": summary.get("overall"),
+        "kind_status_counts": counts,
+        "fresh_coverage_pct": fresh_pct,
+    }
+
+
+def build_report_diagnostics(
+    *,
+    freshness_summary: Mapping[str, Any] | None,
+    bundle_status: str | None,
+    why_no_action: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Assemble the ``snapshot_report_diagnostics`` JSONB payload (PR-B).
+
+    Bundles the three deterministic rollups persisted on the report and exported
+    to Hermes. ``why_no_action`` is computed by the caller (it needs to know
+    whether action items were produced).
+    """
+    return {
+        "why_no_action": why_no_action,
+        "data_sufficiency_by_source": build_data_sufficiency_by_source(
+            freshness_summary
+        ),
+        "report_quality_summary": build_report_quality_summary(
+            freshness_summary=freshness_summary,
+            bundle_status=bundle_status,
+        ),
     }

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -41,7 +41,10 @@ from app.services.action_report.common.critical_kinds import (
     CRITICAL_KIND_DEGRADING_STATUSES,
     CRITICAL_SNAPSHOT_KINDS,
 )
-from app.services.action_report.common.diagnostics import classify_why_no_action
+from app.services.action_report.common.diagnostics import (
+    build_report_diagnostics,
+    classify_why_no_action,
+)
 from app.services.action_report.common.jsonable import to_jsonable
 from app.services.action_report.common.snapshot_bundle import (
     SnapshotBundleEnsureService,
@@ -256,6 +259,25 @@ class SnapshotBackedReportGenerator:
         )
         source_conflicts: dict[str, Any] = {}
 
+        # ROB-318 Phase 3 — deterministic report diagnostics, computed before the
+        # ingest request so they persist on the report row (PR-B). why_no_action
+        # tells a genuine hold from a data-blocked / stale-gated one; the bundle
+        # also carries data_sufficiency_by_source + report_quality_summary. All
+        # deterministic — Hermes composes the prose. Action items are item_kind
+        # 'action' (watch/risk are not buy/sell actions).
+        why_no_action = classify_why_no_action(
+            freshness_summary=freshness_summary,
+            bundle_status=ensure_response.status,
+            has_action_items=any(
+                getattr(it, "item_kind", None) == "action" for it in request.items
+            ),
+        )
+        report_diagnostics = build_report_diagnostics(
+            freshness_summary=freshness_summary,
+            bundle_status=ensure_response.status,
+            why_no_action=why_no_action,
+        )
+
         if request.status == "published":
             self._guard_published(
                 bundle_status=ensure_response.status,
@@ -269,6 +291,7 @@ class SnapshotBackedReportGenerator:
             freshness_summary=freshness_summary,
             unavailable_sources=unavailable_sources,
             source_conflicts=source_conflicts,
+            report_diagnostics=report_diagnostics,
             symbol_derivation=derivation,
         )
 
@@ -285,19 +308,6 @@ class SnapshotBackedReportGenerator:
             )
 
         report = await self._ingestion_service.ingest(ingest_request)
-
-        # ROB-318 Phase 3 (PR-A) — classify why the report is no-action so the
-        # operator can tell a genuine hold from a data-blocked / stale-gated one.
-        # Deterministic; Hermes composes the prose. Action items are item_kind
-        # 'action' (watch/risk are not buy/sell actions).
-        why_no_action = classify_why_no_action(
-            freshness_summary=freshness_summary,
-            bundle_status=ensure_response.status,
-            has_action_items=any(
-                getattr(it, "item_kind", None) == "action"
-                for it in ingest_request.items
-            ),
-        )
 
         return ReportGenerationResponse(
             report_uuid=report.report_uuid,
@@ -503,6 +513,7 @@ class SnapshotBackedReportGenerator:
         freshness_summary: dict[str, Any],
         unavailable_sources: dict[str, Any],
         source_conflicts: dict[str, Any],
+        report_diagnostics: dict[str, Any] | None = None,
         symbol_derivation: SymbolDerivation | None = None,
     ) -> IngestReportRequest:
         # Normalise items — each evidence_snapshot / trigger_checklist /
@@ -570,4 +581,5 @@ class SnapshotBackedReportGenerator:
             snapshot_freshness_summary=freshness_summary,
             source_conflicts=source_conflicts,
             unavailable_sources=unavailable_sources,
+            snapshot_report_diagnostics=report_diagnostics,
         )

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -95,6 +95,8 @@ class InvestmentReportIngestionService:
             snapshot_freshness_summary=request.snapshot_freshness_summary,
             source_conflicts=request.source_conflicts,
             unavailable_sources=request.unavailable_sources,
+            # ROB-318 Phase 3 — deterministic report diagnostics bundle.
+            snapshot_report_diagnostics=request.snapshot_report_diagnostics,
         )
 
         for item_req in request.items:

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -31,6 +31,11 @@ from app.schemas.hermes_composition import (
     HermesStageInput,
 )
 from app.schemas.investment_stages import StageArtifactPayload, StageVerdict
+from app.services.action_report.common.diagnostics import (
+    build_data_sufficiency_by_source,
+    build_report_quality_summary,
+    classify_why_no_action,
+)
 from app.services.invest_screener_snapshots.repository import (
     InvestScreenerSnapshotsRepository,
 )
@@ -244,6 +249,18 @@ class HermesContextExporter:
                     }
                 )
 
+        # ROB-318 Phase 3 — deterministic data-sufficiency signals for Hermes,
+        # derived from the bundle's freshness/coverage. why_no_action here uses
+        # has_action_items=True so only data/stale gating surfaces (Hermes has
+        # not produced items yet — a 'real_no_action' verdict is its call, not
+        # ours).
+        freshness_summary = dict(bundle.freshness_summary or {})
+        why_no_action = classify_why_no_action(
+            freshness_summary=freshness_summary,
+            bundle_status=bundle.status,
+            has_action_items=True,
+        )
+
         return HermesContextPayload(
             snapshot_bundle_uuid=bundle.bundle_uuid,
             bundle_status=bundle.status,
@@ -252,9 +269,17 @@ class HermesContextExporter:
             account_scope=bundle.account_scope,
             policy_version=bundle.policy_version,
             coverage_summary=dict(bundle.coverage_summary or {}),
-            freshness_summary=dict(bundle.freshness_summary or {}),
+            freshness_summary=freshness_summary,
             unavailable_sources=self._derive_unavailable_sources(stage_inputs),
             source_conflicts={},
+            data_sufficiency_by_source=build_data_sufficiency_by_source(
+                freshness_summary
+            ),
+            report_quality_summary=build_report_quality_summary(
+                freshness_summary=freshness_summary,
+                bundle_status=bundle.status,
+            ),
+            why_no_action=why_no_action,
             dimension_evidence=dimension_evidence,
             dimension_reports=dimension_reports,
             symbol_intermediate_reports=symbol_intermediate_reports,

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -100,6 +100,9 @@ async def session() -> AsyncSession:
                         "ADD COLUMN IF NOT EXISTS source_conflicts JSONB",
                         "ALTER TABLE review.investment_reports "
                         "ADD COLUMN IF NOT EXISTS unavailable_sources JSONB",
+                        # ROB-318 Phase 3 (PR-B) — deterministic report diagnostics.
+                        "ALTER TABLE review.investment_reports "
+                        "ADD COLUMN IF NOT EXISTS snapshot_report_diagnostics JSONB",
                         "CREATE INDEX IF NOT EXISTS "
                         "ix_investment_reports_snapshot_bundle_uuid "
                         "ON review.investment_reports (snapshot_bundle_uuid)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -510,6 +510,13 @@ async def db_session():
                         "ADD COLUMN IF NOT EXISTS unavailable_sources JSONB"
                     )
                 )
+                # ROB-318 Phase 3 (PR-B) — deterministic report diagnostics.
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_reports "
+                        "ADD COLUMN IF NOT EXISTS snapshot_report_diagnostics JSONB"
+                    )
+                )
                 await conn.execute(
                     text(
                         "CREATE INDEX IF NOT EXISTS "

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import pytest
 
 from app.services.action_report.common.diagnostics import (
+    build_data_sufficiency_by_source,
     build_kind_diagnostic,
+    build_report_diagnostics,
+    build_report_quality_summary,
     classify_why_no_action,
     reason_code_for,
     sanitize_reason,
@@ -160,3 +163,78 @@ def test_why_no_action_none_when_action_present_and_fresh() -> None:
         has_action_items=True,
     )
     assert out is None
+
+
+# --- build_data_sufficiency_by_source ---------------------------------------
+def test_data_sufficiency_carries_status_and_reason_code() -> None:
+    out = build_data_sufficiency_by_source(
+        {
+            "overall": "unavailable",
+            "portfolio": {
+                "status": "unavailable",
+                "reason_code": "user_id_missing",
+                "reason": "...",
+            },
+            "market": {"status": "fresh", "as_of": "2026-05-26T00:00:00"},
+        }
+    )
+    assert "overall" not in out
+    assert out["portfolio"]["status"] == "unavailable"
+    assert out["portfolio"]["reason_code"] == "user_id_missing"
+    assert out["market"]["status"] == "fresh"
+    assert out["market"]["as_of"] == "2026-05-26T00:00:00"
+
+
+# --- build_report_quality_summary -------------------------------------------
+def test_quality_grade_high_confidence_all_fresh() -> None:
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "fresh",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+        },
+        bundle_status="complete",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["fresh_coverage_pct"] == 100
+
+
+def test_quality_grade_informational_when_critical_degraded() -> None:
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "unavailable",
+            "portfolio": {"status": "unavailable"},
+            "market": {"status": "fresh"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "informational_only"
+    assert out["kind_status_counts"]["unavailable"] == 1
+
+
+def test_quality_grade_no_action_when_bundle_failed() -> None:
+    out = build_report_quality_summary(
+        freshness_summary={"overall": "failed"},
+        bundle_status="failed",
+    )
+    assert out["grade"] == "no_action"
+
+
+# --- build_report_diagnostics -----------------------------------------------
+def test_build_report_diagnostics_bundles_three_rollups() -> None:
+    why = {"kind": "data_insufficient", "blocking_sources": ["portfolio"]}
+    out = build_report_diagnostics(
+        freshness_summary={
+            "overall": "unavailable",
+            "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
+        },
+        bundle_status="partial",
+        why_no_action=why,
+    )
+    assert out["why_no_action"] == why
+    assert out["data_sufficiency_by_source"]["portfolio"]["reason_code"] == (
+        "user_id_missing"
+    )
+    assert out["report_quality_summary"]["grade"] == "informational_only"

--- a/tests/services/investment_stages/test_hermes_context.py
+++ b/tests/services/investment_stages/test_hermes_context.py
@@ -116,6 +116,36 @@ async def test_exporter_builds_frozen_payload_with_stage_inputs() -> None:
 
 
 @pytest.mark.asyncio
+async def test_exporter_includes_report_diagnostics() -> None:
+    """ROB-318 PR-B — exporter surfaces deterministic data-sufficiency signals:
+    data_sufficiency_by_source + report_quality_summary + why_no_action (data
+    gating only at export time)."""
+    bundle = _make_bundle(status="partial")
+    bundle.freshness_summary = {
+        "overall": "unavailable",
+        "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
+        "market": {"status": "fresh"},
+    }
+    repo = AsyncMock()
+    repo.get_bundle_by_uuid.return_value = bundle
+    repo.list_bundle_items_with_snapshots.return_value = []
+
+    exporter = HermesContextExporter(
+        session=AsyncMock(), snapshots_repository=repo, stages=[]
+    )
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    assert (
+        payload.data_sufficiency_by_source["portfolio"]["reason_code"]
+        == "user_id_missing"
+    )
+    assert payload.report_quality_summary["grade"] == "informational_only"
+    assert payload.why_no_action is not None
+    assert payload.why_no_action["kind"] == "data_insufficient"
+    assert payload.why_no_action["blocking_sources"] == ["portfolio"]
+
+
+@pytest.mark.asyncio
 async def test_exporter_raises_when_bundle_missing() -> None:
     repo = AsyncMock()
     repo.get_bundle_by_uuid.return_value = None

--- a/tests/test_investment_reports_snapshot_metadata.py
+++ b/tests/test_investment_reports_snapshot_metadata.py
@@ -103,6 +103,41 @@ async def test_legacy_report_without_snapshot_fields_still_ingests(
     assert row.snapshot_freshness_summary is None
     assert row.source_conflicts is None
     assert row.unavailable_sources is None
+    # ROB-318 PR-B — legacy reports carry NULL diagnostics (regression).
+    assert row.snapshot_report_diagnostics is None
+
+
+@pytest.mark.asyncio
+async def test_ingest_persists_report_diagnostics(session: AsyncSession) -> None:
+    """ROB-318 PR-B — snapshot_report_diagnostics round-trips to the DB row."""
+    diagnostics = {
+        "why_no_action": {
+            "kind": "data_insufficient",
+            "blocking_sources": ["portfolio"],
+            "reason_ko": "데이터 부족 — portfolio 확인 불가로 매수/매도 권고 보류",
+        },
+        "data_sufficiency_by_source": {
+            "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
+        },
+        "report_quality_summary": {"grade": "informational_only"},
+    }
+    request = _base_request(snapshot_report_diagnostics=diagnostics)
+
+    svc = InvestmentReportIngestionService(session)
+    report = await svc.ingest(request)
+    await session.commit()
+
+    row = await session.scalar(
+        sa.select(InvestmentReport).where(InvestmentReport.id == report.id)
+    )
+    assert row is not None
+    diag = row.snapshot_report_diagnostics
+    assert diag["why_no_action"]["kind"] == "data_insufficient"
+    assert (
+        diag["data_sufficiency_by_source"]["portfolio"]["reason_code"]
+        == "user_id_missing"
+    )
+    assert diag["report_quality_summary"]["grade"] == "informational_only"
 
 
 @pytest.mark.asyncio
@@ -391,6 +426,17 @@ async def test_response_schema_exposes_snapshot_metadata_fields(
     assert response.source_conflicts == conflicts
     assert response.unavailable_sources == unavailable
 
+    # ROB-318 PR-B — diagnostics bundle also exposed when present.
+    diag_request = _base_request(
+        snapshot_report_diagnostics={"report_quality_summary": {"grade": "no_action"}}
+    )
+    diag_report = await svc.ingest(diag_request)
+    await session.commit()
+    diag_response = InvestmentReportResponse.model_validate(diag_report)
+    assert diag_response.snapshot_report_diagnostics == {
+        "report_quality_summary": {"grade": "no_action"}
+    }
+
 
 @pytest.mark.asyncio
 async def test_response_schema_legacy_report_renders_explicit_nulls(
@@ -416,6 +462,8 @@ async def test_response_schema_legacy_report_renders_explicit_nulls(
         "snapshot_freshness_summary",
         "source_conflicts",
         "unavailable_sources",
+        # ROB-318 PR-B CRITICAL — new field also serialises as explicit null.
+        "snapshot_report_diagnostics",
     ):
         assert field in payload, f"{field!r} missing from serialised response"
         assert payload[field] is None, f"{field!r} should serialise as null"


### PR DESCRIPTION
## What

ROB-318 Phase 3 **PR-B** (migration + Hermes). Persists the deterministic report-level diagnostics from PR-A (#958, merged) and exports them to Hermes.

> Recreated from #959 (which GitHub auto-closed when its stacked base branch was deleted on PR-A merge). Now cleanly rebased onto main — single PR-B commit.

## Slice 3 — column + migration + persist

- New nullable JSONB column `review.investment_reports.snapshot_report_diagnostics` (alembic `20260526_rob318_p3`, down_revision `20260525_rob315`; additive, no CHECK/index). **Operator runs `alembic upgrade head`**.
- `diagnostics.py`: `build_data_sufficiency_by_source` (canonical structured-unavailable feed), `build_report_quality_summary` (grade + per-status counts), `build_report_diagnostics`.
- Generator computes the bundle (why_no_action moved before ingest so it persists) → `IngestReportRequest` → ingestion → new column. `ReportGenerationResponse` keeps `why_no_action`.
- `IngestReportRequest` + `InvestmentReportResponse` expose `snapshot_report_diagnostics`.

## Slice 4 — Hermes export

- `HermesContextPayload` gains `data_sufficiency_by_source`, `report_quality_summary`, `why_no_action` as **optional** (graceful degradation). Exporter derives from the bundle; `why_no_action` uses `has_action_items=True` so only data/stale gating surfaces.

## CRITICAL regression

Legacy pre-Phase-3 reports carry `NULL` diagnostics and read back / serialize as null across ORM, ingestion, and `InvestmentReportResponse`.

## Safety / tests

No in-process LLM (PR #898 guard green); deterministic rollups; sanitized reasons (PR-A). Additive nullable column. ruff check + format clean; no_internal_llm + import_contracts + hermes roundtrip/http/mcp green (303 + 43 passed locally); alembic head links cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Investment reports now include comprehensive diagnostic information providing transparency on report generation and data quality assessment
  * Added report quality grading system and data sufficiency tracking by source
  * Enhanced context exports with diagnostic summaries including no-action classifications and quality metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->