### PR TITLE
feat(rob-339): vectorize catalog fixed-point decode (PR2)

### DIFF
--- a/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
@@ -173,12 +173,18 @@ explicitly. Final `validated` stays owned by the unchanged
   `discover.py` driver, artifact schema + fast-fail classifier, discovery-path real
   window filter, unit tests (no 75-day tick data in CI). Optional: one bounded smoke
   run against the rob-320 catalog with elapsed time + artifact path in PR notes.
-- **PR2:** `backtest_runner` real window constraint (catalog start/end query if the
-  API supports it, else post-load `ts_event` filter + documented limitation with a
-  test), baseline run caching keyed by catalog/window/symbol/params/code-version,
-  vectorized fixed-point decode (PR1 uses a per-row Python decode — ~50s for a
-  15-day 2-symbol window; numpy/int128 vectorization makes the full 75-day window
-  "fast"), optional precise maker-viability re-sim borrowing ROB-324's `maker_fill`.
+- **PR2 (this PR — vectorized decode):** replace the per-row `int.from_bytes` map
+  with a vectorized integer-view decode of the fixed_size_binary columns (low 64
+  bits unsigned + high 64 bits signed), and build only the columns discovery needs
+  (skip the `to_pandas` bytes-object materialization). Verified on the same 15-day
+  2-symbol smoke: **~50s → ~7s** with identical verdicts/prices. Unit-tested for
+  scalar parity (incl. negative two's-complement) and arrow-slice offsets.
+- **PR3 (deferred):** `backtest_runner` real window constraint (catalog start/end
+  query if the API supports it, else post-load `ts_event` filter + documented
+  limitation with a test), baseline run caching keyed by
+  catalog/window/symbol/params/code-version, optional precise maker-viability re-sim
+  borrowing ROB-324's `maker_fill`. These touch the Nautilus subprocess path, which
+  needs the research venv (not the repo uv venv), so they are sliced separately.
 
 ## 9. Tests (no full 75-day data; CI-safe)
 

--- a/research/nautilus_scalping/discovery/data.py
+++ b/research/nautilus_scalping/discovery/data.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 import pyarrow.types as patypes
@@ -49,25 +51,70 @@ def _decode_int128_le(raw: bytes, precision: int) -> float:
 _RAW_PRECISION_BY_WIDTH = {16: 16, 8: 9}
 
 
-def _decode_if_binary(
-    df: pd.DataFrame, schema, col: str, display_precision: int | None, meta_key: bytes
-) -> None:
-    """Decode ``col`` in-place if it's fixed-point binary; leave plain numerics alone.
+def _decode_fixed_binary_array(arrow_col, raw_precision: int) -> np.ndarray:
+    """Vectorized decode of a fixed_size_binary column to ``int_LE / 10**raw_precision``.
 
-    The decode divisor is the fixed raw scale (by byte width); ``display_precision``
-    (arg or schema metadata) only rounds the decoded float for presentation.
+    Reads the contiguous data buffer as ``(n, width)`` uint8 and reinterprets it with
+    integer views (low 64 bits unsigned + high 64 bits signed for the 128-bit case),
+    which is exact and far faster than a per-row ``int.from_bytes`` map; the float64
+    conversion error is well below display precision.
     """
-    ftype = schema.field(col).type
-    if not (patypes.is_fixed_size_binary(ftype) or patypes.is_binary(ftype)):
-        return
-    width = ftype.byte_width if patypes.is_fixed_size_binary(ftype) else 16
-    raw_precision = _RAW_PRECISION_BY_WIDTH.get(width, 16)
-    df[col] = df[col].map(lambda b: _decode_int128_le(bytes(b), raw_precision))
+    arr = (
+        arrow_col.combine_chunks()
+        if isinstance(arrow_col, pa.ChunkedArray)
+        else arrow_col
+    )
+    width = arr.type.byte_width
+    n = len(arr)
+    raw = np.frombuffer(
+        arr.buffers()[1], dtype=np.uint8, count=n * width, offset=arr.offset * width
+    ).reshape(n, width)
+    # Decode via integer views (exact, little-endian x86): low 64 bits unsigned + high
+    # 64 bits SIGNED carries two's complement, avoiding the float64 rounding that a
+    # magnitude-then-subtract-2**128 approach hits at the int128 scale.
+    if width == 16:
+        lo = (
+            np.ascontiguousarray(raw[:, :8])
+            .view(np.uint64)
+            .reshape(n)
+            .astype(np.float64)
+        )
+        hi = (
+            np.ascontiguousarray(raw[:, 8:])
+            .view(np.int64)
+            .reshape(n)
+            .astype(np.float64)
+        )
+        val = hi * (2.0**64) + lo
+    elif width == 8:
+        val = np.ascontiguousarray(raw).view(np.int64).reshape(n).astype(np.float64)
+    else:  # uncommon width: exact per-row fallback
+        val = np.array(
+            [int.from_bytes(raw[i].tobytes(), "little", signed=True) for i in range(n)],
+            dtype=np.float64,
+        )
+    return val / (10.0**raw_precision)
+
+
+def _decode_or_passthrough(
+    table, col: str, display_precision: int | None, meta_key: bytes
+) -> np.ndarray:
+    """Decode a fixed-point binary column (by byte-width raw scale) else pass numerics through.
+
+    ``display_precision`` (arg or schema metadata) only rounds the decoded float.
+    """
+    ftype = table.schema.field(col).type
+    arr = table.column(col)
+    if not patypes.is_fixed_size_binary(ftype):
+        return arr.to_numpy(zero_copy_only=False)
+    raw_precision = _RAW_PRECISION_BY_WIDTH.get(ftype.byte_width, 16)
+    vals = _decode_fixed_binary_array(arr, raw_precision)
     if display_precision is None:
-        md = schema.metadata or {}
+        md = table.schema.metadata or {}
         display_precision = int(md[meta_key]) if meta_key in md else None
     if display_precision is not None:
-        df[col] = df[col].round(display_precision)
+        vals = np.round(vals, display_precision)
+    return vals
 
 
 def read_ticks(
@@ -94,10 +141,19 @@ def read_ticks(
         upper = ds.field("ts_event") < ts_to
         expr = upper if expr is None else (expr & upper)
     table = dataset.to_table(filter=expr)
-    df = table.to_pandas()
-    _decode_if_binary(df, table.schema, "price", price_precision, b"price_precision")
-    _decode_if_binary(df, table.schema, "size", size_precision, b"size_precision")
-    return df
+    # Build only the columns discovery needs; decode fixed-point binary vectorized
+    # (avoids materializing bytes objects via to_pandas on multi-million-row columns).
+    return pd.DataFrame(
+        {
+            "ts_event": table.column("ts_event").to_numpy(),
+            "price": _decode_or_passthrough(
+                table, "price", price_precision, b"price_precision"
+            ),
+            "size": _decode_or_passthrough(
+                table, "size", size_precision, b"size_precision"
+            ),
+        }
+    )
 
 
 def aggregate_to_bars(ticks: pd.DataFrame, freq: str = "1min") -> pd.DataFrame:

--- a/research/nautilus_scalping/tests/test_discovery_decode.py
+++ b/research/nautilus_scalping/tests/test_discovery_decode.py
@@ -8,10 +8,15 @@ metadata. read_ticks must decode these to floats while leaving plain-float parqu
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-from discovery.data import _decode_int128_le, read_ticks
+from discovery.data import (
+    _decode_fixed_binary_array,
+    _decode_int128_le,
+    read_ticks,
+)
 
 
 def test_decode_int128_le_fixed_point() -> None:
@@ -21,6 +26,27 @@ def test_decode_int128_le_fixed_point() -> None:
 
 def test_decode_int128_le_negative_and_zero_precision() -> None:
     assert _decode_int128_le((-5).to_bytes(16, "little", signed=True), 0) == -5.0
+
+
+def test_decode_fixed_binary_array_matches_scalar(tmp_path) -> None:
+    # PR2: the vectorized array decoder must match the per-value reference,
+    # including the 128-bit raw scale (10**16) and negative two's-complement.
+    raws = [int(1.3761 * 10**16), int(0.5 * 10**16), -3 * 10**16, 0]
+    arr = pa.array([v.to_bytes(16, "little", signed=True) for v in raws], pa.binary(16))
+    got = _decode_fixed_binary_array(arr, 16)
+    expected = [
+        _decode_int128_le(v.to_bytes(16, "little", signed=True), 16) for v in raws
+    ]
+    assert isinstance(got, np.ndarray)
+    assert np.allclose(got, expected, rtol=0, atol=1e-9)
+
+
+def test_decode_fixed_binary_array_respects_arrow_slice() -> None:
+    # a sliced (offset != 0) arrow array must decode only its own window
+    raws = [10**16, 2 * 10**16, 3 * 10**16]
+    arr = pa.array([v.to_bytes(16, "little", signed=True) for v in raws], pa.binary(16))
+    got = _decode_fixed_binary_array(arr.slice(1, 2), 16)
+    assert np.allclose(got, [2.0, 3.0], rtol=0, atol=1e-9)
 
 
 def test_read_ticks_decodes_binary_price_size(tmp_path) -> None:


### PR DESCRIPTION
PR2 of ROB-339 (follows #987). Makes the discovery harness actually fast on real catalog data by vectorizing the Nautilus fixed-point decode.

## Problem
PR1's `read_ticks` decoded the catalog's `fixed_size_binary[16]` price/size columns with a per-row `int.from_bytes` map. On a 15-day 2-symbol window that was **~50s** — the whole runtime cost of the screen (the catalog is 128-bit high-precision Nautilus: raw = value × 10¹⁶, ~1.76M ticks/day for BTC).

## Change
- **Vectorized decode** (`_decode_fixed_binary_array`): read the contiguous data buffer as `(n, width)` uint8 and reinterpret with integer views — **low 64 bits unsigned + high 64 bits signed** (two's complement). Exact, and avoids the float64 cancellation that a magnitude-then-subtract-2¹²⁸ approach hits at the int128 scale.
- **Build only what discovery needs** (`ts_event`/`price`/`size`) instead of materializing bytes objects via `to_pandas` on multi-million-row columns.
- Display precision (schema metadata) still only **rounds** the decoded float; the raw scale is fixed by byte width (16→10¹⁶, 8→10⁹).

## Verification
- Same 15-day XRPUSDT+BTCUSDT smoke (rob-320 catalog, read-only): **~50s → ~7s** (~7×), **identical verdicts** (all 10 `screened_out`) and prices (XRP close 1.3361..1.4693). Decode correctness preserved.
- **36 discovery unit tests** green; new tests cover scalar parity (incl. negative two's-complement) and arrow-slice offset handling; **ruff clean**.

## Scope / deferred
**PR3 (deferred):** Nautilus `backtest_runner` real window constraint, baseline run caching, precise maker-viability re-sim (ROB-324 `maker_fill`). Those touch the Nautilus subprocess path, which needs the research venv (not the repo uv venv), so they are sliced separately.

## Safety boundary
Research/backtest only. No live trading, no Binance Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod DB/env/secret mutation, no runtime strategy-parameter application, no `/invest` surfacing. Public trade-tick parquet catalog is read-only; no `app/`/Nautilus-engine imports; artifacts contain no secrets/balances/positions/account ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)