### PR TITLE
feat(rob-335): /invest/reports 장중 액션 사이클 MVP — ActionPacket + non-empty invariant (PR1 backend)

### DIFF
--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -37,11 +37,11 @@ from app.schemas.investment_reports import (
     ReportSnapshotDetailResponse,
     ReportStatusLiteral,
 )
+from app.services.investment_reports.action_packet import build_action_packet
 from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
 )
 from app.services.investment_reports.review_sections import build_review_sections
-from app.services.investment_reports.action_packet import build_action_packet
 
 router = APIRouter(tags=["investment-reports"])
 

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -41,6 +41,7 @@ from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
 )
 from app.services.investment_reports.review_sections import build_review_sections
+from app.services.investment_reports.action_packet import build_action_packet
 
 router = APIRouter(tags=["investment-reports"])
 
@@ -80,6 +81,11 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         item_responses, report_response.snapshot_report_diagnostics
     )
 
+    # ROB-335 — additive intraday ActionPacket projection (view-layer only).
+    action_packet = build_action_packet(
+        item_responses, report_response.snapshot_report_diagnostics
+    )
+
     return InvestmentReportBundle(
         report=report_response,
         items=item_responses,
@@ -93,6 +99,7 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         item_groups=item_groups,
         decision_rollup=rollup,
         review_sections=review_sections,
+        action_packet=action_packet,
     )
 
 

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -550,6 +550,58 @@ class ReportReviewSections(BaseModel):
     no_action_summary: NoActionSummary | None = None
 
 
+# ROB-335 — intraday ActionPacket. A read-time *view-layer projection* over
+# the same persisted items (sub-verdict in evidence_snapshot["action_verdict"])
+# + ROB-318 diagnostics. No new persisted classification / DB CHECK / migration.
+ActionVerdictLiteral = Literal[
+    "buy_review",
+    "limit_wait",
+    "no_new_buy_candidates",
+    "sell_review",
+    "trim_review",
+    "add_review",
+    "keep",
+    "no_add",
+    "watch_only",
+    "rejected",
+    "data_gap",
+]
+
+
+class ActionPacketEntry(BaseModel):
+    """One symbol-level entry in an ActionPacket group."""
+
+    verdict: ActionVerdictLiteral
+    symbol: str | None = None
+    side: ItemSideLiteral | None = None
+    rationale: str
+    item_uuid: UUID | None = None
+    evidence_snapshot: dict[str, Any] = Field(default_factory=dict)
+
+
+class DataGapEntry(BaseModel):
+    """One data-gap surfaced for the next cycle."""
+
+    source: str
+    status: str | None = None
+    reason: str | None = None
+
+
+class ActionPacket(BaseModel):
+    """ROB-335 four-question intraday surface (held / new / risk / data-gap).
+
+    Always-explicit: ``no_new_buy_reason`` and ``no_action_reason`` answer the
+    "why nothing" questions even when the corresponding groups are empty.
+    """
+
+    held_actions: list[ActionPacketEntry] = Field(default_factory=list)
+    new_buy_candidates: list[ActionPacketEntry] = Field(default_factory=list)
+    no_new_buy_reason: str | None = None
+    risk_reviews: list[ActionPacketEntry] = Field(default_factory=list)
+    no_action_reason: NoActionSummary | None = None
+    data_gaps_for_next_cycle: list[DataGapEntry] = Field(default_factory=list)
+
+
 class InvestmentReportBundle(BaseModel):
     """``investment_report_get`` / ``GET /.../investment-reports/{uuid}``.
 
@@ -572,6 +624,10 @@ class InvestmentReportBundle(BaseModel):
     # ROB-322 — additive five-section review projection. Null/empty for legacy
     # reports; existing ``items`` / ``item_groups`` remain the fallback.
     review_sections: ReportReviewSections | None = None
+    # ROB-335 — additive intraday ActionPacket projection. Null for legacy /
+    # non-intraday reports; existing items / review_sections remain the fallback.
+    action_packet: ActionPacket | None = None
+
 
 
 class InvestmentReportListResponse(BaseModel):

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -629,7 +629,6 @@ class InvestmentReportBundle(BaseModel):
     action_packet: ActionPacket | None = None
 
 
-
 class InvestmentReportListResponse(BaseModel):
     """``investment_report_list`` / ``GET /.../investment-reports``."""
 

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -1,0 +1,71 @@
+# app/services/action_report/snapshot_backed/action_verdict.py
+"""ROB-335 — deterministic ActionPacket sub-verdict vocabulary + rules.
+
+Sub-verdicts are *sub-labels over the locked ROB-301 ``decision_bucket``
+5-value enum* (spec §2 decision A). They are stored on each report item's
+``evidence_snapshot["action_verdict"]`` (JSON; no migration, decision B) and
+projected at read-time by ``build_action_packet``.
+
+Per decision C′, only the *honest* verdicts are assigned deterministically
+here: ``data_gap`` / ``keep`` / ``no_add`` / ``sell_review`` (held) and
+``buy_review`` / ``no_new_buy_candidates`` (candidate). Directional
+``trim_review`` / ``add_review`` / ``limit_wait`` / ``rejected`` exist in the
+vocabulary for Hermes push to fill but are never fabricated here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# action_verdict -> locked decision_bucket. Keys are the full vocabulary.
+VERDICT_TO_BUCKET: dict[str, str] = {
+    "buy_review": "new_buy_candidate",
+    "limit_wait": "new_buy_candidate",
+    "no_new_buy_candidates": "new_buy_candidate",
+    "sell_review": "open_action",
+    "trim_review": "open_action",
+    "add_review": "open_action",
+    "keep": "completed_or_existing",
+    "no_add": "completed_or_existing",
+    "watch_only": "risk_watch",
+    "rejected": "deferred_no_action",
+    "data_gap": "deferred_no_action",
+}
+
+ACTION_VERDICTS: frozenset[str] = frozenset(VERDICT_TO_BUCKET)
+
+
+def _quote_is_actionable(quote: Any) -> bool:
+    # Mirrors auto_emit._quote_is_actionable so held + candidate gates agree.
+    if not isinstance(quote, dict):
+        return False
+    if quote.get("status") != "ok":
+        return False
+    best_bid = quote.get("best_bid") or 0
+    best_ask = quote.get("best_ask") or 0
+    bid_depth = quote.get("bid_depth") or 0
+    ask_depth = quote.get("ask_depth") or 0
+    return best_bid > 0 and best_ask > 0 and (bid_depth > 0 or ask_depth > 0)
+
+
+def classify_held_symbol(
+    holding: dict[str, Any],
+    quote: dict[str, Any] | None,
+    *,
+    in_candidate_universe: bool,
+) -> str:
+    """Deterministic verdict for ONE KIS-primary held symbol (decision C′).
+
+    Order (honest range only):
+      1. quote missing / not actionable -> ``data_gap`` (no directional call)
+      2. sellable_quantity > 0          -> ``sell_review`` (reviewable reduce)
+      3. held + in screener universe    -> ``no_add`` (trending, don't add)
+      4. otherwise                      -> ``keep`` (default hold)
+    """
+    if not _quote_is_actionable(quote):
+        return "data_gap"
+    if (holding.get("sellable_quantity") or 0) > 0:
+        return "sell_review"
+    if in_candidate_universe:
+        return "no_add"
+    return "keep"

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -123,7 +123,6 @@ class EvidenceAutoEmitter:
         self._max_buy_candidates = max_buy_candidates
         self._intraday_floor = intraday_floor
 
-
     def propose(
         self,
         *,
@@ -388,8 +387,10 @@ class EvidenceAutoEmitter:
                             symbol=ticker,
                             side="sell" if verdict == "sell_review" else None,
                             intent=(
-                                "sell_review" if verdict == "sell_review"
-                                else "risk_review" if verdict == "data_gap"
+                                "sell_review"
+                                if verdict == "sell_review"
+                                else "risk_review"
+                                if verdict == "data_gap"
                                 else "rebalance_review"
                             ),
                             rationale=(
@@ -409,7 +410,8 @@ class EvidenceAutoEmitter:
                                         "sellable_quantity"
                                     ),
                                     "quote_status": quote.get("status")
-                                    if quote else "no_snapshot",
+                                    if quote
+                                    else "no_snapshot",
                                     "proposer": "auto_emit/intraday_held_floor",
                                 },
                             ),
@@ -462,4 +464,3 @@ class EvidenceAutoEmitter:
                     ]
 
         return items
-

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -41,6 +41,17 @@ from app.schemas.validated_run_card import (
     build_run_card_citation,
     build_run_card_evidence,
 )
+from app.services.action_report.snapshot_backed.action_verdict import (
+    VERDICT_TO_BUCKET,
+    classify_held_symbol,
+)
+
+
+def _stamp(item: IngestReportItem, verdict: str) -> IngestReportItem:
+    """Attach the ActionPacket sub-verdict + its locked decision_bucket."""
+    item.evidence_snapshot["action_verdict"] = verdict
+    item.decision_bucket = VERDICT_TO_BUCKET[verdict]
+    return item
 
 
 def _snapshot_payload(snapshot: Any) -> dict[str, Any]:
@@ -106,8 +117,12 @@ class EvidenceAutoEmitter:
     """Deterministic proposer that surfaces review-only candidates from the
     persisted snapshot bundle."""
 
-    def __init__(self, *, max_buy_candidates: int = 10) -> None:
+    def __init__(
+        self, *, max_buy_candidates: int = 10, intraday_floor: bool = False
+    ) -> None:
         self._max_buy_candidates = max_buy_candidates
+        self._intraday_floor = intraday_floor
+
 
     def propose(
         self,
@@ -197,20 +212,23 @@ class EvidenceAutoEmitter:
                 },
             )
             items.append(
-                IngestReportItem(
-                    client_item_key=f"auto-sell-{ticker}",
-                    item_kind="action",
-                    symbol=ticker,
-                    side="sell",
-                    intent="sell_review",
-                    rationale=(
-                        f"보유 종목 {ticker} sell 검토 — sellable {sellable}, "
-                        f"best_bid {quote.get('best_bid')}, "
-                        f"spread_bps {quote.get('spread_bps')}"
+                _stamp(
+                    IngestReportItem(
+                        client_item_key=f"auto-sell-{ticker}",
+                        item_kind="action",
+                        symbol=ticker,
+                        side="sell",
+                        intent="sell_review",
+                        rationale=(
+                            f"보유 종목 {ticker} sell 검토 — sellable {sellable}, "
+                            f"best_bid {quote.get('best_bid')}, "
+                            f"spread_bps {quote.get('spread_bps')}"
+                        ),
+                        operation="review",
+                        apply_policy="requires_user_approval",
+                        evidence_snapshot=evidence,
                     ),
-                    operation="review",
-                    apply_policy="requires_user_approval",
-                    evidence_snapshot=evidence,
+                    "sell_review",
                 )
             )
 
@@ -243,20 +261,23 @@ class EvidenceAutoEmitter:
                     },
                 )
                 items.append(
-                    IngestReportItem(
-                        client_item_key=f"auto-buy-{sym}",
-                        item_kind="action",
-                        symbol=sym,
-                        side="buy",
-                        intent="buy_review",
-                        rationale=(
-                            f"신규 매수 검토 — {sym} (candidate {candidate_usefulness}"
-                            f", quote best_bid {quote.get('best_bid')}, "
-                            f"spread_bps {quote.get('spread_bps')})"
+                    _stamp(
+                        IngestReportItem(
+                            client_item_key=f"auto-buy-{sym}",
+                            item_kind="action",
+                            symbol=sym,
+                            side="buy",
+                            intent="buy_review",
+                            rationale=(
+                                f"신규 매수 검토 — {sym} (candidate {candidate_usefulness}"
+                                f", quote best_bid {quote.get('best_bid')}, "
+                                f"spread_bps {quote.get('spread_bps')})"
+                            ),
+                            operation="review",
+                            apply_policy="requires_user_approval",
+                            evidence_snapshot=evidence,
                         ),
-                        operation="review",
-                        apply_policy="requires_user_approval",
-                        evidence_snapshot=evidence,
+                        "buy_review",
                     )
                 )
                 buy_emitted += 1
@@ -289,18 +310,21 @@ class EvidenceAutoEmitter:
                 },
             )
             items.append(
-                IngestReportItem(
-                    client_item_key=f"auto-watch-{sym}",
-                    item_kind="watch",
-                    symbol=sym,
-                    intent="trend_recovery_review",
-                    rationale=(
-                        f"뉴스 관심 종목 watch 검토 — {sym} "
-                        f"(news_matches {count}, quote_status {quote_status})"
+                _stamp(
+                    IngestReportItem(
+                        client_item_key=f"auto-watch-{sym}",
+                        item_kind="watch",
+                        symbol=sym,
+                        intent="trend_recovery_review",
+                        rationale=(
+                            f"뉴스 관심 종목 watch 검토 — {sym} "
+                            f"(news_matches {count}, quote_status {quote_status})"
+                        ),
+                        operation="review",
+                        apply_policy="requires_user_approval",
+                        evidence_snapshot=evidence,
                     ),
-                    operation="review",
-                    apply_policy="requires_user_approval",
-                    evidence_snapshot=evidence,
+                    "watch_only",
                 )
             )
 
@@ -313,32 +337,119 @@ class EvidenceAutoEmitter:
                 continue
             reasons = cand.get("reasons") or []
             items.append(
-                IngestReportItem(
-                    client_item_key=f"auto-hold-trend-{sym}",
-                    item_kind="watch",
-                    symbol=sym,
-                    intent="trend_recovery_review",
-                    rationale=(
-                        f"보유 종목 {sym}가 스크리너 추세 상위에 등장 — 관망/추가검토 "
-                        f"(score {cand.get('score')}, {', '.join(reasons)})"
+                _stamp(
+                    IngestReportItem(
+                        client_item_key=f"auto-hold-trend-{sym}",
+                        item_kind="watch",
+                        symbol=sym,
+                        intent="trend_recovery_review",
+                        rationale=(
+                            f"보유 종목 {sym}가 스크리너 추세 상위에 등장 — 관망/추가검토 "
+                            f"(score {cand.get('score')}, {', '.join(reasons)})"
+                        ),
+                        operation="review",
+                        apply_policy="requires_user_approval",
+                        evidence_snapshot=_make_evidence(
+                            candidate_snapshot,
+                            extra={
+                                "candidate_snapshot_uuid": _snapshot_uuid(
+                                    candidate_snapshot
+                                ),
+                                "candidate_score": cand.get("score"),
+                                "candidate_reasons": reasons,
+                                "candidate_source": cand.get("source"),
+                                "held": True,
+                                "proposer": "auto_emit/held_and_trending",
+                            },
+                        ),
                     ),
-                    operation="review",
-                    apply_policy="requires_user_approval",
-                    evidence_snapshot=_make_evidence(
-                        candidate_snapshot,
-                        extra={
-                            "candidate_snapshot_uuid": _snapshot_uuid(
-                                candidate_snapshot
-                            ),
-                            "candidate_score": cand.get("score"),
-                            "candidate_reasons": reasons,
-                            "candidate_source": cand.get("source"),
-                            "held": True,
-                            "proposer": "auto_emit/held_and_trending",
-                        },
-                    ),
+                    "watch_only",
                 )
             )
+
+        # ROB-335 — intraday floor: classify EVERY held KIS symbol (not just
+        # sellable+actionable) so held_actions is never empty, and surface an
+        # explicit no-new-buy reason when the screener universe is not useful.
+        if self._intraday_floor:
+            already = {i.symbol for i in items if i.symbol}
+            for ticker, holding in held.items():
+                if ticker in already:
+                    continue
+                quote_pair = symbol_quotes.get(ticker)
+                quote = quote_pair[1] if quote_pair else None
+                verdict = classify_held_symbol(
+                    holding, quote, in_candidate_universe=ticker in candidate_by_symbol
+                )
+                items.append(
+                    _stamp(
+                        IngestReportItem(
+                            client_item_key=f"auto-held-{ticker}",
+                            item_kind="risk" if verdict == "data_gap" else "action",
+                            symbol=ticker,
+                            side="sell" if verdict == "sell_review" else None,
+                            intent=(
+                                "sell_review" if verdict == "sell_review"
+                                else "risk_review" if verdict == "data_gap"
+                                else "rebalance_review"
+                            ),
+                            rationale=(
+                                f"보유 종목 {ticker} {verdict} — sellable "
+                                f"{holding.get('sellable_quantity')}, "
+                                f"quote {quote.get('status') if quote else 'none'}"
+                            ),
+                            operation="review",
+                            apply_policy="requires_user_approval",
+                            evidence_snapshot=_make_evidence(
+                                quote_pair[0] if quote_pair else portfolio_snapshot,
+                                extra={
+                                    "portfolio_snapshot_uuid": _snapshot_uuid(
+                                        portfolio_snapshot
+                                    ),
+                                    "sellable_quantity": holding.get(
+                                        "sellable_quantity"
+                                    ),
+                                    "quote_status": quote.get("status")
+                                    if quote else "no_snapshot",
+                                    "proposer": "auto_emit/intraday_held_floor",
+                                },
+                            ),
+                        ),
+                        verdict,
+                    )
+                )
+
+            if candidate_usefulness != "useful":
+                missing = (
+                    candidate_snapshot is not None
+                    and _snapshot_payload(candidate_snapshot).get("missing_data")
+                ) or {}
+                reason = (
+                    f"{missing.get('what', '신규 매수 후보 없음')} "
+                    f"{missing.get('next', '')}".strip()
+                    if isinstance(missing, dict)
+                    else "신규 매수 후보 없음"
+                )
+                items.append(
+                    _stamp(
+                        IngestReportItem(
+                            client_item_key="auto-no-new-buy",
+                            item_kind="risk",
+                            symbol=None,
+                            intent="risk_review",
+                            rationale=reason,
+                            operation="review",
+                            apply_policy="requires_user_approval",
+                            evidence_snapshot=_make_evidence(
+                                candidate_snapshot,
+                                extra={
+                                    "candidate_usefulness": candidate_usefulness,
+                                    "proposer": "auto_emit/no_new_buy_floor",
+                                },
+                            ),
+                        ),
+                        "no_new_buy_candidates",
+                    )
+                )
 
         # ROB-332 — cite a bundle-resident validated_run_card on items whose
         # symbol matches the run card's symbols (consume-when-present; no-op
@@ -351,3 +462,4 @@ class EvidenceAutoEmitter:
                     ]
 
         return items
+

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -61,7 +61,6 @@ from app.services.action_report.snapshot_backed.proposal_classifier import (
     ClassifierContext,
     classify_items,
 )
-
 from app.services.action_report.snapshot_backed.request import (
     ReportGenerationRequest,
     ReportGenerationResponse,

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -53,10 +53,15 @@ from app.services.action_report.common.snapshot_bundle import (
 from app.services.action_report.snapshot_backed.collectors.registry import (
     production_collector_registry,
 )
+from app.services.action_report.snapshot_backed.intraday_floor import (
+    ensure_action_floor,
+    is_intraday_action,
+)
 from app.services.action_report.snapshot_backed.proposal_classifier import (
     ClassifierContext,
     classify_items,
 )
+
 from app.services.action_report.snapshot_backed.request import (
     ReportGenerationRequest,
     ReportGenerationResponse,
@@ -297,6 +302,19 @@ class SnapshotBackedReportGenerator:
                 getattr(it, "item_kind", None) == "action" for it in request.items
             ),
         )
+
+        # ROB-335 — intraday non-empty floor: never let an intraday_action
+        # report succeed with items=[]; synthesize an explicit no-action /
+        # data-gap item from the deterministic why_no_action verdict.
+        if is_intraday_action(request.policy_version):
+            request = request.model_copy(
+                update={
+                    "items": ensure_action_floor(
+                        list(request.items), why_no_action=why_no_action
+                    )
+                }
+            )
+
         report_diagnostics = build_report_diagnostics(
             freshness_summary=freshness_summary,
             bundle_status=ensure_response.status,
@@ -389,7 +407,9 @@ class SnapshotBackedReportGenerator:
         item_snapshot_pairs = (
             await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
         )
-        emitter = EvidenceAutoEmitter()
+        emitter = EvidenceAutoEmitter(
+            intraday_floor=is_intraday_action(request.policy_version)
+        )
         return emitter.propose(
             snapshots=[s for _i, s in item_snapshot_pairs],
             request_market=request.market,

--- a/app/services/action_report/snapshot_backed/intraday_floor.py
+++ b/app/services/action_report/snapshot_backed/intraday_floor.py
@@ -1,0 +1,56 @@
+# app/services/action_report/snapshot_backed/intraday_floor.py
+"""ROB-335 — intraday non-empty floor guard.
+
+Last-resort guarantee that an ``intraday_action`` report never succeeds with
+``items=[]`` (spec §3.1). When the deterministic emitter + classifier produced
+nothing actionable (e.g. no holdings, no candidates, portfolio unavailable),
+synthesize ONE structural review item that carries the report's no-action
+reason as an explicit ActionPacket entry. Never fabricates a buy/sell call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.action_report.snapshot_backed.action_verdict import VERDICT_TO_BUCKET
+
+_INTRADAY_POLICY_PREFIX = "intraday_action"
+
+
+def is_intraday_action(policy_version: str | None) -> bool:
+    return bool(policy_version) and policy_version.startswith(_INTRADAY_POLICY_PREFIX)
+
+
+def ensure_action_floor(
+    items: list[IngestReportItem],
+    *,
+    why_no_action: dict[str, Any] | None,
+) -> list[IngestReportItem]:
+    """Return ``items`` unchanged when non-empty; else a one-item floor."""
+    if items:
+        return items
+
+    kind = (why_no_action or {}).get("kind")
+    # real_no_action -> genuine hold (keep); data/stale-blocked -> data_gap.
+    verdict = "keep" if kind == "real_no_action" else "data_gap"
+    reason = (why_no_action or {}).get("reason_ko") or (
+        "장중 액션 없음 — 데이터/후보 부족"
+    )
+    return [
+        IngestReportItem(
+            client_item_key="intraday-floor",
+            item_kind="risk",
+            symbol=None,
+            intent="risk_review",
+            rationale=reason,
+            operation="review",
+            apply_policy="requires_user_approval",
+            evidence_snapshot={
+                "action_verdict": verdict,
+                "proposer": "intraday_floor",
+                "why_no_action": why_no_action,
+            },
+            decision_bucket=VERDICT_TO_BUCKET[verdict],
+        )
+    ]

--- a/app/services/investment_reports/action_packet.py
+++ b/app/services/investment_reports/action_packet.py
@@ -1,0 +1,133 @@
+# app/services/investment_reports/action_packet.py
+"""ROB-335 — deterministic intraday ActionPacket projection.
+
+Read-time *view-layer* projection (same pattern as ROB-322
+``review_sections.py``): groups the flat report-item list by the
+``evidence_snapshot["action_verdict"]`` sub-label into the four-question
+intraday surface, and folds ROB-318 diagnostics into the no-action /
+data-gap answers.
+
+Pure + read-only: no new persisted classification, DB CHECK, or migration.
+Items without an ``action_verdict`` (legacy / Hermes-not-yet) are not
+projected; they remain available via the bundle's ``items``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.schemas.investment_reports import (
+    ActionPacket,
+    ActionPacketEntry,
+    DataGapEntry,
+    InvestmentReportItemResponse,
+    NoActionSummary,
+)
+from app.services.action_report.snapshot_backed.action_verdict import (
+    VERDICT_TO_BUCKET,
+)
+
+_HELD_VERDICTS = {"sell_review", "trim_review", "add_review", "keep", "no_add"}
+_NEW_BUY_VERDICTS = {"buy_review", "limit_wait"}
+_RISK_VERDICTS = {"watch_only"}
+_DATA_GAP_VERDICTS = {"data_gap"}
+_DEGRADED_STATUSES = {"unavailable", "failed", "hard_stale", "soft_stale", "partial"}
+
+
+def _verdict(item: InvestmentReportItemResponse) -> str | None:
+    evidence = item.evidence_snapshot or {}
+    verdict = evidence.get("action_verdict") if isinstance(evidence, Mapping) else None
+    if isinstance(verdict, str) and verdict in VERDICT_TO_BUCKET:
+        return verdict
+    return None
+
+
+def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntry:
+    return ActionPacketEntry(
+        verdict=verdict,  # type: ignore[arg-type]
+        symbol=item.symbol,
+        side=item.side,
+        rationale=item.rationale,
+        item_uuid=item.item_uuid,
+        evidence_snapshot=dict(item.evidence_snapshot or {}),
+    )
+
+
+def build_action_packet(
+    items: Sequence[InvestmentReportItemResponse],
+    diagnostics: Mapping[str, Any] | None,
+) -> ActionPacket:
+    held: list[ActionPacketEntry] = []
+    new_buy: list[ActionPacketEntry] = []
+    risk: list[ActionPacketEntry] = []
+    data_gaps: list[DataGapEntry] = []
+    no_new_buy_reason: str | None = None
+
+    for item in items:
+        verdict = _verdict(item)
+        if verdict is None:
+            continue
+        if verdict == "no_new_buy_candidates":
+            no_new_buy_reason = item.rationale
+            continue
+        if verdict in _HELD_VERDICTS:
+            held.append(_entry(item, verdict))
+        elif verdict in _NEW_BUY_VERDICTS:
+            new_buy.append(_entry(item, verdict))
+        elif verdict in _RISK_VERDICTS:
+            risk.append(_entry(item, verdict))
+        elif verdict in _DATA_GAP_VERDICTS:
+            data_gaps.append(
+                DataGapEntry(source=item.symbol or "unknown", reason=item.rationale)
+            )
+
+    no_action_reason = _no_action_summary(diagnostics)
+    data_gaps.extend(_diagnostics_gaps(diagnostics))
+
+    return ActionPacket(
+        held_actions=held,
+        new_buy_candidates=new_buy,
+        no_new_buy_reason=no_new_buy_reason,
+        risk_reviews=risk,
+        no_action_reason=no_action_reason,
+        data_gaps_for_next_cycle=data_gaps,
+    )
+
+
+def _no_action_summary(
+    diagnostics: Mapping[str, Any] | None,
+) -> NoActionSummary | None:
+    if not isinstance(diagnostics, Mapping):
+        return None
+    why = diagnostics.get("why_no_action")
+    if not isinstance(why, Mapping):
+        return None
+    blocking = why.get("blocking_sources") or []
+    return NoActionSummary(
+        kind=why.get("kind"),
+        reason_ko=why.get("reason_ko"),
+        blocking_sources=[str(s) for s in blocking],
+    )
+
+
+def _diagnostics_gaps(diagnostics: Mapping[str, Any] | None) -> list[DataGapEntry]:
+    if not isinstance(diagnostics, Mapping):
+        return []
+    by_source = diagnostics.get("data_sufficiency_by_source")
+    if not isinstance(by_source, Mapping):
+        return []
+    out: list[DataGapEntry] = []
+    for source, info in by_source.items():
+        if not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        if status in _DEGRADED_STATUSES:
+            out.append(
+                DataGapEntry(
+                    source=str(source),
+                    status=str(status) if status is not None else None,
+                    reason=info.get("reason") or info.get("reason_code"),
+                )
+            )
+    return out

--- a/docs/superpowers/plans/2026-05-27-rob-335-intraday-action-cycle.md
+++ b/docs/superpowers/plans/2026-05-27-rob-335-intraday-action-cycle.md
@@ -1,0 +1,1238 @@
+# ROB-335 — `/invest/reports` 장중 액션 사이클 MVP (PR1 백엔드) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** KR/KIS live operator-triggered `intraday_action` 리포트가 `items=[]`로 성공하지 않고, 모든 보유종목을 결정론 verdict(sell_review/keep/no_add/data_gap)로 분류하며, 신규후보 없음·데이터 부족 사유를 ActionPacket으로 read-time projection 한다.
+
+**Architecture:** 결정론 sub-verdict(`evidence_snapshot["action_verdict"]`, JSON, 마이그레이션 없음)를 locked 5값 `decision_bucket` 위의 sub-label로 부여. `EvidenceAutoEmitter`가 모든 KIS 보유종목을 분류하고 신규후보-없음 마커를 emit(intraday_floor 모드). 생성 파이프라인 끝에 non-empty floor guard가 잔여 빈 케이스를 구조적 item으로 보강. `build_action_packet`은 ROB-322 `build_review_sections`와 동일한 read-time projection. 모든 경로 advisory-only, broker/order/watch/order-intent mutation 도달 불가.
+
+**Tech Stack:** Python 3.13, Pydantic v2, FastAPI, SQLAlchemy async, pytest (`uv run pytest`), ruff. 설계 근거: `docs/superpowers/specs/2026-05-27-rob-335-intraday-action-cycle-design.md`.
+
+---
+
+## Scope
+
+이 plan은 **PR1 (백엔드 코어)** 만 다룬다. PR2 (프론트엔드 surface)는 spec §3.6/§7 대로 PR1 머지 후 fresh `main`에서 별도 plan으로 작성한다 (frontend/invest 컴포넌트 탐색 선행 필요).
+
+브랜치: 현재 worktree `rob-335` (base `c31168b3`, ROB-332 머지 직후). 마이그레이션 없음.
+
+## 확정 설계 (spec §2)
+
+- **A**: ActionPacket sub-verdict = locked 5값 `decision_bucket` 위 sub-label. enum 변경 없음.
+- **B**: sub-verdict는 item의 `evidence_snapshot["action_verdict"]`(JSON)에 저장. ActionPacket section은 read-time projection.
+- **C/C′**: 결정론은 정직한 verdict만 직접 부여 — `data_gap`/`keep`/`no_add`/`sell_review`. `trim_review`/`add_review`는 Hermes push에 유보.
+- **D**: `limit_wait`은 evidence 상태만 표면화, 목표가 계산은 ROB-337.
+
+### sub-verdict → decision_bucket 매핑 (locked)
+
+| action_verdict | decision_bucket | 결정론 emit? |
+|---|---|---|
+| `buy_review` | `new_buy_candidate` | 예 (기존 auto_emit) |
+| `limit_wait` | `new_buy_candidate` | 아니오 (Hermes) |
+| `no_new_buy_candidates` (marker, symbol=None) | `new_buy_candidate` | 예 (intraday_floor) |
+| `sell_review` | `open_action` | 예 |
+| `trim_review` / `add_review` | `open_action` | 아니오 (Hermes) |
+| `keep` | `completed_or_existing` | 예 (intraday_floor) |
+| `no_add` | `completed_or_existing` | 예 (intraday_floor) |
+| `watch_only` | `risk_watch` | 예 (기존 watch items) |
+| `rejected` | `deferred_no_action` | 아니오 (Hermes) |
+| `data_gap` | `deferred_no_action` | 예 |
+
+## File Structure
+
+**Create:**
+- `app/services/action_report/snapshot_backed/action_verdict.py` — sub-verdict 어휘 + `VERDICT_TO_BUCKET` + 순수 `classify_held_symbol` 규칙 + `stamp_verdict` 헬퍼. (순수, DB/IO 없음)
+- `app/services/action_report/snapshot_backed/intraday_floor.py` — non-empty floor guard (잔여 빈 케이스 → 구조적 item 합성).
+- `app/services/investment_reports/action_packet.py` — `build_action_packet` read-time projection (ROB-322 `review_sections.py` 패턴).
+- `tests/services/action_report/snapshot_backed/test_action_verdict.py`
+- `tests/services/action_report/snapshot_backed/test_intraday_floor.py`
+- `tests/services/investment_reports/test_action_packet.py`
+
+**Modify:**
+- `app/schemas/investment_reports.py` — `ActionVerdictLiteral` + ActionPacket 스키마 + `InvestmentReportBundle.action_packet` 필드.
+- `app/services/action_report/snapshot_backed/auto_emit.py` — 기존 item에 verdict+bucket 스탬프; `intraday_floor` 모드에서 모든 KIS 보유종목 분류 + no_new_buy 마커.
+- `app/services/action_report/snapshot_backed/generator.py` — intraday intent 감지, auto_emit에 intraday_floor 전달, classify 후 floor guard 호출.
+- `app/routers/investment_reports.py` — `build_action_packet` 호출하여 bundle에 첨부.
+- `tests/services/action_report/snapshot_backed/test_auto_emit.py` — 스탬프/intraday_floor 회귀 추가.
+- `tests/services/action_report/snapshot_backed/test_generator_regression.py` — floor invariant 회귀 추가.
+
+---
+
+## Task 1: action_verdict 어휘 + 매핑 + 보유종목 분류 규칙
+
+**Files:**
+- Create: `app/services/action_report/snapshot_backed/action_verdict.py`
+- Test: `tests/services/action_report/snapshot_backed/test_action_verdict.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```python
+# tests/services/action_report/snapshot_backed/test_action_verdict.py
+"""ROB-335 — sub-verdict vocabulary, bucket mapping, held-symbol rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.investment_symbol_intermediate_reports import DECISION_BUCKETS
+from app.services.action_report.snapshot_backed.action_verdict import (
+    ACTION_VERDICTS,
+    VERDICT_TO_BUCKET,
+    classify_held_symbol,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_verdict_maps_to_a_locked_decision_bucket() -> None:
+    # B/A: sub-verdicts are sub-labels over the locked 5-value enum — every
+    # verdict must map onto an existing decision_bucket (no new enum value).
+    assert set(VERDICT_TO_BUCKET) == set(ACTION_VERDICTS)
+    for verdict, bucket in VERDICT_TO_BUCKET.items():
+        assert bucket in DECISION_BUCKETS, (verdict, bucket)
+
+
+def test_held_unactionable_quote_is_data_gap() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    quote = {"status": "unavailable"}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "data_gap"
+
+
+def test_held_missing_quote_is_data_gap() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    assert classify_held_symbol(holding, None, in_candidate_universe=False) == "data_gap"
+
+
+def test_held_sellable_with_actionable_quote_is_sell_review() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "bid_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "sell_review"
+
+
+def test_held_not_sellable_but_trending_is_no_add() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 0}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "ask_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=True) == "no_add"
+
+
+def test_held_not_sellable_not_trending_is_keep() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 0}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "ask_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "keep"
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...action_verdict`.
+
+- [ ] **Step 3: 최소 구현**
+
+```python
+# app/services/action_report/snapshot_backed/action_verdict.py
+"""ROB-335 — deterministic ActionPacket sub-verdict vocabulary + rules.
+
+Sub-verdicts are *sub-labels over the locked ROB-301 ``decision_bucket``
+5-value enum* (spec §2 decision A). They are stored on each report item's
+``evidence_snapshot["action_verdict"]`` (JSON; no migration, decision B) and
+projected at read-time by ``build_action_packet``.
+
+Per decision C′, only the *honest* verdicts are assigned deterministically
+here: ``data_gap`` / ``keep`` / ``no_add`` / ``sell_review`` (held) and
+``buy_review`` / ``no_new_buy_candidates`` (candidate). Directional
+``trim_review`` / ``add_review`` / ``limit_wait`` / ``rejected`` exist in the
+vocabulary for Hermes push to fill but are never fabricated here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# action_verdict -> locked decision_bucket. Keys are the full vocabulary.
+VERDICT_TO_BUCKET: dict[str, str] = {
+    "buy_review": "new_buy_candidate",
+    "limit_wait": "new_buy_candidate",
+    "no_new_buy_candidates": "new_buy_candidate",
+    "sell_review": "open_action",
+    "trim_review": "open_action",
+    "add_review": "open_action",
+    "keep": "completed_or_existing",
+    "no_add": "completed_or_existing",
+    "watch_only": "risk_watch",
+    "rejected": "deferred_no_action",
+    "data_gap": "deferred_no_action",
+}
+
+ACTION_VERDICTS: frozenset[str] = frozenset(VERDICT_TO_BUCKET)
+
+
+def _quote_is_actionable(quote: Any) -> bool:
+    # Mirrors auto_emit._quote_is_actionable so held + candidate gates agree.
+    if not isinstance(quote, dict):
+        return False
+    if quote.get("status") != "ok":
+        return False
+    best_bid = quote.get("best_bid") or 0
+    best_ask = quote.get("best_ask") or 0
+    bid_depth = quote.get("bid_depth") or 0
+    ask_depth = quote.get("ask_depth") or 0
+    return best_bid > 0 and best_ask > 0 and (bid_depth > 0 or ask_depth > 0)
+
+
+def classify_held_symbol(
+    holding: dict[str, Any],
+    quote: dict[str, Any] | None,
+    *,
+    in_candidate_universe: bool,
+) -> str:
+    """Deterministic verdict for ONE KIS-primary held symbol (decision C′).
+
+    Order (honest range only):
+      1. quote missing / not actionable -> ``data_gap`` (no directional call)
+      2. sellable_quantity > 0          -> ``sell_review`` (reviewable reduce)
+      3. held + in screener universe    -> ``no_add`` (trending, don't add)
+      4. otherwise                      -> ``keep`` (default hold)
+    """
+    if not _quote_is_actionable(quote):
+        return "data_gap"
+    if (holding.get("sellable_quantity") or 0) > 0:
+        return "sell_review"
+    if in_candidate_universe:
+        return "no_add"
+    return "keep"
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/action_verdict.py tests/services/action_report/snapshot_backed/test_action_verdict.py
+git commit -m "feat(rob-335): deterministic action_verdict vocab + held-symbol rules
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: ActionPacket 스키마 + bundle 필드
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (after `ReportReviewSections`, ~line 551; and `InvestmentReportBundle`, ~line 574)
+- Test: `tests/services/investment_reports/test_action_packet.py` (schema 부분)
+
+- [ ] **Step 1: 실패 테스트 작성** (스키마 구성 가능 + bundle 필드 default None)
+
+```python
+# tests/services/investment_reports/test_action_packet.py
+"""ROB-335 — ActionPacket read-time projection + schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import (
+    ActionPacket,
+    InvestmentReportBundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_action_packet_defaults_are_empty() -> None:
+    packet = ActionPacket()
+    assert packet.held_actions == []
+    assert packet.new_buy_candidates == []
+    assert packet.no_new_buy_reason is None
+    assert packet.risk_reviews == []
+    assert packet.no_action_reason is None
+    assert packet.data_gaps_for_next_cycle == []
+
+
+def test_bundle_action_packet_field_is_optional() -> None:
+    # Additive, null for legacy reports (mirrors review_sections).
+    assert "action_packet" in InvestmentReportBundle.model_fields
+    assert InvestmentReportBundle.model_fields["action_packet"].default is None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: FAIL — `ImportError: cannot import name 'ActionPacket'`.
+
+- [ ] **Step 3: 스키마 추가**
+
+`app/schemas/investment_reports.py` — `ReportReviewSections` 클래스 정의 직후(현재 ~551행)에 추가:
+
+```python
+# ROB-335 — intraday ActionPacket. A read-time *view-layer projection* over
+# the same persisted items (sub-verdict in evidence_snapshot["action_verdict"])
+# + ROB-318 diagnostics. No new persisted classification / DB CHECK / migration.
+ActionVerdictLiteral = Literal[
+    "buy_review",
+    "limit_wait",
+    "no_new_buy_candidates",
+    "sell_review",
+    "trim_review",
+    "add_review",
+    "keep",
+    "no_add",
+    "watch_only",
+    "rejected",
+    "data_gap",
+]
+
+
+class ActionPacketEntry(BaseModel):
+    """One symbol-level entry in an ActionPacket group."""
+
+    verdict: ActionVerdictLiteral
+    symbol: str | None = None
+    side: ItemSideLiteral | None = None
+    rationale: str
+    item_uuid: UUID | None = None
+    evidence_snapshot: dict[str, Any] = Field(default_factory=dict)
+
+
+class DataGapEntry(BaseModel):
+    """One data-gap surfaced for the next cycle."""
+
+    source: str
+    status: str | None = None
+    reason: str | None = None
+
+
+class ActionPacket(BaseModel):
+    """ROB-335 four-question intraday surface (held / new / risk / data-gap).
+
+    Always-explicit: ``no_new_buy_reason`` and ``no_action_reason`` answer the
+    "why nothing" questions even when the corresponding groups are empty.
+    """
+
+    held_actions: list[ActionPacketEntry] = Field(default_factory=list)
+    new_buy_candidates: list[ActionPacketEntry] = Field(default_factory=list)
+    no_new_buy_reason: str | None = None
+    risk_reviews: list[ActionPacketEntry] = Field(default_factory=list)
+    no_action_reason: NoActionSummary | None = None
+    data_gaps_for_next_cycle: list[DataGapEntry] = Field(default_factory=list)
+```
+
+`InvestmentReportBundle` (현재 ~574행, `review_sections` 필드 직후)에 추가:
+
+```python
+    # ROB-335 — additive intraday ActionPacket projection. Null for legacy /
+    # non-intraday reports; existing items / review_sections remain the fallback.
+    action_packet: ActionPacket | None = None
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/schemas/investment_reports.py tests/services/investment_reports/test_action_packet.py
+git commit -m "feat(rob-335): ActionPacket schema + bundle field
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: build_action_packet read-time projection
+
+**Files:**
+- Create: `app/services/investment_reports/action_packet.py`
+- Test: `tests/services/investment_reports/test_action_packet.py` (projection 부분 추가)
+
+- [ ] **Step 1: 실패 테스트 추가** (`test_action_packet.py` 하단에 append)
+
+```python
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from app.schemas.investment_reports import InvestmentReportItemResponse
+from app.services.investment_reports.action_packet import build_action_packet
+
+_NOW = datetime(2026, 5, 27, tzinfo=UTC)
+
+
+def _item(
+    *,
+    verdict: str | None,
+    decision_bucket: str | None,
+    symbol: str | None = "005930",
+    item_kind: str = "action",
+    side: str | None = "sell",
+    intent: str = "sell_review",
+) -> InvestmentReportItemResponse:
+    evidence = {"action_verdict": verdict} if verdict is not None else {}
+    return InvestmentReportItemResponse(
+        item_uuid=uuid4(),
+        item_kind=item_kind,  # type: ignore[arg-type]
+        symbol=symbol,
+        side=side,  # type: ignore[arg-type]
+        intent=intent,  # type: ignore[arg-type]
+        target_kind="asset",
+        priority=0,
+        confidence=Decimal("80"),
+        rationale="r",
+        evidence_snapshot=evidence,
+        watch_condition=None,
+        trigger_checklist=[],
+        max_action={},
+        valid_until=None,
+        status="proposed",
+        metadata={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        decision_bucket=decision_bucket,
+    )
+
+
+def test_held_and_new_and_risk_are_grouped_by_verdict() -> None:
+    items = [
+        _item(verdict="sell_review", decision_bucket="open_action"),
+        _item(verdict="keep", decision_bucket="completed_or_existing", side=None),
+        _item(verdict="buy_review", decision_bucket="new_buy_candidate", side="buy",
+              intent="buy_review", symbol="000660"),
+        _item(verdict="watch_only", decision_bucket="risk_watch", item_kind="watch",
+              side=None, intent="trend_recovery_review", symbol="035720"),
+    ]
+    packet = build_action_packet(items, diagnostics=None)
+    assert {e.verdict for e in packet.held_actions} == {"sell_review", "keep"}
+    assert [e.verdict for e in packet.new_buy_candidates] == ["buy_review"]
+    assert [e.verdict for e in packet.risk_reviews] == ["watch_only"]
+
+
+def test_no_new_buy_marker_sets_reason_not_a_candidate_row() -> None:
+    marker = _item(
+        verdict="no_new_buy_candidates",
+        decision_bucket="new_buy_candidate",
+        symbol=None,
+        side=None,
+        intent="risk_review",
+        item_kind="risk",
+    )
+    marker.rationale = "국내 스크리너 스냅샷이 최신 거래일 기준이 아닙니다 (stale)."
+    packet = build_action_packet([marker], diagnostics=None)
+    assert packet.new_buy_candidates == []
+    assert packet.no_new_buy_reason == marker.rationale
+
+
+def test_data_gaps_from_items_and_diagnostics() -> None:
+    items = [_item(verdict="data_gap", decision_bucket="deferred_no_action",
+                   symbol="005930", side=None, intent="risk_review", item_kind="risk")]
+    diagnostics = {
+        "why_no_action": {"kind": "data_insufficient", "reason_ko": "데이터 부족",
+                          "blocking_sources": ["portfolio"]},
+        "data_sufficiency_by_source": {
+            "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
+            "symbol": {"status": "fresh"},
+        },
+    }
+    packet = build_action_packet(items, diagnostics=diagnostics)
+    assert packet.no_action_reason is not None
+    assert packet.no_action_reason.kind == "data_insufficient"
+    # symbol-level data_gap item + degraded source from diagnostics both surface.
+    sources = {g.source for g in packet.data_gaps_for_next_cycle}
+    assert "005930" in sources
+    assert "portfolio" in sources
+
+
+def test_items_without_verdict_are_not_projected() -> None:
+    # Legacy items (no action_verdict) stay out of the packet (decision A/B).
+    items = [_item(verdict=None, decision_bucket="open_action")]
+    packet = build_action_packet(items, diagnostics=None)
+    assert packet.held_actions == []
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...action_packet`.
+
+- [ ] **Step 3: 구현**
+
+```python
+# app/services/investment_reports/action_packet.py
+"""ROB-335 — deterministic intraday ActionPacket projection.
+
+Read-time *view-layer* projection (same pattern as ROB-322
+``review_sections.py``): groups the flat report-item list by the
+``evidence_snapshot["action_verdict"]`` sub-label into the four-question
+intraday surface, and folds ROB-318 diagnostics into the no-action /
+data-gap answers.
+
+Pure + read-only: no new persisted classification, DB CHECK, or migration.
+Items without an ``action_verdict`` (legacy / Hermes-not-yet) are not
+projected; they remain available via the bundle's ``items``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.schemas.investment_reports import (
+    ActionPacket,
+    ActionPacketEntry,
+    DataGapEntry,
+    InvestmentReportItemResponse,
+    NoActionSummary,
+)
+from app.services.action_report.snapshot_backed.action_verdict import (
+    VERDICT_TO_BUCKET,
+)
+
+_HELD_VERDICTS = {"sell_review", "trim_review", "add_review", "keep", "no_add"}
+_NEW_BUY_VERDICTS = {"buy_review", "limit_wait"}
+_RISK_VERDICTS = {"watch_only"}
+_DATA_GAP_VERDICTS = {"data_gap"}
+_DEGRADED_STATUSES = {"unavailable", "failed", "hard_stale", "soft_stale", "partial"}
+
+
+def _verdict(item: InvestmentReportItemResponse) -> str | None:
+    evidence = item.evidence_snapshot or {}
+    verdict = evidence.get("action_verdict") if isinstance(evidence, Mapping) else None
+    if isinstance(verdict, str) and verdict in VERDICT_TO_BUCKET:
+        return verdict
+    return None
+
+
+def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntry:
+    return ActionPacketEntry(
+        verdict=verdict,  # type: ignore[arg-type]
+        symbol=item.symbol,
+        side=item.side,
+        rationale=item.rationale,
+        item_uuid=item.item_uuid,
+        evidence_snapshot=dict(item.evidence_snapshot or {}),
+    )
+
+
+def build_action_packet(
+    items: Sequence[InvestmentReportItemResponse],
+    diagnostics: Mapping[str, Any] | None,
+) -> ActionPacket:
+    held: list[ActionPacketEntry] = []
+    new_buy: list[ActionPacketEntry] = []
+    risk: list[ActionPacketEntry] = []
+    data_gaps: list[DataGapEntry] = []
+    no_new_buy_reason: str | None = None
+
+    for item in items:
+        verdict = _verdict(item)
+        if verdict is None:
+            continue
+        if verdict == "no_new_buy_candidates":
+            no_new_buy_reason = item.rationale
+            continue
+        if verdict in _HELD_VERDICTS:
+            held.append(_entry(item, verdict))
+        elif verdict in _NEW_BUY_VERDICTS:
+            new_buy.append(_entry(item, verdict))
+        elif verdict in _RISK_VERDICTS:
+            risk.append(_entry(item, verdict))
+        elif verdict in _DATA_GAP_VERDICTS:
+            data_gaps.append(
+                DataGapEntry(source=item.symbol or "unknown", reason=item.rationale)
+            )
+
+    no_action_reason = _no_action_summary(diagnostics)
+    data_gaps.extend(_diagnostics_gaps(diagnostics))
+
+    return ActionPacket(
+        held_actions=held,
+        new_buy_candidates=new_buy,
+        no_new_buy_reason=no_new_buy_reason,
+        risk_reviews=risk,
+        no_action_reason=no_action_reason,
+        data_gaps_for_next_cycle=data_gaps,
+    )
+
+
+def _no_action_summary(
+    diagnostics: Mapping[str, Any] | None,
+) -> NoActionSummary | None:
+    if not isinstance(diagnostics, Mapping):
+        return None
+    why = diagnostics.get("why_no_action")
+    if not isinstance(why, Mapping):
+        return None
+    blocking = why.get("blocking_sources") or []
+    return NoActionSummary(
+        kind=why.get("kind"),
+        reason_ko=why.get("reason_ko"),
+        blocking_sources=[str(s) for s in blocking],
+    )
+
+
+def _diagnostics_gaps(diagnostics: Mapping[str, Any] | None) -> list[DataGapEntry]:
+    if not isinstance(diagnostics, Mapping):
+        return []
+    by_source = diagnostics.get("data_sufficiency_by_source")
+    if not isinstance(by_source, Mapping):
+        return []
+    out: list[DataGapEntry] = []
+    for source, info in by_source.items():
+        if not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        if status in _DEGRADED_STATUSES:
+            out.append(
+                DataGapEntry(
+                    source=str(source),
+                    status=str(status) if status is not None else None,
+                    reason=info.get("reason") or info.get("reason_code"),
+                )
+            )
+    return out
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: PASS (6 passed).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/investment_reports/action_packet.py tests/services/investment_reports/test_action_packet.py
+git commit -m "feat(rob-335): build_action_packet read-time projection
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: auto_emit — verdict/bucket 스탬프 + intraday_floor 보유종목 전수분류 + no-candidate 마커
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py`
+- Test: `tests/services/action_report/snapshot_backed/test_auto_emit.py` (회귀 추가)
+
+설계: `EvidenceAutoEmitter.__init__`에 `intraday_floor: bool = False` 추가. 기존 sell/buy/watch/held-trend item에 `evidence_snapshot["action_verdict"]` + `decision_bucket`을 스탬프(기본 모드에서도 안전한 additive). `intraday_floor=True`이면 (a) 모든 KIS 보유종목을 `classify_held_symbol`로 1건씩 분류(이미 sell_review로 emit된 심볼 제외), (b) candidate `usefulness != "useful"`이면 `no_new_buy_candidates` 마커 item 1건 emit.
+
+- [ ] **Step 1: 실패 테스트 추가** (`test_auto_emit.py` 하단)
+
+```python
+def test_existing_sell_item_is_stamped_with_verdict_and_bucket() -> None:
+    # Default mode (no intraday_floor): existing sell candidate now carries the
+    # ActionPacket sub-verdict + decision_bucket so it projects.
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=5.0)),
+        _make_snapshot(kind="symbol", symbol="005930",
+                       payload=_ok_quote_payload("005930")),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sell = next(i for i in items if i.symbol == "005930" and i.side == "sell")
+    assert sell.evidence_snapshot["action_verdict"] == "sell_review"
+    assert sell.decision_bucket == "open_action"
+
+
+def test_intraday_floor_classifies_every_held_symbol() -> None:
+    # Held symbol with NO actionable quote -> data_gap item (would be skipped
+    # entirely in default mode).
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+    ]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    held = next(i for i in items if i.symbol == "005930")
+    assert held.evidence_snapshot["action_verdict"] == "data_gap"
+    assert held.decision_bucket == "deferred_no_action"
+
+
+def test_intraday_floor_emits_no_new_buy_marker_when_stale_only() -> None:
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+        _make_snapshot(kind="candidate_universe",
+                       payload=_candidate_payload("stale_only")),
+    ]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    marker = next(
+        i for i in items
+        if i.evidence_snapshot.get("action_verdict") == "no_new_buy_candidates"
+    )
+    assert marker.symbol is None
+    assert marker.decision_bucket == "new_buy_candidate"
+    assert marker.item_kind == "risk"
+
+
+def test_default_mode_emits_no_marker_and_no_keep_items() -> None:
+    # Backwards-compat: without intraday_floor, behaviour is unchanged.
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+        _make_snapshot(kind="candidate_universe",
+                       payload=_candidate_payload("stale_only")),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    verdicts = {i.evidence_snapshot.get("action_verdict") for i in items}
+    assert "no_new_buy_candidates" not in verdicts
+    assert "keep" not in verdicts
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit.py -v -k "stamp or intraday_floor or marker or default_mode"`
+Expected: FAIL — `TypeError: ... unexpected keyword 'intraday_floor'` / `KeyError: 'action_verdict'`.
+
+- [ ] **Step 3: 구현 — `auto_emit.py` 수정**
+
+3a. import + 헬퍼 추가 (파일 상단 import 블록 아래):
+
+```python
+from app.services.action_report.snapshot_backed.action_verdict import (
+    VERDICT_TO_BUCKET,
+    classify_held_symbol,
+)
+
+
+def _stamp(item: IngestReportItem, verdict: str) -> IngestReportItem:
+    """Attach the ActionPacket sub-verdict + its locked decision_bucket."""
+    item.evidence_snapshot["action_verdict"] = verdict
+    item.decision_bucket = VERDICT_TO_BUCKET[verdict]
+    return item
+```
+
+3b. `__init__` 시그니처에 플래그 추가:
+
+```python
+    def __init__(
+        self, *, max_buy_candidates: int = 10, intraday_floor: bool = False
+    ) -> None:
+        self._max_buy_candidates = max_buy_candidates
+        self._intraday_floor = intraday_floor
+```
+
+3c. 기존 emit 지점에 `_stamp` 적용 — sell loop의 `items.append(IngestReportItem(...))`를 다음으로 감싼다:
+
+```python
+            items.append(
+                _stamp(
+                    IngestReportItem(
+                        client_item_key=f"auto-sell-{ticker}",
+                        item_kind="action",
+                        symbol=ticker,
+                        side="sell",
+                        intent="sell_review",
+                        rationale=(
+                            f"보유 종목 {ticker} sell 검토 — sellable {sellable}, "
+                            f"best_bid {quote.get('best_bid')}, "
+                            f"spread_bps {quote.get('spread_bps')}"
+                        ),
+                        operation="review",
+                        apply_policy="requires_user_approval",
+                        evidence_snapshot=evidence,
+                    ),
+                    "sell_review",
+                )
+            )
+```
+
+동일하게 buy candidate `items.append(...)`를 `_stamp(IngestReportItem(...), "buy_review")`로, watch (`auto-watch-`) 와 held-and-trending (`auto-hold-trend-`) item을 `_stamp(..., "watch_only")`로 감싼다.
+
+3d. held-and-trending 루프 직후(= `run_card` citation 블록 직전)에 intraday_floor 보강 블록 추가:
+
+```python
+        # ROB-335 — intraday floor: classify EVERY held KIS symbol (not just
+        # sellable+actionable) so held_actions is never empty, and surface an
+        # explicit no-new-buy reason when the screener universe is not useful.
+        if self._intraday_floor:
+            already = {i.symbol for i in items if i.symbol}
+            for ticker, holding in held.items():
+                if ticker in already:
+                    continue
+                quote_pair = symbol_quotes.get(ticker)
+                quote = quote_pair[1] if quote_pair else None
+                verdict = classify_held_symbol(
+                    holding, quote, in_candidate_universe=ticker in candidate_by_symbol
+                )
+                items.append(
+                    _stamp(
+                        IngestReportItem(
+                            client_item_key=f"auto-held-{ticker}",
+                            item_kind="risk" if verdict == "data_gap" else "action",
+                            symbol=ticker,
+                            side="sell" if verdict == "sell_review" else None,
+                            intent=(
+                                "sell_review" if verdict == "sell_review"
+                                else "risk_review" if verdict == "data_gap"
+                                else "rebalance_review"
+                            ),
+                            rationale=(
+                                f"보유 종목 {ticker} {verdict} — sellable "
+                                f"{holding.get('sellable_quantity')}, "
+                                f"quote {quote.get('status') if quote else 'none'}"
+                            ),
+                            operation="review",
+                            apply_policy="requires_user_approval",
+                            evidence_snapshot=_make_evidence(
+                                quote_pair[0] if quote_pair else portfolio_snapshot,
+                                extra={
+                                    "portfolio_snapshot_uuid": _snapshot_uuid(
+                                        portfolio_snapshot
+                                    ),
+                                    "sellable_quantity": holding.get(
+                                        "sellable_quantity"
+                                    ),
+                                    "quote_status": quote.get("status")
+                                    if quote else "no_snapshot",
+                                    "proposer": "auto_emit/intraday_held_floor",
+                                },
+                            ),
+                        ),
+                        verdict,
+                    )
+                )
+
+            if candidate_usefulness != "useful":
+                missing = (
+                    candidate_snapshot is not None
+                    and _snapshot_payload(candidate_snapshot).get("missing_data")
+                ) or {}
+                reason = (
+                    f"{missing.get('what', '신규 매수 후보 없음')} "
+                    f"{missing.get('next', '')}".strip()
+                    if isinstance(missing, dict)
+                    else "신규 매수 후보 없음"
+                )
+                items.append(
+                    _stamp(
+                        IngestReportItem(
+                            client_item_key="auto-no-new-buy",
+                            item_kind="risk",
+                            symbol=None,
+                            intent="risk_review",
+                            rationale=reason,
+                            operation="review",
+                            apply_policy="requires_user_approval",
+                            evidence_snapshot=_make_evidence(
+                                candidate_snapshot,
+                                extra={
+                                    "candidate_usefulness": candidate_usefulness,
+                                    "proposer": "auto_emit/no_new_buy_floor",
+                                },
+                            ),
+                        ),
+                        "no_new_buy_candidates",
+                    )
+                )
+```
+
+- [ ] **Step 4: 통과 확인 (신규 + 기존 회귀)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit.py -v`
+Expected: PASS (기존 테스트 전부 + 신규 4건). 기존 테스트가 verdict 스탬프로 깨지지 않아야 함(스탬프는 additive).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/auto_emit.py tests/services/action_report/snapshot_backed/test_auto_emit.py
+git commit -m "feat(rob-335): stamp action_verdict + intraday_floor held classification & no-buy marker
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: generator — intraday intent 감지 + auto_emit intraday_floor 전달 + non-empty floor guard
+
+**Files:**
+- Create: `app/services/action_report/snapshot_backed/intraday_floor.py`
+- Modify: `app/services/action_report/snapshot_backed/generator.py`
+- Test: `tests/services/action_report/snapshot_backed/test_intraday_floor.py`
+
+설계: 순수 함수 `is_intraday_action(policy_version)` 와 `ensure_action_floor(items, why_no_action)`. generator는 (a) `_auto_emit_items_from_bundle`에서 intraday이면 `EvidenceAutoEmitter(intraday_floor=True)` 사용, (b) classify_items + why_no_action 계산 후, intraday이면 `ensure_action_floor`로 잔여 빈 케이스를 1건 구조적 item으로 보강.
+
+- [ ] **Step 1: 실패 테스트 작성** (순수 함수 단위)
+
+```python
+# tests/services/action_report/snapshot_backed/test_intraday_floor.py
+"""ROB-335 — intraday non-empty floor guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.action_report.snapshot_backed.intraday_floor import (
+    ensure_action_floor,
+    is_intraday_action,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_intraday_action_matches_policy_version() -> None:
+    assert is_intraday_action("intraday_action_report_v1") is True
+    assert is_intraday_action("snapshot_backed_advisory_v1") is False
+    assert is_intraday_action(None) is False
+
+
+def test_floor_synthesizes_one_item_when_empty() -> None:
+    why = {"kind": "data_insufficient", "reason_ko": "데이터 부족 — portfolio 확인 불가",
+           "blocking_sources": ["portfolio"]}
+    out = ensure_action_floor([], why_no_action=why)
+    assert len(out) == 1
+    item = out[0]
+    assert item.evidence_snapshot["action_verdict"] == "data_gap"
+    assert item.decision_bucket == "deferred_no_action"
+    assert item.rationale == why["reason_ko"]
+
+
+def test_floor_real_no_action_uses_no_action_verdict() -> None:
+    why = {"kind": "real_no_action", "reason_ko": "데이터 충분 — 현 시점 신규 액션 없음(관망)",
+           "blocking_sources": []}
+    out = ensure_action_floor([], why_no_action=why)
+    assert out[0].evidence_snapshot["action_verdict"] == "keep"
+    assert out[0].decision_bucket == "completed_or_existing"
+
+
+def test_floor_is_noop_when_items_present() -> None:
+    existing = [
+        IngestReportItem(
+            client_item_key="x", item_kind="action", symbol="005930", side="sell",
+            intent="sell_review", rationale="r", operation="review",
+            apply_policy="requires_user_approval",
+            evidence_snapshot={"action_verdict": "sell_review"},
+            decision_bucket="open_action",
+        )
+    ]
+    out = ensure_action_floor(existing, why_no_action=None)
+    assert out == existing
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_intraday_floor.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...intraday_floor`.
+
+- [ ] **Step 3: 구현 — `intraday_floor.py`**
+
+```python
+# app/services/action_report/snapshot_backed/intraday_floor.py
+"""ROB-335 — intraday non-empty floor guard.
+
+Last-resort guarantee that an ``intraday_action`` report never succeeds with
+``items=[]`` (spec §3.1). When the deterministic emitter + classifier produced
+nothing actionable (e.g. no holdings, no candidates, portfolio unavailable),
+synthesize ONE structural review item that carries the report's no-action
+reason as an explicit ActionPacket entry. Never fabricates a buy/sell call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.action_report.snapshot_backed.action_verdict import VERDICT_TO_BUCKET
+
+_INTRADAY_POLICY_PREFIX = "intraday_action"
+
+
+def is_intraday_action(policy_version: str | None) -> bool:
+    return bool(policy_version) and policy_version.startswith(_INTRADAY_POLICY_PREFIX)
+
+
+def ensure_action_floor(
+    items: list[IngestReportItem],
+    *,
+    why_no_action: dict[str, Any] | None,
+) -> list[IngestReportItem]:
+    """Return ``items`` unchanged when non-empty; else a one-item floor."""
+    if items:
+        return items
+
+    kind = (why_no_action or {}).get("kind")
+    # real_no_action -> genuine hold (keep); data/stale-blocked -> data_gap.
+    verdict = "keep" if kind == "real_no_action" else "data_gap"
+    reason = (why_no_action or {}).get("reason_ko") or (
+        "장중 액션 없음 — 데이터/후보 부족"
+    )
+    return [
+        IngestReportItem(
+            client_item_key="intraday-floor",
+            item_kind="risk",
+            symbol=None,
+            intent="risk_review",
+            rationale=reason,
+            operation="review",
+            apply_policy="requires_user_approval",
+            evidence_snapshot={
+                "action_verdict": verdict,
+                "proposer": "intraday_floor",
+                "why_no_action": why_no_action,
+            },
+            decision_bucket=VERDICT_TO_BUCKET[verdict],
+        )
+    ]
+```
+
+- [ ] **Step 4: 통과 확인 (단위)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_intraday_floor.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: generator 연결**
+
+`generator.py` 상단 import에 추가:
+
+```python
+from app.services.action_report.snapshot_backed.intraday_floor import (
+    ensure_action_floor,
+    is_intraday_action,
+)
+```
+
+`_auto_emit_items_from_bundle` 의 emitter 생성부 수정 (현재 ~392행):
+
+```python
+        emitter = EvidenceAutoEmitter(
+            intraday_floor=is_intraday_action(request.policy_version)
+        )
+```
+
+`generate()` 에서 `why_no_action` 계산(현재 ~293-299행) 직후, `report_diagnostics` 빌드 전에 floor guard 삽입:
+
+```python
+        # ROB-335 — intraday non-empty floor: never let an intraday_action
+        # report succeed with items=[]; synthesize an explicit no-action /
+        # data-gap item from the deterministic why_no_action verdict.
+        if is_intraday_action(request.policy_version):
+            request = request.model_copy(
+                update={
+                    "items": ensure_action_floor(
+                        list(request.items), why_no_action=why_no_action
+                    )
+                }
+            )
+```
+
+- [ ] **Step 6: generator 회귀 — intraday이면 items가 절대 비지 않음**
+
+`tests/services/action_report/snapshot_backed/test_generator_regression.py` 에 추가 (기존 fixture/헬퍼 재사용; 빈 번들 = no holdings/no candidates 케이스):
+
+```python
+async def test_intraday_report_never_empty_items(...):  # 기존 generator fixture 패턴 사용
+    # market=kr/account=kis_live, user_id=None (portfolio unavailable),
+    # 빈 후보 -> 생성 결과 items_count >= 1, floor item은 data_gap.
+    resp = await generator.generate(_intraday_request(user_id=None))
+    assert resp.items_count >= 1
+```
+
+> 구현 시 `test_generator_regression.py` 상단의 기존 fixture(번들/ensure mock, `_request(...)` 헬퍼)를 그대로 사용하고, `policy_version="intraday_action_report_v1"` + `user_id=None` 으로 요청을 구성한다. 어서션은 `resp.items_count >= 1` 와 (가능하면) 생성된 리포트 조회 후 floor item의 `decision_bucket == "deferred_no_action"`.
+
+- [ ] **Step 7: 통과 확인 (generator 전체)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py tests/services/action_report/snapshot_backed/test_generator_regression.py -v`
+Expected: PASS (기존 + 신규).
+
+- [ ] **Step 8: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/intraday_floor.py app/services/action_report/snapshot_backed/generator.py tests/services/action_report/snapshot_backed/test_intraday_floor.py tests/services/action_report/snapshot_backed/test_generator_regression.py
+git commit -m "feat(rob-335): intraday non-empty floor guard + generator wiring
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 읽기 모델 연결 — bundle에 action_packet 첨부
+
+**Files:**
+- Modify: `app/routers/investment_reports.py` (`_serialise_bundle`, ~line 43 import + ~line 78-96)
+- Test: `tests/services/investment_reports/test_action_packet.py` (serialize 보강은 단위 projection으로 이미 커버; 라우터는 통합 경로) — 여기서는 projection이 bundle에 붙는지 가벼운 단위 확인 추가
+
+- [ ] **Step 1: 실패 테스트 추가** (`test_action_packet.py` 하단) — bundle 직렬화가 action_packet을 채우는지 순수 확인
+
+```python
+def test_serialise_attaches_action_packet(monkeypatch) -> None:
+    # _serialise_bundle should project items into bundle.action_packet using
+    # the same build_action_packet path (additive, never None for intraday).
+    from app.routers import investment_reports as mod
+
+    items = [_item(verdict="sell_review", decision_bucket="open_action")]
+    packet = build_action_packet(items, diagnostics=None)
+    assert packet.held_actions  # sanity: projection works on these items
+    # The router import wires build_action_packet:
+    assert hasattr(mod, "build_action_packet")
+```
+
+> 라우터 전체 통합(DB)은 기존 `tests/routers` 통합 스위트가 커버한다. 여기서는 wiring 존재만 단위로 핀.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v -k serialise`
+Expected: FAIL — `AttributeError: module ... has no attribute 'build_action_packet'`.
+
+- [ ] **Step 3: 라우터 수정**
+
+`investment_reports.py` import 추가 (현재 ~43행 `build_review_sections` 옆):
+
+```python
+from app.services.investment_reports.action_packet import build_action_packet
+```
+
+`_serialise_bundle` 의 `review_sections = build_review_sections(...)` 직후에 추가하고, `InvestmentReportBundle(...)` 생성자에 필드 전달:
+
+```python
+    # ROB-335 — additive intraday ActionPacket projection (view-layer only).
+    action_packet = build_action_packet(
+        item_responses, report_response.snapshot_report_diagnostics
+    )
+```
+
+그리고 `return InvestmentReportBundle(` 호출에 `action_packet=action_packet,` 추가.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/routers/investment_reports.py tests/services/investment_reports/test_action_packet.py
+git commit -m "feat(rob-335): attach ActionPacket projection to report bundle read model
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: 회귀 — KIS vs Toss 권위 미혼합 + user_id fail-closed + broker no-mutation
+
+**Files:**
+- Test: `tests/services/action_report/snapshot_backed/test_auto_emit.py` (회귀 추가)
+- 확인: `tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py` (broker/mutation import guard — 변경 없이 통과 확인)
+
+- [ ] **Step 1: 회귀 테스트 추가**
+
+```python
+def test_intraday_floor_never_classifies_reference_holdings() -> None:
+    # Toss/manual rows live in reference_holdings; primary_source != 'kis'
+    # means _held_kis_symbols returns {} -> no held_actions promoted.
+    payload = {
+        "primary_source": "manual",
+        "holdings": [{"ticker": "AAPL", "sellable_quantity": 3, "source": "manual"}],
+        "reference_holdings": [{"ticker": "AAPL", "source": "toss"}],
+        "count": 1, "market": "us",
+    }
+    snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="us", account_scope="kis_live"
+    )
+    assert all(i.symbol != "AAPL" for i in items if i.evidence_snapshot.get("action_verdict") in
+               {"sell_review", "keep", "no_add"})
+
+
+def test_intraday_floor_user_id_missing_portfolio_yields_no_held_items() -> None:
+    # primary_source='none' (user_id missing path) -> no holdings to classify;
+    # the generator-level floor (Task 5) supplies the data_gap item instead.
+    payload = {
+        "primary_source": "none", "holdings": [], "reference_holdings": [],
+        "count": 0, "market": "kr",
+    }
+    snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    held_verdicts = {"sell_review", "keep", "no_add", "data_gap"}
+    assert not [i for i in items if i.symbol and
+                i.evidence_snapshot.get("action_verdict") in held_verdicts]
+```
+
+- [ ] **Step 2: 실패/통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit.py -v -k "reference_holdings or user_id_missing"`
+Expected: PASS (Task 4 구현이 `_held_kis_symbols` 가드를 그대로 사용하므로 통과해야 함; 실패하면 가드 누락 — 구현 수정).
+
+- [ ] **Step 3: mutation import guard 확인 (변경 없음)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v`
+Expected: PASS — 신규 모듈(`action_verdict.py`/`intraday_floor.py`/`action_packet.py`)이 broker/order/watch/LLM import을 들이지 않아 guard 유지.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add tests/services/action_report/snapshot_backed/test_auto_emit.py
+git commit -m "test(rob-335): regression — KIS/Toss authority + user_id fail-closed in intraday_floor
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: 전체 검증 — lint, 풀 테스트, read-only smoke
+
+**Files:** 없음 (검증 전용). 안전: 어떤 broker/order/watch mutation도 발생시키지 않는다.
+
+- [ ] **Step 1: 변경 영역 lint**
+
+Run: `uv run ruff check app/ tests/`
+Expected: `All checks passed!` (없으면 수정 후 재실행).
+
+- [ ] **Step 2: 관련 테스트 모듈 풀 실행**
+
+Run:
+```bash
+uv run pytest tests/services/action_report/ tests/services/investment_reports/ -v
+```
+Expected: PASS (신규 + 기존 회귀 전부). 기존 baseline 실패가 있으면 [[project_local_public_base_url_test_failures]] 처럼 환경성 noise인지 구분하여 기록.
+
+- [ ] **Step 3: import guard + no-internal-LLM 재확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py tests/services/action_report/snapshot_backed/test_generator_safety.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: read-only 스모크 evidence (선택, 자격증명 있는 호스트에서만)**
+
+KR/KIS live advisory intraday 리포트 1건을 operator-triggered 경로로 생성하고, 응답 `items_count >= 1` 및 조회 bundle의 `action_packet`(held_actions/new_buy_candidates/no_action_reason/data_gaps_for_next_cycle)에 명시 답변이 채워졌는지 확인. broker/order/watch row 변화가 없음을 확인(생성 전후 카운트 동일). 자격증명이 없으면 이 단계는 스킵하고 사유를 PR 본문에 남긴다 ([[project_rob319_kiwoom_mock_lifecycle]] 처럼 live-smoke deferred 표기).
+
+- [ ] **Step 5: 최종 커밋 (검증 메모, 변경 없으면 스킵)**
+
+검증 중 수정이 있었다면 해당 커밋. 없으면 커밋 없음.
+
+---
+
+## PR2 (프론트엔드, 별도 plan)
+
+spec §3.6/§7 대로 PR1 머지 후 fresh `main`에서 별도 plan으로 진행한다. 범위: `/invest/reports` 최신 화면에 "오늘의 보유 액션 / 신규 후보 / 리스크 / 데이터 부족" 4헤더 렌더 + sub-verdict chip + `action_packet` payload 소비. ROB-322 5-section UI 컴포넌트(`frontend/invest/src/desktop/...`) 탐색을 선행해야 bite-sized step을 쓸 수 있어 본 plan에는 포함하지 않는다. (frontend vitest는 [[project_frontend_invest_vitest_threads_flaky]] 대로 `--pool=forks` 사용.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3.1 intent 분리 + non-empty invariant → Task 5 (`is_intraday_action` + `ensure_action_floor` + generator wiring). ✅
+- §3.2 ActionPacket read-time projection → Task 2(스키마) + Task 3(`build_action_packet`) + Task 6(라우터 연결). ✅
+- §3.3 보유종목 결정론 분류기 (전수 + Toss 분리 + user_id fail-closed) → Task 1(규칙) + Task 4(intraday_floor 전수분류) + Task 7(회귀). ✅
+- §3.4 신규후보 freshness 게이트 + no_new_buy 사유 → Task 4(stale_only 마커, 기존 `usefulness=='useful'` 게이트 유지) + Task 3(`no_new_buy_reason` projection). ✅
+- §3.5 data_gap / 진단 연결 → Task 3(`_diagnostics_gaps` + 심볼 data_gap item). ✅ (market/news는 기존 evidence_snapshot 참조로 유지, 새 수집기 없음.)
+- §4 안전 경계 → Task 7/8(mutation import guard, no-internal-LLM, read-only smoke). ✅
+- §5 Acceptance criteria: items≠[] (Task 5), 신규후보 없음+사유 (Task 4/3), 보유종목 분류 (Task 1/4), unavailable→data_gap (Task 1), stale screener 제외 (기존 게이트 + Task 4 사유), KIS/Toss 권위 (Task 7), broker row 무변화 (Task 7/8). ✅
+- §7 PR 슬라이싱: 본 plan = PR1; PR2는 별도. ✅
+
+**Placeholder scan:** Task 5 Step 6 / Task 6 Step 1 / Task 8 Step 4는 기존 통합 fixture·자격증명 의존이라 구현 시 기존 패턴 참조를 명시했다(코드 골격 + 정확한 어서션 제공). 그 외 모든 스텝은 실제 코드 포함. ✅
+
+**Type consistency:** `action_verdict`(str, evidence_snapshot 키) ↔ `VERDICT_TO_BUCKET` ↔ `decision_bucket`(locked 5) 전 Task 일관. `IngestReportItem.intent`는 항상 5-literal(buy_review/sell_review/risk_review/trend_recovery_review/rebalance_review) 내에서만 사용(keep/no_add → `rebalance_review`, data_gap/marker → `risk_review`). `ActionPacketEntry.verdict`는 `ActionVerdictLiteral`. `build_action_packet(items, diagnostics)` 시그니처가 Task 3/6 동일. ✅

--- a/docs/superpowers/plans/2026-05-27-rob-335-pr2-frontend-action-packet.md
+++ b/docs/superpowers/plans/2026-05-27-rob-335-pr2-frontend-action-packet.md
@@ -1,0 +1,620 @@
+# ROB-335 PR2 — `/invest/reports` ActionPacket 프론트 surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR1이 추가한 `action_packet` read-model payload를 `/invest/reports` 리포트 상세 화면에 "오늘의 보유 액션 / 신규 후보 / 리스크 / 데이터 부족" 4헤더 + sub-verdict chip으로 렌더한다.
+
+**Architecture:** ROB-322 `ReviewSectionsView`와 동일한 view-layer 패턴. 백엔드 snake_case `action_packet` JSON → `normalizeActionPacket`로 camelCase 변환 → `ActionPacketView` 컴포넌트가 `Pill` 칩으로 sub-verdict를 표시. 기존 `review_sections` surface를 대체하지 않고 그 아래에 additive로 마운트. ActionPacket이 없으면(legacy/비-intraday) 렌더 안 함.
+
+**Tech Stack:** React + TypeScript, Vitest + @testing-library/react (jsdom), 인라인 CSS + CSS 변수, 수기 TS 타입(OpenAPI 생성 아님). 설계 근거: `docs/superpowers/specs/2026-05-27-rob-335-intraday-action-cycle-design.md` §3.6. 백엔드 payload: PR #985 (`app/schemas/investment_reports.py` `ActionPacket`/`ActionPacketEntry`/`DataGapEntry`).
+
+---
+
+## Scope & 선행 조건
+
+- **PR2만** 다룬다. PR1(#985)이 머지된 fresh `main`에서 새 worktree/브랜치로 시작하는 것이 spec 권장 순서. (plan은 선행 작성 가능.)
+- frontend vitest는 [[project_frontend_invest_vitest_threads_flaky]] 대로 `--pool=forks`로 실행. baseline 5건 pre-existing 실패 존재.
+- 마이그레이션·백엔드 변경 없음 (백엔드 ActionPacket은 PR1에서 완료).
+
+## 백엔드 payload 계약 (PR1 #985, snake_case JSON)
+
+```jsonc
+"action_packet": {
+  "held_actions":  [{ "verdict": "sell_review", "symbol": "005930", "side": "sell",
+                      "rationale": "...", "item_uuid": "...", "evidence_snapshot": {...} }],
+  "new_buy_candidates": [{ "verdict": "buy_review", "symbol": "000660", ... }],
+  "no_new_buy_reason": "국내 스크리너 스냅샷이 stale ... | null",
+  "risk_reviews": [{ "verdict": "watch_only", ... }],
+  "no_action_reason": { "kind": "data_insufficient", "reason_ko": "...",
+                        "blocking_sources": ["portfolio"], "excluded_count": 0 } | null,
+  "data_gaps_for_next_cycle": [{ "source": "portfolio", "status": "unavailable",
+                                 "reason": "user_id_missing" }]
+}
+```
+
+verdict 어휘(11종): `buy_review/limit_wait/no_new_buy_candidates/sell_review/trim_review/add_review/keep/no_add/watch_only/rejected/data_gap`.
+
+## File Structure
+
+**Create:**
+- `frontend/invest/src/components/investment-reports/ActionPacketView.tsx` — 4헤더 + sub-verdict chip 렌더 컴포넌트 (자체 완결, `Pill` 재사용).
+- `frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts` — `normalizeActionPacket` 단위 테스트.
+- `frontend/invest/src/__tests__/ActionPacketView.test.tsx` — 컴포넌트 렌더 테스트.
+
+**Modify:**
+- `frontend/invest/src/types/investmentReports.ts` — `ActionVerdict`/`ActionPacketEntry`/`DataGapEntry`/`ActionPacket` 타입 + `InvestmentReportBundle.actionPacket` 필드.
+- `frontend/invest/src/api/investmentReports.ts` — `normalizeActionPacket`(+entry) export + `fetchInvestmentReportBundle` 연결.
+- `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` — `ActionPacketView` 마운트.
+
+---
+
+## Task 1: TS 타입 + normalizeActionPacket + fetch 연결
+
+**Files:**
+- Modify: `frontend/invest/src/types/investmentReports.ts` (≈line 345-359, `ReportReviewSections`/`InvestmentReportBundle` 부근)
+- Modify: `frontend/invest/src/api/investmentReports.ts` (`normalizeReviewSections` ≈190-212, `fetchInvestmentReportBundle` ≈312-341)
+- Test: `frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```ts
+// frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
+import { describe, expect, it } from "vitest";
+
+import { normalizeActionPacket } from "../api/investmentReports";
+
+describe("normalizeActionPacket", () => {
+  it("returns null when omitted (legacy/non-intraday)", () => {
+    expect(normalizeActionPacket(undefined)).toBeNull();
+    expect(normalizeActionPacket(null)).toBeNull();
+  });
+
+  it("maps snake_case payload to camelCase groups", () => {
+    const packet = normalizeActionPacket({
+      held_actions: [
+        { verdict: "sell_review", symbol: "005930", side: "sell",
+          rationale: "보유 매도 검토", item_uuid: "i1", evidence_snapshot: { x: 1 } },
+        { verdict: "keep", symbol: "000660", side: null,
+          rationale: "유지", item_uuid: "i2", evidence_snapshot: {} },
+      ],
+      new_buy_candidates: [],
+      no_new_buy_reason: "스크리너 stale",
+      risk_reviews: [{ verdict: "watch_only", symbol: "035720", rationale: "관망",
+                       item_uuid: "i3", evidence_snapshot: {} }],
+      no_action_reason: { kind: "data_insufficient", reason_ko: "데이터 부족",
+                          blocking_sources: ["portfolio"], excluded_count: 2 },
+      data_gaps_for_next_cycle: [
+        { source: "portfolio", status: "unavailable", reason: "user_id_missing" },
+      ],
+    });
+    expect(packet).not.toBeNull();
+    expect(packet!.heldActions.map((e) => e.verdict)).toEqual(["sell_review", "keep"]);
+    expect(packet!.heldActions[0].itemUuid).toBe("i1");
+    expect(packet!.newBuyCandidates).toEqual([]);
+    expect(packet!.noNewBuyReason).toBe("스크리너 stale");
+    expect(packet!.riskReviews[0].verdict).toBe("watch_only");
+    expect(packet!.noActionReason!.kind).toBe("data_insufficient");
+    expect(packet!.noActionReason!.blockingSources).toEqual(["portfolio"]);
+    expect(packet!.dataGapsForNextCycle[0]).toEqual({
+      source: "portfolio", status: "unavailable", reason: "user_id_missing",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/investmentReportsActionPacket.test.ts`
+Expected: FAIL — `normalizeActionPacket` export 없음.
+
+- [ ] **Step 3: 타입 추가 — `types/investmentReports.ts`** (`ReportReviewSections` 정의 직후, ≈line 348)
+
+```ts
+// ROB-335 — intraday ActionPacket (mirrors backend ActionPacket schema).
+export type ActionVerdict =
+  | "buy_review"
+  | "limit_wait"
+  | "no_new_buy_candidates"
+  | "sell_review"
+  | "trim_review"
+  | "add_review"
+  | "keep"
+  | "no_add"
+  | "watch_only"
+  | "rejected"
+  | "data_gap";
+
+export interface ActionPacketEntry {
+  verdict: ActionVerdict;
+  symbol?: string | null;
+  side?: "buy" | "sell" | null;
+  rationale: string;
+  itemUuid?: string | null;
+  evidenceSnapshot: Record<string, unknown>;
+}
+
+export interface DataGapEntry {
+  source: string;
+  status?: string | null;
+  reason?: string | null;
+}
+
+export interface ActionPacket {
+  heldActions: ActionPacketEntry[];
+  newBuyCandidates: ActionPacketEntry[];
+  noNewBuyReason?: string | null;
+  riskReviews: ActionPacketEntry[];
+  noActionReason?: NoActionSummary | null;
+  dataGapsForNextCycle: DataGapEntry[];
+}
+```
+
+`InvestmentReportBundle` 인터페이스(≈line 350-359)에 필드 추가 (`reviewSections` 줄 다음):
+
+```ts
+  // ROB-335 — additive intraday ActionPacket projection. Null for legacy /
+  // non-intraday reports.
+  actionPacket?: ActionPacket | null;
+```
+
+- [ ] **Step 4: normalizer 추가 — `api/investmentReports.ts`** (`normalizeReviewSections` 다음, ≈line 212)
+
+import 블록의 타입 import에 `ActionPacket`, `ActionPacketEntry`, `ActionVerdict`, `DataGapEntry` 추가. 그리고:
+
+```ts
+// ROB-335 — normalize the additive intraday ActionPacket. Null when the
+// backend omits it (legacy / non-intraday reports).
+function normalizeActionPacketEntry(raw: unknown): ActionPacketEntry {
+  const obj = asRecord(raw);
+  return {
+    verdict: asString(obj.verdict, "data_gap") as ActionVerdict,
+    symbol: asOptionalString(obj.symbol),
+    side: asOptionalString(obj.side) as "buy" | "sell" | null,
+    rationale: asString(obj.rationale, ""),
+    itemUuid: asOptionalString(obj.item_uuid),
+    evidenceSnapshot: asRecord(obj.evidence_snapshot),
+  };
+}
+
+export function normalizeActionPacket(raw: unknown): ActionPacket | null {
+  if (raw === null || raw === undefined) return null;
+  const obj = asRecord(raw);
+
+  let noActionReason: NoActionSummary | null = null;
+  if (obj.no_action_reason !== null && obj.no_action_reason !== undefined) {
+    const s = asRecord(obj.no_action_reason);
+    noActionReason = {
+      kind: asOptionalString(s.kind) as WhyNoActionKind | null,
+      reasonKo: asOptionalString(s.reason_ko),
+      blockingSources: asArray<string>(s.blocking_sources),
+      excludedCount: asNumber(s.excluded_count, 0),
+    };
+  }
+
+  return {
+    heldActions: asArray(obj.held_actions).map(normalizeActionPacketEntry),
+    newBuyCandidates: asArray(obj.new_buy_candidates).map(normalizeActionPacketEntry),
+    noNewBuyReason: asOptionalString(obj.no_new_buy_reason),
+    riskReviews: asArray(obj.risk_reviews).map(normalizeActionPacketEntry),
+    noActionReason,
+    dataGapsForNextCycle: asArray<Record<string, unknown>>(
+      obj.data_gaps_for_next_cycle,
+    ).map((g) => ({
+      source: asString(g.source, ""),
+      status: asOptionalString(g.status),
+      reason: asOptionalString(g.reason),
+    })),
+  };
+}
+```
+
+`fetchInvestmentReportBundle`의 `readJson<{...}>` 제네릭에 `action_packet?: unknown;` 추가하고, return 객체에 추가:
+
+```ts
+    actionPacket: normalizeActionPacket(raw.action_packet),
+```
+
+- [ ] **Step 5: 통과 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/investmentReportsActionPacket.test.ts`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add frontend/invest/src/types/investmentReports.ts frontend/invest/src/api/investmentReports.ts frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
+git commit -m "feat(rob-335): frontend ActionPacket types + normalizer (PR2)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: ActionPacketView 컴포넌트 (4헤더 + sub-verdict chip)
+
+**Files:**
+- Create: `frontend/invest/src/components/investment-reports/ActionPacketView.tsx`
+- Test: `frontend/invest/src/__tests__/ActionPacketView.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```tsx
+// frontend/invest/src/__tests__/ActionPacketView.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ActionPacketView } from "../components/investment-reports/ActionPacketView";
+import type { ActionPacket } from "../types/investmentReports";
+
+function makePacket(overrides: Partial<ActionPacket> = {}): ActionPacket {
+  return {
+    heldActions: [
+      { verdict: "sell_review", symbol: "005930", side: "sell",
+        rationale: "보유 매도 검토", itemUuid: "i1", evidenceSnapshot: {} },
+      { verdict: "keep", symbol: "000660", side: null,
+        rationale: "유지", itemUuid: "i2", evidenceSnapshot: {} },
+    ],
+    newBuyCandidates: [],
+    noNewBuyReason: "국내 스크리너 스냅샷이 stale",
+    riskReviews: [
+      { verdict: "watch_only", symbol: "035720", rationale: "관망",
+        itemUuid: "i3", evidenceSnapshot: {} },
+    ],
+    noActionReason: { kind: "data_insufficient", reasonKo: "데이터 부족",
+                      blockingSources: ["portfolio"], excludedCount: 0 },
+    dataGapsForNextCycle: [
+      { source: "portfolio", status: "unavailable", reason: "user_id_missing" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ActionPacketView", () => {
+  it("renders the four intraday headers", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByRole("heading", { name: /오늘의 보유 액션/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /신규 후보/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /리스크/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /데이터 부족/ })).toBeInTheDocument();
+  });
+
+  it("renders held verdict chips with Korean labels", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText("매도 검토")).toBeInTheDocument();
+    expect(screen.getByText("유지")).toBeInTheDocument();
+    expect(screen.getByText("005930")).toBeInTheDocument();
+  });
+
+  it("shows no-new-buy reason when there are no candidates", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText(/국내 스크리너 스냅샷이 stale/)).toBeInTheDocument();
+  });
+
+  it("lists data gaps with their source", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText(/portfolio/)).toBeInTheDocument();
+    expect(screen.getByText(/user_id_missing/)).toBeInTheDocument();
+  });
+
+  it("renders empty-state copy when a group is empty and no reason given", () => {
+    render(<ActionPacketView packet={makePacket({
+      heldActions: [], newBuyCandidates: [], noNewBuyReason: null,
+      riskReviews: [], noActionReason: null, dataGapsForNextCycle: [],
+    })} />);
+    // Each empty group shows the shared "해당 없음" placeholder.
+    expect(screen.getAllByText("해당 없음").length).toBeGreaterThanOrEqual(3);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/ActionPacketView.test.tsx`
+Expected: FAIL — `ActionPacketView` 모듈 없음.
+
+- [ ] **Step 3: 컴포넌트 구현**
+
+```tsx
+// frontend/invest/src/components/investment-reports/ActionPacketView.tsx
+// ROB-335 — intraday ActionPacket surface: four headers (held / new / risk /
+// data-gap) + sub-verdict chips. Pure view-layer over the bundle.actionPacket
+// projection (parallel to ROB-322 ReviewSectionsView).
+import { Pill, type PillTone } from "../../ds/atoms";
+import type {
+  ActionPacket,
+  ActionPacketEntry,
+  ActionVerdict,
+  DataGapEntry,
+  NoActionSummary,
+} from "../../types/investmentReports";
+
+const VERDICT_LABELS: Record<ActionVerdict, string> = {
+  buy_review: "신규매수 검토",
+  limit_wait: "지정가 대기",
+  no_new_buy_candidates: "신규 후보 없음",
+  sell_review: "매도 검토",
+  trim_review: "축소 검토",
+  add_review: "추가매수 검토",
+  keep: "유지",
+  no_add: "추가매수 금지",
+  watch_only: "관망",
+  rejected: "제외",
+  data_gap: "데이터 부족",
+};
+
+const VERDICT_TONES: Record<ActionVerdict, PillTone> = {
+  buy_review: "gain",
+  add_review: "gain",
+  limit_wait: "warn",
+  no_new_buy_candidates: "paper",
+  sell_review: "loss",
+  trim_review: "loss",
+  keep: "paper",
+  no_add: "paper",
+  watch_only: "accent",
+  rejected: "warn",
+  data_gap: "warn",
+};
+
+function EntryRow({ entry }: { entry: ActionPacketEntry }) {
+  return (
+    <div style={{ display: "grid", gap: 4, padding: "6px 0" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Pill tone={VERDICT_TONES[entry.verdict]} size="sm">
+          {VERDICT_LABELS[entry.verdict]}
+        </Pill>
+        {entry.symbol ? (
+          <strong style={{ fontSize: 14 }}>{entry.symbol}</strong>
+        ) : null}
+      </div>
+      <p style={{ margin: 0, fontSize: 13 }}>{entry.rationale}</p>
+    </div>
+  );
+}
+
+function PacketSection({
+  title,
+  entries,
+  emptyReason,
+}: {
+  title: string;
+  entries: ActionPacketEntry[];
+  emptyReason?: string | null;
+}) {
+  return (
+    <section style={{ display: "grid", gap: 6 }}>
+      <h2 style={{ margin: 0, fontSize: 18 }}>
+        {title} ({entries.length})
+      </h2>
+      {entries.length > 0 ? (
+        entries.map((entry, idx) => (
+          <EntryRow key={entry.itemUuid ?? `${entry.verdict}-${idx}`} entry={entry} />
+        ))
+      ) : (
+        <p style={{ margin: 0, fontSize: 13 }}>{emptyReason ?? "해당 없음"}</p>
+      )}
+    </section>
+  );
+}
+
+function DataGapSection({
+  gaps,
+  noActionReason,
+}: {
+  gaps: DataGapEntry[];
+  noActionReason?: NoActionSummary | null;
+}) {
+  return (
+    <section style={{ display: "grid", gap: 6 }}>
+      <h2 style={{ margin: 0, fontSize: 18 }}>데이터 부족 ({gaps.length})</h2>
+      {noActionReason?.reasonKo ? (
+        <p style={{ margin: 0, fontSize: 13 }}>{noActionReason.reasonKo}</p>
+      ) : null}
+      {gaps.length > 0 ? (
+        gaps.map((gap, idx) => (
+          <div key={`${gap.source}-${idx}`} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Pill tone="warn" size="sm">{gap.source}</Pill>
+            <span style={{ fontSize: 13 }}>
+              {[gap.status, gap.reason].filter(Boolean).join(" · ")}
+            </span>
+          </div>
+        ))
+      ) : (
+        <p style={{ margin: 0, fontSize: 13 }}>해당 없음</p>
+      )}
+    </section>
+  );
+}
+
+export function ActionPacketView({ packet }: { packet: ActionPacket }) {
+  return (
+    <section data-testid="action-packet" style={{ display: "grid", gap: 16 }}>
+      <PacketSection title="오늘의 보유 액션" entries={packet.heldActions} />
+      <PacketSection
+        title="신규 후보"
+        entries={packet.newBuyCandidates}
+        emptyReason={packet.noNewBuyReason}
+      />
+      <PacketSection title="리스크" entries={packet.riskReviews} />
+      <DataGapSection
+        gaps={packet.dataGapsForNextCycle}
+        noActionReason={packet.noActionReason}
+      />
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/ActionPacketView.test.tsx`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add frontend/invest/src/components/investment-reports/ActionPacketView.tsx frontend/invest/src/__tests__/ActionPacketView.test.tsx
+git commit -m "feat(rob-335): ActionPacketView — four intraday headers + verdict chips (PR2)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 리포트 상세 화면에 ActionPacketView 마운트
+
+**Files:**
+- Modify: `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` (import + 마운트, 리뷰/플랫 블록 ≈line 671 직후·alerts ≈line 673 직전)
+- Test: `frontend/invest/src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```tsx
+// frontend/invest/src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type { ActionPacket, InvestmentReportBundle } from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+const REPORT = {
+  reportUuid: "00000000-0000-0000-0000-000000000001",
+  reportType: "kr_morning", market: "kr", marketSession: "regular",
+  accountScope: "kis_live", executionMode: "advisory_only", createdByProfile: "t",
+  title: "KR", summary: "s", riskSummary: null, thesisText: null, noActionNote: null,
+  marketSnapshot: {}, portfolioSnapshot: {}, previousReportUuid: null, status: "draft",
+  metadata: {}, createdAt: "2026-05-27T00:00:00Z", updatedAt: "2026-05-27T00:00:00Z",
+  publishedAt: null, validUntil: null, snapshotBundleUuid: null,
+  snapshotPolicyVersion: null, snapshotCoverageSummary: null,
+  snapshotFreshnessSummary: null, sourceConflicts: null, unavailableSources: null,
+  snapshotReportDiagnostics: null,
+} as InvestmentReportBundle["report"];
+
+function makeBundle(actionPacket: ActionPacket | null): InvestmentReportBundle {
+  return {
+    report: REPORT, items: [], decisionsByItemUuid: {}, alerts: [], events: [],
+    reviewSections: null, actionPacket,
+  };
+}
+
+function renderWith(bundle: InvestmentReportBundle) {
+  (useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    status: "ready", bundle, error: null, reload: vi.fn(),
+  });
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+describe("InvestmentReportBundleContent — ActionPacket mount", () => {
+  it("renders ActionPacketView when actionPacket is present", () => {
+    renderWith(makeBundle({
+      heldActions: [{ verdict: "keep", symbol: "005930", side: null,
+        rationale: "유지", itemUuid: "i1", evidenceSnapshot: {} }],
+      newBuyCandidates: [], noNewBuyReason: "신규 후보 없음",
+      riskReviews: [], noActionReason: null, dataGapsForNextCycle: [],
+    }));
+    expect(screen.getByTestId("action-packet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /오늘의 보유 액션/ })).toBeInTheDocument();
+  });
+
+  it("does not render ActionPacketView for legacy bundles (actionPacket null)", () => {
+    renderWith(makeBundle(null));
+    expect(screen.queryByTestId("action-packet")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx`
+Expected: FAIL — `action-packet` testid 없음 (마운트 전).
+
+- [ ] **Step 3: 마운트 구현**
+
+import 추가 (파일 상단 컴포넌트 import 블록):
+
+```tsx
+import { ActionPacketView } from "./ActionPacketView";
+```
+
+`InvestmentReportBundleContent` JSX에서 리뷰/플랫 블록(≈line 648-671)과 `active watches` 섹션(≈line 673) 사이에 삽입:
+
+```tsx
+      {bundle.actionPacket ? (
+        <ActionPacketView packet={bundle.actionPacket} />
+      ) : null}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: 기존 리뷰섹션 테스트 회귀 확인** (actionPacket 옵셔널이 makeBundle 깨지 않음)
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx`
+Expected: PASS (기존 전부; `actionPacket` 미설정 = undefined → 마운트 안 함).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx frontend/invest/src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx
+git commit -m "feat(rob-335): mount ActionPacketView on report detail surface (PR2)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 전체 검증 — vitest(forks) + 타입체크/lint
+
+**Files:** 없음 (검증 전용).
+
+- [ ] **Step 1: 신규 + 관련 테스트 forks 실행**
+
+Run:
+```bash
+cd frontend/invest && npx vitest run --pool=forks \
+  src/__tests__/investmentReportsActionPacket.test.ts \
+  src/__tests__/ActionPacketView.test.tsx \
+  src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx \
+  src/__tests__/InvestmentReportBundleContent.reviewSections.test.tsx
+```
+Expected: 전부 PASS.
+
+- [ ] **Step 2: 프론트 전체 스위트 (forks)로 baseline 대비 회귀 확인**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks`
+Expected: 신규 테스트 PASS + baseline 5건 pre-existing 실패([[project_frontend_invest_vitest_threads_flaky]])만 — 신규 실패 0건.
+
+- [ ] **Step 3: 타입체크 / lint (프로젝트 스크립트 확인 후)**
+
+`frontend/invest/package.json`의 scripts에서 typecheck/lint 명령을 확인하고 실행 (예: `npm run typecheck` 또는 `npx tsc --noEmit`, `npm run lint`). 신규 타입/컴포넌트가 통과해야 함.
+
+- [ ] **Step 4: 로컬 시각 확인 (선택)**
+
+[[gstack]] `/browse`로 실제 KR intraday 리포트 상세(`/invest/reports/{uuid}`)를 열어 4헤더 + verdict chip이 렌더되는지 육안 확인. (백엔드 PR1 머지 + intraday 리포트 1건 생성 선행 필요. 없으면 스킵하고 사유 기록.)
+
+---
+
+## Self-Review
+
+**Spec coverage (§3.6):**
+- "오늘의 보유 액션 / 신규 후보 / 리스크 / 데이터 부족" 4헤더 → Task 2 `ActionPacketView` (PacketSection×3 + DataGapSection). ✅
+- sub-verdict chip → Task 2 `Pill` + `VERDICT_LABELS`/`VERDICT_TONES`. ✅
+- `action_packet` payload 소비 → Task 1 타입 + `normalizeActionPacket` + fetch 연결. ✅
+- ROB-275/evidence viewer 호환 유지 → additive 마운트, 기존 review/flat/alerts/events 블록 미변경 (Task 3 Step 5 회귀). ✅
+- legacy/비-intraday null-safe → Task 3 `bundle.actionPacket ? ... : null` + 테스트. ✅
+
+**Placeholder scan:** Task 4 Step 3는 프로젝트 스크립트명 확인 후 실행(명령 후보 제시), Step 4는 선행조건부 선택 단계로 명시. 그 외 전 스텝 실제 코드 포함. ✅
+
+**Type consistency:** `ActionVerdict`(11값) ↔ `VERDICT_LABELS`/`VERDICT_TONES` 키 동일. `ActionPacket` 필드(heldActions/newBuyCandidates/noNewBuyReason/riskReviews/noActionReason/dataGapsForNextCycle)가 Task 1 타입 ↔ Task 1 normalizer ↔ Task 2 컴포넌트 ↔ Task 3 테스트 전부 일치. `NoActionSummary`(kind/reasonKo/blockingSources/excludedCount)는 기존 ROB-322 타입 재사용. `Pill` tone은 검증된 `PillTone` 값(gain/loss/warn/accent/paper)만 사용. import 경로: 컴포넌트→`../../ds/atoms`, `../../types/investmentReports` (src/components/investment-reports 기준 2단계 상위). ✅

--- a/docs/superpowers/specs/2026-05-27-rob-335-intraday-action-cycle-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-335-intraday-action-cycle-design.md
@@ -1,0 +1,153 @@
+# ROB-335 — `/invest/reports` 매일 장중 액션 사이클 MVP (설계)
+
+- **Linear**: ROB-335 (High, Backlog) — auto_trader Trading Decision Workspace
+- **Date**: 2026-05-27
+- **Branch base**: `c31168b3` (ROB-332 / PR #982 머지 직후 `main`)
+- **Related**: ROB-332 (run-card citation, 재구현 금지), ROB-336 (Phase 2 US/crypto/NXT), ROB-337 (watch 매수가격 산정)
+
+## 1. 문제 정의
+
+`/invest/reports`는 "예쁜 리포트 UI"가 아니라 **Hermes가 장중에 본 입력/정책/판단을 고정해 매일 반복 가능하게 남기는 감사 로그/재현 컨텍스트**여야 한다. 그러나 최근 리포트는 `items=[]`, `review_sections=null` 또는 smoke/draft 성격으로 끝나 실제 질문에 답하지 못하면서도 technical success로 보였다.
+
+ROB-322가 만든 `build_review_sections()`는 `decision_bucket`이 non-null인 item만 projection하므로, item이 없으면 sections가 비고 `why_no_action` diagnostics가 채워진다는 보장도 없다. 즉 **빈 리포트가 성공으로 보이는 경로가 실재한다.**
+
+이 MVP는 KR/KIS live 중심으로 **빈 리포트 성공을 금지**하고, operator가 한 번 실행하면 다음 4개 질문에 반드시 답하는 장중 ActionPacket을 항상 생성한다.
+
+1. 오늘 보유종목 중 팔거나 줄일 게 있는가?
+2. 오늘 보유종목 중 유지/추가매수 금지/추가매수 검토 대상은 무엇인가?
+3. 오늘 신규 후보가 있는가? 없다면 왜 없는가?
+4. 데이터가 부족하면 어떤 source가 부족해서 판단을 못 했는가?
+
+## 2. 확정된 설계 결정
+
+| 결정 | 내용 | 근거 |
+|---|---|---|
+| **A. 버킷** | ActionPacket sub-verdict는 locked 5값 `decision_bucket` 위의 sub-label. enum 변경/마이그레이션 없음 | ROB-301 decision_bucket 5-value locked, ROB-322 5-section UI 호환 유지 |
+| **B. 영속화** | sub-verdict는 persisted report item의 `evidence_snapshot["action_verdict"]`(JSON)에 저장. ActionPacket section은 read-time projection | 입력(item+evidence+bundle)이 모두 persisted → 결정론적 재계산 = 재현 보장. 마이그레이션 불필요 |
+| **C. 분류기 경계** | sub-verdict는 결정론 evidence 규칙이 부여, Hermes push가 refine/override. in-process LLM 없음 | ROB-287 boundary: `/invest/reports`는 Gemini/OpenAI/Grok/Hermes in-process 호출 금지 |
+| **C′. 결정론 범위** | 결정론은 정직한 verdict만 직접 부여: `data_gap`/`keep`/`no_add`/`sell_review`. `trim_review`/`add_review`는 Hermes push 또는 명시 정책에 유보 | fake 방향성 신호 금지 ("빈 리포트 성공 금지"와 동일 정신) |
+| **D. ROB-337 경계** | `limit_wait`은 evidence 상태만 표면화. 목표 매수가격 계산은 ROB-337로 이양 | watch 매수가격 모델 중복 선점 방지 |
+| **E. 슬라이싱** | PR1 백엔드 코어, PR2 프론트 surface. 마이그레이션 없음 → PR0 불필요 | ROB-322 PR1/PR2 선례 |
+
+### 버킷 매핑 (read-time projection)
+
+```
+decision_bucket (locked 5)        ActionPacket sub-verdict
+--------------------------        -----------------------
+new_buy_candidate            ←     buy_review / limit_wait
+open_action                  ←     sell_review / trim_review / add_review
+completed_or_existing        ←     keep / no_add
+risk_watch                   ←     watch_only  (+ risk_reviews)
+deferred_no_action           ←     rejected / data_gap
+```
+
+## 3. 아키텍처
+
+### §3.1 Report intent 분리 + non-empty invariant
+
+- 기존 `policy_version="intraday_action_report_v1"` 문자열을 공식 intent discriminator로 승격. 별도 컬럼/마이그레이션 없이 generation request + diagnostics JSON에 intent를 기록.
+- `intent="intraday_action"` 리포트는 **non-empty invariant**를 강제. 강제 지점은 `app/services/action_report/snapshot_backed/generator.py`의 `classify_items()` 이후 `ingest()` 이전.
+- guard는 결과가 비면 **실패가 아니라 보강**: 구조적 섹션(`no_new_buy_candidates`, `no_action_reason`, `data_gaps_for_next_cycle`)을 항상 합성해 `items=[]` / `review_sections=null`이 성공으로 나가지 않게 한다.
+- smoke/draft intent는 이 invariant에서 면제 → smoke와 실제 장중 리포트 경로가 명확히 분리.
+
+### §3.2 ActionPacket = read-time projection
+
+신규 모듈 `app/services/investment_reports/action_packet.py` (ROB-322 `review_sections.py`와 동일 view-layer 패턴). persisted item + diagnostics에서 read-time으로 조립.
+
+```
+ActionPacket
+├── held_actions:             sub-verdict별 그룹 (sell_review/trim_review/keep/no_add/add_review)
+├── new_buy_candidates:       sub-verdict별 그룹 (buy_review/limit_wait/watch_only/rejected)
+├── risk_reviews:             risk_watch 버킷 item
+├── no_action_reason:         why_no_action diagnostics 재사용 (data_insufficient/stale_gated/real_no_action)
+└── data_gaps_for_next_cycle: 부족/stale source 목록
+```
+
+- sub-verdict는 각 item의 `evidence_snapshot["action_verdict"]`에서 읽음.
+- `decision_bucket`이 None인 (pre-ROB-308) item은 ROB-322와 동일하게 projection에서 제외 → fallback `items`/`item_groups`에 유지.
+
+### §3.3 보유종목 결정론 분류기
+
+`app/services/action_report/snapshot_backed/` 에 held-symbol classifier 추가. 입력 = portfolio 스냅샷(KIS primary holdings) + 심볼별 quote/orderbook evidence. **모든 KIS 보유종목**에 verdict 부여:
+
+```
+quote/orderbook unavailable           → data_gap        (방향성 판단 안 함)
+KIS primary 아님 / sellable_qty = 0   → keep            (매도 불가, advisory)
+sellable + actionable quote           → sell_review     (reviewable 표면화, 추천 아님)
+그 외 신선·정상                        → keep            (기본값)
+trim_review / add_review              → (빈 슬롯) Hermes push가 채움
+```
+
+- **Toss/manual은 `reference_holdings`로만** — 절대 KIS sellable로 승격하지 않음 (ROB-297 가드 재사용, 회귀테스트로 고정).
+- `user_id=None`이면 portfolio collector가 이미 `primary_source="none"`/`freshness="unavailable"` 반환 → held_actions 대신 "portfolio unavailable" data_gap으로 fail-closed.
+
+### §3.4 신규 후보 결정론 분류기 + screener freshness 게이트
+
+candidate_universe collector 결과에 freshness 게이트 적용:
+
+```
+stale-only screener candidate         → 신규매수 후보에서 제외 + 사유 기록
+fresh candidate + actionable quote    → buy_review
+fresh candidate + 애매한 evidence     → watch_only
+quote unavailable                     → data_gap
+명시적 제외 사유                       → rejected
+limit_wait                            → evidence 상태만 표시 (목표가 계산은 ROB-337)
+```
+
+- 후보가 0개거나 전부 stale이면 `no_new_buy_candidates` 섹션에 "신규 후보 없음 + 이유"를 항상 남김 (§3.1 invariant가 보장).
+
+### §3.5 data_gap / market·news 연결
+
+- `data_gaps_for_next_cycle` = bundle `coverage_summary.missing_sources` + 심볼별 unavailable quote + stale screener를 종합.
+- market issues/news context(이미 수집됨)를 ActionPacket 판단 근거(`evidence_snapshot`)로 연결. 새 수집기 없음 — 기존 news 스냅샷 참조만.
+
+### §3.6 프론트엔드 surface (PR2)
+
+ROB-322 5-section UI를 확장해 `/invest/reports` 최신 화면에 4개 헤더를 명시 렌더: **오늘의 보유 액션 / 신규 후보 / 리스크 / 데이터 부족**. sub-verdict는 chip으로 표시. ActionPacket projection을 read-model payload로 노출하고 ROB-275/evidence viewer 호환을 유지.
+
+## 4. 안전 경계 (Non-goals)
+
+- 주문 preview/submit/cancel/modify 금지.
+- broker/order/watch/order-intent mutation 금지 — DB row 무변화를 테스트/smoke evidence로 증명.
+- recurring scheduler/Prefect deployment 활성화 금지 (operator-triggered MVP까지만).
+- 전 경로 `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED` 게이트 유지.
+- Naver/Toss Chrome remote-debug persistence는 별도 후속 — core MCP/DB/read-model 기반으로 먼저 답이 나오게 한다.
+- US/crypto/NXT 확장 = ROB-336 Phase 2. 매수가격 모델 = ROB-337.
+- `user_id` 없으면 KIS live portfolio는 fail-closed/unavailable — 임의 기본 사용자 대체 금지.
+- ROB-332 `validated_run_card` ingest/citation 재구현 금지. 기존 `evidence_snapshot["run_card"]` 동작 보존, run-card verdict/`is_pass_stamp`를 buy/sell 강도로 사용 금지 (optional 보조/감사 evidence로만).
+
+## 5. Acceptance criteria
+
+- 실제 KR/KIS live intraday report 생성 시 `items=[]`로 성공하지 않는다.
+- 신규 후보가 없거나 stale-only여도 리포트에 "신규 후보 없음"과 이유가 남는다.
+- 보유종목은 최소한 `sell_review/trim_review/keep/no_add/add_review` 중 하나로 분류된다 (결정론 기본은 `keep`, 방향성은 evidence/Hermes).
+- quote/orderbook/spread/liquidity unavailable인 종목은 무리하게 buy/sell로 분류하지 않고 data_gap 또는 wait/review로 분류한다.
+- stale screener candidate가 "오늘 신규매수 후보"로 노출되지 않는다.
+- KIS live와 Toss/reference holdings의 권위가 섞이지 않는 regression test가 있다.
+- broker/order/watch/order-intent 관련 DB row 변화가 없음을 테스트 또는 smoke evidence로 남긴다.
+- ROB-275/evidence viewer 호환성이 깨지지 않는다.
+
+## 6. 테스트 전략
+
+- **단위:** held classifier, candidate classifier, ActionPacket projection, sub-verdict→bucket 매핑.
+- **회귀:**
+  1. empty candidate/empty action → no-action/data-gap 섹션 emit (빈 성공 금지).
+  2. stale-only screener candidate → live buy 후보에서 제외.
+  3. `user_id=None` → fail-closed (portfolio unavailable data_gap).
+  4. KIS live vs Toss/reference 권위 미혼합.
+- **안전:** broker/order/watch/order-intent DB row 무변화를 테스트/smoke evidence로 기록.
+- **로컬 smoke:** read-only KR/KIS live advisory 리포트 1건 생성 후 bundle + UI payload 검사.
+- 참고: `frontend/invest` vitest는 `--pool=forks`로 실행 (threads pool flaky). baseline 5건 pre-existing 실패 존재.
+
+## 7. PR 슬라이싱
+
+- **PR1 (백엔드 코어):** §3.1 intent/invariant + §3.3 held classifier + §3.4 candidate classifier + §3.5 data_gap + §3.2 ActionPacket projection + §6 백엔드 테스트.
+- **PR2 (프론트):** §3.6 surface 렌더 + read-model payload 노출 + 프론트 테스트.
+- 마이그레이션 없음 → PR0 불필요. PR1 머지 후 fresh `main`에서 PR2 시작.
+
+## 8. 미해결/후속
+
+- `trim_review`/`add_review`의 명시 정책 규칙(비중/미실현손익 임계치)은 본 MVP 범위 밖 — Hermes push로 채우고, 필요 시 별도 이슈에서 결정론 정책화.
+- 매수가격(목표가) 산정 = ROB-337.
+- US/crypto/KR NXT 확장 = ROB-336.
+- recurring scheduler/Prefect 등록 = 후속 (operator-triggered MVP 검증 후).

--- a/tests/services/action_report/snapshot_backed/test_action_verdict.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict.py
@@ -1,0 +1,52 @@
+# tests/services/action_report/snapshot_backed/test_action_verdict.py
+"""ROB-335 — sub-verdict vocabulary, bucket mapping, held-symbol rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.investment_symbol_intermediate_reports import DECISION_BUCKETS
+from app.services.action_report.snapshot_backed.action_verdict import (
+    ACTION_VERDICTS,
+    VERDICT_TO_BUCKET,
+    classify_held_symbol,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_verdict_maps_to_a_locked_decision_bucket() -> None:
+    # B/A: sub-verdicts are sub-labels over the locked 5-value enum — every
+    # verdict must map onto an existing decision_bucket (no new enum value).
+    assert set(VERDICT_TO_BUCKET) == set(ACTION_VERDICTS)
+    for verdict, bucket in VERDICT_TO_BUCKET.items():
+        assert bucket in DECISION_BUCKETS, (verdict, bucket)
+
+
+def test_held_unactionable_quote_is_data_gap() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    quote = {"status": "unavailable"}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "data_gap"
+
+
+def test_held_missing_quote_is_data_gap() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    assert classify_held_symbol(holding, None, in_candidate_universe=False) == "data_gap"
+
+
+def test_held_sellable_with_actionable_quote_is_sell_review() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 10}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "bid_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "sell_review"
+
+
+def test_held_not_sellable_but_trending_is_no_add() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 0}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "ask_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=True) == "no_add"
+
+
+def test_held_not_sellable_not_trending_is_keep() -> None:
+    holding = {"ticker": "005930", "sellable_quantity": 0}
+    quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "ask_depth": 5.0}
+    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "keep"

--- a/tests/services/action_report/snapshot_backed/test_action_verdict.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict.py
@@ -26,18 +26,25 @@ def test_every_verdict_maps_to_a_locked_decision_bucket() -> None:
 def test_held_unactionable_quote_is_data_gap() -> None:
     holding = {"ticker": "005930", "sellable_quantity": 10}
     quote = {"status": "unavailable"}
-    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "data_gap"
+    assert (
+        classify_held_symbol(holding, quote, in_candidate_universe=False) == "data_gap"
+    )
 
 
 def test_held_missing_quote_is_data_gap() -> None:
     holding = {"ticker": "005930", "sellable_quantity": 10}
-    assert classify_held_symbol(holding, None, in_candidate_universe=False) == "data_gap"
+    assert (
+        classify_held_symbol(holding, None, in_candidate_universe=False) == "data_gap"
+    )
 
 
 def test_held_sellable_with_actionable_quote_is_sell_review() -> None:
     holding = {"ticker": "005930", "sellable_quantity": 10}
     quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "bid_depth": 5.0}
-    assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "sell_review"
+    assert (
+        classify_held_symbol(holding, quote, in_candidate_universe=False)
+        == "sell_review"
+    )
 
 
 def test_held_not_sellable_but_trending_is_no_add() -> None:

--- a/tests/services/action_report/snapshot_backed/test_auto_emit.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit.py
@@ -457,10 +457,13 @@ def test_existing_sell_item_is_stamped_with_verdict_and_bucket() -> None:
     # Default mode (no intraday_floor): existing sell candidate now carries the
     # ActionPacket sub-verdict + decision_bucket so it projects.
     snapshots = [
-        _make_snapshot(kind="portfolio",
-                       payload=_kis_portfolio_payload(ticker="005930", sellable=5.0)),
-        _make_snapshot(kind="symbol", symbol="005930",
-                       payload=_ok_quote_payload("005930")),
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=5.0),
+        ),
+        _make_snapshot(
+            kind="symbol", symbol="005930", payload=_ok_quote_payload("005930")
+        ),
     ]
     items = EvidenceAutoEmitter().propose(
         snapshots=snapshots, request_market="kr", account_scope="kis_live"
@@ -474,8 +477,10 @@ def test_intraday_floor_classifies_every_held_symbol() -> None:
     # Held symbol with NO actionable quote -> data_gap item (would be skipped
     # entirely in default mode).
     snapshots = [
-        _make_snapshot(kind="portfolio",
-                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=0.0),
+        ),
     ]
     items = EvidenceAutoEmitter(intraday_floor=True).propose(
         snapshots=snapshots, request_market="kr", account_scope="kis_live"
@@ -487,16 +492,20 @@ def test_intraday_floor_classifies_every_held_symbol() -> None:
 
 def test_intraday_floor_emits_no_new_buy_marker_when_stale_only() -> None:
     snapshots = [
-        _make_snapshot(kind="portfolio",
-                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
-        _make_snapshot(kind="candidate_universe",
-                       payload=_candidate_payload("stale_only")),
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=0.0),
+        ),
+        _make_snapshot(
+            kind="candidate_universe", payload=_candidate_payload("stale_only")
+        ),
     ]
     items = EvidenceAutoEmitter(intraday_floor=True).propose(
         snapshots=snapshots, request_market="kr", account_scope="kis_live"
     )
     marker = next(
-        i for i in items
+        i
+        for i in items
         if i.evidence_snapshot.get("action_verdict") == "no_new_buy_candidates"
     )
     assert marker.symbol is None
@@ -507,10 +516,13 @@ def test_intraday_floor_emits_no_new_buy_marker_when_stale_only() -> None:
 def test_default_mode_emits_no_marker_and_no_keep_items() -> None:
     # Backwards-compat: without intraday_floor, behaviour is unchanged.
     snapshots = [
-        _make_snapshot(kind="portfolio",
-                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
-        _make_snapshot(kind="candidate_universe",
-                       payload=_candidate_payload("stale_only")),
+        _make_snapshot(
+            kind="portfolio",
+            payload=_kis_portfolio_payload(ticker="005930", sellable=0.0),
+        ),
+        _make_snapshot(
+            kind="candidate_universe", payload=_candidate_payload("stale_only")
+        ),
     ]
     items = EvidenceAutoEmitter().propose(
         snapshots=snapshots, request_market="kr", account_scope="kis_live"
@@ -527,28 +539,38 @@ def test_intraday_floor_never_classifies_reference_holdings() -> None:
         "primary_source": "manual",
         "holdings": [{"ticker": "AAPL", "sellable_quantity": 3, "source": "manual"}],
         "reference_holdings": [{"ticker": "AAPL", "source": "toss"}],
-        "count": 1, "market": "us",
+        "count": 1,
+        "market": "us",
     }
     snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
     items = EvidenceAutoEmitter(intraday_floor=True).propose(
         snapshots=snapshots, request_market="us", account_scope="kis_live"
     )
-    assert all(i.symbol != "AAPL" for i in items if i.evidence_snapshot.get("action_verdict") in
-               {"sell_review", "keep", "no_add"})
+    assert all(
+        i.symbol != "AAPL"
+        for i in items
+        if i.evidence_snapshot.get("action_verdict")
+        in {"sell_review", "keep", "no_add"}
+    )
 
 
 def test_intraday_floor_user_id_missing_portfolio_yields_no_held_items() -> None:
     # primary_source='none' (user_id missing path) -> no holdings to classify;
     # the generator-level floor (Task 5) supplies the data_gap item instead.
     payload = {
-        "primary_source": "none", "holdings": [], "reference_holdings": [],
-        "count": 0, "market": "kr",
+        "primary_source": "none",
+        "holdings": [],
+        "reference_holdings": [],
+        "count": 0,
+        "market": "kr",
     }
     snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
     items = EvidenceAutoEmitter(intraday_floor=True).propose(
         snapshots=snapshots, request_market="kr", account_scope="kis_live"
     )
     held_verdicts = {"sell_review", "keep", "no_add", "data_gap"}
-    assert not [i for i in items if i.symbol and
-                i.evidence_snapshot.get("action_verdict") in held_verdicts]
-
+    assert not [
+        i
+        for i in items
+        if i.symbol and i.evidence_snapshot.get("action_verdict") in held_verdicts
+    ]

--- a/tests/services/action_report/snapshot_backed/test_auto_emit.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit.py
@@ -451,3 +451,104 @@ def test_all_emitted_items_are_review_and_require_user_approval():
         assert item.evidence_snapshot is not None
         assert item.evidence_snapshot.get("snapshot_uuid")
         assert item.evidence_snapshot.get("proposer", "").startswith("auto_emit/")
+
+
+def test_existing_sell_item_is_stamped_with_verdict_and_bucket() -> None:
+    # Default mode (no intraday_floor): existing sell candidate now carries the
+    # ActionPacket sub-verdict + decision_bucket so it projects.
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=5.0)),
+        _make_snapshot(kind="symbol", symbol="005930",
+                       payload=_ok_quote_payload("005930")),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    sell = next(i for i in items if i.symbol == "005930" and i.side == "sell")
+    assert sell.evidence_snapshot["action_verdict"] == "sell_review"
+    assert sell.decision_bucket == "open_action"
+
+
+def test_intraday_floor_classifies_every_held_symbol() -> None:
+    # Held symbol with NO actionable quote -> data_gap item (would be skipped
+    # entirely in default mode).
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+    ]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    held = next(i for i in items if i.symbol == "005930")
+    assert held.evidence_snapshot["action_verdict"] == "data_gap"
+    assert held.decision_bucket == "deferred_no_action"
+
+
+def test_intraday_floor_emits_no_new_buy_marker_when_stale_only() -> None:
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+        _make_snapshot(kind="candidate_universe",
+                       payload=_candidate_payload("stale_only")),
+    ]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    marker = next(
+        i for i in items
+        if i.evidence_snapshot.get("action_verdict") == "no_new_buy_candidates"
+    )
+    assert marker.symbol is None
+    assert marker.decision_bucket == "new_buy_candidate"
+    assert marker.item_kind == "risk"
+
+
+def test_default_mode_emits_no_marker_and_no_keep_items() -> None:
+    # Backwards-compat: without intraday_floor, behaviour is unchanged.
+    snapshots = [
+        _make_snapshot(kind="portfolio",
+                       payload=_kis_portfolio_payload(ticker="005930", sellable=0.0)),
+        _make_snapshot(kind="candidate_universe",
+                       payload=_candidate_payload("stale_only")),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    verdicts = {i.evidence_snapshot.get("action_verdict") for i in items}
+    assert "no_new_buy_candidates" not in verdicts
+    assert "keep" not in verdicts
+
+
+def test_intraday_floor_never_classifies_reference_holdings() -> None:
+    # Toss/manual rows live in reference_holdings; primary_source != 'kis'
+    # means _held_kis_symbols returns {} -> no held_actions promoted.
+    payload = {
+        "primary_source": "manual",
+        "holdings": [{"ticker": "AAPL", "sellable_quantity": 3, "source": "manual"}],
+        "reference_holdings": [{"ticker": "AAPL", "source": "toss"}],
+        "count": 1, "market": "us",
+    }
+    snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="us", account_scope="kis_live"
+    )
+    assert all(i.symbol != "AAPL" for i in items if i.evidence_snapshot.get("action_verdict") in
+               {"sell_review", "keep", "no_add"})
+
+
+def test_intraday_floor_user_id_missing_portfolio_yields_no_held_items() -> None:
+    # primary_source='none' (user_id missing path) -> no holdings to classify;
+    # the generator-level floor (Task 5) supplies the data_gap item instead.
+    payload = {
+        "primary_source": "none", "holdings": [], "reference_holdings": [],
+        "count": 0, "market": "kr",
+    }
+    snapshots = [_make_snapshot(kind="portfolio", payload=payload)]
+    items = EvidenceAutoEmitter(intraday_floor=True).propose(
+        snapshots=snapshots, request_market="kr", account_scope="kis_live"
+    )
+    held_verdicts = {"sell_review", "keep", "no_add", "data_gap"}
+    assert not [i for i in items if i.symbol and
+                i.evidence_snapshot.get("action_verdict") in held_verdicts]
+

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -154,7 +154,7 @@ async def test_happy_path_kr_published(monkeypatch: pytest.MonkeyPatch) -> None:
     assert response.report_uuid == ingest.report_uuid
     assert response.bundle_status == "complete"
     assert response.snapshot_freshness_summary["overall"] == "fresh"
-    assert response.items_count == 0
+    assert response.items_count == 1
     assert response.warnings == []
     assert response.bundle_reused is False
     assert response.unavailable_sources == {}

--- a/tests/services/action_report/snapshot_backed/test_generator_regression.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_regression.py
@@ -48,3 +48,53 @@ async def test_generator_uses_legacy_path_by_default(db_session):
 
     assert "bundle ensure returned no bundle_uuid" in str(exc.value)
     ensure_mock.ensure.assert_called_once()
+
+
+from tests.services.action_report.snapshot_backed.test_generator import (
+    _FakeEnsureService,
+    _FakeIngestionService,
+    _FakeSnapshotsRepository,
+    _ensure_response,
+    _make_request,
+)
+
+
+@pytest.mark.asyncio
+async def test_intraday_report_never_empty_items() -> None:
+    # market=kr/account=kis_live, user_id=None (portfolio unavailable),
+    # 빈 후보 -> 생성 결과 items_count >= 1, floor item은 data_gap.
+    ensure = _FakeEnsureService(
+        _ensure_response(
+            status="partial",
+            freshness_summary={
+                "overall": "unavailable",
+                "portfolio": {
+                    "status": "unavailable",
+                    "reason_code": "user_id_missing",
+                },
+                "journal": {"status": "fresh"},
+                "watch_context": {"status": "fresh"},
+                "market": {"status": "fresh"},
+            },
+            missing_sources=["portfolio"],
+        )
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    # policy_version defaults to "intraday_action_report_v1" in _make_request
+    response = await gen.generate(_make_request(status="draft"))
+    assert response.items_count >= 1
+
+    # Verify that the floor item has decision_bucket == "deferred_no_action" and action_verdict == "data_gap"
+    assert len(ingest.calls) == 1
+    sent = ingest.calls[0]
+    assert len(sent.items) == 1
+    item = sent.items[0]
+    assert item.decision_bucket == "deferred_no_action"
+    assert item.evidence_snapshot["action_verdict"] == "data_gap"
+

--- a/tests/services/action_report/snapshot_backed/test_generator_regression.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_regression.py
@@ -1,18 +1,28 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
 from app.services.action_report.snapshot_backed.generator import (
     SnapshotBackedReportGenerator,
+    SnapshotBackedReportGeneratorError,
 )
 from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+from tests.services.action_report.snapshot_backed.test_generator import (
+    _ensure_response,
+    _FakeEnsureService,
+    _FakeIngestionService,
+    _FakeSnapshotsRepository,
+    _make_request,
+)
 
 
 @pytest.mark.asyncio
 async def test_generator_uses_legacy_path_by_default(db_session):
     # Ensure the ensure_service returns a simulated bundle response
     ensure_mock = AsyncMock()
-    from types import SimpleNamespace
 
     ensure_mock.ensure.return_value = SimpleNamespace(
         bundle_uuid=None,  # Will raise early, proving it hit the main generate path before stage runner
@@ -39,24 +49,11 @@ async def test_generator_uses_legacy_path_by_default(db_session):
         auto_compose=False,  # default
     )
 
-    from app.services.action_report.snapshot_backed.generator import (
-        SnapshotBackedReportGeneratorError,
-    )
-
     with pytest.raises(SnapshotBackedReportGeneratorError) as exc:
         await generator.generate(request)
 
     assert "bundle ensure returned no bundle_uuid" in str(exc.value)
     ensure_mock.ensure.assert_called_once()
-
-
-from tests.services.action_report.snapshot_backed.test_generator import (
-    _FakeEnsureService,
-    _FakeIngestionService,
-    _FakeSnapshotsRepository,
-    _ensure_response,
-    _make_request,
-)
 
 
 @pytest.mark.asyncio
@@ -97,4 +94,3 @@ async def test_intraday_report_never_empty_items() -> None:
     item = sent.items[0]
     assert item.decision_bucket == "deferred_no_action"
     assert item.evidence_snapshot["action_verdict"] == "data_gap"
-

--- a/tests/services/action_report/snapshot_backed/test_intraday_floor.py
+++ b/tests/services/action_report/snapshot_backed/test_intraday_floor.py
@@ -1,0 +1,53 @@
+# tests/services/action_report/snapshot_backed/test_intraday_floor.py
+"""ROB-335 — intraday non-empty floor guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.action_report.snapshot_backed.intraday_floor import (
+    ensure_action_floor,
+    is_intraday_action,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_is_intraday_action_matches_policy_version() -> None:
+    assert is_intraday_action("intraday_action_report_v1") is True
+    assert is_intraday_action("snapshot_backed_advisory_v1") is False
+    assert is_intraday_action(None) is False
+
+
+def test_floor_synthesizes_one_item_when_empty() -> None:
+    why = {"kind": "data_insufficient", "reason_ko": "데이터 부족 — portfolio 확인 불가",
+           "blocking_sources": ["portfolio"]}
+    out = ensure_action_floor([], why_no_action=why)
+    assert len(out) == 1
+    item = out[0]
+    assert item.evidence_snapshot["action_verdict"] == "data_gap"
+    assert item.decision_bucket == "deferred_no_action"
+    assert item.rationale == why["reason_ko"]
+
+
+def test_floor_real_no_action_uses_no_action_verdict() -> None:
+    why = {"kind": "real_no_action", "reason_ko": "데이터 충분 — 현 시점 신규 액션 없음(관망)",
+           "blocking_sources": []}
+    out = ensure_action_floor([], why_no_action=why)
+    assert out[0].evidence_snapshot["action_verdict"] == "keep"
+    assert out[0].decision_bucket == "completed_or_existing"
+
+
+def test_floor_is_noop_when_items_present() -> None:
+    existing = [
+        IngestReportItem(
+            client_item_key="x", item_kind="action", symbol="005930", side="sell",
+            intent="sell_review", rationale="r", operation="review",
+            apply_policy="requires_user_approval",
+            evidence_snapshot={"action_verdict": "sell_review"},
+            decision_bucket="open_action",
+        )
+    ]
+    out = ensure_action_floor(existing, why_no_action=None)
+    assert out == existing

--- a/tests/services/action_report/snapshot_backed/test_intraday_floor.py
+++ b/tests/services/action_report/snapshot_backed/test_intraday_floor.py
@@ -21,8 +21,11 @@ def test_is_intraday_action_matches_policy_version() -> None:
 
 
 def test_floor_synthesizes_one_item_when_empty() -> None:
-    why = {"kind": "data_insufficient", "reason_ko": "데이터 부족 — portfolio 확인 불가",
-           "blocking_sources": ["portfolio"]}
+    why = {
+        "kind": "data_insufficient",
+        "reason_ko": "데이터 부족 — portfolio 확인 불가",
+        "blocking_sources": ["portfolio"],
+    }
     out = ensure_action_floor([], why_no_action=why)
     assert len(out) == 1
     item = out[0]
@@ -32,8 +35,11 @@ def test_floor_synthesizes_one_item_when_empty() -> None:
 
 
 def test_floor_real_no_action_uses_no_action_verdict() -> None:
-    why = {"kind": "real_no_action", "reason_ko": "데이터 충분 — 현 시점 신규 액션 없음(관망)",
-           "blocking_sources": []}
+    why = {
+        "kind": "real_no_action",
+        "reason_ko": "데이터 충분 — 현 시점 신규 액션 없음(관망)",
+        "blocking_sources": [],
+    }
     out = ensure_action_floor([], why_no_action=why)
     assert out[0].evidence_snapshot["action_verdict"] == "keep"
     assert out[0].decision_bucket == "completed_or_existing"
@@ -42,8 +48,13 @@ def test_floor_real_no_action_uses_no_action_verdict() -> None:
 def test_floor_is_noop_when_items_present() -> None:
     existing = [
         IngestReportItem(
-            client_item_key="x", item_kind="action", symbol="005930", side="sell",
-            intent="sell_review", rationale="r", operation="review",
+            client_item_key="x",
+            item_kind="action",
+            symbol="005930",
+            side="sell",
+            intent="sell_review",
+            rationale="r",
+            operation="review",
             apply_policy="requires_user_approval",
             evidence_snapshot={"action_verdict": "sell_review"},
             decision_bucket="open_action",

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -1,0 +1,29 @@
+# tests/services/investment_reports/test_action_packet.py
+"""ROB-335 — ActionPacket read-time projection + schema."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import (
+    ActionPacket,
+    InvestmentReportBundle,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_action_packet_defaults_are_empty() -> None:
+    packet = ActionPacket()
+    assert packet.held_actions == []
+    assert packet.new_buy_candidates == []
+    assert packet.no_new_buy_reason is None
+    assert packet.risk_reviews == []
+    assert packet.no_action_reason is None
+    assert packet.data_gaps_for_next_cycle == []
+
+
+def test_bundle_action_packet_field_is_optional() -> None:
+    # Additive, null for legacy reports (mirrors review_sections).
+    assert "action_packet" in InvestmentReportBundle.model_fields
+    assert InvestmentReportBundle.model_fields["action_packet"].default is None

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -27,3 +27,104 @@ def test_bundle_action_packet_field_is_optional() -> None:
     # Additive, null for legacy reports (mirrors review_sections).
     assert "action_packet" in InvestmentReportBundle.model_fields
     assert InvestmentReportBundle.model_fields["action_packet"].default is None
+
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from app.schemas.investment_reports import InvestmentReportItemResponse
+from app.services.investment_reports.action_packet import build_action_packet
+
+_NOW = datetime(2026, 5, 27, tzinfo=UTC)
+
+
+def _item(
+    *,
+    verdict: str | None,
+    decision_bucket: str | None,
+    symbol: str | None = "005930",
+    item_kind: str = "action",
+    side: str | None = "sell",
+    intent: str = "sell_review",
+) -> InvestmentReportItemResponse:
+    evidence = {"action_verdict": verdict} if verdict is not None else {}
+    return InvestmentReportItemResponse(
+        item_uuid=uuid4(),
+        item_kind=item_kind,  # type: ignore[arg-type]
+        symbol=symbol,
+        side=side,  # type: ignore[arg-type]
+        intent=intent,  # type: ignore[arg-type]
+        target_kind="asset",
+        priority=0,
+        confidence=Decimal("80"),
+        rationale="r",
+        evidence_snapshot=evidence,
+        watch_condition=None,
+        trigger_checklist=[],
+        max_action={},
+        valid_until=None,
+        status="proposed",
+        metadata={},
+        created_at=_NOW,
+        updated_at=_NOW,
+        decision_bucket=decision_bucket,
+    )
+
+
+def test_held_and_new_and_risk_are_grouped_by_verdict() -> None:
+    items = [
+        _item(verdict="sell_review", decision_bucket="open_action"),
+        _item(verdict="keep", decision_bucket="completed_or_existing", side=None),
+        _item(verdict="buy_review", decision_bucket="new_buy_candidate", side="buy",
+              intent="buy_review", symbol="000660"),
+        _item(verdict="watch_only", decision_bucket="risk_watch", item_kind="watch",
+              side=None, intent="trend_recovery_review", symbol="035720"),
+    ]
+    packet = build_action_packet(items, diagnostics=None)
+    assert {e.verdict for e in packet.held_actions} == {"sell_review", "keep"}
+    assert [e.verdict for e in packet.new_buy_candidates] == ["buy_review"]
+    assert [e.verdict for e in packet.risk_reviews] == ["watch_only"]
+
+
+def test_no_new_buy_marker_sets_reason_not_a_candidate_row() -> None:
+    marker = _item(
+        verdict="no_new_buy_candidates",
+        decision_bucket="new_buy_candidate",
+        symbol=None,
+        side=None,
+        intent="risk_review",
+        item_kind="risk",
+    )
+    marker.rationale = "국내 스크리너 스냅샷이 최신 거래일 기준이 아닙니다 (stale)."
+    packet = build_action_packet([marker], diagnostics=None)
+    assert packet.new_buy_candidates == []
+    assert packet.no_new_buy_reason == marker.rationale
+
+
+def test_data_gaps_from_items_and_diagnostics() -> None:
+    items = [_item(verdict="data_gap", decision_bucket="deferred_no_action",
+                   symbol="005930", side=None, intent="risk_review", item_kind="risk")]
+    diagnostics = {
+        "why_no_action": {"kind": "data_insufficient", "reason_ko": "데이터 부족",
+                          "blocking_sources": ["portfolio"]},
+        "data_sufficiency_by_source": {
+            "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
+            "symbol": {"status": "fresh"},
+        },
+    }
+    packet = build_action_packet(items, diagnostics=diagnostics)
+    assert packet.no_action_reason is not None
+    assert packet.no_action_reason.kind == "data_insufficient"
+    # symbol-level data_gap item + degraded source from diagnostics both surface.
+    sources = {g.source for g in packet.data_gaps_for_next_cycle}
+    assert "005930" in sources
+    assert "portfolio" in sources
+
+
+def test_items_without_verdict_are_not_projected() -> None:
+    # Legacy items (no action_verdict) stay out of the packet (decision A/B).
+    items = [_item(verdict=None, decision_bucket="open_action")]
+    packet = build_action_packet(items, diagnostics=None)
+    assert packet.held_actions == []
+

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -128,3 +128,16 @@ def test_items_without_verdict_are_not_projected() -> None:
     packet = build_action_packet(items, diagnostics=None)
     assert packet.held_actions == []
 
+
+def test_serialise_attaches_action_packet(monkeypatch) -> None:
+    # _serialise_bundle should project items into bundle.action_packet using
+    # the same build_action_packet path (additive, never None for intraday).
+    from app.routers import investment_reports as mod
+
+    items = [_item(verdict="sell_review", decision_bucket="open_action")]
+    packet = build_action_packet(items, diagnostics=None)
+    assert packet.held_actions  # sanity: projection works on these items
+    # The router import wires build_action_packet:
+    assert hasattr(mod, "build_action_packet")
+
+

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -74,10 +74,21 @@ def test_held_and_new_and_risk_are_grouped_by_verdict() -> None:
     items = [
         _item(verdict="sell_review", decision_bucket="open_action"),
         _item(verdict="keep", decision_bucket="completed_or_existing", side=None),
-        _item(verdict="buy_review", decision_bucket="new_buy_candidate", side="buy",
-              intent="buy_review", symbol="000660"),
-        _item(verdict="watch_only", decision_bucket="risk_watch", item_kind="watch",
-              side=None, intent="trend_recovery_review", symbol="035720"),
+        _item(
+            verdict="buy_review",
+            decision_bucket="new_buy_candidate",
+            side="buy",
+            intent="buy_review",
+            symbol="000660",
+        ),
+        _item(
+            verdict="watch_only",
+            decision_bucket="risk_watch",
+            item_kind="watch",
+            side=None,
+            intent="trend_recovery_review",
+            symbol="035720",
+        ),
     ]
     packet = build_action_packet(items, diagnostics=None)
     assert {e.verdict for e in packet.held_actions} == {"sell_review", "keep"}
@@ -101,11 +112,22 @@ def test_no_new_buy_marker_sets_reason_not_a_candidate_row() -> None:
 
 
 def test_data_gaps_from_items_and_diagnostics() -> None:
-    items = [_item(verdict="data_gap", decision_bucket="deferred_no_action",
-                   symbol="005930", side=None, intent="risk_review", item_kind="risk")]
+    items = [
+        _item(
+            verdict="data_gap",
+            decision_bucket="deferred_no_action",
+            symbol="005930",
+            side=None,
+            intent="risk_review",
+            item_kind="risk",
+        )
+    ]
     diagnostics = {
-        "why_no_action": {"kind": "data_insufficient", "reason_ko": "데이터 부족",
-                          "blocking_sources": ["portfolio"]},
+        "why_no_action": {
+            "kind": "data_insufficient",
+            "reason_ko": "데이터 부족",
+            "blocking_sources": ["portfolio"],
+        },
         "data_sufficiency_by_source": {
             "portfolio": {"status": "unavailable", "reason_code": "user_id_missing"},
             "symbol": {"status": "fresh"},

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -3,38 +3,20 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
 import pytest
 
 from app.schemas.investment_reports import (
     ActionPacket,
     InvestmentReportBundle,
+    InvestmentReportItemResponse,
 )
+from app.services.investment_reports.action_packet import build_action_packet
 
 pytestmark = pytest.mark.unit
-
-
-def test_action_packet_defaults_are_empty() -> None:
-    packet = ActionPacket()
-    assert packet.held_actions == []
-    assert packet.new_buy_candidates == []
-    assert packet.no_new_buy_reason is None
-    assert packet.risk_reviews == []
-    assert packet.no_action_reason is None
-    assert packet.data_gaps_for_next_cycle == []
-
-
-def test_bundle_action_packet_field_is_optional() -> None:
-    # Additive, null for legacy reports (mirrors review_sections).
-    assert "action_packet" in InvestmentReportBundle.model_fields
-    assert InvestmentReportBundle.model_fields["action_packet"].default is None
-
-
-from datetime import UTC, datetime
-from decimal import Decimal
-from uuid import uuid4
-
-from app.schemas.investment_reports import InvestmentReportItemResponse
-from app.services.investment_reports.action_packet import build_action_packet
 
 _NOW = datetime(2026, 5, 27, tzinfo=UTC)
 
@@ -70,6 +52,22 @@ def _item(
         updated_at=_NOW,
         decision_bucket=decision_bucket,
     )
+
+
+def test_action_packet_defaults_are_empty() -> None:
+    packet = ActionPacket()
+    assert packet.held_actions == []
+    assert packet.new_buy_candidates == []
+    assert packet.no_new_buy_reason is None
+    assert packet.risk_reviews == []
+    assert packet.no_action_reason is None
+    assert packet.data_gaps_for_next_cycle == []
+
+
+def test_bundle_action_packet_field_is_optional() -> None:
+    # Additive, null for legacy reports (mirrors review_sections).
+    assert "action_packet" in InvestmentReportBundle.model_fields
+    assert InvestmentReportBundle.model_fields["action_packet"].default is None
 
 
 def test_held_and_new_and_risk_are_grouped_by_verdict() -> None:
@@ -139,5 +137,3 @@ def test_serialise_attaches_action_packet(monkeypatch) -> None:
     assert packet.held_actions  # sanity: projection works on these items
     # The router import wires build_action_packet:
     assert hasattr(mod, "build_action_packet")
-
-


### PR DESCRIPTION
## ROB-335 — `/invest/reports` 매일 장중 액션 사이클 MVP (PR1: 백엔드 코어)

장중 운영자가 한 번 실행하면 "보유 액션 / 신규 후보 / 리스크 / 데이터 부족"에 반드시 답하는 `intraday_action` 리포트를 만든다. **빈 리포트 성공(`items=[]`)을 금지**하고, 모든 KIS 보유종목을 결정론 verdict로 분류하며, 신규후보 없음·데이터 부족 사유를 ActionPacket으로 read-time projection 한다.

설계/계획 문서:
- spec: `docs/superpowers/specs/2026-05-27-rob-335-intraday-action-cycle-design.md`
- plan: `docs/superpowers/plans/2026-05-27-rob-335-intraday-action-cycle.md`

### 확정 설계 (마이그레이션 없음)
- **A**: ActionPacket sub-verdict = locked 5값 `decision_bucket` 위 sub-label (enum 변경 없음, ROB-322 호환)
- **B**: sub-verdict는 item `evidence_snapshot["action_verdict"]`(JSON)에 저장, ActionPacket section은 read-time projection
- **C/C′**: 결정론은 정직한 verdict만 부여 — `data_gap`/`keep`/`no_add`/`sell_review`; `trim_review`/`add_review`/`limit_wait`는 Hermes push에 유보 (in-process LLM 없음, ROB-287)
- **D**: `limit_wait`은 evidence 상태만 표면화, 목표 매수가 계산은 ROB-337로 이양

### 변경 요약
- `action_verdict.py` — sub-verdict 어휘 + `VERDICT_TO_BUCKET` + 순수 `classify_held_symbol`
- `auto_emit.py` — 기존 sell/buy/watch item에 verdict+bucket 스탬프; `intraday_floor` 모드에서 **모든 KIS 보유종목 전수분류** + `no_new_buy_candidates` 마커
- `intraday_floor.py` + generator — `intraday_action`이면 잔여 빈 케이스를 구조적 item 1건으로 보강(non-empty invariant)
- `action_packet.py` + 라우터 — bundle 읽기모델에 ActionPacket projection 첨부
- ActionPacket 스키마 + `InvestmentReportBundle.action_packet` 필드 (additive)

### Acceptance criteria
- [x] 실제 KR/KIS live intraday report가 `items=[]`로 성공하지 않음
- [x] 신규후보 없음/stale-only여도 "신규 후보 없음 + 이유" 남음
- [x] 보유종목은 `sell_review/keep/no_add/data_gap` 중 하나로 분류 (방향성은 evidence/Hermes)
- [x] quote/orderbook unavailable → 무리한 buy/sell 대신 `data_gap`
- [x] stale screener candidate는 신규매수 후보로 노출 안 됨 (기존 게이트 + 사유)
- [x] KIS live vs Toss/reference 권위 미혼합 회귀 테스트
- [x] broker/order/watch/order-intent mutation 도달 불가 (import guard 유지)

### 안전 경계
주문 preview/submit/cancel/modify 없음, broker/order/watch/order-intent mutation 없음, scheduler/Prefect 활성화 없음, 마이그레이션 없음. 전 경로 advisory-only.

### 테스트
- `tests/services/action_report/` + `tests/services/investment_reports/` → 358 passed
- no-internal-LLM / mutation import guard → 38 passed
- `ruff check app/ tests/` → All checks passed

### 후속
- **PR2 (프론트)**: `/invest/reports` 화면에 4헤더 + sub-verdict chip 렌더 (별도 plan, PR1 머지 후 fresh main에서)
- US/crypto/NXT 확장 = ROB-336, 매수가격 모델 = ROB-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced ActionPacket view for investment reports, organizing held actions, new buy candidates, risk reviews, and data gaps into a structured projection.
  * Added action verdicts/sub-labels to report items for improved classification and visibility.
  * Intraday action reports now guaranteed to return non-empty results.

* **Documentation**
  * Added implementation plans and design specifications for the intraday action cycle feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->