### PR TITLE
feat(rob-321): KIS mock scalping executor + round-trip ledger (PR4a/b)

### DIFF
--- a/alembic/versions/20260526_rob321_p4a_kis_mock_roundtrip_columns.py
+++ b/alembic/versions/20260526_rob321_p4a_kis_mock_roundtrip_columns.py
@@ -1,0 +1,66 @@
+"""rob-321 PR4a: round-trip scalping columns on kis_mock_order_ledger (additive)
+
+Revision ID: 20260526_rob321_p4a
+Revises: 20260526_rob318_p3
+Create Date: 2026-05-26
+
+Adds 5 nullable columns + 1 index to ``review.kis_mock_order_ledger`` for the
+KIS mock scalping round-trip executor/reconciler (ROB-321 PR4a):
+
+* ``correlation_id`` (Text, indexed) — a buy/sell round trip shares one id.
+* ``scalping_role`` (Text) — 'entry' | 'exit'.
+* ``exit_reason`` (Text) — 'stop_loss' | 'take_profit' | 'time_stop'.
+* ``gross_pnl`` / ``net_pnl`` (Numeric(20,4)) — recorded on the exit leg once
+  the round trip is paired from execution evidence (net = gross - fees).
+
+Purely additive and nullable: existing/legacy rows stay readable (NULL). No
+CHECK change — the terminal closed state reuses the existing ``reconciled``
+lifecycle_state. Operator applies via ``alembic upgrade head`` separately.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260526_rob321_p4a"
+down_revision: str | None = "20260526_rob318_p3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "kis_mock_order_ledger"
+_SCHEMA = "review"
+_INDEX = "ix_kis_mock_ledger_correlation_id"
+
+
+def upgrade() -> None:
+    op.add_column(
+        _TABLE, sa.Column("correlation_id", sa.Text(), nullable=True), schema=_SCHEMA
+    )
+    op.add_column(
+        _TABLE, sa.Column("scalping_role", sa.Text(), nullable=True), schema=_SCHEMA
+    )
+    op.add_column(
+        _TABLE, sa.Column("exit_reason", sa.Text(), nullable=True), schema=_SCHEMA
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("gross_pnl", sa.Numeric(20, 4), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE, sa.Column("net_pnl", sa.Numeric(20, 4), nullable=True), schema=_SCHEMA
+    )
+    op.create_index(_INDEX, _TABLE, ["correlation_id"], schema=_SCHEMA)
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX, table_name=_TABLE, schema=_SCHEMA)
+    op.drop_column(_TABLE, "net_pnl", schema=_SCHEMA)
+    op.drop_column(_TABLE, "gross_pnl", schema=_SCHEMA)
+    op.drop_column(_TABLE, "exit_reason", schema=_SCHEMA)
+    op.drop_column(_TABLE, "scalping_role", schema=_SCHEMA)
+    op.drop_column(_TABLE, "correlation_id", schema=_SCHEMA)

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -25,6 +25,7 @@ from app.mcp_server.tooling.order_journal import (
 )
 from app.mcp_server.tooling.order_validation import (
     DefensiveTrimContext,
+    ScalpingExitContext,
     _check_balance_and_warn,
     _check_daily_order_limit,
     _get_balance_for_order,
@@ -33,6 +34,7 @@ from app.mcp_server.tooling.order_validation import (
     _preview_order,
     _record_order_history,
     _resolve_buy_quantity,
+    _resolve_scalping_exit_context,
     _validate_defensive_trim_preconditions,
     _validate_sell_side,
 )
@@ -319,6 +321,7 @@ async def _build_preview(
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None,
     is_mock: bool = False,
+    scalping_exit_ctx: ScalpingExitContext | None = None,
 ) -> dict[str, Any]:
     """Run preview and enrich result with defaults."""
     dry_run_result = await _preview_order(
@@ -331,6 +334,7 @@ async def _build_preview(
         market_type=market_type,
         defensive_trim_ctx=defensive_trim_ctx,
         is_mock=is_mock,
+        scalping_exit_ctx=scalping_exit_ctx,
     )
     if not isinstance(dry_run_result, dict):
         raise ValueError("Order preview returned invalid result")
@@ -784,6 +788,9 @@ async def _place_order_impl(
     defensive_trim: bool = False,
     approval_issue_id: str | None = None,
     is_mock: bool = False,
+    scalping_exit: bool = False,
+    scalping_strategy_id: str | None = None,
+    scalping_exit_reason: str | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -832,6 +839,18 @@ async def _place_order_impl(
     except ValueError as e:
         return _order_error(str(e))
 
+    try:
+        scalping_exit_ctx = _resolve_scalping_exit_context(
+            scalping_exit=scalping_exit,
+            strategy_id=scalping_strategy_id,
+            reason=scalping_exit_reason,
+            side=side_lower,
+            order_type=order_type_lower,
+            is_mock=is_mock,
+        )
+    except ValueError as e:
+        return _order_error(str(e))
+
     # Check stop-loss cooldown for crypto buys
     if side_lower == "buy" and market_type == "crypto":
         cooldown_service = _get_crypto_trade_cooldown_service()
@@ -876,6 +895,7 @@ async def _place_order_impl(
                 defensive_trim_ctx=defensive_trim_ctx,
                 is_mock=is_mock,
                 dry_run=dry_run,
+                scalping_exit_ctx=scalping_exit_ctx,
             )
             if sell_error is not None:
                 return sell_error
@@ -892,6 +912,7 @@ async def _place_order_impl(
                 market_type=market_type,
                 defensive_trim_ctx=defensive_trim_ctx,
                 is_mock=is_mock,
+                scalping_exit_ctx=scalping_exit_ctx,
             )
         except ValueError as preview_exc:
             preview_error = str(preview_exc) or preview_exc.__class__.__name__

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -199,6 +199,7 @@ class KISMockOrderLedger(Base):
         Index("ix_kis_mock_ledger_trade_date", "trade_date"),
         Index("ix_kis_mock_ledger_symbol", "symbol"),
         Index("ix_kis_mock_ledger_lifecycle_state", "lifecycle_state"),
+        Index("ix_kis_mock_ledger_correlation_id", "correlation_id"),
         {"schema": "review"},
     )
 
@@ -244,6 +245,17 @@ class KISMockOrderLedger(Base):
     )
     reconciled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     last_reconcile_detail: Mapped[dict | None] = mapped_column(JSONB)
+
+    # ROB-321 round-trip scalping columns (additive, nullable). A buy/sell
+    # round trip shares one correlation_id; the exit leg carries exit_reason +
+    # gross/net PnL once paired from execution evidence.
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+    scalping_role: Mapped[str | None] = mapped_column(Text)  # 'entry' | 'exit'
+    exit_reason: Mapped[str | None] = mapped_column(
+        Text
+    )  # stop_loss|take_profit|time_stop
+    gross_pnl: Mapped[float | None] = mapped_column(Numeric(20, 4))
+    net_pnl: Mapped[float | None] = mapped_column(Numeric(20, 4))
 
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/services/brokers/kis/mock_scalping_exec/executor.py
+++ b/app/services/brokers/kis/mock_scalping_exec/executor.py
@@ -1,0 +1,314 @@
+"""ROB-321 PR4a — KIS mock scalping monitored round-trip executor.
+
+Drives one long round trip end to end: submit a mock BUY, confirm its fill,
+monitor the quote, exit on TP/SL/time-stop with a `scalping_exit` aggressive
+limit SELL, confirm the exit fill, and reconcile the pair into the ledger with
+gross/net PnL. The terminal closed state is the existing ``reconciled``.
+
+Round-trip close is reconciled from **execution evidence** (the entry/exit fills
+returned by the broker port), NOT from a holdings delta — so a fast same-session
+round trip that never surfaces an intermediate position is still a clean close,
+not an anomaly (the ROB-321 §5 fix).
+
+All broker/ledger I/O is injected via ports so the orchestration is unit-tested
+with fakes. A real adapter (calling ``_place_order_impl(is_mock=True,
+scalping_exit=...)`` + the kis_mock_ledger writer) is wired in PR4b. The HTTP
+mutation is **confirm-gated**: ``confirm=False`` (default) previews only and
+writes nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from decimal import ROUND_DOWN, Decimal
+from typing import Any, Protocol
+
+from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
+from app.services.brokers.kis.mock_scalping_exec.exit_policy import (
+    TIME_STOP,
+    decide_exit,
+)
+
+logger = logging.getLogger("rob321.kis_mock_scalping_exec")
+
+_BPS = Decimal("10000")
+
+
+@dataclass(frozen=True)
+class Quote:
+    bid: Decimal | None
+    ask: Decimal | None
+    last: Decimal | None
+
+
+@dataclass(frozen=True)
+class Fill:
+    price: Decimal
+    quantity: Decimal
+
+
+class BrokerPort(Protocol):
+    async def submit_buy(
+        self,
+        *,
+        symbol: str,
+        price: Decimal,
+        quantity: Decimal,
+        correlation_id: str,
+        confirm: bool,
+    ) -> dict[str, Any]: ...
+
+    async def submit_exit_sell(
+        self,
+        *,
+        symbol: str,
+        price: Decimal,
+        quantity: Decimal,
+        exit_reason: str,
+        strategy_id: str,
+        correlation_id: str,
+        confirm: bool,
+    ) -> dict[str, Any]: ...
+
+    async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None: ...
+
+    def quote(self, symbol: str) -> Quote | None: ...
+
+
+class LedgerPort(Protocol):
+    async def record_entry(
+        self,
+        *,
+        correlation_id: str,
+        symbol: str,
+        strategy_id: str,
+        fill: Fill,
+    ) -> None: ...
+
+    async def record_exit_reconciled(
+        self,
+        *,
+        correlation_id: str,
+        symbol: str,
+        exit_reason: str,
+        entry_fill: Fill,
+        exit_fill: Fill,
+        gross_pnl: Decimal,
+        net_pnl: Decimal,
+        fees: Decimal,
+    ) -> None: ...
+
+    async def record_anomaly(
+        self, *, correlation_id: str, symbol: str, detail: str
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class ExecutorConfig:
+    max_hold_seconds: float = 120.0
+    poll_interval_seconds: float = 1.0
+    max_poll_count: int = 30
+    max_runtime_seconds: float = 300.0
+    max_fill_polls: int = 10
+    # KR round-trip cost estimate (sell tax + commission, both legs), bps of
+    # notional. Used only for net PnL telemetry; mock has no real fee.
+    round_trip_fee_bps: Decimal = Decimal("23")
+
+
+@dataclass(frozen=True)
+class RoundTripResult:
+    correlation_id: str
+    status: str  # reconciled | dry_run | blocked | entry_unfilled | anomaly
+    exit_reason: str | None = None
+    quantity: Decimal | None = None
+    entry_fill_price: Decimal | None = None
+    exit_fill_price: Decimal | None = None
+    gross_pnl: Decimal | None = None
+    net_pnl: Decimal | None = None
+    fees: Decimal | None = None
+    reason_codes: tuple[str, ...] = field(default_factory=tuple)
+
+
+class MockScalpingExecutor:
+    def __init__(
+        self,
+        *,
+        broker: BrokerPort,
+        ledger: LedgerPort,
+        config: ExecutorConfig | None = None,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        clock: Callable[[], float] = None,  # type: ignore[assignment]
+    ) -> None:
+        import time
+
+        self._broker = broker
+        self._ledger = ledger
+        self._config = config or ExecutorConfig()
+        self._sleep = sleep
+        self._clock = clock or time.monotonic
+
+    def _new_correlation_id(self) -> str:
+        return f"kis-mock-scalp-{uuid.uuid4().hex[:16]}"
+
+    @staticmethod
+    def _size(intent: OrderIntent) -> Decimal:
+        """Whole-share quantity from the KRW notional cap (floor, never round up)."""
+        ref = intent.entry_reference_price
+        if ref is None or ref <= 0:
+            return Decimal("0")
+        return (intent.target_notional_krw / ref).quantize(
+            Decimal("1"), rounding=ROUND_DOWN
+        )
+
+    async def execute_monitored(
+        self, intent: OrderIntent, *, confirm: bool = False
+    ) -> RoundTripResult:
+        cid = self._new_correlation_id()
+        strategy_id = "kis-mock-v1"
+        qty = self._size(intent)
+        if qty <= 0:
+            return RoundTripResult(
+                correlation_id=cid, status="blocked", reason_codes=("size_zero",)
+            )
+        entry_ref = intent.entry_reference_price
+        assert entry_ref is not None  # _size guards None/<=0
+
+        # 1. Submit BUY (confirm-gated).
+        buy = await self._broker.submit_buy(
+            symbol=intent.symbol,
+            price=entry_ref,
+            quantity=qty,
+            correlation_id=cid,
+            confirm=confirm,
+        )
+        if not confirm:
+            logger.info("dry-run scalping entry symbol=%s qty=%s", intent.symbol, qty)
+            return RoundTripResult(correlation_id=cid, status="dry_run", quantity=qty)
+
+        # 2. Confirm entry fill (bounded).
+        entry_fill = await self._await_fill(buy)
+        if entry_fill is None:
+            await self._ledger.record_anomaly(
+                correlation_id=cid, symbol=intent.symbol, detail="entry_unfilled"
+            )
+            return RoundTripResult(
+                correlation_id=cid,
+                status="entry_unfilled",
+                quantity=qty,
+                reason_codes=("entry_unfilled",),
+            )
+        await self._ledger.record_entry(
+            correlation_id=cid,
+            symbol=intent.symbol,
+            strategy_id=strategy_id,
+            fill=entry_fill,
+        )
+
+        # 3. Monitor until TP/SL/time-stop.
+        exit_reason = await self._monitor(intent)
+
+        # 4. Submit exit SELL (aggressive limit at the bid; scalping_exit bypass).
+        sell_price = self._exit_price(intent)
+        sell = await self._broker.submit_exit_sell(
+            symbol=intent.symbol,
+            price=sell_price,
+            quantity=entry_fill.quantity,
+            exit_reason=exit_reason,
+            strategy_id=strategy_id,
+            correlation_id=cid,
+            confirm=True,
+        )
+        exit_fill = await self._await_fill(sell)
+        if exit_fill is None:
+            # Failsafe: cannot prove the close — never report a clean success.
+            await self._ledger.record_anomaly(
+                correlation_id=cid, symbol=intent.symbol, detail="exit_unconfirmed"
+            )
+            return RoundTripResult(
+                correlation_id=cid,
+                status="anomaly",
+                exit_reason=exit_reason,
+                quantity=entry_fill.quantity,
+                entry_fill_price=entry_fill.price,
+                reason_codes=("exit_unconfirmed",),
+            )
+
+        # 5. Reconcile the round trip from fill evidence.
+        gross = (exit_fill.price - entry_fill.price) * entry_fill.quantity
+        fees = self._estimate_fees(entry_fill, exit_fill)
+        net = gross - fees
+        await self._ledger.record_exit_reconciled(
+            correlation_id=cid,
+            symbol=intent.symbol,
+            exit_reason=exit_reason,
+            entry_fill=entry_fill,
+            exit_fill=exit_fill,
+            gross_pnl=gross,
+            net_pnl=net,
+            fees=fees,
+        )
+        logger.info(
+            "scalping round-trip reconciled symbol=%s reason=%s gross=%s net=%s",
+            intent.symbol,
+            exit_reason,
+            gross,
+            net,
+        )
+        return RoundTripResult(
+            correlation_id=cid,
+            status="reconciled",
+            exit_reason=exit_reason,
+            quantity=entry_fill.quantity,
+            entry_fill_price=entry_fill.price,
+            exit_fill_price=exit_fill.price,
+            gross_pnl=gross,
+            net_pnl=net,
+            fees=fees,
+        )
+
+    async def _monitor(self, intent: OrderIntent) -> str:
+        assert intent.tp_price is not None and intent.sl_price is not None
+        start = self._clock()
+        for _ in range(self._config.max_poll_count):
+            elapsed = self._clock() - start
+            q = self._broker.quote(intent.symbol)
+            reason = decide_exit(
+                bid=q.bid if q else None,
+                last_price=q.last if q else None,
+                tp_price=intent.tp_price,
+                sl_price=intent.sl_price,
+                elapsed_seconds=elapsed,
+                max_hold_seconds=self._config.max_hold_seconds,
+            )
+            if reason is not None:
+                return reason
+            if elapsed >= self._config.max_runtime_seconds:
+                return TIME_STOP  # failsafe: never leave a position unattended
+            await self._sleep(self._config.poll_interval_seconds)
+        return TIME_STOP  # poll budget exhausted -> force close
+
+    def _exit_price(self, intent: OrderIntent) -> Decimal:
+        """Aggressive marketable-limit sell at the current bid (fallback sl)."""
+        q = self._broker.quote(intent.symbol)
+        if q is not None and q.bid is not None and q.bid > 0:
+            return q.bid
+        assert intent.sl_price is not None
+        return intent.sl_price
+
+    async def _await_fill(self, submit_result: dict[str, Any]) -> Fill | None:
+        for _ in range(self._config.max_fill_polls):
+            fill = await self._broker.confirm_fill(submit_result)
+            if fill is not None:
+                return fill
+            await self._sleep(self._config.poll_interval_seconds)
+        return None
+
+    def _estimate_fees(self, entry: Fill, exit_: Fill) -> Decimal:
+        rate = self._config.round_trip_fee_bps / _BPS
+        entry_notional = entry.price * entry.quantity
+        exit_notional = exit_.price * exit_.quantity
+        return (entry_notional + exit_notional) * rate

--- a/app/services/brokers/kis/mock_scalping_exec/exit_policy.py
+++ b/app/services/brokers/kis/mock_scalping_exec/exit_policy.py
@@ -1,0 +1,43 @@
+"""ROB-321 PR4a — pure exit decision for a long scalping position.
+
+``decide_exit`` is deterministic over the current quote + elapsed hold time.
+Long-only: the exit is evaluated on the **bid** (the price we can actually sell
+into), never the last trade or the mid — a conservative trigger that avoids the
+"mid looked good but the book wasn't there" fill fallacy. Returns the exit
+reason or None (hold).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+# Stable, append-only exit reason codes (persisted to ledger.exit_reason).
+TAKE_PROFIT = "take_profit"
+STOP_LOSS = "stop_loss"
+TIME_STOP = "time_stop"
+
+
+def decide_exit(
+    *,
+    bid: Decimal | None,
+    last_price: Decimal | None,
+    tp_price: Decimal,
+    sl_price: Decimal,
+    elapsed_seconds: float,
+    max_hold_seconds: float,
+) -> str | None:
+    """Return an exit reason for a long position, or None to keep holding.
+
+    Priority: take-profit, then stop-loss, then time-stop. ``bid`` is the
+    conservative sell reference; ``last_price`` is a fallback only when no bid
+    is available yet.
+    """
+    sell_ref = bid if bid is not None else last_price
+    if sell_ref is not None:
+        if sell_ref >= tp_price:
+            return TAKE_PROFIT
+        if sell_ref <= sl_price:
+            return STOP_LOSS
+    if elapsed_seconds >= max_hold_seconds:
+        return TIME_STOP
+    return None

--- a/tests/brokers/kis/mock_scalping_exec/test_executor.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_executor.py
@@ -1,0 +1,211 @@
+"""Monitored round-trip executor tests with fake broker/ledger (ROB-321 PR4a)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    ExecutorConfig,
+    Fill,
+    MockScalpingExecutor,
+    Quote,
+)
+
+SYMBOL = "005930"
+
+
+def _intent(entry: Decimal | None = Decimal("70000")) -> OrderIntent:
+    return OrderIntent(
+        symbol=SYMBOL,
+        side="BUY",
+        order_type="limit",
+        target_notional_krw=Decimal("100000"),
+        entry_reference_price=entry,
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+class FakeBroker:
+    def __init__(self, *, quotes, entry_fill, exit_fill):
+        self._quotes = list(quotes)
+        self._i = 0
+        self.entry_fill = entry_fill
+        self.exit_fill = exit_fill
+        self.submitted: list[tuple[str, dict]] = []
+
+    async def submit_buy(self, **kw: Any) -> dict:
+        self.submitted.append(("buy", kw))
+        return {"kind": "buy", **kw}
+
+    async def submit_exit_sell(self, **kw: Any) -> dict:
+        self.submitted.append(("sell", kw))
+        return {"kind": "sell", **kw}
+
+    async def confirm_fill(self, submit_result: dict) -> Fill | None:
+        return self.entry_fill if submit_result["kind"] == "buy" else self.exit_fill
+
+    def quote(self, symbol: str) -> Quote | None:
+        if not self._quotes:
+            return None
+        q = self._quotes[min(self._i, len(self._quotes) - 1)]
+        self._i += 1
+        return q
+
+
+class FakeLedger:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def record_entry(self, **kw: Any) -> None:
+        self.calls.append(("entry", kw))
+
+    async def record_exit_reconciled(self, **kw: Any) -> None:
+        self.calls.append(("exit_reconciled", kw))
+
+    async def record_anomaly(self, **kw: Any) -> None:
+        self.calls.append(("anomaly", kw))
+
+    def names(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+
+def _executor(broker, ledger, **cfg):
+    async def _no_sleep(_s: float) -> None:
+        return None
+
+    return MockScalpingExecutor(
+        broker=broker,
+        ledger=ledger,
+        config=ExecutorConfig(**cfg) if cfg else ExecutorConfig(),
+        sleep=_no_sleep,
+        clock=lambda: 0.0,  # frozen clock -> no time-stop unless max_hold=0
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dry_run_submits_no_fill_and_no_ledger() -> None:
+    broker = FakeBroker(
+        quotes=[Quote(bid=Decimal("70300"), ask=None, last=None)],
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("70300"), Decimal("1")),
+    )
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger).execute_monitored(_intent(), confirm=False)
+    assert result.status == "dry_run"
+    assert result.quantity == Decimal("1")
+    assert ledger.calls == []  # dry-run writes nothing
+    assert [s[0] for s in broker.submitted] == ["buy"]  # buy preview only
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_take_profit_round_trip_reconciles_with_pnl() -> None:
+    broker = FakeBroker(
+        quotes=[
+            Quote(bid=Decimal("70000"), ask=None, last=None),  # poll 1: hold
+            Quote(bid=Decimal("70300"), ask=None, last=None),  # poll 2: TP
+        ],
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("70300"), Decimal("1")),
+    )
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger).execute_monitored(_intent(), confirm=True)
+
+    assert result.status == "reconciled"
+    assert result.exit_reason == "take_profit"
+    assert result.gross_pnl == Decimal("300")  # (70300-70000)*1
+    assert result.net_pnl == result.gross_pnl - result.fees
+    assert ledger.names() == ["entry", "exit_reconciled"]
+    # exit submitted as scalping exit with the reason
+    sell = next(kw for kind, kw in broker.submitted if kind == "sell")
+    assert sell["exit_reason"] == "take_profit"
+    assert sell["confirm"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stop_loss_round_trip_uses_scalping_exit() -> None:
+    broker = FakeBroker(
+        quotes=[Quote(bid=Decimal("69800"), ask=None, last=None)],  # <= sl
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("69800"), Decimal("1")),
+    )
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger).execute_monitored(_intent(), confirm=True)
+    assert result.status == "reconciled"
+    assert result.exit_reason == "stop_loss"
+    assert result.gross_pnl == Decimal("-200")  # loss
+    assert ledger.names() == ["entry", "exit_reconciled"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_entry_unfilled_records_anomaly_no_exit() -> None:
+    broker = FakeBroker(
+        quotes=[Quote(bid=Decimal("70000"), ask=None, last=None)],
+        entry_fill=None,  # never fills
+        exit_fill=None,
+    )
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger, max_fill_polls=2).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "entry_unfilled"
+    assert ledger.names() == ["anomaly"]
+    assert [s[0] for s in broker.submitted] == ["buy"]  # no sell attempted
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_exit_unconfirmed_records_anomaly_not_clean_success() -> None:
+    broker = FakeBroker(
+        quotes=[Quote(bid=Decimal("70300"), ask=None, last=None)],  # TP
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=None,  # exit never confirms
+    )
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger, max_fill_polls=2).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "anomaly"
+    assert "exit_unconfirmed" in result.reason_codes
+    assert ledger.names() == ["entry", "anomaly"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zero_size_blocked() -> None:
+    broker = FakeBroker(quotes=[], entry_fill=None, exit_fill=None)
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger).execute_monitored(
+        _intent(entry=None), confirm=True
+    )
+    assert result.status == "blocked"
+    assert broker.submitted == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_time_stop_when_quote_never_triggers() -> None:
+    broker = FakeBroker(
+        quotes=[Quote(bid=Decimal("70000"), ask=None, last=None)],  # always hold range
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("70000"), Decimal("1")),
+    )
+    ledger = FakeLedger()
+    # max_hold_seconds=0 with frozen clock -> immediate time-stop
+    result = await _executor(broker, ledger, max_hold_seconds=0.0).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "reconciled"
+    assert result.exit_reason == "time_stop"

--- a/tests/brokers/kis/mock_scalping_exec/test_exit_policy.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_exit_policy.py
@@ -1,0 +1,63 @@
+"""Pure exit-policy tests (ROB-321 PR4a)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_exec.exit_policy import (
+    STOP_LOSS,
+    TAKE_PROFIT,
+    TIME_STOP,
+    decide_exit,
+)
+
+_TP = Decimal("70210")
+_SL = Decimal("69860")
+
+
+def _decide(bid, *, last=None, elapsed=0.0, max_hold=120.0):
+    return decide_exit(
+        bid=bid,
+        last_price=last,
+        tp_price=_TP,
+        sl_price=_SL,
+        elapsed_seconds=elapsed,
+        max_hold_seconds=max_hold,
+    )
+
+
+@pytest.mark.unit
+def test_take_profit_on_bid_at_or_above_tp() -> None:
+    assert _decide(Decimal("70210")) == TAKE_PROFIT
+    assert _decide(Decimal("70300")) == TAKE_PROFIT
+
+
+@pytest.mark.unit
+def test_stop_loss_on_bid_at_or_below_sl() -> None:
+    assert _decide(Decimal("69860")) == STOP_LOSS
+    assert _decide(Decimal("69000")) == STOP_LOSS
+
+
+@pytest.mark.unit
+def test_hold_between_sl_and_tp() -> None:
+    assert _decide(Decimal("70000")) is None
+
+
+@pytest.mark.unit
+def test_time_stop_when_held_too_long() -> None:
+    assert _decide(Decimal("70000"), elapsed=120.0, max_hold=120.0) == TIME_STOP
+
+
+@pytest.mark.unit
+def test_price_exit_takes_priority_over_time_stop() -> None:
+    # both tp hit and over time -> take_profit (price priority)
+    assert _decide(Decimal("70300"), elapsed=999.0) == TAKE_PROFIT
+
+
+@pytest.mark.unit
+def test_falls_back_to_last_price_when_no_bid() -> None:
+    assert _decide(None, last=Decimal("70300")) == TAKE_PROFIT
+    # no bid, no last, not timed out -> hold
+    assert _decide(None, last=None) is None

--- a/tests/test_kis_mock_scalping_exit_wiring.py
+++ b/tests/test_kis_mock_scalping_exit_wiring.py
@@ -1,0 +1,97 @@
+"""ROB-321 PR4 — ScalpingExitContext wiring through _place_order_impl.
+
+PR1 added the context + resolver + guard bypass but left it unwired (forward
+scaffolding). These tests pin that _place_order_impl now resolves and threads it:
+fail-closed on live / flag-off, and bypasses the sell floor for a mock scalping
+exit. (The executor in PR4 calls _place_order_impl with scalping_exit=True.)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+from app.mcp_server.tooling import order_execution, order_validation
+
+
+@pytest.fixture(autouse=True)
+def _mock_io(monkeypatch: pytest.MonkeyPatch):
+    # avg 70000 -> floor 70700; current 69500. A scalping stop-loss at 69000 is
+    # below BOTH the avg*1.01 floor and the current price.
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=69500.0)
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 70000.0, "quantity": 10}),
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_kis_mock_shadow_exposure",
+        AsyncMock(return_value={"sell_reserved_quantity": 0}),
+    )
+
+
+async def _place(**kw):
+    params = {
+        "symbol": "005930",
+        "side": "sell",
+        "market": "kr",
+        "order_type": "limit",
+        "quantity": 1,
+        "price": 69000.0,
+        "dry_run": True,
+    }
+    params.update(kw)
+    return await order_execution._place_order_impl(**params)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scalping_exit_fail_closed_on_live(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    result = await _place(
+        is_mock=False, scalping_exit=True, scalping_strategy_id="kis-mock-v1"
+    )
+    assert result["success"] is False
+    assert "kis_mock" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scalping_exit_fail_closed_when_flag_off(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", False, raising=False)
+    result = await _place(
+        is_mock=True, scalping_exit=True, scalping_strategy_id="kis-mock-v1"
+    )
+    assert result["success"] is False
+    assert "KIS_MOCK_SCALPING_ENABLED" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mock_scalping_exit_bypasses_sell_floor(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    result = await _place(
+        is_mock=True, scalping_exit=True, scalping_strategy_id="kis-mock-v1"
+    )
+    # The dry-run preview must NOT be rejected by the avg*1.01 floor or the
+    # current-price guard — the scalping exit context bypasses both.
+    err = result.get("error", "")
+    assert "below minimum" not in err
+    assert "below current price" not in err
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_live_sell_below_floor_still_blocked(monkeypatch) -> None:
+    # Regression: no scalping_exit, live path -> floor still enforced.
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+    result = await _place(is_mock=False)
+    assert result["success"] is False
+    assert (
+        "below minimum" in result["error"] or "below current price" in result["error"]
+    )


### PR DESCRIPTION
## ROB-321 PR4a — Monitored round-trip executor + round-trip ledger + ScalpingExitContext wiring

The execution decision/orchestration layer of the KIS mock scalping loop. PR4 split into **PR4a** (this) + **PR4b** (exec bridge + dry-run daemon + smoke runbook). Builds on PR1/PR2/PR3 (all merged). Edge-agnostic plumbing (ROB-316: net-negative after fees).

### What's here

1. **ScalpingExitContext wiring** — `_place_order_impl` now takes `scalping_exit` / `scalping_strategy_id` / `scalping_exit_reason`, resolves via PR1's `_resolve_scalping_exit_context` (fail-closed: mock-only + `KIS_MOCK_SCALPING_ENABLED`), and threads it to `_validate_sell_side` + `_build_preview`. Lets a mock stop-loss sell pass the avg*1.01 floor + current-price guard. **Live/generic path unchanged** (regression test: live sell below floor still blocked).

2. **Round-trip ledger schema** — additive nullable columns on `review.kis_mock_order_ledger`: `correlation_id` (indexed; shared by a buy/sell pair), `scalping_role` (entry|exit), `exit_reason`, `gross_pnl`, `net_pnl`. Terminal close reuses the existing `reconciled` state (no CHECK change). Migration `20260526_rob321_p4a` (chains off `rob318_p3`); **operator applies via `alembic upgrade head`** (not auto-run).

3. **Monitored round-trip executor** (`mock_scalping_exec/`):
   - `exit_policy.decide_exit` — pure long-only TP/SL/time-stop, evaluated on the **bid** (conservative sell reference).
   - `executor.MockScalpingExecutor.execute_monitored` — BUY (confirm-gated; **dry-run writes nothing**) → bounded fill confirm → monitor quote → exit on TP/SL/time-stop with a `scalping_exit` aggressive-limit SELL → bounded exit-fill confirm → **reconcile from FILL EVIDENCE** (gross/net PnL, mark `reconciled`), **not holdings delta** — so a fast same-session round trip is a clean close, not an anomaly (the ROB-321 §5 fix). Entry-unfilled / exit-unconfirmed → `anomaly`, never a fake clean success. Broker/Ledger are injected ports.

### Safety boundary
- Confirm-gated mutation (`confirm=False` default = preview/dry-run, no order, no ledger write).
- ScalpingExitContext is mock-only + flag-gated (fail-closed); live order/guard paths untouched.
- Round-trip never reports success without proven exit fill (anomaly otherwise).

### Tests
109 passing across `tests/brokers/kis/` + order regressions (`_place_order_impl` wiring fail-closed/live-unaffected, defensive_trim, sell-guard). Full lint trio clean. `alembic heads` = single head `20260526_rob321_p4a`.

### Deferred to PR4b
Real broker/ledger **adapters** (BrokerPort → `_place_order_impl(is_mock=True, scalping_exit=…)`, LedgerPort → `kis_mock_ledger` writer populating the new columns), the **exec bridge** (TriggerEvent → confirm gate + concurrency → executor), the **dry-run daemon** (callback→queue adapter wiring `KISQuoteWebSocket` → supervisor → bridge), and the **smoke runbook**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)