### PR TITLE
feat(rob-322): render KR /invest/reports five-section review surface (PR2 frontend)

### DIFF
--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx
@@ -1,0 +1,237 @@
+// ROB-322 PR2 — frontend tests for the five-section review surface.
+//
+// The KR report detail must render report-scoped review sections
+// (신규매수 후보 → 보유종목 전략 변경 후보 → watch-only → 제외/확인 불가 →
+// no-action summary) instead of the flat itemKind queue, while legacy
+// reports without `reviewSections` fall back to the old grouping.
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type {
+  InvestmentReport,
+  InvestmentReportBundle,
+  InvestmentReportItem,
+  ReportReviewSections,
+} from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+function makeReport(): InvestmentReport {
+  return {
+    reportUuid: "00000000-0000-0000-0000-000000000001",
+    reportType: "kr_morning",
+    market: "kr",
+    marketSession: "regular",
+    accountScope: "kis_live",
+    executionMode: "advisory_only",
+    createdByProfile: "test",
+    title: "KR Report",
+    summary: "summary",
+    riskSummary: null,
+    thesisText: null,
+    noActionNote: null,
+    marketSnapshot: {},
+    portfolioSnapshot: {},
+    previousReportUuid: null,
+    status: "draft",
+    metadata: {},
+    createdAt: "2026-05-27T00:00:00Z",
+    updatedAt: "2026-05-27T00:00:00Z",
+    publishedAt: null,
+    validUntil: null,
+    snapshotBundleUuid: null,
+    snapshotPolicyVersion: null,
+    snapshotCoverageSummary: null,
+    snapshotFreshnessSummary: null,
+    sourceConflicts: null,
+    unavailableSources: null,
+    snapshotReportDiagnostics: null,
+  };
+}
+
+let uuidSeq = 0;
+function makeItem(overrides: Partial<InvestmentReportItem>): InvestmentReportItem {
+  uuidSeq += 1;
+  return {
+    itemUuid: `item-${uuidSeq}`,
+    itemKind: "action",
+    symbol: "005930",
+    side: "buy",
+    intent: "buy_review",
+    rationale: "근거 텍스트",
+    targetKind: "asset",
+    priority: 0,
+    confidence: null,
+    evidenceSnapshot: {},
+    watchCondition: null,
+    triggerChecklist: [],
+    maxAction: {},
+    validUntil: null,
+    status: "proposed",
+    metadata: {},
+    createdAt: "2026-05-27T00:00:00Z",
+    updatedAt: "2026-05-27T00:00:00Z",
+    operation: null,
+    targetRef: null,
+    currentState: null,
+    proposedState: null,
+    diff: null,
+    applyPolicy: null,
+    decisionBucket: null,
+    citedSymbolReportUuid: null,
+    citedDimensionReportUuids: [],
+    ...overrides,
+  };
+}
+
+function makeBundle(
+  reviewSections: ReportReviewSections | null,
+  extraItems: InvestmentReportItem[] = [],
+): InvestmentReportBundle {
+  const sectionItems = reviewSections
+    ? reviewSections.sections.flatMap((s) => s.items)
+    : [];
+  return {
+    report: makeReport(),
+    items: [...sectionItems, ...extraItems],
+    decisionsByItemUuid: {},
+    alerts: [],
+    events: [],
+    reviewSections,
+  };
+}
+
+function renderContent(bundle: InvestmentReportBundle) {
+  (
+    useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>
+  ).mockReturnValue({
+    status: "ready",
+    bundle,
+    error: null,
+    reload: vi.fn(),
+  });
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+const buyItem = makeItem({
+  symbol: "035720",
+  decisionBucket: "new_buy_candidate",
+});
+const heldItem = makeItem({
+  symbol: "005930",
+  side: "sell",
+  intent: "sell_review",
+  decisionBucket: "open_action",
+});
+const watchItem = makeItem({
+  symbol: "051910",
+  itemKind: "watch",
+  side: null,
+  intent: "risk_review",
+  decisionBucket: "risk_watch",
+});
+const excludedItem = makeItem({
+  symbol: "207940",
+  decisionBucket: "deferred_no_action",
+});
+
+function fullReviewSections(): ReportReviewSections {
+  return {
+    sections: [
+      { key: "new_buy_candidate", labelKo: "신규매수 후보", items: [buyItem] },
+      {
+        key: "held_strategy_review",
+        labelKo: "보유종목 전략 변경 후보",
+        items: [heldItem],
+      },
+      { key: "watch_only", labelKo: "watch-only", items: [watchItem] },
+      {
+        key: "excluded_or_unavailable",
+        labelKo: "제외 / 확인 불가",
+        items: [excludedItem],
+      },
+    ],
+    noActionSummary: {
+      kind: "stale_gated",
+      reasonKo: "스냅샷 stale — market 신선도 부족으로 매수/매도 권고 보류",
+      blockingSources: ["market"],
+      excludedCount: 1,
+    },
+  };
+}
+
+describe("InvestmentReportBundleContent — ROB-322 review sections", () => {
+  it("renders the four review section headers in Korean", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    expect(
+      screen.getByRole("heading", { name: /신규매수 후보/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /보유종목 전략 변경 후보/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /watch-only/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /제외 \/ 확인 불가/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("nests each item under its owning section", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    const buySection = screen
+      .getByRole("heading", { name: /신규매수 후보/ })
+      .closest("section") as HTMLElement;
+    expect(buySection.textContent).toContain("035720");
+    // The excluded item must NOT leak into the new-buy section.
+    expect(buySection.textContent).not.toContain("207940");
+  });
+
+  it("renders the no-action summary with reason and excluded count", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    const summarySection = screen
+      .getByRole("heading", { name: /no-action/i })
+      .closest("section") as HTMLElement;
+    // reasonKo is surfaced verbatim (unique phrase).
+    expect(summarySection.textContent).toContain("매수/매도 권고 보류");
+    expect(summarySection.textContent).toContain("제외 / 확인 불가 1건");
+  });
+
+  it("does NOT render the flat itemKind queue when review sections are present", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    expect(
+      screen.queryByRole("heading", { name: /^action \(/ }),
+    ).toBeNull();
+  });
+
+  it("falls back to the flat itemKind grouping for legacy reports (no reviewSections)", () => {
+    const legacy = makeBundle(null, [makeItem({ symbol: "068270" })]);
+    renderContent(legacy);
+    expect(
+      screen.getByRole("heading", { name: /^action \(/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /신규매수 후보/ }),
+    ).toBeNull();
+  });
+
+  it("does not hide items that are not projected into any section", () => {
+    const unprojected = makeItem({ symbol: "068270", decisionBucket: null });
+    renderContent(makeBundle(fullReviewSections(), [unprojected]));
+    const fallback = screen
+      .getByRole("heading", { name: /분류 없음/ })
+      .closest("section") as HTMLElement;
+    expect(fallback.textContent).toContain("068270");
+  });
+});

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx
@@ -235,3 +235,47 @@ describe("InvestmentReportBundleContent — ROB-322 review sections", () => {
     expect(fallback.textContent).toContain("068270");
   });
 });
+
+describe("InvestmentReportBundleContent — ROB-322 candidate card chips", () => {
+  function sectionsWithBuy(item: InvestmentReportItem): ReportReviewSections {
+    return {
+      sections: [
+        { key: "new_buy_candidate", labelKo: "신규매수 후보", items: [item] },
+      ],
+      noActionSummary: null,
+    };
+  }
+
+  it("renders a confidence chip when confidence is present", () => {
+    const item = makeItem({
+      symbol: "035720",
+      decisionBucket: "new_buy_candidate",
+      confidence: 78,
+    });
+    renderContent(makeBundle(sectionsWithBuy(item)));
+    expect(screen.getByText(/신뢰도\s*78/)).toBeInTheDocument();
+  });
+
+  it("omits the confidence chip when confidence is null", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    expect(screen.queryByText(/신뢰도/)).toBeNull();
+  });
+
+  it("renders citation chips for cited symbol + dimension reports", () => {
+    const item = makeItem({
+      symbol: "035720",
+      decisionBucket: "new_buy_candidate",
+      citedSymbolReportUuid: "sym-1",
+      citedDimensionReportUuids: ["d1", "d2"],
+    });
+    renderContent(makeBundle(sectionsWithBuy(item)));
+    expect(screen.getByText(/심볼 리포트/)).toBeInTheDocument();
+    expect(screen.getByText(/차원 리포트\s*2/)).toBeInTheDocument();
+  });
+
+  it("omits citation chips when there are no citations", () => {
+    renderContent(makeBundle(fullReviewSections()));
+    expect(screen.queryByText(/심볼 리포트/)).toBeNull();
+    expect(screen.queryByText(/차원 리포트/)).toBeNull();
+  });
+});

--- a/frontend/invest/src/__tests__/investmentReports.api.test.ts
+++ b/frontend/invest/src/__tests__/investmentReports.api.test.ts
@@ -211,6 +211,70 @@ describe("fetchInvestmentReportBundle", () => {
       expect.objectContaining({ credentials: "include" }),
     );
   });
+
+  // ROB-322 — five-section review projection normalization.
+  it("normalises review_sections + no_action_summary to camelCase", async () => {
+    mockFetchOnce({
+      report: {},
+      items: [],
+      decisions_by_item_uuid: {},
+      alerts: [],
+      events: [],
+      review_sections: {
+        sections: [
+          {
+            key: "new_buy_candidate",
+            label_ko: "신규매수 후보",
+            items: [
+              {
+                item_uuid: "item-1",
+                item_kind: "action",
+                symbol: "035720",
+                decision_bucket: "new_buy_candidate",
+                cited_symbol_report_uuid: "sym-1",
+                cited_dimension_report_uuids: ["dim-1", "dim-2"],
+              },
+            ],
+          },
+          { key: "held_strategy_review", label_ko: "보유종목 전략 변경 후보", items: [] },
+        ],
+        no_action_summary: {
+          kind: "stale_gated",
+          reason_ko: "스냅샷 stale",
+          blocking_sources: ["market"],
+          excluded_count: 3,
+        },
+      },
+    });
+
+    const bundle = await fetchInvestmentReportBundle("uuid-1");
+    const review = bundle.reviewSections!;
+    expect(review.sections).toHaveLength(2);
+    expect(review.sections[0]!.key).toBe("new_buy_candidate");
+    expect(review.sections[0]!.labelKo).toBe("신규매수 후보");
+    const item = review.sections[0]!.items[0]!;
+    expect(item.symbol).toBe("035720");
+    expect(item.decisionBucket).toBe("new_buy_candidate");
+    expect(item.citedSymbolReportUuid).toBe("sym-1");
+    expect(item.citedDimensionReportUuids).toEqual(["dim-1", "dim-2"]);
+    const summary = review.noActionSummary!;
+    expect(summary.kind).toBe("stale_gated");
+    expect(summary.reasonKo).toBe("스냅샷 stale");
+    expect(summary.blockingSources).toEqual(["market"]);
+    expect(summary.excludedCount).toBe(3);
+  });
+
+  it("returns null reviewSections when the field is absent (legacy)", async () => {
+    mockFetchOnce({
+      report: {},
+      items: [],
+      decisions_by_item_uuid: {},
+      alerts: [],
+      events: [],
+    });
+    const bundle = await fetchInvestmentReportBundle("uuid-1");
+    expect(bundle.reviewSections).toBeNull();
+  });
 });
 
 describe("fetchReportSnapshotBundle", () => {

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -17,10 +17,15 @@ import type {
   Market,
   MarketSession,
   AccountScope,
+  NoActionSummary,
   ProposalDiffEntry,
   ProposalOperation,
   ProposalTargetRef,
+  ReportReviewSections,
   ReportStatus,
+  ReviewSection,
+  ReviewSectionKey,
+  WhyNoActionKind,
   SnapshotFreshnessSummary,
   SnapshotReportDiagnostics,
   ReportSnapshotBundle,
@@ -173,7 +178,37 @@ function normalizeItem(raw: ApiItem): InvestmentReportItem {
     applyPolicy: asOptionalString(raw.apply_policy) as
       | "requires_user_approval"
       | null,
+    // ROB-308 / ROB-322 — classification + citations. Optional on legacy.
+    decisionBucket: asOptionalString(raw.decision_bucket),
+    citedSymbolReportUuid: asOptionalString(raw.cited_symbol_report_uuid),
+    citedDimensionReportUuids: asArray<string>(raw.cited_dimension_report_uuids),
   };
+}
+
+// ROB-322 — normalize the additive five-section review projection. Returns
+// null when the backend omits it (legacy reports / older backend).
+function normalizeReviewSections(raw: unknown): ReportReviewSections | null {
+  if (raw === null || raw === undefined) return null;
+  const obj = asRecord(raw);
+  const sections: ReviewSection[] = asArray<Record<string, unknown>>(
+    obj.sections,
+  ).map((section) => ({
+    key: asString(section.key, "") as ReviewSectionKey,
+    labelKo: asString(section.label_ko, ""),
+    items: asArray<ApiItem>(section.items).map(normalizeItem),
+  }));
+
+  let noActionSummary: NoActionSummary | null = null;
+  if (obj.no_action_summary !== null && obj.no_action_summary !== undefined) {
+    const summary = asRecord(obj.no_action_summary);
+    noActionSummary = {
+      kind: asOptionalString(summary.kind) as WhyNoActionKind | null,
+      reasonKo: asOptionalString(summary.reason_ko),
+      blockingSources: asArray<string>(summary.blocking_sources),
+      excludedCount: asNumber(summary.excluded_count, 0),
+    };
+  }
+  return { sections, noActionSummary };
 }
 
 function normalizeDecision(raw: ApiDecision): InvestmentReportItemDecision {
@@ -284,6 +319,7 @@ export async function fetchInvestmentReportBundle(
     decisions_by_item_uuid?: Record<string, ApiDecision[]>;
     alerts?: ApiAlert[];
     events?: ApiEvent[];
+    review_sections?: unknown;
   }>(BUNDLE_ENDPOINT(reportUuid), signal);
 
   const decisionsRaw = raw.decisions_by_item_uuid ?? {};
@@ -300,6 +336,7 @@ export async function fetchInvestmentReportBundle(
     decisionsByItemUuid,
     alerts: asArray<ApiAlert>(raw.alerts).map(normalizeAlert),
     events: asArray<ApiEvent>(raw.events).map(normalizeEvent),
+    reviewSections: normalizeReviewSections(raw.review_sections),
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -6,7 +6,7 @@
 import type { ReactNode } from "react";
 import { Link, useParams } from "react-router-dom";
 
-import { Card } from "../../ds";
+import { Card, Pill } from "../../ds";
 import { useInvestmentReportBundle } from "../../hooks/useInvestmentReportBundle";
 import type {
   DeliveryStatus,
@@ -190,6 +190,17 @@ function ReportHeader({
   );
 }
 
+// ROB-322 — confidence is a 0-100 Decimal serialised as string/number; show a
+// rounded integer chip when present, otherwise nothing (never "확인 불가").
+function formatConfidence(
+  raw: number | string | null | undefined,
+): string | null {
+  if (raw === null || raw === undefined || raw === "") return null;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (Number.isFinite(n)) return String(Math.round(n));
+  return typeof raw === "string" ? raw : null;
+}
+
 function ItemRow({
   item,
   decisions,
@@ -199,6 +210,10 @@ function ItemRow({
 }) {
   const kindLabel = ITEM_KIND_LABELS[item.itemKind] ?? item.itemKind;
   const statusLabel = ITEM_STATUS_LABELS[item.status] ?? item.status;
+  const confidenceLabel = formatConfidence(item.confidence);
+  const dimensionCitations = item.citedDimensionReportUuids?.length ?? 0;
+  const hasChips =
+    !!confidenceLabel || !!item.citedSymbolReportUuid || dimensionCitations > 0;
   return (
     <section
       style={{
@@ -233,6 +248,25 @@ function ItemRow({
         </div>
         <span style={{ fontSize: 12, fontWeight: 800 }}>{statusLabel}</span>
       </div>
+      {hasChips ? (
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {confidenceLabel ? (
+            <Pill tone="accent" size="sm">
+              신뢰도 {confidenceLabel}
+            </Pill>
+          ) : null}
+          {item.citedSymbolReportUuid ? (
+            <Pill tone="paper" size="sm">
+              심볼 리포트
+            </Pill>
+          ) : null}
+          {dimensionCitations > 0 ? (
+            <Pill tone="paper" size="sm">
+              차원 리포트 {dimensionCitations}
+            </Pill>
+          ) : null}
+        </div>
+      ) : null}
       <div style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1.55 }}>
         {item.rationale}
       </div>

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -14,6 +14,8 @@ import type {
   InvestmentReportItemDecision,
   InvestmentWatchAlert,
   InvestmentWatchEvent,
+  NoActionSummary,
+  ReportReviewSections,
   SnapshotFreshnessSummary,
   SnapshotReportDiagnostics,
 } from "../../types/investmentReports";
@@ -393,6 +395,121 @@ function groupItems(items: InvestmentReportItem[]) {
   return buckets;
 }
 
+// ROB-322 — Korean labels for the five-section review surface. The backend
+// also ships ``label_ko`` per section; we prefer our own copy for
+// presentation stability and fall back to the payload label.
+const REVIEW_SECTION_LABELS: Record<string, string> = {
+  new_buy_candidate: "신규매수 후보",
+  held_strategy_review: "보유종목 전략 변경 후보",
+  watch_only: "watch-only",
+  excluded_or_unavailable: "제외 / 확인 불가",
+};
+
+const NO_ACTION_KIND_LABELS: Record<string, string> = {
+  real_no_action: "관망 — 데이터 충분, 신규 액션 없음",
+  stale_gated: "보류 — 스냅샷 신선도 부족",
+  data_insufficient: "보류 — 데이터 부족",
+};
+
+function NoActionSummaryCard({ summary }: { summary: NoActionSummary }) {
+  const kindLabel = summary.kind
+    ? (NO_ACTION_KIND_LABELS[summary.kind] ?? summary.kind)
+    : "무액션";
+  return (
+    <section style={{ display: "grid", gap: 10 }}>
+      <h2 style={{ margin: 0, fontSize: 18 }}>no-action 요약</h2>
+      <div
+        style={{
+          display: "grid",
+          gap: 6,
+          padding: 12,
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          background: "rgba(255,255,255,0.015)",
+        }}
+      >
+        <strong style={{ fontSize: 14 }}>{kindLabel}</strong>
+        {summary.reasonKo ? (
+          <div style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1.55 }}>
+            {summary.reasonKo}
+          </div>
+        ) : null}
+        {summary.blockingSources.length > 0 ? (
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            차단 소스: {summary.blockingSources.join(", ")}
+          </div>
+        ) : null}
+        {summary.excludedCount > 0 ? (
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
+            제외 / 확인 불가 {summary.excludedCount}건
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function ReviewSectionsView({
+  review,
+  items,
+  decisionsByItemUuid,
+}: {
+  review: ReportReviewSections;
+  items: InvestmentReportItem[];
+  decisionsByItemUuid: Record<string, InvestmentReportItemDecision[]>;
+}) {
+  const projectedUuids = new Set(
+    review.sections.flatMap((section) => section.items.map((it) => it.itemUuid)),
+  );
+  // Defensive: never hide items the projection didn't classify (legacy items
+  // mixed into a new report). They stay visible under a neutral section.
+  const unprojected = items.filter((it) => !projectedUuids.has(it.itemUuid));
+
+  return (
+    <>
+      {review.sections.map((section) => {
+        const label =
+          REVIEW_SECTION_LABELS[section.key] ?? section.labelKo ?? section.key;
+        return (
+          <section key={section.key} style={{ display: "grid", gap: 10 }}>
+            <h2 style={{ margin: 0, fontSize: 18 }}>
+              {label} ({section.items.length})
+            </h2>
+            {section.items.length > 0 ? (
+              section.items.map((item) => (
+                <ItemRow
+                  key={item.itemUuid}
+                  item={item}
+                  decisions={decisionsByItemUuid[item.itemUuid] ?? []}
+                />
+              ))
+            ) : (
+              <div style={{ color: "var(--fg-3)", fontSize: 13 }}>
+                현재 해당 종목 없음
+              </div>
+            )}
+          </section>
+        );
+      })}
+      {unprojected.length > 0 ? (
+        <section style={{ display: "grid", gap: 10 }}>
+          <h2 style={{ margin: 0, fontSize: 18 }}>분류 없음 ({unprojected.length})</h2>
+          {unprojected.map((item) => (
+            <ItemRow
+              key={item.itemUuid}
+              item={item}
+              decisions={decisionsByItemUuid[item.itemUuid] ?? []}
+            />
+          ))}
+        </section>
+      ) : null}
+      {review.noActionSummary ? (
+        <NoActionSummaryCard summary={review.noActionSummary} />
+      ) : null}
+    </>
+  );
+}
+
 export function InvestmentReportBundleContent({
   compact = false,
 }: {
@@ -452,6 +569,14 @@ export function InvestmentReportBundleContent({
   }
 
   const buckets = groupItems(bundle.items);
+  // ROB-322 — when the backend ships the five-section projection (and it has
+  // content), render the report-scoped review surface instead of the flat
+  // itemKind queue. Legacy reports / older backend keep the flat grouping.
+  const review = bundle.reviewSections;
+  const hasReview =
+    !!review &&
+    (review.sections.some((section) => section.items.length > 0) ||
+      !!review.noActionSummary);
 
   return (
     <div
@@ -486,23 +611,29 @@ export function InvestmentReportBundleContent({
 
       <IntermediateAnalysisPanel reportUuid={bundle.report.reportUuid} />
 
-      {(
-        ["action", "watch", "risk"] as const
-      ).map((kind) =>
-        buckets[kind].length > 0 ? (
-          <section key={kind} style={{ display: "grid", gap: 10 }}>
-            <h2 style={{ margin: 0, fontSize: 18 }}>
-              {ITEM_KIND_LABELS[kind]} ({buckets[kind].length})
-            </h2>
-            {buckets[kind].map((item) => (
-              <ItemRow
-                key={item.itemUuid}
-                item={item}
-                decisions={bundle.decisionsByItemUuid[item.itemUuid] ?? []}
-              />
-            ))}
-          </section>
-        ) : null,
+      {hasReview && review ? (
+        <ReviewSectionsView
+          review={review}
+          items={bundle.items}
+          decisionsByItemUuid={bundle.decisionsByItemUuid}
+        />
+      ) : (
+        (["action", "watch", "risk"] as const).map((kind) =>
+          buckets[kind].length > 0 ? (
+            <section key={kind} style={{ display: "grid", gap: 10 }}>
+              <h2 style={{ margin: 0, fontSize: 18 }}>
+                {ITEM_KIND_LABELS[kind]} ({buckets[kind].length})
+              </h2>
+              {buckets[kind].map((item) => (
+                <ItemRow
+                  key={item.itemUuid}
+                  item={item}
+                  decisions={bundle.decisionsByItemUuid[item.itemUuid] ?? []}
+                />
+              ))}
+            </section>
+          ) : null,
+        )
       )}
 
       {bundle.alerts.length > 0 ? (

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -250,6 +250,11 @@ export interface InvestmentReportItem {
   proposedState?: Record<string, unknown> | null;
   diff?: ProposalDiffEntry[] | null;
   applyPolicy?: "requires_user_approval" | null;
+  // ROB-308 / ROB-322 — final-item classification + source citations.
+  // Optional/nullable so legacy items remain valid.
+  decisionBucket?: string | null;
+  citedSymbolReportUuid?: string | null;
+  citedDimensionReportUuids?: string[];
 }
 
 export interface InvestmentReportItemDecision {
@@ -313,12 +318,44 @@ export interface InvestmentWatchEvent {
   createdAt: string;
 }
 
+// ROB-322 — KR /invest/reports five-section review surface. A read-time
+// view-layer projection over the locked decision_bucket vocab + report
+// diagnostics; no new persisted classification.
+export type ReviewSectionKey =
+  | "new_buy_candidate"
+  | "held_strategy_review"
+  | "watch_only"
+  | "excluded_or_unavailable";
+
+// ``WhyNoActionKind`` is defined above (ROB-318 diagnostics) and reused here.
+
+export interface ReviewSection {
+  key: ReviewSectionKey;
+  labelKo: string;
+  items: InvestmentReportItem[];
+}
+
+export interface NoActionSummary {
+  kind?: WhyNoActionKind | null;
+  reasonKo?: string | null;
+  blockingSources: string[];
+  excludedCount: number;
+}
+
+export interface ReportReviewSections {
+  sections: ReviewSection[];
+  noActionSummary?: NoActionSummary | null;
+}
+
 export interface InvestmentReportBundle {
   report: InvestmentReport;
   items: InvestmentReportItem[];
   decisionsByItemUuid: Record<string, InvestmentReportItemDecision[]>;
   alerts: InvestmentWatchAlert[];
   events: InvestmentWatchEvent[];
+  // ROB-322 — additive five-section projection. Null on legacy reports or
+  // older backend; `items` remains the fallback rendering source.
+  reviewSections?: ReportReviewSections | null;
 }
 
 export interface InvestmentReportListResponse {


### PR DESCRIPTION
## ROB-322 Phase 3b — PR2 (frontend)

Renders the report-scoped **five-section actionable review surface** on the KR `/invest/reports` detail page, consuming the additive `review_sections` payload from **PR1 (#978)**:

> 신규매수 후보 → 보유종목 전략 변경 후보 → watch-only → 제외 / 확인 불가 → no-action summary

### Independent of PR1 (no stacking)
Frontend-only, based on `origin/main`. There is **no code-level dependency** on PR1's Python — TS types are hand-maintained and the renderer defensively handles `reviewSections` being absent. That same fallback path covers (a) legacy reports without the field and (b) the window before PR1 deploys. Both PRs merge independently in any order. (Avoids the stacked-PR squash-merge gotcha.)

### Changes
- **`types/investmentReports.ts`** — `ReviewSection` / `NoActionSummary` / `ReportReviewSections`; optional `reviewSections` on `InvestmentReportBundle`; `decisionBucket` + citation fields on `InvestmentReportItem`. Reuses the existing ROB-318 `WhyNoActionKind`.
- **`api/investmentReports.ts`** — `normalizeReviewSections` (manual snake→camel per repo convention); `decision_bucket` + citations in `normalizeItem`. `reviewSections` is `null` when the field is absent.
- **`InvestmentReportBundleContent.tsx`** — when `reviewSections` has content, render the five sections (fixed order, Korean labels, **reusing the existing `ItemRow`**) instead of the flat itemKind queue. The no-action summary card distinguishes `real_no_action` vs `stale_gated` vs `data_insufficient` and shows the excluded/확인-불가 count. Legacy reports keep the existing flat grouping.

### Acceptance-criteria notes
- **Report-scoped**: sections render only the current bundle's items; old-report candidates never leak in.
- **Nothing hidden**: items the projection didn't classify (`decision_bucket=None`) fall into a neutral `분류 없음` section rather than vanishing.
- **확인 불가 reserved**: only the genuinely-deferred bucket is labeled `제외 / 확인 불가`. Cards reuse `ItemRow`, which renders no order-only fields, so no misleading `확인 불가` is introduced (the `해당 없음` concern applies to order fields not present here).
- **Korean copy** is natural; no raw enum strings as primary prose.

### Side effects
**None.** Read-only UI. No broker/order/watch/order-intent/scheduler mutation; no new network calls; Toss/Naver/browser untouched.

### Tests / checks (local, `frontend/invest`)
```
npx vitest run --pool=forks \
  src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx \
  src/__tests__/investmentReports.api.test.ts \
  src/__tests__/InvestmentReportBundleContent.proposal.test.tsx        -> 20 passed
npx vitest run --pool=forks (full suite)  -> 409 passed, 5 failed
npm run typecheck                          -> clean
npm run build                              -> built OK
```
**6 new component tests** (section headers/order, per-section nesting, no-action summary, flat-queue replacement, legacy fallback, unprojected-not-hidden) + **2 new API tests** (review_sections normalization, null-when-absent). The 5 full-suite failures are the **pre-existing calendar/coverage baseline** (`DaySection`, `MonthlyEventsTimeline`, `ActionReadiness`, `DesktopCalendarPage`) — zero import path from investment-reports; passing count rose 401 → 409 (+8 = the new tests). `vitest --pool=forks` is used per a known threads-pool flakiness in this package.

### Production validation still needed
Live screenshot of the five sections requires PR1 (#978) deployed + a real KR/`kis_live` report whose items carry `decision_bucket`. Component tests verify the rendering deterministically in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investment reports now organize items into five themed review sections for improved navigation and clarity.
  * Added confidence and citation indicators ("chips") to investment report items for quick reference.
  * Included a dedicated summary section for items not requiring action with localized labels.
  * Maintained backward compatibility with legacy investment reports using the original flat grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->