### PR TITLE
feat(rob-325): Naver remote-debug audit live-smoke resolve hardening

### DIFF
--- a/app/services/action_report/remote_debug_audit/cdp_client.py
+++ b/app/services/action_report/remote_debug_audit/cdp_client.py
@@ -10,7 +10,10 @@ Never touches pre-existing operator tabs.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
 import httpx
@@ -19,13 +22,21 @@ from app.services.action_report.remote_debug_audit.host_allowlist import (
     assert_cdp_debug_host,
 )
 
+# Default cadence for the post-load readiness poll (overridable for tests).
+_POLL_INTERVAL_S = 0.25
+
+# An async CDP command channel: ``(method, params, session_id) -> response``.
+CdpCommand = Callable[[str, dict[str, Any], str | None], Awaitable[dict[str, Any]]]
+
 
 class CdpUnavailableError(RuntimeError):
     """Raised when the local Chrome remote-debug endpoint cannot be reached."""
 
 
 class CdpSession(Protocol):
-    async def fetch_rendered(self, url: str, js: str, *, timeout_s: float) -> Any: ...
+    async def fetch_rendered(
+        self, url: str, js: str, *, timeout_s: float, ready_js: str | None = None
+    ) -> Any: ...
 
 
 class FakeCdpSession:
@@ -34,7 +45,9 @@ class FakeCdpSession:
     def __init__(self, *, results: dict[str, Any]) -> None:
         self._results = results
 
-    async def fetch_rendered(self, url: str, js: str, *, timeout_s: float) -> Any:
+    async def fetch_rendered(
+        self, url: str, js: str, *, timeout_s: float, ready_js: str | None = None
+    ) -> Any:
         if url not in self._results:
             raise RuntimeError(f"no canned result for {url!r}")
         value = self._results[url]
@@ -43,18 +56,70 @@ class FakeCdpSession:
         return value
 
 
+async def _evaluate(
+    cmd: CdpCommand, expr: str, session_id: str | None, *, await_promise: bool
+) -> Any:
+    res = await cmd(
+        "Runtime.evaluate",
+        {"expression": expr, "returnByValue": True, "awaitPromise": await_promise},
+        session_id,
+    )
+    return res.get("result", {}).get("result", {}).get("value")
+
+
+async def await_rendered_value(
+    cmd: CdpCommand,
+    *,
+    session_id: str | None,
+    extract_js: str,
+    ready_js: str | None,
+    timeout_s: float,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> Any:
+    """Enable Page+Runtime, optionally wait for ``ready_js`` to gate on render,
+    then run ``extract_js`` once and return its value.
+
+    The readiness poll is bounded by the first of: ``ready_js`` returning True,
+    ``timeout_s`` elapsing, or a hard max-poll cap (so a misbehaving clock can
+    never produce an infinite loop). The final extraction always runs — a
+    not-ready page yields a partial/None value that the caller treats as
+    fail-open ``unavailable``. This never raises on a slow/blocked page.
+    """
+    await cmd("Page.enable", {}, session_id)
+    await cmd("Runtime.enable", {}, session_id)
+
+    if ready_js is not None:
+        interval = poll_interval_s if poll_interval_s > 0 else _POLL_INTERVAL_S
+        max_polls = max(1, int(timeout_s / interval) + 1)
+        deadline = monotonic() + timeout_s
+        for _ in range(max_polls):
+            ready = await _evaluate(cmd, ready_js, session_id, await_promise=False)
+            if ready is True:
+                break
+            if monotonic() >= deadline:
+                break
+            await sleep(interval)
+
+    return await _evaluate(cmd, extract_js, session_id, await_promise=True)
+
+
 class CdpClient:
     """Real CDP client. Host-locked to 127.0.0.1:9222 at construction.
 
     NOTE: ``fetch_rendered`` talks to a live browser; it is not unit-tested
-    (no browser in CI). It is covered by the operator runbook smoke only.
+    (no browser in CI). The render-wait orchestration it delegates to
+    (``await_rendered_value``) is unit-tested via a fake command channel.
     """
 
     def __init__(self, *, host_port: str = "127.0.0.1:9222") -> None:
         assert_cdp_debug_host(host_port)
         self._host_port = host_port
 
-    async def fetch_rendered(self, url: str, js: str, *, timeout_s: float) -> Any:
+    async def fetch_rendered(
+        self, url: str, js: str, *, timeout_s: float, ready_js: str | None = None
+    ) -> Any:
         from websockets.asyncio.client import connect as ws_connect
 
         # 1. Discover the browser-level websocket endpoint.
@@ -97,14 +162,14 @@ class CdpClient:
                     "Target.attachToTarget", {"targetId": target_id, "flatten": True}
                 )
                 session_id = attached["result"]["sessionId"]
-                # Give the page a beat to render, then read.
-                await cmd("Runtime.enable", {}, session_id)
-                evaluated = await cmd(
-                    "Runtime.evaluate",
-                    {"expression": js, "returnByValue": True, "awaitPromise": True},
-                    session_id,
+                # Wait for the page to render (bounded) before the final read.
+                return await await_rendered_value(
+                    cmd,
+                    session_id=session_id,
+                    extract_js=js,
+                    ready_js=ready_js,
+                    timeout_s=timeout_s,
                 )
-                return evaluated.get("result", {}).get("result", {}).get("value")
             finally:
                 if target_id is not None:
                     await cmd("Target.closeTarget", {"targetId": target_id})

--- a/app/services/action_report/remote_debug_audit/cross_check.py
+++ b/app/services/action_report/remote_debug_audit/cross_check.py
@@ -119,6 +119,10 @@ def build_audit(
         "as_of": dt.datetime.now(tz=dt.UTC).isoformat(),
         "affects_report_generation": False,
         "checked_symbols": len(findings),
+        # Live-smoke acceptance signal: how many symbols Naver actually resolved
+        # (``ok`` or ``mismatch``), independent of the auto_trader side. All
+        # results being ``unavailable`` means the CDP/Naver read never landed.
+        "symbols_resolved": sum(1 for f in findings if f.get("symbol_resolved")),
         "findings": findings,
         "gaps": gaps,
     }

--- a/app/services/action_report/remote_debug_audit/naver_quote.py
+++ b/app/services/action_report/remote_debug_audit/naver_quote.py
@@ -23,19 +23,53 @@ def naver_url(code: str) -> str:
     return f"https://finance.naver.com/item/main.naver?code={code}"
 
 
+# Naver Finance item/main DOM has shifted over time, so the extraction tries a
+# small ordered list of selector variants and uses the first one with non-empty
+# text. ``.no_today .blind`` / ``.wrap_company h2`` are the long-standing
+# selectors and stay first; the rest are fallbacks for layout variants.
+NAVER_PRICE_SELECTORS: tuple[str, ...] = (
+    ".no_today .blind",
+    ".no_today em .blind",
+    "#_nowVal",
+    "#chart_area .rate_info .no_today .blind",
+)
+NAVER_NAME_SELECTORS: tuple[str, ...] = (
+    ".wrap_company h2 a",
+    ".wrap_company h2",
+    "#middle .h_company .wrap_company h2",
+)
+
+# In-page helper: first selector whose element has non-empty trimmed text.
+_PICK_FN: str = (
+    "function pick(sels){"
+    "for(var i=0;i<sels.length;i++){"
+    "var e=document.querySelector(sels[i]);"
+    "if(e&&e.textContent&&e.textContent.trim())return e.textContent.trim();"
+    "}return null;}"
+)
+
+
+def _selectors_json(selectors: tuple[str, ...]) -> str:
+    return json.dumps(list(selectors))
+
+
 # Returns a JSON string read back via Runtime.evaluate(returnByValue=true).
-# Selectors: current price lives in ``.no_today .blind``; company name in
-# ``.wrap_company h2``. Both are stable on the item/main page.
 NAVER_EXTRACT_JS: str = (
     "(function(){"
-    "function t(s){var e=document.querySelector(s);"
-    "return e?e.textContent.trim():null;}"
-    "return JSON.stringify({"
-    "code:(new URLSearchParams(location.search)).get('code'),"
-    "name:t('.wrap_company h2'),"
-    "price_text:t('.no_today .blind')"
-    "});"
-    "})()"
+    + _PICK_FN
+    + "return JSON.stringify({"
+    + "code:(new URLSearchParams(location.search)).get('code'),"
+    + f"name:pick({_selectors_json(NAVER_NAME_SELECTORS)}),"
+    + f"price_text:pick({_selectors_json(NAVER_PRICE_SELECTORS)})"
+    + "});})()"
+)
+
+# Render gate for the CDP poll loop: true once any price selector has text.
+NAVER_READY_JS: str = (
+    "(function(){"
+    + _PICK_FN
+    + f"return pick({_selectors_json(NAVER_PRICE_SELECTORS)})!==null;"
+    + "})()"
 )
 
 

--- a/app/services/action_report/remote_debug_audit/service.py
+++ b/app/services/action_report/remote_debug_audit/service.py
@@ -18,6 +18,7 @@ from app.services.action_report.remote_debug_audit.cross_check import (
 )
 from app.services.action_report.remote_debug_audit.naver_quote import (
     NAVER_EXTRACT_JS,
+    NAVER_READY_JS,
     naver_url,
     parse_naver_quote,
 )
@@ -98,7 +99,10 @@ class RemoteDebugAuditService:
     async def _fetch_naver(self, symbol: str):
         try:
             raw = await self._cdp.fetch_rendered(
-                naver_url(symbol), NAVER_EXTRACT_JS, timeout_s=_PER_SYMBOL_TIMEOUT_S
+                naver_url(symbol),
+                NAVER_EXTRACT_JS,
+                timeout_s=_PER_SYMBOL_TIMEOUT_S,
+                ready_js=NAVER_READY_JS,
             )
         except Exception:  # noqa: BLE001 — per-symbol fail-open
             return None

--- a/docs/runbooks/remote-debug-audit-smoke.md
+++ b/docs/runbooks/remote-debug-audit-smoke.md
@@ -35,9 +35,40 @@ uv run python -m scripts.remote_debug_audit_smoke --mode audit \
   --report-uuid <uuid> --max-symbols 10
 ```
 
-Output: `{source, snapshot_bundle_uuid, findings[], gaps[], affects_report_generation:false}`.
-`gaps` severities are `info`/`warning` only — this audit never gates report
-generation or publish.
+Output envelope (ROB-325):
+
+```json
+{
+  "step": "audit",
+  "target_kind": "report",        // or "bundle"
+  "report_uuid": "...",            // null when --bundle-uuid was used
+  "bundle_uuid": "...",
+  "checked_symbols": 5,
+  "symbols_resolved": 3,           // Naver resolved a price (ok|mismatch)
+  "audit": { "source": "naver_remote_debug", "findings": [], "gaps": [], "affects_report_generation": false }
+}
+```
+
+`audit.gaps` severities are `info`/`warning` only — this audit never gates
+report generation or publish.
+
+### Acceptance (live smoke)
+
+The fix landed correctly when `checked_symbols > 0` **and**
+`symbols_resolved > 0` (i.e. not every symbol comes back
+`naver_symbol_unresolved`). `symbols_resolved` counts symbols Naver actually
+resolved, independent of the auto_trader side, so it is the direct signal that
+the CDP render-wait works. The CLI exit code mirrors this (see below).
+
+## Render wait (ROB-325)
+
+`CdpClient.fetch_rendered` enables the Page + Runtime domains, then polls a
+price-selector readiness check (`NAVER_READY_JS`) before the final extraction.
+The poll is bounded by the per-symbol timeout (15s) and a hard max-poll cap, so
+a slow/blocked page can never loop forever — it falls open to `unavailable`.
+Extraction tries an ordered list of Naver selector variants
+(`NAVER_PRICE_SELECTORS` / `NAVER_NAME_SELECTORS`); if Naver changes its DOM,
+add the new selector to those lists.
 
 ## Safety
 
@@ -45,8 +76,12 @@ generation or publish.
 - Read-only: zero DB writes; no broker/order/watch/order-intent.
 - Naver access happens only here — never in the frontend request path or
   server-side `ensure()`. The `ensure()` registry stubs are unchanged.
-- Exit codes: `0` audit completed (any number of gaps); `2` disabled / no Chrome
-  at 127.0.0.1:9222 / bundle not found.
+- Exit codes:
+  - `0` audit completed and at least one symbol resolved on Naver.
+  - `2` disabled / no Chrome at 127.0.0.1:9222 / bundle not found.
+  - `3` audit completed but zero symbols resolved — operator-actionable
+    (env/config or external Naver page change), **not** a report-generation
+    failure (generation never calls this audit).
 
 ## Scope
 

--- a/scripts/remote_debug_audit_smoke.py
+++ b/scripts/remote_debug_audit_smoke.py
@@ -45,6 +45,34 @@ def require_target(args: argparse.Namespace) -> tuple[str, uuid.UUID]:
     raise ValueError("audit mode requires --bundle-uuid or --report-uuid")
 
 
+def build_smoke_output(
+    kind: str, target: uuid.UUID, bundle_uuid: uuid.UUID, audit: dict[str, Any]
+) -> dict[str, Any]:
+    """Operator envelope: surface the resolved target + key counts above the
+    full audit payload so the runbook acceptance check is readable at a glance.
+    """
+    return {
+        "step": "audit",
+        "target_kind": kind,
+        "report_uuid": str(target) if kind == "report" else None,
+        "bundle_uuid": str(bundle_uuid),
+        "checked_symbols": audit.get("checked_symbols", 0),
+        "symbols_resolved": audit.get("symbols_resolved", 0),
+        "audit": audit,
+    }
+
+
+def audit_exit_code(audit: dict[str, Any]) -> int:
+    """0 when at least one symbol resolved on Naver; 3 otherwise.
+
+    A non-zero audit exit is operator-actionable (env/config or external page
+    change), NOT a report-generation failure — generation never calls this.
+    """
+    checked = audit.get("checked_symbols", 0)
+    resolved = audit.get("symbols_resolved", 0)
+    return 0 if checked > 0 and resolved > 0 else 3
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Naver remote-debug data-quality audit (ROB-323, operator-only)"
@@ -78,8 +106,8 @@ async def _amain(args: argparse.Namespace) -> int:
             await svc.resolve_bundle_uuid(target) if kind == "report" else target
         )
         audit = await svc.audit_bundle(bundle_uuid, max_symbols=args.max_symbols)
-    _emit(audit)
-    return 0
+    _emit(build_smoke_output(kind, target, bundle_uuid, audit))
+    return audit_exit_code(audit)
 
 
 def main() -> None:

--- a/tests/services/action_report/remote_debug_audit/test_cdp_client.py
+++ b/tests/services/action_report/remote_debug_audit/test_cdp_client.py
@@ -1,8 +1,11 @@
+from typing import Any
+
 import pytest
 
 from app.services.action_report.remote_debug_audit.cdp_client import (
     CdpClient,
     FakeCdpSession,
+    await_rendered_value,
 )
 from app.services.action_report.remote_debug_audit.host_allowlist import (
     CdpDebugHostBlocked,
@@ -27,3 +30,151 @@ async def test_fake_session_raises_for_unknown_url() -> None:
     fake = FakeCdpSession(results={})
     with pytest.raises(RuntimeError):
         await fake.fetch_rendered("https://x/?code=000660", "js", timeout_s=1.0)
+
+
+@pytest.mark.asyncio
+async def test_fake_session_ignores_ready_js_kwarg() -> None:
+    fake = FakeCdpSession(results={"u": "v"})
+    out = await fake.fetch_rendered("u", "js", timeout_s=1.0, ready_js="READY")
+    assert out == "v"
+
+
+class _ScriptedCmd:
+    """Fake CDP command channel: records calls, scripts ready/extract evals.
+
+    ``READY`` evaluates to False for the first ``ready_after_polls`` calls then
+    True; any other expression is the extraction and returns ``extract_value``.
+    """
+
+    def __init__(self, *, ready_after_polls: int, extract_value: Any) -> None:
+        self.calls: list[tuple[str, str | None, str | None]] = []
+        self._ready_after = ready_after_polls
+        self._ready_polls = 0
+        self._extract_value = extract_value
+
+    async def __call__(
+        self, method: str, params: dict[str, Any], session_id: str | None = None
+    ) -> dict[str, Any]:
+        expr = params.get("expression")
+        self.calls.append((method, expr, session_id))
+        if method != "Runtime.evaluate":
+            return {"result": {}}
+        if expr == "READY":
+            self._ready_polls += 1
+            return {
+                "result": {"result": {"value": self._ready_polls > self._ready_after}}
+            }
+        return {"result": {"result": {"value": self._extract_value}}}
+
+
+class _SleepRecorder:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+class _FakeClock:
+    """Monotonic stand-in returning ``start`` then advancing by ``step`` each call."""
+
+    def __init__(self, *, start: float = 0.0, step: float = 0.0) -> None:
+        self._t = start
+        self._step = step
+
+    def __call__(self) -> float:
+        v = self._t
+        self._t += self._step
+        return v
+
+
+@pytest.mark.asyncio
+async def test_await_rendered_value_polls_until_ready_then_extracts() -> None:
+    cmd = _ScriptedCmd(ready_after_polls=2, extract_value='{"code":"005930"}')
+    sleeps = _SleepRecorder()
+    out = await await_rendered_value(
+        cmd,
+        session_id="s1",
+        extract_js="EXTRACT",
+        ready_js="READY",
+        timeout_s=10.0,
+        poll_interval_s=0.25,
+        sleep=sleeps,
+        monotonic=_FakeClock(),  # stuck at 0 → ready gate, not timeout, ends it
+    )
+    assert out == '{"code":"005930"}'
+
+    methods = [m for (m, _e, _s) in cmd.calls]
+    # Page + Runtime enabled before the first evaluate.
+    first_eval = methods.index("Runtime.evaluate")
+    assert "Page.enable" in methods[:first_eval]
+    assert "Runtime.enable" in methods[:first_eval]
+    # Three ready polls (False, False, True), two sleeps between them.
+    ready_evals = [c for c in cmd.calls if c[1] == "READY"]
+    assert len(ready_evals) == 3
+    assert sleeps.calls == [0.25, 0.25]
+    # Final call is the single extraction.
+    assert cmd.calls[-1] == ("Runtime.evaluate", "EXTRACT", "s1")
+
+
+@pytest.mark.asyncio
+async def test_await_rendered_value_is_bounded_when_never_ready() -> None:
+    # Clock never advances, so the deadline never fires; the hard max-poll cap
+    # must still terminate the loop (no infinite poll).
+    cmd = _ScriptedCmd(ready_after_polls=10**9, extract_value=None)
+    sleeps = _SleepRecorder()
+    out = await await_rendered_value(
+        cmd,
+        session_id="s1",
+        extract_js="EXTRACT",
+        ready_js="READY",
+        timeout_s=1.0,
+        poll_interval_s=0.25,
+        sleep=sleeps,
+        monotonic=_FakeClock(step=0.0),
+    )
+    assert out is None
+    ready_evals = [c for c in cmd.calls if c[1] == "READY"]
+    assert 1 <= len(ready_evals) <= 6  # bounded by timeout/interval cap
+    # Still performs the final extraction even though the gate never opened.
+    assert cmd.calls[-1] == ("Runtime.evaluate", "EXTRACT", "s1")
+
+
+@pytest.mark.asyncio
+async def test_await_rendered_value_times_out_via_deadline() -> None:
+    cmd = _ScriptedCmd(ready_after_polls=10**9, extract_value=None)
+    sleeps = _SleepRecorder()
+    out = await await_rendered_value(
+        cmd,
+        session_id="s1",
+        extract_js="EXTRACT",
+        ready_js="READY",
+        timeout_s=1.0,
+        poll_interval_s=0.25,
+        sleep=sleeps,
+        monotonic=_FakeClock(step=0.5),  # 0 (deadline=1.0), 0.5, 1.0 → break
+    )
+    assert out is None
+    ready_evals = [c for c in cmd.calls if c[1] == "READY"]
+    assert len(ready_evals) == 2  # poll@0.5 sleeps, poll@1.0 hits deadline
+
+
+@pytest.mark.asyncio
+async def test_await_rendered_value_without_ready_js_extracts_once() -> None:
+    cmd = _ScriptedCmd(ready_after_polls=0, extract_value="V")
+    sleeps = _SleepRecorder()
+    out = await await_rendered_value(
+        cmd,
+        session_id="s1",
+        extract_js="EXTRACT",
+        ready_js=None,
+        timeout_s=5.0,
+        sleep=sleeps,
+        monotonic=_FakeClock(),
+    )
+    assert out == "V"
+    assert sleeps.calls == []  # no polling
+    assert [c for c in cmd.calls if c[1] == "READY"] == []
+    methods = [m for (m, _e, _s) in cmd.calls]
+    assert methods.count("Runtime.evaluate") == 1
+    assert "Page.enable" in methods and "Runtime.enable" in methods

--- a/tests/services/action_report/remote_debug_audit/test_cli.py
+++ b/tests/services/action_report/remote_debug_audit/test_cli.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from app.core import config
@@ -35,3 +37,37 @@ def test_audit_mode_requires_a_uuid_arg() -> None:
     # Neither bundle nor report uuid -> validated in _amain, surfaced as ValueError.
     with pytest.raises(ValueError):
         cli.require_target(args)
+
+
+def test_build_smoke_output_echoes_target_kind_and_counts() -> None:
+    rid, bid = uuid.uuid4(), uuid.uuid4()
+    audit = {
+        "checked_symbols": 3,
+        "symbols_resolved": 2,
+        "source": "naver_remote_debug",
+    }
+    out = cli.build_smoke_output("report", rid, bid, audit)
+    assert out["target_kind"] == "report"
+    assert out["report_uuid"] == str(rid)
+    assert out["bundle_uuid"] == str(bid)
+    assert out["checked_symbols"] == 3
+    assert out["symbols_resolved"] == 2
+    assert out["audit"] is audit
+
+
+def test_build_smoke_output_bundle_kind_has_null_report_uuid() -> None:
+    bid = uuid.uuid4()
+    out = cli.build_smoke_output(
+        "bundle", bid, bid, {"checked_symbols": 1, "symbols_resolved": 1}
+    )
+    assert out["target_kind"] == "bundle"
+    assert out["report_uuid"] is None
+    assert out["bundle_uuid"] == str(bid)
+
+
+def test_audit_exit_code_zero_only_when_a_symbol_resolved() -> None:
+    assert cli.audit_exit_code({"checked_symbols": 5, "symbols_resolved": 1}) == 0
+    # Every symbol unresolved -> non-zero so the operator sees it failed,
+    # categorized as env/external-page-change (not a report-generation failure).
+    assert cli.audit_exit_code({"checked_symbols": 5, "symbols_resolved": 0}) == 3
+    assert cli.audit_exit_code({"checked_symbols": 0, "symbols_resolved": 0}) == 3

--- a/tests/services/action_report/remote_debug_audit/test_cross_check.py
+++ b/tests/services/action_report/remote_debug_audit/test_cross_check.py
@@ -66,6 +66,9 @@ def test_build_audit_assembles_gaps_and_never_blocks() -> None:
     assert audit["source"] == "naver_remote_debug"
     assert audit["affects_report_generation"] is False
     assert audit["checked_symbols"] == 3
+    # Two findings resolved on the Naver side (mismatch still counts as resolved),
+    # one unresolved. ``symbols_resolved`` is the live-smoke acceptance signal.
+    assert audit["symbols_resolved"] == 2
     assert audit["snapshot_bundle_uuid"] == "b-1"
     severities = {g["severity"] for g in audit["gaps"]}
     assert "blocking" not in severities

--- a/tests/services/action_report/remote_debug_audit/test_naver_quote.py
+++ b/tests/services/action_report/remote_debug_audit/test_naver_quote.py
@@ -1,6 +1,10 @@
 import json
 
 from app.services.action_report.remote_debug_audit.naver_quote import (
+    NAVER_EXTRACT_JS,
+    NAVER_NAME_SELECTORS,
+    NAVER_PRICE_SELECTORS,
+    NAVER_READY_JS,
     NaverQuote,
     naver_url,
     parse_naver_quote,
@@ -35,3 +39,22 @@ def test_parse_garbage_returns_none() -> None:
     assert parse_naver_quote("not-json") is None
     assert parse_naver_quote(None) is None
     assert parse_naver_quote(123) is None
+
+
+def test_extract_js_wires_every_price_and_name_selector_variant() -> None:
+    # Legacy selectors preserved, and at least one fallback variant added.
+    assert ".no_today .blind" in NAVER_PRICE_SELECTORS
+    assert ".wrap_company h2" in NAVER_NAME_SELECTORS
+    assert len(NAVER_PRICE_SELECTORS) > 1
+    assert len(NAVER_NAME_SELECTORS) > 1
+    for sel in NAVER_PRICE_SELECTORS:
+        assert sel in NAVER_EXTRACT_JS, sel
+    for sel in NAVER_NAME_SELECTORS:
+        assert sel in NAVER_EXTRACT_JS, sel
+
+
+def test_ready_js_probes_price_selectors_and_returns_boolean() -> None:
+    for sel in NAVER_PRICE_SELECTORS:
+        assert sel in NAVER_READY_JS, sel
+    # Returns a boolean (selector present) so the CDP poll loop can gate on it.
+    assert "!==null" in NAVER_READY_JS.replace(" ", "")

--- a/tests/services/action_report/remote_debug_audit/test_service.py
+++ b/tests/services/action_report/remote_debug_audit/test_service.py
@@ -6,7 +6,10 @@ import pytest
 
 from app.services.action_report.remote_debug_audit.cdp_client import FakeCdpSession
 from app.services.action_report.remote_debug_audit.cross_check import SymbolQuote
-from app.services.action_report.remote_debug_audit.naver_quote import naver_url
+from app.services.action_report.remote_debug_audit.naver_quote import (
+    NAVER_READY_JS,
+    naver_url,
+)
 from app.services.action_report.remote_debug_audit.service import (
     RemoteDebugAuditService,
     extract_symbol_quotes,
@@ -152,6 +155,51 @@ async def test_audit_bundle_per_symbol_failopen() -> None:
     statuses = {f["symbol"]: f["status"] for f in audit["findings"]}
     assert statuses["005930"] == "ok"
     assert statuses["999999"] == "unavailable"
+
+
+class _RecordingCdp:
+    """Captures the kwargs each ``fetch_rendered`` call received."""
+
+    def __init__(self, value) -> None:
+        self._value = value
+        self.calls: list[dict] = []
+
+    async def fetch_rendered(self, url, js, *, timeout_s, ready_js=None):
+        self.calls.append(
+            {"url": url, "js": js, "timeout_s": timeout_s, "ready_js": ready_js}
+        )
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_audit_bundle_passes_naver_ready_js_to_cdp() -> None:
+    bundle = _FakeBundle()
+    pairs = [
+        (
+            object(),
+            _snap(
+                "symbol",
+                "005930",
+                {
+                    "symbol": "005930",
+                    "name": "삼성전자",
+                    "quote": {"status": "ok", "last_price": 81000.0},
+                },
+            ),
+        ),
+    ]
+    cdp = _RecordingCdp(
+        json.dumps({"code": "005930", "name": "삼성전자", "price_text": "81,100"})
+    )
+    svc = RemoteDebugAuditService(
+        snapshots_repo=_FakeSnapshotsRepo(bundle, pairs),
+        reports_repo=None,
+        cdp_session=cdp,
+    )
+    await svc.audit_bundle(bundle.bundle_uuid, max_symbols=10)
+    # The render gate must be threaded through so the CDP poll waits for it.
+    assert cdp.calls[0]["ready_js"] == NAVER_READY_JS
+    assert cdp.calls[0]["url"] == naver_url("005930")
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -89,6 +89,13 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # imports + the BINANCE_DEMO_SCALPING_* env-flag names.
         "app/jobs/binance_demo_scalping_runner.py",
         "app/tasks/binance_demo_scalping_tasks.py",
+        # ROB-323 / ROB-325 — the operator Naver remote-debug audit's Chrome
+        # CDP host allowlist. Contains NO Binance HTTP/WS/signed surface; it is
+        # a strict 127.0.0.1:9222 allowlist and references "binance" only in a
+        # docstring naming binance/spot_demo/host_allowlist as the design
+        # precedent it mirrors (strict-equality, no wildcard). String reference
+        # only — same class as the other entries here.
+        "app/services/action_report/remote_debug_audit/host_allowlist.py",
     }
 )
 


### PR DESCRIPTION
## Summary

Follow-up to #973 (ROB-323). Post-merge smoke found Chrome CDP reachable but every checked KR symbol returned `naver_symbol_unresolved` — root cause: `Runtime.evaluate` ran immediately after `Target.createTarget`, before the Naver page rendered (the old comment said "give the page a beat" but there was no actual wait). This PR adds a bounded render-wait and makes the smoke directly verifiable, keeping the audit operator-only / default-disabled / fail-open and out of report generation.

- **CDP render-wait** (`cdp_client.py`): new `await_rendered_value` enables Page + Runtime domains, then polls a price-selector readiness check (`NAVER_READY_JS`) before the final extraction. Bounded by the per-symbol timeout deadline **and** a hard max-poll cap, so a slow/blocked page can never loop forever — it falls open to a partial/None value (`unavailable`). Real client delegates to it; orchestration is unit-tested via a fake command channel (no browser in CI).
- **Naver selector variants** (`naver_quote.py`): extraction tries an ordered list of price/name selectors (legacy `.no_today .blind` / `.wrap_company h2` first, then fallbacks) and emits a `NAVER_READY_JS` render gate. Parser unchanged, still browser-free.
- **`symbols_resolved` acceptance signal** (`cross_check.py`): counts symbols Naver actually resolved (`ok`|`mismatch`), independent of the auto_trader side. This is the direct signal that the CDP read landed (the prior acceptance wording "ok or mismatch" implicitly also required the auto_trader quote to be present, which could mask a working fix).
- **Service wiring** (`service.py`): `_fetch_naver` threads `ready_js` so the poll waits for render.
- **Smoke output + exit codes** (`scripts/remote_debug_audit_smoke.py`): `build_smoke_output` echoes `target_kind`/`report_uuid`/`bundle_uuid` + `checked_symbols`/`symbols_resolved`; exit `0` when ≥1 symbol resolved, `3` when none (operator-actionable env/external-page-change, **not** a report-generation failure), `2` unchanged for disabled/no-chrome.
- **Runbook**: documents the render-wait, output envelope, exit codes, and the `symbols_resolved > 0` acceptance check.

### Engineering note: `Page.loadEventFired` vs selector polling
The issue listed `Page.loadEventFired` "or equivalent lifecycle signal". The existing `cmd` helper drops CDP event messages (it loops until an id-matched response), so subscribing to `loadEventFired` would need an event pump and is brittle. Bounded selector polling is strictly more reliable for the actual need — that the price element has rendered — so I enable the Page domain (per scope) but gate on the selector. Documented in the runbook.

## Test Coverage

TDD throughout (every change had a failing test first). New/updated tests under `tests/services/action_report/remote_debug_audit/`, all using fake CDP seams only:
- `await_rendered_value`: polls until ready then extracts; bounded when never ready (misbehaving clock); times out via deadline; no-`ready_js` path extracts once.
- selector variants wired into extract JS; `NAVER_READY_JS` probes price selectors.
- `symbols_resolved` count; service passes `NAVER_READY_JS`; smoke envelope + exit-code helper.

Suite: **42 passed**. Hot-path import guard still green (`/invest/reports` generation never imports this audit).

## Pre-Landing Review
No issues. No SQL, no LLM trust-boundary, no broker/order/watch/order-intent mutation, no DB writes. CDP change is bounded and fail-open. Host allowlist (`127.0.0.1:9222`) and default-disabled gate unchanged.

Pre-existing (out of scope, not touched by this PR, flagging per collaborative repo): `scripts/debug_economic_calendar.py:56` (C401) and `scripts/test_discord_webhook_e2e.py:38-39` (E402) trip `ruff check`.

## Verification (acceptance criteria from ROB-325)
```
uv run --group test --group dev pytest tests/services/action_report/remote_debug_audit/ -q   → 42 passed
uv run --group dev ruff check <scope>                                                         → All checks passed
uv run --group dev ruff format --check <scope>                                                → 16 files already formatted
uv run --group dev ty check app/services/action_report/remote_debug_audit --error-on-warning  → All checks passed
```

**Operator live smoke (NOT run here — requires logged-in local Chrome; this host has no browser/cookies).** Must be run by the operator to confirm `symbols_resolved > 0`:
```bash
open -na "Google Chrome" --args --remote-debugging-address=127.0.0.1 \
  --remote-debugging-port=9222 --user-data-dir="$HOME/.hermes/chrome-toss-debug"
REMOTE_DEBUG_AUDIT_ENABLED=true uv run python -m scripts.remote_debug_audit_smoke \
  --mode audit --report-uuid <latest-kr-report-uuid> --max-symbols 5
```

## Test plan
- [x] Focused pytest suite green (42 passed)
- [x] ruff check + format + ty all green on touched scope
- [x] Hot-path import guard green
- [ ] Operator live smoke: `symbols_resolved > 0` (manual, requires local Chrome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional render-readiness detection when extracting data from pages
  * Added symbol resolution tracking to audit reports
  * Enhanced audit output with structured smoke test results envelope

* **Bug Fixes**
  * Improved quote extraction resilience with fallback selector strategies
  * Updated audit exit codes for clearer error signaling

* **Documentation**
  * Updated audit smoke test runbook with new output format and acceptance criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Pre-existing main fix (ROB-285 Binance guard)
CI surfaced that `main` is currently **red** on `tests/services/brokers/binance/test_audit_no_signed_endpoints.py::test_only_one_binance_package_path_exists` — `app/services/action_report/remote_debug_audit/host_allowlist.py` (added in #973, after the guard last re-scanned in #948) trips the `grep -i binance app/` invariant. The file has **zero** Binance HTTP/WS/signed surface; its docstring names `binance/spot_demo/host_allowlist` only as the strict-equality design precedent it mirrors. Per the guard's own instructions, this PR adds it to `ALLOWED_LEGACY_FILES` (string-reference class, like the other docstring-mention entries). This unblocks this PR's CI and repairs the pre-existing main breakage.
