### PR TITLE
feat(rob-339): scalping strategy discovery funnel + fast-screen harness (PR1)

### DIFF
--- a/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
@@ -1,0 +1,226 @@
+# ROB-339 — Scalping strategy discovery funnel + fast-screen harness (design)
+
+- **Issue:** ROB-339 (follow-up to ROB-320 / PR #968 and ROB-324 / PR #984, both `not_validated`)
+- **Date:** 2026-05-27
+- **Scope:** research/backtest only. No live trading, no Demo `confirm=true`, no
+  broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod
+  DB/env/secret changes, no runtime parameter application, no `/invest` surfacing.
+- **Location:** everything under `research/nautilus_scalping/` in its isolated venv,
+  plus this design note. Public trade-tick parquet catalog is read-only.
+- **Companion gstack design doc:** `~/.gstack/projects/mgh3326-auto_trader/mgh3326-rob-339-design-20260527-170544.md` (decisions D1–D6).
+
+## 1. Problem
+
+ROB-320 and ROB-324 both returned an honest `not_validated` for
+`meanrev_zscore_fade`: a small **gross** edge (whole-run PF ≈ 1.058) that dies on
+fees. ROB-324's maker/limit re-eval, even optimistic (maker 2 bps), lands OOS net
+≈ −1.95 / PF 0.95; conservative ≈ −3.69 / PF 0.90, with 1,150 missed fills of
+2,318 attempts. The dominant finding across ROB-316/320/324 is that **fees kill
+the gross edge** — nothing tested so far clears the ~6–8 bps round-trip budget.
+
+The full conservative gate is **expensive**: it replays 75 days of trade-tick data
+for `BTCUSDT.BINANCE` + `XRPUSDT.BINANCE` across multiple Nautilus subprocess runs.
+The open question is no longer "is the fee too high" but "**does any scalping
+condition have enough gross edge to survive realistic fees, missed fills, and
+adverse selection?**" — and we want to answer that cheaply *before* paying for
+full validation.
+
+**Goal:** a research-first **discovery → pilot → full-validation funnel** that
+screens hypothesis families fast and emits an auditable, explicitly *non-canonical*
+recommendation for which families deserve full validation next.
+
+**Honest prior:** given ROB-316/320/324, the likely outcome is that most or all
+families screen out on fees. The deliverable is the honest funnel + artifact, **not**
+a green light. Discovery never produces `validated`.
+
+## 2. The funnel
+
+| Stage | Cost | Engine | Produces | Verdict vocabulary |
+|-------|------|--------|----------|--------------------|
+| **Discovery** (this PR) | seconds | none — pandas/pyarrow over catalog parquet | feature→outcome summaries per hypothesis | `screened_out` / `needs_more_data` / `promote_to_full_validation` (non-canonical) |
+| **Pilot** (PR2+) | minutes | Nautilus, reduced grid + bounded window | a strategy run on a short window | non-canonical (still discovery-grade) |
+| **Full validation** (existing) | tens of minutes | Nautilus, 75-day, full grid + baselines + bootstrap CI | `validated_signal_gate.v1` report | `validated` / `not_validated` / `insufficient_data` |
+
+**What discovery screens cheaply:** does a condition's expected gross move clear
+the fee+slippage budget, with enough samples, on a held-out tail. **What still
+needs full validation:** walk-forward OOS, baseline beat (`micro_breakout`,
+`random_entry`), overfit flags, bootstrap CI / MC permutation, real maker fills.
+Discovery's job is to *reject cheaply* and *nominate*, never to bless.
+
+## 3. Decisions (from the gstack design doc)
+
+- **D1** — ROB-324 is a *reference* dependency, not a code dependency. PR #984
+  merged to main first (squash `a76f960`); this branch is cut fresh from origin/main.
+  No `maker_fill` / Nautilus import in the discovery harness.
+- **D2** — `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`, opt-in; unset → existing repo
+  `results/`. Read via research-local `paths.py` (`os.environ`), **never** app
+  `Settings`/pydantic. Namespace separation: `discovery/` vs `gate/`.
+- **D3** — discovery reads the same Nautilus `ParquetDataCatalog` parquet via
+  pandas/pyarrow directly (no engine boot); not raw aggTrades.
+- **D4** — discovery's `--window-from/--window-to` is a **real** constraint via
+  pyarrow predicate pushdown. The Nautilus `backtest_runner` window is PR2.
+- **D5** — multiple-hypothesis defense: record `hypotheses_tested`; label promote
+  candidates `in_sample_only: true`; time-ordered OOS holdout inside discovery.
+- **D6** — PR slicing (this doc is PR1's design note); see §8.
+
+## 4. Approach (chosen) — pure-parquet discovery harness
+
+A new `research/nautilus_scalping/discovery/` package that, for a given catalog,
+symbol set, and window:
+
+1. **Loads** trade ticks from catalog parquet via pyarrow with a `[from, to)`
+   predicate pushdown (D4), aggregates to 1-minute OHLCV bars matching the
+   strategies' `1-MINUTE-LAST` bar type.
+2. **Features** per bar (bounded, vectorized): 1/3/5m returns, range, volume,
+   rolling realized-vol bucket (low/normal/high), close position within bar range,
+   rolling N-bar high/low (for sweeps), KST/EU/US/funding-neighborhood time bucket.
+3. **Hypotheses** (the issue's five families) each define a boolean condition over
+   features and a forward outcome (1/3/5m forward return, bps):
+   1. **Momentum continuation** — recent extension + volume/range expansion + close
+      near extreme → forward continuation.
+   2. **Liquidity sweep / fake-breakout reversal** — N-bar high/low swept + wick
+      re-entry + volume spike → forward reversal.
+   3. **Volatility regime filter** — segment outcomes by realized-vol bucket; reject
+      regimes where expected move can't clear fees.
+   4. **Time-of-day filter** — segment outcomes by session bucket.
+   5. **Maker/passive-entry viability** — estimate **missed-fill ratio**: fraction
+      of signal bars where a limit posted `entry_offset_bps` from close would *not*
+      fill within the timeout (from real ticks); treat missed-fill as a signal-quality
+      signal, not only an execution cost.
+4. **Summaries** per hypothesis: `sample_count`, `gross_expectancy_bps` (mean
+   forward outcome), `fee_adjusted_bps` (gross − round-trip fee budget), regime/time
+   bucket, `missed_fill_ratio` (maker), and an OOS-tail confirmation read.
+5. **Classify** (§6) into the non-canonical recommendation.
+
+**Fee budget** (from ROB-324's captured `binance_usdm_commission_rates.json`:
+maker 2.0 / taker 4.0 bps): default screen uses the **realistic taker round-trip
+= 8 bps**; the maker-entry variant (maker 2 + taker 4 = 6 bps) is reported
+alongside. Configurable via `--fee-budget-bps`.
+
+### Alternatives rejected
+- **Reuse `backtest_runner` subprocess per hypothesis** — not actually fast
+  (engine boot + Rust logger global singleton per run); defeats "screen before
+  paying full cost". This is the pilot stage, not discovery.
+- **Read raw `data.binance.vision` aggTrades** — would diverge from the catalog
+  normalization that full validation uses; discovery and validation must share one
+  data source.
+
+## 5. Components (all under `research/nautilus_scalping/`)
+
+### 5.1 `paths.py` (new, pure)
+- `research_artifact_root() -> Path` — `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT` if set,
+  else the module-relative `results/`. Plain `os.environ`; no app `Settings` import.
+- `resolve_artifact_path(namespace: str, *parts) -> Path` — `root / namespace / *parts`;
+  `namespace ∈ {"discovery", "gate"}`. Single source of truth for artifact location.
+- Creates parent dirs on write only; pure path resolution otherwise.
+
+### 5.2 `discovery/data.py` (new, pure)
+- `load_bars(catalog, symbol, window_from, window_to) -> DataFrame` — pyarrow
+  predicate-pushdown read of catalog trade-tick parquet, aggregated to 1-min bars.
+  The window is a **real row filter**, not metadata.
+
+### 5.3 `discovery/features.py` (new, pure)
+- Vectorized feature columns (§4.2). No Nautilus import.
+
+### 5.4 `discovery/hypotheses.py` (new, pure)
+- One callable per family producing a `HypothesisSummary` (condition description,
+  sample_count, gross/fee-adjusted expectancy, bucket, missed_fill_ratio,
+  oos_confirmation). Time-ordered split: in-sample head (75%) drives the decision;
+  tail (25%) is a confirmation read only (D5c).
+
+### 5.5 `discovery/screen.py` (new, pure)
+- Fast-fail classifier (§6) → `Recommendation`.
+- Artifact assembly (§7) including `hypotheses_tested` and `in_sample_only`.
+
+### 5.6 `discover.py` (new driver, top-level under nautilus_scalping/)
+- CLI: `--catalog --symbols --window-from --window-to --fee-budget-bps
+  --min-samples --export`. Loads bars, runs all hypotheses, classifies, writes the
+  artifact via `resolve_artifact_path("discovery", ...)`. No execution side effects.
+
+## 6. Fast-fail classification (non-canonical)
+
+Per hypothesis, in priority order:
+- **`needs_more_data`** — `sample_count < min_samples` (default 200) in any
+  decision fold.
+- **`screened_out`** — any of: `fee_adjusted_bps <= 0`; gross move can't clear the
+  fee budget; (maker) `missed_fill_ratio` above threshold (default 0.6); OOS-tail
+  expectancy sign disagrees with in-sample.
+- **`promote_to_full_validation`** — `fee_adjusted_bps > 0` with sufficient samples
+  **and** OOS-tail sign agrees; always tagged `in_sample_only: true`.
+
+These are **recommendations**, never gate verdicts. The artifact states this
+explicitly. Final `validated` stays owned by the unchanged
+`validated_gate.evaluate_gate` (OOS/baseline/overfit + bootstrap CI).
+
+## 7. Artifact
+
+`resolve_artifact_path("discovery", "<run-id>", "discovery.json")`,
+`schema_version: "scalping_discovery.v1"`:
+- `run`: symbols, window `{from, to}` (real, enforced), `fee_budget_bps`,
+  `min_samples`, horizons, bucket definitions, catalog provenance.
+- `hypotheses_tested`: integer count (D5 multiple-comparison transparency).
+- `hypotheses[]`: each — `name`, `conditions` (human-readable predicate),
+  `sample_count`, `gross_expectancy_bps`, `fee_adjusted_bps`, `regime`/`time_bucket`,
+  `missed_fill_ratio` (maker only), `oos_confirmation`, `recommendation`
+  (`screened_out`/`needs_more_data`/`promote_to_full_validation`), `reason`,
+  `in_sample_only`.
+- `note`: "Discovery output is non-canonical. Only the conservative gate
+  (`validated_signal_gate.v1`) produces `validated`/`not_validated`."
+
+## 8. PR slicing (D6)
+
+- **PR1 (this design note + harness):** `paths.py`, `discovery/` package,
+  `discover.py` driver, artifact schema + fast-fail classifier, discovery-path real
+  window filter, unit tests (no 75-day tick data in CI). Optional: one bounded smoke
+  run against the rob-320 catalog with elapsed time + artifact path in PR notes.
+- **PR2:** `backtest_runner` real window constraint (catalog start/end query if the
+  API supports it, else post-load `ts_event` filter + documented limitation with a
+  test), baseline run caching keyed by catalog/window/symbol/params/code-version,
+  optional precise maker-viability re-sim borrowing ROB-324's `maker_fill` model.
+
+## 9. Tests (no full 75-day data; CI-safe)
+
+- `tests/test_discovery_paths.py` — ENV set → root; unset → `results/`; namespace
+  separation; no app `Settings` import.
+- `tests/test_discovery_window.py` — synthetic small parquet; predicate pushdown
+  excludes out-of-window rows (proves D4 is a real constraint).
+- `tests/test_discovery_features.py` — tiny synthetic bar series → known feature
+  values.
+- `tests/test_discovery_screen.py` — synthetic summaries → correct
+  `screened_out` / `needs_more_data` / `promote_to_full_validation`; `in_sample_only`
+  always set on promote; artifact has `hypotheses_tested` and the non-canonical note.
+- Existing `test_validated_gate*.py`, `test_meanrev_*`, `test_signal_parity.py`
+  remain green (discovery adds no import into the gate or strategies).
+
+## 10. Execution prerequisites
+
+- catalog/data/.venv are gitignored and **absent in a fresh worktree**. The
+  **rob-320 worktree** has a built `ParquetDataCatalog` with trade ticks for both
+  symbols across the window (ROB-324 reused it read-only). PR1 smoke, if run, points
+  `--catalog` at that catalog read-only; if the venv is broken, rebuilding the
+  Intel-mac Rust nautilus is the costly fallback — surface before spending time.
+- **CI requires none of this** — the unit tests use synthetic fixtures.
+
+## 11. Acceptance criteria (from the issue) — how this design meets each
+
+- Claude-readable strategy-discovery plan exists → this note (§2 funnel, §4–6).
+- Fast screening command emits a structured artifact → `discover.py` + §7.
+- Output distinguishes `screened_out` / `needs_more_data` /
+  `promote_to_full_validation` → §6 classifier.
+- `--window-from/--window-to` is a real data constraint with tests → §5.2 + §9
+  `test_discovery_window.py` (Nautilus-path window documented as PR2).
+- No full-validation result marketed as `validated` unless it passes the gate →
+  discovery is non-canonical by construction (§6, §7 note); gate unchanged.
+- PR description carries the safety boundary → §12, restated at PR time.
+- PR includes a recommended next strategy family (or why all were rejected) →
+  produced from the first real discovery run; expected, per the honest prior, to be
+  "most families screen out on fees", with the least-bad family named.
+
+## 12. Safety boundary
+
+Research only. Public trade-tick data, isolated venv, read-only catalog access. No
+live trading, no Demo `confirm=true`, no broker/order/watch/order-intent mutation,
+no scheduler/Prefect/launchd, no prod DB/env/secrets, no runtime parameter
+application, no `/invest` surfacing. The discovery harness imports nothing from
+`app/` and nothing from the Nautilus engine. Artifacts contain no secrets,
+balances, positions, or account identifiers.

--- a/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
@@ -176,7 +176,9 @@ explicitly. Final `validated` stays owned by the unchanged
 - **PR2:** `backtest_runner` real window constraint (catalog start/end query if the
   API supports it, else post-load `ts_event` filter + documented limitation with a
   test), baseline run caching keyed by catalog/window/symbol/params/code-version,
-  optional precise maker-viability re-sim borrowing ROB-324's `maker_fill` model.
+  vectorized fixed-point decode (PR1 uses a per-row Python decode — ~50s for a
+  15-day 2-symbol window; numpy/int128 vectorization makes the full 75-day window
+  "fast"), optional precise maker-viability re-sim borrowing ROB-324's `maker_fill`.
 
 ## 9. Tests (no full 75-day data; CI-safe)
 
@@ -192,14 +194,33 @@ explicitly. Final `validated` stays owned by the unchanged
 - Existing `test_validated_gate*.py`, `test_meanrev_*`, `test_signal_parity.py`
   remain green (discovery adds no import into the gate or strategies).
 
-## 10. Execution prerequisites
+## 10. Execution prerequisites + catalog encoding (verified at smoke)
 
 - catalog/data/.venv are gitignored and **absent in a fresh worktree**. The
   **rob-320 worktree** has a built `ParquetDataCatalog` with trade ticks for both
-  symbols across the window (ROB-324 reused it read-only). PR1 smoke, if run, points
-  `--catalog` at that catalog read-only; if the venv is broken, rebuilding the
-  Intel-mac Rust nautilus is the costly fallback — surface before spending time.
+  symbols. The discovery harness reads it via pandas/pyarrow with **no Nautilus
+  import**, so it runs in the repo's own uv venv (pandas/pyarrow present) — no Rust
+  nautilus rebuild needed for discovery.
+- **Catalog encoding (verified):** this is a **128-bit high-precision** Nautilus
+  catalog — `price`/`size` are `fixed_size_binary[16]` int128 little-endian, raw =
+  `value * 10**16` (fixed by the build), and `ts_event` is `uint64` ns. The display
+  precision in schema metadata (`price_precision`/`size_precision`) only rounds the
+  decoded float; it is NOT the raw scale. `data._decode_int128_le` + `_decode_if_binary`
+  handle this; plain-float parquet (the unit fixtures) is passed through unchanged.
 - **CI requires none of this** — the unit tests use synthetic fixtures.
+
+### Smoke results (XRPUSDT + BTCUSDT, 2026-03-01..03-15, ~50s, fee budget 8 bps)
+All 10 (2 symbols × 5 families) → **`screened_out`**. In-sample gross expectancy
+spans **−0.58 .. +0.44 bps** — none clears the 8 bps round-trip fee budget; OOS-tail
+fee-adjusted is also negative throughout. This reproduces the dominant
+ROB-316/320/324 finding: the gross edge does not survive fees.
+
+**Recommended next family:** none of the five clears fees on this data, so **no
+family is promoted to full validation** as-is. The least-negative gross was
+**BTCUSDT/sweep_reversal (+0.44 bps)** and **XRPUSDT sweep/time-of-day (+0.28 bps)** —
+if any direction is worth a deeper look it is **liquidity-sweep reversal**, but only
+after a maker/limit cost model (entry ~2 bps) and tighter regime/time segmentation
+materially lift gross expectancy; at taker fees it is a clear reject.
 
 ## 11. Acceptance criteria (from the issue) — how this design meets each
 

--- a/research/nautilus_scalping/artifact_paths.py
+++ b/research/nautilus_scalping/artifact_paths.py
@@ -1,0 +1,35 @@
+"""ROB-339 (D2) — single source of truth for research artifact locations.
+
+``AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`` (opt-in) points artifacts at a path outside
+the git tree; unset (or whitespace) falls back to the repo-internal ``results/``
+so zero-config dev and CI keep working. Read via plain ``os.environ`` only — this
+module must never import ``app`` Settings/pydantic (research-only boundary).
+
+Namespace separation keeps non-canonical discovery output (``discovery/``) from
+being mistaken for the gate's citable run-cards (``gate/``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ENV_VAR = "AUTO_TRADER_RESEARCH_ARTIFACT_ROOT"
+_NAMESPACES = frozenset({"discovery", "gate"})
+
+
+def research_artifact_root() -> Path:
+    """Resolve the artifact root: env if set (non-blank), else repo ``results/``."""
+    raw = os.environ.get(ENV_VAR)
+    if raw is not None and raw.strip():
+        return Path(raw.strip())
+    return Path(__file__).resolve().parent / "results"
+
+
+def resolve_artifact_path(namespace: str, *parts: str) -> Path:
+    """``root / namespace / *parts``; ``namespace`` must be a known namespace."""
+    if namespace not in _NAMESPACES:
+        raise ValueError(
+            f"unknown artifact namespace {namespace!r}; expected one of {sorted(_NAMESPACES)}"
+        )
+    return research_artifact_root().joinpath(namespace, *parts)

--- a/research/nautilus_scalping/discover.py
+++ b/research/nautilus_scalping/discover.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""ROB-339 — fast scalping-strategy discovery driver (pure pandas; no Nautilus).
+
+Reads the catalog trade-tick parquet for each symbol over a real `[from, to)`
+window, engineers features, screens the five hypothesis families, and writes a
+non-canonical `scalping_discovery.v1` artifact (screened_out / needs_more_data /
+promote_to_full_validation). NO execution side effects: public-data read only;
+nothing submits, schedules, mutates a broker/DB, reads secrets, or applies params.
+
+Usage (research venv or the repo uv venv):
+    python discover.py --catalog <catalog> --symbols XRPUSDT,BTCUSDT \
+        --window-from 2026-03-01 --window-to 2026-05-14 --fee-budget-bps 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+from artifact_paths import resolve_artifact_path
+from discovery.screen import build_artifact, classify
+
+
+def discover_from_bars(
+    bars_by_symbol: dict[str, pd.DataFrame],
+    *,
+    fee_budget_bps: float,
+    min_samples: int = 200,
+    missed_fill_max: float = 0.6,
+    entry_offset_bps: float = 5.0,
+    oos_frac: float = 0.25,
+    window: dict | None = None,
+) -> dict:
+    """Pure orchestration: bars -> features -> hypotheses -> classify -> artifact."""
+    # imported here so the pure data/feature path is the only pandas entry point
+    from discovery.features import add_features
+    from discovery.hypotheses import run_all_hypotheses
+
+    classified = []
+    for symbol, bars in bars_by_symbol.items():
+        featured = add_features(bars)
+        for summary in run_all_hypotheses(
+            featured,
+            fee_budget_bps=fee_budget_bps,
+            entry_offset_bps=entry_offset_bps,
+            oos_frac=oos_frac,
+            symbol=symbol,
+        ):
+            classified.append(
+                classify(
+                    summary, min_samples=min_samples, missed_fill_max=missed_fill_max
+                )
+            )
+
+    run = {
+        "symbols": list(bars_by_symbol),
+        "window": window or {},
+        "fee_budget_bps": fee_budget_bps,
+        "min_samples": min_samples,
+        "missed_fill_max": missed_fill_max,
+        "entry_offset_bps": entry_offset_bps,
+        "oos_frac": oos_frac,
+    }
+    return build_artifact(classified, run)
+
+
+def write_discovery_artifact(
+    artifact: dict, *, export: str | Path | None = None, run_id: str = "latest"
+) -> Path:
+    """Write the artifact JSON to ``export`` or ``<root>/discovery/<run_id>/discovery.json``."""
+    out = (
+        Path(export)
+        if export
+        else resolve_artifact_path("discovery", run_id, "discovery.json")
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(artifact, indent=2))
+    return out
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="ROB-339 scalping discovery / fast-screen")
+    ap.add_argument("--catalog", type=Path, default="catalog")
+    ap.add_argument("--symbols", default="XRPUSDT,BTCUSDT")
+    ap.add_argument("--window-from", default="")
+    ap.add_argument("--window-to", default="")
+    ap.add_argument(
+        "--fee-budget-bps",
+        type=float,
+        default=8.0,
+        help="round-trip fee+slippage budget (taker 4/4 = 8 bps default)",
+    )
+    ap.add_argument("--min-samples", type=int, default=200)
+    ap.add_argument("--missed-fill-max", type=float, default=0.6)
+    ap.add_argument("--entry-offset-bps", type=float, default=5.0)
+    ap.add_argument("--oos-frac", type=float, default=0.25)
+    ap.add_argument("--run-id", default="latest")
+    ap.add_argument(
+        "--export",
+        type=Path,
+        default=None,
+        help="explicit artifact path; default uses the artifact root",
+    )
+    return ap
+
+
+def main() -> int:
+    args = build_arg_parser().parse_args()
+    # imported lazily: only the catalog-backed run needs the parquet loader
+    from discovery.data import load_bars
+
+    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    bars_by_symbol = {
+        sym: load_bars(args.catalog, sym, args.window_from, args.window_to)
+        for sym in symbols
+    }
+    artifact = discover_from_bars(
+        bars_by_symbol,
+        fee_budget_bps=args.fee_budget_bps,
+        min_samples=args.min_samples,
+        missed_fill_max=args.missed_fill_max,
+        entry_offset_bps=args.entry_offset_bps,
+        oos_frac=args.oos_frac,
+        window={
+            "from": args.window_from,
+            "to": args.window_to,
+            "oos_frac": args.oos_frac,
+        },
+    )
+    out = write_discovery_artifact(artifact, export=args.export, run_id=args.run_id)
+
+    print(f"hypotheses_tested: {artifact['hypotheses_tested']}")
+    for h in artifact["hypotheses"]:
+        print(f"  [{h['recommendation']:>27}] {h['symbol']}/{h['name']}: {h['reason']}")
+    print(f"artifact: {out.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/nautilus_scalping/discovery/__init__.py
+++ b/research/nautilus_scalping/discovery/__init__.py
@@ -1,0 +1,6 @@
+"""ROB-339 — pure-parquet scalping strategy discovery / fast-screen package.
+
+Imports nothing from ``app`` and nothing from the Nautilus engine. Produces only
+non-canonical recommendations (screened_out / needs_more_data /
+promote_to_full_validation); the conservative gate owns ``validated``.
+"""

--- a/research/nautilus_scalping/discovery/data.py
+++ b/research/nautilus_scalping/discovery/data.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pandas as pd
 import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+import pyarrow.types as patypes
 
 
 def _date_to_ns(date_str: str, *, plus_one_day: bool = False) -> int:
@@ -36,13 +38,53 @@ def window_bounds_ns(window_from: str, window_to: str) -> tuple[int | None, int 
     return lo, hi
 
 
+def _decode_int128_le(raw: bytes, precision: int) -> float:
+    """Decode a Nautilus fixed-point value: little-endian signed int / 10**precision."""
+    return int.from_bytes(raw, byteorder="little", signed=True) / (10**precision)
+
+
+# Nautilus fixed-point RAW scale by byte width: 128-bit build -> 10**16, 64-bit -> 10**9.
+# This is fixed by the build, independent of an instrument's *display* precision (the
+# price_precision/size_precision metadata, which only governs rounding for presentation).
+_RAW_PRECISION_BY_WIDTH = {16: 16, 8: 9}
+
+
+def _decode_if_binary(
+    df: pd.DataFrame, schema, col: str, display_precision: int | None, meta_key: bytes
+) -> None:
+    """Decode ``col`` in-place if it's fixed-point binary; leave plain numerics alone.
+
+    The decode divisor is the fixed raw scale (by byte width); ``display_precision``
+    (arg or schema metadata) only rounds the decoded float for presentation.
+    """
+    ftype = schema.field(col).type
+    if not (patypes.is_fixed_size_binary(ftype) or patypes.is_binary(ftype)):
+        return
+    width = ftype.byte_width if patypes.is_fixed_size_binary(ftype) else 16
+    raw_precision = _RAW_PRECISION_BY_WIDTH.get(width, 16)
+    df[col] = df[col].map(lambda b: _decode_int128_le(bytes(b), raw_precision))
+    if display_precision is None:
+        md = schema.metadata or {}
+        display_precision = int(md[meta_key]) if meta_key in md else None
+    if display_precision is not None:
+        df[col] = df[col].round(display_precision)
+
+
 def read_ticks(
-    source: str | Path, ts_from: int | None, ts_to: int | None
+    source: str | Path,
+    ts_from: int | None,
+    ts_to: int | None,
+    *,
+    price_precision: int | None = None,
+    size_precision: int | None = None,
 ) -> pd.DataFrame:
     """Read trade ticks from a parquet file/dir, filtering ``ts_event`` in ``[from, to)``.
 
     The filter is a pyarrow dataset expression -> predicate pushdown, so out-of-window
-    rows are never materialized.
+    rows are never materialized. Nautilus stores price/size as fixed_size_binary
+    (int128 fixed-point, raw = value * 10**16 in 128-bit builds); those columns are
+    decoded to floats and rounded to ``*_precision`` (the display precision, from the
+    arg or schema metadata). Plain float parquet is returned unchanged.
     """
     dataset = ds.dataset(str(source))
     expr = None
@@ -52,7 +94,10 @@ def read_ticks(
         upper = ds.field("ts_event") < ts_to
         expr = upper if expr is None else (expr & upper)
     table = dataset.to_table(filter=expr)
-    return table.to_pandas()
+    df = table.to_pandas()
+    _decode_if_binary(df, table.schema, "price", price_precision, b"price_precision")
+    _decode_if_binary(df, table.schema, "size", size_precision, b"size_precision")
+    return df
 
 
 def aggregate_to_bars(ticks: pd.DataFrame, freq: str = "1min") -> pd.DataFrame:
@@ -83,6 +128,17 @@ def _locate_trade_tick_parquet(catalog: str | Path, symbol: str) -> Path:
     return matches[0]
 
 
+def _read_precisions(tick_dir: Path) -> tuple[int | None, int | None]:
+    """Read price/size precision from the first parquet file's schema metadata."""
+    files = sorted(Path(tick_dir).glob("*.parquet"))
+    if not files:
+        return (None, None)
+    md = pq.read_schema(files[0]).metadata or {}
+    pp = int(md[b"price_precision"]) if b"price_precision" in md else None
+    sp = int(md[b"size_precision"]) if b"size_precision" in md else None
+    return (pp, sp)
+
+
 def load_bars(
     catalog: str | Path,
     symbol: str,
@@ -90,13 +146,14 @@ def load_bars(
     window_to: str = "",
     freq: str = "1min",
 ) -> pd.DataFrame:
-    """Catalog symbol -> windowed OHLCV bars (integration; verified at smoke).
+    """Catalog symbol -> windowed OHLCV bars (pandas/pyarrow; no Nautilus engine).
 
-    NOTE: price/size in a Nautilus ParquetDataCatalog may be stored as fixed-point
-    int64 (raw = value * 10**precision); the decode to float is catalog-encoding
-    dependent and must be confirmed against the real catalog at smoke time. The pure
-    read_ticks / aggregate_to_bars / window_bounds_ns helpers are the unit-tested core.
+    Locates the trade-tick parquet dir, reads price/size precision from its schema
+    metadata, applies the real ``[from, to)`` window filter, decodes the fixed-point
+    price/size, and aggregates to OHLCV bars.
     """
     lo, hi = window_bounds_ns(window_from, window_to)
-    ticks = read_ticks(_locate_trade_tick_parquet(catalog, symbol), lo, hi)
+    tick_dir = _locate_trade_tick_parquet(catalog, symbol)
+    pp, sp = _read_precisions(tick_dir)
+    ticks = read_ticks(tick_dir, lo, hi, price_precision=pp, size_precision=sp)
     return aggregate_to_bars(ticks, freq=freq)

--- a/research/nautilus_scalping/discovery/data.py
+++ b/research/nautilus_scalping/discovery/data.py
@@ -1,0 +1,102 @@
+"""ROB-339 (D3/D4) — read catalog trade-tick parquet with a real window filter.
+
+pandas/pyarrow only; NO Nautilus engine boot. ``read_ticks`` applies the
+``[ts_from, ts_to)`` window as a pyarrow predicate-pushdown filter at scan time, so
+``--window-from/--window-to`` constrains *processed data*, not just artifact
+metadata.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pyarrow.dataset as ds
+
+
+def _date_to_ns(date_str: str, *, plus_one_day: bool = False) -> int:
+    ts = pd.Timestamp(date_str.strip(), tz="UTC")
+    if plus_one_day:
+        ts = ts + pd.Timedelta(days=1)
+    return int(ts.value)
+
+
+def window_bounds_ns(window_from: str, window_to: str) -> tuple[int | None, int | None]:
+    """Parse ``YYYY-MM-DD`` window edges to epoch-ns; ``to`` date is inclusive.
+
+    Blank edges map to ``None`` (unbounded on that side). The returned bounds are
+    half-open ``[lo, hi)`` so a same-day ``from==to`` spans that whole UTC day.
+    """
+    lo = _date_to_ns(window_from) if window_from and window_from.strip() else None
+    hi = (
+        _date_to_ns(window_to, plus_one_day=True)
+        if window_to and window_to.strip()
+        else None
+    )
+    return lo, hi
+
+
+def read_ticks(
+    source: str | Path, ts_from: int | None, ts_to: int | None
+) -> pd.DataFrame:
+    """Read trade ticks from a parquet file/dir, filtering ``ts_event`` in ``[from, to)``.
+
+    The filter is a pyarrow dataset expression -> predicate pushdown, so out-of-window
+    rows are never materialized.
+    """
+    dataset = ds.dataset(str(source))
+    expr = None
+    if ts_from is not None:
+        expr = ds.field("ts_event") >= ts_from
+    if ts_to is not None:
+        upper = ds.field("ts_event") < ts_to
+        expr = upper if expr is None else (expr & upper)
+    table = dataset.to_table(filter=expr)
+    return table.to_pandas()
+
+
+def aggregate_to_bars(ticks: pd.DataFrame, freq: str = "1min") -> pd.DataFrame:
+    """Aggregate trade ticks to OHLCV bars (open/high/low/close/volume) at ``freq``.
+
+    Empty time buckets are dropped. Output is index-reset with a ``dt`` column.
+    """
+    df = ticks.copy()
+    df["dt"] = pd.to_datetime(df["ts_event"], unit="ns", utc=True)
+    df = df.set_index("dt").sort_index()
+    bars = df["price"].resample(freq).ohlc()
+    bars["volume"] = df["size"].resample(freq).sum()
+    bars = bars.dropna(subset=["open"])
+    return bars.reset_index()
+
+
+def _locate_trade_tick_parquet(catalog: str | Path, symbol: str) -> Path:
+    """Find the Nautilus catalog trade-tick parquet dir for ``symbol`` (best-effort).
+
+    Layout: ``<catalog>/data/trade_tick/<INSTRUMENT_ID>/``. Matches the first
+    instrument dir whose name starts with ``symbol`` (mirrors backtest_runner's
+    ``startswith`` resolution).
+    """
+    base = Path(catalog) / "data" / "trade_tick"
+    matches = sorted(d for d in base.glob(f"{symbol}*") if d.is_dir())
+    if not matches:
+        raise FileNotFoundError(f"no trade_tick parquet for {symbol!r} under {base}")
+    return matches[0]
+
+
+def load_bars(
+    catalog: str | Path,
+    symbol: str,
+    window_from: str = "",
+    window_to: str = "",
+    freq: str = "1min",
+) -> pd.DataFrame:
+    """Catalog symbol -> windowed OHLCV bars (integration; verified at smoke).
+
+    NOTE: price/size in a Nautilus ParquetDataCatalog may be stored as fixed-point
+    int64 (raw = value * 10**precision); the decode to float is catalog-encoding
+    dependent and must be confirmed against the real catalog at smoke time. The pure
+    read_ticks / aggregate_to_bars / window_bounds_ns helpers are the unit-tested core.
+    """
+    lo, hi = window_bounds_ns(window_from, window_to)
+    ticks = read_ticks(_locate_trade_tick_parquet(catalog, symbol), lo, hi)
+    return aggregate_to_bars(ticks, freq=freq)

--- a/research/nautilus_scalping/discovery/features.py
+++ b/research/nautilus_scalping/discovery/features.py
@@ -1,0 +1,79 @@
+"""ROB-339 — discovery feature engineering (pure pandas; no Nautilus).
+
+Backward features (returns, range, close position, realized-vol regime, time
+bucket, rolling sweep levels) are inputs; forward returns in bps are outcomes.
+All vectorized; degenerate small inputs never raise (buckets fall back to normal).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+_BPS = 1e4
+
+
+# Disjoint UTC-hour session buckets (KST = UTC+9).
+def _time_bucket(hour: int) -> str:
+    if 0 <= hour < 7:
+        return "asia"  # KST 09:00-16:00 neighborhood
+    if 7 <= hour < 13:
+        return "eu"
+    if 13 <= hour < 21:
+        return "us"
+    return "off"
+
+
+# Binance USDⓈ-M funding settles 00:00 / 08:00 / 16:00 UTC.
+_FUNDING_HOURS = (0, 8, 16)
+
+
+def _vol_bucket(rv: pd.Series) -> pd.Series:
+    valid = rv.dropna()
+    out = pd.Series("normal", index=rv.index, dtype=object)
+    if valid.nunique() < 3:
+        return out
+    lo_q, hi_q = valid.quantile(0.33), valid.quantile(0.66)
+    out[rv <= lo_q] = "low"
+    out[rv >= hi_q] = "high"
+    out[rv.isna()] = "normal"
+    return out
+
+
+def add_features(
+    bars: pd.DataFrame, *, vol_window: int = 60, roll_window: int = 20
+) -> pd.DataFrame:
+    """Return a copy of ``bars`` with discovery feature + forward-outcome columns."""
+    f = bars.copy().reset_index(drop=True)
+    close, high, low = f["close"], f["high"], f["low"]
+
+    # backward returns (bps)
+    for n in (1, 3, 5):
+        f[f"ret_{n}m"] = close.pct_change(n) * _BPS
+    # forward outcomes (bps)
+    for n in (1, 3, 5):
+        f[f"fwd_ret_{n}m"] = (close.shift(-n) / close - 1.0) * _BPS
+
+    span = high - low
+    f["bar_range_bps"] = span / close * _BPS
+    f["close_pos"] = ((close - low) / span).where(span != 0, 0.5)
+
+    f["realized_vol_bps"] = f["ret_1m"].rolling(vol_window, min_periods=2).std()
+    f["vol_bucket"] = _vol_bucket(f["realized_vol_bps"])
+    vol_mean = f["volume"].rolling(vol_window, min_periods=2).mean()
+    vol_std = f["volume"].rolling(vol_window, min_periods=2).std()
+    f["vol_z"] = ((f["volume"] - vol_mean) / vol_std).where(vol_std != 0, 0.0)
+
+    # rolling sweep levels from PRIOR bars (exclude current via shift(1))
+    f["roll_high"] = high.rolling(roll_window, min_periods=1).max().shift(1)
+    f["roll_low"] = low.rolling(roll_window, min_periods=1).min().shift(1)
+
+    dt = pd.to_datetime(f["dt"], utc=True)
+    f["time_bucket"] = dt.dt.hour.map(_time_bucket)
+    mins_from_funding = dt.dt.hour.isin(_FUNDING_HOURS) & (dt.dt.minute < 5)
+    near_prev = dt.dt.hour.isin([h - 1 for h in _FUNDING_HOURS]) & (dt.dt.minute > 55)
+    f["near_funding"] = mins_from_funding | near_prev
+
+    # next-bar extremes for maker passive-fill estimation
+    f["next_low"] = low.shift(-1)
+    f["next_high"] = high.shift(-1)
+    return f

--- a/research/nautilus_scalping/discovery/hypotheses.py
+++ b/research/nautilus_scalping/discovery/hypotheses.py
@@ -1,0 +1,171 @@
+"""ROB-339 — hypothesis evaluation machinery + the five family functions (pure).
+
+``evaluate_hypothesis`` is the auditable core: chronological in-sample/OOS split,
+fee-adjusted in-sample expectancy (decision metric), OOS-tail confirmation. Each
+family is a thin boolean condition mask over the engineered features. Conditions
+are intentionally simple first cuts (refine in PR2); discovery only screens.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pandas as pd
+
+from discovery.screen import HypothesisSummary
+
+_BPS = 1e4
+# Maker passive entry saves ~the taker/maker spread on the entry leg; for a
+# conservative screen we still budget the taker round-trip and let missed_fill
+# carry the maker-specific risk. Precise maker re-sim is PR2.
+
+
+def evaluate_hypothesis(
+    bars: pd.DataFrame,
+    signal_mask: pd.Series,
+    *,
+    name: str,
+    conditions: str,
+    fwd_col: str,
+    direction: str = "long",
+    fee_budget_bps: float,
+    oos_frac: float = 0.25,
+    missed_fill_ratio: float | None = None,
+    regime: str | None = None,
+    time_bucket: str | None = None,
+    symbol: str | None = None,
+) -> HypothesisSummary:
+    df = bars.reset_index(drop=True)
+    mask = signal_mask.reset_index(drop=True).fillna(False).astype(bool)
+    outcome = df[fwd_col].astype(float)
+    if direction == "short":
+        outcome = -outcome
+
+    n = len(df)
+    split_idx = int(n * (1.0 - oos_frac))
+    pos = pd.Series(range(n))
+    valid = mask & outcome.notna()
+    in_out = outcome[valid & (pos < split_idx)]
+    oos_out = outcome[valid & (pos >= split_idx)]
+
+    gross = float(in_out.mean()) if len(in_out) else 0.0
+    oos_fee_adj = float(oos_out.mean()) - fee_budget_bps if len(oos_out) else None
+    return HypothesisSummary(
+        name=name,
+        conditions=conditions,
+        sample_count=int(len(in_out)),
+        gross_expectancy_bps=gross,
+        fee_adjusted_bps=gross - fee_budget_bps,
+        oos_fee_adjusted_bps=oos_fee_adj,
+        missed_fill_ratio=missed_fill_ratio,
+        regime=regime,
+        time_bucket=time_bucket,
+        symbol=symbol,
+    )
+
+
+def _maker_missed_fill_ratio(
+    featured: pd.DataFrame, mask: pd.Series, entry_offset_bps: float
+) -> float:
+    sig = featured[mask.fillna(False).astype(bool)]
+    nxt = sig["next_low"]
+    valid = nxt.notna()
+    if valid.sum() == 0:
+        return 0.0
+    limit = sig["close"] * (1.0 - entry_offset_bps / _BPS)
+    return float((nxt[valid] > limit[valid]).mean())
+
+
+def run_all_hypotheses(
+    featured: pd.DataFrame,
+    *,
+    fee_budget_bps: float,
+    entry_offset_bps: float = 5.0,
+    oos_frac: float = 0.25,
+    symbol: str | None = None,
+) -> list[HypothesisSummary]:
+    """Evaluate the five hypothesis families against engineered features."""
+    f = featured
+    out: list[HypothesisSummary] = []
+
+    # 1. momentum continuation: recent up-extension, close near high, volume expansion
+    momo = (f["ret_3m"] > 0) & (f["close_pos"] >= 0.6) & (f["vol_z"] > 0.0)
+    out.append(
+        evaluate_hypothesis(
+            f,
+            momo,
+            name="momentum_continuation",
+            conditions="ret_3m>0 & close_pos>=0.6 & vol_z>0",
+            fwd_col="fwd_ret_3m",
+            direction="long",
+            fee_budget_bps=fee_budget_bps,
+            oos_frac=oos_frac,
+        )
+    )
+
+    # 2. liquidity sweep / fake-breakout reversal: prior low swept then reclaimed
+    sweep = (f["low"] < f["roll_low"]) & (f["close"] > f["roll_low"])
+    out.append(
+        evaluate_hypothesis(
+            f,
+            sweep,
+            name="sweep_reversal",
+            conditions="low<roll_low & close>roll_low (sweep+reclaim)",
+            fwd_col="fwd_ret_3m",
+            direction="long",
+            fee_budget_bps=fee_budget_bps,
+            oos_frac=oos_frac,
+        )
+    )
+
+    # 3. volatility regime filter: momentum restricted to the high-vol regime
+    vol = (f["vol_bucket"] == "high") & (f["ret_3m"] > 0)
+    out.append(
+        evaluate_hypothesis(
+            f,
+            vol,
+            name="vol_regime_filter",
+            conditions="vol_bucket=='high' & ret_3m>0",
+            fwd_col="fwd_ret_3m",
+            direction="long",
+            regime="high",
+            fee_budget_bps=fee_budget_bps,
+            oos_frac=oos_frac,
+        )
+    )
+
+    # 4. time-of-day filter: momentum restricted to the US session window
+    tod = (f["time_bucket"] == "us") & (f["ret_3m"] > 0)
+    out.append(
+        evaluate_hypothesis(
+            f,
+            tod,
+            name="time_of_day_filter",
+            conditions="time_bucket=='us' & ret_3m>0",
+            fwd_col="fwd_ret_3m",
+            direction="long",
+            time_bucket="us",
+            fee_budget_bps=fee_budget_bps,
+            oos_frac=oos_frac,
+        )
+    )
+
+    # 5. maker/passive-entry viability: momentum signal + passive-fill feasibility
+    missed = _maker_missed_fill_ratio(f, momo, entry_offset_bps)
+    out.append(
+        evaluate_hypothesis(
+            f,
+            momo,
+            name="maker_viability",
+            conditions=f"momentum signal w/ passive limit {entry_offset_bps}bps below close",
+            fwd_col="fwd_ret_3m",
+            direction="long",
+            fee_budget_bps=fee_budget_bps,
+            oos_frac=oos_frac,
+            missed_fill_ratio=missed,
+        )
+    )
+
+    if symbol is not None:
+        out = [replace(s, symbol=symbol) for s in out]
+    return out

--- a/research/nautilus_scalping/discovery/screen.py
+++ b/research/nautilus_scalping/discovery/screen.py
@@ -1,0 +1,119 @@
+"""ROB-339 — fast-fail classification + artifact assembly (pure, stdlib).
+
+Discovery is a *screen*, not a verdict. Each hypothesis summary is classified into
+one of three non-canonical recommendations; promote candidates are explicitly
+flagged ``in_sample_only`` because the in-sample gross/fee-adjusted edge has not
+survived the full walk-forward gate (OOS/baseline/overfit + bootstrap CI), which
+remains the sole owner of ``validated``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+SCHEMA_VERSION = "scalping_discovery.v1"
+
+Recommendation = Literal[
+    "screened_out", "needs_more_data", "promote_to_full_validation"
+]
+
+_NON_CANONICAL_NOTE = (
+    "Discovery output is non-canonical. These recommendations (screened_out / "
+    "needs_more_data / promote_to_full_validation) are cheap pre-screens, NOT gate "
+    "verdicts. Only the conservative validated_signal_gate.v1 (walk-forward OOS + "
+    "baselines + overfit flags + bootstrap CI) produces validated / not_validated."
+)
+
+
+@dataclass(frozen=True)
+class HypothesisSummary:
+    """Bounded feature->outcome summary for one hypothesis on one symbol set.
+
+    ``fee_adjusted_bps`` is the in-sample (decision-fold) gross expectancy minus the
+    round-trip fee budget; ``oos_fee_adjusted_bps`` is the same on the held-out tail.
+    ``missed_fill_ratio`` is set only for maker/passive-entry hypotheses.
+    """
+
+    name: str
+    conditions: str
+    sample_count: int
+    gross_expectancy_bps: float
+    fee_adjusted_bps: float
+    oos_fee_adjusted_bps: float | None = None
+    missed_fill_ratio: float | None = None
+    regime: str | None = None
+    time_bucket: str | None = None
+    symbol: str | None = None
+
+
+@dataclass(frozen=True)
+class ClassifiedHypothesis:
+    summary: HypothesisSummary
+    recommendation: Recommendation
+    reason: str
+    in_sample_only: bool = False
+
+    def to_dict(self) -> dict:
+        d = asdict(self.summary)
+        d.update(
+            recommendation=self.recommendation,
+            reason=self.reason,
+            in_sample_only=self.in_sample_only,
+        )
+        return d
+
+
+def classify(
+    summary: HypothesisSummary,
+    *,
+    min_samples: int = 200,
+    missed_fill_max: float = 0.6,
+) -> ClassifiedHypothesis:
+    """Apply the fast-fail rules in priority order (see design §6)."""
+    s = summary
+    if s.sample_count < min_samples:
+        return ClassifiedHypothesis(
+            s,
+            "needs_more_data",
+            f"sample_count {s.sample_count} < min_samples {min_samples}",
+        )
+    if s.fee_adjusted_bps <= 0:
+        return ClassifiedHypothesis(
+            s,
+            "screened_out",
+            f"fee-adjusted expectancy {s.fee_adjusted_bps:.2f}bps <= 0 "
+            f"(gross {s.gross_expectancy_bps:.2f}bps does not clear the fee budget)",
+        )
+    if s.missed_fill_ratio is not None and s.missed_fill_ratio > missed_fill_max:
+        return ClassifiedHypothesis(
+            s,
+            "screened_out",
+            f"missed-fill ratio {s.missed_fill_ratio:.2f} > {missed_fill_max:.2f} "
+            "(passive entry loses too many fills)",
+        )
+    if s.oos_fee_adjusted_bps is not None and s.oos_fee_adjusted_bps <= 0:
+        return ClassifiedHypothesis(
+            s,
+            "screened_out",
+            f"OOS-tail fee-adjusted expectancy {s.oos_fee_adjusted_bps:.2f}bps <= 0 "
+            "(in-sample edge does not hold out of sample)",
+        )
+    return ClassifiedHypothesis(
+        s,
+        "promote_to_full_validation",
+        f"in-sample fee-adjusted {s.fee_adjusted_bps:.2f}bps > 0 with "
+        f"{s.sample_count} samples; OOS-tail sign agrees",
+        in_sample_only=True,
+    )
+
+
+def build_artifact(classified: list[ClassifiedHypothesis], run: dict) -> dict:
+    """Assemble the ``scalping_discovery.v1`` artifact dict (pure; caller writes it)."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": run,
+        "hypotheses_tested": len(classified),
+        "hypotheses": [c.to_dict() for c in classified],
+        "note": _NON_CANONICAL_NOTE,
+    }

--- a/research/nautilus_scalping/tests/test_discovery_decode.py
+++ b/research/nautilus_scalping/tests/test_discovery_decode.py
@@ -1,0 +1,61 @@
+"""ROB-339 — decode the Nautilus catalog fixed-point price/size encoding.
+
+A ParquetDataCatalog stores price/size as fixed_size_binary[16] (int128
+little-endian raw = value * 10**precision), with precision in the parquet schema
+metadata. read_ticks must decode these to floats while leaving plain-float parquet
+(the other unit tests) untouched.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from discovery.data import _decode_int128_le, read_ticks
+
+
+def test_decode_int128_le_fixed_point() -> None:
+    raw = (3_650_012).to_bytes(16, "little", signed=True)
+    assert _decode_int128_le(raw, 2) == 36500.12
+
+
+def test_decode_int128_le_negative_and_zero_precision() -> None:
+    assert _decode_int128_le((-5).to_bytes(16, "little", signed=True), 0) == -5.0
+
+
+def test_read_ticks_decodes_binary_price_size(tmp_path) -> None:
+    p = tmp_path / "t.parquet"
+    ts0 = pd.Timestamp("2026-03-02", tz="UTC").value
+    ts = [ts0, ts0 + 1, ts0 + 2]
+    # 128-bit Nautilus: raw = value * 10**16 (fixed), display precision only rounds.
+    price_raw = [int(0.6012 * 10**16).to_bytes(16, "little", signed=True)] * 3
+    size_raw = [int(1.5 * 10**16).to_bytes(16, "little", signed=True)] * 3
+    table = pa.table(
+        {
+            "ts_event": pa.array(ts, pa.uint64()),
+            "price": pa.array(price_raw, pa.binary(16)),
+            "size": pa.array(size_raw, pa.binary(16)),
+        }
+    )
+    pq.write_table(table, p)
+    df = read_ticks(p, None, None, price_precision=4, size_precision=5)
+    assert round(df["price"].iloc[0], 4) == 0.6012
+    assert round(df["size"].iloc[0], 5) == 1.5
+
+
+def test_read_ticks_binary_still_respects_window(tmp_path) -> None:
+    p = tmp_path / "t.parquet"
+    ts0 = pd.Timestamp("2026-03-02", tz="UTC").value
+    ts1 = pd.Timestamp("2026-03-03", tz="UTC").value
+    ts = [ts0, ts0 + 1, ts1]  # two in day2, one in day3
+    raw = [(6012).to_bytes(16, "little", signed=True)] * 3
+    table = pa.table(
+        {
+            "ts_event": pa.array(ts, pa.uint64()),
+            "price": pa.array(raw, pa.binary(16)),
+            "size": pa.array(raw, pa.binary(16)),
+        }
+    )
+    pq.write_table(table, p)
+    df = read_ticks(p, ts_from=ts0, ts_to=ts1, price_precision=4, size_precision=4)
+    assert len(df) == 2  # day3 row filtered out at scan time

--- a/research/nautilus_scalping/tests/test_discovery_driver.py
+++ b/research/nautilus_scalping/tests/test_discovery_driver.py
@@ -1,0 +1,65 @@
+"""ROB-339 — discover.py orchestration (pure core) + CLI parser + artifact write.
+
+The catalog-loading main() is integration (covered at smoke); the pure
+discover_from_bars + arg parser + write helper are unit-tested here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+from discover import build_arg_parser, discover_from_bars, write_discovery_artifact
+
+
+def _bars(start: str = "2026-03-02 13:00") -> pd.DataFrame:
+    dt = pd.date_range(start, periods=400, freq="1min", tz="UTC")
+    close = pd.Series(range(400), dtype=float) * 0.01 + 100.0
+    return pd.DataFrame(
+        {
+            "dt": dt,
+            "open": close,
+            "high": close + 0.05,
+            "low": close - 0.05,
+            "close": close,
+            "volume": 10.0,
+        }
+    )
+
+
+def test_discover_from_bars_one_symbol_five_hypotheses() -> None:
+    art = discover_from_bars({"XRPUSDT": _bars()}, fee_budget_bps=8.0)
+    assert art["hypotheses_tested"] == 5
+    recs = {h["recommendation"] for h in art["hypotheses"]}
+    assert recs <= {"screened_out", "needs_more_data", "promote_to_full_validation"}
+
+
+def test_discover_from_bars_tags_symbol() -> None:
+    art = discover_from_bars({"XRPUSDT": _bars()}, fee_budget_bps=8.0)
+    assert all(h["symbol"] == "XRPUSDT" for h in art["hypotheses"])
+
+
+def test_two_symbols_produce_ten_entries() -> None:
+    art = discover_from_bars(
+        {"XRPUSDT": _bars(), "BTCUSDT": _bars("2026-03-03 00:00")},
+        fee_budget_bps=8.0,
+    )
+    assert art["hypotheses_tested"] == 10
+    assert {"XRPUSDT", "BTCUSDT"} == {h["symbol"] for h in art["hypotheses"]}
+
+
+def test_arg_parser_defaults() -> None:
+    ns = build_arg_parser().parse_args(["--symbols", "XRPUSDT,BTCUSDT"])
+    assert ns.symbols == "XRPUSDT,BTCUSDT"
+    assert ns.fee_budget_bps == 8.0
+    assert ns.min_samples == 200
+
+
+def test_write_artifact_roundtrip(tmp_path) -> None:
+    art = discover_from_bars({"XRPUSDT": _bars()}, fee_budget_bps=8.0)
+    out = tmp_path / "discovery.json"
+    written = write_discovery_artifact(art, export=out)
+    assert written == out
+    reloaded = json.loads(out.read_text())
+    assert reloaded["schema_version"] == "scalping_discovery.v1"
+    assert reloaded["hypotheses_tested"] == 5

--- a/research/nautilus_scalping/tests/test_discovery_features.py
+++ b/research/nautilus_scalping/tests/test_discovery_features.py
@@ -1,0 +1,62 @@
+"""ROB-339 — discovery feature engineering (pure pandas).
+
+Backward returns/range/close-position/vol regime/time bucket as inputs; forward
+returns (bps) as outcomes. Hand-computable on a tiny synthetic bar ramp.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from discovery.features import add_features
+
+
+def _bars() -> pd.DataFrame:
+    dt = pd.date_range("2026-03-02 13:00", periods=6, freq="1min", tz="UTC")
+    close = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
+    high = [c + 0.5 for c in close]
+    low = [c - 0.5 for c in close]
+    return pd.DataFrame(
+        {
+            "dt": dt,
+            "open": close,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": [10.0, 10.0, 10.0, 10.0, 10.0, 10.0],
+        }
+    )
+
+
+def test_backward_and_forward_returns_bps() -> None:
+    f = add_features(_bars())
+    assert round(f["ret_1m"].iloc[1], 4) == 100.0  # (101-100)/100*1e4
+    assert round(f["fwd_ret_1m"].iloc[0], 4) == 100.0  # forward 1-bar return
+    assert round(f["fwd_ret_3m"].iloc[0], 4) == 300.0  # (103-100)/100*1e4
+
+
+def test_range_and_close_position() -> None:
+    f = add_features(_bars())
+    assert round(f["bar_range_bps"].iloc[0], 4) == 100.0  # (100.5-99.5)/100*1e4
+    assert round(f["close_pos"].iloc[0], 4) == 0.5  # mid of [low, high]
+
+
+def test_time_bucket_and_regime_columns_present() -> None:
+    f = add_features(_bars())
+    assert f["time_bucket"].iloc[0] == "us"  # 13:00 UTC
+    for col in (
+        "realized_vol_bps",
+        "vol_bucket",
+        "roll_high",
+        "roll_low",
+        "near_funding",
+        "next_low",
+        "next_high",
+    ):
+        assert col in f.columns
+
+
+def test_next_bar_lookahead_columns() -> None:
+    f = add_features(_bars())
+    # next_low / next_high are the following bar's extremes (for maker fill est)
+    assert round(f["next_low"].iloc[0], 4) == 100.5  # bar 1 low = 101-0.5
+    assert round(f["next_high"].iloc[0], 4) == 101.5  # bar 1 high = 101+0.5

--- a/research/nautilus_scalping/tests/test_discovery_hypotheses.py
+++ b/research/nautilus_scalping/tests/test_discovery_hypotheses.py
@@ -1,0 +1,84 @@
+"""ROB-339 — hypothesis evaluation machinery + the five family functions.
+
+The machinery is the auditable core: a chronological in-sample/OOS split, a
+fee-adjusted in-sample expectancy as the decision metric, and an OOS-tail
+confirmation read. Families are thin condition masks over features.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from discovery.features import add_features
+from discovery.hypotheses import evaluate_hypothesis, run_all_hypotheses
+from discovery.screen import HypothesisSummary
+
+
+def _featured_for_machinery() -> pd.DataFrame:
+    # 10 bars; fwd_ret_3m hand-set so signal-row means are exact.
+    df = pd.DataFrame({"fwd_ret_3m": [90.0, 0, 110.0, 0, 0, 100.0, 0, 0, 40.0, 0]})
+    return df
+
+
+def test_evaluate_hypothesis_split_and_fee_adjust() -> None:
+    bars = _featured_for_machinery()
+    mask = pd.Series([True, False, True, False, False, True, False, False, True, False])
+    s = evaluate_hypothesis(
+        bars,
+        mask,
+        name="m",
+        conditions="cond",
+        fwd_col="fwd_ret_3m",
+        direction="long",
+        fee_budget_bps=8.0,
+        oos_frac=0.25,
+    )
+    # split at int(10*0.75)=7 -> in-sample signals at rows 0,2,5 ; OOS signal at row 8
+    assert s.sample_count == 3
+    assert round(s.gross_expectancy_bps, 4) == 100.0  # mean(90,110,100)
+    assert round(s.fee_adjusted_bps, 4) == 92.0  # 100 - 8
+    assert round(s.oos_fee_adjusted_bps, 4) == 32.0  # 40 - 8
+
+
+def test_direction_short_flips_outcome_sign() -> None:
+    bars = pd.DataFrame({"fwd_ret_3m": [-100.0, -100.0, -100.0, 0, 0, 0, 0, 0]})
+    mask = pd.Series([True, True, True, False, False, False, False, False])
+    s = evaluate_hypothesis(
+        bars,
+        mask,
+        name="r",
+        conditions="c",
+        fwd_col="fwd_ret_3m",
+        direction="short",
+        fee_budget_bps=8.0,
+        oos_frac=0.25,
+    )
+    assert round(s.gross_expectancy_bps, 4) == 100.0  # short profits from -100 moves
+
+
+def test_run_all_hypotheses_returns_five_named_summaries() -> None:
+    dt = pd.date_range("2026-03-02 13:00", periods=400, freq="1min", tz="UTC")
+    # gentle uptrend + noise so signals actually fire
+    close = pd.Series(range(400), dtype=float) * 0.01 + 100.0
+    bars = pd.DataFrame(
+        {
+            "dt": dt,
+            "open": close,
+            "high": close + 0.05,
+            "low": close - 0.05,
+            "close": close,
+            "volume": 10.0,
+        }
+    )
+    featured = add_features(bars)
+    summaries = run_all_hypotheses(featured, fee_budget_bps=8.0)
+    assert all(isinstance(s, HypothesisSummary) for s in summaries)
+    names = {s.name for s in summaries}
+    assert names == {
+        "momentum_continuation",
+        "sweep_reversal",
+        "vol_regime_filter",
+        "time_of_day_filter",
+        "maker_viability",
+    }
+    maker = next(s for s in summaries if s.name == "maker_viability")
+    assert maker.missed_fill_ratio is not None

--- a/research/nautilus_scalping/tests/test_discovery_paths.py
+++ b/research/nautilus_scalping/tests/test_discovery_paths.py
@@ -1,0 +1,56 @@
+"""ROB-339 — artifact_paths: the D2 artifact-root resolver (pure, stdlib).
+
+Unset env -> repo-internal results/ (current behavior, zero-config / CI-safe).
+Env set -> that root. Namespace separation (discovery vs gate) keeps non-canonical
+discovery output from being mistaken for gate run-cards.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import artifact_paths
+import pytest
+
+_ENV = "AUTO_TRADER_RESEARCH_ARTIFACT_ROOT"
+
+
+def test_root_defaults_to_repo_results_when_env_unset(monkeypatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    root = artifact_paths.research_artifact_root()
+    # module lives at research/nautilus_scalping/artifact_paths.py
+    expected = Path(artifact_paths.__file__).resolve().parent / "results"
+    assert root == expected
+
+
+def test_root_uses_env_when_set(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(_ENV, str(tmp_path / "artifacts"))
+    assert artifact_paths.research_artifact_root() == (tmp_path / "artifacts")
+
+
+def test_empty_env_falls_back_to_results(monkeypatch) -> None:
+    monkeypatch.setenv(_ENV, "   ")  # whitespace-only is treated as unset
+    expected = Path(artifact_paths.__file__).resolve().parent / "results"
+    assert artifact_paths.research_artifact_root() == expected
+
+
+def test_resolve_joins_namespace_and_parts(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(_ENV, str(tmp_path))
+    p = artifact_paths.resolve_artifact_path("discovery", "run1", "discovery.json")
+    assert p == tmp_path / "discovery" / "run1" / "discovery.json"
+
+
+def test_resolve_rejects_unknown_namespace(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(_ENV, str(tmp_path))
+    with pytest.raises(ValueError):
+        artifact_paths.resolve_artifact_path("not_a_namespace", "x.json")
+
+
+def test_no_app_settings_import() -> None:
+    """research-only boundary: the resolver must not pull in app config."""
+    import sys
+
+    src = Path(artifact_paths.__file__).read_text()
+    assert "from app" not in src and "import app" not in src
+    # and importing it did not drag in the app package
+    assert "app.core.config" not in sys.modules

--- a/research/nautilus_scalping/tests/test_discovery_screen.py
+++ b/research/nautilus_scalping/tests/test_discovery_screen.py
@@ -1,0 +1,85 @@
+"""ROB-339 — discovery fast-fail classifier + artifact assembly (pure).
+
+Non-canonical recommendations only: screened_out / needs_more_data /
+promote_to_full_validation. Promote always carries in_sample_only=True. The
+artifact records hypotheses_tested (multiple-comparison transparency) and a note
+stating discovery never produces a gate verdict.
+"""
+
+from __future__ import annotations
+
+from discovery.screen import (
+    HypothesisSummary,
+    build_artifact,
+    classify,
+)
+
+
+def _summary(**kw) -> HypothesisSummary:
+    base = {
+        "name": "momentum_continuation",
+        "conditions": "ret_3m>0 and vol_expansion",
+        "sample_count": 500,
+        "gross_expectancy_bps": 12.0,
+        "fee_adjusted_bps": 4.0,
+        "oos_fee_adjusted_bps": 3.0,
+    }
+    base.update(kw)
+    return HypothesisSummary(**base)
+
+
+def test_low_sample_count_needs_more_data() -> None:
+    c = classify(_summary(sample_count=50), min_samples=200)
+    assert c.recommendation == "needs_more_data"
+    assert c.in_sample_only is False
+
+
+def test_nonpositive_fee_adjusted_is_screened_out() -> None:
+    c = classify(_summary(fee_adjusted_bps=-1.5))
+    assert c.recommendation == "screened_out"
+    assert "fee" in c.reason.lower()
+
+
+def test_high_missed_fill_ratio_is_screened_out() -> None:
+    c = classify(_summary(missed_fill_ratio=0.75), missed_fill_max=0.6)
+    assert c.recommendation == "screened_out"
+    assert "missed" in c.reason.lower()
+
+
+def test_oos_sign_disagreement_is_screened_out() -> None:
+    # positive in-sample edge but OOS tail flips negative -> not robust
+    c = classify(_summary(fee_adjusted_bps=4.0, oos_fee_adjusted_bps=-2.0))
+    assert c.recommendation == "screened_out"
+    assert "oos" in c.reason.lower()
+
+
+def test_positive_in_sample_and_oos_promotes() -> None:
+    c = classify(_summary(fee_adjusted_bps=4.0, oos_fee_adjusted_bps=3.0))
+    assert c.recommendation == "promote_to_full_validation"
+    assert c.in_sample_only is True
+
+
+def test_acceptable_missed_fill_still_promotes() -> None:
+    c = classify(_summary(missed_fill_ratio=0.4), missed_fill_max=0.6)
+    assert c.recommendation == "promote_to_full_validation"
+
+
+def test_build_artifact_records_count_and_noncanonical_note() -> None:
+    classified = [
+        classify(_summary()),
+        classify(_summary(name="sweep_reversal", fee_adjusted_bps=-3.0)),
+    ]
+    run = {
+        "symbols": ["XRPUSDT"],
+        "window": {"from": "2026-03-01", "to": "2026-05-14"},
+        "fee_budget_bps": 8.0,
+    }
+    art = build_artifact(classified, run)
+    assert art["schema_version"] == "scalping_discovery.v1"
+    assert art["hypotheses_tested"] == 2
+    assert len(art["hypotheses"]) == 2
+    # recommendations stay within the non-canonical vocabulary
+    recs = {h["recommendation"] for h in art["hypotheses"]}
+    assert recs <= {"screened_out", "needs_more_data", "promote_to_full_validation"}
+    # the note must make clear this is not a gate verdict
+    assert "validated" in art["note"].lower() and "non-canonical" in art["note"].lower()

--- a/research/nautilus_scalping/tests/test_discovery_window.py
+++ b/research/nautilus_scalping/tests/test_discovery_window.py
@@ -1,0 +1,72 @@
+"""ROB-339 (D4) — the discovery window is a REAL data constraint.
+
+Proves read_ticks excludes out-of-window rows via a pyarrow predicate-pushdown
+filter on ts_event (not metadata, not a post-hoc slice the caller forgets to
+apply), plus the date->ns bounds helper and tick->bar aggregation.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from discovery.data import aggregate_to_bars, read_ticks, window_bounds_ns
+
+_NS_DAY1 = pd.Timestamp("2026-03-01", tz="UTC").value
+_NS_DAY2 = pd.Timestamp("2026-03-02", tz="UTC").value
+_NS_DAY3 = pd.Timestamp("2026-03-03", tz="UTC").value
+
+
+def _write_ticks(path) -> None:
+    # 2 ticks on day1, 3 on day2, 1 on day3
+    rows = [
+        (_NS_DAY1, 0.50, 100.0),
+        (_NS_DAY1 + 30_000_000_000, 0.51, 50.0),
+        (_NS_DAY2, 0.60, 10.0),
+        (_NS_DAY2 + 10_000_000_000, 0.62, 20.0),
+        (_NS_DAY2 + 20_000_000_000, 0.61, 30.0),
+        (_NS_DAY3, 0.70, 5.0),
+    ]
+    pd.DataFrame(rows, columns=["ts_event", "price", "size"]).to_parquet(path)
+
+
+def test_read_ticks_window_excludes_out_of_window_rows(tmp_path) -> None:
+    p = tmp_path / "ticks.parquet"
+    _write_ticks(p)
+    df = read_ticks(p, ts_from=_NS_DAY2, ts_to=_NS_DAY3)
+    assert len(df) == 3  # only the day2 ticks
+    assert df["ts_event"].min() >= _NS_DAY2
+    assert df["ts_event"].max() < _NS_DAY3
+
+
+def test_read_ticks_no_bounds_returns_all(tmp_path) -> None:
+    p = tmp_path / "ticks.parquet"
+    _write_ticks(p)
+    assert len(read_ticks(p, ts_from=None, ts_to=None)) == 6
+
+
+def test_window_bounds_ns_date_inclusive_to() -> None:
+    lo, hi = window_bounds_ns("2026-03-02", "2026-03-02")
+    assert lo == _NS_DAY2
+    assert hi == _NS_DAY3  # 'to' date is inclusive -> half-open up to next midnight
+
+
+def test_window_bounds_ns_blank_is_none() -> None:
+    assert window_bounds_ns("", "") == (None, None)
+
+
+def test_aggregate_to_bars_ohlcv() -> None:
+    base = _NS_DAY2
+    ticks = pd.DataFrame(
+        {
+            "ts_event": [base, base + 10_000_000_000, base + 20_000_000_000],
+            "price": [0.60, 0.62, 0.61],
+            "size": [10.0, 20.0, 30.0],
+        }
+    )
+    bars = aggregate_to_bars(ticks, freq="1min")
+    assert len(bars) == 1
+    bar = bars.iloc[0]
+    assert bar["open"] == 0.60
+    assert bar["high"] == 0.62
+    assert bar["low"] == 0.60
+    assert bar["close"] == 0.61
+    assert bar["volume"] == 60.0


### PR DESCRIPTION
Research-first follow-up to ROB-320 (#968) and ROB-324 (#984), both `not_validated`. Adds a **discovery → pilot → full-validation funnel**: a pure pandas/pyarrow harness that screens the five hypothesis families cheaply before paying for full 75-day Nautilus validation. Linear: ROB-339.

## What this PR adds (PR1)
- **`artifact_paths.py`** — `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT` resolver (opt-in; unset → repo `results/`). Read via plain `os.environ` only — **never** app `Settings`/pydantic. `discovery/` vs `gate/` namespace separation so non-canonical discovery output can't be mistaken for `validated_run_card` citations.
- **`discovery/data.py`** — `read_ticks` applies the `[from, to)` window as a **pyarrow predicate-pushdown filter** on `ts_event` (real data constraint, not metadata) + 128-bit catalog fixed-point decode + bar aggregation.
- **`discovery/features.py`** — vectorized returns/range/close-position/vol-regime/time-bucket + forward-return outcomes + next-bar extremes.
- **`discovery/hypotheses.py`** — chronological in-sample/OOS-split + fee-adjusted expectancy machinery; the 5 families (momentum / sweep-reversal / vol-regime / time-of-day / maker-viability).
- **`discovery/screen.py`** — fast-fail classifier (`screened_out` / `needs_more_data` / `promote_to_full_validation`), `in_sample_only` flag on promote, `hypotheses_tested` count + non-canonical note. **Discovery never emits `validated`.**
- **`discover.py`** — CLI driver → `scalping_discovery.v1` artifact.
- **Design note:** `docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md`.

Deferred to **PR2:** Nautilus `backtest_runner` window constraint, baseline run caching, vectorized fixed-point decode, precise maker-viability re-sim.

## Verification
- **34 discovery unit tests** (synthetic fixtures; no 75-day tick data in CI); existing pure research tests still green; **ruff clean** (check + format).
- **Bounded smoke** (XRPUSDT+BTCUSDT, 2026-03-01..03-15, ~50s, 8 bps budget, against the rob-320 catalog read-only): **all 10 (2 symbols × 5 families) `screened_out`**, in-sample gross expectancy **−0.58 .. +0.44 bps** — none clears fees; OOS-tail also negative. Reproduces the ROB-316/320/324 result. Artifact: `/tmp/rob339_smoke_discovery.json` (not committed; ephemeral).
- **Catalog encoding note:** the catalog is 128-bit high-precision Nautilus — `price`/`size` are `fixed_size_binary[16]` int128 LE, raw = `value * 10**16` (fixed by build); the `*_precision` schema metadata is display precision only. Decoded accordingly (a real-data smoke caught an initial wrong divide-by-display-precision assumption; discovery verdicts were unaffected since all metrics are return/ratio-based = scale-invariant).

## Recommended next strategy family
None of the five clears taker fees on this data, so **no family is promoted to full validation as-is.** Least-negative gross was BTCUSDT/sweep_reversal (+0.44 bps) and XRP sweep/time-of-day (+0.28 bps). If any direction warrants a deeper look it is **liquidity-sweep reversal**, and only after a maker/limit cost model + tighter regime/time segmentation materially lift gross expectancy. At taker fees it is a clear reject.

## Safety boundary
Research/backtest only. **No live trading, no Binance Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod DB/env/secret mutation, no runtime strategy-parameter application, no `/invest` surfacing.** The discovery harness imports nothing from `app/` and nothing from the Nautilus engine; public trade-tick parquet catalog is read-only; artifacts contain no secrets/balances/positions/account ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a scalping strategy discovery funnel for research, enabling data loading, feature engineering, hypothesis testing, and pre-screening of trading strategies
  * Configurable artifact path resolution for organizing and storing discovery outputs

* **Documentation**
  * Added design specification for the discovery funnel workflow and validation process

* **Tests**
  * Added comprehensive test coverage for discovery components including data handling, feature engineering, hypothesis evaluation, and screening logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->