### PR TITLE
feat(ROB-350): classify non-buy /invest/reports candidates instead of dropping them

### DIFF
--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -578,6 +578,7 @@ class ActionPacketEntry(BaseModel):
     item_uuid: UUID | None = None
     priority: int | None = None
     rank: int | None = None
+    reject_or_wait_reason: str | None = None
     evidence_snapshot: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -69,3 +69,30 @@ def classify_held_symbol(
     if in_candidate_universe:
         return "no_add"
     return "keep"
+
+
+def classify_candidate_symbol(
+    quote: dict[str, Any] | None,
+    *,
+    universe_useful: bool,
+    quote_snapshot_present: bool,
+) -> str:
+    """Deterministic verdict for ONE non-held screener candidate.
+
+    Honest-verdict only (mirrors ``classify_held_symbol``): never returns the
+    directional ``rejected`` / ``limit_wait`` — those are Hermes-only.
+
+    Order:
+      1. no symbol/quote snapshot at all   -> ``data_gap``   (호가 근거 부족)
+      2. quote present but not actionable  -> ``watch_only`` (저유동성)
+      3. quote actionable, universe stale  -> ``watch_only`` (스크리너 stale)
+      4. quote actionable, universe useful -> ``buy_review``
+    """
+    if not quote_snapshot_present:
+        return "data_gap"
+    if not _quote_is_actionable(quote):
+        return "watch_only"
+    if not universe_useful:
+        return "watch_only"
+    return "buy_review"
+

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -95,4 +95,3 @@ def classify_candidate_symbol(
     if not universe_useful:
         return "watch_only"
     return "buy_review"
-

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -167,7 +167,11 @@ def _candidate_item(
         "best_bid": q.get("best_bid"),
         "best_ask": q.get("best_ask"),
         "spread_bps": q.get("spread_bps"),
-        "proposer": f"auto_emit/candidate_{verdict}",
+        "proposer": (
+            "auto_emit/buy_from_candidate"
+            if is_buy
+            else f"auto_emit/candidate_{verdict}"
+        ),
     }
     if reject_or_wait_reason is not None:
         extra["reject_or_wait_reason"] = reject_or_wait_reason

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -43,6 +43,7 @@ from app.schemas.validated_run_card import (
 )
 from app.services.action_report.snapshot_backed.action_verdict import (
     VERDICT_TO_BUCKET,
+    classify_candidate_symbol,
     classify_held_symbol,
 )
 
@@ -136,6 +137,77 @@ def _candidate_sort_key(candidate: dict[str, Any]) -> tuple[int, float, str]:
     score = _to_float(candidate.get("score"))
     symbol = str(candidate.get("symbol") or "")
     return (rank if rank is not None else 1_000_000, -(score or 0.0), symbol)
+
+
+def _candidate_item(
+    *,
+    symbol_snapshot: Any,
+    candidate_snapshot: Any,
+    sym: str,
+    cand: dict[str, Any],
+    quote: dict[str, Any] | None,
+    verdict: str,
+    priority: int,
+    reject_or_wait_reason: str | None,
+    candidate_usefulness: str | None,
+    news_match_count: int,
+) -> IngestReportItem:
+    is_buy = verdict == "buy_review"
+    is_gap = verdict == "data_gap"
+    q = quote if isinstance(quote, dict) else {}
+    extra: dict[str, Any] = {
+        "candidate_snapshot_uuid": _snapshot_uuid(candidate_snapshot),
+        "candidate_usefulness": candidate_usefulness,
+        "candidate_rank": priority,
+        "candidate_score": cand.get("score"),
+        "candidate_reasons": cand.get("reasons"),
+        "candidate_source": cand.get("source"),
+        "news_matches": news_match_count,
+        "quote_status": q.get("status") if quote is not None else "no_snapshot",
+        "best_bid": q.get("best_bid"),
+        "best_ask": q.get("best_ask"),
+        "spread_bps": q.get("spread_bps"),
+        "proposer": f"auto_emit/candidate_{verdict}",
+    }
+    if reject_or_wait_reason is not None:
+        extra["reject_or_wait_reason"] = reject_or_wait_reason
+
+    if is_buy:
+        rationale = (
+            f"신규 매수 검토 {priority}순위 — {sym} "
+            f"(candidate {candidate_usefulness}, score {cand.get('score')}, "
+            f"quote best_bid {q.get('best_bid')}, spread_bps {q.get('spread_bps')})"
+        )
+    elif is_gap:
+        rationale = f"신규 후보 판단 보류 — {sym} (호가 스냅샷 없음)"
+    elif reject_or_wait_reason == "low_liquidity":
+        rationale = (
+            f"신규 후보 관망 {priority}순위 — {sym} "
+            f"(저유동성: spread_bps {q.get('spread_bps')})"
+        )
+    elif reject_or_wait_reason == "beyond_candidate_budget":
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} (후보 예산 초과)"
+    else:  # screener_stale
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} (스크리너 stale)"
+
+    return IngestReportItem(
+        client_item_key=(f"auto-buy-{sym}" if is_buy else f"auto-cand-{verdict}-{sym}"),
+        item_kind="action" if is_buy else "risk",
+        symbol=sym,
+        side="buy" if is_buy else None,
+        intent=(
+            "buy_review"
+            if is_buy
+            else "risk_review"
+            if is_gap
+            else "trend_recovery_review"
+        ),
+        priority=priority,
+        rationale=rationale,
+        operation="review",
+        apply_policy="requires_user_approval",
+        evidence_snapshot=_make_evidence(symbol_snapshot, extra=extra),
+    )
 
 
 class EvidenceAutoEmitter:
@@ -263,70 +335,59 @@ class EvidenceAutoEmitter:
                 )
             )
 
-        # Buy candidates — symbols with actionable quote + a usefulness
-        # signal from candidate_universe and not currently held. Iterate by
-        # candidate rank/score, not incidental symbol-snapshot insertion order.
-        if candidate_actionable:
-            buy_emitted = 0
-            for cand in sorted(candidate_order, key=_candidate_sort_key):
+        # Candidate classification — every non-held screener candidate gets
+        # exactly ONE honest verdict (buy_review / watch_only / data_gap). No
+        # candidate is silently dropped (ROB-350). Always-on whenever a
+        # candidate_universe snapshot is present, independent of intraday_floor.
+        buy_emitted = 0
+        for cand in sorted(candidate_order, key=_candidate_sort_key):
+            sym = cand.get("symbol")
+            if not isinstance(sym, str) or sym in held:
+                continue  # held names handled by held_and_trending below
+            symbol_pair = symbol_quotes.get(sym)
+            quote = symbol_pair[1] if symbol_pair else None
+            verdict = classify_candidate_symbol(
+                quote,
+                universe_useful=candidate_actionable,
+                quote_snapshot_present=symbol_pair is not None,
+            )
+            reject_or_wait_reason: str | None = None
+            if verdict == "data_gap":
+                reject_or_wait_reason = "quote_missing"
+            elif verdict == "watch_only":
+                reject_or_wait_reason = (
+                    "low_liquidity"
+                    if symbol_pair is not None and not _quote_is_actionable(quote)
+                    else "screener_stale"
+                )
+            elif verdict == "buy_review":
                 if buy_emitted >= self._max_buy_candidates:
-                    break
-                sym = cand.get("symbol")
-                if not isinstance(sym, str):
-                    continue
-                if sym in held:
-                    continue
-                symbol_pair = symbol_quotes.get(sym)
-                if symbol_pair is None:
-                    continue
-                symbol_snapshot, quote = symbol_pair
-                if not _quote_is_actionable(quote):
-                    continue
-                candidate_rank = _candidate_rank(cand)
-                priority = (
-                    candidate_rank if candidate_rank is not None else buy_emitted + 1
-                )
-                evidence = _make_evidence(
-                    symbol_snapshot,
-                    extra={
-                        "candidate_snapshot_uuid": _snapshot_uuid(candidate_snapshot),
-                        "candidate_usefulness": candidate_usefulness,
-                        "candidate_rank": priority,
-                        "candidate_score": cand.get("score"),
-                        "candidate_reasons": cand.get("reasons"),
-                        "candidate_source": cand.get("source"),
-                        "news_matches": news_matches.get(sym, 0),
-                        "quote_status": quote.get("status"),
-                        "best_bid": quote.get("best_bid"),
-                        "best_ask": quote.get("best_ask"),
-                        "spread_bps": quote.get("spread_bps"),
-                        "proposer": "auto_emit/buy_from_candidate",
-                    },
-                )
-                items.append(
-                    _stamp(
-                        IngestReportItem(
-                            client_item_key=f"auto-buy-{sym}",
-                            item_kind="action",
-                            symbol=sym,
-                            side="buy",
-                            intent="buy_review",
-                            priority=priority,
-                            rationale=(
-                                f"신규 매수 검토 {priority}순위 — {sym} "
-                                f"(candidate {candidate_usefulness}, "
-                                f"score {cand.get('score')}, "
-                                f"quote best_bid {quote.get('best_bid')}, "
-                                f"spread_bps {quote.get('spread_bps')})"
-                            ),
-                            operation="review",
-                            apply_policy="requires_user_approval",
-                            evidence_snapshot=evidence,
+                    verdict = "watch_only"
+                    reject_or_wait_reason = "beyond_candidate_budget"
+                else:
+                    buy_emitted += 1
+
+            candidate_rank = _candidate_rank(cand)
+            priority = candidate_rank if candidate_rank is not None else buy_emitted
+            items.append(
+                _stamp(
+                    _candidate_item(
+                        symbol_snapshot=(
+                            symbol_pair[0] if symbol_pair else candidate_snapshot
                         ),
-                        "buy_review",
-                    )
+                        candidate_snapshot=candidate_snapshot,
+                        sym=sym,
+                        cand=cand,
+                        quote=quote,
+                        verdict=verdict,
+                        priority=priority,
+                        reject_or_wait_reason=reject_or_wait_reason,
+                        candidate_usefulness=candidate_usefulness,
+                        news_match_count=news_matches.get(sym, 0),
+                    ),
+                    verdict,
                 )
-                buy_emitted += 1
+            )
 
         # Watch candidates — news-active symbols whose quote evidence is
         # missing or whose candidate evidence is stale/empty (action

--- a/app/services/investment_reports/action_packet.py
+++ b/app/services/investment_reports/action_packet.py
@@ -63,9 +63,7 @@ def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntr
     rank = _entry_rank(item)
     evidence = item.evidence_snapshot or {}
     reason = (
-        evidence.get("reject_or_wait_reason")
-        if isinstance(evidence, Mapping)
-        else None
+        evidence.get("reject_or_wait_reason") if isinstance(evidence, Mapping) else None
     )
     return ActionPacketEntry(
         verdict=verdict,  # type: ignore[arg-type]

--- a/app/services/investment_reports/action_packet.py
+++ b/app/services/investment_reports/action_packet.py
@@ -61,6 +61,12 @@ def _entry_rank(item: InvestmentReportItemResponse) -> int | None:
 
 def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntry:
     rank = _entry_rank(item)
+    evidence = item.evidence_snapshot or {}
+    reason = (
+        evidence.get("reject_or_wait_reason")
+        if isinstance(evidence, Mapping)
+        else None
+    )
     return ActionPacketEntry(
         verdict=verdict,  # type: ignore[arg-type]
         symbol=item.symbol,
@@ -69,6 +75,7 @@ def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntr
         item_uuid=item.item_uuid,
         priority=item.priority if item.priority > 0 else None,
         rank=rank,
+        reject_or_wait_reason=str(reason) if isinstance(reason, str) else None,
         evidence_snapshot=dict(item.evidence_snapshot or {}),
     )
 
@@ -103,6 +110,7 @@ def build_action_packet(
 
     no_action_reason = _no_action_summary(diagnostics)
     new_buy.sort(key=lambda entry: entry.rank or entry.priority or 1_000_000)
+    risk.sort(key=lambda entry: entry.rank or entry.priority or 1_000_000)
     data_gaps.extend(_diagnostics_gaps(diagnostics))
 
     return ActionPacket(

--- a/docs/superpowers/plans/2026-05-29-rob-350-candidate-classification-gap.md
+++ b/docs/superpowers/plans/2026-05-29-rob-350-candidate-classification-gap.md
@@ -1,0 +1,698 @@
+# ROB-350 Candidate Classification Gap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop silently dropping ranked new-buy candidates that fail the actionable-quote gate; classify every non-held screener candidate as `buy_review` / `watch_only` / `data_gap` with a reason, surfaced through the ActionPacket and UI.
+
+**Architecture:** Add a pure `classify_candidate_symbol()` helper to `action_verdict.py` (symmetric with `classify_held_symbol`), restructure the `EvidenceAutoEmitter` buy block into a single always-on classification loop, thread a `reject_or_wait_reason` field through the schema/projection, and render it in the ActionPacket UI. No migration (classification lives in `evidence_snapshot` JSON). Every emitted item stays `operation="review"` + `apply_policy="requires_user_approval"`.
+
+**Tech Stack:** Python 3.13 / Pydantic v2 / pytest (`uv run --all-groups`), React + TypeScript / vitest (`--pool=forks`).
+
+Design doc: `docs/superpowers/specs/2026-05-29-rob-350-candidate-classification-gap-design.md`
+
+---
+
+## File Structure
+
+- `app/services/action_report/snapshot_backed/action_verdict.py` — add `classify_candidate_symbol` (pure helper).
+- `app/services/action_report/snapshot_backed/auto_emit.py` — replace buy block with one classification loop + a `_candidate_item` factory.
+- `app/schemas/investment_reports.py` — add `ActionPacketEntry.reject_or_wait_reason`.
+- `app/services/investment_reports/action_packet.py` — read `reject_or_wait_reason`, rank-sort `risk_reviews`.
+- `frontend/invest/src/types/investmentReports.ts` — add `rejectOrWaitReason`.
+- `frontend/invest/src/api/investmentReports.ts` — normalize `reject_or_wait_reason`.
+- `frontend/invest/src/components/investment-reports/ActionPacketView.tsx` — render reason chip.
+- Tests: `tests/services/action_report/snapshot_backed/test_action_verdict.py` (new or existing), `tests/test_auto_emit_candidate_citation.py`, `tests/services/investment_reports/test_action_packet.py`, `frontend/invest/src/__tests__/ActionPacketView.test.tsx`, `frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts`.
+
+---
+
+## Task 1: `classify_candidate_symbol` pure helper
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/action_verdict.py`
+- Test: `tests/services/action_report/snapshot_backed/test_action_verdict.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create/append `tests/services/action_report/snapshot_backed/test_action_verdict.py`:
+
+```python
+import pytest
+
+from app.services.action_report.snapshot_backed.action_verdict import (
+    classify_candidate_symbol,
+)
+
+_OK_QUOTE = {
+    "status": "ok",
+    "best_bid": 100,
+    "best_ask": 101,
+    "bid_depth": 5,
+    "ask_depth": 5,
+    "spread_bps": 10,
+}
+_DEAD_QUOTE = {"status": "ok", "best_bid": 0, "best_ask": 0, "bid_depth": 0, "ask_depth": 0}
+
+
+@pytest.mark.parametrize(
+    "quote, present, useful, expected",
+    [
+        (None, False, True, "data_gap"),            # no snapshot at all
+        (_DEAD_QUOTE, True, True, "watch_only"),     # 저유동성
+        (_OK_QUOTE, True, False, "watch_only"),      # screener stale
+        (_OK_QUOTE, True, True, "buy_review"),       # actionable + useful
+    ],
+)
+def test_classify_candidate_symbol(quote, present, useful, expected):
+    assert (
+        classify_candidate_symbol(
+            quote, universe_useful=useful, quote_snapshot_present=present
+        )
+        == expected
+    )
+
+
+def test_classify_candidate_symbol_never_rejects():
+    # Honest-verdict only: rejected / limit_wait are Hermes-only.
+    for present in (True, False):
+        for useful in (True, False):
+            v = classify_candidate_symbol(
+                _DEAD_QUOTE, universe_useful=useful, quote_snapshot_present=present
+            )
+            assert v in {"data_gap", "watch_only", "buy_review"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --all-groups pytest tests/services/action_report/snapshot_backed/test_action_verdict.py -v`
+Expected: FAIL with `ImportError: cannot import name 'classify_candidate_symbol'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/services/action_report/snapshot_backed/action_verdict.py`, add after `classify_held_symbol` (reuse the existing module-level `_quote_is_actionable`):
+
+```python
+def classify_candidate_symbol(
+    quote: dict[str, Any] | None,
+    *,
+    universe_useful: bool,
+    quote_snapshot_present: bool,
+) -> str:
+    """Deterministic verdict for ONE non-held screener candidate.
+
+    Honest-verdict only (mirrors ``classify_held_symbol``): never returns the
+    directional ``rejected`` / ``limit_wait`` — those are Hermes-only.
+
+    Order:
+      1. no symbol/quote snapshot at all   -> ``data_gap``   (호가 근거 부족)
+      2. quote present but not actionable  -> ``watch_only`` (저유동성)
+      3. quote actionable, universe stale  -> ``watch_only`` (스크리너 stale)
+      4. quote actionable, universe useful -> ``buy_review``
+    """
+    if not quote_snapshot_present:
+        return "data_gap"
+    if not _quote_is_actionable(quote):
+        return "watch_only"
+    if not universe_useful:
+        return "watch_only"
+    return "buy_review"
+```
+
+Note: `_quote_is_actionable` already guards `not isinstance(quote, dict)` → returns `False`, so `quote=None` with `present=True` is safe.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --all-groups pytest tests/services/action_report/snapshot_backed/test_action_verdict.py -v`
+Expected: PASS (5 cases)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/action_verdict.py tests/services/action_report/snapshot_backed/test_action_verdict.py
+git commit -m "feat(ROB-350): add classify_candidate_symbol honest-verdict helper
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Restructure auto_emit into a single classification loop
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py:266-329` (the `if candidate_actionable:` buy block)
+- Test: `tests/test_auto_emit_candidate_citation.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_auto_emit_candidate_citation.py` (reuses the module's `_Snap` / `_OK_QUOTE`):
+
+```python
+_DEAD_QUOTE = {
+    "status": "ok",
+    "best_bid": 0,
+    "best_ask": 0,
+    "bid_depth": 0,
+    "ask_depth": 0,
+    "spread_bps": 0,
+}
+
+
+def _verdict_of(item):
+    return item.evidence_snapshot.get("action_verdict")
+
+
+def test_candidate_without_quote_snapshot_is_data_gap_not_dropped():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        # No symbol snapshot for 000660 at all.
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "data_gap"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "quote_missing"
+    assert cand[0].operation == "review"
+    assert cand[0].apply_policy == "requires_user_approval"
+
+
+def test_low_liquidity_candidate_is_watch_only():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _DEAD_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "watch_only"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "low_liquidity"
+
+
+def test_stale_universe_candidates_are_watch_only_not_buy():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "stale",  # not "useful"
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    assert [i for i in items if i.side == "buy"] == []
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "watch_only"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "screener_stale"
+
+
+def test_overflow_beyond_cap_downgrades_to_watch_only():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap("symbol", {"symbol": "005930", "quote": _OK_QUOTE}, symbol="005930"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [
+                    {"symbol": "000660", "score": 9.0, "rank": 1},
+                    {"symbol": "005930", "score": 8.0, "rank": 2},
+                ],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter(max_buy_candidates=1).propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert [i.symbol for i in buys] == ["000660"]
+    overflow = [i for i in items if i.symbol == "005930"]
+    assert len(overflow) == 1
+    assert _verdict_of(overflow[0]) == "watch_only"
+    assert overflow[0].evidence_snapshot["reject_or_wait_reason"] == "beyond_candidate_budget"
+
+
+def test_held_candidate_not_double_emitted():
+    snaps = [
+        _Snap(
+            "portfolio",
+            {
+                "primary_source": "kis",
+                "holdings": [{"ticker": "000660", "sellable_quantity": 0}],
+            },
+        ),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    keys = [i.client_item_key for i in items if i.symbol == "000660"]
+    # Held name routes through held_and_trending only — no candidate buy/watch row.
+    assert all(not k.startswith("auto-cand-") for k in keys)
+    assert all(not k.startswith("auto-buy-") for k in keys)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --all-groups pytest tests/test_auto_emit_candidate_citation.py -v`
+Expected: the 5 new tests FAIL (candidates dropped → `cand` empty; `KeyError`/assertion failures).
+
+- [ ] **Step 3: Add the `_candidate_item` factory**
+
+In `app/services/action_report/snapshot_backed/auto_emit.py`, add a module-level factory after `_candidate_sort_key` (before the class). It builds one review-only item for any candidate verdict:
+
+```python
+def _candidate_item(
+    *,
+    symbol_snapshot: Any,
+    candidate_snapshot: Any,
+    sym: str,
+    cand: dict[str, Any],
+    quote: dict[str, Any] | None,
+    verdict: str,
+    priority: int,
+    reject_or_wait_reason: str | None,
+    candidate_usefulness: str | None,
+    news_match_count: int,
+) -> IngestReportItem:
+    is_buy = verdict == "buy_review"
+    is_gap = verdict == "data_gap"
+    q = quote if isinstance(quote, dict) else {}
+    extra: dict[str, Any] = {
+        "candidate_snapshot_uuid": _snapshot_uuid(candidate_snapshot),
+        "candidate_usefulness": candidate_usefulness,
+        "candidate_rank": priority,
+        "candidate_score": cand.get("score"),
+        "candidate_reasons": cand.get("reasons"),
+        "candidate_source": cand.get("source"),
+        "news_matches": news_match_count,
+        "quote_status": q.get("status") if quote is not None else "no_snapshot",
+        "best_bid": q.get("best_bid"),
+        "best_ask": q.get("best_ask"),
+        "spread_bps": q.get("spread_bps"),
+        "proposer": f"auto_emit/candidate_{verdict}",
+    }
+    if reject_or_wait_reason is not None:
+        extra["reject_or_wait_reason"] = reject_or_wait_reason
+
+    if is_buy:
+        rationale = (
+            f"신규 매수 검토 {priority}순위 — {sym} "
+            f"(candidate {candidate_usefulness}, score {cand.get('score')}, "
+            f"quote best_bid {q.get('best_bid')}, spread_bps {q.get('spread_bps')})"
+        )
+    elif is_gap:
+        rationale = f"신규 후보 판단 보류 — {sym} (호가 스냅샷 없음)"
+    elif reject_or_wait_reason == "low_liquidity":
+        rationale = (
+            f"신규 후보 관망 {priority}순위 — {sym} "
+            f"(저유동성: spread_bps {q.get('spread_bps')})"
+        )
+    elif reject_or_wait_reason == "beyond_candidate_budget":
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} (후보 예산 초과)"
+    else:  # screener_stale
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} (스크리너 stale)"
+
+    return IngestReportItem(
+        client_item_key=(f"auto-buy-{sym}" if is_buy else f"auto-cand-{verdict}-{sym}"),
+        item_kind="action" if is_buy else "risk",
+        symbol=sym,
+        side="buy" if is_buy else None,
+        intent=(
+            "buy_review"
+            if is_buy
+            else "risk_review"
+            if is_gap
+            else "trend_recovery_review"
+        ),
+        priority=priority,
+        rationale=rationale,
+        operation="review",
+        apply_policy="requires_user_approval",
+        evidence_snapshot=_make_evidence(symbol_snapshot, extra=extra),
+    )
+```
+
+- [ ] **Step 4: Import the helper and replace the buy block**
+
+At the top of `auto_emit.py`, extend the existing import:
+
+```python
+from app.services.action_report.snapshot_backed.action_verdict import (
+    VERDICT_TO_BUCKET,
+    classify_candidate_symbol,
+    classify_held_symbol,
+)
+```
+
+Replace the entire block from the `# Buy candidates —` comment through `buy_emitted += 1` (currently `auto_emit.py:266-329`) with:
+
+```python
+        # Candidate classification — every non-held screener candidate gets
+        # exactly ONE honest verdict (buy_review / watch_only / data_gap). No
+        # candidate is silently dropped (ROB-350). Always-on whenever a
+        # candidate_universe snapshot is present, independent of intraday_floor.
+        buy_emitted = 0
+        for cand in sorted(candidate_order, key=_candidate_sort_key):
+            sym = cand.get("symbol")
+            if not isinstance(sym, str) or sym in held:
+                continue  # held names handled by held_and_trending below
+            symbol_pair = symbol_quotes.get(sym)
+            quote = symbol_pair[1] if symbol_pair else None
+            verdict = classify_candidate_symbol(
+                quote,
+                universe_useful=candidate_actionable,
+                quote_snapshot_present=symbol_pair is not None,
+            )
+            reject_or_wait_reason: str | None = None
+            if verdict == "data_gap":
+                reject_or_wait_reason = "quote_missing"
+            elif verdict == "watch_only":
+                reject_or_wait_reason = (
+                    "low_liquidity"
+                    if symbol_pair is not None and not _quote_is_actionable(quote)
+                    else "screener_stale"
+                )
+            elif verdict == "buy_review":
+                if buy_emitted >= self._max_buy_candidates:
+                    verdict = "watch_only"
+                    reject_or_wait_reason = "beyond_candidate_budget"
+                else:
+                    buy_emitted += 1
+
+            candidate_rank = _candidate_rank(cand)
+            priority = candidate_rank if candidate_rank is not None else buy_emitted
+            items.append(
+                _stamp(
+                    _candidate_item(
+                        symbol_snapshot=(
+                            symbol_pair[0] if symbol_pair else candidate_snapshot
+                        ),
+                        candidate_snapshot=candidate_snapshot,
+                        sym=sym,
+                        cand=cand,
+                        quote=quote,
+                        verdict=verdict,
+                        priority=priority,
+                        reject_or_wait_reason=reject_or_wait_reason,
+                        candidate_usefulness=candidate_usefulness,
+                        news_match_count=news_matches.get(sym, 0),
+                    ),
+                    verdict,
+                )
+            )
+```
+
+Note: `_quote_is_actionable(quote)` with `quote=None` returns `False` safely. The old `if candidate_actionable:` gate is removed — `candidate_actionable` is now passed as `universe_useful` so stale universes still iterate and classify.
+
+- [ ] **Step 5: Run the new + existing auto_emit tests**
+
+Run: `uv run --all-groups pytest tests/test_auto_emit_candidate_citation.py -v`
+Expected: PASS — the 5 new tests plus the pre-existing `test_buy_item_cites_candidate_evidence` and `test_buy_candidates_follow_candidate_rank_and_limit` (buys still keyed `auto-buy-`, ordered by rank).
+
+- [ ] **Step 6: Run the generator regression test**
+
+Run: `uv run --all-groups pytest tests/services/action_report/snapshot_backed/test_generator.py -v`
+Expected: PASS — `test_auto_emit_from_evidence_respects_request_candidate_limit` still sees exactly 2 `auto-buy-` items (the 3rd candidate now becomes a `watch_only` row, which the test's `auto-buy-` filter ignores), and the intraday-floor / no-new-buy tests stay green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/auto_emit.py tests/test_auto_emit_candidate_citation.py
+git commit -m "feat(ROB-350): classify non-buy candidates instead of dropping them
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Surface `reject_or_wait_reason` through schema + ActionPacket projection
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (`ActionPacketEntry`)
+- Modify: `app/services/investment_reports/action_packet.py`
+- Test: `tests/services/investment_reports/test_action_packet.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/services/investment_reports/test_action_packet.py`:
+
+```python
+def test_data_gap_candidate_becomes_data_gap_entry_with_symbol() -> None:
+    gap = _item(
+        verdict="data_gap",
+        decision_bucket="deferred_no_action",
+        side=None,
+        intent="risk_review",
+        symbol="000660",
+        evidence_extra={"reject_or_wait_reason": "quote_missing"},
+    )
+    packet = build_action_packet([gap], diagnostics=None)
+    sources = [g.source for g in packet.data_gaps_for_next_cycle]
+    assert "000660" in sources
+
+
+def test_watch_only_candidate_exposes_reject_reason_and_rank_sort() -> None:
+    low = _item(
+        verdict="watch_only",
+        decision_bucket="risk_watch",
+        side=None,
+        intent="trend_recovery_review",
+        symbol="005930",
+        priority=2,
+        evidence_extra={"candidate_rank": 2, "reject_or_wait_reason": "low_liquidity"},
+    )
+    high = _item(
+        verdict="watch_only",
+        decision_bucket="risk_watch",
+        side=None,
+        intent="trend_recovery_review",
+        symbol="000660",
+        priority=1,
+        evidence_extra={"candidate_rank": 1, "reject_or_wait_reason": "screener_stale"},
+    )
+    packet = build_action_packet([low, high], diagnostics=None)
+    assert [e.symbol for e in packet.risk_reviews] == ["000660", "005930"]
+    assert packet.risk_reviews[0].reject_or_wait_reason == "screener_stale"
+    assert packet.risk_reviews[1].reject_or_wait_reason == "low_liquidity"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run --all-groups pytest tests/services/investment_reports/test_action_packet.py -v -k "reject or data_gap_candidate"`
+Expected: FAIL — `AttributeError: 'ActionPacketEntry' object has no attribute 'reject_or_wait_reason'` and risk-sort assertion failing (risk_reviews currently unsorted).
+
+- [ ] **Step 3: Add the schema field**
+
+In `app/schemas/investment_reports.py`, add to `ActionPacketEntry` (after `rank`):
+
+```python
+    reject_or_wait_reason: str | None = None
+```
+
+- [ ] **Step 4: Read the reason and rank-sort risk_reviews**
+
+In `app/services/investment_reports/action_packet.py`, update `_entry` to populate the field:
+
+```python
+def _entry(item: InvestmentReportItemResponse, verdict: str) -> ActionPacketEntry:
+    rank = _entry_rank(item)
+    evidence = item.evidence_snapshot or {}
+    reason = (
+        evidence.get("reject_or_wait_reason")
+        if isinstance(evidence, Mapping)
+        else None
+    )
+    return ActionPacketEntry(
+        verdict=verdict,  # type: ignore[arg-type]
+        symbol=item.symbol,
+        side=item.side,
+        rationale=item.rationale,
+        item_uuid=item.item_uuid,
+        priority=item.priority if item.priority > 0 else None,
+        rank=rank,
+        reject_or_wait_reason=str(reason) if isinstance(reason, str) else None,
+        evidence_snapshot=dict(item.evidence_snapshot or {}),
+    )
+```
+
+Then, in `build_action_packet`, next to the existing `new_buy.sort(...)` line, add a matching sort for risk reviews:
+
+```python
+    new_buy.sort(key=lambda entry: entry.rank or entry.priority or 1_000_000)
+    risk.sort(key=lambda entry: entry.rank or entry.priority or 1_000_000)
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `uv run --all-groups pytest tests/services/investment_reports/test_action_packet.py -v`
+Expected: PASS — new tests plus existing `test_held_and_new_and_risk_are_grouped_by_verdict` / `test_new_buy_candidates_are_sorted_and_expose_rank_priority`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/schemas/investment_reports.py app/services/investment_reports/action_packet.py tests/services/investment_reports/test_action_packet.py
+git commit -m "feat(ROB-350): expose reject_or_wait_reason + rank-sort risk reviews
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Frontend — render the reject/wait reason
+
+**Files:**
+- Modify: `frontend/invest/src/types/investmentReports.ts` (`ActionPacketEntry`)
+- Modify: `frontend/invest/src/api/investmentReports.ts` (`normalizeActionPacketEntry`)
+- Modify: `frontend/invest/src/components/investment-reports/ActionPacketView.tsx` (`EntryRow`)
+- Test: `frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts`, `frontend/invest/src/__tests__/ActionPacketView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts`, extend the `risk_reviews` fixture object (the one with `verdict: "watch_only"`) to include `reject_or_wait_reason` and assert it normalizes:
+
+```typescript
+      risk_reviews: [{ verdict: "watch_only", symbol: "035720", rationale: "관망",
+                       item_uuid: "i3", reject_or_wait_reason: "low_liquidity",
+                       evidence_snapshot: {} }],
+```
+
+and add an assertion in the same test after the existing `riskReviews[0]!.verdict` check:
+
+```typescript
+    expect(packet!.riskReviews[0]!.rejectOrWaitReason).toBe("low_liquidity");
+```
+
+In `frontend/invest/src/__tests__/ActionPacketView.test.tsx`, add a test:
+
+```typescript
+  it("renders the reject/wait reason on risk rows", () => {
+    render(<ActionPacketView packet={makePacket({
+      riskReviews: [
+        { verdict: "watch_only", symbol: "035720", side: null, rationale: "관망",
+          itemUuid: "r1", evidenceSnapshot: {}, rejectOrWaitReason: "low_liquidity" },
+      ],
+    })} />);
+    expect(screen.getByText("low_liquidity")).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/investmentReportsActionPacket.test.ts src/__tests__/ActionPacketView.test.tsx`
+Expected: FAIL — `rejectOrWaitReason` is `undefined` (type/normalizer missing) and the chip text is not in the document.
+
+- [ ] **Step 3: Add the type field**
+
+In `frontend/invest/src/types/investmentReports.ts`, add to `ActionPacketEntry` (after `rank`):
+
+```typescript
+  rejectOrWaitReason?: string | null;
+```
+
+- [ ] **Step 4: Normalize the snake_case field**
+
+In `frontend/invest/src/api/investmentReports.ts`, inside `normalizeActionPacketEntry`, add (after the `rank:` line):
+
+```typescript
+    rejectOrWaitReason: asOptionalString(obj.reject_or_wait_reason),
+```
+
+- [ ] **Step 5: Render the chip**
+
+In `frontend/invest/src/components/investment-reports/ActionPacketView.tsx`, inside `EntryRow`, after the `priority` Pill block, add:
+
+```tsx
+        {entry.rejectOrWaitReason ? (
+          <Pill tone="muted" size="sm">{entry.rejectOrWaitReason}</Pill>
+        ) : null}
+```
+
+If `tone="muted"` is not a valid `Pill` tone in this codebase, use the same tone already used for neutral chips in this file (check the existing `Pill` usages at the top of `ActionPacketView.tsx`); fall back to a plain `<span>` styled like the `rank` span if no neutral tone exists.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/investmentReportsActionPacket.test.ts src/__tests__/ActionPacketView.test.tsx`
+Expected: PASS — new assertions plus the existing rank/priority and data-gap rendering tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/invest/src/types/investmentReports.ts frontend/invest/src/api/investmentReports.ts frontend/invest/src/components/investment-reports/ActionPacketView.tsx frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts frontend/invest/src/__tests__/ActionPacketView.test.tsx
+git commit -m "feat(ROB-350): render candidate reject/wait reason in ActionPacket UI
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full-suite verification + no-mutation evidence
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Ruff**
+
+Run: `uv run ruff check app/ tests/`
+Expected: `All checks passed!`
+
+- [ ] **Step 2: Backend touched modules**
+
+Run:
+```bash
+uv run --all-groups pytest \
+  tests/services/action_report/snapshot_backed/test_action_verdict.py \
+  tests/test_auto_emit_candidate_citation.py \
+  tests/services/action_report/snapshot_backed/test_generator.py \
+  tests/services/investment_reports/test_action_packet.py -q
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Static import guard (no broker/order mutation)**
+
+Run: `uv run --all-groups pytest -k "import_guard or no_mutation" tests/ -q`
+Expected: PASS — confirms `app/services/action_report/snapshot_backed/` reaches no broker/order/watch/order-intent mutation path. (If the guard test name differs, find it with `grep -rln "import.*guard" tests/services/action_report/`.)
+
+- [ ] **Step 4: Frontend suite for touched files**
+
+Run: `cd frontend/invest && npx vitest run --pool=forks src/__tests__/ActionPacketView.test.tsx src/__tests__/investmentReportsActionPacket.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Record handoff evidence**
+
+In the PR description, record (per ROB-350 handoff requirements): branch name, changed files, the exact test commands + results above, "no migration", "no feature flag/env" (additive evidence_snapshot field only, default-safe), and "no broker/order/watch/order-intent mutation — every emitted item is operation=review + requires_user_approval, static import guard green". Note remaining ROB-350 scope still open: budget-generous candidate count tuning (§2) and Toss/Naver supplementary evidence (§3).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Q1 taxonomy → Task 1/2 (`data_gap`/`watch_only`, no `rejected`). Q2 always-on → Task 2 (gate removed, `candidate_actionable` passed as `universe_useful`). Reason surfacing → Task 3/4. No-mutation invariant → Task 5 step 3. Out-of-scope (§2 budget tuning, §3 Toss/Naver) explicitly deferred in Task 5 step 5.
+- **Type consistency:** helper name `classify_candidate_symbol` and field name `reject_or_wait_reason` (backend) / `rejectOrWaitReason` (frontend) are used identically across all tasks. `_candidate_item` factory and its keyword args match the call site in Task 2 step 4.
+- **Edge case:** `priority = candidate_rank if not None else buy_emitted` — collector always stamps `rank`, so the fallback is effectively dead for the standard path; kept for snapshots lacking rank.

--- a/docs/superpowers/specs/2026-05-29-rob-350-candidate-classification-gap-design.md
+++ b/docs/superpowers/specs/2026-05-29-rob-350-candidate-classification-gap-design.md
@@ -1,0 +1,146 @@
+# ROB-350 follow-up — classify non-buy new-buy candidates (no silent drop)
+
+Date: 2026-05-29
+Issue: ROB-350 (auto_trader: KR /invest/reports 매수·매도·신규매수 후보 리포트 고도화)
+Branch base: `rob-350` (follow-up slice on top of `73bd9f1d feat(ROB-350): rank new-buy candidates in reports`)
+
+## Problem (gap #1 from code review)
+
+`EvidenceAutoEmitter.propose` (`app/services/action_report/snapshot_backed/auto_emit.py`)
+ranks new-buy candidates and emits `buy_review` items, but **silently drops**
+any ranked candidate that does not clear the actionable-quote gate:
+
+- `symbol_pair is None` (no symbol snapshot / no quote evidence) → `continue`
+- `not _quote_is_actionable(quote)` (status≠ok or zero best/depth) → `continue`
+- the whole buy loop is gated by `if candidate_actionable:` so when the
+  screener universe usefulness ≠ `"useful"` (stale/empty), **every** candidate
+  is skipped.
+
+ROB-350 acceptance criteria require the opposite: *"stale screener, 저유동성,
+가격/호가/뉴스 근거 부족 후보는 바로 buy 후보로 올리지 않고 `watch_only` 또는
+`rejected`로 분류하고 이유를 남긴다."* Dropped candidates currently vanish with
+no row and no reason.
+
+## Decisions (locked with operator)
+
+1. **Taxonomy (Q1):** deterministic verdicts only — `data_gap` + `watch_only`.
+   `rejected` / `limit_wait` are directional judgments left to Hermes (matches
+   the existing "honest verdict only" discipline in `action_verdict.py`).
+   - no quote snapshot → `data_gap` (호가 근거 부족)
+   - quote present but not actionable (저유동성) → `watch_only`
+   - quote actionable but screener stale (`usefulness != "useful"`) → `watch_only`
+   - quote actionable + universe useful → `buy_review`
+2. **Trigger (Q2):** **always-on** — runs whenever a `candidate_universe`
+   snapshot is in the bundle, regardless of `intraday_floor`. This changes
+   non-intraday reports too (they now emit watch_only/data_gap candidate rows),
+   which is the intended ROB-350 behavior.
+3. **Structure:** Approach A + C — extract a pure `classify_candidate_symbol()`
+   helper into `action_verdict.py` (symmetric with `classify_held_symbol`), and
+   restructure the auto_emit buy loop into a single "classify every candidate"
+   pass.
+
+## Design
+
+### 1. `classify_candidate_symbol` (action_verdict.py)
+
+Pure function, symmetric with `classify_held_symbol`, honest-verdict only:
+
+```python
+def classify_candidate_symbol(
+    quote: dict[str, Any] | None,
+    *,
+    universe_useful: bool,
+    quote_snapshot_present: bool,
+) -> str:
+    # 1. no quote snapshot at all          -> "data_gap"
+    # 2. quote present, not actionable     -> "watch_only"  (저유동성)
+    # 3. quote actionable, universe stale   -> "watch_only"  (스크리너 stale)
+    # 4. quote actionable, universe useful  -> "buy_review"
+```
+
+`quote_snapshot_present` lets the caller distinguish "no snapshot row" (data_gap)
+from "snapshot present but quote not actionable" (watch_only). Never returns
+`rejected` / `limit_wait`.
+
+### 2. auto_emit.py — single classification loop
+
+Replace the `if candidate_actionable:` gate + buy emit block with one loop over
+`sorted(candidate_order, key=_candidate_sort_key)`:
+
+- `sym in held` → skip (handled by the existing held_and_trending path).
+- resolve quote (None if no symbol snapshot), compute verdict via
+  `classify_candidate_symbol`.
+- `buy_review` honors `max_buy_candidates` cap; overflow beyond the cap
+  (edge case — cap normally == candidate_limit == universe size) downgrades to
+  `watch_only` with reason `beyond_candidate_budget`.
+- emit exactly one `IngestReportItem` per candidate with:
+  - `item_kind`: `action` for buy_review, `risk` for watch_only/data_gap
+  - `rank`/`priority` stamped for all verdicts (rank-sorted projection works in
+    risk/data_gap sections too)
+  - `evidence_snapshot["reject_or_wait_reason"]` ∈
+    {`quote_missing`, `low_liquidity`, `screener_stale`, `beyond_candidate_budget`}
+    (absent for buy_review) + existing candidate_rank/score/source/quote meta
+  - `operation="review"`, `apply_policy="requires_user_approval"` (unchanged
+    lockdown — no mutation)
+- emitted symbols feed `already_proposed`, so news-watch and held_and_trending
+  loops dedup as today.
+
+Korean rationale per verdict:
+- watch_only/low_liquidity: `신규 후보 관망 N순위 — {sym} (저유동성: spread_bps {x})`
+- watch_only/screener_stale: `신규 후보 관망 N순위 — {sym} (스크리너 stale)`
+- data_gap: `신규 후보 판단 보류 — {sym} (호가 스냅샷 없음)`
+
+### 3. Schema + ActionPacket projection
+
+- `ActionPacketEntry` (`app/schemas/investment_reports.py`): add optional
+  `reject_or_wait_reason: str | None = None` (additive, mirrors the prior
+  rank/priority addition).
+- `action_packet.py`: `_entry` reads `reject_or_wait_reason` from
+  `evidence_snapshot`. Existing routing already sends `watch_only` →
+  `risk_reviews` and `data_gap` → `data_gaps`; verify `DataGapEntry` for a
+  candidate carries `source=symbol` + `reason=rationale`. `risk_reviews` should
+  be rank-sorted like `new_buy_candidates`.
+- No migration: classification lives in `evidence_snapshot` JSON only.
+
+### 4. Frontend
+
+- `types/investmentReports.ts`: add `rejectOrWaitReason?: string | null` to
+  `ActionPacketEntry`.
+- `api/investmentReports.ts`: normalize `reject_or_wait_reason`.
+- `components/.../ActionPacketView.tsx`: render the reason as a small chip on
+  risk/data-gap rows so the operator sees *why* a candidate was held back.
+
+### 5. Tests
+
+Backend:
+- `classify_candidate_symbol`: all 4 branches (unit).
+- auto_emit:
+  - high-rank candidate with no quote snapshot → `data_gap` row (not dropped).
+  - candidate with non-actionable quote → `watch_only` (low_liquidity).
+  - stale universe (`usefulness != "useful"`) → all candidates `watch_only`
+    (screener_stale), zero `buy_review`.
+  - useful universe, mixed quotes → actionable→buy_review, others classified.
+  - held candidate is not double-emitted (dedup).
+  - regression: existing buy-rank/limit and no_new_buy floor tests stay green.
+- action_packet: data_gap candidate → `data_gaps` with symbol+reason; watch_only
+  candidate → `risk_reviews` rank-sorted; `reject_or_wait_reason` exposed.
+
+Frontend:
+- ActionPacketView renders reject_or_wait_reason chip on risk/data-gap rows.
+
+## Non-goals / safety boundaries (unchanged)
+
+- No broker/order/watch/order-intent mutation; every item stays
+  `operation="review"` + `requires_user_approval`. Static import guard intact.
+- No `rejected`/`limit_wait` fabrication (Hermes-only).
+- No migration, no scheduler, no recurring scraping.
+- Toss/Naver supplementary evidence and budget-generous candidate count (§2/§3
+  of ROB-350) remain separate follow-up slices, out of scope here.
+
+## Verification
+
+- `uv run --all-groups pytest` on the touched test modules.
+- `uv run ruff check app/ tests/`.
+- `npx vitest run --pool=forks` on touched frontend tests (threads pool is flaky).
+- No-mutation evidence: static import guard test + assert all emitted items are
+  review/requires_user_approval in the auto_emit tests.

--- a/frontend/invest/src/__tests__/ActionPacketView.test.tsx
+++ b/frontend/invest/src/__tests__/ActionPacketView.test.tsx
@@ -74,4 +74,15 @@ describe("ActionPacketView", () => {
     })} />);
     expect(screen.getAllByText("해당 없음").length).toBeGreaterThanOrEqual(3);
   });
+
+  it("renders the reject/wait reason on risk rows", () => {
+    render(<ActionPacketView packet={makePacket({
+      riskReviews: [
+        { verdict: "watch_only", symbol: "035720", side: null, rationale: "관망",
+          itemUuid: "r1", evidenceSnapshot: {}, rejectOrWaitReason: "low_liquidity" },
+      ],
+    })} />);
+    expect(screen.getByText("low_liquidity")).toBeInTheDocument();
+  });
 });
+

--- a/frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
+++ b/frontend/invest/src/__tests__/investmentReportsActionPacket.test.ts
@@ -23,7 +23,8 @@ describe("normalizeActionPacket", () => {
       ],
       no_new_buy_reason: "스크리너 stale",
       risk_reviews: [{ verdict: "watch_only", symbol: "035720", rationale: "관망",
-                       item_uuid: "i3", evidence_snapshot: {} }],
+                       item_uuid: "i3", reject_or_wait_reason: "low_liquidity",
+                       evidence_snapshot: {} }],
       no_action_reason: { kind: "data_insufficient", reason_ko: "데이터 부족",
                           blocking_sources: ["portfolio"], excluded_count: 2 },
       data_gaps_for_next_cycle: [
@@ -37,6 +38,7 @@ describe("normalizeActionPacket", () => {
     expect(packet!.newBuyCandidates[0]!.rank).toBe(1);
     expect(packet!.noNewBuyReason).toBe("스크리너 stale");
     expect(packet!.riskReviews[0]!.verdict).toBe("watch_only");
+    expect(packet!.riskReviews[0]!.rejectOrWaitReason).toBe("low_liquidity");
     expect(packet!.noActionReason!.kind).toBe("data_insufficient");
     expect(packet!.noActionReason!.blockingSources).toEqual(["portfolio"]);
     expect(packet!.dataGapsForNextCycle[0]).toEqual({

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -227,6 +227,7 @@ function normalizeActionPacketEntry(raw: unknown): ActionPacketEntry {
     itemUuid: asOptionalString(obj.item_uuid),
     priority: asOptionalNumber(obj.priority),
     rank: asOptionalNumber(obj.rank),
+    rejectOrWaitReason: asOptionalString(obj.reject_or_wait_reason),
     evidenceSnapshot: asRecord(obj.evidence_snapshot),
   };
 }

--- a/frontend/invest/src/components/investment-reports/ActionPacketView.tsx
+++ b/frontend/invest/src/components/investment-reports/ActionPacketView.tsx
@@ -56,6 +56,9 @@ function EntryRow({ entry }: { entry: ActionPacketEntry }) {
         {typeof entry.priority === "number" ? (
           <Pill tone="accent" size="sm">P{entry.priority}</Pill>
         ) : null}
+        {entry.rejectOrWaitReason ? (
+          <Pill tone="paper" size="sm">{entry.rejectOrWaitReason}</Pill>
+        ) : null}
       </div>
       <p style={{ margin: 0, fontSize: 13 }}>{entry.rationale}</p>
     </div>

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -369,6 +369,7 @@ export interface ActionPacketEntry {
   itemUuid?: string | null;
   priority?: number | null;
   rank?: number | null;
+  rejectOrWaitReason?: string | null;
   evidenceSnapshot: Record<string, unknown>;
 }
 

--- a/tests/services/action_report/snapshot_backed/test_action_verdict.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict.py
@@ -68,16 +68,22 @@ _OK_QUOTE = {
     "ask_depth": 5,
     "spread_bps": 10,
 }
-_DEAD_QUOTE = {"status": "ok", "best_bid": 0, "best_ask": 0, "bid_depth": 0, "ask_depth": 0}
+_DEAD_QUOTE = {
+    "status": "ok",
+    "best_bid": 0,
+    "best_ask": 0,
+    "bid_depth": 0,
+    "ask_depth": 0,
+}
 
 
 @pytest.mark.parametrize(
     "quote, present, useful, expected",
     [
-        (None, False, True, "data_gap"),            # no snapshot at all
-        (_DEAD_QUOTE, True, True, "watch_only"),     # 저유동성
-        (_OK_QUOTE, True, False, "watch_only"),      # screener stale
-        (_OK_QUOTE, True, True, "buy_review"),       # actionable + useful
+        (None, False, True, "data_gap"),  # no snapshot at all
+        (_DEAD_QUOTE, True, True, "watch_only"),  # 저유동성
+        (_OK_QUOTE, True, False, "watch_only"),  # screener stale
+        (_OK_QUOTE, True, True, "buy_review"),  # actionable + useful
     ],
 )
 def test_classify_candidate_symbol(quote, present, useful, expected):
@@ -97,4 +103,3 @@ def test_classify_candidate_symbol_never_rejects():
                 _DEAD_QUOTE, universe_useful=useful, quote_snapshot_present=present
             )
             assert v in {"data_gap", "watch_only", "buy_review"}
-

--- a/tests/services/action_report/snapshot_backed/test_action_verdict.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict.py
@@ -9,6 +9,7 @@ from app.models.investment_symbol_intermediate_reports import DECISION_BUCKETS
 from app.services.action_report.snapshot_backed.action_verdict import (
     ACTION_VERDICTS,
     VERDICT_TO_BUCKET,
+    classify_candidate_symbol,
     classify_held_symbol,
 )
 
@@ -57,3 +58,43 @@ def test_held_not_sellable_not_trending_is_keep() -> None:
     holding = {"ticker": "005930", "sellable_quantity": 0}
     quote = {"status": "ok", "best_bid": 1.0, "best_ask": 2.0, "ask_depth": 5.0}
     assert classify_held_symbol(holding, quote, in_candidate_universe=False) == "keep"
+
+
+_OK_QUOTE = {
+    "status": "ok",
+    "best_bid": 100,
+    "best_ask": 101,
+    "bid_depth": 5,
+    "ask_depth": 5,
+    "spread_bps": 10,
+}
+_DEAD_QUOTE = {"status": "ok", "best_bid": 0, "best_ask": 0, "bid_depth": 0, "ask_depth": 0}
+
+
+@pytest.mark.parametrize(
+    "quote, present, useful, expected",
+    [
+        (None, False, True, "data_gap"),            # no snapshot at all
+        (_DEAD_QUOTE, True, True, "watch_only"),     # 저유동성
+        (_OK_QUOTE, True, False, "watch_only"),      # screener stale
+        (_OK_QUOTE, True, True, "buy_review"),       # actionable + useful
+    ],
+)
+def test_classify_candidate_symbol(quote, present, useful, expected):
+    assert (
+        classify_candidate_symbol(
+            quote, universe_useful=useful, quote_snapshot_present=present
+        )
+        == expected
+    )
+
+
+def test_classify_candidate_symbol_never_rejects():
+    # Honest-verdict only: rejected / limit_wait are Hermes-only.
+    for present in (True, False):
+        for useful in (True, False):
+            v = classify_candidate_symbol(
+                _DEAD_QUOTE, universe_useful=useful, quote_snapshot_present=present
+            )
+            assert v in {"data_gap", "watch_only", "buy_review"}
+

--- a/tests/services/action_report/snapshot_backed/test_auto_emit.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit.py
@@ -78,13 +78,22 @@ def _kis_portfolio_payload(*, ticker: str, sellable: float) -> dict:
     }
 
 
-def _candidate_payload(usefulness: str, actionable_count: int = 5) -> dict:
+def _candidate_payload(
+    usefulness: str,
+    actionable_count: int = 5,
+    candidates: list[dict] | None = None,
+) -> dict:
+    # Production candidate_universe snapshots always carry a ranked
+    # ``candidates`` list (the collector stamps rank/candidate_rank). Buy
+    # candidates are sourced from it (ROB-350 / 73bd9f1d), so tests expecting
+    # buys must populate it.
     return {
         "market": "kr",
         "actionable_count": actionable_count,
         "stale_count": 0,
         "usefulness": usefulness,
         "no_data_reason": None if usefulness == "useful" else "no fresh candidates",
+        "candidates": candidates or [],
     }
 
 
@@ -249,7 +258,11 @@ def test_buy_emitted_when_candidate_useful_and_quote_ok_and_not_held():
         ),
         _make_snapshot(
             kind="candidate_universe",
-            payload=_candidate_payload("useful", actionable_count=5),
+            payload=_candidate_payload(
+                "useful",
+                actionable_count=5,
+                candidates=[{"symbol": "000660", "score": 9.0, "rank": 1}],
+            ),
         ),
     ]
     items = emitter.propose(
@@ -316,7 +329,13 @@ def test_buy_respects_cap():
     snapshots = [
         _make_snapshot(
             kind="candidate_universe",
-            payload=_candidate_payload("useful"),
+            payload=_candidate_payload(
+                "useful",
+                candidates=[
+                    {"symbol": f"00500{i}", "score": 9.0 - i, "rank": i + 1}
+                    for i in range(5)
+                ],
+            ),
         ),
     ]
     for i in range(5):
@@ -372,7 +391,10 @@ def test_no_duplicate_watch_when_already_proposed_as_buy():
         ),
         _make_snapshot(
             kind="candidate_universe",
-            payload=_candidate_payload("useful"),
+            payload=_candidate_payload(
+                "useful",
+                candidates=[{"symbol": "000660", "score": 9.0, "rank": 1}],
+            ),
         ),
         _make_snapshot(
             kind="news",

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -231,4 +231,3 @@ def test_watch_only_candidate_exposes_reject_reason_and_rank_sort() -> None:
     assert [e.symbol for e in packet.risk_reviews] == ["000660", "005930"]
     assert packet.risk_reviews[0].reject_or_wait_reason == "screener_stale"
     assert packet.risk_reviews[1].reject_or_wait_reason == "low_liquidity"
-

--- a/tests/services/investment_reports/test_action_packet.py
+++ b/tests/services/investment_reports/test_action_packet.py
@@ -192,3 +192,43 @@ def test_serialise_attaches_action_packet(monkeypatch) -> None:
     assert packet.held_actions  # sanity: projection works on these items
     # The router import wires build_action_packet:
     assert hasattr(mod, "build_action_packet")
+
+
+def test_data_gap_candidate_becomes_data_gap_entry_with_symbol() -> None:
+    gap = _item(
+        verdict="data_gap",
+        decision_bucket="deferred_no_action",
+        side=None,
+        intent="risk_review",
+        symbol="000660",
+        evidence_extra={"reject_or_wait_reason": "quote_missing"},
+    )
+    packet = build_action_packet([gap], diagnostics=None)
+    sources = [g.source for g in packet.data_gaps_for_next_cycle]
+    assert "000660" in sources
+
+
+def test_watch_only_candidate_exposes_reject_reason_and_rank_sort() -> None:
+    low = _item(
+        verdict="watch_only",
+        decision_bucket="risk_watch",
+        side=None,
+        intent="trend_recovery_review",
+        symbol="005930",
+        priority=2,
+        evidence_extra={"candidate_rank": 2, "reject_or_wait_reason": "low_liquidity"},
+    )
+    high = _item(
+        verdict="watch_only",
+        decision_bucket="risk_watch",
+        side=None,
+        intent="trend_recovery_review",
+        symbol="000660",
+        priority=1,
+        evidence_extra={"candidate_rank": 1, "reject_or_wait_reason": "screener_stale"},
+    )
+    packet = build_action_packet([low, high], diagnostics=None)
+    assert [e.symbol for e in packet.risk_reviews] == ["000660", "005930"]
+    assert packet.risk_reviews[0].reject_or_wait_reason == "screener_stale"
+    assert packet.risk_reviews[1].reject_or_wait_reason == "low_liquidity"
+

--- a/tests/test_auto_emit_candidate_citation.py
+++ b/tests/test_auto_emit_candidate_citation.py
@@ -132,3 +132,138 @@ def test_held_symbol_in_screener_surfaces_watch():
     assert item.evidence_snapshot["candidate_score"] == 8.0
     # Held symbol must NOT also be proposed as a buy.
     assert not [i for i in items if i.side == "buy" and i.symbol == "005930"]
+
+
+_DEAD_QUOTE = {
+    "status": "ok",
+    "best_bid": 0,
+    "best_ask": 0,
+    "bid_depth": 0,
+    "ask_depth": 0,
+    "spread_bps": 0,
+}
+
+
+def _verdict_of(item):
+    return item.evidence_snapshot.get("action_verdict")
+
+
+def test_candidate_without_quote_snapshot_is_data_gap_not_dropped():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        # No symbol snapshot for 000660 at all.
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "data_gap"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "quote_missing"
+    assert cand[0].operation == "review"
+    assert cand[0].apply_policy == "requires_user_approval"
+
+
+def test_low_liquidity_candidate_is_watch_only():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _DEAD_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "watch_only"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "low_liquidity"
+
+
+def test_stale_universe_candidates_are_watch_only_not_buy():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "stale",  # not "useful"
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    assert [i for i in items if i.side == "buy"] == []
+    cand = [i for i in items if i.symbol == "000660"]
+    assert len(cand) == 1
+    assert _verdict_of(cand[0]) == "watch_only"
+    assert cand[0].evidence_snapshot["reject_or_wait_reason"] == "screener_stale"
+
+
+def test_overflow_beyond_cap_downgrades_to_watch_only():
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap("symbol", {"symbol": "005930", "quote": _OK_QUOTE}, symbol="005930"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [
+                    {"symbol": "000660", "score": 9.0, "rank": 1},
+                    {"symbol": "005930", "score": 8.0, "rank": 2},
+                ],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter(max_buy_candidates=1).propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    buys = [i for i in items if i.side == "buy"]
+    assert [i.symbol for i in buys] == ["000660"]
+    overflow = [i for i in items if i.symbol == "005930"]
+    assert len(overflow) == 1
+    assert _verdict_of(overflow[0]) == "watch_only"
+    assert overflow[0].evidence_snapshot["reject_or_wait_reason"] == "beyond_candidate_budget"
+
+
+def test_held_candidate_not_double_emitted():
+    snaps = [
+        _Snap(
+            "portfolio",
+            {
+                "primary_source": "kis",
+                "holdings": [{"ticker": "000660", "sellable_quantity": 0}],
+            },
+        ),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [{"symbol": "000660", "score": 9.0, "rank": 1}],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    keys = [i.client_item_key for i in items if i.symbol == "000660"]
+    # Held name routes through held_and_trending only — no candidate buy/watch row.
+    assert all(not k.startswith("auto-cand-") for k in keys)
+    assert all(not k.startswith("auto-buy-") for k in keys)
+

--- a/tests/test_auto_emit_candidate_citation.py
+++ b/tests/test_auto_emit_candidate_citation.py
@@ -238,7 +238,10 @@ def test_overflow_beyond_cap_downgrades_to_watch_only():
     overflow = [i for i in items if i.symbol == "005930"]
     assert len(overflow) == 1
     assert _verdict_of(overflow[0]) == "watch_only"
-    assert overflow[0].evidence_snapshot["reject_or_wait_reason"] == "beyond_candidate_budget"
+    assert (
+        overflow[0].evidence_snapshot["reject_or_wait_reason"]
+        == "beyond_candidate_budget"
+    )
 
 
 def test_held_candidate_not_double_emitted():
@@ -266,4 +269,3 @@ def test_held_candidate_not_double_emitted():
     # Held name routes through held_and_trending only — no candidate buy/watch row.
     assert all(not k.startswith("auto-cand-") for k in keys)
     assert all(not k.startswith("auto-buy-") for k in keys)
-


### PR DESCRIPTION
## Summary

ROB-350 follow-up slice — fixes **gap #1** from the code review: `EvidenceAutoEmitter` ranked new-buy candidates but **silently dropped** any candidate that failed the actionable-quote gate (no quote snapshot, low liquidity, or a stale screener universe). ROB-350 requires those to surface as classified rows with reasons, not vanish.

- New pure helper `classify_candidate_symbol()` in `action_verdict.py` (symmetric with `classify_held_symbol`, honest-verdict only — never `rejected`/`limit_wait`, those stay Hermes-only).
- `auto_emit` buy block restructured into a single **always-on** classification loop (runs whenever a `candidate_universe` snapshot is present, independent of `intraday_floor`):
  - no quote snapshot → `data_gap` (`quote_missing`)
  - quote present but not actionable → `watch_only` (`low_liquidity`)
  - actionable but screener stale → `watch_only` (`screener_stale`)
  - actionable + useful → `buy_review`; overflow beyond `max_buy_candidates` → `watch_only` (`beyond_candidate_budget`)
- `ActionPacketEntry.reject_or_wait_reason` threaded through schema → projection (`risk_reviews` now rank-sorted) → frontend chip on risk/data-gap rows.

Design + plan: `docs/superpowers/specs/2026-05-29-rob-350-candidate-classification-gap-design.md`, `docs/superpowers/plans/2026-05-29-rob-350-candidate-classification-gap.md`.

## Changed files

- `app/services/action_report/snapshot_backed/action_verdict.py` — `classify_candidate_symbol`
- `app/services/action_report/snapshot_backed/auto_emit.py` — single classification loop + `_candidate_item` factory
- `app/schemas/investment_reports.py` — `ActionPacketEntry.reject_or_wait_reason`
- `app/services/investment_reports/action_packet.py` — read reason, rank-sort `risk_reviews`
- `frontend/invest/src/{types,api}/investmentReports.ts`, `components/investment-reports/ActionPacketView.tsx` — render reason chip

## Test plan

- [x] `uv run ruff check app/ tests/` → clean
- [x] backend touched modules (action_verdict / auto_emit / generator / action_packet) → **59 passed**
- [x] import guard / no-mutation suite → **114 passed**
- [x] `npx vitest run --pool=forks` (ActionPacketView + normalize) → **9 passed**
- [ ] CI Test workflow green before merge (manual merge — no `--auto`)

## Handoff notes

- **Migration:** none — classification lives in `evidence_snapshot` JSON.
- **Feature flag / env:** none — additive, default-safe.
- **No broker/order/watch/order-intent mutation:** every emitted item stays `operation="review"` + `apply_policy="requires_user_approval"`; static import guard green.
- **Chrome remote-debug evidence:** not used in this slice.
- **Still open in ROB-350 (separate slices):** §2 budget-generous candidate-count tuning, §3 Toss/Naver supplementary evidence, live KR-report render smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Classified non-held screener candidates into explicit verdicts (buy_review, watch_only, data_gap) with rejection/wait reasons
  * Added reason chips to investment action packet display
  * Deterministic sorting of risk reviews by rank and priority

* **Documentation**
  * Added implementation plan and design specification for candidate classification updates

* **Tests**
  * Expanded test coverage for candidate classification, verdict assignment, and reason surfacing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->