### PR TITLE
feat(rob-324): maker/limit-fill scalping edge re-evaluation (research-only)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-rob324-maker-limit-fill.md
+++ b/docs/superpowers/plans/2026-05-26-rob324-maker-limit-fill.md
@@ -1,0 +1,1200 @@
+# ROB-324 Maker/Limit-Fill Edge Re-evaluation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-evaluate whether a conservative maker/limit-fill execution model recovers a net-after-cost edge for the `meanrev_zscore_fade` candidate (XRPUSDT + BTCUSDT) that the taker model couldn't — producing an honest `validated`/`not_validated`/`insufficient_data` verdict and an auditable artifact.
+
+**Architecture:** Real tick-level limit-fill re-simulation in NautilusTrader (limit entry filled against trade ticks, 1-bar cancel = missed fill, maker-limit TP, taker-stop SL) plus a pure deterministic conservative overlay (queue-loss drop + adverse-selection cost). Three scenarios — realistic taker (4 bps), data-derived maker, conservative maker — are fed to the **unchanged** `validated_gate.evaluate_gate`. Research/backtest only; no broker, order, scheduler, prod, or runtime side effects.
+
+**Tech Stack:** Python 3.13, NautilusTrader 1.227.0 (rob-320 research venv), pytest 9 (main `uv` env for pure tests), Binance public trade-tick parquet catalog (read-only, from the rob-320 worktree).
+
+**Design spec:** `docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md`
+
+---
+
+## Conventions used throughout
+
+- **Repo root (this worktree):** `/Users/mgh3326/work/auto_trader.rob-324`
+- **Research dir:** `<repo>/research/nautilus_scalping` — most commands `cd` here.
+- **Nautilus venv (runs backtests):** `/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/.venv/bin/python` — referenced below as `$NVENV`. Set once per shell:
+  ```bash
+  export NVENV=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/.venv/bin/python
+  export CATALOG=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/catalog
+  ```
+- **Pure tests** (no nautilus) run from repo root with `uv run pytest research/nautilus_scalping/tests/<file> -v`.
+- **Result artifacts** live under `results/` which is gitignored — curated artifacts are force-added (`git add -f`), exactly as `results/rob320/meanrev.json` was.
+- **Commit co-author line:** `Co-Authored-By: Paperclip <noreply@paperclip.ing>` (project convention).
+
+## File structure
+
+| File | Create/Modify | Responsibility |
+|------|---------------|----------------|
+| `research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json` | Create (copy) | Fee provenance input (force-added). |
+| `research/nautilus_scalping/maker_fill.py` | Create | **Pure** scenario builders + conservative overlay. No nautilus import. |
+| `research/nautilus_scalping/tests/test_maker_fill.py` | Create | Pure tests: missed-fill, queue-loss, adverse cost, determinism, verdict vocab. |
+| `research/nautilus_scalping/strategy_meanrev.py` | Modify | Add `execution_mode="maker"` branch (limit entry, timeout, maker TP, taker SL, records). Default `"taker"` unchanged. |
+| `research/nautilus_scalping/backtest_runner.py` | Modify | Maker mode: real-fee instrument override + richer records + counters. |
+| `research/nautilus_scalping/validate_maker_fill.py` | Create | Driver: 3 scenarios → `evaluate_gate` → write v2 artifact. |
+| `research/nautilus_scalping/results/rob324/maker_fill.json` | Create (generated) | The auditable result (force-added). |
+
+---
+
+## Task 1: Branch setup + catalog wiring smoke
+
+**Files:**
+- Create: `research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json` (copied)
+
+- [ ] **Step 1: Copy the commission artifact into this branch**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+mkdir -p results/rob324
+cp /Users/mgh3326/work/auto_trader/research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json results/rob324/
+```
+
+- [ ] **Step 2: Verify the venv + catalog are reachable and the existing taker pipeline still runs**
+
+This reproduces a small slice of ROB-320 to prove `$NVENV` + `$CATALOG` work from this worktree before building anything.
+
+```bash
+export NVENV=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/.venv/bin/python
+export CATALOG=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/catalog
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+PYTHONPATH=../.. $NVENV -c "
+from pathlib import Path
+from backtest_runner import run
+trades = run(Path('$CATALOG'), 'XRPUSDT', 'meanrev_zscore_fade',
+             {'lookback':20,'z_entry':'2.0','tp_bps':30,'sl_bps':30}, '100')
+print('XRPUSDT taker trades:', len(trades))
+assert len(trades) > 50, 'expected a few hundred trades'
+print('OK: catalog + venv wired')
+"
+```
+Expected: prints a trade count (a few hundred) and `OK: catalog + venv wired`.
+
+- [ ] **Step 3: Commit setup**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add -f research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json
+git commit -m "chore(rob-324): vendor Binance USDM Demo commission artifact into branch
+
+Force-added past results/ gitignore (mirrors results/rob320/meanrev.json).
+Fee provenance input for the maker/limit-fill re-evaluation. Read-only;
+contains no secrets, signatures, balances, positions, or account ids.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: `maker_fill.py` — module skeleton + constants
+
+**Files:**
+- Create: `research/nautilus_scalping/maker_fill.py`
+- Test: `research/nautilus_scalping/tests/test_maker_fill.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# research/nautilus_scalping/tests/test_maker_fill.py
+"""ROB-324 — pure maker/limit-fill scenario builders.
+
+Records in, validated_gate.Trade lists out. No nautilus; fully deterministic."""
+from __future__ import annotations
+
+from maker_fill import (
+    MAKER_FEE_BPS,
+    TAKER_BASELINE_BPS,
+    MakerTradeRecord,
+)
+
+
+def test_module_constants_match_demo_fees() -> None:
+    assert MAKER_FEE_BPS == 2.0
+    assert TAKER_BASELINE_BPS == 4.0
+
+
+def _rec(net, comm, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> MakerTradeRecord:
+    return MakerTradeRecord(
+        net_at_real_fees=net, commission_real=comm, notional=notional,
+        ts_opened=ts, filled=filled, tp_hit=tp_hit, adverse_excursion_bps=adverse,
+    )
+
+
+def test_record_is_frozen_dataclass() -> None:
+    r = _rec(1.0, 0.04, 100.0, 0)
+    assert r.net_at_real_fees == 1.0 and r.filled is True
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'maker_fill'`.
+
+- [ ] **Step 3: Write the minimal module**
+
+```python
+# research/nautilus_scalping/maker_fill.py
+"""ROB-324 — PURE maker/limit-fill scenario builders (no nautilus import).
+
+Consumes ``MakerTradeRecord``s emitted by the maker re-sim and produces plain
+``validated_gate.Trade`` lists for the unchanged gate. Fees are the REAL Binance
+USDⓈ-M Futures Demo schedule (maker 2.0 / taker 4.0 bps) captured in
+``results/rob324/binance_usdm_commission_rates.json``.
+
+Gate convention (see spec §3.5): maker scenarios cannot use the gate's single-rate
+fee rescale (mixed maker/taker legs), so each ``Trade`` carries the TRUE net at real
+per-leg fees in ``net_ref_pnl`` and the true commission magnitude in
+``commission_ref``. The driver evaluates maker scenarios at ``REF_FEE_BPS`` (scale=0
+→ net_after_cost = as-run) and 0 (gross adds commission back). The taker baseline,
+being single-rate, uses the gate's NATIVE rescale (call ``evaluate_gate`` at 4.0 bps
+on the raw 10-bps taker trades) — no builder needed for it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import blake2b
+
+REF_FEE_BPS = 10.0          # mirrors validated_gate.REF_FEE_BPS (as-run reference point)
+TAKER_BASELINE_BPS = 4.0    # real demo taker
+MAKER_FEE_BPS = 2.0         # real demo maker
+
+
+@dataclass(frozen=True)
+class MakerTradeRecord:
+    net_at_real_fees: float      # realized pnl already net of maker/taker per-leg fees
+    commission_real: float       # total commission magnitude actually paid (>= 0)
+    notional: float
+    ts_opened: int
+    filled: bool                 # False = limit cancelled (missed fill)
+    tp_hit: bool                 # exit was the maker-limit TP (vs taker-stop SL)
+    adverse_excursion_bps: float # worst adverse move between fill and exit, bps
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/maker_fill.py research/nautilus_scalping/tests/test_maker_fill.py
+git commit -m "feat(rob-324): maker_fill module skeleton + MakerTradeRecord
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: `build_maker_optimistic` (filled-only, true-net Trades)
+
+**Files:**
+- Modify: `research/nautilus_scalping/maker_fill.py`
+- Test: `research/nautilus_scalping/tests/test_maker_fill.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_maker_fill.py`:
+
+```python
+from maker_fill import build_maker_optimistic
+from validated_gate import Trade, metrics_at_fee
+
+
+def test_optimistic_excludes_missed_fills_and_preserves_true_net() -> None:
+    recs = [
+        _rec(0.50, 0.04, 100.0, 1, filled=True),
+        _rec(0.00, 0.00, 100.0, 2, filled=False),   # missed fill -> dropped
+        _rec(-0.30, 0.04, 100.0, 3, filled=True),
+    ]
+    trades = build_maker_optimistic(recs)
+    assert len(trades) == 2                          # missed fill excluded
+    assert all(isinstance(t, Trade) for t in trades)
+    # net_after_cost at the gate's reference point == as-run true net
+    m = metrics_at_fee(trades, fee_bps=10.0, fold="net_after_cost")
+    assert round(m.net_pnl, 2) == 0.20               # 0.50 + (-0.30)
+    # gross (fee=0) adds the real commission back
+    g = metrics_at_fee(trades, fee_bps=0.0, fold="gross")
+    assert round(g.net_pnl, 2) == 0.28               # 0.20 + 0.04 + 0.04
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py::test_optimistic_excludes_missed_fills_and_preserves_true_net -v`
+Expected: FAIL — `ImportError: cannot import name 'build_maker_optimistic'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `maker_fill.py`:
+
+```python
+from validated_gate import Trade  # pure import (stdlib-only module)
+
+
+def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
+    """Filled maker trades at real fees; missed fills contribute nothing.
+
+    net_ref_pnl carries the true net (maker 2 / taker 4 bps already applied);
+    commission_ref carries the true commission magnitude so the gate's gross
+    column reconstructs correctly. Evaluate at REF_FEE_BPS for as-run net."""
+    return [
+        Trade(net_ref_pnl=r.net_at_real_fees, commission_ref=r.commission_real,
+              notional=r.notional, ts_opened=r.ts_opened)
+        for r in records if r.filled
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/maker_fill.py research/nautilus_scalping/tests/test_maker_fill.py
+git commit -m "feat(rob-324): build_maker_optimistic (filled-only, true-net Trades)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: conservative overlay — `classify_easy_tp` + `build_maker_conservative`
+
+**Files:**
+- Modify: `research/nautilus_scalping/maker_fill.py`
+- Test: `research/nautilus_scalping/tests/test_maker_fill.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_maker_fill.py`:
+
+```python
+from maker_fill import build_maker_conservative, classify_easy_tp
+
+
+def test_classify_easy_tp_boundary() -> None:
+    # TP hit with tiny adverse excursion = easy (front-of-queue) fill
+    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=1.0)) is True
+    # TP hit but price moved against us first = a real fill, not easy
+    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=5.0)) is False
+    # SL exits are never "easy TP"
+    assert classify_easy_tp(_rec(-0.5, 0.04, 100, 1, tp_hit=False, adverse=0.0)) is False
+
+
+def test_conservative_applies_adverse_cost_to_survivors() -> None:
+    # a non-easy filled trade is kept but charged the adverse cost
+    recs = [_rec(0.50, 0.04, 100.0, 1, tp_hit=True, adverse=9.0)]  # not easy -> kept
+    trades = build_maker_conservative(recs, queue_loss_pct=0.25, adverse_bps=1.0)
+    assert len(trades) == 1
+    # adverse cost = 1.0 bp * 100 notional / 10_000 = 0.01
+    assert round(trades[0].net_ref_pnl, 4) == 0.49
+
+
+def test_conservative_drops_about_quarter_of_easy_tp_fills_deterministically() -> None:
+    easy = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(2000)]
+    first = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
+    second = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
+    # deterministic across runs (hash of ts, not RNG)
+    assert [t.ts_opened for t in first] == [t.ts_opened for t in second]
+    kept = len(first)
+    dropped = 2000 - kept
+    assert 400 <= dropped <= 600          # ~25% dropped (hash uniformity tolerance)
+
+
+def test_conservative_excludes_missed_fills() -> None:
+    recs = [_rec(0.0, 0.0, 100.0, 1, filled=False)]
+    assert build_maker_conservative(recs) == []
+
+
+def test_conservative_is_strictly_worse_than_optimistic() -> None:
+    recs = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(500)]
+    from validated_gate import metrics_at_fee
+    opt = metrics_at_fee(build_maker_optimistic(recs), 10.0).net_pnl
+    con = metrics_at_fee(build_maker_conservative(recs), 10.0).net_pnl
+    assert con < opt                      # queue-loss + adverse cost only ever hurt
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -k conservative -v`
+Expected: FAIL — `ImportError: cannot import name 'build_maker_conservative'`.
+
+- [ ] **Step 3: Implement**
+
+Append to `maker_fill.py`:
+
+```python
+def classify_easy_tp(record: MakerTradeRecord, excursion_eps_bps: float = 2.0) -> bool:
+    """A TP fill that barely moved against us before reaching target — i.e. a
+    front-of-queue fill we would not realistically win against real queue priority."""
+    return record.tp_hit and record.adverse_excursion_bps <= excursion_eps_bps
+
+
+def _uniform_from_ts(ts_opened: int) -> float:
+    """Deterministic uniform [0,1) from the trade timestamp (reproducible, no RNG)."""
+    digest = blake2b(str(ts_opened).encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") / 2.0 ** 64
+
+
+def build_maker_conservative(
+    records: list[MakerTradeRecord],
+    *,
+    queue_loss_pct: float = 0.25,
+    adverse_bps: float = 1.0,
+    excursion_eps_bps: float = 2.0,
+) -> list[Trade]:
+    """Conservative maker scenario: an honest lower bound on the re-sim.
+
+    Two haircuts on top of the data-derived fills:
+      1. Queue loss — deterministically drop ``queue_loss_pct`` of the easy-TP fills
+         (Nautilus has no order-queue model, so it over-fills passive limits).
+      2. Adverse selection — charge ``adverse_bps`` on every surviving maker entry.
+    Missed fills are excluded (they earn nothing)."""
+    out: list[Trade] = []
+    for r in records:
+        if not r.filled:
+            continue
+        if classify_easy_tp(r, excursion_eps_bps) and _uniform_from_ts(r.ts_opened) < queue_loss_pct:
+            continue  # queue loss
+        adverse_cost = adverse_bps * r.notional / 10_000.0
+        out.append(Trade(
+            net_ref_pnl=r.net_at_real_fees - adverse_cost,
+            commission_ref=r.commission_real,
+            notional=r.notional, ts_opened=r.ts_opened,
+        ))
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/maker_fill.py research/nautilus_scalping/tests/test_maker_fill.py
+git commit -m "feat(rob-324): conservative overlay (queue-loss drop + adverse cost)
+
+Covers the adverse-selection and missed-fill paths (issue acceptance criterion).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: Nautilus limit-fill mechanics spike (DE-RISK — verify before building the strategy)
+
+The maker scenario assumes Nautilus's backtest matching engine (a) fills a resting LIMIT entry against trade ticks and charges **maker** fee, and (b) lets us cancel an unfilled limit. This task validates those assumptions on a 1-day slice **before** the full strategy is built. No production code; throwaway script printed to stdout.
+
+**Files:** none committed (exploratory; delete after).
+
+- [ ] **Step 1: Write a throwaway probe**
+
+```bash
+cat > /tmp/rob324_limit_probe.py <<'PY'
+from pathlib import Path
+from decimal import Decimal
+from nautilus_trader.backtest.engine import BacktestEngine, BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model.currencies import USDT
+from nautilus_trader.model.enums import AccountType, OmsType, OrderSide, TimeInForce
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.objects import Money, Price
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from nautilus_trader.trading.strategy import Strategy, StrategyConfig
+import os
+
+CATALOG = os.environ["CATALOG"]
+
+
+class ProbeCfg(StrategyConfig, frozen=True):
+    instrument_id: object
+
+
+class Probe(Strategy):
+    def __init__(self, cfg):
+        super().__init__(cfg)
+        self._submitted = False
+        self._order = None
+
+    def on_start(self):
+        self._inst = self.cache.instrument(self.config.instrument_id)
+        self.subscribe_trade_ticks(self.config.instrument_id)
+
+    def on_trade_tick(self, tick):
+        if not self._submitted:
+            # post a passive BUY limit 20 bps BELOW the first tick -> should rest, then
+            # fill maker when price dips to it (or never -> we cancel in on_stop)
+            px = tick.price.as_decimal() * Decimal("0.998")
+            self._order = self.order_factory.limit(
+                instrument_id=self.config.instrument_id, order_side=OrderSide.BUY,
+                quantity=self._inst.make_qty(Decimal("100")),
+                price=self._inst.make_price(px), time_in_force=TimeInForce.GTC)
+            self.submit_order(self._order)
+            self._submitted = True
+
+    def on_order_filled(self, event):
+        self.log.error(f"FILLED liquidity={event.liquidity_side} comm={event.commission}")
+
+    def on_stop(self):
+        for o in self.cache.orders_open(instrument_id=self.config.instrument_id):
+            self.cancel_order(o)
+
+
+cat_obj = ParquetDataCatalog(CATALOG)
+inst = next(i for i in cat_obj.instruments() if i.id.value.startswith("XRPUSDT"))
+# rebuild instrument at REAL demo fees: maker 2bps / taker 4bps
+from nautilus_trader.model.instruments import CurrencyPair
+inst2 = CurrencyPair(
+    instrument_id=inst.id, raw_symbol=inst.raw_symbol, base_currency=inst.base_currency,
+    quote_currency=inst.quote_currency, price_precision=inst.price_precision,
+    size_precision=inst.size_precision, price_increment=inst.price_increment,
+    size_increment=inst.size_increment, lot_size=inst.lot_size,
+    max_quantity=inst.max_quantity, min_quantity=inst.min_quantity,
+    max_notional=inst.max_notional, min_notional=inst.min_notional,
+    max_price=inst.max_price, min_price=inst.min_price,
+    margin_init=inst.margin_init, margin_maint=inst.margin_maint,
+    maker_fee=Decimal("0.0002"), taker_fee=Decimal("0.0004"),
+    ts_event=0, ts_init=0)
+ticks = cat_obj.trade_ticks(instrument_ids=[inst.id.value])[:200_000]
+eng = BacktestEngine(config=BacktestEngineConfig(trader_id="PROBE-001",
+      logging=LoggingConfig(log_level="ERROR")))
+eng.add_venue(venue=Venue("BINANCE"), oms_type=OmsType.HEDGING,
+              account_type=AccountType.CASH, base_currency=None,
+              starting_balances=[Money(10_000_000, USDT)])
+eng.add_instrument(inst2)
+eng.add_data(ticks)
+eng.add_strategy(Probe(ProbeCfg(instrument_id=inst2.id)))
+eng.run()
+print("positions_closed:", len(eng.cache.positions_closed()))
+for p in eng.cache.positions_closed()[:3]:
+    print("  comm:", [str(c) for c in p.commissions()], "pnl:", p.realized_pnl)
+eng.dispose()
+PY
+```
+
+- [ ] **Step 2: Run the probe and record observations**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+PYTHONPATH=../.. $NVENV /tmp/rob324_limit_probe.py
+```
+Expected observations to record in the task notes:
+- At least one `FILLED liquidity=...` line. **Confirm `liquidity_side` is `MAKER`** for the resting limit. If it shows `TAKER`, the entry limit is being treated as marketable — note it; the strategy must post the entry passively enough to rest (the design posts at the signal close on a fade entry, which is already a local low, so it should rest).
+- The maker commission on a filled entry ≈ `notional * 0.0002` (2 bps). Sanity-check the printed `comm`.
+- `cancel_order` in `on_stop` raises no error (unfilled orders cancellable).
+
+- [ ] **Step 3: Decide & document**
+
+If maker fills + cancel both work → proceed to Task 6 as written. If the entry limit fills as TAKER even when posted below market, document the finding and adjust Task 6 to post the entry limit one tick more passive (still data-derived) — do **not** silently keep taker fees on the "maker" scenario. Delete `/tmp/rob324_limit_probe.py`. No commit.
+
+---
+
+## Task 6: `strategy_meanrev.py` — `execution_mode="maker"` branch
+
+**Files:**
+- Modify: `research/nautilus_scalping/strategy_meanrev.py`
+- Test (regression): `research/nautilus_scalping/tests/test_meanrev_parity.py` (must stay green; default is taker)
+
+- [ ] **Step 1: Add the config flag + maker state**
+
+In `MeanRevScalperConfig`, add (after `allow_short`):
+
+```python
+    execution_mode: str = "taker"   # "taker" (default, unchanged) | "maker"
+    fill_timeout_bars: int = 1      # cancel an unfilled maker entry after N closed bars
+```
+
+In `MeanRevScalper.__init__`, after the existing attributes, add:
+
+```python
+        # maker-mode bookkeeping
+        self._entry_order = None
+        self._entry_submitted_bar: int | None = None
+        self._bar_count = 0
+        self._tp_order = None
+        self._entry_px: Decimal | None = None
+        self._adverse_px: Decimal | None = None   # worst price seen vs entry while in position
+        self.records: list[dict] = []             # maker: completed trade records
+        self.entries_attempted = 0
+        self.entries_filled = 0
+```
+
+- [ ] **Step 2: Branch `on_bar` / `_enter` by execution mode**
+
+Replace `on_bar` and `_enter` with mode-aware versions (taker path is byte-identical to before):
+
+```python
+    def on_bar(self, bar: Bar) -> None:
+        self._bar_count += 1
+        self._candles.append(bar_to_candle(bar))
+
+        # maker: cancel a stale unfilled entry limit (missed fill)
+        if (self.config.execution_mode == "maker" and self._entry_order is not None
+                and self._entry_submitted_bar is not None
+                and self._bar_count - self._entry_submitted_bar >= self.config.fill_timeout_bars):
+            self.cancel_order(self._entry_order)
+            self._entry_order = None
+            self._entry_submitted_bar = None
+
+        if len(self._candles) < self._needed:
+            return
+        if not self.portfolio.is_flat(self.config.instrument_id):
+            return
+        if self._entry_order is not None:   # maker: a limit is still working
+            return
+        d = evaluate_meanrev(list(self._candles), self._cfg)
+        if d.has_entry and d.side == "BUY":
+            self._enter(OrderSide.BUY, d.entry_price, d.tp_price, d.sl_price)
+        elif d.has_entry and d.side == "SELL":
+            self._enter(OrderSide.SELL, d.entry_price, d.tp_price, d.sl_price)
+
+    def _enter(self, side, entry, tp, sl) -> None:
+        self._tp, self._sl, self._side = tp, sl, side
+        if self.config.execution_mode == "taker":
+            order = self.order_factory.market(
+                instrument_id=self.config.instrument_id, order_side=side,
+                quantity=self._instrument.make_qty(Decimal(self.config.trade_size)))
+            self.submit_order(order)
+            return
+        # maker: passive limit entry at the signal close (fade entry rests at a local low)
+        self.entries_attempted += 1
+        order = self.order_factory.limit(
+            instrument_id=self.config.instrument_id, order_side=side,
+            quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
+            price=self._instrument.make_price(entry))
+        self._entry_order = order
+        self._entry_submitted_bar = self._bar_count
+        self.submit_order(order)
+```
+
+- [ ] **Step 3: Add maker fill/exit handling + record building**
+
+Add these methods (taker mode never calls them because it never submits limit entries / TP limits):
+
+```python
+    def on_order_filled(self, event) -> None:
+        if self.config.execution_mode != "maker":
+            return
+        if self._entry_order is not None and event.client_order_id == self._entry_order.client_order_id:
+            # entry filled -> post a resting maker-limit TP; SL handled on ticks
+            self.entries_filled += 1
+            self._entry_order = None
+            self._entry_submitted_bar = None
+            self._entry_px = event.last_px.as_decimal()
+            self._adverse_px = self._entry_px
+            self._tp_order = self.order_factory.limit(
+                instrument_id=self.config.instrument_id,
+                order_side=(OrderSide.SELL if self._side == OrderSide.BUY else OrderSide.BUY),
+                quantity=event.last_qty,
+                price=self._instrument.make_price(self._tp))
+            self.submit_order(self._tp_order)
+
+    def on_trade_tick(self, tick: TradeTick) -> None:
+        if self.config.execution_mode == "taker":
+            return self._taker_exit_check(tick)
+        # maker: track adverse excursion; trigger taker SL via market if breached
+        if self.portfolio.is_flat(self.config.instrument_id) or self._entry_px is None:
+            return
+        price = tick.price.as_decimal()
+        if self._side == OrderSide.BUY:
+            self._adverse_px = min(self._adverse_px, price)
+            if self._sl is not None and price <= self._sl:
+                self._maker_sl_exit()
+        else:
+            self._adverse_px = max(self._adverse_px, price)
+            if self._sl is not None and price >= self._sl:
+                self._maker_sl_exit()
+
+    def _taker_exit_check(self, tick: TradeTick) -> None:
+        # unchanged taker logic
+        if self.portfolio.is_flat(self.config.instrument_id):
+            return
+        price = tick.price.as_decimal()
+        if self._side == OrderSide.BUY:
+            if self._sl is not None and price <= self._sl:
+                self._exit()
+            elif self._tp is not None and price >= self._tp:
+                self._exit()
+        else:
+            if self._sl is not None and price >= self._sl:
+                self._exit()
+            elif self._tp is not None and price <= self._tp:
+                self._exit()
+
+    def _maker_sl_exit(self) -> None:
+        if self._tp_order is not None:
+            self.cancel_order(self._tp_order)
+            self._tp_order = None
+        self.close_all_positions(self.config.instrument_id)  # taker stop-out
+
+    def on_position_closed(self, event) -> None:
+        if self.config.execution_mode != "maker":
+            return
+        pos = self.cache.position(event.position_id)
+        entry = self._entry_px if self._entry_px is not None else Decimal(str(pos.avg_px_open))
+        if self._side == OrderSide.BUY:
+            adverse = (entry - (self._adverse_px or entry)) / entry * Decimal("10000")
+        else:
+            adverse = ((self._adverse_px or entry) - entry) / entry * Decimal("10000")
+        tp_hit = self._tp_order is not None  # TP order existed and was not cancelled by SL
+        self.records.append({
+            "net": pos.realized_pnl.as_double(),
+            "comm": sum(c.as_double() for c in pos.commissions()),
+            "notional": float(pos.avg_px_open) * float(pos.peak_qty),
+            "ts": int(pos.ts_opened),
+            "filled": True,
+            "tp_hit": bool(tp_hit),
+            "adverse_bps": float(max(Decimal("0"), adverse)),
+        })
+        self._tp_order = None
+        self._entry_px = None
+        self._adverse_px = None
+        self._tp = self._sl = self._side = None
+```
+
+> **Note on `tp_hit`:** when the TP limit fills, the position closes with the TP order still referenced (not cancelled) → `tp_hit=True`. When SL fires, `_maker_sl_exit` cancels the TP order first → `tp_hit=False`. This is the deterministic signal the conservative overlay's `classify_easy_tp` uses.
+
+- [ ] **Step 4: Keep the existing `_exit` (taker) and run the parity regression**
+
+`_exit` and `on_stop` stay as-is. Verify the taker default is unchanged:
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping && PYTHONPATH=../.. $NVENV -m pytest tests/test_meanrev_parity.py tests/test_meanrev_signal.py -v`
+Expected: PASS (taker behavior untouched; default `execution_mode="taker"`).
+
+- [ ] **Step 5: Smoke the maker strategy end-to-end on one symbol**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+PYTHONPATH=../.. $NVENV -c "
+from pathlib import Path
+from decimal import Decimal
+from nautilus_trader.backtest.engine import BacktestEngine, BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.model.currencies import USDT
+from nautilus_trader.model.data import BarType
+from nautilus_trader.model.enums import AccountType, OmsType
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments import CurrencyPair
+from nautilus_trader.model.objects import Money
+from nautilus_trader.persistence.catalog import ParquetDataCatalog
+from strategy_meanrev import MeanRevScalper, MeanRevScalperConfig
+import os
+c = ParquetDataCatalog(os.environ['CATALOG'])
+inst = next(i for i in c.instruments() if i.id.value.startswith('XRPUSDT'))
+inst = CurrencyPair(instrument_id=inst.id, raw_symbol=inst.raw_symbol, base_currency=inst.base_currency, quote_currency=inst.quote_currency, price_precision=inst.price_precision, size_precision=inst.size_precision, price_increment=inst.price_increment, size_increment=inst.size_increment, lot_size=inst.lot_size, max_quantity=inst.max_quantity, min_quantity=inst.min_quantity, max_notional=inst.max_notional, min_notional=inst.min_notional, max_price=inst.max_price, min_price=inst.min_price, margin_init=inst.margin_init, margin_maint=inst.margin_maint, maker_fee=Decimal('0.0002'), taker_fee=Decimal('0.0004'), ts_event=0, ts_init=0)
+e = BacktestEngine(config=BacktestEngineConfig(trader_id='SMOKE-001', logging=LoggingConfig(log_level='ERROR')))
+e.add_venue(venue=Venue('BINANCE'), oms_type=OmsType.HEDGING, account_type=AccountType.CASH, base_currency=None, starting_balances=[Money(10_000_000, USDT)])
+e.add_instrument(inst); e.add_data(c.trade_ticks(instrument_ids=[inst.id.value]))
+s = MeanRevScalper(MeanRevScalperConfig(instrument_id=inst.id, bar_type=BarType.from_str(f'{inst.id.value}-1-MINUTE-LAST-INTERNAL'), trade_size='100', execution_mode='maker'))
+e.add_strategy(s); e.run()
+print('attempted', s.entries_attempted, 'filled', s.entries_filled, 'records', len(s.records))
+assert s.entries_attempted > 0 and len(s.records) > 0
+miss = s.entries_attempted - s.entries_filled
+print('missed fills', miss)
+print('sample', s.records[0])
+e.dispose()
+"
+```
+Expected: prints non-zero attempted/filled/records, a plausible missed-fill count, and a sample record with `tp_hit`/`adverse_bps`. (No assertion on the exact numbers — this only proves the wiring runs.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/strategy_meanrev.py
+git commit -m "feat(rob-324): maker execution_mode for MeanRevScalper (limit entry, maker TP, taker SL)
+
+Default execution_mode=taker preserves ROB-320 behavior. Maker mode posts a
+passive limit entry (1-bar timeout = missed fill), a resting maker-limit TP, and
+a taker stop-out SL; records per-trade net/commission/adverse-excursion/tp_hit.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: `backtest_runner.py` — maker-mode run (real fees + records + counters)
+
+**Files:**
+- Modify: `research/nautilus_scalping/backtest_runner.py`
+
+- [ ] **Step 1: Add a real-fee instrument helper + maker branch in `_run_single`**
+
+At the top of `_run_single`'s nautilus imports, also import `CurrencyPair`:
+
+```python
+    from nautilus_trader.model.instruments import CurrencyPair
+```
+
+After `instrument = next(...)` is resolved and **before** `engine.add_instrument(instrument)`, insert the maker fee override:
+
+```python
+    execution_mode = str(params.get("execution_mode", "taker"))
+    if execution_mode == "maker":
+        instrument = CurrencyPair(
+            instrument_id=instrument.id, raw_symbol=instrument.raw_symbol,
+            base_currency=instrument.base_currency, quote_currency=instrument.quote_currency,
+            price_precision=instrument.price_precision, size_precision=instrument.size_precision,
+            price_increment=instrument.price_increment, size_increment=instrument.size_increment,
+            lot_size=instrument.lot_size, max_quantity=instrument.max_quantity,
+            min_quantity=instrument.min_quantity, max_notional=instrument.max_notional,
+            min_notional=instrument.min_notional, max_price=instrument.max_price,
+            min_price=instrument.min_price, margin_init=instrument.margin_init,
+            margin_maint=instrument.margin_maint,
+            maker_fee=Decimal("0.0002"), taker_fee=Decimal("0.0004"),   # real demo 2/4 bps
+            ts_event=0, ts_init=0)
+```
+
+Add `from decimal import Decimal` to the top-level imports of `backtest_runner.py` (module scope) if not present.
+
+- [ ] **Step 2: Wire `execution_mode` into the meanrev strategy and emit maker records**
+
+In the `meanrev_zscore_fade` branch, pass the flag:
+
+```python
+        strat = MeanRevScalper(MeanRevScalperConfig(
+            instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
+            lookback=int(params.get("lookback", 20)), z_entry=str(params.get("z_entry", "2.0")),
+            tp_bps=int(params.get("tp_bps", 30)), sl_bps=int(params.get("sl_bps", 30)),
+            require_vol=bool(params.get("require_vol", True)),
+            execution_mode=execution_mode))
+```
+
+Replace the trade-emission tail of `_run_single` so maker runs emit the rich records + counters:
+
+```python
+    engine.add_strategy(strat)
+    engine.run()
+    if execution_mode == "maker":
+        payload = {
+            "execution_mode": "maker",
+            "records": list(strat.records),
+            "entries_attempted": int(strat.entries_attempted),
+            "entries_filled": int(strat.entries_filled),
+        }
+        engine.dispose()
+        print(_SENTINEL + json.dumps(payload))
+        return
+    trades = []
+    for p in engine.cache.positions_closed():
+        net_ref = p.realized_pnl.as_double()
+        comm_ref = sum(c.as_double() for c in p.commissions())
+        notional = float(p.avg_px_open) * float(p.peak_qty)
+        trades.append([net_ref, comm_ref, notional, int(p.ts_opened)])
+    engine.dispose()
+    print(_SENTINEL + json.dumps({"trades": trades}))
+```
+
+- [ ] **Step 3: Add a maker-aware `run_maker(...)` helper that returns `MakerTradeRecord`s**
+
+Add after the existing `run(...)`:
+
+```python
+def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100"):
+    """Run the maker re-sim; return (records, attempted, filled).
+
+    records are maker_fill.MakerTradeRecord; attempted-filled = missed fills."""
+    from maker_fill import MakerTradeRecord
+    p = dict(params); p["execution_mode"] = "maker"
+    venv_python = sys.executable
+    cmd = [venv_python, os.path.abspath(__file__), "--single", "--catalog", str(catalog),
+           "--symbol", symbol, "--strategy", "meanrev_zscore_fade",
+           "--params", json.dumps(p), "--trade-size", trade_size]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + "../.."
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    for line in proc.stdout.splitlines():
+        if line.startswith(_SENTINEL):
+            data = json.loads(line[len(_SENTINEL):])
+            recs = [MakerTradeRecord(
+                net_at_real_fees=r["net"], commission_real=abs(r["comm"]),
+                notional=r["notional"], ts_opened=r["ts"], filled=r["filled"],
+                tp_hit=r["tp_hit"], adverse_excursion_bps=r["adverse_bps"])
+                for r in data["records"]]
+            return recs, data["entries_attempted"], data["entries_filled"]
+    raise RuntimeError(f"maker runner {symbol} failed:\n{proc.stderr[-800:]}")
+```
+
+- [ ] **Step 4: Smoke `run_maker` for both symbols**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+PYTHONPATH=../.. $NVENV -c "
+from pathlib import Path; import os
+from backtest_runner import run_maker
+for sym, size in [('XRPUSDT','100'), ('BTCUSDT','0.002')]:
+    recs, att, fil = run_maker(Path(os.environ['CATALOG']), sym, {'lookback':20,'z_entry':'2.0','tp_bps':30,'sl_bps':30}, size)
+    print(sym, 'records', len(recs), 'attempted', att, 'filled', fil, 'missed', att-fil)
+    assert len(recs) > 0
+print('OK')
+"
+```
+Expected: both symbols print record/attempt/fill/miss counts and `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/backtest_runner.py
+git commit -m "feat(rob-324): backtest_runner maker mode (real 2/4bps fees, records, fill counts)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 8: `validate_maker_fill.py` — driver + v2 artifact
+
+**Files:**
+- Create: `research/nautilus_scalping/validate_maker_fill.py`
+
+- [ ] **Step 1: Write the driver**
+
+```python
+#!/usr/bin/env python3
+"""ROB-324 — maker/limit-fill edge re-evaluation driver.
+
+Produces three scenarios and feeds each to the UNCHANGED validated_gate:
+  1. taker_baseline   — ROB-320 taker trades, gate's native rescale to 4.0 bps
+  2. maker_optimistic — data-derived limit fills at real maker/taker fees
+  3. maker_conservative — (2) minus queue-loss drop + adverse-selection cost  [HEADLINE]
+
+NO execution side effects: public-data backtest only. Nothing submits, schedules,
+mutates a broker/DB, reads secrets, or applies params to a daemon.
+
+Usage (rob-320 venv):
+    export CATALOG=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/catalog
+    PYTHONPATH=../.. $NVENV validate_maker_fill.py --catalog "$CATALOG" \
+        --symbols XRPUSDT,BTCUSDT --window-from 2026-03-01 --window-to 2026-05-14 \
+        --export results/rob324/maker_fill.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from backtest_runner import run, run_maker
+from candidates import get_candidate
+from maker_fill import (
+    MAKER_FEE_BPS,
+    TAKER_BASELINE_BPS,
+    build_maker_conservative,
+    build_maker_optimistic,
+)
+from validated_gate import REF_FEE_BPS, Trade, evaluate_gate
+
+_GRID = [
+    ("z2.0/tp30/sl30", {"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30}),
+    ("z2.5/tp40/sl40", {"lookback": 20, "z_entry": "2.5", "tp_bps": 40, "sl_bps": 40}),
+]
+_SIZE = {"BTCUSDT": "0.002"}
+_FILL_MODEL = {
+    "entry_rule": "passive limit @ signal-bar close",
+    "fill_timeout_bars": 1,
+    "tp_execution": "maker limit",
+    "sl_execution": "taker stop (market)",
+    "queue_loss_pct": 0.25,
+    "adverse_bps": 1.0,
+    "excursion_eps_bps": 2.0,
+}
+
+
+def _merge(runs: list[list[Trade]]) -> list[Trade]:
+    return sorted((t for r in runs for t in r), key=lambda t: t.ts_opened)
+
+
+def _merge_recs(runs):
+    return sorted((rec for r in runs for rec in r), key=lambda rec: rec.ts_opened)
+
+
+def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name):
+    return evaluate_gate(
+        candidate_runs=candidate_runs,
+        baseline_breakout=breakout, baseline_random=random_ctrl,
+        fee_bps=fee_bps, min_trades=100,
+        candidate_name=name, hypothesis="mean_reversion",
+        symbols=symbols, window=window,
+    ).to_dict()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="ROB-324 maker/limit-fill driver")
+    ap.add_argument("--catalog", type=Path, default="catalog")
+    ap.add_argument("--symbols", default="XRPUSDT,BTCUSDT")
+    ap.add_argument("--window-from", default="")
+    ap.add_argument("--window-to", default="")
+    ap.add_argument("--export", type=Path, default="results/rob324/maker_fill.json")
+    args = ap.parse_args()
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    window = {"from": args.window_from, "to": args.window_to,
+              "folds": {"train": 0.5, "val": 0.25, "oos": 0.25}}
+
+    # --- baselines (taker, single config each), merged across symbols ---
+    print("Running taker baselines (breakout, random)...")
+    breakout = _merge([run(args.catalog, s, "micro_breakout",
+                           get_candidate("micro_breakout").default_params,
+                           _SIZE.get(s, "100")) for s in symbols])
+    random_ctrl = _merge([run(args.catalog, s, "random_entry",
+                              get_candidate("random_entry").default_params,
+                              _SIZE.get(s, "100")) for s in symbols])
+
+    # --- scenario 1: taker baseline candidate over the param grid (gate rescales 10->4) ---
+    print("Scenario 1: taker baseline @ 4 bps (grid)...")
+    taker_runs = {label: _merge([run(args.catalog, s, "meanrev_zscore_fade",
+                                     dict(params), _SIZE.get(s, "100")) for s in symbols])
+                  for label, params in _GRID}
+    taker_report = _gate(taker_runs, breakout, random_ctrl, TAKER_BASELINE_BPS,
+                         symbols, window, "meanrev_taker_baseline")
+
+    # --- scenarios 2 & 3: maker re-sim over the SAME grid (param-stability preserved) ---
+    print("Scenarios 2 & 3: maker re-sim (grid)...")
+    maker_recs: dict[str, list] = {}
+    attempted = filled = 0
+    for label, params in _GRID:
+        per_symbol = []
+        for s in symbols:
+            recs, att, fil = run_maker(args.catalog, s, dict(params), _SIZE.get(s, "100"))
+            per_symbol.append(recs)
+            attempted += att
+            filled += fil
+        maker_recs[label] = _merge_recs(per_symbol)
+
+    opt_runs = {label: build_maker_optimistic(recs) for label, recs in maker_recs.items()}
+    con_runs = {label: build_maker_conservative(
+                    recs, queue_loss_pct=_FILL_MODEL["queue_loss_pct"],
+                    adverse_bps=_FILL_MODEL["adverse_bps"],
+                    excursion_eps_bps=_FILL_MODEL["excursion_eps_bps"])
+                for label, recs in maker_recs.items()}
+
+    # maker scenarios: net already at real fees -> evaluate at REF (as-run)
+    opt_report = _gate(opt_runs, breakout, random_ctrl, REF_FEE_BPS,
+                       symbols, window, "meanrev_maker_optimistic")
+    con_report = _gate(con_runs, breakout, random_ctrl, REF_FEE_BPS,
+                       symbols, window, "meanrev_maker_conservative")
+
+    artifact = {
+        "schema_version": "validated_signal_gate.v2",
+        "candidate": "meanrev_zscore_fade",
+        "hypothesis": "mean_reversion",
+        "symbols": symbols,
+        "window": window,
+        "cost_model": {
+            "maker_fee_bps": MAKER_FEE_BPS, "taker_fee_bps": TAKER_BASELINE_BPS,
+            "commission_source": "results/rob324/binance_usdm_commission_rates.json",
+            "note": ("maker scenarios bake real per-leg fees into net; gate evaluated "
+                     "at its reference point (as-run). taker baseline uses the gate's "
+                     "native single-rate rescale to 4.0 bps."),
+        },
+        "fill_model": _FILL_MODEL,
+        "fill_stats": {"entries_attempted": attempted, "entries_filled": filled,
+                       "missed_fills": attempted - filled},
+        "scenarios": {
+            "taker_baseline": taker_report,
+            "maker_optimistic": opt_report,
+            "maker_conservative": con_report,
+        },
+        "verdict": con_report["verdict"],            # headline = conservative (honest bound)
+        "verdict_reasons": con_report["verdict_reasons"],
+        "verdict_source": "maker_conservative",
+    }
+
+    args.export.parent.mkdir(parents=True, exist_ok=True)
+    args.export.write_text(json.dumps(artifact, indent=2))
+    print("\n=============================================================")
+    print(f"HEADLINE VERDICT (conservative): {artifact['verdict'].upper()}")
+    for r in artifact["verdict_reasons"]:
+        print(f"  - {r}")
+    print(f"taker_baseline   verdict: {taker_report['verdict']}")
+    print(f"maker_optimistic verdict: {opt_report['verdict']}")
+    print(f"missed fills: {attempted - filled} / {attempted} attempted")
+    print(f"Report exported to: {args.export.resolve()}")
+    print("=============================================================")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Syntax/lint check (no run yet)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run ruff check research/nautilus_scalping/validate_maker_fill.py research/nautilus_scalping/maker_fill.py`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/validate_maker_fill.py
+git commit -m "feat(rob-324): validate_maker_fill driver writes validated_signal_gate.v2 artifact
+
+Three scenarios (taker 4bps, maker optimistic, maker conservative) through the
+unchanged gate; headline verdict = conservative (honest lower bound).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 9: Run the pipeline → produce `maker_fill.json`
+
+**Files:**
+- Create (generated): `research/nautilus_scalping/results/rob324/maker_fill.json`
+
+- [ ] **Step 1: Run the full driver**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping
+export NVENV=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/.venv/bin/python
+export CATALOG=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/catalog
+PYTHONPATH=../.. $NVENV validate_maker_fill.py --catalog "$CATALOG" \
+    --symbols XRPUSDT,BTCUSDT --window-from 2026-03-01 --window-to 2026-05-14 \
+    --export results/rob324/maker_fill.json
+```
+Expected: prints the headline conservative verdict plus the taker/optimistic verdicts and missed-fill count; writes `results/rob324/maker_fill.json`.
+
+- [ ] **Step 2: Sanity-check the artifact**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+uv run python -c "
+import json
+a = json.load(open('research/nautilus_scalping/results/rob324/maker_fill.json'))
+assert a['schema_version'] == 'validated_signal_gate.v2'
+assert a['verdict'] in {'validated','not_validated','insufficient_data'}
+assert set(a['scenarios']) == {'taker_baseline','maker_optimistic','maker_conservative'}
+assert a['cost_model']['maker_fee_bps'] == 2.0 and a['cost_model']['taker_fee_bps'] == 4.0
+for name, rep in a['scenarios'].items():
+    oos = next(f for f in rep['per_fold'] if f['fold']=='oos')
+    print(f\"{name:18} verdict={rep['verdict']:16} oos_net={oos['net_pnl']:.2f} oos_pf={oos['profit_factor']:.2f}\")
+print('headline', a['verdict'], '| missed', a['fill_stats']['missed_fills'])
+"
+```
+Expected: all asserts pass; prints each scenario's OOS net/PF and the headline verdict. (Per the analytic prior, expect the conservative — and likely optimistic — verdicts to be `not_validated`. That is a legitimate result, not a failure.)
+
+- [ ] **Step 3: Commit the artifact (force-add past gitignore)**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add -f research/nautilus_scalping/results/rob324/maker_fill.json
+git commit -m "feat(rob-324): maker/limit-fill re-evaluation result artifact
+
+validated_signal_gate.v2 with taker(4bps)/maker-optimistic/maker-conservative
+scenarios for XRPUSDT+BTCUSDT. Headline verdict from the conservative scenario.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 10: Verdict-vocabulary gate test + final lint
+
+**Files:**
+- Modify: `research/nautilus_scalping/tests/test_maker_fill.py`
+
+- [ ] **Step 1: Write a report-shape / verdict-vocabulary test (pure, synthetic)**
+
+Append to `tests/test_maker_fill.py`:
+
+```python
+from validated_gate import evaluate_gate
+
+
+def test_maker_scenario_verdict_stays_in_vocabulary() -> None:
+    # synthetic filled maker records -> optimistic/conservative Trades -> gate
+    recs = [_rec(0.20, 0.04, 100.0, ts, tp_hit=(ts % 2 == 0), adverse=float(ts % 5))
+            for ts in range(400)]
+    losers = [Trade(net_ref_pnl=-0.5, commission_ref=0.04, notional=100.0, ts_opened=ts)
+              for ts in range(400)]
+    for builder in (build_maker_optimistic, build_maker_conservative):
+        trades = builder(recs)
+        report = evaluate_gate(
+            candidate_runs={"maker_fill": trades},
+            baseline_breakout=losers, baseline_random=losers,
+            fee_bps=10.0, min_trades=100,
+            candidate_name="t", hypothesis="mean_reversion", symbols=["XRPUSDT"])
+        assert report.verdict in {"validated", "not_validated", "insufficient_data"}
+```
+
+- [ ] **Step 2: Run the full pure suite**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run pytest research/nautilus_scalping/tests/test_maker_fill.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 3: Lint everything touched**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324 && uv run ruff check research/nautilus_scalping/`
+Expected: PASS. Fix any findings, re-run.
+
+- [ ] **Step 4: Run the nautilus-dependent regression once more**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-324/research/nautilus_scalping && PYTHONPATH=../.. $NVENV -m pytest tests/ -v`
+Expected: PASS or `skipped` (nautilus-gated tests run here; pure tests pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git add research/nautilus_scalping/tests/test_maker_fill.py
+git commit -m "test(rob-324): assert maker scenarios keep the three-value verdict vocabulary
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 11: PR handoff
+
+- [ ] **Step 1: Push the branch and open the PR (base `main`)**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-324
+git push -u origin rob-324
+gh pr create --base main --title "feat(rob-324): maker/limit-fill scalping edge re-evaluation (research-only)" --body "$(cat <<'EOF'
+## Summary
+Research-only follow-up to ROB-320 (#968). Re-evaluates whether a conservative
+maker/limit-fill execution model recovers a net-after-cost edge for
+`meanrev_zscore_fade` on XRPUSDT + BTCUSDT, using the REAL Binance USDⓈ-M Futures
+Demo fees (maker 2.0 / taker 4.0 bps) captured in the committed commission artifact.
+
+## Artifact
+`research/nautilus_scalping/results/rob324/maker_fill.json` (`validated_signal_gate.v2`):
+three scenarios (taker 4 bps baseline, data-derived maker, conservative maker overlay).
+
+## Verdict
+Headline verdict (conservative scenario): **<fill from Task 9 output>**.
+<one line on optimistic + taker baseline verdicts and missed-fill count>.
+
+## Side-effect boundary
+Research/backtest only. No live trading, no Demo `confirm=true`, no
+broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod
+DB/env/secret changes, no runtime parameter application, no `/invest` surfacing.
+Reads the rob-320 ParquetDataCatalog read-only. The captured commission artifact
+contains no secrets, signatures, balances, positions, or account identifiers.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Fill the verdict line in the PR body from the Task 9 output, and post the issue handoff comment** (artifact path, verdict, side-effect boundary) on ROB-324.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** taker/maker/conservative scenarios (spec §2 → Tasks 8–9); real tick re-sim (§3.1, §3.2 → Tasks 5–7); pure overlay + missed-fill/adverse tests (§5 → Tasks 3–4, 10); gate unchanged + convention (§3.5 → Task 3 docstring, Task 8 `_gate`/`REF_FEE_BPS`); v2 artifact fields (§4 → Task 8); fee provenance (§4 → Task 1); execution prereqs (§6 → Conventions + Task 1 Step 2); safety boundary (§8 → driver docstring + PR body).
+- **Type consistency:** `MakerTradeRecord` fields (`net_at_real_fees`, `commission_real`, `notional`, `ts_opened`, `filled`, `tp_hit`, `adverse_excursion_bps`) are identical across Tasks 2/3/4/7/10. `run_maker` returns `(records, attempted, filled)` and is consumed that way in Task 8. `build_maker_optimistic`/`build_maker_conservative` signatures match call sites. Strategy `records` dict keys (`net/comm/notional/ts/filled/tp_hit/adverse_bps`) map 1:1 to `run_maker`'s `MakerTradeRecord` construction.
+- **Placeholder scan:** the only intentional fill-in is the PR-body verdict line (Task 11), which depends on the Task 9 run output and cannot be known in advance.
+- **Risk:** Task 5 spike gates the maker-fee assumption before the strategy is built; if Nautilus treats the entry limit as taker, Task 6 is adjusted (documented, no silent taker-as-maker).

--- a/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
+++ b/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
@@ -1,0 +1,188 @@
+# ROB-324 — Maker/limit-fill scalping edge re-evaluation (design)
+
+- **Issue:** ROB-324 (follow-up to ROB-320 / PR #968)
+- **Date:** 2026-05-26
+- **Scope:** research/backtest only. No live trading, no Demo `confirm=true`, no
+  broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod
+  DB/env/secret changes, no runtime parameter application, no `/invest` surfacing.
+- **Location:** everything lives under `research/nautilus_scalping/` in its isolated venv.
+
+## 1. Problem
+
+ROB-320 produced an honest `not_validated` for the `meanrev_zscore_fade` candidate on
+`XRPUSDT` + `BTCUSDT`: there is a small **gross** edge (whole-run PF ≈ 1.058) that
+collapses once taker fees are applied (`net_after_cost` OOS ≈ −51.43 USDT, PF ≈ 0.37).
+
+Two facts make a re-evaluation worthwhile:
+
+1. **The fee assumption was doubly pessimistic.** ROB-320's catalog instrument and gate
+   used **10 bps** per leg. The captured live commission artifact shows the real Binance
+   **USDⓈ-M Futures Demo** schedule for both symbols is **maker 2.0 bps / taker 4.0 bps**
+   (`research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json`).
+2. **Both legs were taker.** Entry is `order_factory.market(...)`; exit is
+   `close_all_positions(...)` on a tick TP/SL hit. A maker/limit execution model could
+   pay less fee and capture price improvement.
+
+**Question:** can a *conservative* maker/limit execution model recover a net-after-cost
+edge without overclaiming validation?
+
+**Honest prior:** even an optimistic maker rescale (2 bps, assuming every limit fills)
+leaves the ROB-320 OOS fold ≈ −7 USDT. The likely outcome is another `not_validated`.
+The deliverable is the honest model + auditable artifact, **not** a green light.
+
+### Non-negotiable: no fee-only rescale
+The commission artifact's own note (line 53) states: *"Use maker_fee_bps only with a real
+maker/limit-fill model; fee-only rescale is not sufficient evidence for maker execution."*
+Simply lowering `fee_bps` on the existing taker trade set would silently assume 100% fill
+at favorable prices — exactly the overclaim to avoid. **Fills must be derived from real
+price action.**
+
+## 2. Approach (chosen)
+
+Real tick-level limit-fill **re-simulation** in Nautilus, plus a pure deterministic
+conservative overlay. Three scenarios are produced and fed to the **existing, unchanged**
+`validated_gate.evaluate_gate`:
+
+| # | Scenario | Production | Fees |
+|---|----------|------------|------|
+| 1 | **Taker baseline (realistic)** | Taker run, evaluated at **4 bps** both legs (corrects ROB-320's 10 bps). Single-rate, so the gate's existing linear rescale is valid. | 4 / 4 bps |
+| 2 | **Maker/limit (data-derived)** | **New** Nautilus re-sim: LIMIT entry posted at the signal-bar close, filled against real trade ticks; if the next bar (60 s) of ticks never reaches it → cancel = **missed fill** (0 pnl, 0 fee). TP = maker limit (2 bps), SL = taker stop (4 bps). Entry maker = 2 bps. True per-leg fees baked into realized net. | maker 2 / taker 4 |
+| 3 | **Conservative** | Pure overlay on Scenario 2 records: drop **25%** of "easy-TP" fills (TP hit with ~0 adverse excursion → front-of-queue fills you would not realistically win) **plus** a **1.0 bp** adverse-selection cost on every maker entry. | as #2 + haircut |
+
+Baselines inside the gate (`micro_breakout`, `random_entry`) are evaluated at the same
+**4 bps** taker so the candidate comparison is apples-to-apples.
+
+### Alternatives rejected
+- **Pure parametric overlay only** (no re-sim): fast and pure, but fills are assumptions,
+  not price-derived — contradicts the artifact note's requirement for a real fill model.
+- **Both side-by-side**: most auditable, but heaviest; deferred. The re-sim already gives
+  the honest answer.
+
+## 3. Components
+
+All under `research/nautilus_scalping/`.
+
+### 3.1 `strategy_meanrev.py` (extend)
+Add `execution_mode: str = "taker"` to `MeanRevScalperConfig`.
+- **Default `"taker"` preserves current behavior** — existing runs and parity tests
+  (`test_meanrev_parity.py`, `test_signal_parity.py`) are unaffected.
+- `"maker"` branch:
+  - Entry: `order_factory.limit(...)` at the signal-bar close price (BUY at close, SELL
+    mirror). Track submission bar.
+  - Fill timeout: if not filled by the end of the next bar, cancel the working order =
+    missed fill. Implemented via bar count since submission in `on_bar`.
+  - Exit: TP as a resting maker `limit`; SL remains a taker stop/market (must get out).
+    SL-first conservative ordering retained.
+  - Record per-trade **adverse excursion** (max unfavorable price move between fill and
+    exit, in bps) so the overlay can classify "easy-TP" fills.
+
+### 3.2 `backtest_runner.py` (extend)
+- When `execution_mode == "maker"`, build a **real-fee instrument override** (maker
+  0.0002 / taker 0.0004) from the catalog instrument in-process — **no catalog rebuild**.
+- Emit richer per-trade records for maker runs: `net_ref_pnl` (true realized net at real
+  per-leg fees), `commission_ref` (true total commission magnitude), `notional`,
+  `ts_opened`, `filled` (bool), `adverse_excursion_bps`, `tp_hit` (bool).
+- Taker runs emit the existing 4-field record unchanged.
+
+### 3.3 `maker_fill.py` (new, pure — no Nautilus import)
+- `MakerTradeRecord` dataclass (the rich record above).
+- `build_taker_baseline(taker_trades, fee_bps=4.0) -> list[Trade]` — rescale 10→4.
+- `build_maker_optimistic(records) -> list[Trade]` — keep all fills; net already at real
+  fees; `commission_ref` carries true commission so the gate's gross column still works.
+- `build_maker_conservative(records, queue_loss_pct=0.25, adverse_bps=1.0,
+  excursion_eps_bps=2.0) -> list[Trade]` — deterministically drop easy-TP fills (selection
+  by a stable hash of `ts_opened`, so it is reproducible and not random) and subtract
+  `adverse_bps * notional / 10_000` from each surviving maker entry.
+- `classify_easy_tp(record, excursion_eps_bps=2.0) -> bool` — `True` when the trade hit TP
+  and its `adverse_excursion_bps <= excursion_eps_bps` (i.e. price barely moved against the
+  fill before reaching TP → a front-of-queue fill unlikely to be won in reality).
+- All functions pure and unit-testable; they output plain `validated_gate.Trade` lists.
+
+### 3.4 `validate_maker_fill.py` (new driver)
+- Runs the taker meanrev + baselines (existing runner) and the **maker** meanrev re-sim,
+  across `XRPUSDT` + `BTCUSDT`, merged chronologically (mirrors `validate_candidate.py`).
+- Builds the three scenarios via `maker_fill.py`.
+- Calls the existing `evaluate_gate` once per scenario (candidate = that scenario's
+  trades; baselines at 4 bps). The headline verdict is taken from the **conservative**
+  scenario (the honest lower bound); the optimistic and taker results are reported for
+  comparison.
+- Writes the artifact (§4). No execution side effects — public-data backtest only.
+
+### 3.5 Gate reuse — the one subtlety
+`validated_gate.py` stays **byte-for-byte unchanged**. Maker scenarios cannot use the
+single-rate fee rescale (mixed maker/taker legs break linearity). Convention:
+
+- Each maker `Trade` carries the **true net at real per-leg fees** in `net_ref_pnl`
+  (post-haircut for the conservative scenario) and the **true total commission magnitude**
+  in `commission_ref`.
+- The driver calls `evaluate_gate(..., fee_bps=REF_FEE_BPS)`. At the reference point
+  `scale = 0`, so `net_after_cost = net_ref_pnl` (as-run), while the gross column
+  (`fee_bps=0`, `scale=1`) adds `commission_ref` back. The driver only ever evaluates
+  maker scenarios at the reference point and 0 — never intermediate fees — so the mixed-leg
+  non-linearity is never exercised.
+- `cost_model` in the artifact records the **real** maker/taker bps (not 10) to prevent
+  confusion, with a note explaining the convention.
+
+**Fallback** (only if review finds the convention too implicit): a minimal *additive,
+non-verdict-affecting* gate parameter (e.g. `rescale=False`). Tried the convention first
+to honor "gate unchanged".
+
+## 4. Artifact
+
+`research/nautilus_scalping/results/rob324/maker_fill.json`, `schema_version:
+"validated_signal_gate.v2"`. Superset of the ROB-320 v1 report, adding:
+
+- `fill_model`: `{entry_rule, fill_timeout_bars, tp_execution, sl_execution,
+  queue_loss_pct, adverse_bps, excursion_eps_bps}`.
+- `cost_model`: real `maker_fee_bps: 2.0`, `taker_fee_bps: 4.0`, and
+  `commission_source: "results/rob324/binance_usdm_commission_rates.json"`.
+- `scenarios`: for each of the three — symbols, window, OOS + per-fold metrics, baseline
+  comparison, overfit flags, trade/fill/missed-fill counts.
+- Top-level `verdict` (from the conservative scenario) + `verdict_reasons`.
+
+The captured `binance_usdm_commission_rates.json` is copied into this branch under
+`results/rob324/` so the fee provenance ships with the result.
+
+## 5. Tests
+
+- `tests/test_maker_fill.py` (new, pure):
+  - **Missed-fill path:** an unfilled record contributes 0 pnl and 0 fee; missed-fill
+    count is correct.
+  - **Adverse-selection / queue-loss path:** conservative overlay drops the right easy-TP
+    fills (deterministic) and applies the adverse cost; net is strictly worse than the
+    optimistic scenario.
+  - **Fee math:** maker net uses 2/4 bps; taker baseline rescales 10→4 correctly.
+  - **Determinism:** the queue-loss selection is stable across runs (hash-based).
+- Gate/report test asserting the produced verdict is always one of
+  `validated` / `not_validated` / `insufficient_data`.
+- Existing `test_validated_gate.py`, `test_meanrev_*`, `test_signal_parity.py` remain
+  green (the `execution_mode` default is `"taker"`).
+
+## 6. Execution prerequisites
+
+- The rob-324 worktree has no venv/catalog (both gitignored). The **rob-320 worktree**
+  has a built ParquetDataCatalog with trade-tick data for both symbols across the window.
+- Plan: verify the rob-320 nautilus venv imports; run with `--catalog <rob-320 catalog>`
+  (read-only). If the venv is broken, rebuilding the Intel-mac Rust nautilus is the costly
+  fallback — surface before spending time on it.
+
+## 7. Acceptance criteria (from the issue) — how this design meets each
+
+- Pure tests cover maker/limit-fill assumptions + ≥1 adverse-selection/missed-fill path →
+  `tests/test_maker_fill.py` (§5).
+- Gate/report tests prove the verdict stays within the three-value vocabulary →
+  gate/report test (§5); verdict logic is the unchanged `evaluate_gate`.
+- Artifact records symbols, window, fee model, fill model, OOS metrics, baseline
+  comparison, overfit flags → `maker_fill.json` (§4).
+- PR handoff comment states artifact path, verdict, and side-effect boundary → produced at
+  PR time.
+- CI/lint passes for the touched research code → `ruff` on the research files + the pure
+  test suite.
+
+## 8. Safety boundary
+
+Research only. Public trade-tick data, isolated venv, read-only catalog access. No live
+trading, no Demo `confirm=true`, no broker/order/watch/order-intent mutation, no
+scheduler/Prefect/launchd, no prod DB/env/secrets, no runtime parameter application, no
+`/invest` surfacing. The commission artifact is read-only input and contains no secrets,
+signatures, balances, positions, or account identifiers.

--- a/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
+++ b/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
@@ -7,6 +7,33 @@
   DB/env/secret changes, no runtime parameter application, no `/invest` surfacing.
 - **Location:** everything lives under `research/nautilus_scalping/` in its isolated venv.
 
+## 0. Design revision (2026-05-27, approved)
+
+The original §3 design rested the take-profit as a Nautilus LIMIT order. In testing,
+a resting TP limit **under-filled** vs the taker's touch-based exit (`tp_hit` ~17% vs
+the taker's ~51% win rate): positions rode to SL or end-of-data, collapsing maker
+trade count to `insufficient_data` — a backtest matching-engine artifact, not economics.
+Approved pivot to a cleaner, equivalent-fidelity model:
+
+- **Entry** stays a passive, data-derived Nautilus limit, now posted `entry_offset_bps`
+  (default 5) **below** the close (BUY) / above (SELL). Immediate reversions are **real
+  missed fills** (~45% observed); continued moves fill → genuine entry-side adverse
+  selection from real ticks.
+- **Exit** is **touch-based**, identical trigger logic to the taker (SL-first), so the
+  maker trade set is comparable to taker (~284 vs 466 for one symbol/config) instead of
+  collapsing. `tp_hit` returns to ~47%.
+- **Fees** are applied analytically, not by Nautilus: the maker re-sim runs on a
+  **zero-fee instrument** (so `realized_pnl` = pure gross price P&L) and `maker_fill`
+  charges the **real per-leg fees** — maker 2 bps on the entry + the TP leg, taker 4 bps
+  on the SL leg — plus the conservative overlay. This is still a re-sim with real fills,
+  not a fee-only rescale (it satisfies the commission-artifact note).
+- Because there is no longer a resting exit limit, the venue reverts to ROB-320's
+  `OmsType.HEDGING` + USDT-only funding for both modes (every exit is an explicit market
+  `close_all_positions`, OMS-agnostic; taker reproduces ROB-320 exactly).
+
+Sections below retain the original framing; where they describe a resting TP limit, read
+the touch-based + analytic-fee model above.
+
 ## 1. Problem
 
 ROB-320 produced an honest `not_validated` for the `meanrev_zscore_fade` candidate on

--- a/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
+++ b/docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md
@@ -101,9 +101,12 @@ Add `execution_mode: str = "taker"` to `MeanRevScalperConfig`.
 ### 3.4 `validate_maker_fill.py` (new driver)
 - Runs the taker meanrev + baselines (existing runner) and the **maker** meanrev re-sim,
   across `XRPUSDT` + `BTCUSDT`, merged chronologically (mirrors `validate_candidate.py`).
+- **Reuses ROB-320's 2-config param grid** (`z2.0/tp30/sl30`, `z2.5/tp40/sl40`) for the
+  taker and maker candidate scenarios, so the gate's param-stability / `param_island`
+  overfit guard is preserved (a single config would make that check trivially pass).
 - Builds the three scenarios via `maker_fill.py`.
-- Calls the existing `evaluate_gate` once per scenario (candidate = that scenario's
-  trades; baselines at 4 bps). The headline verdict is taken from the **conservative**
+- Calls the existing `evaluate_gate` once per scenario (per-label `candidate_runs`;
+  baselines at 4 bps). The headline verdict is taken from the **conservative**
   scenario (the honest lower bound); the optimistic and taker results are reported for
   comparison.
 - Writes the artifact (§4). No execution side effects — public-data backtest only.

--- a/research/nautilus_scalping/backtest_runner.py
+++ b/research/nautilus_scalping/backtest_runner.py
@@ -41,6 +41,10 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
 
     execution_mode = str(params.get("execution_mode", "taker"))
     if execution_mode == "maker":
+        # ZERO-fee instrument: realized_pnl is pure (fee-free) gross price P&L. maker_fill
+        # then applies the REAL Binance Demo per-leg fees analytically (maker 2bps on the
+        # entry + the TP leg, taker 4bps on the SL leg). Keeps the gate-feeding net exact
+        # without relying on a single Nautilus commission rate for the mixed maker/taker mix.
         instrument = CurrencyPair(
             instrument_id=instrument.id, raw_symbol=instrument.raw_symbol,
             base_currency=instrument.base_currency, quote_currency=instrument.quote_currency,
@@ -51,23 +55,19 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
             min_notional=instrument.min_notional, max_price=instrument.max_price,
             min_price=instrument.min_price, margin_init=instrument.margin_init,
             margin_maint=instrument.margin_maint,
-            maker_fee=Decimal("0.0002"), taker_fee=Decimal("0.0004"),   # real demo 2/4 bps
+            maker_fee=Decimal("0"), taker_fee=Decimal("0"),
             ts_event=0, ts_init=0)
 
     engine = BacktestEngine(config=BacktestEngineConfig(
         trader_id="ROB320-001", logging=LoggingConfig(log_level="ERROR")))
 
-    # Taker baseline keeps ROB-320's USDT-only funding (verified to reproduce it exactly:
-    # 789 trades, net@10bps -209.71). The maker re-sim ALSO seeds base currency so the
-    # resting maker-limit TP (a SELL of the just-opened long) settles in the CASH account
-    # without tripping AccountBalanceNegative on the fee leg. Scoped to maker so the taker
-    # baseline funding is byte-for-byte ROB-320.
-    starting_balances = [Money(10_000_000, USDT)]
-    if execution_mode == "maker":
-        starting_balances.append(Money(10_000_000, instrument.base_currency))
+    # Both modes use ROB-320's venue: HEDGING is fine because every exit is an explicit
+    # market close_all_positions (OMS-agnostic) — maker mode no longer rests a TP limit,
+    # so the earlier counter-position problem is gone. Taker reproduces ROB-320 exactly
+    # (789 trades, net@10bps -209.71).
     engine.add_venue(venue=Venue("BINANCE"), oms_type=OmsType.HEDGING,
                      account_type=AccountType.CASH, base_currency=None,
-                     starting_balances=starting_balances)
+                     starting_balances=[Money(10_000_000, USDT)])
     engine.add_instrument(instrument)
     engine.add_data(ticks)
     bar_type = BarType.from_str(f"{instrument.id.value}-1-MINUTE-LAST-INTERNAL")
@@ -159,9 +159,10 @@ def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100")
         if line.startswith(_SENTINEL):
             data = json.loads(line[len(_SENTINEL):])
             recs = [MakerTradeRecord(
-                net_at_real_fees=r["net"], commission_real=abs(r["comm"]),
-                notional=r["notional"], ts_opened=r["ts"], filled=r["filled"],
-                tp_hit=r["tp_hit"], adverse_excursion_bps=r["adverse_bps"])
+                gross=r["gross"], entry_notional=r["entry_notional"],
+                exit_notional=r["exit_notional"], ts_opened=r["ts"],
+                filled=r["filled"], tp_hit=r["tp_hit"],
+                adverse_excursion_bps=r["adverse_bps"])
                 for r in data["records"]]
             return recs, data["entries_attempted"], data["entries_filled"]
     raise RuntimeError(f"maker runner {symbol} failed:\n{proc.stderr[-800:]}")

--- a/research/nautilus_scalping/backtest_runner.py
+++ b/research/nautilus_scalping/backtest_runner.py
@@ -16,6 +16,7 @@ import json
 import os
 import subprocess
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 from validated_gate import Trade
@@ -30,6 +31,7 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     from nautilus_trader.model.data import BarType
     from nautilus_trader.model.enums import AccountType, OmsType
     from nautilus_trader.model.identifiers import Venue
+    from nautilus_trader.model.instruments import CurrencyPair
     from nautilus_trader.model.objects import Money
     from nautilus_trader.persistence.catalog import ParquetDataCatalog
 
@@ -37,11 +39,31 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     instrument = next(i for i in catalog_obj.instruments() if i.id.value.startswith(symbol))
     ticks = catalog_obj.trade_ticks(instrument_ids=[instrument.id.value])
 
+    execution_mode = str(params.get("execution_mode", "taker"))
+    if execution_mode == "maker":
+        instrument = CurrencyPair(
+            instrument_id=instrument.id, raw_symbol=instrument.raw_symbol,
+            base_currency=instrument.base_currency, quote_currency=instrument.quote_currency,
+            price_precision=instrument.price_precision, size_precision=instrument.size_precision,
+            price_increment=instrument.price_increment, size_increment=instrument.size_increment,
+            lot_size=instrument.lot_size, max_quantity=instrument.max_quantity,
+            min_quantity=instrument.min_quantity, max_notional=instrument.max_notional,
+            min_notional=instrument.min_notional, max_price=instrument.max_price,
+            min_price=instrument.min_price, margin_init=instrument.margin_init,
+            margin_maint=instrument.margin_maint,
+            maker_fee=Decimal("0.0002"), taker_fee=Decimal("0.0004"),   # real demo 2/4 bps
+            ts_event=0, ts_init=0)
+
     engine = BacktestEngine(config=BacktestEngineConfig(
         trader_id="ROB320-001", logging=LoggingConfig(log_level="ERROR")))
+    
+    # Dynamic starting balances: add base currency to starting_balances to avoid AccountBalanceNegative due to fees
     engine.add_venue(venue=Venue("BINANCE"), oms_type=OmsType.HEDGING,
                      account_type=AccountType.CASH, base_currency=None,
-                     starting_balances=[Money(10_000_000, USDT)])
+                     starting_balances=[
+                         Money(10_000_000, USDT),
+                         Money(10_000_000, instrument.base_currency)
+                     ])
     engine.add_instrument(instrument)
     engine.add_data(ticks)
     bar_type = BarType.from_str(f"{instrument.id.value}-1-MINUTE-LAST-INTERNAL")
@@ -57,7 +79,8 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
             instrument_id=instrument.id, bar_type=bar_type, trade_size=trade_size,
             lookback=int(params.get("lookback", 20)), z_entry=str(params.get("z_entry", "2.0")),
             tp_bps=int(params.get("tp_bps", 30)), sl_bps=int(params.get("sl_bps", 30)),
-            require_vol=bool(params.get("require_vol", True))))
+            require_vol=bool(params.get("require_vol", True)),
+            execution_mode=execution_mode))
     elif strategy == "random_entry":
         from strategy_random import RandomScalper, RandomScalperConfig
         strat = RandomScalper(RandomScalperConfig(
@@ -69,6 +92,18 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
 
     engine.add_strategy(strat)
     engine.run()
+
+    if execution_mode == "maker":
+        payload = {
+            "execution_mode": "maker",
+            "records": list(strat.records),
+            "entries_attempted": int(strat.entries_attempted),
+            "entries_filled": int(strat.entries_filled),
+        }
+        engine.dispose()
+        print(_SENTINEL + json.dumps(payload))
+        return
+
     trades = []
     for p in engine.cache.positions_closed():
         net_ref = p.realized_pnl.as_double()
@@ -100,6 +135,32 @@ def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str
             return [Trade(net_ref_pnl=r[0], commission_ref=r[1], notional=r[2], ts_opened=r[3])
                     for r in raw]
     raise RuntimeError(f"runner {strategy} on {symbol} failed:\n{proc.stderr[-800:]}")
+
+
+def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100"):
+    """Run the maker re-sim; return (records, attempted, filled).
+
+    records are maker_fill.MakerTradeRecord; attempted-filled = missed fills."""
+    from maker_fill import MakerTradeRecord
+    p = dict(params)
+    p["execution_mode"] = "maker"
+    venv_python = sys.executable
+    cmd = [venv_python, os.path.abspath(__file__), "--single", "--catalog", str(catalog),
+           "--symbol", symbol, "--strategy", "meanrev_zscore_fade",
+           "--params", json.dumps(p), "--trade-size", trade_size]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + "../.."
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    for line in proc.stdout.splitlines():
+        if line.startswith(_SENTINEL):
+            data = json.loads(line[len(_SENTINEL):])
+            recs = [MakerTradeRecord(
+                net_at_real_fees=r["net"], commission_real=abs(r["comm"]),
+                notional=r["notional"], ts_opened=r["ts"], filled=r["filled"],
+                tp_hit=r["tp_hit"], adverse_excursion_bps=r["adverse_bps"])
+                for r in data["records"]]
+            return recs, data["entries_attempted"], data["entries_filled"]
+    raise RuntimeError(f"maker runner {symbol} failed:\n{proc.stderr[-800:]}")
 
 
 def main() -> int:

--- a/research/nautilus_scalping/backtest_runner.py
+++ b/research/nautilus_scalping/backtest_runner.py
@@ -56,14 +56,18 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
 
     engine = BacktestEngine(config=BacktestEngineConfig(
         trader_id="ROB320-001", logging=LoggingConfig(log_level="ERROR")))
-    
-    # Dynamic starting balances: add base currency to starting_balances to avoid AccountBalanceNegative due to fees
+
+    # Taker baseline keeps ROB-320's USDT-only funding (verified to reproduce it exactly:
+    # 789 trades, net@10bps -209.71). The maker re-sim ALSO seeds base currency so the
+    # resting maker-limit TP (a SELL of the just-opened long) settles in the CASH account
+    # without tripping AccountBalanceNegative on the fee leg. Scoped to maker so the taker
+    # baseline funding is byte-for-byte ROB-320.
+    starting_balances = [Money(10_000_000, USDT)]
+    if execution_mode == "maker":
+        starting_balances.append(Money(10_000_000, instrument.base_currency))
     engine.add_venue(venue=Venue("BINANCE"), oms_type=OmsType.HEDGING,
                      account_type=AccountType.CASH, base_currency=None,
-                     starting_balances=[
-                         Money(10_000_000, USDT),
-                         Money(10_000_000, instrument.base_currency)
-                     ])
+                     starting_balances=starting_balances)
     engine.add_instrument(instrument)
     engine.add_data(ticks)
     bar_type = BarType.from_str(f"{instrument.id.value}-1-MINUTE-LAST-INTERNAL")

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -1,18 +1,26 @@
 # research/nautilus_scalping/maker_fill.py
 """ROB-324 — PURE maker/limit-fill scenario builders (no nautilus import).
 
-Consumes ``MakerTradeRecord``s emitted by the maker re-sim and produces plain
+Consumes ``MakerTradeRecord``s emitted by the maker re-sim (run on a ZERO-FEE
+instrument, so ``gross`` is pure price P&L) and produces plain
 ``validated_gate.Trade`` lists for the unchanged gate. Fees are the REAL Binance
 USDⓈ-M Futures Demo schedule (maker 2.0 / taker 4.0 bps) captured in
 ``results/rob324/binance_usdm_commission_rates.json``.
 
-Gate convention (see spec §3.5): maker scenarios cannot use the gate's single-rate
-fee rescale (mixed maker/taker legs), so each ``Trade`` carries the TRUE net at real
-per-leg fees in ``net_ref_pnl`` and the true commission magnitude in
-``commission_ref``. The driver evaluates maker scenarios at ``REF_FEE_BPS`` (scale=0
-→ net_after_cost = as-run) and 0 (gross adds commission back). The taker baseline,
-being single-rate, uses the gate's NATIVE rescale (call ``evaluate_gate`` at 4.0 bps
-on the raw 10-bps taker trades) — no builder needed for it.
+Fee model (per leg): the entry is a passive limit (MAKER, 2 bps); the exit is the
+maker-limit take-profit (MAKER, 2 bps) when ``tp_hit`` else the taker stop
+(TAKER, 4 bps). Applying fees here — rather than via a single Nautilus commission
+rate — keeps the mixed maker/taker mix exact.
+
+Gate convention (spec §3.5): each ``Trade`` carries the TRUE net at real fees in
+``net_ref_pnl`` and the fee magnitude in ``commission_ref``; the driver evaluates
+maker scenarios at ``validated_gate.REF_FEE_BPS`` (scale=0 → net_after_cost =
+as-run) and 0 (gross adds the fee back). The taker baseline, being single-rate,
+uses the gate's NATIVE rescale (``evaluate_gate`` at 4.0 bps on the raw 10-bps
+taker trades) — no builder needed for it.
+
+Missed fills (entry limit cancelled on timeout) earn nothing and are simply
+ABSENT from the record list; the re-sim reports the missed count separately.
 """
 from __future__ import annotations
 
@@ -28,26 +36,36 @@ MAKER_FEE_BPS = 2.0         # real demo maker
 
 @dataclass(frozen=True)
 class MakerTradeRecord:
-    net_at_real_fees: float      # realized pnl already net of maker/taker per-leg fees
-    commission_real: float       # total commission magnitude actually paid (>= 0)
-    notional: float
+    gross: float                 # realized price P&L on the zero-fee re-sim (fee-free)
+    entry_notional: float        # entry leg notional (price * qty)
+    exit_notional: float         # exit leg notional (price * qty)
     ts_opened: int
     filled: bool                 # False = limit cancelled (missed fill)
-    tp_hit: bool                 # exit was the maker-limit TP (vs taker-stop SL)
+    tp_hit: bool                 # exit was the maker-limit TP (vs the taker stop SL)
     adverse_excursion_bps: float # worst adverse move between fill and exit, bps
 
 
-def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
-    """Filled maker trades at real fees; missed fills contribute nothing.
+def _legs_fee(record: MakerTradeRecord) -> float:
+    """Real per-leg fee: maker on the entry + maker on the TP leg / taker on the SL leg."""
+    entry_fee = MAKER_FEE_BPS * record.entry_notional / 10_000.0
+    exit_rate = MAKER_FEE_BPS if record.tp_hit else TAKER_BASELINE_BPS
+    exit_fee = exit_rate * record.exit_notional / 10_000.0
+    return entry_fee + exit_fee
 
-    net_ref_pnl carries the true net (maker 2 / taker 4 bps already applied);
-    commission_ref carries the true commission magnitude so the gate's gross
-    column reconstructs correctly. Evaluate at REF_FEE_BPS for as-run net."""
-    return [
-        Trade(net_ref_pnl=r.net_at_real_fees, commission_ref=r.commission_real,
-              notional=r.notional, ts_opened=r.ts_opened)
-        for r in records if r.filled
-    ]
+
+def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
+    """Filled maker trades, real per-leg fees applied to the zero-fee gross.
+
+    Optimistic = every touched TP is assumed to fill (no queue loss); that
+    pessimism is added by build_maker_conservative."""
+    out: list[Trade] = []
+    for r in records:
+        if not r.filled:
+            continue
+        fee = _legs_fee(r)
+        out.append(Trade(net_ref_pnl=r.gross - fee, commission_ref=fee,
+                         notional=r.entry_notional, ts_opened=r.ts_opened))
+    return out
 
 
 def classify_easy_tp(record: MakerTradeRecord, excursion_eps_bps: float = 2.0) -> bool:
@@ -69,11 +87,11 @@ def build_maker_conservative(
     adverse_bps: float = 1.0,
     excursion_eps_bps: float = 2.0,
 ) -> list[Trade]:
-    """Conservative maker scenario: an honest lower bound on the re-sim.
+    """Conservative maker scenario: an honest lower bound on the optimistic re-sim.
 
     Two haircuts on top of the data-derived fills:
       1. Queue loss — deterministically drop ``queue_loss_pct`` of the easy-TP fills
-         (Nautilus has no order-queue model, so it over-fills passive limits).
+         (a touch-based TP fill assumes front-of-queue priority we would not always win).
       2. Adverse selection — charge ``adverse_bps`` on every surviving maker entry.
     Missed fills are excluded (they earn nothing)."""
     out: list[Trade] = []
@@ -82,10 +100,8 @@ def build_maker_conservative(
             continue
         if classify_easy_tp(r, excursion_eps_bps) and _uniform_from_ts(r.ts_opened) < queue_loss_pct:
             continue  # queue loss
-        adverse_cost = adverse_bps * r.notional / 10_000.0
-        out.append(Trade(
-            net_ref_pnl=r.net_at_real_fees - adverse_cost,
-            commission_ref=r.commission_real,
-            notional=r.notional, ts_opened=r.ts_opened,
-        ))
+        fee = _legs_fee(r)
+        adverse_cost = adverse_bps * r.entry_notional / 10_000.0
+        out.append(Trade(net_ref_pnl=r.gross - fee - adverse_cost, commission_ref=fee,
+                         notional=r.entry_notional, ts_opened=r.ts_opened))
     return out

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -49,3 +49,44 @@ def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
               notional=r.notional, ts_opened=r.ts_opened)
         for r in records if r.filled
     ]
+
+
+def classify_easy_tp(record: MakerTradeRecord, excursion_eps_bps: float = 2.0) -> bool:
+    """A TP fill that barely moved against us before reaching target — i.e. a
+    front-of-queue fill we would not realistically win against real queue priority."""
+    return record.tp_hit and record.adverse_excursion_bps <= excursion_eps_bps
+
+
+def _uniform_from_ts(ts_opened: int) -> float:
+    """Deterministic uniform [0,1) from the trade timestamp (reproducible, no RNG)."""
+    digest = blake2b(str(ts_opened).encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") / 2.0 ** 64
+
+
+def build_maker_conservative(
+    records: list[MakerTradeRecord],
+    *,
+    queue_loss_pct: float = 0.25,
+    adverse_bps: float = 1.0,
+    excursion_eps_bps: float = 2.0,
+) -> list[Trade]:
+    """Conservative maker scenario: an honest lower bound on the re-sim.
+
+    Two haircuts on top of the data-derived fills:
+      1. Queue loss — deterministically drop ``queue_loss_pct`` of the easy-TP fills
+         (Nautilus has no order-queue model, so it over-fills passive limits).
+      2. Adverse selection — charge ``adverse_bps`` on every surviving maker entry.
+    Missed fills are excluded (they earn nothing)."""
+    out: list[Trade] = []
+    for r in records:
+        if not r.filled:
+            continue
+        if classify_easy_tp(r, excursion_eps_bps) and _uniform_from_ts(r.ts_opened) < queue_loss_pct:
+            continue  # queue loss
+        adverse_cost = adverse_bps * r.notional / 10_000.0
+        out.append(Trade(
+            net_ref_pnl=r.net_at_real_fees - adverse_cost,
+            commission_ref=r.commission_real,
+            notional=r.notional, ts_opened=r.ts_opened,
+        ))
+    return out

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from hashlib import blake2b
 
+from validated_gate import Trade  # pure import (stdlib-only module)
+
 REF_FEE_BPS = 10.0          # mirrors validated_gate.REF_FEE_BPS (as-run reference point)
 TAKER_BASELINE_BPS = 4.0    # real demo taker
 MAKER_FEE_BPS = 2.0         # real demo maker
@@ -33,9 +35,6 @@ class MakerTradeRecord:
     filled: bool                 # False = limit cancelled (missed fill)
     tp_hit: bool                 # exit was the maker-limit TP (vs taker-stop SL)
     adverse_excursion_bps: float # worst adverse move between fill and exit, bps
-
-
-from validated_gate import Trade  # pure import (stdlib-only module)
 
 
 def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -33,3 +33,19 @@ class MakerTradeRecord:
     filled: bool                 # False = limit cancelled (missed fill)
     tp_hit: bool                 # exit was the maker-limit TP (vs taker-stop SL)
     adverse_excursion_bps: float # worst adverse move between fill and exit, bps
+
+
+from validated_gate import Trade  # pure import (stdlib-only module)
+
+
+def build_maker_optimistic(records: list[MakerTradeRecord]) -> list[Trade]:
+    """Filled maker trades at real fees; missed fills contribute nothing.
+
+    net_ref_pnl carries the true net (maker 2 / taker 4 bps already applied);
+    commission_ref carries the true commission magnitude so the gate's gross
+    column reconstructs correctly. Evaluate at REF_FEE_BPS for as-run net."""
+    return [
+        Trade(net_ref_pnl=r.net_at_real_fees, commission_ref=r.commission_real,
+              notional=r.notional, ts_opened=r.ts_opened)
+        for r in records if r.filled
+    ]

--- a/research/nautilus_scalping/maker_fill.py
+++ b/research/nautilus_scalping/maker_fill.py
@@ -1,0 +1,35 @@
+# research/nautilus_scalping/maker_fill.py
+"""ROB-324 — PURE maker/limit-fill scenario builders (no nautilus import).
+
+Consumes ``MakerTradeRecord``s emitted by the maker re-sim and produces plain
+``validated_gate.Trade`` lists for the unchanged gate. Fees are the REAL Binance
+USDⓈ-M Futures Demo schedule (maker 2.0 / taker 4.0 bps) captured in
+``results/rob324/binance_usdm_commission_rates.json``.
+
+Gate convention (see spec §3.5): maker scenarios cannot use the gate's single-rate
+fee rescale (mixed maker/taker legs), so each ``Trade`` carries the TRUE net at real
+per-leg fees in ``net_ref_pnl`` and the true commission magnitude in
+``commission_ref``. The driver evaluates maker scenarios at ``REF_FEE_BPS`` (scale=0
+→ net_after_cost = as-run) and 0 (gross adds commission back). The taker baseline,
+being single-rate, uses the gate's NATIVE rescale (call ``evaluate_gate`` at 4.0 bps
+on the raw 10-bps taker trades) — no builder needed for it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import blake2b
+
+REF_FEE_BPS = 10.0          # mirrors validated_gate.REF_FEE_BPS (as-run reference point)
+TAKER_BASELINE_BPS = 4.0    # real demo taker
+MAKER_FEE_BPS = 2.0         # real demo maker
+
+
+@dataclass(frozen=True)
+class MakerTradeRecord:
+    net_at_real_fees: float      # realized pnl already net of maker/taker per-leg fees
+    commission_real: float       # total commission magnitude actually paid (>= 0)
+    notional: float
+    ts_opened: int
+    filled: bool                 # False = limit cancelled (missed fill)
+    tp_hit: bool                 # exit was the maker-limit TP (vs taker-stop SL)
+    adverse_excursion_bps: float # worst adverse move between fill and exit, bps

--- a/research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json
+++ b/research/nautilus_scalping/results/rob324/binance_usdm_commission_rates.json
@@ -1,0 +1,56 @@
+{
+  "artifact_type": "binance_usdm_futures_commission_rates",
+  "purpose": "ROB-324 maker/limit-fill scalping research fee input",
+  "captured_at": "2026-05-26T07:54:38Z",
+  "source": "binance_signed_readonly_api",
+  "api": {
+    "venue": "binance_usdm_futures_demo",
+    "base_url": "https://demo-fapi.binance.com",
+    "endpoint_path": "/fapi/v1/commissionRate",
+    "method": "GET",
+    "mutation": false,
+    "credential_source": "shared_demo_env",
+    "symbols": [
+      "BTCUSDT",
+      "XRPUSDT"
+    ],
+    "time_endpoint_status": 200,
+    "clock_offset_ms": 164
+  },
+  "safety": {
+    "order_mutation": false,
+    "broker_order_submission": false,
+    "scheduler_or_prefect_activation": false,
+    "secret_values_written": false,
+    "signed_query_or_signature_written": false
+  },
+  "rates": [
+    {
+      "symbol": "BTCUSDT",
+      "status": "ok",
+      "http_status": 200,
+      "maker_commission_rate_decimal": "0.000200",
+      "taker_commission_rate_decimal": "0.000400",
+      "maker_fee_pct": 0.02,
+      "taker_fee_pct": 0.04,
+      "maker_fee_bps": 2.0,
+      "taker_fee_bps": 4.0
+    },
+    {
+      "symbol": "XRPUSDT",
+      "status": "ok",
+      "http_status": 200,
+      "maker_commission_rate_decimal": "0.000200",
+      "taker_commission_rate_decimal": "0.000400",
+      "maker_fee_pct": 0.02,
+      "taker_fee_pct": 0.04,
+      "maker_fee_bps": 2.0,
+      "taker_fee_bps": 4.0
+    }
+  ],
+  "notes": [
+    "Rates are returned by Binance as decimal commission rates; bps = decimal_rate * 10000.",
+    "Use maker_fee_bps only with a real maker/limit-fill model; fee-only rescale is not sufficient evidence for maker execution.",
+    "Artifact intentionally omits API key, API secret, query signature, balances, positions, and account identifiers."
+  ]
+}

--- a/research/nautilus_scalping/results/rob324/maker_fill.json
+++ b/research/nautilus_scalping/results/rob324/maker_fill.json
@@ -32,8 +32,8 @@
   },
   "fill_stats": {
     "entries_attempted": 2318,
-    "entries_filled": 1166,
-    "missed_fills": 1152
+    "entries_filled": 1168,
+    "missed_fills": 1150
   },
   "scenarios": {
     "taker_baseline": {
@@ -221,11 +221,11 @@
         "net_after_cost": {
           "fold": "net_after_cost",
           "trades": 474,
-          "net_pnl": -21.442318236,
+          "net_pnl": -21.442250736,
           "win_rate_pct": 46.20253164556962,
-          "max_drawdown": -27.417398187999996,
-          "profit_factor": 0.8547439958433818,
-          "expectancy": -0.04523695830379747
+          "max_drawdown": -27.417330687999996,
+          "profit_factor": 0.8547443866864247,
+          "expectancy": -0.04523681589873418
         }
       },
       "per_fold": [
@@ -241,11 +241,11 @@
         {
           "fold": "val",
           "trades": 118,
-          "net_pnl": -8.115986084,
+          "net_pnl": -8.115918584,
           "win_rate_pct": 44.067796610169495,
-          "max_drawdown": -15.49548758,
-          "profit_factor": 0.7803738896784984,
-          "expectancy": -0.06877954308474575
+          "max_drawdown": -15.49542008,
+          "profit_factor": 0.7803753151218822,
+          "expectancy": -0.06877897105084745
         },
         {
           "fold": "oos",
@@ -290,18 +290,18 @@
         "net edge not statistically distinguishable from 0 (bootstrap 95% CI straddles 0)"
       ],
       "bootstrap_sharpe_ci": {
-        "observed_sharpe": -0.07828035614737876,
-        "ci_lower": -0.16839093643052883,
-        "ci_upper": 0.014879112106786689,
-        "median_sharpe": -0.07695202985510026,
+        "observed_sharpe": -0.07828011141749915,
+        "ci_lower": -0.16839069341534962,
+        "ci_upper": 0.014879593916047497,
+        "median_sharpe": -0.07695166283026685,
         "prob_positive": 0.046,
         "confidence": 0.95,
         "n_bootstrap": 1000,
         "seed": 42
       },
       "monte_carlo_permutation": {
-        "actual_sharpe": -0.07823588558375752,
-        "actual_max_dd": -27.417398187999996,
+        "actual_sharpe": -0.07823564083815798,
+        "actual_max_dd": -27.417330687999996,
         "p_value_sharpe": 0.277,
         "p_value_maxdd": 0.615,
         "n_sim": 1000,
@@ -339,29 +339,29 @@
         "gross": {
           "fold": "gross",
           "trades": 473,
-          "net_pnl": 5.021367842000002,
+          "net_pnl": 5.021401592000002,
           "win_rate_pct": 46.088794926004226,
-          "max_drawdown": -14.105361804000001,
-          "profit_factor": 1.0387012895280223,
-          "expectancy": 0.01061599966596195
+          "max_drawdown": -14.105328054000001,
+          "profit_factor": 1.0387015597172065,
+          "expectancy": 0.010616071019027487
         },
         "zero_fee": {
           "fold": "zero_fee",
           "trades": 473,
-          "net_pnl": 5.021367842000002,
+          "net_pnl": 5.021401592000002,
           "win_rate_pct": 46.088794926004226,
-          "max_drawdown": -14.105361804000001,
-          "profit_factor": 1.0387012895280223,
-          "expectancy": 0.01061599966596195
+          "max_drawdown": -14.105328054000001,
+          "profit_factor": 1.0387015597172065,
+          "expectancy": 0.010616071019027487
         },
         "net_after_cost": {
           "fold": "net_after_cost",
           "trades": 473,
-          "net_pnl": -28.670627917999997,
+          "net_pnl": -28.670526668,
           "win_rate_pct": 46.088794926004226,
-          "max_drawdown": -31.733700723999984,
-          "profit_factor": 0.8103814797063633,
-          "expectancy": -0.06061443534460888
+          "max_drawdown": -31.733599473999984,
+          "profit_factor": 0.8103820223670731,
+          "expectancy": -0.060614221285412266
         }
       },
       "per_fold": [
@@ -377,11 +377,11 @@
         {
           "fold": "val",
           "trades": 118,
-          "net_pnl": -9.734464126,
+          "net_pnl": -9.734362876,
           "win_rate_pct": 44.067796610169495,
-          "max_drawdown": -16.579354906,
-          "profit_factor": 0.7428724205816818,
-          "expectancy": -0.08249545869491526
+          "max_drawdown": -16.579253656,
+          "profit_factor": 0.7428744073491546,
+          "expectancy": -0.0824946006440678
         },
         {
           "fold": "oos",
@@ -426,18 +426,18 @@
         "net edge statistically <= 0 (bootstrap 95% CI upper -0.0174 < 0)"
       ],
       "bootstrap_sharpe_ci": {
-        "observed_sharpe": -0.10491188039886097,
-        "ci_lower": -0.1929001978389124,
-        "ci_upper": -0.017445294330228577,
-        "median_sharpe": -0.10405353479761338,
+        "observed_sharpe": -0.10491151297976853,
+        "ci_lower": -0.19290018845208304,
+        "ci_upper": -0.017443839999901258,
+        "median_sharpe": -0.10405335159457815,
         "prob_positive": 0.01,
         "confidence": 0.95,
         "n_bootstrap": 1000,
         "seed": 42
       },
       "monte_carlo_permutation": {
-        "actual_sharpe": -0.10486307590049901,
-        "actual_max_dd": -31.733700723999984,
+        "actual_sharpe": -0.1048627084202146,
+        "actual_max_dd": -31.733599473999984,
         "p_value_sharpe": 0.317,
         "p_value_maxdd": 0.404,
         "n_sim": 1000,

--- a/research/nautilus_scalping/results/rob324/maker_fill.json
+++ b/research/nautilus_scalping/results/rob324/maker_fill.json
@@ -150,8 +150,27 @@
       "verdict": "not_validated",
       "verdict_reasons": [
         "oos net-after-cost -16.48 <= 0",
-        "oos profit_factor 0.75 <= 1.0"
-      ]
+        "oos profit_factor 0.75 <= 1.0",
+        "net edge statistically <= 0 (bootstrap 95% CI upper -0.1029 < 0)"
+      ],
+      "bootstrap_sharpe_ci": {
+        "observed_sharpe": -0.17101733050888313,
+        "ci_lower": -0.24404344100241346,
+        "ci_upper": -0.10293243600437266,
+        "median_sharpe": -0.1725669067140685,
+        "prob_positive": 0.0,
+        "confidence": 0.95,
+        "n_bootstrap": 1000,
+        "seed": 42
+      },
+      "monte_carlo_permutation": {
+        "actual_sharpe": -0.17095616088765767,
+        "actual_max_dd": -78.69952133799997,
+        "p_value_sharpe": 0.347,
+        "p_value_maxdd": 0.51,
+        "n_sim": 1000,
+        "seed": 42
+      }
     },
     "maker_optimistic": {
       "schema_version": "validated_signal_gate.v1",
@@ -267,8 +286,27 @@
       "verdict": "not_validated",
       "verdict_reasons": [
         "oos net-after-cost -1.95 <= 0",
-        "oos profit_factor 0.95 <= 1.0"
-      ]
+        "oos profit_factor 0.95 <= 1.0",
+        "net edge not statistically distinguishable from 0 (bootstrap 95% CI straddles 0)"
+      ],
+      "bootstrap_sharpe_ci": {
+        "observed_sharpe": -0.07828035614737876,
+        "ci_lower": -0.16839093643052883,
+        "ci_upper": 0.014879112106786689,
+        "median_sharpe": -0.07695202985510026,
+        "prob_positive": 0.046,
+        "confidence": 0.95,
+        "n_bootstrap": 1000,
+        "seed": 42
+      },
+      "monte_carlo_permutation": {
+        "actual_sharpe": -0.07823588558375752,
+        "actual_max_dd": -27.417398187999996,
+        "p_value_sharpe": 0.277,
+        "p_value_maxdd": 0.615,
+        "n_sim": 1000,
+        "seed": 42
+      }
     },
     "maker_conservative": {
       "schema_version": "validated_signal_gate.v1",
@@ -384,14 +422,34 @@
       "verdict": "not_validated",
       "verdict_reasons": [
         "oos net-after-cost -3.69 <= 0",
-        "oos profit_factor 0.90 <= 1.0"
-      ]
+        "oos profit_factor 0.90 <= 1.0",
+        "net edge statistically <= 0 (bootstrap 95% CI upper -0.0174 < 0)"
+      ],
+      "bootstrap_sharpe_ci": {
+        "observed_sharpe": -0.10491188039886097,
+        "ci_lower": -0.1929001978389124,
+        "ci_upper": -0.017445294330228577,
+        "median_sharpe": -0.10405353479761338,
+        "prob_positive": 0.01,
+        "confidence": 0.95,
+        "n_bootstrap": 1000,
+        "seed": 42
+      },
+      "monte_carlo_permutation": {
+        "actual_sharpe": -0.10486307590049901,
+        "actual_max_dd": -31.733700723999984,
+        "p_value_sharpe": 0.317,
+        "p_value_maxdd": 0.404,
+        "n_sim": 1000,
+        "seed": 42
+      }
     }
   },
   "verdict": "not_validated",
   "verdict_reasons": [
     "oos net-after-cost -3.69 <= 0",
-    "oos profit_factor 0.90 <= 1.0"
+    "oos profit_factor 0.90 <= 1.0",
+    "net edge statistically <= 0 (bootstrap 95% CI upper -0.0174 < 0)"
   ],
   "verdict_source": "maker_conservative"
 }

--- a/research/nautilus_scalping/results/rob324/maker_fill.json
+++ b/research/nautilus_scalping/results/rob324/maker_fill.json
@@ -1,0 +1,397 @@
+{
+  "schema_version": "validated_signal_gate.v2",
+  "candidate": "meanrev_zscore_fade",
+  "hypothesis": "mean_reversion",
+  "symbols": [
+    "XRPUSDT",
+    "BTCUSDT"
+  ],
+  "window": {
+    "from": "2026-03-01",
+    "to": "2026-05-14",
+    "folds": {
+      "train": 0.5,
+      "val": 0.25,
+      "oos": 0.25
+    }
+  },
+  "cost_model": {
+    "maker_fee_bps": 2.0,
+    "taker_fee_bps": 4.0,
+    "commission_source": "results/rob324/binance_usdm_commission_rates.json",
+    "note": "maker scenarios bake real per-leg fees into net; gate evaluated at its reference point (as-run). taker baseline uses the gate's native single-rate rescale to 4.0 bps."
+  },
+  "fill_model": {
+    "entry_rule": "passive limit @ signal-bar close",
+    "fill_timeout_bars": 1,
+    "tp_execution": "maker limit",
+    "sl_execution": "taker stop (market)",
+    "queue_loss_pct": 0.25,
+    "adverse_bps": 1.0,
+    "excursion_eps_bps": 2.0
+  },
+  "fill_stats": {
+    "entries_attempted": 2318,
+    "entries_filled": 1166,
+    "missed_fills": 1152
+  },
+  "scenarios": {
+    "taker_baseline": {
+      "schema_version": "validated_signal_gate.v1",
+      "candidate": "meanrev_taker_baseline",
+      "hypothesis": "mean_reversion",
+      "symbols": [
+        "XRPUSDT",
+        "BTCUSDT"
+      ],
+      "window": {
+        "from": "2026-03-01",
+        "to": "2026-05-14",
+        "folds": {
+          "train": 0.5,
+          "val": 0.25,
+          "oos": 0.25
+        }
+      },
+      "cost_model": {
+        "fee_bps_per_leg": 4.0,
+        "fee_grid_bps": [
+          10.0,
+          7.5,
+          5.0,
+          2.0,
+          0.0
+        ]
+      },
+      "results": {
+        "gross": {
+          "fold": "gross",
+          "trades": 789,
+          "net_pnl": 12.49863233,
+          "win_rate_pct": 51.71102661596958,
+          "max_drawdown": -12.088404520000001,
+          "profit_factor": 1.057673604357708,
+          "expectancy": 0.015841105614702155
+        },
+        "zero_fee": {
+          "fold": "zero_fee",
+          "trades": 789,
+          "net_pnl": 12.49863233,
+          "win_rate_pct": 51.71102661596958,
+          "max_drawdown": -12.088404520000001,
+          "profit_factor": 1.057673604357708,
+          "expectancy": 0.015841105614702155
+        },
+        "net_after_cost": {
+          "fold": "net_after_cost",
+          "trades": 789,
+          "net_pnl": -76.38333652600001,
+          "win_rate_pct": 51.71102661596958,
+          "max_drawdown": -78.69952133799997,
+          "profit_factor": 0.7057599545350742,
+          "expectancy": -0.09681031245373892
+        }
+      },
+      "per_fold": [
+        {
+          "fold": "train",
+          "trades": 394,
+          "net_pnl": -39.966424394,
+          "win_rate_pct": 51.26903553299493,
+          "max_drawdown": -40.61261761399999,
+          "profit_factor": 0.6922680505778294,
+          "expectancy": -0.10143762536548223
+        },
+        {
+          "fold": "val",
+          "trades": 197,
+          "net_pnl": -19.938214558000002,
+          "win_rate_pct": 51.26903553299493,
+          "max_drawdown": -24.56567964,
+          "profit_factor": 0.6880022582457112,
+          "expectancy": -0.10120921095431473
+        },
+        {
+          "fold": "oos",
+          "trades": 198,
+          "net_pnl": -16.478697574,
+          "win_rate_pct": 53.03030303030303,
+          "max_drawdown": -19.97338527,
+          "profit_factor": 0.7496253917036927,
+          "expectancy": -0.08322574532323233
+        }
+      ],
+      "baselines": {
+        "micro_breakout": {
+          "net_after_cost": -475.653735542,
+          "trades": 4025
+        },
+        "random_entry": {
+          "net_after_cost": -286.86553483,
+          "trades": 2350
+        }
+      },
+      "param_stability": {
+        "grid": [
+          "z2.0/tp30/sl30",
+          "z2.5/tp40/sl40"
+        ],
+        "val_best_param": "z2.5/tp40/sl40",
+        "oos_rank_of_val_best": 1,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "overfit_flags": {
+        "low_trades": false,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "trade_count": 789,
+      "verdict": "not_validated",
+      "verdict_reasons": [
+        "oos net-after-cost -16.48 <= 0",
+        "oos profit_factor 0.75 <= 1.0"
+      ]
+    },
+    "maker_optimistic": {
+      "schema_version": "validated_signal_gate.v1",
+      "candidate": "meanrev_maker_optimistic",
+      "hypothesis": "mean_reversion",
+      "symbols": [
+        "XRPUSDT",
+        "BTCUSDT"
+      ],
+      "window": {
+        "from": "2026-03-01",
+        "to": "2026-05-14",
+        "folds": {
+          "train": 0.5,
+          "val": 0.25,
+          "oos": 0.25
+        }
+      },
+      "cost_model": {
+        "fee_bps_per_leg": 10.0,
+        "fee_grid_bps": [
+          10.0,
+          7.5,
+          5.0,
+          2.0,
+          0.0
+        ]
+      },
+      "results": {
+        "gross": {
+          "fold": "gross",
+          "trades": 474,
+          "net_pnl": 12.307463400000001,
+          "win_rate_pct": 46.20253164556962,
+          "max_drawdown": -11.456891399999996,
+          "profit_factor": 1.0975523975578538,
+          "expectancy": 0.025965112658227853
+        },
+        "zero_fee": {
+          "fold": "zero_fee",
+          "trades": 474,
+          "net_pnl": 12.307463400000001,
+          "win_rate_pct": 46.20253164556962,
+          "max_drawdown": -11.456891399999996,
+          "profit_factor": 1.0975523975578538,
+          "expectancy": 0.025965112658227853
+        },
+        "net_after_cost": {
+          "fold": "net_after_cost",
+          "trades": 474,
+          "net_pnl": -21.442318236,
+          "win_rate_pct": 46.20253164556962,
+          "max_drawdown": -27.417398187999996,
+          "profit_factor": 0.8547439958433818,
+          "expectancy": -0.04523695830379747
+        }
+      },
+      "per_fold": [
+        {
+          "fold": "train",
+          "trades": 237,
+          "net_pnl": -11.377236724,
+          "win_rate_pct": 45.9915611814346,
+          "max_drawdown": -14.195092552000002,
+          "profit_factor": 0.8456244071564271,
+          "expectancy": -0.048005218244725735
+        },
+        {
+          "fold": "val",
+          "trades": 118,
+          "net_pnl": -8.115986084,
+          "win_rate_pct": 44.067796610169495,
+          "max_drawdown": -15.49548758,
+          "profit_factor": 0.7803738896784984,
+          "expectancy": -0.06877954308474575
+        },
+        {
+          "fold": "oos",
+          "trades": 119,
+          "net_pnl": -1.949095428,
+          "win_rate_pct": 48.739495798319325,
+          "max_drawdown": -5.665382816000001,
+          "profit_factor": 0.9472723900599821,
+          "expectancy": -0.016378953176470586
+        }
+      ],
+      "baselines": {
+        "micro_breakout": {
+          "net_after_cost": -1163.85537806,
+          "trades": 4025
+        },
+        "random_entry": {
+          "net_after_cost": -688.64263018,
+          "trades": 2350
+        }
+      },
+      "param_stability": {
+        "grid": [
+          "z2.0/tp30/sl30",
+          "z2.5/tp40/sl40"
+        ],
+        "val_best_param": "z2.5/tp40/sl40",
+        "oos_rank_of_val_best": 1,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "overfit_flags": {
+        "low_trades": false,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "trade_count": 474,
+      "verdict": "not_validated",
+      "verdict_reasons": [
+        "oos net-after-cost -1.95 <= 0",
+        "oos profit_factor 0.95 <= 1.0"
+      ]
+    },
+    "maker_conservative": {
+      "schema_version": "validated_signal_gate.v1",
+      "candidate": "meanrev_maker_conservative",
+      "hypothesis": "mean_reversion",
+      "symbols": [
+        "XRPUSDT",
+        "BTCUSDT"
+      ],
+      "window": {
+        "from": "2026-03-01",
+        "to": "2026-05-14",
+        "folds": {
+          "train": 0.5,
+          "val": 0.25,
+          "oos": 0.25
+        }
+      },
+      "cost_model": {
+        "fee_bps_per_leg": 10.0,
+        "fee_grid_bps": [
+          10.0,
+          7.5,
+          5.0,
+          2.0,
+          0.0
+        ]
+      },
+      "results": {
+        "gross": {
+          "fold": "gross",
+          "trades": 473,
+          "net_pnl": 5.021367842000002,
+          "win_rate_pct": 46.088794926004226,
+          "max_drawdown": -14.105361804000001,
+          "profit_factor": 1.0387012895280223,
+          "expectancy": 0.01061599966596195
+        },
+        "zero_fee": {
+          "fold": "zero_fee",
+          "trades": 473,
+          "net_pnl": 5.021367842000002,
+          "win_rate_pct": 46.088794926004226,
+          "max_drawdown": -14.105361804000001,
+          "profit_factor": 1.0387012895280223,
+          "expectancy": 0.01061599966596195
+        },
+        "net_after_cost": {
+          "fold": "net_after_cost",
+          "trades": 473,
+          "net_pnl": -28.670627917999997,
+          "win_rate_pct": 46.088794926004226,
+          "max_drawdown": -31.733700723999984,
+          "profit_factor": 0.8103814797063633,
+          "expectancy": -0.06061443534460888
+        }
+      },
+      "per_fold": [
+        {
+          "fold": "train",
+          "trades": 236,
+          "net_pnl": -15.241313587999999,
+          "win_rate_pct": 45.76271186440678,
+          "max_drawdown": -17.28622237,
+          "profit_factor": 0.7980876813156198,
+          "expectancy": -0.06458183723728814
+        },
+        {
+          "fold": "val",
+          "trades": 118,
+          "net_pnl": -9.734464126,
+          "win_rate_pct": 44.067796610169495,
+          "max_drawdown": -16.579354906,
+          "profit_factor": 0.7428724205816818,
+          "expectancy": -0.08249545869491526
+        },
+        {
+          "fold": "oos",
+          "trades": 119,
+          "net_pnl": -3.6948502039999997,
+          "win_rate_pct": 48.739495798319325,
+          "max_drawdown": -6.669474636,
+          "profit_factor": 0.9024031946315251,
+          "expectancy": -0.03104916137815126
+        }
+      ],
+      "baselines": {
+        "micro_breakout": {
+          "net_after_cost": -1163.85537806,
+          "trades": 4025
+        },
+        "random_entry": {
+          "net_after_cost": -688.64263018,
+          "trades": 2350
+        }
+      },
+      "param_stability": {
+        "grid": [
+          "z2.0/tp30/sl30",
+          "z2.5/tp40/sl40"
+        ],
+        "val_best_param": "z2.5/tp40/sl40",
+        "oos_rank_of_val_best": 1,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "overfit_flags": {
+        "low_trades": false,
+        "single_fold_edge": false,
+        "param_island": false
+      },
+      "trade_count": 473,
+      "verdict": "not_validated",
+      "verdict_reasons": [
+        "oos net-after-cost -3.69 <= 0",
+        "oos profit_factor 0.90 <= 1.0"
+      ]
+    }
+  },
+  "verdict": "not_validated",
+  "verdict_reasons": [
+    "oos net-after-cost -3.69 <= 0",
+    "oos profit_factor 0.90 <= 1.0"
+  ],
+  "verdict_source": "maker_conservative"
+}

--- a/research/nautilus_scalping/strategy_meanrev.py
+++ b/research/nautilus_scalping/strategy_meanrev.py
@@ -124,15 +124,18 @@ class MeanRevScalper(Strategy):
         self._entry_submitted_bar = self._bar_count
         self.submit_order(order)
 
-    def on_order_filled(self, event) -> None:
+    def on_position_opened(self, event) -> None:
+        # maker entry capture keyed on the POSITION lifecycle (robust to a fill that lands
+        # in the same bar the timeout-cancel fired: the fill wins and the position opens,
+        # so we must track it rather than leave _entry_px None and ride to on_stop).
         if self.config.execution_mode != "maker":
             return
-        if self._entry_order is not None and event.client_order_id == self._entry_order.client_order_id:
-            self.entries_filled += 1
-            self._entry_order = None
-            self._entry_submitted_bar = None
-            self._entry_px = event.last_px.as_decimal()
-            self._adverse_px = self._entry_px
+        pos = self.cache.position(event.position_id)
+        self.entries_filled += 1
+        self._entry_order = None
+        self._entry_submitted_bar = None
+        self._entry_px = Decimal(str(pos.avg_px_open))
+        self._adverse_px = self._entry_px
 
     def on_trade_tick(self, tick: TradeTick) -> None:
         if self.config.execution_mode == "taker":

--- a/research/nautilus_scalping/strategy_meanrev.py
+++ b/research/nautilus_scalping/strategy_meanrev.py
@@ -1,8 +1,16 @@
-"""ROB-320 — z-score mean-reversion fade scalper as a Nautilus Strategy.
+"""ROB-320/324 — z-score mean-reversion fade scalper as a Nautilus Strategy.
 
-Wiring only: decide on each closed bar via the pure ``evaluate_meanrev``,
-enter on a market order (no-lookahead), exit on tick-level TP/SL (conservative
-SL-first). Spot long-only MVP, futures short mirror supported via allow_short.
+Taker mode (ROB-320, default, unchanged): market entry, tick-level TP/SL exit
+(conservative SL-first), spot long-only MVP / futures short mirror via allow_short.
+
+Maker mode (ROB-324): a PASSIVE limit entry posted ``entry_offset_bps`` below the
+signal close (BUY) / above (SELL), so an immediate reversion is MISSED (a real
+missed fill) while a continued move FILLS — capturing the entry-side adverse
+selection of resting orders. Exit is touch-based, identical to taker (so the
+maker trade set is comparable to taker, not collapsed by resting-limit
+under-fills); the maker/taker per-leg fees are NOT charged here — the re-sim runs
+on a ZERO-FEE instrument and ``maker_fill`` applies real fees to the gross P&L
+(maker on entry + the TP leg, taker on the SL leg) plus the conservative overlay.
 """
 from __future__ import annotations
 
@@ -30,7 +38,8 @@ class MeanRevScalperConfig(StrategyConfig, frozen=True):
     require_vol: bool = True
     allow_short: bool = False
     execution_mode: str = "taker"   # "taker" (default, unchanged) | "maker"
-    fill_timeout_bars: int = 1      # cancel an unfilled maker entry after N closed bars
+    entry_offset_bps: int = 5       # maker: passive entry distance below/above close
+    fill_timeout_bars: int = 1      # maker: cancel an unfilled entry after N closed bars
 
 
 class MeanRevScalper(Strategy):
@@ -57,10 +66,11 @@ class MeanRevScalper(Strategy):
         self._entry_order = None
         self._entry_submitted_bar: int | None = None
         self._bar_count = 0
-        self._tp_order = None
         self._entry_px: Decimal | None = None
-        self._adverse_px: Decimal | None = None   # worst price seen vs entry while in position
-        self.records: list[dict] = []             # maker: completed trade records
+        self._adverse_px: Decimal | None = None    # worst price vs entry while in position
+        self._exit_px: Decimal | None = None       # price that triggered the exit
+        self._tp_hit = False                       # last exit was the TP leg (vs SL)
+        self.records: list[dict] = []              # maker: completed trade records
         self.entries_attempted = 0
         self.entries_filled = 0
 
@@ -101,12 +111,15 @@ class MeanRevScalper(Strategy):
                 quantity=self._instrument.make_qty(Decimal(self.config.trade_size)))
             self.submit_order(order)
             return
-        # maker: passive limit entry at the signal close (fade entry rests at a local low)
+        # maker: passive limit OFFSET from the close (below for BUY, above for SELL) so
+        # immediate reversions are missed and continued moves fill (entry adverse selection).
         self.entries_attempted += 1
+        off = Decimal(self.config.entry_offset_bps) / Decimal("10000")
+        limit_px = entry * (Decimal("1") - off) if side == OrderSide.BUY else entry * (Decimal("1") + off)
         order = self.order_factory.limit(
             instrument_id=self.config.instrument_id, order_side=side,
             quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
-            price=self._instrument.make_price(entry))
+            price=self._instrument.make_price(limit_px))
         self._entry_order = order
         self._entry_submitted_bar = self._bar_count
         self.submit_order(order)
@@ -115,34 +128,32 @@ class MeanRevScalper(Strategy):
         if self.config.execution_mode != "maker":
             return
         if self._entry_order is not None and event.client_order_id == self._entry_order.client_order_id:
-            # entry filled -> post a resting maker-limit TP; SL handled on ticks
             self.entries_filled += 1
             self._entry_order = None
             self._entry_submitted_bar = None
             self._entry_px = event.last_px.as_decimal()
             self._adverse_px = self._entry_px
-            self._tp_order = self.order_factory.limit(
-                instrument_id=self.config.instrument_id,
-                order_side=(OrderSide.SELL if self._side == OrderSide.BUY else OrderSide.BUY),
-                quantity=event.last_qty,
-                price=self._instrument.make_price(self._tp))
-            self.submit_order(self._tp_order)
 
     def on_trade_tick(self, tick: TradeTick) -> None:
         if self.config.execution_mode == "taker":
             return self._taker_exit_check(tick)
-        # maker: track adverse excursion; trigger taker SL via market if breached
+        # maker: touch-based exit (same trigger prices as taker), SL-first conservative,
+        # tagging which leg exited so maker_fill can charge the right fee.
         if self.portfolio.is_flat(self.config.instrument_id) or self._entry_px is None:
             return
         price = tick.price.as_decimal()
         if self._side == OrderSide.BUY:
             self._adverse_px = min(self._adverse_px, price)
             if self._sl is not None and price <= self._sl:
-                self._maker_sl_exit()
+                self._maker_exit(tp_hit=False, exit_px=price)
+            elif self._tp is not None and price >= self._tp:
+                self._maker_exit(tp_hit=True, exit_px=price)
         else:
             self._adverse_px = max(self._adverse_px, price)
             if self._sl is not None and price >= self._sl:
-                self._maker_sl_exit()
+                self._maker_exit(tp_hit=False, exit_px=price)
+            elif self._tp is not None and price <= self._tp:
+                self._maker_exit(tp_hit=True, exit_px=price)
 
     def _taker_exit_check(self, tick: TradeTick) -> None:
         # unchanged taker logic
@@ -160,35 +171,35 @@ class MeanRevScalper(Strategy):
             elif self._tp is not None and price <= self._tp:
                 self._exit()
 
-    def _maker_sl_exit(self) -> None:
-        if self._tp_order is not None:
-            self.cancel_order(self._tp_order)
-            self._tp_order = None
-        self.close_all_positions(self.config.instrument_id)  # taker stop-out
+    def _maker_exit(self, tp_hit: bool, exit_px: Decimal) -> None:
+        self._tp_hit = tp_hit
+        self._exit_px = exit_px
+        self.close_all_positions(self.config.instrument_id)
 
     def on_position_closed(self, event) -> None:
         if self.config.execution_mode != "maker":
             return
         pos = self.cache.position(event.position_id)
         entry = self._entry_px if self._entry_px is not None else Decimal(str(pos.avg_px_open))
-        if self._side == OrderSide.BUY:
-            adverse = (entry - (self._adverse_px or entry)) / entry * Decimal("10000")
-        else:
+        exit_px = self._exit_px if self._exit_px is not None else Decimal(str(pos.avg_px_open))
+        qty = float(pos.peak_qty)
+        if self._side == OrderSide.SELL:
             adverse = ((self._adverse_px or entry) - entry) / entry * Decimal("10000")
-        tp_hit = self._tp_order is not None  # TP order existed and was not cancelled by SL
+        else:
+            adverse = (entry - (self._adverse_px or entry)) / entry * Decimal("10000")
         self.records.append({
-            "net": pos.realized_pnl.as_double(),
-            "comm": sum(c.as_double() for c in pos.commissions()),
-            "notional": float(pos.avg_px_open) * float(pos.peak_qty),
+            "gross": pos.realized_pnl.as_double(),       # zero-fee instrument => pure price P&L
+            "entry_notional": float(entry) * qty,
+            "exit_notional": float(exit_px) * qty,
             "ts": int(pos.ts_opened),
+            "ts_closed": int(pos.ts_closed),
             "filled": True,
-            "tp_hit": bool(tp_hit),
+            "tp_hit": bool(self._tp_hit),
             "adverse_bps": float(max(Decimal("0"), adverse)),
         })
-        self._tp_order = None
-        self._entry_px = None
-        self._adverse_px = None
+        self._entry_px = self._adverse_px = self._exit_px = None
         self._tp = self._sl = self._side = None
+        self._tp_hit = False
 
     def _exit(self) -> None:
         self._tp = self._sl = self._side = None

--- a/research/nautilus_scalping/strategy_meanrev.py
+++ b/research/nautilus_scalping/strategy_meanrev.py
@@ -29,6 +29,8 @@ class MeanRevScalperConfig(StrategyConfig, frozen=True):
     atr_min_bps: int = 8
     require_vol: bool = True
     allow_short: bool = False
+    execution_mode: str = "taker"   # "taker" (default, unchanged) | "maker"
+    fill_timeout_bars: int = 1      # cancel an unfilled maker entry after N closed bars
 
 
 class MeanRevScalper(Strategy):
@@ -51,46 +53,142 @@ class MeanRevScalper(Strategy):
         self._sl: Decimal | None = None
         self._side: OrderSide | None = None
 
+        # maker-mode bookkeeping
+        self._entry_order = None
+        self._entry_submitted_bar: int | None = None
+        self._bar_count = 0
+        self._tp_order = None
+        self._entry_px: Decimal | None = None
+        self._adverse_px: Decimal | None = None   # worst price seen vs entry while in position
+        self.records: list[dict] = []             # maker: completed trade records
+        self.entries_attempted = 0
+        self.entries_filled = 0
+
     def on_start(self) -> None:
         self._instrument = self.cache.instrument(self.config.instrument_id)
         self.subscribe_bars(self.config.bar_type)
         self.subscribe_trade_ticks(self.config.instrument_id)
 
     def on_bar(self, bar: Bar) -> None:
+        self._bar_count += 1
         self._candles.append(bar_to_candle(bar))
+
+        # maker: cancel a stale unfilled entry limit (missed fill)
+        if (self.config.execution_mode == "maker" and self._entry_order is not None
+                and self._entry_submitted_bar is not None
+                and self._bar_count - self._entry_submitted_bar >= self.config.fill_timeout_bars):
+            self.cancel_order(self._entry_order)
+            self._entry_order = None
+            self._entry_submitted_bar = None
+
         if len(self._candles) < self._needed:
             return
         if not self.portfolio.is_flat(self.config.instrument_id):
             return
+        if self._entry_order is not None:   # maker: a limit is still working
+            return
         d = evaluate_meanrev(list(self._candles), self._cfg)
         if d.has_entry and d.side == "BUY":
-            self._enter(OrderSide.BUY, d.tp_price, d.sl_price)
+            self._enter(OrderSide.BUY, d.entry_price, d.tp_price, d.sl_price)
         elif d.has_entry and d.side == "SELL":
-            self._enter(OrderSide.SELL, d.tp_price, d.sl_price)
+            self._enter(OrderSide.SELL, d.entry_price, d.tp_price, d.sl_price)
 
-    def _enter(self, side: OrderSide, tp: Decimal | None, sl: Decimal | None) -> None:
-        order = self.order_factory.market(
-            instrument_id=self.config.instrument_id,
-            order_side=side,
-            quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
-        )
+    def _enter(self, side: OrderSide, entry: Decimal, tp: Decimal | None, sl: Decimal | None) -> None:
         self._tp, self._sl, self._side = tp, sl, side
+        if self.config.execution_mode == "taker":
+            order = self.order_factory.market(
+                instrument_id=self.config.instrument_id, order_side=side,
+                quantity=self._instrument.make_qty(Decimal(self.config.trade_size)))
+            self.submit_order(order)
+            return
+        # maker: passive limit entry at the signal close (fade entry rests at a local low)
+        self.entries_attempted += 1
+        order = self.order_factory.limit(
+            instrument_id=self.config.instrument_id, order_side=side,
+            quantity=self._instrument.make_qty(Decimal(self.config.trade_size)),
+            price=self._instrument.make_price(entry))
+        self._entry_order = order
+        self._entry_submitted_bar = self._bar_count
         self.submit_order(order)
 
+    def on_order_filled(self, event) -> None:
+        if self.config.execution_mode != "maker":
+            return
+        if self._entry_order is not None and event.client_order_id == self._entry_order.client_order_id:
+            # entry filled -> post a resting maker-limit TP; SL handled on ticks
+            self.entries_filled += 1
+            self._entry_order = None
+            self._entry_submitted_bar = None
+            self._entry_px = event.last_px.as_decimal()
+            self._adverse_px = self._entry_px
+            self._tp_order = self.order_factory.limit(
+                instrument_id=self.config.instrument_id,
+                order_side=(OrderSide.SELL if self._side == OrderSide.BUY else OrderSide.BUY),
+                quantity=event.last_qty,
+                price=self._instrument.make_price(self._tp))
+            self.submit_order(self._tp_order)
+
     def on_trade_tick(self, tick: TradeTick) -> None:
+        if self.config.execution_mode == "taker":
+            return self._taker_exit_check(tick)
+        # maker: track adverse excursion; trigger taker SL via market if breached
+        if self.portfolio.is_flat(self.config.instrument_id) or self._entry_px is None:
+            return
+        price = tick.price.as_decimal()
+        if self._side == OrderSide.BUY:
+            self._adverse_px = min(self._adverse_px, price)
+            if self._sl is not None and price <= self._sl:
+                self._maker_sl_exit()
+        else:
+            self._adverse_px = max(self._adverse_px, price)
+            if self._sl is not None and price >= self._sl:
+                self._maker_sl_exit()
+
+    def _taker_exit_check(self, tick: TradeTick) -> None:
+        # unchanged taker logic
         if self.portfolio.is_flat(self.config.instrument_id):
             return
         price = tick.price.as_decimal()
         if self._side == OrderSide.BUY:
-            if self._sl is not None and price <= self._sl:   # SL-first (conservative)
+            if self._sl is not None and price <= self._sl:
                 self._exit()
             elif self._tp is not None and price >= self._tp:
                 self._exit()
-        else:  # SELL
+        else:
             if self._sl is not None and price >= self._sl:
                 self._exit()
             elif self._tp is not None and price <= self._tp:
                 self._exit()
+
+    def _maker_sl_exit(self) -> None:
+        if self._tp_order is not None:
+            self.cancel_order(self._tp_order)
+            self._tp_order = None
+        self.close_all_positions(self.config.instrument_id)  # taker stop-out
+
+    def on_position_closed(self, event) -> None:
+        if self.config.execution_mode != "maker":
+            return
+        pos = self.cache.position(event.position_id)
+        entry = self._entry_px if self._entry_px is not None else Decimal(str(pos.avg_px_open))
+        if self._side == OrderSide.BUY:
+            adverse = (entry - (self._adverse_px or entry)) / entry * Decimal("10000")
+        else:
+            adverse = ((self._adverse_px or entry) - entry) / entry * Decimal("10000")
+        tp_hit = self._tp_order is not None  # TP order existed and was not cancelled by SL
+        self.records.append({
+            "net": pos.realized_pnl.as_double(),
+            "comm": sum(c.as_double() for c in pos.commissions()),
+            "notional": float(pos.avg_px_open) * float(pos.peak_qty),
+            "ts": int(pos.ts_opened),
+            "filled": True,
+            "tp_hit": bool(tp_hit),
+            "adverse_bps": float(max(Decimal("0"), adverse)),
+        })
+        self._tp_order = None
+        self._entry_px = None
+        self._adverse_px = None
+        self._tp = self._sl = self._side = None
 
     def _exit(self) -> None:
         self._tp = self._sl = self._side = None

--- a/research/nautilus_scalping/tests/test_maker_fill.py
+++ b/research/nautilus_scalping/tests/test_maker_fill.py
@@ -8,7 +8,9 @@ from maker_fill import (
     MAKER_FEE_BPS,
     TAKER_BASELINE_BPS,
     MakerTradeRecord,
+    build_maker_optimistic,
 )
+from validated_gate import Trade, metrics_at_fee
 
 
 def test_module_constants_match_demo_fees() -> None:
@@ -26,3 +28,20 @@ def _rec(net, comm, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> M
 def test_record_is_frozen_dataclass() -> None:
     r = _rec(1.0, 0.04, 100.0, 0)
     assert r.net_at_real_fees == 1.0 and r.filled is True
+
+
+def test_optimistic_excludes_missed_fills_and_preserves_true_net() -> None:
+    recs = [
+        _rec(0.50, 0.04, 100.0, 1, filled=True),
+        _rec(0.00, 0.00, 100.0, 2, filled=False),   # missed fill -> dropped
+        _rec(-0.30, 0.04, 100.0, 3, filled=True),
+    ]
+    trades = build_maker_optimistic(recs)
+    assert len(trades) == 2                          # missed fill excluded
+    assert all(isinstance(t, Trade) for t in trades)
+    # net_after_cost at the gate's reference point == as-run true net
+    m = metrics_at_fee(trades, fee_bps=10.0, fold="net_after_cost")
+    assert round(m.net_pnl, 2) == 0.20               # 0.50 + (-0.30)
+    # gross (fee=0) adds the real commission back
+    g = metrics_at_fee(trades, fee_bps=0.0, fold="gross")
+    assert round(g.net_pnl, 2) == 0.28               # 0.20 + 0.04 + 0.04

--- a/research/nautilus_scalping/tests/test_maker_fill.py
+++ b/research/nautilus_scalping/tests/test_maker_fill.py
@@ -1,18 +1,27 @@
-# research/nautilus_scalping/tests/test_maker_fill.py
+# tests/test_maker_fill.py
 """ROB-324 — pure maker/limit-fill scenario builders.
 
-Records in, validated_gate.Trade lists out. No nautilus; fully deterministic."""
+Records (zero-fee gross + notionals) in, validated_gate.Trade lists out. No
+nautilus; fully deterministic. Fees applied per leg: maker 2bps on entry + the TP
+leg, taker 4bps on the SL leg."""
 from __future__ import annotations
 
 from maker_fill import (
     MAKER_FEE_BPS,
     TAKER_BASELINE_BPS,
     MakerTradeRecord,
-    build_maker_optimistic,
     build_maker_conservative,
+    build_maker_optimistic,
     classify_easy_tp,
 )
-from validated_gate import Trade, metrics_at_fee
+from validated_gate import Trade, evaluate_gate, metrics_at_fee
+
+
+def _rec(gross, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> MakerTradeRecord:
+    return MakerTradeRecord(
+        gross=gross, entry_notional=notional, exit_notional=notional,
+        ts_opened=ts, filled=filled, tp_hit=tp_hit, adverse_excursion_bps=adverse,
+    )
 
 
 def test_module_constants_match_demo_fees() -> None:
@@ -20,72 +29,80 @@ def test_module_constants_match_demo_fees() -> None:
     assert TAKER_BASELINE_BPS == 4.0
 
 
-def _rec(net, comm, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> MakerTradeRecord:
-    return MakerTradeRecord(
-        net_at_real_fees=net, commission_real=comm, notional=notional,
-        ts_opened=ts, filled=filled, tp_hit=tp_hit, adverse_excursion_bps=adverse,
-    )
-
-
 def test_record_is_frozen_dataclass() -> None:
-    r = _rec(1.0, 0.04, 100.0, 0)
-    assert r.net_at_real_fees == 1.0 and r.filled is True
+    r = _rec(1.0, 100.0, 0)
+    assert r.gross == 1.0 and r.filled is True and r.entry_notional == 100.0
 
 
-def test_optimistic_excludes_missed_fills_and_preserves_true_net() -> None:
+def test_optimistic_excludes_missed_fills_and_applies_maker_fees() -> None:
+    # tp_hit => exit leg is maker (2bps); fee = 2bps*100/1e4 (entry) + 2bps*100/1e4 (TP) = 0.04
     recs = [
-        _rec(0.50, 0.04, 100.0, 1, filled=True),
-        _rec(0.00, 0.00, 100.0, 2, filled=False),   # missed fill -> dropped
-        _rec(-0.30, 0.04, 100.0, 3, filled=True),
+        _rec(0.50, 100.0, 1, filled=True, tp_hit=True),
+        _rec(0.00, 100.0, 2, filled=False),              # missed fill -> dropped
+        _rec(-0.30, 100.0, 3, filled=True, tp_hit=True),
     ]
     trades = build_maker_optimistic(recs)
-    assert len(trades) == 2                          # missed fill excluded
+    assert len(trades) == 2                              # missed fill excluded
     assert all(isinstance(t, Trade) for t in trades)
-    # net_after_cost at the gate's reference point == as-run true net
+    # net_after_cost at the gate reference point == as-run true net (gross - fees)
     m = metrics_at_fee(trades, fee_bps=10.0, fold="net_after_cost")
-    assert round(m.net_pnl, 2) == 0.20               # 0.50 + (-0.30)
-    # gross (fee=0) adds the real commission back
+    assert round(m.net_pnl, 4) == round((0.50 - 0.04) + (-0.30 - 0.04), 4)   # 0.12
+    # gross column (fee=0) adds the fee back -> recovers the fee-free gross sum
     g = metrics_at_fee(trades, fee_bps=0.0, fold="gross")
-    assert round(g.net_pnl, 2) == 0.28               # 0.20 + 0.04 + 0.04
+    assert round(g.net_pnl, 4) == round(0.50 + (-0.30), 4)                   # 0.20
+
+
+def test_sl_exit_charges_taker_fee_on_exit_leg() -> None:
+    # SL exit (tp_hit=False): fee = 2bps entry + 4bps exit = (0.02 + 0.04) on 100 notional = 0.06
+    t = build_maker_optimistic([_rec(-0.40, 100.0, 1, tp_hit=False)])[0]
+    assert round(t.commission_ref, 4) == 0.06
+    assert round(t.net_ref_pnl, 4) == round(-0.40 - 0.06, 4)
 
 
 def test_classify_easy_tp_boundary() -> None:
-    # TP hit with tiny adverse excursion = easy (front-of-queue) fill
-    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=1.0)) is True
-    # TP hit but price moved against us first = a real fill, not easy
-    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=5.0)) is False
-    # SL exits are never "easy TP"
-    assert classify_easy_tp(_rec(-0.5, 0.04, 100, 1, tp_hit=False, adverse=0.0)) is False
+    assert classify_easy_tp(_rec(0.5, 100, 1, tp_hit=True, adverse=1.0)) is True
+    assert classify_easy_tp(_rec(0.5, 100, 1, tp_hit=True, adverse=5.0)) is False
+    assert classify_easy_tp(_rec(-0.5, 100, 1, tp_hit=False, adverse=0.0)) is False
 
 
 def test_conservative_applies_adverse_cost_to_survivors() -> None:
-    # a non-easy filled trade is kept but charged the adverse cost
-    recs = [_rec(0.50, 0.04, 100.0, 1, tp_hit=True, adverse=9.0)]  # not easy -> kept
-    trades = build_maker_conservative(recs, queue_loss_pct=0.25, adverse_bps=1.0)
-    assert len(trades) == 1
-    # adverse cost = 1.0 bp * 100 notional / 10_000 = 0.01
-    assert round(trades[0].net_ref_pnl, 4) == 0.49
+    # not-easy TP fill (adverse 9 > eps) -> kept, charged fees + adverse cost
+    recs = [_rec(0.50, 100.0, 1, tp_hit=True, adverse=9.0)]
+    t = build_maker_conservative(recs, queue_loss_pct=0.25, adverse_bps=1.0)[0]
+    # fee 0.04 (maker entry + maker TP) + adverse 1bps*100/1e4 = 0.01
+    assert round(t.net_ref_pnl, 4) == round(0.50 - 0.04 - 0.01, 4)           # 0.45
 
 
 def test_conservative_drops_about_quarter_of_easy_tp_fills_deterministically() -> None:
-    easy = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(2000)]
+    easy = [_rec(0.50, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(2000)]
     first = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
     second = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
-    # deterministic across runs (hash of ts, not RNG)
-    assert [t.ts_opened for t in first] == [t.ts_opened for t in second]
-    kept = len(first)
-    dropped = 2000 - kept
-    assert 400 <= dropped <= 600          # ~25% dropped (hash uniformity tolerance)
+    assert [t.ts_opened for t in first] == [t.ts_opened for t in second]     # deterministic
+    dropped = 2000 - len(first)
+    assert 400 <= dropped <= 600                                            # ~25%
 
 
 def test_conservative_excludes_missed_fills() -> None:
-    recs = [_rec(0.0, 0.0, 100.0, 1, filled=False)]
-    assert build_maker_conservative(recs) == []
+    assert build_maker_conservative([_rec(0.0, 100.0, 1, filled=False)]) == []
 
 
 def test_conservative_is_strictly_worse_than_optimistic() -> None:
-    recs = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(500)]
-    from validated_gate import metrics_at_fee
+    recs = [_rec(0.50, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(500)]
     opt = metrics_at_fee(build_maker_optimistic(recs), 10.0).net_pnl
     con = metrics_at_fee(build_maker_conservative(recs), 10.0).net_pnl
-    assert con < opt                      # queue-loss + adverse cost only ever hurt
+    assert con < opt                                                        # haircuts only hurt
+
+
+def test_maker_scenario_verdict_stays_in_vocabulary() -> None:
+    recs = [_rec(0.20, 100.0, ts, tp_hit=(ts % 2 == 0), adverse=float(ts % 5))
+            for ts in range(400)]
+    losers = [Trade(net_ref_pnl=-0.5, commission_ref=0.04, notional=100.0, ts_opened=ts)
+              for ts in range(400)]
+    for builder in (build_maker_optimistic, build_maker_conservative):
+        trades = builder(recs)
+        report = evaluate_gate(
+            candidate_runs={"maker_fill": trades},
+            baseline_breakout=losers, baseline_random=losers,
+            fee_bps=10.0, min_trades=100,
+            candidate_name="t", hypothesis="mean_reversion", symbols=["XRPUSDT"])
+        assert report.verdict in {"validated", "not_validated", "insufficient_data"}

--- a/research/nautilus_scalping/tests/test_maker_fill.py
+++ b/research/nautilus_scalping/tests/test_maker_fill.py
@@ -1,0 +1,28 @@
+# research/nautilus_scalping/tests/test_maker_fill.py
+"""ROB-324 — pure maker/limit-fill scenario builders.
+
+Records in, validated_gate.Trade lists out. No nautilus; fully deterministic."""
+from __future__ import annotations
+
+from maker_fill import (
+    MAKER_FEE_BPS,
+    TAKER_BASELINE_BPS,
+    MakerTradeRecord,
+)
+
+
+def test_module_constants_match_demo_fees() -> None:
+    assert MAKER_FEE_BPS == 2.0
+    assert TAKER_BASELINE_BPS == 4.0
+
+
+def _rec(net, comm, notional, ts, *, filled=True, tp_hit=True, adverse=0.0) -> MakerTradeRecord:
+    return MakerTradeRecord(
+        net_at_real_fees=net, commission_real=comm, notional=notional,
+        ts_opened=ts, filled=filled, tp_hit=tp_hit, adverse_excursion_bps=adverse,
+    )
+
+
+def test_record_is_frozen_dataclass() -> None:
+    r = _rec(1.0, 0.04, 100.0, 0)
+    assert r.net_at_real_fees == 1.0 and r.filled is True

--- a/research/nautilus_scalping/tests/test_maker_fill.py
+++ b/research/nautilus_scalping/tests/test_maker_fill.py
@@ -9,6 +9,8 @@ from maker_fill import (
     TAKER_BASELINE_BPS,
     MakerTradeRecord,
     build_maker_optimistic,
+    build_maker_conservative,
+    classify_easy_tp,
 )
 from validated_gate import Trade, metrics_at_fee
 
@@ -45,3 +47,45 @@ def test_optimistic_excludes_missed_fills_and_preserves_true_net() -> None:
     # gross (fee=0) adds the real commission back
     g = metrics_at_fee(trades, fee_bps=0.0, fold="gross")
     assert round(g.net_pnl, 2) == 0.28               # 0.20 + 0.04 + 0.04
+
+
+def test_classify_easy_tp_boundary() -> None:
+    # TP hit with tiny adverse excursion = easy (front-of-queue) fill
+    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=1.0)) is True
+    # TP hit but price moved against us first = a real fill, not easy
+    assert classify_easy_tp(_rec(0.5, 0.04, 100, 1, tp_hit=True, adverse=5.0)) is False
+    # SL exits are never "easy TP"
+    assert classify_easy_tp(_rec(-0.5, 0.04, 100, 1, tp_hit=False, adverse=0.0)) is False
+
+
+def test_conservative_applies_adverse_cost_to_survivors() -> None:
+    # a non-easy filled trade is kept but charged the adverse cost
+    recs = [_rec(0.50, 0.04, 100.0, 1, tp_hit=True, adverse=9.0)]  # not easy -> kept
+    trades = build_maker_conservative(recs, queue_loss_pct=0.25, adverse_bps=1.0)
+    assert len(trades) == 1
+    # adverse cost = 1.0 bp * 100 notional / 10_000 = 0.01
+    assert round(trades[0].net_ref_pnl, 4) == 0.49
+
+
+def test_conservative_drops_about_quarter_of_easy_tp_fills_deterministically() -> None:
+    easy = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(2000)]
+    first = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
+    second = build_maker_conservative(easy, queue_loss_pct=0.25, adverse_bps=1.0)
+    # deterministic across runs (hash of ts, not RNG)
+    assert [t.ts_opened for t in first] == [t.ts_opened for t in second]
+    kept = len(first)
+    dropped = 2000 - kept
+    assert 400 <= dropped <= 600          # ~25% dropped (hash uniformity tolerance)
+
+
+def test_conservative_excludes_missed_fills() -> None:
+    recs = [_rec(0.0, 0.0, 100.0, 1, filled=False)]
+    assert build_maker_conservative(recs) == []
+
+
+def test_conservative_is_strictly_worse_than_optimistic() -> None:
+    recs = [_rec(0.50, 0.04, 100.0, ts, tp_hit=True, adverse=0.0) for ts in range(500)]
+    from validated_gate import metrics_at_fee
+    opt = metrics_at_fee(build_maker_optimistic(recs), 10.0).net_pnl
+    con = metrics_at_fee(build_maker_conservative(recs), 10.0).net_pnl
+    assert con < opt                      # queue-loss + adverse cost only ever hurt

--- a/research/nautilus_scalping/validate_maker_fill.py
+++ b/research/nautilus_scalping/validate_maker_fill.py
@@ -29,7 +29,15 @@ from maker_fill import (
     build_maker_conservative,
     build_maker_optimistic,
 )
-from validated_gate import REF_FEE_BPS, Trade, evaluate_gate
+from validated_gate import (
+    REF_FEE_BPS,
+    Trade,
+    apply_statistical_evidence,
+    bootstrap_sharpe_ci,
+    evaluate_gate,
+    monte_carlo_permutation,
+    net_pnls_at_fee,
+)
 
 _GRID = [
     ("z2.0/tp30/sl30", {"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30}),
@@ -55,14 +63,28 @@ def _merge_recs(runs):
     return sorted((rec for r in runs for rec in r), key=lambda rec: rec.ts_opened)
 
 
-def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name):
-    return evaluate_gate(
+def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name, seed=42):
+    report = evaluate_gate(
         candidate_runs=candidate_runs,
         baseline_breakout=breakout, baseline_random=random_ctrl,
         fee_bps=fee_bps, min_trades=100,
         candidate_name=name, hypothesis="mean_reversion",
         symbols=symbols, window=window,
-    ).to_dict()
+    )
+    # ROB-328 statistical robustness on the val-best config's net-after-fee per-trade PnL:
+    # bootstrap Sharpe CI + Monte-Carlo permutation. apply_statistical_evidence only
+    # downgrades a validated verdict (CI upper < 0); it never upgrades. No new edge claim.
+    val_best = report.param_stability.get("val_best_param")
+    stats: dict = {}
+    if val_best and val_best in candidate_runs:
+        net_pnls = net_pnls_at_fee(candidate_runs[val_best], fee_bps)
+        bootstrap = bootstrap_sharpe_ci(net_pnls, n_bootstrap=1000, seed=seed)
+        monte_carlo = monte_carlo_permutation(net_pnls, n_sim=1000, seed=seed)
+        apply_statistical_evidence(report, bootstrap)
+        stats = {"bootstrap_sharpe_ci": bootstrap, "monte_carlo_permutation": monte_carlo}
+    out = report.to_dict()
+    out.update(stats)
+    return out
 
 
 def main() -> int:

--- a/research/nautilus_scalping/validate_maker_fill.py
+++ b/research/nautilus_scalping/validate_maker_fill.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""ROB-324 — maker/limit-fill edge re-evaluation driver.
+
+Produces three scenarios and feeds each to the UNCHANGED validated_gate:
+  1. Taker baseline   — ROB-320 taker trades, gate's native rescale to 4.0 bps
+  2. Maker optimistic — data-derived limit fills at real maker/taker fees
+  3. Maker conservative — (2) minus queue-loss drop + adverse-selection cost  [HEADLINE]
+
+NO execution side effects: public-data backtest only. Nothing submits, schedules,
+mutates a broker/DB, reads secrets, or applies params to a daemon.
+
+Usage (rob-320 venv):
+    export CATALOG=/Users/mgh3326/work/auto_trader.rob-320/research/nautilus_scalping/catalog
+    PYTHONPATH=../.. $NVENV validate_maker_fill.py --catalog "$CATALOG" \
+        --symbols XRPUSDT,BTCUSDT --window-from 2026-03-01 --window-to 2026-05-14 \
+        --export results/rob324/maker_fill.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from backtest_runner import run, run_maker
+from candidates import get_candidate
+from maker_fill import (
+    MAKER_FEE_BPS,
+    TAKER_BASELINE_BPS,
+    build_maker_conservative,
+    build_maker_optimistic,
+)
+from validated_gate import REF_FEE_BPS, Trade, evaluate_gate
+
+_GRID = [
+    ("z2.0/tp30/sl30", {"lookback": 20, "z_entry": "2.0", "tp_bps": 30, "sl_bps": 30}),
+    ("z2.5/tp40/sl40", {"lookback": 20, "z_entry": "2.5", "tp_bps": 40, "sl_bps": 40}),
+]
+_SIZE = {"BTCUSDT": "0.002"}
+_FILL_MODEL = {
+    "entry_rule": "passive limit @ signal-bar close",
+    "fill_timeout_bars": 1,
+    "tp_execution": "maker limit",
+    "sl_execution": "taker stop (market)",
+    "queue_loss_pct": 0.25,
+    "adverse_bps": 1.0,
+    "excursion_eps_bps": 2.0,
+}
+
+
+def _merge(runs: list[list[Trade]]) -> list[Trade]:
+    return sorted((t for r in runs for t in r), key=lambda t: t.ts_opened)
+
+
+def _merge_recs(runs):
+    return sorted((rec for r in runs for rec in r), key=lambda rec: rec.ts_opened)
+
+
+def _gate(candidate_runs, breakout, random_ctrl, fee_bps, symbols, window, name):
+    return evaluate_gate(
+        candidate_runs=candidate_runs,
+        baseline_breakout=breakout, baseline_random=random_ctrl,
+        fee_bps=fee_bps, min_trades=100,
+        candidate_name=name, hypothesis="mean_reversion",
+        symbols=symbols, window=window,
+    ).to_dict()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="ROB-324 maker/limit-fill driver")
+    ap.add_argument("--catalog", type=Path, default="catalog")
+    ap.add_argument("--symbols", default="XRPUSDT,BTCUSDT")
+    ap.add_argument("--window-from", default="")
+    ap.add_argument("--window-to", default="")
+    ap.add_argument("--export", type=Path, default="results/rob324/maker_fill.json")
+    args = ap.parse_args()
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    window = {"from": args.window_from, "to": args.window_to,
+              "folds": {"train": 0.5, "val": 0.25, "oos": 0.25}}
+
+    # --- baselines (taker, single config each), merged across symbols ---
+    print("Running taker baselines (breakout, random)...")
+    breakout = _merge([run(args.catalog, s, "micro_breakout",
+                           get_candidate("micro_breakout").default_params,
+                           _SIZE.get(s, "100")) for s in symbols])
+    random_ctrl = _merge([run(args.catalog, s, "random_entry",
+                              get_candidate("random_entry").default_params,
+                              _SIZE.get(s, "100")) for s in symbols])
+
+    # --- scenario 1: taker baseline candidate over the param grid (grid rescales 10->4) ---
+    print("Scenario 1: taker baseline @ 4 bps (grid)...")
+    taker_runs = {label: _merge([run(args.catalog, s, "meanrev_zscore_fade",
+                                     dict(params), _SIZE.get(s, "100")) for s in symbols])
+                  for label, params in _GRID}
+    taker_report = _gate(taker_runs, breakout, random_ctrl, TAKER_BASELINE_BPS,
+                         symbols, window, "meanrev_taker_baseline")
+
+    # --- scenarios 2 & 3: maker re-sim over the SAME grid (param-stability preserved) ---
+    print("Scenarios 2 & 3: maker re-sim (grid)...")
+    maker_recs: dict[str, list] = {}
+    attempted = filled = 0
+    for label, params in _GRID:
+        per_symbol = []
+        for s in symbols:
+            recs, att, fil = run_maker(args.catalog, s, dict(params), _SIZE.get(s, "100"))
+            per_symbol.append(recs)
+            attempted += att
+            filled += fil
+        maker_recs[label] = _merge_recs(per_symbol)
+
+    opt_runs = {label: build_maker_optimistic(recs) for label, recs in maker_recs.items()}
+    con_runs = {label: build_maker_conservative(
+                    recs, queue_loss_pct=_FILL_MODEL["queue_loss_pct"],
+                    adverse_bps=_FILL_MODEL["adverse_bps"],
+                    excursion_eps_bps=_FILL_MODEL["excursion_eps_bps"])
+                for label, recs in maker_recs.items()}
+
+    # maker scenarios: net already at real fees -> evaluate at REF (as-run)
+    opt_report = _gate(opt_runs, breakout, random_ctrl, REF_FEE_BPS,
+                       symbols, window, "meanrev_maker_optimistic")
+    con_report = _gate(con_runs, breakout, random_ctrl, REF_FEE_BPS,
+                       symbols, window, "meanrev_maker_conservative")
+
+    artifact = {
+        "schema_version": "validated_signal_gate.v2",
+        "candidate": "meanrev_zscore_fade",
+        "hypothesis": "mean_reversion",
+        "symbols": symbols,
+        "window": window,
+        "cost_model": {
+            "maker_fee_bps": MAKER_FEE_BPS, "taker_fee_bps": TAKER_BASELINE_BPS,
+            "commission_source": "results/rob324/binance_usdm_commission_rates.json",
+            "note": ("maker scenarios bake real per-leg fees into net; gate evaluated "
+                     "at its reference point (as-run). taker baseline uses the gate's "
+                     "native single-rate rescale to 4.0 bps."),
+        },
+        "fill_model": _FILL_MODEL,
+        "fill_stats": {"entries_attempted": attempted, "entries_filled": filled,
+                       "missed_fills": attempted - filled},
+        "scenarios": {
+            "taker_baseline": taker_report,
+            "maker_optimistic": opt_report,
+            "maker_conservative": con_report,
+        },
+        "verdict": con_report["verdict"],            # headline = conservative (honest bound)
+        "verdict_reasons": con_report["verdict_reasons"],
+        "verdict_source": "maker_conservative",
+    }
+
+    args.export.parent.mkdir(parents=True, exist_ok=True)
+    args.export.write_text(json.dumps(artifact, indent=2))
+    print("\n=============================================================")
+    print(f"HEADLINE VERDICT (conservative): {artifact['verdict'].upper()}")
+    for r in artifact["verdict_reasons"]:
+        print(f"  - {r}")
+    print(f"taker_baseline   verdict: {taker_report['verdict']}")
+    print(f"maker_optimistic verdict: {opt_report['verdict']}")
+    print(f"missed fills: {attempted - filled} / {attempted} attempted")
+    print(f"Report exported to: {args.export.resolve()}")
+    print("=============================================================")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Research-only follow-up to ROB-320 (#968). Re-evaluates whether a conservative maker/limit-fill execution model recovers a net-after-cost edge for the `meanrev_zscore_fade` scalper on XRPUSDT + BTCUSDT that taker fees killed in ROB-320 — using the **real** Binance USDⓈ-M Futures Demo fees (maker 2.0 / taker 4.0 bps) captured (read-only, signed API) in the committed commission artifact, not an estimate.

Everything lives under `research/nautilus_scalping/` in its isolated venv.

## Approach (no fee-only rescale)
The commission artifact's own note rules out a fee-only rescale, so this is a real re-simulation:
- **Entry**: passive Nautilus limit posted `entry_offset_bps` (5) below close (BUY) / above (SELL) → immediate reversions are **real missed fills** (~50%); continued moves fill (entry-side adverse selection from real ticks).
- **Exit**: touch-based TP/SL, identical trigger logic to the taker strategy, so the maker trade set is comparable to taker (not collapsed by resting-limit under-fills).
- **Fees**: the re-sim runs on a **zero-fee instrument** (gross price P&L); `maker_fill` applies real per-leg fees analytically — maker 2 bps on entry + the TP leg, taker 4 bps on the SL leg — plus a conservative overlay (deterministic queue-loss drop of easy-TP fills + adverse-selection cost).
- The `validated_signal_gate` (incl. rob-328 bootstrap CI + MC permutation) is **unchanged**; maker scenarios bake real fees into net and are evaluated at the gate's reference point.

## Artifact
`research/nautilus_scalping/results/rob324/maker_fill.json` (`validated_signal_gate.v2`), three scenarios over the ROB-320 window (2026-03-01 → 05-14), each with OOS/fold metrics, baseline comparison, overfit flags, and bootstrap/MC stats:

| scenario | verdict | OOS net | OOS PF |
|---|---|---|---|
| taker_baseline @4bps | not_validated | −16.48 | 0.75 |
| maker_optimistic | not_validated | −1.95 | 0.95 |
| **maker_conservative** (headline) | **not_validated** | **−3.69** | **0.90** |

## Verdict: `not_validated` (honest)
Maker execution markedly improves on taker (lower fees + passive-entry improvement: OOS −16.48 → −3.69) but stays just below breakeven after costs. Statistically backed: bootstrap 95% CI upper −0.0174 < 0 (only 1% of bootstrap samples positive); MC permutation p_sharpe 0.317. The maker/limit-fill model does **not** recover a net-after-cost edge for this scalper.

Fill realism: 1150 / 2318 entry attempts missed (~50%) — the passive entry genuinely misses immediate reversions.

## Side-effect boundary
Research/backtest only. **No** live trading, no Binance Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod DB/env/secret changes, no automatic runtime parameter application, no `/invest` surfacing. Reads the public trade-tick parquet catalog read-only; the committed commission artifact contains no secrets, signatures, balances, positions, or account identifiers.

## Tests
62 research tests pass (taker parity intact; 11 new `test_maker_fill` covering missed-fill, per-leg fee math, SL-taker-fee, adverse-selection/queue-loss, determinism, verdict-vocabulary). `ruff` clean. Independent code review: ready-for-PR, no Critical/Important findings.

Design spec: `docs/superpowers/specs/2026-05-26-rob324-maker-limit-fill-design.md` · plan: `docs/superpowers/plans/2026-05-26-rob324-maker-limit-fill.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maker limit-fill execution mode to mean reversion strategy alongside existing taker mode
  * Introduced maker fill validation and evaluation framework with optimistic and conservative scenario builders

* **Documentation**
  * Added ROB-324 maker/limit-fill design specification and implementation plan

* **Tests**
  * Added comprehensive test suite for maker fill scenario builders and validation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->