### PR TITLE
feat(ROB-353): PIT data layer for Binance USD-M campaign (PR1/2)

### DIFF
--- a/docs/runbooks/rob-353-pit-data-layer.md
+++ b/docs/runbooks/rob-353-pit-data-layer.md
@@ -1,0 +1,32 @@
+# ROB-353 PIT data layer runbook
+
+Research/backtest only. Read-only public data. No live/Demo/broker/scheduler/DB mutation.
+
+## Data source & retrieval
+- Source: `data.binance.vision` USDⓈ-M futures (`futures/um`), public, no keys.
+- Universe index: `build_pit_universe.py` (read-only S3 listing + boundary-month 1d klines).
+- Bars: `pit_klines_fetcher.py --symbol <S> --interval {1d,1h} --from-month --to-month`.
+
+## Universe definition
+- USDT perpetuals only via `PITManifest.strict_usdt_perp()`: `status ∈ {live, dead}` plain
+  `*USDT`; excludes `settling`, BUSD/USDC-quoted, dated/quarterly (`_`), `*SETTLED`.
+- Active + delisted symbols included (the survivorship fix ROB-349 verified).
+- PIT membership: each symbol tradeable only over `[listed_from, delisted_at)` (epoch ms,
+  `delisted_at` exclusive); post-delist price-frozen zero-volume tail trimmed in `pit_bars`.
+
+## Manifest
+- Committed (metadata only): `data_manifests/pit_universe.v1.json` + `pit_universe.v1.meta.json`.
+- Pinned by `snapshot_hash` (sha256 over canonical records). Editing the manifest requires
+  updating `pit_universe.v1.meta.json` or `test_committed_manifest_loads_and_hash_matches_meta` fails.
+
+## Raw-data root (NOT committed)
+- `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT/data/klines/<interval>/<symbol>/` if set, else
+  `research/nautilus_scalping/data/...`. Both gitignored. No secrets logged.
+
+## Regenerate the manifest (operator)
+    curl -s https://fapi.binance.com/fapi/v1/exchangeInfo > /tmp/pit_audit_exchangeinfo.json
+    uv run --no-project python build_pit_universe.py --exchange-info /tmp/pit_audit_exchangeinfo.json \
+        --out data_manifests/pit_universe.v1.json
+
+## Not in this PR
+- The `specs → campaign.run_campaign` bridge and families 1–3 RUN/verdict are PR2.

--- a/docs/runbooks/rob-353-pit-data-layer.md
+++ b/docs/runbooks/rob-353-pit-data-layer.md
@@ -28,5 +28,12 @@ Research/backtest only. Read-only public data. No live/Demo/broker/scheduler/DB 
     uv run --no-project python build_pit_universe.py --exchange-info /tmp/pit_audit_exchangeinfo.json \
         --out data_manifests/pit_universe.v1.json
 
+> Caveat: `write_outputs` emits a minimal `.meta.json` (schema_version, snapshot_hash,
+> symbol_count, source, source_records). The committed v1 `.meta.json` carries two extra
+> hand annotations (`build_window`, `note`); regeneration overwrites them. Re-add those by
+> hand, or fold richer-meta emission into PR2 (tracked there).
+
 ## Not in this PR
 - The `specs → campaign.run_campaign` bridge and families 1–3 RUN/verdict are PR2.
+- `build_pit_universe.write_outputs` should emit `build_window`/`note` so regeneration is
+  faithful to the committed sidecar (Minor; from PR1 final review).

--- a/docs/superpowers/plans/2026-05-29-rob-353-pit-data-layer.md
+++ b/docs/superpowers/plans/2026-05-29-rob-353-pit-data-layer.md
@@ -1,0 +1,1112 @@
+# ROB-353 PR1 — PIT data layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Durableize the ROB-349 Binance USD-M point-in-time (PIT) universe + klines prototype into reusable, tested repo modules so ROB-353 PR2 can run families 1–3 through the committed funnel on real, survivorship-safe data.
+
+**Architecture:** Four focused modules under `research/nautilus_scalping/` — a public-data klines fetcher, an extended PIT manifest (with `strict_usdt_perp` filter), a ported index builder, and a PIT-trimmed `families.Bar` loader — plus one committed metadata-only manifest artifact (`pit_universe.v1.json`) pinned by a snapshot hash. The bridge to `campaign.run_campaign` and the actual RUN are PR2.
+
+**Tech Stack:** Python 3.13 (repo `.python-version`), pure stdlib + the isolated `research/nautilus_scalping/.venv`, pytest. No `app.*` imports (research-only boundary, ROB-339). Run everything with `uv run --no-project python ...` / `uv run --no-project pytest ...` from inside `research/nautilus_scalping/`.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-rob-353-pit-data-layer-design.md`
+
+**Working dir for ALL commands below:** `/Users/mgh3326/work/auto_trader.rob-353/research/nautilus_scalping` (branch `rob-353`). Tests import modules flat (e.g. `import pit_universe`), matching the existing `conftest.py`.
+
+---
+
+## File structure
+
+| File | Responsibility | Create/Modify |
+|------|----------------|---------------|
+| `artifact_paths.py` | add `pit_data_root()` — gitignored raw-data root, `os.environ` only | Modify |
+| `pit_universe.py` | extend `SymbolListing`/`PITManifest` with ROB-349 fields; `from_pit_index_records`; `strict_usdt_perp` | Modify |
+| `build_pit_universe.py` | ported ROB-349 index builder (read-only public data) + snapshot hash; RUN operator-gated | Create |
+| `pit_klines_fetcher.py` | download `{1d,1h}` USD-M klines from data.binance.vision (public, no keys) | Create |
+| `pit_bars.py` | load klines CSV → PIT-trimmed `families.Bar`; panel accessor for XS families | Create |
+| `data_manifests/pit_universe.v1.json` | committed metadata-only manifest (843 symbols, canonical PITManifest format) | Create (committed) |
+| `data_manifests/pit_universe.v1.meta.json` | snapshot hash + build provenance | Create (committed) |
+| `tests/test_pit_universe.py` | extend: new fields, conversion, strict filter, committed-manifest load + hash | Modify |
+| `tests/test_pit_klines_fetcher.py` | URL build, daily/monthly path, 404 tolerance, no-secrets | Create |
+| `tests/test_pit_bars.py` | trimming + Bar mapping + panel alignment | Create |
+| `tests/test_pit_data_layer_guard.py` | new modules import no `app.*`; raw-data root gitignored | Create |
+| `docs/runbooks/rob-353-pit-data-layer.md` | data/universe definition runbook (feeds PR2 report) | Create |
+
+**Units / contracts in this PR:**
+- `artifact_paths.pit_data_root() -> Path`
+- `pit_universe.SymbolListing(symbol, listed_from, delisted_at=None, status=None, kline_coverage=None, funding_coverage=None, confidence=None, missing_data_reason=None)`
+- `pit_universe._date_to_epoch_ms(date_str: str) -> int`
+- `pit_universe.PITManifest.from_pit_index_records(rows: list[dict]) -> PITManifest`
+- `pit_universe.PITManifest.strict_usdt_perp() -> PITManifest`
+- `pit_universe.PITManifest.snapshot_hash() -> str`
+- `pit_klines_fetcher.kline_url(symbol, interval, year, month, market="um", cadence="monthly") -> str`
+- `pit_bars.load_bars(symbol, interval, manifest, root=None) -> list[families.Bar]`
+- `pit_bars.load_panel(symbols, interval, manifest, root=None) -> dict[str, list[tuple[int, float]]]`
+
+---
+
+## Task 0: Baseline — confirm green starting point
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm self-test passes and record config hash**
+
+Run: `uv run --no-project python run_rob351_campaign.py --self-test | grep -E "schema_version|config_hash"`
+Expected: prints `rob351_campaign.v1` and `config_hash 8f02dffd51dc5bedf5ab4c1521edb2185f4768304b5b60fa7dd0836ef8872adf`.
+
+- [ ] **Step 2: Confirm existing tests pass**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py tests/test_panel.py -q`
+Expected: PASS (no failures). This is the regression baseline for Tasks 2–4.
+
+---
+
+## Task 1: `pit_data_root()` — gitignored raw-data root helper
+
+**Files:**
+- Modify: `artifact_paths.py`
+- Test: `tests/test_artifact_paths.py` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_artifact_paths.py
+import importlib
+from pathlib import Path
+
+import artifact_paths
+
+
+def test_pit_data_root_defaults_to_repo_data(monkeypatch):
+    monkeypatch.delenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", raising=False)
+    importlib.reload(artifact_paths)
+    root = artifact_paths.pit_data_root()
+    assert root.name == "data"
+    assert root.parent.name == "nautilus_scalping"
+
+
+def test_pit_data_root_honors_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", str(tmp_path))
+    root = artifact_paths.pit_data_root()
+    assert root == tmp_path / "data"
+
+
+def test_pit_data_root_blank_env_falls_back(monkeypatch):
+    monkeypatch.setenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", "   ")
+    root = artifact_paths.pit_data_root()
+    assert root.name == "data" and root.parent.name == "nautilus_scalping"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_artifact_paths.py -q`
+Expected: FAIL — `AttributeError: module 'artifact_paths' has no attribute 'pit_data_root'`.
+
+- [ ] **Step 3: Implement `pit_data_root()`**
+
+Append to `artifact_paths.py` (after `resolve_artifact_path`):
+
+```python
+def pit_data_root() -> Path:
+    """Raw-data root for downloaded klines (gitignored). Distinct from
+    ``resolve_artifact_path`` (citable discovery/gate outputs). Env if set
+    (non-blank), else repo-internal ``data/`` (matched by ``.gitignore``)."""
+    raw = os.environ.get(ENV_VAR)
+    base = Path(raw.strip()) if raw is not None and raw.strip() else Path(__file__).resolve().parent
+    return base / "data"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_artifact_paths.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add artifact_paths.py tests/test_artifact_paths.py
+git commit -m "feat(ROB-353): pit_data_root() gitignored raw-data root helper"
+```
+
+---
+
+## Task 2: Extend `SymbolListing` / `PITManifest` with ROB-349 metadata fields
+
+**Files:**
+- Modify: `pit_universe.py:26-73`
+- Test: `tests/test_pit_universe.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_pit_universe.py`:
+
+```python
+def test_symbollisting_optional_metadata_roundtrips():
+    rec = {
+        "symbol": "EOSUSDT", "listed_from": 1672531200000, "delisted_at": 1700000000000,
+        "status": "dead", "kline_coverage": 1.0, "funding_coverage": 1.0,
+        "confidence": "high", "missing_data_reason": "delisted",
+    }
+    m = pit_universe.PITManifest.from_records([rec])
+    (only,) = m.listings
+    assert only.status == "dead"
+    assert only.kline_coverage == 1.0
+    assert only.confidence == "high"
+    # round-trip preserves the optional fields
+    back = pit_universe.PITManifest.from_records(m.to_records())
+    assert back.listings[0].missing_data_reason == "delisted"
+
+
+def test_symbollisting_metadata_defaults_none():
+    m = pit_universe.PITManifest.from_records(
+        [{"symbol": "BTCUSDT", "listed_from": 0, "delisted_at": None}]
+    )
+    only = m.listings[0]
+    assert only.status is None and only.confidence is None
+    # legacy round-trip must NOT emit None metadata noise it can't read back
+    assert pit_universe.PITManifest.from_records(m.to_records()).listings[0].symbol == "BTCUSDT"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k metadata`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'status'`.
+
+- [ ] **Step 3: Implement the extension**
+
+Replace the `SymbolListing` dataclass and the `from_records`/`to_records` methods in `pit_universe.py`:
+
+```python
+from typing import Literal
+
+_META_FIELDS = ("status", "kline_coverage", "funding_coverage", "confidence", "missing_data_reason")
+
+
+@dataclass(frozen=True)
+class SymbolListing:
+    symbol: str
+    listed_from: int
+    delisted_at: int | None = None
+    # ROB-349 metadata (optional; None for hand-built/synthetic manifests)
+    status: Literal["live", "settling", "dead"] | None = None
+    kline_coverage: float | None = None
+    funding_coverage: float | None = None
+    confidence: Literal["high", "medium", "low"] | None = None
+    missing_data_reason: str | None = None
+
+    def validate(self) -> "SymbolListing":
+        if self.delisted_at is not None and self.delisted_at < self.listed_from:
+            raise ValueError(
+                f"{self.symbol}: delisted_at {self.delisted_at} < listed_from {self.listed_from}"
+            )
+        return self
+
+    def tradeable_at(self, ts: int, min_seasoning: int = 0) -> bool:
+        if ts < self.listed_from + min_seasoning:
+            return False
+        if self.delisted_at is not None and ts >= self.delisted_at:
+            return False
+        return True
+```
+
+Update `from_records` to read the optional fields, and `to_records` to emit only those present:
+
+```python
+    @classmethod
+    def from_records(cls, records: list[dict]) -> "PITManifest":
+        listings = tuple(
+            SymbolListing(
+                symbol=r["symbol"],
+                listed_from=int(r["listed_from"]),
+                delisted_at=None if r.get("delisted_at") is None else int(r["delisted_at"]),
+                status=r.get("status"),
+                kline_coverage=r.get("kline_coverage"),
+                funding_coverage=r.get("funding_coverage"),
+                confidence=r.get("confidence"),
+                missing_data_reason=r.get("missing_data_reason"),
+            ).validate()
+            for r in records
+        )
+        seen: set[str] = set()
+        for listing in listings:
+            if listing.symbol in seen:
+                raise ValueError(f"duplicate symbol in manifest: {listing.symbol}")
+            seen.add(listing.symbol)
+        return cls(listings=listings)
+
+    def to_records(self) -> list[dict]:
+        out = []
+        for x in self.listings:
+            rec = {"symbol": x.symbol, "listed_from": x.listed_from, "delisted_at": x.delisted_at}
+            for f in _META_FIELDS:
+                v = getattr(x, f)
+                if v is not None:
+                    rec[f] = v
+            out.append(rec)
+        return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass (incl. regression)**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py tests/test_panel.py -q`
+Expected: PASS (all existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pit_universe.py tests/test_pit_universe.py
+git commit -m "feat(ROB-353): extend PIT manifest with ROB-349 status/coverage/confidence fields"
+```
+
+---
+
+## Task 3: `from_pit_index_records` + `_date_to_epoch_ms` (ROB-349 row → SymbolListing)
+
+**Files:**
+- Modify: `pit_universe.py`
+- Test: `tests/test_pit_universe.py`
+
+The ROB-349 index emits rows with day-precise `active_from`/`active_to` date strings (and `"ongoing"` for live). Convert to the epoch-ms `listed_from`/`delisted_at` contract: `listed_from = midnight-UTC(active_from)`; `delisted_at = midnight-UTC(active_to + 1 day)` (exclusive, keeps the last active day tradeable); `"ongoing"`/None → `delisted_at=None`. Rows with no usable `active_from` (fall back to `first_seen` month's day 1) are kept; rows with neither are skipped.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_from_pit_index_records_maps_dates_to_epoch_ms():
+    rows = [
+        {"symbol": "EOSUSDT", "status": "dead", "first_seen": "2023-01", "last_seen": "2024-01",
+         "active_from": "2023-01-26", "active_to": "2024-01-11",
+         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
+         "missing_data_reason": "delisted"},
+        {"symbol": "BTCUSDT", "status": "live", "first_seen": "2020-01", "last_seen": "2026-05",
+         "active_from": "2020-01-01", "active_to": "ongoing",
+         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
+         "missing_data_reason": ""},
+    ]
+    m = pit_universe.PITManifest.from_pit_index_records(rows)
+    eos = next(x for x in m.listings if x.symbol == "EOSUSDT")
+    btc = next(x for x in m.listings if x.symbol == "BTCUSDT")
+    assert eos.listed_from == pit_universe._date_to_epoch_ms("2023-01-26")
+    # delisted_at is exclusive: last active day (2024-01-11) + 1 day
+    assert eos.delisted_at == pit_universe._date_to_epoch_ms("2024-01-12")
+    assert btc.delisted_at is None
+    # EOS tradeable on its last active day, not the day after
+    assert eos.tradeable_at(pit_universe._date_to_epoch_ms("2024-01-11"))
+    assert not eos.tradeable_at(pit_universe._date_to_epoch_ms("2024-01-12"))
+
+
+def test_from_pit_index_records_skips_rows_without_dates():
+    rows = [{"symbol": "GHOSTUSDT", "status": "dead", "first_seen": None, "last_seen": None,
+             "active_from": None, "active_to": None}]
+    m = pit_universe.PITManifest.from_pit_index_records(rows)
+    assert m.listings == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k from_pit_index`
+Expected: FAIL — `AttributeError: ... has no attribute 'from_pit_index_records'`.
+
+- [ ] **Step 3: Implement conversion**
+
+Add imports + helper + classmethod to `pit_universe.py`:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+
+def _date_to_epoch_ms(date_str: str) -> int:
+    """Midnight-UTC epoch ms for ``YYYY-MM-DD``."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _month_first_day(month_str: str) -> str:
+    """``YYYY-MM`` -> ``YYYY-MM-01``."""
+    return f"{month_str}-01"
+```
+
+```python
+    @classmethod
+    def from_pit_index_records(cls, rows: list[dict]) -> "PITManifest":
+        """Build from ROB-349 index rows (day-precise active_from/active_to)."""
+        recs: list[dict] = []
+        for r in rows:
+            af = r.get("active_from") or (
+                _month_first_day(r["first_seen"]) if r.get("first_seen") else None
+            )
+            if not af:
+                continue  # cannot place this symbol in time — skip
+            listed_from = _date_to_epoch_ms(af)
+            at = r.get("active_to")
+            if at in (None, "ongoing"):
+                delisted_at = None
+            else:
+                delisted_at = _date_to_epoch_ms(
+                    (datetime.strptime(at, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+                )
+            recs.append({
+                "symbol": r["symbol"], "listed_from": listed_from, "delisted_at": delisted_at,
+                "status": r.get("status"), "kline_coverage": r.get("kline_coverage"),
+                "funding_coverage": r.get("funding_coverage"), "confidence": r.get("confidence"),
+                "missing_data_reason": r.get("missing_data_reason") or None,
+            })
+        return cls.from_records(recs)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k from_pit_index`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pit_universe.py tests/test_pit_universe.py
+git commit -m "feat(ROB-353): map ROB-349 index rows to epoch-ms PIT listings"
+```
+
+---
+
+## Task 4: `strict_usdt_perp()` filter + `snapshot_hash()`
+
+**Files:**
+- Modify: `pit_universe.py`
+- Test: `tests/test_pit_universe.py`
+
+Keep only `status ∈ {live, dead}` plain `*USDT` perps; drop `settling`, BUSD/USDC-quoted, dated/quarterly (symbols with `_`), and `*SETTLED`. `snapshot_hash` is a stable sha256 over canonical records (for the committed-manifest pin).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+import hashlib, json
+
+
+def _row(sym, status):
+    return {"symbol": sym, "status": status, "active_from": "2023-01-01", "active_to": "2024-01-01"}
+
+
+def test_strict_usdt_perp_keeps_live_and_dead_plain_usdt():
+    rows = [
+        _row("BTCUSDT", "live"), _row("EOSUSDT", "dead"),
+        _row("ETHUSDC", "live"),               # wrong quote
+        _row("BTCBUSD", "dead"),               # BUSD
+        _row("BTCUSDT_230331", "settling"),    # dated/quarterly
+        _row("XRPUSDT", "settling"),           # settling perp -> excluded
+        _row("FOOUSDT-SETTLED", "dead"),       # settled marker
+    ]
+    m = pit_universe.PITManifest.from_pit_index_records(rows).strict_usdt_perp()
+    kept = {x.symbol for x in m.listings}
+    assert kept == {"BTCUSDT", "EOSUSDT"}
+
+
+def test_snapshot_hash_is_stable_and_order_independent():
+    a = pit_universe.PITManifest.from_records([
+        {"symbol": "A", "listed_from": 1, "delisted_at": None},
+        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+    ])
+    b = pit_universe.PITManifest.from_records([
+        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+        {"symbol": "A", "listed_from": 1, "delisted_at": None},
+    ])
+    assert a.snapshot_hash() == b.snapshot_hash()
+    assert len(a.snapshot_hash()) == 64
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k "strict or snapshot"`
+Expected: FAIL — `AttributeError: ... 'strict_usdt_perp'`.
+
+- [ ] **Step 3: Implement filter + hash**
+
+Add `import hashlib` and `import json` (json already imported) to `pit_universe.py`, then add methods to `PITManifest`:
+
+```python
+    def strict_usdt_perp(self) -> "PITManifest":
+        """Perp-only honest universe: live/dead plain *USDT, excl. settling/BUSD/USDC/dated/SETTLED."""
+        kept = tuple(
+            x for x in self.listings
+            if x.status in ("live", "dead")
+            and x.symbol.endswith("USDT")
+            and "_" not in x.symbol
+            and "SETTLED" not in x.symbol
+        )
+        return PITManifest(listings=kept)
+
+    def snapshot_hash(self) -> str:
+        """Stable sha256 over canonical (order-independent) records — pins a committed manifest."""
+        canon = json.dumps(sorted(self.to_records(), key=lambda r: r["symbol"]),
+                            sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canon.encode()).hexdigest()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pit_universe.py tests/test_pit_universe.py
+git commit -m "feat(ROB-353): strict_usdt_perp filter + stable snapshot_hash"
+```
+
+---
+
+## Task 5: Commit the v1 metadata manifest + meta sidecar (one-shot conversion)
+
+**Files:**
+- Create (committed): `data_manifests/pit_universe.v1.json`, `data_manifests/pit_universe.v1.meta.json`
+- Test: `tests/test_pit_universe.py`
+
+**Precondition:** the ROB-349 source `/tmp/factor_research/pit_universe.json` (843 records) exists. If absent, regenerate it via the ported builder (Task 6) first, or stop with a `data-precondition` blocker — do not fabricate.
+
+- [ ] **Step 1: Convert + write the committed artifacts (one-shot script, run once)**
+
+Run this exact snippet from the research dir:
+
+```bash
+uv run --no-project python - <<'PY'
+import json, datetime
+import pit_universe as pu
+rows = json.load(open("/tmp/factor_research/pit_universe.json"))
+m = pu.PITManifest.from_pit_index_records(rows)
+import os
+os.makedirs("data_manifests", exist_ok=True)
+m.save("data_manifests/pit_universe.v1.json")
+meta = {
+    "schema_version": "pit_universe.v1",
+    "snapshot_hash": m.snapshot_hash(),
+    "symbol_count": len(m.listings),
+    "source": "data.binance.vision/futures/um (ROB-349 build_pit_universe.py)",
+    "source_records": len(rows),
+    "build_window": "2020-01..2026-05 (archived monthly klines coverage)",
+    "note": "Metadata only — no raw OHLCV. Day-precise active_from/active_to mapped to "
+            "epoch-ms listed_from/delisted_at (exclusive). strict_usdt_perp() applied at use.",
+}
+json.dump(meta, open("data_manifests/pit_universe.v1.meta.json", "w"), indent=2)
+print("wrote", len(m.listings), "listings; hash", m.snapshot_hash())
+PY
+```
+
+Expected: prints `wrote 843 listings; hash <64-hex>` (count may differ slightly if rows lack dates — that is fine and recorded in meta as `source_records` vs `symbol_count`).
+
+- [ ] **Step 2: Write the failing test (committed manifest loads and matches its pinned hash)**
+
+```python
+import json
+from pathlib import Path
+
+_MANIFEST = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.json"
+_META = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.meta.json"
+
+
+def test_committed_manifest_loads_and_hash_matches_meta():
+    m = pit_universe.PITManifest.load(_MANIFEST)
+    meta = json.loads(_META.read_text())
+    assert len(m.listings) == meta["symbol_count"]
+    assert m.snapshot_hash() == meta["snapshot_hash"]  # pin: edits must update meta
+
+
+def test_committed_manifest_has_a_usable_perp_universe():
+    m = pit_universe.PITManifest.load(_MANIFEST).strict_usdt_perp()
+    # ROB-349 reported a materially larger perp universe than the 23-symbol survivor panel
+    assert len(m.listings) > 100
+    # the 16 survivorship-relevant dead perps must survive the strict filter
+    syms = {x.symbol for x in m.listings}
+    assert {"EOSUSDT", "GALUSDT", "HNTUSDT"}.issubset(syms)
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k "committed_manifest"`
+Expected: PASS (2 passed). If `test_committed_manifest_has_a_usable_perp_universe` fails on the specific symbols, inspect the manifest (`status`/symbol spelling) and adjust the asserted set to three confirmed dead-perp symbols from `pit_universe.v1.json` — do not weaken the `>100` check.
+
+- [ ] **Step 4: Confirm the raw klines are NOT staged, only metadata**
+
+Run: `git status --porcelain data_manifests/ && git check-ignore data/ || true`
+Expected: only `data_manifests/pit_universe.v1.json` and `.meta.json` show as new; `data/` is ignored.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data_manifests/pit_universe.v1.json data_manifests/pit_universe.v1.meta.json tests/test_pit_universe.py
+git commit -m "feat(ROB-353): commit metadata-only PIT universe v1 manifest (843 symbols, hash-pinned)"
+```
+
+---
+
+## Task 6: Port `build_pit_universe.py` into the repo (RUN operator-gated)
+
+**Files:**
+- Create: `build_pit_universe.py`
+- Test: `tests/test_pit_universe.py` (pure helpers only — no network)
+
+Port the ROB-349 builder verbatim in logic, with three changes: (1) write outputs under `data_manifests/` via a `--out` arg (default the v1 paths), (2) emit the `.meta.json` sidecar with `PITManifest(...).snapshot_hash()`, (3) make `expected_months` importable and tested. The network RUN stays operator-gated (needs `/tmp/pit_audit_exchangeinfo.json` + outbound S3); CI tests only the pure helper.
+
+- [ ] **Step 1: Write the failing test (pure helper)**
+
+```python
+def test_expected_months_inclusive_span():
+    import build_pit_universe as b
+    assert b.expected_months("2023-01", "2023-01") == 1
+    assert b.expected_months("2023-01", "2023-12") == 12
+    assert b.expected_months("2023-11", "2024-02") == 4
+    assert b.expected_months(None, "2024-02") == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k expected_months`
+Expected: FAIL — `ModuleNotFoundError: No module named 'build_pit_universe'`.
+
+- [ ] **Step 3: Create `build_pit_universe.py`**
+
+Copy `/tmp/factor_research/build_pit_universe.py` into `research/nautilus_scalping/build_pit_universe.py` with this header and the output/CLI changes. Keep `list_symbols`, `months_listed`, `expected_months`, `boundary_active`, `classify`, `build_row` byte-for-byte except output paths. Add at the top:
+
+```python
+#!/usr/bin/env python3
+"""ROB-353 (PR1) — ported ROB-349 PIT Binance USD-M universe index builder.
+
+Read-only PUBLIC data only (data.binance.vision S3 listing + monthly 1d klines for
+non-live boundary detection) + a local fapi exchangeInfo dump. Emits the metadata-only
+manifest (symbol + listing window + coverage/confidence) and a snapshot-hash sidecar.
+NO raw OHLCV persisted. No keys, no orders, no scheduler. The network RUN is operator-
+gated; CI exercises only the pure helpers.
+
+Usage (operator):
+    # 1) save exchangeInfo once (public):
+    #    curl -s https://fapi.binance.com/fapi/v1/exchangeInfo > /tmp/pit_audit_exchangeinfo.json
+    # 2) build:
+    uv run --no-project python build_pit_universe.py \\
+        --exchange-info /tmp/pit_audit_exchangeinfo.json \\
+        --out data_manifests/pit_universe.v1.json
+"""
+```
+
+Replace the hardcoded output tail of the original (the `csv.DictWriter` / `json.dump` block) with:
+
+```python
+def write_outputs(rows: list[dict], out_json: str) -> str:
+    import pit_universe as pu
+    m = pu.PITManifest.from_pit_index_records(rows)
+    m.save(out_json)
+    meta = {
+        "schema_version": "pit_universe.v1",
+        "snapshot_hash": m.snapshot_hash(),
+        "symbol_count": len(m.listings),
+        "source": "data.binance.vision/futures/um",
+        "source_records": len(rows),
+    }
+    meta_path = out_json.replace(".json", ".meta.json")
+    json.dump(meta, open(meta_path, "w"), indent=2)
+    return m.snapshot_hash()
+```
+
+Wrap the gather/build in `def main(argv=None)` with `argparse` (`--exchange-info`, default `/tmp/pit_audit_exchangeinfo.json`; `--out`, default `data_manifests/pit_universe.v1.json`), reading exchangeInfo from the arg instead of the hardcoded path, then call `write_outputs(rows, args.out)`. Guard with `if __name__ == "__main__": sys.exit(main())`. The `__main__` path must be the ONLY place that does network I/O, so importing the module for tests triggers no requests.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_universe.py -q -k expected_months`
+Expected: PASS. Also confirm import is side-effect free: `uv run --no-project python -c "import build_pit_universe"` returns instantly with no network.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build_pit_universe.py tests/test_pit_universe.py
+git commit -m "feat(ROB-353): port ROB-349 PIT universe builder (operator-gated RUN, snapshot-hash output)"
+```
+
+---
+
+## Task 7: `pit_klines_fetcher.py` — public USD-M klines downloader (1d + 1h)
+
+**Files:**
+- Create: `pit_klines_fetcher.py`
+- Test: `tests/test_pit_klines_fetcher.py`
+
+Mirror `fetch_agg_trades.py` (stdlib, CHECKSUM verify, 404-tolerant). Klines live under `futures/um/{monthly|daily}/klines/<SYM>/<interval>/`. The testable pure surface is URL construction + interval validation; network download reuses the proven `_download`/`_verify` pattern and writes under `pit_data_root()`.
+
+- [ ] **Step 1: Write the failing test (no network)**
+
+```python
+# tests/test_pit_klines_fetcher.py
+import pytest
+
+import pit_klines_fetcher as f
+
+
+def test_kline_url_monthly_um():
+    url = f.kline_url("EOSUSDT", "1d", 2024, 1, market="um", cadence="monthly")
+    assert url == ("https://data.binance.vision/data/futures/um/monthly/klines/"
+                   "EOSUSDT/1d/EOSUSDT-1d-2024-01.zip")
+
+
+def test_kline_url_daily_1h_zero_pads():
+    url = f.kline_url("BTCUSDT", "1h", 2026, 3, market="um", cadence="daily", day=5)
+    assert url.endswith("futures/um/daily/klines/BTCUSDT/1h/BTCUSDT-1h-2026-03-05.zip")
+
+
+def test_kline_url_rejects_unknown_interval():
+    with pytest.raises(ValueError, match="interval"):
+        f.kline_url("BTCUSDT", "5m", 2024, 1)
+
+
+def test_intervals_supported():
+    assert set(f.SUPPORTED_INTERVALS) == {"1d", "1h"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_klines_fetcher.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'pit_klines_fetcher'`.
+
+- [ ] **Step 3: Implement the fetcher**
+
+```python
+#!/usr/bin/env python3
+"""ROB-353 (PR1) — download Binance USDⓈ-M public klines dumps (1d, 1h).
+
+Pure stdlib. PUBLIC data only (data.binance.vision) — no keys, no auth, no orders.
+Each archive is verified against its sibling ``.CHECKSUM`` when published. Writes
+under ``artifact_paths.pit_data_root()`` (gitignored). No secrets are printed.
+
+Usage:
+    uv run --no-project python pit_klines_fetcher.py --symbol EOSUSDT \\
+        --interval 1d --from-month 2023-01 --to-month 2024-01
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+from artifact_paths import pit_data_root
+
+BASE = "https://data.binance.vision/data"
+SUPPORTED_INTERVALS = ("1d", "1h")
+_CHUNK = 1 << 16
+
+
+def kline_url(symbol, interval, year, month, market="um", cadence="monthly", day=None):
+    if interval not in SUPPORTED_INTERVALS:
+        raise ValueError(f"unsupported interval {interval!r}; expected {SUPPORTED_INTERVALS}")
+    if cadence == "monthly":
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}"
+        sub = f"futures/{market}/monthly/klines/{symbol}/{interval}"
+    elif cadence == "daily":
+        if day is None:
+            raise ValueError("daily cadence requires day")
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}-{day:02d}"
+        sub = f"futures/{market}/daily/klines/{symbol}/{interval}"
+    else:
+        raise ValueError(f"unknown cadence {cadence!r}")
+    return f"{BASE}/{sub}/{stem}.zip"
+
+
+def _download(url: str, dest: Path) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp, dest.open("wb") as fh:
+            while chunk := resp.read(_CHUNK):
+                fh.write(chunk)
+        return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while chunk := fh.read(_CHUNK):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify(zip_path: Path, checksum_path: Path) -> None:
+    expected = checksum_path.read_text().split()[0].strip().lower()
+    if _sha256(zip_path) != expected:
+        raise ValueError(f"checksum mismatch for {zip_path.name}")
+
+
+def _months(from_month: str, to_month: str):
+    y0, m0 = int(from_month[:4]), int(from_month[5:7])
+    y1, m1 = int(to_month[:4]), int(to_month[5:7])
+    cur = y0 * 12 + (m0 - 1)
+    end = y1 * 12 + (m1 - 1)
+    while cur <= end:
+        yield cur // 12, cur % 12 + 1
+        cur += 1
+
+
+def fetch_months(symbol, interval, from_month, to_month, market="um", out_root=None) -> dict:
+    out_root = Path(out_root) if out_root else pit_data_root()
+    out_dir = out_root / "klines" / interval / symbol
+    out_dir.mkdir(parents=True, exist_ok=True)
+    downloaded = skipped = missing = 0
+    for year, month in _months(from_month, to_month):
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}"
+        csv_path = out_dir / f"{stem}.csv"
+        if csv_path.exists():
+            skipped += 1
+            continue
+        url = kline_url(symbol, interval, year, month, market=market, cadence="monthly")
+        zip_path = out_dir / f"{stem}.zip"
+        if not _download(url, zip_path):
+            missing += 1
+            continue
+        chk_path = out_dir / f"{stem}.zip.CHECKSUM"
+        if _download(f"{url}.CHECKSUM", chk_path):
+            _verify(zip_path, chk_path)
+            chk_path.unlink()
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(out_dir)
+        zip_path.unlink()
+        downloaded += 1
+    return {"downloaded": downloaded, "skipped": skipped, "missing": missing, "dir": str(out_dir)}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Download Binance USDⓈ-M public klines (1d/1h)")
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--interval", choices=SUPPORTED_INTERVALS, required=True)
+    ap.add_argument("--from-month", required=True, help="YYYY-MM")
+    ap.add_argument("--to-month", required=True, help="YYYY-MM")
+    ap.add_argument("--market", default="um")
+    args = ap.parse_args(argv)
+    summary = fetch_months(args.symbol, args.interval, args.from_month, args.to_month, args.market)
+    print(f"done: {summary['downloaded']} downloaded, {summary['skipped']} skipped, "
+          f"{summary['missing']} missing -> {summary['dir']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_klines_fetcher.py -q`
+Expected: PASS (4 passed). Confirm side-effect-free import: `uv run --no-project python -c "import pit_klines_fetcher"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pit_klines_fetcher.py tests/test_pit_klines_fetcher.py
+git commit -m "feat(ROB-353): public USD-M klines fetcher (1d/1h, checksum-verified, gitignored root)"
+```
+
+---
+
+## Task 8: `pit_bars.py` — PIT-trimmed `families.Bar` loader
+
+**Files:**
+- Create: `pit_bars.py`
+- Test: `tests/test_pit_bars.py`
+
+Read the standard Binance kline CSV (header or headerless), build `families.Bar(ts, high, low, close)`, and trim to PIT membership: keep bars with `manifest listing.tradeable_at(ts)`, then drop leading/trailing zero-volume bars (defense against any freeze tail inside the window). Kline columns: `open_time, open, high, low, close, volume, ...`.
+
+- [ ] **Step 1: Write the failing test (synthetic CSVs)**
+
+```python
+# tests/test_pit_bars.py
+from pathlib import Path
+
+import pit_bars
+import pit_universe
+
+KCOLS = "open_time,open,high,low,close,volume,close_time,qv,n,tbv,tbqv,ig"
+DAY = 86_400_000
+
+
+def _write_csv(root, symbol, interval, month, rows):
+    d = root / "klines" / interval / symbol
+    d.mkdir(parents=True, exist_ok=True)
+    lines = [KCOLS] + [",".join(str(x) for x in r) for r in rows]
+    (d / f"{symbol}-{interval}-{month}.csv").write_text("\n".join(lines) + "\n")
+
+
+def test_load_bars_trims_to_membership_and_zero_vol_tail(tmp_path):
+    # 5 daily bars; ts 0..4*DAY. volume 0 on first and last (freeze/zero-vol) -> trimmed.
+    rows = [
+        [0 * DAY, 10, 11, 9, 10, 0.0, 0, 0, 0, 0, 0, 0],
+        [1 * DAY, 10, 12, 9, 11, 5.0, 0, 0, 0, 0, 0, 0],
+        [2 * DAY, 11, 13, 10, 12, 6.0, 0, 0, 0, 0, 0, 0],
+        [3 * DAY, 12, 14, 11, 13, 7.0, 0, 0, 0, 0, 0, 0],
+        [4 * DAY, 13, 13, 13, 13, 0.0, 0, 0, 0, 0, 0, 0],
+    ]
+    _write_csv(tmp_path, "EOSUSDT", "1d", "1970-01", rows)
+    # manifest: listed at ts=DAY, delisted_at exclusive at 4*DAY (so ts=3*DAY is last tradeable)
+    m = pit_universe.PITManifest.from_records(
+        [{"symbol": "EOSUSDT", "listed_from": 1 * DAY, "delisted_at": 4 * DAY}]
+    )
+    bars = pit_bars.load_bars("EOSUSDT", "1d", m, root=tmp_path)
+    assert [b.ts for b in bars] == [1 * DAY, 2 * DAY, 3 * DAY]
+    assert bars[0].close == 11 and bars[-1].close == 13
+
+
+def test_load_bars_unknown_symbol_returns_empty(tmp_path):
+    m = pit_universe.PITManifest.from_records([{"symbol": "X", "listed_from": 0}])
+    assert pit_bars.load_bars("X", "1d", m, root=tmp_path) == []
+
+
+def test_load_panel_aligns_close_series(tmp_path):
+    _write_csv(tmp_path, "AUSDT", "1d", "1970-01",
+               [[1 * DAY, 1, 1, 1, 100, 5, 0, 0, 0, 0, 0, 0],
+                [2 * DAY, 1, 1, 1, 110, 5, 0, 0, 0, 0, 0, 0]])
+    _write_csv(tmp_path, "BUSDT", "1d", "1970-01",
+               [[1 * DAY, 1, 1, 1, 200, 5, 0, 0, 0, 0, 0, 0],
+                [2 * DAY, 1, 1, 1, 220, 5, 0, 0, 0, 0, 0, 0]])
+    m = pit_universe.PITManifest.from_records([
+        {"symbol": "AUSDT", "listed_from": 0}, {"symbol": "BUSDT", "listed_from": 0},
+    ])
+    panel = pit_bars.load_panel(["AUSDT", "BUSDT"], "1d", m, root=tmp_path)
+    assert panel["AUSDT"] == [(1 * DAY, 100.0), (2 * DAY, 110.0)]
+    assert panel["BUSDT"] == [(1 * DAY, 200.0), (2 * DAY, 220.0)]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --no-project pytest tests/test_pit_bars.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'pit_bars'`.
+
+- [ ] **Step 3: Implement the loader**
+
+```python
+"""ROB-353 (PR1) — load PIT-trimmed bars from downloaded klines (data half of the PR2 bridge).
+
+Reads the standard Binance kline CSV under ``pit_data_root()/klines/<interval>/<symbol>/``,
+emits ``families.Bar`` (ts, high, low, close), trimmed to PIT membership (the manifest's
+survivorship-safe ``tradeable_at`` window) with leading/trailing zero-volume bars dropped.
+Pure transformation — no network. ``load_panel`` returns per-symbol (ts, close) series for
+cross-sectional families.
+"""
+from __future__ import annotations
+
+import csv
+import glob
+from pathlib import Path
+
+import families
+from artifact_paths import pit_data_root
+from pit_universe import PITManifest
+
+_KCOLS = ("open_time", "open", "high", "low", "close", "volume")
+
+
+def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float, float, float, float]]:
+    """Return sorted, de-duplicated (ts, high, low, close, volume) for a symbol."""
+    d = root / "klines" / interval / symbol
+    seen: dict[int, tuple[int, float, float, float, float]] = {}
+    for path in sorted(glob.glob(str(d / f"{symbol}-{interval}-*.csv"))):
+        with open(path, newline="") as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                if not row or row[0].lower().startswith("open_time"):
+                    continue
+                try:
+                    ts = int(row[0])
+                    seen[ts] = (ts, float(row[2]), float(row[3]), float(row[4]), float(row[5]))
+                except (ValueError, IndexError):
+                    continue
+    return [seen[k] for k in sorted(seen)]
+
+
+def _trim_zero_vol_edges(rows):
+    lo, hi = 0, len(rows)
+    while lo < hi and rows[lo][4] <= 0.0:
+        lo += 1
+    while hi > lo and rows[hi - 1][4] <= 0.0:
+        hi -= 1
+    return rows[lo:hi]
+
+
+def load_bars(symbol: str, interval: str, manifest: PITManifest, root=None) -> list[families.Bar]:
+    root = Path(root) if root else pit_data_root()
+    listing = next((x for x in manifest.listings if x.symbol == symbol), None)
+    rows = _read_rows(symbol, interval, root)
+    if listing is not None:
+        rows = [r for r in rows if listing.tradeable_at(r[0])]
+    rows = _trim_zero_vol_edges(rows)
+    return [families.Bar(ts=r[0], high=r[1], low=r[2], close=r[3]) for r in rows]
+
+
+def load_panel(symbols, interval: str, manifest: PITManifest, root=None) -> dict[str, list[tuple[int, float]]]:
+    root = Path(root) if root else pit_data_root()
+    out: dict[str, list[tuple[int, float]]] = {}
+    for s in symbols:
+        bars = load_bars(s, interval, manifest, root=root)
+        if bars:
+            out[s] = [(b.ts, b.close) for b in bars]
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --no-project pytest tests/test_pit_bars.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pit_bars.py tests/test_pit_bars.py
+git commit -m "feat(ROB-353): PIT-trimmed families.Bar loader + cross-sectional panel accessor"
+```
+
+---
+
+## Task 9: Import guard — new modules import no `app.*`; raw-data root is gitignored
+
+**Files:**
+- Create: `tests/test_pit_data_layer_guard.py`
+
+Mirror the existing `tests/test_discovery_paths.py` guard. Parse each new module's AST and assert no `import app...` / `from app...`; assert `pit_data_root()` resolves inside a gitignored path.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_pit_data_layer_guard.py
+import ast
+from pathlib import Path
+
+import artifact_paths
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py"]
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_no_app_imports_in_data_layer():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            assert not name.startswith("app"), f"{mod} imports forbidden app module {name!r}"
+
+
+def test_pit_data_root_is_gitignored(monkeypatch):
+    monkeypatch.delenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", raising=False)
+    root = artifact_paths.pit_data_root()
+    gitignore = (_ROOT / ".gitignore").read_text()
+    assert "data/" in gitignore
+    assert root.name == "data"
+```
+
+- [ ] **Step 2: Run test to verify it fails then passes**
+
+Run: `uv run --no-project pytest tests/test_pit_data_layer_guard.py -q`
+Expected: PASS immediately (the modules already avoid `app.*` and `data/` is gitignored). If it FAILS, a prior task introduced an `app` import or dropped the `data/` ignore — fix the offending module, not the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pit_data_layer_guard.py
+git commit -m "test(ROB-353): guard data layer against app imports + raw-data leakage"
+```
+
+---
+
+## Task 10: Runbook — data/universe definition
+
+**Files:**
+- Create: `docs/runbooks/rob-353-pit-data-layer.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/runbooks/rob-353-pit-data-layer.md` with these exact sections (fill values from the committed `pit_universe.v1.meta.json`):
+
+```markdown
+# ROB-353 PIT data layer runbook
+
+Research/backtest only. Read-only public data. No live/Demo/broker/scheduler/DB mutation.
+
+## Data source & retrieval
+- Source: `data.binance.vision` USDⓈ-M futures (`futures/um`), public, no keys.
+- Universe index: `build_pit_universe.py` (read-only S3 listing + boundary-month 1d klines).
+- Bars: `pit_klines_fetcher.py --symbol <S> --interval {1d,1h} --from-month --to-month`.
+
+## Universe definition
+- USDT perpetuals only via `PITManifest.strict_usdt_perp()`: `status ∈ {live, dead}` plain
+  `*USDT`; excludes `settling`, BUSD/USDC-quoted, dated/quarterly (`_`), `*SETTLED`.
+- Active + delisted symbols included (the survivorship fix ROB-349 verified).
+- PIT membership: each symbol tradeable only over `[listed_from, delisted_at)` (epoch ms,
+  `delisted_at` exclusive); post-delist price-frozen zero-volume tail trimmed in `pit_bars`.
+
+## Manifest
+- Committed (metadata only): `data_manifests/pit_universe.v1.json` + `.meta.json`.
+- Pinned by `snapshot_hash` (sha256 over canonical records). Editing the manifest requires
+  updating `.meta.json` or `test_committed_manifest_loads_and_hash_matches_meta` fails.
+
+## Raw-data root (NOT committed)
+- `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT/data/klines/<interval>/<symbol>/` if set, else
+  `research/nautilus_scalping/data/...`. Both gitignored. No secrets logged.
+
+## Regenerate the manifest (operator)
+    curl -s https://fapi.binance.com/fapi/v1/exchangeInfo > /tmp/pit_audit_exchangeinfo.json
+    uv run --no-project python build_pit_universe.py --exchange-info /tmp/pit_audit_exchangeinfo.json \
+        --out data_manifests/pit_universe.v1.json
+
+## Not in this PR
+- The `specs → campaign.run_campaign` bridge and families 1–3 RUN/verdict are PR2.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/rob-353-pit-data-layer.md
+git commit -m "docs(ROB-353): PIT data-layer runbook (data/universe definition)"
+```
+
+---
+
+## Task 11: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full research test suite green**
+
+Run: `uv run --no-project pytest -q`
+Expected: PASS. Investigate any failure before proceeding; do not weaken tests to pass.
+
+- [ ] **Step 2: Self-test + config hash unchanged**
+
+Run: `uv run --no-project python run_rob351_campaign.py --self-test | grep config_hash`
+Expected: `config_hash 8f02dffd51dc5bedf5ab4c1521edb2185f4768304b5b60fa7dd0836ef8872adf` (PR1 must not touch the frozen config).
+
+- [ ] **Step 3: Confirm no raw data / secrets staged**
+
+Run: `git diff --stat origin/main...HEAD && git ls-files data/ data_manifests/`
+Expected: only source modules, tests, `data_manifests/*.json` (metadata), and docs; no `data/` files, no `*.csv` klines, no `.parquet`.
+
+- [ ] **Step 4: Lint (match repo style)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-353 && uv run ruff check research/nautilus_scalping/`
+Expected: clean (or only pre-existing warnings unrelated to new files).
+
+- [ ] **Step 5: Push + open PR (base `main`)**
+
+```bash
+git push -u origin rob-353
+gh pr create --base main --title "feat(ROB-353): PIT data layer for Binance USD-M campaign (PR1/2)" \
+  --body "Durableizes the ROB-349 PIT universe + klines prototype into reusable repo infra (fetcher, extended manifest, ported builder, PIT-trimmed Bar loader) + a committed metadata-only manifest. Research-only; no RUN. Bridge + families 1-3 verdict are PR2. Spec: docs/superpowers/specs/2026-05-29-rob-353-pit-data-layer-design.md"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** fetcher (Task 7), extended manifest (Tasks 2–4), builder (Task 6), bar loader (Task 8), committed metadata manifest + hash (Task 5), tests/guards (Tasks 1–9), runbook (Task 10), boundaries (Tasks 5/9/11). PR2 bridge explicitly out of scope.
+- **Type consistency:** `load_bars`/`load_panel`/`kline_url`/`strict_usdt_perp`/`snapshot_hash`/`from_pit_index_records`/`_date_to_epoch_ms`/`pit_data_root` names are used identically across tasks and the file-structure contract table.
+- **Known soft spot:** Task 5 Step 3 asserts three specific dead-perp symbols; if spelling differs in the real manifest, the step says to swap to three confirmed symbols (not weaken the `>100` check). This is the one place reality may differ from the plan.

--- a/docs/superpowers/specs/2026-05-29-rob-353-pit-data-layer-design.md
+++ b/docs/superpowers/specs/2026-05-29-rob-353-pit-data-layer-design.md
@@ -1,0 +1,160 @@
+# ROB-353 PR1 — PIT data layer (Binance USD-M universe + klines) design
+
+**Status:** approved (brainstorming, 2026-05-29)
+**Issue:** ROB-353 (blocked-by ROB-349). This is **PR1 of 2**. PR2 = `specs → run_campaign`
+bridge + the actual families 1–3 RUN + verdict artifact/report.
+**Boundary:** research/backtest only. Read-only public data. No live, no Demo `confirm=true`,
+no broker/order/watch/order-intent mutation, no scheduler/TaskIQ/Prefect/cron/daemon, no prod
+DB/env/secret, no `/invest` exposure, no raw large data committed, no credential logging.
+
+## Background
+
+PR #993 (ROB-351) landed the cost-blind funnel **code + synthetic self-test** under
+`research/nautilus_scalping/`, but no real Binance USD-M market-data verdict exists. The
+`run_rob351_campaign.py` default mode is a print stub; `--self-test` builds `specs` from
+hand-coded synthetic trades. There is **no bridge** that turns real OHLCV + a PIT manifest into
+`campaign.run_campaign` inputs.
+
+ROB-349 already built the hard part as a `/tmp/factor_research` prototype (read-only, public
+data) and recorded it in three gstack notes:
+
+- A PIT universe index over **all 843** archived Binance USD-M symbols
+  (`build_pit_universe.py` → `pit_universe.csv`/`.json`, metadata only — not raw klines).
+- Per-symbol PIT klines (`pit_raw/<SYM>/<SYM>-1d-YYYY-MM.csv`, standard Binance kline schema)
+  and funding (`pit_fund/`).
+- A PIT-membership backtest harness (`pit_backtest.py`) with freeze-tail trimming.
+
+ROB-349 explicitly recommended durableizing this as **reusable infra** and verified the
+survivorship blocker is resolvable from `data.binance.vision` alone (no vendor). It also already
+re-ran the cross-sectional momentum/carry family (≈ ROB-353 **family 3**) on the corrected panel
+and reached **reject / needs_more_data** (the strongest promote argument — smooth per-year carry
+— collapsed once delisted coins were included). So ROB-353's only *untested* families are
+**family 1 (breakout/range-expansion continuation)** and **family 2 (time-series trend basket)**.
+
+PR1's job is therefore to **durableize the ROB-349 PIT data layer into the repo as reusable
+infra**, wired to the existing `pit_universe.PITManifest` and `families.Bar`, so PR2 can run
+families 1–2 through the official funnel and re-confirm family 3, leaving a durable verdict even
+if the honest outcome is negative.
+
+## Goals / non-goals
+
+**Goals**
+- Port the ROB-349 builder + PIT-membership trimming into committed repo modules.
+- Commit a versioned **metadata-only** PIT universe manifest (JSON) with a snapshot hash.
+- Provide a public-data klines fetcher (1d + 1h) and a bar loader that emits PIT-trimmed
+  `families.Bar` series — the data half of the PR2 bridge.
+- Tests + research-local import guards; full docs of source/window/universe/exclusions.
+
+**Non-goals (deferred to PR2 or out of scope)**
+- The `specs → campaign.run_campaign` bridge and the actual families 1–3 RUN / verdict report.
+- Funding/OI/liquidation families (ROB-351 family 4/5; parked in `TODOS.md`).
+- Any change to `validated_gate.py`, `campaign.py`, `rob343_label.py`, `frozen_config.py`.
+
+## Components (all under `research/nautilus_scalping/`, pure stdlib + existing venv)
+
+### 1. `pit_klines_fetcher.py`
+Download USD-M klines daily dumps for `{1d, 1h}` from `data.binance.vision`, mirroring
+`fetch_agg_trades.py` (pure stdlib `urllib`, public data only, `.CHECKSUM` verify when present,
+404 ⇒ missing month tolerated, no keys). Writes to the **raw-data root** (gitignored), layout
+`klines/<interval>/<SYMBOL>/<SYMBOL>-<interval>-YYYY-MM.csv`. CLI: `--symbol --interval
+{1d,1h} --from --to [--market um]`. No secrets printed.
+
+**Raw-data root resolution** (new tiny helper `pit_data_root()`, distinct from
+`artifact_paths.resolve_artifact_path` which is reserved for citable discovery/gate outputs):
+`AUTO_TRADER_RESEARCH_ARTIFACT_ROOT` if set (non-blank), else `<research>/data`. Either path is
+gitignored, so raw klines never enter git regardless of which is used. Read via `os.environ` only.
+
+- URL base: `https://data.binance.vision/data/futures/um/{daily|monthly}/klines/<SYM>/<iv>/`.
+
+### 2. `pit_universe.py` (extend in place — keep PR #993 contract)
+Add ROB-349 fields without breaking the existing minimal contract:
+
+- `SymbolListing` gains optional `status: Literal["live","settling","dead"] | None`,
+  `kline_coverage: float | None`, `funding_coverage: float | None`,
+  `confidence: Literal["high","medium","low"] | None`, `missing_data_reason: str | None`.
+  Existing `listed_from` / `delisted_at` (epoch ms, `delisted_at` exclusive) and
+  `tradeable_at` / `validate` are **unchanged**. ROB-349 day-precise `active_from`/`active_to`
+  map to `listed_from`/`delisted_at` via midnight-UTC → epoch ms during load.
+- `from_records` / `to_records` round-trip the new optional fields (absent ⇒ `None`).
+- New `PITManifest.strict_usdt_perp() -> PITManifest`: keep `status ∈ {live, dead}` `*USDT`
+  perps; drop `settling`, dated/quarterly, BUSD/USDC-quoted, `*SETTLED`. This is the
+  perp-only universe ROB-349 named for an honest re-run.
+- `universe_as_of` unchanged (still the per-rebalance survivorship-safe authority).
+
+### 3. `build_pit_universe.py`
+Port the ROB-349 builder: read-only parallel S3 listing of `data.binance.vision/futures/um` +
+bounded boundary-month downloads for non-live symbols, emitting the metadata manifest (JSON) and
+a `*.meta.json` sidecar carrying a **snapshot hash** (sha256 over canonical manifest records) +
+provenance (build window, symbol count, source URL, schema version). Reproduces / audits the
+committed snapshot; never writes raw klines to git.
+
+### 4. `pit_bars.py`
+The data half of the PR2 bridge. `load_bars(symbol, interval, manifest) -> list[families.Bar]`:
+read klines CSVs from the raw-data root, parse the standard kline schema, build `families.Bar`,
+and apply **PIT membership trimming** — keep only `[first vol>0, last vol>0]` and drop the
+post-delist price-frozen zero-volume tail — using the manifest's listing bounds. Also a
+panel-aligned accessor for cross-sectional families (timestamp-indexed close/volume across the
+`universe_as_of` membership at each rebalance). Pure transformation; no network.
+
+### 5. Committed artifact (metadata only)
+- `research/nautilus_scalping/data_manifests/pit_universe.v1.json` — the ROB-349 metadata
+  manifest (~334 KB; 843 symbols). **JSON only** — `.gitignore` globally ignores `*.csv`, so the
+  CSV stays a regenerable convenience export (not committed; avoids the force-add smell).
+- `research/nautilus_scalping/data_manifests/pit_universe.v1.meta.json` — snapshot hash + build
+  provenance. The v1 snapshot is the verified `/tmp/factor_research` manifest, re-validated
+  through `PITManifest.from_records` before commit.
+
+### 6. Tests (`research/nautilus_scalping/tests/`)
+- Extend `test_pit_universe.py`: new optional fields round-trip; `strict_usdt_perp` keeps/drops
+  the right classes; committed `pit_universe.v1.json` loads and its snapshot hash matches
+  `*.meta.json` (stability guard); existing contract tests still pass.
+- New `test_pit_bars.py`: synthetic klines CSVs prove trimming (leading/trailing zero-vol and
+  freeze-tail removed; interior kept) and `families.Bar` mapping; panel alignment respects
+  `universe_as_of`.
+- New `test_pit_klines_fetcher.py`: **no network** — URL construction for `{1d,1h}`, daily/
+  monthly path selection, 404-tolerance, and "no secrets in output" only.
+- Guard (mirroring `test_discovery_paths.py`): new modules import no `app.*` Settings/pydantic;
+  raw-data paths resolve under a gitignored root via `os.environ` only.
+
+### 7. Docs
+`docs/runbooks/rob-353-pit-data-layer.md`: data source + retrieval,
+date window, intervals, USDT-perp-only universe, active+delisted handling, exclusions
+(BUSD/USDC/dated/SETTLED/settling), liquidity/membership timestamps, manifest format + snapshot
+hash, raw-data root path shape (no secrets), and the fetch procedure. Feeds PR2's required
+"data/universe definition" report section.
+
+## Data flow
+
+```
+build_pit_universe.py ──(read-only S3 list + boundary dl)──> data_manifests/pit_universe.v1.json  (committed, metadata only)
+pit_klines_fetcher.py ──(public daily/monthly dumps)───────> <raw-root>/klines/<iv>/<SYM>/...      (gitignored)
+                                                                      │
+PITManifest.load(pit_universe.v1.json).strict_usdt_perp() ───────────┤
+                                                                      ▼
+                                          pit_bars.load_bars(sym, iv, manifest) → [families.Bar...] (PIT-trimmed)
+                                                                      │
+                                                                      ▼  (PR2: build specs → campaign.run_campaign)
+```
+
+## Safety / boundaries
+- Raw klines + `*.csv` never committed (`data/`, `*.csv` already gitignored; raw-data root is
+  gitignored). Only metadata JSON manifests are committed.
+- Research-local `os.environ` only; zero `app.*` imports (ROB-339 boundary, guard-tested).
+- Network limited to public `data.binance.vision`, read-only, no secrets. No broker/order/
+  scheduler/DB/env mutation.
+- PR1 stops at the data layer. The `specs → run_campaign` bridge and the RUN are PR2.
+
+## Acceptance (PR1)
+- New modules + extended `pit_universe.py` committed with tests green under uv/Python 3.13.
+- `pit_universe.v1.json` committed (metadata only) with a matching snapshot-hash sidecar.
+- `pit_bars.load_bars` returns PIT-trimmed `families.Bar` series proven by tests.
+- Fetcher CLI documented; runbook covers the full data/universe definition.
+- Import guards + gitignore confirm no `app.*` import and no raw-data/secret leakage.
+- `run_rob351_campaign.py --self-test` still passes; config hash unchanged.
+
+## Expectations (honesty note)
+ROB-349 already labeled the cross-sectional family (≈ family 3) reject/needs_more_data on the
+PIT-corrected panel, and ROB-316/320/324/339/342 repeatedly killed generic trend/momentum/
+reversal families net-negative. The likely PR2 outcome is mostly reject/needs_more_data →
+recommend family 4/5 feasibility. PR1's value is the durable, auditable, reusable PIT data layer
+that lets PR2 reach that verdict through the committed ex-ante funnel rather than ad hoc.

--- a/research/nautilus_scalping/artifact_paths.py
+++ b/research/nautilus_scalping/artifact_paths.py
@@ -33,3 +33,12 @@ def resolve_artifact_path(namespace: str, *parts: str) -> Path:
             f"unknown artifact namespace {namespace!r}; expected one of {sorted(_NAMESPACES)}"
         )
     return research_artifact_root().joinpath(namespace, *parts)
+
+
+def pit_data_root() -> Path:
+    """Raw-data root for downloaded klines (gitignored). Distinct from
+    ``resolve_artifact_path`` (citable discovery/gate outputs). Env if set
+    (non-blank), else repo-internal ``data/`` (matched by ``.gitignore``)."""
+    raw = os.environ.get(ENV_VAR)
+    base = Path(raw.strip()) if raw is not None and raw.strip() else Path(__file__).resolve().parent
+    return base / "data"

--- a/research/nautilus_scalping/build_pit_universe.py
+++ b/research/nautilus_scalping/build_pit_universe.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""ROB-353 (PR1) — ported ROB-349 PIT Binance USD-M universe index builder.
+
+Read-only PUBLIC data only (data.binance.vision S3 listing + monthly 1d klines for
+non-live boundary detection) + a local fapi exchangeInfo dump. Emits the metadata-only
+manifest (symbol + listing window + coverage/confidence) and a snapshot-hash sidecar.
+NO raw OHLCV persisted. No keys, no orders, no scheduler. The network RUN is operator-
+gated; CI exercises only the pure helpers.
+
+Usage (operator):
+    # 1) save exchangeInfo once (public):
+    #    curl -s https://fapi.binance.com/fapi/v1/exchangeInfo > /tmp/pit_audit_exchangeinfo.json
+    # 2) build:
+    uv run --no-project python build_pit_universe.py \\
+        --exchange-info /tmp/pit_audit_exchangeinfo.json \\
+        --out data_manifests/pit_universe.v1.json
+"""
+
+import argparse
+import io
+import json
+import re
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+import zipfile
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+
+S3 = "https://s3-ap-northeast-1.amazonaws.com/data.binance.vision"
+BASE = "https://data.binance.vision/data/futures/um/monthly"
+
+RENAME = {
+    "MATICUSDT": "POLUSDT",
+    "RNDRUSDT": "RENDERUSDT",
+    "AGIXUSDT": "FETUSDT(merge)",
+    "OCEANUSDT": "FETUSDT(merge)",
+}
+
+_ctx = ssl.create_default_context()
+
+
+def _get(url: str, timeout: int = 60) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "pit-audit/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout, context=_ctx) as r:
+        return r.read()
+
+
+def list_symbols(prefix: str) -> list[str]:
+    out: list[str] = []
+    marker = ""
+    while True:
+        q: dict[str, str] = {"delimiter": "/", "prefix": prefix}
+        if marker:
+            q["marker"] = marker
+        xml = _get(S3 + "?" + urllib.parse.urlencode(q)).decode()
+        cps = re.findall(r"<Prefix>" + re.escape(prefix) + r"([^/<]+)/</Prefix>", xml)
+        out.extend(cps)
+        if "<IsTruncated>true</IsTruncated>" in xml and cps:
+            marker = prefix + cps[-1] + "/"
+        else:
+            break
+    return out
+
+
+def months_listed(prefix: str, pat: str) -> list[str]:
+    try:
+        xml = _get(S3 + "?" + urllib.parse.urlencode({"prefix": prefix})).decode()
+    except Exception:
+        return []
+    return sorted(set(re.findall(pat, xml)))
+
+
+def expected_months(fm: str | None, lm: str | None) -> int:
+    if not fm or not lm:
+        return 0
+    (y0, m0), (y1, m1) = ((int(s[:4]), int(s[5:7])) for s in (fm, lm))
+    return (y1 - y0) * 12 + (m1 - m0) + 1
+
+
+def boundary_active(
+    symbol: str, month: str, which: str
+) -> tuple[str | None, bool | None]:
+    """Return (day, frozen) from a monthly 1d file: first/last day with volume>0."""
+    url = f"{BASE}/klines/{symbol}/1d/{symbol}-1d-{month}.zip"
+    try:
+        raw = _get(url, timeout=60)
+    except Exception:
+        return (None, None)
+    z = zipfile.ZipFile(io.BytesIO(raw))
+    data = z.read(z.namelist()[0]).decode()
+    rows = [r.split(",") for r in data.splitlines() if r and not r.lower().startswith("open_time")]
+    days: list[tuple[str, float]] = []
+    for r in rows:
+        try:
+            ms = int(r[0])
+            d = datetime.fromtimestamp(ms / 1000, tz=UTC).date().isoformat()
+            v = float(r[5])
+            days.append((d, v))
+        except Exception:
+            pass
+    if not days:
+        return (None, None)
+    traded = [d for d, v in days if v > 0]
+    frozen = which == "last" and days[-1][1] == 0  # delisting-freeze tail
+    if which == "first":
+        return (traded[0] if traded else days[0][0], None)
+    return (traded[-1] if traded else days[-1][0], frozen)
+
+
+def classify(sym: str, live_perp: set[str], live_all: set[str]) -> str:
+    if sym in live_perp:
+        return "live"
+    if sym in live_all:
+        return "settling"  # in exchangeInfo but not trading-perp (delivery/close-only/pending)
+    return "dead"
+
+
+def build_row(sym: str, live_perp: set[str], live_all: set[str]) -> dict:
+    km = months_listed(
+        f"data/futures/um/monthly/klines/{sym}/1d/",
+        re.escape(sym) + r"-1d-(\d{4}-\d{2})\.zip",
+    )
+    fm = months_listed(
+        f"data/futures/um/monthly/fundingRate/{sym}/",
+        re.escape(sym) + r"-fundingRate-(\d{4}-\d{2})\.zip",
+    )
+    status = classify(sym, live_perp, live_all)
+    first_seen = km[0] if km else None
+    last_seen = km[-1] if km else None
+    exp = expected_months(first_seen, last_seen)
+    kcov = round(len(km) / exp, 3) if exp else 0.0
+    fexp = expected_months(fm[0], fm[-1]) if fm else 0
+    fcov = round(len(fm) / fexp, 3) if fexp else 0.0
+    # day-precise active interval + freeze detection: only for non-live (where it differs/matters)
+    active_from = active_to = None
+    frozen: bool | None = False
+    if status != "live" and km:
+        active_from, _ = boundary_active(sym, km[0], "first")
+        active_to, frozen = boundary_active(sym, km[-1], "last")
+    elif status == "live" and km:
+        active_from, _ = boundary_active(sym, km[0], "first")
+        active_to = "ongoing"
+    # confidence + reason
+    reasons: list[str] = []
+    if status == "dead":
+        reasons.append("delisted")
+    if status == "settling":
+        reasons.append("settling_or_close_only")
+    if frozen:
+        reasons.append("delisting_freeze_tail")
+    if len(fm) == 0:
+        reasons.append("no_funding_data")
+    if exp and kcov < 0.95:
+        reasons.append("kline_month_gaps")
+    if sym in RENAME:
+        reasons.append(f"rebranded->{RENAME[sym]}")
+    if status == "live":
+        conf = "high"
+    elif kcov >= 0.95 and len(fm) > 0:
+        conf = "high"
+    elif kcov >= 0.8:
+        conf = "medium"
+    else:
+        conf = "low"
+    return {
+        "symbol": sym,
+        "status": status,
+        "first_seen": first_seen,
+        "last_seen": last_seen,
+        "active_from": active_from,
+        "active_to": active_to,
+        "kline_months": len(km),
+        "kline_coverage": kcov,
+        "funding_first": fm[0] if fm else None,
+        "funding_last": fm[-1] if fm else None,
+        "funding_months": len(fm),
+        "funding_coverage": fcov,
+        "source": "data.binance.vision/futures/um",
+        "confidence": conf,
+        "missing_data_reason": ";".join(reasons),
+    }
+
+
+def write_outputs(rows: list[dict], out_json: str) -> str:
+    import pit_universe as pu
+
+    m = pu.PITManifest.from_pit_index_records(rows)
+    m.save(out_json)
+    meta = {
+        "schema_version": "pit_universe.v1",
+        "snapshot_hash": m.snapshot_hash(),
+        "symbol_count": len(m.listings),
+        "source": "data.binance.vision/futures/um",
+        "source_records": len(rows),
+    }
+    meta_path = out_json.replace(".json", ".meta.json")
+    json.dump(meta, open(meta_path, "w"), indent=2)  # noqa: SIM115
+    return m.snapshot_hash()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build ROB-353 PIT Binance USD-M universe index.")
+    parser.add_argument(
+        "--exchange-info",
+        default="/tmp/pit_audit_exchangeinfo.json",
+        help="Path to local fapi exchangeInfo JSON dump.",
+    )
+    parser.add_argument(
+        "--out",
+        default="data_manifests/pit_universe.v1.json",
+        help="Output manifest path.",
+    )
+    args = parser.parse_args(argv)
+
+    ei = json.load(open(args.exchange_info))  # noqa: SIM115
+    live_all = {s["symbol"] for s in ei["symbols"]}
+    live_perp = {
+        s["symbol"]
+        for s in ei["symbols"]
+        if s.get("status") == "TRADING" and s.get("contractType") == "PERPETUAL"
+    }
+
+    arch = set(list_symbols("data/futures/um/monthly/klines/"))
+    syms = sorted(arch)
+    print(f"building PIT index for {len(syms)} symbols...")
+
+    with ThreadPoolExecutor(max_workers=12) as ex:
+        rows = list(ex.map(lambda s: build_row(s, live_perp, live_all), syms))
+    rows.sort(key=lambda r: (r["status"], r["symbol"]))
+
+    snap = write_outputs(rows, args.out)
+
+    c = Counter(r["status"] for r in rows)
+    cf = Counter(r["confidence"] for r in rows)
+    print("status :", dict(c))
+    print("conf   :", dict(cf))
+    print("with funding:", sum(1 for r in rows if r["funding_months"] > 0), "/", len(rows))
+    print(
+        "freeze-tail detected:",
+        sum(1 for r in rows if "delisting_freeze_tail" in r["missing_data_reason"]),
+    )
+    print(f"snapshot_hash: {snap}")
+    print(f"manifest: {args.out}")
+    print("\n-- sample DEAD rows alive in 2023+ (survivorship-relevant) --")
+    for r in rows:
+        if (
+            r["status"] == "dead"
+            and (r["last_seen"] or "") >= "2023-01"
+            and r["symbol"].endswith("USDT")
+            and "_" not in r["symbol"]
+            and "BUSD" not in r["symbol"]
+        ):
+            print(
+                f'  {r["symbol"]:14} {r["first_seen"]}..{r["last_seen"]}'
+                f'  active {r["active_from"]}..{r["active_to"]}'
+                f'  kcov={r["kline_coverage"]} fcov={r["funding_coverage"]}'
+                f'  conf={r["confidence"]} [{r["missing_data_reason"]}]'
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/data_manifests/pit_universe.v1.json
+++ b/research/nautilus_scalping/data_manifests/pit_universe.v1.json
@@ -1,0 +1,7871 @@
+{
+  "listings": [
+    {
+      "symbol": "1000BTTCUSDT",
+      "listed_from": 1643155200000,
+      "delisted_at": 1649721600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "1000LUNCBUSD",
+      "listed_from": 1653955200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "1000SHIBBUSD",
+      "listed_from": 1658275200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ADABUSD",
+      "listed_from": 1627862400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AERGOUSDTSETTLED",
+      "listed_from": 1744761600000,
+      "delisted_at": 1744848000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "AGIXBUSD",
+      "listed_from": 1674086400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AIAUSDTSETTLED",
+      "listed_from": 1768867200000,
+      "delisted_at": 1768953600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "AKROUSDT",
+      "listed_from": 1611014400000,
+      "delisted_at": 1653696000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "AMBBUSD",
+      "listed_from": 1663113600000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ANCBUSD",
+      "listed_from": 1653436800000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ANCUSDT",
+      "listed_from": 1646697600000,
+      "delisted_at": 1652486400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "ANTUSDT",
+      "listed_from": 1640563200000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "APEBUSD",
+      "listed_from": 1652918400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "APTBUSD",
+      "listed_from": 1666656000000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AUCTIONBUSD",
+      "listed_from": 1659657600000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AUDIOUSDT",
+      "listed_from": 1629331200000,
+      "delisted_at": 1715904000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AVAXBUSD",
+      "listed_from": 1652400000000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BDXNUSDT",
+      "listed_from": 1748908800000,
+      "delisted_at": 1773792000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BDXNUSDTSETTLED",
+      "listed_from": 1777334400000,
+      "delisted_at": 1777420800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BLUEBIRDUSDT",
+      "listed_from": 1667347200000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BNBBUSD",
+      "listed_from": 1627430400000,
+      "delisted_at": 1702080000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BNXUSDTSETTLED",
+      "listed_from": 1648771200000,
+      "delisted_at": 1676160000000,
+      "status": "dead",
+      "kline_coverage": 0.545,
+      "funding_coverage": 0.0,
+      "confidence": "low",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data;kline_month_gaps"
+    },
+    {
+      "symbol": "BTCBUSD",
+      "listed_from": 1610409600000,
+      "delisted_at": 1702339200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BTCBUSD_210129",
+      "listed_from": 1609804800000,
+      "delisted_at": 1610409600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCBUSD_210226",
+      "listed_from": 1609804800000,
+      "delisted_at": 1610409600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_210326",
+      "listed_from": 1612310400000,
+      "delisted_at": 1616803200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_210625",
+      "listed_from": 1615852800000,
+      "delisted_at": 1624665600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_210924",
+      "listed_from": 1623974400000,
+      "delisted_at": 1632528000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_211231",
+      "listed_from": 1632268800000,
+      "delisted_at": 1640995200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_220325",
+      "listed_from": 1640304000000,
+      "delisted_at": 1648252800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_220624",
+      "listed_from": 1647907200000,
+      "delisted_at": 1656115200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_220930",
+      "listed_from": 1655683200000,
+      "delisted_at": 1664582400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_221230",
+      "listed_from": 1663891200000,
+      "delisted_at": 1672444800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_230331",
+      "listed_from": 1671753600000,
+      "delisted_at": 1680307200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_230630",
+      "listed_from": 1679875200000,
+      "delisted_at": 1688169600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_230929",
+      "listed_from": 1687651200000,
+      "delisted_at": 1700006400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_231229",
+      "listed_from": 1692316800000,
+      "delisted_at": 1704844800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_240329",
+      "listed_from": 1695945600000,
+      "delisted_at": 1711756800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_240628",
+      "listed_from": 1703808000000,
+      "delisted_at": 1719878400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_240927",
+      "listed_from": 1711670400000,
+      "delisted_at": 1727481600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_241227",
+      "listed_from": 1719532800000,
+      "delisted_at": 1735344000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_250328",
+      "listed_from": 1727395200000,
+      "delisted_at": 1743206400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_250627",
+      "listed_from": 1735257600000,
+      "delisted_at": 1751068800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_250926",
+      "listed_from": 1743120000000,
+      "delisted_at": 1758931200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_251226",
+      "listed_from": 1750982400000,
+      "delisted_at": 1768953600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_260327",
+      "listed_from": 1758844800000,
+      "delisted_at": 1776384000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "BTSUSDT",
+      "listed_from": 1612137600000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BTTUSDT",
+      "listed_from": 1617667200000,
+      "delisted_at": 1642204800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BZRXUSDT",
+      "listed_from": 1599264000000,
+      "delisted_at": 1639958400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "COCOSUSDT",
+      "listed_from": 1676937600000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "CTKUSDTSETTLED",
+      "listed_from": 1745971200000,
+      "delisted_at": 1746057600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "CVCUSDTSETTLED",
+      "listed_from": 1747353600000,
+      "delisted_at": 1747440000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "CVXBUSD",
+      "listed_from": 1657670400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "CVXUSDTSETTLED",
+      "listed_from": 1753228800000,
+      "delisted_at": 1753315200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "DODOBUSD",
+      "listed_from": 1653436800000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DODOUSDT",
+      "listed_from": 1613692800000,
+      "delisted_at": 1653696000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "DOGEBUSD",
+      "listed_from": 1629244800000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DOTBUSD",
+      "listed_from": 1654646400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DOTECOUSDT",
+      "listed_from": 1611100800000,
+      "delisted_at": 1613779200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "EOSUSDT",
+      "listed_from": 1578441600000,
+      "delisted_at": 1747872000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "ETCBUSD",
+      "listed_from": 1658966400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ETHBUSD",
+      "listed_from": 1623801600000,
+      "delisted_at": 1702339200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ETHUSDT_210326",
+      "listed_from": 1612396800000,
+      "delisted_at": 1616803200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_210625",
+      "listed_from": 1615852800000,
+      "delisted_at": 1624665600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_210924",
+      "listed_from": 1623974400000,
+      "delisted_at": 1632528000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_211231",
+      "listed_from": 1632268800000,
+      "delisted_at": 1640995200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_220325",
+      "listed_from": 1640304000000,
+      "delisted_at": 1648252800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_220624",
+      "listed_from": 1647907200000,
+      "delisted_at": 1656115200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_220930",
+      "listed_from": 1655683200000,
+      "delisted_at": 1664582400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_221230",
+      "listed_from": 1663891200000,
+      "delisted_at": 1672444800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_230331",
+      "listed_from": 1671753600000,
+      "delisted_at": 1680307200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_230630",
+      "listed_from": 1679875200000,
+      "delisted_at": 1688169600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_230929",
+      "listed_from": 1687651200000,
+      "delisted_at": 1700006400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_231229",
+      "listed_from": 1692316800000,
+      "delisted_at": 1704844800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_240329",
+      "listed_from": 1695945600000,
+      "delisted_at": 1711756800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_240628",
+      "listed_from": 1703808000000,
+      "delisted_at": 1719878400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_240927",
+      "listed_from": 1711670400000,
+      "delisted_at": 1727481600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_241227",
+      "listed_from": 1719532800000,
+      "delisted_at": 1735344000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_250328",
+      "listed_from": 1727395200000,
+      "delisted_at": 1743206400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_250627",
+      "listed_from": 1735257600000,
+      "delisted_at": 1751068800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_250926",
+      "listed_from": 1743120000000,
+      "delisted_at": 1758931200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_251226",
+      "listed_from": 1750982400000,
+      "delisted_at": 1768953600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_260327",
+      "listed_from": 1758844800000,
+      "delisted_at": 1776384000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "FILBUSD",
+      "listed_from": 1658275200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FOOTBALLUSDT",
+      "listed_from": 1661990400000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FRONTUSDT",
+      "listed_from": 1695340800000,
+      "delisted_at": 1726099200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FTMBUSD",
+      "listed_from": 1653350400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FTTBUSD",
+      "listed_from": 1631059200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GALABUSD",
+      "listed_from": 1653523200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GALBUSD",
+      "listed_from": 1653350400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GALUSDT",
+      "listed_from": 1651708800000,
+      "delisted_at": 1720742400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GMTBUSD",
+      "listed_from": 1652832000000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "HNTUSDT",
+      "listed_from": 1601251200000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ICPBUSD",
+      "listed_from": 1654732800000,
+      "delisted_at": 1679529600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "ICPUSDT_SETTLED",
+      "listed_from": 1640995200000,
+      "delisted_at": 1664236800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "KEEPUSDT",
+      "listed_from": 1624320000000,
+      "delisted_at": 1644969600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "LDOBUSD",
+      "listed_from": 1658966400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LENDUSDT",
+      "listed_from": 1595462400000,
+      "delisted_at": 1605052800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LEVERBUSD",
+      "listed_from": 1658275200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LINKBUSD",
+      "listed_from": 1656547200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LITUSDTSETTLED",
+      "listed_from": 1766448000000,
+      "delisted_at": 1766534400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "LTCBUSD",
+      "listed_from": 1657152000000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LUNA2BUSD",
+      "listed_from": 1654041600000,
+      "delisted_at": 1679529600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "LUNABUSD",
+      "listed_from": 1652313600000,
+      "delisted_at": 1652486400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "LUNAUSDT",
+      "listed_from": 1611792000000,
+      "delisted_at": 1652400000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MATICBUSD",
+      "listed_from": 1657670400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MATICUSDC",
+      "listed_from": 1714003200000,
+      "delisted_at": 1725494400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MATICUSDT",
+      "listed_from": 1603324800000,
+      "delisted_at": 1725494400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail;rebranded->POLUSDT"
+    },
+    {
+      "symbol": "MAVIAUSDTSETTLED",
+      "listed_from": 1742947200000,
+      "delisted_at": 1743033600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "MBLUSDT",
+      "listed_from": 1699920000000,
+      "delisted_at": 1715644800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MINAUSDTSETTLED",
+      "listed_from": 1675641600000,
+      "delisted_at": 1675728000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "NEARBUSD",
+      "listed_from": 1652745600000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NUUSDT",
+      "listed_from": 1634774400000,
+      "delisted_at": 1644969600000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "PHBBUSD",
+      "listed_from": 1663286400000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "PUMPUSDTSETTLED",
+      "listed_from": 1752105600000,
+      "delisted_at": 1752192000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "RNDRUSDT",
+      "listed_from": 1675382400000,
+      "delisted_at": 1721174400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail;rebranded->RENDERUSDT"
+    },
+    {
+      "symbol": "SANDBUSD",
+      "listed_from": 1657152000000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SLPUSDTSETTLED",
+      "listed_from": 1753228800000,
+      "delisted_at": 1753315200000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data"
+    },
+    {
+      "symbol": "SOLBUSD",
+      "listed_from": 1630627200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SRMUSDT",
+      "listed_from": 1599264000000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TLMBUSD",
+      "listed_from": 1654732800000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TLMUSDTSETTLED",
+      "listed_from": 1640995200000,
+      "delisted_at": 1680220800000,
+      "status": "dead",
+      "kline_coverage": 0.6,
+      "funding_coverage": 0.0,
+      "confidence": "low",
+      "missing_data_reason": "delisted;delisting_freeze_tail;no_funding_data;kline_month_gaps"
+    },
+    {
+      "symbol": "TOMOUSDT",
+      "listed_from": 1602460800000,
+      "delisted_at": 1716940800000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TRXBUSD",
+      "listed_from": 1653523200000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "UNIBUSD",
+      "listed_from": 1659657600000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "WAVESBUSD",
+      "listed_from": 1656460800000,
+      "delisted_at": 1703030400000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "XRPBUSD",
+      "listed_from": 1628467200000,
+      "delisted_at": 1702080000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted;delisting_freeze_tail"
+    },
+    {
+      "symbol": "YFIIUSDT",
+      "listed_from": 1599091200000,
+      "delisted_at": 1649808000000,
+      "status": "dead",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "delisted"
+    },
+    {
+      "symbol": "0GUSDT",
+      "listed_from": 1758067200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000000BOBUSDT",
+      "listed_from": 1749081600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000000MOGUSDT",
+      "listed_from": 1730937600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000BONKUSDC",
+      "listed_from": 1714608000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000BONKUSDT",
+      "listed_from": 1700611200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000CATUSDT",
+      "listed_from": 1729468800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000CHEEMSUSDT",
+      "listed_from": 1732492800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000FLOKIUSDT",
+      "listed_from": 1683331200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000LUNCUSDT",
+      "listed_from": 1662681600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000PEPEUSDC",
+      "listed_from": 1709769600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000PEPEUSDT",
+      "listed_from": 1683244800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000RATSUSDT",
+      "listed_from": 1702598400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000SATSUSDT",
+      "listed_from": 1702339200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000SHIBUSDC",
+      "listed_from": 1711584000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000SHIBUSDT",
+      "listed_from": 1620604800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000XECUSDT",
+      "listed_from": 1631836800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1INCHUSDT",
+      "listed_from": 1608854400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1MBABYDOGEUSDT",
+      "listed_from": 1726444800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "2ZUSDT",
+      "listed_from": 1759363200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "4USDT",
+      "listed_from": 1759881600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AAVEUSDC",
+      "listed_from": 1750032000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AAVEUSDT",
+      "listed_from": 1602806400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ACEUSDT",
+      "listed_from": 1702857600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ACHUSDT",
+      "listed_from": 1677024000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ACTUSDT",
+      "listed_from": 1731283200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ACUUSDT",
+      "listed_from": 1768953600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ACXUSDT",
+      "listed_from": 1733443200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ADAUSDC",
+      "listed_from": 1741219200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ADAUSDT",
+      "listed_from": 1580428800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AERGOUSDT",
+      "listed_from": 1725926400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AEROUSDT",
+      "listed_from": 1733270400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AEVOUSDT",
+      "listed_from": 1710288000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AGLDUSDT",
+      "listed_from": 1690588800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AGTUSDT",
+      "listed_from": 1747699200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AIAUSDT",
+      "listed_from": 1758153600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AIGENSYNUSDT",
+      "listed_from": 1777420800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AINUSDT",
+      "listed_from": 1752105600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AIOTUSDT",
+      "listed_from": 1745971200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AIOUSDT",
+      "listed_from": 1755043200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AIXBTUSDT",
+      "listed_from": 1734652800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AKEUSDT",
+      "listed_from": 1758844800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AKTUSDT",
+      "listed_from": 1731888000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALCHUSDT",
+      "listed_from": 1736208000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALGOUSDT",
+      "listed_from": 1592265600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALICEUSDT",
+      "listed_from": 1615852800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALLOUSDT",
+      "listed_from": 1762819200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALLUSDT",
+      "listed_from": 1754438400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALPINEUSDT",
+      "listed_from": 1746489600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ALTUSDT",
+      "listed_from": 1706140800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ANIMEUSDT",
+      "listed_from": 1737590400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ANKRUSDT",
+      "listed_from": 1611619200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "APEUSDT",
+      "listed_from": 1647475200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "API3USDT",
+      "listed_from": 1645488000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "APRUSDT",
+      "listed_from": 1761177600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "APTUSDT",
+      "listed_from": 1666137600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARBUSDC",
+      "listed_from": 1713398400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARBUSDT",
+      "listed_from": 1679529600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARCUSDT",
+      "listed_from": 1737072000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARIAUSDT",
+      "listed_from": 1756857600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARKMUSDT",
+      "listed_from": 1690502400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARKUSDT",
+      "listed_from": 1695081600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARPAUSDT",
+      "listed_from": 1634601600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ARUSDT",
+      "listed_from": 1632787200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ASRUSDT",
+      "listed_from": 1746489600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ASTERUSDT",
+      "listed_from": 1758240000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ASTRUSDT",
+      "listed_from": 1676332800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ATHUSDT",
+      "listed_from": 1743552000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ATOMUSDT",
+      "listed_from": 1581033600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ATUSDT",
+      "listed_from": 1761696000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AUCTIONUSDT",
+      "listed_from": 1702598400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AUSDT",
+      "listed_from": 1748390400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AVAAIUSDT",
+      "listed_from": 1737072000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AVAUSDT",
+      "listed_from": 1734048000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AVAXUSDC",
+      "listed_from": 1710892800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AVAXUSDT",
+      "listed_from": 1600819200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AVNTUSDT",
+      "listed_from": 1757376000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AWEUSDT",
+      "listed_from": 1747785600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AXLUSDT",
+      "listed_from": 1709251200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AXSUSDT",
+      "listed_from": 1605830400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "AZTECUSDT",
+      "listed_from": 1770768000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "B2USDT",
+      "listed_from": 1746489600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BABYUSDT",
+      "listed_from": 1743811200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BANANAS31USDT",
+      "listed_from": 1742601600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BANANAUSDT",
+      "listed_from": 1723680000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BANDUSDT",
+      "listed_from": 1595980800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BANKUSDT",
+      "listed_from": 1744934400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BANUSDT",
+      "listed_from": 1731888000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BARDUSDT",
+      "listed_from": 1758153600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BASEDUSDT",
+      "listed_from": 1774828800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BASUSDT",
+      "listed_from": 1756166400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BATUSDT",
+      "listed_from": 1581552000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BBUSDT",
+      "listed_from": 1715558400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BCHUSDC",
+      "listed_from": 1712188800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BCHUSDT",
+      "listed_from": 1577836800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BEAMXUSDT",
+      "listed_from": 1700179200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BEATUSDT",
+      "listed_from": 1762905600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BELUSDT",
+      "listed_from": 1605657600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BERAUSDT",
+      "listed_from": 1738800000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BICOUSDT",
+      "listed_from": 1695859200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BIGTIMEUSDT",
+      "listed_from": 1697068800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BIOUSDC",
+      "listed_from": 1756080000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BIOUSDT",
+      "listed_from": 1735862400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BIRBUSDT",
+      "listed_from": 1769644800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BLESSUSDT",
+      "listed_from": 1758585600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BLUAIUSDT",
+      "listed_from": 1761004800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BLURUSDT",
+      "listed_from": 1682640000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BMTUSDT",
+      "listed_from": 1742169600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BNBUSDC",
+      "listed_from": 1704326400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BNBUSDT",
+      "listed_from": 1581292800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BNTUSDT",
+      "listed_from": 1691625600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.578,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BOMEUSDC",
+      "listed_from": 1714003200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BOMEUSDT",
+      "listed_from": 1710547200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BRETTUSDT",
+      "listed_from": 1724112000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BREVUSDT",
+      "listed_from": 1767052800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BROCCOLI714USDT",
+      "listed_from": 1742515200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BROCCOLIF3BUSDT",
+      "listed_from": 1742515200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BRUSDT",
+      "listed_from": 1742515200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BSBUSDT",
+      "listed_from": 1774396800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BSVUSDT",
+      "listed_from": 1697760000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BTCDOMUSDT",
+      "listed_from": 1624233600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BTCUSDC",
+      "listed_from": 1704326400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BTCUSDT",
+      "listed_from": 1577836800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BTRUSDT",
+      "listed_from": 1756252800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BULLAUSDT",
+      "listed_from": 1751587200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "BUSDT",
+      "listed_from": 1747872000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "C98USDT",
+      "listed_from": 1629763200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CAKEUSDT",
+      "listed_from": 1698883200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CARVUSDT",
+      "listed_from": 1754524800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CATIUSDT",
+      "listed_from": 1726790400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CCUSDT",
+      "listed_from": 1761868800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CELOUSDT",
+      "listed_from": 1632700800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CELRUSDT",
+      "listed_from": 1616976000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CETUSUSDT",
+      "listed_from": 1730851200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CFGUSDT",
+      "listed_from": 1773619200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CFXUSDT",
+      "listed_from": 1676851200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CGPTUSDT",
+      "listed_from": 1734652800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CHILLGUYUSDT",
+      "listed_from": 1732665600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CHIPUSDT",
+      "listed_from": 1776297600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CHRUSDT",
+      "listed_from": 1615507200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CHZUSDT",
+      "listed_from": 1611187200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CKBUSDT",
+      "listed_from": 1677542400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CLANKERUSDT",
+      "listed_from": 1762905600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CLOUSDT",
+      "listed_from": 1760400000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COAIUSDT",
+      "listed_from": 1758758400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COLLECTUSDT",
+      "listed_from": 1767139200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COMPUSDT",
+      "listed_from": 1593475200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COOKIEUSDT",
+      "listed_from": 1736208000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COSUSDT",
+      "listed_from": 1727654400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COTIUSDT",
+      "listed_from": 1615334400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "COWUSDT",
+      "listed_from": 1730851200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CROSSUSDT",
+      "listed_from": 1752105600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CRVUSDC",
+      "listed_from": 1720051200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CRVUSDT",
+      "listed_from": 1598918400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CTKUSDT",
+      "listed_from": 1605744000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CTSIUSDT",
+      "listed_from": 1635206400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CUSDT",
+      "listed_from": 1752537600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CVCUSDT",
+      "listed_from": 1605052800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CVXUSDT",
+      "listed_from": 1663804800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CYBERUSDT",
+      "listed_from": 1692576000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "CYSUSDT",
+      "listed_from": 1765497600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DASHUSDT",
+      "listed_from": 1580774400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DEEPUSDT",
+      "listed_from": 1745280000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DEXEUSDT",
+      "listed_from": 1734998400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DIAUSDT",
+      "listed_from": 1727827200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DODOXUSDT",
+      "listed_from": 1691452800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOGEUSDC",
+      "listed_from": 1705536000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOGEUSDT",
+      "listed_from": 1594339200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOGSUSDT",
+      "listed_from": 1724630400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOLOUSDT",
+      "listed_from": 1746057600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOODUSDT",
+      "listed_from": 1746748800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DOTUSDT",
+      "listed_from": 1598054400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DRIFTUSDT",
+      "listed_from": 1731024000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DUSDT",
+      "listed_from": 1736380800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DUSKUSDT",
+      "listed_from": 1641513600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DYDXUSDT",
+      "listed_from": 1631232000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "DYMUSDT",
+      "listed_from": 1707264000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EDENUSDT",
+      "listed_from": 1759190400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EDGEUSDT",
+      "listed_from": 1773878400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EDUUSDT",
+      "listed_from": 1682812800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EGLDUSDT",
+      "listed_from": 1600041600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EIGENUSDT",
+      "listed_from": 1727740800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ELSAUSDT",
+      "listed_from": 1769040000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ENAUSDC",
+      "listed_from": 1714608000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ENAUSDT",
+      "listed_from": 1712016000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ENJUSDT",
+      "listed_from": 1601337600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ENSOUSDT",
+      "listed_from": 1760400000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ENSUSDT",
+      "listed_from": 1638230400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EPICUSDT",
+      "listed_from": 1741824000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ERAUSDT",
+      "listed_from": 1752710400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ESPORTSUSDT",
+      "listed_from": 1753747200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ESPUSDT",
+      "listed_from": 1770681600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETCUSDT",
+      "listed_from": 1579132800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHBTC",
+      "listed_from": 1682467200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHFIUSDC",
+      "listed_from": 1714608000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHFIUSDT",
+      "listed_from": 1710720000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHUSDC",
+      "listed_from": 1704326400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHUSDT",
+      "listed_from": 1577836800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ETHWUSDT",
+      "listed_from": 1701129600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EULUSDT",
+      "listed_from": 1760313600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "EVAAUSDT",
+      "listed_from": 1759449600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FARTCOINUSDT",
+      "listed_from": 1734652800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FETUSDT",
+      "listed_from": 1673913600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FFUSDT",
+      "listed_from": 1759104000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FHEUSDT",
+      "listed_from": 1744416000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FIDAUSDT",
+      "listed_from": 1726704000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FIGHTUSDT",
+      "listed_from": 1769126400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FILUSDC",
+      "listed_from": 1713398400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FILUSDT",
+      "listed_from": 1602806400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FLOCKUSDT",
+      "listed_from": 1757376000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FLOWUSDT",
+      "listed_from": 1644451200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FLUIDUSDT",
+      "listed_from": 1758672000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FLUXUSDT",
+      "listed_from": 1725321600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FOGOUSDT",
+      "listed_from": 1768003200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FOLKSUSDT",
+      "listed_from": 1762387200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FORMUSDT",
+      "listed_from": 1742342400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FRAXUSDT",
+      "listed_from": 1768435200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "FUSDT",
+      "listed_from": 1750204800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GALAUSDT",
+      "listed_from": 1631923200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GASUSDT",
+      "listed_from": 1698192000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GENIUSUSDT",
+      "listed_from": 1776297600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GIGGLEUSDT",
+      "listed_from": 1759968000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GLMUSDT",
+      "listed_from": 1708560000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GMTUSDT",
+      "listed_from": 1647302400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GMXUSDT",
+      "listed_from": 1676592000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GOATUSDT",
+      "listed_from": 1729728000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GPSUSDT",
+      "listed_from": 1739750400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GRASSUSDT",
+      "listed_from": 1731024000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GRIFFAINUSDT",
+      "listed_from": 1735776000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GRTUSDT",
+      "listed_from": 1608336000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GTCUSDT",
+      "listed_from": 1623369600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GUAUSDT",
+      "listed_from": 1766275200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GUNUSDT",
+      "listed_from": 1743379200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GUSDT",
+      "listed_from": 1723680000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "GWEIUSDT",
+      "listed_from": 1769644800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HAEDALUSDT",
+      "listed_from": 1746057600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HANAUSDT",
+      "listed_from": 1758844800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HBARUSDC",
+      "listed_from": 1741305600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HBARUSDT",
+      "listed_from": 1615939200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HEIUSDT",
+      "listed_from": 1739404800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HEMIUSDT",
+      "listed_from": 1756425600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HFTUSDT",
+      "listed_from": 1680739200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HIGHUSDT",
+      "listed_from": 1675728000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HIVEUSDT",
+      "listed_from": 1734912000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HMSTRUSDT",
+      "listed_from": 1727308800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HOLOUSDT",
+      "listed_from": 1757548800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HOMEUSDT",
+      "listed_from": 1749513600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HOTUSDT",
+      "listed_from": 1617062400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HUMAUSDT",
+      "listed_from": 1748217600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HUSDT",
+      "listed_from": 1750809600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HYPERUSDT",
+      "listed_from": 1745280000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "HYPEUSDT",
+      "listed_from": 1748563200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ICNTUSDT",
+      "listed_from": 1751500800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ICPUSDT",
+      "listed_from": 1620691200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ICXUSDT",
+      "listed_from": 1600128000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IDOLUSDT",
+      "listed_from": 1751587200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IDUSDT",
+      "listed_from": 1679529600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ILVUSDT",
+      "listed_from": 1699574400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IMXUSDT",
+      "listed_from": 1644537600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "INITUSDT",
+      "listed_from": 1744761600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "INJUSDT",
+      "listed_from": 1660694400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "INUSDT",
+      "listed_from": 1754524800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "INXUSDT",
+      "listed_from": 1769731200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IOSTUSDT",
+      "listed_from": 1582243200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IOTAUSDT",
+      "listed_from": 1581465600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IOTXUSDT",
+      "listed_from": 1628726400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IOUSDT",
+      "listed_from": 1718064000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IPUSDC",
+      "listed_from": 1741132800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IPUSDT",
+      "listed_from": 1739404800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "IRYSUSDT",
+      "listed_from": 1764115200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JASMYUSDT",
+      "listed_from": 1650412800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JCTUSDT",
+      "listed_from": 1762732800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JELLYJELLYUSDT",
+      "listed_from": 1742947200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JOEUSDT",
+      "listed_from": 1680048000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JSTUSDT",
+      "listed_from": 1745798400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JTOUSDT",
+      "listed_from": 1701993600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "JUPUSDT",
+      "listed_from": 1706659200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KAIAUSDT",
+      "listed_from": 1733270400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KAITOUSDC",
+      "listed_from": 1741132800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KAITOUSDT",
+      "listed_from": 1740009600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KASUSDT",
+      "listed_from": 1700179200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KATUSDT",
+      "listed_from": 1772409600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KAVAUSDT",
+      "listed_from": 1595894400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KERNELUSDT",
+      "listed_from": 1744588800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KGENUSDT",
+      "listed_from": 1759795200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KITEUSDT",
+      "listed_from": 1761696000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KMNOUSDT",
+      "listed_from": 1734652800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KNCUSDT",
+      "listed_from": 1592784000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KOMAUSDT",
+      "listed_from": 1733788800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "KSMUSDT",
+      "listed_from": 1602633600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LABUSDT",
+      "listed_from": 1760659200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LAUSDT",
+      "listed_from": 1749081600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LAYERUSDT",
+      "listed_from": 1739232000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LDOUSDT",
+      "listed_from": 1663804800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LIGHTUSDT",
+      "listed_from": 1758931200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LINEAUSDT",
+      "listed_from": 1756684800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LINKUSDC",
+      "listed_from": 1708041600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LINKUSDT",
+      "listed_from": 1579219200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LISTAUSDT",
+      "listed_from": 1718841600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LITUSDT",
+      "listed_from": 1613606400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.921,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LPTUSDT",
+      "listed_from": 1636588800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LQTYUSDT",
+      "listed_from": 1678406400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LSKUSDT",
+      "listed_from": 1706140800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LTCUSDC",
+      "listed_from": 1712793600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LTCUSDT",
+      "listed_from": 1578528000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LUMIAUSDT",
+      "listed_from": 1734480000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LUNA2USDT",
+      "listed_from": 1662768000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "LYNUSDT",
+      "listed_from": 1759708800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MAGICUSDT",
+      "listed_from": 1674604800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MAGMAUSDT",
+      "listed_from": 1767139200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MANAUSDT",
+      "listed_from": 1615766400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MANTAUSDT",
+      "listed_from": 1705536000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MANTRAUSDT",
+      "listed_from": 1772582400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MASKUSDT",
+      "listed_from": 1630022400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MAVIAUSDT",
+      "listed_from": 1708473600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MAVUSDT",
+      "listed_from": 1687996800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MBOXUSDT",
+      "listed_from": 1724803200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MEGAUSDT",
+      "listed_from": 1769731200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MELANIAUSDT",
+      "listed_from": 1737331200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MEMEUSDT",
+      "listed_from": 1698969600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MERLUSDT",
+      "listed_from": 1748476800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "METISUSDT",
+      "listed_from": 1710201600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "METUSDT",
+      "listed_from": 1760140800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MEUSDT",
+      "listed_from": 1733788800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MEWUSDT",
+      "listed_from": 1718582400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MINAUSDT",
+      "listed_from": 1675728000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MIRAUSDT",
+      "listed_from": 1758844800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MITOUSDT",
+      "listed_from": 1756339200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MMTUSDT",
+      "listed_from": 1762214400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MOCAUSDT",
+      "listed_from": 1734307200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MONUSDT",
+      "listed_from": 1760054400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MOODENGUSDT",
+      "listed_from": 1729814400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MORPHOUSDT",
+      "listed_from": 1732665600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MOVEUSDT",
+      "listed_from": 1733702400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MOVRUSDT",
+      "listed_from": 1703548800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MTLUSDT",
+      "listed_from": 1617148800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MUBARAKUSDT",
+      "listed_from": 1742169600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MUSDT",
+      "listed_from": 1751846400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "MYXUSDT",
+      "listed_from": 1750204800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NAORISUSDT",
+      "listed_from": 1753920000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEARUSDC",
+      "listed_from": 1712793600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEARUSDT",
+      "listed_from": 1602720000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEIROUSDT",
+      "listed_from": 1726444800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEOUSDC",
+      "listed_from": 1713398400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEOUSDT",
+      "listed_from": 1581897600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NEWTUSDT",
+      "listed_from": 1750291200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NFPUSDT",
+      "listed_from": 1703635200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NIGHTUSDT",
+      "listed_from": 1765324800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NILUSDT",
+      "listed_from": 1742774400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NMRUSDT",
+      "listed_from": 1687392000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NOMUSDT",
+      "listed_from": 1759276800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NOTUSDT",
+      "listed_from": 1715817600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "NXPCUSDT",
+      "listed_from": 1747267200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OGNUSDT",
+      "listed_from": 1617235200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OGUSDT",
+      "listed_from": 1747008000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ONDOUSDT",
+      "listed_from": 1705708800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ONEUSDT",
+      "listed_from": 1616025600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ONGUSDT",
+      "listed_from": 1701043200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ONTUSDT",
+      "listed_from": 1581379200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ONUSDT",
+      "listed_from": 1761264000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OPENUSDT",
+      "listed_from": 1757289600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OPGUSDT",
+      "listed_from": 1776816000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OPNUSDT",
+      "listed_from": 1771632000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "OPUSDT",
+      "listed_from": 1654041600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ORCAUSDT",
+      "listed_from": 1733443200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ORDERUSDT",
+      "listed_from": 1758844800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ORDIUSDC",
+      "listed_from": 1708560000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ORDIUSDT",
+      "listed_from": 1699315200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PARTIUSDT",
+      "listed_from": 1742860800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PAXGUSDT",
+      "listed_from": 1743033600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PENDLEUSDT",
+      "listed_from": 1690502400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PENGUUSDC",
+      "listed_from": 1753228800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PENGUUSDT",
+      "listed_from": 1734393600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PEOPLEUSDT",
+      "listed_from": 1640304000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PHAUSDT",
+      "listed_from": 1735516800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PIEVERSEUSDT",
+      "listed_from": 1763078400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PIPPINUSDT",
+      "listed_from": 1737676800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PIXELUSDT",
+      "listed_from": 1708300800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PLAYUSDT",
+      "listed_from": 1753920000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PLUMEUSDT",
+      "listed_from": 1742515200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PNUTUSDC",
+      "listed_from": 1741305600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PNUTUSDT",
+      "listed_from": 1731283200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "POLUSDT",
+      "listed_from": 1726185600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "POLYXUSDT",
+      "listed_from": 1698192000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "POPCATUSDT",
+      "listed_from": 1724284800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PORTALUSDT",
+      "listed_from": 1709164800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "POWERUSDT",
+      "listed_from": 1764979200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "POWRUSDT",
+      "listed_from": 1698364800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PRLUSDT",
+      "listed_from": 1775001600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PROMPTUSDT",
+      "listed_from": 1744329600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PROMUSDT",
+      "listed_from": 1736899200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PROVEUSDT",
+      "listed_from": 1754352000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PTBUSDT",
+      "listed_from": 1756857600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PUMPBTCUSDT",
+      "listed_from": 1749772800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PUMPUSDT",
+      "listed_from": 1744416000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PUNDIXUSDT",
+      "listed_from": 1745971200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "PYTHUSDT",
+      "listed_from": 1700611200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "QNTUSDT",
+      "listed_from": 1666224000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "QTUMUSDT",
+      "listed_from": 1582156800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "QUSDT",
+      "listed_from": 1756771200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RAREUSDT",
+      "listed_from": 1723680000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RAVEUSDT",
+      "listed_from": 1765670400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RAYSOLUSDT",
+      "listed_from": 1733788800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RECALLUSDT",
+      "listed_from": 1760486400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "REDUSDT",
+      "listed_from": 1741219200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RENDERUSDT",
+      "listed_from": 1721952000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RESOLVUSDT",
+      "listed_from": 1749513600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "REZUSDT",
+      "listed_from": 1714435200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RIFUSDT",
+      "listed_from": 1697846400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RIVERUSDT",
+      "listed_from": 1760659200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RLCUSDT",
+      "listed_from": 1596153600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ROBOUSDT",
+      "listed_from": 1772150400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RONINUSDT",
+      "listed_from": 1707177600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ROSEUSDT",
+      "listed_from": 1640908800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RPLUSDT",
+      "listed_from": 1725840000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RSRUSDT",
+      "listed_from": 1603065600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RUNEUSDT",
+      "listed_from": 1599177600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "RVNUSDT",
+      "listed_from": 1614038400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SAFEUSDT",
+      "listed_from": 1729814400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SAGAUSDT",
+      "listed_from": 1712620800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SAHARAUSDT",
+      "listed_from": 1750896000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SANDUSDT",
+      "listed_from": 1611532800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SANTOSUSDT",
+      "listed_from": 1730073600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SAPIENUSDT",
+      "listed_from": 1755648000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SCRTUSDT",
+      "listed_from": 1732147200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SCRUSDT",
+      "listed_from": 1729555200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SEIUSDT",
+      "listed_from": 1692230400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SENTUSDT",
+      "listed_from": 1763078400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SFPUSDT",
+      "listed_from": 1614124800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SHELLUSDT",
+      "listed_from": 1739750400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SIGNUSDT",
+      "listed_from": 1745798400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SIRENUSDT",
+      "listed_from": 1742601600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SKLUSDT",
+      "listed_from": 1607385600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SKRUSDT",
+      "listed_from": 1769040000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SKYAIUSDT",
+      "listed_from": 1747094400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SKYUSDT",
+      "listed_from": 1757376000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SLPUSDT",
+      "listed_from": 1698710400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SNXUSDT",
+      "listed_from": 1597363200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOLUSDC",
+      "listed_from": 1704326400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOLUSDT",
+      "listed_from": 1600041600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOLVUSDT",
+      "listed_from": 1737072000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOMIUSDT",
+      "listed_from": 1756080000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SONICUSDT",
+      "listed_from": 1736294400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOONUSDT",
+      "listed_from": 1747958400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SOPHUSDT",
+      "listed_from": 1748390400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SPACEUSDT",
+      "listed_from": 1769126400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SPELLUSDT",
+      "listed_from": 1662422400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SPKUSDT",
+      "listed_from": 1750118400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SPORTFUNUSDT",
+      "listed_from": 1768521600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SPXUSDT",
+      "listed_from": 1733788800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SQDUSDT",
+      "listed_from": 1749600000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SSVUSDT",
+      "listed_from": 1677196800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STABLEUSDT",
+      "listed_from": 1762387200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STBLUSDT",
+      "listed_from": 1758067200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STEEMUSDT",
+      "listed_from": 1699401600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STGUSDT",
+      "listed_from": 1661385600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STORJUSDT",
+      "listed_from": 1600214400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STOUSDT",
+      "listed_from": 1744416000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STRKUSDT",
+      "listed_from": 1708387200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "STXUSDT",
+      "listed_from": 1676937600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUIUSDC",
+      "listed_from": 1707350400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUIUSDT",
+      "listed_from": 1683072000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUNUSDT",
+      "listed_from": 1724284800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUPERUSDT",
+      "listed_from": 1700956800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUSDT",
+      "listed_from": 1736985600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SUSHIUSDT",
+      "listed_from": 1599177600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SWARMSUSDT",
+      "listed_from": 1736208000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SXTUSDT",
+      "listed_from": 1746144000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SYNUSDT",
+      "listed_from": 1723766400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "SYRUPUSDT",
+      "listed_from": 1746576000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TACUSDT",
+      "listed_from": 1752537600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TAGUSDT",
+      "listed_from": 1753401600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TAIKOUSDT",
+      "listed_from": 1749600000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TAKEUSDT",
+      "listed_from": 1756857600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TAOUSDT",
+      "listed_from": 1712793600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TAUSDT",
+      "listed_from": 1753056000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "THETAUSDT",
+      "listed_from": 1590537600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "THEUSDT",
+      "listed_from": 1732665600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TIAUSDC",
+      "listed_from": 1714003200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TIAUSDT",
+      "listed_from": 1698710400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TLMUSDT",
+      "listed_from": 1626393600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TNSRUSDT",
+      "listed_from": 1712534400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TONUSDT",
+      "listed_from": 1709251200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TOSHIUSDT",
+      "listed_from": 1758067200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TOWNSUSDT",
+      "listed_from": 1754352000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRADOORUSDT",
+      "listed_from": 1758240000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRBUSDT",
+      "listed_from": 1599091200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TREEUSDT",
+      "listed_from": 1753747200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRIAUSDT",
+      "listed_from": 1770336000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRUMPUSDC",
+      "listed_from": 1741219200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRUMPUSDT",
+      "listed_from": 1737158400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRUSTUSDT",
+      "listed_from": 1762300800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRUTHUSDT",
+      "listed_from": 1759276800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TRXUSDT",
+      "listed_from": 1579046400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TSTUSDT",
+      "listed_from": 1739059200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TURBOUSDT",
+      "listed_from": 1717027200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TURTLEUSDT",
+      "listed_from": 1761091200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TUSDT",
+      "listed_from": 1675209600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TUTUSDT",
+      "listed_from": 1742428800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "TWTUSDT",
+      "listed_from": 1698969600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "UAIUSDT",
+      "listed_from": 1762387200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "UBUSDT",
+      "listed_from": 1757635200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "UMAUSDT",
+      "listed_from": 1683676800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "UNIUSDC",
+      "listed_from": 1750032000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "UNIUSDT",
+      "listed_from": 1600387200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "USDCUSDT",
+      "listed_from": 1678579200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "USELESSUSDT",
+      "listed_from": 1755216000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "USTCUSDT",
+      "listed_from": 1701043200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "USUALUSDT",
+      "listed_from": 1734480000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "USUSDT",
+      "listed_from": 1765497600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VANAUSDT",
+      "listed_from": 1734307200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VANRYUSDT",
+      "listed_from": 1710288000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VELODROMEUSDT",
+      "listed_from": 1734048000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VELVETUSDT",
+      "listed_from": 1752537600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VETUSDT",
+      "listed_from": 1581638400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VICUSDT",
+      "listed_from": 1741737600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VIRTUALUSDT",
+      "listed_from": 1733788800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VTHOUSDT",
+      "listed_from": 1737504000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "VVVUSDT",
+      "listed_from": 1738108800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WALUSDT",
+      "listed_from": 1743033600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WAXPUSDT",
+      "listed_from": 1697587200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WCTUSDT",
+      "listed_from": 1744675200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WETUSDT",
+      "listed_from": 1765324800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WIFUSDC",
+      "listed_from": 1712188800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WIFUSDT",
+      "listed_from": 1705536000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WLDUSDC",
+      "listed_from": 1710374400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WLDUSDT",
+      "listed_from": 1690156800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WLFIUSDC",
+      "listed_from": 1757289600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WLFIUSDT",
+      "listed_from": 1755907200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WOOUSDT",
+      "listed_from": 1649376000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "WUSDT",
+      "listed_from": 1712102400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XAIUSDT",
+      "listed_from": 1704758400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XANUSDT",
+      "listed_from": 1759104000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XAUTUSDT",
+      "listed_from": 1774483200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XLMUSDT",
+      "listed_from": 1579478400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XMRUSDT",
+      "listed_from": 1580688000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XNYUSDT",
+      "listed_from": 1755043200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XPINUSDT",
+      "listed_from": 1757635200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XPLUSDT",
+      "listed_from": 1755820800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XRPUSDC",
+      "listed_from": 1704326400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XRPUSDT",
+      "listed_from": 1578268800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XTZUSDT",
+      "listed_from": 1580947200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XVGUSDT",
+      "listed_from": 1688515200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "XVSUSDT",
+      "listed_from": 1681344000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "YBUSDT",
+      "listed_from": 1760054400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "YFIUSDT",
+      "listed_from": 1598832000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "YGGUSDT",
+      "listed_from": 1691193600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZAMAUSDT",
+      "listed_from": 1767916800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZBTUSDT",
+      "listed_from": 1760659200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZECUSDC",
+      "listed_from": 1763510400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZECUSDT",
+      "listed_from": 1580860800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZENUSDT",
+      "listed_from": 1606176000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZEREBROUSDT",
+      "listed_from": 1735776000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZETAUSDT",
+      "listed_from": 1706832000000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZILUSDT",
+      "listed_from": 1592438400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZKCUSDT",
+      "listed_from": 1757894400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZKPUSDT",
+      "listed_from": 1766275200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZKUSDT",
+      "listed_from": 1718582400000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZORAUSDT",
+      "listed_from": 1753401600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZROUSDT",
+      "listed_from": 1718841600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "ZRXUSDT",
+      "listed_from": 1592956800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "\u5e01\u5b89\u4eba\u751fUSDT",
+      "listed_from": 1759276800000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "\u6211\u8e0f\u9a6c\u6765\u4e86USDT",
+      "listed_from": 1767225600000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "\u9f99\u867eUSDT",
+      "listed_from": 1772323200000,
+      "delisted_at": null,
+      "status": "live",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high"
+    },
+    {
+      "symbol": "1000WHYUSDT",
+      "listed_from": 1732492800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "1000XUSDT",
+      "listed_from": 1731456000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "42USDT",
+      "listed_from": 1761523200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "A2ZUSDT",
+      "listed_from": 1753833600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AAPLUSDT",
+      "listed_from": 1775433600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "AGIXUSDT",
+      "listed_from": 1676505600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail;rebranded->FETUSDT(merge)"
+    },
+    {
+      "symbol": "AI16ZUSDT",
+      "listed_from": 1735776000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AIUSDT",
+      "listed_from": 1704672000000,
+      "delisted_at": 1777420800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ALPACAUSDT",
+      "listed_from": 1724284800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ALPHAUSDT",
+      "listed_from": 1606089600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AMBUSDT",
+      "listed_from": 1680134400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "AMZNUSDT",
+      "listed_from": 1770595200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "ATAUSDT",
+      "listed_from": 1630368000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "AVGOUSDT",
+      "listed_from": 1776643200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "B3USDT",
+      "listed_from": 1739404800000,
+      "delisted_at": 1777420800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BABAUSDT",
+      "listed_from": 1776643200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "BADGERUSDT",
+      "listed_from": 1699488000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BAKEUSDT",
+      "listed_from": 1621382400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BALUSDT",
+      "listed_from": 1598918400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BIDUSDT",
+      "listed_from": 1742428800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BLZUSDT",
+      "listed_from": 1600300800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BNXUSDT",
+      "listed_from": 1648771200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BOBUSDT",
+      "listed_from": 1763683200000,
+      "delisted_at": 1777420800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BONDUSDT",
+      "listed_from": 1697328000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BSWUSDT",
+      "listed_from": 1725494400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BTCSTUSDT",
+      "listed_from": 1614816000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.984,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "BTCUSDT_260626",
+      "listed_from": 1766707200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "settling_or_close_only;no_funding_data"
+    },
+    {
+      "symbol": "BTCUSDT_260925",
+      "listed_from": 1774569600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "settling_or_close_only;no_funding_data"
+    },
+    {
+      "symbol": "BZUSDT",
+      "listed_from": 1775001600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "CHESSUSDT",
+      "listed_from": 1724889600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "CLUSDT",
+      "listed_from": 1775001600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "COINUSDT",
+      "listed_from": 1770595200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "COMBOUSDT",
+      "listed_from": 1685664000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "COMMONUSDT",
+      "listed_from": 1761523200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "COPPERUSDT",
+      "listed_from": 1772755200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "CRCLUSDT",
+      "listed_from": 1770595200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "CUDISUSDT",
+      "listed_from": 1755648000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DAMUSDT",
+      "listed_from": 1755475200000,
+      "delisted_at": 1777507200000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DARUSDT",
+      "listed_from": 1651190400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DEFIUSDT",
+      "listed_from": 1598572800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DEGENUSDT",
+      "listed_from": 1731628800000,
+      "delisted_at": 1777420800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DEGOUSDT",
+      "listed_from": 1734048000000,
+      "delisted_at": 1776816000000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DENTUSDT",
+      "listed_from": 1616544000000,
+      "delisted_at": 1776816000000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DFUSDT",
+      "listed_from": 1735516800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DGBUSDT",
+      "listed_from": 1618963200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "DMCUSDT",
+      "listed_from": 1750723200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "EPTUSDT",
+      "listed_from": 1745193600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ETHUSDT_260626",
+      "listed_from": 1766707200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "settling_or_close_only;no_funding_data"
+    },
+    {
+      "symbol": "ETHUSDT_260925",
+      "listed_from": 1774569600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 0.0,
+      "confidence": "medium",
+      "missing_data_reason": "settling_or_close_only;no_funding_data"
+    },
+    {
+      "symbol": "EWJUSDT",
+      "listed_from": 1773878400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "EWYUSDT",
+      "listed_from": 1773619200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "FIOUSDT",
+      "listed_from": 1726790400000,
+      "delisted_at": 1776297600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FISUSDT",
+      "listed_from": 1745539200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FLMUSDT",
+      "listed_from": 1601337600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FORTHUSDT",
+      "listed_from": 1744070400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FTMUSDT",
+      "listed_from": 1600905600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FTTUSDT",
+      "listed_from": 1649980800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FUNUSDT",
+      "listed_from": 1743379200000,
+      "delisted_at": 1776297600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "FXSUSDT",
+      "listed_from": 1674172800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GHSTUSDT",
+      "listed_from": 1727049600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GLMRUSDT",
+      "listed_from": 1695686400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "GOOGLUSDT",
+      "listed_from": 1774483200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "HIFIUSDT",
+      "listed_from": 1694822400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "HIPPOUSDT",
+      "listed_from": 1731456000000,
+      "delisted_at": 1775692800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "HOODUSDT",
+      "listed_from": 1769990400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "HOOKUSDT",
+      "listed_from": 1674432000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "IDEXUSDT",
+      "listed_from": 1683072000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "INTCUSDT",
+      "listed_from": 1769990400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "IRUSDT",
+      "listed_from": 1766275200000,
+      "delisted_at": 1777507200000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "KDAUSDT",
+      "listed_from": 1726617600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "KEYUSDT",
+      "listed_from": 1684886400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "KLAYUSDT",
+      "listed_from": 1633996800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LEVERUSDT",
+      "listed_from": 1680134400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LINAUSDT",
+      "listed_from": 1616112000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LOKAUSDT",
+      "listed_from": 1727136000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LOOMUSDT",
+      "listed_from": 1696982400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "LRCUSDT",
+      "listed_from": 1603065600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MDTUSDT",
+      "listed_from": 1688083200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MEMEFIUSDT",
+      "listed_from": 1745539200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "METAUSDT",
+      "listed_from": 1774483200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "MILKUSDT",
+      "listed_from": 1746489600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MKRUSDT",
+      "listed_from": 1597276800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "MLNUSDT",
+      "listed_from": 1743379200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "MSFTUSDT",
+      "listed_from": 1776643200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "MSTRUSDT",
+      "listed_from": 1770595200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "MUUSDT",
+      "listed_from": 1775520000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "MYROUSDT",
+      "listed_from": 1709596800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NATGASUSDT",
+      "listed_from": 1775001600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "NEIROETHUSDT",
+      "listed_from": 1725580800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NKNUSDT",
+      "listed_from": 1617926400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NTRNUSDT",
+      "listed_from": 1699920000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NULSUSDT",
+      "listed_from": 1724630400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "NVDAUSDT",
+      "listed_from": 1774483200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "OBOLUSDT",
+      "listed_from": 1746576000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "OCEANUSDT",
+      "listed_from": 1604361600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail;rebranded->FETUSDT(merge)"
+    },
+    {
+      "symbol": "OLUSDT",
+      "listed_from": 1750809600000,
+      "delisted_at": 1775692800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "OMGUSDT",
+      "listed_from": 1593648000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "OMNIUSDT",
+      "listed_from": 1713312000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "OMUSDT",
+      "listed_from": 1707782400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ORBSUSDT",
+      "listed_from": 1697500800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "OXTUSDT",
+      "listed_from": 1691712000000,
+      "delisted_at": 1776297600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "PAYPUSDT",
+      "listed_from": 1774224000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "PERPUSDT",
+      "listed_from": 1678060800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "PHBUSDT",
+      "listed_from": 1676505600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "PLTRUSDT",
+      "listed_from": 1770595200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "PONKEUSDT",
+      "listed_from": 1730678400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "PORT3USDT",
+      "listed_from": 1748995200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "PUFFERUSDT",
+      "listed_from": 1748995200000,
+      "delisted_at": 1775692800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "QQQUSDT",
+      "listed_from": 1775433600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "QUICKUSDT",
+      "listed_from": 1725580800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RADUSDT",
+      "listed_from": 1683676800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RAYUSDT",
+      "listed_from": 1629417600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RDNTUSDT",
+      "listed_from": 1680652800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "REEFUSDT",
+      "listed_from": 1613952000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "REIUSDT",
+      "listed_from": 1727395200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RENUSDT",
+      "listed_from": 1602547200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RLSUSDT",
+      "listed_from": 1764633600000,
+      "delisted_at": 1775692800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "RVVUSDT",
+      "listed_from": 1760745600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SCUSDT",
+      "listed_from": 1618185600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SKATEUSDT",
+      "listed_from": 1749427200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SLERFUSDT",
+      "listed_from": 1732147200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SNDKUSDT",
+      "listed_from": 1775520000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "SNTUSDT",
+      "listed_from": 1698883200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SPYUSDT",
+      "listed_from": 1775433600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "STMXUSDT",
+      "listed_from": 1616371200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "STPTUSDT",
+      "listed_from": 1697587200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "STRAXUSDT",
+      "listed_from": 1696982400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SWELLUSDT",
+      "listed_from": 1731024000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SXPUSDT",
+      "listed_from": 1595289600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "SYSUSDT",
+      "listed_from": 1724025600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "TANSSIUSDT",
+      "listed_from": 1752019200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TOKENUSDT",
+      "listed_from": 1698969600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TROYUSDT",
+      "listed_from": 1730332800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TRUUSDT",
+      "listed_from": 1678147200000,
+      "delisted_at": 1776816000000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "TSLAUSDT",
+      "listed_from": 1769558400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "TSMUSDT",
+      "listed_from": 1775433600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "UNFIUSDT",
+      "listed_from": 1613692800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "UXLINKUSDT",
+      "listed_from": 1726358400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "VFYUSDT",
+      "listed_from": 1759190400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "VIDTUSDT",
+      "listed_from": 1724371200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "VINEUSDT",
+      "listed_from": 1737676800000,
+      "delisted_at": 1777420800000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "VOXELUSDT",
+      "listed_from": 1724112000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "WAVESUSDT",
+      "listed_from": 1597190400000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "XAGUSDT",
+      "listed_from": 1767744000000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "XAUUSDT",
+      "listed_from": 1765411200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "XCNUSDT",
+      "listed_from": 1744329600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "XEMUSDT",
+      "listed_from": 1614729600000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "XPDUSDT",
+      "listed_from": 1769731200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "XPTUSDT",
+      "listed_from": 1769731200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only"
+    },
+    {
+      "symbol": "YALAUSDT",
+      "listed_from": 1754524800000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ZKJUSDT",
+      "listed_from": 1747094400000,
+      "delisted_at": 1777507200000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    },
+    {
+      "symbol": "ZRCUSDT",
+      "listed_from": 1753747200000,
+      "delisted_at": 1777593600000,
+      "status": "settling",
+      "kline_coverage": 1.0,
+      "funding_coverage": 1.0,
+      "confidence": "high",
+      "missing_data_reason": "settling_or_close_only;delisting_freeze_tail"
+    }
+  ]
+}

--- a/research/nautilus_scalping/data_manifests/pit_universe.v1.meta.json
+++ b/research/nautilus_scalping/data_manifests/pit_universe.v1.meta.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "pit_universe.v1",
+  "snapshot_hash": "e715de33042e9b897ecc43e016ad4b651bbbf58c522fa8e14f1c762593a16cf6",
+  "symbol_count": 843,
+  "source": "data.binance.vision/futures/um (ROB-349 build_pit_universe.py)",
+  "source_records": 843,
+  "build_window": "2020-01..2026-05 (archived monthly klines coverage)",
+  "note": "Metadata only \u2014 no raw OHLCV. Day-precise active_from/active_to mapped to epoch-ms listed_from/delisted_at (exclusive). strict_usdt_perp() applied at use."
+}

--- a/research/nautilus_scalping/pit_bars.py
+++ b/research/nautilus_scalping/pit_bars.py
@@ -1,0 +1,66 @@
+"""ROB-353 (PR1) — load PIT-trimmed bars from downloaded klines (data half of the PR2 bridge).
+
+Reads the standard Binance kline CSV under ``pit_data_root()/klines/<interval>/<symbol>/``,
+emits ``families.Bar`` (ts, high, low, close), trimmed to PIT membership (the manifest's
+survivorship-safe ``tradeable_at`` window) with leading/trailing zero-volume bars dropped.
+Pure transformation — no network. ``load_panel`` returns per-symbol (ts, close) series for
+cross-sectional families.
+"""
+from __future__ import annotations
+
+import csv
+import glob
+from pathlib import Path
+
+import families
+from artifact_paths import pit_data_root
+from pit_universe import PITManifest
+
+_KCOLS = ("open_time", "open", "high", "low", "close", "volume")
+
+
+def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float, float, float, float]]:
+    """Return sorted, de-duplicated (ts, high, low, close, volume) for a symbol."""
+    d = root / "klines" / interval / symbol
+    seen: dict[int, tuple[int, float, float, float, float]] = {}
+    for path in sorted(glob.glob(str(d / f"{symbol}-{interval}-*.csv"))):
+        with open(path, newline="") as fh:
+            reader = csv.reader(fh)
+            for row in reader:
+                if not row or row[0].lower().startswith("open_time"):
+                    continue
+                try:
+                    ts = int(row[0])
+                    seen[ts] = (ts, float(row[2]), float(row[3]), float(row[4]), float(row[5]))
+                except (ValueError, IndexError):
+                    continue
+    return [seen[k] for k in sorted(seen)]
+
+
+def _trim_zero_vol_edges(rows):
+    lo, hi = 0, len(rows)
+    while lo < hi and rows[lo][4] <= 0.0:
+        lo += 1
+    while hi > lo and rows[hi - 1][4] <= 0.0:
+        hi -= 1
+    return rows[lo:hi]
+
+
+def load_bars(symbol: str, interval: str, manifest: PITManifest, root=None) -> list[families.Bar]:
+    root = Path(root) if root else pit_data_root()
+    listing = next((x for x in manifest.listings if x.symbol == symbol), None)
+    rows = _read_rows(symbol, interval, root)
+    if listing is not None:
+        rows = [r for r in rows if listing.tradeable_at(r[0])]
+    rows = _trim_zero_vol_edges(rows)
+    return [families.Bar(ts=r[0], high=r[1], low=r[2], close=r[3]) for r in rows]
+
+
+def load_panel(symbols, interval: str, manifest: PITManifest, root=None) -> dict[str, list[tuple[int, float]]]:
+    root = Path(root) if root else pit_data_root()
+    out: dict[str, list[tuple[int, float]]] = {}
+    for s in symbols:
+        bars = load_bars(s, interval, manifest, root=root)
+        if bars:
+            out[s] = [(b.ts, b.close) for b in bars]
+    return out

--- a/research/nautilus_scalping/pit_bars.py
+++ b/research/nautilus_scalping/pit_bars.py
@@ -16,8 +16,6 @@ import families
 from artifact_paths import pit_data_root
 from pit_universe import PITManifest
 
-_KCOLS = ("open_time", "open", "high", "low", "close", "volume")
-
 
 def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float, float, float, float]]:
     """Return sorted, de-duplicated (ts, high, low, close, volume) for a symbol."""
@@ -29,6 +27,7 @@ def _read_rows(symbol: str, interval: str, root: Path) -> list[tuple[int, float,
             for row in reader:
                 if not row or row[0].lower().startswith("open_time"):
                     continue
+                # Binance kline columns: 0=open_time(ms) 2=high 3=low 4=close 5=volume
                 try:
                     ts = int(row[0])
                     seen[ts] = (ts, float(row[2]), float(row[3]), float(row[4]), float(row[5]))

--- a/research/nautilus_scalping/pit_klines_fetcher.py
+++ b/research/nautilus_scalping/pit_klines_fetcher.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""ROB-353 (PR1) — download Binance USDⓈ-M public klines dumps (1d, 1h).
+
+Pure stdlib. PUBLIC data only (data.binance.vision) — no keys, no auth, no orders.
+Each archive is verified against its sibling ``.CHECKSUM`` when published. Writes
+under ``artifact_paths.pit_data_root()`` (gitignored). No secrets are printed.
+
+Usage:
+    uv run --no-project python pit_klines_fetcher.py --symbol EOSUSDT \\
+        --interval 1d --from-month 2023-01 --to-month 2024-01
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+from artifact_paths import pit_data_root
+
+BASE = "https://data.binance.vision/data"
+SUPPORTED_INTERVALS = ("1d", "1h")
+_CHUNK = 1 << 16
+
+
+def kline_url(symbol, interval, year, month, market="um", cadence="monthly", day=None):
+    if interval not in SUPPORTED_INTERVALS:
+        raise ValueError(f"unsupported interval {interval!r}; expected {SUPPORTED_INTERVALS}")
+    if cadence == "monthly":
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}"
+        sub = f"futures/{market}/monthly/klines/{symbol}/{interval}"
+    elif cadence == "daily":
+        if day is None:
+            raise ValueError("daily cadence requires day")
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}-{day:02d}"
+        sub = f"futures/{market}/daily/klines/{symbol}/{interval}"
+    else:
+        raise ValueError(f"unknown cadence {cadence!r}")
+    return f"{BASE}/{sub}/{stem}.zip"
+
+
+def _download(url: str, dest: Path) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp, dest.open("wb") as fh:
+            while chunk := resp.read(_CHUNK):
+                fh.write(chunk)
+        return True
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while chunk := fh.read(_CHUNK):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify(zip_path: Path, checksum_path: Path) -> None:
+    expected = checksum_path.read_text().split()[0].strip().lower()
+    if _sha256(zip_path) != expected:
+        raise ValueError(f"checksum mismatch for {zip_path.name}")
+
+
+def _months(from_month: str, to_month: str):
+    y0, m0 = int(from_month[:4]), int(from_month[5:7])
+    y1, m1 = int(to_month[:4]), int(to_month[5:7])
+    cur = y0 * 12 + (m0 - 1)
+    end = y1 * 12 + (m1 - 1)
+    while cur <= end:
+        yield cur // 12, cur % 12 + 1
+        cur += 1
+
+
+def fetch_months(symbol, interval, from_month, to_month, market="um", out_root=None) -> dict:
+    out_root = Path(out_root) if out_root else pit_data_root()
+    out_dir = out_root / "klines" / interval / symbol
+    out_dir.mkdir(parents=True, exist_ok=True)
+    downloaded = skipped = missing = 0
+    for year, month in _months(from_month, to_month):
+        stem = f"{symbol}-{interval}-{year:04d}-{month:02d}"
+        csv_path = out_dir / f"{stem}.csv"
+        if csv_path.exists():
+            skipped += 1
+            continue
+        url = kline_url(symbol, interval, year, month, market=market, cadence="monthly")
+        zip_path = out_dir / f"{stem}.zip"
+        if not _download(url, zip_path):
+            missing += 1
+            continue
+        chk_path = out_dir / f"{stem}.zip.CHECKSUM"
+        if _download(f"{url}.CHECKSUM", chk_path):
+            _verify(zip_path, chk_path)
+            chk_path.unlink()
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(out_dir)
+        zip_path.unlink()
+        downloaded += 1
+    return {"downloaded": downloaded, "skipped": skipped, "missing": missing, "dir": str(out_dir)}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Download Binance USDⓈ-M public klines (1d/1h)")
+    ap.add_argument("--symbol", required=True)
+    ap.add_argument("--interval", choices=SUPPORTED_INTERVALS, required=True)
+    ap.add_argument("--from-month", required=True, help="YYYY-MM")
+    ap.add_argument("--to-month", required=True, help="YYYY-MM")
+    ap.add_argument("--market", default="um")
+    args = ap.parse_args(argv)
+    summary = fetch_months(args.symbol, args.interval, args.from_month, args.to_month, args.market)
+    print(f"done: {summary['downloaded']} downloaded, {summary['skipped']} skipped, "
+          f"{summary['missing']} missing -> {summary['dir']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/pit_universe.py
+++ b/research/nautilus_scalping/pit_universe.py
@@ -20,10 +20,22 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
 _META_FIELDS = ("status", "kline_coverage", "funding_coverage", "confidence", "missing_data_reason")
+
+
+def _date_to_epoch_ms(date_str: str) -> int:
+    """Midnight-UTC epoch ms for ``YYYY-MM-DD``."""
+    dt = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
+def _month_first_day(month_str: str) -> str:
+    """``YYYY-MM`` -> ``YYYY-MM-01``."""
+    return f"{month_str}-01"
 
 
 @dataclass(frozen=True)
@@ -78,6 +90,36 @@ class PITManifest:
                 raise ValueError(f"duplicate symbol in manifest: {listing.symbol}")
             seen.add(listing.symbol)
         return cls(listings=listings)
+
+    @classmethod
+    def from_pit_index_records(cls, rows: list[dict]) -> PITManifest:
+        """Build from ROB-349 index rows (day-precise active_from/active_to)."""
+        recs: list[dict] = []
+        for r in rows:
+            af = r.get("active_from") or (
+                _month_first_day(r["first_seen"]) if r.get("first_seen") else None
+            )
+            if not af:
+                continue
+            listed_from = _date_to_epoch_ms(af)
+            at = r.get("active_to")
+            if at in (None, "ongoing"):
+                delisted_at = None
+            else:
+                delisted_at = _date_to_epoch_ms(
+                    (datetime.strptime(at, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+                )
+            recs.append({
+                "symbol": r["symbol"],
+                "listed_from": listed_from,
+                "delisted_at": delisted_at,
+                "status": r.get("status"),
+                "kline_coverage": r.get("kline_coverage"),
+                "funding_coverage": r.get("funding_coverage"),
+                "confidence": r.get("confidence"),
+                "missing_data_reason": r.get("missing_data_reason") or None,
+            })
+        return cls.from_records(recs)
 
     def to_records(self) -> list[dict]:
         out = []

--- a/research/nautilus_scalping/pit_universe.py
+++ b/research/nautilus_scalping/pit_universe.py
@@ -18,6 +18,7 @@ delisted_at``).
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -141,6 +142,26 @@ class PITManifest:
         return frozenset(
             x.symbol for x in self.listings if x.tradeable_at(ts, min_seasoning)
         )
+
+    def strict_usdt_perp(self) -> PITManifest:
+        """Perp-only honest universe: live/dead plain *USDT, excl. settling/BUSD/USDC/dated/SETTLED."""
+        kept = tuple(
+            x for x in self.listings
+            if x.status in ("live", "dead")
+            and x.symbol.endswith("USDT")
+            and "_" not in x.symbol
+            and "SETTLED" not in x.symbol
+        )
+        return PITManifest(listings=kept)
+
+    def snapshot_hash(self) -> str:
+        """Stable sha256 over canonical (order-independent) records — pins a committed manifest."""
+        canon = json.dumps(
+            sorted(self.to_records(), key=lambda r: r["symbol"]),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canon.encode()).hexdigest()
 
     @classmethod
     def load(cls, path: str | Path) -> PITManifest:

--- a/research/nautilus_scalping/pit_universe.py
+++ b/research/nautilus_scalping/pit_universe.py
@@ -21,6 +21,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
+
+_META_FIELDS = ("status", "kline_coverage", "funding_coverage", "confidence", "missing_data_reason")
 
 
 @dataclass(frozen=True)
@@ -28,6 +31,11 @@ class SymbolListing:
     symbol: str
     listed_from: int
     delisted_at: int | None = None
+    status: Literal["live", "settling", "dead"] | None = None
+    kline_coverage: float | None = None
+    funding_coverage: float | None = None
+    confidence: Literal["high", "medium", "low"] | None = None
+    missing_data_reason: str | None = None
 
     def validate(self) -> SymbolListing:
         if self.delisted_at is not None and self.delisted_at < self.listed_from:
@@ -56,6 +64,11 @@ class PITManifest:
                 symbol=r["symbol"],
                 listed_from=int(r["listed_from"]),
                 delisted_at=None if r.get("delisted_at") is None else int(r["delisted_at"]),
+                status=r.get("status"),
+                kline_coverage=r.get("kline_coverage"),
+                funding_coverage=r.get("funding_coverage"),
+                confidence=r.get("confidence"),
+                missing_data_reason=r.get("missing_data_reason"),
             ).validate()
             for r in records
         )
@@ -67,10 +80,19 @@ class PITManifest:
         return cls(listings=listings)
 
     def to_records(self) -> list[dict]:
-        return [
-            {"symbol": x.symbol, "listed_from": x.listed_from, "delisted_at": x.delisted_at}
-            for x in self.listings
-        ]
+        out = []
+        for x in self.listings:
+            rec: dict = {
+                "symbol": x.symbol,
+                "listed_from": x.listed_from,
+                "delisted_at": x.delisted_at,
+            }
+            for f in _META_FIELDS:
+                v = getattr(x, f)
+                if v is not None:
+                    rec[f] = v
+            out.append(rec)
+        return out
 
     def universe_as_of(self, ts: int, min_seasoning: int = 0) -> frozenset[str]:
         """Symbols tradeable at ``ts`` (survivorship-safe). Call per rebalance."""

--- a/research/nautilus_scalping/tests/test_artifact_paths.py
+++ b/research/nautilus_scalping/tests/test_artifact_paths.py
@@ -1,0 +1,23 @@
+import importlib
+
+import artifact_paths
+
+
+def test_pit_data_root_defaults_to_repo_data(monkeypatch):
+    monkeypatch.delenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", raising=False)
+    importlib.reload(artifact_paths)
+    root = artifact_paths.pit_data_root()
+    assert root.name == "data"
+    assert root.parent.name == "nautilus_scalping"
+
+
+def test_pit_data_root_honors_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", str(tmp_path))
+    root = artifact_paths.pit_data_root()
+    assert root == tmp_path / "data"
+
+
+def test_pit_data_root_blank_env_falls_back(monkeypatch):
+    monkeypatch.setenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", "   ")
+    root = artifact_paths.pit_data_root()
+    assert root.name == "data" and root.parent.name == "nautilus_scalping"

--- a/research/nautilus_scalping/tests/test_pit_bars.py
+++ b/research/nautilus_scalping/tests/test_pit_bars.py
@@ -1,0 +1,50 @@
+# tests/test_pit_bars.py
+import pit_bars
+import pit_universe
+
+KCOLS = "open_time,open,high,low,close,volume,close_time,qv,n,tbv,tbqv,ig"
+DAY = 86_400_000
+
+
+def _write_csv(root, symbol, interval, month, rows):
+    d = root / "klines" / interval / symbol
+    d.mkdir(parents=True, exist_ok=True)
+    lines = [KCOLS] + [",".join(str(x) for x in r) for r in rows]
+    (d / f"{symbol}-{interval}-{month}.csv").write_text("\n".join(lines) + "\n")
+
+
+def test_load_bars_trims_to_membership_and_zero_vol_tail(tmp_path):
+    rows = [
+        [0 * DAY, 10, 11, 9, 10, 0.0, 0, 0, 0, 0, 0, 0],
+        [1 * DAY, 10, 12, 9, 11, 5.0, 0, 0, 0, 0, 0, 0],
+        [2 * DAY, 11, 13, 10, 12, 6.0, 0, 0, 0, 0, 0, 0],
+        [3 * DAY, 12, 14, 11, 13, 7.0, 0, 0, 0, 0, 0, 0],
+        [4 * DAY, 13, 13, 13, 13, 0.0, 0, 0, 0, 0, 0, 0],
+    ]
+    _write_csv(tmp_path, "EOSUSDT", "1d", "1970-01", rows)
+    m = pit_universe.PITManifest.from_records(
+        [{"symbol": "EOSUSDT", "listed_from": 1 * DAY, "delisted_at": 4 * DAY}]
+    )
+    bars = pit_bars.load_bars("EOSUSDT", "1d", m, root=tmp_path)
+    assert [b.ts for b in bars] == [1 * DAY, 2 * DAY, 3 * DAY]
+    assert bars[0].close == 11 and bars[-1].close == 13
+
+
+def test_load_bars_unknown_symbol_returns_empty(tmp_path):
+    m = pit_universe.PITManifest.from_records([{"symbol": "X", "listed_from": 0}])
+    assert pit_bars.load_bars("X", "1d", m, root=tmp_path) == []
+
+
+def test_load_panel_aligns_close_series(tmp_path):
+    _write_csv(tmp_path, "AUSDT", "1d", "1970-01",
+               [[1 * DAY, 1, 1, 1, 100, 5, 0, 0, 0, 0, 0, 0],
+                [2 * DAY, 1, 1, 1, 110, 5, 0, 0, 0, 0, 0, 0]])
+    _write_csv(tmp_path, "BUSDT", "1d", "1970-01",
+               [[1 * DAY, 1, 1, 1, 200, 5, 0, 0, 0, 0, 0, 0],
+                [2 * DAY, 1, 1, 1, 220, 5, 0, 0, 0, 0, 0, 0]])
+    m = pit_universe.PITManifest.from_records([
+        {"symbol": "AUSDT", "listed_from": 0}, {"symbol": "BUSDT", "listed_from": 0},
+    ])
+    panel = pit_bars.load_panel(["AUSDT", "BUSDT"], "1d", m, root=tmp_path)
+    assert panel["AUSDT"] == [(1 * DAY, 100.0), (2 * DAY, 110.0)]
+    assert panel["BUSDT"] == [(1 * DAY, 200.0), (2 * DAY, 220.0)]

--- a/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
+++ b/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
@@ -1,0 +1,32 @@
+# tests/test_pit_data_layer_guard.py
+import ast
+from pathlib import Path
+
+import artifact_paths
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py"]
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_no_app_imports_in_data_layer():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            assert not name.startswith("app"), f"{mod} imports forbidden app module {name!r}"
+
+
+def test_pit_data_root_is_gitignored(monkeypatch):
+    monkeypatch.delenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", raising=False)
+    root = artifact_paths.pit_data_root()
+    gitignore = (_ROOT / ".gitignore").read_text()
+    assert "data/" in gitignore
+    assert root.name == "data"

--- a/research/nautilus_scalping/tests/test_pit_klines_fetcher.py
+++ b/research/nautilus_scalping/tests/test_pit_klines_fetcher.py
@@ -1,0 +1,22 @@
+import pit_klines_fetcher as f
+import pytest
+
+
+def test_kline_url_monthly_um():
+    url = f.kline_url("EOSUSDT", "1d", 2024, 1, market="um", cadence="monthly")
+    assert url == ("https://data.binance.vision/data/futures/um/monthly/klines/"
+                   "EOSUSDT/1d/EOSUSDT-1d-2024-01.zip")
+
+
+def test_kline_url_daily_1h_zero_pads():
+    url = f.kline_url("BTCUSDT", "1h", 2026, 3, market="um", cadence="daily", day=5)
+    assert url.endswith("futures/um/daily/klines/BTCUSDT/1h/BTCUSDT-1h-2026-03-05.zip")
+
+
+def test_kline_url_rejects_unknown_interval():
+    with pytest.raises(ValueError, match="interval"):
+        f.kline_url("BTCUSDT", "5m", 2024, 1)
+
+
+def test_intervals_supported():
+    assert set(f.SUPPORTED_INTERVALS) == {"1d", "1h"}

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -10,8 +10,14 @@ ts/listed_from/delisted_at/min_seasoning are all integers in the SAME unit
 (caller-defined, e.g. epoch ms); delisted_at is exclusive, None = still live.
 """
 
+import json
+from pathlib import Path
+
 import pit_universe
 from pit_universe import PITManifest, SymbolListing
+
+_MANIFEST = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.json"
+_META = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.meta.json"
 
 
 def _manifest():
@@ -151,3 +157,17 @@ def test_snapshot_hash_is_stable_and_order_independent():
     ])
     assert a.snapshot_hash() == b.snapshot_hash()
     assert len(a.snapshot_hash()) == 64
+
+
+def test_committed_manifest_loads_and_hash_matches_meta():
+    m = pit_universe.PITManifest.load(_MANIFEST)
+    meta = json.loads(_META.read_text())
+    assert len(m.listings) == meta["symbol_count"]
+    assert m.snapshot_hash() == meta["snapshot_hash"]
+
+
+def test_committed_manifest_has_a_usable_perp_universe():
+    m = pit_universe.PITManifest.load(_MANIFEST).strict_usdt_perp()
+    assert len(m.listings) > 100
+    syms = {x.symbol for x in m.listings}
+    assert {"EOSUSDT", "GALUSDT", "HNTUSDT"}.issubset(syms)

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -92,3 +92,31 @@ def test_symbollisting_metadata_defaults_none():
     only = m.listings[0]
     assert only.status is None and only.confidence is None
     assert pit_universe.PITManifest.from_records(m.to_records()).listings[0].symbol == "BTCUSDT"
+
+
+def test_from_pit_index_records_maps_dates_to_epoch_ms():
+    rows = [
+        {"symbol": "EOSUSDT", "status": "dead", "first_seen": "2023-01", "last_seen": "2024-01",
+         "active_from": "2023-01-26", "active_to": "2024-01-11",
+         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
+         "missing_data_reason": "delisted"},
+        {"symbol": "BTCUSDT", "status": "live", "first_seen": "2020-01", "last_seen": "2026-05",
+         "active_from": "2020-01-01", "active_to": "ongoing",
+         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
+         "missing_data_reason": ""},
+    ]
+    m = pit_universe.PITManifest.from_pit_index_records(rows)
+    eos = next(x for x in m.listings if x.symbol == "EOSUSDT")
+    btc = next(x for x in m.listings if x.symbol == "BTCUSDT")
+    assert eos.listed_from == pit_universe._date_to_epoch_ms("2023-01-26")
+    assert eos.delisted_at == pit_universe._date_to_epoch_ms("2024-01-12")
+    assert btc.delisted_at is None
+    assert eos.tradeable_at(pit_universe._date_to_epoch_ms("2024-01-11"))
+    assert not eos.tradeable_at(pit_universe._date_to_epoch_ms("2024-01-12"))
+
+
+def test_from_pit_index_records_skips_rows_without_dates():
+    rows = [{"symbol": "GHOSTUSDT", "status": "dead", "first_seen": None, "last_seen": None,
+             "active_from": None, "active_to": None}]
+    m = pit_universe.PITManifest.from_pit_index_records(rows)
+    assert m.listings == ()

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -120,3 +120,34 @@ def test_from_pit_index_records_skips_rows_without_dates():
              "active_from": None, "active_to": None}]
     m = pit_universe.PITManifest.from_pit_index_records(rows)
     assert m.listings == ()
+
+
+def _row(sym, status):
+    return {"symbol": sym, "status": status, "active_from": "2023-01-01", "active_to": "2024-01-01"}
+
+
+def test_strict_usdt_perp_keeps_live_and_dead_plain_usdt():
+    rows = [
+        _row("BTCUSDT", "live"), _row("EOSUSDT", "dead"),
+        _row("ETHUSDC", "live"),
+        _row("BTCBUSD", "dead"),
+        _row("BTCUSDT_230331", "settling"),
+        _row("XRPUSDT", "settling"),
+        _row("FOOUSDT-SETTLED", "dead"),
+    ]
+    m = pit_universe.PITManifest.from_pit_index_records(rows).strict_usdt_perp()
+    kept = {x.symbol for x in m.listings}
+    assert kept == {"BTCUSDT", "EOSUSDT"}
+
+
+def test_snapshot_hash_is_stable_and_order_independent():
+    a = pit_universe.PITManifest.from_records([
+        {"symbol": "A", "listed_from": 1, "delisted_at": None},
+        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+    ])
+    b = pit_universe.PITManifest.from_records([
+        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+        {"symbol": "A", "listed_from": 1, "delisted_at": None},
+    ])
+    assert a.snapshot_hash() == b.snapshot_hash()
+    assert len(a.snapshot_hash()) == 64

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -171,3 +171,12 @@ def test_committed_manifest_has_a_usable_perp_universe():
     assert len(m.listings) > 100
     syms = {x.symbol for x in m.listings}
     assert {"EOSUSDT", "GALUSDT", "HNTUSDT"}.issubset(syms)
+
+
+def test_expected_months_inclusive_span():
+    import build_pit_universe as b
+
+    assert b.expected_months("2023-01", "2023-01") == 1
+    assert b.expected_months("2023-01", "2023-12") == 12
+    assert b.expected_months("2023-11", "2024-02") == 4
+    assert b.expected_months(None, "2024-02") == 0

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -10,6 +10,7 @@ ts/listed_from/delisted_at/min_seasoning are all integers in the SAME unit
 (caller-defined, e.g. epoch ms); delisted_at is exclusive, None = still live.
 """
 
+import pit_universe
 from pit_universe import PITManifest, SymbolListing
 
 
@@ -67,3 +68,27 @@ def test_rejects_delist_before_list():
     except ValueError:
         return
     raise AssertionError("expected ValueError for delisted_at < listed_from")
+
+
+def test_symbollisting_optional_metadata_roundtrips():
+    rec = {
+        "symbol": "EOSUSDT", "listed_from": 1672531200000, "delisted_at": 1700000000000,
+        "status": "dead", "kline_coverage": 1.0, "funding_coverage": 1.0,
+        "confidence": "high", "missing_data_reason": "delisted",
+    }
+    m = pit_universe.PITManifest.from_records([rec])
+    (only,) = m.listings
+    assert only.status == "dead"
+    assert only.kline_coverage == 1.0
+    assert only.confidence == "high"
+    back = pit_universe.PITManifest.from_records(m.to_records())
+    assert back.listings[0].missing_data_reason == "delisted"
+
+
+def test_symbollisting_metadata_defaults_none():
+    m = pit_universe.PITManifest.from_records(
+        [{"symbol": "BTCUSDT", "listed_from": 0, "delisted_at": None}]
+    )
+    only = m.listings[0]
+    assert only.status is None and only.confidence is None
+    assert pit_universe.PITManifest.from_records(m.to_records()).listings[0].symbol == "BTCUSDT"


### PR DESCRIPTION
## What

PR1 of 2 for ROB-353. Durableizes the ROB-349 Binance USDⓈ-M point-in-time (PIT) universe + klines prototype into reusable, tested repo infra under `research/nautilus_scalping/`, so PR2 can run families 1–3 through the committed ROB-351 funnel on survivorship-safe data.

**Research/backtest only.** No live trading, no Demo `confirm=true`, no broker/order/watch/scheduler/DB mutation, no `/invest` exposure. The empirical RUN + verdict are PR2.

## Components
- `artifact_paths.pit_data_root()` — gitignored raw-data root (env or repo `data/`).
- `pit_universe.py` (extended) — optional ROB-349 metadata fields (status/coverage/confidence), `from_pit_index_records` (day-precise → epoch-ms, exclusive `delisted_at`), `strict_usdt_perp()` (live/dead plain `*USDT`; excl settling/BUSD/USDC/dated/SETTLED), `snapshot_hash()`.
- `data_manifests/pit_universe.v1.json` + `.meta.json` — committed **metadata-only** manifest (843 symbols, hash-pinned). No raw OHLCV.
- `build_pit_universe.py` — ported ROB-349 index builder (read-only public data; network RUN operator-gated; import side-effect-free).
- `pit_klines_fetcher.py` — public 1d/1h klines fetcher (checksum-verified, 404-tolerant, no keys).
- `pit_bars.py` — PIT-trimmed `families.Bar` loader + cross-sectional panel accessor (the data half of the PR2 bridge).
- Tests + AST import-guard (no `app.*`, raw-data gitignored) + runbook.

## Verification
- `pytest -q --ignore=tests/test_signal_parity.py` → **165 passed, 1 skipped**. (`test_signal_parity` is a pre-existing `nautilus_trader`-dependency collection error, unrelated to this branch.)
- Frozen funnel config untouched: `run_rob351_campaign.py --self-test` config_hash `8f02dffd…` unchanged.
- No `.csv`/`.parquet`/`data/` committed — only metadata JSON manifests.

## Boundaries verified (final review)
Raw-data-not-committed ✅ · no `app.*` imports ✅ · no import-time I/O ✅ · no live/broker/scheduler code ✅ · frozen config intact ✅. End-to-end composition (manifest → strict_usdt_perp → pit_bars → families.Bar) verified by execution.

## Known follow-ups (Minor, non-blocking)
- `build_pit_universe.write_outputs` emits a minimal `.meta.json`; the committed v1 sidecar has extra hand annotations (`build_window`/`note`) that regeneration overwrites — documented in the runbook; fold richer-meta emission into PR2.

## Context
Spec: `docs/superpowers/specs/2026-05-29-rob-353-pit-data-layer-design.md`
Plan: `docs/superpowers/plans/2026-05-29-rob-353-pit-data-layer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added runbook, planning document, and design specification for PIT data layer workflow
  
* **New Features**
  * Added CLI tools to download Binance kline data and build PIT universe metadata
  * Added ability to load kline bars trimmed to PIT membership windows
  * Extended PIT manifest with filtering capabilities for perpetuals and snapshot integrity verification

* **Tests**
  * Added comprehensive test coverage for data layer functionality, import guards, and manifest operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->