### PR TITLE
feat(ROB-341): KIS mock same-day fill confirmation via holdings/cash delta

### DIFF
--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from decimal import Decimal
 from typing import Any
 
+from app.core.symbol import to_db_symbol
 from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
 from app.mcp_server.tooling.order_execution import _create_kis_client, _place_order_impl
 from app.services.brokers.kis import KISClient
@@ -35,6 +36,10 @@ from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     FillEvidence,
     FillVerdict,
     classify_fill_evidence,
+)
+from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    BaselineSnapshot,
+    confirm_fill_from_holdings_delta,
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 
@@ -76,7 +81,10 @@ class KisMockBroker:
         correlation_id: str,
         confirm: bool,
     ) -> dict[str, Any]:
-        return await _place_order_impl(
+        baseline = await self._capture_baseline(
+            symbol=symbol, side="buy", qty=quantity, limit_price=price
+        )
+        result = await _place_order_impl(
             symbol=symbol,
             side="buy",
             market="kr",
@@ -88,6 +96,9 @@ class KisMockBroker:
             reason=f"scalp_entry:{correlation_id}",
             strategy=self._strategy_id,
         )
+        if isinstance(result, dict):
+            result["_baseline"] = baseline
+        return result
 
     async def submit_exit_sell(
         self,
@@ -100,7 +111,10 @@ class KisMockBroker:
         correlation_id: str,
         confirm: bool,
     ) -> dict[str, Any]:
-        return await _place_order_impl(
+        baseline = await self._capture_baseline(
+            symbol=symbol, side="sell", qty=quantity, limit_price=price
+        )
+        result = await _place_order_impl(
             symbol=symbol,
             side="sell",
             market="kr",
@@ -116,6 +130,9 @@ class KisMockBroker:
             scalping_strategy_id=strategy_id,
             scalping_exit_reason=exit_reason,
         )
+        if isinstance(result, dict):
+            result["_baseline"] = baseline
+        return result
 
     def _get_mock_client(self) -> KISClient:
         # Mock-host client (live singleton would 401/EGW02005); cached so the
@@ -124,27 +141,82 @@ class KisMockBroker:
             self._mock_client = _create_kis_client(is_mock=True)
         return self._mock_client
 
-    async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None:
-        # ROB-334: authoritative fill evidence from the KIS daily order-execution
-        # inquiry. Returns a Fill only when fully filled; every other outcome is
-        # fail-closed (None -> executor records entry_unfilled/exit_unconfirmed
-        # anomaly). Never fabricates a fill.
-        evidence = await self._poll_fill_evidence(submit_result)
-        if (
-            evidence.verdict is FillVerdict.FILLED
-            and evidence.avg_price is not None
-            and evidence.filled_qty is not None
-        ):
-            return Fill(price=evidence.avg_price, quantity=evidence.filled_qty)
-        logger.info(
-            "kis-mock fill unconfirmed verdict=%s category=%s reason=%s",
-            evidence.verdict.value,
-            evidence.category.value if evidence.category else "-",
-            evidence.reason_code,
-        )
-        return None
+    async def _read_snapshot(self, symbol: str) -> tuple[Decimal, Decimal | None]:
+        """Read-only mock domestic balance snapshot -> (holdings_qty, cash).
 
-    async def _poll_fill_evidence(self, submit_result: dict[str, Any]) -> FillEvidence:
+        Holdings qty is the per-symbol position from output1; cash is
+        ``dnca_tot_amt`` from output2. Mock host only (VTTC8434R).
+        """
+        client = self._get_mock_client()
+        snap = await client.account.fetch_domestic_balance_snapshot(is_mock=True)
+        target = to_db_symbol(symbol)
+        qty = Decimal("0")
+        for holding in snap.get("holdings") or []:
+            if to_db_symbol(str(holding.get("pdno") or "")) == target:
+                qty = _to_decimal(holding.get("hldg_qty")) or Decimal("0")
+                break
+        cash = _to_decimal((snap.get("cash") or {}).get("dnca_tot_amt"))
+        return qty, cash
+
+    async def _capture_baseline(
+        self, *, symbol: str, side: str, qty: Decimal, limit_price: Decimal
+    ) -> dict[str, str | None]:
+        """Snapshot holdings + cash immediately before a submit.
+
+        A read failure leaves ``holdings_qty=None`` so confirm_fill fails closed
+        (we cannot prove a delta against an unknown baseline).
+        """
+        try:
+            holdings_qty, cash = await self._read_snapshot(symbol)
+            hq: str | None = str(holdings_qty)
+        except Exception as exc:  # noqa: BLE001 - baseline read failure fails closed
+            logger.info("kis-mock baseline snapshot failed sym=%s: %s", symbol, exc)
+            hq, cash = None, None
+        return {
+            "symbol": symbol,
+            "side": side,
+            "ordered_qty": str(qty),
+            "limit_price": str(limit_price),
+            "holdings_qty": hq,
+            "cash": (str(cash) if cash is not None else None),
+        }
+
+    async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None:
+        # ROB-341: same-day fill confirmation from the baseline-vs-post holdings
+        # delta (primary) + cash delta (price). daily-ccld is NOT consulted here
+        # (it can return empty rows for same-day mock fills); it remains
+        # supplementary/post-settlement evidence only. Every ambiguous outcome
+        # is fail-closed (None -> executor records entry_unfilled/exit_unconfirmed
+        # anomaly). Never fabricates a fill.
+        raw = submit_result.get("_baseline")
+        if not isinstance(raw, dict):
+            logger.info("kis-mock confirm: no baseline snapshot -> fail closed")
+            return None
+        baseline = BaselineSnapshot(
+            symbol=str(raw["symbol"]),
+            side=raw["side"],
+            ordered_qty=Decimal(str(raw["ordered_qty"])),
+            limit_price=Decimal(str(raw["limit_price"])),
+            holdings_qty=(
+                Decimal(str(raw["holdings_qty"]))
+                if raw.get("holdings_qty") is not None
+                else None
+            ),
+            cash=(Decimal(str(raw["cash"])) if raw.get("cash") is not None else None),
+        )
+        return await confirm_fill_from_holdings_delta(
+            baseline, fetch_post=self._read_snapshot
+        )
+
+    async def poll_daily_ccld_diagnostic(
+        self, submit_result: dict[str, Any]
+    ) -> FillEvidence:
+        """Supplementary, NON-GATING daily-ccld read (ROB-341).
+
+        Retained for post-settlement evidence / the smoke packet only. Its empty
+        same-day result is classified clearly but never gates or overrides the
+        holdings-delta verdict in :meth:`confirm_fill`.
+        """
         order_no = submit_result.get("odno") or submit_result.get("order_no")
         if not order_no:
             return FillEvidence(

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -81,8 +81,14 @@ class KisMockBroker:
         correlation_id: str,
         confirm: bool,
     ) -> dict[str, Any]:
-        baseline = await self._capture_baseline(
-            symbol=symbol, side="buy", qty=quantity, limit_price=price
+        # Baseline is only consumed by confirm_fill on the confirm path; a
+        # dry-run returns before confirm, so skip the balance read entirely.
+        baseline = (
+            await self._capture_baseline(
+                symbol=symbol, side="buy", qty=quantity, limit_price=price
+            )
+            if confirm
+            else None
         )
         result = await _place_order_impl(
             symbol=symbol,
@@ -96,7 +102,7 @@ class KisMockBroker:
             reason=f"scalp_entry:{correlation_id}",
             strategy=self._strategy_id,
         )
-        if isinstance(result, dict):
+        if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
         return result
 
@@ -111,8 +117,12 @@ class KisMockBroker:
         correlation_id: str,
         confirm: bool,
     ) -> dict[str, Any]:
-        baseline = await self._capture_baseline(
-            symbol=symbol, side="sell", qty=quantity, limit_price=price
+        baseline = (
+            await self._capture_baseline(
+                symbol=symbol, side="sell", qty=quantity, limit_price=price
+            )
+            if confirm
+            else None
         )
         result = await _place_order_impl(
             symbol=symbol,
@@ -130,7 +140,7 @@ class KisMockBroker:
             scalping_strategy_id=strategy_id,
             scalping_exit_reason=exit_reason,
         )
-        if isinstance(result, dict):
+        if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
         return result
 

--- a/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
+++ b/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
@@ -14,8 +14,19 @@ post-settlement evidence only.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Literal
+
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
+from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
+
+logger = logging.getLogger("rob341.kis_mock_holdings_delta")
+
+# (symbol) -> (observed_holdings_qty, observed_cash | None)
+PostFetch = Callable[[str], Awaitable[tuple[Decimal, Decimal | None]]]
 
 
 def derive_fill_price(
@@ -38,3 +49,78 @@ def derive_fill_price(
         if cash_delta > 0:
             return cash_delta / filled_qty, "cash_delta"
     return limit_price, "limit_fallback"
+
+
+@dataclass
+class BaselineSnapshot:
+    """Holdings + cash captured immediately before a mock submit.
+
+    ``holdings_qty is None`` means the baseline read failed: confirmation then
+    fails closed (we cannot prove a delta against an unknown baseline).
+    """
+
+    symbol: str
+    side: Literal["buy", "sell"]
+    ordered_qty: Decimal
+    limit_price: Decimal
+    holdings_qty: Decimal | None
+    cash: Decimal | None
+
+
+async def confirm_fill_from_holdings_delta(
+    baseline: BaselineSnapshot,
+    *,
+    fetch_post: PostFetch,
+) -> Fill | None:
+    """Return a ``Fill`` only when the post-submit holdings delta unambiguously
+    proves a (full or partial) fill in the order's direction.
+
+    Every other outcome is fail-closed (``None``): missing baseline, snapshot
+    read failure, or a zero / wrong-direction delta. Never fabricates a fill.
+    """
+    if baseline.holdings_qty is None:
+        logger.info(
+            "kis-mock holdings-delta confirm: baseline missing sym=%s -> fail closed",
+            baseline.symbol,
+        )
+        return None
+    try:
+        observed_qty, observed_cash = await fetch_post(baseline.symbol)
+    except Exception as exc:  # noqa: BLE001 - any read fault fails closed
+        logger.info(
+            "kis-mock holdings-delta confirm: post-snapshot error sym=%s: %s",
+            baseline.symbol,
+            exc,
+        )
+        return None
+
+    decision = classify_fill_by_delta(
+        side=baseline.side,
+        ordered_qty=baseline.ordered_qty,
+        baseline_qty=baseline.holdings_qty,
+        observed_qty=observed_qty,
+    )
+    if decision.verdict == "none":
+        logger.info(
+            "kis-mock holdings-delta confirm: no fill delta sym=%s delta=%s -> fail closed",
+            baseline.symbol,
+            decision.delta,
+        )
+        return None
+
+    price, price_source = derive_fill_price(
+        side=baseline.side,
+        filled_qty=decision.filled_qty,
+        cash_baseline=baseline.cash,
+        cash_observed=observed_cash,
+        limit_price=baseline.limit_price,
+    )
+    logger.info(
+        "kis-mock holdings-delta confirm: %s sym=%s qty=%s price=%s (%s)",
+        decision.verdict,
+        baseline.symbol,
+        decision.filled_qty,
+        price,
+        price_source,
+    )
+    return Fill(price=price, quantity=decision.filled_qty)

--- a/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
+++ b/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
@@ -1,0 +1,40 @@
+"""ROB-341 — synchronous holdings/cash-delta fill confirmation for KIS mock.
+
+Primary same-day fill signal is the baseline-vs-post **holdings delta** (load
+bearing). **Cash delta** is corroboration plus the preferred fill-price source.
+This module performs the broker-facing async snapshot reads and orchestration;
+the delta -> verdict decision lives in the pure ``classify_fill_by_delta``
+kernel (shared with the ROB-102 reconciler).
+
+``inquire_daily_order_domestic`` (daily-ccld) is never consulted here: it can
+return empty rows for same-day mock fills, so an empty same-day daily-ccld can
+neither gate nor override this verdict. daily-ccld remains supplementary,
+post-settlement evidence only.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+
+
+def derive_fill_price(
+    *,
+    side: Literal["buy", "sell"],
+    filled_qty: Decimal,
+    cash_baseline: Decimal | None,
+    cash_observed: Decimal | None,
+    limit_price: Decimal,
+) -> tuple[Decimal, str]:
+    """Derive a fill price for PnL telemetry.
+
+    Prefer the cash delta (``|Δcash| / filled_qty``); fall back to the submitted
+    limit price when cash is unavailable, unmoved, or qty is zero. Returns
+    ``(price, source)`` where ``source`` is ``"cash_delta"`` or
+    ``"limit_fallback"``.
+    """
+    if cash_baseline is not None and cash_observed is not None and filled_qty > 0:
+        cash_delta = abs(cash_observed - cash_baseline)
+        if cash_delta > 0:
+            return cash_delta / filled_qty, "cash_delta"
+    return limit_price, "limit_fallback"

--- a/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
+++ b/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
@@ -10,6 +10,17 @@ kernel (shared with the ROB-102 reconciler).
 return empty rows for same-day mock fills, so an empty same-day daily-ccld can
 neither gate nor override this verdict. daily-ccld remains supplementary,
 post-settlement evidence only.
+
+**Attribution boundary (ROB-341 §4, known limitation).** The delta attributes
+*any* directional holdings change in the poll window to *this* order — it cannot
+distinguish this order's fill from a concurrent same-symbol fill. Two mitigations
+bound the risk: (1) the scalping ws_bridge serializes per-symbol entries via an
+in-flight set + global semaphore, so two concurrent scalps on the same symbol do
+not overlap; (2) a wrong-direction or zero delta already fails closed. The
+residual, un-disambiguated case is external/manual same-symbol account activity
+during the bounded poll; holdings alone cannot resolve it, and a future
+ledger/open-order cross-check is the deeper fix (tracked as follow-up). Keep the
+confirmed smoke to idle symbols with no concurrent manual activity.
 """
 
 from __future__ import annotations
@@ -72,11 +83,19 @@ async def confirm_fill_from_holdings_delta(
     *,
     fetch_post: PostFetch,
 ) -> Fill | None:
-    """Return a ``Fill`` only when the post-submit holdings delta unambiguously
-    proves a (full or partial) fill in the order's direction.
+    """Return a ``Fill`` only when the post-submit holdings delta proves a
+    **full** fill in the order's direction.
 
-    Every other outcome is fail-closed (``None``): missing baseline, snapshot
-    read failure, or a zero / wrong-direction delta. Never fabricates a fill.
+    A partial delta is treated as not-yet-filled and returns ``None`` so the
+    executor's bounded poll either reaches a full fill or times out into an
+    ``entry_unfilled`` / ``exit_unconfirmed`` anomaly — the executor has no
+    partial-fill handling, so confirming a partial would strand the residual
+    position and fabricate full-size PnL. (The periodic ROB-102 reconciler
+    keeps its own partial semantics via the shared kernel.)
+
+    Every non-full outcome is fail-closed (``None``): missing baseline, snapshot
+    read failure, a zero / wrong-direction delta, or a partial. Never fabricates
+    a fill.
     """
     if baseline.holdings_qty is None:
         logger.info(
@@ -100,11 +119,17 @@ async def confirm_fill_from_holdings_delta(
         baseline_qty=baseline.holdings_qty,
         observed_qty=observed_qty,
     )
-    if decision.verdict == "none":
+    if decision.verdict != "filled":
+        # 'none' (no/wrong-direction delta) or 'partial' (not yet fully filled)
+        # both fail closed; on a partial the bounded poll keeps trying.
         logger.info(
-            "kis-mock holdings-delta confirm: no fill delta sym=%s delta=%s -> fail closed",
+            "kis-mock holdings-delta confirm: verdict=%s (not full) sym=%s "
+            "delta=%s filled=%s/%s -> fail closed",
+            decision.verdict,
             baseline.symbol,
             decision.delta,
+            decision.filled_qty,
+            baseline.ordered_qty,
         )
         return None
 

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -66,6 +66,36 @@ class LifecycleTransitionProposal:
     observed_delta: Decimal | None
 
 
+@dataclass(frozen=True, slots=True)
+class DeltaFillResult:
+    verdict: Literal["filled", "partial", "none"]
+    filled_qty: Decimal  # magnitude in the order's direction, clamped to ordered_qty
+    delta: Decimal
+
+
+def classify_fill_by_delta(
+    *,
+    side: Literal["buy", "sell"],
+    ordered_qty: Decimal,
+    baseline_qty: Decimal,
+    observed_qty: Decimal,
+) -> DeltaFillResult:
+    """Pure delta -> fill decision shared by the periodic reconciler and the
+    synchronous confirm path (ROB-341).
+
+    ``filled_qty`` is the magnitude of the position change in the order's
+    direction, clamped to ``ordered_qty``. A delta in the wrong direction
+    (holdings dropped on a buy / rose on a sell) yields ``none`` — never a fill.
+    """
+    delta = observed_qty - baseline_qty
+    directional = delta if side == "buy" else -delta
+    if directional <= 0:
+        return DeltaFillResult("none", Decimal("0"), delta)
+    filled = directional if directional < ordered_qty else ordered_qty
+    verdict = "filled" if directional >= ordered_qty else "partial"
+    return DeltaFillResult(verdict, filled, delta)
+
+
 _TERMINAL: frozenset[str] = frozenset({"reconciled", "failed", "stale"})
 _RECONCILABLE_INPUTS: frozenset[str] = frozenset({"accepted", "pending", "fill"})
 
@@ -146,21 +176,19 @@ def classify_orders(
                 )
             continue
 
-        # accepted / pending paths
-        if order.side == "buy":
-            if delta >= order.ordered_qty:
-                next_state, reason = "fill", "fill_detected"
-            elif delta > 0:
-                next_state, reason = "fill", "partial_fill_detected"
-            else:
-                next_state, reason = _pending_or_stale(order, now, thresholds)
-        else:  # sell
-            if delta <= -order.ordered_qty:
-                next_state, reason = "fill", "fill_detected"
-            elif delta < 0:
-                next_state, reason = "fill", "partial_fill_detected"
-            else:
-                next_state, reason = _pending_or_stale(order, now, thresholds)
+        # accepted / pending paths — delegate the delta decision to the kernel.
+        decision = classify_fill_by_delta(
+            side=order.side,
+            ordered_qty=order.ordered_qty,
+            baseline_qty=order.holdings_baseline_qty,
+            observed_qty=snapshot.quantity,
+        )
+        if decision.verdict == "filled":
+            next_state, reason = "fill", "fill_detected"
+        elif decision.verdict == "partial":
+            next_state, reason = "fill", "partial_fill_detected"
+        else:
+            next_state, reason = _pending_or_stale(order, now, thresholds)
 
         proposals.append(
             LifecycleTransitionProposal(
@@ -188,10 +216,12 @@ def _pending_or_stale(
 
 
 __all__ = [
+    "DeltaFillResult",
     "HoldingsSnapshot",
     "LedgerOrderInput",
     "LifecycleTransitionProposal",
     "ReasonCode",
     "ReconcilerThresholds",
+    "classify_fill_by_delta",
     "classify_orders",
 ]

--- a/docs/plans/ROB-341-kis-mock-holdings-delta-fill-confirmation.md
+++ b/docs/plans/ROB-341-kis-mock-holdings-delta-fill-confirmation.md
@@ -1,0 +1,649 @@
+# ROB-341 — KIS mock same-day fill confirmation via holdings/cash delta Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make KIS **mock** same-day scalping fill confirmation use a baseline-vs-post **holdings delta** (primary, load-bearing) + **cash delta** (corroboration + fill-price derivation) instead of `inquire_daily_order_domestic` (daily-ccld), which returns empty rows for same-day mock fills.
+
+**Architecture:** Extract the existing ROB-102 reconciler's delta→verdict decision into a shared pure kernel (`classify_fill_by_delta`) reused by both the periodic reconciler and a new **synchronous** confirm path. `KisMockBroker` captures a baseline holdings+cash snapshot immediately before each submit, then `confirm_fill` polls a post-submit snapshot, computes the per-symbol delta, classifies it, derives a fill price from the cash delta (fallback = submitted limit price), and returns a `Fill` only when the delta unambiguously proves a fill — every other outcome is fail-closed (`None`). daily-ccld is demoted to a supplementary diagnostic that can never gate or override the holdings verdict.
+
+**Tech Stack:** Python 3.13, asyncio, Decimal, pytest, KIS REST (`fetch_domestic_balance_snapshot` TR `VTTC8434R` mock), existing executor port architecture.
+
+**Decided trade-off (surfaced for reviewer):** holdings delta proves *quantity* but not *price*. Price priority = (1) cash-delta-implied `|Δdnca_tot_amt| / qty` when cash moved and qty>0; (2) submitted limit price from `submit_result`. The chosen source is recorded in evidence. This keeps PnL telemetry meaningful while holdings remains the authoritative fill signal.
+
+**Safety boundaries (hard):** KIS mock only (no live), limit orders only (no market), no scheduler / no persistent `KIS_MOCK_SCALPING_WS_CONFIRM=true`, no Prefect/TaskIQ/cron/launchd, no prod env/secret/DB-destructive change, no secret logging. Ambiguous evidence fails closed. Confirmed smoke only after read-only preflight + operator approval.
+
+**STOP conditions (report with evidence, do not force):** (a) reconciler kernel reuse turns out infeasible; (b) the confirmed smoke shows mock holdings do **not** reflect a same-day fill within the bounded poll window.
+
+---
+
+## File Structure
+
+- `app/services/kis_mock_holdings_reconciler.py` — **modify**: add pure `classify_fill_by_delta` kernel + `DeltaFillResult`; refactor `classify_orders` to delegate the delta→verdict decision to it (DRY, behavior-preserving).
+- `app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py` — **create**: async snapshot fetch + `confirm_fill_from_holdings_delta` orchestration (baseline/post delta, cash-delta price derivation, fail-closed) — the broker-facing glue, separate from the pure kernel.
+- `app/services/brokers/kis/mock_scalping_exec/adapters.py` — **modify**: `submit_buy`/`submit_exit_sell` capture a baseline snapshot before placing and stamp it (+ side/ordered_qty/intended_price) into the returned dict; `confirm_fill` rewired to the holdings-delta path; daily-ccld kept only as a logged supplementary diagnostic.
+- `scripts/kis_mock_holdings_delta_smoke.py` — **create**: read-only preflight (snapshot read, no orders) + operator-gated bounded confirmed round-trip producing the ROB-341 evidence packet.
+- `docs/runbooks/kis-mock-scalping-smoke.md` — **modify**: state daily-ccld is not primary same-day evidence; document new preflight + confirmed-smoke command shapes.
+- `tests/test_kis_mock_holdings_delta_fill.py` — **create**: kernel + price-derivation + confirm fail-closed tests.
+- `tests/test_kis_mock_holdings_reconciler.py` — **modify if present**: ensure refactor keeps reconciler behavior green.
+
+---
+
+## Task 1: Shared pure delta kernel
+
+**Files:**
+- Modify: `app/services/kis_mock_holdings_reconciler.py`
+- Test: `tests/test_kis_mock_holdings_delta_fill.py` (create)
+
+- [ ] **Step 1: Write the failing kernel test**
+
+```python
+# tests/test_kis_mock_holdings_delta_fill.py
+from decimal import Decimal
+import pytest
+from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "side,baseline,observed,ordered,verdict,filled",
+    [
+        ("buy", "0", "10", "10", "filled", "10"),
+        ("buy", "0", "4", "10", "partial", "4"),
+        ("buy", "0", "0", "10", "none", "0"),
+        ("buy", "5", "15", "10", "filled", "10"),    # baseline position present
+        ("buy", "5", "9", "10", "partial", "4"),     # delta below ordered
+        ("buy", "5", "3", "10", "none", "0"),         # holdings DROPPED after a buy -> impossible -> none
+        ("sell", "10", "0", "10", "filled", "10"),
+        ("sell", "10", "6", "10", "partial", "4"),
+        ("sell", "10", "10", "10", "none", "0"),
+        ("sell", "10", "12", "10", "none", "0"),      # holdings ROSE after a sell -> impossible -> none
+    ],
+)
+def test_classify_fill_by_delta(side, baseline, observed, ordered, verdict, filled):
+    res = classify_fill_by_delta(
+        side=side,
+        ordered_qty=Decimal(ordered),
+        baseline_qty=Decimal(baseline),
+        observed_qty=Decimal(observed),
+    )
+    assert res.verdict == verdict
+    assert res.filled_qty == Decimal(filled)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py -v`
+Expected: FAIL with `ImportError: cannot import name 'classify_fill_by_delta'`
+
+- [ ] **Step 3: Implement the kernel + refactor `classify_orders` to use it**
+
+Add to `app/services/kis_mock_holdings_reconciler.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class DeltaFillResult:
+    verdict: Literal["filled", "partial", "none"]
+    filled_qty: Decimal  # signed-magnitude: always >= 0
+    delta: Decimal
+
+
+def classify_fill_by_delta(
+    *,
+    side: Literal["buy", "sell"],
+    ordered_qty: Decimal,
+    baseline_qty: Decimal,
+    observed_qty: Decimal,
+) -> DeltaFillResult:
+    """Pure delta→fill decision shared by the periodic reconciler and the
+    synchronous confirm path. ``filled_qty`` is the magnitude of the position
+    change in the order's direction, clamped to ``ordered_qty``. A delta in the
+    wrong direction (holdings dropped on a buy / rose on a sell) yields ``none``.
+    """
+    delta = observed_qty - baseline_qty
+    directional = delta if side == "buy" else -delta
+    if directional <= 0:
+        return DeltaFillResult("none", Decimal("0"), delta)
+    filled = directional if directional < ordered_qty else ordered_qty
+    verdict = "filled" if directional >= ordered_qty else "partial"
+    return DeltaFillResult(verdict, filled, delta)
+```
+
+Then refactor the `accepted / pending paths` block inside `classify_orders` (lines ~149-163) to delegate:
+
+```python
+        # accepted / pending paths — delegate the delta decision to the kernel.
+        decision = classify_fill_by_delta(
+            side=order.side,
+            ordered_qty=order.ordered_qty,
+            baseline_qty=order.holdings_baseline_qty,
+            observed_qty=snapshot.quantity,
+        )
+        if decision.verdict == "filled":
+            next_state, reason = "fill", "fill_detected"
+        elif decision.verdict == "partial":
+            next_state, reason = "fill", "partial_fill_detected"
+        else:
+            next_state, reason = _pending_or_stale(order, now, thresholds)
+```
+
+Add `"DeltaFillResult"` and `"classify_fill_by_delta"` to `__all__`.
+
+- [ ] **Step 4: Run kernel + reconciler tests**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py tests/test_kis_mock_holdings_reconciler.py -v`
+Expected: PASS (reconciler tests unchanged — behavior preserved)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/kis_mock_holdings_reconciler.py tests/test_kis_mock_holdings_delta_fill.py
+git commit -m "feat(ROB-341): shared classify_fill_by_delta kernel reused by reconciler"
+```
+
+---
+
+## Task 2: Cash-delta fill-price derivation (pure)
+
+**Files:**
+- Modify: `app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py` (create in this task)
+- Test: `tests/test_kis_mock_holdings_delta_fill.py`
+
+- [ ] **Step 1: Write the failing price-derivation test**
+
+```python
+from decimal import Decimal
+import pytest
+from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    derive_fill_price,
+)
+
+@pytest.mark.unit
+def test_price_from_cash_delta_buy():
+    # cash dropped 100000 for 10 shares -> 10000/share
+    price, source = derive_fill_price(
+        side="buy", filled_qty=Decimal("10"),
+        cash_baseline=Decimal("1000000"), cash_observed=Decimal("900000"),
+        limit_price=Decimal("9999"),
+    )
+    assert price == Decimal("10000")
+    assert source == "cash_delta"
+
+@pytest.mark.unit
+def test_price_falls_back_to_limit_when_cash_unmoved():
+    price, source = derive_fill_price(
+        side="buy", filled_qty=Decimal("10"),
+        cash_baseline=Decimal("1000000"), cash_observed=Decimal("1000000"),
+        limit_price=Decimal("9999"),
+    )
+    assert price == Decimal("9999")
+    assert source == "limit_fallback"
+
+@pytest.mark.unit
+def test_price_falls_back_when_cash_unavailable():
+    price, source = derive_fill_price(
+        side="sell", filled_qty=Decimal("10"),
+        cash_baseline=None, cash_observed=Decimal("900000"),
+        limit_price=Decimal("8888"),
+    )
+    assert price == Decimal("8888")
+    assert source == "limit_fallback"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py -k price -v`
+Expected: FAIL with `ModuleNotFoundError`
+
+- [ ] **Step 3: Create the module with `derive_fill_price`**
+
+```python
+# app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
+"""ROB-341 — synchronous holdings/cash-delta fill confirmation for KIS mock.
+
+Primary same-day fill signal is the baseline-vs-post holdings delta (load
+bearing). Cash delta is corroboration + the preferred fill-price source. This
+module performs the broker-facing async snapshot reads and orchestration; the
+delta→verdict decision lives in the pure ``classify_fill_by_delta`` kernel.
+daily-ccld is never consulted here — empty same-day daily-ccld can neither
+gate nor override this verdict.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Literal
+
+
+def derive_fill_price(
+    *,
+    side: Literal["buy", "sell"],
+    filled_qty: Decimal,
+    cash_baseline: Decimal | None,
+    cash_observed: Decimal | None,
+    limit_price: Decimal,
+) -> tuple[Decimal, str]:
+    """Derive a fill price. Prefer the cash delta (``|Δcash| / filled_qty``);
+    fall back to the submitted limit price when cash is unavailable, unmoved,
+    or qty is zero. Returns ``(price, source)``."""
+    if (
+        cash_baseline is not None
+        and cash_observed is not None
+        and filled_qty > 0
+    ):
+        cash_delta = abs(cash_observed - cash_baseline)
+        if cash_delta > 0:
+            return cash_delta / filled_qty, "cash_delta"
+    return limit_price, "limit_fallback"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py -k price -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py tests/test_kis_mock_holdings_delta_fill.py
+git commit -m "feat(ROB-341): cash-delta fill-price derivation with limit fallback"
+```
+
+---
+
+## Task 3: Async confirm orchestration (snapshot fetch + fail-closed)
+
+**Files:**
+- Modify: `app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py`
+- Test: `tests/test_kis_mock_holdings_delta_fill.py`
+
+- [ ] **Step 1: Write the failing confirm test (with a fake snapshot provider)**
+
+```python
+from decimal import Decimal
+import pytest
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
+from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    BaselineSnapshot, confirm_fill_from_holdings_delta,
+)
+
+def _baseline(qty="0", cash="1000000"):
+    return BaselineSnapshot(
+        symbol="005930", side="buy", ordered_qty=Decimal("10"),
+        limit_price=Decimal("70000"),
+        holdings_qty=Decimal(qty),
+        cash=(Decimal(cash) if cash is not None else None),
+    )
+
+@pytest.mark.unit
+async def test_confirm_filled_returns_fill():
+    async def post(symbol):  # observed holdings + cash
+        return Decimal("10"), Decimal("300000")  # bought 10, cash dropped 700000
+    fill = await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post)
+    assert isinstance(fill, Fill)
+    assert fill.quantity == Decimal("10")
+    assert fill.price == Decimal("70000")  # 700000/10 cash-delta
+
+@pytest.mark.unit
+async def test_confirm_no_delta_fails_closed():
+    async def post(symbol):
+        return Decimal("0"), Decimal("1000000")
+    assert await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post) is None
+
+@pytest.mark.unit
+async def test_confirm_baseline_missing_fails_closed():
+    b = _baseline()
+    object.__setattr__(b, "holdings_qty", None)
+    async def post(symbol):
+        return Decimal("10"), Decimal("300000")
+    assert await confirm_fill_from_holdings_delta(b, fetch_post=post) is None
+
+@pytest.mark.unit
+async def test_confirm_snapshot_error_fails_closed():
+    async def post(symbol):
+        raise RuntimeError("VTS read failed")
+    assert await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py -k confirm -v`
+Expected: FAIL with `ImportError: cannot import name 'BaselineSnapshot'`
+
+- [ ] **Step 3: Implement `BaselineSnapshot` + `confirm_fill_from_holdings_delta`**
+
+Append to `holdings_delta_confirm.py`:
+
+```python
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
+from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
+
+logger = logging.getLogger("rob341.kis_mock_holdings_delta")
+
+# (symbol) -> (observed_holdings_qty, observed_cash | None)
+PostFetch = Callable[[str], Awaitable[tuple[Decimal, Decimal | None]]]
+
+
+@dataclass
+class BaselineSnapshot:
+    symbol: str
+    side: Literal["buy", "sell"]
+    ordered_qty: Decimal
+    limit_price: Decimal
+    holdings_qty: Decimal | None  # None => baseline read failed => fail closed
+    cash: Decimal | None
+
+
+async def confirm_fill_from_holdings_delta(
+    baseline: BaselineSnapshot,
+    *,
+    fetch_post: PostFetch,
+) -> Fill | None:
+    """Return a ``Fill`` only when the post-submit holdings delta unambiguously
+    proves a (full or partial) fill in the order's direction. Every other
+    outcome — missing baseline, snapshot read failure, zero/wrong-direction
+    delta — is fail-closed (``None``)."""
+    if baseline.holdings_qty is None:
+        logger.info("kis-mock holdings-delta confirm: baseline missing -> fail closed")
+        return None
+    try:
+        observed_qty, observed_cash = await fetch_post(baseline.symbol)
+    except Exception as exc:  # noqa: BLE001 - any read fault fails closed
+        logger.info("kis-mock holdings-delta confirm: post-snapshot error %s", exc)
+        return None
+
+    decision = classify_fill_by_delta(
+        side=baseline.side,
+        ordered_qty=baseline.ordered_qty,
+        baseline_qty=baseline.holdings_qty,
+        observed_qty=observed_qty,
+    )
+    if decision.verdict == "none":
+        logger.info(
+            "kis-mock holdings-delta confirm: no fill delta sym=%s delta=%s",
+            baseline.symbol, decision.delta,
+        )
+        return None
+
+    price, price_source = derive_fill_price(
+        side=baseline.side,
+        filled_qty=decision.filled_qty,
+        cash_baseline=baseline.cash,
+        cash_observed=observed_cash,
+        limit_price=baseline.limit_price,
+    )
+    logger.info(
+        "kis-mock holdings-delta confirm: %s sym=%s qty=%s price=%s (%s)",
+        decision.verdict, baseline.symbol, decision.filled_qty, price, price_source,
+    )
+    return Fill(price=price, quantity=decision.filled_qty)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_fill.py -k confirm -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py tests/test_kis_mock_holdings_delta_fill.py
+git commit -m "feat(ROB-341): fail-closed async holdings-delta confirm orchestration"
+```
+
+---
+
+## Task 4: Wire baseline capture + holdings-delta confirm into `KisMockBroker`
+
+**Files:**
+- Modify: `app/services/brokers/kis/mock_scalping_exec/adapters.py`
+- Test: `tests/test_kis_mock_scalping_adapters.py` (create if absent)
+
+- [ ] **Step 1: Write the failing adapter test**
+
+```python
+# tests/test_kis_mock_scalping_adapters.py
+from decimal import Decimal
+import pytest
+from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockBroker
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
+
+
+@pytest.mark.unit
+async def test_confirm_fill_uses_holdings_delta(monkeypatch):
+    broker = KisMockBroker(get_state=lambda s: None)
+
+    # Fake the snapshot reads: baseline 0 holdings / 1,000,000 cash;
+    # post 10 holdings / 300,000 cash.
+    calls = {"n": 0}
+    async def fake_snapshot(symbol):
+        calls["n"] += 1
+        return (Decimal("0"), Decimal("1000000")) if calls["n"] == 1 \
+            else (Decimal("10"), Decimal("300000"))
+    monkeypatch.setattr(broker, "_read_snapshot", fake_snapshot)
+
+    submit_result = {
+        "odno": "0001",
+        "_baseline": {
+            "symbol": "005930", "side": "buy", "ordered_qty": "10",
+            "limit_price": "70000", "holdings_qty": "0", "cash": "1000000",
+        },
+    }
+    fill = await broker.confirm_fill(submit_result)
+    assert isinstance(fill, Fill)
+    assert fill.quantity == Decimal("10")
+
+
+@pytest.mark.unit
+async def test_confirm_fill_no_baseline_fails_closed():
+    broker = KisMockBroker(get_state=lambda s: None)
+    assert await broker.confirm_fill({"odno": "0001"}) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_adapters.py -v`
+Expected: FAIL (current `confirm_fill` reads daily-ccld, has no `_baseline`/`_read_snapshot`)
+
+- [ ] **Step 3: Rewire `KisMockBroker`**
+
+In `adapters.py`:
+
+1. Add a snapshot reader that returns `(holdings_qty_for_symbol, cash)` from the mock domestic balance snapshot:
+
+```python
+    async def _read_snapshot(self, symbol: str) -> tuple[Decimal, Decimal | None]:
+        from app.core.symbol import to_db_symbol
+        client = self._get_mock_client()
+        snap = await client.account.fetch_domestic_balance_snapshot(is_mock=True)
+        target = to_db_symbol(symbol)
+        qty = Decimal("0")
+        for h in snap.get("holdings") or []:
+            if to_db_symbol(str(h.get("pdno") or "")) == target:
+                qty = _to_decimal(h.get("hldg_qty")) or Decimal("0")
+                break
+        cash = _to_decimal((snap.get("cash") or {}).get("dnca_tot_amt"))
+        return qty, cash
+```
+
+2. Capture a baseline immediately before each submit and stamp it into the result. Wrap the existing `submit_buy`/`submit_exit_sell` bodies:
+
+```python
+    async def _capture_baseline(
+        self, *, symbol: str, side: str, qty: Decimal, limit_price: Decimal
+    ) -> dict[str, str | None]:
+        try:
+            h, cash = await self._read_snapshot(symbol)
+            hq: str | None = str(h)
+        except Exception:  # noqa: BLE001 - baseline read failure => confirm fails closed
+            hq, cash = None, None
+        return {
+            "symbol": symbol, "side": side, "ordered_qty": str(qty),
+            "limit_price": str(limit_price),
+            "holdings_qty": hq, "cash": (str(cash) if cash is not None else None),
+        }
+```
+
+In `submit_buy` (and `submit_exit_sell` with `side="sell"`), before the `_place_order_impl` call, capture the baseline; after, attach it:
+
+```python
+        baseline = await self._capture_baseline(
+            symbol=symbol, side="buy", qty=quantity, limit_price=price
+        )
+        result = await _place_order_impl(... unchanged ...)
+        if isinstance(result, dict):
+            result["_baseline"] = baseline
+        return result
+```
+
+3. Replace `confirm_fill` body to use the holdings-delta path (drop daily-ccld as the gate; keep it only as a logged diagnostic):
+
+```python
+    async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None:
+        raw = submit_result.get("_baseline")
+        if not isinstance(raw, dict):
+            logger.info("kis-mock confirm: no baseline snapshot -> fail closed")
+            return None
+        baseline = BaselineSnapshot(
+            symbol=str(raw["symbol"]),
+            side=raw["side"],
+            ordered_qty=Decimal(str(raw["ordered_qty"])),
+            limit_price=Decimal(str(raw["limit_price"])),
+            holdings_qty=(Decimal(str(raw["holdings_qty"])) if raw.get("holdings_qty") is not None else None),
+            cash=(Decimal(str(raw["cash"])) if raw.get("cash") is not None else None),
+        )
+        fill = await confirm_fill_from_holdings_delta(baseline, fetch_post=self._read_snapshot)
+        # Supplementary, non-gating: log daily-ccld for post-settlement evidence only.
+        await self._log_daily_ccld_diagnostic(submit_result)
+        return fill
+```
+
+4. Rename the existing daily-ccld method to `_log_daily_ccld_diagnostic` and make it log-only (never returns a verdict that gates). It must classify empty same-day rows clearly (`pending`/`no_matching_order`) and log them, but its result MUST NOT influence the return of `confirm_fill`. Add imports: `from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import BaselineSnapshot, confirm_fill_from_holdings_delta`.
+
+- [ ] **Step 4: Run adapter + full scalping-exec tests**
+
+Run: `uv run pytest tests/test_kis_mock_scalping_adapters.py tests/ -k "scalping or fill_evidence" -v`
+Expected: PASS (executor port contract unchanged; daily-ccll classifier tests still pass as a diagnostic)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/kis/mock_scalping_exec/adapters.py tests/test_kis_mock_scalping_adapters.py
+git commit -m "feat(ROB-341): KisMockBroker confirms fills via holdings/cash delta, daily-ccld demoted"
+```
+
+---
+
+## Task 5: Read-only preflight + operator-gated confirmed smoke
+
+**Files:**
+- Create: `scripts/kis_mock_holdings_delta_smoke.py`
+- Test: `tests/test_kis_mock_holdings_delta_smoke_cli.py` (create)
+
+- [ ] **Step 1: Write the failing CLI-shape test (no secrets, no network)**
+
+```python
+# tests/test_kis_mock_holdings_delta_smoke_cli.py
+import subprocess, sys
+import pytest
+
+@pytest.mark.unit
+def test_smoke_help_runs_without_secrets():
+    out = subprocess.run(
+        [sys.executable, "-m", "scripts.kis_mock_holdings_delta_smoke", "--help"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0
+    assert "--confirm" in out.stdout
+    assert "--preflight" in out.stdout
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_smoke_cli.py -v`
+Expected: FAIL (module missing)
+
+- [ ] **Step 3: Implement the smoke CLI**
+
+Create `scripts/kis_mock_holdings_delta_smoke.py`. Requirements:
+- `argparse` with `--preflight` (read-only: fetch baseline snapshot, print holdings+cash for `--symbol`, exit 0; no orders), `--confirm` (place ONE small limit buy below market, poll holdings delta, derive fill, then cleanup-sell, print the full evidence packet), `--symbol`, `--notional-krw` (small cap, default 10000), `--max-poll`/`--poll-interval`.
+- Lazy-import Settings-backed modules **only inside** the command body (per `feedback_operator_cli_lazy_settings_import` — `--help` must run without secrets).
+- Default-disabled: require `KIS_MOCK_ENABLED=true` (or the existing scalping enable gate) and refuse confirm unless `--confirm` is explicitly passed.
+- Never print secret values; print only missing env var **names**.
+- Evidence packet (printed as JSON) MUST include: symbol, side(s), order id(s), baseline holdings/cash, post-submit holdings/cash, selected confirmation signal + price source, pending-order count, cleanup result, final position delta vs baseline.
+- Always attempt cleanup-sell of any acquired position in a `finally` block; if cleanup cannot be confirmed, exit non-zero and label `anomaly`.
+
+- [ ] **Step 4: Run CLI-shape test**
+
+Run: `uv run pytest tests/test_kis_mock_holdings_delta_smoke_cli.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/kis_mock_holdings_delta_smoke.py tests/test_kis_mock_holdings_delta_smoke_cli.py
+git commit -m "feat(ROB-341): read-only preflight + operator-gated holdings-delta confirmed smoke"
+```
+
+---
+
+## Task 6: Runbook update
+
+**Files:**
+- Modify: `docs/runbooks/kis-mock-scalping-smoke.md`
+
+- [ ] **Step 1: Document the change**
+
+Add a section stating:
+- daily-ccld (`inquire_daily_order_domestic`) is **not** the primary same-day fill signal; its empty same-day result is supplementary/post-settlement only and never gates or overrides the holdings verdict.
+- Same-day fills are confirmed via baseline-vs-post **holdings delta** (primary) + **cash delta** (corroboration + fill-price source); ambiguous/zero/wrong-direction deltas fail closed.
+- `H0STCNI9` remains an unimplemented, documented gap and an explicit follow-up (out of ROB-341 scope).
+- Read-only preflight command: `uv run python -m scripts.kis_mock_holdings_delta_smoke --preflight --symbol <code>`.
+- Bounded confirmed-smoke command shape (operator-gated, secrets excluded): `KIS_MOCK_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke --confirm --symbol <code> --notional-krw 10000`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/kis-mock-scalping-smoke.md
+git commit -m "docs(ROB-341): daily-ccld demoted; holdings/cash-delta confirm runbook"
+```
+
+---
+
+## Task 7: Verification, smoke, evidence
+
+- [ ] **Step 1: Full lint + targeted tests**
+
+Run: `uv run ruff check app/ tests/ scripts/ && uv run pytest tests/test_kis_mock_holdings_delta_fill.py tests/test_kis_mock_scalping_adapters.py tests/test_kis_mock_holdings_reconciler.py tests/test_kis_mock_holdings_delta_smoke_cli.py -v`
+Expected: clean + all PASS
+
+- [ ] **Step 2: Import guards** (binance/host grep guards that historically tripped red main)
+
+Run: existing repo guard test(s), e.g. `uv run pytest tests/ -k "import_guard or host_allowlist" -v`
+Expected: PASS
+
+- [ ] **Step 3: Read-only preflight on host** (no orders)
+
+Run: `uv run python -m scripts.kis_mock_holdings_delta_smoke --preflight --symbol <liquid KRX code>`
+Expected: prints baseline holdings + cash; exit 0. If snapshot read fails → STOP, report.
+
+- [ ] **Step 4: Operator-gated bounded confirmed smoke** (one small limit order + cleanup)
+
+Run only after Step 3 passes and operator approves:
+`KIS_MOCK_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke --confirm --symbol <code> --notional-krw 10000`
+Expected: holdings delta reflects the fill within the bounded poll; evidence packet printed; cleanup confirmed; no residual pending order / position delta.
+**STOP condition:** if holdings do NOT reflect the fill within the bounded window → do not force; capture the evidence and report (the same-day-reflection assumption failed).
+
+- [ ] **Step 5: Linear evidence comment**
+
+Post a comment on ROB-341 with: the chosen primary signal (holdings delta + cash corroboration), the smoke evidence packet (symbol/side/order ids/baseline+post holdings+cash/selected signal+price source/pending count/cleanup/final delta), confirmation that daily-ccld is demoted, and the merged PR link. Do not mark Done on an open PR alone.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 inspect (done in investigation) · §2 H0STCNI9 → documented-gap follow-up (Task 6) · §3 holdings/cash delta confirm (Tasks 1–4) · §4 ambiguity fail-closed (Task 1 wrong-direction `none`, Task 3 baseline-missing/snapshot-error/no-delta) · §5 runbook (Task 6) · §6 focused tests (Tasks 1–5) · §7 bounded confirmed smoke after preflight (Task 7). ✓
+- **Acceptance:** primary source = holdings/cash delta with baseline + ledger correlation ✓; daily-ccld supplementary, empty classified ✓ (Task 4 diagnostic); unit tests cover delta success / baseline present / ambiguous-no-delta / stale-snapshot-error / cleanup ✓; runbook command shapes ✓; smoke evidence fields ✓.
+- **Cash narrowing clause:** domestic mock cash is supported (verified), so cash is retained as corroboration + price source rather than dropped; the holdings-only fallback path still exists implicitly because `derive_fill_price` falls back to the limit price whenever cash is `None`/unmoved — so a future cash-unsupported regression degrades gracefully without breaking fill confirmation.
+- **Type consistency:** `classify_fill_by_delta` / `DeltaFillResult` / `derive_fill_price` / `BaselineSnapshot` / `confirm_fill_from_holdings_delta` signatures match across Tasks 1–4. ✓

--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -98,34 +98,71 @@ mock-session smoke returns exit 4 during market hours.
 
 ---
 
-## Execution-evidence gate (ROB-334)
+## Execution-evidence gate (ROB-334, revised by ROB-341)
 
 Before any confirmed mock scalping run (`KIS_MOCK_SCALPING_WS_CONFIRM=true`), the
 fill-evidence path below must be available; otherwise the executor fails closed
 (no fabricated fill) and records an `entry_unfilled` / `exit_unconfirmed` anomaly.
 
-**Authoritative source:** KIS daily order-execution inquiry
-`inquire_daily_order_domestic(is_mock=True)`. Holdings/cash delta (ROB-102)
-remains secondary. `inquire_korea_orders` (TTTC8036R, pending inquiry) is
-**live-only** and is never used in mock.
+**Primary same-day source (ROB-341):** the baseline-vs-post **holdings delta**
+read from `account.fetch_domestic_balance_snapshot(is_mock=True)` (load-bearing),
+corroborated by the **cash delta** (`dnca_tot_amt`), which also derives the fill
+price (`|Δcash| / qty`, falling back to the submitted limit price). The baseline
+holdings+cash snapshot is captured immediately before each submit and stamped
+into the submit result; `confirm_fill` then polls a post-submit snapshot and
+classifies the delta via the shared `classify_fill_by_delta` kernel (the same
+kernel the ROB-102 reconciler uses). Ambiguous, zero, or wrong-direction deltas,
+a missing baseline, or a snapshot read failure all fail closed.
 
-**Deferred gap:** the execution-notice WebSocket `H0STCNI9` (실시간 체결통보) is
-NOT implemented (requires an AES-CBC-decrypted, HTS-ID handshake frame path). It
-is a fail-closed, documented gap and a candidate follow-up issue.
+**daily-ccld is NOT the primary same-day signal (ROB-341).** KIS official mock
+`inquire_daily_order_domestic` / daily-ccld can return `rt_cd=0` with **empty
+rows even after same-day mock order activity**, so an empty same-day daily-ccld
+result must never be read as "no fill" and can neither gate nor override the
+holdings verdict. daily-ccld is retained only as a **supplementary,
+post-settlement diagnostic** (`KisMockBroker.poll_daily_ccld_diagnostic`), whose
+empty same-day result is classified clearly (`pending` / `no_matching_order`).
+`inquire_korea_orders` (TTTC8036R, pending inquiry) is **live-only**, never mock.
 
-### Read-only preflight (no order submission)
+**Deferred gap (follow-up):** the execution-notice WebSocket `H0STCNI9`
+(실시간 체결통보) is NOT implemented (requires an AES-CBC-decrypted, HTS-ID
+handshake frame path). It is a fail-closed, documented gap and remains an
+explicit follow-up — out of ROB-341 scope.
+
+### Read-only preflight (no order submission, ROB-341)
 
 ```bash
-KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_fill_evidence_smoke \
-    --order-no <ODNO> --symbol <KR_CODE>
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+    --preflight --symbol <KR_CODE>
 ```
 
 Required env (names only — never echo values): `KIS_MOCK_APP_KEY`,
-`KIS_MOCK_APP_SECRET`, `KIS_MOCK_ACCOUNT_NO`.
+`KIS_MOCK_APP_SECRET`, `KIS_MOCK_ACCOUNT_NO`. Expected success signal: exit `0`
+and a printed JSON line with `holdings_qty` + `cash_dnca_tot_amt` for the symbol.
+If the snapshot read fails (exit `2`), stop — the primary same-day path is
+unavailable.
 
-Expected success signal: exit `0`, a printed `verdict=...` line, and the
-observed `row keys: [...]` (use these to confirm/tighten the classifier's
-candidate field names).
+The legacy daily-ccld field-name probe
+(`scripts/kis_mock_fill_evidence_smoke.py --order-no <ODNO>`) is still available
+for **post-settlement** diagnostics only; it is no longer the same-day gate.
+
+### Bounded confirmed smoke (operator-gated, ROB-341)
+
+Run ONLY after the read-only preflight passes and operator approval boundaries
+are satisfied, during a KRX regular session:
+
+```bash
+KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+    --confirm --symbol <KR_CODE> --notional-krw 10000
+```
+
+Places one small marketable limit BUY (at best ask), confirms the fill via the
+holdings/cash delta, then flattens with a cleanup SELL (at best bid) back to
+baseline. Prints a JSON evidence packet: symbol, side(s), order id(s), baseline
+holdings/cash, post-submit holdings/cash, confirmation signal + price source,
+cleanup result, and final position delta vs baseline. Exit `0` clean, `2` if the
+fill could not be confirmed in the poll window (ROB-341 STOP condition — capture
+the packet and report; do not force), `3` if a residual position/pending order
+could not be cleaned up, `4` disabled/not configured.
 
 ### Failure categories
 
@@ -140,12 +177,7 @@ candidate field names).
 Exit codes: `0` ok · `2` inquiry error / unsupported · `4` disabled or not
 configured · `1` unexpected.
 
-### Confirmed one-off mock smoke (operator-gated, NOT run by this change)
-
-The operator-approved bounded confirmed mock smoke (one minimal KRX limit order
-round-trip) is a **separate, operator-gated step**. It is deferred here:
-this change ships code + runbook + tests + the read-only preflight only.
-
-Rollback / no-op: all additions are read-only or fail-closed. Reverting the PR
-restores the prior `confirm_fill` stub (always-unfilled). No migration, no
+Rollback / no-op: all additions are read-only or fail-closed. Reverting the
+ROB-341 PR restores the prior daily-ccld-based `confirm_fill` (which fails closed
+on the empty same-day mock rows this change works around). No migration, no
 scheduler, no env mutation.

--- a/scripts/kis_mock_holdings_delta_smoke.py
+++ b/scripts/kis_mock_holdings_delta_smoke.py
@@ -193,23 +193,22 @@ async def run_confirm(args: argparse.Namespace) -> int:
         entry_fill = await _await_fill(
             broker, buy, max_poll=args.max_poll, interval=args.poll_interval
         )
+        evidence["confirmation_signal"] = "holdings_delta"
         if entry_fill is None:
             # STOP condition: holdings did not reflect the fill within the window.
-            evidence["confirmation_signal"] = "holdings_delta"
+            # Do NOT early-return — fall through to the finally so cleanup can
+            # detect+flatten a fill that landed just after the poll window and
+            # set the authoritative exit code (residual that can't be flattened
+            # -> 3 outranks fill-unconfirmed -> 2).
             evidence["entry_filled"] = False
             evidence["note"] = (
                 "entry fill UNCONFIRMED within poll window — holdings did not "
                 "reflect a same-day mock fill (ROB-341 STOP condition)"
             )
-            post_qty, _ = await broker._read_snapshot(args.symbol)
-            evidence["post_holdings_qty"] = str(post_qty)
-            logger.info(json.dumps(evidence))
-            # No proven position to clean up beyond baseline; still verify below.
-            return 2
-        evidence["entry_filled"] = True
-        evidence["confirmation_signal"] = "holdings_delta"
-        evidence["entry_fill_price"] = str(entry_fill.price)
-        evidence["entry_fill_qty"] = str(entry_fill.quantity)
+        else:
+            evidence["entry_filled"] = True
+            evidence["entry_fill_price"] = str(entry_fill.price)
+            evidence["entry_fill_qty"] = str(entry_fill.quantity)
     finally:
         result = await _cleanup_and_verify(
             broker, client, args, cid, base_qty, evidence, entry_fill

--- a/scripts/kis_mock_holdings_delta_smoke.py
+++ b/scripts/kis_mock_holdings_delta_smoke.py
@@ -79,9 +79,7 @@ def _gate_or_exit() -> object | None:
     from app.core.config import settings
 
     if not settings.kis_mock_scalping_ws_enabled:
-        logger.info(
-            "KIS_MOCK_SCALPING_WS_ENABLED is not set; smoke disabled (no-op)."
-        )
+        logger.info("KIS_MOCK_SCALPING_WS_ENABLED is not set; smoke disabled (no-op).")
         return None
     missing = [
         name

--- a/scripts/kis_mock_holdings_delta_smoke.py
+++ b/scripts/kis_mock_holdings_delta_smoke.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""KIS mock holdings/cash-delta fill-confirmation smoke (ROB-341).
+
+Two modes, both KIS **mock** only (host VTTC8434R / mockapi):
+
+* ``--preflight`` — READ-ONLY. Reads the mock domestic balance snapshot and
+  prints the per-symbol holdings + cash. Places NO order. Run this first.
+* ``--confirm``   — operator-gated bounded round trip: one small marketable
+  limit BUY, holdings/cash-delta fill confirmation, then a cleanup SELL to
+  flatten back to baseline. Prints the ROB-341 evidence packet as JSON.
+
+Same-day fill confirmation is the baseline-vs-post **holdings delta** (primary)
+plus the **cash delta** (fill-price source). daily-ccld is NOT used as the gate
+(it can return empty rows for same-day mock fills); it is read only as a
+non-gating, post-settlement diagnostic and surfaced in the evidence packet.
+
+Safety: KIS mock only (no live), limit orders only (no market), no scheduler,
+no persistent confirm flag. Default-disabled — requires
+KIS_MOCK_SCALPING_WS_ENABLED=true plus KIS mock config. ``--confirm`` must be
+passed explicitly; without it the round trip never runs. Prints only missing
+env var NAMES, never secret values. Always attempts cleanup in a finally block.
+
+Exit codes:
+    0  - success (preflight printed, or confirmed round trip cleaned up)
+    1  - unexpected exception
+    2  - order/inquiry error, or fill could not be confirmed in the poll window
+    3  - anomaly: residual position/pending order could not be cleaned up
+    4  - disabled or KIS mock not configured (env/config no-op)
+
+Usage:
+    KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+        --preflight --symbol 005930
+    KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+        --confirm --symbol 005930 --notional-krw 10000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from decimal import ROUND_DOWN, Decimal
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="KIS mock holdings/cash-delta fill-confirmation smoke"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--preflight",
+        action="store_true",
+        help="read-only: print holdings + cash for --symbol, place no order",
+    )
+    mode.add_argument(
+        "--confirm",
+        action="store_true",
+        help="operator-gated bounded round trip (one small limit buy + cleanup sell)",
+    )
+    parser.add_argument("--symbol", required=True, help="KR stock code, e.g. 005930")
+    parser.add_argument("--market", default="J", help="KIS market div code (default J)")
+    parser.add_argument(
+        "--notional-krw",
+        type=int,
+        default=10000,
+        help="max buy notional in KRW (default 10000)",
+    )
+    parser.add_argument("--max-poll", type=int, default=10)
+    parser.add_argument("--poll-interval", type=float, default=1.0)
+    return parser.parse_args(argv)
+
+
+def _gate_or_exit() -> object | None:
+    """Lazy import + env gate. Returns the settings object, or None if disabled."""
+    from app.core.config import settings
+
+    if not settings.kis_mock_scalping_ws_enabled:
+        logger.info(
+            "KIS_MOCK_SCALPING_WS_ENABLED is not set; smoke disabled (no-op)."
+        )
+        return None
+    missing = [
+        name
+        for name, value in (
+            ("KIS_MOCK_APP_KEY", settings.kis_mock_app_key),
+            ("KIS_MOCK_APP_SECRET", settings.kis_mock_app_secret),
+            ("KIS_MOCK_ACCOUNT_NO", settings.kis_mock_account_no),
+        )
+        if not value
+    ]
+    if missing:
+        logger.error("KIS mock not configured. Missing (names only): %s", missing)
+        return None
+    return settings
+
+
+def _best_ask_bid(orderbook: dict) -> tuple[Decimal | None, Decimal | None]:
+    def _dec(key: str) -> Decimal | None:
+        raw = orderbook.get(key)
+        try:
+            v = Decimal(str(raw).replace(",", "").strip())
+        except Exception:  # noqa: BLE001
+            return None
+        return v if v > 0 else None
+
+    return _dec("askp1"), _dec("bidp1")
+
+
+async def run_preflight(args: argparse.Namespace) -> int:
+    if _gate_or_exit() is None:
+        return 4
+    from app.mcp_server.tooling.order_execution import _create_kis_client
+    from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockBroker
+
+    client = _create_kis_client(is_mock=True)
+    broker = KisMockBroker(get_state=lambda s: None)
+    broker._mock_client = client  # reuse the same mock-host client
+    try:
+        holdings_qty, cash = await broker._read_snapshot(args.symbol)
+    except Exception as exc:  # noqa: BLE001 - read-only preflight, classify the fault
+        logger.error("balance snapshot read failed: %s", str(exc)[:300])
+        return 2
+    logger.info(
+        json.dumps(
+            {
+                "mode": "preflight",
+                "symbol": args.symbol,
+                "holdings_qty": str(holdings_qty),
+                "cash_dnca_tot_amt": (str(cash) if cash is not None else None),
+            }
+        )
+    )
+    return 0
+
+
+async def _await_fill(broker, submit_result, *, max_poll: int, interval: float):
+    for _ in range(max_poll):
+        fill = await broker.confirm_fill(submit_result)
+        if fill is not None:
+            return fill
+        await asyncio.sleep(interval)
+    return None
+
+
+async def run_confirm(args: argparse.Namespace) -> int:
+    if _gate_or_exit() is None:
+        return 4
+    import uuid
+
+    from app.mcp_server.tooling.order_execution import _create_kis_client
+    from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockBroker
+
+    client = _create_kis_client(is_mock=True)
+    broker = KisMockBroker(get_state=lambda s: None)
+    broker._mock_client = client
+    cid = f"rob341-smoke-{uuid.uuid4().hex[:12]}"
+    evidence: dict[str, object] = {"mode": "confirm", "symbol": args.symbol, "cid": cid}
+
+    base_qty, base_cash = await broker._read_snapshot(args.symbol)
+    evidence["baseline_holdings_qty"] = str(base_qty)
+    evidence["baseline_cash"] = str(base_cash) if base_cash is not None else None
+
+    orderbook = await client.inquire_orderbook(args.symbol, args.market)
+    ask, bid = _best_ask_bid(orderbook)
+    if ask is None or bid is None:
+        logger.error("no valid ask/bid in orderbook; cannot place a marketable limit")
+        evidence["error"] = "no_quote"
+        logger.info(json.dumps(evidence))
+        return 2
+    qty = (Decimal(args.notional_krw) / ask).quantize(Decimal("1"), rounding=ROUND_DOWN)
+    if qty <= 0:
+        logger.error("notional %s too small for ask %s", args.notional_krw, ask)
+        evidence["error"] = "size_zero"
+        logger.info(json.dumps(evidence))
+        return 2
+    evidence["buy_limit_price"] = str(ask)
+    evidence["quantity"] = str(qty)
+
+    entry_fill = None
+    try:
+        buy = await broker.submit_buy(
+            symbol=args.symbol,
+            price=ask,
+            quantity=qty,
+            correlation_id=cid,
+            confirm=True,
+        )
+        evidence["buy_order_id"] = buy.get("odno") or buy.get("order_no")
+        entry_fill = await _await_fill(
+            broker, buy, max_poll=args.max_poll, interval=args.poll_interval
+        )
+        if entry_fill is None:
+            # STOP condition: holdings did not reflect the fill within the window.
+            evidence["confirmation_signal"] = "holdings_delta"
+            evidence["entry_filled"] = False
+            evidence["note"] = (
+                "entry fill UNCONFIRMED within poll window — holdings did not "
+                "reflect a same-day mock fill (ROB-341 STOP condition)"
+            )
+            post_qty, _ = await broker._read_snapshot(args.symbol)
+            evidence["post_holdings_qty"] = str(post_qty)
+            logger.info(json.dumps(evidence))
+            # No proven position to clean up beyond baseline; still verify below.
+            return 2
+        evidence["entry_filled"] = True
+        evidence["confirmation_signal"] = "holdings_delta"
+        evidence["entry_fill_price"] = str(entry_fill.price)
+        evidence["entry_fill_qty"] = str(entry_fill.quantity)
+    finally:
+        result = await _cleanup_and_verify(
+            broker, client, args, cid, base_qty, evidence, entry_fill
+        )
+        evidence["exit_code"] = result
+        logger.info(json.dumps(evidence))
+    return result
+
+
+async def _cleanup_and_verify(
+    broker, client, args, cid, base_qty, evidence, entry_fill
+) -> int:
+    """Flatten any position acquired by this smoke back to baseline. Returns the
+    process exit code (0 clean, 2 fill-unconfirmed, 3 anomaly/residual)."""
+    try:
+        cur_qty, _ = await broker._read_snapshot(args.symbol)
+    except Exception as exc:  # noqa: BLE001
+        evidence["cleanup_error"] = str(exc)[:200]
+        return 3
+    delta = cur_qty - base_qty
+    if delta <= 0:
+        evidence["cleanup"] = "nothing_to_flatten"
+        evidence["final_position_delta_vs_baseline"] = str(cur_qty - base_qty)
+        # If the entry never filled, propagate the fill-unconfirmed code.
+        return 0 if entry_fill is not None else 2
+
+    orderbook = await client.inquire_orderbook(args.symbol, args.market)
+    _, bid = _best_ask_bid(orderbook)
+    if bid is None:
+        evidence["cleanup"] = "no_bid_for_exit"
+        return 3
+    sell = await broker.submit_exit_sell(
+        symbol=args.symbol,
+        price=bid,
+        quantity=delta,
+        exit_reason="smoke_cleanup",
+        strategy_id="kis-mock-v1",
+        correlation_id=cid,
+        confirm=True,
+    )
+    evidence["cleanup_sell_order_id"] = sell.get("odno") or sell.get("order_no")
+    exit_fill = await _await_fill(
+        broker, sell, max_poll=args.max_poll, interval=args.poll_interval
+    )
+    final_qty, final_cash = await broker._read_snapshot(args.symbol)
+    evidence["post_holdings_qty"] = str(final_qty)
+    evidence["post_cash"] = str(final_cash) if final_cash is not None else None
+    evidence["final_position_delta_vs_baseline"] = str(final_qty - base_qty)
+    if exit_fill is None or final_qty > base_qty:
+        evidence["cleanup"] = "UNCONFIRMED_residual_position"
+        return 3
+    evidence["cleanup"] = "flattened"
+    return 0
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.preflight:
+        return await run_preflight(args)
+    return await run_confirm(args)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        return asyncio.run(_run(_parse_args(argv)))
+    except KeyboardInterrupt:
+        return 1
+    except Exception:  # noqa: BLE001
+        logger.exception("unexpected error in holdings-delta smoke")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -23,6 +23,9 @@ async def test_submit_buy_dry_run_calls_place_order_impl(mocker) -> None:
         mod, "_place_order_impl", new=AsyncMock(return_value={})
     )
     broker = KisMockBroker(get_state=lambda s: None)
+    mocker.patch.object(
+        broker, "_read_snapshot", new=AsyncMock(return_value=(Decimal("0"), None))
+    )
     await broker.submit_buy(
         symbol="005930",
         price=Decimal("70000"),
@@ -43,6 +46,9 @@ async def test_submit_exit_sell_uses_scalping_exit(mocker) -> None:
         mod, "_place_order_impl", new=AsyncMock(return_value={})
     )
     broker = KisMockBroker(get_state=lambda s: None)
+    mocker.patch.object(
+        broker, "_read_snapshot", new=AsyncMock(return_value=(Decimal("1"), None))
+    )
     await broker.submit_exit_sell(
         symbol="005930",
         price=Decimal("69800"),
@@ -86,56 +92,44 @@ def _daily_rows(**kw):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_confirm_fill_returns_none_when_no_odno() -> None:
-    # No odno in the submit response -> data-precondition, no network call.
+async def test_confirm_fill_returns_none_when_no_baseline() -> None:
+    # ROB-341: confirm_fill now needs the baseline snapshot stamped at submit
+    # time. No baseline -> fail closed, no network call.
     broker = KisMockBroker(get_state=lambda s: None)
-    assert await broker.confirm_fill({"any": "result"}) is None
+    assert await broker.confirm_fill({"odno": "0000123456"}) is None
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_confirm_fill_returns_fill_when_filled(mocker) -> None:
+async def test_confirm_fill_uses_holdings_delta_not_daily_ccld(mocker) -> None:
+    # ROB-341: a filled buy is proven by the holdings delta (0 -> 1), with the
+    # fill price derived from the cash delta. daily-ccld is NOT consulted.
     broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
-        return_value=_daily_rows(tot_ccld_qty="1", avg_prvs="70000")
+    mocker.patch.object(
+        broker,
+        "_read_snapshot",
+        new=AsyncMock(return_value=(Decimal("1"), Decimal("930000"))),
     )
-    mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
-    fill = await broker.confirm_fill({"odno": "0000123456"})
+    submit_result = {
+        "odno": "0000123456",
+        "_baseline": {
+            "symbol": "005930",
+            "side": "buy",
+            "ordered_qty": "1",
+            "limit_price": "70000",
+            "holdings_qty": "0",
+            "cash": "1000000",
+        },
+    }
+    fill = await broker.confirm_fill(submit_result)
     assert fill == Fill(price=Decimal("70000"), quantity=Decimal("1"))
-    # Bounded read-only inquiry: is_mock pinned True, filtered by order number.
-    kw = fake_client.domestic_orders.inquire_daily_order_domestic.await_args.kwargs
-    assert kw["is_mock"] is True
-    assert kw["order_number"] == "0000123456"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_confirm_fill_none_when_pending(mocker) -> None:
-    broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
-        return_value=_daily_rows(tot_ccld_qty="0")
-    )
-    mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
-    assert await broker.confirm_fill({"odno": "0000123456"}) is None
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_confirm_fill_none_on_unsupported_mock_api(mocker) -> None:
-    broker = KisMockBroker(get_state=lambda s: None)
-    fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
-        side_effect=RuntimeError("TR is not available in mock mode.")
-    )
-    mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
-    assert await broker.confirm_fill({"odno": "0000123456"}) is None
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_poll_fill_evidence_maps_unsupported_category(mocker) -> None:
+async def test_poll_daily_ccld_diagnostic_maps_unsupported_category(mocker) -> None:
+    # ROB-341: daily-ccld is retained only as a NON-GATING supplementary /
+    # post-settlement diagnostic. Its classification wiring stays covered.
     from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
         EvidenceCategory,
         FillVerdict,
@@ -147,9 +141,27 @@ async def test_poll_fill_evidence_maps_unsupported_category(mocker) -> None:
         side_effect=RuntimeError("VTTC8001R not available in mock")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
-    ev = await broker._poll_fill_evidence({"odno": "123456"})
+    ev = await broker.poll_daily_ccld_diagnostic({"odno": "123456"})
     assert ev.verdict is FillVerdict.UNSUPPORTED
     assert ev.category is EvidenceCategory.UNSUPPORTED_MOCK_API
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_poll_daily_ccld_diagnostic_classifies_filled_rows(mocker) -> None:
+    # daily-ccld still parses a populated same-day row when present (post-
+    # settlement evidence) — but it does not gate confirm_fill.
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    broker = KisMockBroker(get_state=lambda s: None)
+    fake_client = mocker.MagicMock()
+    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+        return_value=_daily_rows(tot_ccld_qty="1", avg_prvs="70000")
+    )
+    mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
+    ev = await broker.poll_daily_ccld_diagnostic({"odno": "0000123456"})
+    assert ev.verdict is FillVerdict.FILLED
+    assert ev.avg_price == Decimal("70000")
 
 
 @pytest.mark.unit

--- a/tests/test_kis_mock_holdings_delta_fill.py
+++ b/tests/test_kis_mock_holdings_delta_fill.py
@@ -1,0 +1,41 @@
+"""ROB-341 — holdings/cash-delta fill-confirmation tests.
+
+Covers the pure delta kernel (shared with the ROB-102 reconciler), the
+cash-delta fill-price derivation, and the fail-closed async confirm
+orchestration. stdlib + fakes only; no broker / network.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "side,baseline,observed,ordered,verdict,filled",
+    [
+        ("buy", "0", "10", "10", "filled", "10"),
+        ("buy", "0", "4", "10", "partial", "4"),
+        ("buy", "0", "0", "10", "none", "0"),
+        ("buy", "5", "15", "10", "filled", "10"),  # baseline position present
+        ("buy", "5", "9", "10", "partial", "4"),  # delta below ordered
+        ("buy", "5", "3", "10", "none", "0"),  # holdings DROPPED after a buy -> impossible
+        ("sell", "10", "0", "10", "filled", "10"),
+        ("sell", "10", "6", "10", "partial", "4"),
+        ("sell", "10", "10", "10", "none", "0"),
+        ("sell", "10", "12", "10", "none", "0"),  # holdings ROSE after a sell -> impossible
+    ],
+)
+def test_classify_fill_by_delta(side, baseline, observed, ordered, verdict, filled):
+    res = classify_fill_by_delta(
+        side=side,
+        ordered_qty=Decimal(ordered),
+        baseline_qty=Decimal(baseline),
+        observed_qty=Decimal(observed),
+    )
+    assert res.verdict == verdict
+    assert res.filled_qty == Decimal(filled)

--- a/tests/test_kis_mock_holdings_delta_fill.py
+++ b/tests/test_kis_mock_holdings_delta_fill.py
@@ -11,7 +11,10 @@ from decimal import Decimal
 
 import pytest
 
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
 from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    BaselineSnapshot,
+    confirm_fill_from_holdings_delta,
     derive_fill_price,
 )
 from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
@@ -82,3 +85,68 @@ def test_price_falls_back_when_cash_unavailable():
     )
     assert price == Decimal("8888")
     assert source == "limit_fallback"
+
+
+def _baseline(qty: str | None = "0", cash: str | None = "1000000") -> BaselineSnapshot:
+    return BaselineSnapshot(
+        symbol="005930",
+        side="buy",
+        ordered_qty=Decimal("10"),
+        limit_price=Decimal("70000"),
+        holdings_qty=(Decimal(qty) if qty is not None else None),
+        cash=(Decimal(cash) if cash is not None else None),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_filled_returns_fill():
+    async def post(symbol):  # observed holdings + cash: bought 10, cash dropped 700000
+        return Decimal("10"), Decimal("300000")
+
+    fill = await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post)
+    assert isinstance(fill, Fill)
+    assert fill.quantity == Decimal("10")
+    assert fill.price == Decimal("70000")  # 700000 / 10 cash-delta
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_no_delta_fails_closed():
+    async def post(symbol):
+        return Decimal("0"), Decimal("1000000")
+
+    assert await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_baseline_missing_fails_closed():
+    async def post(symbol):
+        return Decimal("10"), Decimal("300000")
+
+    result = await confirm_fill_from_holdings_delta(
+        _baseline(qty=None), fetch_post=post
+    )
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_snapshot_error_fails_closed():
+    async def post(symbol):
+        raise RuntimeError("VTS read failed")
+
+    assert await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_partial_returns_partial_fill():
+    async def post(symbol):
+        return Decimal("4"), Decimal("720000")  # 4 of 10 filled, cash dropped 280000
+
+    fill = await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post)
+    assert isinstance(fill, Fill)
+    assert fill.quantity == Decimal("4")
+    assert fill.price == Decimal("70000")  # 280000 / 4

--- a/tests/test_kis_mock_holdings_delta_fill.py
+++ b/tests/test_kis_mock_holdings_delta_fill.py
@@ -142,11 +142,13 @@ async def test_confirm_snapshot_error_fails_closed():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_confirm_partial_returns_partial_fill():
+async def test_confirm_partial_fails_closed():
+    # ROB-341 review #1: the synchronous confirm path returns a Fill ONLY on a
+    # FULL fill. A partial delta is not-yet-filled -> None, so the executor's
+    # bounded poll either reaches a full fill or times out into an anomaly
+    # (the executor has no partial-fill handling and would otherwise strand the
+    # residual). The periodic reconciler keeps its own partial semantics.
     async def post(symbol):
-        return Decimal("4"), Decimal("720000")  # 4 of 10 filled, cash dropped 280000
+        return Decimal("4"), Decimal("720000")  # 4 of 10 filled
 
-    fill = await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post)
-    assert isinstance(fill, Fill)
-    assert fill.quantity == Decimal("4")
-    assert fill.price == Decimal("70000")  # 280000 / 4
+    assert await confirm_fill_from_holdings_delta(_baseline(), fetch_post=post) is None

--- a/tests/test_kis_mock_holdings_delta_fill.py
+++ b/tests/test_kis_mock_holdings_delta_fill.py
@@ -29,11 +29,25 @@ from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
         ("buy", "0", "0", "10", "none", "0"),
         ("buy", "5", "15", "10", "filled", "10"),  # baseline position present
         ("buy", "5", "9", "10", "partial", "4"),  # delta below ordered
-        ("buy", "5", "3", "10", "none", "0"),  # holdings DROPPED after a buy -> impossible
+        (
+            "buy",
+            "5",
+            "3",
+            "10",
+            "none",
+            "0",
+        ),  # holdings DROPPED after a buy -> impossible
         ("sell", "10", "0", "10", "filled", "10"),
         ("sell", "10", "6", "10", "partial", "4"),
         ("sell", "10", "10", "10", "none", "0"),
-        ("sell", "10", "12", "10", "none", "0"),  # holdings ROSE after a sell -> impossible
+        (
+            "sell",
+            "10",
+            "12",
+            "10",
+            "none",
+            "0",
+        ),  # holdings ROSE after a sell -> impossible
     ],
 )
 def test_classify_fill_by_delta(side, baseline, observed, ordered, verdict, filled):

--- a/tests/test_kis_mock_holdings_delta_fill.py
+++ b/tests/test_kis_mock_holdings_delta_fill.py
@@ -11,6 +11,9 @@ from decimal import Decimal
 
 import pytest
 
+from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    derive_fill_price,
+)
 from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
 
 
@@ -39,3 +42,43 @@ def test_classify_fill_by_delta(side, baseline, observed, ordered, verdict, fill
     )
     assert res.verdict == verdict
     assert res.filled_qty == Decimal(filled)
+
+
+@pytest.mark.unit
+def test_price_from_cash_delta_buy():
+    # cash dropped 100000 for 10 shares -> 10000/share
+    price, source = derive_fill_price(
+        side="buy",
+        filled_qty=Decimal("10"),
+        cash_baseline=Decimal("1000000"),
+        cash_observed=Decimal("900000"),
+        limit_price=Decimal("9999"),
+    )
+    assert price == Decimal("10000")
+    assert source == "cash_delta"
+
+
+@pytest.mark.unit
+def test_price_falls_back_to_limit_when_cash_unmoved():
+    price, source = derive_fill_price(
+        side="buy",
+        filled_qty=Decimal("10"),
+        cash_baseline=Decimal("1000000"),
+        cash_observed=Decimal("1000000"),
+        limit_price=Decimal("9999"),
+    )
+    assert price == Decimal("9999")
+    assert source == "limit_fallback"
+
+
+@pytest.mark.unit
+def test_price_falls_back_when_cash_unavailable():
+    price, source = derive_fill_price(
+        side="sell",
+        filled_qty=Decimal("10"),
+        cash_baseline=None,
+        cash_observed=Decimal("900000"),
+        limit_price=Decimal("8888"),
+    )
+    assert price == Decimal("8888")
+    assert source == "limit_fallback"

--- a/tests/test_kis_mock_holdings_delta_smoke_cli.py
+++ b/tests/test_kis_mock_holdings_delta_smoke_cli.py
@@ -1,0 +1,44 @@
+"""ROB-341 — CLI-shape tests for the holdings-delta smoke.
+
+The CLI must parse --help and the flag surface WITHOUT importing Settings or
+touching secrets/network (Settings-backed imports are lazy, inside the command
+body). No order is ever placed by these tests.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.unit
+def test_smoke_help_runs_without_secrets():
+    out = subprocess.run(
+        [sys.executable, "-m", "scripts.kis_mock_holdings_delta_smoke", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "--preflight" in out.stdout
+    assert "--confirm" in out.stdout
+    assert "--symbol" in out.stdout
+    assert "--notional-krw" in out.stdout
+
+
+@pytest.mark.unit
+def test_smoke_requires_a_mode():
+    # Neither --preflight nor --confirm -> usage error (exit 2), no network.
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.kis_mock_holdings_delta_smoke",
+            "--symbol",
+            "005930",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 2

--- a/tests/test_kis_mock_scalping_adapters.py
+++ b/tests/test_kis_mock_scalping_adapters.py
@@ -1,0 +1,72 @@
+"""ROB-341 — KisMockBroker holdings/cash-delta confirm_fill wiring tests.
+
+confirm_fill must derive its verdict from the baseline-vs-post holdings delta
+(stamped into the submit result at submit time), never from daily-ccld. Fakes
+the snapshot read; no broker / network.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockBroker
+from app.services.brokers.kis.mock_scalping_exec.executor import Fill
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fill_uses_holdings_delta(monkeypatch):
+    broker = KisMockBroker(get_state=lambda s: None)
+
+    async def fake_snapshot(symbol):  # post-submit observed holdings + cash
+        return Decimal("10"), Decimal("300000")
+
+    monkeypatch.setattr(broker, "_read_snapshot", fake_snapshot)
+
+    submit_result = {
+        "odno": "0001",
+        "_baseline": {
+            "symbol": "005930",
+            "side": "buy",
+            "ordered_qty": "10",
+            "limit_price": "70000",
+            "holdings_qty": "0",
+            "cash": "1000000",
+        },
+    }
+    fill = await broker.confirm_fill(submit_result)
+    assert isinstance(fill, Fill)
+    assert fill.quantity == Decimal("10")
+    assert fill.price == Decimal("70000")  # 700000 cash delta / 10
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fill_no_baseline_fails_closed():
+    broker = KisMockBroker(get_state=lambda s: None)
+    assert await broker.confirm_fill({"odno": "0001"}) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fill_no_delta_fails_closed(monkeypatch):
+    broker = KisMockBroker(get_state=lambda s: None)
+
+    async def fake_snapshot(symbol):
+        return Decimal("0"), Decimal("1000000")  # nothing filled
+
+    monkeypatch.setattr(broker, "_read_snapshot", fake_snapshot)
+    submit_result = {
+        "odno": "0001",
+        "_baseline": {
+            "symbol": "005930",
+            "side": "buy",
+            "ordered_qty": "10",
+            "limit_price": "70000",
+            "holdings_qty": "0",
+            "cash": "1000000",
+        },
+    }
+    assert await broker.confirm_fill(submit_result) is None

--- a/tests/test_kis_mock_scalping_adapters.py
+++ b/tests/test_kis_mock_scalping_adapters.py
@@ -51,6 +51,36 @@ async def test_confirm_fill_no_baseline_fails_closed():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_dry_run_buy_skips_baseline_snapshot(monkeypatch):
+    # ROB-341 review #6: a dry-run (confirm=False) submit never reaches
+    # confirm_fill, so it must not pay for a baseline balance snapshot.
+    import app.services.brokers.kis.mock_scalping_exec.adapters as mod
+
+    async def fake_place(**kwargs):
+        return {"odno": "0001"}
+
+    monkeypatch.setattr(mod, "_place_order_impl", fake_place)
+    broker = KisMockBroker(get_state=lambda s: None)
+    called = {"n": 0}
+
+    async def fake_snapshot(symbol):
+        called["n"] += 1
+        return Decimal("0"), None
+
+    monkeypatch.setattr(broker, "_read_snapshot", fake_snapshot)
+    result = await broker.submit_buy(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        correlation_id="cid1",
+        confirm=False,
+    )
+    assert called["n"] == 0  # no baseline read on dry-run
+    assert "_baseline" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_confirm_fill_no_delta_fails_closed(monkeypatch):
     broker = KisMockBroker(get_state=lambda s: None)
 


### PR DESCRIPTION
## What & why

Follow-up to ROB-334 / ROB-338 / PR #989. The confirmed KIS **official mock** smoke proved that `inquire_daily_order_domestic` (daily-ccld) can return `rt_cd=0` with **empty rows even after same-day mock order activity** — so daily-ccld cannot be the load-bearing same-day fill-confirmation signal (it produces false negatives / ambiguous fail-closed runs).

This PR moves same-day mock fill confirmation to a **baseline-vs-post holdings delta** (primary) + **cash delta** (corroboration + fill-price source), reusing the existing ROB-102 reconciler logic. H0STCNI9 execution-notice WS is left as a documented follow-up (out of scope).

## Approach

- **Shared pure kernel** `classify_fill_by_delta` extracted into `kis_mock_holdings_reconciler.py`; the periodic ROB-102 reconciler now delegates its delta→verdict decision to it (DRY, behavior-preserving — existing reconciler tests unchanged).
- **`KisMockBroker`**: captures a holdings+cash baseline (`fetch_domestic_balance_snapshot(is_mock=True)`, VTTC8434R — domestic mock cash IS supported, unlike overseas) immediately before each submit and stamps it into the submit result. `confirm_fill` polls a post-submit snapshot, classifies the delta, and derives the fill price from the cash delta (`|Δdnca_tot_amt| / qty`), falling back to the submitted limit price when cash is unavailable/unmoved. Quantity is load-bearing from holdings; price is telemetry.
- **Fail-closed** on: missing baseline, snapshot read failure, zero/wrong-direction delta.
- **daily-ccld demoted**: no longer consulted in the same-day confirm loop. Retained only as a non-gating, post-settlement diagnostic (`poll_daily_ccld_diagnostic`); its empty same-day result is classified clearly and can never gate or override the holdings verdict.
- **Smoke CLI** `scripts/kis_mock_holdings_delta_smoke.py`: `--preflight` (read-only snapshot, no orders) + `--confirm` (operator-gated bounded marketable-limit round trip + cleanup-sell, prints the full evidence packet). Lazy Settings import so `--help`/usage run without secrets; prints only missing env var **names**.
- **Runbook** updated: daily-ccld is not primary same-day evidence; new preflight + confirmed-smoke command shapes.

## Tests

- `classify_fill_by_delta` kernel: full / partial / none / baseline-present / wrong-direction.
- `derive_fill_price`: cash-delta vs limit fallback.
- `confirm_fill_from_holdings_delta`: filled / partial / no-delta / baseline-missing / snapshot-error fail-closed.
- `KisMockBroker.confirm_fill`: holdings-delta path, no-baseline fail-closed; updated existing adapter tests to the demoted daily-ccld diagnostic.
- Smoke CLI shape (`--help` secret-free, mode-required).
- Reconciler + reconciliation-job tests stay green (behavior preserved).

`ruff check app/ tests/` clean; 47 import/host guards pass; 81 ROB-341-related tests pass. (Pre-existing local-only failures unrelated to this PR: kis_mock_lifecycle DB drift + public_base_url env artifacts — see memory.)

## Safety boundaries

KIS mock only (no live), limit orders only (no market), no scheduler / no persistent confirm flag, no Prefect/TaskIQ/cron, no prod env/secret/DB-destructive change, no secret logging. All paths fail closed on ambiguity.

## Operator step (not run here)

The bounded confirmed mock smoke is operator-gated and **not run in this PR** — KIS mock creds are not loaded in this environment (read-only preflight here returned the configured no-op, printing only missing env var names). Acceptance requires merged code **plus** an operator smoke-evidence comment on ROB-341; do not mark Done on this PR alone.

**STOP condition built in:** if holdings do not reflect a same-day fill within the bounded poll window, the smoke captures the evidence packet and exits non-zero (it never forces a clean-success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)