### PR TITLE
feat(rob-339): real Nautilus-path window constraint in backtest_runner (PR3)

### DIFF
--- a/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
+++ b/docs/superpowers/specs/2026-05-27-rob-339-scalping-discovery-funnel-design.md
@@ -58,7 +58,8 @@ Discovery's job is to *reject cheaply* and *nominate*, never to bless.
 - **D3** — discovery reads the same Nautilus `ParquetDataCatalog` parquet via
   pandas/pyarrow directly (no engine boot); not raw aggTrades.
 - **D4** — discovery's `--window-from/--window-to` is a **real** constraint via
-  pyarrow predicate pushdown. The Nautilus `backtest_runner` window is PR2.
+  pyarrow predicate pushdown. The Nautilus `backtest_runner` window lands in PR3
+  (pre-`add_data` tick filter; verified end-to-end).
 - **D5** — multiple-hypothesis defense: record `hypotheses_tested`; label promote
   candidates `in_sample_only: true`; time-ordered OOS holdout inside discovery.
 - **D6** — PR slicing (this doc is PR1's design note); see §8.
@@ -179,12 +180,18 @@ explicitly. Final `validated` stays owned by the unchanged
   (skip the `to_pandas` bytes-object materialization). Verified on the same 15-day
   2-symbol smoke: **~50s → ~7s** with identical verdicts/prices. Unit-tested for
   scalar parity (incl. negative two's-complement) and arrow-slice offsets.
-- **PR3 (deferred):** `backtest_runner` real window constraint (catalog start/end
-  query if the API supports it, else post-load `ts_event` filter + documented
-  limitation with a test), baseline run caching keyed by
-  catalog/window/symbol/params/code-version, optional precise maker-viability re-sim
-  borrowing ROB-324's `maker_fill`. These touch the Nautilus subprocess path, which
-  needs the research venv (not the repo uv venv), so they are sliced separately.
+- **PR3 (this PR — Nautilus-path window constraint):** `backtest_runner` now applies
+  a real `[from, to)` filter (`_filter_ticks_window`) to the loaded ticks BEFORE
+  `engine.add_data`, so `--window-from/--window-to` bound *processed data*, not just
+  report metadata. Stdlib `_window_bounds_ns` keeps the module venv-free at import and
+  is unit-tested for parity with `discovery.data.window_bounds_ns` (one window meaning
+  across both paths). Window threaded through `run`/`run_maker`/CLI and into
+  `validate_candidate.py` + `validate_maker_fill.py`. **Verified end-to-end** with the
+  rob-320 research venv (nautilus 1.227.0): XRPUSDT 1-day window = 94 trades, 3-day =
+  160 (scales with the window; both far below the 789 of the unbounded ROB-320 run).
+- **PR4 (deferred):** baseline run caching keyed by
+  catalog/window/symbol/params/code-version, and optional precise maker-viability
+  re-sim borrowing ROB-324's `maker_fill`.
 
 ## 9. Tests (no full 75-day data; CI-safe)
 
@@ -234,8 +241,9 @@ materially lift gross expectancy; at taker fees it is a clear reject.
 - Fast screening command emits a structured artifact → `discover.py` + §7.
 - Output distinguishes `screened_out` / `needs_more_data` /
   `promote_to_full_validation` → §6 classifier.
-- `--window-from/--window-to` is a real data constraint with tests → §5.2 + §9
-  `test_discovery_window.py` (Nautilus-path window documented as PR2).
+- `--window-from/--window-to` is a real data constraint with tests → discovery path
+  §5.2 + §9 `test_discovery_window.py`; Nautilus path implemented + verified
+  end-to-end in PR3 (`test_backtest_runner_window.py` + the 94/160-trade scaling run).
 - No full-validation result marketed as `validated` unless it passes the gate →
   discovery is non-canonical by construction (§6, §7 note); gate unchanged.
 - PR description carries the safety boundary → §12, restated at PR time.

--- a/research/nautilus_scalping/backtest_runner.py
+++ b/research/nautilus_scalping/backtest_runner.py
@@ -16,6 +16,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 
@@ -24,7 +25,34 @@ from validated_gate import Trade
 _SENTINEL = "RESULT_JSON "
 
 
-def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str) -> None:
+def _window_bounds_ns(window_from: str, window_to: str) -> tuple[int | None, int | None]:
+    """Parse YYYY-MM-DD window edges to epoch-ns; 'to' date inclusive ([lo, hi)).
+
+    Stdlib-only (keeps this module venv-free at import) and integer-exact; matches
+    discovery.data.window_bounds_ns so the Nautilus path and the discovery path
+    interpret --window-from/--window-to identically.
+    """
+    def _to_ns(s: str, *, plus_one_day: bool = False) -> int:
+        dt = datetime.strptime(s.strip(), "%Y-%m-%d").replace(tzinfo=UTC)
+        return int((dt + timedelta(days=1) if plus_one_day else dt).timestamp()) * 1_000_000_000
+
+    lo = _to_ns(window_from) if window_from and window_from.strip() else None
+    hi = _to_ns(window_to, plus_one_day=True) if window_to and window_to.strip() else None
+    return lo, hi
+
+
+def _filter_ticks_window(ticks, ts_from: int | None, ts_to: int | None):
+    """Keep ticks with ts_event in [ts_from, ts_to); None = unbounded. Applied BEFORE
+    engine.add_data so the window constrains processed data, not just metadata."""
+    if ts_from is None and ts_to is None:
+        return ticks
+    return [t for t in ticks
+            if (ts_from is None or t.ts_event >= ts_from)
+            and (ts_to is None or t.ts_event < ts_to)]
+
+
+def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str,
+                window_from: str = "", window_to: str = "") -> None:
     from nautilus_trader.backtest.engine import BacktestEngine, BacktestEngineConfig
     from nautilus_trader.config import LoggingConfig
     from nautilus_trader.model.currencies import USDT
@@ -38,6 +66,8 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     catalog_obj = ParquetDataCatalog(str(catalog))
     instrument = next(i for i in catalog_obj.instruments() if i.id.value.startswith(symbol))
     ticks = catalog_obj.trade_ticks(instrument_ids=[instrument.id.value])
+    lo, hi = _window_bounds_ns(window_from, window_to)
+    ticks = _filter_ticks_window(ticks, lo, hi)  # real window constraint (pre-add_data)
 
     execution_mode = str(params.get("execution_mode", "taker"))
     if execution_mode == "maker":
@@ -118,12 +148,14 @@ def _run_single(catalog: Path, symbol: str, strategy: str, params: dict, trade_s
     print(_SENTINEL + json.dumps({"trades": trades}))
 
 
-def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str = "100") -> list[Trade]:
+def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str = "100",
+        window_from: str = "", window_to: str = "") -> list[Trade]:
     # We must explicitly use the python interpreter inside our research .venv and pass PYTHONPATH
     venv_python = sys.executable
     cmd = [venv_python, os.path.abspath(__file__), "--single",
            "--catalog", str(catalog), "--symbol", symbol, "--strategy", strategy,
-           "--params", json.dumps(params), "--trade-size", trade_size]
+           "--params", json.dumps(params), "--trade-size", trade_size,
+           "--window-from", window_from, "--window-to", window_to]
 
     # Propagate the current PYTHONPATH so we can resolve the app package inside the child process
     env = dict(os.environ)
@@ -141,7 +173,8 @@ def run(catalog: Path, symbol: str, strategy: str, params: dict, trade_size: str
     raise RuntimeError(f"runner {strategy} on {symbol} failed:\n{proc.stderr[-800:]}")
 
 
-def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100"):
+def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100",
+              window_from: str = "", window_to: str = ""):
     """Run the maker re-sim; return (records, attempted, filled).
 
     records are maker_fill.MakerTradeRecord; attempted-filled = missed fills."""
@@ -151,7 +184,8 @@ def run_maker(catalog: Path, symbol: str, params: dict, trade_size: str = "100")
     venv_python = sys.executable
     cmd = [venv_python, os.path.abspath(__file__), "--single", "--catalog", str(catalog),
            "--symbol", symbol, "--strategy", "meanrev_zscore_fade",
-           "--params", json.dumps(p), "--trade-size", trade_size]
+           "--params", json.dumps(p), "--trade-size", trade_size,
+           "--window-from", window_from, "--window-to", window_to]
     env = dict(os.environ)
     env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + "../.."
     proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
@@ -176,9 +210,12 @@ def main() -> int:
     ap.add_argument("--strategy", required=True)
     ap.add_argument("--params", default="{}")
     ap.add_argument("--trade-size", default="100")
+    ap.add_argument("--window-from", default="")
+    ap.add_argument("--window-to", default="")
     args = ap.parse_args()
     if args.single:
-        _run_single(args.catalog, args.symbol, args.strategy, json.loads(args.params), args.trade_size)
+        _run_single(args.catalog, args.symbol, args.strategy, json.loads(args.params),
+                    args.trade_size, args.window_from, args.window_to)
         return 0
     raise SystemExit("backtest_runner is a library; use run() or --single")
 

--- a/research/nautilus_scalping/tests/test_backtest_runner_window.py
+++ b/research/nautilus_scalping/tests/test_backtest_runner_window.py
@@ -1,0 +1,39 @@
+"""ROB-339 PR3 — backtest_runner Nautilus-path window constraint (pure helpers).
+
+backtest_runner stays venv-free at import (stdlib + validated_gate only), so the
+window helpers are stdlib and unit-testable without Nautilus. The end-to-end
+engine run (which applies the filter before engine.add_data) is verified at smoke
+— no research venv in this environment.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+from backtest_runner import _filter_ticks_window, _window_bounds_ns
+from discovery.data import window_bounds_ns
+
+_Tick = namedtuple("_Tick", "ts_event")
+
+
+def test_window_bounds_matches_discovery_path() -> None:
+    # the Nautilus-path bounds must equal the discovery-path bounds (one window meaning)
+    for wf, wt in [
+        ("2026-03-01", "2026-03-05"),
+        ("", ""),
+        ("2026-03-02", ""),
+        ("", "2026-04-01"),
+    ]:
+        assert _window_bounds_ns(wf, wt) == window_bounds_ns(wf, wt)
+
+
+def test_filter_ticks_window_half_open() -> None:
+    ticks = [_Tick(10), _Tick(20), _Tick(30)]
+    assert _filter_ticks_window(ticks, 20, 30) == [_Tick(20)]  # [lo, hi): 30 excluded
+    assert [t.ts_event for t in _filter_ticks_window(ticks, 15, None)] == [20, 30]
+    assert [t.ts_event for t in _filter_ticks_window(ticks, None, 25)] == [10, 20]
+
+
+def test_filter_ticks_window_none_bounds_passthrough() -> None:
+    ticks = [_Tick(10), _Tick(20)]
+    assert _filter_ticks_window(ticks, None, None) is ticks  # no-op, same object

--- a/research/nautilus_scalping/validate_candidate.py
+++ b/research/nautilus_scalping/validate_candidate.py
@@ -81,7 +81,8 @@ def main() -> int:
         per_symbol = []
         for sym in symbols:
             size = "0.002" if sym == "BTCUSDT" else args.trade_size
-            per_symbol.append(run(args.catalog, sym, args.candidate, params, size))
+            per_symbol.append(run(args.catalog, sym, args.candidate, params, size,
+                                   args.window_from, args.window_to))
         candidate_runs[label] = _merge(per_symbol)
         print(f"  -> Total trades across all symbols: {len(candidate_runs[label])}")
 
@@ -91,7 +92,8 @@ def main() -> int:
     for sym in symbols:
         size = "0.002" if sym == "BTCUSDT" else args.trade_size
         breakout_runs.append(run(args.catalog, sym, "micro_breakout",
-                                 get_candidate("micro_breakout").default_params, size))
+                                 get_candidate("micro_breakout").default_params, size,
+                                 args.window_from, args.window_to))
     breakout = _merge(breakout_runs)
     print(f"  -> Total trades: {len(breakout)}")
 
@@ -100,7 +102,8 @@ def main() -> int:
     for sym in symbols:
         size = "0.002" if sym == "BTCUSDT" else args.trade_size
         random_runs.append(run(args.catalog, sym, "random_entry",
-                               get_candidate("random_entry").default_params, size))
+                               get_candidate("random_entry").default_params, size,
+                               args.window_from, args.window_to))
     random_ctrl = _merge(random_runs)
     print(f"  -> Total trades: {len(random_ctrl)}")
 

--- a/research/nautilus_scalping/validate_maker_fill.py
+++ b/research/nautilus_scalping/validate_maker_fill.py
@@ -103,15 +103,18 @@ def main() -> int:
     print("Running taker baselines (breakout, random)...")
     breakout = _merge([run(args.catalog, s, "micro_breakout",
                            get_candidate("micro_breakout").default_params,
-                           _SIZE.get(s, "100")) for s in symbols])
+                           _SIZE.get(s, "100"), args.window_from, args.window_to)
+                       for s in symbols])
     random_ctrl = _merge([run(args.catalog, s, "random_entry",
                               get_candidate("random_entry").default_params,
-                              _SIZE.get(s, "100")) for s in symbols])
+                              _SIZE.get(s, "100"), args.window_from, args.window_to)
+                          for s in symbols])
 
     # --- scenario 1: taker baseline candidate over the param grid (grid rescales 10->4) ---
     print("Scenario 1: taker baseline @ 4 bps (grid)...")
     taker_runs = {label: _merge([run(args.catalog, s, "meanrev_zscore_fade",
-                                     dict(params), _SIZE.get(s, "100")) for s in symbols])
+                                     dict(params), _SIZE.get(s, "100"),
+                                     args.window_from, args.window_to) for s in symbols])
                   for label, params in _GRID}
     taker_report = _gate(taker_runs, breakout, random_ctrl, TAKER_BASELINE_BPS,
                          symbols, window, "meanrev_taker_baseline")
@@ -123,7 +126,8 @@ def main() -> int:
     for label, params in _GRID:
         per_symbol = []
         for s in symbols:
-            recs, att, fil = run_maker(args.catalog, s, dict(params), _SIZE.get(s, "100"))
+            recs, att, fil = run_maker(args.catalog, s, dict(params), _SIZE.get(s, "100"),
+                                       args.window_from, args.window_to)
             per_symbol.append(recs)
             attempted += att
             filled += fil


### PR DESCRIPTION
PR3 of ROB-339 (follows #987/#988). Closes the issue's `--window-from`/`--window-to` acceptance criterion for the Nautilus full-validation path.

## Problem
PR1 made the window a real constraint on the **discovery** path (pyarrow pushdown), but `backtest_runner` (the Nautilus subprocess path used by full validation) still loaded **all** catalog ticks — `--window-from`/`--window-to` only reached report metadata, not processed data.

## Change
- **`_window_bounds_ns`** (stdlib, keeps backtest_runner venv-free at import) — parses `YYYY-MM-DD` edges to epoch-ns, `to`-inclusive `[lo, hi)`; unit-tested for **parity with `discovery.data.window_bounds_ns`** so both paths mean the same window.
- **`_filter_ticks_window`** — drops out-of-window ticks **before `engine.add_data`**, so the engine processes only windowed data.
- Threaded through `run` / `run_maker` / `--single` CLI and into `validate_candidate.py` + `validate_maker_fill.py` call sites.

## Verification
- **End-to-end** with the rob-320 research venv (nautilus 1.227.0): XRPUSDT **1-day window = 94 trades, 3-day = 160** — scales with the window, both far below the **789** of the unbounded ROB-320 run. Confirms the engine processes only windowed ticks (not metadata-only).
- Pure helpers unit-tested (bounds/discovery-parity, half-open filter, `None` passthrough); **39 research tests green**; `ruff check` clean. Diff is functional-only (no reformat churn; CI lint scopes `app/`+`tests/`, not `research/`).

## Scope / deferred
**PR4 (deferred):** baseline run caching (keyed by catalog/window/symbol/params/code-version) + precise maker-viability re-sim borrowing ROB-324's `maker_fill`.

## Safety boundary
Research/backtest only. No live trading, no Binance Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/Prefect/launchd, no prod DB/env/secret mutation, no runtime strategy-parameter application, no `/invest` surfacing. Public trade-tick parquet catalog is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Backtests now support `--window-from` and `--window-to` CLI parameters to restrict tick data to a specified date window, with consistent enforcement across discovery and full validation pipelines.

* **Tests**
  * Added unit tests verifying window filtering behavior and consistency with discovery-path constraints.

* **Documentation**
  * Updated design specifications for window constraint implementation across all backtest paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->