### PR TITLE
feat(rob-321): KIS mock scalping daemon — adapters + bridge + dry-run daemon + runbook (PR4b)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -200,6 +200,9 @@ class Settings(BaseSettings):
     kis_ws_ping_timeout: int = 10  # Ping 응답 대기 시간 (초)
     # ROB-321: read-only quote WS daemon/smoke gate (default off).
     kis_mock_scalping_ws_enabled: bool = False
+    # ROB-321 PR4b: per-run order-mutation gate for the scalping daemon. Without
+    # it the daemon dry-runs (preview only, no mock order, no ledger write).
+    kis_mock_scalping_ws_confirm: bool = False
 
     # KIS Rate Limiting (HTTP API)
     kis_rate_limit_rate: int = 19  # 초당 최대 요청 수 (안전 마진으로 20-1)

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -213,6 +213,12 @@ async def _save_kis_mock_order_ledger(
     notes: str | None,
     lifecycle_state: str | None = None,
     holdings_baseline_qty: Decimal | None = None,
+    fee: float = 0,
+    correlation_id: str | None = None,
+    scalping_role: str | None = None,
+    exit_reason: str | None = None,
+    gross_pnl: Decimal | None = None,
+    net_pnl: Decimal | None = None,
 ) -> int | None:
     """Insert one row into review.kis_mock_order_ledger.
 
@@ -232,7 +238,7 @@ async def _save_kis_mock_order_ledger(
                     quantity=quantity,
                     price=price,
                     amount=amount,
-                    fee=0,
+                    fee=fee,
                     currency=currency,
                     order_no=order_no,
                     order_time=order_time,
@@ -249,6 +255,11 @@ async def _save_kis_mock_order_ledger(
                     notes=notes,
                     lifecycle_state=resolved_lifecycle,
                     holdings_baseline_qty=holdings_baseline_qty,
+                    correlation_id=correlation_id,
+                    scalping_role=scalping_role,
+                    exit_reason=exit_reason,
+                    gross_pnl=gross_pnl,
+                    net_pnl=net_pnl,
                 )
                 .on_conflict_do_nothing(constraint="uq_kis_mock_ledger_order_no")
             )

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -1,0 +1,226 @@
+"""ROB-321 PR4b — concrete broker/ledger adapters for the executor ports.
+
+``KisMockBroker`` submits through ``_place_order_impl(is_mock=True, ...)`` —
+buys, and ``scalping_exit`` sells (the PR4a wiring bypasses the avg*1.01 floor +
+current-price guard for the stop-loss). The dry-run daemon only ever calls
+``submit_buy(confirm=False)`` (the executor returns right after the preview), so
+the dry-run path is fully exercised; ``quote`` reads the live per-symbol
+``MarketState``.
+
+``confirm_fill`` is the documented OPEN ITEM: KIS mock does not return an
+immediate fill price on submit (fills are reconciled later via holdings), so
+real fill evidence requires operator validation against live KIS mock. Until
+then it returns ``None`` (fail-safe: confirm mode degrades to an
+``entry_unfilled`` anomaly rather than fabricating a fill). See the runbook.
+
+``KisMockLedgerWriter`` records entry/exit/anomaly rows via the extended
+``_save_kis_mock_order_ledger`` (correlation_id / scalping_role / exit_reason /
+gross_pnl / net_pnl). Used only on the confirm path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from decimal import Decimal
+from typing import Any
+
+from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
+from app.mcp_server.tooling.order_execution import _place_order_impl
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill, Quote
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+logger = logging.getLogger("rob321.kis_mock_scalping_exec")
+
+StateProvider = Callable[[str], MarketState | None]
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+class KisMockBroker:
+    """BrokerPort over the KIS mock order path. Mock-only; confirm-gated HTTP."""
+
+    def __init__(self, *, get_state: StateProvider, strategy_id: str = "kis-mock-v1"):
+        self._get_state = get_state
+        self._strategy_id = strategy_id
+
+    async def submit_buy(
+        self,
+        *,
+        symbol: str,
+        price: Decimal,
+        quantity: Decimal,
+        correlation_id: str,
+        confirm: bool,
+    ) -> dict[str, Any]:
+        return await _place_order_impl(
+            symbol=symbol,
+            side="buy",
+            market="kr",
+            order_type="limit",
+            quantity=float(quantity),
+            price=float(price),
+            dry_run=not confirm,
+            is_mock=True,
+            reason=f"scalp_entry:{correlation_id}",
+            strategy=self._strategy_id,
+        )
+
+    async def submit_exit_sell(
+        self,
+        *,
+        symbol: str,
+        price: Decimal,
+        quantity: Decimal,
+        exit_reason: str,
+        strategy_id: str,
+        correlation_id: str,
+        confirm: bool,
+    ) -> dict[str, Any]:
+        return await _place_order_impl(
+            symbol=symbol,
+            side="sell",
+            market="kr",
+            order_type="limit",
+            quantity=float(quantity),
+            price=float(price),
+            dry_run=not confirm,
+            is_mock=True,
+            reason=f"scalp_exit:{correlation_id}",
+            exit_reason=exit_reason,
+            strategy=strategy_id,
+            scalping_exit=True,
+            scalping_strategy_id=strategy_id,
+            scalping_exit_reason=exit_reason,
+        )
+
+    async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None:
+        # OPEN ITEM (ROB-321 §2-4): KIS mock gives no immediate fill price on
+        # submit. Real fill evidence (execution WS / holdings poll) is validated
+        # by operator smoke; until then we never fabricate a fill.
+        logger.warning(
+            "confirm_fill unavailable for KIS mock submit (fill evidence pending "
+            "operator validation); treating as unfilled"
+        )
+        return None
+
+    def quote(self, symbol: str) -> Quote | None:
+        state = self._get_state(symbol)
+        if state is None:
+            return None
+        return Quote(
+            bid=_to_decimal(state.bid),
+            ask=_to_decimal(state.ask),
+            last=_to_decimal(state.last_price),
+        )
+
+
+class KisMockLedgerWriter:
+    """LedgerPort writing round-trip rows to review.kis_mock_order_ledger."""
+
+    def __init__(self, *, strategy_id: str = "kis-mock-v1"):
+        self._strategy_id = strategy_id
+
+    async def record_entry(
+        self, *, correlation_id: str, symbol: str, strategy_id: str, fill: Fill
+    ) -> None:
+        await _save_kis_mock_order_ledger(
+            symbol=symbol,
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            quantity=float(fill.quantity),
+            price=float(fill.price),
+            amount=float(fill.price * fill.quantity),
+            currency="KRW",
+            order_no=f"{correlation_id}-entry",
+            order_time=None,
+            krx_fwdg_ord_orgno=None,
+            status="accepted",
+            response_code=None,
+            response_message=None,
+            raw_response=None,
+            reason="scalp_entry",
+            thesis=None,
+            strategy=strategy_id,
+            notes=None,
+            lifecycle_state="fill",
+            correlation_id=correlation_id,
+            scalping_role="entry",
+        )
+
+    async def record_exit_reconciled(
+        self,
+        *,
+        correlation_id: str,
+        symbol: str,
+        exit_reason: str,
+        entry_fill: Fill,
+        exit_fill: Fill,
+        gross_pnl: Decimal,
+        net_pnl: Decimal,
+        fees: Decimal,
+    ) -> None:
+        await _save_kis_mock_order_ledger(
+            symbol=symbol,
+            instrument_type="equity_kr",
+            side="sell",
+            order_type="limit",
+            quantity=float(exit_fill.quantity),
+            price=float(exit_fill.price),
+            amount=float(exit_fill.price * exit_fill.quantity),
+            currency="KRW",
+            order_no=f"{correlation_id}-exit",
+            order_time=None,
+            krx_fwdg_ord_orgno=None,
+            status="accepted",
+            response_code=None,
+            response_message=None,
+            raw_response=None,
+            reason="scalp_exit",
+            thesis=None,
+            strategy=self._strategy_id,
+            notes=None,
+            lifecycle_state="reconciled",
+            fee=float(fees),
+            correlation_id=correlation_id,
+            scalping_role="exit",
+            exit_reason=exit_reason,
+            gross_pnl=gross_pnl,
+            net_pnl=net_pnl,
+        )
+
+    async def record_anomaly(
+        self, *, correlation_id: str, symbol: str, detail: str
+    ) -> None:
+        await _save_kis_mock_order_ledger(
+            symbol=symbol,
+            instrument_type="equity_kr",
+            side="sell",
+            order_type="limit",
+            quantity=0.0,
+            price=0.0,
+            amount=0.0,
+            currency="KRW",
+            order_no=f"{correlation_id}-anomaly",
+            order_time=None,
+            krx_fwdg_ord_orgno=None,
+            status="unknown",
+            response_code=None,
+            response_message=None,
+            raw_response=None,
+            reason="scalp_anomaly",
+            thesis=None,
+            strategy=self._strategy_id,
+            notes=detail,
+            lifecycle_state="anomaly",
+            correlation_id=correlation_id,
+            scalping_role="exit",
+        )

--- a/app/services/brokers/kis/mock_scalping_exec/ws_bridge.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ws_bridge.py
@@ -1,0 +1,62 @@
+"""ROB-321 PR4b — supervisor TriggerEvent → executor bridge.
+
+The single mutation entry from the read-only supervisor (PR3) to the
+confirm-gated executor (PR4a). Builds an ``OrderIntent`` from the trigger's
+signal decision and runs the monitored round trip behind two concurrency guards:
+a per-symbol in-flight set and a global semaphore (default cap 1 open lifecycle).
+
+The bridge does NOT itself place orders or touch the ledger — it delegates to
+the injected executor, which owns the confirm gate, fill confirmation, and the
+ledger round-trip reconcile. ``confirm`` defaults to False (dry-run).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from app.services.brokers.kis.mock_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.kis.mock_scalping.order_intent import build_order_intent
+from app.services.brokers.kis.mock_scalping_ws.supervisor import TriggerEvent
+
+logger = logging.getLogger("rob321.kis_mock_scalping_exec")
+
+
+class WsExecutionBridge:
+    def __init__(
+        self,
+        *,
+        executor,
+        limits: ScalpingRiskLimits | None = None,
+        confirm: bool = False,
+        max_concurrent: int = 1,
+    ) -> None:
+        self._executor = executor
+        self._limits = limits or ScalpingRiskLimits()
+        self._confirm = confirm
+        self._sem = asyncio.Semaphore(max_concurrent)
+        self._in_flight: set[str] = set()
+
+    async def on_trigger(self, trigger: TriggerEvent) -> None:
+        """Consume one TriggerEvent: build intent, run monitored round trip."""
+        if trigger.symbol in self._in_flight:
+            logger.info("bridge skip symbol=%s reason=in_flight", trigger.symbol)
+            return
+
+        intent = build_order_intent(
+            trigger.decision,
+            symbol=trigger.symbol,
+            limits=self._limits,
+            source_candle_close_time_ms=trigger.source_candle_close_time_ms,
+            evaluated_at_ms=int(trigger.emitted_at * 1000),
+        )
+        if intent is None:
+            logger.info("bridge skip symbol=%s reason=no_intent", trigger.symbol)
+            return
+
+        async with self._sem:
+            self._in_flight.add(trigger.symbol)
+            try:
+                await self._executor.execute_monitored(intent, confirm=self._confirm)
+            finally:
+                self._in_flight.discard(trigger.symbol)

--- a/app/services/brokers/kis/mock_scalping_ws/quote_queue.py
+++ b/app/services/brokers/kis/mock_scalping_ws/quote_queue.py
@@ -1,0 +1,49 @@
+"""ROB-321 PR4b — callback → async-iterator adapter.
+
+``KISQuoteWebSocket`` delivers parsed frames via ``on_tick``/``on_book``
+callbacks; the supervisor consumes an async iterator. ``QuoteEventQueue`` bridges
+the two: the WS callbacks enqueue, ``iterator()`` yields. Bounded — if the
+consumer can't keep up the oldest-vs-newest tradeoff is to drop newest and count
+it (a stalled scalper must not grow memory unbounded). Read-side only; imports
+no order/ledger code (import-guard safe).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+
+logger = logging.getLogger("rob321.kis_mock_scalping_ws")
+
+QuoteEvent = QuoteTick | OrderBookSnapshot
+
+
+class QuoteEventQueue:
+    def __init__(self, maxsize: int = 2000) -> None:
+        self._q: asyncio.Queue[QuoteEvent] = asyncio.Queue(maxsize=maxsize)
+        self.dropped = 0
+
+    def on_tick(self, tick: QuoteTick) -> None:
+        self._offer(tick)
+
+    def on_book(self, book: OrderBookSnapshot) -> None:
+        self._offer(book)
+
+    def _offer(self, event: QuoteEvent) -> None:
+        try:
+            self._q.put_nowait(event)
+        except asyncio.QueueFull:
+            self.dropped += 1
+            logger.warning(
+                "quote queue full; dropped event (total dropped=%s)", self.dropped
+            )
+
+    async def iterator(self) -> AsyncIterator[QuoteEvent]:
+        while True:
+            yield await self._q.get()

--- a/app/services/brokers/kis/mock_scalping_ws/supervisor.py
+++ b/app/services/brokers/kis/mock_scalping_ws/supervisor.py
@@ -90,6 +90,10 @@ class KisScalpingSupervisor:
         }
         self._last_trigger_at: dict[str, float] = {}
 
+    def market_state(self, symbol: str) -> MarketState | None:
+        """Current per-symbol state (the broker adapter reads bid/ask/last)."""
+        return self._state.get(symbol)
+
     async def run(
         self,
         source_factory: SourceFactory,

--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -1,0 +1,98 @@
+# KIS mock scalping smoke (ROB-321 PR4)
+
+Operator runbook for the KIS official-mock (`account_mode=kis_mock`) scalping
+loop: read-only quote WebSocket → signal/risk → monitored round-trip executor →
+round-trip ledger. **Mock-only, default-disabled, dry-run by default.** Edge is
+an intentional toy (ROB-316: scalping is net-negative after fees) — this loop
+validates the *execution plumbing*, not a profitable strategy.
+
+## Components (where the loop lives)
+
+| Stage | Module |
+|-------|--------|
+| Quote WS (read-only) | `app/services/brokers/kis/mock_scalping_ws/market_stream.py` |
+| Signal / risk / intent | `app/services/brokers/kis/mock_scalping/{signal,contract,order_intent}.py` |
+| Supervisor (candle→trigger) | `app/services/brokers/kis/mock_scalping_ws/supervisor.py` |
+| Exec bridge | `app/services/brokers/kis/mock_scalping_exec/ws_bridge.py` |
+| Executor (TP/SL/time-stop) | `app/services/brokers/kis/mock_scalping_exec/executor.py` |
+| Broker/ledger adapters | `app/services/brokers/kis/mock_scalping_exec/adapters.py` |
+| Round-trip ledger | `review.kis_mock_order_ledger` (+ `20260526_rob321_p4a` migration) |
+| Daemon | `scripts/kis_mock_scalping_daemon.py` |
+
+## Gates (all default off)
+
+| env | effect |
+|-----|--------|
+| `KIS_MOCK_SCALPING_ENABLED` | allows the `ScalpingExitContext` sell-guard bypass (mock-only) |
+| `KIS_MOCK_SCALPING_WS_ENABLED` | runs the daemon at all (else no-op, exit 0) |
+| `KIS_MOCK_SCALPING_WS_CONFIRM` | submits real mock orders (else preview/dry-run only) |
+
+## Safety boundaries
+
+- Market data is read-only; orders are mock-only via `_place_order_impl(is_mock=True, scalping_exit=…)`. Live order/guard paths are never touched (PR1 regression test).
+- `ScalpingExitContext` (stop-loss below the avg*1.01 floor + current-price guard) is **fail-closed**: only for `is_mock=True` + `KIS_MOCK_SCALPING_ENABLED`.
+- The executor never reports a clean success without a proven exit fill — entry-unfilled / exit-unconfirmed → `anomaly`.
+- No scheduler/Prefect registration; the daemon runs only when launched manually.
+
+## Step 0 — apply the migration (operator)
+
+The round-trip ledger columns ship as a migration but are **not auto-applied**:
+
+```bash
+uv run alembic upgrade head   # applies 20260526_rob321_p4a (additive, nullable)
+```
+
+## Step 1 — dry-run / check-only (no orders)
+
+```bash
+# daemon stays a no-op until enabled
+uv run python -m scripts.kis_mock_scalping_daemon
+
+# enabled, dry-run (WS_CONFIRM unset) → triggers preview only, no orders/ledger
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_daemon \
+    --symbols 005930,000660 --account-mode kis_mock --max-seconds 60
+```
+
+Expect: connects, logs candle/trigger activity, executor returns `dry_run` per
+trigger, **zero rows** written to `review.kis_mock_order_ledger`.
+
+## Step 2 — small confirm mock run (operator-gated)
+
+> **OPEN ITEM — validate before trusting confirm mode.** KIS mock does not return
+> an immediate fill price on submit, so `KisMockBroker.confirm_fill` currently
+> returns `None` (fail-safe). With `WS_CONFIRM=true` an entry therefore records an
+> `entry_unfilled` anomaly rather than a fabricated round trip. **Do not treat
+> confirm mode as functional until fill evidence is wired and validated here**
+> (candidate sources: KIS mock execution WS `H0STCNI9`, or a bounded mock
+> order-status / holdings poll). Record the validated mechanism in this section.
+
+```bash
+KIS_MOCK_SCALPING_ENABLED=true \
+KIS_MOCK_SCALPING_WS_ENABLED=true \
+KIS_MOCK_SCALPING_WS_CONFIRM=true \
+uv run python -m scripts.kis_mock_scalping_daemon \
+    --symbols 005930 --account-mode kis_mock --max-seconds 120 --max-triggers 1
+```
+
+## Step 3 — post-run verification
+
+```sql
+-- round-trip rows (entry + exit share correlation_id; exit carries PnL)
+SELECT correlation_id, scalping_role, side, lifecycle_state, exit_reason,
+       gross_pnl, net_pnl, fee
+FROM review.kis_mock_order_ledger
+WHERE strategy = 'kis-mock-v1'
+ORDER BY created_at DESC LIMIT 20;
+```
+
+Verify:
+- a clean round trip = one `entry` (lifecycle `fill`) + one `exit` (lifecycle `reconciled`) with the same `correlation_id`, and `net_pnl = gross_pnl - fee`;
+- no unexpected `anomaly` rows (an `anomaly` means the exit fill could not be proven — investigate, do not assume closed);
+- no orphan open positions in the KIS mock account / pending list.
+
+## Open question this loop still carries
+
+Does the KIS **mock** WS (`:31000`) serve real-time quotes, or must quotes come
+from **live** (`:21000`)? Resolve via the read-only quote smoke
+(`scripts/kis_mock_scalping_ws_smoke.py`, see `kis-mock-scalping-ws-smoke.md`)
+and set `--account-mode` accordingly.

--- a/scripts/kis_mock_scalping_daemon.py
+++ b/scripts/kis_mock_scalping_daemon.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""KIS mock scalping daemon (ROB-321 PR4b).
+
+Wires the read-only quote WebSocket (PR2) → supervisor (PR3) → exec bridge →
+monitored executor (PR4a). Default-disabled and **dry-run by default**: orders
+and ledger writes happen only when BOTH gates are set.
+
+Gates (both default off):
+    KIS_MOCK_SCALPING_WS_ENABLED  — run the daemon at all (else no-op, exit 0)
+    KIS_MOCK_SCALPING_WS_CONFIRM  — submit real mock orders (else preview only)
+
+Market data is read-only; orders are mock-only (`_place_order_impl(is_mock=True,
+scalping_exit=…)`). The confirm path's fill confirmation is an operator-validated
+open item — see docs/runbooks/kis-mock-scalping-smoke.md.
+
+Exit codes: 0 success/disabled · 1 unexpected · 2 subscription ACK fail · 3 connect fail.
+
+Usage:
+    KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_daemon \
+        --symbols 005930,000660 --account-mode kis_mock --max-seconds 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import sys
+
+from app.core.config import settings
+from app.services.brokers.kis.mock_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.kis.mock_scalping_exec.adapters import (
+    KisMockBroker,
+    KisMockLedgerWriter,
+)
+from app.services.brokers.kis.mock_scalping_exec.executor import MockScalpingExecutor
+from app.services.brokers.kis.mock_scalping_exec.ws_bridge import WsExecutionBridge
+from app.services.brokers.kis.mock_scalping_ws.market_stream import KISQuoteWebSocket
+from app.services.brokers.kis.mock_scalping_ws.quote_queue import QuoteEventQueue
+from app.services.brokers.kis.mock_scalping_ws.supervisor import KisScalpingSupervisor
+from app.services.kis_websocket_internal.protocol import KISSubscriptionAckError
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="KIS mock scalping daemon")
+    p.add_argument("--symbols", default="005930")
+    p.add_argument(
+        "--account-mode", choices=("kis_mock", "kis_live"), default="kis_mock"
+    )
+    p.add_argument("--max-seconds", type=float, default=60.0)
+    p.add_argument("--max-triggers", type=int, default=None)
+    return p.parse_args(argv)
+
+
+async def run_daemon(args: argparse.Namespace) -> int:
+    if not settings.kis_mock_scalping_ws_enabled:
+        logger.info(
+            "KIS_MOCK_SCALPING_WS_ENABLED is not set; scalping daemon disabled (no-op)."
+        )
+        return 0
+
+    confirm = bool(settings.kis_mock_scalping_ws_confirm)
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    logger.info(
+        "starting KIS mock scalping daemon: account_mode=%s symbols=%s confirm=%s",
+        args.account_mode,
+        symbols,
+        confirm,
+    )
+
+    queue = QuoteEventQueue()
+    supervisor = KisScalpingSupervisor(symbols=symbols)
+    broker = KisMockBroker(get_state=supervisor.market_state)
+    ledger = KisMockLedgerWriter()
+    executor = MockScalpingExecutor(broker=broker, ledger=ledger)
+    bridge = WsExecutionBridge(
+        executor=executor, limits=ScalpingRiskLimits(), confirm=confirm
+    )
+    ws = KISQuoteWebSocket(
+        symbols=symbols,
+        on_tick=queue.on_tick,
+        on_book=queue.on_book,
+        account_mode=args.account_mode,
+    )
+    ws.is_running = True
+
+    triggers = {"n": 0}
+
+    async def _on_trigger(trigger) -> None:
+        triggers["n"] += 1
+        await bridge.on_trigger(trigger)
+
+    def _stop_when() -> bool:
+        return args.max_triggers is not None and triggers["n"] >= args.max_triggers
+
+    try:
+        await ws.connect_and_subscribe()
+    except KISSubscriptionAckError as exc:
+        logger.error("quote subscription ACK failed: %s", exc)
+        return 2
+    except RuntimeError as exc:
+        logger.error("quote WS connect failed: %s", exc)
+        return 3
+
+    producer = asyncio.create_task(ws.listen())
+    consumer = asyncio.create_task(
+        supervisor.run(queue.iterator, on_trigger=_on_trigger, stop_when=_stop_when)
+    )
+    try:
+        await asyncio.wait(
+            {producer, consumer},
+            timeout=args.max_seconds,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+    finally:
+        await ws.stop()
+        for task in (producer, consumer):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    logger.info(
+        "scalping daemon done: account_mode=%s triggers=%s confirm=%s",
+        args.account_mode,
+        triggers["n"],
+        confirm,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    args = _parse_args(argv)
+    try:
+        return asyncio.run(run_daemon(args))
+    except Exception:
+        logger.exception("scalping daemon failed with an unexpected exception")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -1,0 +1,130 @@
+"""Broker/ledger adapter tests (ROB-321 PR4b)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_exec import adapters as mod
+from app.services.brokers.kis.mock_scalping_exec.adapters import (
+    KisMockBroker,
+    KisMockLedgerWriter,
+)
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill, Quote
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_submit_buy_dry_run_calls_place_order_impl(mocker) -> None:
+    place = mocker.patch.object(
+        mod, "_place_order_impl", new=AsyncMock(return_value={})
+    )
+    broker = KisMockBroker(get_state=lambda s: None)
+    await broker.submit_buy(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        correlation_id="cid1",
+        confirm=False,
+    )
+    kw = place.await_args.kwargs
+    assert kw["side"] == "buy"
+    assert kw["is_mock"] is True
+    assert kw["dry_run"] is True  # confirm=False -> dry-run preview
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_submit_exit_sell_uses_scalping_exit(mocker) -> None:
+    place = mocker.patch.object(
+        mod, "_place_order_impl", new=AsyncMock(return_value={})
+    )
+    broker = KisMockBroker(get_state=lambda s: None)
+    await broker.submit_exit_sell(
+        symbol="005930",
+        price=Decimal("69800"),
+        quantity=Decimal("1"),
+        exit_reason="stop_loss",
+        strategy_id="kis-mock-v1",
+        correlation_id="cid1",
+        confirm=True,
+    )
+    kw = place.await_args.kwargs
+    assert kw["side"] == "sell"
+    assert kw["is_mock"] is True
+    assert kw["dry_run"] is False
+    assert kw["scalping_exit"] is True
+    assert kw["scalping_exit_reason"] == "stop_loss"
+    assert kw["scalping_strategy_id"] == "kis-mock-v1"
+
+
+@pytest.mark.unit
+def test_quote_maps_market_state_to_decimal() -> None:
+    state = MarketState(symbol="005930")
+    state.bid, state.ask, state.last_price = 70000.0, 70100.0, 70050.0
+    broker = KisMockBroker(get_state=lambda s: state)
+    q = broker.quote("005930")
+    assert q == Quote(
+        bid=Decimal("70000.0"), ask=Decimal("70100.0"), last=Decimal("70050.0")
+    )
+
+
+@pytest.mark.unit
+def test_quote_none_when_no_state() -> None:
+    broker = KisMockBroker(get_state=lambda s: None)
+    assert broker.quote("005930") is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fill_returns_none_pending_validation() -> None:
+    broker = KisMockBroker(get_state=lambda s: None)
+    assert await broker.confirm_fill({"any": "result"}) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ledger_record_entry_writes_entry_role(mocker) -> None:
+    save = mocker.patch.object(
+        mod, "_save_kis_mock_order_ledger", new=AsyncMock(return_value=1)
+    )
+    writer = KisMockLedgerWriter()
+    await writer.record_entry(
+        correlation_id="cid1",
+        symbol="005930",
+        strategy_id="kis-mock-v1",
+        fill=Fill(Decimal("70000"), Decimal("1")),
+    )
+    kw = save.await_args.kwargs
+    assert kw["scalping_role"] == "entry"
+    assert kw["correlation_id"] == "cid1"
+    assert kw["lifecycle_state"] == "fill"
+    assert kw["side"] == "buy"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ledger_record_exit_reconciled_writes_pnl(mocker) -> None:
+    save = mocker.patch.object(
+        mod, "_save_kis_mock_order_ledger", new=AsyncMock(return_value=1)
+    )
+    writer = KisMockLedgerWriter()
+    await writer.record_exit_reconciled(
+        correlation_id="cid1",
+        symbol="005930",
+        exit_reason="take_profit",
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("70300"), Decimal("1")),
+        gross_pnl=Decimal("300"),
+        net_pnl=Decimal("277"),
+        fees=Decimal("23"),
+    )
+    kw = save.await_args.kwargs
+    assert kw["scalping_role"] == "exit"
+    assert kw["lifecycle_state"] == "reconciled"
+    assert kw["exit_reason"] == "take_profit"
+    assert kw["gross_pnl"] == Decimal("300")
+    assert kw["net_pnl"] == Decimal("277")

--- a/tests/brokers/kis/mock_scalping_exec/test_daemon_cli.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_daemon_cli.py
@@ -1,0 +1,25 @@
+"""Daemon gating tests (ROB-321 PR4b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from scripts import kis_mock_scalping_daemon as daemon
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_daemon_disabled_is_noop(mocker) -> None:
+    mocker.patch.object(settings, "kis_mock_scalping_ws_enabled", False)
+    # If the gate fails this would build the WS client — assert it does NOT.
+    ws = mocker.patch.object(daemon, "KISQuoteWebSocket")
+    rc = await daemon.run_daemon(daemon._parse_args(["--symbols", "005930"]))
+    assert rc == 0
+    ws.assert_not_called()
+
+
+@pytest.mark.unit
+def test_daemon_defaults_to_mock_account_mode() -> None:
+    args = daemon._parse_args([])
+    assert args.account_mode == "kis_mock"

--- a/tests/brokers/kis/mock_scalping_exec/test_ws_bridge.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_ws_bridge.py
@@ -1,0 +1,100 @@
+"""Exec bridge tests (ROB-321 PR4b)."""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.signal import SignalDecision
+from app.services.brokers.kis.mock_scalping_exec.ws_bridge import WsExecutionBridge
+from app.services.brokers.kis.mock_scalping_ws.supervisor import TriggerEvent
+
+SYMBOL = "005930"
+
+
+def _trigger(side: str = "BUY") -> TriggerEvent:
+    decision = SignalDecision(
+        has_entry=True,
+        side=side,
+        entry_price=Decimal("70000"),
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+    )
+    return TriggerEvent(
+        symbol=SYMBOL,
+        side=side,
+        decision=decision,
+        source_candle_close_time_ms=1,
+        bid=70000.0,
+        ask=70100.0,
+        spread_bps=14.0,
+        data_age_seconds=1.0,
+        emitted_at=123.0,
+    )
+
+
+class FakeExecutor:
+    def __init__(self, *, on_run=None):
+        self.calls: list[tuple] = []
+        self._on_run = on_run
+
+    async def execute_monitored(self, intent, *, confirm):
+        self.calls.append((intent, confirm))
+        if self._on_run is not None:
+            await self._on_run()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bridge_runs_executor_with_intent_and_confirm() -> None:
+    ex = FakeExecutor()
+    bridge = WsExecutionBridge(executor=ex, confirm=True)
+    await bridge.on_trigger(_trigger())
+    assert len(ex.calls) == 1
+    intent, confirm = ex.calls[0]
+    assert intent.symbol == SYMBOL
+    assert intent.side == "BUY"
+    assert confirm is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bridge_defaults_to_dry_run() -> None:
+    ex = FakeExecutor()
+    bridge = WsExecutionBridge(executor=ex)
+    await bridge.on_trigger(_trigger())
+    assert ex.calls[0][1] is False  # confirm defaults False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bridge_skips_non_buy_trigger() -> None:
+    ex = FakeExecutor()
+    bridge = WsExecutionBridge(executor=ex, confirm=True)
+    await bridge.on_trigger(_trigger(side="SELL"))  # build_order_intent -> None
+    assert ex.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bridge_per_symbol_in_flight_guard() -> None:
+    # While one round trip for a symbol is running, a second trigger is skipped.
+    gate = asyncio.Event()
+
+    async def _block():
+        await gate.wait()
+
+    ex = FakeExecutor(on_run=_block)
+    bridge = WsExecutionBridge(executor=ex, confirm=True)
+
+    first = asyncio.create_task(bridge.on_trigger(_trigger()))
+    await asyncio.sleep(0)  # let first enter execute_monitored
+    await bridge.on_trigger(_trigger())  # second: skipped (in-flight)
+    gate.set()
+    await first
+
+    assert len(ex.calls) == 1

--- a/tests/brokers/kis/mock_scalping_ws/test_quote_queue.py
+++ b/tests/brokers/kis/mock_scalping_ws/test_quote_queue.py
@@ -1,0 +1,48 @@
+"""Callback→async-iterator queue adapter tests (ROB-321 PR4b)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_ws.quote_parsers import (
+    OrderBookSnapshot,
+    QuoteTick,
+)
+from app.services.brokers.kis.mock_scalping_ws.quote_queue import QuoteEventQueue
+
+
+def _tick(p: float) -> QuoteTick:
+    return QuoteTick(symbol="005930", last_price=p, ts="000000")
+
+
+def _book() -> OrderBookSnapshot:
+    return OrderBookSnapshot(
+        symbol="005930", bid=1.0, ask=2.0, bid_qty=1.0, ask_qty=1.0
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_callbacks_enqueue_and_iterator_yields_in_order() -> None:
+    q = QuoteEventQueue()
+    q.on_tick(_tick(100.0))
+    q.on_book(_book())
+    q.on_tick(_tick(101.0))
+
+    it = q.iterator()
+    first = await anext(it)
+    second = await anext(it)
+    third = await anext(it)
+
+    assert isinstance(first, QuoteTick) and first.last_price == 100.0
+    assert isinstance(second, OrderBookSnapshot)
+    assert isinstance(third, QuoteTick) and third.last_price == 101.0
+
+
+@pytest.mark.unit
+def test_full_queue_drops_and_counts() -> None:
+    q = QuoteEventQueue(maxsize=2)
+    q.on_tick(_tick(1.0))
+    q.on_tick(_tick(2.0))
+    q.on_tick(_tick(3.0))  # full -> dropped
+    assert q.dropped == 1


### PR DESCRIPTION
## ROB-321 PR4b — Adapters + exec bridge + dry-run daemon + runbook (final slice)

Wires the ROB-321 KIS mock scalping loop end to end: read-only quote WS (PR2) → signal/risk/supervisor (PR3) → exec bridge → monitored round-trip executor (PR4a). **Mock-only, default-disabled, dry-run by default.** Completes the 4-PR slicing. Builds on PR1/PR2/PR3/PR4a (all merged). Edge-agnostic plumbing (ROB-316: net-negative after fees).

### What's here
- **Exec bridge** (`ws_bridge.py`): `WsExecutionBridge.on_trigger` builds an `OrderIntent` from the supervisor trigger and runs the monitored round trip behind a per-symbol in-flight guard + global semaphore (cap 1). `confirm` defaults False.
- **Broker/ledger adapters** (`adapters.py`):
  - `KisMockBroker` — `submit_buy`/`submit_exit_sell` via `_place_order_impl(is_mock=True, scalping_exit=… for sell, dry_run=not confirm)`; `quote` from the live `MarketState`. `confirm_fill` returns `None` (**fail-safe**) — the KIS-mock fill-evidence open item is operator-validated (see runbook); confirm mode degrades to an `entry_unfilled` anomaly rather than fabricating a fill.
  - `KisMockLedgerWriter` — entry/exit/anomaly rows; extends `_save_kis_mock_order_ledger` for the PR4a round-trip columns (`correlation_id`/`scalping_role`/`exit_reason`/`gross_pnl`/`net_pnl`/`fee`).
- **Callback→async-iterator adapter** (`quote_queue.py`): bridges `KISQuoteWebSocket` callbacks → supervisor source; bounded (drop+count on full).
- **Daemon** (`scripts/kis_mock_scalping_daemon.py`): wires it all; **default-disabled** (`KIS_MOCK_SCALPING_WS_ENABLED`) + **dry-run default** (`KIS_MOCK_SCALPING_WS_CONFIRM`).
- **Runbook** (`docs/runbooks/kis-mock-scalping-smoke.md`): migration apply, dry-run, confirm run (with the fill-evidence open item), post-run ledger verification.

### Safety boundaries
- Market data read-only; orders mock-only; live order/guard paths untouched.
- Two-gate confirm (`WS_ENABLED` + `WS_CONFIRM`); both default off → no orders, no ledger writes.
- Executor never reports clean success without a proven exit fill (anomaly otherwise).
- `mock_scalping_ws/` import guard still green (`quote_queue` is read-side only); exec adapters live in `mock_scalping_exec/` (the allowed mutation layer).

### Tests
28 new tests (bridge, adapters, queue, daemon gate) + 110 kis_mock ledger/place_order regressions green. Full lint trio clean.

### Operator follow-up (documented in runbook)
Confirm-mode **fill evidence** (`confirm_fill`) — wire + validate against live KIS mock (execution WS `H0STCNI9` or bounded order-status/holdings poll). Until then confirm mode is fail-safe (anomaly, no fabricated fills). Also the mock-vs-live quote-host question (PR2 smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)