### PR TITLE
feat(ROB-352): snapshot evidence + prior-report hygiene (Slice B)

### DIFF
--- a/alembic/versions/20260529_rob352_cited_snapshot_uuids.py
+++ b/alembic/versions/20260529_rob352_cited_snapshot_uuids.py
@@ -1,0 +1,36 @@
+"""rob352 per-item cited_snapshot_uuids
+
+Revision ID: 20260529_rob352
+Revises: 20260527_rob329
+Create Date: 2026-05-29
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260529_rob352"
+down_revision: str | Sequence[str] | None = "20260527_rob329"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investment_report_items",
+        sa.Column(
+            "cited_snapshot_uuids",
+            sa.ARRAY(sa.UUID()),
+            server_default=sa.text("ARRAY[]::uuid[]"),
+            nullable=False,
+        ),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "investment_report_items", "cited_snapshot_uuids", schema="review"
+    )

--- a/alembic/versions/20260529_rob352_cited_snapshot_uuids.py
+++ b/alembic/versions/20260529_rob352_cited_snapshot_uuids.py
@@ -31,6 +31,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column(
-        "investment_report_items", "cited_snapshot_uuids", schema="review"
-    )
+    op.drop_column("investment_report_items", "cited_snapshot_uuids", schema="review")

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -361,6 +361,14 @@ class InvestmentReportItem(Base):
         nullable=False,
         server_default=text("ARRAY[]::uuid[]"),
     )
+    # ROB-352 Slice B — per-item snapshot provenance citations. Mirrors
+    # cited_dimension_report_uuids; derived from the item's evidence_snapshot
+    # by the generator unless the caller supplies them explicitly.
+    cited_snapshot_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("ARRAY[]::uuid[]"),
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -162,6 +162,7 @@ class IngestReportItem(BaseModel):
     decision_bucket: str | None = None
     cited_symbol_report_uuid: UUID | None = None
     cited_dimension_report_uuids: list[UUID] = Field(default_factory=list)
+    cited_snapshot_uuids: list[UUID] = Field(default_factory=list)
 
     @field_validator("decision_bucket")
     @classmethod
@@ -404,6 +405,7 @@ class InvestmentReportItemResponse(BaseModel):
     decision_bucket: str | None = None
     cited_symbol_report_uuid: UUID | None = None
     cited_dimension_report_uuids: list[UUID] = Field(default_factory=list)
+    cited_snapshot_uuids: list[UUID] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -139,6 +139,32 @@ def _derive_overall_from_kind_statuses(
     return _RANK_TO_KIND_STATUS[worst_rank]
 
 
+def _extract_cited_snapshot_uuids(evidence_snapshot: Any) -> list[UUID]:
+    """ROB-352 Slice B — collect snapshot UUIDs cited by an item's evidence.
+
+    Picks the ``snapshot_uuid`` key plus any ``*_snapshot_uuid`` extra
+    (candidate/portfolio/news). Skips non-UUID values; dedupes preserving
+    first-seen order.
+    """
+    if not isinstance(evidence_snapshot, Mapping):
+        return []
+    out: list[UUID] = []
+    seen: set[UUID] = set()
+    for key, value in evidence_snapshot.items():
+        if key != "snapshot_uuid" and not str(key).endswith("_snapshot_uuid"):
+            continue
+        if not isinstance(value, (str, UUID)):
+            continue
+        try:
+            parsed = value if isinstance(value, UUID) else UUID(str(value))
+        except (ValueError, AttributeError, TypeError):
+            continue
+        if parsed not in seen:
+            seen.add(parsed)
+            out.append(parsed)
+    return out
+
+
 def _optional_kind_names(coverage_summary: Any) -> frozenset[str]:
     """Kinds that must not pollute the derived core ``overall`` (ROB-323).
 
@@ -669,6 +695,12 @@ class SnapshotBackedReportGenerator:
             ):
                 if key in item_dict and item_dict[key] is not None:
                     item_dict[key] = to_jsonable(item_dict[key])
+            # ROB-352 Slice B — derive snapshot citations from evidence unless
+            # the caller supplied them explicitly.
+            if not item_dict.get("cited_snapshot_uuids"):
+                item_dict["cited_snapshot_uuids"] = _extract_cited_snapshot_uuids(
+                    item_dict.get("evidence_snapshot") or {}
+                )
             normalized_items.append(item_dict)
 
         metadata = to_jsonable(dict(request.metadata) or {})

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -326,6 +326,11 @@ class SnapshotBackedReportGenerator:
         )
         source_conflicts: dict[str, Any] = {}
 
+        market_snapshot, portfolio_snapshot = await self._section_snapshot_descriptors(
+            bundle_uuid=ensure_response.bundle_uuid,
+            unavailable_sources=unavailable_sources,
+        )
+
         # ROB-318 Phase 3 — deterministic report diagnostics, computed before the
         # ingest request so they persist on the report row (PR-B). why_no_action
         # tells a genuine hold from a data-blocked / stale-gated one; the bundle
@@ -374,6 +379,8 @@ class SnapshotBackedReportGenerator:
             source_conflicts=source_conflicts,
             report_diagnostics=report_diagnostics,
             symbol_derivation=derivation,
+            market_snapshot=market_snapshot,
+            portfolio_snapshot=portfolio_snapshot,
         )
 
         # Authoritative gate runs inside ingest(); this pre-flight is a
@@ -517,6 +524,49 @@ class SnapshotBackedReportGenerator:
             request_market=request.market,
             account_scope=request.account_scope,
         )
+
+    async def _section_snapshot_descriptors(
+        self,
+        *,
+        bundle_uuid: UUID,
+        unavailable_sources: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """ROB-352 Slice B — compact provenance descriptors for the report's
+        market / portfolio sections.
+
+        Pointer + freshness into ``investment_snapshots`` (never a full
+        payload copy). Absent kinds get an explicit unavailable reason.
+        """
+
+        def _unavailable(kind: str) -> dict[str, Any]:
+            info = unavailable_sources.get(kind)
+            reason = "not_collected"
+            if isinstance(info, Mapping):
+                reason = str(info.get("reason") or info.get("status") or reason)
+            return {"status": "unavailable", "reason": reason}
+
+        def _descriptor(snapshot: Any) -> dict[str, Any]:
+            as_of = getattr(snapshot, "as_of", None)
+            return {
+                "snapshot_uuid": str(snapshot.snapshot_uuid),
+                "snapshot_kind": snapshot.snapshot_kind,
+                "as_of": as_of.isoformat() if as_of is not None else None,
+                "freshness_status": getattr(snapshot, "freshness_status", None),
+                "coverage": getattr(snapshot, "coverage_json", None) or {},
+            }
+
+        market = _unavailable("market")
+        portfolio = _unavailable("portfolio")
+        bundle = await self._snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+        if bundle is None:
+            return market, portfolio
+        pairs = await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
+        for _item, snapshot in pairs:
+            if snapshot.snapshot_kind == "market":
+                market = _descriptor(snapshot)
+            elif snapshot.snapshot_kind == "portfolio":
+                portfolio = _descriptor(snapshot)
+        return market, portfolio
 
     async def _build_classifier_context(
         self,
@@ -676,6 +726,8 @@ class SnapshotBackedReportGenerator:
         source_conflicts: dict[str, Any],
         report_diagnostics: dict[str, Any] | None = None,
         symbol_derivation: SymbolDerivation | None = None,
+        market_snapshot: dict[str, Any] | None = None,
+        portfolio_snapshot: dict[str, Any] | None = None,
     ) -> IngestReportRequest:
         # Normalise items — each evidence_snapshot / trigger_checklist /
         # max_action / metadata is a free-form dict the caller filled in,
@@ -733,8 +785,8 @@ class SnapshotBackedReportGenerator:
             risk_summary=request.risk_summary,
             thesis_text=request.thesis_text,
             no_action_note=request.no_action_note,
-            market_snapshot={},
-            portfolio_snapshot={},
+            market_snapshot=market_snapshot or {},
+            portfolio_snapshot=portfolio_snapshot or {},
             previous_report_uuid=request.previous_report_uuid,
             status=request.status,
             metadata=metadata,

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -309,4 +309,5 @@ class InvestmentReportIngestionService:
             decision_bucket=item_req.decision_bucket,
             cited_symbol_report_uuid=item_req.cited_symbol_report_uuid,
             cited_dimension_report_uuids=list(item_req.cited_dimension_report_uuids),
+            cited_snapshot_uuids=list(item_req.cited_snapshot_uuids),
         )

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -255,17 +255,24 @@ class InvestmentReportQueryService:
         the unresolved/deferred items, active watches, triggered watch
         events, and recent decisions that span those reports.
         """
+        # ROB-352 Slice B — fetch a buffer so dropping drafts (smoke
+        # boilerplate ships as draft) + the excluded uuid still yields up to
+        # n_prior published rows. NOTE: silently under-fills (returns < n_prior)
+        # if more than _DRAFT_FETCH_BUFFER consecutive drafts precede the last
+        # wanted published row; raise the buffer if smoke density grows.
+        _DRAFT_FETCH_BUFFER = 5
         prior_reports: list[InvestmentReport] = await self._repo.list_reports(
             market=market,
             market_session=market_session,
             account_scope=account_scope,
             report_type=report_type,
-            limit=n_prior + 1,  # +1 so we can drop the excluded one cleanly
+            limit=n_prior + 1 + _DRAFT_FETCH_BUFFER,
         )
         if exclude_report_uuid is not None:
             prior_reports = [
                 r for r in prior_reports if r.report_uuid != exclude_report_uuid
             ]
+        prior_reports = [r for r in prior_reports if r.status != "draft"]
         prior_reports = prior_reports[:n_prior]
 
         prior_report_uuids = [r.report_uuid for r in prior_reports]

--- a/docs/superpowers/plans/2026-05-29-rob-352-slice-b-snapshot-evidence.md
+++ b/docs/superpowers/plans/2026-05-29-rob-352-slice-b-snapshot-evidence.md
@@ -1,0 +1,674 @@
+# ROB-352 Slice B — snapshot evidence & prior-report hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make snapshot-backed reports auditable — add a per-item `cited_snapshot_uuids` citation column populated from evidence, populate report-level `market_snapshot`/`portfolio_snapshot` with compact bundle provenance descriptors, and exclude `status='draft'` smoke boilerplate from prior-report context.
+
+**Architecture:** Additive alembic column + ORM/schema/repository/response plumbing for `cited_snapshot_uuids` (mirrors ROB-308 `cited_dimension_report_uuids`). The generator derives citations deterministically from each item's `evidence_snapshot` and builds market/portfolio provenance descriptors from the frozen bundle's `market`/`portfolio` snapshots (pointer + freshness, never a full payload copy). The query service drops drafts before slicing `n_prior`.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async + alembic, Pydantic v2, pytest against the real-Postgres `session` fixture. `uv run pytest ...`. Spec: `docs/superpowers/specs/2026-05-29-rob-352-slice-b-snapshot-evidence-design.md`.
+
+**Conventions:** end commit messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`. Current alembic head = `20260527_rob329`.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `alembic/versions/<rev>_rob352_cited_snapshot_uuids.py` | NEW additive migration |
+| `app/models/investment_reports.py` | `InvestmentReportItem.cited_snapshot_uuids` ARRAY column |
+| `app/schemas/investment_reports.py` | `IngestReportItem` + `InvestmentReportItemResponse` field |
+| `app/services/investment_reports/repository.py` | `insert_item` passthrough |
+| `app/services/investment_reports/ingestion.py` | pass `cited_snapshot_uuids` to repo |
+| `app/services/action_report/snapshot_backed/generator.py` | derive citations + section descriptors |
+| `app/services/investment_reports/query_service.py` | drop `status='draft'` from prior_reports |
+| `tests/_investment_reports_helpers.py` | idempotent ALTER for the new column |
+
+---
+
+## Task B1: Migration + ORM column
+
+**Files:**
+- Create: `alembic/versions/rob352_cited_snapshot_uuids.py`
+- Modify: `app/models/investment_reports.py` (InvestmentReportItem, after `cited_dimension_report_uuids`)
+
+- [ ] **Step 1: Write the migration**
+
+Create `alembic/versions/rob352_cited_snapshot_uuids.py`:
+
+```python
+"""rob352 per-item cited_snapshot_uuids
+
+Revision ID: 20260529_rob352
+Revises: 20260527_rob329
+Create Date: 2026-05-29
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260529_rob352"
+down_revision: str | Sequence[str] | None = "20260527_rob329"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investment_report_items",
+        sa.Column(
+            "cited_snapshot_uuids",
+            sa.ARRAY(sa.UUID()),
+            server_default=sa.text("ARRAY[]::uuid[]"),
+            nullable=False,
+        ),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "investment_report_items", "cited_snapshot_uuids", schema="review"
+    )
+```
+
+- [ ] **Step 2: Verify the migration applies + reverts**
+
+Run:
+```bash
+uv run alembic upgrade head && uv run alembic downgrade -1 && uv run alembic upgrade head
+```
+Expected: no errors; head ends at `20260529_rob352`.
+
+- [ ] **Step 3: Add the ORM column**
+
+In `app/models/investment_reports.py`, `InvestmentReportItem`, immediately after the `cited_dimension_report_uuids` mapped_column (the ROB-308 block):
+
+```python
+    # ROB-352 Slice B — per-item snapshot provenance citations. Mirrors
+    # cited_dimension_report_uuids; derived from the item's evidence_snapshot
+    # by the generator unless the caller supplies them explicitly.
+    cited_snapshot_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(PG_UUID(as_uuid=True)),
+        nullable=False,
+        server_default=text("ARRAY[]::uuid[]"),
+    )
+```
+
+(`ARRAY`, `PG_UUID`, `text`, `uuid` are already imported — used by `cited_dimension_report_uuids`.)
+
+- [ ] **Step 4: Verify import + model load**
+
+Run: `uv run python -c "from app.models.investment_reports import InvestmentReportItem; print('cited_snapshot_uuids' in InvestmentReportItem.__table__.c)"`
+Expected: `True`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add alembic/versions/rob352_cited_snapshot_uuids.py app/models/investment_reports.py
+git commit -m "feat(ROB-352): cited_snapshot_uuids column + migration (Slice B)"
+```
+
+---
+
+## Task B2: Schema + repository + response + test-fixture column
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (`IngestReportItem` ~line 164; `InvestmentReportItemResponse` ~line 406)
+- Modify: `app/services/investment_reports/ingestion.py` (`_insert_item`, the `insert_item(...)` call)
+- Modify: `tests/_investment_reports_helpers.py` (idempotent ALTER block ~line 147)
+- Test: `tests/test_investment_reports_ingestion.py`
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Append to `tests/test_investment_reports_ingestion.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_round_trip(session: AsyncSession) -> None:
+    """ROB-352 Slice B — cited_snapshot_uuids persists and reads back."""
+    import uuid as _uuid
+
+    u1, u2 = _uuid.uuid4(), _uuid.uuid4()
+    service = InvestmentReportIngestionService(session)
+    report = await service.ingest(
+        _base_request(
+            items=[_action_item("a1", cited_snapshot_uuids=[u1, u2])]
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert items[0].cited_snapshot_uuids == [u1, u2]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_investment_reports_ingestion.py -k cited_snapshot_uuids -v`
+Expected: FAIL — `IngestReportItem` has no field `cited_snapshot_uuids` (TypeError/ValidationError) or the column is missing.
+
+- [ ] **Step 3: Add the schema fields**
+
+In `app/schemas/investment_reports.py`, `IngestReportItem`, after `cited_dimension_report_uuids` (line ~164):
+
+```python
+    cited_snapshot_uuids: list[UUID] = Field(default_factory=list)
+```
+
+In `InvestmentReportItemResponse`, after `cited_dimension_report_uuids` (line ~406):
+
+```python
+    cited_snapshot_uuids: list[UUID] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Forward through the repository**
+
+In `app/services/investment_reports/ingestion.py`, `_insert_item`, in the `await self._repo.insert_item(...)` call, after the `cited_dimension_report_uuids=...` line:
+
+```python
+            cited_snapshot_uuids=list(item_req.cited_snapshot_uuids),
+```
+
+- [ ] **Step 5: Add the idempotent ALTER to the test fixture**
+
+In `tests/_investment_reports_helpers.py`, in the `investment_report_items` ALTER list, after the `cited_dimension_report_uuids` line (line ~147):
+
+```python
+                        "ALTER TABLE review.investment_report_items "
+                        "ADD COLUMN IF NOT EXISTS cited_snapshot_uuids "
+                        "UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_investment_reports_ingestion.py -k cited_snapshot_uuids -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/schemas/investment_reports.py app/services/investment_reports/ingestion.py tests/_investment_reports_helpers.py tests/test_investment_reports_ingestion.py
+git commit -m "feat(ROB-352): cited_snapshot_uuids schema/response/repository round-trip (Slice B)"
+```
+
+---
+
+## Task B3: Generator derives citations from evidence_snapshot
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py` (`_build_ingest_request` normalized-items loop; new module helper)
+- Test: `tests/services/action_report/snapshot_backed/test_generator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/action_report/snapshot_backed/test_generator.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_derived_from_evidence() -> None:
+    """ROB-352 Slice B — citations derived from evidence_snapshot UUIDs."""
+    snap_a = str(uuid.uuid4())
+    snap_b = str(uuid.uuid4())
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="risk",
+        intent="risk_review",
+        rationale="r",
+        evidence_snapshot={
+            "snapshot_uuid": snap_a,
+            "candidate_snapshot_uuid": snap_b,
+            "snapshot_kind": "symbol",
+            "not_a_uuid": "hello",
+        },
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request(items=[item]))
+
+    sent_items = ingest.calls[0].items
+    cited = sent_items[0].cited_snapshot_uuids
+    assert {str(u) for u in cited} == {snap_a, snap_b}
+
+
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_caller_supplied_wins() -> None:
+    """ROB-352 Slice B — explicit caller citations are not overwritten."""
+    explicit = uuid.uuid4()
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="risk",
+        intent="risk_review",
+        rationale="r",
+        evidence_snapshot={"snapshot_uuid": str(uuid.uuid4())},
+        cited_snapshot_uuids=[explicit],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request(items=[item]))
+    assert ingest.calls[0].items[0].cited_snapshot_uuids == [explicit]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py -k cited_snapshot_uuids -v`
+Expected: FAIL — derived list empty (feature absent).
+
+- [ ] **Step 3: Add the derivation helper**
+
+In `app/services/action_report/snapshot_backed/generator.py`, add a module-level helper (near the other module helpers, after `_optional_kind_names`):
+
+```python
+def _extract_cited_snapshot_uuids(evidence_snapshot: Any) -> list[UUID]:
+    """ROB-352 Slice B — collect snapshot UUIDs cited by an item's evidence.
+
+    Picks the ``snapshot_uuid`` key plus any ``*_snapshot_uuid`` extra
+    (candidate/portfolio/news). Skips non-UUID values; dedupes preserving
+    first-seen order.
+    """
+    if not isinstance(evidence_snapshot, Mapping):
+        return []
+    out: list[UUID] = []
+    seen: set[UUID] = set()
+    for key, value in evidence_snapshot.items():
+        if key != "snapshot_uuid" and not str(key).endswith("_snapshot_uuid"):
+            continue
+        if not isinstance(value, (str, UUID)):
+            continue
+        try:
+            parsed = value if isinstance(value, UUID) else UUID(str(value))
+        except (ValueError, AttributeError, TypeError):
+            continue
+        if parsed not in seen:
+            seen.add(parsed)
+            out.append(parsed)
+    return out
+```
+
+(`UUID`, `Any`, `Mapping` are already imported in this module.)
+
+- [ ] **Step 4: Wire it into `_build_ingest_request`**
+
+In `_build_ingest_request`, inside the `for item in request.items:` loop, after the `to_jsonable` key-normalisation block and before `normalized_items.append(item_dict)`:
+
+```python
+            # ROB-352 Slice B — derive snapshot citations from evidence unless
+            # the caller supplied them explicitly.
+            if not item_dict.get("cited_snapshot_uuids"):
+                item_dict["cited_snapshot_uuids"] = _extract_cited_snapshot_uuids(
+                    item_dict.get("evidence_snapshot") or {}
+                )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py -k cited_snapshot_uuids -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/generator.py tests/services/action_report/snapshot_backed/test_generator.py
+git commit -m "feat(ROB-352): derive per-item cited_snapshot_uuids from evidence (Slice B)"
+```
+
+---
+
+## Task B4: Generator populates market/portfolio provenance descriptors
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py` (`generate`, `_build_ingest_request`, new helper)
+- Test: `tests/services/action_report/snapshot_backed/test_generator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/services/action_report/snapshot_backed/test_generator.py`:
+
+```python
+class _FakeSnap:
+    def __init__(self, *, kind, symbol=None):
+        self.snapshot_uuid = uuid.uuid4()
+        self.snapshot_kind = kind
+        self.symbol = symbol
+        self.as_of = dt.datetime(2026, 5, 29, 12, 0, tzinfo=dt.timezone.utc)
+        self.freshness_status = "fresh"
+        self.coverage_json = {"rows": 3}
+        self.payload_json = {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_market_portfolio_descriptors_from_bundle() -> None:
+    """ROB-352 Slice B — present kinds → provenance descriptor (pointer)."""
+    market = _FakeSnap(kind="market")
+    portfolio = _FakeSnap(kind="portfolio")
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market), (object(), portfolio)],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(_make_request())
+    sent = ingest.calls[0]
+    assert sent.market_snapshot["snapshot_uuid"] == str(market.snapshot_uuid)
+    assert sent.market_snapshot["freshness_status"] == "fresh"
+    assert sent.portfolio_snapshot["snapshot_kind"] == "portfolio"
+    # Provenance pointer only — never the full payload.
+    assert "payload_json" not in sent.market_snapshot
+
+
+@pytest.mark.asyncio
+async def test_missing_portfolio_descriptor_is_unavailable() -> None:
+    """ROB-352 Slice B — absent kind → explicit unavailable reason."""
+    market = _FakeSnap(kind="market")
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market)],
+    )
+    ensure = _FakeEnsureService(
+        _ensure_response(missing_sources=["portfolio"])
+    )
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(_make_request())
+    sent = ingest.calls[0]
+    assert sent.portfolio_snapshot["status"] == "unavailable"
+    assert "reason" in sent.portfolio_snapshot
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py -k "descriptor" -v`
+Expected: FAIL — `market_snapshot` is `{}` (hardcoded).
+
+- [ ] **Step 3: Add the descriptor helper**
+
+In `generator.py`, add a method on `SnapshotBackedReportGenerator` (near `_build_classifier_context`):
+
+```python
+    async def _section_snapshot_descriptors(
+        self,
+        *,
+        bundle_uuid: UUID,
+        unavailable_sources: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """ROB-352 Slice B — compact provenance descriptors for the report's
+        market / portfolio sections.
+
+        Pointer + freshness into ``investment_snapshots`` (never a full
+        payload copy). Absent kinds get an explicit unavailable reason.
+        """
+
+        def _unavailable(kind: str) -> dict[str, Any]:
+            info = unavailable_sources.get(kind)
+            reason = "not_collected"
+            if isinstance(info, Mapping):
+                reason = str(info.get("reason") or info.get("status") or reason)
+            return {"status": "unavailable", "reason": reason}
+
+        def _descriptor(snapshot: Any) -> dict[str, Any]:
+            as_of = getattr(snapshot, "as_of", None)
+            return {
+                "snapshot_uuid": str(snapshot.snapshot_uuid),
+                "snapshot_kind": snapshot.snapshot_kind,
+                "as_of": as_of.isoformat() if as_of is not None else None,
+                "freshness_status": getattr(snapshot, "freshness_status", None),
+                "coverage": getattr(snapshot, "coverage_json", None) or {},
+            }
+
+        market = _unavailable("market")
+        portfolio = _unavailable("portfolio")
+        bundle = await self._snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+        if bundle is None:
+            return market, portfolio
+        pairs = await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
+        for _item, snapshot in pairs:
+            if snapshot.snapshot_kind == "market":
+                market = _descriptor(snapshot)
+            elif snapshot.snapshot_kind == "portfolio":
+                portfolio = _descriptor(snapshot)
+        return market, portfolio
+```
+
+- [ ] **Step 4: Compute descriptors in `generate` and thread them through**
+
+In `generate`, after `unavailable_sources = self._build_unavailable_sources(...)` and before `ingest_request = self._build_ingest_request(...)`:
+
+```python
+        market_snapshot, portfolio_snapshot = await self._section_snapshot_descriptors(
+            bundle_uuid=ensure_response.bundle_uuid,
+            unavailable_sources=unavailable_sources,
+        )
+```
+
+Change the `_build_ingest_request(...)` call to pass them:
+
+```python
+        ingest_request = self._build_ingest_request(
+            request=request,
+            bundle_uuid=ensure_response.bundle_uuid,
+            coverage_summary=coverage_summary,
+            freshness_summary=freshness_summary,
+            unavailable_sources=unavailable_sources,
+            source_conflicts=source_conflicts,
+            report_diagnostics=report_diagnostics,
+            symbol_derivation=derivation,
+            market_snapshot=market_snapshot,
+            portfolio_snapshot=portfolio_snapshot,
+        )
+```
+
+In `_build_ingest_request`, add the two parameters to the signature (after `symbol_derivation`):
+
+```python
+        symbol_derivation: SymbolDerivation | None = None,
+        market_snapshot: dict[str, Any] | None = None,
+        portfolio_snapshot: dict[str, Any] | None = None,
+    ) -> IngestReportRequest:
+```
+
+and replace the hardcoded lines:
+
+```python
+            market_snapshot=market_snapshot or {},
+            portfolio_snapshot=portfolio_snapshot or {},
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py -k "descriptor" -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Run the full generator suite (no regression)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_generator.py -q`
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/generator.py tests/services/action_report/snapshot_backed/test_generator.py
+git commit -m "feat(ROB-352): populate market/portfolio provenance descriptors from bundle (Slice B)"
+```
+
+---
+
+## Task B5: prior_reports excludes drafts
+
+**Files:**
+- Modify: `app/services/investment_reports/query_service.py` (`previous_report_context`)
+- Test: `tests/test_investment_reports_query_prior_drafts.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_investment_reports_query_prior_drafts.py`:
+
+```python
+"""ROB-352 Slice B — prior_reports excludes draft (smoke) reports."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+async def _make_report(repo, *, key, status, title):
+    return await repo.insert_report(
+        idempotency_key=key,
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="t",
+        title=title,
+        summary="s",
+        status=status,
+        report_metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_prior_reports_excludes_drafts(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    await _make_report(repo, key="pub:1", status="published", title="real-1")
+    await _make_report(repo, key="draft:1", status="draft", title="hermes-smoke-1")
+    await _make_report(repo, key="draft:2", status="draft", title="hermes-smoke-2")
+    await _make_report(repo, key="pub:2", status="published", title="real-2")
+
+    svc = InvestmentReportQueryService(session)
+    ctx = await svc.previous_report_context(
+        market="us", account_scope="kis_live",
+        report_type="snapshot_backed_advisory_v1", n_prior=3,
+    )
+    titles = {r.title for r in ctx["prior_reports"]}
+    assert titles == {"real-1", "real-2"}
+    assert all(r.status != "draft" for r in ctx["prior_reports"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_investment_reports_query_prior_drafts.py -v`
+Expected: FAIL — draft titles present in `prior_reports`.
+
+- [ ] **Step 3: Exclude drafts in `previous_report_context`**
+
+In `app/services/investment_reports/query_service.py`, replace the prior-reports fetch/slice block (lines ~258-269):
+
+```python
+        # ROB-352 Slice B — fetch a buffer so dropping drafts (smoke
+        # boilerplate ships as draft) + the excluded uuid still yields up to
+        # n_prior published rows.
+        _DRAFT_FETCH_BUFFER = 5
+        prior_reports: list[InvestmentReport] = await self._repo.list_reports(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            report_type=report_type,
+            limit=n_prior + 1 + _DRAFT_FETCH_BUFFER,
+        )
+        if exclude_report_uuid is not None:
+            prior_reports = [
+                r for r in prior_reports if r.report_uuid != exclude_report_uuid
+            ]
+        prior_reports = [r for r in prior_reports if r.status != "draft"]
+        prior_reports = prior_reports[:n_prior]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_investment_reports_query_prior_drafts.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/query_service.py tests/test_investment_reports_query_prior_drafts.py
+git commit -m "feat(ROB-352): exclude draft (smoke) reports from prior_reports context (Slice B)"
+```
+
+---
+
+## Task B6: Full verification + lint + push
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the touched + broad suites**
+
+Run:
+```bash
+uv run pytest \
+  tests/test_investment_reports_ingestion.py \
+  tests/test_investment_reports_query_prior_drafts.py \
+  tests/services/action_report/snapshot_backed/test_generator.py \
+  tests/services/action_report/ tests/ -k "investment_report or ingestion or snapshot_backed or hermes" -q
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Lint + format**
+
+Run: `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/`
+Expected: clean. (`uv run ruff format app/ tests/` if needed.)
+
+- [ ] **Step 3: Import/host guards**
+
+Run: `uv run pytest tests/ -k "guard or import_guard" -q`
+Expected: PASS — no new in-process LLM import under the snapshot_backed/investment_stages trees.
+
+- [ ] **Step 4: Typecheck (best-effort)**
+
+Run: `uv run ty check app/services/action_report/snapshot_backed/ app/services/investment_reports/ app/models/investment_reports.py app/schemas/investment_reports.py`
+Expected: no new errors.
+
+- [ ] **Step 5: Push + open PR (base main)**
+
+```bash
+git push -u origin rob-352-slice-b
+gh pr create --base main --title "feat(ROB-352): snapshot evidence + prior-report hygiene (Slice B)" --body "<summary + test plan + side-effect boundary; link spec + Slice A #994>"
+```
+Then confirm the CI Test workflow + lint are green before merge (branch protection does not gate them).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Change 1 (cited_snapshot_uuids column + derivation) → B1 (migration+ORM), B2 (schema/response/repo/fixture), B3 (derivation). ✓
+- Change 2 (market/portfolio provenance descriptors, unavailable reason) → B4. ✓
+- Change 3 (prior_reports draft exclusion) → B5. ✓
+- Testing (migration round-trip, derivation, round-trip persist, descriptors, draft exclusion, fixture column) → B1S2, B2, B3, B4, B5. ✓
+
+**Placeholder scan:** PR body in B6S5 is the only `<...>` — intentional, filled at push time from the spec. All code steps contain complete code.
+
+**Type consistency:** `cited_snapshot_uuids: list[UUID]` consistent across ORM (ARRAY(PG_UUID)), `IngestReportItem`, `InvestmentReportItemResponse`, repo passthrough, and the `_extract_cited_snapshot_uuids -> list[UUID]` helper. `_section_snapshot_descriptors` returns `(market, portfolio)` dicts threaded as `market_snapshot`/`portfolio_snapshot` kwargs matching `_build_ingest_request`'s new params and `IngestReportRequest` JSONB dict fields. `_DRAFT_FETCH_BUFFER` local constant used once.
+
+**Note on B4 DB reads:** `_section_snapshot_descriptors` issues its own `get_bundle_by_uuid` + `list_bundle_items_with_snapshots` (one extra read alongside the classifier-context read). Acceptable for clarity; a future refactor could share a single bundle-items read if it shows up in profiling.

--- a/docs/superpowers/specs/2026-05-29-rob-352-slice-b-snapshot-evidence-design.md
+++ b/docs/superpowers/specs/2026-05-29-rob-352-slice-b-snapshot-evidence-design.md
@@ -1,0 +1,65 @@
+# ROB-352 Slice B — snapshot evidence & prior-report hygiene (design)
+
+**Status:** approved 2026-05-29. Follows Slice A (PR #994, merged 93c3f8b0).
+
+**Goal:** make "snapshot-backed" reports actually auditable — per-item snapshot citations, populated report-level market/portfolio provenance, and prior-report context that excludes smoke/draft boilerplate. Three independent changes shipped in one PR.
+
+## Scope decisions (locked)
+
+1. **Per-item citations** → new `cited_snapshot_uuids` ARRAY(UUID) column (not response-time derivation).
+2. **market/portfolio_snapshot** → compact provenance descriptor (not full payload copy).
+3. **Smoke filter** → exclude `status='draft'` reports from `prior_reports` auto-context.
+
+Out of scope: Slice C (candidate quality, ROB-346); the supersede/revision model for overwrite (separate follow-up); production smoke. No broker/order/watch/order-intent/trade-journal mutation; no scheduler.
+
+## Change 1 — per-item `cited_snapshot_uuids`
+
+**Migration** (additive, mirrors ROB-308 `cited_dimension_report_uuids`): on `review.investment_report_items`,
+`cited_snapshot_uuids ARRAY(sa.UUID())`, `server_default ARRAY[]::uuid[]`, `nullable=False`. down_revision = `20260527_rob329` (current head). up adds column; down drops it.
+
+**ORM** (`app/models/investment_reports.py`, `InvestmentReportItem`): add
+```python
+cited_snapshot_uuids: Mapped[list[uuid.UUID]] = mapped_column(
+    ARRAY(PG_UUID(as_uuid=True)), nullable=False, server_default=text("ARRAY[]::uuid[]"),
+)
+```
+next to `cited_dimension_report_uuids`.
+
+**Schema** (`IngestReportItem`): add `cited_snapshot_uuids: list[UUID] = Field(default_factory=list)`.
+**Response** (`InvestmentReportItemResponse`): add `cited_snapshot_uuids: list[UUID]`.
+**Repository** (`insert_item`): forward `cited_snapshot_uuids=list(item_req.cited_snapshot_uuids)`.
+
+**Population (deterministic, in the generator):** in `_build_ingest_request`, for each item, if the caller did **not** supply `cited_snapshot_uuids`, derive it from the item's `evidence_snapshot`: collect the value at key `snapshot_uuid` plus any key matching `*_snapshot_uuid` (e.g. `candidate_snapshot_uuid`, `portfolio_snapshot_uuid`, `news_snapshot_uuid`). Parse each to `UUID`, skip non-UUID/None values, dedupe preserving first-seen order. Caller-supplied non-empty lists win (Hermes may set its own). Helper: `_extract_cited_snapshot_uuids(evidence_snapshot) -> list[UUID]`.
+
+## Change 2 — report-level market/portfolio provenance
+
+Currently `_build_ingest_request` hardcodes `market_snapshot={}` / `portfolio_snapshot={}`. Replace with a descriptor built from the frozen bundle.
+
+New generator helper `_section_snapshot_descriptors(bundle_uuid, unavailable_sources) -> tuple[dict, dict]`: read `list_bundle_items_with_snapshots(bundle.id)`; for the snapshot of kind `market` (resp. `portfolio`), build
+```python
+{"snapshot_uuid": str(s.snapshot_uuid), "snapshot_kind": s.snapshot_kind,
+ "as_of": iso(s.as_of), "freshness_status": s.freshness_status,
+ "coverage": s.coverage_json or {}}
+```
+If the kind is absent from the bundle, store `{"status": "unavailable", "reason": <reason from unavailable_sources[kind] or "not_collected">}`. No full `payload_json` copy — snapshots are reusable artifacts (`investment_snapshots`); the report stores a pointer + freshness, not a duplicate.
+
+The generator already loads bundle items for classifier context; reuse that read (one query) rather than adding a second pass where practical.
+
+## Change 3 — prior_reports draft exclusion
+
+`InvestmentReportQueryService.previous_report_context`: after fetching prior reports, drop any with `status == "draft"` before slicing to `n_prior`. Fetch a larger buffer (`n_prior + DRAFT_FETCH_BUFFER`, e.g. +5) from `list_reports` so dropping drafts/excluded still yields up to `n_prior` published rows. Published/decided/expired/superseded continue to flow. This removes `hermes-smoke-*` boilerplate (created as drafts) from automatic next-report context.
+
+## Testing
+
+- **Migration**: `alembic upgrade head` then `downgrade -1` round-trip clean (operator-run; CI applies upgrade).
+- **Citation derivation** (generator unit): item whose `evidence_snapshot` has `snapshot_uuid` + `candidate_snapshot_uuid` → both in `cited_snapshot_uuids`, deduped, non-UUID skipped; caller-supplied list preserved.
+- **Round-trip** (ingestion/repo, real DB): ingest item with `cited_snapshot_uuids` → persisted + read back.
+- **Section descriptors** (generator unit): bundle with market+portfolio snapshots → descriptors with uuid/freshness; missing portfolio → `{status:"unavailable", reason}`.
+- **prior_reports** (query_service, real DB): draft excluded, published retained, `n_prior` honored across a draft-heavy set.
+- **Test fixture**: ensure the `tests/_investment_reports_helpers.py` session fixture creates/patches the new `cited_snapshot_uuids` column (it idempotently patches ROB-269/274/318 columns).
+
+## Files
+
+- Create: `alembic/versions/<rev>_rob352_cited_snapshot_uuids.py`
+- Modify: `app/models/investment_reports.py`, `app/schemas/investment_reports.py`, `app/services/investment_reports/repository.py`, `app/services/action_report/snapshot_backed/generator.py`, `app/services/investment_reports/query_service.py`, `tests/_investment_reports_helpers.py`
+- Tests: `tests/services/action_report/snapshot_backed/test_generator.py`, `tests/test_investment_reports_ingestion.py` (or repo test), `tests/` query_service prior_reports test.

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -241,6 +241,27 @@ def future_datetime(days: int = 7) -> datetime:
     return datetime.now(UTC) + timedelta(days=days)
 
 
+async def publish_report(session: AsyncSession, report: InvestmentReport) -> None:
+    """ROB-352: flip a report to ``status='published'`` for prior-context tests.
+
+    Clears ``snapshot_freshness_summary`` to SQL NULL so the DB CHECK constraint
+    ``ck_investment_reports_no_published_on_hard_stale`` is satisfied. Direct SQL
+    avoids asyncpg serialising Python ``None`` → JSON ``null`` (which the
+    constraint would reject). Reports default to ``draft`` on ingest, and Slice B
+    excludes drafts from ``previous_report_context`` — so tests that expect a
+    report to appear as prior context must publish it first.
+    """
+    await session.execute(
+        sa.text(
+            "UPDATE review.investment_reports"
+            " SET status = 'published', snapshot_freshness_summary = NULL"
+            " WHERE id = :id"
+        ).bindparams(id=report.id)
+    )
+    await session.flush()
+    await session.refresh(report)
+
+
 async def assert_integrity_error(session: AsyncSession, *rows: object) -> None:
     """Add ``rows``, commit, expect ``IntegrityError``, then rollback.
 

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -146,6 +146,9 @@ async def session() -> AsyncSession:
                         "ALTER TABLE review.investment_report_items "
                         "ADD COLUMN IF NOT EXISTS cited_dimension_report_uuids UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
                         "ALTER TABLE review.investment_report_items "
+                        "ADD COLUMN IF NOT EXISTS cited_snapshot_uuids "
+                        "UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
+                        "ALTER TABLE review.investment_report_items "
                         "DROP CONSTRAINT IF EXISTS ck_investment_report_items_ck_investment_report_items_decision_bucket",
                         "ALTER TABLE review.investment_report_items "
                         "DROP CONSTRAINT IF EXISTS ck_investment_report_items_decision_bucket",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -596,6 +596,7 @@ async def db_session():
                     "ADD COLUMN IF NOT EXISTS decision_bucket TEXT",
                     "ADD COLUMN IF NOT EXISTS cited_symbol_report_uuid UUID",
                     "ADD COLUMN IF NOT EXISTS cited_dimension_report_uuids UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
+                    "ADD COLUMN IF NOT EXISTS cited_snapshot_uuids UUID[] NOT NULL DEFAULT ARRAY[]::uuid[]",
                 ):
                     await conn.execute(
                         text(f"ALTER TABLE review.investment_report_items {column_sql}")

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1468,7 +1468,7 @@ class _FakeSnap:
         self.snapshot_uuid = uuid.uuid4()
         self.snapshot_kind = kind
         self.symbol = symbol
-        self.as_of = dt.datetime(2026, 5, 29, 12, 0, tzinfo=dt.timezone.utc)
+        self.as_of = dt.datetime(2026, 5, 29, 12, 0, tzinfo=dt.UTC)
         self.freshness_status = "fresh"
         self.coverage_json = {"rows": 3}
         self.payload_json = {"x": 1}

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1395,3 +1395,59 @@ async def test_reuse_via_ingest_race_rebuilds_from_stored() -> None:
     assert response.report_uuid == stored.report_uuid
     assert response.items_count == 4
     assert response.bundle_reused is True
+
+
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_derived_from_evidence() -> None:
+    """ROB-352 Slice B — citations derived from evidence_snapshot UUIDs."""
+    snap_a = str(uuid.uuid4())
+    snap_b = str(uuid.uuid4())
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="risk",
+        intent="risk_review",
+        rationale="r",
+        evidence_snapshot={
+            "snapshot_uuid": snap_a,
+            "candidate_snapshot_uuid": snap_b,
+            "snapshot_kind": "symbol",
+            "not_a_uuid": "hello",
+        },
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request(items=[item]))
+
+    sent_items = ingest.calls[0].items
+    cited = sent_items[0].cited_snapshot_uuids
+    assert {str(u) for u in cited} == {snap_a, snap_b}
+
+
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_caller_supplied_wins() -> None:
+    """ROB-352 Slice B — explicit caller citations are not overwritten."""
+    explicit = uuid.uuid4()
+    item = IngestReportItem(
+        client_item_key="k1",
+        item_kind="risk",
+        intent="risk_review",
+        rationale="r",
+        evidence_snapshot={"snapshot_uuid": str(uuid.uuid4())},
+        cited_snapshot_uuids=[explicit],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(_make_request(items=[item]))
+    assert ingest.calls[0].items[0].cited_snapshot_uuids == [explicit]

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -616,8 +616,13 @@ async def test_generator_classifies_items_against_active_watches_and_pending_ord
     assert response.items_count == 1
 
     # Verify the generator actually queried the bundle back from the repo.
-    assert fake_repo.get_bundle_calls == [ensure.response.bundle_uuid]
-    assert fake_repo.list_items_calls == [fake_bundle.id]
+    # ROB-352 Slice B — _build_classifier_context + _section_snapshot_descriptors
+    # both call get_bundle_by_uuid; two calls expected, both for the same UUID.
+    assert fake_repo.get_bundle_calls == [
+        ensure.response.bundle_uuid,
+        ensure.response.bundle_uuid,
+    ]
+    assert fake_repo.list_items_calls == [fake_bundle.id, fake_bundle.id]
 
     # The classifier should have rewritten the watch item to operation='keep'
     # because the bundle's active_alerts has a matching alert at the same
@@ -1451,3 +1456,66 @@ async def test_cited_snapshot_uuids_caller_supplied_wins() -> None:
     )
     await gen.generate(_make_request(items=[item]))
     assert ingest.calls[0].items[0].cited_snapshot_uuids == [explicit]
+
+
+# ---------------------------------------------------------------------------
+# ROB-352 Slice B — market / portfolio provenance descriptors from bundle.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSnap:
+    def __init__(self, *, kind, symbol=None):
+        self.snapshot_uuid = uuid.uuid4()
+        self.snapshot_kind = kind
+        self.symbol = symbol
+        self.as_of = dt.datetime(2026, 5, 29, 12, 0, tzinfo=dt.timezone.utc)
+        self.freshness_status = "fresh"
+        self.coverage_json = {"rows": 3}
+        self.payload_json = {"x": 1}
+
+
+@pytest.mark.asyncio
+async def test_market_portfolio_descriptors_from_bundle() -> None:
+    """ROB-352 Slice B — present kinds -> provenance descriptor (pointer)."""
+    market = _FakeSnap(kind="market")
+    portfolio = _FakeSnap(kind="portfolio")
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market), (object(), portfolio)],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(_make_request())
+    sent = ingest.calls[0]
+    assert sent.market_snapshot["snapshot_uuid"] == str(market.snapshot_uuid)
+    assert sent.market_snapshot["freshness_status"] == "fresh"
+    assert sent.portfolio_snapshot["snapshot_kind"] == "portfolio"
+    assert "payload_json" not in sent.market_snapshot
+
+
+@pytest.mark.asyncio
+async def test_missing_portfolio_descriptor_is_unavailable() -> None:
+    """ROB-352 Slice B — absent kind -> explicit unavailable reason."""
+    market = _FakeSnap(kind="market")
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market)],
+    )
+    ensure = _FakeEnsureService(_ensure_response(missing_sources=["portfolio"]))
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(_make_request())
+    sent = ingest.calls[0]
+    assert sent.portfolio_snapshot["status"] == "unavailable"
+    assert "reason" in sent.portfolio_snapshot

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -307,3 +307,20 @@ async def test_overwrite_blocked_when_item_has_operator_decision(
     still = await repo.list_items_for_report(first.id)
     assert len(still) == 1
     assert len(await repo.list_decisions_for_items([items[0].id])) == 1
+
+
+@pytest.mark.asyncio
+async def test_cited_snapshot_uuids_round_trip(session: AsyncSession) -> None:
+    """ROB-352 Slice B — cited_snapshot_uuids persists and reads back."""
+    import uuid as _uuid
+
+    u1, u2 = _uuid.uuid4(), _uuid.uuid4()
+    service = InvestmentReportIngestionService(session)
+    report = await service.ingest(
+        _base_request(
+            items=[_action_item("a1", cited_snapshot_uuids=[u1, u2])]
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert items[0].cited_snapshot_uuids == [u1, u2]

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -317,9 +317,7 @@ async def test_cited_snapshot_uuids_round_trip(session: AsyncSession) -> None:
     u1, u2 = _uuid.uuid4(), _uuid.uuid4()
     service = InvestmentReportIngestionService(session)
     report = await service.ingest(
-        _base_request(
-            items=[_action_item("a1", cited_snapshot_uuids=[u1, u2])]
-        )
+        _base_request(items=[_action_item("a1", cited_snapshot_uuids=[u1, u2])])
     )
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.mcp_server.tooling.investment_reports_handlers import (
@@ -24,6 +25,25 @@ from app.mcp_server.tooling.investment_reports_handlers import (
     investment_report_list_impl,
 )
 from tests._investment_reports_helpers import future_datetime
+
+
+async def _publish_by_uuid(report_uuid: str) -> None:
+    """ROB-352: set status='published', clearing snapshot_freshness_summary to SQL
+    NULL so the DB CHECK constraint is satisfied. Opens and commits its own session
+    so the change is visible to subsequent MCP handler sessions.
+    Direct SQL avoids asyncpg serialising Python None → JSON null for JSONB columns.
+    """
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            sa.text(
+                "UPDATE review.investment_reports"
+                " SET status = 'published', snapshot_freshness_summary = NULL"
+                " WHERE report_uuid = :uuid"
+            ).bindparams(uuid=uuid.UUID(report_uuid))
+        )
+        await db.commit()
 
 
 def _create_kwargs(
@@ -230,6 +250,9 @@ async def test_context_get_aggregates_across_prior_reports(
     r3 = await investment_report_create_impl(
         items=[_action_item_dict()], **_create_kwargs(kst_date="2026-05-18")
     )
+    # ROB-352: publish r1 and r2 so they appear in prior context (drafts excluded).
+    await _publish_by_uuid(r1["report"]["report_uuid"])
+    await _publish_by_uuid(r2["report"]["report_uuid"])
     bundle_r1 = await investment_report_get_impl(r1["report"]["report_uuid"])
     await investment_report_decide_item_impl(
         item_uuid=bundle_r1["items"][0]["item_uuid"],
@@ -251,10 +274,12 @@ async def test_context_get_aggregates_across_prior_reports(
 async def test_context_get_n_prior_clamped_to_ten(session: AsyncSession) -> None:
     # 15 reports, asking for 50 prior — should be clamped to 10.
     for i in range(15):
-        await investment_report_create_impl(
+        r = await investment_report_create_impl(
             items=[_action_item_dict()],
             **_create_kwargs(kst_date=f"2026-05-{i + 1:02d}"),
         )
+        # ROB-352: publish each report so it appears in prior context (drafts excluded).
+        await _publish_by_uuid(r["report"]["report_uuid"])
     ctx = await investment_report_context_get_impl(market="kr", n_prior=50)
     assert len(ctx["prior_reports"]) == 10
 

--- a/tests/test_investment_reports_query_prior_drafts.py
+++ b/tests/test_investment_reports_query_prior_drafts.py
@@ -1,0 +1,45 @@
+"""ROB-352 Slice B — prior_reports excludes draft (smoke) reports."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+async def _make_report(repo, *, key, status, title):
+    return await repo.insert_report(
+        idempotency_key=key,
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="t",
+        title=title,
+        summary="s",
+        status=status,
+        report_metadata={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_prior_reports_excludes_drafts(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    await _make_report(repo, key="pub:1", status="published", title="real-1")
+    await _make_report(repo, key="draft:1", status="draft", title="hermes-smoke-1")
+    await _make_report(repo, key="draft:2", status="draft", title="hermes-smoke-2")
+    await _make_report(repo, key="pub:2", status="published", title="real-2")
+
+    svc = InvestmentReportQueryService(session)
+    ctx = await svc.previous_report_context(
+        market="us", account_scope="kis_live",
+        report_type="snapshot_backed_advisory_v1", n_prior=3,
+    )
+    titles = {r.title for r in ctx["prior_reports"]}
+    assert titles == {"real-1", "real-2"}
+    assert all(r.status != "draft" for r in ctx["prior_reports"])

--- a/tests/test_investment_reports_query_prior_drafts.py
+++ b/tests/test_investment_reports_query_prior_drafts.py
@@ -37,8 +37,10 @@ async def test_prior_reports_excludes_drafts(session: AsyncSession) -> None:
 
     svc = InvestmentReportQueryService(session)
     ctx = await svc.previous_report_context(
-        market="us", account_scope="kis_live",
-        report_type="snapshot_backed_advisory_v1", n_prior=3,
+        market="us",
+        account_scope="kis_live",
+        report_type="snapshot_backed_advisory_v1",
+        n_prior=3,
     )
     titles = {r.title for r in ctx["prior_reports"]}
     assert titles == {"real-1", "real-2"}

--- a/tests/test_investment_reports_query_service.py
+++ b/tests/test_investment_reports_query_service.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import uuid
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.investment_reports import InvestmentReport
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
     IngestReportItem,
@@ -26,6 +28,22 @@ from app.services.investment_reports.query_service import (
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
 from tests._investment_reports_helpers import future_datetime
+
+
+async def _publish(session: AsyncSession, report: InvestmentReport) -> None:
+    """ROB-352: set status='published', clearing snapshot_freshness_summary to SQL
+    NULL so the DB CHECK constraint (ck_investment_reports_no_published_on_hard_stale)
+    is satisfied.  Direct SQL avoids asyncpg serialising Python None → JSON null.
+    """
+    await session.execute(
+        sa.text(
+            "UPDATE review.investment_reports"
+            " SET status = 'published', snapshot_freshness_summary = NULL"
+            " WHERE id = :id"
+        ).bindparams(id=report.id)
+    )
+    await session.flush()
+    await session.refresh(report)
 
 
 def _request(*, kst_date: str, market: str = "kr", **overrides) -> IngestReportRequest:
@@ -198,6 +216,9 @@ async def test_previous_context_aggregates_across_prior_reports(
             items=[_action_item(client_item_key="r2-action-1", symbol="035420")],
         )
     )
+    # ROB-352: publish r1 and r2 so they appear in prior context (drafts excluded).
+    await _publish(session, r1)
+    await _publish(session, r2)
 
     repo = InvestmentReportsRepository(session)
     r1_items = await repo.list_items_for_report(r1.id)
@@ -251,6 +272,9 @@ async def test_previous_context_excludes_named_report(
     ingest = InvestmentReportIngestionService(session)
     r1 = await ingest.ingest(_request(kst_date="2026-05-17"))
     r2 = await ingest.ingest(_request(kst_date="2026-05-18"))
+    # ROB-352: publish r1 so it appears in prior context (drafts excluded).
+    await _publish(session, r1)
+    await _publish(session, r2)
 
     query = InvestmentReportQueryService(session)
     ctx = await query.previous_report_context(
@@ -264,8 +288,13 @@ async def test_previous_context_respects_n_prior_limit(
     session: AsyncSession,
 ) -> None:
     ingest = InvestmentReportIngestionService(session)
+    reports = []
     for date in ("2026-05-14", "2026-05-15", "2026-05-16", "2026-05-17"):
-        await ingest.ingest(_request(kst_date=date))
+        r = await ingest.ingest(_request(kst_date=date))
+        reports.append(r)
+    # ROB-352: publish all so they appear in prior context (drafts excluded).
+    for r in reports:
+        await _publish(session, r)
 
     query = InvestmentReportQueryService(session)
     ctx = await query.previous_report_context(market="kr", n_prior=2)

--- a/tests/test_investment_reports_query_service.py
+++ b/tests/test_investment_reports_query_service.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.investment_reports import InvestmentReport
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
     IngestReportItem,
@@ -27,23 +25,12 @@ from app.services.investment_reports.query_service import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
-from tests._investment_reports_helpers import future_datetime
-
-
-async def _publish(session: AsyncSession, report: InvestmentReport) -> None:
-    """ROB-352: set status='published', clearing snapshot_freshness_summary to SQL
-    NULL so the DB CHECK constraint (ck_investment_reports_no_published_on_hard_stale)
-    is satisfied.  Direct SQL avoids asyncpg serialising Python None → JSON null.
-    """
-    await session.execute(
-        sa.text(
-            "UPDATE review.investment_reports"
-            " SET status = 'published', snapshot_freshness_summary = NULL"
-            " WHERE id = :id"
-        ).bindparams(id=report.id)
-    )
-    await session.flush()
-    await session.refresh(report)
+from tests._investment_reports_helpers import (
+    future_datetime,
+)
+from tests._investment_reports_helpers import (
+    publish_report as _publish,
+)
 
 
 def _request(*, kst_date: str, market: str = "kr", **overrides) -> IngestReportRequest:

--- a/tests/test_investment_reports_router.py
+++ b/tests/test_investment_reports_router.py
@@ -36,7 +36,7 @@ from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
-from tests._investment_reports_helpers import future_datetime
+from tests._investment_reports_helpers import future_datetime, publish_report
 
 _USER = SimpleNamespace(username="operator-test", id=1)
 
@@ -190,6 +190,9 @@ async def test_previous_context_with_prior_reports(session: AsyncSession) -> Non
     r1 = await ingest.ingest(_request(kst_date="2026-05-16"))
     r2 = await ingest.ingest(_request(kst_date="2026-05-17"))
     r3 = await ingest.ingest(_request(kst_date="2026-05-18"))
+    # ROB-352 Slice B — prior context excludes drafts; publish so r1/r2 appear.
+    await publish_report(session, r1)
+    await publish_report(session, r2)
     await session.commit()
 
     service = InvestmentReportQueryService(session)

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -247,10 +247,12 @@ def test_item_accepts_decision_bucket_and_citations():
         decision_bucket="new_buy_candidate",
         cited_symbol_report_uuid=su,
         cited_dimension_report_uuids=[du],
+        cited_snapshot_uuids=[su, du],
     )
     assert item.decision_bucket == "new_buy_candidate"
     assert item.cited_symbol_report_uuid == su
     assert item.cited_dimension_report_uuids == [du]
+    assert item.cited_snapshot_uuids == [su, du]
 
 
 def test_item_rejects_unknown_decision_bucket():
@@ -277,3 +279,4 @@ def test_item_decision_bucket_optional():
     )
     assert item.decision_bucket is None
     assert item.cited_dimension_report_uuids == []
+    assert item.cited_snapshot_uuids == []


### PR DESCRIPTION
## Summary

ROB-352 **Slice B** — make snapshot-backed reports auditable. Follows Slice A (#994, merged). Three independent changes, one PR.

1. **Per-item `cited_snapshot_uuids`** — new additive `ARRAY(UUID)` column on `review.investment_report_items` (migration mirrors ROB-308 `cited_dimension_report_uuids`; NOT NULL + `ARRAY[]::uuid[]` default). Plumbed through ORM, `IngestReportItem`, `InvestmentReportItemResponse`, and the repository. The generator derives it **deterministically** from each item's `evidence_snapshot` (the `snapshot_uuid` key + any `*_snapshot_uuid` extra; deduped, parse-guarded), unless the caller supplied a non-empty list (Hermes wins).

2. **`market_snapshot` / `portfolio_snapshot` provenance** — the generator no longer hardcodes `{}`. It now builds a **compact pointer descriptor** `{snapshot_uuid, snapshot_kind, as_of, freshness_status, coverage}` from the frozen bundle's `market`/`portfolio` snapshots, or `{status:"unavailable", reason}` when a kind is absent. Never copies the full `payload_json` (snapshots are reusable artifacts).

3. **prior_reports draft exclusion** — `previous_report_context` drops `status='draft'` reports (the `hermes-smoke-*` boilerplate ships as draft) with a buffered fetch so up to `n_prior` published rows still flow. Published/decided/expired/superseded continue to inform context.

### Decisions (locked during brainstorming)
New column over response-time derivation; compact descriptor over full-payload copy; `status='draft'` as the smoke marker. Spec: `docs/superpowers/specs/2026-05-29-rob-352-slice-b-snapshot-evidence-design.md`.

### Not in scope
Slice C (US candidate/data quality, ROB-346); the overwrite supersede/revision model; production smoke. No broker/order/watch/order-intent/trade-journal mutation; no scheduler; no in-process LLM.

## Test Plan
- [x] DB round-trip for the new column; schema-layer parity tests
- [x] Generator: citation derivation (evidence + caller-precedence), market/portfolio descriptors + unavailable reason
- [x] query_service: drafts excluded / published retained (real DB)
- [x] Broad suite (`-k "investment_report or ingestion or snapshot_backed or hermes"`) green; 88 import/host guards green; `ruff check`+`format` clean; `ty` clean
- [ ] CI Test workflow green before merge
- [ ] (deferred, operator-gated) live US/KIS-live report render smoke

### Notes for reviewers
- `_DRAFT_FETCH_BUFFER=5`: documented tradeoff — silently under-fills if >5 consecutive drafts precede the wanted published rows.
- `_section_snapshot_descriptors` issues its own bundle read (a 2nd within the call); accepted for clarity, future consolidation opportunity.
- Existing query-service/mcp tests were updated to publish reports they previously left as draft (legitimate fallout of the draft-exclusion; no assertions weakened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Investment report items now track snapshot citations for enhanced provenance and auditability.
  * Snapshot evidence is automatically derived and recorded when generating reports.

* **Improvements**
  * Draft reports are now excluded from prior report context, improving data consistency and report hygiene.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->