### PR TITLE
feat(ROB-356): operator-gated builder CLI + report + readiness verdict (PR3/3)

### DIFF
--- a/docs/runbooks/rob-356-funding-oi-pit-features.md
+++ b/docs/runbooks/rob-356-funding-oi-pit-features.md
@@ -1,0 +1,178 @@
+# ROB-356 — Binance USD-M funding + OI PIT feature builder
+
+Research/feature-construction only. Read-only PUBLIC data (`data.binance.vision`
+`futures/um` monthly `fundingRate` + daily `metrics`). **No strategy, no backtest, no
+parameter sweep, no runtime strategy params, no `/invest` exposure, no
+broker/order/watch/order-intent mutation, no Binance Demo `confirm=true`, no
+live/mainnet endpoint, no scheduler/TaskIQ/Prefect/cron/daemon, no production DB write,
+no raw large market-data committed, no secrets, no OHLCV/volume proxy for OI.**
+
+This issue builds the deterministic, point-in-time (PIT), survivorship-safe funding+OI
+**feature artifact** that a later bounded crowding/deleveraging event study would consume.
+It is the step after ROB-355/PR #1000, which audited the data and found funding-only
+`feasible` (baseline/control) and **funding + open-interest `feasible` and the primary next
+line**. It does **not** open or run that backtest — [ROB-343](https://linear.app/mgh3326/issue/ROB-343)
+remains deferred.
+
+## Why this issue exists (context)
+
+ROB-353 screened out the generic price-action families (trend / momentum / breakout) on
+**gross** expectancy — the failure was edge, not fees. ROB-355 then audited derivatives-native
+data and ranked **funding + OI crowding/deleveraging** as the feasible primary line
+(liquidation `needs_vendor_data` — no archive; sweep `partial`). This issue proves the
+funding+OI features can be constructed cleanly and PIT-safely so the crowding study, *if*
+opened, starts from trustworthy inputs.
+
+## What this builds
+
+| Component | Path | Role |
+|---|---|---|
+| Archive parsers (pure) | `research/nautilus_scalping/funding_oi_archive.py` | zip-CSV text → normalized `FundingRow` / `MetricRow`; dedup; UTC epoch-ms |
+| Feature core (pure) | `research/nautilus_scalping/funding_oi_features.py` | PIT join, delist trim, OI-start bounding, OI features, backward as-of funding |
+| `oi_coverage` field | `research/nautilus_scalping/pit_universe.py` | additive `SymbolListing` / `_META_FIELDS` coverage field |
+| Builder CLI (operator-gated) | `research/nautilus_scalping/build_funding_oi_features.py` | read-only network RUN + coverage summary + deterministic verdict |
+| Tests | `research/nautilus_scalping/tests/test_funding_oi_{archive,features,readiness}.py` + `test_pit_universe.py` | PIT semantics + verdict |
+
+Generated feature tables and the coverage summary are written **only** under the gitignored
+`results/` artifact root (`AUTO_TRADER_RESEARCH_ARTIFACT_ROOT` if set). No raw market data is
+committed.
+
+## Confirmed archive schemas (read-only probe, `2026-05-29`)
+
+- **funding** `futures/um/monthly/fundingRate/<sym>/<sym>-fundingRate-YYYY-MM.zip`
+  CSV `calc_time, funding_interval_hours, last_funding_rate`. `calc_time` is epoch **ms UTC**;
+  ~3 rows/day (8h). `funding_interval_hours` is **per-row** — 8h→4h interval changes live in
+  the data and are carried as a feature, never assumed constant.
+- **OI** `futures/um/daily/metrics/<sym>/<sym>-metrics-YYYY-MM-DD.zip`
+  CSV `create_time, symbol, sum_open_interest, sum_open_interest_value,
+  count_toptrader_long_short_ratio, sum_toptrader_long_short_ratio, count_long_short_ratio,
+  sum_taker_long_short_vol_ratio`. `create_time` is a **string UTC** datetime, 5-min grid.
+  **Duplicate rows occur** (same `(symbol, create_time)` repeated) → deduped (first wins);
+  genuinely-distinct timestamps are preserved.
+
+## PIT semantics (the point of the artifact)
+
+1. **Canonical grid = OI metrics timestamps** (5-min, UTC, deduped) — the dense
+   crowding/deleveraging axis. Funding (monthly, ~3/day) is sparse context, not the grid.
+2. **Backward as-of funding join, no future leakage.** For an OI row at `t`, attach the most
+   recent funding row with `calc_time <= t`. Realized `last_funding_rate` and per-row
+   `funding_interval_hours` reach an OI row only **at/after** the funding `calc_time`
+   (known-after). OI rows before the first funding `calc_time` carry `None` funding fields.
+3. **`delisted_at` is EXCLUSIVE.** Rows at/after `delisted_at` are dropped from both series
+   before join — no post-delist frozen-tail leakage.
+4. **Per-symbol OI-start bounding** is implicit: the grid starts at the first OI row, so
+   funding observations earlier than OI simply have no row to attach to. OI archives start
+   later than funding/klines for most symbols (ROB-355), so this bound is real and reported.
+5. **All timestamps normalized to epoch-ms UTC** (`create_time` parsed as UTC).
+6. **OI from actual open interest only.** `sum_open_interest` / `sum_open_interest_value`
+   come straight from the metrics archive; **no OHLCV/volume/wick proxy** is used for OI.
+   Rolling z-scores use population std and are bounded to `0.0` on a zero-variance window
+   (never NaN/inf).
+
+## Feature schema (`FeatureRow`)
+
+`ts` (epoch ms UTC), `symbol`; OI: `sum_open_interest`, `sum_open_interest_value`,
+`oi_delta`, `oi_pct_change`, `oi_zscore`; positioning passthrough:
+`count_toptrader_long_short_ratio`, `sum_toptrader_long_short_ratio`,
+`count_long_short_ratio`, `sum_taker_long_short_vol_ratio`; funding (backward as-of):
+`funding_calc_time`, `last_funding_rate`, `funding_interval_hours`, `funding_rate_zscore`.
+
+Funding-only carry remains a **baseline/control** and is not promoted here. An OI-to-ADV
+crowding ratio (real volume denominator, not an OI proxy) is a deliberate **additive
+extension** left out of this artifact so the build stays within the two declared archives
+(`fundingRate` + `metrics`) and carries zero OI-proxy risk; the OI-native crowding signal
+(`oi_zscore` / OI vs. its trailing level) is provided instead.
+
+## `oi_coverage` manifest extension
+
+`oi_coverage` is added to `SymbolListing` and `_META_FIELDS` **additively** alongside
+`kline_coverage` / `funding_coverage`. `to_records()` omits it when `None`, so existing
+manifests serialize byte-for-byte unchanged and the committed `pit_universe.v1.json`
+`snapshot_hash` is preserved (proven by `test_oi_coverage_absent_is_not_emitted_so_committed_hash_is_stable`
+and the existing `test_committed_manifest_loads_and_hash_matches_meta`).
+
+## Deterministic readiness verdict
+
+`classify_feature_readiness(ReadinessInputs, ReadinessThresholds)` → `("ready", [])` or
+`("needs_more_data", [reasons])`, mirroring ROB-355's `classify_verdict`. Default thresholds:
+
+| Threshold | Default | Rationale |
+|---|---|---|
+| `min_usable_symbols` | 20 | enough cross-section for a crowding panel |
+| `min_delisted_usable` | 3 | survivorship must be exercised, not just claimed |
+| `min_oi_window_rows` | 500 | per-symbol OI history long enough to be meaningful |
+| `max_missingness` | 0.05 | worst per-symbol day-level OI gap fraction (`1 − oi_coverage`) |
+
+Plus a hard gate: **every** attempted delisted symbol must be `survivorship_ok` (its metrics
+archive reaches its last active day, `delisted_at − 1`). Below any threshold → the builder
+prints `needs_more_data` with reasons and **does not** recommend opening a backtest issue.
+
+## Operator RUN
+
+```bash
+cd research/nautilus_scalping
+# dry (no network): prints what would run
+uv run --no-project python build_funding_oi_features.py --limit 40
+# probe only (read-only network; prints the verdict, writes NOTHING):
+uv run --no-project python build_funding_oi_features.py --run --limit 40
+# probe + persist artifacts (read-only network; writes only to gitignored results/):
+uv run --no-project python build_funding_oi_features.py --run --limit 40 --out
+```
+
+`--out` gates **all** disk writes. `--run` alone performs the read-only network RUN and prints
+the readiness verdict but writes nothing. Adding `--out` additionally writes per-symbol feature
+CSVs under `results/discovery/rob356/features/` and the coverage summary
+`results/discovery/rob356/funding_oi_coverage.v1.json` (coverage + verdict). All gitignored —
+the RUN downloads each symbol's full monthly `fundingRate` + daily `metrics` history (a daily
+archive per OI day — thousands of small files for long-lived symbols) but never commits raw data.
+
+## Validation evidence (bounded real-data smoke, `2026-05-29`)
+
+A bounded smoke (read-only, nothing persisted) on the **delisted** symbol `EOSUSDT`:
+
+- funding `2024-01`: 93 rows parsed; `calc_time` epoch-ms, `funding_interval_hours=8`,
+  realized `last_funding_rate` present.
+- metrics `2024-01-15`: **576 raw rows → 288 after dedup** (clean 5-min grid; confirms the
+  duplicate-row observation and the `(symbol, create_time)` dedup).
+- `build_features` produced 288 rows; `oi_delta` computed; funding as-of attached
+  (`last_funding_rate`, `funding_interval_hours`).
+- **future-leakage rows = 0** (no attached funding `calc_time` exceeded its OI `ts`) — the
+  known-after rule holds on real data.
+
+This proves construction is clean and reusable. The **at-scale** coverage numbers and the
+final `ready` / `needs_more_data` verdict require the operator RUN above (the full
+multi-thousand-file download is operator-scale and intentionally not run in CI).
+
+## Recommendation (open a bounded funding-OI event backtest issue next?)
+
+**Conditional — gated on the operator RUN's deterministic verdict.**
+
+- Construction is proven clean, PIT-safe, and survivorship-aware; ROB-355 already ruled the
+  funding+OI data `feasible` with delisted coverage. The expected RUN outcome is `ready`.
+- **Open a bounded funding-OI crowding/deleveraging event backtest issue iff** the full RUN
+  returns `verdict == "ready"`. That issue would still be cost-blind-first and must clear a
+  gross-edge screen before any cost/OOS gauntlet — consistent with ROB-351/353.
+- **If the RUN returns `needs_more_data`**, stop: do not open the backtest issue; address the
+  named coverage gaps (symbols / OI window / survivorship / missingness) first.
+- [ROB-343](https://linear.app/mgh3326/issue/ROB-343) stays deferred regardless — it is only
+  justified once a real candidate shows positive gross edge and is materially cost-sensitive.
+
+## Tests
+
+```bash
+cd research/nautilus_scalping
+uv run --no-project --with pytest python -m pytest \
+  tests/test_funding_oi_archive.py tests/test_funding_oi_features.py \
+  tests/test_funding_oi_readiness.py tests/test_pit_universe.py -q
+```
+
+Covers: funding/metrics parsing incl. interval-change and dup-dedup; delist trim (exclusive);
+OI-start bounding; backward as-of join with no future leakage; per-row interval carry;
+known-after; OI delta/pct/z (zero-variance bounded); additive `oi_coverage` round-trip
+(committed hash preserved); and the deterministic readiness verdict.
+
+> **Note on `ruff`:** all ROB-356 files pass both `ruff check` and `ruff format --check`
+> (project-pinned ruff 0.15.9). Note that `research/nautilus_scalping/` as a whole is outside
+> the CI ruff scope — `make lint` gates `app/` + root `tests/` only — so most sibling research
+> files are not `ruff format`-clean; the ROB-356 files are formatted regardless to satisfy the
+> acceptance criteria.

--- a/research/nautilus_scalping/build_funding_oi_features.py
+++ b/research/nautilus_scalping/build_funding_oi_features.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""ROB-356 — Binance USD-M funding + OI PIT feature builder (operator-gated).
+
+Builds the deterministic, point-in-time, survivorship-safe funding+OI feature artifact
+described in ROB-356, on top of the ROB-349/353 PIT universe manifest. This is feature
+construction + coverage validation ONLY — not a strategy, not a backtest.
+
+Read-only PUBLIC data only (``data.binance.vision/futures/um`` monthly fundingRate +
+daily metrics). The network RUN is operator-gated behind ``--run``; CI exercises only
+the pure helpers (parsers in ``funding_oi_archive``, features in ``funding_oi_features``,
+and ``classify_feature_readiness`` below). ``--out`` gates ALL disk writes; with it, the
+per-symbol feature tables and the coverage summary are written under the gitignored
+``results/`` artifact root (``AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`` if set) — never raw
+market data. No keys, no orders, no Demo, no live/mainnet trading endpoint, no scheduler, no DB.
+
+See the durable report at ``docs/runbooks/rob-356-funding-oi-pit-features.md``.
+
+Usage (operator):
+    cd research/nautilus_scalping
+    uv run --no-project python build_funding_oi_features.py --run --limit 40 --out
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+import zipfile
+from dataclasses import asdict, dataclass, fields
+from datetime import UTC, datetime
+
+import funding_oi_features as fof
+import pit_universe as pu
+from funding_oi_archive import parse_funding_csv, parse_metrics_csv
+
+S3 = "https://s3-ap-northeast-1.amazonaws.com/data.binance.vision"
+BASE = "https://data.binance.vision"
+
+_ctx = ssl.create_default_context()
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic readiness verdict (pure; unit-tested)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ReadinessThresholds:
+    """Explicit gate for "is this artifact ready for a bounded event backtest?"."""
+
+    min_usable_symbols: int = 20
+    min_delisted_usable: int = 3
+    min_oi_window_rows: int = 500
+    max_missingness: float = 0.05
+
+
+@dataclass(frozen=True)
+class ReadinessInputs:
+    """Aggregate coverage signals measured by the RUN (or supplied by a test)."""
+
+    usable_symbols: int
+    delisted_usable: int
+    all_delisted_survivorship_ok: bool
+    min_oi_window_rows: int  # smallest per-symbol usable OI row count
+    max_missingness: float  # worst per-symbol day-level gap fraction (1 - oi_coverage)
+
+
+def classify_feature_readiness(
+    inp: ReadinessInputs, thr: ReadinessThresholds | None = None
+) -> tuple[str, list[str]]:
+    """``("ready", [])`` iff every threshold is met and delisted survivorship is proven;
+    otherwise ``("needs_more_data", [reasons...])``. Below threshold -> do NOT open a
+    backtest issue."""
+    thr = thr or ReadinessThresholds()
+    reasons: list[str] = []
+    if inp.usable_symbols < thr.min_usable_symbols:
+        reasons.append(
+            f"usable_symbols {inp.usable_symbols} < {thr.min_usable_symbols}"
+        )
+    if not inp.all_delisted_survivorship_ok:
+        reasons.append("delisted survivorship not proven (archive ends before delist)")
+    if inp.delisted_usable < thr.min_delisted_usable:
+        reasons.append(
+            f"delisted_usable {inp.delisted_usable} < {thr.min_delisted_usable}"
+        )
+    if inp.min_oi_window_rows < thr.min_oi_window_rows:
+        reasons.append(
+            f"min oi_window rows {inp.min_oi_window_rows} < {thr.min_oi_window_rows}"
+        )
+    if inp.max_missingness > thr.max_missingness:
+        reasons.append(
+            f"missingness {inp.max_missingness:.3f} > {thr.max_missingness:.3f}"
+        )
+    return ("ready" if not reasons else "needs_more_data"), reasons
+
+
+# --------------------------------------------------------------------------- #
+# Coverage helpers (pure)
+# --------------------------------------------------------------------------- #
+def expected_days(first: str | None, last: str | None) -> int:
+    """Inclusive day span between two ``YYYY-MM-DD`` tokens (0 if either missing)."""
+    if not first or not last:
+        return 0
+    d0 = datetime.strptime(first, "%Y-%m-%d").replace(tzinfo=UTC)
+    d1 = datetime.strptime(last, "%Y-%m-%d").replace(tzinfo=UTC)
+    return (d1 - d0).days + 1
+
+
+def _day_str(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=UTC).date().isoformat()
+
+
+def survivorship_ok(last_day: str | None, delisted_at: int | None) -> bool:
+    """A delisted symbol's metrics archive must reach its delisting day."""
+    if delisted_at is None:
+        return last_day is not None
+    if last_day is None:
+        return False
+    return last_day >= _day_str(delisted_at - 1)  # delisted_at is exclusive
+
+
+# --------------------------------------------------------------------------- #
+# Network helpers (operator RUN only)
+# --------------------------------------------------------------------------- #
+def _get(url: str, timeout: int = 60) -> bytes:
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "rob356-feature-builder/1.0"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout, context=_ctx) as r:  # noqa: S310
+        return r.read()
+
+
+def list_periods(prefix: str, pat: str) -> list[str]:
+    out: list[str] = []
+    marker = ""
+    while True:
+        q: dict[str, str] = {"prefix": prefix}
+        if marker:
+            q["marker"] = marker
+        xml = _get(S3 + "?" + urllib.parse.urlencode(q)).decode()
+        out.extend(re.findall(pat, xml))
+        keys = re.findall(r"<Key>([^<]+)</Key>", xml)
+        if "<IsTruncated>true</IsTruncated>" in xml and keys:
+            marker = keys[-1]
+        else:
+            break
+    return sorted(set(out))
+
+
+def _csv_in_zip(url: str) -> str:
+    z = zipfile.ZipFile(io.BytesIO(_get(url)))
+    return z.read(z.namelist()[0]).decode()
+
+
+def fetch_funding(sym: str) -> list:
+    months = list_periods(
+        f"data/futures/um/monthly/fundingRate/{sym}/",
+        re.escape(sym) + r"-fundingRate-(\d{4}-\d{2})\.zip",
+    )
+    rows: list = []
+    for m in months:
+        rows += parse_funding_csv(
+            _csv_in_zip(
+                f"{BASE}/data/futures/um/monthly/fundingRate/{sym}/{sym}-fundingRate-{m}.zip"
+            )
+        )
+    return sorted(rows, key=lambda r: r.calc_time)
+
+
+def fetch_metrics(sym: str) -> tuple[list, list[str]]:
+    days = list_periods(
+        f"data/futures/um/daily/metrics/{sym}/",
+        re.escape(sym) + r"-metrics-(\d{4}-\d{2}-\d{2})\.zip",
+    )
+    rows: list = []
+    for d in days:
+        rows += parse_metrics_csv(
+            _csv_in_zip(
+                f"{BASE}/data/futures/um/daily/metrics/{sym}/{sym}-metrics-{d}.zip"
+            )
+        )
+    return sorted(rows, key=lambda r: r.create_time), days
+
+
+def _write_feature_csv(path, feats: list) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cols = [f.name for f in fields(fof.FeatureRow)]
+    with open(path, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        for row in feats:
+            w.writerow(asdict(row))
+
+
+def build_symbol(listing: pu.SymbolListing) -> dict:
+    """Operator RUN per symbol: fetch, build PIT features, return coverage stats."""
+    sym = listing.symbol
+    funding = fetch_funding(sym)
+    metrics, metric_days = fetch_metrics(sym)
+    feats = fof.build_features(sym, funding, metrics, delisted_at=listing.delisted_at)
+    first_day = metric_days[0] if metric_days else None
+    last_day = metric_days[-1] if metric_days else None
+    exp = expected_days(first_day, last_day)
+    oi_cov = round(len(metric_days) / exp, 3) if exp else 0.0
+    return {
+        "symbol": sym,
+        "status": listing.status,
+        "delisted": listing.delisted_at is not None,
+        "feature_rows": len(feats),
+        "oi_first_day": first_day,
+        "oi_last_day": last_day,
+        "oi_days_present": len(metric_days),
+        "oi_coverage": oi_cov,
+        "missingness": round(1.0 - oi_cov, 3),
+        "survivorship_ok": survivorship_ok(last_day, listing.delisted_at),
+        "_feats": feats,
+    }
+
+
+def summarize(stats: list[dict], thr: ReadinessThresholds) -> dict:
+    usable = [s for s in stats if s["feature_rows"] >= thr.min_oi_window_rows]
+    delisted_attempted = [s for s in stats if s["delisted"]]
+    inp = ReadinessInputs(
+        usable_symbols=len(usable),
+        delisted_usable=sum(1 for s in usable if s["delisted"]),
+        all_delisted_survivorship_ok=all(
+            s["survivorship_ok"] for s in delisted_attempted
+        ),
+        min_oi_window_rows=min((s["feature_rows"] for s in usable), default=0),
+        max_missingness=max((s["missingness"] for s in usable), default=1.0),
+    )
+    verdict, reasons = classify_feature_readiness(inp, thr)
+    return {
+        "source": "data.binance.vision/futures/um",
+        "schema_version": "funding_oi_coverage.v1",
+        "symbols_attempted": len(stats),
+        "active_attempted": sum(1 for s in stats if not s["delisted"]),
+        "delisted_attempted": len(delisted_attempted),
+        "thresholds": asdict(thr),
+        "readiness_inputs": asdict(inp),
+        "verdict": verdict,
+        "verdict_reasons": reasons,
+        "per_symbol": [{k: v for k, v in s.items() if k != "_feats"} for s in stats],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="ROB-356 funding+OI PIT feature builder (read-only)."
+    )
+    parser.add_argument(
+        "--run", action="store_true", help="Perform the network RUN (operator-gated)."
+    )
+    parser.add_argument(
+        "--manifest",
+        default="data_manifests/pit_universe.v1.json",
+        help="PIT universe manifest path.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0, help="Cap symbols processed (0 = all)."
+    )
+    parser.add_argument(
+        "--out",
+        action="store_true",
+        help=(
+            "Write all artifacts to the gitignored results/ root: per-symbol feature CSVs "
+            "+ the coverage summary JSON. Without --out the RUN only probes and prints the "
+            "verdict (writes nothing)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    manifest = pu.PITManifest.load(args.manifest).strict_usdt_perp()
+    syms = list(manifest.listings)
+    if args.limit:
+        syms = syms[: args.limit]
+
+    if not args.run:
+        print(
+            f"DRY: would build funding+OI PIT features for {len(syms)} perp symbols "
+            f"from {args.manifest}.\nAdd --run to perform the read-only network RUN (prints "
+            f"the readiness verdict, writes nothing). Add --out to also write per-symbol "
+            f"feature CSVs + the coverage summary JSON to the gitignored results/ root."
+        )
+        return 0
+
+    from artifact_paths import resolve_artifact_path
+
+    feat_dir = resolve_artifact_path("discovery", "rob356", "features")
+    stats: list[dict] = []
+    for i, listing in enumerate(syms, 1):
+        try:
+            s = build_symbol(listing)
+        except Exception as exc:  # noqa: BLE001 — coverage probe must be resilient per-symbol
+            print(f"  [{i}/{len(syms)}] {listing.symbol}: SKIP ({type(exc).__name__})")
+            continue
+        feats = s.pop("_feats")
+        if args.out:  # --out gates ALL disk writes (feature CSVs + summary)
+            _write_feature_csv(feat_dir / f"{s['symbol']}.csv", feats)
+        stats.append(s)
+        print(
+            f"  [{i}/{len(syms)}] {s['symbol']:14} rows={s['feature_rows']:6} "
+            f"oi={s['oi_first_day']}..{s['oi_last_day']} cov={s['oi_coverage']} "
+            f"surv={int(s['survivorship_ok'])}"
+        )
+
+    summary = summarize(stats, ReadinessThresholds())
+    print("\nverdict:", summary["verdict"])
+    for r in summary["verdict_reasons"]:
+        print("  -", r)
+
+    if args.out:
+        out = resolve_artifact_path(
+            "discovery", "rob356", "funding_oi_coverage.v1.json"
+        )
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(summary, indent=2))
+        print(f"\nsummary + per-symbol feature CSVs written (gitignored): {out.parent}")
+    else:
+        print("\n(no --out: nothing written to disk)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/tests/test_funding_oi_readiness.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_readiness.py
@@ -1,0 +1,119 @@
+"""ROB-356 (PR3) — deterministic ready vs needs_more_data verdict.
+
+Mirrors ROB-355's ``classify_verdict``: the decision to open a bounded funding-OI
+event backtest issue is a function of explicit coverage thresholds, not prose. Below
+ANY threshold (or unproven survivorship) -> ``needs_more_data`` with named reasons, and
+the builder must stop rather than hand off to a backtest.
+"""
+
+import build_funding_oi_features as b
+
+
+def _ready_inputs(**over):
+    base = {
+        "usable_symbols": 30,
+        "delisted_usable": 8,
+        "all_delisted_survivorship_ok": True,
+        "min_oi_window_rows": 2000,
+        "max_missingness": 0.01,
+    }
+    base.update(over)
+    return b.ReadinessInputs(**base)
+
+
+def test_all_thresholds_met_is_ready():
+    verdict, reasons = b.classify_feature_readiness(_ready_inputs())
+    assert verdict == "ready"
+    assert reasons == []
+
+
+def test_too_few_usable_symbols_blocks():
+    verdict, reasons = b.classify_feature_readiness(_ready_inputs(usable_symbols=3))
+    assert verdict == "needs_more_data"
+    assert any("usable_symbols" in r for r in reasons)
+
+
+def test_unproven_delisted_survivorship_blocks():
+    verdict, reasons = b.classify_feature_readiness(
+        _ready_inputs(all_delisted_survivorship_ok=False)
+    )
+    assert verdict == "needs_more_data"
+    assert any("survivorship" in r for r in reasons)
+
+
+def test_too_few_delisted_usable_blocks():
+    verdict, reasons = b.classify_feature_readiness(_ready_inputs(delisted_usable=0))
+    assert verdict == "needs_more_data"
+    assert any("delisted" in r for r in reasons)
+
+
+def test_short_oi_window_blocks():
+    verdict, reasons = b.classify_feature_readiness(
+        _ready_inputs(min_oi_window_rows=10)
+    )
+    assert verdict == "needs_more_data"
+    assert any("oi_window" in r for r in reasons)
+
+
+def test_excess_missingness_blocks():
+    verdict, reasons = b.classify_feature_readiness(_ready_inputs(max_missingness=0.5))
+    assert verdict == "needs_more_data"
+    assert any("missingness" in r for r in reasons)
+
+
+def test_multiple_failures_all_reported():
+    verdict, reasons = b.classify_feature_readiness(
+        _ready_inputs(usable_symbols=1, delisted_usable=0)
+    )
+    assert verdict == "needs_more_data"
+    assert len(reasons) >= 2
+
+
+def test_custom_thresholds_respected():
+    thr = b.ReadinessThresholds(min_usable_symbols=2)
+    verdict, _ = b.classify_feature_readiness(_ready_inputs(usable_symbols=2), thr)
+    assert verdict == "ready"
+
+
+# --------------------------------------------------------------------------- #
+# pure coverage helpers
+# --------------------------------------------------------------------------- #
+def test_expected_days_inclusive_span():
+    assert b.expected_days("2024-01-01", "2024-01-01") == 1
+    assert b.expected_days("2024-01-01", "2024-01-31") == 31
+    assert b.expected_days(None, "2024-01-31") == 0
+
+
+def test_survivorship_ok_live_symbol_needs_any_data():
+    assert b.survivorship_ok("2024-01-10", delisted_at=None) is True
+    assert b.survivorship_ok(None, delisted_at=None) is False
+
+
+def test_survivorship_ok_delisted_archive_must_reach_delist_day():
+    # delisted_at is EXCLUSIVE epoch ms; archive must reach the last active day (delist-1).
+    from datetime import UTC, datetime
+
+    delist_ms = int(datetime(2024, 1, 12, tzinfo=UTC).timestamp() * 1000)  # exclusive
+    assert b.survivorship_ok("2024-01-11", delist_ms) is True  # reaches last active day
+    assert b.survivorship_ok("2024-01-09", delist_ms) is False  # archive ends early
+
+
+def test_summarize_drops_internal_feats_and_emits_verdict():
+    stats = [
+        {
+            "symbol": "BTCUSDT",
+            "status": "live",
+            "delisted": False,
+            "feature_rows": 9,
+            "missingness": 0.0,
+            "survivorship_ok": True,
+            "_feats": [1, 2, 3],
+        },
+    ]
+    out = b.summarize(
+        stats, b.ReadinessThresholds(min_usable_symbols=1, min_oi_window_rows=1000)
+    )
+    assert "_feats" not in out["per_symbol"][0]
+    assert (
+        out["verdict"] == "needs_more_data"
+    )  # 9 rows < 1000 -> not usable -> 0 usable symbols


### PR DESCRIPTION
Stacked PR **3 of 3** for ROB-356. **Base = `rob-356-pr2`** (merge PR1 → PR2 → PR3, bottom-up). Wires PR1/PR2 into an operator-gated RUN, durable report, and deterministic verdict.

## What
- **`build_funding_oi_features.py`**
  - `classify_feature_readiness(...)` → `ready` / `needs_more_data`, mirroring ROB-355's `classify_verdict`. Explicit thresholds (min usable symbols / min delisted usable / min OI window rows / max missingness) + **hard delisted-survivorship gate**. Below threshold → stop, do **not** open a backtest issue.
  - Operator-gated network RUN (`--run`): read-only `data.binance.vision` fetch over the strict-USDT-perp PIT universe; per-symbol PIT features + `oi_coverage` written **only** to the gitignored `results/` artifact root.
- **`docs/runbooks/rob-356-funding-oi-pit-features.md`** — durable report: confirmed schemas, join rule, known-after, delist-exclusive trim, OI-start bounding, feature + `oi_coverage` schema, verdict thresholds, operator RUN, **bounded real-data smoke** (EOSUSDT: 576→288 dedup, 0 future-leakage), and the recommendation.

## Recommendation (in report)
**Conditional** — open a bounded funding-OI crowding/deleveraging event backtest issue **iff** the operator RUN returns `verdict == "ready"`; else stop at `needs_more_data`. **ROB-343 stays deferred** regardless.

## Tests
Deterministic verdict (ready / each breach / multi-failure / custom thresholds) + pure coverage helpers (`expected_days`, delist-exclusive `survivorship_ok`, `summarize`).

## Safety
Operator-gated read-only; no raw-data commit (gitignored `results/`), no keys/orders/Demo `confirm`/live/scheduler/DB, no secrets, no OHLCV proxy for OI.

> Note: `research/nautilus_scalping/` is outside the CI ruff scope (`make lint` gates `app/` + root `tests/`); the subtree is intentionally not `ruff format`-clean. `ruff check` passes on all ROB-356 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)