### PR TITLE
fix(rob-338): KIS mock fill-evidence facade wiring + confirmed mock smoke

### DIFF
--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -158,7 +158,7 @@ class KisMockBroker:
         today = datetime.datetime.now().strftime("%Y%m%d")
         try:
             client = self._get_mock_client()
-            rows = await client.domestic_orders.inquire_daily_order_domestic(
+            rows = await client.inquire_daily_order_domestic(
                 start_date=today,
                 end_date=today,
                 stock_code="",

--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -109,6 +109,15 @@ fill-evidence path below must be available; otherwise the executor fails closed
 remains secondary. `inquire_korea_orders` (TTTC8036R, pending inquiry) is
 **live-only** and is never used in mock.
 
+> **Facade wiring (ROB-338).** The smoke CLI and `KisMockBroker._poll_fill_evidence`
+> reach the inquiry through the **public** `KISClient.inquire_daily_order_domestic(...)`
+> facade. An earlier wiring called a nonexistent `client.domestic_orders.<...>`
+> attribute (`_domestic_orders` is private), which made the read-only preflight
+> exit `2` with `AttributeError` and would have driven a confirmed run to an
+> `inquiry_exception` anomaly. Regression guard: the adapter/CLI tests mock the
+> client with `spec=KISClient`, so any regression to a missing attribute raises
+> instead of auto-vivifying.
+
 **Deferred gap:** the execution-notice WebSocket `H0STCNI9` (실시간 체결통보) is
 NOT implemented (requires an AES-CBC-decrypted, HTS-ID handshake frame path). It
 is a fail-closed, documented gap and a candidate follow-up issue.
@@ -127,6 +136,21 @@ Expected success signal: exit `0`, a printed `verdict=...` line, and the
 observed `row keys: [...]` (use these to confirm/tighten the classifier's
 candidate field names).
 
+Observed read-only preflight (ROB-338, 2026-05-27 KST, secrets excluded) — run
+with `--symbol 005930` and no `--order-no`:
+
+```text
+국내주식 체결조회 시작 - 20260527 ~ 20260527
+GET .../uapi/domestic-stock/v1/trading/inquire-daily-ccld?... (tr_id VTTC8001R) 200 OK
+국내주식 체결조회 완료: 총 0건
+rows=0 (showing up to 10)
+exit code: 0
+```
+
+`rows=0` with exit `0` is a clean pass when the mock account has no same-day
+orders for the symbol (the classifier is only invoked when `--order-no` is
+given). Host is the KIS mock gateway `openapivts.koreainvestment.com:29443`.
+
 ### Failure categories
 
 | category | meaning | operator action |
@@ -140,12 +164,63 @@ candidate field names).
 Exit codes: `0` ok · `2` inquiry error / unsupported · `4` disabled or not
 configured · `1` unexpected.
 
-### Confirmed one-off mock smoke (operator-gated, NOT run by this change)
+### Confirmed one-off mock smoke (bounded, KRX-session-only)
 
-The operator-approved bounded confirmed mock smoke (one minimal KRX limit order
-round-trip) is a **separate, operator-gated step**. It is deferred here:
-this change ships code + runbook + tests + the read-only preflight only.
+Bounded confirmed round-trip shape (safest reversible variant): one minimal
+**BUY LIMIT** (1 share, price `> 0`, **never market**) placed a few percent
+**below** the best bid so it rests unfilled → read the daily-order row by order
+number via the fixed facade (capture row keys + classify) → **cancel**. If the
+order unexpectedly fills, **sell** the acquired share to flatten. Pick a liquid
+KRX symbol that is **not currently held** so the position delta is unambiguous.
 
-Rollback / no-op: all additions are read-only or fail-closed. Reverting the PR
-restores the prior `confirm_fill` stub (always-unfilled). No migration, no
-scheduler, no env mutation.
+KIS mock constraints observed (ROB-338, confirmed live smoke 2026-05-28 KST):
+
+- **Market hours gate.** Outside the KRX regular session (09:00–15:30 KST,
+  Mon–Fri) the order endpoint rejects with `40580000 모의투자 장종료 입니다.`
+  (market closed). The confirmed leg **must** run during a live session; quotes
+  returned after hours are last-session values. This is a `data-precondition`,
+  not a code fault — no order is placed, account is unchanged.
+- **Cancel orgno.** `inquire_korea_orders` (pending inquiry) is live-only, so
+  `cancel_korea_order` cannot auto-resolve `KRX_FWDG_ORD_ORGNO` in mock, and the
+  daily-ccld inquiry has no row for an unfilled resting order to read it from.
+  The org number **is** returned in the order-cash response output
+  (`KRX_FWDG_ORD_ORGNO`, observed `00950`) alongside `ODNO`, `ORD_TMD`,
+  `SOR_ODNO` — capture it from the submit response and pass it explicitly to
+  cancel. It is account/exchange-constant.
+- **Rate limit.** The order/cancel endpoints are not auto-retried on `EGW00201`
+  (초당 거래건수 초과); space bursts out / back off on that code.
+- **⚠️ Same-day daily-ccld is empty in mock.** This is the load-bearing finding.
+  `inquire_daily_order_domestic(is_mock=True)` returns `rt_cd=0` with an **empty
+  `output1`** for same-day mock orders — verified against orders that
+  **demonstrably filled** (holdings delta `0 → 1 → 0` on a marketable BUY then
+  SELL), and with no `PDNO`/`ODNO`/side filter at all. So the ROB-334
+  authoritative fill-evidence path classifies every same-day intraday mock fill
+  as `verdict=none / reason=no_matching_order` (`data-precondition`). The gate
+  stays fail-closed (never fabricates), but it **cannot positively confirm a
+  same-day mock fill** via this inquiry. Holdings/cash delta (ROB-102) is the
+  only signal that reflects same-day mock fills. Tracked as a follow-up issue
+  (see below); the facade fix in this change is still required for the path to
+  run at all.
+
+Confirmed round-trip observed (ROB-338, 035720 / Kakao, KRX session): a real
+mock BUY was accepted (`모의투자 매수주문이 완료`), a marketable BUY+SELL filled
+(holdings `0 → 1 → 0`), resting buys were cancelled (`모의투자 취소주문이 완료`),
+and the account reconciled flat (position delta `0`). The daily-ccld inquiry
+returned 0 rows throughout — hence no FILLED row keys could be captured; the
+real fill signal was the holdings delta.
+
+Final report must include: symbol, side(s), order id(s), exit code(s), observed
+row keys, the daily-order row evidence (filled/remaining/cancel status), final
+position delta vs baseline, and the classification on any ambiguity.
+
+**Follow-up (ROB-334 path effectiveness in mock):** because same-day daily-ccld
+is empty in mock, a confirmed mock scalping daemon wired to this inquiry would
+record `entry_unfilled` / `exit_unconfirmed` anomalies even on real fills. A
+child issue should decide whether to (a) promote holdings/cash delta to the
+primary same-day mock confirmation signal, (b) gate confirmation on the
+`H0STCNI9` execution-notice WebSocket (currently a deferred gap), or (c) confirm
+only after settlement (T+1) when daily-ccld populates.
+
+Rollback / no-op: all additions are read-only or fail-closed. Reverting restores
+the prior `confirm_fill` stub (always-unfilled). No migration, no scheduler, no
+env mutation.

--- a/scripts/kis_mock_fill_evidence_smoke.py
+++ b/scripts/kis_mock_fill_evidence_smoke.py
@@ -74,7 +74,7 @@ async def run_smoke(args: argparse.Namespace) -> int:
 
     client = _create_kis_client(is_mock=True)
     try:
-        rows = await client.domestic_orders.inquire_daily_order_domestic(
+        rows = await client.inquire_daily_order_domestic(
             start_date=args.from_date,
             end_date=args.to_date,
             stock_code=args.symbol or "",

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from app.services.brokers.kis import KISClient
 from app.services.brokers.kis.mock_scalping_exec import adapters as mod
 from app.services.brokers.kis.mock_scalping_exec.adapters import (
     KisMockBroker,
@@ -93,18 +94,30 @@ async def test_confirm_fill_returns_none_when_no_odno() -> None:
 
 
 @pytest.mark.unit
+def test_kis_client_exposes_public_fill_inquiry_facade_only() -> None:
+    # ROB-338 regression: the daily order-execution inquiry must be reached via
+    # the public KISClient facade. `domestic_orders` is a private impl detail
+    # (`_domestic_orders`); a public `.domestic_orders` attribute never existed,
+    # so the smoke/adapter must not depend on one.
+    assert hasattr(KISClient, "inquire_daily_order_domestic")
+    assert not hasattr(KISClient, "domestic_orders")
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_confirm_fill_returns_fill_when_filled(mocker) -> None:
     broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    # spec=KISClient (ROB-338): regressing to `client.domestic_orders` would
+    # raise AttributeError here instead of silently auto-vivifying a mock.
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         return_value=_daily_rows(tot_ccld_qty="1", avg_prvs="70000")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
     fill = await broker.confirm_fill({"odno": "0000123456"})
     assert fill == Fill(price=Decimal("70000"), quantity=Decimal("1"))
     # Bounded read-only inquiry: is_mock pinned True, filtered by order number.
-    kw = fake_client.domestic_orders.inquire_daily_order_domestic.await_args.kwargs
+    kw = fake_client.inquire_daily_order_domestic.await_args.kwargs
     assert kw["is_mock"] is True
     assert kw["order_number"] == "0000123456"
 
@@ -113,8 +126,8 @@ async def test_confirm_fill_returns_fill_when_filled(mocker) -> None:
 @pytest.mark.asyncio
 async def test_confirm_fill_none_when_pending(mocker) -> None:
     broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         return_value=_daily_rows(tot_ccld_qty="0")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
@@ -125,8 +138,8 @@ async def test_confirm_fill_none_when_pending(mocker) -> None:
 @pytest.mark.asyncio
 async def test_confirm_fill_none_on_unsupported_mock_api(mocker) -> None:
     broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         side_effect=RuntimeError("TR is not available in mock mode.")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
@@ -142,8 +155,8 @@ async def test_poll_fill_evidence_maps_unsupported_category(mocker) -> None:
     )
 
     broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         side_effect=RuntimeError("VTTC8001R not available in mock")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)

--- a/tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from app.services.brokers.kis import KISClient
 from scripts import kis_mock_fill_evidence_smoke as smoke
 
 
@@ -31,8 +32,10 @@ async def test_classifies_when_order_no_given(mocker) -> None:
     mocker.patch.object(smoke.settings, "kis_mock_app_key", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_app_secret", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_account_no", "fake")
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    # spec=KISClient (ROB-338): a nonexistent attribute (e.g. the old
+    # `.domestic_orders`) raises AttributeError instead of auto-vivifying a mock.
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         return_value=[
             {"odno": "123456", "ord_qty": "1", "tot_ccld_qty": "1", "avg_prvs": "70000"}
         ]
@@ -40,6 +43,7 @@ async def test_classifies_when_order_no_given(mocker) -> None:
     mocker.patch.object(smoke, "_create_kis_client", return_value=fake_client)
     rc = await smoke.run_smoke(smoke._parse_args(["--order-no", "123456"]))
     assert rc == 0
+    fake_client.inquire_daily_order_domestic.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -49,8 +53,8 @@ async def test_inquiry_error_returns_2(mocker) -> None:
     mocker.patch.object(smoke.settings, "kis_mock_app_key", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_app_secret", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_account_no", "fake")
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client = mocker.MagicMock(spec=KISClient)
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         side_effect=RuntimeError("boom")
     )
     mocker.patch.object(smoke, "_create_kis_client", return_value=fake_client)


### PR DESCRIPTION
## Summary

ROB-334 follow-up. The KIS mock fill-evidence inquiry was wired through a **nonexistent** `KISClient.domestic_orders` attribute (`_domestic_orders` is private), so:
- the read-only fill-evidence preflight exited `2` with `AttributeError`, and
- a confirmed daemon run would have classified every fill as an `inquiry_exception` anomaly (the adapter's broad `except Exception` catches it).

The existing tests mocked a plain `MagicMock`, which **auto-vivified** the bad attribute and masked the bug.

## Changes

- **Fix both call sites** to use the public `client.inquire_daily_order_domestic(...)` facade:
  - `scripts/kis_mock_fill_evidence_smoke.py:77`
  - `app/services/brokers/kis/mock_scalping_exec/adapters.py:161`
- **Regression coverage**: pin the adapter/CLI test client to `spec=KISClient` so a missing attribute *raises* instead of auto-vivifying, plus a static guard `test_kis_client_exposes_public_fill_inquiry_facade_only` asserting the public facade exists and `domestic_orders` does not.
- **Runbook** (`docs/runbooks/kis-mock-scalping-smoke.md`): the facade-wiring note, the verified read-only preflight result, and the confirmed round-trip findings.

## Verification (live KIS mock, KRX session 2026-05-28 KST)

- **Scope #1–2** — facade fix + tests: RED confirmed on old code (`Mock object has no attribute 'domestic_orders'`), GREEN after fix. `ruff check app/ tests/` clean; `mock_scalping_exec` + import-guard suites green.
- **Scope #3** — read-only preflight: **exit 0**, `rows=0`, no `AttributeError` (real call to `openapivts.koreainvestment.com`, TR `VTTC8001R`).
- **Scope #4** — confirmed round-trip (035720 / Kakao, unheld): a real mock BUY was accepted; a marketable BUY+SELL **filled** (holdings `0 → 1 → 0`); resting buys were cancelled; account **reconciled flat (position delta 0)**. No live, no market orders, no scheduler, no env/secret mutation.

## ⚠️ Load-bearing finding (ROB-334 follow-up needed)

The KIS **mock** daily-ccld inquiry returns `rt_cd=0` with an **empty `output1`** for same-day orders — verified against orders that demonstrably **filled** (holdings delta), and with no symbol/odno filter at all. So ROB-334's authoritative fill-evidence path classifies every same-day intraday mock fill as `none / no_matching_order` (`data-precondition`). The gate stays fail-closed (never fabricates), but it **cannot positively confirm a same-day mock fill** via this inquiry; holdings/cash delta is the only same-day signal.

A child issue should decide whether to (a) promote holdings/cash delta to the primary same-day mock confirmation signal, (b) gate on the `H0STCNI9` execution-notice WebSocket (deferred gap), or (c) confirm only post-settlement. **This PR's facade fix is still required for the path to run at all.**

Also captured: cancel in mock needs an explicit `KRX_FWDG_ORD_ORGNO` (observed `00950`) from the order-cash response output, since the pending inquiry (TTTC8036R) is mock-unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)