### PR TITLE
feat(rob-321): live KIS quote/orderbook WebSocket (read-only) + account-mode approval keys (PR2/4)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -198,6 +198,8 @@ class Settings(BaseSettings):
     kis_ws_max_reconnect_attempts: int = 10  # 최대 재연결 시도 횟수
     kis_ws_ping_interval: int = 30  # Ping 전송 간격 (초)
     kis_ws_ping_timeout: int = 10  # Ping 응답 대기 시간 (초)
+    # ROB-321: read-only quote WS daemon/smoke gate (default off).
+    kis_mock_scalping_ws_enabled: bool = False
 
     # KIS Rate Limiting (HTTP API)
     kis_rate_limit_rate: int = 19  # 초당 최대 요청 수 (안전 마진으로 20-1)

--- a/app/services/brokers/kis/mock_scalping_ws/market_stream.py
+++ b/app/services/brokers/kis/mock_scalping_ws/market_stream.py
@@ -1,0 +1,268 @@
+"""Read-only KIS quote/orderbook WebSocket client for the mock scalping loop.
+
+This client streams real-time 체결가/호가 (H0STCNT0/H0STASP0) and dispatches
+parsed snapshots to caller-supplied callbacks. It is **read-only by
+construction**: there is no order/submit method, and the package may not import
+any order/ledger module (enforced by an AST import-guard test).
+
+Host separation is fail-closed: the WebSocket URL is built from
+``WEBSOCKET_ENDPOINT_HOSTS[account_mode]`` and the resolved host:port is
+asserted against that allowlist. The approval key is issued via the
+account-mode-aware ``approval_keys.get_approval_key`` (live vs mock endpoints +
+credentials + Redis namespaces).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from inspect import isawaitable
+from typing import Any
+from urllib.parse import urlparse
+
+import websockets
+from websockets.exceptions import ConnectionClosed, WebSocketException
+
+from app.core.config import settings
+from app.services.kis_websocket_internal import approval_keys
+from app.services.kis_websocket_internal.constants import WEBSOCKET_ENDPOINT_HOSTS
+from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+from .quote_parsers import OrderBookSnapshot, QuoteTick, parse_quote_frame
+from .quote_protocol import DOMESTIC_ORDERBOOK_TR, DOMESTIC_TRADE_TR
+
+logger = logging.getLogger(__name__)
+
+TickCallback = Callable[[QuoteTick], Any | Awaitable[Any]]
+BookCallback = Callable[[OrderBookSnapshot], Any | Awaitable[Any]]
+
+# TRs this read-only client subscribes to per symbol.
+_SUBSCRIBE_TRS = (DOMESTIC_TRADE_TR, DOMESTIC_ORDERBOOK_TR)
+
+
+class KISQuoteWebSocket:
+    """Read-only real-time quote/orderbook stream. No order surface."""
+
+    def __init__(
+        self,
+        *,
+        symbols: Sequence[str],
+        on_tick: TickCallback,
+        on_book: BookCallback,
+        account_mode: str = "kis_live",
+    ) -> None:
+        if account_mode not in WEBSOCKET_ENDPOINT_HOSTS:
+            raise ValueError(
+                f"account_mode must be one of {tuple(WEBSOCKET_ENDPOINT_HOSTS)}, "
+                f"got {account_mode!r}"
+            )
+        self.symbols = [s for s in symbols if s]
+        self.on_tick = on_tick
+        self.on_book = on_book
+        self.account_mode = account_mode
+
+        self.websocket: Any | None = None
+        self.is_running = False
+        self.is_connected = False
+        self.approval_key: str | None = None
+
+        self.reconnect_delay = settings.kis_ws_reconnect_delay_seconds
+        self.max_reconnect_attempts = settings.kis_ws_max_reconnect_attempts
+        self.current_attempt = 0
+        self.ping_interval = settings.kis_ws_ping_interval
+        self.ping_timeout = settings.kis_ws_ping_timeout
+
+        self.messages_received = 0
+        self.tick_events_received = 0
+        self.book_events_received = 0
+        self.last_message_at: str | None = None
+
+    # ----- URL / host allowlist (fail-closed) -----
+
+    def _build_url(self) -> str:
+        host = WEBSOCKET_ENDPOINT_HOSTS[self.account_mode]
+        url = f"ws://{host}/tryitout"
+        parsed = urlparse(url)
+        resolved = f"{parsed.hostname}:{parsed.port}"
+        if resolved != host:
+            raise ValueError(
+                f"websocket endpoint {resolved!r} not allowed for "
+                f"{self.account_mode} (expected {host!r})"
+            )
+        return url
+
+    # ----- subscription -----
+
+    def _build_subscription_request(self, tr_id: str, tr_key: str) -> dict[str, Any]:
+        if not self.approval_key:
+            raise RuntimeError("Approval key is not issued")
+        return {
+            "header": {
+                "approval_key": self.approval_key,
+                "custtype": "P",
+                "tr_type": "1",
+                "content-type": "utf-8",
+            },
+            "body": {"input": {"tr_id": tr_id, "tr_key": tr_key}},
+        }
+
+    async def _subscribe_quotes(self) -> None:
+        if self.websocket is None:
+            raise RuntimeError("WebSocket is not connected")
+        if not self.symbols:
+            raise ValueError("No symbols to subscribe")
+
+        for symbol in self.symbols:
+            for tr_id in _SUBSCRIBE_TRS:
+                request = self._build_subscription_request(tr_id, symbol)
+                await self.websocket.send(json.dumps(request))
+                response = await self.websocket.recv()
+                self._validate_subscription_ack(response, tr_id, symbol)
+        logger.info(
+            "Subscribed to KIS quote TRs: account_mode=%s symbols=%s",
+            self.account_mode,
+            self.symbols,
+        )
+
+    def _validate_subscription_ack(
+        self, response: str | bytes, tr_id: str, tr_key: str
+    ) -> None:
+        if isinstance(response, bytes):
+            response = response.decode("utf-8")
+        text = response.strip()
+        # Real-time data frames (pipe-delimited) are not ACKs — accept them.
+        if not text.startswith("{"):
+            return
+        parsed = json.loads(text)
+        body = parsed.get("body")
+        if not isinstance(body, dict):
+            raise KISSubscriptionAckError(
+                tr_id=tr_id, rt_cd="", msg_cd="", msg1="ACK body missing"
+            )
+        rt_cd = str(body.get("rt_cd", ""))
+        if rt_cd != "0":
+            raise KISSubscriptionAckError(
+                tr_id=tr_id,
+                rt_cd=rt_cd,
+                msg_cd=str(body.get("msg_cd", "")),
+                msg1=f"{body.get('msg1', '')} (tr_key={tr_key})",
+            )
+
+    # ----- connect / listen -----
+
+    async def connect_and_subscribe(self) -> None:
+        """Issue approval key, connect, and subscribe (bounded reconnect)."""
+        self.approval_key = await approval_keys.get_approval_key(self.account_mode)
+        url = self._build_url()
+
+        while self.current_attempt < self.max_reconnect_attempts and self.is_running:
+            try:
+                self.websocket = await websockets.connect(
+                    url,
+                    ping_interval=self.ping_interval,
+                    ping_timeout=self.ping_timeout,
+                    close_timeout=10,
+                )
+                self.is_connected = True
+                await self._subscribe_quotes()
+                self.current_attempt = 0
+                return
+            except Exception as e:
+                self.current_attempt += 1
+                logger.error(
+                    "KIS quote WebSocket connect failed: account_mode=%s attempt=%s/%s error=%s",
+                    self.account_mode,
+                    self.current_attempt,
+                    self.max_reconnect_attempts,
+                    e,
+                )
+                await self._close_websocket_best_effort()
+                if self.current_attempt >= self.max_reconnect_attempts:
+                    break
+                if self.is_running:
+                    await asyncio.sleep(self.reconnect_delay)
+
+        if not self.is_connected:
+            raise RuntimeError("KIS quote WebSocket connection not established")
+
+    async def listen(self) -> None:
+        """Consume messages and dispatch parsed quotes to callbacks."""
+        if self.websocket is None:
+            raise RuntimeError("WebSocket is not connected")
+        websocket = self.websocket
+        try:
+            async for message in websocket:
+                self.messages_received += 1
+                self.last_message_at = self._now_iso()
+                try:
+                    await self._dispatch(message)
+                except Exception as e:
+                    logger.error("Quote message processing error: %s", e, exc_info=True)
+        except ConnectionClosed:
+            logger.warning(
+                "KIS quote WebSocket closed: messages_received=%s",
+                self.messages_received,
+            )
+            self.is_connected = False
+        except WebSocketException as e:
+            logger.error("KIS quote WebSocket error: %s", e, exc_info=True)
+            self.is_connected = False
+
+    async def _dispatch(self, message: str | bytes) -> None:
+        if self._is_pingpong(message):
+            await self._handle_pingpong()
+            return
+        parsed = parse_quote_frame(message)
+        if parsed is None:
+            return
+        if isinstance(parsed, QuoteTick):
+            self.tick_events_received += 1
+            result = self.on_tick(parsed)
+            if isawaitable(result):
+                await result
+        elif isinstance(parsed, OrderBookSnapshot):
+            self.book_events_received += 1
+            result = self.on_book(parsed)
+            if isawaitable(result):
+                await result
+
+    @staticmethod
+    def _is_pingpong(message: str | bytes) -> bool:
+        if isinstance(message, bytes):
+            try:
+                message = message.decode("utf-8")
+            except Exception:
+                return False
+        return "pingpong" in message.lower()
+
+    async def _handle_pingpong(self) -> None:
+        if self.websocket:
+            await self.websocket.send("0|pingpong")
+
+    @staticmethod
+    def _now_iso() -> str:
+        from datetime import UTC, datetime
+
+        return datetime.now(UTC).isoformat()
+
+    async def _close_websocket_best_effort(self) -> None:
+        websocket = self.websocket
+        self.websocket = None
+        self.is_connected = False
+        if websocket is None:
+            return
+        try:
+            await websocket.close()
+        except Exception as e:
+            logger.debug("Failed to close quote websocket during cleanup: %s", e)
+
+    async def stop(self) -> None:
+        self.is_running = False
+        try:
+            if self.websocket:
+                await self.websocket.close()
+        finally:
+            self.websocket = None
+            self.is_connected = False

--- a/app/services/brokers/kis/mock_scalping_ws/quote_parsers.py
+++ b/app/services/brokers/kis/mock_scalping_ws/quote_parsers.py
@@ -1,0 +1,92 @@
+"""Pure parser: KIS plaintext quote frame -> typed snapshot. No I/O, no state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .quote_protocol import (
+    DOMESTIC_ORDERBOOK_TR,
+    DOMESTIC_TRADE_TR,
+    ORDERBOOK_FIELDS,
+    QUOTE_TR_CODES,
+    TRADE_FIELDS,
+)
+
+
+@dataclass(frozen=True)
+class QuoteTick:
+    symbol: str
+    last_price: float
+    ts: str  # HHMMSS as reported by KIS
+
+
+@dataclass(frozen=True)
+class OrderBookSnapshot:
+    symbol: str
+    bid: float
+    ask: float
+    bid_qty: float
+    ask_qty: float
+
+
+def _to_float(value: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_quote_frame(message: str | bytes) -> QuoteTick | OrderBookSnapshot | None:
+    """Parse one plaintext KIS real-time quote frame.
+
+    Returns None for: bytes-decode failure, empty/malformed frames, encrypted
+    frames (leading '1'), or non-quote TR codes. Read-only; never raises on
+    bad input.
+    """
+    if isinstance(message, bytes):
+        try:
+            message = message.decode("utf-8")
+        except Exception:
+            return None
+    message = (message or "").strip()
+    if not message:
+        return None
+
+    parts = message.split("|")
+    if len(parts) < 4:
+        return None
+
+    encryption_flag, tr_code, _count, payload = parts[0], parts[1], parts[2], parts[3]
+    if encryption_flag != "0":  # quotes are never encrypted
+        return None
+    if tr_code not in QUOTE_TR_CODES:
+        return None
+
+    fields = payload.split("^")
+
+    def at(idx: int) -> str:
+        return fields[idx] if idx < len(fields) else ""
+
+    if tr_code == DOMESTIC_TRADE_TR:
+        symbol = at(TRADE_FIELDS["symbol"])
+        if not symbol:
+            return None
+        return QuoteTick(
+            symbol=symbol,
+            last_price=_to_float(at(TRADE_FIELDS["last_price"])),
+            ts=at(TRADE_FIELDS["time"]),
+        )
+
+    if tr_code == DOMESTIC_ORDERBOOK_TR:
+        symbol = at(ORDERBOOK_FIELDS["symbol"])
+        if not symbol:
+            return None
+        return OrderBookSnapshot(
+            symbol=symbol,
+            bid=_to_float(at(ORDERBOOK_FIELDS["bid"])),
+            ask=_to_float(at(ORDERBOOK_FIELDS["ask"])),
+            bid_qty=_to_float(at(ORDERBOOK_FIELDS["bid_qty"])),
+            ask_qty=_to_float(at(ORDERBOOK_FIELDS["ask_qty"])),
+        )
+
+    return None

--- a/app/services/brokers/kis/mock_scalping_ws/quote_protocol.py
+++ b/app/services/brokers/kis/mock_scalping_ws/quote_protocol.py
@@ -1,0 +1,29 @@
+"""KIS real-time quote/orderbook TR codes and field-index maps (read-only).
+
+Indices follow KIS real-time TR docs (H0STCNT0 주식체결, H0STASP0 주식호가).
+Encoded as named maps so a single map can be corrected if the smoke test
+(PR2 Task 4) observes a different live layout.
+"""
+
+from __future__ import annotations
+
+DOMESTIC_TRADE_TR = "H0STCNT0"  # 실시간 주식 체결가
+DOMESTIC_ORDERBOOK_TR = "H0STASP0"  # 실시간 주식 호가
+
+QUOTE_TR_CODES = frozenset({DOMESTIC_TRADE_TR, DOMESTIC_ORDERBOOK_TR})
+
+# H0STCNT0 field indices
+TRADE_FIELDS = {
+    "symbol": 0,
+    "time": 1,  # HHMMSS
+    "last_price": 2,
+}
+
+# H0STASP0 field indices (best level only)
+ORDERBOOK_FIELDS = {
+    "symbol": 0,
+    "ask": 3,  # ASKP1
+    "bid": 13,  # BIDP1
+    "ask_qty": 23,  # ASKP_RSQN1
+    "bid_qty": 33,  # BIDP_RSQN1
+}

--- a/app/services/brokers/kis/mock_scalping_ws/state.py
+++ b/app/services/brokers/kis/mock_scalping_ws/state.py
@@ -1,0 +1,52 @@
+"""Per-symbol market state built from quote/orderbook frames.
+
+Pure in-memory tracker. The caller injects ``now`` (monotonic seconds) so
+freshness is deterministic and testable; this module performs no I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .quote_parsers import OrderBookSnapshot, QuoteTick
+
+
+@dataclass
+class MarketState:
+    symbol: str
+    last_price: float | None = None
+    last_ts: str | None = None
+    bid: float | None = None
+    ask: float | None = None
+    bid_qty: float | None = None
+    ask_qty: float | None = None
+    _updated_at: float | None = None
+
+    def update_from_tick(self, tick: QuoteTick, *, now: float) -> None:
+        self.last_price = tick.last_price
+        self.last_ts = tick.ts
+        self._updated_at = now
+
+    def update_from_book(self, book: OrderBookSnapshot, *, now: float) -> None:
+        self.bid = book.bid
+        self.ask = book.ask
+        self.bid_qty = book.bid_qty
+        self.ask_qty = book.ask_qty
+        self._updated_at = now
+
+    def spread_bps(self) -> float | None:
+        """(ask - bid) / mid in basis points. None until a valid book is seen."""
+        if self.bid is None or self.ask is None:
+            return None
+        if self.bid <= 0 or self.ask <= 0:
+            return None
+        mid = (self.bid + self.ask) / 2
+        if mid <= 0:
+            return None
+        return (self.ask - self.bid) / mid * 10_000
+
+    def age_seconds(self, *, now: float) -> float | None:
+        """Seconds since the most recent tick or book update. None if never updated."""
+        if self._updated_at is None:
+            return None
+        return now - self._updated_at

--- a/app/services/kis_websocket.py
+++ b/app/services/kis_websocket.py
@@ -17,9 +17,12 @@ from app.services.kis_websocket_internal.client import (
     KISExecutionWebSocket,
 )
 from app.services.kis_websocket_internal.constants import (
+    APPROVAL_ENDPOINT_HOSTS,
     APPROVAL_KEY_CACHE_KEY,
+    APPROVAL_KEY_CACHE_KEYS,
     APPROVAL_KEY_TTL_SECONDS,
     RECOVERABLE_APPROVAL_MSG_CODES,
+    WEBSOCKET_ENDPOINT_HOSTS,
 )
 from app.services.kis_websocket_internal.events import build_lifecycle_event
 from app.services.kis_websocket_internal.parsers import ExecutionMessageParser
@@ -43,8 +46,11 @@ from app.services.kis_websocket_internal.protocol import (
 )
 
 __all__ = [
+    "APPROVAL_ENDPOINT_HOSTS",
     "APPROVAL_KEY_CACHE_KEY",
+    "APPROVAL_KEY_CACHE_KEYS",
     "APPROVAL_KEY_TTL_SECONDS",
+    "WEBSOCKET_ENDPOINT_HOSTS",
     "DOMESTIC_COMPACT_FILL_FIELDS",
     "DOMESTIC_EXECUTION_TR",
     "DOMESTIC_EXECUTION_TR_CODES",

--- a/app/services/kis_websocket_internal/approval_keys.py
+++ b/app/services/kis_websocket_internal/approval_keys.py
@@ -1,16 +1,67 @@
 import logging
+from urllib.parse import urlparse
 
 import httpx
 import redis.asyncio as redis
 
-from app.core.config import settings
+from app.core.config import settings, validate_kis_mock_config
 
 from .constants import (
-    APPROVAL_KEY_CACHE_KEY,
+    APPROVAL_ENDPOINT_HOSTS,
+    APPROVAL_KEY_CACHE_KEYS,
     APPROVAL_KEY_TTL_SECONDS,
 )
 
 logger = logging.getLogger(__name__)
+
+# WebSocket approval keys are only issued for KIS environments.
+_SUPPORTED_ACCOUNT_MODES = ("kis_live", "kis_mock")
+
+
+def _resolve_ws_account_mode(account_mode: str) -> str:
+    """Validate the account mode for WebSocket approval-key issuance.
+
+    Only ``kis_live`` / ``kis_mock`` are supported — anything else fails closed.
+    """
+    if account_mode not in _SUPPORTED_ACCOUNT_MODES:
+        raise ValueError(
+            f"account_mode must be one of {_SUPPORTED_ACCOUNT_MODES}, got {account_mode!r}"
+        )
+    return account_mode
+
+
+def _resolve_approval_credentials(account_mode: str) -> tuple[str, str, str]:
+    """Return ``(base_url, appkey, secret)`` for the mode.
+
+    Mock fails closed via ``validate_kis_mock_config`` and surfaces only the
+    missing env var *names* — never the configured secret values.
+    """
+    if account_mode == "kis_mock":
+        missing = validate_kis_mock_config()
+        if missing:
+            raise ValueError(
+                "KIS mock WebSocket approval key requires configuration: "
+                + ", ".join(missing)
+            )
+        return (
+            settings.kis_mock_base_url,
+            settings.kis_mock_app_key,
+            settings.kis_mock_app_secret,
+        )
+    return settings.kis_base_url, settings.kis_app_key, settings.kis_app_secret
+
+
+def _assert_approval_endpoint_host(account_mode: str, base_url: str) -> None:
+    """Fail-closed: the approval endpoint host:port must match the mode's allowlist."""
+    parsed = urlparse(base_url)
+    host_port = f"{parsed.hostname}:{parsed.port}"
+    allowed = APPROVAL_ENDPOINT_HOSTS[account_mode]
+    if host_port != allowed:
+        raise ValueError(
+            f"approval endpoint {host_port!r} not allowed for {account_mode} "
+            f"(expected {allowed!r})"
+        )
+
 
 # 전역 Redis 클라이언트 (지연 초기화)
 _redis_client: redis.Redis | None = None
@@ -70,31 +121,37 @@ def _is_valid_approval_key(key: str | None) -> bool:
     return key is not None and bool(key.strip())
 
 
-async def get_approval_key() -> str:
+async def get_approval_key(account_mode: str = "kis_live") -> str:
     """
-    KIS WebSocket Approval Key 발급
+    KIS WebSocket Approval Key 발급 (account-mode aware)
 
     Approval Key는 24시간 유효하며, 23시간 캐시하여 재발급을 줄입니다.
+    live / mock 은 별도 Redis 네임스페이스 + 별도 endpoint/credential 을 사용합니다.
+
+    Args:
+        account_mode: "kis_live" (default) 또는 "kis_mock".
 
     Returns:
         str: Approval Key
 
     Raises:
+        ValueError: account_mode 미지원 또는 mock 설정 누락 시 (fail-closed)
         Exception: Approval Key 발급 실패 시
     """
-    approval_key = await _get_cached_approval_key()
+    account_mode = _resolve_ws_account_mode(account_mode)
+    approval_key = await _get_cached_approval_key(account_mode)
 
     if not _is_valid_approval_key(approval_key):
-        approval_key = await _issue_approval_key()
-        await _cache_approval_key(approval_key)
+        approval_key = await _issue_approval_key(account_mode)
+        await _cache_approval_key(approval_key, account_mode)
 
     assert approval_key is not None  # _issue_approval_key() guarantees str return
     return approval_key
 
 
-async def _get_cached_approval_key() -> str | None:
+async def _get_cached_approval_key(account_mode: str = "kis_live") -> str | None:
     """
-    캐시된 Approval Key 조회 (만료 체크 포함)
+    캐시된 Approval Key 조회 (account-mode 별 네임스페이스, 만료 체크 포함)
 
     Returns:
         str | None: 캐시된 Approval Key (없거나 만료된 경우 None)
@@ -102,41 +159,49 @@ async def _get_cached_approval_key() -> str | None:
     Raises:
         redis.RedisError: Redis 접근 실패 시 (엄격 실패 정책)
     """
+    cache_key = APPROVAL_KEY_CACHE_KEYS[_resolve_ws_account_mode(account_mode)]
     redis_client = await _get_redis_client()
-    cached_key = await redis_client.get(APPROVAL_KEY_CACHE_KEY)
+    cached_key = await redis_client.get(cache_key)
     return cached_key
 
 
-async def _cache_approval_key(approval_key: str) -> None:
+async def _cache_approval_key(
+    approval_key: str, account_mode: str = "kis_live"
+) -> None:
     """
-    Approval Key 캐싱 (23시간 TTL)
+    Approval Key 캐싱 (account-mode 별 네임스페이스, 23시간 TTL)
 
     Args:
         approval_key: 캐싱할 Approval Key
+        account_mode: "kis_live" (default) 또는 "kis_mock".
 
     Raises:
         redis.RedisError: Redis 접근 실패 시 (엄격 실패 정책)
     """
+    cache_key = APPROVAL_KEY_CACHE_KEYS[_resolve_ws_account_mode(account_mode)]
     redis_client = await _get_redis_client()
-    await redis_client.set(
-        APPROVAL_KEY_CACHE_KEY, approval_key, ex=APPROVAL_KEY_TTL_SECONDS
+    await redis_client.set(cache_key, approval_key, ex=APPROVAL_KEY_TTL_SECONDS)
+    logger.info(
+        "KIS Approval Key cached in Redis: account_mode=%s (TTL: 23h)", account_mode
     )
-    logger.info("KIS Approval Key cached in Redis (TTL: 23h)")
 
 
-async def _issue_approval_key() -> str:
+async def _issue_approval_key(account_mode: str = "kis_live") -> str:
     """
-    KIS Approval Key 발급 API 호출
+    KIS Approval Key 발급 API 호출 (account-mode 별 endpoint/credential)
 
     Returns:
         str: 발급된 Approval Key
 
     Raises:
+        ValueError: account_mode 미지원, mock 설정 누락, endpoint host 불일치 시
         Exception: HTTP 요청 실패 또는 응답에 approval_key 없음
     """
-    base_url = "https://openapi.koreainvestment.com:9443"
-    path = "/oauth2/Approval"
-    url = f"{base_url}{path}"
+    account_mode = _resolve_ws_account_mode(account_mode)
+    base_url, appkey, secret = _resolve_approval_credentials(account_mode)
+    _assert_approval_endpoint_host(account_mode, base_url)
+
+    url = f"{base_url}/oauth2/Approval"
 
     headers = {
         "Content-Type": "application/json",
@@ -144,8 +209,8 @@ async def _issue_approval_key() -> str:
 
     request_body = {
         "grant_type": "client_credentials",
-        "appkey": settings.kis_app_key,
-        "secretkey": settings.kis_app_secret,
+        "appkey": appkey,
+        "secretkey": secret,
     }
 
     async with httpx.AsyncClient() as client:
@@ -159,5 +224,5 @@ async def _issue_approval_key() -> str:
     if not issued_key:
         raise Exception("Approval Key not found in response")
 
-    logger.info("KIS Approval Key issued successfully")
+    logger.info("KIS Approval Key issued successfully: account_mode=%s", account_mode)
     return issued_key

--- a/app/services/kis_websocket_internal/client.py
+++ b/app/services/kis_websocket_internal/client.py
@@ -14,7 +14,7 @@ from app.core.config import settings
 from app.schemas.execution_contracts import AccountMode
 
 from . import approval_keys
-from .constants import RECOVERABLE_APPROVAL_MSG_CODES
+from .constants import RECOVERABLE_APPROVAL_MSG_CODES, WEBSOCKET_ENDPOINT_HOSTS
 from .parsers import ExecutionMessageParser
 from .protocol import (
     DOMESTIC_EXECUTION_TR_MOCK,
@@ -177,8 +177,12 @@ class KISExecutionWebSocket:
                     ):
                         # 동일한 ACK 오류가 연속으로 반복되면 최소 1초 대기 후 재발급합니다.
                         await asyncio.sleep(1)
-                    self.approval_key = await approval_keys._issue_approval_key()
-                    await approval_keys._cache_approval_key(self.approval_key)
+                    self.approval_key = await approval_keys._issue_approval_key(
+                        self.account_mode
+                    )
+                    await approval_keys._cache_approval_key(
+                        self.approval_key, self.account_mode
+                    )
                     self._last_reissue_msg_code = (
                         ack_error.msg_cd if ack_error else None
                     )
@@ -220,8 +224,8 @@ class KISExecutionWebSocket:
             raise RuntimeError("KIS WebSocket connection not established")
 
     async def _issue_approval_key_if_needed(self):
-        """Approval Key 발급 (캐시 미스 시)"""
-        self.approval_key = await approval_keys.get_approval_key()
+        """Approval Key 발급 (캐시 미스 시) — account_mode 별 endpoint/credential"""
+        self.approval_key = await approval_keys.get_approval_key(self.account_mode)
 
     async def _build_websocket_url(self) -> str:
         """
@@ -235,8 +239,20 @@ class KISExecutionWebSocket:
             if self.mock_mode
             else "ws://ops.koreainvestment.com:21000"
         )
+        self._assert_websocket_endpoint_host(base_url)
         path = "/tryitout"
         return f"{base_url}{path}"
+
+    def _assert_websocket_endpoint_host(self, base_url: str) -> None:
+        """Fail-closed: the WebSocket host:port must match the mode's allowlist."""
+        parsed = urlparse(base_url)
+        host_port = f"{parsed.hostname}:{parsed.port}"
+        allowed = WEBSOCKET_ENDPOINT_HOSTS[self.account_mode]
+        if host_port != allowed:
+            raise ValueError(
+                f"websocket endpoint {host_port!r} not allowed for "
+                f"{self.account_mode} (expected {allowed!r})"
+            )
 
     async def _connect_and_subscribe_internal(self):
         """

--- a/app/services/kis_websocket_internal/constants.py
+++ b/app/services/kis_websocket_internal/constants.py
@@ -1,3 +1,24 @@
 APPROVAL_KEY_CACHE_KEY = "kis:websocket:approval_key"
 APPROVAL_KEY_TTL_SECONDS = 82800
 RECOVERABLE_APPROVAL_MSG_CODES = {"OPSP0011", "OPSP8996"}
+
+# Per-account-mode Redis namespaces for the WebSocket approval key.
+# Live keeps the historical key (== APPROVAL_KEY_CACHE_KEY); mock is isolated so
+# a mock approval key can never satisfy a live cache lookup or vice versa.
+APPROVAL_KEY_CACHE_KEYS = {
+    "kis_live": "kis:websocket:approval_key",
+    "kis_mock": "kis_mock:websocket:approval_key",
+}
+
+# Transport-layer host allowlists (fail-closed). Two layers:
+#   1. approval endpoint (REST /oauth2/Approval) — issues the approval key
+#   2. websocket endpoint (real-time stream) — consumes the approval key
+# Each account mode may only ever touch its own host:port pair.
+APPROVAL_ENDPOINT_HOSTS = {
+    "kis_live": "openapi.koreainvestment.com:9443",
+    "kis_mock": "openapivts.koreainvestment.com:29443",
+}
+WEBSOCKET_ENDPOINT_HOSTS = {
+    "kis_live": "ops.koreainvestment.com:21000",
+    "kis_mock": "ops.koreainvestment.com:31000",
+}

--- a/docs/plans/ROB-321-pr2-quote-ws-plan.md
+++ b/docs/plans/ROB-321-pr2-quote-ws-plan.md
@@ -286,9 +286,22 @@ git commit -m "feat(rob-321): KIS quote-frame pure parser (read-only, PR2 task 1
 
 `state.py`: `MarketState(symbol)` with `update_from_tick(QuoteTick, now)`, `update_from_book(OrderBookSnapshot, now)`, `spread_bps() -> float | None`, `age_seconds(now) -> float`, `last_price`/`bid`/`ask` accessors. Pure (clock injected). Tests: tick updates last_price+ts; book updates bid/ask+spread_bps; age increases with `now`; spread None until a book seen.
 
+## Task 2b: Account-mode aware WS approval key + two-layer host allowlist  *(DONE)*
+
+Done ahead of the client (Task 3) so the quote client + mock execution WS both issue the *correct* approval key. Extended `kis_websocket_internal/approval_keys.py` (no new client):
+
+- `get_approval_key/_issue_approval_key/_cache_approval_key/_get_cached_approval_key` take `account_mode="kis_live" | "kis_mock"` (default `kis_live` → backward compatible).
+- live: `settings.kis_base_url` + `kis_app_key`/`kis_app_secret`, cache `kis:websocket:approval_key`.
+- mock: `settings.kis_mock_base_url` + `kis_mock_app_key`/`kis_mock_app_secret`, cache `kis_mock:websocket:approval_key`; missing config → fail-closed via `validate_kis_mock_config()` (env var names only, never values).
+- **Two-layer fail-closed host allowlists** in `kis_websocket_internal/constants.py`:
+  1. `APPROVAL_ENDPOINT_HOSTS` — live `openapi.koreainvestment.com:9443`, mock `openapivts.koreainvestment.com:29443`
+  2. `WEBSOCKET_ENDPOINT_HOSTS` — live `ops.koreainvestment.com:21000`, mock `ops.koreainvestment.com:31000`
+- `KISExecutionWebSocket._issue_approval_key_if_needed()` + recoverable-ACK reissue pass `self.account_mode`; `_build_websocket_url` asserts the WS allowlist.
+- Result: **mock execution WS now auto-issues a MOCK approval key** (previously always live — latent bug). Live order/mutation paths untouched. Tests in `tests/services/kis_websocket/test_approval_keys.py` (+ updated `test_client.py`): live/mock endpoint+creds, cache namespace, fail-closed, host-allowlist rejection, reissue path. 88 green.
+
 ## Task 3: `KISQuoteWebSocket` read-only client + host allowlist  *(outline)*
 
-`market_stream.py`: connect to resolved quote host, subscribe to `QUOTE_TR_CODES` for given symbols (reuse approval-key + subscription-request shape), `async listen(on_tick, on_book)`, reconnect/backoff/heartbeat copied from `KISExecutionWebSocket`. **No order method.** Add `KIS_QUOTE_WS_HOSTS` allowlist; constructor asserts the resolved `host:port` is in it (fail-closed). Tests: fake WS server feeds canned frames → `on_tick`/`on_book` called with parsed objects; host not in allowlist → raises; reconnect/heartbeat-timeout paths. Add `app/core/config.py` flag `kis_mock_scalping_ws_enabled` (default False) gating the daemon/smoke.
+`market_stream.py`: connect to resolved quote host (using `get_approval_key(account_mode)` from Task 2b), subscribe to `QUOTE_TR_CODES` for given symbols (reuse subscription-request shape), `async listen(on_tick, on_book)`, reconnect/backoff/heartbeat copied from `KISExecutionWebSocket`. **No order method.** Reuse `WEBSOCKET_ENDPOINT_HOSTS` allowlist (Task 2b); constructor asserts the resolved `host:port` is in it (fail-closed). Tests: fake WS server feeds canned frames → `on_tick`/`on_book` called with parsed objects; host not in allowlist → raises; reconnect/heartbeat-timeout paths. Add `app/core/config.py` flag `kis_mock_scalping_ws_enabled` (default False) gating the daemon/smoke.
 
 ## Task 4: Read-only smoke script + import guard + host resolution  *(outline)*
 

--- a/docs/plans/ROB-321-pr2-quote-ws-plan.md
+++ b/docs/plans/ROB-321-pr2-quote-ws-plan.md
@@ -299,13 +299,15 @@ Done ahead of the client (Task 3) so the quote client + mock execution WS both i
 - `KISExecutionWebSocket._issue_approval_key_if_needed()` + recoverable-ACK reissue pass `self.account_mode`; `_build_websocket_url` asserts the WS allowlist.
 - Result: **mock execution WS now auto-issues a MOCK approval key** (previously always live — latent bug). Live order/mutation paths untouched. Tests in `tests/services/kis_websocket/test_approval_keys.py` (+ updated `test_client.py`): live/mock endpoint+creds, cache namespace, fail-closed, host-allowlist rejection, reissue path. 88 green.
 
-## Task 3: `KISQuoteWebSocket` read-only client + host allowlist  *(outline)*
+## Task 3: `KISQuoteWebSocket` read-only client + host allowlist  *(DONE)*
 
-`market_stream.py`: connect to resolved quote host (using `get_approval_key(account_mode)` from Task 2b), subscribe to `QUOTE_TR_CODES` for given symbols (reuse subscription-request shape), `async listen(on_tick, on_book)`, reconnect/backoff/heartbeat copied from `KISExecutionWebSocket`. **No order method.** Reuse `WEBSOCKET_ENDPOINT_HOSTS` allowlist (Task 2b); constructor asserts the resolved `host:port` is in it (fail-closed). Tests: fake WS server feeds canned frames → `on_tick`/`on_book` called with parsed objects; host not in allowlist → raises; reconnect/heartbeat-timeout paths. Add `app/core/config.py` flag `kis_mock_scalping_ws_enabled` (default False) gating the daemon/smoke.
+`market_stream.py`: `get_approval_key(account_mode)` (Task 2b) → connect → subscribe `_SUBSCRIBE_TRS` (H0STCNT0/H0STASP0) per symbol → `listen()` dispatches `parse_quote_frame` results to `on_tick`/`on_book`. Bounded reconnect, pingpong echo. **No order method** (`test_has_no_order_surface`). `_build_url` built from + asserted against `WEBSOCKET_ENDPOINT_HOSTS[account_mode]` (fail-closed). 10 tests: unknown-mode reject, live/mock URL, sub-request shape, dispatch routing (tick/book/junk), fake-WS listen, pingpong echo, mock approval-key wiring.
 
-## Task 4: Read-only smoke script + import guard + host resolution  *(outline)*
+## Task 4: Read-only smoke script + import guard + flag  *(DONE)*
 
-`scripts/kis_mock_scalping_ws_smoke.py`: default-disabled (`KIS_MOCK_SCALPING_WS_ENABLED` required), connects, prints N parsed ticks/books, no orders. **Resolves the OPEN QUESTION**: confirm whether mock (`:31000`) or live (`:21000`) host serves quotes; record in `docs/runbooks/`. `test_import_guard.py`: AST-assert `mock_scalping_ws/` imports nothing from execution/order/ledger packages.
+`app/core/config.py` flag `kis_mock_scalping_ws_enabled` (default False, in the `kis_ws` block). `scripts/kis_mock_scalping_ws_smoke.py`: default-disabled (flag-off → no-op exit 0), bounded ticks/books print, no orders; exit 4 = no events on that host. **Resolves the OPEN QUESTION** via `--account-mode kis_mock|kis_live` (runbook records which serves quotes). `tests/brokers/kis/mock_scalping_ws/test_import_guard.py`: AST-asserts the package imports no order/ledger/execution-mutation module. `docs/runbooks/kis-mock-scalping-ws-smoke.md`. `test_smoke_cli.py`: default-disabled no-op + default account_mode.
+
+**PR2 status: implementation complete.** 104 tests green (incl. live-unaffected regressions), ruff check/format + ty clean. Branch `rob-321-pr2` (4 feature commits + docs); not yet pushed. Field indices + mock-vs-live host remain to be confirmed by the operator smoke (runbook table).
 
 ---
 

--- a/docs/plans/ROB-321-pr2-quote-ws-plan.md
+++ b/docs/plans/ROB-321-pr2-quote-ws-plan.md
@@ -1,0 +1,304 @@
+# ROB-321 PR2 — Live KIS quote/orderbook WebSocket (read-only) Implementation Plan
+
+> Sibling of `docs/plans/ROB-321-kis-mock-scalping-loop-plan.md`. Executes that plan's PR2. Steps use `- [ ]` checkboxes.
+
+**Goal:** A read-only KIS quote/orderbook WebSocket market-data feed for the mock scalping loop — tick (체결가) and orderbook (호가) frames parsed into typed snapshots and tracked per symbol. **Zero order surface** (the WS client has no order method; orders are a separate REST/mock transport handled by PR1/PR4).
+
+**Architecture:** New package `app/services/brokers/kis/mock_scalping_ws/`. A pure parser layer (`quote_protocol.py` + `quote_parsers.py`) converts plaintext KIS real-time frames into `QuoteTick`/`OrderBookSnapshot`. A per-symbol `MarketState` tracks bid/ask/last + freshness. A read-only `KISQuoteWebSocket` client reuses the reconnect/backoff/heartbeat shape of `KISExecutionWebSocket` but subscribes to quote TRs only and asserts a host allowlist. The order safety boundary is structural: this package contains no order code, and an AST import guard forbids it from importing any execution/order/ledger module.
+
+**Tech Stack:** Python 3.13, asyncio, `websockets`, pytest. Frame format: `0|TR_ID|count|f0^f1^...` — leading `0` = plaintext (quotes are never AES-encrypted; a leading `1` is rejected).
+
+---
+
+## Key facts established from the existing code (`app/services/kis_websocket_internal/`)
+
+- WS host is `ops.koreainvestment.com`, port `21000` (live) / `31000` (mock). Same domain, port differs. (`client.py:233-239`)
+- Existing `KISExecutionWebSocket` is **execution-only** (TRs `H0STCNI0/9`, `H0GSCNI0/9`), AES-encrypted payloads. We do **not** modify it.
+- Frame envelope split on `|`; payload fields split on `^`; leading token `0`=plain / `1`=encrypted. (`parsers.py:76-106`)
+- Approval-key handshake + subscription request shape (`tr_type:"1"`, `custtype:"P"`) reusable. (`client.py:288-305`)
+- Orders never traverse WS — they go via REST (`kis_mock_base_url`). So a quote WS client is read-only by construction.
+
+**OPEN QUESTION (resolved in Task 4, the smoke task — not Task 1-3):** does the KIS **mock** WS (`:31000`) serve real-time quotes, or must quotes come from the **live** WS (`:21000`)? Design accommodates both via a resolved host constant + allowlist; the smoke script confirms empirically and the runbook records the answer. Task 1 (pure parser) is host-independent and proceeds regardless.
+
+---
+
+## File Structure
+
+- Create: `app/services/brokers/kis/mock_scalping_ws/__init__.py`
+- Create: `app/services/brokers/kis/mock_scalping_ws/quote_protocol.py` — quote TR codes + field-index maps.
+- Create: `app/services/brokers/kis/mock_scalping_ws/quote_parsers.py` — `QuoteTick`, `OrderBookSnapshot`, `parse_quote_frame()`.
+- Create: `app/services/brokers/kis/mock_scalping_ws/state.py` — `MarketState`.
+- Create: `app/services/brokers/kis/mock_scalping_ws/market_stream.py` — read-only `KISQuoteWebSocket` + host allowlist.
+- Modify: `app/core/config.py` — add `kis_mock_scalping_ws_enabled: bool = False`.
+- Create: `scripts/kis_mock_scalping_ws_smoke.py` — read-only tick smoke (no orders), default-disabled.
+- Create tests: `tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py`, `test_state.py`, `test_market_stream.py`, `test_import_guard.py`.
+
+---
+
+## Task 1: Quote protocol + pure parser  *(detailed — implement now)*
+
+**Files:**
+- Create: `app/services/brokers/kis/mock_scalping_ws/__init__.py`
+- Create: `app/services/brokers/kis/mock_scalping_ws/quote_protocol.py`
+- Create: `app/services/brokers/kis/mock_scalping_ws/quote_parsers.py`
+- Test: `tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py`
+
+> **Field indices** below follow KIS real-time TR documentation (`H0STCNT0` 주식체결, `H0STASP0` 주식호가). They are encoded as named maps so the empirical check in Task 4 (smoke against a real frame) can adjust a single map if KIS's live layout differs. Tests build synthetic frames from these same maps, proving the parser reads the configured indices.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Create `tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py`:
+
+```python
+"""Pure KIS quote-frame parser tests (ROB-321 PR2 Task 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+    parse_quote_frame,
+)
+from app.services.brokers.kis.mock_scalping_ws.quote_protocol import (
+    DOMESTIC_ORDERBOOK_TR,
+    DOMESTIC_TRADE_TR,
+)
+
+
+def _trade_frame(symbol: str = "005930", time: str = "131502", price: str = "70500") -> str:
+    # H0STCNT0: idx0 symbol, idx1 time(HHMMSS), idx2 last price. Pad to 20 fields.
+    fields = [""] * 20
+    fields[0] = symbol
+    fields[1] = time
+    fields[2] = price
+    return f"0|{DOMESTIC_TRADE_TR}|001|" + "^".join(fields)
+
+
+def _orderbook_frame(
+    symbol: str = "005930", ask1: str = "70600", bid1: str = "70500",
+    ask_qty1: str = "120", bid_qty1: str = "200",
+) -> str:
+    # H0STASP0: idx0 symbol, idx3 ASKP1, idx13 BIDP1, idx23 ASKP_RSQN1, idx33 BIDP_RSQN1.
+    fields = [""] * 60
+    fields[0] = symbol
+    fields[3] = ask1
+    fields[13] = bid1
+    fields[23] = ask_qty1
+    fields[33] = bid_qty1
+    return f"0|{DOMESTIC_ORDERBOOK_TR}|001|" + "^".join(fields)
+
+
+@pytest.mark.unit
+def test_parse_trade_frame() -> None:
+    result = parse_quote_frame(_trade_frame(price="70500"))
+    assert isinstance(result, QuoteTick)
+    assert result.symbol == "005930"
+    assert result.last_price == 70500.0
+    assert result.ts == "131502"
+
+
+@pytest.mark.unit
+def test_parse_orderbook_frame() -> None:
+    result = parse_quote_frame(_orderbook_frame())
+    assert isinstance(result, OrderBookSnapshot)
+    assert result.symbol == "005930"
+    assert result.ask == 70600.0
+    assert result.bid == 70500.0
+    assert result.ask_qty == 120.0
+    assert result.bid_qty == 200.0
+
+
+@pytest.mark.unit
+def test_encrypted_frame_rejected() -> None:
+    # Leading "1" = encrypted; quotes are never encrypted -> reject (return None).
+    enc = _trade_frame().replace("0|", "1|", 1)
+    assert parse_quote_frame(enc) is None
+
+
+@pytest.mark.unit
+def test_unknown_tr_returns_none() -> None:
+    assert parse_quote_frame("0|H0STCNI0|001|005930^x^y") is None
+
+
+@pytest.mark.unit
+def test_malformed_frame_returns_none() -> None:
+    assert parse_quote_frame("garbage") is None
+    assert parse_quote_frame("") is None
+    assert parse_quote_frame("0|H0STCNT0") is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `quote_protocol.py`**
+
+```python
+"""KIS real-time quote/orderbook TR codes and field-index maps (read-only).
+
+Indices follow KIS real-time TR docs (H0STCNT0 주식체결, H0STASP0 주식호가).
+Encoded as named maps so a single map can be corrected if the smoke test
+(PR2 Task 4) observes a different live layout.
+"""
+
+from __future__ import annotations
+
+DOMESTIC_TRADE_TR = "H0STCNT0"  # 실시간 주식 체결가
+DOMESTIC_ORDERBOOK_TR = "H0STASP0"  # 실시간 주식 호가
+
+QUOTE_TR_CODES = frozenset({DOMESTIC_TRADE_TR, DOMESTIC_ORDERBOOK_TR})
+
+# H0STCNT0 field indices
+TRADE_FIELDS = {
+    "symbol": 0,
+    "time": 1,  # HHMMSS
+    "last_price": 2,
+}
+
+# H0STASP0 field indices (best level only)
+ORDERBOOK_FIELDS = {
+    "symbol": 0,
+    "ask": 3,  # ASKP1
+    "bid": 13,  # BIDP1
+    "ask_qty": 23,  # ASKP_RSQN1
+    "bid_qty": 33,  # BIDP_RSQN1
+}
+```
+
+- [ ] **Step 4: Implement `quote_parsers.py`**
+
+```python
+"""Pure parser: KIS plaintext quote frame -> typed snapshot. No I/O, no state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .quote_protocol import (
+    DOMESTIC_ORDERBOOK_TR,
+    DOMESTIC_TRADE_TR,
+    ORDERBOOK_FIELDS,
+    QUOTE_TR_CODES,
+    TRADE_FIELDS,
+)
+
+
+@dataclass(frozen=True)
+class QuoteTick:
+    symbol: str
+    last_price: float
+    ts: str  # HHMMSS as reported by KIS
+
+
+@dataclass(frozen=True)
+class OrderBookSnapshot:
+    symbol: str
+    bid: float
+    ask: float
+    bid_qty: float
+    ask_qty: float
+
+
+def _to_float(value: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_quote_frame(message: str | bytes) -> QuoteTick | OrderBookSnapshot | None:
+    """Parse one plaintext KIS real-time quote frame.
+
+    Returns None for: bytes-decode failure, empty/malformed frames, encrypted
+    frames (leading '1'), or non-quote TR codes. Read-only; never raises on
+    bad input.
+    """
+    if isinstance(message, bytes):
+        try:
+            message = message.decode("utf-8")
+        except Exception:
+            return None
+    message = (message or "").strip()
+    if not message:
+        return None
+
+    parts = message.split("|")
+    if len(parts) < 4:
+        return None
+
+    encryption_flag, tr_code, _count, payload = parts[0], parts[1], parts[2], parts[3]
+    if encryption_flag != "0":  # quotes are never encrypted
+        return None
+    if tr_code not in QUOTE_TR_CODES:
+        return None
+
+    fields = payload.split("^")
+
+    def at(idx: int) -> str:
+        return fields[idx] if idx < len(fields) else ""
+
+    if tr_code == DOMESTIC_TRADE_TR:
+        symbol = at(TRADE_FIELDS["symbol"])
+        if not symbol:
+            return None
+        return QuoteTick(
+            symbol=symbol,
+            last_price=_to_float(at(TRADE_FIELDS["last_price"])),
+            ts=at(TRADE_FIELDS["time"]),
+        )
+
+    if tr_code == DOMESTIC_ORDERBOOK_TR:
+        symbol = at(ORDERBOOK_FIELDS["symbol"])
+        if not symbol:
+            return None
+        return OrderBookSnapshot(
+            symbol=symbol,
+            bid=_to_float(at(ORDERBOOK_FIELDS["bid"])),
+            ask=_to_float(at(ORDERBOOK_FIELDS["ask"])),
+            bid_qty=_to_float(at(ORDERBOOK_FIELDS["bid_qty"])),
+            ask_qty=_to_float(at(ORDERBOOK_FIELDS["ask_qty"])),
+        )
+
+    return None
+```
+
+Also create `app/services/brokers/kis/mock_scalping_ws/__init__.py` (empty).
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `uv run pytest tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff check app/ tests/ && uv run ruff format app/ tests/ && uv run ty check app/ --error-on-warning
+git add app/services/brokers/kis/mock_scalping_ws/ tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py
+git commit -m "feat(rob-321): KIS quote-frame pure parser (read-only, PR2 task 1)"
+```
+
+---
+
+## Task 2: `MarketState` per-symbol tracker  *(outline — detail before implementing)*
+
+`state.py`: `MarketState(symbol)` with `update_from_tick(QuoteTick, now)`, `update_from_book(OrderBookSnapshot, now)`, `spread_bps() -> float | None`, `age_seconds(now) -> float`, `last_price`/`bid`/`ask` accessors. Pure (clock injected). Tests: tick updates last_price+ts; book updates bid/ask+spread_bps; age increases with `now`; spread None until a book seen.
+
+## Task 3: `KISQuoteWebSocket` read-only client + host allowlist  *(outline)*
+
+`market_stream.py`: connect to resolved quote host, subscribe to `QUOTE_TR_CODES` for given symbols (reuse approval-key + subscription-request shape), `async listen(on_tick, on_book)`, reconnect/backoff/heartbeat copied from `KISExecutionWebSocket`. **No order method.** Add `KIS_QUOTE_WS_HOSTS` allowlist; constructor asserts the resolved `host:port` is in it (fail-closed). Tests: fake WS server feeds canned frames → `on_tick`/`on_book` called with parsed objects; host not in allowlist → raises; reconnect/heartbeat-timeout paths. Add `app/core/config.py` flag `kis_mock_scalping_ws_enabled` (default False) gating the daemon/smoke.
+
+## Task 4: Read-only smoke script + import guard + host resolution  *(outline)*
+
+`scripts/kis_mock_scalping_ws_smoke.py`: default-disabled (`KIS_MOCK_SCALPING_WS_ENABLED` required), connects, prints N parsed ticks/books, no orders. **Resolves the OPEN QUESTION**: confirm whether mock (`:31000`) or live (`:21000`) host serves quotes; record in `docs/runbooks/`. `test_import_guard.py`: AST-assert `mock_scalping_ws/` imports nothing from execution/order/ledger packages.
+
+---
+
+## Self-Review
+
+- **Spec coverage (master plan PR2):** quote/orderbook streaming (Task 1 parser + Task 3 client), reconnect/backoff/heartbeat (Task 3), host separation fail-closed (Task 3 allowlist + structural read-only), live/mock tagging (carried on parsed frames + client account_mode). ✅
+- **Placeholder scan:** Task 1 is complete code; Tasks 2-4 are explicitly outlines to be detailed before implementing (not in-task placeholders).
+- **Type consistency:** `QuoteTick(symbol, last_price, ts)`, `OrderBookSnapshot(symbol, bid, ask, bid_qty, ask_qty)`, `parse_quote_frame()` names match across protocol/parser/tests.
+- **Open verification item:** field indices for `H0STCNT0`/`H0STASP0` are documented-but-unconfirmed-against-live; Task 4 smoke validates against a real frame and adjusts the single field map if needed.

--- a/docs/runbooks/kis-mock-scalping-ws-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-ws-smoke.md
@@ -1,0 +1,72 @@
+# KIS mock scalping quote WebSocket smoke (ROB-321 PR2)
+
+Read-only verification that the KIS quote/orderbook WebSocket connects, issues
+the correct (account-mode-aware) approval key, subscribes, and delivers parsed
+real-time ticks/orderbook snapshots. **No orders, no mutation, no Redis publish.**
+
+- **Script:** `scripts/kis_mock_scalping_ws_smoke.py`
+- **Client:** `app/services/brokers/kis/mock_scalping_ws/market_stream.KISQuoteWebSocket` (read-only; no order method)
+- **Gate:** `KIS_MOCK_SCALPING_WS_ENABLED=true` (default off → no-op, exit 0)
+
+## Safety boundary
+
+- The quote WS client has **no order surface** (enforced by `tests/brokers/kis/mock_scalping_ws/test_import_guard.py` — the package may not import any order/ledger/execution-mutation module).
+- Host separation is fail-closed: the URL is built from `WEBSOCKET_ENDPOINT_HOSTS[account_mode]` (`ops.koreainvestment.com:21000` live / `:31000` mock) and asserted against that allowlist.
+- The approval key is issued via the account-mode-aware path (`approval_keys.get_approval_key(account_mode)`): live uses `openapi.koreainvestment.com:9443` + `KIS_APP_KEY/SECRET`; mock uses `openapivts.koreainvestment.com:29443` + `KIS_MOCK_APP_KEY/SECRET` and fails closed (env-name-only error) when mock config is missing.
+
+## Prerequisites
+
+- Approval-key credentials for the chosen `--account-mode`:
+  - `kis_mock`: `KIS_MOCK_ENABLED=true`, `KIS_MOCK_APP_KEY`, `KIS_MOCK_APP_SECRET`, `KIS_MOCK_ACCOUNT_NO`.
+  - `kis_live`: `KIS_APP_KEY`, `KIS_APP_SECRET`.
+- Redis reachable (approval-key cache).
+
+## Run
+
+```bash
+# disabled by default → no-op, exit 0
+uv run python -m scripts.kis_mock_scalping_ws_smoke
+
+# enabled, mock environment
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_ws_smoke \
+    --account-mode kis_mock --symbols 005930,000660 --max-events 5 --max-seconds 30
+```
+
+### Exit codes
+
+| code | meaning |
+|------|---------|
+| 0 | success (or disabled no-op) |
+| 1 | unexpected exception |
+| 2 | subscription ACK failure |
+| 3 | connection not established |
+| 4 | connected/subscribed but no quote events arrived in the window |
+
+## OPEN QUESTION this smoke resolves
+
+Does the KIS **mock** WS (`:31000`) serve real-time quotes, or must quotes come
+from the **live** WS (`:21000`)? Run both and record the result here:
+
+```bash
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_ws_smoke --account-mode kis_mock --max-events 5 --max-seconds 30
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_ws_smoke --account-mode kis_live --max-events 5 --max-seconds 30
+```
+
+- Exit 0 with `ticks>0`/`books>0` → that host serves quotes.
+- Exit 4 (no events) → that host does not serve quotes during the window; use the other.
+
+**Result (fill in after running):**
+
+| account_mode | ticks | books | verdict |
+|--------------|-------|-------|---------|
+| kis_mock     | _TBD_ | _TBD_ | _TBD_   |
+| kis_live     | _TBD_ | _TBD_ | _TBD_   |
+
+> Note: also confirm the parsed `last_price`/`bid`/`ask` look sane against a known
+> quote. If a field is consistently wrong, the documented `H0STCNT0`/`H0STASP0`
+> field indices in `quote_protocol.py` need a one-line adjustment.
+
+## Caveats
+
+- Run **during KRX market hours** — outside trading hours the stream is idle and the smoke will return exit 4 (no events) even on a healthy connection.
+- This is the market-data half only. Orders remain a separate mock-only REST path (PR1 guard + PR4 executor) and are never reachable from this client.

--- a/scripts/kis_mock_scalping_ws_smoke.py
+++ b/scripts/kis_mock_scalping_ws_smoke.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""KIS mock scalping quote WebSocket smoke (ROB-321 PR2).
+
+Read-only: connects the quote/orderbook WebSocket, prints a bounded number of
+parsed ticks/orderbook snapshots, and exits. Never places orders, never mutates,
+never publishes. Default-disabled — requires KIS_MOCK_SCALPING_WS_ENABLED=true.
+
+This smoke also RESOLVES the open question "does the KIS mock (:31000) WS serve
+real-time quotes, or must quotes come from the live (:21000) WS?": run it once
+with --account-mode kis_mock and once with kis_live and record which yields
+ticks in docs/runbooks/kis-mock-scalping-ws-smoke.md.
+
+Exit codes:
+    0  - success (or disabled no-op)
+    1  - unexpected exception
+    2  - subscription ACK failure
+    3  - connection not established
+    4  - no quote events received within the window
+
+Usage:
+    KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_ws_smoke \
+        --account-mode kis_mock --symbols 005930,000660 --max-events 5 --max-seconds 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import sys
+
+from app.core.config import settings
+from app.services.brokers.kis.mock_scalping_ws.market_stream import KISQuoteWebSocket
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="KIS quote WS read-only smoke")
+    parser.add_argument(
+        "--account-mode",
+        choices=("kis_mock", "kis_live"),
+        default="kis_mock",
+        help="Quote WS environment (default: kis_mock).",
+    )
+    parser.add_argument(
+        "--symbols",
+        default="005930",
+        help="Comma-separated KR stock codes (default: 005930).",
+    )
+    parser.add_argument("--max-events", type=int, default=5)
+    parser.add_argument("--max-seconds", type=float, default=30.0)
+    return parser.parse_args(argv)
+
+
+async def run_smoke(args: argparse.Namespace) -> int:
+    if not settings.kis_mock_scalping_ws_enabled:
+        logger.info(
+            "KIS_MOCK_SCALPING_WS_ENABLED is not set; quote WS smoke is disabled (no-op)."
+        )
+        return 0
+
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    counters = {"ticks": 0, "books": 0}
+    done = asyncio.Event()
+
+    def _maybe_done() -> None:
+        if counters["ticks"] + counters["books"] >= args.max_events:
+            done.set()
+
+    def _on_tick(tick: QuoteTick) -> None:
+        counters["ticks"] += 1
+        logger.info("tick %s last=%s ts=%s", tick.symbol, tick.last_price, tick.ts)
+        _maybe_done()
+
+    def _on_book(book: OrderBookSnapshot) -> None:
+        counters["books"] += 1
+        logger.info(
+            "book %s bid=%s ask=%s bid_qty=%s ask_qty=%s",
+            book.symbol,
+            book.bid,
+            book.ask,
+            book.bid_qty,
+            book.ask_qty,
+        )
+        _maybe_done()
+
+    client = KISQuoteWebSocket(
+        symbols=symbols,
+        on_tick=_on_tick,
+        on_book=_on_book,
+        account_mode=args.account_mode,
+    )
+    client.is_running = True
+
+    try:
+        await client.connect_and_subscribe()
+    except KISSubscriptionAckError as exc:
+        logger.error("Quote subscription ACK failed: %s", exc)
+        return 2
+    except RuntimeError as exc:
+        logger.error("Quote WS connection failed: %s", exc)
+        return 3
+
+    listen_task = asyncio.create_task(client.listen())
+    try:
+        await asyncio.wait_for(done.wait(), timeout=args.max_seconds)
+    except TimeoutError:
+        logger.info("max-seconds reached without hitting max-events")
+    finally:
+        await client.stop()
+        listen_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await listen_task
+
+    total = counters["ticks"] + counters["books"]
+    logger.info(
+        "quote WS smoke done: account_mode=%s ticks=%s books=%s",
+        args.account_mode,
+        counters["ticks"],
+        counters["books"],
+    )
+    if total == 0:
+        logger.error(
+            "No quote events received on account_mode=%s — this host may not serve "
+            "real-time quotes; retry with the other --account-mode.",
+            args.account_mode,
+        )
+        return 4
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    args = _parse_args(argv)
+    try:
+        return asyncio.run(run_smoke(args))
+    except Exception:
+        logger.exception("Quote WS smoke failed with an unexpected exception")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/brokers/kis/mock_scalping_ws/test_import_guard.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_import_guard.py
@@ -1,0 +1,69 @@
+"""AST import guard: the read-only quote WS package must reach no order/ledger code.
+
+ROB-321 PR2: ``app/services/brokers/kis/mock_scalping_ws/`` streams market data
+only. It may use read-only infra (approval keys, WS constants/protocol, parsers)
+but must never import any order-submission, order-validation, trading-service,
+execution-mutation, or ledger/reconcile module — keeping the order safety
+boundary structural, not merely conventional.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import app.services.brokers.kis.mock_scalping_ws as pkg
+
+_PACKAGE_DIR = Path(pkg.__file__).parent
+
+# Substrings that must not appear in any imported module path.
+_FORBIDDEN_IMPORT_FRAGMENTS = (
+    "order_execution",
+    "order_validation",
+    "orders_",
+    ".orders",
+    "kis_trading_service",
+    "trading_service",
+    "execution_client",
+    "domestic_orders",
+    "overseas_orders",
+    "kis_mock_lifecycle",
+    "kis_mock_holdings",
+    "holdings_reconciler",
+    "ledger",
+    "reconcil",
+    "brokers.binance",
+)
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                modules.append(node.module)
+    return modules
+
+
+@pytest.mark.unit
+def test_quote_ws_package_imports_no_order_or_ledger_module() -> None:
+    py_files = sorted(_PACKAGE_DIR.glob("*.py"))
+    assert py_files, "expected at least one module in mock_scalping_ws"
+
+    violations: list[str] = []
+    for path in py_files:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for module in _imported_modules(tree):
+            for fragment in _FORBIDDEN_IMPORT_FRAGMENTS:
+                if fragment in module:
+                    violations.append(
+                        f"{path.name}: imports {module!r} (matched {fragment!r})"
+                    )
+
+    assert not violations, (
+        "read-only quote WS package reached forbidden code:\n" + "\n".join(violations)
+    )

--- a/tests/brokers/kis/mock_scalping_ws/test_market_stream.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_market_stream.py
@@ -179,3 +179,106 @@ async def test_connect_uses_account_mode_approval_key(mocker) -> None:
     assert client.is_connected is True
     # 1 symbol x 2 TRs = 2 subscription sends
     assert fake_ws.send.await_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_connect_raises_after_max_attempts(mocker) -> None:
+    from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+    client = _make_client(account_mode="kis_mock")
+    client.is_running = True
+    client.reconnect_delay = 0
+    client.max_reconnect_attempts = 2
+
+    mocker.patch(f"{INTERNAL}.get_approval_key", new=AsyncMock(return_value="k"))
+    mocker.patch(
+        "app.services.brokers.kis.mock_scalping_ws.market_stream.websockets.connect",
+        new=AsyncMock(
+            side_effect=KISSubscriptionAckError("H0STCNT0", "9", "X", "boom")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="not established"):
+        await client.connect_and_subscribe()
+    assert client.current_attempt == 2
+    assert client.is_connected is False
+
+
+@pytest.mark.unit
+def test_validate_ack_rejects_bad_rt_cd() -> None:
+    from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+    client = _make_client()
+    with pytest.raises(KISSubscriptionAckError):
+        client._validate_subscription_ack(
+            '{"body": {"rt_cd": "1", "msg_cd": "E", "msg1": "nope"}}',
+            DOMESTIC_TRADE_TR,
+            "005930",
+        )
+
+
+@pytest.mark.unit
+def test_validate_ack_accepts_realtime_data_frame() -> None:
+    client = _make_client()
+    # A pipe-delimited data frame is not an ACK envelope -> accepted (no raise).
+    client._validate_subscription_ack(_trade_frame(), DOMESTIC_TRADE_TR, "005930")
+
+
+@pytest.mark.unit
+def test_validate_ack_missing_body_raises() -> None:
+    from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+    client = _make_client()
+    with pytest.raises(KISSubscriptionAckError):
+        client._validate_subscription_ack('{"header": {}}', DOMESTIC_TRADE_TR, "005930")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_subscribe_quotes_requires_symbols() -> None:
+    client = _make_client()
+    client.websocket = AsyncMock()
+    client.approval_key = "k"
+    client.symbols = []
+    with pytest.raises(ValueError, match="No symbols"):
+        await client._subscribe_quotes()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_supports_sync_callbacks() -> None:
+    seen: list[str] = []
+    client = _make_client(
+        on_tick=lambda t: seen.append(f"tick:{t.symbol}"),
+        on_book=lambda b: seen.append(f"book:{b.symbol}"),
+    )
+    await client._dispatch(_trade_frame())
+    await client._dispatch(_orderbook_frame())
+    assert seen == ["tick:005930", "book:005930"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stop_closes_websocket() -> None:
+    client = _make_client()
+    ws = AsyncMock()
+    client.websocket = ws
+    client.is_running = True
+
+    await client.stop()
+
+    ws.close.assert_awaited_once()
+    assert client.websocket is None
+    assert client.is_connected is False
+    assert client.is_running is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_close_best_effort_is_none_safe() -> None:
+    client = _make_client()
+    client.websocket = None
+    # Should not raise.
+    await client._close_websocket_best_effort()
+    assert client.websocket is None

--- a/tests/brokers/kis/mock_scalping_ws/test_market_stream.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_market_stream.py
@@ -1,0 +1,181 @@
+"""Read-only KISQuoteWebSocket client tests (ROB-321 PR2 Task 3)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.market_stream import KISQuoteWebSocket
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.brokers.kis.mock_scalping_ws.quote_protocol import (
+    DOMESTIC_ORDERBOOK_TR,
+    DOMESTIC_TRADE_TR,
+)
+
+INTERNAL = "app.services.kis_websocket_internal.approval_keys"
+
+
+def _trade_frame(symbol: str = "005930", price: str = "70500") -> str:
+    fields = [""] * 20
+    fields[0] = symbol
+    fields[1] = "131502"
+    fields[2] = price
+    return f"0|{DOMESTIC_TRADE_TR}|001|" + "^".join(fields)
+
+
+def _orderbook_frame(symbol: str = "005930") -> str:
+    fields = [""] * 60
+    fields[0] = symbol
+    fields[3] = "70600"  # ask1
+    fields[13] = "70500"  # bid1
+    fields[23] = "120"  # ask qty1
+    fields[33] = "200"  # bid qty1
+    return f"0|{DOMESTIC_ORDERBOOK_TR}|001|" + "^".join(fields)
+
+
+def _make_client(**kwargs) -> KISQuoteWebSocket:
+    return KISQuoteWebSocket(
+        symbols=kwargs.pop("symbols", ["005930"]),
+        on_tick=kwargs.pop("on_tick", AsyncMock()),
+        on_book=kwargs.pop("on_book", AsyncMock()),
+        **kwargs,
+    )
+
+
+@pytest.mark.unit
+def test_rejects_unknown_account_mode() -> None:
+    with pytest.raises(ValueError, match="account_mode"):
+        _make_client(account_mode="alpaca_paper")
+
+
+@pytest.mark.unit
+def test_build_url_live_and_mock() -> None:
+    live = _make_client(account_mode="kis_live")
+    assert live._build_url() == "ws://ops.koreainvestment.com:21000/tryitout"
+    mock = _make_client(account_mode="kis_mock")
+    assert mock._build_url() == "ws://ops.koreainvestment.com:31000/tryitout"
+
+
+@pytest.mark.unit
+def test_has_no_order_surface() -> None:
+    client = _make_client()
+    for forbidden in ("submit_order", "place_order", "send_order", "cancel_order"):
+        assert not hasattr(client, forbidden)
+
+
+@pytest.mark.unit
+def test_subscription_request_shape() -> None:
+    client = _make_client()
+    client.approval_key = "approval-123"
+    req = client._build_subscription_request(DOMESTIC_TRADE_TR, "005930")
+    assert req["header"]["approval_key"] == "approval-123"
+    assert req["header"]["tr_type"] == "1"
+    assert req["body"]["input"]["tr_id"] == DOMESTIC_TRADE_TR
+    assert req["body"]["input"]["tr_key"] == "005930"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_routes_tick_and_book() -> None:
+    on_tick = AsyncMock()
+    on_book = AsyncMock()
+    client = _make_client(on_tick=on_tick, on_book=on_book)
+
+    await client._dispatch(_trade_frame(price="70500"))
+    await client._dispatch(_orderbook_frame())
+
+    on_tick.assert_awaited_once()
+    assert isinstance(on_tick.await_args.args[0], QuoteTick)
+    assert on_tick.await_args.args[0].last_price == 70500.0
+    on_book.assert_awaited_once()
+    assert isinstance(on_book.await_args.args[0], OrderBookSnapshot)
+    assert client.tick_events_received == 1
+    assert client.book_events_received == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_ignores_junk_and_unknown_tr() -> None:
+    on_tick = AsyncMock()
+    on_book = AsyncMock()
+    client = _make_client(on_tick=on_tick, on_book=on_book)
+
+    await client._dispatch("garbage")
+    await client._dispatch("0|H0STCNI0|001|005930^x")  # execution TR, not a quote
+
+    on_tick.assert_not_awaited()
+    on_book.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_listen_dispatches_from_fake_ws() -> None:
+    on_tick = AsyncMock()
+    on_book = AsyncMock()
+    client = _make_client(on_tick=on_tick, on_book=on_book)
+    client.websocket = AsyncMock()
+    client.websocket.__aiter__.return_value = [
+        _trade_frame(price="70500"),
+        _orderbook_frame(),
+    ]
+
+    await client.listen()
+
+    on_tick.assert_awaited_once()
+    on_book.assert_awaited_once()
+    assert client.messages_received == 2
+    assert client.last_message_at is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_listen_echoes_pingpong_without_dispatch() -> None:
+    on_tick = AsyncMock()
+    client = _make_client(on_tick=on_tick)
+    client.websocket = AsyncMock()
+    client.websocket.send = AsyncMock()
+    client.websocket.__aiter__.return_value = ["0|pingpong"]
+
+    await client.listen()
+
+    client.websocket.send.assert_awaited_once_with("0|pingpong")
+    on_tick.assert_not_awaited()
+    assert client.messages_received == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_listen_without_websocket_raises() -> None:
+    client = _make_client()
+    client.websocket = None
+    with pytest.raises(RuntimeError, match="not connected"):
+        await client.listen()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_connect_uses_account_mode_approval_key(mocker) -> None:
+    client = _make_client(account_mode="kis_mock")
+    client.is_running = True
+
+    get_key = mocker.patch(
+        f"{INTERNAL}.get_approval_key", new=AsyncMock(return_value="mock-key")
+    )
+    fake_ws = AsyncMock()
+    fake_ws.recv = AsyncMock(return_value='{"body": {"rt_cd": "0"}}')
+    mocker.patch(
+        "app.services.brokers.kis.mock_scalping_ws.market_stream.websockets.connect",
+        new=AsyncMock(return_value=fake_ws),
+    )
+
+    await client.connect_and_subscribe()
+
+    get_key.assert_awaited_once_with("kis_mock")
+    assert client.approval_key == "mock-key"
+    assert client.is_connected is True
+    # 1 symbol x 2 TRs = 2 subscription sends
+    assert fake_ws.send.await_count == 2

--- a/tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py
@@ -1,0 +1,82 @@
+"""Pure KIS quote-frame parser tests (ROB-321 PR2 Task 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+    parse_quote_frame,
+)
+from app.services.brokers.kis.mock_scalping_ws.quote_protocol import (
+    DOMESTIC_ORDERBOOK_TR,
+    DOMESTIC_TRADE_TR,
+)
+
+
+def _trade_frame(
+    symbol: str = "005930", time: str = "131502", price: str = "70500"
+) -> str:
+    # H0STCNT0: idx0 symbol, idx1 time(HHMMSS), idx2 last price. Pad to 20 fields.
+    fields = [""] * 20
+    fields[0] = symbol
+    fields[1] = time
+    fields[2] = price
+    return f"0|{DOMESTIC_TRADE_TR}|001|" + "^".join(fields)
+
+
+def _orderbook_frame(
+    symbol: str = "005930",
+    ask1: str = "70600",
+    bid1: str = "70500",
+    ask_qty1: str = "120",
+    bid_qty1: str = "200",
+) -> str:
+    # H0STASP0: idx0 symbol, idx3 ASKP1, idx13 BIDP1, idx23 ASKP_RSQN1, idx33 BIDP_RSQN1.
+    fields = [""] * 60
+    fields[0] = symbol
+    fields[3] = ask1
+    fields[13] = bid1
+    fields[23] = ask_qty1
+    fields[33] = bid_qty1
+    return f"0|{DOMESTIC_ORDERBOOK_TR}|001|" + "^".join(fields)
+
+
+@pytest.mark.unit
+def test_parse_trade_frame() -> None:
+    result = parse_quote_frame(_trade_frame(price="70500"))
+    assert isinstance(result, QuoteTick)
+    assert result.symbol == "005930"
+    assert result.last_price == 70500.0
+    assert result.ts == "131502"
+
+
+@pytest.mark.unit
+def test_parse_orderbook_frame() -> None:
+    result = parse_quote_frame(_orderbook_frame())
+    assert isinstance(result, OrderBookSnapshot)
+    assert result.symbol == "005930"
+    assert result.ask == 70600.0
+    assert result.bid == 70500.0
+    assert result.ask_qty == 120.0
+    assert result.bid_qty == 200.0
+
+
+@pytest.mark.unit
+def test_encrypted_frame_rejected() -> None:
+    # Leading "1" = encrypted; quotes are never encrypted -> reject (return None).
+    enc = _trade_frame().replace("0|", "1|", 1)
+    assert parse_quote_frame(enc) is None
+
+
+@pytest.mark.unit
+def test_unknown_tr_returns_none() -> None:
+    assert parse_quote_frame("0|H0STCNI0|001|005930^x^y") is None
+
+
+@pytest.mark.unit
+def test_malformed_frame_returns_none() -> None:
+    assert parse_quote_frame("garbage") is None
+    assert parse_quote_frame("") is None
+    assert parse_quote_frame("0|H0STCNT0") is None

--- a/tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py
@@ -80,3 +80,22 @@ def test_malformed_frame_returns_none() -> None:
     assert parse_quote_frame("garbage") is None
     assert parse_quote_frame("") is None
     assert parse_quote_frame("0|H0STCNT0") is None
+
+
+@pytest.mark.unit
+def test_parses_bytes_frame() -> None:
+    result = parse_quote_frame(_trade_frame(price="70500").encode("utf-8"))
+    assert isinstance(result, QuoteTick)
+    assert result.last_price == 70500.0
+
+
+@pytest.mark.unit
+def test_invalid_bytes_returns_none() -> None:
+    assert parse_quote_frame(b"\xff\xfe\x00bad") is None
+
+
+@pytest.mark.unit
+def test_empty_symbol_returns_none() -> None:
+    fields = [""] * 20
+    fields[2] = "70500"  # price set but symbol (idx 0) blank
+    assert parse_quote_frame(f"0|{DOMESTIC_TRADE_TR}|001|" + "^".join(fields)) is None

--- a/tests/brokers/kis/mock_scalping_ws/test_smoke_cli.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_smoke_cli.py
@@ -1,0 +1,28 @@
+"""Quote WS smoke gating tests (ROB-321 PR2 Task 4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from scripts import kis_mock_scalping_ws_smoke as smoke
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_disabled_is_noop(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", False)
+    # If the gate fails, this construction would be attempted — assert it is NOT.
+    construct = mocker.patch.object(smoke, "KISQuoteWebSocket")
+
+    args = smoke._parse_args(["--symbols", "005930", "--max-events", "1"])
+    rc = await smoke.run_smoke(args)
+
+    assert rc == 0
+    construct.assert_not_called()
+
+
+@pytest.mark.unit
+def test_smoke_defaults_to_mock_account_mode() -> None:
+    args = smoke._parse_args([])
+    assert args.account_mode == "kis_mock"

--- a/tests/brokers/kis/mock_scalping_ws/test_smoke_cli.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_smoke_cli.py
@@ -2,10 +2,37 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.core.config import settings
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import QuoteTick
+from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
 from scripts import kis_mock_scalping_ws_smoke as smoke
+
+
+def _fake_client(mocker, *, listen=None, connect_exc=None):
+    """Patch KISQuoteWebSocket with a fake whose listen() can drive callbacks."""
+    captured: dict = {}
+
+    def _factory(**kwargs):
+        captured.update(kwargs)
+        client = AsyncMock()
+        client.is_running = False
+        if connect_exc is not None:
+            client.connect_and_subscribe = AsyncMock(side_effect=connect_exc)
+        else:
+            client.connect_and_subscribe = AsyncMock()
+        if listen is not None:
+            client.listen = lambda: listen(captured)
+        else:
+            client.listen = AsyncMock()
+        client.stop = AsyncMock()
+        return client
+
+    mocker.patch.object(smoke, "KISQuoteWebSocket", side_effect=_factory)
+    return captured
 
 
 @pytest.mark.unit
@@ -26,3 +53,53 @@ async def test_smoke_disabled_is_noop(mocker) -> None:
 def test_smoke_defaults_to_mock_account_mode() -> None:
     args = smoke._parse_args([])
     assert args.account_mode == "kis_mock"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_success_returns_0(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", True)
+
+    async def _listen(captured):
+        # Drive enough events to hit max-events -> done.set()
+        captured["on_tick"](QuoteTick(symbol="005930", last_price=1.0, ts="1"))
+
+    _fake_client(mocker, listen=_listen)
+    args = smoke._parse_args(["--max-events", "1", "--max-seconds", "5"])
+    rc = await smoke.run_smoke(args)
+    assert rc == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_ack_failure_returns_2(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", True)
+    _fake_client(
+        mocker,
+        connect_exc=KISSubscriptionAckError("H0STCNT0", "9", "X", "boom"),
+    )
+    rc = await smoke.run_smoke(smoke._parse_args([]))
+    assert rc == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_connect_failure_returns_3(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", True)
+    _fake_client(mocker, connect_exc=RuntimeError("not established"))
+    rc = await smoke.run_smoke(smoke._parse_args([]))
+    assert rc == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_smoke_no_events_returns_4(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", True)
+
+    async def _listen(_captured):
+        return None  # connected but emits nothing
+
+    _fake_client(mocker, listen=_listen)
+    args = smoke._parse_args(["--max-events", "5", "--max-seconds", "0.05"])
+    rc = await smoke.run_smoke(args)
+    assert rc == 4

--- a/tests/brokers/kis/mock_scalping_ws/test_state.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_state.py
@@ -1,0 +1,77 @@
+"""Per-symbol MarketState tracker tests (ROB-321 PR2 Task 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+
+@pytest.mark.unit
+def test_tick_updates_last_price_and_ts() -> None:
+    state = MarketState(symbol="005930")
+    state.update_from_tick(
+        QuoteTick(symbol="005930", last_price=70500.0, ts="131502"), now=100.0
+    )
+    assert state.last_price == 70500.0
+    assert state.last_ts == "131502"
+
+
+@pytest.mark.unit
+def test_book_updates_bid_ask_and_spread() -> None:
+    state = MarketState(symbol="005930")
+    state.update_from_book(
+        OrderBookSnapshot(
+            symbol="005930", bid=70500.0, ask=70600.0, bid_qty=200.0, ask_qty=120.0
+        ),
+        now=100.0,
+    )
+    assert state.bid == 70500.0
+    assert state.ask == 70600.0
+    # spread_bps = (ask-bid)/mid * 10000 = 100 / 70550 * 10000 ≈ 14.17
+    assert state.spread_bps() == pytest.approx(14.17, abs=0.1)
+
+
+@pytest.mark.unit
+def test_spread_none_until_book_seen() -> None:
+    state = MarketState(symbol="005930")
+    assert state.spread_bps() is None
+    state.update_from_tick(
+        QuoteTick(symbol="005930", last_price=70500.0, ts="131502"), now=100.0
+    )
+    # tick alone does not establish a book
+    assert state.spread_bps() is None
+
+
+@pytest.mark.unit
+def test_age_seconds_tracks_latest_update() -> None:
+    state = MarketState(symbol="005930")
+    assert state.age_seconds(now=100.0) is None  # never updated
+    state.update_from_tick(
+        QuoteTick(symbol="005930", last_price=70500.0, ts="131502"), now=100.0
+    )
+    assert state.age_seconds(now=102.5) == pytest.approx(2.5)
+    # a newer book update resets the freshness clock
+    state.update_from_book(
+        OrderBookSnapshot(
+            symbol="005930", bid=70500.0, ask=70600.0, bid_qty=1.0, ask_qty=1.0
+        ),
+        now=105.0,
+    )
+    assert state.age_seconds(now=106.0) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_spread_none_when_bid_or_ask_nonpositive() -> None:
+    state = MarketState(symbol="005930")
+    state.update_from_book(
+        OrderBookSnapshot(
+            symbol="005930", bid=0.0, ask=70600.0, bid_qty=1.0, ask_qty=1.0
+        ),
+        now=100.0,
+    )
+    assert state.spread_bps() is None

--- a/tests/services/kis_websocket/test_approval_keys.py
+++ b/tests/services/kis_websocket/test_approval_keys.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core.config import settings
 from app.services import kis_websocket as mod
 from app.services.kis_websocket_internal.constants import (
     APPROVAL_KEY_CACHE_KEY,
@@ -48,7 +49,7 @@ async def test_get_approval_key_miss_flow(mocker):
 
     assert result == "fresh"
     mock_issue.assert_awaited_once()
-    mock_cache.assert_awaited_once_with("fresh")
+    mock_cache.assert_awaited_once_with("fresh", "kis_live")
 
 
 @pytest.mark.asyncio
@@ -252,7 +253,7 @@ class TestApprovalKeyRedisCache:
                     result = await mod.get_approval_key()
 
                     assert result == "fresh_key_abc"
-                    cache_spy.assert_called_once_with("fresh_key_abc")
+                    cache_spy.assert_called_once_with("fresh_key_abc", "kis_live")
 
     @pytest.mark.asyncio
     async def test_cache_constants_are_correct(self):
@@ -320,7 +321,7 @@ class TestApprovalKeyEmptyCacheMiss:
                     result = await mod.get_approval_key()
 
                     assert result == "fresh_key_empty"
-                    cache_spy.assert_called_once_with("fresh_key_empty")
+                    cache_spy.assert_called_once_with("fresh_key_empty", "kis_live")
 
     @pytest.mark.asyncio
     async def test_whitespace_cache_treated_as_miss(self):
@@ -351,7 +352,7 @@ class TestApprovalKeyEmptyCacheMiss:
                     result = await mod.get_approval_key()
 
                     assert result == "fresh_key_ws"
-                    cache_spy.assert_called_once_with("fresh_key_ws")
+                    cache_spy.assert_called_once_with("fresh_key_ws", "kis_live")
 
 
 @pytest.mark.unit
@@ -430,3 +431,156 @@ class TestCloseApprovalKeyRedis:
         assert mock_redis.close.call_count == 1  # Not called again
 
         assert internal_mod._redis_client is None
+
+
+@pytest.mark.unit
+class TestAccountModeAwareApprovalKey:
+    """ROB-321: live/mock split for WebSocket approval-key issuance."""
+
+    def _mock_httpx(self, mocker, *, approval_key: str = "issued_key"):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"approval_key": approval_key}
+        mock_response.raise_for_status = MagicMock()
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_client = mocker.patch(f"{INTERNAL}.httpx.AsyncClient")
+        mock_client.return_value.__aenter__ = AsyncMock(
+            return_value=mock_client_instance
+        )
+        mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+        return mock_client_instance
+
+    @pytest.mark.asyncio
+    async def test_live_uses_live_endpoint_and_credentials(self, mocker):
+        mocker.patch.object(
+            settings, "kis_base_url", "https://openapi.koreainvestment.com:9443"
+        )
+        mocker.patch.object(settings, "kis_app_key", "LIVE_KEY")
+        mocker.patch.object(settings, "kis_app_secret", "LIVE_SECRET")
+        post = self._mock_httpx(mocker)
+
+        result = await mod._issue_approval_key("kis_live")
+
+        assert result == "issued_key"
+        call = post.post.call_args
+        assert (
+            call.args[0] == "https://openapi.koreainvestment.com:9443/oauth2/Approval"
+        )
+        assert call.kwargs["json"]["appkey"] == "LIVE_KEY"
+        assert call.kwargs["json"]["secretkey"] == "LIVE_SECRET"
+
+    @pytest.mark.asyncio
+    async def test_mock_uses_mock_endpoint_and_credentials(self, mocker):
+        mocker.patch.object(settings, "kis_mock_enabled", True)
+        mocker.patch.object(settings, "kis_mock_app_key", "MOCK_KEY")
+        mocker.patch.object(settings, "kis_mock_app_secret", "MOCK_SECRET")
+        mocker.patch.object(settings, "kis_mock_account_no", "50000000-01")
+        mocker.patch.object(
+            settings,
+            "kis_mock_base_url",
+            "https://openapivts.koreainvestment.com:29443",
+        )
+        post = self._mock_httpx(mocker)
+
+        result = await mod._issue_approval_key("kis_mock")
+
+        assert result == "issued_key"
+        call = post.post.call_args
+        assert (
+            call.args[0]
+            == "https://openapivts.koreainvestment.com:29443/oauth2/Approval"
+        )
+        assert call.kwargs["json"]["appkey"] == "MOCK_KEY"
+        assert call.kwargs["json"]["secretkey"] == "MOCK_SECRET"
+
+    @pytest.mark.asyncio
+    async def test_mock_fail_closed_when_config_missing(self, mocker):
+        mocker.patch.object(settings, "kis_mock_enabled", False)
+        mocker.patch.object(settings, "kis_mock_app_key", None)
+        mocker.patch.object(settings, "kis_mock_app_secret", None)
+        mocker.patch.object(settings, "kis_mock_account_no", None)
+        post = self._mock_httpx(mocker)
+
+        with pytest.raises(ValueError) as exc:
+            await mod._issue_approval_key("kis_mock")
+
+        msg = str(exc.value)
+        # Surfaces only the missing env var NAMES, never secret values.
+        assert "KIS_MOCK_ENABLED" in msg
+        assert "KIS_MOCK_APP_KEY" in msg
+        assert "KIS_MOCK_APP_SECRET" in msg
+        # Fail-closed: no HTTP request was ever issued.
+        post.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_namespace_live_vs_mock(self, mocker):
+        mock_redis = AsyncMock()
+        mocker.patch(f"{INTERNAL}._get_redis_client", return_value=mock_redis)
+
+        await mod._cache_approval_key("k", "kis_live")
+        await mod._cache_approval_key("k", "kis_mock")
+
+        set_keys = [c.args[0] for c in mock_redis.set.call_args_list]
+        assert set_keys == [
+            "kis:websocket:approval_key",
+            "kis_mock:websocket:approval_key",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_cached_namespace_mock(self, mocker):
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value="cached_mock")
+        mocker.patch(f"{INTERNAL}._get_redis_client", return_value=mock_redis)
+
+        result = await mod._get_cached_approval_key("kis_mock")
+
+        assert result == "cached_mock"
+        mock_redis.get.assert_called_once_with("kis_mock:websocket:approval_key")
+
+    @pytest.mark.asyncio
+    async def test_unknown_account_mode_rejected(self):
+        with pytest.raises(ValueError, match="account_mode"):
+            await mod._issue_approval_key("alpaca_paper")
+        with pytest.raises(ValueError, match="account_mode"):
+            await mod.get_approval_key("db_simulated")
+
+    @pytest.mark.asyncio
+    async def test_host_allowlist_rejects_tampered_base_url(self, mocker):
+        mocker.patch.object(settings, "kis_base_url", "https://evil.example.com:443")
+        post = self._mock_httpx(mocker)
+
+        with pytest.raises(ValueError, match="not allowed"):
+            await mod._issue_approval_key("kis_live")
+
+        post.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mock_reissue_path_uses_mock_endpoint_and_namespace(self, mocker):
+        # Mirrors the client recoverable-ACK reissue sequence:
+        # _issue_approval_key(account_mode) then _cache_approval_key(key, account_mode).
+        mocker.patch.object(settings, "kis_mock_enabled", True)
+        mocker.patch.object(settings, "kis_mock_app_key", "MOCK_KEY")
+        mocker.patch.object(settings, "kis_mock_app_secret", "MOCK_SECRET")
+        mocker.patch.object(settings, "kis_mock_account_no", "50000000-01")
+        mocker.patch.object(
+            settings,
+            "kis_mock_base_url",
+            "https://openapivts.koreainvestment.com:29443",
+        )
+        post = self._mock_httpx(mocker, approval_key="reissued_mock")
+        mock_redis = AsyncMock()
+        mocker.patch(f"{INTERNAL}._get_redis_client", return_value=mock_redis)
+
+        key = await mod._issue_approval_key("kis_mock")
+        await mod._cache_approval_key(key, "kis_mock")
+
+        assert key == "reissued_mock"
+        assert (
+            post.post.call_args.args[0]
+            == "https://openapivts.koreainvestment.com:29443/oauth2/Approval"
+        )
+        mock_redis.set.assert_called_once_with(
+            "kis_mock:websocket:approval_key",
+            "reissued_mock",
+            ex=APPROVAL_KEY_TTL_SECONDS,
+        )

--- a/tests/services/kis_websocket/test_client.py
+++ b/tests/services/kis_websocket/test_client.py
@@ -231,7 +231,7 @@ class TestKISWebSocketClient:
         assert client.is_connected is True
         assert client.approval_key == "fresh-key"
         reissue_mock.assert_awaited_once()
-        cache_mock.assert_awaited_once_with("fresh-key")
+        cache_mock.assert_awaited_once_with("fresh-key", "kis_live")
         assert close_mock.await_count >= 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## ROB-321 PR2/4 — Read-only KIS quote/orderbook WebSocket + account-mode approval keys

The market-data half of the KIS mock scalping loop: a **read-only** quote/orderbook WebSocket feeding parsed ticks/orderbook snapshots. Edge-agnostic plumbing (strategy is known net-negative per ROB-316; v1 is intentionally a toy). Plan: `docs/plans/ROB-321-pr2-quote-ws-plan.md`.

Builds on PR1 (#963, merged). No order surface anywhere in this PR.

### What's here

- **Pure quote parser** (`mock_scalping_ws/quote_protocol.py`, `quote_parsers.py`): plaintext `H0STCNT0`(체결가)/`H0STASP0`(호가) frames → `QuoteTick`/`OrderBookSnapshot`. Encrypted frames (leading `1`) and non-quote TRs rejected.
- **`MarketState`** (`state.py`): per-symbol bid/ask/last + `spread_bps()` + injected-clock `age_seconds()`. Pure.
- **Account-mode aware WS approval key** — *extended* `kis_websocket_internal/approval_keys.py` (no new client): `get_approval_key/_issue/_cache/_get_cached(account_mode="kis_live"|"kis_mock")`, default `kis_live` (backward compatible). live=`kis_base_url`+`KIS_APP_KEY/SECRET` cache `kis:websocket:approval_key`; mock=`kis_mock_base_url`+`KIS_MOCK_APP_KEY/SECRET` cache `kis_mock:websocket:approval_key`, **fail-closed** via `validate_kis_mock_config()` (env names only). **Fixes a latent bug**: the mock execution WS previously always issued a *live* approval key.
- **Two-layer fail-closed host allowlists** (`constants.py`): approval endpoint (`openapi:9443`/`openapivts:29443`) + websocket endpoint (`ops:21000`/`ops:31000`). `KISExecutionWebSocket` reissue + `_issue_approval_key_if_needed` pass `self.account_mode`; `_build_websocket_url` asserts the WS allowlist.
- **`KISQuoteWebSocket`** (`market_stream.py`): `get_approval_key(account_mode)` → connect → subscribe quote TRs per symbol → `listen()` dispatches to `on_tick`/`on_book`. Bounded reconnect, pingpong echo. **No order method** (structural read-only).
- **Smoke + flag + guard**: `KIS_MOCK_SCALPING_WS_ENABLED` (default off); `scripts/kis_mock_scalping_ws_smoke.py` (default-disabled, no orders, exit 4 = no events); AST **import guard** forbidding any order/ledger/execution import from `mock_scalping_ws/`; `docs/runbooks/kis-mock-scalping-ws-smoke.md`.

### Safety boundary

- Quote WS is **read-only by construction** — no order method + import guard.
- Host separation fail-closed at the transport layer (per the venue-adapter fail-closed convention), not config flags alone.
- Default-disabled flag; no scheduler/Prefect registration. Live order/mutation paths untouched; live safety guards unchanged.

### Tests

115 passing (incl. PR1 sell-guard + live-unaffected regressions). Full lint trio clean (`ruff check` + `ruff format --check` + `ty check app/`).

### Operator follow-up (documented in the runbook)

Two items are documented-but-not-live-verified and resolved by the operator smoke (runbook has a fill-in table):
1. Does the KIS **mock** (`:31000`) WS serve real-time quotes, or must quotes come from **live** (`:21000`)? Run `--account-mode kis_mock` vs `kis_live`.
2. Confirm `H0STCNT0`/`H0STASP0` field indices against a real frame (single-map adjustment if off).

### Next (ROB-321)

PR3 = signal/risk contract + supervisor (dry-run); PR4 = exec bridge + round-trip reconcile (wires PR1's `ScalpingExitContext`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)