### PR TITLE
feat(ROB-356): PIT join + delist trim + as-of funding×OI features (PR2/3)

### DIFF
--- a/research/nautilus_scalping/funding_oi_features.py
+++ b/research/nautilus_scalping/funding_oi_features.py
@@ -1,0 +1,152 @@
+"""ROB-356 (PR2) — PIT-safe funding + open-interest feature construction (pure).
+
+Joins parsed funding rows (``funding_oi_archive.FundingRow``) onto the open-interest
+metrics grid (``MetricRow``) under strict point-in-time rules so a later
+crowding/deleveraging study cannot see the future or a survivor-only tail.
+
+Join rule (locked in the ROB-356 plan):
+  * canonical feature grid = OI metrics timestamps (5-min, UTC) — the dense crowding
+    axis. Funding (monthly, ~3/day) is the sparse context, not the grid.
+  * funding attached by BACKWARD as-of join: for an OI row at ``t`` take the most
+    recent funding row with ``calc_time <= t``. Realized ``last_funding_rate`` and the
+    per-row ``funding_interval_hours`` therefore reach an OI row only at/after the
+    funding ``calc_time`` (known-after). Rows before the first funding carry None.
+  * ``delisted_at`` is EXCLUSIVE: rows at/after it are dropped (frozen-tail guard).
+  * per-symbol OI-start bounding is implicit — the grid starts at the first OI row, so
+    funding observations earlier than OI simply have no row to attach to.
+
+OI features come straight from ``sum_open_interest`` (actual exchange OI). No
+OHLCV/volume/wick proxy is used for OI. Rolling z-scores use population std and are
+bounded to 0.0 on a zero-variance window (never NaN/inf).
+"""
+
+from __future__ import annotations
+
+import bisect
+from dataclasses import dataclass
+
+from funding_oi_archive import FundingRow, MetricRow
+
+
+@dataclass(frozen=True)
+class FeatureRow:
+    ts: int  # epoch ms UTC == OI create_time (the PIT observation time)
+    symbol: str
+    # --- open interest (actual exchange OI) ---
+    sum_open_interest: float
+    sum_open_interest_value: float
+    oi_delta: float | None
+    oi_pct_change: float | None
+    oi_zscore: float | None
+    # --- positioning passthrough (from the metrics archive) ---
+    count_toptrader_long_short_ratio: float | None
+    sum_toptrader_long_short_ratio: float | None
+    count_long_short_ratio: float | None
+    sum_taker_long_short_vol_ratio: float | None
+    # --- funding (backward as-of, known-after) ---
+    funding_calc_time: int | None
+    last_funding_rate: float | None
+    funding_interval_hours: int | None
+    funding_rate_zscore: float | None
+
+
+def trim_metrics(rows: list[MetricRow], delisted_at: int | None) -> list[MetricRow]:
+    """Drop OI rows at/after ``delisted_at`` (EXCLUSIVE). ``None`` keeps all."""
+    if delisted_at is None:
+        return rows
+    return [r for r in rows if r.create_time < delisted_at]
+
+
+def trim_funding(rows: list[FundingRow], delisted_at: int | None) -> list[FundingRow]:
+    """Drop funding rows at/after ``delisted_at`` (EXCLUSIVE). ``None`` keeps all."""
+    if delisted_at is None:
+        return rows
+    return [r for r in rows if r.calc_time < delisted_at]
+
+
+def asof_funding(ts: int, funding: list[FundingRow]) -> FundingRow | None:
+    """Most recent funding row with ``calc_time <= ts``; ``None`` if none yet known.
+
+    ``funding`` must be ascending by ``calc_time`` (the parser guarantees this).
+    """
+    times = [f.calc_time for f in funding]
+    i = bisect.bisect_right(times, ts)
+    return funding[i - 1] if i > 0 else None
+
+
+def _rolling_zscore(values: list[float], window: int) -> list[float | None]:
+    """Causal rolling z-score (population std) over the trailing ``window`` values.
+
+    ``None`` until ``window`` observations exist; ``0.0`` on a zero-variance window
+    (bounded, never NaN/inf).
+    """
+    out: list[float | None] = []
+    for idx in range(len(values)):
+        if idx + 1 < window:
+            out.append(None)
+            continue
+        win = values[idx + 1 - window : idx + 1]
+        mean = sum(win) / window
+        var = sum((v - mean) ** 2 for v in win) / window
+        if var <= 0.0:
+            out.append(0.0)
+        else:
+            out.append((values[idx] - mean) / var**0.5)
+    return out
+
+
+def build_features(
+    symbol: str,
+    funding: list[FundingRow],
+    metrics: list[MetricRow],
+    delisted_at: int | None = None,
+    oi_window: int = 30,
+    funding_window: int = 30,
+) -> list[FeatureRow]:
+    """Build PIT-safe funding+OI feature rows on the OI grid.
+
+    ``funding``/``metrics`` are the parsed (ascending) rows for one symbol.
+    """
+    funding = trim_funding(funding, delisted_at)
+    metrics = trim_metrics(metrics, delisted_at)
+
+    # funding-rate causal z-score on the funding series, then as-of attached
+    f_z_by_calc: dict[int, float | None] = {}
+    if funding:
+        zs = _rolling_zscore([f.last_funding_rate for f in funding], funding_window)
+        f_z_by_calc = {f.calc_time: z for f, z in zip(funding, zs, strict=True)}
+
+    oi_vals = [m.sum_open_interest for m in metrics]
+    oi_z = _rolling_zscore(oi_vals, oi_window)
+
+    feats: list[FeatureRow] = []
+    prev_oi: float | None = None
+    for m, z in zip(metrics, oi_z, strict=True):
+        oi_delta = None if prev_oi is None else m.sum_open_interest - prev_oi
+        oi_pct = (
+            None
+            if prev_oi is None or prev_oi == 0.0
+            else (m.sum_open_interest - prev_oi) / prev_oi
+        )
+        af = asof_funding(m.create_time, funding)
+        feats.append(
+            FeatureRow(
+                ts=m.create_time,
+                symbol=symbol,
+                sum_open_interest=m.sum_open_interest,
+                sum_open_interest_value=m.sum_open_interest_value,
+                oi_delta=oi_delta,
+                oi_pct_change=oi_pct,
+                oi_zscore=z,
+                count_toptrader_long_short_ratio=m.count_toptrader_long_short_ratio,
+                sum_toptrader_long_short_ratio=m.sum_toptrader_long_short_ratio,
+                count_long_short_ratio=m.count_long_short_ratio,
+                sum_taker_long_short_vol_ratio=m.sum_taker_long_short_vol_ratio,
+                funding_calc_time=af.calc_time if af else None,
+                last_funding_rate=af.last_funding_rate if af else None,
+                funding_interval_hours=af.funding_interval_hours if af else None,
+                funding_rate_zscore=f_z_by_calc.get(af.calc_time) if af else None,
+            )
+        )
+        prev_oi = m.sum_open_interest
+    return feats

--- a/research/nautilus_scalping/tests/test_funding_oi_features.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_features.py
@@ -1,0 +1,143 @@
+"""ROB-356 (PR2) — PIT-safe funding+OI feature construction.
+
+These tests pin the survivorship/known-after semantics that are the whole point of
+the artifact:
+
+  * post-delist frozen rows trimmed at ``delisted_at`` EXCLUSIVE (funding + OI);
+  * funding attached to the OI grid by BACKWARD as-of join (no future leakage):
+    a realized ``last_funding_rate`` reaches an OI row only at/after its ``calc_time``;
+  * per-row ``funding_interval_hours`` carried through interval changes (8h->4h);
+  * feature rows bounded by per-symbol OI availability (the dense crowding axis);
+  * OI features (delta / pct-change / rolling z) derived from ACTUAL open interest,
+    never an OHLCV/volume proxy; zero-variance windows are bounded, not NaN.
+"""
+
+import funding_oi_features as fof
+from funding_oi_archive import FundingRow, MetricRow
+
+
+def _m(ts: int, oi: float = 100.0, oiv: float = 1.0) -> MetricRow:
+    return MetricRow(
+        create_time=ts,
+        symbol="EOSUSDT",
+        sum_open_interest=oi,
+        sum_open_interest_value=oiv,
+        count_toptrader_long_short_ratio=1.0,
+        sum_toptrader_long_short_ratio=1.0,
+        count_long_short_ratio=1.0,
+        sum_taker_long_short_vol_ratio=1.0,
+    )
+
+
+def _f(ts: int, rate: float = 0.0001, interval: int = 8) -> FundingRow:
+    return FundingRow(
+        calc_time=ts, funding_interval_hours=interval, last_funding_rate=rate
+    )
+
+
+# --------------------------------------------------------------------------- #
+# delist trim — EXCLUSIVE
+# --------------------------------------------------------------------------- #
+def test_trim_metrics_at_delist_is_exclusive():
+    rows = [_m(100), _m(200), _m(300)]
+    out = fof.trim_metrics(rows, delisted_at=200)
+    assert [r.create_time for r in out] == [100]  # 200 dropped (>= exclusive bound)
+
+
+def test_trim_funding_at_delist_is_exclusive():
+    rows = [_f(100), _f(200), _f(300)]
+    out = fof.trim_funding(rows, delisted_at=200)
+    assert [r.calc_time for r in out] == [100]
+
+
+def test_trim_none_keeps_all_rows():
+    rows = [_m(100), _m(200)]
+    assert fof.trim_metrics(rows, delisted_at=None) == rows
+
+
+# --------------------------------------------------------------------------- #
+# backward as-of join — KNOWN-AFTER, no future leakage
+# --------------------------------------------------------------------------- #
+def test_asof_funding_picks_latest_at_or_before():
+    funding = [_f(100, 0.1), _f(300, 0.2)]
+    assert fof.asof_funding(250, funding).last_funding_rate == 0.1  # 300 not yet known
+    assert (
+        fof.asof_funding(300, funding).last_funding_rate == 0.2
+    )  # known exactly at calc_time
+
+
+def test_asof_funding_none_before_first_calc_time():
+    funding = [_f(200, 0.2)]
+    assert fof.asof_funding(199, funding) is None  # known-after: nothing realized yet
+
+
+# --------------------------------------------------------------------------- #
+# build_features — grid, bounding, leakage, interval carry
+# --------------------------------------------------------------------------- #
+def test_features_are_on_the_oi_grid_and_bounded_by_oi_start():
+    # funding starts BEFORE OI; the feature grid still starts at the first OI row
+    funding = [_f(50, 0.1), _f(150, 0.2)]
+    metrics = [_m(100), _m(200)]
+    feats = fof.build_features("EOSUSDT", funding, metrics)
+    assert [f.ts for f in feats] == [100, 200]  # OI start bounds the panel
+
+
+def test_features_no_future_funding_leakage():
+    funding = [_f(150, 0.2)]
+    metrics = [_m(100), _m(200)]
+    feats = fof.build_features("EOSUSDT", funding, metrics)
+    # OI@100 predates the only funding calc (150) -> no realized funding known yet
+    assert feats[0].last_funding_rate is None
+    assert feats[0].funding_calc_time is None
+    # OI@200 is at/after calc 150 -> realized funding now known
+    assert feats[1].last_funding_rate == 0.2
+    assert feats[1].funding_calc_time == 150
+
+
+def test_features_carry_per_row_funding_interval_change():
+    funding = [_f(100, 0.1, interval=8), _f(160, 0.2, interval=4)]  # 8h -> 4h
+    metrics = [_m(120), _m(180)]
+    feats = fof.build_features("EOSUSDT", funding, metrics)
+    assert feats[0].funding_interval_hours == 8  # asof 100
+    assert feats[1].funding_interval_hours == 4  # asof 160 (interval changed)
+
+
+def test_features_trim_delisted_before_building():
+    funding = [_f(100, 0.1)]
+    metrics = [_m(100), _m(200), _m(300)]
+    feats = fof.build_features("EOSUSDT", funding, metrics, delisted_at=300)
+    assert [f.ts for f in feats] == [100, 200]  # 300 frozen-tail dropped (exclusive)
+
+
+# --------------------------------------------------------------------------- #
+# OI features from ACTUAL open interest
+# --------------------------------------------------------------------------- #
+def test_oi_delta_and_pct_change():
+    metrics = [_m(100, oi=100.0), _m(200, oi=110.0)]
+    feats = fof.build_features("EOSUSDT", [], metrics)
+    assert feats[0].oi_delta is None and feats[0].oi_pct_change is None  # no prior
+    assert feats[1].oi_delta == 10.0
+    assert abs(feats[1].oi_pct_change - 0.1) < 1e-12
+
+
+def test_oi_pct_change_none_when_prev_is_zero():
+    metrics = [_m(100, oi=0.0), _m(200, oi=5.0)]
+    feats = fof.build_features("EOSUSDT", [], metrics)
+    assert feats[1].oi_pct_change is None  # guard div-by-zero
+
+
+def test_oi_rolling_zscore_zero_variance_is_zero_not_nan():
+    metrics = [_m(t, oi=100.0) for t in (100, 200, 300)]
+    feats = fof.build_features("EOSUSDT", [], metrics, oi_window=3)
+    assert feats[0].oi_zscore is None and feats[1].oi_zscore is None  # warmup
+    assert feats[2].oi_zscore == 0.0  # constant series -> bounded 0, never NaN
+
+
+def test_oi_rolling_zscore_known_value():
+    # window=3 over [100,110,120]; mean=110, pop std=sqrt(200/3); z of last
+    metrics = [_m(100, oi=100.0), _m(200, oi=110.0), _m(300, oi=120.0)]
+    feats = fof.build_features("EOSUSDT", [], metrics, oi_window=3)
+    import math
+
+    expected = (120.0 - 110.0) / math.sqrt(200.0 / 3.0)
+    assert abs(feats[2].oi_zscore - expected) < 1e-9


### PR DESCRIPTION
Stacked PR **2 of 3** for ROB-356. **Base = `rob-356-pr1`** (review/merge PR1 first). Pure feature core on PR1's parsers; no network, **no strategy/backtest**.

## What — `funding_oi_features.py`
- Canonical grid = **OI metrics timestamps** (5-min UTC); funding is sparse context.
- **Backward as-of funding join, no future leakage**: realized `last_funding_rate` + per-row `funding_interval_hours` reach an OI row only at/after the funding `calc_time` (known-after); pre-first-funding rows carry `None`.
- **`delisted_at` EXCLUSIVE** trim on both series (frozen-tail guard); per-symbol **OI-start bounding** implicit (grid starts at first OI row).
- OI features from **actual `sum_open_interest` only** (no OHLCV/volume proxy): `oi_delta`, `oi_pct_change` (div-by-zero guarded), causal rolling `oi_zscore` (population std, zero-variance → `0.0` not NaN); `funding_rate_zscore` as-of.

## Tests
Exclusive delist trim, OI-start bounding, as-of no-leakage, per-row interval carry (8h→4h), known-after, OI delta/pct, zero-variance z bounded. Validated on real data (EOSUSDT bounded smoke): 0 future-leakage rows.

## Safety
Same boundaries as PR1 (read-only pure code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)