### PR TITLE
feat(rob-317): bounded operator mode for the WS scalping daemon (demo-only, default-disabled)

### DIFF
--- a/app/services/brokers/binance/demo_scalping_ws/supervisor.py
+++ b/app/services/brokers/binance/demo_scalping_ws/supervisor.py
@@ -50,6 +50,7 @@ SourceFactory = Callable[[], AsyncIterator[FuturesWsEvent]]
 OnTrigger = Callable[["TriggerEvent"], Awaitable[None]]
 Clock = Callable[[], dt.datetime]
 Sleep = Callable[[float], Awaitable[None]]
+StopWhen = Callable[[], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,14 +104,22 @@ class ScalpingDaemonSupervisor:
         *,
         on_trigger: OnTrigger,
         stop_after: int | None = None,
+        stop_when: StopWhen | None = None,
     ) -> None:
-        """Consume one source to exhaustion (single pass; reconnect: Task 5)."""
+        """Consume one source to exhaustion (single connection pass).
+
+        ``stop_after`` bounds events consumed; ``stop_when`` is a predicate
+        checked after each emitted trigger — bounded operator mode (e.g. a
+        trigger-count cap) returns cleanly once it is true.
+        """
         consumed = 0
         source = source_factory()
         async for event in source:
             trigger = self._handle_event(event)
             if trigger is not None:
                 await on_trigger(trigger)
+                if stop_when is not None and stop_when():
+                    return
             consumed += 1
             if stop_after is not None and consumed >= stop_after:
                 return
@@ -193,6 +202,7 @@ class ScalpingDaemonSupervisor:
         *,
         on_trigger: OnTrigger,
         sleep: Sleep = asyncio.sleep,
+        stop_when: StopWhen | None = None,
     ) -> None:
         """Run with reconnect: back off on connection errors until unhealthy.
 
@@ -201,6 +211,10 @@ class ScalpingDaemonSupervisor:
         consecutive failures reach the unhealthy threshold the error is
         re-raised for the operator/supervisor above to handle.
 
+        ``stop_when`` (bounded operator mode) is checked both at the top of each
+        reconnect iteration and after each trigger inside ``run`` — so the count
+        survives reconnects and the loop exits cleanly once the bound is hit.
+
         ``websockets.exceptions.ConnectionClosed`` (incl. ConnectionClosedOK/
         ConnectionClosedError) is caught explicitly — it is NOT a subclass of
         ConnectionError/OSError, so a real socket close would otherwise crash
@@ -208,8 +222,12 @@ class ScalpingDaemonSupervisor:
         """
         consecutive_failures = 0
         while True:
+            if stop_when is not None and stop_when():
+                return
             try:
-                await self.run(source_factory, on_trigger=on_trigger)
+                await self.run(
+                    source_factory, on_trigger=on_trigger, stop_when=stop_when
+                )
                 return
             except (ConnectionError, OSError, ConnectionClosed) as exc:
                 consecutive_failures += 1

--- a/docs/runbooks/binance-demo-ws-scalping.md
+++ b/docs/runbooks/binance-demo-ws-scalping.md
@@ -33,6 +33,17 @@ Before starting the daemon, ensure the following requirements are met:
    ```
    (Reuses the existing `binance_demo_order_ledger` and `scalp_trade_analytics` tables.)
 
+> **⚠️ Credential loading — do NOT blindly `source shared/.env.prod.native`.**
+> That file is the native production service's full env (it may carry mainnet/
+> testnet and unrelated secrets). Blindly `set -a; source ...` into an
+> interactive shell pollutes your session, can export mainnet/testnet vars, and
+> risks echoing secrets. Instead use **dotenv-aware / native-service env
+> loading**: let the launchd/native service load its own env file, or load only
+> the Demo-prefixed keys (`BINANCE_FUTURES_DEMO_*` / `BINANCE_DEMO_*`) into a
+> scoped subprocess — never `BINANCE_TESTNET_*` (which do nothing for Demo) —
+> and never print credential values. The daemon resolves Demo credentials via
+> `resolve_demo_credentials()`; only those keys are needed.
+
 ---
 
 ## 3. The Three Gates
@@ -52,7 +63,9 @@ The behavior of the WebSocket daemon is strictly gated by three environment vari
 | `false` / unset | (any) | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
 | `true` | `false` / unset | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
 | `true` | `true` | `false` / unset | **Dry-Run**. Subscribes to websocket streams, runs signal generation, but passes `confirm=False` to the executor (zero broker mutation). |
-| `true` | `true` | `true` | **Confirmed Demo Mode**. Real mock orders are placed on `demo-fapi.binance.com`. |
+| `true` | `true` | `true` | **Confirmed-eligible**. Real mock orders are placed on `demo-fapi.binance.com` **only if the CLI also passes `--confirm` and a trigger bound** (§4.3/§4.4). The env gate alone runs dry-run. |
+
+> The `--confirm` CLI flag is an **independent** second gate on top of the env var: the flag alone never enables mutation, and the env var alone never enables mutation. Confirmed runs additionally **must** be bounded (`--max-triggers` / `--exit-after-first-trigger`) or the daemon exits 2 without placing an order.
 
 ---
 
@@ -92,14 +105,15 @@ uv run python -m scripts.binance_demo_scalping_ws_daemon
 
 ### 4.3. Confirmed Demo Mode (Active Trading)
 
-To engage active trading on the Demo backend, add `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`:
+Confirmed mode requires **all three**: the env gate `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`, the explicit `--confirm` flag, **and** a trigger bound (`--max-triggers` / `--exit-after-first-trigger`). Missing the flag → dry-run; missing the bound → fail-closed (exit 2, no order). See §4.4 for the bounded first-live procedure.
 
 ```bash
 export BINANCE_DEMO_SCALPING_ENABLED=true
 export BINANCE_DEMO_SCALPING_WS_ENABLED=true
 export BINANCE_DEMO_SCALPING_WS_CONFIRM=true
 
-uv run python -m scripts.binance_demo_scalping_ws_daemon
+# --confirm AND a trigger bound are both mandatory for real orders.
+uv run python -m scripts.binance_demo_scalping_ws_daemon --confirm --max-triggers 1
 ```
 
 **Risk Safeguards:**
@@ -107,6 +121,38 @@ uv run python -m scripts.binance_demo_scalping_ws_daemon
 * Subject to **authoritative live-ledger risk checks** (`_preflight`) inside the executor.
 * Guided by an **in-process concurrency lock** (max `1` global position open at any time) to prevent race conditions or duplicate entries under fast websocket updates.
 * Writes full order histories to `binance_demo_order_ledger` and telemetry to `scalp_trade_analytics`.
+
+### 4.4. Bounded Operator Mode (First-Live Validation)
+
+The daemon is a long-running loop by default. For a **first-live validation of the plumbing/harness** (real `fstream` ingest → state → trigger → bridge), use the bounded flags so the run is small, observable, and self-terminating:
+
+| Flag | Effect |
+|---|---|
+| `--max-runtime-sec N` | Wall-clock cap — exits cleanly after N seconds (cancels even a quiet stream). |
+| `--max-triggers N` | Exits cleanly after N triggers (count survives reconnects). |
+| `--exit-after-first-trigger` | Shorthand for `--max-triggers 1`. |
+| `--confirm` | Required **in addition to** `BINANCE_DEMO_SCALPING_WS_CONFIRM=true` to place real Demo orders. Confirmed runs **must** also carry a trigger bound or the daemon **fails closed (exit 2, no order)**. |
+
+> **Scope reminder (ROB-316):** this validates *plumbing*, not alpha. The current micro-breakout signal has no backtested edge — keep first-live validation **dry-run**. Only do a confirmed bounded run if you specifically need to prove the order-placement path end-to-end against Demo, and keep it to a single trigger.
+
+**Step 1 — bounded dry-run (real fstream, no orders, time-boxed):**
+```bash
+# Load ONLY Demo creds into a scoped subprocess (see Preconditions caveat) —
+# do not blindly `source` the prod env file into your shell.
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+uv run python -m scripts.binance_demo_scalping_ws_daemon --max-runtime-sec 120
+```
+Subscribes to `wss://fstream.binance.com`, evaluates triggers, runs the executor with `confirm=False` (zero mutation), and exits after 120s. Confirm clean reconnect/freshness logs and no errors.
+
+**Step 2 — confirmed single-trigger plumbing check (real Demo order, bounded):**
+```bash
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_CONFIRM=true \
+uv run python -m scripts.binance_demo_scalping_ws_daemon --confirm --exit-after-first-trigger
+```
+Places at most **one** real Demo order on `demo-fapi.binance.com`, then exits. Omitting `--confirm` (or the env gate) → dry-run. Omitting a trigger bound while confirmed → **exit 2, no order placed**. Verify the resulting `binance_demo_order_ledger` lifecycle + `scalp_trade_analytics` row (§5) and confirm it reconciled (no `anomaly`).
 
 ---
 

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -12,6 +12,12 @@ opening a socket. With the gates on it prints a ``running`` summary, subscribes
 to the read-only fstream futures streams, and routes triggers to the
 confirm-gated WsExecutionBridge. Demo hosts only; no live/testnet path; no
 secrets printed.
+
+Bounded operator mode (for first-live validation): ``--max-runtime-sec`` and
+``--max-triggers`` / ``--exit-after-first-trigger`` make the daemon exit cleanly
+after a small, observable run. Real Demo orders need BOTH
+``BINANCE_DEMO_SCALPING_WS_CONFIRM=true`` AND the explicit ``--confirm`` flag,
+and confirmed runs must carry a trigger bound (fail-closed otherwise).
 """
 
 from __future__ import annotations
@@ -72,7 +78,42 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         )
     )
     parser.add_argument("--log-level", default="INFO")
+    parser.add_argument(
+        "--max-runtime-sec",
+        type=float,
+        default=None,
+        help="Wall-clock cap: exit cleanly after this many seconds.",
+    )
+    parser.add_argument(
+        "--max-triggers",
+        type=int,
+        default=None,
+        help="Exit cleanly after N triggers (bounded operator mode).",
+    )
+    parser.add_argument(
+        "--exit-after-first-trigger",
+        action="store_true",
+        help="Shorthand for --max-triggers 1.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "Required (in addition to BINANCE_DEMO_SCALPING_WS_CONFIRM=true) to "
+            "place real Demo orders. Confirmed runs also require a trigger bound."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def resolve_confirm(gates: WsDaemonGates, *, confirm_flag: bool) -> bool:
+    """Whether real Demo order mutation is permitted.
+
+    Requires BOTH the env gate (all three env vars, surfaced as
+    ``gates.mutation_allowed``) AND the explicit ``--confirm`` flag. Either one
+    missing → dry-run (fail-closed). The flag alone never enables mutation.
+    """
+    return gates.mutation_allowed and confirm_flag
 
 
 logger = logging.getLogger("rob317.demo_scalping_ws_daemon")
@@ -100,12 +141,18 @@ async def run_daemon(
     on_trigger: OnTrigger | None = None,
     confirm: bool = False,
     clock: Callable[[], dt.datetime] | None = None,
-) -> None:
-    """Run the trigger pipeline.
+    max_triggers: int | None = None,
+    max_runtime_sec: float | None = None,
+) -> int:
+    """Run the trigger pipeline; return the number of triggers processed.
+
+    Bounded operator mode: ``max_triggers`` stops cleanly after N triggers
+    (count survives reconnects); ``max_runtime_sec`` is a wall-clock cap that
+    cancels even a stream blocked with no events. Both default off (unbounded).
 
     Production: ``on_trigger`` defaults to the env-built WsExecutionBridge
-    (confirm passed in from gates). Tests inject ``source_factory`` +
-    ``on_trigger`` to stay network/DB-free.
+    (confirm passed in). Tests inject ``source_factory`` + ``on_trigger`` to
+    stay network/DB-free.
     """
     factory = source_factory or _real_source_factory(symbols)
     sup = ScalpingDaemonSupervisor(
@@ -119,11 +166,37 @@ async def run_daemon(
 
         bridge, aclose = await build_ws_execution_bridge_from_env(confirm=confirm)
         on_trigger = bridge
+
+    triggers = 0
+    sink = on_trigger
+
+    async def _counting(trigger: TriggerEvent) -> None:
+        nonlocal triggers
+        await sink(trigger)
+        triggers += 1
+
+    def _stop_when() -> bool:
+        return max_triggers is not None and triggers >= max_triggers
+
     try:
-        await sup.run_with_reconnect(factory, on_trigger=on_trigger)
+        runner = sup.run_with_reconnect(
+            factory, on_trigger=_counting, stop_when=_stop_when
+        )
+        if max_runtime_sec is not None:
+            try:
+                await asyncio.wait_for(runner, timeout=max_runtime_sec)
+            except TimeoutError:
+                logger.info(
+                    "daemon exiting: --max-runtime-sec=%.3f reached (triggers=%d)",
+                    max_runtime_sec,
+                    triggers,
+                )
+        else:
+            await runner
     finally:
         if aclose is not None:
             await aclose()
+    return triggers
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -134,12 +207,29 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(summary, sort_keys=True))
     if not gates.daemon_active:
         return 0
+    max_triggers = 1 if args.exit_after_first_trigger else args.max_triggers
+    confirm = resolve_confirm(gates, confirm_flag=args.confirm)
+    if confirm and max_triggers is None:
+        logger.error(
+            "confirmed mode requires a trigger bound: pass --max-triggers N or "
+            "--exit-after-first-trigger (fail-closed; no order placed)"
+        )
+        return 2
     symbols = sorted(DEFAULT_ALLOWLIST)
     logger.info(
-        "WS daemon active (mutation_allowed=%s) — turning triggers into real Demo orders",
-        gates.mutation_allowed,
+        "WS daemon active: confirm=%s max_triggers=%s max_runtime_sec=%s",
+        confirm,
+        max_triggers,
+        args.max_runtime_sec,
     )
-    asyncio.run(run_daemon(symbols=symbols, confirm=gates.mutation_allowed))
+    asyncio.run(
+        run_daemon(
+            symbols=symbols,
+            confirm=confirm,
+            max_triggers=max_triggers,
+            max_runtime_sec=args.max_runtime_sec,
+        )
+    )
     return 0
 
 

--- a/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+++ b/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import json
 from collections.abc import AsyncIterator
@@ -12,7 +13,14 @@ import pytest
 from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
 from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
 from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
-from scripts.binance_demo_scalping_ws_daemon import build_summary, main, run_daemon
+from scripts.binance_demo_scalping_ws_daemon import (
+    build_summary,
+    main,
+    resolve_confirm,
+    run_daemon,
+)
+
+_MODULE = "scripts.binance_demo_scalping_ws_daemon"
 
 _T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
 
@@ -100,3 +108,132 @@ async def test_run_daemon_routes_triggers_to_injected_on_trigger() -> None:
 async def _source(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
     for ev in events:
         yield ev
+
+
+# --- bounded operator mode (ROB-317 follow-up) -----------------------------
+
+
+async def _noop_on_trigger(_trigger) -> None:
+    return None
+
+
+def _fail_if_called(**_kwargs) -> None:
+    raise AssertionError("run_daemon must not be invoked here")
+
+
+def _book_for(symbol: str) -> BookTickerEvent:
+    return BookTickerEvent(
+        symbol=symbol,
+        bid_price=Decimal("0.50"),
+        bid_qty=Decimal("1"),
+        ask_price=Decimal("0.5001"),
+        ask_qty=Decimal("1"),
+        received_at=_T0,
+    )
+
+
+def _kline_for(symbol: str, close: str, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol=symbol,
+        interval="1m",
+        open_time=base,
+        close_time=base + dt.timedelta(seconds=59),
+        open=Decimal(close),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
+
+
+def _breakout_for(symbol: str) -> list[FuturesWsEvent]:
+    out: list[FuturesWsEvent] = [_book_for(symbol)]
+    for m in range(25):
+        out.append(_kline_for(symbol, "0.50", "0.51", "0.49", m))
+    out.append(_kline_for(symbol, "0.60", "0.60", "0.50", 25))
+    return out
+
+
+def test_main_disabled_does_not_invoke_run_daemon(monkeypatch) -> None:
+    # Default-disabled must exit without ever building a source / opening a
+    # socket: run_daemon is never reached.
+    for key in (
+        "BINANCE_DEMO_SCALPING_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_CONFIRM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fail_if_called)
+    assert main([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_max_runtime_exits_cleanly() -> None:
+    # A stream that never yields must not hang — --max-runtime-sec bounds it.
+    async def _never() -> AsyncIterator[FuturesWsEvent]:
+        await asyncio.sleep(3600)
+        yield  # pragma: no cover - unreachable, makes this an async generator
+
+    count = await run_daemon(
+        symbols=["XRPUSDT"],
+        source_factory=lambda: _never(),
+        on_trigger=_noop_on_trigger,
+        max_runtime_sec=0.05,
+    )
+    assert count == 0  # exited via the runtime bound, no triggers
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_max_triggers_stops_after_n() -> None:
+    seen: list[str] = []
+
+    async def sink(trigger) -> None:
+        seen.append(trigger.symbol)
+
+    seq = _breakout_for("XRPUSDT") + _breakout_for("DOGEUSDT")
+    count = await run_daemon(
+        symbols=["XRPUSDT", "DOGEUSDT"],
+        source_factory=lambda: _source(seq),
+        on_trigger=sink,
+        clock=lambda: _T0 + dt.timedelta(seconds=5),
+        max_triggers=1,
+    )
+    assert count == 1
+    assert seen == ["XRPUSDT"]  # stopped after the first symbol's trigger
+
+
+def test_resolve_confirm_requires_env_and_flag() -> None:
+    all_on = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=True)
+    env_only = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=False)
+    assert resolve_confirm(all_on, confirm_flag=True) is True
+    assert resolve_confirm(all_on, confirm_flag=False) is False  # --confirm missing
+    assert resolve_confirm(env_only, confirm_flag=True) is False  # env gate missing
+
+
+def test_main_confirm_without_bound_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_CONFIRM", "true")
+    # Confirmed mode with no trigger bound must fail closed before running.
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fail_if_called)
+    assert main(["--confirm"]) == 2
+
+
+def test_main_confirmed_bounded_wires_run_daemon(monkeypatch) -> None:
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_CONFIRM", "true")
+    captured: dict = {}
+
+    async def _fake_run_daemon(**kwargs) -> int:
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fake_run_daemon)
+    assert main(["--confirm", "--exit-after-first-trigger"]) == 0
+    assert captured["confirm"] is True
+    assert captured["max_triggers"] == 1

--- a/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
@@ -276,3 +276,25 @@ async def test_trigger_carries_source_candle_close_time() -> None:
     assert captured[0].source_candle_close_time_ms == int(
         expected_close.timestamp() * 1000
     )
+
+
+async def test_run_with_reconnect_stops_when_stop_when_true() -> None:
+    # Bounded operator mode: a stop_when predicate halts the loop cleanly after
+    # the Nth trigger (here 1), even though a second eligible breakout follows.
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock, debounce_seconds=0)
+    count = 0
+
+    async def on_trig(_trigger: TriggerEvent) -> None:
+        nonlocal count
+        count += 1
+
+    def stop_when() -> bool:
+        return count >= 1
+
+    seq = _breakout_sequence()
+    seq.append(_kline("0.70", high="0.70", low="0.60", minute=26))  # 2nd breakout
+    await sup.run_with_reconnect(
+        lambda: _source_from(seq), on_trigger=on_trig, stop_when=stop_when
+    )
+    assert count == 1  # stopped after the first trigger; second not fired


### PR DESCRIPTION
## ROB-317 follow-up — bounded operator mode for the WS scalping daemon

Adds time/trigger bounds + a second confirm gate so the **first-live validation** of the daemon's plumbing is small, observable, and self-terminating (instead of an open-ended order-placing loop).

### Safety properties
- **Demo-only.** Market data is read-only from `fstream.binance.com`; order mutation stays on `demo-fapi.binance.com`. No live/mainnet/testnet path.
- **Default-disabled.** With the env gates unset the CLI prints `{"status":"disabled","subscribed":false,...}` and exits 0 **without opening a socket or invoking `run_daemon`** — even when bounded flags are passed (test-covered).
- **No scheduler/Prefect recurrence added.** No cron, launchd, TaskIQ, or Prefect wiring. This is an operator-invoked CLI only.
- **Confirmed mode requires all three:** env gate `BINANCE_DEMO_SCALPING_WS_CONFIRM=true` **AND** the explicit `--confirm` flag **AND** a trigger bound (`--max-triggers` / `--exit-after-first-trigger`). Missing the flag → dry-run; missing the bound → **fail-closed, exit 2, no order placed**. Flag-alone and env-alone both stay dry-run (`resolve_confirm`).
- **Live/order paths untouched.** No change to KIS, Upbit, Alpaca, or any live broker path; the read-only `demo_scalping_ws/` vs mutation `demo_scalping_exec/` boundary is preserved (AST import-guard stays green). No migrations.

### What changed
- `supervisor.py`: `run` / `run_with_reconnect` take a `stop_when` predicate (clean stop after N triggers; count survives reconnects).
- CLI flags: `--max-runtime-sec` (wall-clock cap via `asyncio.wait_for` — cancels even a quiet stream), `--max-triggers`, `--exit-after-first-trigger`, `--confirm`.
- `run_daemon` returns the trigger count and enforces both bounds.
- `resolve_confirm(gates, confirm_flag)`: real Demo mutation needs env gate **and** `--confirm`.
- Runbook §4.4: bounded first-live-validation procedure (dry-run-first → confirmed single-trigger), framed against the ROB-316 "no backtested edge → validate plumbing, not alpha" caveat; plus a Preconditions note to **not blindly `source shared/.env.prod.native`** (use dotenv-aware/native-service env loading, Demo-prefixed keys only, never TESTNET, never print secrets).

### Tests
- default-disabled never invokes `run_daemon` (no socket)
- `--max-runtime-sec` exits cleanly on a never-yielding stream
- `--max-triggers` stops after N
- `resolve_confirm` env+flag matrix
- confirm-without-bound fails closed (exit 2)
- confirmed+bounded wires `run_daemon`
- supervisor `stop_when` stops after N

### Verification
- `uv run ruff check app/ tests/` ✅ · `ruff format --check app/ tests/` ✅ (the 3 `ruff check app scripts tests` errors are pre-existing in unrelated `scripts/debug_economic_calendar.py` + `scripts/test_discord_webhook_e2e.py`, present on `main`, outside CI scope).
- `uv run pytest tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py` → **21 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bounded operator mode with `--max-runtime-sec`, `--max-triggers`, and `--exit-after-first-trigger` CLI flags to limit execution scope.
  * Introduced explicit `--confirm` flag requirement for real Demo order mutations, enforcing safer operational controls.

* **Documentation**
  * Enhanced runbook with clearer guidance on Demo credential handling and confirmation requirements.

* **Tests**
  * Added coverage for bounded execution and confirmation flow validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->