### PR TITLE
feat(rob-335): /invest/reports ActionPacket 프론트 surface — 4헤더 + verdict chips (PR2 frontend)

### DIFF
--- a/frontend/invest/src/__tests__/ActionPacketView.test.tsx
+++ b/frontend/invest/src/__tests__/ActionPacketView.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ActionPacketView } from "../components/investment-reports/ActionPacketView";
+import type { ActionPacket } from "../types/investmentReports";
+
+function makePacket(overrides: Partial<ActionPacket> = {}): ActionPacket {
+  return {
+    heldActions: [
+      { verdict: "sell_review", symbol: "005930", side: "sell",
+        rationale: "보유 매도 검토", itemUuid: "i1", evidenceSnapshot: {} },
+      { verdict: "keep", symbol: "000660", side: null,
+        rationale: "보유 유지 권장", itemUuid: "i2", evidenceSnapshot: {} },
+    ],
+    newBuyCandidates: [],
+    noNewBuyReason: "국내 스크리너 스냅샷이 stale",
+    riskReviews: [
+      { verdict: "watch_only", symbol: "035720", rationale: "관망",
+        itemUuid: "i3", evidenceSnapshot: {} },
+    ],
+    noActionReason: { kind: "data_insufficient", reasonKo: "데이터 부족",
+                      blockingSources: ["portfolio"], excludedCount: 0 },
+    dataGapsForNextCycle: [
+      { source: "portfolio", status: "unavailable", reason: "user_id_missing" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ActionPacketView", () => {
+  it("renders the four intraday headers", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByRole("heading", { name: /오늘의 보유 액션/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /신규 후보/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /리스크/ })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /데이터 부족/ })).toBeInTheDocument();
+  });
+
+  it("renders held verdict chips with Korean labels", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText("매도 검토")).toBeInTheDocument();
+    expect(screen.getByText("유지")).toBeInTheDocument();
+    expect(screen.getByText("005930")).toBeInTheDocument();
+  });
+
+  it("shows no-new-buy reason when there are no candidates", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText(/국내 스크리너 스냅샷이 stale/)).toBeInTheDocument();
+  });
+
+  it("lists data gaps with their source", () => {
+    render(<ActionPacketView packet={makePacket()} />);
+    expect(screen.getByText(/portfolio/)).toBeInTheDocument();
+    expect(screen.getByText(/user_id_missing/)).toBeInTheDocument();
+  });
+
+  it("renders empty-state copy when a group is empty and no reason given", () => {
+    render(<ActionPacketView packet={makePacket({
+      heldActions: [], newBuyCandidates: [], noNewBuyReason: null,
+      riskReviews: [], noActionReason: null, dataGapsForNextCycle: [],
+    })} />);
+    expect(screen.getAllByText("해당 없음").length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.actionPacket.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type { ActionPacket, InvestmentReportBundle } from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+const REPORT = {
+  reportUuid: "00000000-0000-0000-0000-000000000001",
+  reportType: "kr_morning", market: "kr", marketSession: "regular",
+  accountScope: "kis_live", executionMode: "advisory_only", createdByProfile: "t",
+  title: "KR", summary: "s", riskSummary: null, thesisText: null, noActionNote: null,
+  marketSnapshot: {}, portfolioSnapshot: {}, previousReportUuid: null, status: "draft",
+  metadata: {}, createdAt: "2026-05-27T00:00:00Z", updatedAt: "2026-05-27T00:00:00Z",
+  publishedAt: null, validUntil: null, snapshotBundleUuid: null,
+  snapshotPolicyVersion: null, snapshotCoverageSummary: null,
+  snapshotFreshnessSummary: null, sourceConflicts: null, unavailableSources: null,
+  snapshotReportDiagnostics: null,
+} as InvestmentReportBundle["report"];
+
+function makeBundle(actionPacket: ActionPacket | null): InvestmentReportBundle {
+  return {
+    report: REPORT, items: [], decisionsByItemUuid: {}, alerts: [], events: [],
+    reviewSections: null, actionPacket,
+  };
+}
+
+function renderWith(bundle: InvestmentReportBundle) {
+  (useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+    status: "ready", bundle, error: null, reload: vi.fn(),
+  });
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+describe("InvestmentReportBundleContent — ActionPacket mount", () => {
+  it("renders ActionPacketView when actionPacket is present", () => {
+    renderWith(makeBundle({
+      heldActions: [{ verdict: "keep", symbol: "005930", side: null,
+        rationale: "보유 유지 권장", itemUuid: "i1", evidenceSnapshot: {} }],
+      newBuyCandidates: [], noNewBuyReason: "신규 후보 없음",
+      riskReviews: [], noActionReason: null, dataGapsForNextCycle: [],
+    }));
+    expect(screen.getByTestId("action-packet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /오늘의 보유 액션/ })).toBeInTheDocument();
+  });
+
+  it("does not render ActionPacketView for legacy bundles (actionPacket null)", () => {
+    renderWith(makeBundle(null));
+    expect(screen.queryByTestId("action-packet")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
+++ b/frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeActionPacket } from "../api/investmentReports";
+
+describe("normalizeActionPacket", () => {
+  it("returns null when omitted (legacy/non-intraday)", () => {
+    expect(normalizeActionPacket(undefined)).toBeNull();
+    expect(normalizeActionPacket(null)).toBeNull();
+  });
+
+  it("maps snake_case payload to camelCase groups", () => {
+    const packet = normalizeActionPacket({
+      held_actions: [
+        { verdict: "sell_review", symbol: "005930", side: "sell",
+          rationale: "보유 매도 검토", item_uuid: "i1", evidence_snapshot: { x: 1 } },
+        { verdict: "keep", symbol: "000660", side: null,
+          rationale: "유지", item_uuid: "i2", evidence_snapshot: {} },
+      ],
+      new_buy_candidates: [],
+      no_new_buy_reason: "스크리너 stale",
+      risk_reviews: [{ verdict: "watch_only", symbol: "035720", rationale: "관망",
+                       item_uuid: "i3", evidence_snapshot: {} }],
+      no_action_reason: { kind: "data_insufficient", reason_ko: "데이터 부족",
+                          blocking_sources: ["portfolio"], excluded_count: 2 },
+      data_gaps_for_next_cycle: [
+        { source: "portfolio", status: "unavailable", reason: "user_id_missing" },
+      ],
+    });
+    expect(packet).not.toBeNull();
+    expect(packet!.heldActions.map((e) => e.verdict)).toEqual(["sell_review", "keep"]);
+    expect(packet!.heldActions[0]!.itemUuid).toBe("i1");
+    expect(packet!.newBuyCandidates).toEqual([]);
+    expect(packet!.noNewBuyReason).toBe("스크리너 stale");
+    expect(packet!.riskReviews[0]!.verdict).toBe("watch_only");
+    expect(packet!.noActionReason!.kind).toBe("data_insufficient");
+    expect(packet!.noActionReason!.blockingSources).toEqual(["portfolio"]);
+    expect(packet!.dataGapsForNextCycle[0]).toEqual({
+      source: "portfolio", status: "unavailable", reason: "user_id_missing",
+    });
+  });
+});

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -7,6 +7,10 @@
 // ``../types/investmentReports``.
 
 import type {
+  ActionPacket,
+  ActionPacketEntry,
+  ActionVerdict,
+  DataGapEntry,
   InvestmentReport,
   InvestmentReportBundle,
   InvestmentReportItem,
@@ -211,6 +215,51 @@ function normalizeReviewSections(raw: unknown): ReportReviewSections | null {
   return { sections, noActionSummary };
 }
 
+// ROB-335 — normalize the additive intraday ActionPacket. Null when the
+// backend omits it (legacy / non-intraday reports).
+function normalizeActionPacketEntry(raw: unknown): ActionPacketEntry {
+  const obj = asRecord(raw);
+  return {
+    verdict: asString(obj.verdict, "data_gap") as ActionVerdict,
+    symbol: asOptionalString(obj.symbol),
+    side: asOptionalString(obj.side) as "buy" | "sell" | null,
+    rationale: asString(obj.rationale, ""),
+    itemUuid: asOptionalString(obj.item_uuid),
+    evidenceSnapshot: asRecord(obj.evidence_snapshot),
+  };
+}
+
+export function normalizeActionPacket(raw: unknown): ActionPacket | null {
+  if (raw === null || raw === undefined) return null;
+  const obj = asRecord(raw);
+
+  let noActionReason: NoActionSummary | null = null;
+  if (obj.no_action_reason !== null && obj.no_action_reason !== undefined) {
+    const s = asRecord(obj.no_action_reason);
+    noActionReason = {
+      kind: asOptionalString(s.kind) as WhyNoActionKind | null,
+      reasonKo: asOptionalString(s.reason_ko),
+      blockingSources: asArray<string>(s.blocking_sources),
+      excludedCount: asNumber(s.excluded_count, 0),
+    };
+  }
+
+  return {
+    heldActions: asArray(obj.held_actions).map(normalizeActionPacketEntry),
+    newBuyCandidates: asArray(obj.new_buy_candidates).map(normalizeActionPacketEntry),
+    noNewBuyReason: asOptionalString(obj.no_new_buy_reason),
+    riskReviews: asArray(obj.risk_reviews).map(normalizeActionPacketEntry),
+    noActionReason,
+    dataGapsForNextCycle: asArray<Record<string, unknown>>(
+      obj.data_gaps_for_next_cycle,
+    ).map((g) => ({
+      source: asString(g.source, ""),
+      status: asOptionalString(g.status),
+      reason: asOptionalString(g.reason),
+    })),
+  };
+}
+
 function normalizeDecision(raw: ApiDecision): InvestmentReportItemDecision {
   return {
     decisionUuid: asString(raw.decision_uuid),
@@ -320,6 +369,7 @@ export async function fetchInvestmentReportBundle(
     alerts?: ApiAlert[];
     events?: ApiEvent[];
     review_sections?: unknown;
+    action_packet?: unknown;
   }>(BUNDLE_ENDPOINT(reportUuid), signal);
 
   const decisionsRaw = raw.decisions_by_item_uuid ?? {};
@@ -337,6 +387,7 @@ export async function fetchInvestmentReportBundle(
     alerts: asArray<ApiAlert>(raw.alerts).map(normalizeAlert),
     events: asArray<ApiEvent>(raw.events).map(normalizeEvent),
     reviewSections: normalizeReviewSections(raw.review_sections),
+    actionPacket: normalizeActionPacket(raw.action_packet),
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/ActionPacketView.tsx
+++ b/frontend/invest/src/components/investment-reports/ActionPacketView.tsx
@@ -1,0 +1,127 @@
+// ROB-335 — intraday ActionPacket surface: four headers (held / new / risk /
+// data-gap) + sub-verdict chips. Pure view-layer over the bundle.actionPacket
+// projection (parallel to ROB-322 ReviewSectionsView).
+import { Pill, type PillTone } from "../../ds/atoms";
+import type {
+  ActionPacket,
+  ActionPacketEntry,
+  ActionVerdict,
+  DataGapEntry,
+  NoActionSummary,
+} from "../../types/investmentReports";
+
+const VERDICT_LABELS: Record<ActionVerdict, string> = {
+  buy_review: "신규매수 검토",
+  limit_wait: "지정가 대기",
+  no_new_buy_candidates: "신규 후보 없음",
+  sell_review: "매도 검토",
+  trim_review: "축소 검토",
+  add_review: "추가매수 검토",
+  keep: "유지",
+  no_add: "추가매수 금지",
+  watch_only: "관망",
+  rejected: "제외",
+  data_gap: "데이터 부족",
+};
+
+const VERDICT_TONES: Record<ActionVerdict, PillTone> = {
+  buy_review: "gain",
+  add_review: "gain",
+  limit_wait: "warn",
+  no_new_buy_candidates: "paper",
+  sell_review: "loss",
+  trim_review: "loss",
+  keep: "paper",
+  no_add: "paper",
+  watch_only: "accent",
+  rejected: "warn",
+  data_gap: "warn",
+};
+
+function EntryRow({ entry }: { entry: ActionPacketEntry }) {
+  return (
+    <div style={{ display: "grid", gap: 4, padding: "6px 0" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Pill tone={VERDICT_TONES[entry.verdict]} size="sm">
+          {VERDICT_LABELS[entry.verdict]}
+        </Pill>
+        {entry.symbol ? (
+          <strong style={{ fontSize: 14 }}>{entry.symbol}</strong>
+        ) : null}
+      </div>
+      <p style={{ margin: 0, fontSize: 13 }}>{entry.rationale}</p>
+    </div>
+  );
+}
+
+function PacketSection({
+  title,
+  entries,
+  emptyReason,
+}: {
+  title: string;
+  entries: ActionPacketEntry[];
+  emptyReason?: string | null;
+}) {
+  return (
+    <section style={{ display: "grid", gap: 6 }}>
+      <h2 style={{ margin: 0, fontSize: 18 }}>
+        {title} ({entries.length})
+      </h2>
+      {entries.length > 0 ? (
+        entries.map((entry, idx) => (
+          <EntryRow key={entry.itemUuid ?? `${entry.verdict}-${idx}`} entry={entry} />
+        ))
+      ) : (
+        <p style={{ margin: 0, fontSize: 13 }}>{emptyReason ?? "해당 없음"}</p>
+      )}
+    </section>
+  );
+}
+
+function DataGapSection({
+  gaps,
+  noActionReason,
+}: {
+  gaps: DataGapEntry[];
+  noActionReason?: NoActionSummary | null;
+}) {
+  return (
+    <section style={{ display: "grid", gap: 6 }}>
+      <h2 style={{ margin: 0, fontSize: 18 }}>데이터 부족 ({gaps.length})</h2>
+      {noActionReason?.reasonKo ? (
+        <p style={{ margin: 0, fontSize: 13 }}>{noActionReason.reasonKo}</p>
+      ) : null}
+      {gaps.length > 0 ? (
+        gaps.map((gap, idx) => (
+          <div key={`${gap.source}-${idx}`} style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Pill tone="warn" size="sm">{gap.source}</Pill>
+            <span style={{ fontSize: 13 }}>
+              {[gap.status, gap.reason].filter(Boolean).join(" · ")}
+            </span>
+          </div>
+        ))
+      ) : (
+        <p style={{ margin: 0, fontSize: 13 }}>해당 없음</p>
+      )}
+    </section>
+  );
+}
+
+export function ActionPacketView({ packet }: { packet: ActionPacket }) {
+  return (
+    <section data-testid="action-packet" style={{ display: "grid", gap: 16 }}>
+      <PacketSection title="오늘의 보유 액션" entries={packet.heldActions} />
+      <PacketSection
+        title="신규 후보"
+        entries={packet.newBuyCandidates}
+        emptyReason={packet.noNewBuyReason}
+      />
+      <PacketSection title="리스크" entries={packet.riskReviews} />
+      <DataGapSection
+        gaps={packet.dataGapsForNextCycle}
+        noActionReason={packet.noActionReason}
+      />
+    </section>
+  );
+}

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -19,6 +19,7 @@ import type {
   SnapshotFreshnessSummary,
   SnapshotReportDiagnostics,
 } from "../../types/investmentReports";
+import { ActionPacketView } from "./ActionPacketView";
 import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";
 import { ProposalDiffPanel } from "./ProposalDiffPanel";
 import { ReportDiagnosticsPanel } from "./ReportDiagnosticsPanel";
@@ -669,6 +670,10 @@ export function InvestmentReportBundleContent({
           ) : null,
         )
       )}
+
+      {bundle.actionPacket ? (
+        <ActionPacketView packet={bundle.actionPacket} />
+      ) : null}
 
       {bundle.alerts.length > 0 ? (
         <section style={{ display: "grid", gap: 10 }}>

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -347,6 +347,44 @@ export interface ReportReviewSections {
   noActionSummary?: NoActionSummary | null;
 }
 
+// ROB-335 — intraday ActionPacket (mirrors backend ActionPacket schema).
+export type ActionVerdict =
+  | "buy_review"
+  | "limit_wait"
+  | "no_new_buy_candidates"
+  | "sell_review"
+  | "trim_review"
+  | "add_review"
+  | "keep"
+  | "no_add"
+  | "watch_only"
+  | "rejected"
+  | "data_gap";
+
+export interface ActionPacketEntry {
+  verdict: ActionVerdict;
+  symbol?: string | null;
+  side?: "buy" | "sell" | null;
+  rationale: string;
+  itemUuid?: string | null;
+  evidenceSnapshot: Record<string, unknown>;
+}
+
+export interface DataGapEntry {
+  source: string;
+  status?: string | null;
+  reason?: string | null;
+}
+
+export interface ActionPacket {
+  heldActions: ActionPacketEntry[];
+  newBuyCandidates: ActionPacketEntry[];
+  noNewBuyReason?: string | null;
+  riskReviews: ActionPacketEntry[];
+  noActionReason?: NoActionSummary | null;
+  dataGapsForNextCycle: DataGapEntry[];
+}
+
 export interface InvestmentReportBundle {
   report: InvestmentReport;
   items: InvestmentReportItem[];
@@ -356,6 +394,9 @@ export interface InvestmentReportBundle {
   // ROB-322 — additive five-section projection. Null on legacy reports or
   // older backend; `items` remains the fallback rendering source.
   reviewSections?: ReportReviewSections | null;
+  // ROB-335 — additive intraday ActionPacket projection. Null for legacy /
+  // non-intraday reports.
+  actionPacket?: ActionPacket | null;
 }
 
 export interface InvestmentReportListResponse {


### PR DESCRIPTION
## ROB-335 — `/invest/reports` 장중 액션 사이클 MVP (PR2: 프론트엔드 surface)

PR1(#985, 백엔드)이 추가한 `action_packet` read-model payload를 `/invest/reports` 리포트 상세 화면에 **"오늘의 보유 액션 / 신규 후보 / 리스크 / 데이터 부족"** 4헤더 + sub-verdict chip으로 렌더한다. ROB-322 5-section surface와 동일한 view-layer 패턴 (additive, 기존 surface 미변경).

Plan: `docs/superpowers/plans/2026-05-27-rob-335-pr2-frontend-action-packet.md`

### 변경 요약
- **타입** (`types/investmentReports.ts`): `ActionVerdict`(11값 union) / `ActionPacketEntry` / `DataGapEntry` / `ActionPacket` + `InvestmentReportBundle.actionPacket?` (additive, legacy/비-intraday는 null)
- **정규화** (`api/investmentReports.ts`): `normalizeActionPacket` (snake_case→camelCase, 기존 `normalizeReviewSections` 패턴) + `fetchInvestmentReportBundle` 연결
- **컴포넌트** (`components/investment-reports/ActionPacketView.tsx`): 4헤더 + `Pill` 칩으로 sub-verdict 표시 (verdict별 한글 라벨 + tone). `no_new_buy_reason`/`no_action_reason`/data_gap 명시 렌더, 빈 그룹은 "해당 없음"
- **마운트** (`InvestmentReportBundleContent.tsx`): `bundle.actionPacket` 있을 때만 additive 렌더

### 안전 / 호환
- 기존 review-section / flat-itemKind / alerts / events 블록 미변경 (additive 마운트, ROB-275/evidence viewer 호환 유지)
- legacy/비-intraday 리포트(`actionPacket` null)는 렌더 안 함
- 백엔드/마이그레이션 변경 없음 (백엔드 ActionPacket은 PR1에서 완료)

### 테스트
- 신규 9 tests pass (`investmentReportsActionPacket` 2 / `ActionPacketView` 5 / `InvestmentReportBundleContent.actionPacket` 2), `--pool=forks`
- `npm run typecheck` clean (exit 0)
- 전체 프론트 스위트: 422 passed, baseline 5건(calendar/coverage) pre-existing 실패만 — **PR2 신규 실패 0건**
- 최종 코드리뷰 APPROVED (백엔드 스키마 대조 일치 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
