### PR TITLE
feat(rob-332): validated_run_card operator ingest CLI + report-item citation wiring

### DIFF
--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -37,6 +37,10 @@ from typing import Any
 from uuid import UUID
 
 from app.schemas.investment_reports import IngestReportItem
+from app.schemas.validated_run_card import (
+    build_run_card_citation,
+    build_run_card_evidence,
+)
 
 
 def _snapshot_payload(snapshot: Any) -> dict[str, Any]:
@@ -123,6 +127,7 @@ class EvidenceAutoEmitter:
         portfolio_snapshot: Any | None = None
         candidate_snapshot: Any | None = None
         news_snapshot: Any | None = None
+        run_card_evidence_by_symbol: dict[str, dict[str, Any]] = {}
 
         for snapshot in snapshots:
             kind = getattr(snapshot, "snapshot_kind", None)
@@ -153,6 +158,15 @@ class EvidenceAutoEmitter:
                     for sym, count in matches.items():
                         if isinstance(sym, str) and isinstance(count, int):
                             news_matches[sym] = count
+            elif kind == "validated_run_card":
+                snap_uuid = _snapshot_uuid(snapshot)
+                citation = build_run_card_citation(payload)
+                if snap_uuid is not None and citation.symbols:
+                    evidence = build_run_card_evidence(
+                        snapshot_uuid=snap_uuid, citation=citation
+                    )
+                    for sym in citation.symbols:
+                        run_card_evidence_by_symbol.setdefault(sym, evidence)
 
         held = _held_kis_symbols(portfolio_payload)
         candidate_actionable = candidate_usefulness == "useful"
@@ -325,5 +339,15 @@ class EvidenceAutoEmitter:
                     ),
                 )
             )
+
+        # ROB-332 — cite a bundle-resident validated_run_card on items whose
+        # symbol matches the run card's symbols (consume-when-present; no-op
+        # when no run card is in the bundle or no symbol overlaps).
+        if run_card_evidence_by_symbol:
+            for item in items:
+                if item.symbol and item.symbol in run_card_evidence_by_symbol:
+                    item.evidence_snapshot["run_card"] = run_card_evidence_by_symbol[
+                        item.symbol
+                    ]
 
         return items

--- a/docs/runbooks/validated-run-card-ingest.md
+++ b/docs/runbooks/validated-run-card-ingest.md
@@ -1,0 +1,47 @@
+# Validated Run-Card Ingest (ROB-332)
+
+Ingest a `validated_run_card.v1` JSON artifact (produced by
+`research/nautilus_scalping`) as an immutable `InvestmentSnapshot`
+(`snapshot_kind="validated_run_card"`, `source_kind="manual"`). Audit-only:
+no broker/order/watch mutation, no scheduler.
+
+## Dry-run (default — no DB write)
+
+    uv run python -m scripts.ingest_validated_run_card \
+      --file path/to/run_card.json --market crypto
+
+Prints the JSON-safe citation headline (`verdict`, `framing`, `trade_count`,
+`is_pass_stamp`, `symbols`). `insufficient_data` / `not_validated` is NOT a
+pass stamp.
+
+## Commit (operator-gated)
+
+    uv run python -m scripts.ingest_validated_run_card \
+      --file path/to/run_card.json --market crypto --commit --confirm
+
+`--commit` requires `--confirm`. Prints the created (or, on re-ingest of an
+identical payload, the reused) `snapshot_uuid`. Re-ingesting the same payload
+is idempotent (dedup on canonical payload hash).
+
+## Arguments
+
+- `--file` (required): run-card JSON path. The path is never recorded as a
+  source URI; only the sanitized payload is persisted.
+- `--market` (required): `kr` | `us` | `crypto`. Binance-demo run cards use
+  `crypto` (there is no `binance_demo` account scope).
+- `--account-scope` (optional): `kis_live` | `kis_mock` | `alpaca_paper` |
+  `upbit_live`.
+- `--as-of` (optional): ISO-8601; defaults to the run card's `generated_at`.
+
+## Citation in /invest/reports
+
+Once a `validated_run_card` snapshot is a member of a report bundle, a
+report item whose symbol matches the run card's `gate_report.symbols` cites it
+under `evidence_snapshot["run_card"]` (verdict-first; bootstrap/Monte-Carlo
+stats stay nested under `validation`). Linking a run-card snapshot into a
+bundle is out of scope for this CLI (operator/Hermes/future work).
+
+## Exit codes
+
+`0` ok · `1` file not found · `2` payload/as-of parse error · `3` ingest
+failure · `4` `--commit` without `--confirm`.

--- a/docs/superpowers/plans/2026-05-27-rob-332-run-card-ingest-citation.md
+++ b/docs/superpowers/plans/2026-05-27-rob-332-run-card-ingest-citation.md
@@ -1,0 +1,695 @@
+# ROB-332 — validated_run_card operator ingest + report-item citation wiring — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator CLI that ingests a `validated_run_card.v1` JSON artifact as an `InvestmentSnapshot`, and wire `auto_emit` so an emitted report item cites a `validated_run_card` snapshot already present in the bundle when their symbols match.
+
+**Architecture:** Two independent seams over the ROB-329 (PR #979) contract. (A) A `scripts/ingest_validated_run_card.py` CLI that reuses `RunCardSnapshotIngestor`; testable core `run_ingest(db=...)` injected with a session, `main_async` wires `AsyncSessionLocal`. (B) A `validated_run_card` branch in `EvidenceAutoEmitter.propose()` that builds a per-symbol evidence map via `build_run_card_evidence`, then a single post-pass attaches it under `evidence_snapshot["run_card"]` to items whose `symbol` matches. Consume-when-present only — this PR does **not** link run-card snapshots into bundles.
+
+**Tech Stack:** Python 3.13, `argparse`, SQLAlchemy async (`AsyncSessionLocal`), Pydantic v2, pytest (`pytest-asyncio`), `uv`, ruff.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-rob-332-design.md`
+
+---
+
+## File Structure
+
+- **Create** `scripts/ingest_validated_run_card.py` — operator ingest CLI. Responsibility: parse args, read+validate run-card JSON, dry-run summary or `--commit --confirm` persist via `RunCardSnapshotIngestor`. Mirrors `scripts/ingest_research_reports.py`.
+- **Modify** `app/services/action_report/snapshot_backed/auto_emit.py` — add `validated_run_card` capture in `propose()` + symbol-match post-pass attaching `evidence_snapshot["run_card"]`.
+- **Create** `docs/runbooks/validated-run-card-ingest.md` — operator usage runbook (satisfies "documented local command").
+- **Create** `tests/test_ingest_validated_run_card_cli.py` — CLI arg parsing, dry-run, commit persistence, idempotency, no-source-uri.
+- **Create** `tests/test_auto_emit_run_card_citation.py` — symbol-match attach / no-overlap / absent / empty-bundle.
+
+No new migration (PR #979 shipped the `validated_run_card` CHECK extension). No model/schema changes — `RunCardSnapshotIngestor`, `build_run_card_citation`, `build_run_card_evidence` are reused as-is.
+
+---
+
+## Task 1: Operator ingest CLI
+
+**Files:**
+- Create: `scripts/ingest_validated_run_card.py`
+- Test: `tests/test_ingest_validated_run_card_cli.py`
+
+Reference reused symbols (verified to exist):
+- `app.services.investment_snapshots.run_card_ingest.RunCardSnapshotIngestor.ingest(*, run_card_payload, market, account_scope=None, as_of=None, ...) -> tuple[InvestmentSnapshot, RunCardCitation]`
+- `app.schemas.validated_run_card.build_run_card_citation(payload) -> RunCardCitation` (fields: `verdict`, `framing`, `trade_count`, `is_pass_stamp`, `symbols`, `recognized`)
+- `app.services.investment_snapshots.repository.InvestmentSnapshotsRepository(session)`
+- `app.core.db.AsyncSessionLocal`, `app.core.cli.setup_logging_and_sentry(service_name)`, `app.monitoring.sentry.capture_exception`
+
+- [ ] **Step 1: Write the failing tests for arg parsing + dry-run**
+
+Create `tests/test_ingest_validated_run_card_cli.py`:
+
+```python
+"""ROB-332 — operator CLI for validated_run_card ingest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import ingest_validated_run_card as cli
+
+_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "validated_run_card"
+    / "run_card_insufficient_data.json"
+)
+
+
+def _load() -> dict:
+    with _FIXTURE.open() as fh:
+        return json.load(fh)  # default json.loads accepts bare Infinity tokens
+
+
+def test_parse_args_requires_file_and_market():
+    ns = cli.parse_args(["--file", "x.json", "--market", "crypto"])
+    assert ns.file == Path("x.json")
+    assert ns.market == "crypto"
+    assert ns.account_scope is None
+    assert ns.commit is False
+    assert ns.confirm is False
+
+
+def test_parse_args_rejects_unknown_market():
+    with pytest.raises(SystemExit):
+        cli.parse_args(["--file", "x.json", "--market", "forex"])
+
+
+def test_parse_args_rejects_unknown_account_scope():
+    with pytest.raises(SystemExit):
+        cli.parse_args(
+            ["--file", "x.json", "--market", "us", "--account-scope", "binance_demo"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_dry_run_returns_headline_no_db(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=False,
+        confirm=False,
+    )
+    assert code == 0
+    assert summary["dry_run"] is True
+    assert summary["verdict"] == "insufficient_data"
+    assert summary["is_pass_stamp"] is False
+    assert summary["trade_count"] == 2
+    assert summary["symbols"] == ["XRPUSDT"]
+    assert "snapshot_uuid" not in summary
+    # strict-JSON safe (no Infinity/NaN leaks into output)
+    json.dumps(summary, allow_nan=False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_ingest_validated_run_card_cli.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.ingest_validated_run_card'`.
+
+- [ ] **Step 3: Create the CLI module (parse_args + run_ingest dry-run + commit)**
+
+Create `scripts/ingest_validated_run_card.py`:
+
+```python
+#!/usr/bin/env python3
+"""Ingest a validated_run_card.v1 JSON artifact as an InvestmentSnapshot (ROB-332).
+
+Usage:
+    uv run python -m scripts.ingest_validated_run_card --file run_card.json --market crypto
+    uv run python -m scripts.ingest_validated_run_card --file run_card.json --market crypto --commit --confirm
+
+Defaults to dry-run (prints the JSON-safe citation headline, no DB write). Commit
+mode also requires --confirm. The snapshot is append-only audit evidence with no
+broker mutation, so --commit --confirm is the only operator gate (no env flag).
+
+Boundary (ROB-332): reuses RunCardSnapshotIngestor from PR #979. The local
+run-card file path is never recorded as a source_uri (the ingestor sets
+source_kind="manual"). No broker/order/watch mutation, no scheduler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from app.core.cli import setup_logging_and_sentry
+from app.core.db import AsyncSessionLocal
+from app.monitoring.sentry import capture_exception
+from app.schemas.validated_run_card import RunCardCitation, build_run_card_citation
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_snapshots.run_card_ingest import RunCardSnapshotIngestor
+
+logger = logging.getLogger(__name__)
+
+_MARKETS = ("kr", "us", "crypto")
+_ACCOUNT_SCOPES = ("kis_live", "kis_mock", "alpaca_paper", "upbit_live")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Ingest a validated_run_card.v1 JSON artifact (ROB-332)."
+    )
+    parser.add_argument("--file", required=True, type=Path, help="Run-card JSON path.")
+    parser.add_argument("--market", required=True, choices=_MARKETS)
+    parser.add_argument("--account-scope", choices=_ACCOUNT_SCOPES, default=None)
+    parser.add_argument(
+        "--as-of", default=None, help="ISO-8601 as_of; defaults to run-card generated_at."
+    )
+    parser.add_argument(
+        "--commit", action="store_true", help="Persist; default is dry-run only."
+    )
+    parser.add_argument(
+        "--confirm", action="store_true", help="Required with --commit."
+    )
+    return parser.parse_args(argv)
+
+
+def _headline(citation: RunCardCitation) -> dict[str, Any]:
+    return {
+        "recognized": citation.recognized,
+        "verdict": citation.verdict,
+        "framing": citation.framing,
+        "trade_count": citation.trade_count,
+        "is_pass_stamp": citation.is_pass_stamp,
+        "symbols": citation.symbols,
+    }
+
+
+def _parse_as_of(raw: str | None) -> dt.datetime | None:
+    if raw is None:
+        return None
+    parsed = dt.datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+async def run_ingest(
+    *,
+    db: Any,
+    raw_payload: dict[str, Any],
+    market: str,
+    account_scope: str | None,
+    as_of: dt.datetime | None,
+    commit: bool,
+    confirm: bool,
+) -> tuple[int, dict[str, Any]]:
+    """Core ingest. Returns (exit_code, summary). Does not commit the session;
+    the caller (main_async) commits on success so tests can introspect + roll back."""
+    citation = build_run_card_citation(raw_payload)
+
+    if not commit:
+        return 0, {"dry_run": True, **_headline(citation)}
+
+    if not confirm:
+        return 4, {"error": "commit mode requires --confirm"}
+
+    ingestor = RunCardSnapshotIngestor(InvestmentSnapshotsRepository(db))
+    snapshot, citation = await ingestor.ingest(
+        run_card_payload=raw_payload,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        as_of=as_of,
+    )
+    return 0, {
+        "dry_run": False,
+        "snapshot_uuid": str(snapshot.snapshot_uuid),
+        **_headline(citation),
+    }
+
+
+async def main_async(argv: list[str] | None = None) -> int:
+    setup_logging_and_sentry(service_name="ingest-validated-run-card")
+    ns = parse_args(argv)
+
+    if not ns.file.is_file():
+        logger.error("file not found: %s", ns.file)
+        return 1
+
+    try:
+        raw_payload = json.loads(ns.file.read_text(encoding="utf-8"))
+        as_of = _parse_as_of(ns.as_of)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.error("payload/as-of parse failed: %s", exc)
+        capture_exception(exc, process="ingest_validated_run_card")
+        return 2
+
+    if not ns.commit:
+        _code, summary = await run_ingest(
+            db=None,
+            raw_payload=raw_payload,
+            market=ns.market,
+            account_scope=ns.account_scope,
+            as_of=as_of,
+            commit=False,
+            confirm=False,
+        )
+        print(json.dumps(summary, allow_nan=False, ensure_ascii=False))
+        return 0
+
+    async with AsyncSessionLocal() as db:
+        try:
+            code, summary = await run_ingest(
+                db=db,
+                raw_payload=raw_payload,
+                market=ns.market,
+                account_scope=ns.account_scope,
+                as_of=as_of,
+                commit=True,
+                confirm=ns.confirm,
+            )
+            if code == 0:
+                await db.commit()
+            else:
+                await db.rollback()
+        except Exception as exc:
+            await db.rollback()
+            logger.error("ingest failed: %s", exc, exc_info=True)
+            capture_exception(exc, process="ingest_validated_run_card")
+            return 3
+
+    print(json.dumps(summary, allow_nan=False, ensure_ascii=False))
+    return code
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(main_async()))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run the dry-run + parse tests to verify they pass**
+
+Run: `uv run pytest tests/test_ingest_validated_run_card_cli.py -v -k "parse_args or dry_run"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Add commit + idempotency + commit-gate + no-source-uri tests**
+
+Append to `tests/test_ingest_validated_run_card_cli.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_run_ingest_commit_persists_sanitized_snapshot(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=True,
+    )
+    assert code == 0
+    assert summary["dry_run"] is False
+    uuid_str = summary["snapshot_uuid"]
+    assert uuid_str
+
+    import uuid as _uuid
+
+    from app.services.investment_snapshots.repository import (
+        InvestmentSnapshotsRepository,
+    )
+
+    repo = InvestmentSnapshotsRepository(db_session)
+    snap = await repo.get_snapshot_by_uuid(_uuid.UUID(uuid_str))
+    assert snap is not None
+    assert snap.snapshot_kind == "validated_run_card"
+    assert snap.source_kind == "manual"  # never the local file path
+    # Non-finite metric sanitized to null -> strict-JSON safe payload.
+    assert snap.payload_json["net_after_cost"]["profit_factor"] is None
+    json.dumps(snap.payload_json, allow_nan=False)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_is_idempotent_reuses_snapshot(db_session):
+    payload = _load()
+    _c1, s1 = await cli.run_ingest(
+        db=db_session, raw_payload=payload, market="crypto",
+        account_scope=None, as_of=None, commit=True, confirm=True,
+    )
+    _c2, s2 = await cli.run_ingest(
+        db=db_session, raw_payload=payload, market="crypto",
+        account_scope=None, as_of=None, commit=True, confirm=True,
+    )
+    # Same canonical payload dedups to the same snapshot row.
+    assert s1["snapshot_uuid"] == s2["snapshot_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_commit_without_confirm_is_gated(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=False,
+    )
+    assert code == 4
+    assert "snapshot_uuid" not in summary
+```
+
+- [ ] **Step 6: Run the full CLI test file to verify all pass**
+
+Run: `uv run pytest tests/test_ingest_validated_run_card_cli.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/ingest_validated_run_card.py tests/test_ingest_validated_run_card_cli.py
+git commit -m "feat(rob-332): operator CLI to ingest validated_run_card.v1 snapshots
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: auto_emit symbol-match citation wiring
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py`
+- Test: `tests/test_auto_emit_run_card_citation.py`
+
+Reference reused symbols:
+- `app.schemas.validated_run_card.build_run_card_citation(payload) -> RunCardCitation` (has `.symbols`)
+- `app.schemas.validated_run_card.build_run_card_evidence(*, snapshot_uuid, citation) -> dict` (headline-first: `verdict`/`framing`/`trade_count`/`is_pass_stamp`, stats nested under `validation`)
+- Existing `_snapshot_uuid(snapshot)` helper in `auto_emit.py`.
+- `EvidenceAutoEmitter.propose(*, snapshots, request_market, account_scope) -> list[IngestReportItem]`
+
+- [ ] **Step 1: Write the failing wiring tests**
+
+Create `tests/test_auto_emit_run_card_citation.py`:
+
+```python
+"""ROB-332 — auto_emit cites a validated_run_card snapshot when symbols match."""
+
+import json
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+class _Snap:
+    def __init__(self, kind, payload, symbol=None, uuid="rc-uuid-0001"):
+        self.snapshot_kind = kind
+        self.payload_json = payload
+        self.symbol = symbol
+        self.snapshot_uuid = uuid
+
+
+_OK_QUOTE = {
+    "status": "ok",
+    "best_bid": 100,
+    "best_ask": 101,
+    "bid_depth": 5,
+    "ask_depth": 5,
+    "spread_bps": 10,
+}
+
+
+def _run_card(symbols, verdict="not_validated"):
+    return {
+        "schema_version": "validated_run_card.v1",
+        "verdict": verdict,
+        "framing": "audit evidence, not a pass stamp",
+        "net_after_cost": {"trades": 12, "profit_factor": float("inf")},
+        "validation": {"bootstrap": {"ci_lower": 0.1}, "monte_carlo": {"p_value": 0.4}},
+        "gate_report": {"symbols": symbols, "trade_count": 12},
+    }
+
+
+def _buy_universe(symbol):
+    return [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": symbol, "quote": _OK_QUOTE}, symbol=symbol),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [
+                    {"symbol": symbol, "score": 8.0, "reasons": ["momentum"], "source": "kis"}
+                ],
+            },
+        ),
+    ]
+
+
+def test_buy_item_for_matching_symbol_cites_run_card():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["005930"]), symbol="005930")
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert buys, "expected a buy candidate"
+    rc = buys[0].evidence_snapshot["run_card"]
+    assert rc["verdict"] == "not_validated"
+    assert rc["is_pass_stamp"] is False
+    assert rc["trade_count"] == 12
+    assert rc["snapshot_uuid"] == "rc-uuid-0001"
+    # Non-finite sanitized; bootstrap/MC nested under validation, not standalone.
+    assert rc["net_after_cost"]["profit_factor"] is None
+    assert "bootstrap" in rc["validation"]
+    json.dumps(buys[0].evidence_snapshot, allow_nan=False)
+
+
+def test_validated_verdict_flows_is_pass_stamp_true():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["005930"], verdict="validated"))
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert buys[0].evidence_snapshot["run_card"]["is_pass_stamp"] is True
+
+
+def test_run_card_present_but_symbol_not_overlapping_is_not_cited():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["XRPUSDT"]))
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    assert all("run_card" not in i.evidence_snapshot for i in items)
+
+
+def test_no_run_card_in_bundle_leaves_items_unchanged():
+    items = EvidenceAutoEmitter().propose(
+        snapshots=_buy_universe("005930"), request_market="kr", account_scope=None
+    )
+    assert items
+    assert all("run_card" not in i.evidence_snapshot for i in items)
+
+
+def test_empty_bundle_returns_no_items():
+    items = EvidenceAutoEmitter().propose(
+        snapshots=[], request_market="kr", account_scope=None
+    )
+    assert items == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_auto_emit_run_card_citation.py -v`
+Expected: the four `run_card`-citing assertions FAIL with `KeyError: 'run_card'` (the absent/empty cases already pass).
+
+- [ ] **Step 3: Add the run-card import to auto_emit.py**
+
+In `app/services/action_report/snapshot_backed/auto_emit.py`, after the existing import block (`from app.schemas.investment_reports import IngestReportItem`), add:
+
+```python
+from app.schemas.validated_run_card import (
+    build_run_card_citation,
+    build_run_card_evidence,
+)
+```
+
+- [ ] **Step 4: Capture the run-card snapshot in the propose() loop**
+
+In `EvidenceAutoEmitter.propose`, alongside the other accumulator initializers (near `news_snapshot: Any | None = None`), add:
+
+```python
+        run_card_evidence_by_symbol: dict[str, dict[str, Any]] = {}
+```
+
+Then in the `for snapshot in snapshots:` dispatch chain, after the `elif kind == "news":` block, add a new branch:
+
+```python
+            elif kind == "validated_run_card":
+                snap_uuid = _snapshot_uuid(snapshot)
+                citation = build_run_card_citation(payload)
+                if snap_uuid is not None and citation.symbols:
+                    evidence = build_run_card_evidence(
+                        snapshot_uuid=snap_uuid, citation=citation
+                    )
+                    for sym in citation.symbols:
+                        run_card_evidence_by_symbol.setdefault(sym, evidence)
+```
+
+- [ ] **Step 5: Attach via a single symbol-match post-pass before returning**
+
+Immediately before `return items` at the end of `propose`, add:
+
+```python
+        # ROB-332 — cite a bundle-resident validated_run_card on items whose
+        # symbol matches the run card's symbols (consume-when-present; no-op
+        # when no run card is in the bundle or no symbol overlaps).
+        if run_card_evidence_by_symbol:
+            for item in items:
+                if item.symbol and item.symbol in run_card_evidence_by_symbol:
+                    item.evidence_snapshot["run_card"] = run_card_evidence_by_symbol[
+                        item.symbol
+                    ]
+
+        return items
+```
+
+(Replace the existing bare `return items` with the block above.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_auto_emit_run_card_citation.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Verify the snapshot_backed import guard still passes**
+
+Run: `uv run pytest tests/ -v -k "import_guard or snapshot_backed_guard or no_inprocess_llm"`
+Expected: PASS (no in-process LLM provider introduced — the new imports are pure schema helpers). If no such test is collected by that filter, run the broader guard: `uv run pytest tests/ -k "guard" -v` and confirm green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/auto_emit.py tests/test_auto_emit_run_card_citation.py
+git commit -m "feat(rob-332): cite bundle-resident validated_run_card on symbol-matched report items
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Operator runbook + final lint/test sweep
+
+**Files:**
+- Create: `docs/runbooks/validated-run-card-ingest.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/runbooks/validated-run-card-ingest.md`:
+
+```markdown
+# Validated Run-Card Ingest (ROB-332)
+
+Ingest a `validated_run_card.v1` JSON artifact (produced by
+`research/nautilus_scalping`) as an immutable `InvestmentSnapshot`
+(`snapshot_kind="validated_run_card"`, `source_kind="manual"`). Audit-only:
+no broker/order/watch mutation, no scheduler.
+
+## Dry-run (default — no DB write)
+
+    uv run python -m scripts.ingest_validated_run_card \
+      --file path/to/run_card.json --market crypto
+
+Prints the JSON-safe citation headline (`verdict`, `framing`, `trade_count`,
+`is_pass_stamp`, `symbols`). `insufficient_data` / `not_validated` is NOT a
+pass stamp.
+
+## Commit (operator-gated)
+
+    uv run python -m scripts.ingest_validated_run_card \
+      --file path/to/run_card.json --market crypto --commit --confirm
+
+`--commit` requires `--confirm`. Prints the created (or, on re-ingest of an
+identical payload, the reused) `snapshot_uuid`. Re-ingesting the same payload
+is idempotent (dedup on canonical payload hash).
+
+## Arguments
+
+- `--file` (required): run-card JSON path. The path is never recorded as a
+  source URI; only the sanitized payload is persisted.
+- `--market` (required): `kr` | `us` | `crypto`. Binance-demo run cards use
+  `crypto` (there is no `binance_demo` account scope).
+- `--account-scope` (optional): `kis_live` | `kis_mock` | `alpaca_paper` |
+  `upbit_live`.
+- `--as-of` (optional): ISO-8601; defaults to the run card's `generated_at`.
+
+## Citation in /invest/reports
+
+Once a `validated_run_card` snapshot is a member of a report bundle, a
+report item whose symbol matches the run card's `gate_report.symbols` cites it
+under `evidence_snapshot["run_card"]` (verdict-first; bootstrap/Monte-Carlo
+stats stay nested under `validation`). Linking a run-card snapshot into a
+bundle is out of scope for this CLI (operator/Hermes/future work).
+
+## Exit codes
+
+`0` ok · `1` file not found · `2` payload/as-of parse error · `3` ingest
+failure · `4` `--commit` without `--confirm`.
+```
+
+- [ ] **Step 2: Commit the runbook**
+
+```bash
+git add docs/runbooks/validated-run-card-ingest.md
+git commit -m "docs(rob-332): runbook for validated_run_card operator ingest
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Lint + format check (report exact output in PR)**
+
+Run:
+```bash
+uv run ruff check app/ tests/ scripts/
+uv run ruff format --check scripts/ingest_validated_run_card.py tests/test_ingest_validated_run_card_cli.py tests/test_auto_emit_run_card_citation.py app/services/action_report/snapshot_backed/auto_emit.py
+```
+Expected: `All checks passed!` and format check clean. If format check reports diffs, run `uv run ruff format <those files>` and re-commit.
+
+- [ ] **Step 4: Run the full ROB-332 test surface + the pre-existing run-card tests**
+
+Run:
+```bash
+uv run pytest tests/test_ingest_validated_run_card_cli.py tests/test_auto_emit_run_card_citation.py tests/test_auto_emit_candidate_citation.py tests/test_validated_run_card_citation.py tests/test_run_card_snapshot_ingest.py -v
+```
+Expected: PASS (new files + the two ROB-329 files + the existing auto_emit citation file all green — confirms no regression in the wired path).
+
+- [ ] **Step 5: Final commit if any format fixups were needed**
+
+```bash
+git add -A
+git commit -m "chore(rob-332): ruff format fixups" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+**Spec coverage:**
+- Spec §"Component A — Operator ingest CLI" → Task 1 (parse_args, dry-run, commit, idempotency, no-source-uri, exit codes). ✓
+- Spec §"Component B — auto_emit symbol-match wiring" → Task 2 (capture branch + post-pass attach + import-guard check). ✓
+- Spec §"Testing (net-new only)" → Task 1 Steps 1/5 (CLI), Task 2 Step 1 (wiring), Task 3 Step 4 (regression sweep). Citation-builder internals NOT re-tested. ✓
+- Spec §"Known limitations" → exercised: `test_run_card_present_but_symbol_not_overlapping_is_not_cited` (symbol-format/exact-match), `--market crypto` + no scope for binance-demo (CLI tests), idempotency/orphan-run (idempotency test). ✓
+- Spec acceptance "documented local command" → Task 3 runbook. ✓
+- Spec acceptance "ruff + pytest run and reported" → Task 3 Steps 3–4. ✓
+
+**Deviation from spec (intentional):** The spec described detecting created-vs-reused via `snapshot.run_id` comparison, but `RunCardSnapshotIngestor.ingest` does not return its run. To avoid changing the ROB-329 API, the CLI prints the `snapshot_uuid` (correctly the reused row on re-ingest) and idempotency is proven by `test_run_ingest_is_idempotent_reuses_snapshot` (two commits → same uuid). No explicit reused-label is emitted. This satisfies the acceptance criterion ("print the created or reused snapshot_uuid").
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `run_ingest(db, raw_payload, market, account_scope, as_of, commit, confirm) -> (int, dict)` used identically across Task 1 tests and implementation. `build_run_card_evidence(*, snapshot_uuid, citation)` keyword-only call matches the real signature. `_snapshot_uuid` reused from auto_emit. `evidence_snapshot["run_card"]` key consistent between Task 2 implementation and tests. ✓

--- a/docs/superpowers/specs/2026-05-27-rob-332-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-332-design.md
@@ -1,0 +1,120 @@
+# ROB-332 — validated_run_card operator ingest + report-item citation wiring
+
+**Date:** 2026-05-27
+**Issue:** ROB-332 (follow-up to ROB-329 / PR #979)
+**Scope:** one focused PR, audit-only, non-trading
+
+## Context
+
+PR #979 (ROB-329) landed the backend contract for `validated_run_card.v1`:
+
+- `app/schemas/validated_run_card.py` — `sanitize_non_finite`, `build_run_card_citation`, `RunCardCitation`, `build_run_card_evidence`.
+- `app/services/investment_snapshots/run_card_ingest.py` — `RunCardSnapshotIngestor`.
+- `snapshot_kind="validated_run_card"` + alembic CHECK extension `20260527_rob329_extend_snapshot_kind_run_card.py`.
+- `InvestmentReportItem.evidence_snapshot` JSONB column (`app/models/investment_reports.py:321`).
+
+Verified gaps this follow-up closes:
+
+- `RunCardSnapshotIngestor` has **no caller** outside its class definition — no operator entry point.
+- `build_run_card_evidence` is referenced **only in tests** — it is not wired into any report-item writer.
+
+## Goal
+
+Turn the ROB-329 contract into (A) an operator-usable ingest path and (B) report-item evidence that cites a `validated_run_card` snapshot when one is present in the bundle. Keep scope audit-only: no broker/order/watch/order-intent mutation, no scheduler, no `/invest/screener` change, no production deploy/backfill.
+
+## Locked design decisions
+
+1. **Bundle delivery — consume-when-present only.** The wiring activates only when a `validated_run_card` snapshot is already a member of the report bundle. This PR does **not** add the path that links a run-card snapshot into a bundle (ensure-path auto-pull or operator link). This is a contract-completing PR: in production it does not fire until an external actor (operator / Hermes / a future issue) links the snapshot. Tests inject bundles whose members include the run-card snapshot.
+
+2. **Attachment model — symbol-match.** When a run-card snapshot is present, its citation is attached to the `evidence_snapshot` of any already-emitted report item whose `symbol` is in `citation.symbols`. No matching item → nothing attached (run-card present but uncited is a valid, tested state). Reuses existing items only; does not invent a new item kind.
+
+## Component A — Operator ingest CLI
+
+**File:** `scripts/ingest_validated_run_card.py` (mirrors `scripts/ingest_research_reports.py`).
+
+```
+uv run python -m scripts.ingest_validated_run_card \
+  --file path/to/run_card.json --market crypto [--account-scope ...] [--as-of ISO8601] \
+  [--commit --confirm]
+```
+
+- **Args:** `--file` (required), `--market` (required: `kr|us|crypto`), `--account-scope` (optional: `kis_live|kis_mock|alpaca_paper|upbit_live`), `--as-of` (optional ISO-8601; defaults to run-card `generated_at` → now via the ingestor).
+- **Dry-run (default):** run `build_run_card_citation` + `sanitize_non_finite`, print a strict-JSON headline summary (`verdict`, `framing`, `trade_count`, `is_pass_stamp`, `symbols`, `recognized`) with `dry_run: true`. No DB write.
+- **`--commit --confirm`:** call `RunCardSnapshotIngestor.ingest(...)` inside `AsyncSessionLocal`, commit, print `snapshot_uuid` + headline. **No new env flag** — the target table is append-only audit evidence with zero broker mutation, so `--commit --confirm` operator double-confirmation is the gate. (Deviates from `ingest_research_reports`' extra env gate by intent.)
+- **created vs reused:** the ingestor always inserts a new run, then `insert_snapshot` dedups on `(canonical_payload_hash, snapshot_kind, market, account_scope)`. Detect reuse by comparing the returned `snapshot.run_id` against the run just created (`==` → created, `!=` → reused) and report it in the output.
+- **No local path as source URI:** the ingestor sets `source_kind="manual"` and never records the file path; the CLI passes no `source_uri`. Gitignored `research/nautilus_scalping/results/...` paths are never cited as durable evidence.
+- **Exit codes:** `0` ok / `1` file-not-found / `2` payload validation / `3` ingest failure / `4` commit-gate (`--commit` without `--confirm`).
+
+## Component B — auto_emit symbol-match wiring
+
+**File:** `app/services/action_report/snapshot_backed/auto_emit.py`
+
+- In `EvidenceAutoEmitter.propose()` snapshot loop, add `elif kind == "validated_run_card":` — build the citation via `build_run_card_citation(payload)`, then index a per-symbol evidence map: for each `sym` in `citation.symbols`, store `build_run_card_evidence(snapshot_uuid=..., citation=...)`.
+- When emitting each item (buy / sell / watch / held-trend), if the item's `symbol` is in that map, attach the run-card evidence **nested** under a dedicated key (`evidence_snapshot["run_card"] = <evidence>`), preserving the existing `_make_evidence` keys.
+- The nested entry keeps `verdict` / `framing` / `trade_count` / `is_pass_stamp` as the headline; bootstrap CI and Monte-Carlo stay nested under `validation` (never standalone edge metrics) — `build_run_card_evidence` already enforces this shape.
+- No matching item → no attachment. Run-card present but uncited is valid.
+- **Import-guard safe:** `build_run_card_evidence` / `build_run_card_citation` are pure schema helpers; no in-process LLM provider is introduced (PR #898 static guard over `snapshot_backed/` stays green).
+
+## Data flow
+
+```
+run_card.json ──CLI──▶ RunCardSnapshotIngestor ──▶ InvestmentSnapshot(kind=validated_run_card, source=manual)
+                                                          │ (global, reusable evidence)
+        [external / operator / future issue links via link_bundle_item — OUT OF SCOPE here]
+                                                          ▼
+report generation ──▶ generator.propose(snapshots = bundle members) ──▶ EvidenceAutoEmitter
+        ──▶ on validated_run_card member: symbol-match → item.evidence_snapshot["run_card"]
+```
+
+## Error handling / safety boundaries
+
+- Non-finite floats (`inf`/`-inf`/`nan`) → `null` before DB/API exposure (ingestor + citation builder already sanitize).
+- Unknown / missing `schema_version` → `recognized=False`, citation does not raise.
+- `insufficient_data` / `not_validated` → `is_pass_stamp=false`; cannot read as a buy/recommendation signal.
+- Bootstrap / Monte-Carlo numbers stay nested under `validation`; never surfaced as standalone edge metrics.
+- No broker/order/watch/order-intent mutation. No scheduler / Prefect / TaskIQ registration. No `/invest/screener` scoring change. No frontend chip/UI change (API/report JSON visibility is sufficient).
+- No production DB migration/backfill/deploy in this issue; the `validated_run_card` CHECK migration already shipped in PR #979 and remains operator-gated.
+
+## Testing (net-new only — do not re-test the citation builder)
+
+ROB-329 already covers sanitize / MC three-state / null `strategy_hash` + empty `artifacts` / `insufficient_data` non-pass-stamp / headline-first evidence (`tests/test_validated_run_card_citation.py`) and ingest + bundle-read visibility (`tests/test_run_card_snapshot_ingest.py`). Net-new tests:
+
+**CLI** (`tests/` new file):
+- dry-run prints a strict-JSON headline with `dry_run: true`, no DB write.
+- `--commit --confirm` returns a strict-JSON-safe `snapshot_uuid`; payload persisted is sanitized.
+- re-running the same payload reports `reused` (run_id mismatch path).
+- the local file path is never recorded as a `source_uri`.
+- `--commit` without `--confirm` exits with the commit-gate code.
+
+**Wiring** (`tests/` new file or extend):
+- bundle contains a run-card member + an emitted item whose symbol overlaps `citation.symbols` → that item's `evidence_snapshot["run_card"]` is attached and is JSON-safe.
+- run-card present but no symbol overlap → no attachment (degrade safely).
+- no run-card in bundle → items unchanged.
+- missing bundle → `propose`/generator returns `[]`.
+
+A single `validated` verdict fixture may be added under `tests/fixtures/validated_run_card/` (only `run_card_insufficient_data.json` exists today) to exercise the pass-stamp-true path end to end.
+
+## Known limitations (explicit)
+
+- **Symbol-format mismatch.** Run-card symbols (e.g. `XRPUSDT`) may not equal report-item symbols (e.g. Upbit DB format). Matching is exact-string; cross-venue normalization is out of scope. Tests inject matching symbols. Consistent with consume-when-present (low production fire rate).
+- **No `binance_demo` account scope.** `SnapshotAccountScope` is `kis_live|kis_mock|alpaca_paper|upbit_live`. Binance-demo run cards are ingested with `--market crypto` and no `--account-scope`.
+- **Orphan run on dedup.** The ingestor always creates a run before `insert_snapshot`; if the snapshot dedups to an existing row, the freshly created run is left with no snapshot pointing to it. Harmless (append-only); surfaced as `reused` in CLI output.
+
+## Out of scope / non-goals
+
+- Linking a run-card snapshot into a report bundle (ensure-path or operator link).
+- Broker / order / watch / order-intent mutation.
+- Scheduler / Prefect / TaskIQ recurring registration or activation.
+- `/invest/screener` scoring change.
+- Frontend chip / UI work (unless needed only to keep existing tests compiling).
+- Production DB migration / backfill / deploy.
+- Cross-venue symbol normalization.
+- Turning `validated` / bootstrap / MC metrics into buy/sell recommendation strength.
+
+## Acceptance criteria (from issue)
+
+- Operator can run a documented local command against a run-card JSON fixture and obtain a strict-JSON-safe `validated_run_card` snapshot UUID.
+- A snapshot-backed report containing a validated run-card snapshot surfaces item-level evidence via `InvestmentReportItem.evidence_snapshot`.
+- Citation headline is verdict-first / audit-first; `insufficient_data` is not a pass stamp.
+- Focused unit/integration tests pass.
+- `ruff check`, `ruff format --check`, and the relevant pytest files are run and reported in the PR.

--- a/scripts/ingest_validated_run_card.py
+++ b/scripts/ingest_validated_run_card.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Ingest a validated_run_card.v1 JSON artifact as an InvestmentSnapshot (ROB-332).
+
+Usage:
+    uv run python -m scripts.ingest_validated_run_card --file run_card.json --market crypto
+    uv run python -m scripts.ingest_validated_run_card --file run_card.json --market crypto --commit --confirm
+
+Defaults to dry-run (prints the JSON-safe citation headline, no DB write). Commit
+mode also requires --confirm. The snapshot is append-only audit evidence with no
+broker mutation, so --commit --confirm is the only operator gate (no env flag).
+
+Boundary (ROB-332): reuses RunCardSnapshotIngestor from PR #979. The local
+run-card file path is never recorded as a source_uri (the ingestor sets
+source_kind="manual"). No broker/order/watch mutation, no scheduler.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from app.core.cli import setup_logging_and_sentry
+from app.core.db import AsyncSessionLocal
+from app.monitoring.sentry import capture_exception
+from app.schemas.validated_run_card import RunCardCitation, build_run_card_citation
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_snapshots.run_card_ingest import RunCardSnapshotIngestor
+
+logger = logging.getLogger(__name__)
+
+_MARKETS = ("kr", "us", "crypto")
+_ACCOUNT_SCOPES = ("kis_live", "kis_mock", "alpaca_paper", "upbit_live")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Ingest a validated_run_card.v1 JSON artifact (ROB-332)."
+    )
+    parser.add_argument("--file", required=True, type=Path, help="Run-card JSON path.")
+    parser.add_argument("--market", required=True, choices=_MARKETS)
+    parser.add_argument("--account-scope", choices=_ACCOUNT_SCOPES, default=None)
+    parser.add_argument(
+        "--as-of", default=None, help="ISO-8601 as_of; defaults to run-card generated_at."
+    )
+    parser.add_argument(
+        "--commit", action="store_true", help="Persist; default is dry-run only."
+    )
+    parser.add_argument(
+        "--confirm", action="store_true", help="Required with --commit."
+    )
+    return parser.parse_args(argv)
+
+
+def _headline(citation: RunCardCitation) -> dict[str, Any]:
+    return {
+        "recognized": citation.recognized,
+        "verdict": citation.verdict,
+        "framing": citation.framing,
+        "trade_count": citation.trade_count,
+        "is_pass_stamp": citation.is_pass_stamp,
+        "symbols": citation.symbols,
+    }
+
+
+def _parse_as_of(raw: str | None) -> dt.datetime | None:
+    if raw is None:
+        return None
+    parsed = dt.datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+async def run_ingest(
+    *,
+    db: Any,
+    raw_payload: dict[str, Any],
+    market: str,
+    account_scope: str | None,
+    as_of: dt.datetime | None,
+    commit: bool,
+    confirm: bool,
+) -> tuple[int, dict[str, Any]]:
+    """Core ingest. Returns (exit_code, summary). Does not commit the session;
+
+    the caller (main_async) commits on success so tests can introspect + roll back.
+    """
+    citation = build_run_card_citation(raw_payload)
+
+    if not commit:
+        return 0, {"dry_run": True, **_headline(citation)}
+
+    if not confirm:
+        return 4, {"error": "commit mode requires --confirm"}
+
+    ingestor = RunCardSnapshotIngestor(InvestmentSnapshotsRepository(db))
+    snapshot, citation = await ingestor.ingest(
+        run_card_payload=raw_payload,
+        market=market,  # type: ignore[arg-type]
+        account_scope=account_scope,  # type: ignore[arg-type]
+        as_of=as_of,
+    )
+    return 0, {
+        "dry_run": False,
+        "snapshot_uuid": str(snapshot.snapshot_uuid),
+        **_headline(citation),
+    }
+
+
+async def main_async(argv: list[str] | None = None) -> int:
+    setup_logging_and_sentry(service_name="ingest-validated-run-card")
+    ns = parse_args(argv)
+
+    if not ns.file.is_file():
+        logger.error("file not found: %s", ns.file)
+        return 1
+
+    try:
+        raw_payload = json.loads(ns.file.read_text(encoding="utf-8"))
+        as_of = _parse_as_of(ns.as_of)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.error("payload/as-of parse failed: %s", exc)
+        capture_exception(exc, process="ingest_validated_run_card")
+        return 2
+
+    if not ns.commit:
+        _code, summary = await run_ingest(
+            db=None,
+            raw_payload=raw_payload,
+            market=ns.market,
+            account_scope=ns.account_scope,
+            as_of=as_of,
+            commit=False,
+            confirm=False,
+        )
+        print(json.dumps(summary, allow_nan=False, ensure_ascii=False))
+        return 0
+
+    async with AsyncSessionLocal() as db:
+        try:
+            code, summary = await run_ingest(
+                db=db,
+                raw_payload=raw_payload,
+                market=ns.market,
+                account_scope=ns.account_scope,
+                as_of=as_of,
+                commit=True,
+                confirm=ns.confirm,
+            )
+            if code == 0:
+                await db.commit()
+            else:
+                await db.rollback()
+        except Exception as exc:
+            await db.rollback()
+            logger.error("ingest failed: %s", exc, exc_info=True)
+            capture_exception(exc, process="ingest_validated_run_card")
+            return 3
+
+    print(json.dumps(summary, allow_nan=False, ensure_ascii=False))
+    return code
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(main_async()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_validated_run_card.py
+++ b/scripts/ingest_validated_run_card.py
@@ -12,6 +12,12 @@ broker mutation, so --commit --confirm is the only operator gate (no env flag).
 Boundary (ROB-332): reuses RunCardSnapshotIngestor from PR #979. The local
 run-card file path is never recorded as a source_uri (the ingestor sets
 source_kind="manual"). No broker/order/watch mutation, no scheduler.
+
+Import boundary: only the pure ``validated_run_card`` schema helper is imported
+at module top. Settings-loading modules (``app.core.cli``/``app.core.db``/
+``app.monitoring.sentry``) and the DB repository/ingestor are imported lazily
+inside the commit path, so ``--help``, dry-run, and file-parse work in a clean
+env without KIS/Upbit/DATABASE_URL/SECRET_KEY (no Settings validation).
 """
 
 from __future__ import annotations
@@ -24,12 +30,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from app.core.cli import setup_logging_and_sentry
-from app.core.db import AsyncSessionLocal
-from app.monitoring.sentry import capture_exception
 from app.schemas.validated_run_card import RunCardCitation, build_run_card_citation
-from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
-from app.services.investment_snapshots.run_card_ingest import RunCardSnapshotIngestor
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,14 @@ async def run_ingest(
     if not confirm:
         return 4, {"error": "commit mode requires --confirm"}
 
+    # Lazy: these pull in app.core.db (Settings). Only the commit path needs them.
+    from app.services.investment_snapshots.repository import (
+        InvestmentSnapshotsRepository,
+    )
+    from app.services.investment_snapshots.run_card_ingest import (
+        RunCardSnapshotIngestor,
+    )
+
     ingestor = RunCardSnapshotIngestor(InvestmentSnapshotsRepository(db))
     snapshot, citation = await ingestor.ingest(
         run_card_payload=raw_payload,
@@ -115,7 +124,9 @@ async def run_ingest(
 
 
 async def main_async(argv: list[str] | None = None) -> int:
-    setup_logging_and_sentry(service_name="ingest-validated-run-card")
+    # Parse + file read + dry-run happen BEFORE any settings-loading import so
+    # --help / dry-run / file-parse work without DB/broker secrets. Logging is
+    # left at the stdlib default for these paths (no Sentry init needed locally).
     ns = parse_args(argv)
 
     if not ns.file.is_file():
@@ -127,7 +138,6 @@ async def main_async(argv: list[str] | None = None) -> int:
         as_of = _parse_as_of(ns.as_of)
     except (json.JSONDecodeError, ValueError) as exc:
         logger.error("payload/as-of parse failed: %s", exc)
-        capture_exception(exc, process="ingest_validated_run_card")
         return 2
 
     if not ns.commit:
@@ -142,6 +152,13 @@ async def main_async(argv: list[str] | None = None) -> int:
         )
         print(json.dumps(summary, allow_nan=False, ensure_ascii=False))
         return 0
+
+    # Commit path only — now it is safe to load Settings-backed modules.
+    from app.core.cli import setup_logging_and_sentry
+    from app.core.db import AsyncSessionLocal
+    from app.monitoring.sentry import capture_exception
+
+    setup_logging_and_sentry(service_name="ingest-validated-run-card")
 
     async with AsyncSessionLocal() as db:
         try:

--- a/scripts/ingest_validated_run_card.py
+++ b/scripts/ingest_validated_run_card.py
@@ -45,7 +45,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--market", required=True, choices=_MARKETS)
     parser.add_argument("--account-scope", choices=_ACCOUNT_SCOPES, default=None)
     parser.add_argument(
-        "--as-of", default=None, help="ISO-8601 as_of; defaults to run-card generated_at."
+        "--as-of",
+        default=None,
+        help="ISO-8601 as_of; defaults to run-card generated_at.",
     )
     parser.add_argument(
         "--commit", action="store_true", help="Persist; default is dry-run only."

--- a/tests/test_auto_emit_run_card_citation.py
+++ b/tests/test_auto_emit_run_card_citation.py
@@ -43,7 +43,12 @@ def _buy_universe(symbol):
             {
                 "usefulness": "useful",
                 "candidates": [
-                    {"symbol": symbol, "score": 8.0, "reasons": ["momentum"], "source": "kis"}
+                    {
+                        "symbol": symbol,
+                        "score": 8.0,
+                        "reasons": ["momentum"],
+                        "source": "kis",
+                    }
                 ],
             },
         ),

--- a/tests/test_auto_emit_run_card_citation.py
+++ b/tests/test_auto_emit_run_card_citation.py
@@ -1,0 +1,106 @@
+"""ROB-332 — auto_emit cites a validated_run_card snapshot when symbols match."""
+
+import json
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+class _Snap:
+    def __init__(self, kind, payload, symbol=None, uuid="rc-uuid-0001"):
+        self.snapshot_kind = kind
+        self.payload_json = payload
+        self.symbol = symbol
+        self.snapshot_uuid = uuid
+
+
+_OK_QUOTE = {
+    "status": "ok",
+    "best_bid": 100,
+    "best_ask": 101,
+    "bid_depth": 5,
+    "ask_depth": 5,
+    "spread_bps": 10,
+}
+
+
+def _run_card(symbols, verdict="not_validated"):
+    return {
+        "schema_version": "validated_run_card.v1",
+        "verdict": verdict,
+        "framing": "audit evidence, not a pass stamp",
+        "net_after_cost": {"trades": 12, "profit_factor": float("inf")},
+        "validation": {"bootstrap": {"ci_lower": 0.1}, "monte_carlo": {"p_value": 0.4}},
+        "gate_report": {"symbols": symbols, "trade_count": 12},
+    }
+
+
+def _buy_universe(symbol):
+    return [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": symbol, "quote": _OK_QUOTE}, symbol=symbol),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [
+                    {"symbol": symbol, "score": 8.0, "reasons": ["momentum"], "source": "kis"}
+                ],
+            },
+        ),
+    ]
+
+
+def test_buy_item_for_matching_symbol_cites_run_card():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["005930"]), symbol="005930")
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert buys, "expected a buy candidate"
+    rc = buys[0].evidence_snapshot["run_card"]
+    assert rc["verdict"] == "not_validated"
+    assert rc["is_pass_stamp"] is False
+    assert rc["trade_count"] == 12
+    assert rc["snapshot_uuid"] == "rc-uuid-0001"
+    # Non-finite sanitized; bootstrap/MC nested under validation, not standalone.
+    assert rc["net_after_cost"]["profit_factor"] is None
+    assert "bootstrap" in rc["validation"]
+    json.dumps(buys[0].evidence_snapshot, allow_nan=False)
+
+
+def test_validated_verdict_flows_is_pass_stamp_true():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["005930"], verdict="validated"))
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert buys[0].evidence_snapshot["run_card"]["is_pass_stamp"] is True
+
+
+def test_run_card_present_but_symbol_not_overlapping_is_not_cited():
+    snaps = _buy_universe("005930") + [
+        _Snap("validated_run_card", _run_card(["XRPUSDT"]))
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    assert all("run_card" not in i.evidence_snapshot for i in items)
+
+
+def test_no_run_card_in_bundle_leaves_items_unchanged():
+    items = EvidenceAutoEmitter().propose(
+        snapshots=_buy_universe("005930"), request_market="kr", account_scope=None
+    )
+    assert items
+    assert all("run_card" not in i.evidence_snapshot for i in items)
+
+
+def test_empty_bundle_returns_no_items():
+    items = EvidenceAutoEmitter().propose(
+        snapshots=[], request_market="kr", account_scope=None
+    )
+    assert items == []

--- a/tests/test_ingest_validated_run_card_cli.py
+++ b/tests/test_ingest_validated_run_card_cli.py
@@ -101,12 +101,22 @@ async def test_run_ingest_commit_persists_sanitized_snapshot(db_session):
 async def test_run_ingest_is_idempotent_reuses_snapshot(db_session):
     payload = _load()
     _c1, s1 = await cli.run_ingest(
-        db=db_session, raw_payload=payload, market="crypto",
-        account_scope=None, as_of=None, commit=True, confirm=True,
+        db=db_session,
+        raw_payload=payload,
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=True,
     )
     _c2, s2 = await cli.run_ingest(
-        db=db_session, raw_payload=payload, market="crypto",
-        account_scope=None, as_of=None, commit=True, confirm=True,
+        db=db_session,
+        raw_payload=payload,
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=True,
     )
     # Same canonical payload dedups to the same snapshot row.
     assert s1["snapshot_uuid"] == s2["snapshot_uuid"]
@@ -125,4 +135,3 @@ async def test_run_ingest_commit_without_confirm_is_gated(db_session):
     )
     assert code == 4
     assert "snapshot_uuid" not in summary
-

--- a/tests/test_ingest_validated_run_card_cli.py
+++ b/tests/test_ingest_validated_run_card_cli.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from scripts import ingest_validated_run_card as cli
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE = (
     Path(__file__).parent
     / "fixtures"
@@ -20,6 +24,17 @@ _FIXTURE = (
 def _load() -> dict:
     with _FIXTURE.open() as fh:
         return json.load(fh)  # default json.loads accepts bare Infinity tokens
+
+
+def _settings_free_env() -> dict[str, str]:
+    """Env that cannot satisfy pydantic Settings: only neutral keys kept, no
+    KIS/Upbit/DATABASE_URL/SECRET_KEY. Combined with running from a cwd that has
+    no ``.env`` file, Settings would have no source — so the CLI must NOT load
+    Settings for the --help / dry-run / file-parse paths."""
+    keep = {"PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "SystemRoot"}
+    env = {k: v for k, v in os.environ.items() if k in keep}
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    return env
 
 
 def test_parse_args_requires_file_and_market():
@@ -135,3 +150,45 @@ async def test_run_ingest_commit_without_confirm_is_gated(db_session):
     )
     assert code == 4
     assert "snapshot_uuid" not in summary
+
+
+# --- Settings-free entry paths (ROB-332 follow-up) -------------------------
+# --help / dry-run / file-parse must work with no DB/broker secrets. Run from
+# tmp_path (no .env) with a settings-free env so Settings has no source; the
+# CLI must reach these paths without ever instantiating Settings.
+
+
+def test_help_runs_without_settings_secrets(tmp_path):
+    proc = subprocess.run(
+        [sys.executable, "-m", "scripts.ingest_validated_run_card", "--help"],
+        cwd=tmp_path,
+        env=_settings_free_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "usage" in proc.stdout.lower()
+    assert "ValidationError" not in proc.stderr
+
+
+def test_dry_run_runs_without_settings_secrets(tmp_path):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.ingest_validated_run_card",
+            "--file",
+            str(_FIXTURE),
+            "--market",
+            "crypto",
+        ],
+        cwd=tmp_path,
+        env=_settings_free_env(),
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ValidationError" not in proc.stderr
+    summary = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert summary["dry_run"] is True
+    assert summary["verdict"] == "insufficient_data"

--- a/tests/test_ingest_validated_run_card_cli.py
+++ b/tests/test_ingest_validated_run_card_cli.py
@@ -1,0 +1,128 @@
+"""ROB-332 — operator CLI for validated_run_card ingest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import ingest_validated_run_card as cli
+
+_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "validated_run_card"
+    / "run_card_insufficient_data.json"
+)
+
+
+def _load() -> dict:
+    with _FIXTURE.open() as fh:
+        return json.load(fh)  # default json.loads accepts bare Infinity tokens
+
+
+def test_parse_args_requires_file_and_market():
+    ns = cli.parse_args(["--file", "x.json", "--market", "crypto"])
+    assert ns.file == Path("x.json")
+    assert ns.market == "crypto"
+    assert ns.account_scope is None
+    assert ns.commit is False
+    assert ns.confirm is False
+
+
+def test_parse_args_rejects_unknown_market():
+    with pytest.raises(SystemExit):
+        cli.parse_args(["--file", "x.json", "--market", "forex"])
+
+
+def test_parse_args_rejects_unknown_account_scope():
+    with pytest.raises(SystemExit):
+        cli.parse_args(
+            ["--file", "x.json", "--market", "us", "--account-scope", "binance_demo"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_dry_run_returns_headline_no_db(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=False,
+        confirm=False,
+    )
+    assert code == 0
+    assert summary["dry_run"] is True
+    assert summary["verdict"] == "insufficient_data"
+    assert summary["is_pass_stamp"] is False
+    assert summary["trade_count"] == 2
+    assert summary["symbols"] == ["XRPUSDT"]
+    assert "snapshot_uuid" not in summary
+    # strict-JSON safe (no Infinity/NaN leaks into output)
+    json.dumps(summary, allow_nan=False)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_commit_persists_sanitized_snapshot(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=True,
+    )
+    assert code == 0
+    assert summary["dry_run"] is False
+    uuid_str = summary["snapshot_uuid"]
+    assert uuid_str
+
+    import uuid as _uuid
+
+    from app.services.investment_snapshots.repository import (
+        InvestmentSnapshotsRepository,
+    )
+
+    repo = InvestmentSnapshotsRepository(db_session)
+    snap = await repo.get_snapshot_by_uuid(_uuid.UUID(uuid_str))
+    assert snap is not None
+    assert snap.snapshot_kind == "validated_run_card"
+    assert snap.source_kind == "manual"  # never the local file path
+    # Non-finite metric sanitized to null -> strict-JSON safe payload.
+    assert snap.payload_json["net_after_cost"]["profit_factor"] is None
+    json.dumps(snap.payload_json, allow_nan=False)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_is_idempotent_reuses_snapshot(db_session):
+    payload = _load()
+    _c1, s1 = await cli.run_ingest(
+        db=db_session, raw_payload=payload, market="crypto",
+        account_scope=None, as_of=None, commit=True, confirm=True,
+    )
+    _c2, s2 = await cli.run_ingest(
+        db=db_session, raw_payload=payload, market="crypto",
+        account_scope=None, as_of=None, commit=True, confirm=True,
+    )
+    # Same canonical payload dedups to the same snapshot row.
+    assert s1["snapshot_uuid"] == s2["snapshot_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_commit_without_confirm_is_gated(db_session):
+    code, summary = await cli.run_ingest(
+        db=db_session,
+        raw_payload=_load(),
+        market="crypto",
+        account_scope=None,
+        as_of=None,
+        commit=True,
+        confirm=False,
+    )
+    assert code == 4
+    assert "snapshot_uuid" not in summary
+


### PR DESCRIPTION
## Summary

Follow-up to ROB-329 (PR #979). Turns the `validated_run_card.v1` backend contract into an operator-usable ingest path and report-item citation wiring. **Audit-only**: no broker/order/watch/order-intent mutation, no scheduler, no `/invest/screener` change, no production migration.

Two seams over the existing ROB-329 contract (`RunCardSnapshotIngestor`, `build_run_card_citation`, `build_run_card_evidence` were unwired — the ingestor had zero callers and the evidence helper was test-only):

**A. Operator ingest CLI** — `scripts/ingest_validated_run_card.py` (mirrors `scripts/ingest_research_reports.py`)
- `uv run python -m scripts.ingest_validated_run_card --file run_card.json --market crypto [--account-scope ...] [--as-of ...] [--commit --confirm]`
- Dry-run by default (prints JSON-safe citation headline); `--commit --confirm` persists via `RunCardSnapshotIngestor`. No new env flag — append-only audit evidence, `--commit --confirm` is the gate.
- Local file path is never recorded as a `source_uri` (`source_kind="manual"`). Idempotent: re-ingesting the same payload dedups to the same `snapshot_uuid`.

**B. auto_emit symbol-match citation** — `app/services/action_report/snapshot_backed/auto_emit.py` (+24 lines)
- `EvidenceAutoEmitter.propose()` gains a `validated_run_card` capture branch + a single symbol-match post-pass that attaches `evidence_snapshot["run_card"]` to emitted items whose symbol ∈ `citation.symbols`.
- **Consume-when-present**: fires only when a run-card snapshot is already a bundle member; this PR does NOT link run-cards into bundles (operator/Hermes/future work). No overlap → not attached (safe degrade).
- Headline-first (`verdict`/`framing`/`trade_count`/`is_pass_stamp`); bootstrap/Monte-Carlo stay nested under `validation`, never standalone edge metrics. `insufficient_data` is not a pass stamp.

## Design / Plan
- Spec: `docs/superpowers/specs/2026-05-27-rob-332-design.md`
- Plan: `docs/superpowers/plans/2026-05-27-rob-332-run-card-ingest-citation.md`

## Test Coverage
New tests (net-new only — ROB-329 already covers the citation builder internals):
- `tests/test_ingest_validated_run_card_cli.py` (7): arg parsing (market/account-scope choices), dry-run headline, commit persists sanitized snapshot, idempotent re-ingest, commit-gate without `--confirm`, no source-uri leak.
- `tests/test_auto_emit_run_card_citation.py` (5): symbol-match attach, `validated` verdict → `is_pass_stamp=true`, present-but-no-overlap (not cited), no run-card (unchanged), empty bundle (`[]`).

Blast-radius run: **198 passed** (`tests/services/action_report/snapshot_backed/`, `investment_snapshots`, run-card citation/ingest, evidence service).

## Pre-Landing Review
- `ruff check` clean on ROB-332 files (3 pre-existing errors live in unrelated `scripts/debug_economic_calendar.py` + `scripts/test_discord_webhook_e2e.py`, untouched by this branch).
- `ruff format --check` clean. Import guards: **84 passed** — only pure schema helpers added, no in-process LLM provider (PR #898 `snapshot_backed/` guard stays green).

## Migration / Deploy Cautions
- **No new migration.** The `validated_run_card` `snapshot_kind` CHECK extension shipped in PR #979 (`20260527_rob329_extend_snapshot_kind_run_card.py`); applying it to prod remains operator-gated. The CLI's `--commit` requires that migration at DB head.
- No scheduler/Prefect/TaskIQ registration. No backfill.

## Known limitations (documented in spec)
- Symbol matching is exact-string; run-card symbols (e.g. `XRPUSDT`) vs report-item symbols may not align across venues. Cross-venue normalization is out of scope.
- `SnapshotAccountScope` has no `binance_demo` — demo run-cards ingest as `--market crypto` with no account scope.

Head SHA: `b72e0ab45085cd2688b25f6016cb1ae8dfc2e1f1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced a new CLI tool for ingesting validated run card JSON artifacts with audit-only dry-run mode and operator-gated commit mode for operational safety
* Report items are now enriched with automatic run card evidence citations based on symbol matching

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/982?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->