### PR TITLE
feat(rob-329): run-card evidence → /invest/reports citation (validated_run_card.v1)

### DIFF
--- a/alembic/versions/20260527_rob329_extend_snapshot_kind_run_card.py
+++ b/alembic/versions/20260527_rob329_extend_snapshot_kind_run_card.py
@@ -1,0 +1,76 @@
+"""ROB-329 — add 'validated_run_card' to investment_snapshots.snapshot_kind CHECK.
+
+Revision ID: 20260527_rob329
+Revises: 20260526_rob321_p4a
+Create Date: 2026-05-27
+
+Pure CHECK extension. No data backfill, no new column. The run-card ingest
+(``app.services.investment_snapshots.run_card_ingest``) emits rows with
+snapshot_kind='validated_run_card'; existing rows are unaffected.
+
+This mirrors 20260520_rob274_p2 (which added 'pending_orders'): the ROB-269
+foundation migration wrote this CHECK under the convention-expanded name
+``ck_investment_snapshots_ck_investment_snapshots_snapshot_kind``, so we drop
+both the canonical and expanded identifiers defensively before recreating.
+
+Operator-gated: ships in the PR but is applied separately via
+``alembic upgrade head`` (no auto-apply, no production backfill).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260527_rob329"
+down_revision: str | None = "20260526_rob321_p4a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Canonical CHECK constraint name supplied to op.create_check_constraint.
+_SNAPSHOT_KIND_CHECK = "ck_investment_snapshots_snapshot_kind"
+# Convention-expanded (``ck_%(table_name)s_%(constraint_name)s``) form that
+# the ROB-269 foundation migration actually wrote to disk.
+_SNAPSHOT_KIND_EXPANDED = (
+    "ck_investment_snapshots_ck_investment_snapshots_snapshot_kind"
+)
+
+# State after 20260520_rob274_p2 (12 foundation kinds + 'pending_orders').
+_OLD_KINDS = (
+    "'portfolio','market','news','symbol',"
+    "'candidate_universe','browser_probe','invest_page','journal',"
+    "'watch_context','naver_remote_debug','toss_remote_debug',"
+    "'llm_input_frozen','pending_orders'"
+)
+_NEW_KINDS = _OLD_KINDS + ",'validated_run_card'"
+
+
+def _drop_snapshot_kind_check_if_exists() -> None:
+    op.execute(
+        f'ALTER TABLE review.investment_snapshots DROP CONSTRAINT IF EXISTS "{_SNAPSHOT_KIND_EXPANDED}"'
+    )
+    op.execute(
+        f'ALTER TABLE review.investment_snapshots DROP CONSTRAINT IF EXISTS "{_SNAPSHOT_KIND_CHECK}"'
+    )
+
+
+def upgrade() -> None:
+    _drop_snapshot_kind_check_if_exists()
+    op.create_check_constraint(
+        op.f(_SNAPSHOT_KIND_CHECK),
+        "investment_snapshots",
+        f"snapshot_kind IN ({_NEW_KINDS})",
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    _drop_snapshot_kind_check_if_exists()
+    op.create_check_constraint(
+        op.f(_SNAPSHOT_KIND_CHECK),
+        "investment_snapshots",
+        f"snapshot_kind IN ({_OLD_KINDS})",
+        schema="review",
+    )

--- a/app/models/investment_snapshots.py
+++ b/app/models/investment_snapshots.py
@@ -130,7 +130,8 @@ class InvestmentSnapshot(Base):
             "snapshot_kind IN ('portfolio','market','news','symbol',"
             "'candidate_universe','browser_probe','invest_page',"
             "'journal','watch_context','naver_remote_debug',"
-            "'toss_remote_debug','llm_input_frozen')",
+            "'toss_remote_debug','llm_input_frozen','pending_orders',"
+            "'validated_run_card')",
             name="ck_investment_snapshots_snapshot_kind",
         ),
         CheckConstraint(_MARKET_CHECK, name="ck_investment_snapshots_market"),

--- a/app/schemas/investment_snapshots.py
+++ b/app/schemas/investment_snapshots.py
@@ -30,6 +30,7 @@ SnapshotKind = Literal[
     "toss_remote_debug",
     "llm_input_frozen",
     "pending_orders",
+    "validated_run_card",
 ]
 SourceKind = Literal[
     "kis_mcp",

--- a/app/schemas/validated_run_card.py
+++ b/app/schemas/validated_run_card.py
@@ -1,0 +1,214 @@
+"""ROB-329 — ``validated_run_card.v1`` → /invest/reports citation contract.
+
+Connects ``research/nautilus_scalping`` ``validated_run_card.v1`` /
+``validated_signal_gate.v1`` artifacts to ``/invest/reports`` as auditable
+evidence. The goal is **not** strategy recommendation — it is to make it
+traceable which research run and which validation evidence a report cited.
+
+Design decisions (locked in ROB-329):
+
+* **Non-finite sanitization (JSON-safe / null).** Run cards carry
+  ``profit_factor: Infinity`` when a fold has no losing trades. Python's
+  ``json.dumps`` emits a bare ``Infinity`` token, which is rejected by
+  PostgreSQL ``jsonb`` *and* JavaScript ``JSON.parse`` (RFC 8259). Every
+  non-finite float (``inf``/``-inf``/``nan``) is therefore replaced by
+  ``None`` before it can reach the DB or an API consumer. ``null`` is the
+  only representation that is safe across all three, and it avoids surfacing
+  a misleading standalone "Infinity" number as if it were an edge.
+* **Verdict-first framing.** The citation headline is ``verdict`` +
+  ``framing`` + ``trade_count`` (``n``). The bootstrap CI / Monte-Carlo
+  numbers live nested under ``validation`` — never as standalone top-level
+  fields — so a reader cannot mistake e.g. "bootstrap CI lower 25 > 0" on
+  ``n=2`` trades for a positive edge. ``is_pass_stamp`` is ``True`` only for
+  a ``validated`` verdict.
+* **Monte-Carlo three-state.** MC evidence is ``present`` (valid run),
+  ``absent`` (no MC block), or ``errored`` (block present but the run failed,
+  e.g. ``{"error": "insufficient_data"}``).
+* **Tolerant reproducibility.** ``strategy_hash`` may be ``null`` and
+  ``artifacts`` may be ``[]``; both are carried through verbatim.
+* **Unknown-schema fallback.** A payload whose ``schema_version`` is not
+  ``validated_run_card.v1`` yields ``recognized=False`` rather than raising.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RUN_CARD_SCHEMA = "validated_run_card.v1"
+GATE_SCHEMA = "validated_signal_gate.v1"
+
+#: Source label stamped on a report item's ``evidence_snapshot`` entry.
+EVIDENCE_SOURCE = "validated_run_card"
+
+
+def sanitize_non_finite(value: Any) -> Any:
+    """Recursively replace non-finite floats (``inf``/``-inf``/``nan``) with
+    ``None`` so the result is strict-JSON / Postgres-jsonb / JS-JSON.parse
+    safe. Returns a new structure; the input is not mutated. Booleans and
+    integers are left untouched (``bool`` is intentionally not treated as a
+    float here)."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, Mapping):
+        return {k: sanitize_non_finite(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [sanitize_non_finite(v) for v in value]
+    return value
+
+
+class RunCardCitation(BaseModel):
+    """Citation-ready, JSON-safe view over a ``validated_run_card.v1`` payload."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    recognized: bool
+    candidate: str | None = None
+    hypothesis: str | None = None
+    symbols: list[str] = Field(default_factory=list)
+    window: dict[str, Any] | None = None
+    verdict: str | None = None
+    verdict_reasons: list[str] = Field(default_factory=list)
+    trade_count: int | None = None
+    framing: str | None = None
+    #: True only for a ``validated`` verdict — an insufficient_data /
+    #: not_validated run card is explicitly *not* a pass/edge stamp.
+    is_pass_stamp: bool = False
+    net_after_cost: dict[str, Any] | None = None
+    #: ``{"bootstrap": {...} | None, "monte_carlo": {"state": ..., ...}}``
+    validation: dict[str, Any] = Field(default_factory=dict)
+    reproducibility: dict[str, Any] = Field(default_factory=dict)
+    data_sources: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+def _monte_carlo_view(raw: Any) -> dict[str, Any]:
+    """Collapse the MC block into a three-state view (present/absent/errored)."""
+    if not isinstance(raw, Mapping) or not raw:
+        return {"state": "absent"}
+    sanitized = sanitize_non_finite(dict(raw))
+    if "error" in sanitized:
+        return {"state": "errored", **sanitized}
+    return {"state": "present", **sanitized}
+
+
+def _bootstrap_view(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, Mapping) or not raw:
+        return None
+    return sanitize_non_finite(dict(raw))
+
+
+def build_run_card_citation(payload: Mapping[str, Any]) -> RunCardCitation:
+    """Build a :class:`RunCardCitation` from a run-card payload.
+
+    Tolerant by contract: an unknown schema, a missing Monte-Carlo block, a
+    null ``strategy_hash`` or empty ``artifacts`` all produce a valid citation
+    rather than raising. Non-finite metrics are sanitized to ``null``.
+    """
+    schema_version = payload.get("schema_version")
+    if not isinstance(schema_version, str):
+        schema_version = "unknown"
+
+    if schema_version != RUN_CARD_SCHEMA:
+        # Unknown-schema fallback — echo the version, flag unrecognized,
+        # never crash. Downstream renders this as "unrecognized evidence".
+        return RunCardCitation(schema_version=schema_version, recognized=False)
+
+    gate = payload.get("gate_report")
+    gate = gate if isinstance(gate, Mapping) else {}
+
+    verdict = payload.get("verdict")
+    verdict = verdict if isinstance(verdict, str) else None
+
+    # trade_count headline: prefer the gate's explicit count, else the
+    # net-after-cost fold's trade tally.
+    trade_count = gate.get("trade_count")
+    nac = payload.get("net_after_cost")
+    nac = nac if isinstance(nac, Mapping) else {}
+    if not isinstance(trade_count, int):
+        tc = nac.get("trades")
+        trade_count = tc if isinstance(tc, int) else None
+
+    validation_raw = payload.get("validation")
+    validation_raw = validation_raw if isinstance(validation_raw, Mapping) else {}
+
+    framing = payload.get("framing")
+    framing = framing if isinstance(framing, str) else None
+
+    return RunCardCitation(
+        schema_version=schema_version,
+        recognized=True,
+        candidate=(
+            payload.get("candidate")
+            if isinstance(payload.get("candidate"), str)
+            else None
+        ),
+        hypothesis=(
+            payload.get("hypothesis")
+            if isinstance(payload.get("hypothesis"), str)
+            else None
+        ),
+        symbols=_as_str_list(gate.get("symbols")),
+        window=(
+            dict(gate["window"]) if isinstance(gate.get("window"), Mapping) else None
+        ),
+        verdict=verdict,
+        verdict_reasons=_as_str_list(payload.get("verdict_reasons")),
+        trade_count=trade_count,
+        framing=framing,
+        is_pass_stamp=(verdict == "validated"),
+        net_after_cost=(sanitize_non_finite(dict(nac)) if nac else None),
+        validation={
+            "bootstrap": _bootstrap_view(validation_raw.get("bootstrap")),
+            "monte_carlo": _monte_carlo_view(validation_raw.get("monte_carlo")),
+        },
+        reproducibility=(
+            sanitize_non_finite(dict(payload["reproducibility"]))
+            if isinstance(payload.get("reproducibility"), Mapping)
+            else {}
+        ),
+        data_sources=_as_str_list(payload.get("data_sources")),
+        warnings=_as_str_list(payload.get("warnings")),
+    )
+
+
+def build_run_card_evidence(
+    *, snapshot_uuid: str, citation: RunCardCitation
+) -> dict[str, Any]:
+    """Build the ``evidence_snapshot`` entry that a report item stores to cite
+    a run-card snapshot (reuses ``InvestmentReportItem.evidence_snapshot``).
+
+    Headline-first per decision #4: ``verdict`` / ``framing`` / ``trade_count``
+    + ``is_pass_stamp`` lead; the bootstrap CI and Monte-Carlo numbers stay
+    nested under ``validation`` so they cannot be read as a standalone edge.
+    The full sanitized artifact lives on the cited snapshot (fetch by
+    ``snapshot_uuid``); this entry is the audit pointer + headline.
+    """
+    return {
+        "source": EVIDENCE_SOURCE,
+        "snapshot_uuid": snapshot_uuid,
+        "schema_version": citation.schema_version,
+        "recognized": citation.recognized,
+        "candidate": citation.candidate,
+        "symbols": citation.symbols,
+        "verdict": citation.verdict,
+        "verdict_reasons": citation.verdict_reasons,
+        "trade_count": citation.trade_count,
+        "framing": citation.framing,
+        "is_pass_stamp": citation.is_pass_stamp,
+        "net_after_cost": citation.net_after_cost,
+        "validation": citation.validation,
+        "reproducibility": citation.reproducibility,
+    }

--- a/app/services/investment_snapshots/run_card_ingest.py
+++ b/app/services/investment_snapshots/run_card_ingest.py
@@ -1,0 +1,110 @@
+"""ROB-329 — ingest a ``validated_run_card.v1`` artifact as an InvestmentSnapshot.
+
+Producer→consumer path: ``run_card.json`` → sanitize → immutable
+``InvestmentSnapshot(snapshot_kind="validated_run_card")`` → cite by
+``snapshot_uuid`` from a report item's ``evidence_snapshot`` (see
+``app.schemas.validated_run_card.build_run_card_evidence``).
+
+The persisted ``payload_json`` is the **sanitized** run card (non-finite
+metrics → ``null``) so it is strict-JSON / Postgres-jsonb safe. ``source_kind``
+is ``manual`` — this is an operator/CLI-driven ingest of a research artifact,
+not a live feed; the gitignored ``results/`` path is intentionally never
+recorded as a ``source_uri``.
+
+Safety: writes go only through ``InvestmentSnapshotsRepository`` (append-only).
+No broker/order/watch/order-intent mutation, no scheduler, no
+``/invest/screener`` scoring change.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.models.investment_snapshots import InvestmentSnapshot
+from app.schemas.investment_snapshots import (
+    SnapshotAccountScope,
+    SnapshotCreate,
+    SnapshotMarket,
+    SnapshotRequestedBy,
+    SnapshotRunCreate,
+)
+from app.schemas.validated_run_card import (
+    RunCardCitation,
+    build_run_card_citation,
+    sanitize_non_finite,
+)
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+
+#: Run/bundle policy label for run-card ingests (echoes the artifact schema).
+RUN_CARD_POLICY_VERSION = "validated_run_card.v1"
+
+
+def _parse_generated_at(payload: dict[str, Any]) -> dt.datetime | None:
+    raw = payload.get("generated_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+class RunCardSnapshotIngestor:
+    """Ingest a run-card payload as an immutable ``validated_run_card`` snapshot."""
+
+    def __init__(self, repository: InvestmentSnapshotsRepository) -> None:
+        self._repo = repository
+
+    async def ingest(
+        self,
+        *,
+        run_card_payload: dict[str, Any],
+        market: SnapshotMarket,
+        account_scope: SnapshotAccountScope | None = None,
+        as_of: dt.datetime | None = None,
+        requested_by: SnapshotRequestedBy = "claude_code",
+        refresh_reason: str | None = None,
+    ) -> tuple[InvestmentSnapshot, RunCardCitation]:
+        """Persist the sanitized run card and return ``(snapshot, citation)``.
+
+        ``as_of`` defaults to the run card's ``generated_at`` (or now). The
+        snapshot ``symbol`` is set only when the run card targets a single
+        symbol, so single-symbol cards remain indexable. Idempotent on the
+        canonical payload via the repository's dedup (re-ingest reuses the row).
+        """
+        citation = build_run_card_citation(run_card_payload)
+        sanitized_payload = sanitize_non_finite(dict(run_card_payload))
+
+        effective_as_of = (
+            as_of or _parse_generated_at(run_card_payload) or dt.datetime.now(dt.UTC)
+        )
+        symbol = citation.symbols[0] if len(citation.symbols) == 1 else None
+
+        run = await self._repo.insert_run(
+            SnapshotRunCreate(
+                purpose="manual_refresh",
+                market=market,
+                account_scope=account_scope,
+                requested_by=requested_by,
+                policy_version=RUN_CARD_POLICY_VERSION,
+                refresh_reason=refresh_reason,
+            )
+        )
+        snapshot = await self._repo.insert_snapshot(
+            SnapshotCreate(
+                run_uuid=run.run_uuid,
+                snapshot_kind="validated_run_card",
+                market=market,
+                account_scope=account_scope,
+                symbol=symbol,
+                source_kind="manual",
+                payload_json=sanitized_payload,
+                as_of=effective_as_of,
+                freshness_status="fresh",
+            )
+        )
+        return snapshot, citation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,6 +551,37 @@ async def db_session():
                         "))"
                     )
                 )
+                # ROB-329 — extend investment_snapshots.snapshot_kind CHECK to
+                # include 'validated_run_card' (and 'pending_orders' from
+                # ROB-274 P2). create_all is no-op on the persistent test
+                # table, so drop+recreate here; canonical schema lives in
+                # migration 20260527_rob329_extend_snapshot_kind_run_card.py.
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_snapshots "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_snapshots_ck_investment_snapshots_snapshot_kind"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_snapshots "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_snapshots_snapshot_kind"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.investment_snapshots "
+                        "ADD CONSTRAINT ck_investment_snapshots_snapshot_kind "
+                        "CHECK (snapshot_kind IN ("
+                        "'portfolio','market','news','symbol','candidate_universe',"
+                        "'browser_probe','invest_page','journal','watch_context',"
+                        "'naver_remote_debug','toss_remote_debug','llm_input_frozen',"
+                        "'pending_orders','validated_run_card'"
+                        "))"
+                    )
+                )
                 # ROB-274 — proposal-state columns + operation-aware CHECKs on
                 # investment_report_items. Mirrors the persistent-DB patch
                 # pattern above; the canonical schema lives in migration

--- a/tests/fixtures/validated_run_card/run_card_insufficient_data.json
+++ b/tests/fixtures/validated_run_card/run_card_insufficient_data.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": "validated_run_card.v1",
+  "generated_at": "2026-05-26T22:44:13.244085+00:00",
+  "candidate": "meanrev_zscore_fade",
+  "hypothesis": "mean_reversion",
+  "verdict": "insufficient_data",
+  "verdict_reasons": [
+    "folds below min_trades=1: val=0",
+    "net edge statistically > 0 (bootstrap 95% CI lower 25.5812 > 0)"
+  ],
+  "net_after_cost": {
+    "fold": "net_after_cost",
+    "trades": 2,
+    "net_pnl": 0.27449256,
+    "win_rate_pct": 100.0,
+    "max_drawdown": 0.0,
+    "profit_factor": Infinity,
+    "expectancy": 0.13724628
+  },
+  "reproducibility": {
+    "config_hash": "870ff843a270742e7cae28eaca3cef369372451ee45107a7664007608bf759a6",
+    "strategy_hash": null,
+    "artifacts": []
+  },
+  "data_sources": [
+    "binance_demo_backtest:XRPUSDT"
+  ],
+  "validation": {
+    "bootstrap": {
+      "observed_sharpe": 25.581164471976745,
+      "ci_lower": 25.581164471976745,
+      "ci_upper": 1000000.0,
+      "median_sharpe": 1000000.0,
+      "prob_positive": 1.0,
+      "confidence": 0.95,
+      "n_bootstrap": 200,
+      "seed": 327
+    },
+    "monte_carlo": {
+      "error": "insufficient_data",
+      "n": 2,
+      "n_sim": 200,
+      "seed": 327
+    }
+  },
+  "warnings": [],
+  "framing": "net-after-fee is the only verdict basis. ROB-316/320 already proved the scalper is net-negative purely on fees; the bootstrap CI and Monte-Carlo permutation here test the statistical robustness of that net result, not a new edge. This run card is audit evidence, not a pass stamp.",
+  "gate_report": {
+    "schema_version": "validated_signal_gate.v1",
+    "candidate": "meanrev_zscore_fade",
+    "hypothesis": "mean_reversion",
+    "symbols": [
+      "XRPUSDT"
+    ],
+    "window": {
+      "from": "2026-05-01",
+      "to": "2026-05-03",
+      "folds": {
+        "train": 0.5,
+        "val": 0.25,
+        "oos": 0.25
+      }
+    },
+    "cost_model": {
+      "fee_bps_per_leg": 10.0,
+      "fee_grid_bps": [
+        10.0,
+        7.5,
+        5.0,
+        2.0,
+        0.0
+      ]
+    },
+    "results": {
+      "gross": {
+        "fold": "gross",
+        "trades": 2,
+        "net_pnl": 0.83256,
+        "win_rate_pct": 100.0,
+        "max_drawdown": 0.0,
+        "profit_factor": Infinity,
+        "expectancy": 0.41628
+      },
+      "zero_fee": {
+        "fold": "zero_fee",
+        "trades": 2,
+        "net_pnl": 0.83256,
+        "win_rate_pct": 100.0,
+        "max_drawdown": 0.0,
+        "profit_factor": Infinity,
+        "expectancy": 0.41628
+      },
+      "net_after_cost": {
+        "fold": "net_after_cost",
+        "trades": 2,
+        "net_pnl": 0.27449256,
+        "win_rate_pct": 100.0,
+        "max_drawdown": 0.0,
+        "profit_factor": Infinity,
+        "expectancy": 0.13724628
+      }
+    },
+    "per_fold": [
+      {
+        "fold": "train",
+        "trades": 1,
+        "net_pnl": 0.14104,
+        "win_rate_pct": 100.0,
+        "max_drawdown": 0.0,
+        "profit_factor": Infinity,
+        "expectancy": 0.14104
+      },
+      {
+        "fold": "val",
+        "trades": 0,
+        "net_pnl": 0.0,
+        "win_rate_pct": 0.0,
+        "max_drawdown": 0.0,
+        "profit_factor": 0.0,
+        "expectancy": 0.0
+      },
+      {
+        "fold": "oos",
+        "trades": 1,
+        "net_pnl": 0.13345256,
+        "win_rate_pct": 100.0,
+        "max_drawdown": 0.0,
+        "profit_factor": Infinity,
+        "expectancy": 0.13345256
+      }
+    ],
+    "baselines": {
+      "micro_breakout": {
+        "net_after_cost": -11.40527001,
+        "trades": 40
+      },
+      "random_entry": {
+        "net_after_cost": -2.7911066399999998,
+        "trades": 23
+      }
+    },
+    "param_stability": {
+      "grid": [
+        "z2.0/tp30/sl30",
+        "z2.5/tp40/sl40"
+      ],
+      "val_best_param": "z2.0/tp30/sl30",
+      "oos_rank_of_val_best": 1,
+      "single_fold_edge": false,
+      "param_island": false
+    },
+    "overfit_flags": {
+      "low_trades": true,
+      "single_fold_edge": false,
+      "param_island": false
+    },
+    "trade_count": 2,
+    "verdict": "insufficient_data",
+    "verdict_reasons": [
+      "folds below min_trades=1: val=0",
+      "net edge statistically > 0 (bootstrap 95% CI lower 25.5812 > 0)"
+    ]
+  }
+}

--- a/tests/test_run_card_snapshot_ingest.py
+++ b/tests/test_run_card_snapshot_ingest.py
@@ -1,0 +1,138 @@
+"""ROB-329 — run-card → InvestmentSnapshot ingest + report-bundle visibility.
+
+Uses the global ``db_session`` fixture (creates every table via
+``Base.metadata.create_all``) because it touches both
+``review.investment_snapshots`` and ``review.investment_reports``.
+
+Producer→consumer path under test (decision #1 + #8):
+  run_card.json → sanitize → InvestmentSnapshot(kind="validated_run_card")
+  → linked into a report's snapshot bundle → visible via the existing
+  report-centric snapshot read endpoints (no new endpoint).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import uuid as _uuid
+from pathlib import Path
+
+import pytest
+
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
+from app.services.investment_snapshots.run_card_ingest import RunCardSnapshotIngestor
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+_NOW = dt.datetime(2026, 5, 26, 22, 44, tzinfo=dt.UTC)
+_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "validated_run_card"
+    / "run_card_insufficient_data.json"
+)
+
+
+def _load_fixture() -> dict:
+    with _FIXTURE.open() as fh:
+        return json.load(fh)
+
+
+@pytest.mark.asyncio
+async def test_ingest_creates_validated_run_card_snapshot(db_session):
+    ingestor = RunCardSnapshotIngestor(InvestmentSnapshotsRepository(db_session))
+    snapshot, citation = await ingestor.ingest(
+        run_card_payload=_load_fixture(), market="crypto"
+    )
+    await db_session.commit()
+
+    assert snapshot.snapshot_kind == "validated_run_card"
+    assert snapshot.source_kind == "manual"
+    assert snapshot.market == "crypto"
+    assert snapshot.account_scope is None
+    assert snapshot.symbol == "XRPUSDT"  # single-symbol run card
+
+    # The persisted payload is the sanitized run card — strict-JSON safe.
+    assert snapshot.payload_json["net_after_cost"]["profit_factor"] is None
+    json.dumps(snapshot.payload_json, allow_nan=False)
+
+    # Citation headline derived from the same payload.
+    assert citation.verdict == "insufficient_data"
+    assert citation.is_pass_stamp is False
+    assert citation.trade_count == 2
+
+    # Citeable by uuid.
+    repo = InvestmentSnapshotsRepository(db_session)
+    refetched = await repo.get_snapshot_by_uuid(snapshot.snapshot_uuid)
+    assert refetched is not None
+    assert refetched.snapshot_kind == "validated_run_card"
+
+
+@pytest.mark.asyncio
+async def test_ingested_snapshot_visible_in_report_bundle_read(db_session):
+    snap_repo = InvestmentSnapshotsRepository(db_session)
+    ingestor = RunCardSnapshotIngestor(snap_repo)
+    snapshot, _citation = await ingestor.ingest(
+        run_card_payload=_load_fixture(), market="crypto"
+    )
+
+    bundle = await snap_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"rob329_{_uuid.uuid4().hex[:8]}",
+            market="crypto",
+            account_scope="upbit_live",
+            policy_version="intraday_action_report_v1",
+            as_of=_NOW,
+            status="partial",
+        )
+    )
+    await snap_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snapshot.snapshot_uuid, role="optional"),
+    )
+
+    report_repo = InvestmentReportsRepository(db_session)
+    report = await report_repo.insert_report(
+        report_uuid=_uuid.uuid4(),
+        idempotency_key=f"k-{_uuid.uuid4().hex[:8]}",
+        report_type="crypto_intraday",
+        market="crypto",
+        market_session="24x7",
+        account_scope="upbit_live",
+        execution_mode="advisory_only",
+        created_by_profile="rob329-test",
+        title="t",
+        summary="s",
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        snapshot_policy_version="intraday_action_report_v1",
+    )
+    await db_session.commit()
+
+    svc = InvestmentReportQueryService(db_session)
+
+    # Bundle read lists the run-card snapshot as a member.
+    response = await svc.get_report_snapshot_bundle(report.report_uuid)
+    assert response is not None
+    assert response.legacy_no_snapshot is False
+    kinds = {item.snapshot_kind: item for item in response.items}
+    assert "validated_run_card" in kinds
+    assert kinds["validated_run_card"].role == "optional"
+
+    # Detail read returns the sanitized payload (membership-checked).
+    detail = await svc.get_report_snapshot_detail(
+        report.report_uuid, snapshot.snapshot_uuid
+    )
+    assert detail is not None
+    assert detail.snapshot_kind == "validated_run_card"
+    assert detail.payload_json["net_after_cost"]["profit_factor"] is None
+    assert detail.payload_json["verdict"] == "insufficient_data"

--- a/tests/test_validated_run_card_citation.py
+++ b/tests/test_validated_run_card_citation.py
@@ -1,0 +1,209 @@
+"""ROB-329 — validated_run_card.v1 → /invest/reports citation contract.
+
+Pure (no DB) tests for the parser/sanitizer/citation builder. The vendored
+fixture ``tests/fixtures/validated_run_card/run_card_insufficient_data.json``
+is a faithful copy of the ROB-327 F1 smoke run card — it contains bare
+``Infinity`` tokens (profit_factor with no losing trades), which Python's
+``json.load`` reads as ``float('inf')``. The whole point of the sanitizer is
+that the citation it produces is strict-JSON / Postgres-jsonb / JS-JSON.parse
+safe, so we assert ``json.dumps(..., allow_nan=False)`` round-trips.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from app.schemas.validated_run_card import (
+    RUN_CARD_SCHEMA,
+    build_run_card_citation,
+    build_run_card_evidence,
+    sanitize_non_finite,
+)
+
+_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "validated_run_card"
+    / "run_card_insufficient_data.json"
+)
+
+
+def _load_fixture() -> dict:
+    # NB: json.load is lenient and parses bare ``Infinity`` -> float('inf'),
+    # which is exactly the raw shape ingestion receives.
+    with _FIXTURE.open() as fh:
+        return json.load(fh)
+
+
+def _assert_strict_json_safe(obj) -> None:
+    """Round-trip under strict JSON: rejects Infinity/-Infinity/NaN.
+
+    ``allow_nan=False`` is the Postgres-jsonb / JavaScript JSON.parse contract.
+    """
+    json.dumps(obj, allow_nan=False)
+
+
+# ---------------------------------------------------------------------------
+# sanitize_non_finite
+# ---------------------------------------------------------------------------
+def test_sanitize_replaces_non_finite_with_null_recursively():
+    raw = {
+        "pf": float("inf"),
+        "neg": float("-inf"),
+        "nan": float("nan"),
+        "finite": 1.5,
+        "ints": [1, float("inf"), 3],
+        "nested": {"a": float("nan"), "b": "ok", "c": 0.0},
+        "text": "Infinity is a string here",
+    }
+    out = sanitize_non_finite(raw)
+    assert out["pf"] is None
+    assert out["neg"] is None
+    assert out["nan"] is None
+    assert out["finite"] == 1.5
+    assert out["ints"] == [1, None, 3]
+    assert out["nested"] == {"a": None, "b": "ok", "c": 0.0}
+    assert out["text"] == "Infinity is a string here"
+    _assert_strict_json_safe(out)
+
+
+def test_sanitize_does_not_mutate_input():
+    raw = {"pf": float("inf")}
+    sanitize_non_finite(raw)
+    assert math.isinf(raw["pf"])
+
+
+# ---------------------------------------------------------------------------
+# build_run_card_citation — happy path on the real smoke fixture
+# ---------------------------------------------------------------------------
+def test_citation_from_real_fixture_does_not_crash_and_is_json_safe():
+    citation = build_run_card_citation(_load_fixture())
+    dump = citation.model_dump()
+    _assert_strict_json_safe(dump)
+
+
+def test_citation_headline_carries_verdict_framing_and_trade_count():
+    citation = build_run_card_citation(_load_fixture())
+    assert citation.recognized is True
+    assert citation.schema_version == RUN_CARD_SCHEMA
+    assert citation.verdict == "insufficient_data"
+    assert citation.candidate == "meanrev_zscore_fade"
+    assert citation.symbols == ["XRPUSDT"]
+    assert citation.trade_count == 2
+    assert citation.framing is not None and "not a pass stamp" in citation.framing
+
+
+def test_insufficient_data_is_not_a_pass_stamp():
+    citation = build_run_card_citation(_load_fixture())
+    assert citation.is_pass_stamp is False
+
+
+def test_non_finite_profit_factor_sanitized_to_null():
+    citation = build_run_card_citation(_load_fixture())
+    assert citation.net_after_cost is not None
+    assert citation.net_after_cost["profit_factor"] is None
+    # finite siblings survive
+    assert citation.net_after_cost["win_rate_pct"] == 100.0
+
+
+def test_bootstrap_numbers_are_nested_under_validation_not_top_level():
+    # decision #4 — the bootstrap CI must never read as a standalone edge.
+    citation = build_run_card_citation(_load_fixture())
+    dump = citation.model_dump()
+    assert "ci_lower" not in dump
+    assert "observed_sharpe" not in dump
+    assert dump["validation"]["bootstrap"]["ci_lower"] == pytest.approx(
+        25.5811, rel=1e-3
+    )
+
+
+# ---------------------------------------------------------------------------
+# Monte-Carlo 3-state — valid / absent / present-but-errored
+# ---------------------------------------------------------------------------
+def test_monte_carlo_errored_state_from_fixture():
+    # The real smoke fixture's MC block carries {"error": "insufficient_data"}.
+    citation = build_run_card_citation(_load_fixture())
+    mc = citation.validation["monte_carlo"]
+    assert mc["state"] == "errored"
+    assert mc["error"] == "insufficient_data"
+
+
+def test_monte_carlo_absent_state():
+    payload = _load_fixture()
+    del payload["validation"]["monte_carlo"]
+    citation = build_run_card_citation(payload)
+    assert citation.validation["monte_carlo"]["state"] == "absent"
+
+
+def test_monte_carlo_present_valid_state():
+    payload = _load_fixture()
+    payload["validation"]["monte_carlo"] = {
+        "actual_sharpe": 1.2,
+        "actual_max_dd": -0.05,
+        "p_value_sharpe": 0.03,
+        "p_value_maxdd": 0.10,
+        "n_sim": 200,
+        "seed": 327,
+    }
+    citation = build_run_card_citation(payload)
+    mc = citation.validation["monte_carlo"]
+    assert mc["state"] == "present"
+    assert mc["p_value_sharpe"] == 0.03
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility — null strategy_hash + empty artifacts allowed
+# ---------------------------------------------------------------------------
+def test_null_strategy_hash_and_empty_artifacts_are_allowed():
+    citation = build_run_card_citation(_load_fixture())
+    repro = citation.reproducibility
+    assert repro["config_hash"].startswith("870ff843")
+    assert repro["strategy_hash"] is None
+    assert repro["artifacts"] == []
+
+
+# ---------------------------------------------------------------------------
+# Unknown-schema fallback — must not crash
+# ---------------------------------------------------------------------------
+def test_unknown_schema_returns_unrecognized_citation_without_crashing():
+    payload = {"schema_version": "something_else.v9", "candidate": "x"}
+    citation = build_run_card_citation(payload)
+    assert citation.recognized is False
+    assert citation.schema_version == "something_else.v9"
+    assert citation.verdict is None
+    assert citation.is_pass_stamp is False
+    _assert_strict_json_safe(citation.model_dump())
+
+
+def test_missing_schema_version_falls_back_to_unrecognized():
+    citation = build_run_card_citation({"candidate": "x"})
+    assert citation.recognized is False
+    assert citation.schema_version == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# build_run_card_evidence — the report-item evidence_snapshot entry
+# ---------------------------------------------------------------------------
+def test_evidence_entry_is_headline_first_and_json_safe():
+    citation = build_run_card_citation(_load_fixture())
+    snap_uuid = "11111111-1111-1111-1111-111111111111"
+    evidence = build_run_card_evidence(snapshot_uuid=snap_uuid, citation=citation)
+
+    assert evidence["source"] == "validated_run_card"
+    assert evidence["snapshot_uuid"] == snap_uuid
+    assert evidence["schema_version"] == RUN_CARD_SCHEMA
+    assert evidence["verdict"] == "insufficient_data"
+    assert evidence["trade_count"] == 2
+    assert evidence["is_pass_stamp"] is False
+    assert "not a pass stamp" in evidence["framing"]
+
+    # decision #4 — bootstrap/MC live under validation, never as standalone
+    # top-level edge numbers.
+    assert "ci_lower" not in evidence
+    assert "observed_sharpe" not in evidence
+    assert evidence["validation"]["monte_carlo"]["state"] == "errored"
+    _assert_strict_json_safe(evidence)


### PR DESCRIPTION
## ROB-327 F2 — run-card evidence → `/invest/reports` citation

Connects `research/nautilus_scalping` `validated_run_card.v1` / `validated_signal_gate.v1` artifacts to `/invest/reports` as **auditable evidence** (not strategy recommendation). The goal: make it traceable which research run + validation evidence a report cited.

Linear: [ROB-329](https://linear.app/mgh3326/issue/ROB-329)

### What changed
- **`app/schemas/validated_run_card.py`** (new) — `sanitize_non_finite` (inf/-inf/nan → `null`; the only representation safe across Postgres `jsonb` + JS `JSON.parse`), `RunCardCitation` parser, and `build_run_card_evidence` (the report-item `evidence_snapshot` entry). Headline is **verdict / framing / trade_count**; bootstrap CI + Monte-Carlo numbers are nested under `validation` so they can never read as a standalone edge. `is_pass_stamp` is `True` only for a `validated` verdict. MC is three-state (`present`/`absent`/`errored`); unknown schema → `recognized=False` (no crash).
- **`app/services/investment_snapshots/run_card_ingest.py`** (new) — `RunCardSnapshotIngestor` persists the **sanitized** run card as `InvestmentSnapshot(snapshot_kind="validated_run_card", source_kind="manual")`, cited by `snapshot_uuid`. The gitignored `results/` path is never recorded.
- **snapshot_kind extension** — ORM `CheckConstraint` + `SnapshotKind` `Literal` + additive migration `20260527_rob329` (mirrors ROB-274 P2). Also fixes a pre-existing ORM/migration drift where the model omitted `'pending_orders'` (which the migration + Literal already had); all three now list 14 kinds.
- **Bundle-read visibility** — uses the existing `get_report_snapshot_bundle` / `get_report_snapshot_detail` read paths (no new endpoint).
- **Tests** — 16 new (citation unit + ingest/visibility DB) + vendored faithful fixture `tests/fixtures/validated_run_card/run_card_insufficient_data.json` (keeps `Infinity` so the sanitizer is actually exercised; `json.load` reads it as `inf`). conftest patches the persistent test DB's CHECK in place (`create_all` is a no-op on existing tables).

### Acceptance criteria
- ✅ A run_card.json-shaped fixture is referenced as a citation without crashing.
- ✅ Citation surfaces `verdict=insufficient_data` + framing ("audit evidence, not a pass stamp"); `is_pass_stamp=False`.
- ✅ Unit tests cover: missing MC (absent) + errored + present, insufficient-data verdict, non-finite sanitization, unknown-schema fallback, null `strategy_hash` / empty `artifacts`.
- ✅ Existing report-generation/snapshot tests remain green (incl. append-only surface lock).

### Verification
```
uv run pytest tests/test_validated_run_card_citation.py tests/test_run_card_snapshot_ingest.py -q   # 16 passed
uv run ruff check app/ tests/                                                                        # All checks passed!
uv run ty check app/schemas/validated_run_card.py app/services/investment_snapshots/run_card_ingest.py app/schemas/investment_snapshots.py app/models/investment_snapshots.py   # All checks passed!
uv run alembic heads                                                                                 # 20260527_rob329 (single head)
# regression (snapshot/report areas + append-only lock): 75 passed, 1 skipped
```

### Safety boundary (all confirmed)
- No broker / order / watch / order-intent **mutation** — writes go only through `InvestmentSnapshotsRepository` (append-only; surface-lock test passes).
- No scheduler / Prefect / TaskIQ activation; no CLI/runtime auto-execution.
- No prod-DB backfill — **additive CHECK extension only** (0 data changes); operator applies via `alembic upgrade head`.
- No `/invest/screener` scoring change; no Vibe runtime/MCP/multi-agent connection; no secrets logged.

### Out of scope (follow-ups)
- Wiring `build_run_card_evidence` into live report generation (Hermes/auto_emit).
- Operator ingest CLI script; frontend citation chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
