### PR TITLE
feat(rob-322): KR /invest/reports five-section actionable review projection (PR1 backend)

### DIFF
--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -40,6 +40,7 @@ from app.schemas.investment_reports import (
 from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
 )
+from app.services.investment_reports.review_sections import build_review_sections
 
 router = APIRouter(tags=["investment-reports"])
 
@@ -73,8 +74,14 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         ],
     }
 
+    report_response = InvestmentReportResponse.model_validate(bundle["report"])
+    # ROB-322 — additive five-section review projection (view-layer only).
+    review_sections = build_review_sections(
+        item_responses, report_response.snapshot_report_diagnostics
+    )
+
     return InvestmentReportBundle(
-        report=InvestmentReportResponse.model_validate(bundle["report"]),
+        report=report_response,
         items=item_responses,
         decisions_by_item_uuid=decisions_by_item_uuid,
         alerts=[
@@ -85,6 +92,7 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         ],
         item_groups=item_groups,
         decision_rollup=rollup,
+        review_sections=review_sections,
     )
 
 

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -498,6 +498,58 @@ class InvestmentWatchEventResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+# ROB-322 — KR /invest/reports five-section review surface. These are a
+# *view-layer projection* over the locked ROB-301 ``decision_bucket`` vocab +
+# ROB-318 report diagnostics; they introduce NO new persisted classification,
+# DB CHECK, or ``decision_bucket`` enum value.
+ReviewSectionKeyLiteral = Literal[
+    "new_buy_candidate",
+    "held_strategy_review",
+    "watch_only",
+    "excluded_or_unavailable",
+]
+# Mirrors WhyNoActionKind in app/services/action_report/common/diagnostics.py
+# (kept local to avoid a schema -> service import, matching this file's pattern
+# of mirroring DB/service enums as Literals).
+WhyNoActionKindLiteral = Literal["data_insufficient", "stale_gated", "real_no_action"]
+
+
+class ReviewSection(BaseModel):
+    """One ordered review queue (sections 1-4 of ROB-322)."""
+
+    key: ReviewSectionKeyLiteral
+    label_ko: str
+    items: list[InvestmentReportItemResponse] = Field(default_factory=list)
+
+
+class NoActionSummary(BaseModel):
+    """Section 5 — report-level no-action summary.
+
+    Distinguishes genuine no-action (``real_no_action``) from
+    ``stale_gated`` / ``data_insufficient`` no-action, derived from the
+    ROB-318 ``snapshot_report_diagnostics.why_no_action`` block. ``kind`` is
+    null on legacy reports that lack diagnostics.
+    """
+
+    kind: WhyNoActionKindLiteral | None = None
+    reason_ko: str | None = None
+    blocking_sources: list[str] = Field(default_factory=list)
+    excluded_count: int = 0
+
+
+class ReportReviewSections(BaseModel):
+    """ROB-322 five-section actionable review projection.
+
+    ``sections`` always carries the four queues in fixed display order (each
+    may be empty); ``no_action_summary`` is null when there is nothing to
+    summarise. Legacy items with ``decision_bucket=None`` are intentionally
+    not projected here and remain available via ``items`` / ``item_groups``.
+    """
+
+    sections: list[ReviewSection] = Field(default_factory=list)
+    no_action_summary: NoActionSummary | None = None
+
+
 class InvestmentReportBundle(BaseModel):
     """``investment_report_get`` / ``GET /.../investment-reports/{uuid}``.
 
@@ -517,6 +569,9 @@ class InvestmentReportBundle(BaseModel):
     decision_rollup: dict[str, list[InvestmentReportItemResponse]] = Field(
         default_factory=dict
     )
+    # ROB-322 — additive five-section review projection. Null/empty for legacy
+    # reports; existing ``items`` / ``item_groups`` remain the fallback.
+    review_sections: ReportReviewSections | None = None
 
 
 class InvestmentReportListResponse(BaseModel):

--- a/app/services/investment_reports/review_sections.py
+++ b/app/services/investment_reports/review_sections.py
@@ -1,0 +1,104 @@
+"""ROB-322 — deterministic five-section review projection.
+
+Turns the flat report-item list into the KR ``/invest/reports`` actionable
+review surface:
+
+1. 신규매수 후보            (``new_buy_candidate``)
+2. 보유종목 전략 변경 후보  (``held_strategy_review``)
+3. watch-only              (``watch_only``)
+4. 제외 / 확인 불가         (``excluded_or_unavailable``)
+5. no-action summary       (``no_action_summary``)
+
+This is a pure, read-time *view-layer mapping* over the already-locked
+ROB-301 ``decision_bucket`` vocabulary + ROB-318 report diagnostics. It does
+**not** introduce a new ``decision_bucket`` value, DB CHECK, or persisted
+classification, and it does not invent a trading-strategy engine.
+
+Backward-compat: items whose ``decision_bucket`` is ``None`` (pre-ROB-308
+reports) are intentionally *not* projected into any section; they stay
+available via the bundle's ``items`` / ``item_groups`` for safe rendering.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.schemas.investment_reports import (
+    InvestmentReportItemResponse,
+    NoActionSummary,
+    ReportReviewSections,
+    ReviewSection,
+)
+
+# Locked ROB-301 decision_bucket -> display section key. The two "held"
+# buckets collapse into one strategy-review queue; legacy/unknown buckets map
+# to ``None`` (not projected).
+_BUCKET_TO_SECTION: dict[str, str] = {
+    "new_buy_candidate": "new_buy_candidate",
+    "open_action": "held_strategy_review",
+    "completed_or_existing": "held_strategy_review",
+    "risk_watch": "watch_only",
+    "deferred_no_action": "excluded_or_unavailable",
+}
+
+# Fixed display order + Korean labels required by ROB-322 §3.
+_SECTION_ORDER: tuple[tuple[str, str], ...] = (
+    ("new_buy_candidate", "신규매수 후보"),
+    ("held_strategy_review", "보유종목 전략 변경 후보"),
+    ("watch_only", "watch-only"),
+    ("excluded_or_unavailable", "제외 / 확인 불가"),
+)
+
+
+def build_review_sections(
+    items: Sequence[InvestmentReportItemResponse],
+    diagnostics: Mapping[str, Any] | None,
+) -> ReportReviewSections:
+    """Project report items into the five-section review surface.
+
+    ``diagnostics`` is the report's ``snapshot_report_diagnostics`` block
+    (or ``None`` on legacy reports).
+    """
+    buckets: dict[str, list[InvestmentReportItemResponse]] = {
+        key: [] for key, _ in _SECTION_ORDER
+    }
+    for item in items:
+        section_key = _BUCKET_TO_SECTION.get(item.decision_bucket or "")
+        if section_key is not None:
+            buckets[section_key].append(item)
+
+    sections = [
+        ReviewSection(key=key, label_ko=label, items=buckets[key])  # type: ignore[arg-type]
+        for key, label in _SECTION_ORDER
+    ]
+
+    no_action_summary = _build_no_action_summary(
+        diagnostics, excluded_count=len(buckets["excluded_or_unavailable"])
+    )
+    return ReportReviewSections(sections=sections, no_action_summary=no_action_summary)
+
+
+def _build_no_action_summary(
+    diagnostics: Mapping[str, Any] | None,
+    *,
+    excluded_count: int,
+) -> NoActionSummary | None:
+    why: Mapping[str, Any] | None = None
+    if isinstance(diagnostics, Mapping):
+        candidate = diagnostics.get("why_no_action")
+        if isinstance(candidate, Mapping):
+            why = candidate
+
+    # Nothing to summarise: no diagnostics verdict and no excluded items.
+    if why is None and excluded_count == 0:
+        return None
+
+    why = why or {}
+    blocking = why.get("blocking_sources") or []
+    return NoActionSummary(
+        kind=why.get("kind"),
+        reason_ko=why.get("reason_ko"),
+        blocking_sources=[str(s) for s in blocking],
+        excluded_count=excluded_count,
+    )

--- a/tests/services/investment_reports/test_review_sections.py
+++ b/tests/services/investment_reports/test_review_sections.py
@@ -1,0 +1,144 @@
+"""ROB-322 — deterministic five-section review projection.
+
+These tests pin the *view-layer* mapping: the five `/invest/reports`
+review sections are derived from the already-locked ROB-301
+``decision_bucket`` vocabulary + ROB-318 report diagnostics. No new
+``decision_bucket`` enum value / DB CHECK / persisted classification is
+introduced — the assembler is a pure read-time projection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.investment_reports import InvestmentReportItemResponse
+from app.services.investment_reports.review_sections import build_review_sections
+
+pytestmark = pytest.mark.unit
+
+_NOW = datetime(2026, 5, 27, tzinfo=UTC)
+
+# Fixed display order required by ROB-322 §3.
+_EXPECTED_ORDER = [
+    "new_buy_candidate",
+    "held_strategy_review",
+    "watch_only",
+    "excluded_or_unavailable",
+]
+
+
+def _item(
+    decision_bucket: str | None = None,
+    *,
+    item_kind: str = "action",
+    symbol: str = "005930",
+    intent: str = "buy_review",
+) -> InvestmentReportItemResponse:
+    return InvestmentReportItemResponse(
+        item_uuid=uuid4(),
+        item_kind=item_kind,  # type: ignore[arg-type]
+        symbol=symbol,
+        side="buy",
+        intent=intent,  # type: ignore[arg-type]
+        target_kind="asset",
+        priority=0,
+        confidence=Decimal("80"),
+        rationale="rationale",
+        evidence_snapshot={},
+        watch_condition=None,
+        trigger_checklist=[],
+        max_action={},
+        valid_until=None,
+        status="proposed",
+        metadata={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        decision_bucket=decision_bucket,
+    )
+
+
+def _section(result, key: str) -> list[InvestmentReportItemResponse]:
+    for section in result.sections:
+        if section.key == key:
+            return section.items
+    raise AssertionError(
+        f"section {key!r} missing from {[s.key for s in result.sections]}"
+    )
+
+
+def test_sections_are_present_in_fixed_order_even_when_empty() -> None:
+    result = build_review_sections([], diagnostics=None)
+    assert [s.key for s in result.sections] == _EXPECTED_ORDER
+    assert all(s.items == [] for s in result.sections)
+
+
+def test_new_buy_candidate_bucket_maps_to_new_buy_section() -> None:
+    item = _item("new_buy_candidate")
+    result = build_review_sections([item], diagnostics=None)
+    assert [i.item_uuid for i in _section(result, "new_buy_candidate")] == [
+        item.item_uuid
+    ]
+
+
+def test_open_action_and_completed_or_existing_map_to_held_strategy_review() -> None:
+    open_action = _item("open_action", intent="sell_review")
+    completed = _item("completed_or_existing", intent="rebalance_review")
+    result = build_review_sections([open_action, completed], diagnostics=None)
+    held = {i.item_uuid for i in _section(result, "held_strategy_review")}
+    assert held == {open_action.item_uuid, completed.item_uuid}
+
+
+def test_risk_watch_maps_to_watch_only() -> None:
+    item = _item("risk_watch", item_kind="watch", intent="risk_review")
+    result = build_review_sections([item], diagnostics=None)
+    assert [i.item_uuid for i in _section(result, "watch_only")] == [item.item_uuid]
+
+
+def test_deferred_no_action_maps_to_excluded_or_unavailable() -> None:
+    item = _item("deferred_no_action")
+    result = build_review_sections([item], diagnostics=None)
+    assert [i.item_uuid for i in _section(result, "excluded_or_unavailable")] == [
+        item.item_uuid
+    ]
+
+
+def test_legacy_items_without_decision_bucket_are_not_projected() -> None:
+    # Backward-compat: pre-ROB-308 reports carry decision_bucket=None.
+    # They must NOT be force-classified into any review section.
+    legacy = _item(None)
+    result = build_review_sections([legacy], diagnostics=None)
+    assert all(
+        legacy.item_uuid not in {i.item_uuid for i in s.items} for s in result.sections
+    )
+
+
+def test_no_action_summary_is_derived_from_why_no_action_diagnostics() -> None:
+    diagnostics = {
+        "why_no_action": {
+            "kind": "stale_gated",
+            "blocking_sources": ["market"],
+            "reason_ko": "스냅샷 stale — market 신선도 부족으로 매수/매도 권고 보류",
+        }
+    }
+    result = build_review_sections([], diagnostics=diagnostics)
+    summary = result.no_action_summary
+    assert summary is not None
+    assert summary.kind == "stale_gated"
+    assert summary.blocking_sources == ["market"]
+    assert summary.reason_ko and "stale" in summary.reason_ko
+
+
+def test_no_action_summary_counts_excluded_items() -> None:
+    items = [_item("deferred_no_action"), _item("deferred_no_action")]
+    result = build_review_sections(items, diagnostics=None)
+    assert result.no_action_summary is not None
+    assert result.no_action_summary.excluded_count == 2
+
+
+def test_no_action_summary_none_when_no_diagnostics_and_nothing_excluded() -> None:
+    result = build_review_sections([_item("new_buy_candidate")], diagnostics=None)
+    assert result.no_action_summary is None

--- a/tests/test_investment_reports_router.py
+++ b/tests/test_investment_reports_router.py
@@ -234,3 +234,20 @@ async def test_get_bundle_groups_items(session: AsyncSession) -> None:
 
     assert len(bundle.decision_rollup["new_candidate"]) == 1
     assert len(bundle.decision_rollup["held_action"]) == 1
+
+    # ROB-322 — additive five-section review projection is wired end-to-end.
+    review = bundle.review_sections
+    assert review is not None
+    by_key = {s.key: s for s in review.sections}
+    assert [s.key for s in review.sections] == [
+        "new_buy_candidate",
+        "held_strategy_review",
+        "watch_only",
+        "excluded_or_unavailable",
+    ]
+    assert len(by_key["new_buy_candidate"].items) == 1
+    assert len(by_key["held_strategy_review"].items) == 1  # open_action
+    assert by_key["watch_only"].items == []
+    assert by_key["excluded_or_unavailable"].items == []
+    # No diagnostics + nothing excluded -> no summary.
+    assert review.no_action_summary is None


### PR DESCRIPTION
## ROB-322 Phase 3b — PR1 (backend thin slice)

Turns the KR `/invest/reports` report-detail payload from a flat item queue into an **actionable five-section review surface**:

1. 신규매수 후보 → 2. 보유종목 전략 변경 후보 → 3. watch-only → 4. 제외 / 확인 불가 → 5. no-action summary

### Locked premise
The five sections are **NOT a new `decision_bucket` enum**. They are a deterministic, read-time **view-layer projection** over the already-locked **ROB-301 `decision_bucket` vocabulary** + **ROB-318 report diagnostics**. This PR introduces **no** new `decision_bucket` value, DB CHECK, Pydantic enum, migration, or persisted classification.

### Mapping
| existing `decision_bucket` (ROB-301 locked) | → display section |
|---|---|
| `new_buy_candidate` | 신규매수 후보 |
| `open_action`, `completed_or_existing` | 보유종목 전략 변경 후보 |
| `risk_watch` | watch-only |
| `deferred_no_action` | 제외 / 확인 불가 |
| `None` (legacy / pre-ROB-308) | **not projected** — stays in `items` / `item_groups` |

`no_action_summary` (section 5) is derived from `snapshot_report_diagnostics.why_no_action` — `kind ∈ {data_insufficient, stale_gated, real_no_action}` + `reason_ko` + `blocking_sources` + excluded count — which is exactly the "진짜 no-action vs stale-gated/data-insufficient no-action" distinction the issue asks for.

### Changes
- **`app/services/investment_reports/review_sections.py`** (new) — pure assembler `build_review_sections(items, diagnostics)`.
- **`app/schemas/investment_reports.py`** — additive `ReviewSection` / `NoActionSummary` / `ReportReviewSections`; bundle gains optional `review_sections` (null/empty for legacy reports). `item_groups` + `decision_rollup` **unchanged**.
- **`app/routers/investment_reports.py`** — wire the projection into `_serialise_bundle`.

Sections always carry the four queues in **fixed display order** (each may be empty) for stable frontend rendering.

### Scope boundary
PR1 is backend payload only. **Frontend rendering of the five sections is a deliberate follow-up slice (PR2)** per ROB-322 §4 ("stop after the contract/backend thin slice ... rather than forcing a large risky PR"). Older reports render safely (empty/null `review_sections`; UI falls back to existing `items`).

### Migrations
None. No schema/model/DB change.

### Side effects
**None.** No broker / order / watch / order-intent / scheduler mutation; no DB write or migration; Toss/Naver/browser not promoted to source-of-truth; no browser scraping added.

### Tests / checks (local)
```
pytest tests/services/action_report/ tests/services/investment_reports/ tests/test_investment_reports_router.py
  -> 339 passed
ruff check app/ tests/                       -> All checks passed
ruff format --check (changed files)          -> clean
ty check app/ --error-on-warning             -> All checks passed
```
9 new unit tests pin the mapping / fixed ordering / backward-compat (legacy items not projected) / no-action-summary derivation; the existing DB-backed `test_get_bundle_groups_items` is extended to assert the projection is wired end-to-end.

### Fixture-backed payload (five sections)
```json
{
  "sections": [
    {"key": "new_buy_candidate", "label_ko": "신규매수 후보", "symbols": ["035720"]},
    {"key": "held_strategy_review", "label_ko": "보유종목 전략 변경 후보", "symbols": ["005930", "000660"]},
    {"key": "watch_only", "label_ko": "watch-only", "symbols": ["051910"]},
    {"key": "excluded_or_unavailable", "label_ko": "제외 / 확인 불가", "symbols": ["207940"]}
  ],
  "no_action_summary": {
    "kind": "stale_gated",
    "reason_ko": "스냅샷 stale — market 신선도 부족으로 매수/매도 권고 보류",
    "blocking_sources": ["market"],
    "excluded_count": 1
  }
}
```
(A legacy item with `decision_bucket=None` was included in the input and correctly does **not** appear in any section.)

### Production validation still needed
Server-side check that real KR/`kis_live` reports populate `review_sections` as expected (depends on upstream `decision_bucket` population), and PR2 frontend rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)