### PR TITLE
feat(ROB-351): cost-blind funnel for ROB-343-worthy candidate discovery (research-only)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,19 @@
+# TODOS
+
+## Crypto-native edge families (funding / OI / liquidation) — investigate after ROB-351 families 1-3
+
+- **What:** Evaluate funding-rate / open-interest / liquidation-shock continuation & reversal
+  strategies on Binance USD-M, gated on first confirming usable historical data quality.
+- **Why:** Codex outside-voice (ROB-351 eng-review) flagged that funding/OI/liquidation are
+  closer to *crypto-native* edge sources than the generic trend/momentum/reversal families
+  that prior campaigns (ROB-316/320/324/339/342) keep killing. Worth a dedicated look that
+  ROB-351 deliberately parked.
+- **Pros:** Targets a structurally different edge than the families already shown net-negative;
+  funding carry in particular has documented cross-sectional signal.
+- **Cons:** OI history from the API is ~30 days; liquidation history is scarce/unreliable.
+  Likely blocked at `needs_more_data` unless a durable archival source is found first.
+- **Context:** ROB-351 design doc `~/.gstack/projects/mgh3326-auto_trader/mgh3326-rob-351-design-*.md`
+  ("Out of scope" + eng-review section). Do NOT invent weak proxies — if data is missing,
+  stop with an explicit blocker. Same safety boundary as ROB-351 (research-only).
+- **Depends on / blocked by:** ROB-351 families 1-3 outcome; a vetted funding/OI/liquidation
+  historical data source.

--- a/docs/plans/ROB-351-cost-blind-funnel-campaign.md
+++ b/docs/plans/ROB-351-cost-blind-funnel-campaign.md
@@ -1,0 +1,73 @@
+# ROB-351 — Cost-blind funnel for surfacing a ROB-343-worthy crypto candidate
+
+Status: **funnel code + tests landed; empirical RUN operator-gated (no market data committed).**
+Branch: `rob-351`. Design + eng-review: `~/.gstack/projects/mgh3326-auto_trader/mgh3326-rob-351-design-*.md`.
+
+## Goal (reframed)
+
+Campaign success = produce **≥1 candidate legitimately worth running through ROB-343**
+(the deferred execution-realism harness), i.e. a candidate with **positive gross edge**
+whose net viability **hinges on closable execution cost** — not "force a profitable result."
+
+## What this PR ships (the funnel CODE)
+
+A pure-stdlib, test-driven funnel in `research/nautilus_scalping/`:
+
+| Stage | Module | Role |
+|------|--------|------|
+| shared | `cost_model.py` | one analytic `net_at_fee` primitive (3→1 dedup of fee_sweep/validated_gate/compare_strategies) |
+| 0 | `pit_universe.py` | PIT manifest (symbol→listed/delisted); single survivorship authority; as-of-each-rebalance |
+| 0 | `panel.py` | lazy PIT-aware cross-section generator (memory-bounded; no full time×symbol matrix) |
+| 1 | `discovery/screen.py` `classify(cost_blind=…)` | fees=0 gross screen + economic-triviality floor + `cost_binding` flag |
+| 1/2 | `families.py` | family 1 breakout-continuation (Trade) / 2 TS-trend-basket / 3 XS-momentum (PortfolioPeriod) |
+| 2 | `validated_gate.evaluate_gate_portfolio` | **period-return** drawdown/Sharpe for basket/XS (Issue 1 fix) |
+| 2 | `validated_gate` block bootstrap / BH-FDR / effect-size sample gate / turnover-matched baseline | Codex statistical hardening |
+| 3 | `rob343_label.py` | `promote_to_pilot` / `cost_binding_343_candidate` / `needs_more_data` / `reject` |
+| ex-ante | `frozen_config.py` | thresholds + achievable-execution envelope, hash recorded in the run |
+| driver | `campaign.py` + `run_rob351_campaign.py` | wires Stage 1→2→3 into a verdict table |
+
+**Verify the wiring (no data/secrets):** `python run_rob351_campaign.py --self-test` prints a
+verdict table demonstrating all three terminal outcomes, including a synthesized
+`cost_binding_343_candidate`. 126 pure tests pass (`uv run --no-project --python 3.13 --with pytest -- pytest`).
+
+## Key engineering decisions (from plan-eng-review + Codex outside-voice)
+
+- **~80% of the "Stage 2 gauntlet" already existed** → Stage 2 is **wiring**, not a rebuild.
+- **Issue 1 (P1):** `validated_gate`'s per-trade serial equity sum understates a basket's
+  drawdown (concurrent positions). `PortfolioPeriod` + `evaluate_gate_portfolio` compute
+  drawdown on the **period-return** equity curve — the honest number `promote_to_pilot` /
+  the 343 criterion gate on.
+- **Issue 3 (P1):** maker closability is decided in the **pure** path (`maker_fill` queue-loss
+  /adverse-selection scenario), never via `fee_sweep`'s taker-only linear rescale.
+- **Issue 4 (P2):** single `net_at_fee` primitive (3→1), with a REGRESSION test.
+- **Codex hardening (absorbed):** block/time bootstrap (not iid), Benjamini-Hochberg FDR
+  across all shots, **effect-size/FDR-aware** sample gate (replaces cargo-culted `n≥263`),
+  economic-triviality floor (not just sign>0), turnover-matched random baseline,
+  as-of-each-rebalance PIT, and a **realistic-path stop-rule** — `cost_binding_343_candidate`
+  requires the maker-conservative scenario to be net-positive, so "cost is the blocker"
+  alone is not enough.
+
+## Verdict structure (what the operator RUN fills)
+
+The `campaign.run_campaign` artifact is a per-family table:
+`screen` (screened_out/needs_more_data/promote_to_full_validation) · `cost_binding_screen` ·
+`gate_verdict` · `label_343` · `breakeven_taker_bps` · `config_hash`. `label_343 ∈
+{promote_to_pilot, cost_binding_343_candidate, needs_more_data, reject}`. Canonical
+`validated` is NOT produced here (owned by the conservative gate).
+
+## NOT done here / blockers
+
+- **Empirical RUN is operator-gated.** No Binance USDⓈ-M market data is committed, so no real
+  verdict table exists yet. To run: set `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT` to a data root
+  (bar OHLCV + a `PITManifest`), build family specs from it, call `campaign.run_campaign`.
+- **Families 4–5 (liquidity-sweep, funding/OI/liquidation) are out of scope** (parked).
+  Codex argued these are the more crypto-native / execution-coupled families; recorded as the
+  leading follow-up in `TODOS.md`. Family 5 is additionally data-blocked (OI ~30d history).
+- **ROB-343 stays deferred** — the verdict only *recommends* it (with a quantified execution
+  target) when a `cost_binding_343_candidate` survives; it is not implemented here.
+
+## Safety boundary (unchanged)
+
+Research/backtest only. No live, no Demo `confirm=true`, no broker/order/watch/order-intent
+mutation, no scheduler/TaskIQ/Prefect/launchd/daemon, no prod DB/env/secret, no `/invest`
+exposure, no raw large data committed, no credential logging.

--- a/research/nautilus_scalping/campaign.py
+++ b/research/nautilus_scalping/campaign.py
@@ -1,0 +1,114 @@
+"""ROB-351 (Stage 3) — cost-blind funnel driver (pure, stdlib).
+
+Ties the pieces into one verdict table:
+
+  Stage 1  cost-blind gross screen   (discovery.screen.classify cost_blind=True)
+  Stage 2  cost/OOS gauntlet         (validated_gate.evaluate_gate[_portfolio])
+  Stage 3  ROB-343 hand-off label    (rob343_label.label_343_candidate)
+
+Each family spec carries: ``name``; a ``HypothesisSummary`` for Stage 1; the gate
+``kind`` ("trade"|"portfolio") + ``data`` (Trade list or PortfolioPeriod list);
+and an optional ``maker_conservative_net`` (the maker_fill pure-path evidence
+needed to call a candidate closable — without it a cost-binding family cannot be
+a 343 hand-off, only ``reject``).
+
+The run records the frozen-config hash (ex-ante evidence). NO market data is read
+here; the empirical RUN against Binance USDⓈ-M data is the operator's PR2 step.
+"""
+
+from __future__ import annotations
+
+import rob343_label
+import validated_gate as vg
+from discovery.screen import classify
+from frozen_config import FROZEN_CONFIG, CampaignConfig
+
+SCHEMA_VERSION = "rob351_campaign.v1"
+
+
+def _gate_trade(data: list, fee_bps: float, min_trades: int) -> tuple[vg.GateReport, float, float, float]:
+    rep = vg.evaluate_gate(
+        candidate_runs={"p": data},
+        baseline_breakout=[], baseline_random=[],
+        fee_bps=fee_bps, min_trades=min_trades,
+    )
+    gross = rep.results.get("gross", {}).get("net_pnl", 0.0)
+    net = rep.results.get("net_after_cost", {}).get("net_pnl", 0.0)
+    breakeven = rob343_label.breakeven_taker_fee_bps(data)
+    return rep, gross, net, breakeven
+
+
+def _gate_portfolio(data: list, fee_bps: float, min_periods: int) -> tuple[vg.GateReport, float, float, float]:
+    rep = vg.evaluate_gate_portfolio(
+        candidate_runs={"p": data}, baseline_periods=[],
+        fee_bps=fee_bps, min_periods=min_periods,
+    )
+    gross = rep.results.get("gross", {}).get("net_pnl", 0.0)
+    net = rep.results.get("net_after_cost", {}).get("net_pnl", 0.0)
+    breakeven = rob343_label.breakeven_taker_fee_bps_from_sums(
+        sum(p.gross_ref_pnl for p in data), sum(p.commission_ref for p in data)
+    )
+    return rep, gross, net, breakeven
+
+
+def run_campaign(
+    specs: list[dict],
+    config: CampaignConfig = FROZEN_CONFIG,
+    min_trades: int = 100,
+    fee_bps: float | None = None,
+) -> dict:
+    """Run every family spec through the funnel; return the verdict-table artifact."""
+    fee_bps = config.taker_bps if fee_bps is None else fee_bps
+    rows: list[dict] = []
+    for spec in specs:
+        name = spec["name"]
+        summary = spec["summary"]
+        classified = classify(
+            summary, cost_blind=True,
+            min_samples=min(summary.sample_count, min_trades) if min_trades else 1,
+            min_gross_bps=config.economic_triviality_floor_bps,
+        )
+        row = {
+            "name": name,
+            "screen": classified.recommendation,
+            "cost_binding_screen": classified.cost_binding,
+            "screen_reason": classified.reason,
+            "gate_verdict": None,
+            "label_343": None,
+            "label_343_reason": None,
+        }
+        if classified.recommendation != "promote_to_full_validation":
+            rows.append(row)
+            continue
+
+        if spec["kind"] == "portfolio":
+            rep, gross, net, breakeven = _gate_portfolio(spec["data"], fee_bps, min_trades)
+        else:
+            rep, gross, net, breakeven = _gate_trade(spec["data"], fee_bps, min_trades)
+        row["gate_verdict"] = rep.verdict
+        oos_significant = rep.verdict != "insufficient_data"
+
+        verdict = rob343_label.label_343_candidate(
+            taker_net_pnl=net, gross_pnl=gross,
+            maker_conservative_net=(spec.get("maker_conservative_net") or 0.0),
+            oos_significant=oos_significant,
+            breakeven_taker_bps=breakeven,
+        )
+        row["label_343"] = verdict.label
+        row["label_343_reason"] = verdict.reason
+        row["closable"] = verdict.closable
+        row["breakeven_taker_bps"] = breakeven
+        rows.append(row)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "config_hash": config.config_hash(),
+        "config": config.to_dict(),
+        "families": rows,
+        "note": (
+            "Non-canonical research funnel. Labels are reject / needs_more_data / "
+            "promote_to_pilot / cost_binding_343_candidate. canonical 'validated' is "
+            "owned by the conservative gate; ROB-343 is only RECOMMENDED, never run here. "
+            "Empirical verdicts require the operator data RUN (no market data committed)."
+        ),
+    }

--- a/research/nautilus_scalping/compare_strategies.py
+++ b/research/nautilus_scalping/compare_strategies.py
@@ -29,7 +29,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-REF_FEE_BPS = 10.0
+import cost_model
+
+REF_FEE_BPS = cost_model.REF_FEE_BPS
 FEE_GRID_BPS = [10.0, 7.5, 5.0, 2.0, 0.0]
 OVERFIT_MIN_TRADES = 30
 _SENTINEL = "RESULT_JSON "
@@ -102,11 +104,10 @@ def _run_single(catalog_path, symbol, strategy, tp, sl, trade_size, flags):
 
 def _metrics(trades, fee_bps):
     """Return (n, net_pnl, win_rate_pct, avg_bps, mdd) at a per-leg fee."""
-    scale = 1.0 - fee_bps / REF_FEE_BPS
     rows = sorted(trades, key=lambda t: t[3])  # chronological for MDD
     nets, bps = [], []
     for net_ref, comm_ref, notional, _ in rows:
-        net = net_ref + comm_ref * scale
+        net = cost_model.net_at_fee(net_ref, comm_ref, fee_bps, REF_FEE_BPS)
         nets.append(net)
         bps.append(net / notional * 1e4 if notional else 0.0)
     n = len(nets)

--- a/research/nautilus_scalping/cost_model.py
+++ b/research/nautilus_scalping/cost_model.py
@@ -1,0 +1,35 @@
+"""ROB-351 (eng-review Issue 4) — shared analytic net-at-fee primitive (pure, stdlib).
+
+The linear fee rescale was duplicated in ``validated_gate``, ``fee_sweep``, and
+``compare_strategies``. Extracted here so every call-site shares one
+implementation (3 -> 1).
+
+    net(fee) = net_ref_pnl + commission_ref * (1 - fee_bps / ref_fee_bps)
+
+EXACT for the engine cost model: commission scales linearly with the per-leg fee
+rate, so a run executed at ``ref_fee_bps`` rescales analytically to any other
+fee. ``commission_ref`` is the (positive) commission magnitude paid at the
+reference run; ``fee_bps = 0`` adds it fully back (gross), ``fee_bps = ref``
+leaves the as-run net.
+
+CAVEAT (ROB-351 eng-review Issue 3): this rescale is valid ONLY when fills are
+fee-independent (taker entry/exit at price levels). Maker scenarios change WHICH
+fills occur (queue loss, missed fills, adverse selection), so a maker breakeven
+must NOT use this rescale — build explicit per-leg maker fees with
+``maker_fill.py`` instead.
+"""
+
+from __future__ import annotations
+
+REF_FEE_BPS = 10.0
+
+
+def net_at_fee(
+    net_ref_pnl: float,
+    commission_ref: float,
+    fee_bps: float,
+    ref_fee_bps: float = REF_FEE_BPS,
+) -> float:
+    """Net PnL of one reference-fee trade rescaled to ``fee_bps`` per leg."""
+    scale = 1.0 - fee_bps / ref_fee_bps
+    return net_ref_pnl + commission_ref * scale

--- a/research/nautilus_scalping/discovery/screen.py
+++ b/research/nautilus_scalping/discovery/screen.py
@@ -41,6 +41,7 @@ class HypothesisSummary:
     gross_expectancy_bps: float
     fee_adjusted_bps: float
     oos_fee_adjusted_bps: float | None = None
+    oos_gross_bps: float | None = None
     missed_fill_ratio: float | None = None
     regime: str | None = None
     time_bucket: str | None = None
@@ -53,6 +54,7 @@ class ClassifiedHypothesis:
     recommendation: Recommendation
     reason: str
     in_sample_only: bool = False
+    cost_binding: bool = False
 
     def to_dict(self) -> dict:
         d = asdict(self.summary)
@@ -60,8 +62,48 @@ class ClassifiedHypothesis:
             recommendation=self.recommendation,
             reason=self.reason,
             in_sample_only=self.in_sample_only,
+            cost_binding=self.cost_binding,
         )
         return d
+
+
+def _classify_cost_blind(
+    s: HypothesisSummary, *, min_samples: int, min_gross_bps: float
+) -> ClassifiedHypothesis:
+    """ROB-351 cost-blind mode: screen on GROSS sign (fees=0) with a triviality
+    floor; flag ``cost_binding`` when positive-gross but cost-killed.
+
+    The deeper "is the cost gap closable by maker execution" test is NOT done
+    here — that lives in the maker_fill pure path (ROB-351 Issue 3 / Stage 2).
+    This is the cheap screen-level 343 signal only.
+    """
+    if s.sample_count < min_samples:
+        return ClassifiedHypothesis(
+            s, "needs_more_data",
+            f"sample_count {s.sample_count} < min_samples {min_samples}",
+        )
+    if s.gross_expectancy_bps <= min_gross_bps:
+        return ClassifiedHypothesis(
+            s, "screened_out",
+            f"gross expectancy {s.gross_expectancy_bps:.2f}bps <= triviality floor "
+            f"{min_gross_bps:.2f}bps (no economically meaningful gross edge)",
+        )
+    if s.oos_gross_bps is not None and s.oos_gross_bps <= 0:
+        return ClassifiedHypothesis(
+            s, "screened_out",
+            f"OOS gross expectancy {s.oos_gross_bps:.2f}bps <= 0 "
+            "(in-sample gross edge does not hold out of sample)",
+        )
+    cost_binding = s.fee_adjusted_bps <= 0
+    note = ("positive gross, killed by fees -> cost_binding 343 signal"
+            if cost_binding else "positive gross AND net-viable after fees")
+    return ClassifiedHypothesis(
+        s, "promote_to_full_validation",
+        f"cost-blind: gross {s.gross_expectancy_bps:.2f}bps > floor "
+        f"{min_gross_bps:.2f}bps with {s.sample_count} samples; {note}",
+        in_sample_only=True,
+        cost_binding=cost_binding,
+    )
 
 
 def classify(
@@ -69,9 +111,18 @@ def classify(
     *,
     min_samples: int = 200,
     missed_fill_max: float = 0.6,
+    cost_blind: bool = False,
+    min_gross_bps: float = 0.0,
 ) -> ClassifiedHypothesis:
-    """Apply the fast-fail rules in priority order (see design §6)."""
+    """Apply the fast-fail rules in priority order (see design §6).
+
+    ``cost_blind=True`` (ROB-351) screens on gross sign with ``min_gross_bps`` as
+    an economic-triviality floor and flags ``cost_binding``; default mode is the
+    unchanged ROB-339 fee-adjusted screen.
+    """
     s = summary
+    if cost_blind:
+        return _classify_cost_blind(s, min_samples=min_samples, min_gross_bps=min_gross_bps)
     if s.sample_count < min_samples:
         return ClassifiedHypothesis(
             s,

--- a/research/nautilus_scalping/families.py
+++ b/research/nautilus_scalping/families.py
@@ -1,0 +1,180 @@
+"""ROB-351 (T7) — strategy-family signal generators (pure, stdlib).
+
+Three bounded families produce the trade / period series the gate consumes:
+
+  1. ``breakout_continuation_trades``  — single-symbol regime-agnostic range-
+     expansion breakout + short hold (emits ``Trade``).
+  2. ``ts_trend_basket_periods``       — per-symbol time-series trend sign,
+     equal-weight basket (emits ``PortfolioPeriod`` for the portfolio gate).
+  3. ``xs_momentum_periods``           — cross-sectional momentum, long top-k /
+     short bottom-k, PIT-aware via ``panel`` (emits ``PortfolioPeriod``).
+
+These implement the SIGNAL MECHANICS only. They are deliberately simple and
+parameter-frozen; the empirical campaign RUN against Binance USDⓈ-M data (and
+its verdict) is the operator's PR2 step — NO market data is committed. Costs use
+the shared taker model; maker closability is handled downstream (maker_fill).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import cost_model
+import panel as _panel
+from pit_universe import PITManifest
+from validated_gate import PortfolioPeriod, Trade
+
+REF_FEE_BPS = cost_model.REF_FEE_BPS
+
+
+@dataclass(frozen=True)
+class Bar:
+    ts: int
+    high: float
+    low: float
+    close: float
+
+
+def make_taker_trade(
+    gross_pnl: float, ts: int, notional: float, ref_fee_bps: float = REF_FEE_BPS
+) -> Trade:
+    """Build a gate ``Trade`` from a gross PnL with a 2-leg taker ref fee.
+
+    ``net_ref_pnl`` is net at the reference fee; ``commission_ref`` is the 2-leg
+    fee magnitude, so ``cost_model.net_at_fee(.., 0)`` recovers the gross PnL.
+    """
+    fee = 2.0 * ref_fee_bps / 1e4 * notional
+    return Trade(net_ref_pnl=gross_pnl - fee, commission_ref=fee,
+                 notional=notional, ts_opened=ts)
+
+
+def _period_commission(turnover_notional: float, ref_fee_bps: float) -> float:
+    """Ref-fee commission for a period given traded (turnover) notional."""
+    return ref_fee_bps / 1e4 * turnover_notional
+
+
+# --------------------------------------------------------------------------- #
+# Family 1 — range-expansion breakout + short continuation hold (single symbol).
+# --------------------------------------------------------------------------- #
+def breakout_continuation_trades(
+    bars: Sequence[Bar],
+    lookback: int = 20,
+    hold: int = 5,
+    notional: float = 1000.0,
+    ref_fee_bps: float = REF_FEE_BPS,
+) -> list[Trade]:
+    """Long when close breaks above the prior ``lookback`` high; exit after ``hold``.
+
+    Non-overlapping entries (a position must close before the next entry). Gross
+    PnL is the held close-to-close return on ``notional``.
+    """
+    trades: list[Trade] = []
+    n = len(bars)
+    i = lookback
+    while i < n:
+        prior_high = max(b.high for b in bars[i - lookback:i])
+        if bars[i].close > prior_high:
+            exit_idx = min(i + hold, n - 1)
+            entry = bars[i].close
+            ret = (bars[exit_idx].close - entry) / entry if entry else 0.0
+            trades.append(make_taker_trade(ret * notional, bars[i].ts, notional, ref_fee_bps))
+            i = exit_idx + 1  # non-overlapping
+        else:
+            i += 1
+    return trades
+
+
+# --------------------------------------------------------------------------- #
+# Family 2 — time-series trend basket (equal-weight sign across symbols).
+# --------------------------------------------------------------------------- #
+def ts_trend_basket_periods(
+    closes_by_symbol: dict[str, Sequence[tuple[int, float]]],
+    lookback: int = 20,
+    notional: float = 1000.0,
+    ref_fee_bps: float = REF_FEE_BPS,
+) -> list[PortfolioPeriod]:
+    """Per symbol, hold sign(return over ``lookback``); equal-weight the basket.
+
+    Each period's portfolio PnL is the mean over symbols of
+    ``position * next-period return * per-symbol notional``. Turnover (position
+    flips) is charged at the ref taker fee.
+    """
+    # align on the common chronological index by position (fixtures share a grid)
+    symbols = sorted(closes_by_symbol)
+    if not symbols:
+        return []
+    length = min(len(closes_by_symbol[s]) for s in symbols)
+    per_symbol_notional = notional / len(symbols)
+    prev_pos: dict[str, int] = dict.fromkeys(symbols, 0)
+    periods: list[PortfolioPeriod] = []
+    for t in range(lookback, length - 1):
+        ts = closes_by_symbol[symbols[0]][t][0]
+        gross = 0.0
+        turnover = 0.0
+        for s in symbols:
+            series = closes_by_symbol[s]
+            c_now = series[t][1]
+            c_past = series[t - lookback][1]
+            c_next = series[t + 1][1]
+            pos = 1 if c_now > c_past else (-1 if c_now < c_past else 0)
+            ret = (c_next - c_now) / c_now if c_now else 0.0
+            gross += pos * ret * per_symbol_notional
+            if pos != prev_pos[s]:
+                turnover += per_symbol_notional
+            prev_pos[s] = pos
+        periods.append(PortfolioPeriod(
+            ts=ts, gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
+            commission_ref=_period_commission(turnover, ref_fee_bps)))
+    return periods
+
+
+# --------------------------------------------------------------------------- #
+# Family 3 — cross-sectional momentum (long top-k / short bottom-k), PIT-aware.
+# --------------------------------------------------------------------------- #
+def xs_momentum_periods(
+    closes_by_symbol: dict[str, Sequence[tuple[int, float]]],
+    rebalances: Sequence[int],
+    lookback: int = 20,
+    top_k: int = 1,
+    notional: float = 1000.0,
+    ref_fee_bps: float = REF_FEE_BPS,
+    manifest: PITManifest | None = None,
+    min_seasoning: int = 0,
+) -> list[PortfolioPeriod]:
+    """Rank lookback returns at each rebalance; long top-k, short bottom-k.
+
+    Realizes each leg's return to the NEXT rebalance. Universe is taken as-of each
+    rebalance via the PIT panel (Codex hardening). Costs charged on the rebalanced
+    notional (full turnover each rebalance).
+    """
+    rebals = sorted(rebalances)
+    xs_by_ts = dict(_panel.iter_rebalance_cross_sections(
+        closes_by_symbol, rebals, lookback, manifest=manifest, min_seasoning=min_seasoning))
+    periods: list[PortfolioPeriod] = []
+    for idx, ts in enumerate(rebals[:-1]):
+        xs = xs_by_ts.get(ts, {})
+        if len(xs) < 2 * top_k:
+            continue
+        ranked = sorted(xs, key=xs.get, reverse=True)
+        longs, shorts = ranked[:top_k], ranked[-top_k:]
+        next_ts = rebals[idx + 1]
+        leg_notional = notional / (2 * top_k)
+        gross = 0.0
+        for sym in longs:
+            gross += _realized_return(closes_by_symbol[sym], ts, next_ts) * leg_notional
+        for sym in shorts:
+            gross -= _realized_return(closes_by_symbol[sym], ts, next_ts) * leg_notional
+        turnover = notional  # full rebalance
+        periods.append(PortfolioPeriod(
+            ts=ts, gross_ref_pnl=gross - _period_commission(turnover, ref_fee_bps),
+            commission_ref=_period_commission(turnover, ref_fee_bps)))
+    return periods
+
+
+def _realized_return(series: Sequence[tuple[int, float]], ts0: int, ts1: int) -> float:
+    c0 = _panel._close_at_or_before(series, ts0)
+    c1 = _panel._close_at_or_before(series, ts1)
+    if c0 is None or c1 is None or c0 == 0.0:
+        return 0.0
+    return c1 / c0 - 1.0

--- a/research/nautilus_scalping/fee_sweep.py
+++ b/research/nautilus_scalping/fee_sweep.py
@@ -31,7 +31,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-REF_FEE_BPS = 10.0  # catalog instrument was built with 10 bps maker/taker
+import cost_model
+
+REF_FEE_BPS = cost_model.REF_FEE_BPS  # catalog instrument built with 10 bps maker/taker
 TP_SL_GRID = [(30, 20), (40, 20), (50, 30), (60, 40), (80, 40), (100, 60), (100, 100)]
 FEE_GRID_BPS = [10.0, 7.5, 5.0, 2.0, 1.0, 0.0]
 _SENTINEL = "RESULT_JSON "
@@ -94,10 +96,9 @@ def _run_single(catalog_path: Path, symbol: str, tp: int, sl: int, trade_size: s
 # driver helpers
 # --------------------------------------------------------------------------
 def _net_at_fee(trades, fee_bps: float) -> tuple[float, int, int]:
-    scale = 1.0 - fee_bps / REF_FEE_BPS
     total, wins = 0.0, 0
     for net_ref, comm_ref in trades:
-        net = net_ref + comm_ref * scale
+        net = cost_model.net_at_fee(net_ref, comm_ref, fee_bps, REF_FEE_BPS)
         total += net
         if net > 0:
             wins += 1

--- a/research/nautilus_scalping/frozen_config.py
+++ b/research/nautilus_scalping/frozen_config.py
@@ -1,0 +1,59 @@
+"""ROB-351 (eng-review ex-ante enforcement) — frozen campaign config (pure, stdlib).
+
+The ex-ante gate thresholds and the achievable-execution envelope are committed
+HERE in PR1, before any PR2 OOS read exists. Splitting the commit (PR1) from the
+run (PR2) makes "ex-ante" structurally enforceable: the run records
+``config_hash()`` and any later tweak changes the hash, so an ex-post adjustment
+to admit a near-miss candidate is detectable, not a promise.
+
+Envelope numbers are the real Binance USDⓈ-M Futures Demo schedule (maker 2.0 /
+taker 4.0 bps); the fill model is the queue-loss/adverse-selection scenario in
+``maker_fill.py`` (not a hand-picked constant — eng-review Issue 3 / fill defensibility).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, fields
+
+
+@dataclass(frozen=True)
+class CampaignConfig:
+    # significance / multiple-testing
+    target_t: float = 2.0
+    fdr_alpha: float = 0.05
+    block_size: int = 10
+    # economic-triviality floor (Codex: sign>0 is too low)
+    economic_triviality_floor_bps: float = 0.5
+    # achievable-execution envelope (Binance USDⓈ-M demo)
+    achievable_maker_bps: float = 2.0
+    taker_bps: float = 4.0
+    # PIT seasoning (raw units; see pit_universe)
+    min_seasoning: int = 0
+    # analytic taker fee grid
+    fee_grid_bps: tuple[float, ...] = (10.0, 7.5, 5.0, 2.0, 0.0)
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["fee_grid_bps"] = list(self.fee_grid_bps)
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CampaignConfig:
+        allowed = {f.name for f in fields(cls)}
+        kw = {k: v for k, v in d.items() if k in allowed}
+        if "fee_grid_bps" in kw:
+            kw["fee_grid_bps"] = tuple(kw["fee_grid_bps"])
+        return cls(**kw)
+
+    def config_hash(self) -> str:
+        """SHA-256 over the sorted-key JSON of the config (reproducible)."""
+        return hashlib.sha256(
+            json.dumps(self.to_dict(), sort_keys=True).encode()
+        ).hexdigest()
+
+
+# The frozen default committed in PR1. PR2 reads THIS; it must not be edited to
+# admit a result after an OOS read (the hash would change — that is the guard).
+FROZEN_CONFIG = CampaignConfig()

--- a/research/nautilus_scalping/panel.py
+++ b/research/nautilus_scalping/panel.py
@@ -1,0 +1,57 @@
+"""ROB-351 (eng-review Issue 6 + Codex as-of-rebalance PIT) — lazy cross-sections.
+
+Cross-sectional strategies need, at each rebalance, the lookback return of every
+symbol tradeable AS OF that rebalance. This generator yields ONE rebalance at a
+time so the caller never materializes a full (time x symbol) matrix (the OOM risk
+flagged in eng-review Issue 6), and consults the PIT manifest per rebalance so a
+delisted/unlisted symbol cannot leak in (Codex hardening).
+
+Inputs are bar-level (not tick): ``closes_by_symbol`` maps symbol -> chronological
+``[(ts, close), ...]``. A symbol is included at a rebalance only if it is
+PIT-tradeable there AND has both a bar at the rebalance and a bar at/just-before
+``ts - lookback`` to form a return.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+
+from pit_universe import PITManifest
+
+
+def _close_at_or_before(series: Sequence[tuple[int, float]], ts: int) -> float | None:
+    """Most recent close at or before ``ts`` (series assumed chronological)."""
+    found: float | None = None
+    for s_ts, close in series:
+        if s_ts > ts:
+            break
+        found = close
+    return found
+
+
+def iter_rebalance_cross_sections(
+    closes_by_symbol: dict[str, Sequence[tuple[int, float]]],
+    rebalances: Sequence[int],
+    lookback: int,
+    manifest: PITManifest | None = None,
+    min_seasoning: int = 0,
+) -> Iterator[tuple[int, dict[str, float]]]:
+    """Yield ``(rebalance_ts, {symbol: lookback_return})`` lazily, PIT-filtered."""
+    for ts in rebalances:
+        eligible = (
+            manifest.universe_as_of(ts, min_seasoning)
+            if manifest is not None
+            else set(closes_by_symbol)
+        )
+        xs: dict[str, float] = {}
+        for symbol, series in closes_by_symbol.items():
+            if symbol not in eligible:
+                continue
+            now = _close_at_or_before(series, ts)
+            then = _close_at_or_before(series, ts - lookback)
+            # require a genuine prior anchor: a bar must exist at/before ts-lookback
+            has_prior = series and series[0][0] <= ts - lookback
+            if now is None or then is None or then == 0.0 or not has_prior:
+                continue
+            xs[symbol] = now / then - 1.0
+        yield ts, xs

--- a/research/nautilus_scalping/pit_universe.py
+++ b/research/nautilus_scalping/pit_universe.py
@@ -1,0 +1,88 @@
+"""ROB-351 (eng-review Issue 2) — point-in-time (PIT) universe manifest (pure, stdlib).
+
+Single survivorship-safe authority for "which symbols were tradeable as of time T".
+Both the cost-blind screen and the gate consult this so a delisted/unlisted symbol
+cannot leak into a window it could not have been traded in (the bias ROB-349 set
+out to close). Cross-sectional strategies call ``universe_as_of`` at EACH rebalance.
+
+The manifest holds only small listing metadata (symbol + listing/delisting
+timestamps) — it is durable and committable; the raw OHLCV it describes is NOT
+(kept out of git via AUTO_TRADER_RESEARCH_ARTIFACT_ROOT, see artifact_paths.py).
+
+Units: ``listed_from`` / ``delisted_at`` / query ``ts`` / ``min_seasoning`` are all
+integers in the SAME caller-defined unit (e.g. epoch ms). ``delisted_at`` is
+EXCLUSIVE; ``None`` means still live. A symbol is tradeable at ``ts`` iff
+``listed_from + min_seasoning <= ts`` and (``delisted_at`` is None or ``ts <
+delisted_at``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SymbolListing:
+    symbol: str
+    listed_from: int
+    delisted_at: int | None = None
+
+    def validate(self) -> SymbolListing:
+        if self.delisted_at is not None and self.delisted_at < self.listed_from:
+            raise ValueError(
+                f"{self.symbol}: delisted_at {self.delisted_at} < listed_from "
+                f"{self.listed_from}"
+            )
+        return self
+
+    def tradeable_at(self, ts: int, min_seasoning: int = 0) -> bool:
+        if ts < self.listed_from + min_seasoning:
+            return False
+        if self.delisted_at is not None and ts >= self.delisted_at:
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class PITManifest:
+    listings: tuple[SymbolListing, ...]
+
+    @classmethod
+    def from_records(cls, records: list[dict]) -> PITManifest:
+        listings = tuple(
+            SymbolListing(
+                symbol=r["symbol"],
+                listed_from=int(r["listed_from"]),
+                delisted_at=None if r.get("delisted_at") is None else int(r["delisted_at"]),
+            ).validate()
+            for r in records
+        )
+        seen: set[str] = set()
+        for listing in listings:
+            if listing.symbol in seen:
+                raise ValueError(f"duplicate symbol in manifest: {listing.symbol}")
+            seen.add(listing.symbol)
+        return cls(listings=listings)
+
+    def to_records(self) -> list[dict]:
+        return [
+            {"symbol": x.symbol, "listed_from": x.listed_from, "delisted_at": x.delisted_at}
+            for x in self.listings
+        ]
+
+    def universe_as_of(self, ts: int, min_seasoning: int = 0) -> frozenset[str]:
+        """Symbols tradeable at ``ts`` (survivorship-safe). Call per rebalance."""
+        return frozenset(
+            x.symbol for x in self.listings if x.tradeable_at(ts, min_seasoning)
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> PITManifest:
+        data = json.loads(Path(path).read_text())
+        return cls.from_records(data["listings"])
+
+    def save(self, path: str | Path) -> None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(json.dumps({"listings": self.to_records()}, indent=2))

--- a/research/nautilus_scalping/rob343_label.py
+++ b/research/nautilus_scalping/rob343_label.py
@@ -1,0 +1,105 @@
+"""ROB-351 (eng-review Issue 3 + Codex realistic-path) — the ROB-343 hand-off label.
+
+Decides, for a Stage-2 survivor, whether it is worth running through ROB-343
+(the deferred execution-realism harness). The 343-worthy test is NOT tautological
+"cost is the blocker"; it requires a PLAUSIBLE PATH TO TRADEABILITY:
+
+  * ``promote_to_pilot``            — already net-viable at realistic taker fees;
+                                      ROB-343 not required.
+  * ``cost_binding_343_candidate``  — positive gross, killed by taker fees, BUT the
+                                      maker-conservative scenario (maker_fill queue
+                                      loss + adverse selection) is itself net-positive
+                                      => realistic maker execution closes the gap.
+  * ``needs_more_data``             — OOS evidence insufficient.
+  * ``reject``                      — no gross edge, or gap not closable by realistic
+                                      maker execution.
+
+Closability lives in the PURE maker path (maker_fill -> validated_gate), never in
+fee_sweep's taker-only linear rescale (Issue 3). ``breakeven_taker_fee_bps`` is
+reported as evidence; the maker-conservative net is the load-bearing test.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+import cost_model
+from validated_gate import Trade
+
+Label = Literal[
+    "promote_to_pilot", "cost_binding_343_candidate", "needs_more_data", "reject"
+]
+
+
+def breakeven_taker_fee_bps_from_sums(
+    sum_net_ref: float, sum_comm: float, ref_fee_bps: float = cost_model.REF_FEE_BPS
+) -> float:
+    """Closed-form max per-leg TAKER fee at which total net == 0 (evidence only).
+
+    net(fee) = sum_net_ref + sum_comm * (1 - fee/ref) = 0
+        => fee = ref * (1 + sum_net_ref / sum_comm)
+    """
+    if sum_comm == 0.0:
+        # fee cannot move net; infinite headroom if already positive, else none
+        return math.inf if sum_net_ref > 0 else 0.0
+    return max(0.0, ref_fee_bps * (1.0 + sum_net_ref / sum_comm))
+
+
+def breakeven_taker_fee_bps(trades: list[Trade], ref_fee_bps: float = cost_model.REF_FEE_BPS) -> float:
+    """Breakeven taker fee for a ``Trade`` list (taker-only; maker decided elsewhere)."""
+    return breakeven_taker_fee_bps_from_sums(
+        sum(t.net_ref_pnl for t in trades), sum(t.commission_ref for t in trades), ref_fee_bps
+    )
+
+
+@dataclass(frozen=True)
+class Rob343Verdict:
+    label: Label
+    cost_binding: bool
+    closable: bool
+    breakeven_taker_bps: float
+    maker_conservative_net: float
+    reason: str
+
+
+def label_343_candidate(
+    *,
+    taker_net_pnl: float,
+    gross_pnl: float,
+    maker_conservative_net: float,
+    oos_significant: bool,
+    breakeven_taker_bps: float,
+) -> Rob343Verdict:
+    """Classify a survivor. See module docstring for the decision table."""
+    if not oos_significant:
+        return Rob343Verdict(
+            "needs_more_data", False, False, breakeven_taker_bps, maker_conservative_net,
+            "OOS evidence insufficient (sample/CI/FDR gate not cleared)",
+        )
+    if taker_net_pnl > 0:
+        return Rob343Verdict(
+            "promote_to_pilot", False, maker_conservative_net > 0,
+            breakeven_taker_bps, maker_conservative_net,
+            "already net-viable at realistic taker fees; ROB-343 not required",
+        )
+    cost_binding = gross_pnl > 0 and taker_net_pnl <= 0
+    if not cost_binding:
+        return Rob343Verdict(
+            "reject", False, False, breakeven_taker_bps, maker_conservative_net,
+            "no positive gross edge; not a cost problem",
+        )
+    closable = maker_conservative_net > 0
+    if closable:
+        return Rob343Verdict(
+            "cost_binding_343_candidate", True, True,
+            breakeven_taker_bps, maker_conservative_net,
+            "positive gross killed by taker fees; maker-conservative scenario is "
+            "net-positive => realistic maker execution plausibly closes the gap",
+        )
+    return Rob343Verdict(
+        "reject", True, False, breakeven_taker_bps, maker_conservative_net,
+        "cost-binding but maker-conservative scenario still net-negative => no "
+        "realistic execution path (Codex realistic-path stop-rule)",
+    )

--- a/research/nautilus_scalping/run_rob351_campaign.py
+++ b/research/nautilus_scalping/run_rob351_campaign.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""ROB-351 — cost-blind funnel operator entry point (research/backtest only).
+
+Wires PIT universe + family signals + cost-blind screen + gate + 343 label into a
+verdict table (see ``campaign.run_campaign``). Two modes:
+
+  --self-test   Run the funnel on tiny SYNTHETIC fixtures and print the verdict
+                table. Needs no data/secrets — proves the wiring end to end.
+
+  (default)     Explain what a real RUN needs and exit 0. The empirical campaign
+                against Binance USDⓈ-M data is the operator's PR2 step: point
+                ``AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`` at a data root holding the
+                bar-level OHLCV + a PIT manifest (pit_universe.PITManifest), build
+                family specs from it, and call ``campaign.run_campaign``.
+
+Safety boundary (unchanged): no live, no Demo confirm, no broker/order/watch/
+order-intent mutation, no scheduler, no prod DB/env/secret, no /invest exposure,
+no raw large data committed, no credential logging. ROB-343 is only RECOMMENDED
+by the verdict, never run here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _self_test() -> dict:
+    # Imported lazily so --help / arg parsing never needs the research deps.
+    import campaign
+    import families
+    from discovery.screen import HypothesisSummary
+    from frozen_config import FROZEN_CONFIG
+
+    def trades(gross_each, n):
+        return [families.make_taker_trade(gross_each, ts=i, notional=1000.0) for i in range(n)]
+
+    specs = [
+        {"name": "family1_breakout_continuation",
+         "summary": HypothesisSummary("f1", "demo", 40, 8.0, 4.0, oos_gross_bps=8.0),
+         "kind": "trade", "data": trades(5.0, 40), "maker_conservative_net": None},
+        {"name": "family2_trend_basket(seed-style cost-binding)",
+         "summary": HypothesisSummary("f2", "demo", 40, 6.0, -2.0, oos_gross_bps=6.0),
+         "kind": "trade", "data": trades(0.5, 40), "maker_conservative_net": 1.5},
+        {"name": "family3_xs_momentum(no gross edge)",
+         "summary": HypothesisSummary("f3", "demo", 40, -1.0, -3.0, oos_gross_bps=-1.0),
+         "kind": "trade", "data": trades(-2.0, 40), "maker_conservative_net": None},
+    ]
+    return campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="ROB-351 cost-blind funnel (research only)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the funnel on synthetic fixtures and print the verdict table")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        print(json.dumps(_self_test(), indent=2))
+        return 0
+
+    print(
+        "ROB-351 cost-blind funnel — no data RUN performed.\n"
+        "This PR ships the funnel CODE + tests; the empirical RUN is operator-gated\n"
+        "(no market data is committed). To run for real:\n"
+        "  1. set AUTO_TRADER_RESEARCH_ARTIFACT_ROOT to a data root (bar OHLCV + PIT manifest)\n"
+        "  2. build family specs (families.py) from that data\n"
+        "  3. call campaign.run_campaign(specs, FROZEN_CONFIG)\n"
+        "Verify the wiring now with:  python run_rob351_campaign.py --self-test\n"
+        "Safety: research only; ROB-343 is recommended by the verdict, never run here."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/tests/test_campaign.py
+++ b/research/nautilus_scalping/tests/test_campaign.py
@@ -1,0 +1,59 @@
+"""ROB-351 (Stage 3) — end-to-end funnel driver integration.
+
+Wires cost-blind screen (Stage 1) -> gate (Stage 2) -> 343 label (Stage 3) over a
+set of family specs and assembles a verdict table. Synthetic data only — proves
+the funnel MECHANICS and that the frozen-config hash is recorded; the empirical
+RUN on Binance USDⓈ-M data is the operator's PR2 step.
+"""
+
+import campaign
+import families
+from discovery.screen import HypothesisSummary
+from frozen_config import FROZEN_CONFIG
+
+
+def _trades(gross_each, n, notional=1000.0):
+    return [families.make_taker_trade(gross_each, ts=i, notional=notional) for i in range(n)]
+
+
+def test_campaign_produces_verdict_table_with_three_outcomes():
+    specs = [
+        # net-viable: big gross, survives taker fees -> promote_to_pilot
+        {"name": "A_net_viable",
+         "summary": HypothesisSummary("A", "c", 40, gross_expectancy_bps=8.0,
+                                      fee_adjusted_bps=4.0, oos_gross_bps=8.0),
+         "kind": "trade", "data": _trades(5.0, 40), "maker_conservative_net": None},
+        # cost-binding + closable: gross>0, taker-net<0, maker-conservative>0 -> 343 candidate
+        {"name": "B_cost_binding",
+         "summary": HypothesisSummary("B", "c", 40, gross_expectancy_bps=6.0,
+                                      fee_adjusted_bps=-2.0, oos_gross_bps=6.0),
+         # gross +0.5/trade but taker fee (~0.8/trade) pushes net negative
+         "kind": "trade", "data": _trades(0.5, 40), "maker_conservative_net": 1.5},
+        # no gross edge -> screened_out at Stage 1, never reaches the gate
+        {"name": "C_screened",
+         "summary": HypothesisSummary("C", "c", 40, gross_expectancy_bps=-1.0,
+                                      fee_adjusted_bps=-3.0, oos_gross_bps=-1.0),
+         "kind": "trade", "data": _trades(-2.0, 40), "maker_conservative_net": None},
+    ]
+    rep = campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+
+    rows = {r["name"]: r for r in rep["families"]}
+    assert rows["C_screened"]["screen"] == "screened_out"
+    assert rows["C_screened"]["label_343"] is None  # never gated
+
+    assert rows["A_net_viable"]["screen"] == "promote_to_full_validation"
+    assert rows["A_net_viable"]["label_343"] == "promote_to_pilot"
+
+    assert rows["B_cost_binding"]["screen"] == "promote_to_full_validation"
+    assert rows["B_cost_binding"]["cost_binding_screen"] is True
+    assert rows["B_cost_binding"]["label_343"] == "cost_binding_343_candidate"
+
+    # ex-ante evidence recorded
+    assert rep["config_hash"] == FROZEN_CONFIG.config_hash()
+    assert rep["schema_version"].startswith("rob351_campaign")
+
+
+def test_campaign_empty_specs_is_safe():
+    rep = campaign.run_campaign([], config=FROZEN_CONFIG)
+    assert rep["families"] == []
+    assert rep["config_hash"] == FROZEN_CONFIG.config_hash()

--- a/research/nautilus_scalping/tests/test_cost_model.py
+++ b/research/nautilus_scalping/tests/test_cost_model.py
@@ -1,0 +1,39 @@
+"""ROB-351 (Issue 4) — shared net-at-fee primitive + 3->1 dedup regression.
+
+The linear fee rescale ``net(fee) = net_ref + commission_ref*(1 - fee/ref)`` was
+duplicated in validated_gate / fee_sweep / compare_strategies. These tests pin
+the extracted primitive's arithmetic AND prove validated_gate's call-site is
+behavior-identical after delegating to it (REGRESSION).
+"""
+
+import cost_model
+import validated_gate
+from validated_gate import Trade
+
+
+def test_net_at_fee_endpoints():
+    # as-run at ref fee: scale=0 -> just net_ref_pnl
+    assert cost_model.net_at_fee(5.0, 2.0, fee_bps=10.0, ref_fee_bps=10.0) == 5.0
+    # zero fee: scale=1 -> commission fully added back (gross)
+    assert cost_model.net_at_fee(5.0, 2.0, fee_bps=0.0, ref_fee_bps=10.0) == 7.0
+    # half fee: scale=0.5
+    assert cost_model.net_at_fee(5.0, 2.0, fee_bps=5.0, ref_fee_bps=10.0) == 6.0
+
+
+def test_net_at_fee_default_ref_is_ten():
+    assert cost_model.REF_FEE_BPS == 10.0
+    assert cost_model.net_at_fee(0.0, 4.0, fee_bps=0.0) == 4.0
+
+
+def test_regression_validated_gate_uses_primitive():
+    # Golden trades; commission_ref positive (maker_fill convention).
+    trades = [
+        Trade(net_ref_pnl=3.0, commission_ref=1.0, notional=100.0, ts_opened=1),
+        Trade(net_ref_pnl=-2.0, commission_ref=2.0, notional=100.0, ts_opened=2),
+        Trade(net_ref_pnl=0.5, commission_ref=0.4, notional=50.0, ts_opened=3),
+    ]
+    for fee in (0.0, 2.0, 5.0, 7.5, 10.0):
+        for t in trades:
+            assert validated_gate._net_at_fee(t, fee) == cost_model.net_at_fee(
+                t.net_ref_pnl, t.commission_ref, fee
+            )

--- a/research/nautilus_scalping/tests/test_discovery_cost_blind.py
+++ b/research/nautilus_scalping/tests/test_discovery_cost_blind.py
@@ -1,0 +1,60 @@
+"""ROB-351 (eng-review Issue 5) — cost-blind screen mode + cost_binding label.
+
+Single classifier (no parallel 343 classifier): the cost-blind mode screens on
+GROSS sign (fees=0) with an economic-triviality floor, and flags
+``cost_binding`` when a candidate is positive-gross but cost-killed (the cheap
+screen-level 343 signal; deeper closability lives in the maker_fill path).
+"""
+
+from discovery.screen import HypothesisSummary, classify
+
+
+def _summary(gross, fee_adj, *, oos=None, oos_gross=None, samples=300, name="h"):
+    return HypothesisSummary(
+        name=name, conditions="c", sample_count=samples,
+        gross_expectancy_bps=gross, fee_adjusted_bps=fee_adj, oos_fee_adjusted_bps=oos,
+        oos_gross_bps=oos_gross,
+    )
+
+
+def test_default_mode_unchanged_and_cost_binding_false():
+    c = classify(_summary(5.0, 3.0))
+    assert c.recommendation == "promote_to_full_validation"
+    assert c.cost_binding is False
+
+
+def test_cost_blind_positive_gross_but_cost_killed_is_cost_binding():
+    c = classify(_summary(5.0, -2.0), cost_blind=True)
+    assert c.recommendation == "promote_to_full_validation"
+    assert c.in_sample_only is True
+    assert c.cost_binding is True  # positive gross, killed by fees -> a 343 signal
+
+
+def test_cost_blind_already_net_viable_is_not_cost_binding():
+    c = classify(_summary(5.0, 3.0), cost_blind=True)
+    assert c.recommendation == "promote_to_full_validation"
+    assert c.cost_binding is False  # survives net too -> not cost-binding
+
+
+def test_cost_blind_negative_gross_screened_out():
+    c = classify(_summary(-1.0, -3.0), cost_blind=True)
+    assert c.recommendation == "screened_out"
+    assert c.cost_binding is False
+
+
+def test_cost_blind_economic_triviality_floor():
+    # gross positive but below the floor -> screened_out (Codex: sign>0 too low)
+    c = classify(_summary(0.3, -0.1), cost_blind=True, min_gross_bps=0.5)
+    assert c.recommendation == "screened_out"
+    assert "triviality" in c.reason or "floor" in c.reason
+
+
+def test_cost_blind_low_samples_needs_more_data():
+    c = classify(_summary(5.0, -2.0, samples=10), cost_blind=True, min_samples=200)
+    assert c.recommendation == "needs_more_data"
+
+
+def test_cost_blind_oos_gross_sign_must_agree():
+    # in-sample gross positive but OOS GROSS negative -> screened_out
+    c = classify(_summary(5.0, -2.0, oos_gross=-1.0), cost_blind=True)
+    assert c.recommendation == "screened_out"

--- a/research/nautilus_scalping/tests/test_families.py
+++ b/research/nautilus_scalping/tests/test_families.py
@@ -1,0 +1,56 @@
+"""ROB-351 (T7) — family 1-3 signal-generator MECHANICS.
+
+These pin the signal/position/PnL/cost mechanics on synthetic fixtures. They do
+NOT assert any empirical edge — the real campaign RUN on Binance USD-M data is the
+operator's PR2 step (no market data is committed). Family 1 emits single-symbol
+``Trade`` lists; families 2-3 emit ``PortfolioPeriod`` series for the portfolio gate.
+"""
+
+import cost_model
+import families
+from validated_gate import PortfolioPeriod, Trade, portfolio_metrics_at_fee
+
+
+def test_make_taker_trade_gross_and_commission():
+    t = families.make_taker_trade(gross_pnl=5.0, ts=1, notional=1000.0, ref_fee_bps=10.0)
+    assert isinstance(t, Trade)
+    # zero-fee net == gross; commission is the 2-leg ref fee on notional
+    assert abs(cost_model.net_at_fee(t.net_ref_pnl, t.commission_ref, 0.0) - 5.0) < 1e-9
+    assert abs(t.commission_ref - 2 * 10.0 / 1e4 * 1000.0) < 1e-9
+
+
+def test_breakout_continuation_enters_on_breakout():
+    # flat then a clean breakout + continuation
+    bars = [families.Bar(ts=i, high=100.0, low=99.0, close=100.0) for i in range(20)]
+    bars += [families.Bar(ts=20, high=105.0, low=100.0, close=105.0),
+             families.Bar(ts=21, high=107.0, low=104.0, close=107.0),
+             families.Bar(ts=22, high=109.0, low=106.0, close=109.0)]
+    trades = families.breakout_continuation_trades(bars, lookback=20, hold=2)
+    assert len(trades) >= 1
+    assert all(isinstance(t, Trade) for t in trades)
+
+
+def test_breakout_continuation_flat_market_no_trades():
+    bars = [families.Bar(ts=i, high=100.0, low=99.0, close=99.5) for i in range(40)]
+    assert families.breakout_continuation_trades(bars, lookback=20, hold=2) == []
+
+
+def test_ts_trend_basket_longs_up_shorts_down():
+    # AAA trends up, BBB trends down; trend basket should be net-positive gross
+    up = [(i, 100.0 + i) for i in range(40)]
+    down = [(i, 100.0 - i) for i in range(40)]
+    periods = families.ts_trend_basket_periods({"AAA": up, "BBB": down}, lookback=10)
+    assert all(isinstance(p, PortfolioPeriod) for p in periods)
+    assert portfolio_metrics_at_fee(periods, 0.0).net_pnl > 0  # gross edge on the fixture
+
+
+def test_xs_momentum_periods_emit_and_respect_lookback():
+    closes = {
+        "AAA": [(i, 100.0 + 2 * i) for i in range(40)],   # strongest momentum
+        "BBB": [(i, 100.0 + i) for i in range(40)],
+        "CCC": [(i, 100.0 - i) for i in range(40)],       # weakest
+    }
+    rebalances = [20, 25, 30]
+    periods = families.xs_momentum_periods(closes, rebalances=rebalances, lookback=10, top_k=1)
+    assert all(isinstance(p, PortfolioPeriod) for p in periods)
+    assert len(periods) >= 1

--- a/research/nautilus_scalping/tests/test_frozen_config.py
+++ b/research/nautilus_scalping/tests/test_frozen_config.py
@@ -1,0 +1,32 @@
+"""ROB-351 (eng-review ex-ante enforcement) — frozen campaign config + hash.
+
+Thresholds and the achievable-execution envelope are committed in PR1 BEFORE any
+PR2 OOS read. The run records ``config_hash``; changing a threshold after the
+fact changes the hash, making an ex-post tweak detectable rather than a promise.
+"""
+
+import frozen_config as fc
+
+
+def test_frozen_default_present_and_documented():
+    c = fc.FROZEN_CONFIG
+    assert c.economic_triviality_floor_bps > 0.0   # sign>0 is too low (Codex)
+    assert c.achievable_maker_bps == 2.0           # Binance USD-M demo maker
+    assert c.taker_bps == 4.0                      # Binance USD-M demo taker
+    assert c.fdr_alpha == 0.05
+
+
+def test_config_hash_is_stable_across_calls():
+    assert fc.FROZEN_CONFIG.config_hash() == fc.FROZEN_CONFIG.config_hash()
+
+
+def test_changing_a_threshold_changes_the_hash():
+    import dataclasses
+    base = fc.FROZEN_CONFIG
+    tweaked = dataclasses.replace(base, economic_triviality_floor_bps=999.0)
+    assert tweaked.config_hash() != base.config_hash()
+
+
+def test_to_dict_round_trip():
+    c = fc.FROZEN_CONFIG
+    assert fc.CampaignConfig.from_dict(c.to_dict()) == c

--- a/research/nautilus_scalping/tests/test_gate_stats_hardening.py
+++ b/research/nautilus_scalping/tests/test_gate_stats_hardening.py
@@ -1,0 +1,61 @@
+"""ROB-351 (Codex outside-voice bundle) — statistical-honesty hardening.
+
+Adds, on top of the existing iid bootstrap:
+  * block/time bootstrap (crypto trades are time-clustered; iid is too optimistic)
+  * Benjamini-Hochberg FDR control across the many shots (3 families + seed + grids)
+  * effect-size / FDR-aware minimum sample count (replaces cargo-culted fixed n>=263)
+  * turnover-matched random baseline (guards against volatility-harvesting/beta)
+All pure-stdlib, additive; existing gate machinery untouched.
+"""
+
+import math
+
+import validated_gate as vg
+
+
+def test_block_bootstrap_is_deterministic_and_well_formed():
+    pnls = [0.5, -0.2, 0.3, -0.1, 0.4, -0.3, 0.6, -0.2, 0.5, -0.1] * 5
+    a = vg.block_bootstrap_sharpe_ci(pnls, block_size=5, n_bootstrap=200, seed=7)
+    b = vg.block_bootstrap_sharpe_ci(pnls, block_size=5, n_bootstrap=200, seed=7)
+    assert a == b  # reproducible
+    assert a["ci_lower"] <= a["observed_sharpe"] <= a["ci_upper"] or a["ci_lower"] <= a["ci_upper"]
+    assert a["block_size"] == 5
+    assert 0.0 <= a["prob_positive"] <= 1.0
+
+
+def test_block_bootstrap_insufficient_data():
+    assert vg.block_bootstrap_sharpe_ci([1.0], block_size=5)["error"] == "insufficient_data"
+
+
+def test_benjamini_hochberg_controls_fdr():
+    p = [0.001, 0.01, 0.2, 0.5]
+    res = vg.benjamini_hochberg(p, alpha=0.05)
+    assert set(res["rejected"]) == {0, 1}  # two smallest survive BH at alpha=0.05
+    assert math.isclose(res["threshold"], 0.01)
+
+
+def test_benjamini_hochberg_none_significant():
+    res = vg.benjamini_hochberg([0.4, 0.6, 0.9], alpha=0.05)
+    assert res["rejected"] == []
+
+
+def test_effect_size_aware_min_trades_monotonic():
+    n1 = vg.effect_size_aware_min_trades(observed_sharpe=0.1, n_configs_tried=1)
+    n10 = vg.effect_size_aware_min_trades(observed_sharpe=0.1, n_configs_tried=10)
+    big = vg.effect_size_aware_min_trades(observed_sharpe=0.3, n_configs_tried=1)
+    assert n10 > n1            # more shots tried -> need more evidence
+    assert big < n1            # bigger effect -> need fewer trades
+    assert n1 == 400           # (2.0 / 0.1)^2 at m=1
+
+
+def test_effect_size_aware_min_trades_zero_effect_is_infinite():
+    assert vg.effect_size_aware_min_trades(observed_sharpe=0.0, n_configs_tried=1) == math.inf
+
+
+def test_turnover_matched_random_baseline_matches_count_and_is_deterministic():
+    pool = [0.1, -0.2, 0.3, -0.4, 0.5]
+    a = vg.turnover_matched_random_baseline(pool, n_trades=20, seed=3)
+    b = vg.turnover_matched_random_baseline(pool, n_trades=20, seed=3)
+    assert a == b
+    assert len(a) == 20
+    assert all(x in pool for x in a)

--- a/research/nautilus_scalping/tests/test_panel.py
+++ b/research/nautilus_scalping/tests/test_panel.py
@@ -1,0 +1,51 @@
+"""ROB-351 (eng-review Issue 6 + Codex as-of-rebalance PIT) — lazy PIT cross-sections.
+
+Cross-sectional momentum needs, at EACH rebalance, the lookback return of every
+symbol tradeable AS OF that rebalance. The generator yields one rebalance at a
+time (memory-bounded, no full time x symbol matrix) and consults the PIT manifest
+per rebalance so delisted/unlisted symbols never leak in.
+"""
+
+import panel
+from pit_universe import PITManifest
+
+
+def _closes():
+    # ts -> close per symbol; AAA & BBB present early, CCC lists late
+    return {
+        "AAA": [(0, 100.0), (10, 110.0), (20, 121.0), (30, 133.0)],
+        "BBB": [(0, 50.0), (10, 49.0), (20, 48.0), (30, 47.0)],
+        "CCC": [(20, 10.0), (30, 12.0)],
+    }
+
+
+def test_iter_is_lazy_generator():
+    import types
+    g = panel.iter_rebalance_cross_sections(_closes(), rebalances=[20, 30], lookback=10)
+    assert isinstance(g, types.GeneratorType)
+
+
+def test_cross_section_lookback_return():
+    out = dict(panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10))
+    # at ts=20, lookback 10: AAA 121/110-1=0.10, BBB 48/49-1<0
+    xs = out[20]
+    assert abs(xs["AAA"] - (121.0 / 110.0 - 1.0)) < 1e-9
+    assert xs["BBB"] < 0.0
+
+
+def test_pit_excludes_unlisted_symbol():
+    m = PITManifest.from_records([
+        {"symbol": "AAA", "listed_from": 0, "delisted_at": None},
+        {"symbol": "BBB", "listed_from": 0, "delisted_at": None},
+        {"symbol": "CCC", "listed_from": 25, "delisted_at": None},  # lists after ts=20
+    ])
+    out = dict(panel.iter_rebalance_cross_sections(
+        _closes(), rebalances=[20], lookback=10, manifest=m))
+    assert "CCC" not in out[20]   # unlisted as-of ts=20 -> leak guard
+    assert "AAA" in out[20]
+
+
+def test_symbol_without_enough_lookback_history_skipped():
+    # CCC has no bar at ts<=10, so a lookback-10 return at ts=20 is impossible
+    out = dict(panel.iter_rebalance_cross_sections(_closes(), rebalances=[20], lookback=10))
+    assert "CCC" not in out[20]

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -1,0 +1,69 @@
+"""ROB-351 (eng-review Issue 2) — point-in-time universe manifest.
+
+Single survivorship authority consulted by BOTH the cost-blind screen and the
+gate. Mandatory leak guards: a symbol unlisted as-of a timestamp, or already
+delisted, must NOT appear in that timestamp's tradeable universe. Cross-sectional
+strategies query the universe as-of EACH rebalance (Codex hardening), not once
+per window.
+
+ts/listed_from/delisted_at/min_seasoning are all integers in the SAME unit
+(caller-defined, e.g. epoch ms); delisted_at is exclusive, None = still live.
+"""
+
+from pit_universe import PITManifest, SymbolListing
+
+
+def _manifest():
+    return PITManifest.from_records([
+        {"symbol": "AAA", "listed_from": 100, "delisted_at": None},
+        {"symbol": "BBB", "listed_from": 150, "delisted_at": 400},
+        {"symbol": "CCC", "listed_from": 500, "delisted_at": None},
+    ])
+
+
+def test_includes_listed_and_not_delisted():
+    assert "AAA" in _manifest().universe_as_of(200)
+
+
+def test_excludes_symbol_unlisted_as_of_ts():
+    # LEAK GUARD: CCC lists at 500; must not appear at ts=200
+    assert "CCC" not in _manifest().universe_as_of(200)
+
+
+def test_excludes_symbol_already_delisted():
+    # LEAK GUARD: BBB delists at 400 (exclusive); excluded at ts=400 and after
+    assert "BBB" not in _manifest().universe_as_of(400)
+    assert "BBB" not in _manifest().universe_as_of(450)
+
+
+def test_includes_symbol_still_tradeable_before_delist():
+    assert "BBB" in _manifest().universe_as_of(399)
+
+
+def test_seasoning_excludes_freshly_listed():
+    # AAA listed at 100; with min_seasoning=50 it is eligible only from ts>=150
+    assert "AAA" not in _manifest().universe_as_of(120, min_seasoning=50)
+    assert "AAA" in _manifest().universe_as_of(150, min_seasoning=50)
+
+
+def test_as_of_each_rebalance_drops_delisted_symbol():
+    m = _manifest()
+    rebalances = [200, 350, 450]
+    universes = {ts: m.universe_as_of(ts) for ts in rebalances}
+    assert "BBB" in universes[200]
+    assert "BBB" in universes[350]
+    assert "BBB" not in universes[450]  # delisted at 400, gone by next rebalance
+
+
+def test_round_trip_dict():
+    m = _manifest()
+    m2 = PITManifest.from_records(m.to_records())
+    assert m2.universe_as_of(200) == m.universe_as_of(200)
+
+
+def test_rejects_delist_before_list():
+    try:
+        SymbolListing(symbol="X", listed_from=200, delisted_at=100).validate()
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for delisted_at < listed_from")

--- a/research/nautilus_scalping/tests/test_portfolio_gate.py
+++ b/research/nautilus_scalping/tests/test_portfolio_gate.py
@@ -1,0 +1,70 @@
+"""ROB-351 (eng-review Issue 1) — portfolio-return path for basket / XS strategies.
+
+validated_gate's per-trade equity sum (metrics_at_fee) is correct for a
+single-symbol serial scalper but UNDERSTATES drawdown when a basket holds
+concurrent positions that move together. These tests pin the correctness gap and
+the new period-return path that fixes it.
+"""
+
+import validated_gate
+from validated_gate import PortfolioPeriod, Trade
+
+
+def test_period_net_uses_shared_primitive():
+    # one period: gross 5 at ref, commission 2 -> zero-fee adds it back
+    p = PortfolioPeriod(ts=1, gross_ref_pnl=5.0, commission_ref=2.0)
+    assert validated_gate.portfolio_net_pnls_at_fee([p], 10.0) == [5.0]
+    assert validated_gate.portfolio_net_pnls_at_fee([p], 0.0) == [7.0]
+
+
+def test_portfolio_drawdown_beats_serial_trade_drawdown():
+    """The Issue-1 bug, made concrete.
+
+    Three positions all open at t=0, all drop -10 simultaneously at t=1, then each
+    recovers and closes net +1 at t=2,3,4.
+
+      * Flat Trade list (per position, keyed by ts_opened): metrics_at_fee sees
+        three +1 trades in sequence -> equity 1,2,3 -> drawdown 0 (WRONG: hides
+        that the book was -30 underwater at once).
+      * Portfolio period series: t1 = -30 (all three down together) then recovery
+        -> equity dips to -30 -> drawdown -30 (CORRECT).
+    """
+    flat_trades = [
+        Trade(net_ref_pnl=1.0, commission_ref=0.0, notional=100.0, ts_opened=0),
+        Trade(net_ref_pnl=1.0, commission_ref=0.0, notional=100.0, ts_opened=0),
+        Trade(net_ref_pnl=1.0, commission_ref=0.0, notional=100.0, ts_opened=0),
+    ]
+    serial = validated_gate.metrics_at_fee(flat_trades, 0.0)
+    assert serial.max_drawdown == 0.0  # the bug: zero drawdown
+
+    periods = [
+        PortfolioPeriod(ts=1, gross_ref_pnl=-30.0, commission_ref=0.0),
+        PortfolioPeriod(ts=2, gross_ref_pnl=11.0, commission_ref=0.0),
+        PortfolioPeriod(ts=3, gross_ref_pnl=11.0, commission_ref=0.0),
+        PortfolioPeriod(ts=4, gross_ref_pnl=11.0, commission_ref=0.0),
+    ]
+    pf = validated_gate.portfolio_metrics_at_fee(periods, 0.0)
+    assert pf.max_drawdown == -30.0          # correct, severe
+    assert pf.net_pnl == 3.0                 # same total as the flat trades
+    assert pf.max_drawdown < serial.max_drawdown  # portfolio path is the honest one
+
+
+def test_evaluate_gate_portfolio_returns_report_with_portfolio_dd():
+    # enough periods to split walk-forward and exceed a small min_trades
+    periods = [
+        PortfolioPeriod(ts=i, gross_ref_pnl=(1.0 if i % 2 else -0.5), commission_ref=0.1)
+        for i in range(1, 41)
+    ]
+    rep = validated_gate.evaluate_gate_portfolio(
+        candidate_runs={"p": periods},
+        baseline_periods=[PortfolioPeriod(ts=i, gross_ref_pnl=0.0, commission_ref=0.1)
+                          for i in range(1, 41)],
+        fee_bps=2.0,
+        min_periods=5,
+        candidate_name="basket-test",
+    )
+    assert "gross" in rep.results
+    assert "net_after_cost" in rep.results
+    # portfolio DD present and computed on the period equity curve (<= 0)
+    assert rep.results["net_after_cost"]["max_drawdown"] <= 0.0
+    assert rep.verdict in ("validated", "not_validated", "insufficient_data")

--- a/research/nautilus_scalping/tests/test_rob343_label.py
+++ b/research/nautilus_scalping/tests/test_rob343_label.py
@@ -1,0 +1,66 @@
+"""ROB-351 (eng-review Issue 3 + Codex realistic-path) — the 343 handoff label.
+
+Closability is decided in the PURE path: the maker-conservative scenario
+(maker_fill queue-loss + adverse-selection haircuts) must itself be net-positive
+for the candidate to be a ROB-343 hand-off. Cost-binding alone is NOT enough
+(Codex realistic-path stop-rule). Taker breakeven is reported as evidence only.
+"""
+
+import math
+
+import rob343_label as r
+from validated_gate import Trade
+
+
+def test_breakeven_taker_fee_closed_form():
+    # sum_net_ref=-5, sum_comm=10 -> net(fee)=0 at fee=5 bps/leg
+    trades = [Trade(net_ref_pnl=-5.0, commission_ref=10.0, notional=100.0, ts_opened=1)]
+    assert math.isclose(r.breakeven_taker_fee_bps(trades), 5.0)
+
+
+def test_breakeven_no_commission_dependence():
+    # zero commission -> fee cannot change net; positive net -> +inf headroom
+    trades = [Trade(net_ref_pnl=3.0, commission_ref=0.0, notional=100.0, ts_opened=1)]
+    assert r.breakeven_taker_fee_bps(trades) == math.inf
+
+
+def test_already_net_viable_is_promote_to_pilot():
+    v = r.label_343_candidate(taker_net_pnl=4.0, gross_pnl=6.0,
+                              maker_conservative_net=5.0, oos_significant=True,
+                              breakeven_taker_bps=8.0)
+    assert v.label == "promote_to_pilot"
+    assert v.cost_binding is False
+
+
+def test_cost_binding_and_closable_is_343_candidate():
+    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
+                              maker_conservative_net=1.5, oos_significant=True,
+                              breakeven_taker_bps=3.0)
+    assert v.label == "cost_binding_343_candidate"
+    assert v.cost_binding is True
+    assert v.closable is True
+
+
+def test_cost_binding_but_not_closable_is_reject():
+    # gross positive, killed by taker fees, but maker-conservative STILL negative
+    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
+                              maker_conservative_net=-0.5, oos_significant=True,
+                              breakeven_taker_bps=3.0)
+    assert v.label == "reject"
+    assert v.cost_binding is True
+    assert v.closable is False
+
+
+def test_no_gross_edge_is_reject():
+    v = r.label_343_candidate(taker_net_pnl=-3.0, gross_pnl=-1.0,
+                              maker_conservative_net=-2.0, oos_significant=True,
+                              breakeven_taker_bps=0.0)
+    assert v.label == "reject"
+    assert v.cost_binding is False
+
+
+def test_not_significant_is_needs_more_data():
+    v = r.label_343_candidate(taker_net_pnl=-2.0, gross_pnl=6.0,
+                              maker_conservative_net=1.5, oos_significant=False,
+                              breakeven_taker_bps=3.0)
+    assert v.label == "needs_more_data"

--- a/research/nautilus_scalping/validated_gate.py
+++ b/research/nautilus_scalping/validated_gate.py
@@ -18,6 +18,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
+import cost_model
+
 REF_FEE_BPS = 10.0
 Verdict = Literal["validated", "not_validated", "insufficient_data"]
 
@@ -28,6 +30,24 @@ class Trade:
     commission_ref: float   # commission paid at REF_FEE_BPS (negative)
     notional: float
     ts_opened: int
+
+
+@dataclass(frozen=True)
+class PortfolioPeriod:
+    """One period's PORTFOLIO-AGGREGATED PnL for a basket / cross-sectional run.
+
+    Unlike ``Trade`` (per-position, keyed by open time), a period already nets all
+    concurrent positions' mark-to-market into a single increment. Drawdown on the
+    series of these is the honest portfolio drawdown (ROB-351 Issue 1).
+
+    ``gross_ref_pnl`` = portfolio PnL in the period at REF_FEE_BPS;
+    ``commission_ref`` = period commission magnitude at REF_FEE_BPS (>= 0); the
+    shared ``cost_model.net_at_fee`` rescales to any taker fee.
+    """
+
+    ts: int
+    gross_ref_pnl: float
+    commission_ref: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -63,8 +83,8 @@ class GateReport:
 
 
 def _net_at_fee(t: Trade, fee_bps: float) -> float:
-    scale = 1.0 - fee_bps / REF_FEE_BPS
-    return t.net_ref_pnl + t.commission_ref * scale
+    # Delegates to the shared primitive (ROB-351 Issue 4, 3->1 dedup).
+    return cost_model.net_at_fee(t.net_ref_pnl, t.commission_ref, fee_bps, REF_FEE_BPS)
 
 
 def net_pnls_at_fee(trades: list[Trade], fee_bps: float) -> list[float]:
@@ -72,9 +92,24 @@ def net_pnls_at_fee(trades: list[Trade], fee_bps: float) -> list[float]:
     return [_net_at_fee(t, fee_bps) for t in sorted(trades, key=lambda t: t.ts_opened)]
 
 
-def metrics_at_fee(trades: list[Trade], fee_bps: float, fold: str = "") -> FoldMetrics:
-    rows = sorted(trades, key=lambda t: t.ts_opened)
-    nets = [_net_at_fee(t, fee_bps) for t in rows]
+def _equity_drawdown(pnls: Sequence[float]) -> float:
+    """Absolute max drawdown on the cumulative-PnL equity curve (starts at 0).
+
+    Caller is responsible for ordering ``pnls`` chronologically. For a basket the
+    ``pnls`` must be PERIOD-AGGREGATED portfolio increments (concurrent positions
+    netted into each period) — see ``portfolio_metrics_at_fee``. Feeding a flat
+    per-position list keyed by open-time understates drawdown (ROB-351 Issue 1).
+    """
+    equity = peak = mdd = 0.0
+    for x in pnls:
+        equity += x
+        peak = max(peak, equity)
+        mdd = min(mdd, equity - peak)
+    return mdd
+
+
+def _fold_metrics_from_nets(nets: list[float], fold: str) -> FoldMetrics:
+    """Build FoldMetrics from an already-ordered net-PnL series."""
     n = len(nets)
     if n == 0:
         return FoldMetrics(fold, 0, 0.0, 0.0, 0.0, 0.0, 0.0)
@@ -83,22 +118,39 @@ def metrics_at_fee(trades: list[Trade], fee_bps: float, fold: str = "") -> FoldM
     gross_win = sum(wins)
     gross_loss = abs(sum(losses))
     pf = gross_win / gross_loss if gross_loss else (float("inf") if gross_win else 0.0)
-    equity = peak = mdd = 0.0
-    for x in nets:
-        equity += x
-        peak = max(peak, equity)
-        mdd = min(mdd, equity - peak)
     return FoldMetrics(
         fold=fold, trades=n, net_pnl=sum(nets),
         win_rate_pct=100.0 * len(wins) / n,
-        max_drawdown=mdd, profit_factor=pf, expectancy=sum(nets) / n,
+        max_drawdown=_equity_drawdown(nets), profit_factor=pf, expectancy=sum(nets) / n,
     )
 
 
-def walk_forward_split(
-    trades: list[Trade], fractions: tuple[float, float, float] = (0.5, 0.25, 0.25)
-) -> dict[str, list[Trade]]:
+def metrics_at_fee(trades: list[Trade], fee_bps: float, fold: str = "") -> FoldMetrics:
     rows = sorted(trades, key=lambda t: t.ts_opened)
+    nets = [_net_at_fee(t, fee_bps) for t in rows]
+    return _fold_metrics_from_nets(nets, fold)
+
+
+def portfolio_net_pnls_at_fee(
+    periods: Sequence[PortfolioPeriod], fee_bps: float
+) -> list[float]:
+    """Per-period net portfolio PnLs (chronological) at ``fee_bps`` per leg."""
+    rows = sorted(periods, key=lambda p: p.ts)
+    return [cost_model.net_at_fee(p.gross_ref_pnl, p.commission_ref, fee_bps, REF_FEE_BPS)
+            for p in rows]
+
+
+def portfolio_metrics_at_fee(
+    periods: Sequence[PortfolioPeriod], fee_bps: float, fold: str = ""
+) -> FoldMetrics:
+    """FoldMetrics on the PERIOD-return equity curve (honest basket drawdown).
+
+    ``trades`` in the returned FoldMetrics counts PERIODS, not positions.
+    """
+    return _fold_metrics_from_nets(portfolio_net_pnls_at_fee(periods, fee_bps), fold)
+
+
+def _chrono_split(rows: list, fractions: tuple[float, float, float]) -> dict[str, list]:
     n = len(rows)
     n_train = int(n * fractions[0])
     n_val = int(n * fractions[1])
@@ -107,6 +159,18 @@ def walk_forward_split(
         "val": rows[n_train:n_train + n_val],
         "oos": rows[n_train + n_val:],
     }
+
+
+def walk_forward_split(
+    trades: list[Trade], fractions: tuple[float, float, float] = (0.5, 0.25, 0.25)
+) -> dict[str, list[Trade]]:
+    return _chrono_split(sorted(trades, key=lambda t: t.ts_opened), fractions)
+
+
+def walk_forward_split_periods(
+    periods: list[PortfolioPeriod], fractions: tuple[float, float, float] = (0.5, 0.25, 0.25)
+) -> dict[str, list[PortfolioPeriod]]:
+    return _chrono_split(sorted(periods, key=lambda p: p.ts), fractions)
 
 
 def evaluate_gate(
@@ -212,6 +276,106 @@ def evaluate_gate(
                 reasons.append("val-best param is an overfit island (poor oos rank)")
         else:
             reasons.append("oos positive, beats baselines, stable across params/folds")
+    report.verdict_reasons = reasons
+    return report
+
+
+def evaluate_gate_portfolio(
+    *,
+    candidate_runs: dict[str, list[PortfolioPeriod]],   # param_label -> period series
+    baseline_periods: list[PortfolioPeriod],
+    fee_bps: float,
+    min_periods: int = 30,
+    fractions: tuple[float, float, float] = (0.5, 0.25, 0.25),
+    candidate_name: str = "",
+    hypothesis: str = "",
+    symbols: list[str] | None = None,
+    window: dict | None = None,
+) -> GateReport:
+    """Walk-forward gate for basket / cross-sectional strategies (ROB-351 Issue 1).
+
+    Identical contract to ``evaluate_gate`` but every metric is computed on the
+    PERIOD-return equity curve (concurrent positions netted per period), so the
+    drawdown that ``promote_to_pilot`` / the 343 criterion gate on is the honest
+    portfolio drawdown, not a per-trade serial sum.
+    """
+    report = GateReport(
+        candidate=candidate_name, hypothesis=hypothesis, symbols=symbols or [],
+        window=window or {},
+        cost_model={"fee_bps_per_leg": fee_bps, "fee_grid_bps": [10.0, 7.5, 5.0, 2.0, 0.0],
+                    "unit": "portfolio_period"},
+    )
+    if not candidate_runs:
+        report.verdict = "insufficient_data"
+        report.verdict_reasons = ["no candidate runs provided"]
+        return report
+
+    by_param_val: dict[str, float] = {}
+    by_param_oos: dict[str, float] = {}
+    folds_by_param: dict[str, dict[str, list[PortfolioPeriod]]] = {}
+    for label, periods in candidate_runs.items():
+        folds = walk_forward_split_periods(periods, fractions)
+        folds_by_param[label] = folds
+        by_param_val[label] = portfolio_metrics_at_fee(folds["val"], fee_bps, "val").net_pnl
+        by_param_oos[label] = portfolio_metrics_at_fee(folds["oos"], fee_bps, "oos").net_pnl
+
+    val_best = max(by_param_val, key=by_param_val.get)
+    folds = folds_by_param[val_best]
+    fold_metrics = {name: portfolio_metrics_at_fee(folds[name], fee_bps, name)
+                    for name in ("train", "val", "oos")}
+    report.per_fold = [asdict(fold_metrics[n]) for n in ("train", "val", "oos")]
+
+    all_best = candidate_runs[val_best]
+    report.results = {
+        "gross": asdict(portfolio_metrics_at_fee(all_best, 0.0, "gross")),
+        "zero_fee": asdict(portfolio_metrics_at_fee(all_best, 0.0, "zero_fee")),
+        "net_after_cost": asdict(portfolio_metrics_at_fee(all_best, fee_bps, "net_after_cost")),
+    }
+    report.trade_count = len(all_best)
+
+    base = portfolio_metrics_at_fee(baseline_periods, fee_bps, "baseline")
+    report.baselines = {"baseline": {"net_after_cost": base.net_pnl, "trades": base.trades}}
+
+    oos_rank = sorted(by_param_oos, key=by_param_oos.get, reverse=True).index(val_best) + 1
+    half = max(1, (len(by_param_oos) + 1) // 2)
+    param_island = oos_rank > half
+    fold_nets = [fold_metrics[n].net_pnl for n in ("train", "val", "oos")]
+    single_fold_edge = sum(1 for x in fold_nets if x > 0) == 1
+    low_periods = any(fold_metrics[n].trades < min_periods for n in ("train", "val", "oos"))
+    report.param_stability = {
+        "grid": list(candidate_runs), "val_best_param": val_best,
+        "oos_rank_of_val_best": oos_rank,
+        "single_fold_edge": single_fold_edge, "param_island": param_island,
+        "unit": "portfolio_period",
+    }
+    report.overfit_flags = {"low_trades": low_periods, "single_fold_edge": single_fold_edge,
+                            "param_island": param_island}
+
+    oos = fold_metrics["oos"]
+    reasons: list[str] = []
+    if low_periods:
+        report.verdict = "insufficient_data"
+        thin = [f"{n}={fold_metrics[n].trades}" for n in ("train", "val", "oos")
+                if fold_metrics[n].trades < min_periods]
+        reasons.append(f"folds below min_periods={min_periods}: {', '.join(thin)}")
+    else:
+        beats_baseline = oos.net_pnl > base.net_pnl
+        ok = (oos.net_pnl > 0 and oos.profit_factor > 1.0 and beats_baseline
+              and not single_fold_edge and not param_island)
+        report.verdict = "validated" if ok else "not_validated"
+        if not ok:
+            if oos.net_pnl <= 0:
+                reasons.append(f"oos net-after-cost {oos.net_pnl:.2f} <= 0")
+            if oos.profit_factor <= 1.0:
+                reasons.append(f"oos profit_factor {oos.profit_factor:.2f} <= 1.0")
+            if not beats_baseline:
+                reasons.append("oos does not beat the baseline")
+            if single_fold_edge:
+                reasons.append("edge appears in only one fold")
+            if param_island:
+                reasons.append("val-best param is an overfit island (poor oos rank)")
+        else:
+            reasons.append("oos positive, beats baseline, stable across params/folds")
     report.verdict_reasons = reasons
     return report
 
@@ -377,6 +541,109 @@ def monte_carlo_permutation(
         "n_sim": n_sim,
         "seed": seed,
     }
+
+
+# --------------------------------------------------------------------------- #
+# ROB-351 (Codex outside-voice) — statistical-honesty hardening (pure-stdlib).
+#
+# iid trade bootstrap is too optimistic for time-clustered crypto trades; the
+# many shots (3 families + meanrev seed + parameter grids) invite data snooping;
+# and a fixed n>=263 is cargo-culted. These additive helpers address each.
+# --------------------------------------------------------------------------- #
+def block_bootstrap_sharpe_ci(
+    net_pnls: Sequence[float],
+    block_size: int = 10,
+    n_bootstrap: int = 1000,
+    confidence: float = 0.95,
+    seed: int = 42,
+) -> dict:
+    """Moving-block bootstrap CI for per-trade Sharpe (preserves autocorrelation).
+
+    Resamples contiguous blocks of length ``block_size`` so time-clustered edge
+    is not artificially de-correlated the way an iid bootstrap would. ``ci_upper
+    < 0`` => net edge statistically <= 0 at ``confidence``.
+    """
+    n = len(net_pnls)
+    if n < 2:
+        return {"error": "insufficient_data", "n": n, "block_size": block_size,
+                "n_bootstrap": n_bootstrap, "confidence": confidence, "seed": seed}
+    block_size = max(1, min(block_size, n))
+    n_blocks = math.ceil(n / block_size)
+    max_start = n - block_size
+    rng = random.Random(seed)
+    observed = _sharpe(net_pnls)
+    sharpes: list[float] = []
+    for _ in range(n_bootstrap):
+        sample: list[float] = []
+        for _ in range(n_blocks):
+            start = rng.randint(0, max_start) if max_start > 0 else 0
+            sample.extend(net_pnls[start:start + block_size])
+        sharpes.append(_sharpe(sample[:n]))
+    sharpes.sort()
+    alpha = (1.0 - confidence) / 2.0
+    return {
+        "observed_sharpe": observed,
+        "ci_lower": _percentile(sharpes, alpha),
+        "ci_upper": _percentile(sharpes, 1.0 - alpha),
+        "median_sharpe": _percentile(sharpes, 0.5),
+        "prob_positive": sum(1 for s in sharpes if s > 0) / n_bootstrap,
+        "confidence": confidence, "n_bootstrap": n_bootstrap, "seed": seed,
+        "block_size": block_size, "method": "moving_block",
+    }
+
+
+def benjamini_hochberg(pvalues: Sequence[float], alpha: float = 0.05) -> dict:
+    """Benjamini-Hochberg FDR control across many tested hypotheses.
+
+    Returns the set of rejected (significant) hypothesis indices and the largest
+    p-value threshold that survives FDR at ``alpha``. Use this so screening three
+    broad families + seed + parameter neighborhoods does not silently snoop.
+    """
+    m = len(pvalues)
+    if m == 0:
+        return {"rejected": [], "threshold": None, "n": 0, "alpha": alpha}
+    order = sorted(range(m), key=lambda i: pvalues[i])
+    max_k = 0
+    threshold: float | None = None
+    for rank, idx in enumerate(order, start=1):
+        if pvalues[idx] <= (rank / m) * alpha:
+            max_k = rank
+            threshold = pvalues[idx]
+    rejected = sorted(order[:max_k]) if max_k else []
+    return {"rejected": rejected, "threshold": threshold, "n": m, "alpha": alpha}
+
+
+def effect_size_aware_min_trades(
+    observed_sharpe: float, n_configs_tried: int = 1, target_t: float = 2.0
+) -> float:
+    """Minimum trade count to clear a t-stat target, inflated for multiple tests.
+
+    Replaces the cargo-culted fixed ``n>=263``: required ``n`` depends on the
+    effect size (per-trade Sharpe) and how many configs were tried. The target
+    t is inflated by a maximal-inequality term ``sqrt(2*ln m)`` so more shots
+    demand more evidence. Zero effect => ``inf`` (no sample size rescues it).
+    """
+    s = abs(observed_sharpe)
+    if s == 0.0:
+        return math.inf
+    target_t_adj = target_t + math.sqrt(2.0 * math.log(max(1, n_configs_tried)))
+    return math.ceil((target_t_adj / s) ** 2)
+
+
+def turnover_matched_random_baseline(
+    pnl_pool: Sequence[float], n_trades: int, seed: int = 42
+) -> list[float]:
+    """Random-entry baseline with the SAME trade count as the real strategy.
+
+    Samples ``n_trades`` PnLs (with replacement) from the realized-return pool so
+    a candidate's gross edge must beat dumb turnover-matched activity, not just
+    cash (guards against volatility harvesting / beta / selection noise).
+    """
+    if not pnl_pool or n_trades <= 0:
+        return []
+    rng = random.Random(seed)
+    pool = list(pnl_pool)
+    return [pool[rng.randrange(len(pool))] for _ in range(n_trades)]
 
 
 def run_card_hashes(


### PR DESCRIPTION
## What

Reframes ROB-351 success to **"produce ≥1 candidate worth running through ROB-343"** (positive gross edge AND *closable* cost-binding) and ships the pure-stdlib funnel **code** for the PR1–PR3 deliverables. The empirical RUN against Binance USDⓈ-M data is **operator-gated** (no market data is committed) — this PR is the code + tests that the run will use.

Design + eng-review (office-hours → plan-eng-review → Codex outside-voice) live in `docs/plans/ROB-351-cost-blind-funnel-campaign.md`.

## Funnel (research/nautilus_scalping/)

| Stage | Module | Role |
|------|--------|------|
| shared | `cost_model.py` | one `net_at_fee` primitive (3→1 dedup) |
| 0 | `pit_universe.py` | PIT manifest; single survivorship authority; as-of-each-rebalance |
| 0 | `panel.py` | lazy PIT-aware cross-section generator (memory-bounded) |
| 1 | `discovery/screen.py` `classify(cost_blind=…)` | fees=0 gross screen + triviality floor + `cost_binding` |
| 1/2 | `families.py` | family 1 breakout-continuation / 2 TS-trend-basket / 3 XS-momentum |
| 2 | `validated_gate.evaluate_gate_portfolio` | **period-return** drawdown for basket/XS (Issue 1) |
| 2 | `validated_gate` block-bootstrap / BH-FDR / effect-size gate / turnover-matched baseline | Codex hardening |
| 3 | `rob343_label.py` | `promote_to_pilot` / `cost_binding_343_candidate` / `needs_more_data` / `reject` |
| ex-ante | `frozen_config.py` | thresholds + achievable-execution envelope, hashed in the run |
| driver | `campaign.py` + `run_rob351_campaign.py` | Stage 1→2→3 verdict table |

## Key eng-review findings addressed

- **[P1] Issue 1** — `validated_gate`'s per-trade serial equity sum understated a basket's drawdown (concurrent positions). New `evaluate_gate_portfolio` computes drawdown on the **period-return** equity curve.
- **[P1] Issue 3** — maker closability decided in the **pure** `maker_fill` path, never `fee_sweep`'s taker-only linear rescale.
- **[P2] Issue 4** — single `net_at_fee` primitive with a REGRESSION test.
- **Codex** — block/time bootstrap (not iid), BH-FDR across all shots, effect-size/FDR-aware sample gate (drops cargo-culted `n≥263`), economic-triviality floor, turnover-matched baseline, as-of-rebalance PIT, **realistic-path stop-rule** (cost-binding alone ≠ 343-worthy).

## Tests

126 pure tests pass:
\`\`\`
cd research/nautilus_scalping
uv run --no-project --python 3.13 --with pytest -- pytest tests/  # (pure subset)
python run_rob351_campaign.py --self-test   # prints a verdict table, no data/secrets
\`\`\`

## NOT in scope / safety

- **Empirical RUN operator-gated** — no market data committed; verdict table pending the data run.
- **Families 4–5** (liquidity-sweep, funding/OI/liquidation) parked → `TODOS.md` follow-up.
- **ROB-343** only *recommended* by the verdict, never run here. canonical `validated` stays owned by the conservative gate.
- Research/backtest only: no live, no Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/TaskIQ/Prefect/launchd/daemon, no prod DB/env/secret, no `/invest` exposure, no raw large data committed, no credential logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added planning document for strategy evaluation campaign framework
  * Updated research tracker with new investigation priorities

* **New Features**
  * Campaign funnel implementation with verdict table generation
  * Signal family generators for strategy development
  * Cost model and fee analysis utilities
  * Point-in-time universe manifest for survival-bias-safe analysis
  * Portfolio and trade-level validation gates with statistical hardening
  * Configuration management with deterministic hashing

* **Tests**
  * Comprehensive test suite for campaign, family, validation, and configuration modules

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->