### PR TITLE
fix(ROB-341): expose KIS balance snapshot facade

### DIFF
--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -275,6 +275,21 @@ class KISClient(BaseKISClient):
             symbol, exchange_code, n, keyb
         )
 
+    async def fetch_domestic_balance_snapshot(
+        self,
+        *,
+        is_mock: bool = False,
+        timeout: float = 5.0,
+        retry_request_errors: bool = True,
+        max_pages: int = 10,
+    ) -> dict[str, Any]:
+        return await self._account.fetch_domestic_balance_snapshot(
+            is_mock=is_mock,
+            timeout=timeout,
+            retry_request_errors=retry_request_errors,
+            max_pages=max_pages,
+        )
+
     async def fetch_my_stocks(
         self,
         is_mock: bool = False,

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -158,7 +158,7 @@ class KisMockBroker:
         ``dnca_tot_amt`` from output2. Mock host only (VTTC8434R).
         """
         client = self._get_mock_client()
-        snap = await client.account.fetch_domestic_balance_snapshot(is_mock=True)
+        snap = await client.fetch_domestic_balance_snapshot(is_mock=True)
         target = to_db_symbol(symbol)
         qty = Decimal("0")
         for holding in snap.get("holdings") or []:
@@ -240,7 +240,7 @@ class KisMockBroker:
         today = datetime.datetime.now().strftime("%Y%m%d")
         try:
             client = self._get_mock_client()
-            rows = await client.domestic_orders.inquire_daily_order_domestic(
+            rows = await client.inquire_daily_order_domestic(
                 start_date=today,
                 end_date=today,
                 stock_code="",

--- a/tests/brokers/kis/mock_scalping_exec/test_adapters.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_adapters.py
@@ -137,7 +137,7 @@ async def test_poll_daily_ccld_diagnostic_maps_unsupported_category(mocker) -> N
 
     broker = KisMockBroker(get_state=lambda s: None)
     fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         side_effect=RuntimeError("VTTC8001R not available in mock")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)
@@ -155,7 +155,7 @@ async def test_poll_daily_ccld_diagnostic_classifies_filled_rows(mocker) -> None
 
     broker = KisMockBroker(get_state=lambda s: None)
     fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         return_value=_daily_rows(tot_ccld_qty="1", avg_prvs="70000")
     )
     mocker.patch.object(broker, "_get_mock_client", return_value=fake_client)

--- a/tests/brokers/kis/test_client_facade.py
+++ b/tests/brokers/kis/test_client_facade.py
@@ -1,0 +1,31 @@
+"""KISClient facade contract tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.brokers.kis.client import KISClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_domestic_balance_snapshot_is_public_facade(mocker) -> None:
+    """ROB-341 smoke adapters need a public balance-snapshot facade."""
+    client = KISClient(is_mock=True)
+    account_call = mocker.patch.object(
+        client._account,
+        "fetch_domestic_balance_snapshot",
+        new=AsyncMock(return_value={"holdings": [], "cash": {}, "page_count": 1}),
+    )
+
+    result = await client.fetch_domestic_balance_snapshot(is_mock=True)
+
+    assert result == {"holdings": [], "cash": {}, "page_count": 1}
+    account_call.assert_awaited_once_with(
+        is_mock=True,
+        timeout=5.0,
+        retry_request_errors=True,
+        max_pages=10,
+    )

--- a/tests/test_kis_mock_scalping_adapters.py
+++ b/tests/test_kis_mock_scalping_adapters.py
@@ -51,6 +51,29 @@ async def test_confirm_fill_no_baseline_fails_closed():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_read_snapshot_uses_kis_client_balance_facade(monkeypatch):
+    # ROB-341 operator smoke uses the KISClient facade object. The facade has no
+    # public .account child, so _read_snapshot must call a public facade method.
+    broker = KisMockBroker(get_state=lambda s: None)
+
+    class FakeClient:
+        async def fetch_domestic_balance_snapshot(self, *, is_mock: bool):
+            assert is_mock is True
+            return {
+                "holdings": [{"pdno": "005930", "hldg_qty": "2"}],
+                "cash": {"dnca_tot_amt": "12345"},
+            }
+
+    monkeypatch.setattr(broker, "_get_mock_client", lambda: FakeClient())
+
+    qty, cash = await broker._read_snapshot("005930")
+
+    assert qty == Decimal("2")
+    assert cash == Decimal("12345")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_dry_run_buy_skips_baseline_snapshot(monkeypatch):
     # ROB-341 review #6: a dry-run (confirm=False) submit never reaches
     # confirm_fill, so it must not pay for a baseline balance snapshot.


### PR DESCRIPTION
## Summary
- Add a public `KISClient.fetch_domestic_balance_snapshot()` facade over the account component.
- Rewire ROB-341 KIS mock scalping snapshot and daily-ccld diagnostic paths to call public KISClient facade methods instead of non-existent child attributes.
- Add regression coverage for the operator-smoke path that failed during ROB-341 evidence collection.

## Evidence
- RED: targeted tests initially failed with missing `KISClient.fetch_domestic_balance_snapshot`, `_read_snapshot` calling `client.account`, and daily-ccld diagnostic awaiting a MagicMock child path.
- GREEN: `uv run --group test pytest tests/brokers/kis/test_client_facade.py::test_fetch_domestic_balance_snapshot_is_public_facade tests/test_kis_mock_scalping_adapters.py::test_read_snapshot_uses_kis_client_balance_facade tests/brokers/kis/mock_scalping_exec/test_adapters.py::test_poll_daily_ccld_diagnostic_classifies_filled_rows -q` → 3 passed.
- Focused suite: `uv run --group test pytest tests/brokers/kis/test_client_facade.py tests/test_kis_mock_scalping_adapters.py tests/brokers/kis/mock_scalping_exec/test_adapters.py tests/test_kis_mock_holdings_delta_fill.py tests/test_kis_mock_holdings_delta_smoke_cli.py tests/test_kis_mock_scalping_exit_wiring.py tests/services/test_kis_mock_holdings_reconciler.py -q` → 51 passed.
- Lint/format: `uv run ruff check ...` → pass; `uv run ruff format --check ...` → pass.

## Safety
- No broker submission/cancel/modify logic changed.
- No KIS live path used; this only unblocks official mock read-only snapshot access for the ROB-341 smoke script.
- Actual operator smoke evidence remains a separate bounded `--confirm` run after this fix is available on main.
