### PR TITLE
feat(ROB-359): registry-hide MCP recommend_stocks; screen_stocks sole discovery entrypoint (PR1)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -111,8 +111,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - Discord button flows: `cancel_order(order_id="...", market="...")` — symbol auto-lookup enabled
 - `modify_order` Discord button flow example:
   - `modify_order(order_id="...", symbol="...", market="...", new_price=123.45, dry_run=false)`
-- `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters.
-- `recommend_stocks(...)` - Recommend stocks based on budget and strategy.
+- `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters. **Single candidate-discovery entrypoint.**
+- ~~`recommend_stocks(...)`~~ — **DEPRECATED / registry-hidden (ROB-359).** No longer registered on the MCP tool surface. Use `screen_stocks` for candidate discovery. The implementation is retained in `analysis_tool_handlers.recommend_stocks_impl` for a possible future narrow `build_buy_plan` tool; do not call it from active report/operator prompts.
 - `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
   - Analyze multiple symbols in parallel and return compact per-symbol summaries
   - Default `quick=True` returns compact summary with: symbol, current_price, rsi_14, consensus, recommendation, supports (top 3), resistances (top 3)
@@ -732,7 +732,12 @@ Response format:
 }
 ```
 
-### `recommend_stocks` spec
+### `recommend_stocks` spec (DEPRECATED — registry-hidden, ROB-359)
+> **This tool is no longer registered on the MCP surface.** It is parked, not
+> deleted: `recommend_stocks_impl` remains in `analysis_tool_handlers` for a
+> future narrow `build_buy_plan` tool. The spec below documents the retained
+> implementation only. For candidate discovery use `screen_stocks`.
+
 Parameters:
 - `budget`: Total budget to allocate (required, must be positive)
 - `market`: Market to screen - "kr", "us", "crypto" (default: "kr")

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -50,7 +50,7 @@ AVAILABLE_TOOL_NAMES = [
     "get_order_history",
     "modify_order",
     "screen_stocks",
-    "recommend_stocks",
+    # ROB-359: recommend_stocks is registry-hidden (parked); not on the tool surface.
     "get_asset_profile",
     "set_asset_profile",
 ]

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -13,7 +13,6 @@ from app.mcp_server.tooling.analysis_tool_handlers import (
     get_dividends_impl,
     get_fear_greed_index_impl,
     get_top_stocks_impl,
-    recommend_stocks_impl,
     screen_stocks_impl,
 )
 from app.mcp_server.tooling.momentum_candidates import get_momentum_candidates_impl
@@ -32,7 +31,10 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "analyze_portfolio",
     "analyze_stock_batch",
     "screen_stocks",
-    "recommend_stocks",
+    # ROB-359: "recommend_stocks" is intentionally registry-hidden (parked).
+    # screen_stocks is the single candidate-discovery entrypoint; the
+    # recommend_stocks_impl implementation is retained in
+    # analysis_tool_handlers for a future narrow build_buy_plan tool.
     "get_top_stocks",
     "get_disclosures",
     "get_correlation",
@@ -250,30 +252,14 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             limit=limit,
         )
 
-    @mcp.tool(
-        name="recommend_stocks",
-        description=(
-            "Recommend stocks from available top ranks using strategy-specific filters."
-        ),
-    )
-    async def recommend_stocks(
-        budget: float,
-        market: str = "kr",
-        strategy: str = "balanced",
-        exclude_symbols: list[str] | None = None,
-        sectors: list[str] | None = None,
-        max_positions: int = 5,
-        exclude_held: bool = True,
-    ) -> dict[str, Any]:
-        return await recommend_stocks_impl(
-            budget=budget,
-            market=market,
-            strategy=strategy,
-            exclude_symbols=exclude_symbols,
-            sectors=sectors,
-            max_positions=max_positions,
-            exclude_held=exclude_held,
-        )
+    # ROB-359: recommend_stocks is intentionally NOT registered on the MCP tool
+    # surface (registry-hidden / parked). Rationale: its role overlapped
+    # ambiguously with screen_stocks and it could be invoked as a new-buy basis.
+    # screen_stocks is now the single candidate-discovery entrypoint. The
+    # read-only recommend_stocks_impl implementation is retained in
+    # app.mcp_server.tooling.analysis_tool_handlers so it can be re-introduced
+    # later as a narrow build_buy_plan tool. Do not call recommend_stocks from
+    # active report/operator prompts.
 
     @mcp.tool(
         name="get_dividends",

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 
 import app.services.brokers.upbit.client as upbit_service
-from app.mcp_server.tooling import market_data_indicators
+from app.mcp_server.tooling import analysis_tool_handlers, market_data_indicators
 from app.mcp_server.tooling.analysis_crypto_score import (
     BEARISH_NORMAL,
     BEARISH_STRONG,
@@ -771,8 +771,8 @@ class TestRecommendStocksCryptoScore:
             mock_collect_portfolio_positions,
         )
 
-        tools = build_tools()
-        result = await tools["recommend_stocks"](
+        # ROB-359: recommend_stocks is registry-hidden; call the retained impl.
+        result = await analysis_tool_handlers.recommend_stocks_impl(
             budget=10_000_000,
             market="crypto",
             strategy="balanced",
@@ -830,8 +830,8 @@ class TestRecommendStocksCryptoScore:
             mock_collect_portfolio_positions,
         )
 
-        tools = build_tools()
-        await tools["recommend_stocks"](
+        # ROB-359: recommend_stocks is registry-hidden; call the retained impl.
+        await analysis_tool_handlers.recommend_stocks_impl(
             budget=10_000_000,
             market="crypto",
             strategy="balanced",

--- a/tests/test_mcp_recommend_flow.py
+++ b/tests/test_mcp_recommend_flow.py
@@ -72,7 +72,13 @@ async def test_recommend_stocks_tool_uses_analysis_screening_alias(
 
     monkeypatch.setattr(analysis_screening, "_recommend_stocks_impl", fake_recommend)
 
-    result = await tools["recommend_stocks"](budget=1_000_000, market="kr")
+    # ROB-359: recommend_stocks is registry-hidden, so it is no longer present
+    # on the MCP tool surface (build_tools). The implementation facade is
+    # retained and still forwards to the analysis_screening alias.
+    assert "recommend_stocks" not in tools
+    result = await analysis_tool_handlers.recommend_stocks_impl(
+        budget=1_000_000, market="kr"
+    )
 
     assert result["warnings"] == ["shim-test"]
     assert called["market"] == "kr"
@@ -81,7 +87,8 @@ async def test_recommend_stocks_tool_uses_analysis_screening_alias(
 class TestRecommendStocksIntegration:
     @pytest.fixture
     def recommend_stocks(self):
-        return build_tools()["recommend_stocks"]
+        # ROB-359: tool is registry-hidden; exercise the retained impl facade.
+        return analysis_tool_handlers.recommend_stocks_impl
 
     @pytest.mark.asyncio
     async def test_rejects_unsupported_market(self, recommend_stocks):
@@ -1208,7 +1215,8 @@ class TestTwoStageRelaxation:
 
     @pytest.fixture
     def recommend_stocks(self):
-        return build_tools()["recommend_stocks"]
+        # ROB-359: tool is registry-hidden; exercise the retained impl facade.
+        return analysis_tool_handlers.recommend_stocks_impl
 
     @pytest.mark.asyncio
     async def test_value_fallback_triggered(

--- a/tests/test_mcp_tool_registration.py
+++ b/tests/test_mcp_tool_registration.py
@@ -47,7 +47,29 @@ def test_compute_dca_price_levels_helper_removed() -> None:
 
 
 @pytest.mark.asyncio
-async def test_recommend_stocks_registration() -> None:
-    """Test recommend_stocks tool is registered."""
+async def test_recommend_stocks_removed_from_build_tools() -> None:
+    """ROB-359: recommend_stocks is registry-hidden (deprecated/parked).
+
+    The MCP tool surface no longer exposes recommend_stocks so agents cannot
+    invoke it as a new-buy basis; screen_stocks is the single candidate-
+    discovery entrypoint. The recommend_stocks_impl implementation is retained
+    in app.mcp_server.tooling.analysis_tool_handlers for future re-use (e.g. a
+    narrow build_buy_plan tool).
+    """
     tools = build_tools()
-    assert "recommend_stocks" in tools
+
+    assert "recommend_stocks" not in tools
+    # Primary discovery entrypoint must remain.
+    assert "screen_stocks" in tools
+
+
+@pytest.mark.asyncio
+async def test_recommend_stocks_removal_leaves_order_surface_untouched() -> None:
+    """Removing the read-only recommend_stocks tool must not alter the
+    broker/order tool surface (no order/watch/order-intent side effects)."""
+    tools = build_tools()
+
+    # Default profile still exposes its order surface unchanged.
+    for order_tool in ("place_order", "cancel_order", "modify_order"):
+        assert order_tool in tools
+    assert "recommend_stocks" not in tools


### PR DESCRIPTION
## ROB-359 split decision

ROB-359 is kept as an **umbrella/parent** (Toss `골라보기` parity 현황 점검 + `screen_stocks` 단일화). It bundles 5 heterogeneous workstreams (조사 matrix · preset 정리 · read-model · MCP surface · /invest/reports 연결) and is being delivered as separate PRs rather than one. See the split-decision comment on ROB-359.

**This PR is PR1 = Scope D only** (`recommend_stocks` cleanup). It deliberately does **not** implement Toss 11-preset parity, fundamentals-source integration, or `/invest/reports` candidate lineage — those are follow-up slices/issues.

## recommend_stocks cleanup

Chosen approach: **registry-hidden (parked), not deleted.**

- `recommend_stocks` is no longer registered on the MCP tool surface — removed from `register_analysis_tools`, `ANALYSIS_TOOL_NAMES`, and `AVAILABLE_TOOL_NAMES`. This is the codebase-idiomatic clean-cut pattern (cf. removed DCA / Paperclip tools) and gives a **hard guarantee** an agent cannot invoke it as a new-buy basis — stronger than a soft deprecation-warning response.
- The read-only `recommend_stocks_impl` implementation is **retained** in `analysis_tool_handlers` so it can be re-introduced later as a narrow `build_buy_plan` tool. Parked, reversible.
- `README.md` marks `recommend_stocks` DEPRECATED / registry-hidden with rationale and the build_buy_plan pointer.

## screen_stocks remains primary

`screen_stocks` is now the single candidate-discovery entrypoint and is unchanged (asserted present in registration tests).

## No active prompt referenced it

Repo-wide search found **no active report/operator prompt** calling `recommend_stocks` (only README docs + the retained impl). No prompt changes were required.

## No broker/order/watch/order-intent mutation

The removed tool was read-only. The order tool surface (`place_order`/`cancel_order`/`modify_order`) is untouched — explicitly asserted in `test_recommend_stocks_removal_leaves_order_surface_untouched`.

## Tests

- `test_mcp_tool_registration.py`: `recommend_stocks` asserted **absent** from `build_tools()`; `screen_stocks` + order surface asserted present.
- `test_mcp_recommend_flow.py` / `test_crypto_composite_score.py`: behavior coverage repointed from the (now-hidden) MCP surface to the retained `analysis_tool_handlers.recommend_stocks_impl` facade — full coverage preserved.
- `uv run --all-groups pytest` on the 3 affected files: **93 passed**.
- `uv run ruff check app/ tests/`: clean.

## Follow-up slices (not in this PR)
- PR2: Scope A Toss 11-preset gap matrix (treat ROB-170 `consecutive_gainers` / ROB-276 `double_buy` as already-implemented `full`).
- PR3: Scope B preset catalog — Toss-parity vs auto_trader-own (`거래량 급증`/`수급 모멘텀`) split + mismatch labeling.
- Separate issues: Scope C fundamentals-source integration (배당성향/매출총이익률/3yr growth/QoQ/연속증가 — the real blocker for the 5 missing presets), Scope E `/invest/reports` candidate lineage. Snapshot freshness cadence stays with ROB-280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `recommend_stocks` tool has been deprecated and removed from the available tools surface. Users should transition to `screen_stocks` for stock candidate discovery.

* **Documentation**
  * Updated documentation to clarify `screen_stocks` as the single candidate-discovery entrypoint across all markets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->