### PR TITLE
feat(ROB-353): campaign bridge + bounded empirical verdict (PR2/2)

### DIFF
--- a/docs/runbooks/rob-353-pr2-empirical-verdict.md
+++ b/docs/runbooks/rob-353-pr2-empirical-verdict.md
@@ -1,0 +1,62 @@
+# ROB-353 PR2 — empirical 1d verdict (families 1–3)
+
+**Status:** RUN executed 2026-05-29. Universe filter 539 strict-perp; effective panel **37 USDT perps** (≥30 daily bars in window). Research/backtest only.
+
+> Reproduce: stage 1d klines under `AUTO_TRADER_RESEARCH_ARTIFACT_ROOT/data/klines/1d/<SYM>/` then
+> `uv run --no-project python run_rob353_campaign.py --from-month 2023-01 --to-month 2026-04 --skip-fetch`
+> (or omit `--skip-fetch` to fetch the full 539-symbol universe from data.binance.vision).
+
+## Verdict (all families reject)
+
+| family | screen | gross expectancy | gate | label_343 |
+|---|---|---|---|---|
+| family1_breakout_continuation | **screened_out** | OOS gross **−70.99 bps** ≤ 0 (in-sample edge does not hold OOS) | — | — |
+| family2_ts_trend_basket | **screened_out** | gross **−27.53 bps** ≤ 0.50 bps floor | — | — |
+| family3_xs_momentum | **screened_out** | gross **−39.38 bps** ≤ 0.50 bps floor | — | — |
+
+All three families are **screened out on GROSS expectancy** — they have no economically meaningful edge *before* fees, so none reaches the conservative gate or a ROB-343 cost-binding label. This is a stronger negative than a cost-bound result: fees are not the bottleneck; there is no gross signal to begin with.
+
+Per-family verdict (ROB-351/343 label space): **reject** for all three (`screen=screened_out`, no gate verdict, no `cost_binding_343_candidate`). Nothing reaches `promote_to_pilot` or `cost_binding_343_candidate`.
+
+## Data source & retrieval
+- Source: `data.binance.vision` USDⓈ-M futures (`futures/um`), public 1d klines, read-only, no keys.
+- This RUN reused the already-downloaded ROB-349 scope-4 1d panel (39 symbols staged: 23 continuous-since-2023 survivors + 16 in-window delisted perps) — real public klines, the survivorship-corrected panel ROB-349 used. The harness fetcher (`pit_klines_fetcher`) can fetch the full universe; here `--skip-fetch` used the staged data.
+
+## Window & interval
+- Window: **2023-01 .. 2026-04** (matches ROB-349/342 so results are comparable). Interval: **1d**.
+
+## Universe definition
+- Authority: `data_manifests/pit_universe.v1.json` (843 symbols; metadata only) → `strict_usdt_perp()` = 552 → `campaign_controls.filter_universe` (active-in-window ∩ kline_coverage ≥ 0.8 ∩ confidence ∈ {high, medium}) = **539 symbols**.
+- Effective panel = the staged 37 symbols with ≥30 in-window daily bars. **2 staged symbols dropped** (`BTSUSDT`, `SRMUSDT` — early-delisted, <30 bars in window).
+- Active **+ delisted** symbols included (survivorship fix). Exclusions (via `strict_usdt_perp`): settling, BUSD/USDC-quoted, dated/quarterly (`_`), `*SETTLED`.
+- PIT membership: each symbol contributes only over `[listed_from, delisted_at)` (epoch ms, exclusive); post-delist freeze tail trimmed (`pit_bars`).
+- PIT manifest: `data_manifests/pit_universe.v1.json`, snapshot_hash `e715de33042e9b897ecc43e016ad4b651bbbf58c522fa8e14f1c762593a16cf6`.
+
+## Frozen config (ex-ante)
+- config_hash **`8f02dffd51dc5bedf5ab4c1521edb2185f4768304b5b60fa7dd0836ef8872adf`** (unchanged — the RUN asserts it). taker_bps 4.0; economic_triviality_floor_bps 0.5; fee_grid [10,7.5,5,2,0].
+- Family params frozen to ROB-351 defaults: breakout lookback 20 / hold 5; ts-trend lookback 20; xs-momentum lookback 20 / top_k 1 / weekly (7d) rebalance; notional 1000. (Note: these differ from ROB-349's hand-tuned quartile L/S L=60 — this is the funnel's ex-ante config, not a re-tune. The negative result is even cleaner here: family 3 has no gross edge under the frozen params, vs ROB-349's gross edge that collapsed under survivorship correction.)
+
+## Controls
+- **Gross vs net:** all families screened out on gross — net is moot. Sample counts: breakout 1366 trades, ts-trend 58 periods, xs-momentum 172 periods.
+- **OOS:** train ≤ 2025-01-01 / test > 2025-01-01 split in the summaries; family 1's OOS gross (−70.99 bps) is what screens it out (in-sample did not hold).
+- **Baselines:** BTC buy&hold over the window **+35,938 bps (+359%)**; cash 0 bps. Every family is far below both — a passive long-BTC or cash stance dominates all three.
+- **Drawdown (net equity, bps):** family2_ts_trend_basket **−2,881 bps**; family3_xs_momentum **−15,811 bps** (family1 is a pooled-trade series, not a portfolio equity curve).
+- **Cost-stress:** moot — no family cleared the gross screen, so breakeven taker fee is not computed.
+
+### Skipped controls (disclosed — a thin run must not pass quietly)
+- Dollar-volume liquidity filter (used manifest coverage/confidence quality gate instead).
+- Parameter-neighborhood sweep.
+- BTC regime/period split.
+- Symbol-concentration analysis.
+- 1h interval (deferred — fetcher supports it).
+- **Universe coverage:** ran the bounded 37-symbol ROB-349 panel, not the full 539-symbol strict universe. A full-universe RUN is a follow-up; given all families fail on gross even on this vetted panel, full-universe is unlikely to reverse the sign (consistent with ROB-349's larger-panel finding).
+
+## Branch recommendation
+All three families are **reject** (no gross edge). Per the ROB-353/351 branch policy:
+
+→ **Move to family 4/5 feasibility: funding-rate / open-interest / liquidation crypto-native edges** (parked in `TODOS.md`), gated first on confirming usable historical data quality (OI history ~30d from the API; liquidation history scarce — needs a durable archival source before any strategy claim).
+
+This closes the generic trend/momentum/reversal line for short-horizon crypto (joins ROB-316 / 320 / 324 / 339 / 342 / 349). Do **not** open a pilot-design issue (nothing reached `promote_to_pilot`); do **not** open a ROB-343 probe (nothing reached `cost_binding_343_candidate` — fees are not the bottleneck); do **not** enable any automation.
+
+## Safety boundary confirmation
+Research/backtest only. Read-only public data. No live, no Demo `confirm=true`, no broker/order/watch/order-intent mutation, no scheduler/TaskIQ/Prefect/cron/daemon, no production DB/env/secret mutation, no `/invest` exposure. No raw market data committed (the verdict JSON lives at gitignored `results/rob353/rob351_campaign.v1.json`; only this report is committed). Canonical `validated` is NOT used. ROB-343 is recommended-not-run; it was not implemented or run here.

--- a/docs/superpowers/plans/2026-05-29-rob-353-pr2-bridge-run.md
+++ b/docs/superpowers/plans/2026-05-29-rob-353-pr2-bridge-run.md
@@ -1,0 +1,705 @@
+# ROB-353 PR2 — campaign bridge + bounded RUN Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `specs → campaign.run_campaign` bridge and run a bounded, survivorship-safe 1d empirical campaign for families 1–3 on real Binance USDⓈ-M data, producing a durable committed verdict report.
+
+**Architecture:** Two pure, tested modules (`campaign_specs.py` = data→family-specs; `campaign_controls.py` = pure RUN analytics) feed one operator/network RUN harness (`run_rob353_campaign.py`). The harness loads the PR1 PIT manifest + klines, builds specs, calls the frozen `campaign.run_campaign`, computes controls, and writes a verdict JSON; a committed markdown report is authored from that output. No funnel/gate/config code is touched.
+
+**Tech Stack:** Python 3.13, pure stdlib + the research `.venv`, pytest. Run with `uv run --no-project python ...` / `uv run --no-project pytest ...` from inside `research/nautilus_scalping/`. Branch `rob-353-pr2` (stacked on `rob-353`).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-rob-353-pr2-bridge-run-design.md`
+
+**Working dir for ALL commands:** `/Users/mgh3326/work/auto_trader.rob-353/research/nautilus_scalping`. Tests import flat. ruff line-length 88 (E501 not selected); F401 (unused imports) IS enforced — import only what you use, add no spurious `# noqa`.
+
+---
+
+## Repo contracts this plan consumes (do NOT modify these files)
+
+- `families.Bar(ts, high, low, close)`; `families.breakout_continuation_trades(bars, lookback=20, hold=5, notional=1000.0, ref_fee_bps)` → `list[Trade]`; `families.ts_trend_basket_periods(closes_by_symbol, lookback=20, notional=1000.0, ref_fee_bps)` → `list[PortfolioPeriod]`; `families.xs_momentum_periods(closes_by_symbol, rebalances, lookback=20, top_k=1, notional=1000.0, ref_fee_bps, manifest, min_seasoning=0)` → `list[PortfolioPeriod]`.
+- `validated_gate.Trade(net_ref_pnl, commission_ref, notional, ts_opened)` — `net_ref_pnl` is ALREADY net at the 2-leg ref fee; true gross = `net_ref_pnl + commission_ref`.
+- `validated_gate.PortfolioPeriod(ts, gross_ref_pnl, commission_ref)` — `gross_ref_pnl` is ALREADY net at ref fee; true gross = `gross_ref_pnl + commission_ref`.
+- `discovery.screen.HypothesisSummary(name, conditions, sample_count, gross_expectancy_bps, fee_adjusted_bps, oos_fee_adjusted_bps=None, oos_gross_bps=None, ...)`.
+- `campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)` → `{"schema_version","config_hash","config","families":[...],"note"}`; each spec = `{"name","summary","kind":"trade"|"portfolio","data","maker_conservative_net"}`.
+- `frozen_config.FROZEN_CONFIG` (`.config_hash()` == `8f02dffd…`).
+- `pit_bars.load_bars(symbol, interval, manifest, root)`, `pit_bars.load_panel(symbols, interval, manifest, root)`.
+- `pit_universe.PITManifest.load(path).strict_usdt_perp()`; each `SymbolListing` has `.symbol, .listed_from, .delisted_at, .status, .kline_coverage, .confidence, .tradeable_at(ts)`.
+- `cost_model.REF_FEE_BPS == 10.0`.
+
+`NOTIONAL = 1000.0` (matches family defaults) is the bps normalization base used across the bridge.
+
+---
+
+## File structure
+
+| File | Responsibility | Create/Modify |
+|------|----------------|---------------|
+| `campaign_specs.py` | data→family specs; `HypothesisSummary` derivation (gross/fee-adjusted/OOS bps) | Create |
+| `campaign_controls.py` | pure RUN analytics: weekly rebalance grid, max drawdown, buy&hold bps, universe filter | Create |
+| `run_rob353_campaign.py` | RUN harness: `--self-test` (synthetic) + bounded real RUN (network, operator) | Create |
+| `tests/test_campaign_specs.py` | summary math + spec builders on synthetic panels | Create |
+| `tests/test_campaign_controls.py` | rebalance grid, drawdown, buy&hold, filter | Create |
+| `tests/test_pit_data_layer_guard.py` | add the 3 new modules to the no-`app.*` guard | Modify |
+| `docs/runbooks/rob-353-pr2-empirical-verdict.md` | committed durable verdict report (authored from RUN) | Create |
+
+**Unit contracts introduced:**
+- `campaign_specs.OOS_SPLIT_TS: int`, `NOTIONAL: float`
+- `campaign_specs._summary_from_trades(name, trades, oos_split_ts) -> HypothesisSummary`
+- `campaign_specs._summary_from_periods(name, periods, oos_split_ts, notional=NOTIONAL) -> HypothesisSummary`
+- `campaign_specs.breakout_spec(panel, oos_split_ts=OOS_SPLIT_TS) -> dict`
+- `campaign_specs.ts_trend_spec(panel, oos_split_ts=OOS_SPLIT_TS) -> dict`
+- `campaign_specs.xs_momentum_spec(panel, rebalances, manifest, oos_split_ts=OOS_SPLIT_TS) -> dict`
+- `campaign_controls.weekly_rebalances(lo_ts, hi_ts, step_days=7) -> list[int]`
+- `campaign_controls.max_drawdown_bps(period_net_pnls, notional=NOTIONAL) -> float`
+- `campaign_controls.buy_hold_bps(close_series) -> float`
+- `campaign_controls.filter_universe(manifest, lo_ts, hi_ts, min_coverage=0.8, confidences=("high","medium")) -> list[str]`
+
+---
+
+## Task 0: Baseline
+
+- [ ] **Step 1: Confirm branch + green baseline**
+
+Run: `git branch --show-current` (expect `rob-353-pr2`) and `uv run --no-project pytest -q --ignore=tests/test_signal_parity.py`
+Expected: branch `rob-353-pr2`; tests `165 passed, 1 skipped` (PR1 baseline; `test_signal_parity` is a pre-existing nautilus_trader collection error — always `--ignore` it).
+
+---
+
+## Task 1: `campaign_specs` summary derivation
+
+**Files:** Create `campaign_specs.py`; Create `tests/test_campaign_specs.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_campaign_specs.py
+import campaign_specs
+import families
+from validated_gate import PortfolioPeriod
+
+DAY = 86_400_000
+
+
+def test_summary_from_trades_gross_net_and_oos_split():
+    # 2 in-sample trades (ts < split) +1% and +0.5% gross; 1 OOS trade (ts > split) -0.2% gross.
+    split = 10 * DAY
+    trades = [
+        families.make_taker_trade(0.01 * 1000.0, 5 * DAY, 1000.0),   # gross +100 bps
+        families.make_taker_trade(0.005 * 1000.0, 6 * DAY, 1000.0),  # gross +50 bps
+        families.make_taker_trade(-0.002 * 1000.0, 20 * DAY, 1000.0),  # OOS gross -20 bps
+    ]
+    s = campaign_specs._summary_from_trades("f1", trades, split)
+    assert s.sample_count == 3
+    assert round(s.gross_expectancy_bps, 6) == round((100 + 50 - 20) / 3, 6)
+    # fee_adjusted = mean net bps; each trade net = gross - 2*REF_FEE_BPS (=20bps round trip)
+    assert round(s.fee_adjusted_bps, 6) == round(((100 - 20) + (50 - 20) + (-20 - 20)) / 3, 6)
+    # OOS uses only the ts>split trade
+    assert round(s.oos_gross_bps, 6) == -20.0
+    assert round(s.oos_fee_adjusted_bps, 6) == -40.0
+
+
+def test_summary_from_periods_uses_notional_bps():
+    split = 10 * DAY
+    # PortfolioPeriod.gross_ref_pnl is NET; true gross = gross_ref_pnl + commission_ref
+    periods = [
+        PortfolioPeriod(ts=5 * DAY, gross_ref_pnl=8.0, commission_ref=2.0),    # gross 10 -> 100bps, net 80bps
+        PortfolioPeriod(ts=20 * DAY, gross_ref_pnl=-4.0, commission_ref=1.0),  # OOS gross -3 -> -30bps, net -40bps
+    ]
+    s = campaign_specs._summary_from_periods("f2", periods, split, notional=1000.0)
+    assert s.sample_count == 2
+    assert round(s.gross_expectancy_bps, 6) == round((100 + (-30)) / 2, 6)
+    assert round(s.fee_adjusted_bps, 6) == round((80 + (-40)) / 2, 6)
+    assert round(s.oos_gross_bps, 6) == -30.0
+    assert round(s.oos_fee_adjusted_bps, 6) == -40.0
+
+
+def test_summary_empty_is_safe():
+    s = campaign_specs._summary_from_trades("f1", [], 0)
+    assert s.sample_count == 0
+    assert s.gross_expectancy_bps == 0.0 and s.oos_gross_bps is None
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run --no-project pytest tests/test_campaign_specs.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'campaign_specs'`.
+
+- [ ] **Step 3: Implement summary helpers**
+
+```python
+"""ROB-353 (PR2) — bridge real PIT bars/panel into ROB-351 funnel family specs (pure).
+
+Turns the data the PR1 layer produces (``pit_bars.load_bars`` / ``load_panel``) into the
+``{name, summary, kind, data, maker_conservative_net}`` specs ``campaign.run_campaign``
+consumes. Family params are FROZEN to the ROB-351 defaults (ex-ante; recorded in the
+report). No market data is read here — the harness passes already-loaded bars/panels in.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import cost_model
+import families
+from discovery.screen import HypothesisSummary
+from validated_gate import PortfolioPeriod, Trade
+
+NOTIONAL = 1000.0
+OOS_SPLIT_TS = 1_735_689_600_000  # 2025-01-01T00:00:00Z in epoch ms (ROB-349 train/test boundary)
+_ROUND_TRIP_FEE_BPS = 2.0 * cost_model.REF_FEE_BPS  # documentation; net is already in the data
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _summary_from_trades(name: str, trades: Sequence[Trade], oos_split_ts: int) -> HypothesisSummary:
+    gross = [(t.net_ref_pnl + t.commission_ref) / t.notional * 1e4 for t in trades]
+    net = [t.net_ref_pnl / t.notional * 1e4 for t in trades]
+    oos_g = [g for g, t in zip(gross, trades, strict=True) if t.ts_opened > oos_split_ts]
+    oos_n = [n for n, t in zip(net, trades, strict=True) if t.ts_opened > oos_split_ts]
+    return HypothesisSummary(
+        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        sample_count=len(trades),
+        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        oos_gross_bps=(_mean(oos_g) if oos_g else None),
+        oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
+    )
+
+
+def _summary_from_periods(name: str, periods: Sequence[PortfolioPeriod], oos_split_ts: int,
+                          notional: float = NOTIONAL) -> HypothesisSummary:
+    gross = [(p.gross_ref_pnl + p.commission_ref) / notional * 1e4 for p in periods]
+    net = [p.gross_ref_pnl / notional * 1e4 for p in periods]
+    oos_g = [g for g, p in zip(gross, periods, strict=True) if p.ts > oos_split_ts]
+    oos_n = [n for n, p in zip(net, periods, strict=True) if p.ts > oos_split_ts]
+    return HypothesisSummary(
+        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        sample_count=len(periods),
+        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        oos_gross_bps=(_mean(oos_g) if oos_g else None),
+        oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run --no-project pytest tests/test_campaign_specs.py -q` → PASS (3). Then ruff: `cd /Users/mgh3326/work/auto_trader.rob-353 && uv run ruff check research/nautilus_scalping/campaign_specs.py research/nautilus_scalping/tests/test_campaign_specs.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add campaign_specs.py tests/test_campaign_specs.py
+git commit -m "feat(ROB-353): campaign_specs summary derivation (gross/fee-adjusted/OOS bps)"
+```
+
+---
+
+## Task 2: `campaign_specs` spec builders (families 1–3)
+
+**Files:** Modify `campaign_specs.py`; Modify `tests/test_campaign_specs.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _ramp(start_ts, n, base=100.0, step=1.0):
+    return [(start_ts + i * DAY, base + i * step) for i in range(n)]
+
+
+def test_breakout_spec_pools_trades_across_symbols():
+    panel = {"AUSDT": _ramp(0, 40), "BUSDT": _ramp(0, 40, base=50.0, step=0.5)}
+    # breakout needs Bar objects per symbol; the builder derives them from the panel closes
+    spec = campaign_specs.breakout_spec(panel, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family1_breakout_continuation"
+    assert spec["kind"] == "trade"
+    assert all(hasattr(t, "net_ref_pnl") for t in spec["data"])
+    assert spec["summary"].sample_count == len(spec["data"])
+    assert spec["maker_conservative_net"] is None
+
+
+def test_ts_trend_spec_is_portfolio():
+    panel = {"AUSDT": _ramp(0, 40), "BUSDT": _ramp(0, 40, base=50.0, step=-0.3)}
+    spec = campaign_specs.ts_trend_spec(panel, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family2_ts_trend_basket"
+    assert spec["kind"] == "portfolio"
+    assert all(isinstance(p, PortfolioPeriod) for p in spec["data"])
+
+
+def test_xs_momentum_spec_is_portfolio_pit_aware():
+    panel = {s: _ramp(0, 40, base=b) for s, b in [("AUSDT", 100), ("BUSDT", 50), ("CUSDT", 75)]}
+    import pit_universe
+    m = pit_universe.PITManifest.from_records([{"symbol": s, "listed_from": 0} for s in panel])
+    rebals = [10 * DAY, 17 * DAY, 24 * DAY, 31 * DAY]
+    spec = campaign_specs.xs_momentum_spec(panel, rebals, m, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family3_xs_momentum"
+    assert spec["kind"] == "portfolio"
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run --no-project pytest tests/test_campaign_specs.py -q -k spec`
+Expected: FAIL — `AttributeError: module 'campaign_specs' has no attribute 'breakout_spec'`.
+
+- [ ] **Step 3: Implement spec builders**
+
+Append to `campaign_specs.py`:
+
+```python
+def _panel_to_bars(series: Sequence[tuple[int, float]]) -> list[families.Bar]:
+    """Build single-symbol Bars from a (ts, close) series (high=low=close; OHLC-from-close)."""
+    return [families.Bar(ts=ts, high=c, low=c, close=c) for ts, c in series]
+
+
+def breakout_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    pooled: list[Trade] = []
+    for symbol in sorted(panel):
+        pooled.extend(families.breakout_continuation_trades(_panel_to_bars(panel[symbol]), notional=NOTIONAL))
+    pooled.sort(key=lambda t: t.ts_opened)
+    return {"name": "family1_breakout_continuation",
+            "summary": _summary_from_trades("family1_breakout_continuation", pooled, oos_split_ts),
+            "kind": "trade", "data": pooled, "maker_conservative_net": None}
+
+
+def ts_trend_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    periods = families.ts_trend_basket_periods(panel, notional=NOTIONAL)
+    return {"name": "family2_ts_trend_basket",
+            "summary": _summary_from_periods("family2_ts_trend_basket", periods, oos_split_ts),
+            "kind": "portfolio", "data": periods, "maker_conservative_net": None}
+
+
+def xs_momentum_spec(panel, rebalances, manifest, oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    periods = families.xs_momentum_periods(panel, rebalances, notional=NOTIONAL, manifest=manifest)
+    return {"name": "family3_xs_momentum",
+            "summary": _summary_from_periods("family3_xs_momentum", periods, oos_split_ts),
+            "kind": "portfolio", "data": periods, "maker_conservative_net": None}
+```
+
+NOTE: `breakout_continuation_trades` reads only `bars[i].high` and `bars[i].close`; building `high=low=close=close` means the breakout triggers on close-vs-prior-close-high — an honest daily-close approximation (documented in the report). Do not invent intrabar highs.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run --no-project pytest tests/test_campaign_specs.py -q` → PASS (6). ruff clean on both files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add campaign_specs.py tests/test_campaign_specs.py
+git commit -m "feat(ROB-353): family 1-3 spec builders (pool breakout, ts-trend, PIT xs-momentum)"
+```
+
+---
+
+## Task 3: `campaign_controls` — pure RUN analytics
+
+**Files:** Create `campaign_controls.py`; Create `tests/test_campaign_controls.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_campaign_controls.py
+import campaign_controls
+import pit_universe
+
+DAY = 86_400_000
+
+
+def test_weekly_rebalances_inclusive_step():
+    r = campaign_controls.weekly_rebalances(0, 21 * DAY, step_days=7)
+    assert r == [0, 7 * DAY, 14 * DAY, 21 * DAY]
+
+
+def test_buy_hold_bps_close_to_close():
+    series = [(0, 100.0), (DAY, 110.0)]  # +10% = 1000 bps
+    assert round(campaign_controls.buy_hold_bps(series), 6) == 1000.0
+    assert campaign_controls.buy_hold_bps([]) == 0.0
+
+
+def test_max_drawdown_bps_on_cumulative_pnl():
+    # net pnls per period on notional 1000: +50, -120, +10 -> equity 1050, 930, 940
+    # peak 1050 then trough 930 -> drawdown 120/1050 in bps
+    dd = campaign_controls.max_drawdown_bps([50.0, -120.0, 10.0], notional=1000.0)
+    assert dd < 0 and round(dd, 2) == round(-120.0 / 1050.0 * 1e4, 2)
+
+
+def test_filter_universe_uses_membership_and_quality():
+    m = pit_universe.PITManifest.from_records([
+        {"symbol": "GOOD", "listed_from": 0, "delisted_at": None, "status": "live",
+         "kline_coverage": 1.0, "confidence": "high"},
+        {"symbol": "LOWCOV", "listed_from": 0, "delisted_at": None, "status": "live",
+         "kline_coverage": 0.5, "confidence": "low"},
+        {"symbol": "OUTWINDOW", "listed_from": 100 * DAY, "delisted_at": None, "status": "live",
+         "kline_coverage": 1.0, "confidence": "high"},
+    ])
+    kept = campaign_controls.filter_universe(m, lo_ts=0, hi_ts=10 * DAY)
+    assert kept == ["GOOD"]
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run --no-project pytest tests/test_campaign_controls.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'campaign_controls'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+"""ROB-353 (PR2) — pure analytics for the empirical RUN (no I/O, no network).
+
+Baselines and robustness numbers the verdict report cites: weekly rebalance grid,
+max drawdown, buy&hold return, and the survivorship-/quality-aware universe filter
+(membership overlap + manifest coverage/confidence). Dollar-volume liquidity
+filtering is intentionally NOT done here (disclosed as a skipped control).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pit_universe import PITManifest
+
+_DAY_MS = 86_400_000
+
+
+def weekly_rebalances(lo_ts: int, hi_ts: int, step_days: int = 7) -> list[int]:
+    step = step_days * _DAY_MS
+    return list(range(lo_ts, hi_ts + 1, step))
+
+
+def buy_hold_bps(close_series: Sequence[tuple[int, float]]) -> float:
+    if len(close_series) < 2:
+        return 0.0
+    first, last = close_series[0][1], close_series[-1][1]
+    return (last - first) / first * 1e4 if first else 0.0
+
+
+def max_drawdown_bps(period_net_pnls: Sequence[float], notional: float = 1000.0) -> float:
+    equity = notional
+    peak = notional
+    worst = 0.0
+    for pnl in period_net_pnls:
+        equity += pnl
+        peak = max(peak, equity)
+        if peak > 0:
+            worst = min(worst, (equity - peak) / peak * 1e4)
+    return worst
+
+
+def filter_universe(manifest: PITManifest, lo_ts: int, hi_ts: int,
+                    min_coverage: float = 0.8, confidences=("high", "medium")) -> list[str]:
+    """Symbols whose listing overlaps [lo_ts, hi_ts] with adequate data quality."""
+    kept = []
+    for x in manifest.listings:
+        overlaps = x.listed_from <= hi_ts and (x.delisted_at is None or x.delisted_at > lo_ts)
+        cov_ok = (x.kline_coverage or 0.0) >= min_coverage
+        conf_ok = x.confidence in confidences
+        if overlaps and cov_ok and conf_ok:
+            kept.append(x.symbol)
+    return sorted(kept)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run --no-project pytest tests/test_campaign_controls.py -q` → PASS (4). ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add campaign_controls.py tests/test_campaign_controls.py
+git commit -m "feat(ROB-353): pure RUN analytics (rebalance grid, drawdown, buy&hold, universe filter)"
+```
+
+---
+
+## Task 4: `run_rob353_campaign.py` — `--self-test` (synthetic, no network)
+
+**Files:** Create `run_rob353_campaign.py`
+
+- [ ] **Step 1: Write the failing test (run the self-test as the test)**
+
+There is no unit test file; the acceptance is the CLI self-test. First create the failing expectation:
+
+Run: `uv run --no-project python run_rob353_campaign.py --self-test`
+Expected (before implementation): FAIL — `python: can't open file ... run_rob353_campaign.py`.
+
+- [ ] **Step 2: Implement the harness with `--self-test` first**
+
+Create `run_rob353_campaign.py`:
+
+```python
+#!/usr/bin/env python3
+"""ROB-353 (PR2) — bounded empirical RUN harness for the ROB-351 funnel (research only).
+
+Two modes:
+  --self-test   Build the three family specs from tiny SYNTHETIC panels (no network,
+                no data, no secrets) and print the rob351_campaign.v1 verdict table.
+                Proves the bridge wiring + that the frozen config_hash is unchanged.
+  (default)     Bounded real RUN: load the PR1 PIT manifest, fetch/cache 1d klines for
+                strict_usdt_perp ∩ window, build specs, call campaign.run_campaign, and
+                write the verdict JSON + controls under results/rob353/ (gitignored).
+                Network/operator-gated. The committed report is authored from this output.
+
+Safety: research/backtest only. No live, no Demo confirm, no broker/order/scheduler/DB,
+no /invest. ROB-343 is RECOMMENDED by the verdict, never run here. No raw data committed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _self_test() -> dict:
+    import campaign
+    import campaign_specs as cs
+    import pit_universe
+    from frozen_config import FROZEN_CONFIG
+
+    DAY = 86_400_000
+    panel = {
+        "AUSDT": [(i * DAY, 100.0 + i) for i in range(40)],
+        "BUSDT": [(i * DAY, 50.0 - 0.2 * i) for i in range(40)],
+        "CUSDT": [(i * DAY, 75.0 + (i % 5)) for i in range(40)],
+    }
+    manifest = pit_universe.PITManifest.from_records(
+        [{"symbol": s, "listed_from": 0} for s in panel]
+    )
+    rebals = [10 * DAY, 17 * DAY, 24 * DAY, 31 * DAY]
+    specs = [
+        cs.breakout_spec(panel),
+        cs.ts_trend_spec(panel),
+        cs.xs_momentum_spec(panel, rebals, manifest),
+    ]
+    return campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="ROB-353 bounded empirical RUN (research only)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="synthetic wiring proof (no network); prints the verdict table")
+    ap.add_argument("--from-month", default="2023-01")
+    ap.add_argument("--to-month", default="2026-04")
+    ap.add_argument("--max-symbols", type=int, default=None,
+                    help="operator bound on universe size (default: all qualifying)")
+    ap.add_argument("--skip-fetch", action="store_true",
+                    help="use already-downloaded klines; do not hit the network")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        result = _self_test()
+        print(json.dumps(result, indent=2))
+        from frozen_config import FROZEN_CONFIG
+        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+        return 0
+
+    return _real_run(args)
+
+
+def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
+    raise SystemExit(
+        "Real RUN is operator-gated and implemented in Task 5. "
+        "Use --self-test to verify wiring without network/data."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: Run the self-test**
+
+Run: `uv run --no-project python run_rob353_campaign.py --self-test`
+Expected: prints a JSON object with `"schema_version": "rob351_campaign.v1"`, `"config_hash": "8f02dffd51dc5bedf5ab4c1521edb2185f4768304b5b60fa7dd0836ef8872adf"`, and 3 `families` rows (family1/2/3). Exit 0 (the assert confirms no config drift).
+
+- [ ] **Step 4: ruff + commit**
+
+ruff: `cd /Users/mgh3326/work/auto_trader.rob-353 && uv run ruff check research/nautilus_scalping/run_rob353_campaign.py` → clean (the `_real_run` stub uses `# pragma: no cover`; keep `args` referenced).
+```bash
+git add run_rob353_campaign.py
+git commit -m "feat(ROB-353): RUN harness --self-test (synthetic wiring, frozen-config assert)"
+```
+
+---
+
+## Task 5: `run_rob353_campaign.py` — real RUN body (`_real_run`)
+
+**Files:** Modify `run_rob353_campaign.py`
+
+The pure helpers (Tasks 1–3) are tested; `_real_run` is thin orchestration over them + the network fetch, so it is not unit-tested (operator-gated). It must stay import-safe (no top-level execution).
+
+- [ ] **Step 1: Implement `_real_run`**
+
+Replace the `_real_run` stub with:
+
+```python
+def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
+    import campaign
+    import campaign_controls as cc
+    import campaign_specs as cs
+    import pit_bars
+    import pit_klines_fetcher
+    import pit_universe
+    from frozen_config import FROZEN_CONFIG
+
+    manifest = pit_universe.PITManifest.load("data_manifests/pit_universe.v1.json").strict_usdt_perp()
+    lo = pit_universe._date_to_epoch_ms(f"{args.from_month}-01")
+    hi = pit_universe._date_to_epoch_ms(f"{args.to_month}-28")
+    symbols = cc.filter_universe(manifest, lo, hi)
+    if args.max_symbols:
+        symbols = symbols[: args.max_symbols]
+    print(f"universe: {len(symbols)} strict-perp symbols (membership+quality filtered)")
+
+    if not args.skip_fetch:
+        for i, sym in enumerate(symbols, 1):
+            summary = pit_klines_fetcher.fetch_months(sym, "1d", args.from_month, args.to_month)
+            if i % 25 == 0:
+                print(f"  fetched {i}/{len(symbols)} (last {sym}: {summary['downloaded']} dl)")
+
+    panel = pit_bars.load_panel(symbols, "1d", manifest)
+    panel = {s: v for s, v in panel.items() if len(v) >= 30}  # need enough bars to be meaningful
+    print(f"panel: {len(panel)} symbols with >=30 daily bars")
+    rebals = cc.weekly_rebalances(lo, hi)
+
+    specs = [
+        cs.breakout_spec(panel),
+        cs.ts_trend_spec(panel),
+        cs.xs_momentum_spec(panel, rebals, manifest),
+    ]
+    result = campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+    assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+
+    # controls
+    btc = panel.get("BTCUSDT")
+    controls = {
+        "universe_size": len(panel),
+        "window": f"{args.from_month}..{args.to_month}",
+        "interval": "1d",
+        "btc_buy_hold_bps": (cc.buy_hold_bps(btc) if btc else None),
+        "family_drawdown_bps": {},
+        "skipped_controls": [
+            "dollar-volume liquidity filter (used manifest coverage/confidence instead)",
+            "parameter-neighborhood sweep", "BTC regime split", "symbol-concentration analysis",
+            "1h interval (deferred)",
+        ],
+    }
+    for spec in specs:
+        if spec["kind"] == "portfolio":
+            controls["family_drawdown_bps"][spec["name"]] = cc.max_drawdown_bps(
+                [p.gross_ref_pnl for p in spec["data"]], notional=cs.NOTIONAL)
+
+    import os
+    os.makedirs("results/rob353", exist_ok=True)
+    out = {"verdict_table": result, "controls": controls,
+           "spec_sample_counts": {s["name"]: s["summary"].sample_count for s in specs}}
+    with open("results/rob353/rob351_campaign.v1.json", "w") as fh:
+        json.dump(out, fh, indent=2, default=str)
+    print(json.dumps(out, indent=2, default=str))
+    print("\nwrote results/rob353/rob351_campaign.v1.json (gitignored). "
+          "Author docs/runbooks/rob-353-pr2-empirical-verdict.md from this output.")
+    return 0
+```
+
+- [ ] **Step 2: Verify import-safety + self-test still green**
+
+Run: `uv run --no-project python -c "import run_rob353_campaign"` (no network, no error) and `uv run --no-project python run_rob353_campaign.py --self-test | grep config_hash` → unchanged hash.
+ruff: `uv run ruff check research/nautilus_scalping/run_rob353_campaign.py` → clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add run_rob353_campaign.py
+git commit -m "feat(ROB-353): real RUN body (manifest->fetch->panel->specs->run_campaign->controls)"
+```
+
+---
+
+## Task 6: Guard extension + suite green
+
+**Files:** Modify `tests/test_pit_data_layer_guard.py`
+
+- [ ] **Step 1: Add the new modules to the guard list**
+
+In `tests/test_pit_data_layer_guard.py`, extend `_MODULES`:
+```python
+_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py",
+            "campaign_specs.py", "campaign_controls.py", "run_rob353_campaign.py"]
+```
+
+- [ ] **Step 2: Run guard + full suite**
+
+Run: `uv run --no-project pytest tests/test_pit_data_layer_guard.py -q` → PASS (the new modules import only `families`/`cost_model`/`discovery`/`pit_*`/`validated_gate`/`campaign`/stdlib — no `app.*`).
+Run: `uv run --no-project pytest -q --ignore=tests/test_signal_parity.py` → all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_pit_data_layer_guard.py
+git commit -m "test(ROB-353): extend data-layer import guard to PR2 modules"
+```
+
+---
+
+## Task 7: Execute the bounded RUN + author the committed report
+
+**Files:** Create `docs/runbooks/rob-353-pr2-empirical-verdict.md`
+
+This task performs the real network RUN and writes the durable report from REAL output. **No fabricated numbers.** If the RUN cannot complete (network/disk), the report records a `run-not-executed` status with the exact rerun command and stops — it must not invent a verdict.
+
+- [ ] **Step 1: Run the bounded campaign**
+
+Run (network; expect minutes): `uv run --no-project python run_rob353_campaign.py --from-month 2023-01 --to-month 2026-04 2>&1 | tee /tmp/rob353_run.log`
+Expected: prints universe size, panel size, the `rob351_campaign.v1` verdict table (3 families with screen/gate/label_343/breakeven), controls (btc_buy_hold_bps, per-family drawdown, skipped_controls), and writes `results/rob353/rob351_campaign.v1.json`. Capture the exact JSON.
+
+If fetch is slow, you may bound with `--max-symbols 120` (still hundreds of perps) and record the bound in the report as a coverage caveat.
+
+- [ ] **Step 2: Author the report from the REAL output**
+
+Create `docs/runbooks/rob-353-pr2-empirical-verdict.md` containing, filled from `results/rob353/rob351_campaign.v1.json`:
+- Status line (RUN executed: date, universe size, panel size, or `run-not-executed` + rerun cmd).
+- Data source/retrieval (`data.binance.vision/futures/um`, public), window (2023-01..2026-04), interval 1d.
+- Universe definition: `strict_usdt_perp` ∩ window-active ∩ (coverage≥0.8, confidence∈{high,medium}); active+delisted included; exclusions (settling/BUSD/USDC/dated/SETTLED); PIT manifest path + `snapshot_hash` from `pit_universe.v1.meta.json`.
+- The verdict table as a JSON fence (the `verdict_table.families` array verbatim) + the `config_hash`.
+- Controls: per-family gross vs net + sample_count (from the run), turnover/breakeven (`breakeven_taker_bps` per family), `btc_buy_hold_bps` baseline + cash(0bps) baseline, per-family `family_drawdown_bps`, OOS handling note (train≤2025-01 split in summaries).
+- **Skipped controls** (verbatim from `controls.skipped_controls`) with the one-line reason each — satisfies the "thin run cannot quietly pass" AC.
+- Per-family verdict (reject / needs_more_data / promote_to_pilot / cost_binding_343_candidate — read from `label_343`/`screen`/`gate_verdict`).
+- Branch recommendation (explicit): if any `promote_to_pilot` → propose bounded pilot design issue; if any `cost_binding_343_candidate` → propose ROB-343 Demo fill-provenance probe; else (all reject/needs_more_data) → recommend family 4/5 feasibility (funding/OI/liquidation, TODOS.md). Do NOT enable automation; do NOT implement ROB-343.
+- Safety boundary confirmation (research-only; no live/broker/scheduler/DB; no raw data committed; canonical `validated` not used).
+
+- [ ] **Step 3: Confirm only the report (no raw data / no verdict-json) is staged**
+
+Run: `git status --porcelain` then `git check-ignore results/rob353/rob351_campaign.v1.json` (must be ignored) and confirm no `.csv`/`data/`/`results/` staged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/runbooks/rob-353-pr2-empirical-verdict.md
+git commit -m "docs(ROB-353): empirical 1d verdict report for families 1-3 (bounded RUN)"
+```
+
+---
+
+## Task 8: Final verification + PR (base `rob-353`)
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Full suite + self-test + lint**
+
+Run: `uv run --no-project pytest -q --ignore=tests/test_signal_parity.py` (green); `uv run --no-project python run_rob353_campaign.py --self-test | grep config_hash` (unchanged `8f02dffd…`); `cd /Users/mgh3326/work/auto_trader.rob-353 && uv run ruff check research/nautilus_scalping/` (clean).
+
+- [ ] **Step 2: Confirm no raw data / secrets in the branch diff**
+
+Run: `git diff --name-only rob-353...HEAD` and `git diff --name-only rob-353...HEAD | grep -iE "\.csv$|\.parquet$|/data/|results/"` → second command empty. Only new code, tests, and the report markdown.
+
+- [ ] **Step 3: Push + open stacked PR (base `rob-353`)**
+
+```bash
+git push -u origin rob-353-pr2
+gh pr create --base rob-353 --title "feat(ROB-353): campaign bridge + bounded empirical verdict (PR2/2)" \
+  --body "Stacked on #995. Bridges PR1 PIT data into the ROB-351 funnel (campaign_specs), runs a bounded 1d survivorship-safe campaign for families 1-3 (run_rob353_campaign), and commits the durable verdict report. Frozen config untouched; research-only; ROB-343 recommended-not-run. Rebase --onto origin/main after #995 squash-merges. Spec: docs/superpowers/specs/2026-05-29-rob-353-pr2-bridge-run-design.md"
+```
+
+Note the stacked-squash gotcha: when #995 squash-merges, rebase `rob-353-pr2` `--onto origin/main` and retarget this PR to `main`.
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** bridge summary (T1), spec builders (T2), controls + universe filter (T3), self-test harness (T4), real RUN body (T5), guard (T6), executed RUN + committed report (T7), final/PR (T8). The spec's "median quote-vol liquidity filter" is intentionally replaced by a manifest coverage/confidence filter and the dollar-volume filter is disclosed as a skipped control (recorded in `controls.skipped_controls` and the report) — a deliberate, documented divergence to avoid re-reading raw CSVs / changing PR1's `pit_bars`.
+- **Type consistency:** `NOTIONAL`/`OOS_SPLIT_TS`, `_summary_from_trades`/`_summary_from_periods`, `breakout_spec`/`ts_trend_spec`/`xs_momentum_spec`, `weekly_rebalances`/`max_drawdown_bps`/`buy_hold_bps`/`filter_universe` are referenced identically across tasks and the contract table. Spec dicts use keys `name/summary/kind/data/maker_conservative_net` matching `campaign.run_campaign`.
+- **Known soft spots:** (1) breakout on daily closes uses high=low=close (honest daily-close approximation, disclosed in report). (2) T7 is the only network task; if it can't run, the report records `run-not-executed` rather than fabricating — the bridge + self-test still land as committed, testable value.

--- a/docs/superpowers/specs/2026-05-29-rob-353-pr2-bridge-run-design.md
+++ b/docs/superpowers/specs/2026-05-29-rob-353-pr2-bridge-run-design.md
@@ -1,0 +1,91 @@
+# ROB-353 PR2 — campaign bridge + bounded empirical RUN + verdict report design
+
+**Status:** approved (brainstorming, 2026-05-29)
+**Issue:** ROB-353. **PR2 of 2** (stacked on PR1 branch `rob-353` / PR #995; PR2 branch `rob-353-pr2`, base `rob-353`; rebase `--onto origin/main` after PR1 squash-merges — stacked-squash gotcha noted).
+**Boundary:** research/backtest only. Read-only PUBLIC data. No live, no Demo `confirm=true`, no broker/order/watch/scheduler/DB mutation, no `/invest` exposure, no raw large data committed, no credential logging. ROB-343 only RECOMMENDED, never run. Never label canonical `validated`.
+
+## Background
+
+PR1 landed the PIT data layer (`pit_universe` extended + `pit_universe.v1.json` manifest + `pit_klines_fetcher` + `pit_bars` + builder). PR #993 (ROB-351) landed the funnel: `campaign.run_campaign(specs, FROZEN_CONFIG)` consumes a list of family **specs** and emits the `rob351_campaign.v1` verdict table. The missing piece is the **bridge** that turns real PIT bars into those specs, plus the actual **bounded empirical RUN** that produces a durable verdict.
+
+ROB-349 already ran the cross-sectional family (≈ family 3) on the PIT-corrected panel → reject/needs_more_data. PR2 re-confirms family 3 through the official funnel and runs the untested families 1 (breakout continuation) and 2 (time-series trend basket). The honest expectation is mostly reject/needs_more_data → recommend family 4/5; the deliverable is a durable, auditable verdict either way.
+
+## Contracts already in the repo (consumed, NOT modified)
+
+- `families.breakout_continuation_trades(bars: Sequence[Bar], lookback=20, hold=5, notional=1000, ref_fee_bps) -> list[Trade]` (family 1, single symbol).
+- `families.ts_trend_basket_periods(closes_by_symbol: dict[str, Seq[(ts,close)]], lookback=20, notional=1000, ref_fee_bps) -> list[PortfolioPeriod]` (family 2).
+- `families.xs_momentum_periods(closes_by_symbol, rebalances: Seq[int], lookback=20, top_k=1, notional=1000, ref_fee_bps, manifest, min_seasoning) -> list[PortfolioPeriod]` (family 3, PIT-aware).
+- `campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)` where each spec is `{"name": str, "summary": HypothesisSummary, "kind": "trade"|"portfolio", "data": list[Trade]|list[PortfolioPeriod], "maker_conservative_net": float|None}`.
+- `discovery.screen.HypothesisSummary(name, conditions, sample_count, gross_expectancy_bps, fee_adjusted_bps, oos_fee_adjusted_bps=None, oos_gross_bps=None, ...)`.
+- `pit_bars.load_bars(symbol, interval, manifest, root)` and `pit_bars.load_panel(symbols, interval, manifest, root)`.
+- `pit_universe.PITManifest.load(...).strict_usdt_perp()`.
+- `frozen_config.FROZEN_CONFIG` (config_hash `8f02dffd…` — MUST stay unchanged; PR2 touches no funnel/gate/config code).
+
+## Goals / non-goals
+
+**Goals**
+- A pure, tested **bridge** (`campaign_specs.py`): real PIT bars/panel → the three family specs (with `HypothesisSummary` derived from the family output, frozen params).
+- A **RUN harness** (`run_rob353_campaign.py`): bounded real RUN (1d, window 2023-01..2026-04, strict_usdt_perp ∩ window-active) → `run_campaign` → controls → durable report. `--self-test` (synthetic, no network) proves wiring.
+- A committed **verdict report** (markdown embedding the `rob351_campaign.v1` table + config hash + data/universe definition + controls + skipped-control disclosure + per-family verdict + branch recommendation).
+
+**Non-goals**
+- 1h interval RUN (deferred; fetcher already supports it).
+- parameter-neighborhood sweep, regime split, symbol-concentration robustness (explicitly **skipped this RUN, disclosed with reason** in the report — satisfies the "thin run cannot quietly pass" AC).
+- Any change to `families.py`, `campaign.py`, `validated_gate.py`, `rob343_label.py`, `frozen_config.py`, `panel.py`.
+- Implementing/running ROB-343.
+
+## Components (all `research/nautilus_scalping/`, pure stdlib + research venv)
+
+### 1. `campaign_specs.py` (pure, tested)
+Bridge real data → family specs. Frozen params match PR1 self-test / family defaults (ex-ante; recorded in the report).
+- `_summary_from_trades(name, trades, oos_split_ts) -> HypothesisSummary`: `sample_count=len(trades)`; `gross_expectancy_bps` = mean per-trade gross return in bps (gross = `net_ref_pnl + commission_ref`, normalized by notional → bps); `fee_adjusted_bps` = gross minus round-trip ref-fee budget (use `cost_model`/`REF_FEE_BPS`); split by `ts_opened <= oos_split_ts` (in-sample) vs `>` (OOS) to fill `oos_gross_bps`/`oos_fee_adjusted_bps`.
+- `_summary_from_periods(name, periods, oos_split_ts) -> HypothesisSummary`: analogous over `PortfolioPeriod` (gross = `gross_ref_pnl + commission_ref`), bps normalized by the period notional.
+- `breakout_spec(panel, oos_split_ts, ...) -> dict`: run `breakout_continuation_trades` on EACH symbol's bars, pool the Trade lists, build summary → `{name:"family1_breakout_continuation", kind:"trade", data:pooled, summary, maker_conservative_net:None}`.
+- `ts_trend_spec(panel, oos_split_ts, ...) -> dict`: `ts_trend_basket_periods(panel)` → `{name:"family2_ts_trend_basket", kind:"portfolio", ...}`.
+- `xs_momentum_spec(panel, rebalances, manifest, oos_split_ts, ...) -> dict`: `xs_momentum_periods(panel, rebalances, manifest=manifest)` → `{name:"family3_xs_momentum", kind:"portfolio", ...}`.
+- `OOS_SPLIT_TS` constant = epoch ms of `2025-01-01` (matches ROB-349 train/test boundary).
+
+### 2. `run_rob353_campaign.py` (RUN harness)
+- `--self-test`: build the three specs from tiny SYNTHETIC panels (no network), call `run_campaign`, print the verdict table + config_hash. Proves wiring; mirrors `run_rob351_campaign.py --self-test`.
+- default (real RUN, operator/network): 
+  1. `manifest = PITManifest.load("data_manifests/pit_universe.v1.json").strict_usdt_perp()`; restrict to symbols active within `[2023-01, 2026-04]` (manifest listing overlaps window).
+  2. ensure 1d klines present via `pit_klines_fetcher.fetch_months` for each symbol (idempotent; writes gitignored root). Liquidity filter: drop symbols whose median daily quote-volume over the window `< MIN_MEDIAN_QUOTE_VOL` (documented constant); record dropped count.
+  3. `panel = pit_bars.load_panel(kept_symbols, "1d", manifest)`; build `rebalances` = weekly (R=7d) timestamps over the window (ROB-349 cadence).
+  4. specs = `[breakout_spec(panel,...), ts_trend_spec(panel,...), xs_momentum_spec(panel, rebalances, manifest,...)]`.
+  5. `result = campaign.run_campaign(specs, FROZEN_CONFIG)`; assert `result["config_hash"] == FROZEN_CONFIG` hash.
+  6. controls: gross vs net + turnover/trade-count (from gate report), OOS in/out split (already in summaries), BTC buy&hold + cash baselines over the window, cost-stress (breakeven taker bps already emitted per family), max drawdown of each portfolio series.
+  7. write live verdict JSON → `results/rob353/rob351_campaign.v1.json` (gitignored) and print a report-ready summary; the committed report (component 3) is authored from this output.
+  - flags: `--from-month`/`--to-month` (default 2023-01/2026-04), `--max-symbols` (operator bound), `--skip-fetch` (use already-downloaded data).
+
+### 3. Committed verdict report (markdown)
+`docs/runbooks/rob-353-pr2-empirical-verdict.md` — the durable artifact. Sections: data source/retrieval, window, interval (1d), universe definition (strict_usdt_perp ∩ window, active+delisted, exclusions, liquidity filter + threshold + dropped count), PIT manifest path + snapshot hash, the embedded `rob351_campaign.v1` verdict table (JSON fence), gross/net + turnover + drawdown + OOS per family, BTC b&h / cash baselines, cost-stress (breakeven) per family, **explicitly enumerated skipped controls (parameter neighborhood, regime split, symbol concentration) and why**, per-family verdict (reject/needs_more_data/promote_to_pilot/cost_binding_343_candidate), and the branch recommendation. Authored from the RUN output; if the operator RUN is not executed in-session, the report records a `data-precondition`/`run-not-executed` status with the exact command to produce it (no fabricated numbers).
+
+### 4. Tests
+- `test_campaign_specs.py`: synthetic panels → each spec has correct `kind`/`name`/`data` type; `_summary_from_*` computes gross/fee-adjusted/oos bps correctly incl. the train/test split; pooled breakout trades across symbols; empty-panel safety.
+- `run_rob353_campaign.py --self-test`: synthetic, no network, prints `rob351_campaign.v1` + unchanged config_hash.
+- extend `test_pit_data_layer_guard.py`: add `campaign_specs.py`, `run_rob353_campaign.py` to the no-`app.*` guard list.
+
+## Data flow
+```
+pit_universe.v1.json → strict_usdt_perp ∩ [2023-01,2026-04] → pit_klines_fetcher (1d) → pit_bars.load_panel
+   → campaign_specs.{breakout,ts_trend,xs_momentum}_spec → campaign.run_campaign(FROZEN_CONFIG)
+   → verdict table + controls → results/rob353/rob351_campaign.v1.json (gitignored)
+   → docs/runbooks/rob-353-pr2-empirical-verdict.md (committed durable report)
+```
+
+## Safety / boundaries
+- No raw klines committed (gitignored). Only the markdown report (with embedded small verdict table) is committed.
+- Research-local `os.environ` only; zero `app.*` (guard-tested, extended).
+- Frozen config untouched; RUN asserts the config_hash is unchanged.
+- Network limited to public `data.binance.vision`, read-only. No broker/order/scheduler/DB.
+- Verdict labels limited to reject / needs_more_data / promote_to_pilot / cost_binding_343_candidate. ROB-343 recommended only.
+
+## Acceptance (PR2)
+- `campaign_specs.py` + tests committed; `run_rob353_campaign.py --self-test` passes under py3.13, config_hash unchanged.
+- Bounded real RUN executed on 1d strict-perp∩window data (or report records an explicit blocker with the exact rerun command — no fabricated numbers).
+- Committed report includes verdict table, data/universe definition, controls, **skipped-control disclosure**, per-family verdict, branch recommendation, safety confirmation.
+- Branch recommendation explicit: pilot design / ROB-343 probe / family 4-5 feasibility / stop as needs_more_data.
+- Guard + gitignore confirm no `app.*` and no raw-data/secret leakage. Research suite green (`--ignore=tests/test_signal_parity.py`).
+
+## Expectations (honesty)
+family 3 ≈ ROB-349 reject/needs_more_data; families 1-2 likely net-negative (ROB-316/320/324/339/342 line) → likely all reject/needs_more_data → recommend family 4/5 (funding/OI/liquidation, TODOS.md). Goal is the honest durable verdict, not a forced promote.

--- a/research/nautilus_scalping/campaign_controls.py
+++ b/research/nautilus_scalping/campaign_controls.py
@@ -1,0 +1,51 @@
+"""ROB-353 (PR2) — pure analytics for the empirical RUN (no I/O, no network).
+
+Baselines and robustness numbers the verdict report cites: weekly rebalance grid,
+max drawdown, buy&hold return, and the survivorship-/quality-aware universe filter
+(membership overlap + manifest coverage/confidence). Dollar-volume liquidity
+filtering is intentionally NOT done here (disclosed as a skipped control).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pit_universe import PITManifest
+
+_DAY_MS = 86_400_000
+
+
+def weekly_rebalances(lo_ts: int, hi_ts: int, step_days: int = 7) -> list[int]:
+    step = step_days * _DAY_MS
+    return list(range(lo_ts, hi_ts + 1, step))
+
+
+def buy_hold_bps(close_series: Sequence[tuple[int, float]]) -> float:
+    if len(close_series) < 2:
+        return 0.0
+    first, last = close_series[0][1], close_series[-1][1]
+    return (last - first) / first * 1e4 if first else 0.0
+
+
+def max_drawdown_bps(period_net_pnls: Sequence[float], notional: float = 1000.0) -> float:
+    equity = notional
+    peak = notional
+    worst = 0.0
+    for pnl in period_net_pnls:
+        equity += pnl
+        peak = max(peak, equity)
+        if peak > 0:
+            worst = min(worst, (equity - peak) / peak * 1e4)
+    return worst
+
+
+def filter_universe(manifest: PITManifest, lo_ts: int, hi_ts: int,
+                    min_coverage: float = 0.8, confidences=("high", "medium")) -> list[str]:
+    """Symbols whose listing overlaps [lo_ts, hi_ts] with adequate data quality."""
+    kept = []
+    for x in manifest.listings:
+        overlaps = x.listed_from <= hi_ts and (x.delisted_at is None or x.delisted_at > lo_ts)
+        cov_ok = (x.kline_coverage or 0.0) >= min_coverage
+        conf_ok = x.confidence in confidences
+        if overlaps and cov_ok and conf_ok:
+            kept.append(x.symbol)
+    return sorted(kept)

--- a/research/nautilus_scalping/campaign_specs.py
+++ b/research/nautilus_scalping/campaign_specs.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 
 import families
 from discovery.screen import HypothesisSummary
+from pit_universe import PITManifest
 from validated_gate import PortfolioPeriod, Trade
 
 NOTIONAL = 1000.0
@@ -74,7 +75,12 @@ def ts_trend_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: i
             "kind": "portfolio", "data": periods, "maker_conservative_net": None}
 
 
-def xs_momentum_spec(panel, rebalances, manifest, oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+def xs_momentum_spec(
+    panel: dict[str, Sequence[tuple[int, float]]],
+    rebalances: Sequence[int],
+    manifest: PITManifest | None,
+    oos_split_ts: int = OOS_SPLIT_TS,
+) -> dict:
     periods = families.xs_momentum_periods(panel, rebalances, notional=NOTIONAL, manifest=manifest)
     return {"name": "family3_xs_momentum",
             "summary": _summary_from_periods("family3_xs_momentum", periods, oos_split_ts),

--- a/research/nautilus_scalping/campaign_specs.py
+++ b/research/nautilus_scalping/campaign_specs.py
@@ -1,0 +1,81 @@
+"""ROB-353 (PR2) — bridge real PIT bars/panel into ROB-351 funnel family specs (pure).
+
+Turns the data the PR1 layer produces (``pit_bars.load_bars`` / ``load_panel``) into the
+``{name, summary, kind, data, maker_conservative_net}`` specs ``campaign.run_campaign``
+consumes. Family params are FROZEN to the ROB-351 defaults (ex-ante; recorded in the
+report). No market data is read here — the harness passes already-loaded bars/panels in.
+
+Round-trip reference fee: 2 * 10.0 bps (taker in + taker out at cost_model.REF_FEE_BPS).
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import families
+from discovery.screen import HypothesisSummary
+from validated_gate import PortfolioPeriod, Trade
+
+NOTIONAL = 1000.0
+OOS_SPLIT_TS = 1_735_689_600_000  # 2025-01-01T00:00:00Z in epoch ms (ROB-349 train/test boundary)
+
+
+def _mean(xs: list[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _summary_from_trades(name: str, trades: Sequence[Trade], oos_split_ts: int) -> HypothesisSummary:
+    gross = [(t.net_ref_pnl + t.commission_ref) / t.notional * 1e4 for t in trades]
+    net = [t.net_ref_pnl / t.notional * 1e4 for t in trades]
+    oos_g = [g for g, t in zip(gross, trades, strict=True) if t.ts_opened > oos_split_ts]
+    oos_n = [n for n, t in zip(net, trades, strict=True) if t.ts_opened > oos_split_ts]
+    return HypothesisSummary(
+        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        sample_count=len(trades),
+        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        oos_gross_bps=(_mean(oos_g) if oos_g else None),
+        oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
+    )
+
+
+def _summary_from_periods(name: str, periods: Sequence[PortfolioPeriod], oos_split_ts: int,
+                          notional: float = NOTIONAL) -> HypothesisSummary:
+    gross = [(p.gross_ref_pnl + p.commission_ref) / notional * 1e4 for p in periods]
+    net = [p.gross_ref_pnl / notional * 1e4 for p in periods]
+    oos_g = [g for g, p in zip(gross, periods, strict=True) if p.ts > oos_split_ts]
+    oos_n = [n for n, p in zip(net, periods, strict=True) if p.ts > oos_split_ts]
+    return HypothesisSummary(
+        name=name, conditions=f"frozen ROB-351 family params; OOS split {oos_split_ts}",
+        sample_count=len(periods),
+        gross_expectancy_bps=_mean(gross), fee_adjusted_bps=_mean(net),
+        oos_gross_bps=(_mean(oos_g) if oos_g else None),
+        oos_fee_adjusted_bps=(_mean(oos_n) if oos_n else None),
+    )
+
+
+def _panel_to_bars(series: Sequence[tuple[int, float]]) -> list[families.Bar]:
+    """Build single-symbol Bars from a (ts, close) series (high=low=close; OHLC-from-close)."""
+    return [families.Bar(ts=ts, high=c, low=c, close=c) for ts, c in series]
+
+
+def breakout_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    pooled: list[Trade] = []
+    for symbol in sorted(panel):
+        pooled.extend(families.breakout_continuation_trades(_panel_to_bars(panel[symbol]), notional=NOTIONAL))
+    pooled.sort(key=lambda t: t.ts_opened)
+    return {"name": "family1_breakout_continuation",
+            "summary": _summary_from_trades("family1_breakout_continuation", pooled, oos_split_ts),
+            "kind": "trade", "data": pooled, "maker_conservative_net": None}
+
+
+def ts_trend_spec(panel: dict[str, Sequence[tuple[int, float]]], oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    periods = families.ts_trend_basket_periods(panel, notional=NOTIONAL)
+    return {"name": "family2_ts_trend_basket",
+            "summary": _summary_from_periods("family2_ts_trend_basket", periods, oos_split_ts),
+            "kind": "portfolio", "data": periods, "maker_conservative_net": None}
+
+
+def xs_momentum_spec(panel, rebalances, manifest, oos_split_ts: int = OOS_SPLIT_TS) -> dict:
+    periods = families.xs_momentum_periods(panel, rebalances, notional=NOTIONAL, manifest=manifest)
+    return {"name": "family3_xs_momentum",
+            "summary": _summary_from_periods("family3_xs_momentum", periods, oos_split_ts),
+            "kind": "portfolio", "data": periods, "maker_conservative_net": None}

--- a/research/nautilus_scalping/run_rob353_campaign.py
+++ b/research/nautilus_scalping/run_rob353_campaign.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""ROB-353 (PR2) — bounded empirical RUN harness for the ROB-351 funnel (research only).
+
+Two modes:
+  --self-test   Build the three family specs from tiny SYNTHETIC panels (no network,
+                no data, no secrets) and print the rob351_campaign.v1 verdict table.
+                Proves the bridge wiring + that the frozen config_hash is unchanged.
+  (default)     Bounded real RUN: load the PR1 PIT manifest, fetch/cache 1d klines for
+                strict_usdt_perp ∩ window, build specs, call campaign.run_campaign, and
+                write the verdict JSON + controls under results/rob353/ (gitignored).
+                Network/operator-gated. The committed report is authored from this output.
+
+Safety: research/backtest only. No live, no Demo confirm, no broker/order/scheduler/DB,
+no /invest. ROB-343 is RECOMMENDED by the verdict, never run here. No raw data committed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _self_test() -> dict:
+    import campaign
+    import campaign_specs as cs
+    import pit_universe
+    from frozen_config import FROZEN_CONFIG
+
+    DAY = 86_400_000
+    panel = {
+        "AUSDT": [(i * DAY, 100.0 + i) for i in range(40)],
+        "BUSDT": [(i * DAY, 50.0 - 0.2 * i) for i in range(40)],
+        "CUSDT": [(i * DAY, 75.0 + (i % 5)) for i in range(40)],
+    }
+    manifest = pit_universe.PITManifest.from_records(
+        [{"symbol": s, "listed_from": 0} for s in panel]
+    )
+    rebals = [10 * DAY, 17 * DAY, 24 * DAY, 31 * DAY]
+    specs = [
+        cs.breakout_spec(panel),
+        cs.ts_trend_spec(panel),
+        cs.xs_momentum_spec(panel, rebals, manifest),
+    ]
+    return campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="ROB-353 bounded empirical RUN (research only)")
+    ap.add_argument("--self-test", action="store_true",
+                    help="synthetic wiring proof (no network); prints the verdict table")
+    ap.add_argument("--from-month", default="2023-01")
+    ap.add_argument("--to-month", default="2026-04")
+    ap.add_argument("--max-symbols", type=int, default=None,
+                    help="operator bound on universe size (default: all qualifying)")
+    ap.add_argument("--skip-fetch", action="store_true",
+                    help="use already-downloaded klines; do not hit the network")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        result = _self_test()
+        print(json.dumps(result, indent=2))
+        from frozen_config import FROZEN_CONFIG
+        assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+        return 0
+
+    return _real_run(args)
+
+
+def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
+    raise SystemExit(
+        f"Real RUN is operator-gated and implemented in Task 5 "
+        f"(from {args.from_month} to {args.to_month}). "
+        "Use --self-test to verify wiring without network/data."
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/run_rob353_campaign.py
+++ b/research/nautilus_scalping/run_rob353_campaign.py
@@ -67,11 +67,70 @@ def main(argv=None) -> int:
 
 
 def _real_run(args) -> int:  # pragma: no cover - network/operator-gated
-    raise SystemExit(
-        f"Real RUN is operator-gated and implemented in Task 5 "
-        f"(from {args.from_month} to {args.to_month}). "
-        "Use --self-test to verify wiring without network/data."
-    )
+    import os
+
+    import campaign
+    import campaign_controls as cc
+    import campaign_specs as cs
+    import pit_bars
+    import pit_klines_fetcher
+    import pit_universe
+    from frozen_config import FROZEN_CONFIG
+
+    manifest = pit_universe.PITManifest.load("data_manifests/pit_universe.v1.json").strict_usdt_perp()
+    lo = pit_universe._date_to_epoch_ms(f"{args.from_month}-01")
+    hi = pit_universe._date_to_epoch_ms(f"{args.to_month}-28")
+    symbols = cc.filter_universe(manifest, lo, hi)
+    if args.max_symbols:
+        symbols = symbols[: args.max_symbols]
+    print(f"universe: {len(symbols)} strict-perp symbols (membership+quality filtered)")
+
+    if not args.skip_fetch:
+        for i, sym in enumerate(symbols, 1):
+            summary = pit_klines_fetcher.fetch_months(sym, "1d", args.from_month, args.to_month)
+            if i % 25 == 0:
+                print(f"  fetched {i}/{len(symbols)} (last {sym}: {summary['downloaded']} dl)")
+
+    panel = pit_bars.load_panel(symbols, "1d", manifest)
+    panel = {s: v for s, v in panel.items() if len(v) >= 30}
+    print(f"panel: {len(panel)} symbols with >=30 daily bars")
+    rebals = cc.weekly_rebalances(lo, hi)
+
+    specs = [
+        cs.breakout_spec(panel),
+        cs.ts_trend_spec(panel),
+        cs.xs_momentum_spec(panel, rebals, manifest),
+    ]
+    result = campaign.run_campaign(specs, config=FROZEN_CONFIG, min_trades=5)
+    assert result["config_hash"] == FROZEN_CONFIG.config_hash(), "frozen config drift!"
+
+    btc = panel.get("BTCUSDT")
+    controls = {
+        "universe_size": len(panel),
+        "window": f"{args.from_month}..{args.to_month}",
+        "interval": "1d",
+        "btc_buy_hold_bps": (cc.buy_hold_bps(btc) if btc else None),
+        "family_drawdown_bps": {},
+        "skipped_controls": [
+            "dollar-volume liquidity filter (used manifest coverage/confidence instead)",
+            "parameter-neighborhood sweep", "BTC regime split", "symbol-concentration analysis",
+            "1h interval (deferred)",
+        ],
+    }
+    for spec in specs:
+        if spec["kind"] == "portfolio":
+            controls["family_drawdown_bps"][spec["name"]] = cc.max_drawdown_bps(
+                [p.gross_ref_pnl for p in spec["data"]], notional=cs.NOTIONAL)
+
+    os.makedirs("results/rob353", exist_ok=True)
+    out = {"verdict_table": result, "controls": controls,
+           "spec_sample_counts": {s["name"]: s["summary"].sample_count for s in specs}}
+    with open("results/rob353/rob351_campaign.v1.json", "w") as fh:
+        json.dump(out, fh, indent=2, default=str)
+    print(json.dumps(out, indent=2, default=str))
+    print("\nwrote results/rob353/rob351_campaign.v1.json (gitignored). "
+          "Author docs/runbooks/rob-353-pr2-empirical-verdict.md from this output.")
+    return 0
 
 
 if __name__ == "__main__":

--- a/research/nautilus_scalping/tests/test_campaign_controls.py
+++ b/research/nautilus_scalping/tests/test_campaign_controls.py
@@ -1,0 +1,33 @@
+import campaign_controls
+import pit_universe
+
+DAY = 86_400_000
+
+
+def test_weekly_rebalances_inclusive_step():
+    r = campaign_controls.weekly_rebalances(0, 21 * DAY, step_days=7)
+    assert r == [0, 7 * DAY, 14 * DAY, 21 * DAY]
+
+
+def test_buy_hold_bps_close_to_close():
+    series = [(0, 100.0), (DAY, 110.0)]
+    assert round(campaign_controls.buy_hold_bps(series), 6) == 1000.0
+    assert campaign_controls.buy_hold_bps([]) == 0.0
+
+
+def test_max_drawdown_bps_on_cumulative_pnl():
+    dd = campaign_controls.max_drawdown_bps([50.0, -120.0, 10.0], notional=1000.0)
+    assert dd < 0 and round(dd, 2) == round(-120.0 / 1050.0 * 1e4, 2)
+
+
+def test_filter_universe_uses_membership_and_quality():
+    m = pit_universe.PITManifest.from_records([
+        {"symbol": "GOOD", "listed_from": 0, "delisted_at": None, "status": "live",
+         "kline_coverage": 1.0, "confidence": "high"},
+        {"symbol": "LOWCOV", "listed_from": 0, "delisted_at": None, "status": "live",
+         "kline_coverage": 0.5, "confidence": "low"},
+        {"symbol": "OUTWINDOW", "listed_from": 100 * DAY, "delisted_at": None, "status": "live",
+         "kline_coverage": 1.0, "confidence": "high"},
+    ])
+    kept = campaign_controls.filter_universe(m, lo_ts=0, hi_ts=10 * DAY)
+    assert kept == ["GOOD"]

--- a/research/nautilus_scalping/tests/test_campaign_specs.py
+++ b/research/nautilus_scalping/tests/test_campaign_specs.py
@@ -38,3 +38,35 @@ def test_summary_empty_is_safe():
     s = campaign_specs._summary_from_trades("f1", [], 0)
     assert s.sample_count == 0
     assert s.gross_expectancy_bps == 0.0 and s.oos_gross_bps is None
+
+
+def _ramp(start_ts, n, base=100.0, step=1.0):
+    return [(start_ts + i * DAY, base + i * step) for i in range(n)]
+
+
+def test_breakout_spec_pools_trades_across_symbols():
+    panel = {"AUSDT": _ramp(0, 40), "BUSDT": _ramp(0, 40, base=50.0, step=0.5)}
+    spec = campaign_specs.breakout_spec(panel, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family1_breakout_continuation"
+    assert spec["kind"] == "trade"
+    assert all(hasattr(t, "net_ref_pnl") for t in spec["data"])
+    assert spec["summary"].sample_count == len(spec["data"])
+    assert spec["maker_conservative_net"] is None
+
+
+def test_ts_trend_spec_is_portfolio():
+    panel = {"AUSDT": _ramp(0, 40), "BUSDT": _ramp(0, 40, base=50.0, step=-0.3)}
+    spec = campaign_specs.ts_trend_spec(panel, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family2_ts_trend_basket"
+    assert spec["kind"] == "portfolio"
+    assert all(isinstance(p, PortfolioPeriod) for p in spec["data"])
+
+
+def test_xs_momentum_spec_is_portfolio_pit_aware():
+    panel = {s: _ramp(0, 40, base=b) for s, b in [("AUSDT", 100), ("BUSDT", 50), ("CUSDT", 75)]}
+    import pit_universe
+    m = pit_universe.PITManifest.from_records([{"symbol": s, "listed_from": 0} for s in panel])
+    rebals = [10 * DAY, 17 * DAY, 24 * DAY, 31 * DAY]
+    spec = campaign_specs.xs_momentum_spec(panel, rebals, m, oos_split_ts=campaign_specs.OOS_SPLIT_TS)
+    assert spec["name"] == "family3_xs_momentum"
+    assert spec["kind"] == "portfolio"

--- a/research/nautilus_scalping/tests/test_campaign_specs.py
+++ b/research/nautilus_scalping/tests/test_campaign_specs.py
@@ -1,0 +1,40 @@
+import campaign_specs
+import families
+from validated_gate import PortfolioPeriod
+
+DAY = 86_400_000
+
+
+def test_summary_from_trades_gross_net_and_oos_split():
+    split = 10 * DAY
+    trades = [
+        families.make_taker_trade(0.01 * 1000.0, 5 * DAY, 1000.0),
+        families.make_taker_trade(0.005 * 1000.0, 6 * DAY, 1000.0),
+        families.make_taker_trade(-0.002 * 1000.0, 20 * DAY, 1000.0),
+    ]
+    s = campaign_specs._summary_from_trades("f1", trades, split)
+    assert s.sample_count == 3
+    assert round(s.gross_expectancy_bps, 6) == round((100 + 50 - 20) / 3, 6)
+    assert round(s.fee_adjusted_bps, 6) == round(((100 - 20) + (50 - 20) + (-20 - 20)) / 3, 6)
+    assert round(s.oos_gross_bps, 6) == -20.0
+    assert round(s.oos_fee_adjusted_bps, 6) == -40.0
+
+
+def test_summary_from_periods_uses_notional_bps():
+    split = 10 * DAY
+    periods = [
+        PortfolioPeriod(ts=5 * DAY, gross_ref_pnl=8.0, commission_ref=2.0),
+        PortfolioPeriod(ts=20 * DAY, gross_ref_pnl=-4.0, commission_ref=1.0),
+    ]
+    s = campaign_specs._summary_from_periods("f2", periods, split, notional=1000.0)
+    assert s.sample_count == 2
+    assert round(s.gross_expectancy_bps, 6) == round((100 + (-30)) / 2, 6)
+    assert round(s.fee_adjusted_bps, 6) == round((80 + (-40)) / 2, 6)
+    assert round(s.oos_gross_bps, 6) == -30.0
+    assert round(s.oos_fee_adjusted_bps, 6) == -40.0
+
+
+def test_summary_empty_is_safe():
+    s = campaign_specs._summary_from_trades("f1", [], 0)
+    assert s.sample_count == 0
+    assert s.gross_expectancy_bps == 0.0 and s.oos_gross_bps is None

--- a/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
+++ b/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import artifact_paths
 
 _ROOT = Path(__file__).resolve().parents[1]
-_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py"]
+_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py",
+            "campaign_specs.py", "campaign_controls.py", "run_rob353_campaign.py"]
 
 
 def _imports(path: Path):


### PR DESCRIPTION
## What

PR2 of 2 for ROB-353 (**stacked on #995** — base `rob-353`). Bridges the PR1 PIT data layer into the frozen ROB-351 funnel and runs a **bounded 1d empirical campaign** for families 1–3, committing a durable verdict report.

**Research/backtest only.** No live, no Demo `confirm=true`, no broker/order/watch/scheduler/DB mutation, no `/invest`. Frozen funnel config untouched. ROB-343 recommended-not-run. Canonical `validated` not used.

## Components
- `campaign_specs.py` — pure bridge: real panel → family 1/2/3 specs; `HypothesisSummary` derived from data (gross/fee-adjusted/OOS bps, train≤2025-01 split). Frozen ROB-351 params.
- `campaign_controls.py` — pure analytics: weekly rebalance grid, max drawdown, buy&hold, membership+quality universe filter.
- `run_rob353_campaign.py` — `--self-test` (synthetic, no network) + bounded real RUN (`strict_usdt_perp ∩ window` → fetch → `pit_bars.load_panel` → specs → `run_campaign` → controls → gitignored verdict JSON). Asserts config_hash unchanged.
- `docs/runbooks/rob-353-pr2-empirical-verdict.md` — the committed durable verdict report.

## Verdict (executed RUN, 2026-05-29)

All three families **screened_out on gross** (no economically meaningful edge before fees), on the 37-symbol survivorship-corrected ROB-349 1d panel (2023-01..2026-04):

| family | gross | verdict |
|---|---|---|
| breakout_continuation | OOS **−70.99 bps** | reject |
| ts_trend_basket | **−27.53 bps** | reject |
| xs_momentum | **−39.38 bps** | reject |

BTC buy&hold over window: **+35,938 bps**. Nothing reached `promote_to_pilot` or `cost_binding_343_candidate` — **fees are not the bottleneck; there is no gross signal**.

→ **Recommendation: move to family 4/5 (funding/OI/liquidation) feasibility.** Closes the generic trend/momentum/reversal line for short-horizon crypto (joins ROB-316/320/324/339/342/349). No pilot issue, no ROB-343 probe.

## Verification
- `pytest -q --ignore=tests/test_signal_parity.py` → **175 passed, 1 skipped** (`test_signal_parity` = pre-existing nautilus_trader collection error).
- config_hash `8f02dffd…` unchanged; ruff clean; no `app.*` imports (guard-tested); no raw data/results committed (verdict JSON gitignored).
- Final review independently reproduced the RUN and matched the report to the JSON number-by-number.

## Coverage caveat
Ran the bounded 37-symbol ROB-349 panel (reused already-downloaded 1d data), not the full 539-symbol strict universe; full-universe RUN deferred (unlikely to reverse the gross-negative sign). Disclosed in the report's skipped-controls section.

## Merge note
When #995 squash-merges, rebase `rob-353-pr2` `--onto origin/main` and retarget this PR to `main` (stacked-squash gotcha).

Spec: `docs/superpowers/specs/2026-05-29-rob-353-pr2-bridge-run-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)