### PR TITLE
feat(rob-318): Phase 3 PR-C — render report diagnostics on /invest/reports detail

### DIFF
--- a/frontend/invest/src/__tests__/ReportDiagnosticsPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ReportDiagnosticsPanel.test.tsx
@@ -1,0 +1,83 @@
+// ROB-318 Phase 3 (PR-C) — ReportDiagnosticsPanel render tests.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ReportDiagnosticsPanel } from "../components/investment-reports/ReportDiagnosticsPanel";
+import type { SnapshotReportDiagnostics } from "../types/investmentReports";
+
+describe("ReportDiagnosticsPanel", () => {
+  it("returns null when diagnostics is null (legacy report)", () => {
+    const { container } = render(<ReportDiagnosticsPanel diagnostics={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when diagnostics is undefined", () => {
+    const { container } = render(
+      <ReportDiagnosticsPanel diagnostics={undefined} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when no sub-field carries anything to show", () => {
+    const { container } = render(
+      <ReportDiagnosticsPanel diagnostics={{}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the quality grade badge with coverage", () => {
+    const diagnostics: SnapshotReportDiagnostics = {
+      report_quality_summary: {
+        grade: "high_confidence",
+        fresh_coverage_pct: 100,
+      },
+    };
+    render(<ReportDiagnosticsPanel diagnostics={diagnostics} />);
+    const grade = screen.getByTestId("report-diagnostics-grade");
+    expect(grade).toHaveTextContent("리포트 품질: 높음");
+    expect(grade).toHaveTextContent("신선도 100%");
+  });
+
+  it("renders why_no_action with kind label + backend reason_ko", () => {
+    const diagnostics: SnapshotReportDiagnostics = {
+      why_no_action: {
+        kind: "data_insufficient",
+        blocking_sources: ["portfolio"],
+        reason_ko: "데이터 부족 — portfolio 확인 불가로 매수/매도 권고 보류",
+      },
+    };
+    render(<ReportDiagnosticsPanel diagnostics={diagnostics} />);
+    const why = screen.getByTestId("report-diagnostics-why");
+    expect(why).toHaveAttribute("data-kind", "data_insufficient");
+    expect(why).toHaveTextContent("데이터 부족");
+    expect(why).toHaveTextContent("매수/매도 권고 보류");
+  });
+
+  it("renders degraded source chips with reason_code label, hides fresh sources", () => {
+    const diagnostics: SnapshotReportDiagnostics = {
+      data_sufficiency_by_source: {
+        portfolio: { status: "unavailable", reason_code: "user_id_missing" },
+        market: { status: "fresh" },
+      },
+    };
+    render(<ReportDiagnosticsPanel diagnostics={diagnostics} />);
+    const chip = screen.getByTestId("report-diagnostics-source-portfolio");
+    expect(chip).toHaveTextContent("포지션");
+    expect(chip).toHaveTextContent("확인 불가");
+    expect(chip).toHaveTextContent("사용자 미지정");
+    // fresh source must not render a chip
+    expect(screen.queryByTestId("report-diagnostics-source-market")).toBeNull();
+  });
+
+  it("falls back to raw reason_code when unmapped", () => {
+    const diagnostics: SnapshotReportDiagnostics = {
+      data_sufficiency_by_source: {
+        journal: { status: "hard_stale", reason_code: "weird_code" },
+      },
+    };
+    render(<ReportDiagnosticsPanel diagnostics={diagnostics} />);
+    const chip = screen.getByTestId("report-diagnostics-source-journal");
+    expect(chip).toHaveTextContent("weird_code");
+  });
+});

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -22,6 +22,7 @@ import type {
   ProposalTargetRef,
   ReportStatus,
   SnapshotFreshnessSummary,
+  SnapshotReportDiagnostics,
   ReportSnapshotBundle,
   ReportSnapshotBundleItem,
   ReportSnapshotBundleSummary,
@@ -116,6 +117,14 @@ function normalizeReport(raw: ApiReport): InvestmentReport {
       : (asRecord(raw.snapshot_freshness_summary) as SnapshotFreshnessSummary),
     sourceConflicts: asOptionalRecord(raw.source_conflicts),
     unavailableSources: asOptionalRecord(raw.unavailable_sources),
+    // ROB-318 Phase 3 — passed through (internal keys stay snake_case, same as
+    // snapshot_freshness_summary). Null on legacy reports.
+    snapshotReportDiagnostics:
+      raw.snapshot_report_diagnostics == null
+        ? null
+        : (asRecord(
+            raw.snapshot_report_diagnostics,
+          ) as SnapshotReportDiagnostics),
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -15,9 +15,11 @@ import type {
   InvestmentWatchAlert,
   InvestmentWatchEvent,
   SnapshotFreshnessSummary,
+  SnapshotReportDiagnostics,
 } from "../../types/investmentReports";
 import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";
 import { ProposalDiffPanel } from "./ProposalDiffPanel";
+import { ReportDiagnosticsPanel } from "./ReportDiagnosticsPanel";
 import { ReportSnapshotEvidencePanel } from "./ReportSnapshotEvidencePanel";
 import { SnapshotBundleFreshnessChip } from "./SnapshotBundleFreshnessChip";
 
@@ -91,6 +93,7 @@ function ReportHeader({
   noActionNote,
   createdAt,
   freshnessSummary,
+  reportDiagnostics,
 }: {
   title: string;
   market: string;
@@ -104,6 +107,7 @@ function ReportHeader({
   noActionNote?: string | null;
   createdAt: string;
   freshnessSummary?: SnapshotFreshnessSummary | null;
+  reportDiagnostics?: SnapshotReportDiagnostics | null;
 }) {
   return (
     <Card>
@@ -157,6 +161,9 @@ function ReportHeader({
             report has no snapshot metadata (legacy reports / Phase 3 flag
             off). Renders Korean-facing summary + degraded per-source chips. */}
         <SnapshotBundleFreshnessChip freshnessSummary={freshnessSummary ?? null} />
+        {/* ROB-318 Phase 3 (PR-C) — deterministic report diagnostics. Returns
+            null for legacy reports / when nothing degraded is worth showing. */}
+        <ReportDiagnosticsPanel diagnostics={reportDiagnostics ?? null} />
         <p style={{ margin: 0, fontSize: 14, lineHeight: 1.65 }}>{summary}</p>
         {thesisText ? (
           <div style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>
@@ -472,6 +479,7 @@ export function InvestmentReportBundleContent({
         noActionNote={bundle.report.noActionNote}
         createdAt={bundle.report.createdAt}
         freshnessSummary={bundle.report.snapshotFreshnessSummary}
+        reportDiagnostics={bundle.report.snapshotReportDiagnostics}
       />
 
       <ReportSnapshotEvidencePanel reportUuid={bundle.report.reportUuid} />

--- a/frontend/invest/src/components/investment-reports/ReportDiagnosticsPanel.tsx
+++ b/frontend/invest/src/components/investment-reports/ReportDiagnosticsPanel.tsx
@@ -1,0 +1,138 @@
+// ROB-318 Phase 3 (PR-C) — deterministic report-diagnostics panel.
+//
+// Renders the report-level diagnostics persisted by PR-B
+// (snapshot_report_diagnostics): a quality-grade badge, the why-no-action
+// distinction (genuine hold vs data-insufficient vs stale-gated), and
+// per-source data-sufficiency chips that surface the reason_code for each
+// degraded source.
+//
+// Null-safe: returns ``null`` for legacy reports (no diagnostics) and when no
+// sub-field carries anything worth showing. All narrative text is either a
+// fixed Korean label or the backend-provided ``reason_ko`` — this component
+// never infers a value.
+
+import type { CSSProperties, JSX } from "react";
+
+import type {
+  DataSufficiencySource,
+  SnapshotReportDiagnostics,
+} from "../../types/investmentReports";
+import { FRESHNESS_LABELS } from "./snapshotEvidenceLabels";
+import {
+  DIAGNOSTIC_KIND_LABELS,
+  QUALITY_GRADE_LABELS,
+  REASON_CODE_LABELS,
+  WHY_NO_ACTION_LABELS,
+} from "./reportDiagnosticsLabels";
+
+// Grade → accent colour, reusing the global CSS variables the rest of the
+// report header uses (var(--success/warn/danger/fg-3)).
+const GRADE_COLORS: Record<string, string> = {
+  high_confidence: "var(--success, #2e7d32)",
+  informational_only: "var(--warn, #b8860b)",
+  no_action: "var(--danger, #c0392b)",
+};
+
+const DEGRADED_STATUSES = new Set(["hard_stale", "unavailable", "failed"]);
+
+function statusLabel(status: string | null | undefined): string {
+  if (status && status in FRESHNESS_LABELS) {
+    return FRESHNESS_LABELS[status as keyof typeof FRESHNESS_LABELS];
+  }
+  return status ?? "확인 불가";
+}
+
+export interface ReportDiagnosticsPanelProps {
+  diagnostics: SnapshotReportDiagnostics | null | undefined;
+}
+
+export function ReportDiagnosticsPanel({
+  diagnostics,
+}: ReportDiagnosticsPanelProps): JSX.Element | null {
+  if (diagnostics == null) return null;
+
+  const quality = diagnostics.report_quality_summary ?? null;
+  const why = diagnostics.why_no_action ?? null;
+  const sufficiency = diagnostics.data_sufficiency_by_source ?? {};
+
+  // Only surface degraded sources — fresh ones are noise on the chip row.
+  const degraded: [string, DataSufficiencySource][] = Object.entries(
+    sufficiency,
+  ).filter(([, info]) => info?.status != null && DEGRADED_STATUSES.has(info.status));
+
+  const hasQuality = quality?.grade != null;
+  const hasWhy = why?.kind != null;
+  if (!hasQuality && !hasWhy && degraded.length === 0) return null;
+
+  const chipStyle: CSSProperties = {
+    fontSize: 12,
+    color: "var(--fg-3)",
+    border: "1px solid var(--border, #ddd)",
+    borderRadius: 6,
+    padding: "2px 8px",
+  };
+
+  return (
+    <div
+      data-testid="report-diagnostics"
+      style={{ display: "grid", gap: 8 }}
+      aria-live="polite"
+    >
+      {hasQuality ? (
+        <span
+          data-testid="report-diagnostics-grade"
+          style={{
+            fontSize: 12,
+            fontWeight: 800,
+            color: GRADE_COLORS[quality!.grade] ?? "var(--fg-3)",
+          }}
+        >
+          리포트 품질: {QUALITY_GRADE_LABELS[quality!.grade] ?? quality!.grade}
+          {typeof quality!.fresh_coverage_pct === "number"
+            ? ` · 신선도 ${quality!.fresh_coverage_pct}%`
+            : null}
+        </span>
+      ) : null}
+
+      {hasWhy ? (
+        <div
+          data-testid="report-diagnostics-why"
+          data-kind={why!.kind}
+          style={{ fontSize: 13, color: "var(--fg-2)", lineHeight: 1.6 }}
+        >
+          <strong style={{ marginRight: 6 }}>
+            {WHY_NO_ACTION_LABELS[why!.kind] ?? why!.kind}
+          </strong>
+          {why!.reason_ko ? <span>{why!.reason_ko}</span> : null}
+        </div>
+      ) : null}
+
+      {degraded.length > 0 ? (
+        <ul
+          aria-label="소스별 데이터 충분성"
+          style={{
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            display: "flex",
+            gap: 6,
+            flexWrap: "wrap",
+          }}
+        >
+          {degraded.map(([kind, info]) => (
+            <li
+              key={kind}
+              data-testid={`report-diagnostics-source-${kind}`}
+              style={chipStyle}
+            >
+              {DIAGNOSTIC_KIND_LABELS[kind] ?? kind} · {statusLabel(info.status)}
+              {info.reason_code
+                ? ` (${REASON_CODE_LABELS[info.reason_code] ?? info.reason_code})`
+                : ""}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/investment-reports/reportDiagnosticsLabels.ts
+++ b/frontend/invest/src/components/investment-reports/reportDiagnosticsLabels.ts
@@ -1,0 +1,43 @@
+// ROB-318 Phase 3 (PR-C) — Korean labels for the report-diagnostics panel.
+//
+// Centralised so the closed enums from the backend
+// (app/services/action_report/common/diagnostics.py) map to operator-facing
+// Korean in one place. Status labels reuse the shared FRESHNESS_LABELS.
+
+import type {
+  ReportQualityGrade,
+  WhyNoActionKind,
+} from "../../types/investmentReports";
+
+export const QUALITY_GRADE_LABELS: Record<ReportQualityGrade, string> = {
+  high_confidence: "높음",
+  informational_only: "정보용",
+  no_action: "액션 불가",
+};
+
+export const WHY_NO_ACTION_LABELS: Record<WhyNoActionKind, string> = {
+  data_insufficient: "데이터 부족",
+  stale_gated: "데이터 오래됨",
+  real_no_action: "관망 (신규 액션 없음)",
+};
+
+// Closed ReasonCode enum → Korean. Unknown codes fall back to the raw value.
+export const REASON_CODE_LABELS: Record<string, string> = {
+  user_id_missing: "사용자 미지정",
+  kis_fetch_failed: "KIS 조회 실패",
+  stale: "오래됨",
+  unavailable: "확인 불가",
+  failed: "실패",
+  unknown: "원인 미상",
+};
+
+// Per-kind Korean labels (mirror snapshot_kind on the backend).
+export const DIAGNOSTIC_KIND_LABELS: Record<string, string> = {
+  portfolio: "포지션",
+  journal: "거래일지",
+  watch_context: "감시",
+  market: "시장",
+  news: "뉴스",
+  candidate_universe: "후보군",
+  symbol: "종목",
+};

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -91,6 +91,50 @@ export interface InvestmentReport {
   snapshotFreshnessSummary?: SnapshotFreshnessSummary | null;
   sourceConflicts?: Record<string, unknown> | null;
   unavailableSources?: Record<string, unknown> | null;
+  // ROB-318 Phase 3 — deterministic report-level diagnostics. Null on legacy
+  // reports. Internal keys stay snake_case (the API passes the JSON through
+  // without deep-transforming nested objects, same as snapshotFreshnessSummary).
+  snapshotReportDiagnostics?: SnapshotReportDiagnostics | null;
+}
+
+// ROB-318 Phase 3 — typed shape of ``snapshot_report_diagnostics``. Mirrors the
+// backend ``app/services/action_report/common/diagnostics.py`` builders. Keys
+// are snake_case to match the wire format (no deep camelCase transform).
+export type WhyNoActionKind =
+  | "data_insufficient"
+  | "stale_gated"
+  | "real_no_action";
+
+export interface WhyNoAction {
+  kind: WhyNoActionKind;
+  blocking_sources: string[];
+  reason_ko: string;
+}
+
+export type ReportQualityGrade =
+  | "high_confidence"
+  | "informational_only"
+  | "no_action";
+
+export interface ReportQualitySummary {
+  grade: ReportQualityGrade;
+  bundle_status?: string | null;
+  freshness_overall?: SnapshotFreshnessStatus | string | null;
+  kind_status_counts?: Record<string, number>;
+  fresh_coverage_pct?: number;
+}
+
+export interface DataSufficiencySource {
+  status?: SnapshotFreshnessStatus | string | null;
+  reason_code?: string | null;
+  reason?: string | null;
+  as_of?: string | null;
+}
+
+export interface SnapshotReportDiagnostics {
+  why_no_action?: WhyNoAction | null;
+  data_sufficiency_by_source?: Record<string, DataSufficiencySource>;
+  report_quality_summary?: ReportQualitySummary | null;
 }
 
 // ROB-269 Phase 4 — typed shape of the snapshot freshness summary on the


### PR DESCRIPTION
## What

ROB-318 Phase 3 **PR-C** (frontend). Renders the deterministic diagnostics persisted in PR-B (#962, merged) on the `/invest/reports` detail view. Completes Phase 3 report-level.

> Recreated from #960 (auto-closed when its stacked base branch was deleted on PR-B merge). Now cleanly rebased onto main — single PR-C commit, frontend-only.

## Changes

- `types/investmentReports.ts`: typed `SnapshotReportDiagnostics` + `WhyNoAction` + `ReportQualitySummary` + `DataSufficiencySource`, optional `snapshotReportDiagnostics` on `InvestmentReport`. Internal keys snake_case to match the wire (no deep camelCase transform, same as `snapshotFreshnessSummary`).
- `api/investmentReports.ts`: `normalizeReport` passes `snapshot_report_diagnostics` through (null on legacy reports).
- `ReportDiagnosticsPanel.tsx` (new): quality-grade badge (높음/정보용/액션 불가 + 신선도 %), `why_no_action` distinction (genuine hold vs data-insufficient vs stale-gated, rendering backend `reason_ko`), per-source data-sufficiency chips with `reason_code` for degraded sources only. **Null-safe** — renders nothing for legacy reports / when nothing degraded.
- `reportDiagnosticsLabels.ts` (new): closed-enum → Korean maps; reuses shared `FRESHNESS_LABELS`.
- Wired into `InvestmentReportBundleContent` ReportHeader after the freshness chip.

## Safety / tests

Render-only of deterministic backend fields; no inference (absent → nothing / backend `reason_ko`). `pnpm typecheck` clean; **19 passed** (panel null-safety / grade / why_no_action+reason_ko / degraded chips / fallback).

⚠️ Pre-existing failures unrelated to this PR: 5 frontend tests (calendar `DaySection`/`MonthlyEventsTimeline`/`DesktopCalendarPage` + coverage `ActionReadiness`) fail on main too — confirmed via stash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)