### PR TITLE
feat(rob-321): KIS mock scalping signal/risk contract + supervisor (PR3/4, dry-run)

### DIFF
--- a/app/services/brokers/kis/mock_scalping/contract.py
+++ b/app/services/brokers/kis/mock_scalping/contract.py
@@ -1,0 +1,155 @@
+"""ROB-321 PR3 — KIS mock scalping risk / order-intent contract.
+
+Deterministic and read-only, mirroring the Binance demo_scalping contract but
+KIS-specific:
+
+* **Cash equities, long-only.** Entry signals are BUY-only; SELL exists only as
+  a close/exit (handled by the exit manager in PR4), never as a short entry.
+* **Notional in KRW.**
+* The risk envelope (ROB-321 §1 mock scalping guards): symbol allowlist, max
+  notional, max open positions, per-symbol cooldown, daily order/loss caps,
+  spread + data-freshness gates.
+
+``evaluate_risk`` is a pure function over value objects (no broker, no DB, no
+network) returning every blocking reason code, not just the first. No order
+mutation reachable from here; the durable ``LedgerSnapshot`` is read by PR4 from
+the KIS mock shadow ledger and injected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Literal
+
+Side = Literal["BUY", "SELL"]
+
+# Conservative default candidate universe — liquid KR large-caps. Operator may
+# override via ScalpingRiskLimits(allowlist=...).
+DEFAULT_ALLOWLIST: frozenset[str] = frozenset({"005930", "000660", "005380"})
+MAX_NOTIONAL_KRW: Decimal = Decimal("100000")  # 10만원 per entry
+
+
+class ReasonCode:
+    """Stable string reason codes for signal/risk audit trails.
+
+    Append-only — never rename an existing code (persisted to ledger/report
+    metadata).
+    """
+
+    # Symbol gates
+    SYMBOL_NOT_ALLOWLISTED = "symbol_not_allowlisted"
+    # Market-condition gates
+    SPREAD_TOO_WIDE = "spread_too_wide"
+    STALE_DATA = "stale_data"
+    # Sizing / notional
+    NOTIONAL_ABOVE_CAP = "notional_above_cap"
+    # Lifecycle / durable-state caps
+    OPEN_POSITION_EXISTS = "open_position_exists"
+    MAX_OPEN_POSITIONS_REACHED = "max_open_positions_reached"
+    DAILY_ORDER_CAP_REACHED = "daily_order_cap_reached"
+    DAILY_LOSS_BUDGET_EXHAUSTED = "daily_loss_budget_exhausted"
+    COOLDOWN_ACTIVE = "cooldown_active"
+    # Direction (cash market is long-only)
+    SHORT_ENTRY_NOT_ALLOWED = "short_entry_not_allowed"
+    # Signal outcomes
+    ENTER_LONG_BREAKOUT = "enter_long_breakout"
+    CHASE_TOO_FAR = "chase_too_far"
+    NO_SIGNAL = "no_signal"
+    INSUFFICIENT_HISTORY = "insufficient_history"
+
+
+@dataclass(frozen=True)
+class ScalpingRiskLimits:
+    """The configured risk envelope. All defaults are conservative."""
+
+    allowlist: frozenset[str] = DEFAULT_ALLOWLIST
+    max_notional_krw: Decimal = MAX_NOTIONAL_KRW
+    max_open_positions: int = 1
+    daily_order_count_cap: int = 10
+    daily_loss_budget_krw: Decimal = Decimal("50000")
+    cooldown_seconds: int = 300
+    max_spread_bps: Decimal = Decimal("30")  # 0.30%
+    max_data_age_seconds: float = 60.0
+
+
+@dataclass(frozen=True)
+class LedgerSnapshot:
+    """Durable lifecycle state read from the KIS mock shadow ledger (PR4).
+
+    Computed from the DB, never held only in memory, so cooldown /
+    single-position enforcement survives a fresh process or scheduler run.
+    """
+
+    has_open_position_for_symbol: bool
+    open_position_count: int
+    orders_today: int
+    realized_loss_today_krw: Decimal
+    seconds_since_last_close_for_symbol: float | None
+
+
+@dataclass(frozen=True)
+class MarketConditions:
+    """Read-only market snapshot relevant to the risk gates."""
+
+    spread_bps: Decimal
+    data_age_seconds: float
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    allowed: bool
+    reason_codes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def evaluate_risk(
+    *,
+    symbol: str,
+    side: Side,
+    target_notional_krw: Decimal,
+    limits: ScalpingRiskLimits,
+    ledger: LedgerSnapshot,
+    market: MarketConditions,
+) -> RiskDecision:
+    """Return every blocking reason for a candidate entry; empty == allowed.
+
+    All checks accumulate (no short-circuit) so the observe-only record
+    surfaces the full set of violations.
+    """
+
+    reasons: list[str] = []
+
+    # --- Direction: cash market is long-only; SELL is never an entry. ---
+    if side == "SELL":
+        reasons.append(ReasonCode.SHORT_ENTRY_NOT_ALLOWED)
+
+    # --- Symbol gate ---
+    if symbol not in limits.allowlist:
+        reasons.append(ReasonCode.SYMBOL_NOT_ALLOWLISTED)
+
+    # --- Market-condition gates ---
+    if market.spread_bps > limits.max_spread_bps:
+        reasons.append(ReasonCode.SPREAD_TOO_WIDE)
+    if market.data_age_seconds > limits.max_data_age_seconds:
+        reasons.append(ReasonCode.STALE_DATA)
+
+    # --- Notional cap (defense in depth; sizing also floors, never rounds up) ---
+    if target_notional_krw > limits.max_notional_krw:
+        reasons.append(ReasonCode.NOTIONAL_ABOVE_CAP)
+
+    # --- Durable lifecycle / daily caps ---
+    if ledger.has_open_position_for_symbol:
+        reasons.append(ReasonCode.OPEN_POSITION_EXISTS)
+    if ledger.open_position_count >= limits.max_open_positions:
+        reasons.append(ReasonCode.MAX_OPEN_POSITIONS_REACHED)
+    if ledger.orders_today >= limits.daily_order_count_cap:
+        reasons.append(ReasonCode.DAILY_ORDER_CAP_REACHED)
+    if ledger.realized_loss_today_krw >= limits.daily_loss_budget_krw:
+        reasons.append(ReasonCode.DAILY_LOSS_BUDGET_EXHAUSTED)
+    if (
+        ledger.seconds_since_last_close_for_symbol is not None
+        and ledger.seconds_since_last_close_for_symbol < limits.cooldown_seconds
+    ):
+        reasons.append(ReasonCode.COOLDOWN_ACTIVE)
+
+    return RiskDecision(allowed=not reasons, reason_codes=tuple(reasons))

--- a/app/services/brokers/kis/mock_scalping/contract.py
+++ b/app/services/brokers/kis/mock_scalping/contract.py
@@ -1,7 +1,7 @@
 """ROB-321 PR3 — KIS mock scalping risk / order-intent contract.
 
-Deterministic and read-only, mirroring the Binance demo_scalping contract but
-KIS-specific:
+Deterministic and read-only, mirroring the demo_scalping risk contract pattern
+(ROB-307) but KIS-specific:
 
 * **Cash equities, long-only.** Entry signals are BUY-only; SELL exists only as
   a close/exit (handled by the exit manager in PR4), never as a short entry.

--- a/app/services/brokers/kis/mock_scalping/order_intent.py
+++ b/app/services/brokers/kis/mock_scalping/order_intent.py
@@ -1,0 +1,87 @@
+"""ROB-321 PR3 — order-intent contract (signal → executor bridge).
+
+``OrderIntent`` is the explicit, validated hand-off from the read-only signal
+layer to the PR4 mock executor. It is pure data — no broker, no DB, no execution
+imports — so it lives in the read-only package. The executor re-fetches live
+price/tick-size for sizing; the intent carries the risk-approved KRW notional
+cap, the candidate TP/SL (for ledger/audit metadata), reason codes, and source
+timestamps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from app.services.brokers.kis.mock_scalping.contract import ScalpingRiskLimits, Side
+from app.services.brokers.kis.mock_scalping.signal import SignalDecision
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    symbol: str
+    side: Side
+    order_type: str
+    target_notional_krw: Decimal
+    entry_reference_price: Decimal | None
+    tp_price: Decimal | None
+    sl_price: Decimal | None
+    confidence: Decimal
+    reason_codes: tuple[str, ...]
+    source_candle_close_time_ms: int
+    evaluated_at_ms: int
+    account_mode: str = "kis_mock"
+
+    def to_evidence_dict(self) -> dict[str, Any]:
+        """JSON-safe metadata for ledger / evidence."""
+        return {
+            "account_mode": self.account_mode,
+            "symbol": self.symbol,
+            "side": self.side,
+            "order_type": self.order_type,
+            "target_notional_krw": str(self.target_notional_krw),
+            "entry_reference_price": (
+                None
+                if self.entry_reference_price is None
+                else str(self.entry_reference_price)
+            ),
+            "tp_price": None if self.tp_price is None else str(self.tp_price),
+            "sl_price": None if self.sl_price is None else str(self.sl_price),
+            "confidence": str(self.confidence),
+            "reason_codes": list(self.reason_codes),
+            "source_candle_close_time_ms": self.source_candle_close_time_ms,
+            "evaluated_at_ms": self.evaluated_at_ms,
+        }
+
+
+def build_order_intent(
+    signal: SignalDecision,
+    *,
+    symbol: str,
+    limits: ScalpingRiskLimits,
+    source_candle_close_time_ms: int,
+    evaluated_at_ms: int,
+    order_type: str = "limit",
+) -> OrderIntent | None:
+    """Build an ``OrderIntent`` from a long entry signal, else ``None``.
+
+    The notional is pinned to the risk cap (``limits.max_notional_krw``); the
+    executor floors it to the share price / tick size and never rounds up.
+    Returns None for non-entry or non-BUY signals (cash market is long-only).
+    """
+    if not signal.has_entry or signal.side != "BUY":
+        return None
+    return OrderIntent(
+        symbol=symbol,
+        side=signal.side,
+        order_type=order_type,
+        target_notional_krw=limits.max_notional_krw,
+        entry_reference_price=signal.entry_price,
+        tp_price=signal.tp_price,
+        sl_price=signal.sl_price,
+        confidence=signal.confidence,
+        reason_codes=signal.reason_codes,
+        source_candle_close_time_ms=source_candle_close_time_ms,
+        evaluated_at_ms=evaluated_at_ms,
+    )

--- a/app/services/brokers/kis/mock_scalping/signal.py
+++ b/app/services/brokers/kis/mock_scalping/signal.py
@@ -1,0 +1,132 @@
+"""ROB-321 PR3 — deterministic long-only trend micro-breakout scalping signal.
+
+Mirrors the Binance demo_scalping signal but for KR cash equities:
+
+* **Long-only.** Enter when ``sma_fast > sma_slow`` (uptrend) AND the latest
+  close breaks above the prior ``breakout_lookback``-bar high. There is no short
+  branch — KR cash equities cannot be shorted here.
+* **No-chase guard** (ROB-321 §3 "당일 급등주 추격 금지"): if the breakout margin
+  above the prior high already exceeds ``max_chase_bps``, the candle has run too
+  far — reject with ``CHASE_TOO_FAR`` rather than chase a spike.
+* Exits are fixed-bps TP/SL relative to the entry candidate.
+
+``evaluate_signal`` is pure over a candle sequence — deterministic, no network,
+no broker, no LLM. Thresholds live in ``SignalConfig`` so they are trivially
+tunable and test-pinned. (Edge is intentionally a conservative toy: ROB-316
+showed scalping is net-negative after fees; this layer validates the plumbing.)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from app.services.brokers.kis.mock_scalping.contract import ReasonCode, Side
+
+_BPS = Decimal("10000")
+# Reference separation/margin (in bps) that maps to full confidence.
+_CONFIDENCE_REFERENCE_BPS = Decimal("50")
+
+
+@dataclass(frozen=True)
+class Candle:
+    open_time_ms: int
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    close_time_ms: int
+
+
+@dataclass(frozen=True)
+class SignalConfig:
+    sma_fast: int = 7
+    sma_slow: int = 25
+    breakout_lookback: int = 20
+    tp_bps: Decimal = Decimal("30")
+    sl_bps: Decimal = Decimal("20")
+    # No-chase ceiling: reject a breakout that already ran more than this many
+    # bps above the prior high (don't chase 급등주).
+    max_chase_bps: Decimal = Decimal("50")
+
+
+@dataclass(frozen=True)
+class SignalDecision:
+    has_entry: bool
+    side: Side | None
+    entry_price: Decimal | None
+    tp_price: Decimal | None
+    sl_price: Decimal | None
+    confidence: Decimal
+    reason_codes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _sma(closes: Sequence[Decimal], period: int) -> Decimal:
+    window = closes[-period:]
+    return sum(window, Decimal("0")) / Decimal(len(window))
+
+
+def _clamp01(value: Decimal) -> Decimal:
+    if value < 0:
+        return Decimal("0")
+    if value > 1:
+        return Decimal("1")
+    return value
+
+
+def _no_entry(reason: str) -> SignalDecision:
+    return SignalDecision(
+        has_entry=False,
+        side=None,
+        entry_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=(reason,),
+    )
+
+
+def _confidence(*, separation_bps: Decimal, margin_bps: Decimal) -> Decimal:
+    sep_norm = _clamp01(abs(separation_bps) / _CONFIDENCE_REFERENCE_BPS)
+    margin_norm = _clamp01(abs(margin_bps) / _CONFIDENCE_REFERENCE_BPS)
+    return _clamp01((sep_norm + margin_norm) / Decimal("2"))
+
+
+def evaluate_signal(candles: Sequence[Candle], config: SignalConfig) -> SignalDecision:
+    """Evaluate the latest candle against the long-only micro-breakout rule."""
+
+    needed = max(config.sma_slow, config.breakout_lookback + 1)
+    if len(candles) < needed:
+        return _no_entry(ReasonCode.INSUFFICIENT_HISTORY)
+
+    closes = [c.close for c in candles]
+    current = candles[-1]
+    prior = candles[:-1]
+
+    sma_fast = _sma(closes, config.sma_fast)
+    sma_slow = _sma(closes, config.sma_slow)
+    separation_bps = (sma_fast - sma_slow) / sma_slow * _BPS
+
+    lookback = prior[-config.breakout_lookback :]
+    prior_high = max(c.high for c in lookback)
+
+    if not (sma_fast > sma_slow and current.close > prior_high):
+        return _no_entry(ReasonCode.NO_SIGNAL)
+
+    entry = current.close
+    margin_bps = (entry - prior_high) / prior_high * _BPS
+
+    # No-chase guard: the breakout already ran too far above the prior high.
+    if margin_bps > config.max_chase_bps:
+        return _no_entry(ReasonCode.CHASE_TOO_FAR)
+
+    return SignalDecision(
+        has_entry=True,
+        side="BUY",
+        entry_price=entry,
+        tp_price=entry * (Decimal("1") + config.tp_bps / _BPS),
+        sl_price=entry * (Decimal("1") - config.sl_bps / _BPS),
+        confidence=_confidence(separation_bps=separation_bps, margin_bps=margin_bps),
+        reason_codes=(ReasonCode.ENTER_LONG_BREAKOUT,),
+    )

--- a/app/services/brokers/kis/mock_scalping/signal.py
+++ b/app/services/brokers/kis/mock_scalping/signal.py
@@ -1,6 +1,6 @@
 """ROB-321 PR3 — deterministic long-only trend micro-breakout scalping signal.
 
-Mirrors the Binance demo_scalping signal but for KR cash equities:
+Mirrors the demo_scalping signal pattern (ROB-307) but for KR cash equities:
 
 * **Long-only.** Enter when ``sma_fast > sma_slow`` (uptrend) AND the latest
   close breaks above the prior ``breakout_lookback``-bar high. There is no short

--- a/app/services/brokers/kis/mock_scalping_ws/candles.py
+++ b/app/services/brokers/kis/mock_scalping_ws/candles.py
@@ -1,0 +1,62 @@
+"""Tick → 1-minute OHLC candle aggregation (pure, deterministic).
+
+KIS quote WS delivers trade ticks (체결가), not exchange klines, so the
+supervisor builds candles itself. ``CandleAggregator.add`` buckets ticks by
+minute (derived from an injected ``now`` in epoch seconds) and returns a closed
+``Candle`` exactly once, when the first tick of a *later* minute arrives. No I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.services.brokers.kis.mock_scalping.signal import Candle
+
+_MINUTE = 60
+
+
+@dataclass
+class CandleAggregator:
+    _bucket: int | None = None
+    _open: Decimal | None = None
+    _high: Decimal | None = None
+    _low: Decimal | None = None
+    _close: Decimal | None = None
+
+    def add(self, price: Decimal, *, now: float) -> Candle | None:
+        """Accumulate a tick. Returns the prior minute's Candle when it closes."""
+        bucket = int(now // _MINUTE)
+        if self._bucket is None:
+            self._start(bucket, price)
+            return None
+        if bucket == self._bucket:
+            assert self._high is not None and self._low is not None
+            self._high = max(self._high, price)
+            self._low = min(self._low, price)
+            self._close = price
+            return None
+        closed = self._finish()
+        self._start(bucket, price)
+        return closed
+
+    def _start(self, bucket: int, price: Decimal) -> None:
+        self._bucket = bucket
+        self._open = self._high = self._low = self._close = price
+
+    def _finish(self) -> Candle:
+        assert (
+            self._bucket is not None
+            and self._open is not None
+            and self._high is not None
+            and self._low is not None
+            and self._close is not None
+        )
+        return Candle(
+            open_time_ms=self._bucket * _MINUTE * 1000,
+            open=self._open,
+            high=self._high,
+            low=self._low,
+            close=self._close,
+            close_time_ms=(self._bucket + 1) * _MINUTE * 1000 - 1,
+        )

--- a/app/services/brokers/kis/mock_scalping_ws/state.py
+++ b/app/services/brokers/kis/mock_scalping_ws/state.py
@@ -21,6 +21,7 @@ class MarketState:
     bid_qty: float | None = None
     ask_qty: float | None = None
     _updated_at: float | None = None
+    _book_updated_at: float | None = None
 
     def update_from_tick(self, tick: QuoteTick, *, now: float) -> None:
         self.last_price = tick.last_price
@@ -33,6 +34,7 @@ class MarketState:
         self.bid_qty = book.bid_qty
         self.ask_qty = book.ask_qty
         self._updated_at = now
+        self._book_updated_at = now
 
     def spread_bps(self) -> float | None:
         """(ask - bid) / mid in basis points. None until a valid book is seen."""
@@ -50,3 +52,14 @@ class MarketState:
         if self._updated_at is None:
             return None
         return now - self._updated_at
+
+    def book_age_seconds(self, *, now: float) -> float | None:
+        """Seconds since the last orderbook update. None until a book is seen.
+
+        The trigger gate uses this (not the combined ``age_seconds``) so a stale
+        bid/ask still trips the freshness guard even while trade ticks arrive —
+        otherwise the spread check could pass on a dead book.
+        """
+        if self._book_updated_at is None:
+            return None
+        return now - self._book_updated_at

--- a/app/services/brokers/kis/mock_scalping_ws/supervisor.py
+++ b/app/services/brokers/kis/mock_scalping_ws/supervisor.py
@@ -1,0 +1,186 @@
+"""ROB-321 PR3 — KIS mock scalping daemon supervisor (read-only, dry-run).
+
+Consumes an injectable event source of parsed quote frames (real
+``KISQuoteWebSocket`` in production via a thin adapter; a fake async iterator in
+tests). Orderbook snapshots refresh per-symbol bid/ask state; trade ticks feed a
+1-minute candle aggregator. When a candle closes, the long-only signal is
+re-evaluated; an entry emits a ``TriggerEvent`` only when the symbol has a fresh
+orderbook quote (within the freshness window) AND the per-symbol debounce window
+has elapsed.
+
+The supervisor performs **NO risk re-check, NO order, NO ledger write** —
+``on_trigger`` is a caller-supplied coroutine. PR4 wires the confirm-gated mock
+executor (which owns the ledger risk re-check). Import-guarded: this package may
+not import any order/ledger/execution module.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from app.services.brokers.kis.mock_scalping.contract import ReasonCode, Side
+from app.services.brokers.kis.mock_scalping.signal import (
+    SignalConfig,
+    SignalDecision,
+    evaluate_signal,
+)
+from app.services.brokers.kis.mock_scalping_ws.candles import CandleAggregator
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+logger = logging.getLogger("rob321.kis_mock_scalping_ws")
+
+QuoteEvent = QuoteTick | OrderBookSnapshot
+SourceFactory = Callable[[], AsyncIterator[QuoteEvent]]
+OnTrigger = Callable[["TriggerEvent"], Awaitable[None]]
+Clock = Callable[[], float]
+StopWhen = Callable[[], bool]
+
+_CANDLE_BUFFER = 200
+
+
+@dataclass(frozen=True, slots=True)
+class TriggerEvent:
+    """An event-driven entry candidate, pre-risk-check (PR4 consumes it)."""
+
+    symbol: str
+    side: Side
+    decision: SignalDecision
+    source_candle_close_time_ms: int
+    bid: float | None
+    ask: float | None
+    spread_bps: float | None
+    data_age_seconds: float | None
+    emitted_at: float
+    account_mode: str = "kis_mock"
+
+
+class KisScalpingSupervisor:
+    """Per-symbol quote router with candle aggregation + freshness/debounce gates."""
+
+    def __init__(
+        self,
+        *,
+        symbols: list[str],
+        signal_config: SignalConfig | None = None,
+        max_data_age_seconds: float = 60.0,
+        debounce_seconds: float = 300.0,
+        clock: Clock = time.monotonic,
+    ) -> None:
+        self._config = signal_config or SignalConfig()
+        self._max_data_age_seconds = max_data_age_seconds
+        self._debounce_seconds = debounce_seconds
+        self._clock = clock
+        self._state: dict[str, MarketState] = {
+            s: MarketState(symbol=s) for s in symbols
+        }
+        self._aggregators: dict[str, CandleAggregator] = {
+            s: CandleAggregator() for s in symbols
+        }
+        self._candles: dict[str, deque] = {
+            s: deque(maxlen=_CANDLE_BUFFER) for s in symbols
+        }
+        self._last_trigger_at: dict[str, float] = {}
+
+    async def run(
+        self,
+        source_factory: SourceFactory,
+        *,
+        on_trigger: OnTrigger,
+        stop_after: int | None = None,
+        stop_when: StopWhen | None = None,
+    ) -> None:
+        """Consume one source to exhaustion (single connection pass)."""
+        consumed = 0
+        source = source_factory()
+        async for event in source:
+            trigger = self._handle_event(event)
+            if trigger is not None:
+                await on_trigger(trigger)
+                if stop_when is not None and stop_when():
+                    return
+            consumed += 1
+            if stop_after is not None and consumed >= stop_after:
+                return
+
+    def _handle_event(self, event: QuoteEvent) -> TriggerEvent | None:
+        now = self._clock()
+        state = self._state.get(event.symbol)
+        if state is None:
+            return None  # not a subscribed/allowlisted symbol
+
+        if isinstance(event, OrderBookSnapshot):
+            state.update_from_book(event, now=now)
+            return None
+
+        # QuoteTick → update last + feed candle aggregator
+        state.update_from_tick(event, now=now)
+        closed = self._aggregators[event.symbol].add(
+            Decimal(str(event.last_price)), now=now
+        )
+        if closed is None:
+            return None
+
+        buffer = self._candles[event.symbol]
+        buffer.append(closed)
+        decision = evaluate_signal(list(buffer), self._config)
+        if not decision.has_entry or decision.side is None:
+            return None
+        return self._gate_and_build(
+            event.symbol, state, decision, closed.close_time_ms, now
+        )
+
+    def _gate_and_build(
+        self,
+        symbol: str,
+        state: MarketState,
+        decision: SignalDecision,
+        source_candle_close_time_ms: int,
+        now: float,
+    ) -> TriggerEvent | None:
+        # Execution requires a fresh live quote: a recent orderbook with both
+        # sides present. Trade-tick freshness alone does not qualify (the spread
+        # guard would otherwise pass on a dead book).
+        book_age = state.book_age_seconds(now=now)
+        if (
+            state.bid is None
+            or state.ask is None
+            or book_age is None
+            or book_age > self._max_data_age_seconds
+        ):
+            logger.info(
+                "trigger suppressed symbol=%s reason=%s", symbol, ReasonCode.STALE_DATA
+            )
+            return None
+
+        last = self._last_trigger_at.get(symbol)
+        if last is not None and (now - last) < self._debounce_seconds:
+            logger.info("trigger suppressed symbol=%s reason=debounce", symbol)
+            return None
+
+        self._last_trigger_at[symbol] = now
+        logger.info(
+            "trigger symbol=%s side=%s reasons=%s",
+            symbol,
+            decision.side,
+            decision.reason_codes,
+        )
+        return TriggerEvent(
+            symbol=symbol,
+            side=decision.side,
+            decision=decision,
+            source_candle_close_time_ms=source_candle_close_time_ms,
+            bid=state.bid,
+            ask=state.ask,
+            spread_bps=state.spread_bps(),
+            data_age_seconds=book_age,
+            emitted_at=now,
+        )

--- a/docs/plans/ROB-321-pr3-signal-supervisor-plan.md
+++ b/docs/plans/ROB-321-pr3-signal-supervisor-plan.md
@@ -1,0 +1,73 @@
+# ROB-321 PR3 — Signal / risk contract + supervisor (dry-run)
+
+> Sibling of `docs/plans/ROB-321-kis-mock-scalping-loop-plan.md` (executes PR3).
+
+**Goal:** The deterministic decision layer of the KIS mock scalping loop — a pure
+signal + risk contract and an event-driven supervisor that turns the PR2 quote
+stream into `TriggerEvent`s. **Dry-run only**: no orders, no ledger, no risk
+re-check side effects. Edge-agnostic plumbing (ROB-316: scalping is net-negative
+after fees; v1 strategy is an intentional toy).
+
+**Architecture:** Mirror the Binance `demo_scalping` pattern, KIS-specific:
+cash-equity **long-only**, KRW notional, and a no-chase guard. The supervisor
+builds 1-minute candles from trade ticks (KIS quote WS has no klines), re-runs
+the signal on each close, and emits a `TriggerEvent` gated on a fresh orderbook
+quote + per-symbol debounce. Order execution + ledger risk re-check are PR4.
+
+---
+
+## Delivered (all committed, 62 tests green, ruff/format/ty clean)
+
+### Pure cores — `app/services/brokers/kis/mock_scalping/`
+- **`contract.py`** — `ScalpingRiskLimits` (KRW; allowlist, max_notional, max
+  open positions, daily order/loss caps, cooldown, spread + freshness gates),
+  `ReasonCode` (append-only string constants), `LedgerSnapshot`,
+  `MarketConditions`, `RiskDecision`, and `evaluate_risk()` which **accumulates
+  every blocking reason** (no short-circuit). Long-only: a `SELL` entry yields
+  `SHORT_ENTRY_NOT_ALLOWED`.
+- **`signal.py`** — `Candle`, `SignalConfig`, `SignalDecision`,
+  `evaluate_signal()`: long-only SMA-trend + prior-high breakout, **no-chase
+  guard** (`CHASE_TOO_FAR` when the breakout already ran past `max_chase_bps` —
+  ROB-321 §3 "당일 급등주 추격 금지"), fixed-bps TP/SL.
+- **`order_intent.py`** — `OrderIntent` (BUY-only, KRW notional pinned to the
+  risk cap) + `build_order_intent()` (None for non-entry/SELL) + JSON evidence.
+
+### Event supervisor — `app/services/brokers/kis/mock_scalping_ws/`
+- **`candles.py`** — `CandleAggregator`: tick → 1-minute OHLC, closes a candle
+  when the first tick of a later minute arrives (pure, injected clock).
+- **`supervisor.py`** — `KisScalpingSupervisor`: consumes a `QuoteTick |
+  OrderBookSnapshot` source; orderbook → state, tick → candle; on close →
+  `evaluate_signal` → `TriggerEvent` gated on fresh orderbook (`book_age <=
+  max`) + per-symbol debounce. **No risk re-check / order / ledger** —
+  `on_trigger` is caller-supplied (PR4 wires the confirm-gated executor).
+- **`state.py`** — added `book_age_seconds()` (book-specific freshness) so a
+  stale bid/ask trips the gate even while trade ticks arrive.
+
+### Gating
+- The PR2 `kis_mock_scalping_ws_enabled` flag (default off) gates any daemon.
+- The PR2 AST import guard already forbids `mock_scalping_ws/` (now incl.
+  supervisor + candles) from importing any order/ledger/execution module — still
+  green, keeping the read-only boundary structural.
+
+---
+
+## Deferred to PR4 (not in this PR)
+- **Dry-run daemon entrypoint** wiring the real `KISQuoteWebSocket`
+  (callback → async-queue adapter) → supervisor → log-only `on_trigger`. Lands
+  with PR4 because that is where `on_trigger` becomes the confirm-gated mock
+  executor + ledger risk re-check; a log-only variant would be throwaway glue.
+- Exec bridge, round-trip ledger/reconcile, smoke runbook (PR4 proper). PR4 also
+  wires PR1's `ScalpingExitContext` for the stop-loss exit.
+
+---
+
+## Self-review
+- **Spec coverage (master plan PR3):** EntrySignal/ScalpingStrategy contract
+  (signal.py), risk envelope incl. max notional / open positions / cooldown /
+  daily caps (contract.py), supervisor candle→signal→trigger with freshness +
+  debounce (supervisor.py). ✅
+- **Long-only correctness:** signal never emits SELL; risk blocks SELL entry;
+  build_order_intent returns None for SELL — three independent guards.
+- **Determinism:** all decision logic is pure with injected clocks; tests pin
+  breakout, no-chase, every risk reason code, candle rollover, trigger gating
+  (fresh-book / stale-book / debounce / unknown-symbol).

--- a/tests/brokers/kis/mock_scalping/test_contract.py
+++ b/tests/brokers/kis/mock_scalping/test_contract.py
@@ -1,0 +1,118 @@
+"""KIS mock scalping risk contract tests (ROB-321 PR3)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
+    evaluate_risk,
+)
+
+
+def _clean_ledger(**kw) -> LedgerSnapshot:
+    base: dict = {
+        "has_open_position_for_symbol": False,
+        "open_position_count": 0,
+        "orders_today": 0,
+        "realized_loss_today_krw": Decimal("0"),
+        "seconds_since_last_close_for_symbol": None,
+    }
+    base.update(kw)
+    return LedgerSnapshot(**base)
+
+
+def _clean_market(**kw) -> MarketConditions:
+    base: dict = {"spread_bps": Decimal("5"), "data_age_seconds": 1.0}
+    base.update(kw)
+    return MarketConditions(**base)
+
+
+def _eval(**kw):
+    params: dict = {
+        "symbol": "005930",
+        "side": "BUY",
+        "target_notional_krw": Decimal("50000"),
+        "limits": ScalpingRiskLimits(),
+        "ledger": _clean_ledger(),
+        "market": _clean_market(),
+    }
+    params.update(kw)
+    return evaluate_risk(**params)
+
+
+@pytest.mark.unit
+def test_clean_buy_is_allowed() -> None:
+    decision = _eval()
+    assert decision.allowed is True
+    assert decision.reason_codes == ()
+
+
+@pytest.mark.unit
+def test_sell_entry_blocked_long_only() -> None:
+    decision = _eval(side="SELL")
+    assert decision.allowed is False
+    assert ReasonCode.SHORT_ENTRY_NOT_ALLOWED in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_symbol_not_allowlisted_blocked() -> None:
+    decision = _eval(symbol="999999")
+    assert ReasonCode.SYMBOL_NOT_ALLOWLISTED in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_spread_and_stale_gates() -> None:
+    decision = _eval(
+        market=_clean_market(spread_bps=Decimal("99"), data_age_seconds=999.0)
+    )
+    assert ReasonCode.SPREAD_TOO_WIDE in decision.reason_codes
+    assert ReasonCode.STALE_DATA in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_notional_above_cap_blocked() -> None:
+    decision = _eval(target_notional_krw=Decimal("200000"))
+    assert ReasonCode.NOTIONAL_ABOVE_CAP in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_lifecycle_and_daily_caps() -> None:
+    ledger = _clean_ledger(
+        has_open_position_for_symbol=True,
+        open_position_count=1,
+        orders_today=10,
+        realized_loss_today_krw=Decimal("50000"),
+        seconds_since_last_close_for_symbol=10.0,
+    )
+    decision = _eval(ledger=ledger)
+    assert ReasonCode.OPEN_POSITION_EXISTS in decision.reason_codes
+    assert ReasonCode.MAX_OPEN_POSITIONS_REACHED in decision.reason_codes
+    assert ReasonCode.DAILY_ORDER_CAP_REACHED in decision.reason_codes
+    assert ReasonCode.DAILY_LOSS_BUDGET_EXHAUSTED in decision.reason_codes
+    assert ReasonCode.COOLDOWN_ACTIVE in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_cooldown_none_is_not_blocking() -> None:
+    decision = _eval(ledger=_clean_ledger(seconds_since_last_close_for_symbol=None))
+    assert ReasonCode.COOLDOWN_ACTIVE not in decision.reason_codes
+
+
+@pytest.mark.unit
+def test_reasons_accumulate_not_short_circuit() -> None:
+    decision = _eval(
+        symbol="999999",
+        target_notional_krw=Decimal("200000"),
+        market=_clean_market(spread_bps=Decimal("99")),
+    )
+    assert {
+        ReasonCode.SYMBOL_NOT_ALLOWLISTED,
+        ReasonCode.NOTIONAL_ABOVE_CAP,
+        ReasonCode.SPREAD_TOO_WIDE,
+    } <= set(decision.reason_codes)

--- a/tests/brokers/kis/mock_scalping/test_order_intent.py
+++ b/tests/brokers/kis/mock_scalping/test_order_intent.py
@@ -1,0 +1,104 @@
+"""KIS mock scalping order-intent tests (ROB-321 PR3)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.kis.mock_scalping.order_intent import build_order_intent
+from app.services.brokers.kis.mock_scalping.signal import SignalDecision
+
+
+def _buy_signal() -> SignalDecision:
+    return SignalDecision(
+        has_entry=True,
+        side="BUY",
+        entry_price=Decimal("70000"),
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+    )
+
+
+@pytest.mark.unit
+def test_build_from_buy_signal_pins_notional_cap() -> None:
+    intent = build_order_intent(
+        _buy_signal(),
+        symbol="005930",
+        limits=ScalpingRiskLimits(),
+        source_candle_close_time_ms=111,
+        evaluated_at_ms=222,
+    )
+    assert intent is not None
+    assert intent.symbol == "005930"
+    assert intent.side == "BUY"
+    assert intent.account_mode == "kis_mock"
+    assert intent.target_notional_krw == ScalpingRiskLimits().max_notional_krw
+    assert intent.entry_reference_price == Decimal("70000")
+    assert intent.source_candle_close_time_ms == 111
+
+
+@pytest.mark.unit
+def test_no_entry_signal_yields_none() -> None:
+    no_entry = SignalDecision(
+        has_entry=False,
+        side=None,
+        entry_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=("no_signal",),
+    )
+    assert (
+        build_order_intent(
+            no_entry,
+            symbol="005930",
+            limits=ScalpingRiskLimits(),
+            source_candle_close_time_ms=1,
+            evaluated_at_ms=2,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_sell_signal_yields_none_long_only() -> None:
+    sell = SignalDecision(
+        has_entry=True,
+        side="SELL",
+        entry_price=Decimal("70000"),
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0.5"),
+        reason_codes=(),
+    )
+    assert (
+        build_order_intent(
+            sell,
+            symbol="005930",
+            limits=ScalpingRiskLimits(),
+            source_candle_close_time_ms=1,
+            evaluated_at_ms=2,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_evidence_dict_is_json_safe() -> None:
+    intent = build_order_intent(
+        _buy_signal(),
+        symbol="005930",
+        limits=ScalpingRiskLimits(),
+        source_candle_close_time_ms=111,
+        evaluated_at_ms=222,
+    )
+    assert intent is not None
+    ev = intent.to_evidence_dict()
+    assert ev["target_notional_krw"] == "100000"
+    assert ev["entry_reference_price"] == "70000"
+    assert ev["account_mode"] == "kis_mock"
+    assert ev["reason_codes"] == ["enter_long_breakout"]

--- a/tests/brokers/kis/mock_scalping/test_signal.py
+++ b/tests/brokers/kis/mock_scalping/test_signal.py
@@ -1,0 +1,86 @@
+"""KIS mock scalping signal tests (ROB-321 PR3)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import ReasonCode
+from app.services.brokers.kis.mock_scalping.signal import (
+    Candle,
+    SignalConfig,
+    evaluate_signal,
+)
+
+
+def _candle(
+    i: int, close: int, high: int | None = None, low: int | None = None
+) -> Candle:
+    return Candle(
+        open_time_ms=i * 60_000,
+        open=Decimal(close),
+        high=Decimal(high if high is not None else close),
+        low=Decimal(low if low is not None else close),
+        close=Decimal(close),
+        close_time_ms=i * 60_000 + 59_999,
+    )
+
+
+def _uptrend(n: int = 30, start: int = 1000, step: int = 5) -> list[Candle]:
+    return [_candle(i, start + i * step) for i in range(n)]
+
+
+@pytest.mark.unit
+def test_insufficient_history_returns_no_entry() -> None:
+    decision = evaluate_signal(_uptrend(n=10), SignalConfig())
+    assert decision.has_entry is False
+    assert decision.reason_codes == (ReasonCode.INSUFFICIENT_HISTORY,)
+
+
+@pytest.mark.unit
+def test_downtrend_returns_no_signal() -> None:
+    candles = [_candle(i, 2000 - i * 5) for i in range(30)]  # descending
+    decision = evaluate_signal(candles, SignalConfig())
+    assert decision.has_entry is False
+    assert decision.reason_codes == (ReasonCode.NO_SIGNAL,)
+
+
+@pytest.mark.unit
+def test_uptrend_breakout_enters_long_with_tp_sl() -> None:
+    decision = evaluate_signal(_uptrend(), SignalConfig())
+    assert decision.has_entry is True
+    assert decision.side == "BUY"
+    assert decision.reason_codes == (ReasonCode.ENTER_LONG_BREAKOUT,)
+    entry = decision.entry_price
+    assert entry == Decimal(1000 + 29 * 5)
+    assert decision.tp_price == entry * (
+        Decimal("1") + Decimal("30") / Decimal("10000")
+    )
+    assert decision.sl_price == entry * (
+        Decimal("1") - Decimal("20") / Decimal("10000")
+    )
+    assert Decimal("0") <= decision.confidence <= Decimal("1")
+
+
+@pytest.mark.unit
+def test_no_chase_guard_rejects_spike() -> None:
+    candles = _uptrend()
+    # Replace the last candle's close with a far breakout above the prior high.
+    prior_high = max(c.high for c in candles[:-1][-20:])
+    spike = int(prior_high * Decimal("1.02"))  # ~200 bps > max_chase_bps 50
+    candles[-1] = _candle(len(candles) - 1, spike)
+    decision = evaluate_signal(candles, SignalConfig())
+    assert decision.has_entry is False
+    assert decision.reason_codes == (ReasonCode.CHASE_TOO_FAR,)
+
+
+@pytest.mark.unit
+def test_no_short_branch_even_on_downtrend_breakdown() -> None:
+    # Strong downtrend breaking below prior low must NOT produce a SELL entry.
+    candles = [
+        _candle(i, 2000 - i * 5, high=2000 - i * 5, low=2000 - i * 5) for i in range(30)
+    ]
+    decision = evaluate_signal(candles, SignalConfig())
+    assert decision.side is None
+    assert decision.has_entry is False

--- a/tests/brokers/kis/mock_scalping_ws/test_candles.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_candles.py
@@ -1,0 +1,41 @@
+"""Tick → 1-minute candle aggregation tests (ROB-321 PR3)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.candles import CandleAggregator
+
+
+@pytest.mark.unit
+def test_first_tick_opens_no_candle() -> None:
+    agg = CandleAggregator()
+    assert agg.add(Decimal("100"), now=0.0) is None
+
+
+@pytest.mark.unit
+def test_same_minute_ticks_accumulate_ohlc() -> None:
+    agg = CandleAggregator()
+    assert agg.add(Decimal("100"), now=0.0) is None
+    assert agg.add(Decimal("105"), now=10.0) is None  # high
+    assert agg.add(Decimal("98"), now=20.0) is None  # low
+    # rollover to next minute closes the first candle
+    closed = agg.add(Decimal("101"), now=60.0)
+    assert closed is not None
+    assert closed.open == Decimal("100")
+    assert closed.high == Decimal("105")
+    assert closed.low == Decimal("98")
+    assert closed.close == Decimal("98")  # last price of minute 0
+
+
+@pytest.mark.unit
+def test_rollover_returns_one_candle_per_minute() -> None:
+    agg = CandleAggregator()
+    agg.add(Decimal("100"), now=0.0)
+    c0 = agg.add(Decimal("101"), now=60.0)
+    c1 = agg.add(Decimal("102"), now=120.0)
+    assert c0 is not None and c0.close == Decimal("100")
+    assert c1 is not None and c1.close == Decimal("101")
+    assert c0.close_time_ms < c1.close_time_ms

--- a/tests/brokers/kis/mock_scalping_ws/test_supervisor.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_supervisor.py
@@ -1,0 +1,130 @@
+"""KIS mock scalping supervisor tests (ROB-321 PR3)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.signal import SignalConfig
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.brokers.kis.mock_scalping_ws.supervisor import (
+    KisScalpingSupervisor,
+    TriggerEvent,
+)
+
+SYMBOL = "005930"
+
+# Small config so a handful of candles suffice; disable no-chase for the
+# trigger-path tests (separate signal tests already cover CHASE_TOO_FAR).
+_CFG = SignalConfig(
+    sma_fast=2, sma_slow=3, breakout_lookback=3, max_chase_bps=Decimal("100000")
+)
+
+
+def _tick(price: float) -> QuoteTick:
+    return QuoteTick(symbol=SYMBOL, last_price=price, ts="000000")
+
+
+def _book(bid: float = 999.0, ask: float = 1001.0) -> OrderBookSnapshot:
+    return OrderBookSnapshot(
+        symbol=SYMBOL, bid=bid, ask=ask, bid_qty=10.0, ask_qty=10.0
+    )
+
+
+def _clock_from(times: list[float]):
+    it = iter(times)
+    return lambda: next(it)
+
+
+def _source(events: list):
+    async def _agen() -> AsyncIterator:
+        for e in events:
+            yield e
+
+    return _agen
+
+
+async def _collect(
+    supervisor: KisScalpingSupervisor, events, times
+) -> list[TriggerEvent]:
+    triggers: list[TriggerEvent] = []
+
+    async def _on_trigger(t: TriggerEvent) -> None:
+        triggers.append(t)
+
+    supervisor._clock = _clock_from(times)
+    await supervisor.run(_source(events), on_trigger=_on_trigger)
+    return triggers
+
+
+def _uptrend_stream() -> tuple[list, list[float]]:
+    """5 (book, tick) pairs with ascending prices → BUY breakout on the last."""
+    events: list = []
+    times: list[float] = []
+    for i, price in enumerate([1000.0, 1001.0, 1002.0, 1003.0, 1004.0]):
+        events.append(_book())
+        times.append(i * 60.0)
+        events.append(_tick(price))
+        times.append(i * 60.0 + 1)
+    return events, times
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_uptrend_breakout_emits_trigger_with_fresh_book() -> None:
+    sup = KisScalpingSupervisor(symbols=[SYMBOL], signal_config=_CFG)
+    events, times = _uptrend_stream()
+    triggers = await _collect(sup, events, times)
+    assert len(triggers) == 1
+    assert triggers[0].symbol == SYMBOL
+    assert triggers[0].side == "BUY"
+    assert triggers[0].bid == 999.0
+    assert triggers[0].account_mode == "kis_mock"
+    assert triggers[0].data_age_seconds is not None
+    assert triggers[0].data_age_seconds <= 60.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stale_book_suppresses_trigger() -> None:
+    sup = KisScalpingSupervisor(
+        symbols=[SYMBOL], signal_config=_CFG, max_data_age_seconds=60.0
+    )
+    # One book at t=0 then only ticks afterwards → book goes stale by the breakout.
+    events: list = [_book()]
+    times: list[float] = [0.0]
+    for i, price in enumerate([1000.0, 1001.0, 1002.0, 1003.0, 1004.0]):
+        events.append(_tick(price))
+        times.append(i * 60.0 + 1)
+    triggers = await _collect(sup, events, times)
+    assert triggers == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_orderbook_and_unknown_symbol_do_not_trigger() -> None:
+    sup = KisScalpingSupervisor(symbols=[SYMBOL], signal_config=_CFG)
+    other = QuoteTick(symbol="999999", last_price=1.0, ts="000000")
+    triggers = await _collect(sup, [_book(), other], [0.0, 1.0])
+    assert triggers == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_debounce_suppresses_second_trigger() -> None:
+    sup = KisScalpingSupervisor(
+        symbols=[SYMBOL], signal_config=_CFG, debounce_seconds=300.0
+    )
+    events, times = _uptrend_stream()
+    # Append another fresh book + breakout tick one minute later (within debounce).
+    events.append(_book())
+    times.append(300.0)
+    events.append(_tick(1010.0))
+    times.append(301.0)
+    triggers = await _collect(sup, events, times)
+    assert len(triggers) == 1  # second breakout debounced


### PR DESCRIPTION
## ROB-321 PR3/4 — Deterministic decision layer + event supervisor (dry-run)

The decision half of the KIS mock scalping loop: a pure long-only signal + risk contract and an event-driven supervisor that turns the PR2 quote stream into `TriggerEvent`s. **Dry-run only** — no orders, no ledger, no risk-recheck side effects. Edge-agnostic plumbing (ROB-316: scalping is net-negative after fees; v1 strategy is an intentional toy). Plan: `docs/plans/ROB-321-pr3-signal-supervisor-plan.md`.

Builds on PR1 (#963) + PR2 (#966), both merged.

### What's here

**Pure cores** — `app/services/brokers/kis/mock_scalping/` (mirror Binance `demo_scalping`, KIS-specific):
- `contract.py` — `ScalpingRiskLimits` (KRW: allowlist, max notional, max open positions, daily order/loss caps, cooldown, spread + freshness gates), `ReasonCode`, `evaluate_risk()` accumulating **every** blocking reason. Cash market is **long-only** → a `SELL` entry yields `SHORT_ENTRY_NOT_ALLOWED`.
- `signal.py` — long-only SMA-trend + prior-high breakout with a **no-chase guard** (`CHASE_TOO_FAR` past `max_chase_bps` — ROB-321 §3 "당일 급등주 추격 금지"), fixed-bps TP/SL.
- `order_intent.py` — BUY-only `OrderIntent` (KRW notional pinned to the risk cap) + JSON evidence.

**Event supervisor** — `app/services/brokers/kis/mock_scalping_ws/`:
- `candles.py` — `CandleAggregator`: trade tick → 1-minute OHLC (KIS quote WS has no klines), pure + injected clock.
- `supervisor.py` — `KisScalpingSupervisor`: consumes `QuoteTick | OrderBookSnapshot`; orderbook → state, tick → candle; on close → `evaluate_signal` → `TriggerEvent` gated on **fresh orderbook** (`book_age <= max`, not trade-tick freshness — a dead book must trip the gate) + per-symbol debounce. **No risk re-check / order / ledger** — `on_trigger` is caller-supplied.
- `state.py` — added `book_age_seconds()` (book-specific freshness).

### Safety boundary
- Dry-run by construction (`on_trigger` supplied by caller; PR4 wires the confirm-gated mock executor + ledger risk re-check).
- The PR2 AST import guard now also covers `supervisor.py`/`candles.py` — `mock_scalping_ws/` may import no order/ledger/execution module (still green).
- Long-only enforced in three independent places (signal, risk, intent builder).
- Daemon gated by the default-off `kis_mock_scalping_ws_enabled` flag.

### Tests
62 passing across `tests/brokers/kis/` (signal breakout/no-chase, every risk reason code, order-intent, candle rollover/OHLC, supervisor trigger happy-path + stale-book/debounce/unknown-symbol suppression). Full lint trio clean (`ruff check` + `ruff format --check` + `ty check app/`).

### Deferred to PR4
Dry-run daemon entrypoint (callback→queue adapter wiring the real `KISQuoteWebSocket` → supervisor), exec bridge, round-trip ledger/reconcile, smoke runbook, and wiring PR1's `ScalpingExitContext` for the stop-loss exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced KIS mock scalping trading system with technical analysis-based signal generation
  * Added risk evaluation and compliance validation for trading decisions
  * Implemented real-time order book freshness verification and debounce protection against excessive order placement
  * Added 1-minute OHLC candle aggregation from market tick data

* **Tests**
  * Added comprehensive test coverage for signal generation, risk validation, and supervisor operations

* **Documentation**
  * Added implementation plan documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->