### PR TITLE
fix(rob-321): keep KIS mock dry-run preview usable

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -819,13 +819,31 @@ async def _check_balance_and_warn(
     try:
         balance = await _get_balance_for_order(market_type, is_mock=is_mock)
     except Exception as balance_exc:
+        error_detail = str(balance_exc) or balance_exc.__class__.__name__
         logger.error(
             "balance_precheck 조회 실패: stage=balance_query, market_type=%s, symbol=%s, side=%s, error=%s",
             market_type,
             normalized_symbol,
             side,
-            balance_exc,
+            error_detail,
         )
+        if is_mock and market_type in ("equity_kr", "equity_us"):
+            message = (
+                "KIS mock balance precheck unavailable for "
+                f"{normalized_symbol}: {error_detail}"
+            )
+            if dry_run:
+                return (
+                    "Preview warning: "
+                    f"{message}; dry_run=True so no order was submitted.",
+                    None,
+                )
+            return (
+                None,
+                order_error_fn(
+                    f"{message}; refusing to submit without verified orderable cash."
+                ),
+            )
         raise
 
     if is_mock and market_type in ("equity_kr", "equity_us"):

--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -93,6 +93,9 @@ Verify:
 ## Open question this loop still carries
 
 Does the KIS **mock** WS (`:31000`) serve real-time quotes, or must quotes come
-from **live** (`:21000`)? Resolve via the read-only quote smoke
-(`scripts/kis_mock_scalping_ws_smoke.py`, see `kis-mock-scalping-ws-smoke.md`)
-and set `--account-mode` accordingly.
+from **live** (`:21000`)? Resolved by the read-only quote smoke
+(`scripts/kis_mock_scalping_ws_smoke.py`, see `kis-mock-scalping-ws-smoke.md`):
+`kis_mock` delivered both orderbook and trade frames during the 2026-05-27 KRX
+regular session, so the domestic mock scalping loop can use `--account-mode
+kis_mock` for quote smoke. Keep live quote WS as a fallback only if a future
+mock-session smoke returns exit 4 during market hours.

--- a/docs/runbooks/kis-mock-scalping-ws-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-ws-smoke.md
@@ -59,8 +59,8 @@ KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_scalping_ws_
 
 | account_mode | ticks | books | verdict |
 |--------------|-------|-------|---------|
-| kis_mock     | _TBD_ | _TBD_ | _TBD_   |
-| kis_live     | _TBD_ | _TBD_ | _TBD_   |
+| kis_mock     | 2     | 2     | **OK** — 2026-05-27 10:44 KST, KRX regular session, `005930,000660`; mock WS (`:31000`) delivered both orderbook and trade frames. |
+| kis_live     | _not run_ | _not run_ | Not required for ROB-321 domestic mock smoke once `kis_mock` quote host was confirmed. |
 
 > Note: also confirm the parsed `last_price`/`bid`/`ask` look sane against a known
 > quote. If a field is consistently wrong, the documented `H0STCNT0`/`H0STASP0`

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -12,7 +12,11 @@ import pytest
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
-from app.mcp_server.tooling import order_execution, orders_registration
+from app.mcp_server.tooling import (
+    order_execution,
+    orders_kis_variants,
+    orders_registration,
+)
 from tests._mcp_tooling_support import (
     _patch_runtime_attr,
     build_tools,
@@ -1352,6 +1356,101 @@ async def test_place_order_kis_mock_sell_preview_uses_mock_holdings(monkeypatch)
     assert result["realized_pnl"] == pytest.approx(2500.0)
     assert kis_calls
     assert all(kis_calls)
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_place_order_dry_run_warns_when_cash_lookup_unavailable(
+    monkeypatch,
+):
+    """KIS mock dry-run preview should not fail solely because cash read is flaky."""
+    tools = build_tools()
+
+    class MockKISClient:
+        def __init__(self, is_mock: bool = False):
+            self.is_mock = is_mock
+
+        async def inquire_domestic_cash_balance(self, *, is_mock: bool = False):
+            assert self.is_mock is True
+            assert is_mock is True
+            raise TimeoutError()
+
+    async def fetch_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 318500.0}
+
+    monkeypatch.setattr(orders_registration, "validate_kis_mock_config", lambda: [])
+    monkeypatch.setattr(orders_kis_variants, "validate_kis_mock_config", lambda: [])
+    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
+
+    result = await tools["kis_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=318500.0,
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["account_mode"] == "kis_mock"
+    assert result["estimated_value"] == pytest.approx(318500.0)
+    assert "balance precheck unavailable" in result["warning"]
+    assert "dry_run=True" in result["warning"]
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_place_order_real_order_blocks_when_cash_lookup_unavailable(
+    monkeypatch,
+):
+    """KIS mock confirmed submit remains fail-closed if cash cannot be verified."""
+    tools = build_tools()
+    order_calls: list[dict[str, object]] = []
+
+    class MockKISClient:
+        def __init__(self, is_mock: bool = False):
+            self.is_mock = is_mock
+
+        async def inquire_domestic_cash_balance(self, *, is_mock: bool = False):
+            assert self.is_mock is True
+            assert is_mock is True
+            raise TimeoutError()
+
+        async def order_korea_stock(self, stock_code, order_type, quantity, price):
+            order_calls.append(
+                {
+                    "stock_code": stock_code,
+                    "order_type": order_type,
+                    "quantity": quantity,
+                    "price": price,
+                }
+            )
+            return {"odno": "mock-should-not-submit"}
+
+    async def fetch_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 318500.0}
+
+    monkeypatch.setattr(orders_registration, "validate_kis_mock_config", lambda: [])
+    monkeypatch.setattr(orders_kis_variants, "validate_kis_mock_config", lambda: [])
+    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
+
+    result = await tools["kis_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=318500.0,
+        dry_run=False,
+    )
+
+    assert result["success"] is False
+    assert result["account_mode"] == "kis_mock"
+    assert "balance precheck unavailable" in result["error"]
+    assert "refusing to submit" in result["error"]
+    assert order_calls == []
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Keep KIS mock buy dry-run previews usable when the mock cash/balance precheck is temporarily unavailable: dry-run now returns a warning instead of `success=false` with an empty error.
- Keep confirmed KIS mock submits fail-closed when orderable cash cannot be verified.
- Record the 2026-05-27 KRX-session `kis_mock` WebSocket smoke result: mock WS delivered domestic orderbook/trade frames, so the domestic mock scalping loop can use `--account-mode kis_mock` for quote smoke.

## Test Plan
- [x] RED: `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' uv run pytest tests/test_mcp_place_order.py::test_kis_mock_place_order_dry_run_warns_when_cash_lookup_unavailable tests/test_mcp_place_order.py::test_kis_mock_place_order_real_order_blocks_when_cash_lookup_unavailable -q` failed before the fix.
- [x] `uv run ruff check app/mcp_server/tooling/order_validation.py tests/test_mcp_place_order.py`
- [x] `uv run ruff format --check app/mcp_server/tooling/order_validation.py tests/test_mcp_place_order.py`
- [x] `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' uv run pytest tests/test_mcp_place_order.py::test_place_order_kr_equity_balance_lookup_failure_returns_query_error tests/test_mcp_place_order.py::test_place_order_kr_equity_balance_lookup_failure_blocks_real_order tests/test_mcp_place_order.py::test_place_order_kis_mock_sell_preview_uses_mock_holdings tests/test_mcp_place_order.py::test_kis_mock_place_order_dry_run_warns_when_cash_lookup_unavailable tests/test_mcp_place_order.py::test_kis_mock_place_order_real_order_blocks_when_cash_lookup_unavailable tests/test_kis_mock_scalping_sell_guard.py tests/test_kis_mock_scalping_exit_wiring.py -q`
- [x] Read-only KIS mock quote WS smoke during KRX session: `kis_mock`, symbols `005930,000660`, ticks=2, books=2.
- [x] KIS mock scalping daemon dry-run smoke: `confirm=False`, no order submission, triggers=0 in bounded run.

## Safety
- No confirmed broker order was submitted.
- No live KIS order path was changed.
- Confirmed KIS mock order submission remains blocked when cash cannot be verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for balance verification during order placement. Mock orders now return user-facing warnings for previews and prevent submission when balance checks fail, while maintaining fail-safe behavior.

* **Documentation**
  * Confirmed KIS mock environment delivers real-time market data including order books and trade information for domestic equity trading.

* **Tests**
  * Added test coverage for balance check failures in order submission workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/981?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->