### PR TITLE
feat(rob-328): validated_signal_gate — bootstrap CI + MC permutation + run-card (ROB-327 F1)

### DIFF
--- a/research/nautilus_scalping/tests/test_validated_gate_stats.py
+++ b/research/nautilus_scalping/tests/test_validated_gate_stats.py
@@ -1,0 +1,195 @@
+# tests/test_validated_gate_stats.py
+"""ROB-328 (ROB-327 F1) — statistical-significance + run-card additions to the
+pure validated-signal gate.
+
+These are additive: bootstrap Sharpe CI, Monte-Carlo permutation p-values,
+config/strategy/artifact SHA-256 hashes, and a json+markdown run card. All
+pure-stdlib (no numpy), seeded for reproducibility. The framing is *not* "find
+an edge" but "prove the net-after-fee result is statistically robust" — see
+ROB-316/320 (fees kill the scalper).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from validated_gate import (
+    GateReport,
+    Trade,
+    _equity_path_metrics,
+    apply_statistical_evidence,
+    bootstrap_sharpe_ci,
+    evaluate_gate,
+    monte_carlo_permutation,
+    net_pnls_at_fee,
+    run_card_hashes,
+    write_run_card,
+)
+
+
+# --------------------------------------------------------------------------- #
+# net_pnls_at_fee (driver helper)
+# --------------------------------------------------------------------------- #
+def test_net_pnls_at_fee_mirrors_per_trade_net() -> None:
+    trades = [Trade(2.0, -0.2, 100, 0), Trade(-1.0, -0.2, 100, 1)]
+    # REF_FEE_BPS=10 => scale 0 => net == net_ref_pnl
+    assert net_pnls_at_fee(trades, fee_bps=10.0) == [2.0, -1.0]
+    # fee 0 => scale 1 => net == net_ref_pnl + commission_ref
+    assert net_pnls_at_fee(trades, fee_bps=0.0) == [1.8, -1.2]
+
+
+# --------------------------------------------------------------------------- #
+# bootstrap_sharpe_ci
+# --------------------------------------------------------------------------- #
+def test_bootstrap_all_positive_ci_strictly_positive() -> None:
+    pnls = [1.0, 2.0, 1.5, 2.5, 1.0, 2.0, 3.0, 1.5] * 8  # all > 0, varied
+    out = bootstrap_sharpe_ci(pnls, n_bootstrap=500, seed=7)
+    assert out["observed_sharpe"] > 0
+    assert out["ci_lower"] <= out["ci_upper"]
+    assert out["ci_lower"] > 0           # every resample of positives is positive
+    assert out["prob_positive"] == 1.0
+
+
+def test_bootstrap_all_negative_ci_upper_below_zero() -> None:
+    pnls = [-1.0, -2.0, -1.5, -2.5, -1.0, -2.0, -3.0, -1.5] * 8
+    out = bootstrap_sharpe_ci(pnls, n_bootstrap=500, seed=7)
+    assert out["observed_sharpe"] < 0
+    assert out["ci_upper"] < 0           # net edge statistically <= 0
+    assert out["prob_positive"] == 0.0
+
+
+def test_bootstrap_is_seeded_reproducible() -> None:
+    pnls = [0.5, -0.3, 0.2, -0.1, 0.4, -0.6, 0.1, 0.3] * 8
+    a = bootstrap_sharpe_ci(pnls, n_bootstrap=300, seed=42)
+    b = bootstrap_sharpe_ci(pnls, n_bootstrap=300, seed=42)
+    assert a == b
+
+
+def test_bootstrap_insufficient_data() -> None:
+    out = bootstrap_sharpe_ci([1.0], n_bootstrap=100, seed=1)
+    assert out.get("error") is not None
+
+
+def test_bootstrap_zero_variance_is_bounded_and_signed() -> None:
+    # constant series => std 0; sign preserved, magnitude bounded (no 5e11 blowup)
+    out = bootstrap_sharpe_ci([-0.5] * 100, n_bootstrap=200, seed=1)
+    assert out["observed_sharpe"] < 0
+    assert out["ci_upper"] < 0
+    assert abs(out["observed_sharpe"]) <= 1e6 + 1
+    assert out["prob_positive"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# equity path metrics + Monte-Carlo permutation
+# --------------------------------------------------------------------------- #
+def test_equity_path_max_drawdown_is_absolute_on_cumulative_pnl() -> None:
+    sharpe, max_dd = _equity_path_metrics([100.0, -50.0, -30.0], base_capital=1000.0)
+    # cumsum 100, 50, 20 ; running peak 100 ; deepest dd = 20 - 100 = -80
+    assert round(max_dd, 6) == -80.0
+    assert isinstance(sharpe, float)
+
+
+def test_monte_carlo_pvalues_in_unit_interval_and_seeded() -> None:
+    pnls = [1.0, -0.8, 0.5, -1.2, 0.9, -0.3, 0.4, -0.7] * 8
+    a = monte_carlo_permutation(pnls, n_sim=300, seed=11)
+    b = monte_carlo_permutation(pnls, n_sim=300, seed=11)
+    assert a == b
+    assert 0.0 <= a["p_value_sharpe"] <= 1.0
+    assert 0.0 <= a["p_value_maxdd"] <= 1.0
+    assert a["n_sim"] == 300
+
+
+def test_monte_carlo_insufficient_data() -> None:
+    out = monte_carlo_permutation([1.0, -1.0], n_sim=100, seed=1)
+    assert out.get("error") is not None
+
+
+# --------------------------------------------------------------------------- #
+# run_card_hashes
+# --------------------------------------------------------------------------- #
+def test_config_hash_is_key_order_independent_sha256() -> None:
+    h1 = run_card_hashes({"a": 1, "b": 2})["config_hash"]
+    h2 = run_card_hashes({"b": 2, "a": 1})["config_hash"]
+    assert h1 == h2
+    expected = hashlib.sha256(
+        json.dumps({"a": 1, "b": 2}, sort_keys=True).encode()
+    ).hexdigest()
+    assert h1 == expected
+
+
+def test_strategy_and_artifact_hashes_match_file_contents(tmp_path: Path) -> None:
+    strat = tmp_path / "signal_engine.py"
+    strat.write_bytes(b"print('hi')\n")
+    art = tmp_path / "equity.csv"
+    art.write_bytes(b"ts,equity\n0,0\n")
+
+    out = run_card_hashes({"x": 1}, strategy_path=strat, artifact_paths=[art])
+    assert out["strategy_hash"] == hashlib.sha256(strat.read_bytes()).hexdigest()
+    assert out["artifacts"][0]["path"] == str(art)
+    assert out["artifacts"][0]["sha256"] == hashlib.sha256(art.read_bytes()).hexdigest()
+
+
+def test_strategy_hash_none_when_absent() -> None:
+    assert run_card_hashes({"x": 1})["strategy_hash"] is None
+
+
+# --------------------------------------------------------------------------- #
+# write_run_card
+# --------------------------------------------------------------------------- #
+def _losing_report() -> GateReport:
+    losing = [Trade(-0.5, -0.1, 100, ts) for ts in range(400)]
+    return evaluate_gate(
+        candidate_runs={"z2.0/tp30/sl30": losing},
+        baseline_breakout=losing, baseline_random=losing,
+        fee_bps=10.0, min_trades=100, fractions=(0.5, 0.25, 0.25),
+        candidate_name="meanrev_demo", hypothesis="mean_reversion",
+    )
+
+
+def test_write_run_card_emits_json_and_md(tmp_path: Path) -> None:
+    report = _losing_report()
+    bs = bootstrap_sharpe_ci([-0.5] * 400, n_bootstrap=200, seed=3)
+    paths = write_run_card(
+        report, tmp_path, config={"fee_bps": 10.0},
+        data_sources=["binance_demo"], bootstrap=bs,
+    )
+    assert paths["json"].exists() and paths["md"].exists()
+
+    card = json.loads(paths["json"].read_text())
+    assert card["schema_version"] == "validated_run_card.v1"
+    assert card["verdict"] == report.verdict
+    assert card["reproducibility"]["config_hash"]
+    assert card["validation"]["bootstrap"] == bs
+
+    md = paths["md"].read_text()
+    assert "net-after-fee" in md.lower()
+    assert "ROB-316" in md          # fee-kill framing is explicit in the card
+    assert report.verdict in md
+
+
+# --------------------------------------------------------------------------- #
+# apply_statistical_evidence (verdict augmentation)
+# --------------------------------------------------------------------------- #
+def test_negative_ci_appends_reason_and_keeps_not_validated() -> None:
+    report = _losing_report()
+    assert report.verdict == "not_validated"
+    bs = bootstrap_sharpe_ci([-0.5, -0.7, -0.4, -0.6] * 50, n_bootstrap=200, seed=5)
+    apply_statistical_evidence(report, bs)
+    assert report.verdict == "not_validated"
+    assert any("statistic" in r.lower() for r in report.verdict_reasons)
+
+
+def test_negative_ci_downgrades_a_validated_verdict() -> None:
+    report = GateReport(verdict="validated", verdict_reasons=["passed gate"])
+    bs = bootstrap_sharpe_ci([-1.0, -2.0, -1.5, -0.5] * 50, n_bootstrap=200, seed=5)
+    apply_statistical_evidence(report, bs)
+    assert report.verdict == "not_validated"   # statistical guard overrides
+    assert any("statistic" in r.lower() for r in report.verdict_reasons)
+
+
+def test_positive_ci_does_not_upgrade_not_validated() -> None:
+    report = GateReport(verdict="not_validated", verdict_reasons=["thin oos"])
+    bs = bootstrap_sharpe_ci([1.0, 2.0, 1.5, 0.5] * 50, n_bootstrap=200, seed=5)
+    apply_statistical_evidence(report, bs)
+    assert report.verdict == "not_validated"    # never flips up; gate owns that

--- a/research/nautilus_scalping/validate_candidate.py
+++ b/research/nautilus_scalping/validate_candidate.py
@@ -23,7 +23,15 @@ from pathlib import Path
 
 from backtest_runner import run
 from candidates import get_candidate
-from validated_gate import Trade, evaluate_gate
+from validated_gate import (
+    Trade,
+    apply_statistical_evidence,
+    bootstrap_sharpe_ci,
+    evaluate_gate,
+    monte_carlo_permutation,
+    net_pnls_at_fee,
+    write_run_card,
+)
 
 # small, fixed param grid (param-stability check, not optimization)
 _GRID = {
@@ -49,6 +57,10 @@ def main() -> int:
     ap.add_argument("--window-from", default="")
     ap.add_argument("--window-to", default="")
     ap.add_argument("--export", type=Path, default="results/rob320/gate.json")
+    ap.add_argument("--seed", type=int, default=42,
+                    help="seed for bootstrap / Monte-Carlo permutation")
+    ap.add_argument("--bootstrap-n", type=int, default=1000)
+    ap.add_argument("--mc-n", type=int, default=1000)
     args = ap.parse_args()
 
     symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
@@ -101,8 +113,34 @@ def main() -> int:
                 "folds": {"train": 0.5, "val": 0.25, "oos": 0.25}},
     )
 
+    # ROB-328 (ROB-327 F1) — statistical robustness of the net-after-fee result.
+    # Bootstrap CI + Monte-Carlo permutation on the val-best config's per-trade
+    # net PnLs. This tests whether the (known net-negative; ROB-316/320) result
+    # is statistically robust, and emits an audit run card. No new edge claim.
+    val_best = report.param_stability.get("val_best_param")
+    bootstrap = monte_carlo = None
+    if val_best in candidate_runs:
+        net_pnls = net_pnls_at_fee(candidate_runs[val_best], args.fee_bps)
+        bootstrap = bootstrap_sharpe_ci(net_pnls, n_bootstrap=args.bootstrap_n, seed=args.seed)
+        monte_carlo = monte_carlo_permutation(net_pnls, n_sim=args.mc_n, seed=args.seed)
+        apply_statistical_evidence(report, bootstrap)  # folds CI evidence into verdict
+
     args.export.parent.mkdir(parents=True, exist_ok=True)
     args.export.write_text(json.dumps(report.to_dict(), indent=2))
+
+    run_card_config = {
+        "candidate": args.candidate, "symbols": symbols, "fee_bps": args.fee_bps,
+        "min_trades": args.min_trades, "grid": dict(grid),
+        "window": {"from": args.window_from, "to": args.window_to},
+        "seed": args.seed, "bootstrap_n": args.bootstrap_n, "mc_n": args.mc_n,
+    }
+    card_paths = write_run_card(
+        report, args.export.parent,
+        config=run_card_config,
+        data_sources=[f"binance_demo_backtest:{','.join(symbols)}"],
+        bootstrap=bootstrap, monte_carlo=monte_carlo,
+    )
+
     print("\n=============================================================")
     print(f"VERDICT: {report.verdict.upper()}")
     print("Reasons:")
@@ -111,6 +149,7 @@ def main() -> int:
     print("=============================================================")
     print(f"Total trades of val-best config: {report.trade_count}")
     print(f"Report exported to: {args.export.resolve()}")
+    print(f"Run card: {card_paths['json'].resolve()} / {card_paths['md'].name}")
     return 0
 
 

--- a/research/nautilus_scalping/validated_gate.py
+++ b/research/nautilus_scalping/validated_gate.py
@@ -8,7 +8,14 @@ reference-fee run (same method as fee_sweep / compare_strategies).
 """
 from __future__ import annotations
 
+import hashlib
+import json
+import math
+import random
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
 from typing import Literal
 
 REF_FEE_BPS = 10.0
@@ -58,6 +65,11 @@ class GateReport:
 def _net_at_fee(t: Trade, fee_bps: float) -> float:
     scale = 1.0 - fee_bps / REF_FEE_BPS
     return t.net_ref_pnl + t.commission_ref * scale
+
+
+def net_pnls_at_fee(trades: list[Trade], fee_bps: float) -> list[float]:
+    """Per-trade net-after-fee PnLs (chronological) for the statistical layer."""
+    return [_net_at_fee(t, fee_bps) for t in sorted(trades, key=lambda t: t.ts_opened)]
 
 
 def metrics_at_fee(trades: list[Trade], fee_bps: float, fold: str = "") -> FoldMetrics:
@@ -202,3 +214,323 @@ def evaluate_gate(
             reasons.append("oos positive, beats baselines, stable across params/folds")
     report.verdict_reasons = reasons
     return report
+
+
+# --------------------------------------------------------------------------- #
+# ROB-328 (ROB-327 F1) — statistical-significance + run-card additions.
+#
+# Additive only; the OOS/verdict/baseline/fee machinery above is unchanged.
+# Pure-stdlib (random/math/hashlib) so the gate stays importable without numpy.
+# Framing: ROB-316/320 already proved the scalper is net-negative on fees; these
+# tools test the *statistical robustness* of that net result, not a new edge.
+# --------------------------------------------------------------------------- #
+
+RUN_CARD_SCHEMA_VERSION = "validated_run_card.v1"
+
+_FEE_KILL_NOTE = (
+    "net-after-fee is the only verdict basis. ROB-316/320 already proved the "
+    "scalper is net-negative purely on fees; the bootstrap CI and Monte-Carlo "
+    "permutation here test the statistical robustness of that net result, not a "
+    "new edge. This run card is audit evidence, not a pass stamp."
+)
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _sample_std(xs: Sequence[float]) -> float:
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = _mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+_MAX_SHARPE = 1e6  # bound the degenerate zero-variance case (sign still preserved)
+
+
+def _sharpe(xs: Sequence[float]) -> float:
+    """Unitless edge-per-unit-risk: mean / sample-std (no annualization).
+
+    Zero variance (constant series) yields a sign-preserving bounded value rather
+    than an eps-division blowup, so run cards stay readable.
+    """
+    if not xs:
+        return 0.0
+    mean = _mean(xs)
+    std = _sample_std(xs)
+    if std == 0.0:
+        return 0.0 if mean == 0.0 else math.copysign(_MAX_SHARPE, mean)
+    return max(-_MAX_SHARPE, min(_MAX_SHARPE, mean / std))
+
+
+def _percentile(sorted_xs: list[float], q: float) -> float:
+    """Linear-interpolation percentile (q in [0, 1]); input must be sorted."""
+    if not sorted_xs:
+        return 0.0
+    n = len(sorted_xs)
+    if n == 1:
+        return sorted_xs[0]
+    pos = q * (n - 1)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return sorted_xs[int(lo)]
+    frac = pos - lo
+    return sorted_xs[int(lo)] * (1.0 - frac) + sorted_xs[int(hi)] * frac
+
+
+def bootstrap_sharpe_ci(
+    net_pnls: Sequence[float],
+    n_bootstrap: int = 1000,
+    confidence: float = 0.95,
+    seed: int = 42,
+) -> dict:
+    """Percentile bootstrap CI for the per-trade Sharpe of net-after-fee PnLs.
+
+    ``ci_upper < 0`` => the net edge is statistically <= 0 at ``confidence``.
+    Seeded via ``random.Random`` for exact reproducibility.
+    """
+    n = len(net_pnls)
+    if n < 2:
+        return {"error": "insufficient_data", "n": n,
+                "n_bootstrap": n_bootstrap, "confidence": confidence, "seed": seed}
+    rng = random.Random(seed)
+    observed = _sharpe(net_pnls)
+    sharpes: list[float] = []
+    for _ in range(n_bootstrap):
+        sample = [net_pnls[rng.randrange(n)] for _ in range(n)]
+        sharpes.append(_sharpe(sample))
+    sharpes.sort()
+    alpha = (1.0 - confidence) / 2.0
+    return {
+        "observed_sharpe": observed,
+        "ci_lower": _percentile(sharpes, alpha),
+        "ci_upper": _percentile(sharpes, 1.0 - alpha),
+        "median_sharpe": _percentile(sharpes, 0.5),
+        "prob_positive": sum(1 for s in sharpes if s > 0) / n_bootstrap,
+        "confidence": confidence,
+        "n_bootstrap": n_bootstrap,
+        "seed": seed,
+    }
+
+
+def _equity_path_metrics(
+    net_pnls: Sequence[float], base_capital: float = 10_000.0
+) -> tuple[float, float]:
+    """Order-dependent path metrics: (returns-Sharpe, absolute max drawdown).
+
+    Max drawdown is absolute on the cumulative-PnL equity curve (starts at 0),
+    matching ``metrics_at_fee``. The returns-Sharpe is computed relative to the
+    running capital, so both are sensitive to trade ordering (the only thing a
+    permutation test can move — the PnL multiset and its sum are invariant).
+    """
+    equity = 0.0
+    peak = 0.0
+    max_dd = 0.0
+    running_capital = base_capital
+    returns: list[float] = []
+    for x in net_pnls:
+        returns.append(x / running_capital if running_capital else 0.0)
+        running_capital += x
+        equity += x
+        peak = max(peak, equity)
+        max_dd = min(max_dd, equity - peak)
+    sharpe = _sharpe(returns) if len(returns) >= 2 else 0.0
+    return sharpe, max_dd
+
+
+def monte_carlo_permutation(
+    net_pnls: Sequence[float],
+    n_sim: int = 1000,
+    seed: int = 42,
+    base_capital: float = 10_000.0,
+) -> dict:
+    """Permutation test on trade ordering (null: order carries no information).
+
+    Shuffles the PnL sequence ``n_sim`` times and recomputes the order-dependent
+    path metrics. ``p_value_*`` = fraction of permutations whose statistic is at
+    least as good as observed (one-tailed; max_dd is negative, so ``>=`` means a
+    less-severe drawdown).
+    """
+    n = len(net_pnls)
+    if n < 3:
+        return {"error": "insufficient_data", "n": n, "n_sim": n_sim, "seed": seed}
+    rng = random.Random(seed)
+    actual_sharpe, actual_max_dd = _equity_path_metrics(net_pnls, base_capital)
+    ge_sharpe = 0
+    ge_maxdd = 0
+    pool = list(net_pnls)
+    for _ in range(n_sim):
+        rng.shuffle(pool)
+        s, dd = _equity_path_metrics(pool, base_capital)
+        if s >= actual_sharpe:
+            ge_sharpe += 1
+        if dd >= actual_max_dd:
+            ge_maxdd += 1
+    return {
+        "actual_sharpe": actual_sharpe,
+        "actual_max_dd": actual_max_dd,
+        "p_value_sharpe": ge_sharpe / n_sim,
+        "p_value_maxdd": ge_maxdd / n_sim,
+        "n_sim": n_sim,
+        "seed": seed,
+    }
+
+
+def run_card_hashes(
+    config: dict,
+    strategy_path: str | Path | None = None,
+    artifact_paths: Sequence[str | Path] = (),
+) -> dict:
+    """SHA-256 reproducibility trio: config (sorted-key JSON) / strategy / artifacts."""
+    config_hash = hashlib.sha256(
+        json.dumps(config, sort_keys=True).encode()
+    ).hexdigest()
+    strategy_hash: str | None = None
+    if strategy_path is not None:
+        p = Path(strategy_path)
+        if p.exists():
+            strategy_hash = hashlib.sha256(p.read_bytes()).hexdigest()
+    artifacts: list[dict] = []
+    for ap in artifact_paths:
+        p = Path(ap)
+        if p.exists():
+            artifacts.append(
+                {"path": str(p), "sha256": hashlib.sha256(p.read_bytes()).hexdigest()}
+            )
+    return {"config_hash": config_hash, "strategy_hash": strategy_hash,
+            "artifacts": artifacts}
+
+
+def apply_statistical_evidence(report: GateReport, bootstrap: dict) -> GateReport:
+    """Fold bootstrap evidence into the verdict (mutates ``report``).
+
+    A negative CI upper bound is a statistical guard: it appends a reason and
+    downgrades a ``validated`` verdict to ``not_validated``. A positive CI lower
+    bound only appends corroborating evidence — it never upgrades, since the full
+    gate (OOS/baseline/overfit) owns the ``validated`` decision.
+    """
+    if not bootstrap or bootstrap.get("error") is not None:
+        return report
+    ci_lower = bootstrap.get("ci_lower")
+    ci_upper = bootstrap.get("ci_upper")
+    conf = bootstrap.get("confidence", 0.95)
+    if ci_upper is not None and ci_upper < 0:
+        report.verdict_reasons.append(
+            f"net edge statistically <= 0 (bootstrap {conf:.0%} CI upper {ci_upper:.4f} < 0)"
+        )
+        if report.verdict == "validated":
+            report.verdict = "not_validated"
+    elif ci_lower is not None and ci_lower > 0:
+        report.verdict_reasons.append(
+            f"net edge statistically > 0 (bootstrap {conf:.0%} CI lower {ci_lower:.4f} > 0)"
+        )
+    else:
+        report.verdict_reasons.append(
+            f"net edge not statistically distinguishable from 0 "
+            f"(bootstrap {conf:.0%} CI straddles 0)"
+        )
+    return report
+
+
+def _render_run_card_md(card: dict) -> str:
+    lines = [
+        f"# Validated Signal Gate — Run Card ({card['schema_version']})",
+        "",
+        f"- Generated: {card['generated_at']}",
+        f"- Candidate: {card['candidate']}",
+        f"- Hypothesis: {card['hypothesis']}",
+        f"- **Verdict: {card['verdict']}**",
+        "",
+        "## Framing",
+        card["framing"],
+        "",
+        "## Net-after-cost (verdict basis)",
+    ]
+    net = card.get("net_after_cost") or {}
+    if net:
+        for key in ("trades", "net_pnl", "profit_factor", "expectancy", "max_drawdown"):
+            if key in net:
+                lines.append(f"- {key}: {net[key]}")
+    else:
+        lines.append("- (no net_after_cost recorded)")
+
+    lines += ["", "## Verdict reasons"]
+    lines += [f"- {r}" for r in card["verdict_reasons"]] or ["- (none)"]
+
+    lines += ["", "## Reproducibility"]
+    repro = card["reproducibility"]
+    lines.append(f"- config_hash: `{repro['config_hash']}`")
+    lines.append(f"- strategy_hash: `{repro['strategy_hash']}`")
+    for art in repro.get("artifacts", []):
+        lines.append(f"- artifact {art['path']}: `{art['sha256']}`")
+
+    lines += ["", "## Statistical validation"]
+    val = card.get("validation") or {}
+    bs = val.get("bootstrap")
+    mc = val.get("monte_carlo")
+    if bs and bs.get("error") is None:
+        lines.append(
+            f"- bootstrap Sharpe: observed {bs['observed_sharpe']:.4f}, "
+            f"{bs['confidence']:.0%} CI [{bs['ci_lower']:.4f}, {bs['ci_upper']:.4f}], "
+            f"prob_positive {bs['prob_positive']:.3f} (n={bs['n_bootstrap']})"
+        )
+    if mc and mc.get("error") is None:
+        lines.append(
+            f"- Monte-Carlo permutation: p_value_sharpe {mc['p_value_sharpe']:.3f}, "
+            f"p_value_maxdd {mc['p_value_maxdd']:.3f} (n={mc['n_sim']})"
+        )
+    if not bs and not mc:
+        lines.append("- (no statistical validation recorded)")
+
+    lines += ["", "## Data sources"]
+    lines += [f"- {s}" for s in card["data_sources"]] or ["- (none recorded)"]
+
+    if card["warnings"]:
+        lines += ["", "## Warnings"]
+        lines += [f"- {w}" for w in card["warnings"]]
+
+    return "\n".join(lines) + "\n"
+
+
+def write_run_card(
+    report: GateReport,
+    out_dir: str | Path,
+    *,
+    config: dict | None = None,
+    strategy_path: str | Path | None = None,
+    artifact_paths: Sequence[str | Path] = (),
+    data_sources: Sequence[str] = (),
+    bootstrap: dict | None = None,
+    monte_carlo: dict | None = None,
+    warnings: Sequence[str] = (),
+) -> dict[str, Path]:
+    """Write ``run_card.json`` + ``run_card.md`` to ``out_dir`` and return paths."""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    hashes = run_card_hashes(
+        config or {}, strategy_path=strategy_path, artifact_paths=artifact_paths
+    )
+    net = report.results.get("net_after_cost", {}) if report.results else {}
+    card = {
+        "schema_version": RUN_CARD_SCHEMA_VERSION,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "candidate": report.candidate,
+        "hypothesis": report.hypothesis,
+        "verdict": report.verdict,
+        "verdict_reasons": list(report.verdict_reasons),
+        "net_after_cost": net,
+        "reproducibility": hashes,
+        "data_sources": list(data_sources),
+        "validation": {"bootstrap": bootstrap, "monte_carlo": monte_carlo},
+        "warnings": list(warnings),
+        "framing": _FEE_KILL_NOTE,
+        "gate_report": report.to_dict(),
+    }
+    json_path = out / "run_card.json"
+    json_path.write_text(json.dumps(card, indent=2))
+    md_path = out / "run_card.md"
+    md_path.write_text(_render_run_card_md(card))
+    return {"json": json_path, "md": md_path}


### PR DESCRIPTION
## Summary

ROB-327 설계 문서(PR #975)의 최우선 후속 슬라이스 **F1** (Linear: ROB-328).

auto_trader `validated_signal_gate.v1`(`research/nautilus_scalping/validated_gate.py`, ROB-320)이 Vibe-Trading `agent/backtest/validation.py`보다 검증 게이트 측면에서 이미 강하다(진짜 OOS holdout + verdict + baseline + overfit flags). Vibe가 *더해 주는* 4가지만 **순수 additive**로 흡수했다. 기존 OOS/verdict/baseline/fee 머신은 변경 없음. 신규 코드 전부 **순수 stdlib (numpy 미사용)**, seeded.

## 추가된 것

- **`bootstrap_sharpe_ci`** — percentile CI + `prob_positive`. `ci_upper < 0` ⇒ net edge가 통계적으로 ≤ 0. zero-variance(상수 시리즈)는 부호 보존 + bound 처리(eps 폭발 방지).
- **`monte_carlo_permutation`** — 거래 순서 permutation p-value (`p_value_sharpe`, `p_value_maxdd`). PnL multiset/합은 순서 불변이므로 순서 의존 metric(경로 Sharpe, max_dd)만 검정.
- **`run_card_hashes`** — config(sorted-key JSON) / strategy / artifact SHA-256 trio.
- **`write_run_card`** — `run_card.json` + `run_card.md`. net-after-fee가 유일한 verdict 근거임 + ROB-316/320 fee-kill 결론을 카드에 명시(합격 도장이 아니라 **감사 evidence**).
- **`apply_statistical_evidence`** — bootstrap CI를 verdict에 반영. `ci_upper<0`면 reason 추가 + `validated`를 `not_validated`로 강등(통계 가드). `not_validated`를 절대 상향하지 않음(full gate가 소유).
- **`validate_candidate.py`** 드라이버 배선 — val-best config의 net-after-fee per-trade PnL로 bootstrap/MC 계산 후 run-card 방출 (`--seed`/`--bootstrap-n`/`--mc-n`).

## 프레이밍

"새 edge 발굴"이 아니다. ROB-316/320이 이미 net-after-fee에서 스캘퍼가 net-negative임을 증명했고, 이 작업은 그 결론의 **통계적 강건성**을 증명한다.

## Acceptance criteria (ROB-328)

- [x] `bootstrap_sharpe_ci(n=1000, conf=0.95, seed)` → observed/ci_lower/ci_upper/median/prob_positive, seeded 재현 가능
- [x] `monte_carlo_permutation(n=1000, seed)` → p_value_sharpe, p_value_maxdd (PnL shuffle, 단측)
- [x] config/strategy/artifact SHA-256 (sorted-key JSON / 파일 내용)
- [x] `run_card.json` + `run_card.md`를 `results/<task>/`에 출력, net-after-fee + ROB-316/320 결론 명시
- [x] verdict에 "net edge 통계적으로 0 이하" reason 추가
- [x] `research/nautilus_scalping/` 밖 변경 없음, 단위 테스트(seed 고정) 포함
- [x] 프로덕션 `research_gate_service` 변경 없음

## Test / lint

- `uv run python -m pytest research/nautilus_scalping/tests/test_validated_gate{,_stats}.py` → **21 passed** (5 기존 + 16 신규)
- `ruff check` 변경 파일 → clean
- diff는 `research/nautilus_scalping/`로 한정. nautilus 의존 테스트는 별도 research venv에서 실행되며 본 변경과 무관(미설치 환경에서 collection-only error는 사전 한계).

## Non-goals

프로덕션 `research_gate_service.GateResult` 변경(후속 F6) · broker/order/watch mutation · 실주문 · 프로덕션 DB · scheduler · 의존성 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)