### PR TITLE
deploy: promote ROB-317 bounded WS scalping + ROB-321 mock sell-guard to production

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -178,6 +178,7 @@ class Settings(BaseSettings):
     kis_mock_base_url: str = "https://openapivts.koreainvestment.com:29443"
     kis_mock_account_no: str | None = None
     kis_mock_access_token: str | None = None
+    kis_mock_scalping_enabled: bool = False
 
     # Kiwoom Securities mock account. Disabled by default; mock-only foundation
     # added in ROB-97. Live URL is recorded so the runtime can defensively

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -61,6 +61,48 @@ class DefensiveTrimContext:
     approval_verified_at: datetime.datetime
 
 
+@dataclass(frozen=True)
+class ScalpingExitContext:
+    """Mock-only authorization to sell a scalping position below both the
+    avg*1.01 floor and the current-price guard (stop-loss / take-profit /
+    time-stop). Only constructible for is_mock=True orders gated by
+    KIS_MOCK_SCALPING_ENABLED. Never threaded from any live/generic path.
+    """
+
+    strategy_id: str
+    reason: str  # "stop_loss" | "take_profit" | "time_stop"
+
+
+def evaluate_sell_price_guards(
+    *,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    defensive_trim_ctx: DefensiveTrimContext | None,
+    scalping_exit_ctx: ScalpingExitContext | None,
+) -> str | None:
+    """Single source of truth for limit-sell price guards.
+
+    Returns an error message if the price violates a guard, else None.
+
+    Matrix:
+      - scalping_exit_ctx present  -> both guards bypassed (mock scalping exit).
+      - defensive_trim_ctx present -> floor bypassed, current-price guard enforced.
+      - neither                    -> both guards enforced.
+    """
+    if scalping_exit_ctx is not None:
+        return None
+    min_sell_price = avg_price * 1.01
+    if price < min_sell_price and defensive_trim_ctx is None:
+        return (
+            f"Sell price {price} below minimum "
+            f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
+        )
+    if price < current_price:
+        return f"Sell price {price} below current price {current_price}"
+    return None
+
+
 def _is_cached_approved(approval_issue_id: str) -> bool:
     expires_at = _defensive_trim_success_cache.get(approval_issue_id)
     if expires_at is None:
@@ -101,6 +143,32 @@ def _log_defensive_trim_bypass(
             "min_floor": min_sell_price,
             "approval_issue_id": defensive_trim_ctx.approval_issue_id,
             "requester_agent_id": defensive_trim_ctx.requester_agent_id,
+            "phase": phase,
+        },
+    )
+
+
+def _log_scalping_exit_bypass(
+    *,
+    symbol: str,
+    market_type: str,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    scalping_exit_ctx: ScalpingExitContext,
+    phase: str,
+) -> None:
+    logger.warning(
+        "kis_mock_scalping_exit_bypass: sell guards bypassed",
+        extra={
+            "account_mode": "kis_mock",
+            "symbol": symbol,
+            "market_type": market_type,
+            "price": price,
+            "current_price": current_price,
+            "avg_price": avg_price,
+            "strategy_id": scalping_exit_ctx.strategy_id,
+            "reason": scalping_exit_ctx.reason,
             "phase": phase,
         },
     )
@@ -194,6 +262,41 @@ async def _validate_defensive_trim_preconditions(
         requester_agent_id=caller_agent_id,
         approval_verified_at=datetime.datetime.now(datetime.UTC),
     )
+
+
+_SCALPING_EXIT_REASONS = frozenset({"stop_loss", "take_profit", "time_stop"})
+
+
+def _resolve_scalping_exit_context(
+    *,
+    scalping_exit: bool,
+    strategy_id: str | None,
+    reason: str | None,
+    side: str,
+    order_type: str,
+    is_mock: bool,
+) -> ScalpingExitContext | None:
+    """Fail-closed resolution of a mock scalping exit authorization.
+
+    Returns None when not requested. Raises ValueError on any condition that
+    would let a live/generic order acquire the bypass.
+    """
+    if not scalping_exit:
+        return None
+    if not settings.kis_mock_scalping_enabled:
+        raise ValueError("scalping_exit requires KIS_MOCK_SCALPING_ENABLED=true")
+    if not is_mock:
+        raise ValueError("scalping_exit is only available for kis_mock orders")
+    if side != "sell":
+        raise ValueError("scalping_exit requires side='sell'")
+    if order_type != "limit":
+        raise ValueError("scalping_exit requires order_type='limit'")
+    if not strategy_id:
+        raise ValueError("scalping_exit requires strategy_id")
+    resolved_reason = reason or "stop_loss"
+    if resolved_reason not in _SCALPING_EXIT_REASONS:
+        raise ValueError(f"invalid scalping_exit reason: {resolved_reason}")
+    return ScalpingExitContext(strategy_id=strategy_id, reason=resolved_reason)
 
 
 async def _get_current_price_for_order(symbol: str, market_type: str) -> float | None:
@@ -439,6 +542,7 @@ async def _preview_sell(
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None = None,
     is_mock: bool = False,
+    scalping_exit_ctx: ScalpingExitContext | None = None,
 ) -> dict[str, Any]:
     """Build a dry-run preview dict for a sell order."""
     result: dict[str, Any] = {
@@ -462,27 +566,37 @@ async def _preview_sell(
         if price is None:
             result["error"] = "price is required for limit sell orders"
             return result
-        min_sell_price = avg_price * 1.01
-        if price < min_sell_price and defensive_trim_ctx is None:
-            result["error"] = (
-                f"Sell price {price} below minimum "
-                f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
-            )
+        guard_error = evaluate_sell_price_guards(
+            price=price,
+            current_price=current_price,
+            avg_price=avg_price,
+            defensive_trim_ctx=defensive_trim_ctx,
+            scalping_exit_ctx=scalping_exit_ctx,
+        )
+        if guard_error is not None:
+            result["error"] = guard_error
             return result
-        if price < min_sell_price and defensive_trim_ctx is not None:
+        if scalping_exit_ctx is not None and price < avg_price * 1.01:
+            _log_scalping_exit_bypass(
+                symbol=symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
+                scalping_exit_ctx=scalping_exit_ctx,
+                phase="preview",
+            )
+        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
             _log_defensive_trim_bypass(
                 symbol=symbol,
                 market_type=market_type,
                 price=price,
                 current_price=current_price,
                 avg_price=avg_price,
-                min_sell_price=min_sell_price,
+                min_sell_price=avg_price * 1.01,
                 defensive_trim_ctx=defensive_trim_ctx,
                 phase="preview",
             )
-        if price < current_price:
-            result["error"] = f"Sell price {price} below current price {current_price}"
-            return result
         order_quantity = holdings["quantity"] if quantity is None else quantity
         execution_price = price
         result["price"] = execution_price
@@ -512,6 +626,7 @@ async def _preview_order(
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None = None,
     is_mock: bool = False,
+    scalping_exit_ctx: ScalpingExitContext | None = None,
 ) -> dict[str, Any]:
     """Validate order and return a dry-run simulation dict.
 
@@ -535,6 +650,7 @@ async def _preview_order(
         market_type=market_type,
         defensive_trim_ctx=defensive_trim_ctx,
         is_mock=is_mock,
+        scalping_exit_ctx=scalping_exit_ctx,
     )
 
 
@@ -600,6 +716,7 @@ async def _validate_sell_side(
     defensive_trim_ctx: DefensiveTrimContext | None = None,
     is_mock: bool = False,
     dry_run: bool = False,
+    scalping_exit_ctx: ScalpingExitContext | None = None,
 ) -> tuple[float, float, dict[str, Any] | None]:
     """Validate sell-side: check holdings, locked, price constraints.
 
@@ -650,34 +767,35 @@ async def _validate_sell_side(
     avg_price = _to_float(holdings.get("avg_price"), default=0.0)
 
     if order_type == "limit" and price is not None:
-        min_sell_price = avg_price * 1.01
-        if price < min_sell_price and defensive_trim_ctx is None:
-            return (
-                0.0,
-                0.0,
-                order_error_fn(
-                    f"Sell price {price} below minimum "
-                    f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
-                ),
+        guard_error = evaluate_sell_price_guards(
+            price=price,
+            current_price=current_price,
+            avg_price=avg_price,
+            defensive_trim_ctx=defensive_trim_ctx,
+            scalping_exit_ctx=scalping_exit_ctx,
+        )
+        if guard_error is not None:
+            return 0.0, 0.0, order_error_fn(guard_error)
+        if scalping_exit_ctx is not None and price < avg_price * 1.01:
+            _log_scalping_exit_bypass(
+                symbol=normalized_symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
+                scalping_exit_ctx=scalping_exit_ctx,
+                phase="execution",
             )
-        if price < min_sell_price and defensive_trim_ctx is not None:
+        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
             _log_defensive_trim_bypass(
                 symbol=normalized_symbol,
                 market_type=market_type,
                 price=price,
                 current_price=current_price,
                 avg_price=avg_price,
-                min_sell_price=min_sell_price,
+                min_sell_price=avg_price * 1.01,
                 defensive_trim_ctx=defensive_trim_ctx,
                 phase="execution",
-            )
-        if price < current_price:
-            return (
-                0.0,
-                0.0,
-                order_error_fn(
-                    f"Sell price {price} below current price {current_price}"
-                ),
             )
 
     return order_quantity, avg_price, None

--- a/app/services/brokers/binance/demo_scalping_ws/supervisor.py
+++ b/app/services/brokers/binance/demo_scalping_ws/supervisor.py
@@ -50,6 +50,7 @@ SourceFactory = Callable[[], AsyncIterator[FuturesWsEvent]]
 OnTrigger = Callable[["TriggerEvent"], Awaitable[None]]
 Clock = Callable[[], dt.datetime]
 Sleep = Callable[[float], Awaitable[None]]
+StopWhen = Callable[[], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,14 +104,22 @@ class ScalpingDaemonSupervisor:
         *,
         on_trigger: OnTrigger,
         stop_after: int | None = None,
+        stop_when: StopWhen | None = None,
     ) -> None:
-        """Consume one source to exhaustion (single pass; reconnect: Task 5)."""
+        """Consume one source to exhaustion (single connection pass).
+
+        ``stop_after`` bounds events consumed; ``stop_when`` is a predicate
+        checked after each emitted trigger — bounded operator mode (e.g. a
+        trigger-count cap) returns cleanly once it is true.
+        """
         consumed = 0
         source = source_factory()
         async for event in source:
             trigger = self._handle_event(event)
             if trigger is not None:
                 await on_trigger(trigger)
+                if stop_when is not None and stop_when():
+                    return
             consumed += 1
             if stop_after is not None and consumed >= stop_after:
                 return
@@ -193,6 +202,7 @@ class ScalpingDaemonSupervisor:
         *,
         on_trigger: OnTrigger,
         sleep: Sleep = asyncio.sleep,
+        stop_when: StopWhen | None = None,
     ) -> None:
         """Run with reconnect: back off on connection errors until unhealthy.
 
@@ -201,6 +211,10 @@ class ScalpingDaemonSupervisor:
         consecutive failures reach the unhealthy threshold the error is
         re-raised for the operator/supervisor above to handle.
 
+        ``stop_when`` (bounded operator mode) is checked both at the top of each
+        reconnect iteration and after each trigger inside ``run`` — so the count
+        survives reconnects and the loop exits cleanly once the bound is hit.
+
         ``websockets.exceptions.ConnectionClosed`` (incl. ConnectionClosedOK/
         ConnectionClosedError) is caught explicitly — it is NOT a subclass of
         ConnectionError/OSError, so a real socket close would otherwise crash
@@ -208,8 +222,12 @@ class ScalpingDaemonSupervisor:
         """
         consecutive_failures = 0
         while True:
+            if stop_when is not None and stop_when():
+                return
             try:
-                await self.run(source_factory, on_trigger=on_trigger)
+                await self.run(
+                    source_factory, on_trigger=on_trigger, stop_when=stop_when
+                )
                 return
             except (ConnectionError, OSError, ConnectionClosed) as exc:
                 consecutive_failures += 1

--- a/docs/plans/ROB-321-kis-mock-scalping-loop-plan.md
+++ b/docs/plans/ROB-321-kis-mock-scalping-loop-plan.md
@@ -1,0 +1,700 @@
+# ROB-321 KIS mock Scalping Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a KIS official mock (`account_mode=kis_mock`) scalping WebSocket execution loop — entry signal → mock buy → fill → TP/SL/time-stop → mock exit → round-trip ledger close — as **edge-agnostic execution plumbing** (the strategy edge is known net-negative per ROB-316; v1 strategy is intentionally a conservative toy whose only job is to exercise the plumbing).
+
+**Architecture:** Mirror the Binance Demo scalping pattern (ROB-317): a read-only **live** KIS quote/orderbook WebSocket feeds a deterministic signal/risk contract; an import-guarded execution bridge is the only path that mutates, routing orders to **mock** only. Market-data (live) and order (mock) transports are host-separated and fail-closed. The `avg*1.01` sell floor and the `price < current_price` guard are bypassed **only** for mock scalping exits via an explicit, flag-gated context object that mirrors the existing `DefensiveTrimContext` mechanism. Live/generic order paths are never touched.
+
+**Tech Stack:** Python 3.13, FastAPI, asyncio, pytest (`-m unit`/`-m integration`), SQLAlchemy async + Alembic, KIS WebSocket (approval-key handshake), existing `KISMockOrderLedger` shadow ledger.
+
+**PR slicing (each PR lands independently, full-CI green before merge):**
+1. **PR1 — Mock scalping sell-guard separation (pure validation logic).** ← *fully detailed below.*
+2. **PR2 — Live KIS quote/orderbook WebSocket (read-only) + host separation.** ← *architected below; detailed plan authored when reached.*
+3. **PR3 — Entry/strategy/risk contract + supervisor (default-off, dry-run).** ← *architected below.*
+4. **PR4 — Execution bridge + round-trip ledger/reconcile + smoke runbook.** ← *architected below.*
+
+> **Scope note (per writing-plans scope check):** This feature spans four independent subsystems. PR1 is specified to bite-sized step level here because it is fully determinable from the current codebase. PR2–PR4 each depend on interfaces that PR1 (and earlier PRs) land, and on internals (KIS WS protocol, executor) that must be read against the merged code before writing faithful step-level code. Their **file structure, public interfaces, and test strategy are locked below**; author the step-level plan for each as a sibling document (`ROB-321-prN-*.md`) at execution time. Do not write fictional step code for PR2–4 now.
+
+---
+
+## Cross-cutting constraints (apply to every PR)
+
+- **Live untouched:** No change to KIS live / generic live order validation. The `avg*1.01` floor and `price < current_price` guard remain fully enforced for `is_mock=False`. Proven by a test that runs the live path and asserts both guards still fire.
+- **Fail-closed activation:** The scalping exit bypass is constructible **only** when `is_mock=True` **and** `settings.kis_mock_scalping_enabled` is true. `is_mock=False` → raise. Flag off → raise. Default flag = `False`.
+- **Host separation (PR2+):** Market data = live KIS quote WS (read-only). Orders = mock only. Enforced at the transport layer via host allowlist, not config flags alone (per `feedback_transport_layer_fail_closed`). Mock order host stays `openapivts.koreainvestment.com`; live quote host is distinct and may never carry an order mutation.
+- **No scheduler:** No TaskIQ/Prefect/cron registration or always-on activation in any PR. CLI/daemon entrypoint only, default-disabled.
+- **No prod mutation:** No production DB backfill, no live journal changes.
+- **Account-mode logging:** Every scalping execution log line carries `account_mode="kis_mock"`.
+- **Out of PR1 scope (live safety boundary):** `app/services/kis_trading_service.py:402` and `app/services/order_service.py:65` carry their own `>= avg*1.01 and >= current_price` filters for KIS auto-trade / crypto order services. The scalping loop does **not** route through these; they are intentionally **not modified** — leaving them untouched preserves live safety.
+
+---
+
+## File Structure (whole feature)
+
+**PR1 (this document, detailed):**
+- Modify: `app/core/config.py` — add `kis_mock_scalping_enabled: bool = False`.
+- Modify: `app/mcp_server/tooling/order_validation.py` — add `ScalpingExitContext`, `evaluate_sell_price_guards()` (pure), `_resolve_scalping_exit_context()`, `_log_scalping_exit_bypass()`; route `_preview_sell` and `_validate_sell_side` through the pure function; thread `scalping_exit_ctx`.
+- Create: `tests/test_kis_mock_scalping_sell_guard.py` — pure-function matrix, resolver fail-closed, preview/validate wiring, live-unaffected regression.
+
+**PR2 (architected):**
+- Modify: `app/services/kis_websocket_internal/protocol.py` — add quote/orderbook TR codes (`H0STCNT0` 체결가, `H0STASP0` 호가; overseas equivalents) as a **separate** subscription set from execution TRs.
+- Create: `app/services/kis_websocket_internal/quote_parsers.py` — parse quote/orderbook frames → `QuoteTick`/`OrderBookSnapshot` (do not touch `parsers.py` which is execution-only).
+- Create: `app/services/brokers/kis/mock_scalping_ws/market_stream.py` — read-only live quote WS client (reconnect/backoff/heartbeat copied from `KISExecutionWebSocket` pattern); host allowlist = live quote host only.
+- Create: `app/services/brokers/kis/mock_scalping_ws/state.py` — per-symbol `MarketState` (bid/ask/qty, last trade, candle aggregation, per-stream freshness timestamps).
+- Create: `scripts/kis_mock_scalping_ws_smoke.py` — read-only tick smoke (no orders).
+
+**PR3 (architected):**
+- Create: `app/services/brokers/kis/mock_scalping/contract.py` — `ScalpingRiskLimits`, `ReasonCode`, `evaluate_risk()` (KIS allowlist, max notional, max open positions, per-symbol cooldown, daily attempt/loss cap, spread guard, data-freshness guard). Mirror `binance/demo_scalping/contract.py`.
+- Create: `app/services/brokers/kis/mock_scalping/signal.py` — pure `evaluate_signal(candles, config) -> SignalDecision` (toy conservative v1: liquidity filter + pullback/no-chase + spread check; single entry per symbol).
+- Create: `app/services/brokers/kis/mock_scalping/order_intent.py` — `OrderIntent` hand-off type.
+- Create: `app/services/brokers/kis/mock_scalping_ws/supervisor.py` — event loop: candle close → re-evaluate signal → freshness + debounce gates → emit `TriggerEvent`.
+- Create: `app/services/brokers/kis/mock_scalping_ws/config.py` — env gates (see below).
+- AST import-guard test: `mock_scalping_ws/` may not import the executor/ledger.
+
+**PR4 (architected):**
+- Create: `app/services/brokers/kis/mock_scalping_exec/executor.py` — `execute_monitored()`: mock buy (confirm gate) → poll fill → track price via `MarketState` → TP/SL/time-stop → aggressive-limit exit (uses `ScalpingExitContext`) → failsafe close. Conservative trigger prices (long exit on bid).
+- Create: `app/services/brokers/kis/mock_scalping_exec/ws_bridge.py` — consume `TriggerEvent`, concurrency guard (per-symbol in-flight lock + global semaphore cap=max-open-positions), build `OrderIntent` + market-conditions snapshot, call executor with confirm gate.
+- Create: `app/services/kis_mock_round_trip_reconciler.py` — round-trip-aware close that pairs entry-fill ↔ exit-fill from **order execution evidence** (not holdings delta), records gross/net PnL + fees + entry/exit reason; holdings snapshot is corroboration only.
+- Modify: `KISMockOrderLedger` / `app/services/kis_mock_lifecycle_service.py` — add round-trip linkage (correlation/strategy id, entry/exit reason, fees, gross/net PnL) and a terminal `closed`/`reconciled` state for same-session round trips.
+- Create: `scripts/kis_mock_scalping_smoke.py` — default-disabled CLI: dry-run/check-only, small mock run, post-run ledger/position/pending verification.
+- Create: `docs/runbooks/kis-mock-scalping-smoke.md` — operator smoke runbook.
+- Modify: `/invest` — minimal read-only hook surfacing current mock scalping session state / latest round-trip (UI polish deferred to a separate issue).
+
+**Env gates (introduced across PR1→PR4, all default `False`):**
+- `KIS_MOCK_SCALPING_ENABLED` (PR1) — master gate; also required to construct `ScalpingExitContext`.
+- `KIS_MOCK_SCALPING_WS_ENABLED` (PR2/3) — daemon/socket gate.
+- `KIS_MOCK_SCALPING_WS_CONFIRM` (PR4) — order-mutation gate; without it the bridge dry-runs (preview, no order).
+
+---
+
+## PR1 — Mock scalping sell-guard separation
+
+**Why first:** Lowest risk, zero WebSocket/order surface, fully unit-testable, and it unblocks PR4's exit path. Produces working, tested software on its own.
+
+### Task 1: Add the feature flag
+
+**Files:**
+- Modify: `app/core/config.py:175-180` (the `kis_mock_*` settings block)
+- Test: `tests/test_kis_mock_scalping_sell_guard.py`
+
+- [ ] **Step 1: Add the setting**
+
+In `app/core/config.py`, in the `kis_mock_*` block (currently ending at `kis_mock_access_token` on line 180), add:
+
+```python
+    kis_mock_scalping_enabled: bool = False
+```
+
+- [ ] **Step 2: Write a test asserting the default is off**
+
+Create `tests/test_kis_mock_scalping_sell_guard.py`:
+
+```python
+"""Unit tests for KIS mock scalping sell-guard separation (ROB-321 PR1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+
+
+@pytest.mark.unit
+def test_kis_mock_scalping_disabled_by_default() -> None:
+    assert settings.kis_mock_scalping_enabled is False
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/core/config.py tests/test_kis_mock_scalping_sell_guard.py
+git commit -m "feat(rob-321): add KIS_MOCK_SCALPING_ENABLED flag (default off)"
+```
+
+---
+
+### Task 2: Extract the sell-price guard into a pure function
+
+The floor + current-price guard is currently duplicated in `_preview_sell` (`order_validation.py:465-485`) and `_validate_sell_side` (`order_validation.py:653-681`). Extract the decision into one pure function so the bypass matrix is single-sourced and trivially testable.
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py` (add types + pure fn after `DefensiveTrimContext`, around line 62)
+- Test: `tests/test_kis_mock_scalping_sell_guard.py`
+
+- [ ] **Step 1: Write the failing tests for the guard matrix**
+
+Append to `tests/test_kis_mock_scalping_sell_guard.py`:
+
+```python
+from app.mcp_server.tooling.order_validation import (
+    DefensiveTrimContext,
+    ScalpingExitContext,
+    evaluate_sell_price_guards,
+)
+import datetime
+
+
+def _trim_ctx() -> DefensiveTrimContext:
+    return DefensiveTrimContext(
+        approval_issue_id="ROB-1",
+        requester_agent_id="agent",
+        approval_verified_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+    )
+
+
+def _scalp_ctx() -> ScalpingExitContext:
+    return ScalpingExitContext(strategy_id="kis-mock-v1", reason="stop_loss")
+
+
+@pytest.mark.unit
+def test_guard_blocks_below_floor_when_no_context() -> None:
+    # price below avg*1.01 -> floor error
+    err = evaluate_sell_price_guards(
+        price=1000.0, current_price=1000.0, avg_price=1000.0,
+        defensive_trim_ctx=None, scalping_exit_ctx=None,
+    )
+    assert err is not None and "below minimum" in err
+
+
+@pytest.mark.unit
+def test_guard_blocks_below_current_price_when_no_context() -> None:
+    # price >= floor (avg low) but below current -> current-price error
+    err = evaluate_sell_price_guards(
+        price=1000.0, current_price=1100.0, avg_price=900.0,
+        defensive_trim_ctx=None, scalping_exit_ctx=None,
+    )
+    assert err is not None and "below current price" in err
+
+
+@pytest.mark.unit
+def test_defensive_trim_bypasses_floor_but_not_current_price() -> None:
+    # below floor: allowed by trim; but also below current -> still blocked
+    err = evaluate_sell_price_guards(
+        price=950.0, current_price=1000.0, avg_price=1000.0,
+        defensive_trim_ctx=_trim_ctx(), scalping_exit_ctx=None,
+    )
+    assert err is not None and "below current price" in err
+
+
+@pytest.mark.unit
+def test_scalping_exit_bypasses_both_guards() -> None:
+    # below floor AND below current: scalping exit allows it (stop-loss)
+    err = evaluate_sell_price_guards(
+        price=950.0, current_price=1000.0, avg_price=1000.0,
+        defensive_trim_ctx=None, scalping_exit_ctx=_scalp_ctx(),
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_no_context_clean_price_passes() -> None:
+    err = evaluate_sell_price_guards(
+        price=1100.0, current_price=1050.0, avg_price=1000.0,
+        defensive_trim_ctx=None, scalping_exit_ctx=None,
+    )
+    assert err is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v`
+Expected: FAIL — `ImportError: cannot import name 'ScalpingExitContext'` / `evaluate_sell_price_guards`.
+
+- [ ] **Step 3: Implement the type + pure function**
+
+In `app/mcp_server/tooling/order_validation.py`, immediately after the `DefensiveTrimContext` dataclass (after line 62), add:
+
+```python
+@dataclass(frozen=True)
+class ScalpingExitContext:
+    """Mock-only authorization to sell a scalping position below both the
+    avg*1.01 floor and the current-price guard (stop-loss / take-profit /
+    time-stop). Only constructible for is_mock=True orders gated by
+    KIS_MOCK_SCALPING_ENABLED. Never threaded from any live/generic path.
+    """
+
+    strategy_id: str
+    reason: str  # "stop_loss" | "take_profit" | "time_stop"
+
+
+def evaluate_sell_price_guards(
+    *,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    defensive_trim_ctx: "DefensiveTrimContext | None",
+    scalping_exit_ctx: "ScalpingExitContext | None",
+) -> str | None:
+    """Single source of truth for limit-sell price guards.
+
+    Returns an error message if the price violates a guard, else None.
+
+    Matrix:
+      - scalping_exit_ctx present  -> both guards bypassed (mock scalping exit).
+      - defensive_trim_ctx present -> floor bypassed, current-price guard enforced.
+      - neither                    -> both guards enforced.
+    """
+    if scalping_exit_ctx is not None:
+        return None
+    min_sell_price = avg_price * 1.01
+    if price < min_sell_price and defensive_trim_ctx is None:
+        return (
+            f"Sell price {price} below minimum "
+            f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
+        )
+    if price < current_price:
+        return f"Sell price {price} below current price {current_price}"
+    return None
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_validation.py tests/test_kis_mock_scalping_sell_guard.py
+git commit -m "feat(rob-321): extract pure sell-price guard with scalping-exit bypass matrix"
+```
+
+---
+
+### Task 3: Add the fail-closed context resolver
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py` (add `_resolve_scalping_exit_context` near `_validate_defensive_trim_preconditions`, ~line 139)
+- Test: `tests/test_kis_mock_scalping_sell_guard.py`
+
+- [ ] **Step 1: Write failing tests for the resolver**
+
+Append to `tests/test_kis_mock_scalping_sell_guard.py`:
+
+```python
+from app.mcp_server.tooling.order_validation import _resolve_scalping_exit_context
+
+
+@pytest.mark.unit
+def test_resolver_returns_none_when_not_requested(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    ctx = _resolve_scalping_exit_context(
+        scalping_exit=False, strategy_id="s", reason="stop_loss",
+        side="sell", order_type="limit", is_mock=True,
+    )
+    assert ctx is None
+
+
+@pytest.mark.unit
+def test_resolver_fail_closed_on_live(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    with pytest.raises(ValueError, match="kis_mock"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True, strategy_id="s", reason="stop_loss",
+            side="sell", order_type="limit", is_mock=False,
+        )
+
+
+@pytest.mark.unit
+def test_resolver_fail_closed_when_flag_off(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", False, raising=False)
+    with pytest.raises(ValueError, match="KIS_MOCK_SCALPING_ENABLED"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True, strategy_id="s", reason="stop_loss",
+            side="sell", order_type="limit", is_mock=True,
+        )
+
+
+@pytest.mark.unit
+def test_resolver_returns_context_when_authorized(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    ctx = _resolve_scalping_exit_context(
+        scalping_exit=True, strategy_id="kis-mock-v1", reason="stop_loss",
+        side="sell", order_type="limit", is_mock=True,
+    )
+    assert ctx is not None and ctx.strategy_id == "kis-mock-v1"
+    assert ctx.reason == "stop_loss"
+
+
+@pytest.mark.unit
+def test_resolver_rejects_buy_and_market_and_bad_reason(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    with pytest.raises(ValueError, match="side='sell'"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True, strategy_id="s", reason="stop_loss",
+            side="buy", order_type="limit", is_mock=True,
+        )
+    with pytest.raises(ValueError, match="order_type='limit'"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True, strategy_id="s", reason="stop_loss",
+            side="sell", order_type="market", is_mock=True,
+        )
+    with pytest.raises(ValueError, match="reason"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True, strategy_id="s", reason="moon",
+            side="sell", order_type="limit", is_mock=True,
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v -k resolver`
+Expected: FAIL — `cannot import name '_resolve_scalping_exit_context'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+In `app/mcp_server/tooling/order_validation.py`, after `_validate_defensive_trim_preconditions` (after line ~192), add:
+
+```python
+_SCALPING_EXIT_REASONS = frozenset({"stop_loss", "take_profit", "time_stop"})
+
+
+def _resolve_scalping_exit_context(
+    *,
+    scalping_exit: bool,
+    strategy_id: str | None,
+    reason: str | None,
+    side: str,
+    order_type: str,
+    is_mock: bool,
+) -> ScalpingExitContext | None:
+    """Fail-closed resolution of a mock scalping exit authorization.
+
+    Returns None when not requested. Raises ValueError on any condition that
+    would let a live/generic order acquire the bypass.
+    """
+    if not scalping_exit:
+        return None
+    if not settings.kis_mock_scalping_enabled:
+        raise ValueError(
+            "scalping_exit requires KIS_MOCK_SCALPING_ENABLED=true"
+        )
+    if not is_mock:
+        raise ValueError("scalping_exit is only available for kis_mock orders")
+    if side != "sell":
+        raise ValueError("scalping_exit requires side='sell'")
+    if order_type != "limit":
+        raise ValueError("scalping_exit requires order_type='limit'")
+    if not strategy_id:
+        raise ValueError("scalping_exit requires strategy_id")
+    resolved_reason = reason or "stop_loss"
+    if resolved_reason not in _SCALPING_EXIT_REASONS:
+        raise ValueError(f"invalid scalping_exit reason: {resolved_reason}")
+    return ScalpingExitContext(strategy_id=strategy_id, reason=resolved_reason)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v -k resolver`
+Expected: PASS (5 resolver tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_validation.py tests/test_kis_mock_scalping_sell_guard.py
+git commit -m "feat(rob-321): fail-closed scalping-exit context resolver (mock + flag gated)"
+```
+
+---
+
+### Task 4: Route `_preview_sell` and `_validate_sell_side` through the pure function
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py:432-502` (`_preview_sell`) and `:590-683` (`_validate_sell_side`)
+- Test: `tests/test_kis_mock_scalping_sell_guard.py`
+
+- [ ] **Step 1: Add a bypass-logging helper**
+
+In `app/mcp_server/tooling/order_validation.py`, after `_log_defensive_trim_bypass` (after line ~138), add:
+
+```python
+def _log_scalping_exit_bypass(
+    *,
+    symbol: str,
+    market_type: str,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    scalping_exit_ctx: ScalpingExitContext,
+    phase: str,
+) -> None:
+    logger.warning(
+        "kis_mock_scalping_exit_bypass: sell guards bypassed",
+        extra={
+            "account_mode": "kis_mock",
+            "symbol": symbol,
+            "market_type": market_type,
+            "price": price,
+            "current_price": current_price,
+            "avg_price": avg_price,
+            "strategy_id": scalping_exit_ctx.strategy_id,
+            "reason": scalping_exit_ctx.reason,
+            "phase": phase,
+        },
+    )
+```
+
+- [ ] **Step 2: Write failing wiring tests (preview + validate, live unaffected)**
+
+Append to `tests/test_kis_mock_scalping_sell_guard.py`:
+
+```python
+from unittest.mock import AsyncMock
+from app.mcp_server.tooling import order_validation
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_scalping_exit_allows_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation, "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    result = await order_validation._preview_sell(
+        symbol="005930", order_type="limit", quantity=10,
+        price=950.0, current_price=980.0, market_type="kr",
+        scalping_exit_ctx=ScalpingExitContext(strategy_id="s", reason="stop_loss"),
+        is_mock=True,
+    )
+    assert "error" not in result
+    assert result["price"] == 950.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_live_still_blocks_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation, "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    # No scalping ctx, no trim ctx: live behavior preserved.
+    result = await order_validation._preview_sell(
+        symbol="005930", order_type="limit", quantity=10,
+        price=950.0, current_price=980.0, market_type="kr",
+        is_mock=False,
+    )
+    assert "error" in result and "below minimum" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_scalping_exit_allows_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation, "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="005930", normalized_symbol="005930", market_type="kr",
+        quantity=10, order_type="limit", price=950.0, current_price=980.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        scalping_exit_ctx=ScalpingExitContext(strategy_id="s", reason="stop_loss"),
+        is_mock=True, dry_run=True,
+    )
+    assert err is None and errors == []
+    assert avg == 1000.0
+```
+
+> Note: confirm `_validate_sell_side`'s holdings/exposure source against the merged code; if it reads exposure separately from `_get_holdings_for_order`, patch that source too. Keep the assertion (no error / err is None) stable.
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v -k "preview or validate_sell"`
+Expected: FAIL — `_preview_sell`/`_validate_sell_side` got unexpected keyword `scalping_exit_ctx`.
+
+- [ ] **Step 4: Thread the param and call the pure function in `_preview_sell`**
+
+In `_preview_sell` (signature at line 432), add the parameter after `defensive_trim_ctx`:
+
+```python
+    scalping_exit_ctx: ScalpingExitContext | None = None,
+```
+
+Replace the limit-branch guard block (current lines 465-485) with:
+
+```python
+        guard_error = evaluate_sell_price_guards(
+            price=price,
+            current_price=current_price,
+            avg_price=avg_price,
+            defensive_trim_ctx=defensive_trim_ctx,
+            scalping_exit_ctx=scalping_exit_ctx,
+        )
+        if guard_error is not None:
+            result["error"] = guard_error
+            return result
+        if scalping_exit_ctx is not None and price < avg_price * 1.01:
+            _log_scalping_exit_bypass(
+                symbol=symbol, market_type=market_type, price=price,
+                current_price=current_price, avg_price=avg_price,
+                scalping_exit_ctx=scalping_exit_ctx, phase="preview",
+            )
+        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
+            _log_defensive_trim_bypass(
+                symbol=symbol, market_type=market_type, price=price,
+                current_price=current_price, avg_price=avg_price,
+                min_sell_price=avg_price * 1.01,
+                defensive_trim_ctx=defensive_trim_ctx, phase="preview",
+            )
+        order_quantity = holdings["quantity"] if quantity is None else quantity
+        execution_price = price
+        result["price"] = execution_price
+```
+
+- [ ] **Step 5: Thread the param and call the pure function in `_validate_sell_side`**
+
+In `_validate_sell_side` (signature at line 590), add after `defensive_trim_ctx`:
+
+```python
+    scalping_exit_ctx: ScalpingExitContext | None = None,
+```
+
+Replace the limit-branch guard block (current lines 652-681) with:
+
+```python
+    if order_type == "limit" and price is not None:
+        guard_error = evaluate_sell_price_guards(
+            price=price,
+            current_price=current_price,
+            avg_price=avg_price,
+            defensive_trim_ctx=defensive_trim_ctx,
+            scalping_exit_ctx=scalping_exit_ctx,
+        )
+        if guard_error is not None:
+            return 0.0, 0.0, order_error_fn(guard_error)
+        if scalping_exit_ctx is not None and price < avg_price * 1.01:
+            _log_scalping_exit_bypass(
+                symbol=normalized_symbol, market_type=market_type, price=price,
+                current_price=current_price, avg_price=avg_price,
+                scalping_exit_ctx=scalping_exit_ctx, phase="execution",
+            )
+        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
+            _log_defensive_trim_bypass(
+                symbol=normalized_symbol, market_type=market_type, price=price,
+                current_price=current_price, avg_price=avg_price,
+                min_sell_price=avg_price * 1.01,
+                defensive_trim_ctx=defensive_trim_ctx, phase="execution",
+            )
+```
+
+- [ ] **Step 6: Run the full PR1 test file**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_sell_guard.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 7: Run the existing defensive-trim regression to prove no behavior change**
+
+Run: `uv run pytest tests/test_mcp_place_order_defensive_trim.py -v`
+Expected: PASS (unchanged — defensive_trim still bypasses floor, still enforces current-price guard).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_validation.py tests/test_kis_mock_scalping_sell_guard.py
+git commit -m "feat(rob-321): route sell preview/validate through pure guard; scalping-exit bypass"
+```
+
+---
+
+### Task 5: PR1 verification gate
+
+- [ ] **Step 1: Lint + import guards + targeted tests (per `feedback_premerge_full_ci_gate`)**
+
+```bash
+uv run ruff check app/ tests/
+uv run pytest tests/test_kis_mock_scalping_sell_guard.py tests/test_mcp_place_order_defensive_trim.py -v
+```
+Expected: ruff clean; all tests PASS.
+
+- [ ] **Step 2: Confirm live path untouched — grep the two out-of-scope filters are unchanged**
+
+```bash
+git diff --name-only origin/main -- app/services/kis_trading_service.py app/services/order_service.py
+```
+Expected: **empty** (neither file modified — live/auto-trade safety preserved).
+
+- [ ] **Step 3: Open PR (base `main`), confirm full Test workflow green before merge.**
+
+---
+
+## PR2 — Live KIS quote/orderbook WebSocket (read-only) + host separation
+
+**Goal:** A read-only market-data feed; zero order surface.
+
+**Key interfaces (lock these):**
+- `QuoteTick(symbol, last_price, ts)`, `OrderBookSnapshot(symbol, bid, ask, bid_qty, ask_qty, ts)` in `quote_parsers.py`.
+- `MarketState.update_from_tick(...)`, `MarketState.update_from_book(...)`, `MarketState.spread_bps()`, `MarketState.age_seconds(now)`.
+- Market-stream client exposes `async listen(on_tick, on_book)` mirroring `KISExecutionWebSocket.listen`.
+
+**Test strategy:**
+- Fake WS server feeds canned quote/orderbook frames → assert parser output and `MarketState` transitions.
+- Reconnect/backoff/heartbeat-timeout tests reuse the execution-WS test harness shape.
+- **Host fail-closed test:** constructing the market-stream client against the mock order host (or any non-quote host) raises; an order mutation can never be issued on the quote transport.
+
+**Detailed step-level plan:** author `docs/plans/ROB-321-pr2-quote-ws.md` after reading `kis_websocket_internal/{client,protocol,parsers}.py` against merged main.
+
+---
+
+## PR3 — Strategy/risk contract + supervisor (default-off, dry-run)
+
+**Goal:** Deterministic signal + risk envelope + trigger emission. No orders.
+
+**Key interfaces (lock these — mirror `binance/demo_scalping`):**
+- `SignalConfig`, `SignalDecision(has_entry, side, entry_price, tp_price, sl_price, confidence, reason_codes)`, `evaluate_signal(candles, config) -> SignalDecision` (pure).
+- `ScalpingRiskLimits` (KIS allowlist, max_notional, max_open_positions, per_symbol_cooldown_s, daily_attempt_cap, daily_loss_budget, spread_bps_guard, data_freshness_s), `ReasonCode` constants, `evaluate_risk(...) -> RiskDecision` (accumulate all blocking codes, no short-circuit).
+- `OrderIntent(symbol, side, order_type, target_notional, entry_reference_price, tp_price, sl_price, strategy_id, reason_codes, source_candle_close_ms, evaluated_at_ms)`.
+- `TriggerEvent` emitted by `supervisor` only when freshness + per-symbol debounce pass.
+- AST import-guard test: `mock_scalping_ws/` must not import `mock_scalping_exec/` or the ledger.
+
+**Test strategy:** pure-function tables for `evaluate_signal` and `evaluate_risk` (each ReasonCode); supervisor fed a synthetic candle stream asserts a single `TriggerEvent` per valid setup and debounce suppression.
+
+**Detailed step-level plan:** author `docs/plans/ROB-321-pr3-signal-supervisor.md`.
+
+---
+
+## PR4 — Execution bridge + round-trip ledger/reconcile + smoke runbook
+
+**Goal:** The only mutation path; mock-only orders; round-trip close.
+
+**Key design (lock these):**
+- `executor.execute_monitored(intent, *, confirm)`: mock buy via existing `_place_order_impl` path → poll fill → track price via `MarketState` → on TP/SL/time-stop submit aggressive-limit exit carrying a `ScalpingExitContext(strategy_id, reason)` (PR1) → failsafe close on timeout. Long exits trigger on **bid** (conservative). Without `confirm`/`KIS_MOCK_SCALPING_WS_CONFIRM`, dry-run preview only.
+- `ws_bridge`: per-symbol in-flight lock + global semaphore (cap = `max_open_positions`) + DB ledger re-check before executor; builds `OrderIntent` + market-conditions snapshot.
+- **Round-trip reconcile (the ROB-316/§2-4 fix):** pair entry-fill ↔ exit-fill from **order execution evidence** (submit response / execution WS), not holdings delta. Record gross/net PnL, entry+exit fees, entry/exit reason; reach a terminal `closed`/`reconciled` state even when the holdings snapshot never showed the intermediate position. Holdings snapshot is corroboration only — a missing intermediate position is **not** an anomaly for a same-session round trip.
+- Ledger linkage columns on `KISMockOrderLedger`: `strategy_id`, `correlation_id`, `entry_exit_reason`, `fees`, `gross_pnl`, `net_pnl` (additive Alembic migration; operator runs `alembic upgrade head` separately — not auto-applied).
+
+**Test strategy (covers Acceptance criteria 3–7):**
+- Fake WS + fake broker: tick → entry signal → mock buy → filled → TP and SL exit paths both close round-trip as `reconciled`/`closed` (not `anomaly`), including the fast round-trip where holdings never reflect the intermediate position.
+- Flag-off (`KIS_MOCK_SCALPING_ENABLED`/`WS_ENABLED` false) → daemon submits no order.
+- Risk gates tested individually: max notional, max open positions, cooldown, daily caps, kill switch.
+- Host fail-closed: order path can only hit the mock host.
+
+**Runbook:** `docs/runbooks/kis-mock-scalping-smoke.md` — dry-run/check-only → small mock run → post-run ledger/position/pending verification (mirror `docs/runbooks/binance-futures-demo-smoke.md`).
+
+**Detailed step-level plan:** author `docs/plans/ROB-321-pr4-exec-bridge.md`.
+
+---
+
+## Self-Review
+
+**Spec coverage (ROB-321 acceptance criteria):**
+1. Mock scalping stop-loss below avg passes validation → **PR1 Task 4** (`test_*_scalping_exit_allows_below_floor`). ✅
+2. Live/generic sell guards unchanged → **PR1 Task 4 + Task 5 Step 2** (live test + diff-empty check). ✅
+3. WS fake/integration tick → entry → buy → filled → TP/SL sell → **PR4 test strategy**. ✅ (planned)
+4. Round-trip ledger closed/reconciled, not anomaly → **PR4 round-trip reconciler** (explicitly handles the fast round-trip). ✅ (planned)
+5. Flag-off submits no order → **PR4 test strategy** (+ PR1 flag default). ✅ (planned)
+6. max notional / max open positions / cooldown / kill switch tested → **PR3 risk contract + PR4 tests**. ✅ (planned)
+7. Operator smoke runbook → **PR4 `docs/runbooks/kis-mock-scalping-smoke.md`**. ✅ (planned)
+
+Scope items §1 (guard separation) and §6 (feature flag, account_mode logging, no live mixing) are fully realized in PR1; §2 (WS) PR2; §3 (entry contract) PR3; §4 (exit manager) + §5 (ledger/reconcile) PR4.
+
+**Placeholder scan:** PR1 steps contain complete code/commands. PR2–4 are explicitly scoped subsystem outlines (locked interfaces + test strategy) with their own detailed plans deferred — not in-task placeholders.
+
+**Type consistency:** `ScalpingExitContext(strategy_id, reason)` and `evaluate_sell_price_guards(price, current_price, avg_price, defensive_trim_ctx, scalping_exit_ctx)` and `_resolve_scalping_exit_context(scalping_exit, strategy_id, reason, side, order_type, is_mock)` are used consistently across PR1 Tasks 2–4 and referenced by PR4's executor.
+
+**Open verification item for the implementer (PR1 Task 4 Step 2 note):** confirm `_validate_sell_side`'s holdings/exposure read path against merged main and patch the correct source in the test; the assertion (no error) stays fixed.

--- a/docs/runbooks/binance-demo-ws-scalping.md
+++ b/docs/runbooks/binance-demo-ws-scalping.md
@@ -33,6 +33,17 @@ Before starting the daemon, ensure the following requirements are met:
    ```
    (Reuses the existing `binance_demo_order_ledger` and `scalp_trade_analytics` tables.)
 
+> **⚠️ Credential loading — do NOT blindly `source shared/.env.prod.native`.**
+> That file is the native production service's full env (it may carry mainnet/
+> testnet and unrelated secrets). Blindly `set -a; source ...` into an
+> interactive shell pollutes your session, can export mainnet/testnet vars, and
+> risks echoing secrets. Instead use **dotenv-aware / native-service env
+> loading**: let the launchd/native service load its own env file, or load only
+> the Demo-prefixed keys (`BINANCE_FUTURES_DEMO_*` / `BINANCE_DEMO_*`) into a
+> scoped subprocess — never `BINANCE_TESTNET_*` (which do nothing for Demo) —
+> and never print credential values. The daemon resolves Demo credentials via
+> `resolve_demo_credentials()`; only those keys are needed.
+
 ---
 
 ## 3. The Three Gates
@@ -52,7 +63,9 @@ The behavior of the WebSocket daemon is strictly gated by three environment vari
 | `false` / unset | (any) | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
 | `true` | `false` / unset | (any) | **Disabled**. Exits instantly, prints JSON metadata, opens no connections. |
 | `true` | `true` | `false` / unset | **Dry-Run**. Subscribes to websocket streams, runs signal generation, but passes `confirm=False` to the executor (zero broker mutation). |
-| `true` | `true` | `true` | **Confirmed Demo Mode**. Real mock orders are placed on `demo-fapi.binance.com`. |
+| `true` | `true` | `true` | **Confirmed-eligible**. Real mock orders are placed on `demo-fapi.binance.com` **only if the CLI also passes `--confirm` and a trigger bound** (§4.3/§4.4). The env gate alone runs dry-run. |
+
+> The `--confirm` CLI flag is an **independent** second gate on top of the env var: the flag alone never enables mutation, and the env var alone never enables mutation. Confirmed runs additionally **must** be bounded (`--max-triggers` / `--exit-after-first-trigger`) or the daemon exits 2 without placing an order.
 
 ---
 
@@ -92,14 +105,15 @@ uv run python -m scripts.binance_demo_scalping_ws_daemon
 
 ### 4.3. Confirmed Demo Mode (Active Trading)
 
-To engage active trading on the Demo backend, add `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`:
+Confirmed mode requires **all three**: the env gate `BINANCE_DEMO_SCALPING_WS_CONFIRM=true`, the explicit `--confirm` flag, **and** a trigger bound (`--max-triggers` / `--exit-after-first-trigger`). Missing the flag → dry-run; missing the bound → fail-closed (exit 2, no order). See §4.4 for the bounded first-live procedure.
 
 ```bash
 export BINANCE_DEMO_SCALPING_ENABLED=true
 export BINANCE_DEMO_SCALPING_WS_ENABLED=true
 export BINANCE_DEMO_SCALPING_WS_CONFIRM=true
 
-uv run python -m scripts.binance_demo_scalping_ws_daemon
+# --confirm AND a trigger bound are both mandatory for real orders.
+uv run python -m scripts.binance_demo_scalping_ws_daemon --confirm --max-triggers 1
 ```
 
 **Risk Safeguards:**
@@ -107,6 +121,38 @@ uv run python -m scripts.binance_demo_scalping_ws_daemon
 * Subject to **authoritative live-ledger risk checks** (`_preflight`) inside the executor.
 * Guided by an **in-process concurrency lock** (max `1` global position open at any time) to prevent race conditions or duplicate entries under fast websocket updates.
 * Writes full order histories to `binance_demo_order_ledger` and telemetry to `scalp_trade_analytics`.
+
+### 4.4. Bounded Operator Mode (First-Live Validation)
+
+The daemon is a long-running loop by default. For a **first-live validation of the plumbing/harness** (real `fstream` ingest → state → trigger → bridge), use the bounded flags so the run is small, observable, and self-terminating:
+
+| Flag | Effect |
+|---|---|
+| `--max-runtime-sec N` | Wall-clock cap — exits cleanly after N seconds (cancels even a quiet stream). |
+| `--max-triggers N` | Exits cleanly after N triggers (count survives reconnects). |
+| `--exit-after-first-trigger` | Shorthand for `--max-triggers 1`. |
+| `--confirm` | Required **in addition to** `BINANCE_DEMO_SCALPING_WS_CONFIRM=true` to place real Demo orders. Confirmed runs **must** also carry a trigger bound or the daemon **fails closed (exit 2, no order)**. |
+
+> **Scope reminder (ROB-316):** this validates *plumbing*, not alpha. The current micro-breakout signal has no backtested edge — keep first-live validation **dry-run**. Only do a confirmed bounded run if you specifically need to prove the order-placement path end-to-end against Demo, and keep it to a single trigger.
+
+**Step 1 — bounded dry-run (real fstream, no orders, time-boxed):**
+```bash
+# Load ONLY Demo creds into a scoped subprocess (see Preconditions caveat) —
+# do not blindly `source` the prod env file into your shell.
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+uv run python -m scripts.binance_demo_scalping_ws_daemon --max-runtime-sec 120
+```
+Subscribes to `wss://fstream.binance.com`, evaluates triggers, runs the executor with `confirm=False` (zero mutation), and exits after 120s. Confirm clean reconnect/freshness logs and no errors.
+
+**Step 2 — confirmed single-trigger plumbing check (real Demo order, bounded):**
+```bash
+BINANCE_DEMO_SCALPING_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_ENABLED=true \
+BINANCE_DEMO_SCALPING_WS_CONFIRM=true \
+uv run python -m scripts.binance_demo_scalping_ws_daemon --confirm --exit-after-first-trigger
+```
+Places at most **one** real Demo order on `demo-fapi.binance.com`, then exits. Omitting `--confirm` (or the env gate) → dry-run. Omitting a trigger bound while confirmed → **exit 2, no order placed**. Verify the resulting `binance_demo_order_ledger` lifecycle + `scalp_trade_analytics` row (§5) and confirm it reconciled (no `anomaly`).
 
 ---
 

--- a/scripts/binance_demo_scalping_ws_daemon.py
+++ b/scripts/binance_demo_scalping_ws_daemon.py
@@ -12,6 +12,12 @@ opening a socket. With the gates on it prints a ``running`` summary, subscribes
 to the read-only fstream futures streams, and routes triggers to the
 confirm-gated WsExecutionBridge. Demo hosts only; no live/testnet path; no
 secrets printed.
+
+Bounded operator mode (for first-live validation): ``--max-runtime-sec`` and
+``--max-triggers`` / ``--exit-after-first-trigger`` make the daemon exit cleanly
+after a small, observable run. Real Demo orders need BOTH
+``BINANCE_DEMO_SCALPING_WS_CONFIRM=true`` AND the explicit ``--confirm`` flag,
+and confirmed runs must carry a trigger bound (fail-closed otherwise).
 """
 
 from __future__ import annotations
@@ -72,7 +78,42 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         )
     )
     parser.add_argument("--log-level", default="INFO")
+    parser.add_argument(
+        "--max-runtime-sec",
+        type=float,
+        default=None,
+        help="Wall-clock cap: exit cleanly after this many seconds.",
+    )
+    parser.add_argument(
+        "--max-triggers",
+        type=int,
+        default=None,
+        help="Exit cleanly after N triggers (bounded operator mode).",
+    )
+    parser.add_argument(
+        "--exit-after-first-trigger",
+        action="store_true",
+        help="Shorthand for --max-triggers 1.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "Required (in addition to BINANCE_DEMO_SCALPING_WS_CONFIRM=true) to "
+            "place real Demo orders. Confirmed runs also require a trigger bound."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def resolve_confirm(gates: WsDaemonGates, *, confirm_flag: bool) -> bool:
+    """Whether real Demo order mutation is permitted.
+
+    Requires BOTH the env gate (all three env vars, surfaced as
+    ``gates.mutation_allowed``) AND the explicit ``--confirm`` flag. Either one
+    missing → dry-run (fail-closed). The flag alone never enables mutation.
+    """
+    return gates.mutation_allowed and confirm_flag
 
 
 logger = logging.getLogger("rob317.demo_scalping_ws_daemon")
@@ -100,12 +141,18 @@ async def run_daemon(
     on_trigger: OnTrigger | None = None,
     confirm: bool = False,
     clock: Callable[[], dt.datetime] | None = None,
-) -> None:
-    """Run the trigger pipeline.
+    max_triggers: int | None = None,
+    max_runtime_sec: float | None = None,
+) -> int:
+    """Run the trigger pipeline; return the number of triggers processed.
+
+    Bounded operator mode: ``max_triggers`` stops cleanly after N triggers
+    (count survives reconnects); ``max_runtime_sec`` is a wall-clock cap that
+    cancels even a stream blocked with no events. Both default off (unbounded).
 
     Production: ``on_trigger`` defaults to the env-built WsExecutionBridge
-    (confirm passed in from gates). Tests inject ``source_factory`` +
-    ``on_trigger`` to stay network/DB-free.
+    (confirm passed in). Tests inject ``source_factory`` + ``on_trigger`` to
+    stay network/DB-free.
     """
     factory = source_factory or _real_source_factory(symbols)
     sup = ScalpingDaemonSupervisor(
@@ -119,11 +166,37 @@ async def run_daemon(
 
         bridge, aclose = await build_ws_execution_bridge_from_env(confirm=confirm)
         on_trigger = bridge
+
+    triggers = 0
+    sink = on_trigger
+
+    async def _counting(trigger: TriggerEvent) -> None:
+        nonlocal triggers
+        await sink(trigger)
+        triggers += 1
+
+    def _stop_when() -> bool:
+        return max_triggers is not None and triggers >= max_triggers
+
     try:
-        await sup.run_with_reconnect(factory, on_trigger=on_trigger)
+        runner = sup.run_with_reconnect(
+            factory, on_trigger=_counting, stop_when=_stop_when
+        )
+        if max_runtime_sec is not None:
+            try:
+                await asyncio.wait_for(runner, timeout=max_runtime_sec)
+            except TimeoutError:
+                logger.info(
+                    "daemon exiting: --max-runtime-sec=%.3f reached (triggers=%d)",
+                    max_runtime_sec,
+                    triggers,
+                )
+        else:
+            await runner
     finally:
         if aclose is not None:
             await aclose()
+    return triggers
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -134,12 +207,29 @@ def main(argv: list[str] | None = None) -> int:
     print(json.dumps(summary, sort_keys=True))
     if not gates.daemon_active:
         return 0
+    max_triggers = 1 if args.exit_after_first_trigger else args.max_triggers
+    confirm = resolve_confirm(gates, confirm_flag=args.confirm)
+    if confirm and max_triggers is None:
+        logger.error(
+            "confirmed mode requires a trigger bound: pass --max-triggers N or "
+            "--exit-after-first-trigger (fail-closed; no order placed)"
+        )
+        return 2
     symbols = sorted(DEFAULT_ALLOWLIST)
     logger.info(
-        "WS daemon active (mutation_allowed=%s) — turning triggers into real Demo orders",
-        gates.mutation_allowed,
+        "WS daemon active: confirm=%s max_triggers=%s max_runtime_sec=%s",
+        confirm,
+        max_triggers,
+        args.max_runtime_sec,
     )
-    asyncio.run(run_daemon(symbols=symbols, confirm=gates.mutation_allowed))
+    asyncio.run(
+        run_daemon(
+            symbols=symbols,
+            confirm=confirm,
+            max_triggers=max_triggers,
+            max_runtime_sec=args.max_runtime_sec,
+        )
+    )
     return 0
 
 

--- a/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
+++ b/tests/scripts/test_binance_demo_scalping_ws_daemon_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import json
 from collections.abc import AsyncIterator
@@ -12,7 +13,14 @@ import pytest
 from app.services.brokers.binance.demo_scalping_ws.config import WsDaemonGates
 from app.services.brokers.binance.demo_scalping_ws.market_stream import FuturesWsEvent
 from app.services.brokers.binance.ws_client import BookTickerEvent, KlineEvent
-from scripts.binance_demo_scalping_ws_daemon import build_summary, main, run_daemon
+from scripts.binance_demo_scalping_ws_daemon import (
+    build_summary,
+    main,
+    resolve_confirm,
+    run_daemon,
+)
+
+_MODULE = "scripts.binance_demo_scalping_ws_daemon"
 
 _T0 = dt.datetime(2026, 5, 26, 10, 0, tzinfo=dt.UTC)
 
@@ -100,3 +108,132 @@ async def test_run_daemon_routes_triggers_to_injected_on_trigger() -> None:
 async def _source(events: list[FuturesWsEvent]) -> AsyncIterator[FuturesWsEvent]:
     for ev in events:
         yield ev
+
+
+# --- bounded operator mode (ROB-317 follow-up) -----------------------------
+
+
+async def _noop_on_trigger(_trigger) -> None:
+    return None
+
+
+def _fail_if_called(**_kwargs) -> None:
+    raise AssertionError("run_daemon must not be invoked here")
+
+
+def _book_for(symbol: str) -> BookTickerEvent:
+    return BookTickerEvent(
+        symbol=symbol,
+        bid_price=Decimal("0.50"),
+        bid_qty=Decimal("1"),
+        ask_price=Decimal("0.5001"),
+        ask_qty=Decimal("1"),
+        received_at=_T0,
+    )
+
+
+def _kline_for(symbol: str, close: str, high: str, low: str, minute: int) -> KlineEvent:
+    base = _T0 + dt.timedelta(minutes=minute)
+    return KlineEvent(
+        symbol=symbol,
+        interval="1m",
+        open_time=base,
+        close_time=base + dt.timedelta(seconds=59),
+        open=Decimal(close),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        base_volume=Decimal("1000"),
+        quote_volume=Decimal("515"),
+        trade_count=42,
+        is_closed=True,
+    )
+
+
+def _breakout_for(symbol: str) -> list[FuturesWsEvent]:
+    out: list[FuturesWsEvent] = [_book_for(symbol)]
+    for m in range(25):
+        out.append(_kline_for(symbol, "0.50", "0.51", "0.49", m))
+    out.append(_kline_for(symbol, "0.60", "0.60", "0.50", 25))
+    return out
+
+
+def test_main_disabled_does_not_invoke_run_daemon(monkeypatch) -> None:
+    # Default-disabled must exit without ever building a source / opening a
+    # socket: run_daemon is never reached.
+    for key in (
+        "BINANCE_DEMO_SCALPING_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_ENABLED",
+        "BINANCE_DEMO_SCALPING_WS_CONFIRM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fail_if_called)
+    assert main([]) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_max_runtime_exits_cleanly() -> None:
+    # A stream that never yields must not hang — --max-runtime-sec bounds it.
+    async def _never() -> AsyncIterator[FuturesWsEvent]:
+        await asyncio.sleep(3600)
+        yield  # pragma: no cover - unreachable, makes this an async generator
+
+    count = await run_daemon(
+        symbols=["XRPUSDT"],
+        source_factory=lambda: _never(),
+        on_trigger=_noop_on_trigger,
+        max_runtime_sec=0.05,
+    )
+    assert count == 0  # exited via the runtime bound, no triggers
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_max_triggers_stops_after_n() -> None:
+    seen: list[str] = []
+
+    async def sink(trigger) -> None:
+        seen.append(trigger.symbol)
+
+    seq = _breakout_for("XRPUSDT") + _breakout_for("DOGEUSDT")
+    count = await run_daemon(
+        symbols=["XRPUSDT", "DOGEUSDT"],
+        source_factory=lambda: _source(seq),
+        on_trigger=sink,
+        clock=lambda: _T0 + dt.timedelta(seconds=5),
+        max_triggers=1,
+    )
+    assert count == 1
+    assert seen == ["XRPUSDT"]  # stopped after the first symbol's trigger
+
+
+def test_resolve_confirm_requires_env_and_flag() -> None:
+    all_on = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=True)
+    env_only = WsDaemonGates(base_enabled=True, ws_enabled=True, ws_confirm=False)
+    assert resolve_confirm(all_on, confirm_flag=True) is True
+    assert resolve_confirm(all_on, confirm_flag=False) is False  # --confirm missing
+    assert resolve_confirm(env_only, confirm_flag=True) is False  # env gate missing
+
+
+def test_main_confirm_without_bound_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_CONFIRM", "true")
+    # Confirmed mode with no trigger bound must fail closed before running.
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fail_if_called)
+    assert main(["--confirm"]) == 2
+
+
+def test_main_confirmed_bounded_wires_run_daemon(monkeypatch) -> None:
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_WS_CONFIRM", "true")
+    captured: dict = {}
+
+    async def _fake_run_daemon(**kwargs) -> int:
+        captured.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(f"{_MODULE}.run_daemon", _fake_run_daemon)
+    assert main(["--confirm", "--exit-after-first-trigger"]) == 0
+    assert captured["confirm"] is True
+    assert captured["max_triggers"] == 1

--- a/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
+++ b/tests/services/brokers/binance/demo_scalping_ws/test_supervisor.py
@@ -276,3 +276,25 @@ async def test_trigger_carries_source_candle_close_time() -> None:
     assert captured[0].source_candle_close_time_ms == int(
         expected_close.timestamp() * 1000
     )
+
+
+async def test_run_with_reconnect_stops_when_stop_when_true() -> None:
+    # Bounded operator mode: a stop_when predicate halts the loop cleanly after
+    # the Nth trigger (here 1), even though a second eligible breakout follows.
+    clock = _Clock(_T0 + dt.timedelta(seconds=5))
+    sup = ScalpingDaemonSupervisor(symbols=["XRPUSDT"], clock=clock, debounce_seconds=0)
+    count = 0
+
+    async def on_trig(_trigger: TriggerEvent) -> None:
+        nonlocal count
+        count += 1
+
+    def stop_when() -> bool:
+        return count >= 1
+
+    seq = _breakout_sequence()
+    seq.append(_kline("0.70", high="0.70", low="0.60", minute=26))  # 2nd breakout
+    await sup.run_with_reconnect(
+        lambda: _source_from(seq), on_trigger=on_trig, stop_when=stop_when
+    )
+    assert count == 1  # stopped after the first trigger; second not fired

--- a/tests/test_kis_mock_scalping_sell_guard.py
+++ b/tests/test_kis_mock_scalping_sell_guard.py
@@ -1,0 +1,256 @@
+"""Unit tests for KIS mock scalping sell-guard separation (ROB-321 PR1)."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import (
+    DefensiveTrimContext,
+    ScalpingExitContext,
+    _resolve_scalping_exit_context,
+    evaluate_sell_price_guards,
+)
+
+
+@pytest.mark.unit
+def test_kis_mock_scalping_disabled_by_default() -> None:
+    assert settings.kis_mock_scalping_enabled is False
+
+
+def _trim_ctx() -> DefensiveTrimContext:
+    return DefensiveTrimContext(
+        approval_issue_id="ROB-1",
+        requester_agent_id="agent",
+        approval_verified_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+    )
+
+
+def _scalp_ctx() -> ScalpingExitContext:
+    return ScalpingExitContext(strategy_id="kis-mock-v1", reason="stop_loss")
+
+
+@pytest.mark.unit
+def test_guard_blocks_below_floor_when_no_context() -> None:
+    # price below avg*1.01 -> floor error
+    err = evaluate_sell_price_guards(
+        price=1000.0,
+        current_price=1000.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+    )
+    assert err is not None and "below minimum" in err
+
+
+@pytest.mark.unit
+def test_guard_blocks_below_current_price_when_no_context() -> None:
+    # price >= floor (avg low) but below current -> current-price error
+    err = evaluate_sell_price_guards(
+        price=1000.0,
+        current_price=1100.0,
+        avg_price=900.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+    )
+    assert err is not None and "below current price" in err
+
+
+@pytest.mark.unit
+def test_defensive_trim_bypasses_floor_but_not_current_price() -> None:
+    # below floor: allowed by trim; but also below current -> still blocked
+    err = evaluate_sell_price_guards(
+        price=950.0,
+        current_price=1000.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=_trim_ctx(),
+        scalping_exit_ctx=None,
+    )
+    assert err is not None and "below current price" in err
+
+
+@pytest.mark.unit
+def test_scalping_exit_bypasses_both_guards() -> None:
+    # below floor AND below current: scalping exit allows it (stop-loss)
+    err = evaluate_sell_price_guards(
+        price=950.0,
+        current_price=1000.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=_scalp_ctx(),
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_no_context_clean_price_passes() -> None:
+    err = evaluate_sell_price_guards(
+        price=1100.0,
+        current_price=1050.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_resolver_returns_none_when_not_requested(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    ctx = _resolve_scalping_exit_context(
+        scalping_exit=False,
+        strategy_id="s",
+        reason="stop_loss",
+        side="sell",
+        order_type="limit",
+        is_mock=True,
+    )
+    assert ctx is None
+
+
+@pytest.mark.unit
+def test_resolver_fail_closed_on_live(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    with pytest.raises(ValueError, match="kis_mock"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True,
+            strategy_id="s",
+            reason="stop_loss",
+            side="sell",
+            order_type="limit",
+            is_mock=False,
+        )
+
+
+@pytest.mark.unit
+def test_resolver_fail_closed_when_flag_off(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", False, raising=False)
+    with pytest.raises(ValueError, match="KIS_MOCK_SCALPING_ENABLED"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True,
+            strategy_id="s",
+            reason="stop_loss",
+            side="sell",
+            order_type="limit",
+            is_mock=True,
+        )
+
+
+@pytest.mark.unit
+def test_resolver_returns_context_when_authorized(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    ctx = _resolve_scalping_exit_context(
+        scalping_exit=True,
+        strategy_id="kis-mock-v1",
+        reason="stop_loss",
+        side="sell",
+        order_type="limit",
+        is_mock=True,
+    )
+    assert ctx is not None and ctx.strategy_id == "kis-mock-v1"
+    assert ctx.reason == "stop_loss"
+
+
+@pytest.mark.unit
+def test_resolver_rejects_buy_and_market_and_bad_reason(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    with pytest.raises(ValueError, match="side='sell'"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True,
+            strategy_id="s",
+            reason="stop_loss",
+            side="buy",
+            order_type="limit",
+            is_mock=True,
+        )
+    with pytest.raises(ValueError, match="order_type='limit'"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True,
+            strategy_id="s",
+            reason="stop_loss",
+            side="sell",
+            order_type="market",
+            is_mock=True,
+        )
+    with pytest.raises(ValueError, match="reason"):
+        _resolve_scalping_exit_context(
+            scalping_exit=True,
+            strategy_id="s",
+            reason="moon",
+            side="sell",
+            order_type="limit",
+            is_mock=True,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_scalping_exit_allows_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    result = await order_validation._preview_sell(
+        symbol="005930",
+        order_type="limit",
+        quantity=10,
+        price=950.0,
+        current_price=980.0,
+        market_type="kr",
+        scalping_exit_ctx=ScalpingExitContext(strategy_id="s", reason="stop_loss"),
+        is_mock=True,
+    )
+    assert "error" not in result
+    assert result["price"] == 950.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_live_still_blocks_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    # No scalping ctx, no trim ctx: live behavior preserved.
+    result = await order_validation._preview_sell(
+        symbol="005930",
+        order_type="limit",
+        quantity=10,
+        price=950.0,
+        current_price=980.0,
+        market_type="kr",
+        is_mock=False,
+    )
+    assert "error" in result and "below minimum" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_scalping_exit_allows_below_floor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 1000.0, "quantity": 10}),
+    )
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="005930",
+        normalized_symbol="005930",
+        market_type="kr",
+        quantity=10,
+        order_type="limit",
+        price=950.0,
+        current_price=980.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        scalping_exit_ctx=ScalpingExitContext(strategy_id="s", reason="stop_loss"),
+        is_mock=True,
+        dry_run=True,
+    )
+    assert err is None and errors == []
+    assert avg == 1000.0


### PR DESCRIPTION
Promote accumulated main to production.\n\nIncluded since current production:\n- #963 ROB-321 KIS mock scalping sell-guard separation (mock-only guardrails)\n- #965 ROB-317 Binance Demo WS bounded operator mode (demo-only, default-disabled)\n\nOperator notes:\n- No live/KIS real-order activation intended.\n- ROB-317 confirmed Demo mode remains gated by env + explicit --confirm + trigger bound.\n- No scheduler/Prefect recurrence added by #965.\n- Post-merge: run alembic upgrade head, healthcheck, bounded WS dry-run, then confirmed 1-trigger Binance Futures Demo smoke.