### PR TITLE
fix(ROB-357): crypto/upbit account_mode label + crypto portfolio symbol derivation

### DIFF
--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -125,6 +125,27 @@ PORTFOLIO_TOOL_NAMES: set[str] = {
 CRYPTO_STOP_LOSS_PCT = -4.5
 CRYPTO_MEAN_REVERSION_RSI_EXIT = 46.0
 
+# ROB-357 — provenance label for Upbit (crypto-live) holdings. The MCP
+# ``account_mode`` selector vocabulary ({db_simulated, kis_mock, kis_live}) is a
+# KIS/paper *routing* selector and has no Upbit member, so an Upbit-only holdings
+# read used to inherit the ``kis_live`` routing default and mislabel the source.
+# This descriptive provenance value never participates in order routing.
+UPBIT_LIVE_PROVENANCE = "upbit_live"
+
+
+def _provenance_account_mode(
+    *, broker: str | None, source: str | None, routing_mode: str
+) -> str:
+    """Derive a per-account holdings provenance label (ROB-357).
+
+    Upbit holdings are crypto-live and must surface ``upbit_live`` rather than
+    inheriting the KIS-defaulted routing selector. KIS / paper / manual groups
+    keep the resolved routing mode unchanged.
+    """
+    if broker == "upbit" or source == "upbit_api":
+        return UPBIT_LIVE_PROVENANCE
+    return routing_mode
+
 
 def _build_crypto_strategy_signal(
     position: dict[str, Any],
@@ -831,6 +852,7 @@ async def _get_holdings_impl(
     minimum_value: float | None = None,
     account_name: str | None = None,
     is_mock: bool = False,
+    routing_account_mode: str = "kis_live",
 ) -> dict[str, Any]:
     """Implementation for get_holdings tool."""
     if minimum_value is not None and minimum_value < 0:
@@ -946,6 +968,13 @@ async def _get_holdings_impl(
                 "account": account_id,
                 "broker": position["broker"],
                 "account_name": position["account_name"],
+                # ROB-357 — per-account provenance label so an Upbit group
+                # never inherits the KIS routing default.
+                "account_mode": _provenance_account_mode(
+                    broker=position.get("broker"),
+                    source=position.get("source"),
+                    routing_mode=routing_account_mode,
+                ),
                 "positions": [],
             },
         )
@@ -1161,7 +1190,7 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
                     "KIS mock account is disabled or missing required "
                     "configuration: " + ", ".join(missing)
                 )
-        return apply_account_routing_metadata(
+        response = apply_account_routing_metadata(
             await _get_holdings_impl(
                 account=account,
                 market=market,
@@ -1169,9 +1198,22 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
                 minimum_value=minimum_value,
                 account_name=account_name,
                 is_mock=routing.is_kis_mock,
+                routing_account_mode=routing.account_mode,
             ),
             routing,
         )
+        # ROB-357 — a crypto/Upbit-scoped read carries no meaningful KIS routing
+        # selector. When the caller did not explicitly choose a KIS/paper mode,
+        # surface the Upbit-live provenance at the top level instead of echoing
+        # the ``kis_live`` default. Order routing is untouched.
+        explicit_selector = account_mode is not None or account_type is not None
+        crypto_scoped = (
+            _parse_holdings_market_filter(market) == "crypto"
+            or (account or "").strip().lower() == "upbit"
+        )
+        if not explicit_selector and crypto_scoped:
+            response["account_mode"] = UPBIT_LIVE_PROVENANCE
+        return response
 
     @mcp.tool(
         name="get_position",

--- a/app/services/action_report/snapshot_backed/symbol_derivation.py
+++ b/app/services/action_report/snapshot_backed/symbol_derivation.py
@@ -41,6 +41,22 @@ _MARKET_TO_TYPES: dict[str, tuple[MarketType, ...]] = {
 }
 
 
+def _normalize_crypto_symbol(raw: object) -> str | None:
+    """Normalize a crypto symbol to the pipeline's ``KRW-XXX`` market code.
+
+    ``UpbitHomeReader`` emits the bare currency (e.g. ``"BTC"``) while
+    ``manual_holdings`` already store the KRW market code. Trim/uppercase,
+    prefix bare currencies with ``KRW-``, keep already-prefixed codes, and
+    drop blanks so the portfolio source unions cleanly.
+    """
+    text = str(raw or "").strip().upper()
+    if not text:
+        return None
+    if text.startswith("KRW-"):
+        return text
+    return f"KRW-{text}"
+
+
 class SymbolDerivation(BaseModel):
     """Result of a single derivation pass."""
 
@@ -147,16 +163,19 @@ class _DefaultLiveHoldingsRepo:
 
         reader = UpbitHomeReader(self._session)
         result = await reader.fetch(user_id=user_id or 0)
-        account = getattr(result, "account", None)
-        holdings = getattr(account, "holdings", None) or []
+        # ``UpbitHomeReader.fetch`` returns a ``_SourceFetchResult`` whose
+        # positions live on ``result.holdings`` (a flat ``list[Holding]``) —
+        # there is no ``result.account``. Reading the wrong attribute silently
+        # drops every live holding (ROB-357 Hermes review).
+        holdings = getattr(result, "holdings", None) or []
         symbols: list[str] = []
+        seen: set[str] = set()
         for holding in holdings:
-            currency = getattr(holding, "symbol", None)
-            if not currency:
+            normalized = _normalize_crypto_symbol(getattr(holding, "symbol", None))
+            if normalized is None or normalized in seen:
                 continue
-            # UpbitHomeReader emits the bare currency (e.g. "BTC"); the
-            # pipeline's crypto convention is the KRW market code "KRW-BTC".
-            symbols.append(f"KRW-{currency}")
+            seen.add(normalized)
+            symbols.append(normalized)
         return symbols
 
 

--- a/app/services/action_report/snapshot_backed/symbol_derivation.py
+++ b/app/services/action_report/snapshot_backed/symbol_derivation.py
@@ -72,6 +72,14 @@ class _CandidateRepoProtocol(Protocol):
     ) -> list[str]: ...
 
 
+class _LiveHoldingsRepoProtocol(Protocol):
+    # ROB-357 — live (broker-held) positions for markets whose holdings do
+    # not live in ``manual_holdings`` (crypto/Upbit). Read-only.
+    async def list_held_symbols(
+        self, *, market: str, user_id: int | None
+    ) -> list[str]: ...
+
+
 # ---------------------------------------------------------------------------
 # Default DB-backed repository adapters. Each is a narrow read-only wrapper
 # around an existing model so the derivation service does no broker I/O.
@@ -116,6 +124,40 @@ class _DefaultWatchRepo:
     async def list_active_watch_symbols(self, *, market: str) -> list[str]:
         alerts = await self._repo.list_active_alerts(market=market)
         return [a.symbol for a in alerts if a.symbol]
+
+
+class _DefaultLiveHoldingsRepo:
+    """ROB-357 — read-only live-holdings adapter.
+
+    Crypto holdings live on the exchange (Upbit), not in ``manual_holdings``,
+    so the symbol scope previously omitted them. We read them through the
+    sanctioned read-only ``UpbitHomeReader`` (the same abstraction the
+    portfolio collector uses for KIS), never the low-level broker client, and
+    fail soft: any error propagates to the service's best-effort ``_safe``
+    wrapper which records it under ``source_errors`` and returns ``[]``.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_held_symbols(self, *, market: str, user_id: int | None) -> list[str]:
+        if market != "crypto":
+            return []
+        from app.services.invest_home_readers import UpbitHomeReader
+
+        reader = UpbitHomeReader(self._session)
+        result = await reader.fetch(user_id=user_id or 0)
+        account = getattr(result, "account", None)
+        holdings = getattr(account, "holdings", None) or []
+        symbols: list[str] = []
+        for holding in holdings:
+            currency = getattr(holding, "symbol", None)
+            if not currency:
+                continue
+            # UpbitHomeReader emits the bare currency (e.g. "BTC"); the
+            # pipeline's crypto convention is the KRW market code "KRW-BTC".
+            symbols.append(f"KRW-{currency}")
+        return symbols
 
 
 class _DefaultCandidateRepo:
@@ -174,6 +216,7 @@ class SymbolDerivationService:
         journal_repo: _JournalRepoProtocol | None = None,
         watch_repo: _WatchRepoProtocol | None = None,
         candidate_repo: _CandidateRepoProtocol | None = None,
+        live_holdings_repo: _LiveHoldingsRepoProtocol | None = None,
         max_symbols: int = 50,
         top_held: int = 20,
         top_candidates: int = 20,
@@ -182,6 +225,7 @@ class SymbolDerivationService:
         self._journal = journal_repo or _DefaultJournalRepo(session)
         self._watch = watch_repo or _DefaultWatchRepo(session)
         self._candidate = candidate_repo or _DefaultCandidateRepo(session)
+        self._live = live_holdings_repo or _DefaultLiveHoldingsRepo(session)
         self._max_symbols = max_symbols
         self._top_held = top_held
         self._top_candidates = top_candidates
@@ -222,9 +266,26 @@ class SymbolDerivationService:
                 source_errors[name] = f"{type(exc).__name__}: {exc}"
                 return []
 
-        portfolio = (
-            await _safe("portfolio", self._manual.list_tickers(market=market))
-        )[: self._top_held]
+        # Portfolio = manual_holdings ∪ live broker holdings. For crypto the
+        # held positions live on Upbit (not manual_holdings), so we union in
+        # the read-only live source; manual rows still come first for KR/US.
+        manual_portfolio = await _safe(
+            "portfolio", self._manual.list_tickers(market=market)
+        )
+        live_portfolio: list[str] = []
+        if market == "crypto":
+            live_portfolio = await _safe(
+                "portfolio_live",
+                self._live.list_held_symbols(market=market, user_id=user_id),
+            )
+        portfolio: list[str] = []
+        _portfolio_seen: set[str] = set()
+        for sym in [*manual_portfolio, *live_portfolio]:
+            if sym in _portfolio_seen:
+                continue
+            _portfolio_seen.add(sym)
+            portfolio.append(sym)
+        portfolio = portfolio[: self._top_held]
         journal = await _safe(
             "journal", self._journal.list_active_journal_symbols(market=market)
         )
@@ -277,8 +338,24 @@ class SymbolDerivationService:
             dropped = derived[remaining_room:]
             kept = seeds_in_union + kept_derived
 
+        # ROB-357 — per-source coverage so an empty source (especially the
+        # candidate universe) is explained rather than silently blank.
+        source_coverage: dict[str, Any] = {}
+        for name, syms in sources.items():
+            entry: dict[str, Any] = {"count": len(syms)}
+            if name in source_errors:
+                entry["error"] = source_errors[name]
+            source_coverage[name] = entry
+        if not candidate:
+            source_coverage["candidate"]["empty_reason"] = (
+                "fetch_error"
+                if "candidate" in source_errors
+                else "no_fresh_candidate_universe"
+            )
+
         provenance: dict[str, Any] = {
             "sources": sources,
+            "source_coverage": source_coverage,
             "dropped_by_cap": dropped,
             "cap": self._max_symbols,
             "total_unique": len(union),

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1519,3 +1519,78 @@ async def test_missing_portfolio_descriptor_is_unavailable() -> None:
     sent = ingest.calls[0]
     assert sent.portfolio_snapshot["status"] == "unavailable"
     assert "reason" in sent.portfolio_snapshot
+
+
+@pytest.mark.asyncio
+async def test_crypto_descriptors_are_pointers_not_empty() -> None:
+    """ROB-357 — a fresh crypto/upbit_live bundle must persist non-empty
+    market/portfolio descriptors (pointer: uuid + freshness + coverage), and
+    must never copy the snapshot payload body. ``7a3e97eb`` showed ``{}`` only
+    because it was a stale insert-only reuse of a pre-Slice-B row.
+    """
+    market = _FakeSnap(kind="market")
+    portfolio = _FakeSnap(kind="portfolio")
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market), (object(), portfolio)],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(
+        _make_request(market="crypto", account_scope="upbit_live", status="draft")
+    )
+    sent = ingest.calls[0]
+
+    # Non-empty pointer descriptors.
+    assert sent.market_snapshot != {}
+    assert sent.portfolio_snapshot != {}
+    assert sent.market_snapshot["snapshot_uuid"] == str(market.snapshot_uuid)
+    assert sent.portfolio_snapshot["snapshot_uuid"] == str(portfolio.snapshot_uuid)
+    assert sent.market_snapshot["freshness_status"] == "fresh"
+    assert sent.portfolio_snapshot["coverage"] == {"rows": 3}
+
+    # Pointer, NOT payload — the snapshot body must never be copied in.
+    for descriptor in (sent.market_snapshot, sent.portfolio_snapshot):
+        assert "payload_json" not in descriptor
+        assert "holdings" not in descriptor
+        assert "events" not in descriptor
+
+
+@pytest.mark.asyncio
+async def test_crypto_item_citations_derived_from_evidence() -> None:
+    """ROB-357 — when a crypto item carries evidence with snapshot UUIDs, the
+    generator fills ``cited_snapshot_uuids`` (citation connection intact)."""
+    snap = str(uuid.uuid4())
+    item = IngestReportItem(
+        client_item_key="c1",
+        item_kind="risk",
+        symbol="KRW-BTC",
+        intent="risk_review",
+        rationale="r",
+        evidence_snapshot={"snapshot_uuid": snap, "snapshot_kind": "symbol"},
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=_FakeSnapshotsRepository(),
+    )
+    await gen.generate(
+        _make_request(
+            market="crypto",
+            account_scope="upbit_live",
+            status="draft",
+            items=[item],
+        )
+    )
+    sent_items = ingest.calls[0].items
+    cited = sent_items[0].cited_snapshot_uuids
+    assert [str(u) for u in cited] == [snap]

--- a/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
+++ b/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
@@ -63,22 +63,43 @@ class _FakeCandidateRepo:
         return list(self.symbols[:limit])
 
 
+class _FakeLiveHoldingsRepo:
+    """ROB-357 — read-only live-holdings source (e.g. Upbit balances)."""
+
+    def __init__(self, symbols: list[str], *, raises: Exception | None = None) -> None:
+        self.symbols = symbols
+        self.raises = raises
+        self.calls: list[str] = []
+
+    async def list_held_symbols(self, *, market: str, user_id: int | None) -> list[str]:
+        self.calls.append(market)
+        if self.raises is not None:
+            raise self.raises
+        return list(self.symbols)
+
+
 def _make_service(
     *,
     manual: list[str] | None = None,
     journal: list[str] | None = None,
     watch: list[str] | None = None,
     candidate: list[str] | None = None,
+    live_holdings: _FakeLiveHoldingsRepo | list[str] | None = None,
     max_symbols: int = 50,
     top_held: int = 20,
     top_candidates: int = 20,
 ) -> SymbolDerivationService:
+    if isinstance(live_holdings, list) or live_holdings is None:
+        live_repo = _FakeLiveHoldingsRepo(live_holdings or [])
+    else:
+        live_repo = live_holdings
     return SymbolDerivationService(
         session=MagicMock(),
         manual_holdings_repo=_FakeManualHoldingsRepo(manual or []),
         journal_repo=_FakeJournalRepo(journal or []),
         watch_repo=_FakeWatchRepo(watch or []),
         candidate_repo=_FakeCandidateRepo(candidate or []),
+        live_holdings_repo=live_repo,
         max_symbols=max_symbols,
         top_held=top_held,
         top_candidates=top_candidates,
@@ -229,3 +250,90 @@ async def test_provenance_exposes_cap_and_counts():
     assert "sources" in result.provenance
     assert "dropped_by_cap" in result.provenance
     assert result.provenance["total_unique"] == 5
+
+
+# ---------------------------------------------------------------------------
+# ROB-357 — crypto portfolio source must include live (Upbit) holdings, not
+# just manual_holdings rows.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_crypto_portfolio_source_includes_live_holdings():
+    service = _make_service(
+        manual=["KRW-ETH", "KRW-SOL"],
+        live_holdings=["KRW-BTC", "KRW-XRP", "KRW-LINK", "KRW-DOT"],
+    )
+    result = await service.derive(
+        market="crypto", account_scope="upbit_live", user_id=42, seed_symbols=None
+    )
+    assert set(result.provenance["sources"]["portfolio"]) == {
+        "KRW-ETH",
+        "KRW-SOL",
+        "KRW-BTC",
+        "KRW-XRP",
+        "KRW-LINK",
+        "KRW-DOT",
+    }
+    assert {"KRW-BTC", "KRW-XRP", "KRW-LINK", "KRW-DOT"}.issubset(set(result.symbols))
+
+
+@pytest.mark.asyncio
+async def test_crypto_portfolio_dedups_manual_and_live_overlap():
+    service = _make_service(
+        manual=["KRW-ETH"],
+        live_holdings=["KRW-ETH", "KRW-BTC"],
+    )
+    result = await service.derive(
+        market="crypto", account_scope="upbit_live", user_id=42, seed_symbols=None
+    )
+    # KRW-ETH appears once despite being in both sources.
+    assert result.provenance["sources"]["portfolio"].count("KRW-ETH") == 1
+    assert set(result.provenance["sources"]["portfolio"]) == {"KRW-ETH", "KRW-BTC"}
+
+
+@pytest.mark.asyncio
+async def test_live_holdings_repo_not_consulted_for_kr():
+    live = _FakeLiveHoldingsRepo(["KRW-BTC"])
+    service = _make_service(manual=["005930"], live_holdings=live)
+    await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    # The crypto live-holdings source is crypto-only; KR uses the KIS-live
+    # collector path, not this repo.
+    assert live.calls == []
+
+
+@pytest.mark.asyncio
+async def test_live_holdings_error_is_soft_and_recorded():
+    live = _FakeLiveHoldingsRepo([], raises=RuntimeError("upbit creds missing"))
+    service = _make_service(manual=["KRW-ETH"], live_holdings=live)
+    result = await service.derive(
+        market="crypto", account_scope="upbit_live", user_id=42, seed_symbols=None
+    )
+    # Manual still present; derivation does not blow up.
+    assert "KRW-ETH" in result.provenance["sources"]["portfolio"]
+    assert "portfolio_live" in result.provenance.get("source_errors", {})
+
+
+# ---------------------------------------------------------------------------
+# ROB-357 — an empty candidate source must be explained, not silently blank.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_candidate_empty_reason_recorded_when_no_fresh_universe():
+    service = _make_service(manual=["005930"], candidate=[])
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    coverage = result.provenance["source_coverage"]
+    assert coverage["candidate"]["count"] == 0
+    assert coverage["candidate"]["empty_reason"] == "no_fresh_candidate_universe"
+
+
+@pytest.mark.asyncio
+async def test_candidate_non_empty_has_count_and_no_empty_reason():
+    service = _make_service(manual=["005930"], candidate=["000660", "035420"])
+    result = await service.derive(
+        market="kr", account_scope="kis_live", user_id=42, seed_symbols=None
+    )
+    coverage = result.provenance["source_coverage"]
+    assert coverage["candidate"]["count"] == 2
+    assert "empty_reason" not in coverage["candidate"]

--- a/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
+++ b/tests/services/action_report/snapshot_backed/test_symbol_derivation.py
@@ -14,6 +14,7 @@ Lockdown policy:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,6 +22,7 @@ import pytest
 from app.services.action_report.snapshot_backed.symbol_derivation import (
     SymbolDerivation,
     SymbolDerivationService,
+    _DefaultLiveHoldingsRepo,
 )
 
 
@@ -337,3 +339,65 @@ async def test_candidate_non_empty_has_count_and_no_empty_reason():
     coverage = result.provenance["source_coverage"]
     assert coverage["candidate"]["count"] == 2
     assert "empty_reason" not in coverage["candidate"]
+
+
+# ---------------------------------------------------------------------------
+# ROB-357 — real default adapter path (Hermes-found blocker). UpbitHomeReader
+# returns holdings on ``result.holdings`` (NOT ``result.account.holdings``);
+# the adapter must read the right attribute or live holdings silently vanish.
+# ---------------------------------------------------------------------------
+class _FakeUpbitHomeReader:
+    """Stand-in for UpbitHomeReader: fetch() returns ``.holdings`` directly."""
+
+    last_user_id: int | None = None
+
+    def __init__(self, session) -> None:  # noqa: ANN001 — test stub
+        self._session = session
+
+    async def fetch(self, *, user_id: int):
+        type(self).last_user_id = user_id
+        # Mixed shapes: bare currency, lowercase, already KRW-prefixed, blank.
+        return SimpleNamespace(
+            holdings=[
+                SimpleNamespace(symbol="BTC"),
+                SimpleNamespace(symbol="krw-eth"),
+                SimpleNamespace(symbol="KRW-XRP"),
+                SimpleNamespace(symbol="  link  "),
+                SimpleNamespace(symbol=""),
+                SimpleNamespace(symbol=None),
+            ]
+        )
+
+
+@pytest.mark.asyncio
+async def test_default_live_holdings_repo_reads_result_holdings(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.invest_home_readers.UpbitHomeReader",
+        _FakeUpbitHomeReader,
+    )
+    repo = _DefaultLiveHoldingsRepo(session=MagicMock())
+
+    symbols = await repo.list_held_symbols(market="crypto", user_id=42)
+
+    # Bare currency → KRW-prefixed; lowercase normalized; already-prefixed kept;
+    # whitespace trimmed; empty/None skipped.
+    assert symbols == ["KRW-BTC", "KRW-ETH", "KRW-XRP", "KRW-LINK"]
+    assert _FakeUpbitHomeReader.last_user_id == 42
+
+
+@pytest.mark.asyncio
+async def test_default_live_holdings_repo_skips_non_crypto(monkeypatch):
+    called = {"n": 0}
+
+    class _ShouldNotFetch(_FakeUpbitHomeReader):
+        async def fetch(self, *, user_id: int):
+            called["n"] += 1
+            return SimpleNamespace(holdings=[])
+
+    monkeypatch.setattr(
+        "app.services.invest_home_readers.UpbitHomeReader", _ShouldNotFetch
+    )
+    repo = _DefaultLiveHoldingsRepo(session=MagicMock())
+
+    assert await repo.list_held_symbols(market="kr", user_id=42) == []
+    assert called["n"] == 0

--- a/tests/test_mcp_holdings_account_mode_provenance.py
+++ b/tests/test_mcp_holdings_account_mode_provenance.py
@@ -1,0 +1,167 @@
+"""ROB-357 — holdings ``account_mode`` provenance for crypto/Upbit.
+
+Regression coverage for the bug where ``get_holdings(market="crypto")`` /
+``get_holdings(account="upbit")`` stamped ``account_mode="kis_live"`` — the
+KIS routing default — on responses whose positions are entirely Upbit.
+
+The fix labels Upbit holdings as ``upbit_live`` (per-account and, for a
+crypto/upbit-scoped query without an explicit KIS/paper selector, top-level)
+WITHOUT altering the KIS order-routing default (``normalize_account_mode()``
+still resolves to ``kis_live`` — covered by ``test_mcp_account_modes``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import portfolio_holdings
+from tests._mcp_tooling_support import DummyMCP
+
+
+def _upbit_position(symbol: str = "KRW-BTC") -> dict:
+    return {
+        "account": "upbit",
+        "account_name": "업비트",
+        "broker": "upbit",
+        "source": "upbit_api",
+        "instrument_type": "crypto",
+        "market": "crypto",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": 100.0,
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+
+def _kis_position(symbol: str = "005930") -> dict:
+    return {
+        "account": "kis",
+        "account_name": "기본 계좌",
+        "broker": "kis",
+        "source": "kis_api",
+        "instrument_type": "equity_kr",
+        "market": "kr",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": 100.0,
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pure provenance helper.
+# ---------------------------------------------------------------------------
+def test_provenance_account_mode_upbit_is_upbit_live():
+    assert (
+        portfolio_holdings._provenance_account_mode(
+            broker="upbit", source="upbit_api", routing_mode="kis_live"
+        )
+        == "upbit_live"
+    )
+
+
+def test_provenance_account_mode_kis_keeps_routing_mode():
+    assert (
+        portfolio_holdings._provenance_account_mode(
+            broker="kis", source="kis_api", routing_mode="kis_live"
+        )
+        == "kis_live"
+    )
+    assert (
+        portfolio_holdings._provenance_account_mode(
+            broker="kis", source="kis_api", routing_mode="kis_mock"
+        )
+        == "kis_mock"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-account label inside the holdings impl.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_holdings_impl_labels_upbit_account_upbit_live(monkeypatch):
+    async def fake_collect(**_kwargs):
+        return [_upbit_position("KRW-BTC"), _kis_position("005930")], [], None, None
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        include_current_price=False,
+        routing_account_mode="kis_live",
+    )
+
+    by_account = {a["account"]: a for a in result["accounts"]}
+    assert by_account["upbit"]["account_mode"] == "upbit_live"
+    assert by_account["kis"]["account_mode"] == "kis_live"
+
+
+# ---------------------------------------------------------------------------
+# Tool-level top-level label.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_holdings_tool_crypto_scope_top_level_upbit_live(monkeypatch):
+    async def fake_collect(**_kwargs):
+        return [_upbit_position("KRW-BTC")], [], "crypto", "upbit"
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    mcp = DummyMCP()
+    portfolio_holdings._register_portfolio_tools_impl(mcp)
+
+    result = await mcp.tools["get_holdings"](
+        market="crypto", include_current_price=False
+    )
+
+    assert result["account_mode"] == "upbit_live"
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_tool_account_upbit_top_level_upbit_live(monkeypatch):
+    async def fake_collect(**_kwargs):
+        return [_upbit_position("KRW-XRP")], [], None, "upbit"
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    mcp = DummyMCP()
+    portfolio_holdings._register_portfolio_tools_impl(mcp)
+
+    result = await mcp.tools["get_holdings"](
+        account="upbit", include_current_price=False
+    )
+
+    assert result["account_mode"] == "upbit_live"
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_tool_kr_kis_live_unchanged(monkeypatch):
+    """Explicit KIS routing on a KR query must stay kis_live (no regression)."""
+
+    async def fake_collect(**_kwargs):
+        return [_kis_position("005930")], [], "equity_kr", None
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    mcp = DummyMCP()
+    portfolio_holdings._register_portfolio_tools_impl(mcp)
+
+    result = await mcp.tools["get_holdings"](
+        market="kr", account_mode="kis_live", include_current_price=False
+    )
+
+    assert result["account_mode"] == "kis_live"


### PR DESCRIPTION
## Summary

Follow-up to ROB-352 (snapshot-backed `generate_from_bundle`). Fixes the two reproducing report-generator defects from ROB-357 and adds regression coverage proving the third (descriptor/citation connection) is already sound.

Verified against the issue's repro report `7a3e97eb` (crypto/upbit_live, draft).

### 1. `account_mode` mislabel — Upbit holdings tagged `kis_live` (priority 1)
- `get_holdings(market="crypto")` / `get_holdings(account="upbit")` stamped `account_mode="kis_live"` (the KIS routing default) on responses whose positions are entirely Upbit. Root cause: `normalize_account_mode()` defaults to `kis_live` and `apply_account_routing_metadata` echoes it; the selector vocabulary `{db_simulated, kis_mock, kis_live}` has no Upbit member.
- Added `_provenance_account_mode()`: each Upbit account group surfaces `"upbit_live"`; a crypto/upbit-scoped query **without** an explicit KIS/paper selector also surfaces `"upbit_live"` at the top level.
- **KIS order routing is untouched** — `normalize_account_mode()` still resolves to `kis_live` by default (asserted by the unchanged `test_mcp_account_modes` suite). This is a descriptive holdings-provenance label only.

### 2. crypto `symbol_derivation.sources.portfolio` missing live holdings (priority 2)
- The portfolio source read `manual_holdings` only, so live Upbit holdings (e.g. `KRW-BTC/XRP/LINK/DOT`) never entered `symbol_derivation`.
- Union in a read-only live-holdings source for `market="crypto"` via the **sanctioned `UpbitHomeReader`** (the same read-only abstraction the portfolio collector uses for KIS) — never the low-level broker client, so the `test_collectors` import-guard stays green. Fail-soft: any error is recorded under `source_errors` and returns `[]` (derivation never crashes).
- Added `provenance.source_coverage` with per-source counts and an explicit **candidate `empty_reason`** (`"no_fresh_candidate_universe"` / `"fetch_error"`). An empty `candidate` list is now explained rather than silently blank — and kept **separate** from the portfolio fix (an empty candidate universe is a legitimate screener-data state, not a bug).

### 3. descriptor / evidence / citation connection (priority 3)
- **Investigation outcome: the code is correct.** Report-level `market_snapshot`/`portfolio_snapshot` descriptors and item `cited_snapshot_uuids` populate correctly when the bundle has fresh `market`/`portfolio` snapshots (existing `test_market_portfolio_descriptors_from_bundle` + new crypto regression tests pass).
- `7a3e97eb`'s empty `market_snapshot:{}` / `portfolio_snapshot:{}` are consistent with the **deterministic insert-only reuse** returning a report row that was created *before* ROB-352 Slice B shipped (the reuse path returns the stored row verbatim by design; `investment_report_get` reads descriptors from that row).
- **No code change** here. Added crypto-specific regression tests for the pointer-not-payload descriptor contract and evidence→citation derivation.
- **Operational remedy:** regenerate the report with `overwrite_existing=true` (+ `overwrite_reason`) to refresh the legacy row. If descriptors are *still* empty on a freshly-overwritten row, that is a true repro — reopen with the new `bundle_uuid`.

## Non-goal (ROB-352 Slice B design preserved)
Pointer descriptors are **not** reverted to full RSI/MACD/bollinger payload copies. The fix only ensures the pointer connection (`snapshot_uuid` / `snapshot_kind` / `freshness_status` / `as_of` / `coverage`) is populated — never the snapshot body.

## Safety boundary
Read-only throughout. No broker / order / watch / order-intent / scheduler / prod-DB mutation. `UpbitHomeReader` is a read-only balance reader; the `symbol_derivation` import-guard (`test_collector_modules_do_not_import_broker_or_activation_paths`) remains green.

## Tests
- `tests/test_mcp_holdings_account_mode_provenance.py` (new) — provenance helper, per-account label, top-level crypto/upbit label, KR no-regression.
- `tests/.../test_symbol_derivation.py` — crypto portfolio ∪ live holdings, manual/live dedupe, KR does-not-consult-live, fail-soft, candidate `empty_reason`.
- `tests/.../test_generator.py` — crypto descriptor pointer-not-payload + crypto item citation derivation.
- `ruff check app/ tests/` clean, `ruff format --check` clean. Affected + adjacent suites green (snapshot_backed 222, account_modes, generate_from_bundle handler, snapshot-backed router, investment_reports_mcp). Pre-existing local-only failures (`portfolio_links` public_base_url, `kis_mock_lifecycle` DB drift) are unrelated env/DB artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)