### PR TITLE
feat(ROB-356): funding+OI archive parsers + additive oi_coverage (PR1/3)

### DIFF
--- a/research/nautilus_scalping/funding_oi_archive.py
+++ b/research/nautilus_scalping/funding_oi_archive.py
@@ -1,0 +1,122 @@
+"""ROB-356 (PR1) — pure parsers for Binance USD-M funding + open-interest archives.
+
+Decompressed-CSV in, normalized rows out. The network/zip read is the operator-gated
+builder's job (PR3); keeping parsing pure (stdlib, no network) makes the PIT semantics
+unit-testable without touching ``data.binance.vision``.
+
+Confirmed archive schemas (read-only public probe, ROB-356):
+
+    futures/um/monthly/fundingRate/{sym}/{sym}-fundingRate-YYYY-MM.zip
+        calc_time,funding_interval_hours,last_funding_rate
+        - calc_time: epoch MS UTC (kept as-is)
+        - funding_interval_hours: per-row int (8h->4h changes live in the data)
+        - last_funding_rate: realized rate, KNOWN ONLY AT/AFTER calc_time
+
+    futures/um/daily/metrics/{sym}/{sym}-metrics-YYYY-MM-DD.zip
+        create_time,symbol,sum_open_interest,sum_open_interest_value,
+        count_toptrader_long_short_ratio,sum_toptrader_long_short_ratio,
+        count_long_short_ratio,sum_taker_long_short_vol_ratio
+        - create_time: STRING UTC datetime ("YYYY-MM-DD HH:MM:SS"), 5-min grid
+        - duplicate (symbol, create_time) rows occur -> deduped (first wins)
+        - ratio columns may be blank -> None (OI columns still parse)
+
+No OHLCV/volume/wick proxy is ever used for OI: ``sum_open_interest`` comes straight
+from the metrics archive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+_FUNDING_HEADER = "calc_time"
+_METRICS_HEADER = "create_time"
+
+
+@dataclass(frozen=True)
+class FundingRow:
+    """One realized funding observation. ``last_funding_rate`` is known at/after
+    ``calc_time`` (the known-after assumption downstream features must respect)."""
+
+    calc_time: int  # epoch ms UTC
+    funding_interval_hours: int
+    last_funding_rate: float
+
+
+@dataclass(frozen=True)
+class MetricRow:
+    """One open-interest / positioning snapshot. ``create_time`` is the observation
+    time (epoch ms UTC). Ratio fields are ``None`` when blank in the archive."""
+
+    create_time: int  # epoch ms UTC
+    symbol: str
+    sum_open_interest: float
+    sum_open_interest_value: float
+    count_toptrader_long_short_ratio: float | None
+    sum_toptrader_long_short_ratio: float | None
+    count_long_short_ratio: float | None
+    sum_taker_long_short_vol_ratio: float | None
+
+
+def _metrics_time_to_epoch_ms(s: str) -> int:
+    """Parse the metrics ``create_time`` string as UTC epoch ms."""
+    dt = datetime.strptime(s.strip(), "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
+def _float_or_none(cell: str) -> float | None:
+    cell = cell.strip()
+    return float(cell) if cell else None
+
+
+def _data_lines(text: str, header_token: str) -> list[str]:
+    """Non-blank lines minus a possible header row."""
+    out: list[str] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.split(",", 1)[0] == header_token:  # header
+            continue
+        out.append(line)
+    return out
+
+
+def parse_funding_csv(text: str) -> list[FundingRow]:
+    """Parse a fundingRate CSV; rows sorted ascending by ``calc_time``."""
+    rows = [
+        FundingRow(
+            calc_time=int(c[0]),
+            funding_interval_hours=int(c[1]),
+            last_funding_rate=float(c[2]),
+        )
+        for c in (line.split(",") for line in _data_lines(text, _FUNDING_HEADER))
+    ]
+    return sorted(rows, key=lambda r: r.calc_time)
+
+
+def parse_metrics_csv(text: str) -> list[MetricRow]:
+    """Parse a daily metrics CSV; deduped by ``(symbol, create_time)`` (first wins),
+    sorted ascending by ``create_time``."""
+    seen: set[tuple[str, int]] = set()
+    rows: list[MetricRow] = []
+    for c in (line.split(",") for line in _data_lines(text, _METRICS_HEADER)):
+        ts = _metrics_time_to_epoch_ms(c[0])
+        symbol = c[1].strip()
+        key = (symbol, ts)
+        if key in seen:
+            continue
+        seen.add(key)
+        rows.append(
+            MetricRow(
+                create_time=ts,
+                symbol=symbol,
+                sum_open_interest=float(c[2]),
+                sum_open_interest_value=float(c[3]),
+                count_toptrader_long_short_ratio=_float_or_none(c[4]),
+                sum_toptrader_long_short_ratio=_float_or_none(c[5]),
+                count_long_short_ratio=_float_or_none(c[6]),
+                sum_taker_long_short_vol_ratio=_float_or_none(c[7]),
+            )
+        )
+    return sorted(rows, key=lambda r: r.create_time)

--- a/research/nautilus_scalping/pit_universe.py
+++ b/research/nautilus_scalping/pit_universe.py
@@ -25,7 +25,14 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
-_META_FIELDS = ("status", "kline_coverage", "funding_coverage", "confidence", "missing_data_reason")
+_META_FIELDS = (
+    "status",
+    "kline_coverage",
+    "funding_coverage",
+    "oi_coverage",
+    "confidence",
+    "missing_data_reason",
+)
 
 
 def _date_to_epoch_ms(date_str: str) -> int:
@@ -47,6 +54,7 @@ class SymbolListing:
     status: Literal["live", "settling", "dead"] | None = None
     kline_coverage: float | None = None
     funding_coverage: float | None = None
+    oi_coverage: float | None = None
     confidence: Literal["high", "medium", "low"] | None = None
     missing_data_reason: str | None = None
 
@@ -76,10 +84,13 @@ class PITManifest:
             SymbolListing(
                 symbol=r["symbol"],
                 listed_from=int(r["listed_from"]),
-                delisted_at=None if r.get("delisted_at") is None else int(r["delisted_at"]),
+                delisted_at=None
+                if r.get("delisted_at") is None
+                else int(r["delisted_at"]),
                 status=r.get("status"),
                 kline_coverage=r.get("kline_coverage"),
                 funding_coverage=r.get("funding_coverage"),
+                oi_coverage=r.get("oi_coverage"),
                 confidence=r.get("confidence"),
                 missing_data_reason=r.get("missing_data_reason"),
             ).validate()
@@ -108,18 +119,23 @@ class PITManifest:
                 delisted_at = None
             else:
                 delisted_at = _date_to_epoch_ms(
-                    (datetime.strptime(at, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d")
+                    (datetime.strptime(at, "%Y-%m-%d") + timedelta(days=1)).strftime(
+                        "%Y-%m-%d"
+                    )
                 )
-            recs.append({
-                "symbol": r["symbol"],
-                "listed_from": listed_from,
-                "delisted_at": delisted_at,
-                "status": r.get("status"),
-                "kline_coverage": r.get("kline_coverage"),
-                "funding_coverage": r.get("funding_coverage"),
-                "confidence": r.get("confidence"),
-                "missing_data_reason": r.get("missing_data_reason") or None,
-            })
+            recs.append(
+                {
+                    "symbol": r["symbol"],
+                    "listed_from": listed_from,
+                    "delisted_at": delisted_at,
+                    "status": r.get("status"),
+                    "kline_coverage": r.get("kline_coverage"),
+                    "funding_coverage": r.get("funding_coverage"),
+                    "oi_coverage": r.get("oi_coverage"),
+                    "confidence": r.get("confidence"),
+                    "missing_data_reason": r.get("missing_data_reason") or None,
+                }
+            )
         return cls.from_records(recs)
 
     def to_records(self) -> list[dict]:
@@ -146,7 +162,8 @@ class PITManifest:
     def strict_usdt_perp(self) -> PITManifest:
         """Perp-only honest universe: live/dead plain *USDT, excl. settling/BUSD/USDC/dated/SETTLED."""
         kept = tuple(
-            x for x in self.listings
+            x
+            for x in self.listings
             if x.status in ("live", "dead")
             and x.symbol.endswith("USDT")
             and "_" not in x.symbol

--- a/research/nautilus_scalping/tests/test_funding_oi_archive.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_archive.py
@@ -1,0 +1,135 @@
+"""ROB-356 (PR1) — pure parsers for Binance USD-M funding + OI (metrics) archives.
+
+No network here: the parsers take the decompressed CSV text (the network/zip read
+is the operator-gated builder's job). These tests pin the confirmed archive schemas:
+
+    fundingRate (monthly): calc_time,funding_interval_hours,last_funding_rate
+        calc_time is epoch MS UTC; realized last_funding_rate is known only at/after
+        calc_time; funding_interval_hours is per-row (8h->4h changes live in the data).
+    metrics (daily): create_time,symbol,sum_open_interest,sum_open_interest_value,
+        count_toptrader_long_short_ratio,sum_toptrader_long_short_ratio,
+        count_long_short_ratio,sum_taker_long_short_vol_ratio
+        create_time is a STRING UTC datetime at 5-min grid; duplicate rows occur and
+        must be deduped by (symbol, create_time).
+"""
+
+from datetime import UTC, datetime
+
+import funding_oi_archive as foa
+
+
+def _ms(s: str) -> int:
+    return int(
+        datetime.strptime(s, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC).timestamp() * 1000
+    )
+
+
+# --------------------------------------------------------------------------- #
+# funding
+# --------------------------------------------------------------------------- #
+FUNDING_CSV = (
+    "calc_time,funding_interval_hours,last_funding_rate\n"
+    "1577836800000,8,-0.00012359\n"
+    "1577865600000,8,-0.00012383\n"
+)
+
+
+def test_parse_funding_csv_basic():
+    rows = foa.parse_funding_csv(FUNDING_CSV)
+    assert len(rows) == 2
+    r = rows[0]
+    assert r.calc_time == 1577836800000  # epoch ms UTC, kept as-is
+    assert r.funding_interval_hours == 8
+    assert r.last_funding_rate == -0.00012359
+
+
+def test_parse_funding_csv_skips_header():
+    # header row must never be parsed as data
+    rows = foa.parse_funding_csv(FUNDING_CSV)
+    assert all(isinstance(r.calc_time, int) for r in rows)
+    assert len(rows) == 2
+
+
+def test_parse_funding_csv_preserves_per_row_interval_change():
+    # 8h -> 4h interval change must survive as a per-row feature, not a constant
+    csv = (
+        "calc_time,funding_interval_hours,last_funding_rate\n"
+        "1700000000000,8,0.0001\n"
+        "1700028800000,4,0.0002\n"  # interval dropped to 4h
+        "1700043200000,4,0.00015\n"
+    )
+    rows = foa.parse_funding_csv(csv)
+    assert [r.funding_interval_hours for r in rows] == [8, 4, 4]
+
+
+def test_parse_funding_csv_sorted_by_calc_time():
+    csv = (
+        "calc_time,funding_interval_hours,last_funding_rate\n"
+        "1700028800000,8,0.0002\n"
+        "1700000000000,8,0.0001\n"  # out of order
+    )
+    rows = foa.parse_funding_csv(csv)
+    assert [r.calc_time for r in rows] == [1700000000000, 1700028800000]
+
+
+# --------------------------------------------------------------------------- #
+# metrics / open interest
+# --------------------------------------------------------------------------- #
+METRICS_HEADER = (
+    "create_time,symbol,sum_open_interest,sum_open_interest_value,"
+    "count_toptrader_long_short_ratio,sum_toptrader_long_short_ratio,"
+    "count_long_short_ratio,sum_taker_long_short_vol_ratio\n"
+)
+METRICS_CSV = METRICS_HEADER + (
+    "2020-09-01 00:00:00,BTCUSDT,39080.23100000,456144339.23360443,"
+    "1.17547937,1.23012681,1.35731217,0.78373373\n"
+    "2020-09-01 00:05:00,BTCUSDT,39100.00000000,456400000.00000000,"
+    "1.10000000,1.20000000,1.30000000,0.80000000\n"
+)
+
+
+def test_parse_metrics_csv_basic():
+    rows = foa.parse_metrics_csv(METRICS_CSV)
+    assert len(rows) == 2
+    r = rows[0]
+    assert r.create_time == _ms("2020-09-01 00:00:00")  # string parsed as UTC epoch ms
+    assert r.symbol == "BTCUSDT"
+    assert r.sum_open_interest == 39080.231
+    assert r.sum_open_interest_value == 456144339.23360443
+    assert r.count_toptrader_long_short_ratio == 1.17547937
+    assert r.sum_taker_long_short_vol_ratio == 0.78373373
+
+
+def test_parse_metrics_csv_dedupes_identical_timestamp_rows():
+    # observed in the real archive: same (symbol, create_time) row repeated
+    dup = (
+        METRICS_HEADER
+        + (
+            "2020-09-01 00:00:00,BTCUSDT,39080.23100000,456144339.23360443,"
+            "1.17547937,1.23012681,1.35731217,0.78373373\n"
+        )
+        * 2
+    )
+    rows = foa.parse_metrics_csv(dup)
+    assert len(rows) == 1
+
+
+def test_parse_metrics_csv_sorted_by_create_time():
+    csv = METRICS_HEADER + (
+        "2020-09-01 00:05:00,BTCUSDT,2,2,1,1,1,1\n"
+        "2020-09-01 00:00:00,BTCUSDT,1,1,1,1,1,1\n"  # out of order
+    )
+    rows = foa.parse_metrics_csv(csv)
+    assert [r.create_time for r in rows] == [
+        _ms("2020-09-01 00:00:00"),
+        _ms("2020-09-01 00:05:00"),
+    ]
+
+
+def test_parse_metrics_csv_empty_ratio_field_is_none():
+    # some symbols/days have blank ratio columns; OI must still parse, ratio -> None
+    csv = METRICS_HEADER + "2020-09-01 00:00:00,BTCUSDT,39080.231,456144339.23,,,,\n"
+    (r,) = foa.parse_metrics_csv(csv)
+    assert r.sum_open_interest == 39080.231
+    assert r.count_toptrader_long_short_ratio is None
+    assert r.sum_taker_long_short_vol_ratio is None

--- a/research/nautilus_scalping/tests/test_pit_universe.py
+++ b/research/nautilus_scalping/tests/test_pit_universe.py
@@ -16,16 +16,22 @@ from pathlib import Path
 import pit_universe
 from pit_universe import PITManifest, SymbolListing
 
-_MANIFEST = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.json"
-_META = Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.meta.json"
+_MANIFEST = (
+    Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.json"
+)
+_META = (
+    Path(__file__).resolve().parents[1] / "data_manifests" / "pit_universe.v1.meta.json"
+)
 
 
 def _manifest():
-    return PITManifest.from_records([
-        {"symbol": "AAA", "listed_from": 100, "delisted_at": None},
-        {"symbol": "BBB", "listed_from": 150, "delisted_at": 400},
-        {"symbol": "CCC", "listed_from": 500, "delisted_at": None},
-    ])
+    return PITManifest.from_records(
+        [
+            {"symbol": "AAA", "listed_from": 100, "delisted_at": None},
+            {"symbol": "BBB", "listed_from": 150, "delisted_at": 400},
+            {"symbol": "CCC", "listed_from": 500, "delisted_at": None},
+        ]
+    )
 
 
 def test_includes_listed_and_not_delisted():
@@ -78,9 +84,14 @@ def test_rejects_delist_before_list():
 
 def test_symbollisting_optional_metadata_roundtrips():
     rec = {
-        "symbol": "EOSUSDT", "listed_from": 1672531200000, "delisted_at": 1700000000000,
-        "status": "dead", "kline_coverage": 1.0, "funding_coverage": 1.0,
-        "confidence": "high", "missing_data_reason": "delisted",
+        "symbol": "EOSUSDT",
+        "listed_from": 1672531200000,
+        "delisted_at": 1700000000000,
+        "status": "dead",
+        "kline_coverage": 1.0,
+        "funding_coverage": 1.0,
+        "confidence": "high",
+        "missing_data_reason": "delisted",
     }
     m = pit_universe.PITManifest.from_records([rec])
     (only,) = m.listings
@@ -91,25 +102,83 @@ def test_symbollisting_optional_metadata_roundtrips():
     assert back.listings[0].missing_data_reason == "delisted"
 
 
+def test_oi_coverage_is_additive_and_preserves_existing_coverage():
+    # ROB-356: oi_coverage added alongside funding_coverage/kline_coverage without
+    # disturbing the existing fields on round-trip.
+    rec = {
+        "symbol": "EOSUSDT",
+        "listed_from": 1672531200000,
+        "delisted_at": 1700000000000,
+        "status": "dead",
+        "kline_coverage": 1.0,
+        "funding_coverage": 0.97,
+        "oi_coverage": 0.83,
+        "confidence": "high",
+        "missing_data_reason": "delisted",
+    }
+    m = pit_universe.PITManifest.from_records([rec])
+    (only,) = m.listings
+    assert only.oi_coverage == 0.83
+    assert only.kline_coverage == 1.0
+    assert only.funding_coverage == 0.97
+    back = pit_universe.PITManifest.from_records(m.to_records())
+    b = back.listings[0]
+    assert (b.oi_coverage, b.kline_coverage, b.funding_coverage) == (0.83, 1.0, 0.97)
+
+
+def test_oi_coverage_absent_is_not_emitted_so_committed_hash_is_stable():
+    # additive guarantee: a record without oi_coverage must serialize identically
+    # to before (None field is dropped by to_records), so the committed manifest
+    # snapshot_hash does not change.
+    rec = {
+        "symbol": "BTCUSDT",
+        "listed_from": 0,
+        "delisted_at": None,
+        "kline_coverage": 1.0,
+        "funding_coverage": 1.0,
+    }
+    out = pit_universe.PITManifest.from_records([rec]).to_records()[0]
+    assert "oi_coverage" not in out
+
+
 def test_symbollisting_metadata_defaults_none():
     m = pit_universe.PITManifest.from_records(
         [{"symbol": "BTCUSDT", "listed_from": 0, "delisted_at": None}]
     )
     only = m.listings[0]
     assert only.status is None and only.confidence is None
-    assert pit_universe.PITManifest.from_records(m.to_records()).listings[0].symbol == "BTCUSDT"
+    assert (
+        pit_universe.PITManifest.from_records(m.to_records()).listings[0].symbol
+        == "BTCUSDT"
+    )
 
 
 def test_from_pit_index_records_maps_dates_to_epoch_ms():
     rows = [
-        {"symbol": "EOSUSDT", "status": "dead", "first_seen": "2023-01", "last_seen": "2024-01",
-         "active_from": "2023-01-26", "active_to": "2024-01-11",
-         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
-         "missing_data_reason": "delisted"},
-        {"symbol": "BTCUSDT", "status": "live", "first_seen": "2020-01", "last_seen": "2026-05",
-         "active_from": "2020-01-01", "active_to": "ongoing",
-         "kline_coverage": 1.0, "funding_coverage": 1.0, "confidence": "high",
-         "missing_data_reason": ""},
+        {
+            "symbol": "EOSUSDT",
+            "status": "dead",
+            "first_seen": "2023-01",
+            "last_seen": "2024-01",
+            "active_from": "2023-01-26",
+            "active_to": "2024-01-11",
+            "kline_coverage": 1.0,
+            "funding_coverage": 1.0,
+            "confidence": "high",
+            "missing_data_reason": "delisted",
+        },
+        {
+            "symbol": "BTCUSDT",
+            "status": "live",
+            "first_seen": "2020-01",
+            "last_seen": "2026-05",
+            "active_from": "2020-01-01",
+            "active_to": "ongoing",
+            "kline_coverage": 1.0,
+            "funding_coverage": 1.0,
+            "confidence": "high",
+            "missing_data_reason": "",
+        },
     ]
     m = pit_universe.PITManifest.from_pit_index_records(rows)
     eos = next(x for x in m.listings if x.symbol == "EOSUSDT")
@@ -122,19 +191,33 @@ def test_from_pit_index_records_maps_dates_to_epoch_ms():
 
 
 def test_from_pit_index_records_skips_rows_without_dates():
-    rows = [{"symbol": "GHOSTUSDT", "status": "dead", "first_seen": None, "last_seen": None,
-             "active_from": None, "active_to": None}]
+    rows = [
+        {
+            "symbol": "GHOSTUSDT",
+            "status": "dead",
+            "first_seen": None,
+            "last_seen": None,
+            "active_from": None,
+            "active_to": None,
+        }
+    ]
     m = pit_universe.PITManifest.from_pit_index_records(rows)
     assert m.listings == ()
 
 
 def _row(sym, status):
-    return {"symbol": sym, "status": status, "active_from": "2023-01-01", "active_to": "2024-01-01"}
+    return {
+        "symbol": sym,
+        "status": status,
+        "active_from": "2023-01-01",
+        "active_to": "2024-01-01",
+    }
 
 
 def test_strict_usdt_perp_keeps_live_and_dead_plain_usdt():
     rows = [
-        _row("BTCUSDT", "live"), _row("EOSUSDT", "dead"),
+        _row("BTCUSDT", "live"),
+        _row("EOSUSDT", "dead"),
         _row("ETHUSDC", "live"),
         _row("BTCBUSD", "dead"),
         _row("BTCUSDT_230331", "settling"),
@@ -147,14 +230,18 @@ def test_strict_usdt_perp_keeps_live_and_dead_plain_usdt():
 
 
 def test_snapshot_hash_is_stable_and_order_independent():
-    a = pit_universe.PITManifest.from_records([
-        {"symbol": "A", "listed_from": 1, "delisted_at": None},
-        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
-    ])
-    b = pit_universe.PITManifest.from_records([
-        {"symbol": "B", "listed_from": 2, "delisted_at": 3},
-        {"symbol": "A", "listed_from": 1, "delisted_at": None},
-    ])
+    a = pit_universe.PITManifest.from_records(
+        [
+            {"symbol": "A", "listed_from": 1, "delisted_at": None},
+            {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+        ]
+    )
+    b = pit_universe.PITManifest.from_records(
+        [
+            {"symbol": "B", "listed_from": 2, "delisted_at": 3},
+            {"symbol": "A", "listed_from": 1, "delisted_at": None},
+        ]
+    )
     assert a.snapshot_hash() == b.snapshot_hash()
     assert len(a.snapshot_hash()) == 64
 


### PR DESCRIPTION
Stacked PR **1 of 3** for ROB-356 (Binance USD-M funding+OI PIT feature builder, after ROB-355 ranked funding+OI crowding `feasible`). Research-only foundation: pure parsers, no network, **no strategy/backtest**.

## What
- **`funding_oi_archive.py`** — pure stdlib parsers for the confirmed archive schemas:
  - `parse_funding_csv`: `calc_time` epoch-ms UTC, **per-row** `funding_interval_hours` (8h→4h changes survive), realized `last_funding_rate` known-after `calc_time`.
  - `parse_metrics_csv`: `create_time` string parsed as UTC epoch-ms; **dedup by `(symbol, create_time)`** (the archive repeats rows — observed 576→288/day); blank ratio cols → `None`; OI from actual `sum_open_interest`.
- **`pit_universe.py`** — `oi_coverage` added to `SymbolListing` + `_META_FIELDS` **additively** beside `kline_coverage`/`funding_coverage`. `None` is omitted by `to_records`, so the committed `pit_universe.v1.json` `snapshot_hash` is unchanged.

## Tests
Parser schema incl. interval-change, dup-dedup, blank-ratio; additive `oi_coverage` round-trip preserving existing coverage and the committed manifest hash. `220 passed / 1 skipped` across the research suite; `ruff check` clean.

## Safety
Read-only/no-network pure code. No broker/order/watch mutation, no Demo `confirm`, no live endpoint, no scheduler/DB, no raw-data commit, no secrets, no OHLCV proxy for OI.

Plan/criteria locked in the [ROB-356 Linear comment](https://linear.app/mgh3326/issue/ROB-356). PR2 (feature core) stacks on this; PR3 (builder CLI + report + verdict) stacks on PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added CSV parsing for Binance funding rate and open-interest metrics archives
  - Added open-interest coverage tracking to the universe manifest

* **Tests**
  - Added test coverage for funding and metrics CSV parsers
  - Added tests for open-interest coverage field persistence and handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1002?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->