### PR TITLE
fix(ROB-358): harden KIS mock holdings-delta smoke cleanup gate/reason

### DIFF
--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -173,12 +173,19 @@ Places one small marketable limit BUY (at best ask), confirms the fill via the
 holdings/cash delta, then flattens with a cleanup SELL (at best bid) back to
 baseline. Prints a JSON evidence packet: symbol, side(s), order id(s), baseline
 holdings/cash, post-submit holdings/cash, confirmation signal + price source,
-cleanup result, and final position delta vs baseline. Exit `0` clean, `2` if the
-fill could not be confirmed in the poll window (ROB-341 STOP condition — capture
-the packet and report; do not force), `3` if a residual position/pending order
-could not be cleaned up (including a cleanup SELL the broker **rejected** or one
-that returned no `odno`/`order_no` — surfaced as `cleanup_error` + non-zero
-`final_position_delta_vs_baseline`, not a silent exit 1), `4` disabled/not
+cleanup result, and final position delta vs baseline. A clean exit `0` requires
+`final_position_delta_vs_baseline` to be **exactly `0`** — any non-zero delta is
+an anomaly. Exit `2` if the fill could not be confirmed in the poll window
+(ROB-341 STOP condition — capture the packet and report; do not force), `3` if
+the position could not be returned to baseline, including:
+- a residual position remaining (`final delta > 0`);
+- an over-flatten / below-baseline drop (`final delta < 0`, e.g. sold past
+  baseline or holdings dropped before the cleanup SELL) — `cleanup` =
+  `over_flattened_anomaly` / `below_baseline_anomaly`;
+- a cleanup SELL the broker **rejected** or one that returned no `odno`/`order_no`.
+
+All exit-3 cases surface `cleanup_error` + the non-zero
+`final_position_delta_vs_baseline` (never a silent exit 1). Exit `4` disabled/not
 configured **or a cleanup preflight gate failure (no order placed)**.
 
 ### Failure categories

--- a/docs/runbooks/kis-mock-scalping-smoke.md
+++ b/docs/runbooks/kis-mock-scalping-smoke.md
@@ -151,9 +151,23 @@ Run ONLY after the read-only preflight passes and operator approval boundaries
 are satisfied, during a KRX regular session:
 
 ```bash
-KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+KIS_MOCK_SCALPING_ENABLED=true KIS_MOCK_SCALPING_WS_ENABLED=true \
+    uv run python -m scripts.kis_mock_holdings_delta_smoke \
     --confirm --symbol <KR_CODE> --notional-krw 10000
 ```
+
+The cleanup SELL flattens through the mock scalping-exit bypass, so `--confirm`
+requires **both** `KIS_MOCK_SCALPING_ENABLED=true` (the sell-guard bypass) and
+`KIS_MOCK_SCALPING_WS_ENABLED=true`. **Set both ephemerally for this run only —
+never as persistent env/shell exports.** The cleanup exit reason defaults to
+`stop_loss` (an existing allowed `ScalpingExitContext` reason — ROB-358 does not
+add a smoke-only reason); override with `--cleanup-reason {stop_loss,take_profit,time_stop}`
+only if deliberately needed.
+
+Both gates (plus the cleanup reason) are **preflighted before any BUY** (ROB-358):
+if `KIS_MOCK_SCALPING_ENABLED` is unset or the cleanup reason is not an allowed
+`ScalpingExitContext` reason, the run stops with exit `4` and **no position is
+acquired** — it never buys something it cannot flatten.
 
 Places one small marketable limit BUY (at best ask), confirms the fill via the
 holdings/cash delta, then flattens with a cleanup SELL (at best bid) back to
@@ -162,7 +176,10 @@ holdings/cash, post-submit holdings/cash, confirmation signal + price source,
 cleanup result, and final position delta vs baseline. Exit `0` clean, `2` if the
 fill could not be confirmed in the poll window (ROB-341 STOP condition — capture
 the packet and report; do not force), `3` if a residual position/pending order
-could not be cleaned up, `4` disabled/not configured.
+could not be cleaned up (including a cleanup SELL the broker **rejected** or one
+that returned no `odno`/`order_no` — surfaced as `cleanup_error` + non-zero
+`final_position_delta_vs_baseline`, not a silent exit 1), `4` disabled/not
+configured **or a cleanup preflight gate failure (no order placed)**.
 
 ### Failure categories
 

--- a/scripts/kis_mock_holdings_delta_smoke.py
+++ b/scripts/kis_mock_holdings_delta_smoke.py
@@ -27,10 +27,17 @@ Exit codes:
     3  - anomaly: residual position/pending order could not be cleaned up
     4  - disabled or KIS mock not configured (env/config no-op)
 
+The cleanup SELL goes through the mock scalping-exit bypass, so ``--confirm``
+also requires KIS_MOCK_SCALPING_ENABLED=true and an allowed cleanup exit reason
+(default ``stop_loss`` — no smoke-only reason is added to the validator). Both
+gates are preflighted BEFORE any BUY, so a missing/invalid gate stops the run
+with no position acquired (exit 4). Set the gate flags ephemerally only.
+
 Usage:
     KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
         --preflight --symbol 005930
-    KIS_MOCK_SCALPING_WS_ENABLED=true uv run python -m scripts.kis_mock_holdings_delta_smoke \
+    KIS_MOCK_SCALPING_ENABLED=true KIS_MOCK_SCALPING_WS_ENABLED=true \
+        uv run python -m scripts.kis_mock_holdings_delta_smoke \
         --confirm --symbol 005930 --notional-krw 10000
 """
 
@@ -44,6 +51,11 @@ import sys
 from decimal import ROUND_DOWN, Decimal
 
 logger = logging.getLogger(__name__)
+
+# Cleanup SELL reuses an existing allowed ScalpingExitContext reason. We do NOT
+# add a smoke-only synthetic reason to the validator surface (ROB-358), so no
+# synthetic reason ever lands in the ledger.exit_reason column.
+_DEFAULT_CLEANUP_EXIT_REASON = "stop_loss"
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -71,6 +83,15 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--max-poll", type=int, default=10)
     parser.add_argument("--poll-interval", type=float, default=1.0)
+    parser.add_argument(
+        "--cleanup-reason",
+        default=_DEFAULT_CLEANUP_EXIT_REASON,
+        help=(
+            "scalping exit reason for the cleanup SELL "
+            f"(default {_DEFAULT_CLEANUP_EXIT_REASON!r}; must be an allowed "
+            "ScalpingExitContext reason — no smoke-only reason is introduced)"
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -94,6 +115,31 @@ def _gate_or_exit() -> object | None:
         logger.error("KIS mock not configured. Missing (names only): %s", missing)
         return None
     return settings
+
+
+def _confirm_cleanup_preflight_error(
+    settings_obj: object, cleanup_reason: str
+) -> str | None:
+    """Fail-fast check that the cleanup SELL is submittable, run BEFORE any BUY.
+
+    Returns an error string when a required cleanup gate is missing/invalid,
+    else None. ``KIS_MOCK_SCALPING_ENABLED`` gates the mock scalping-exit sell
+    bypass; the cleanup reason must be an allowed ``ScalpingExitContext`` reason
+    (we reuse ``stop_loss`` — no smoke-only synthetic reason is introduced).
+    """
+    if not getattr(settings_obj, "kis_mock_scalping_enabled", False):
+        return (
+            "KIS_MOCK_SCALPING_ENABLED=true is required for the cleanup SELL; "
+            "set it ephemerally for this run only (no persistent flag)"
+        )
+    from app.mcp_server.tooling.order_validation import _SCALPING_EXIT_REASONS
+
+    if cleanup_reason not in _SCALPING_EXIT_REASONS:
+        return (
+            f"invalid cleanup exit reason {cleanup_reason!r}; must be one of "
+            f"{sorted(_SCALPING_EXIT_REASONS)}"
+        )
+    return None
 
 
 def _best_ask_bid(orderbook: dict) -> tuple[Decimal | None, Decimal | None]:
@@ -145,7 +191,26 @@ async def _await_fill(broker, submit_result, *, max_poll: int, interval: float):
 
 
 async def run_confirm(args: argparse.Namespace) -> int:
-    if _gate_or_exit() is None:
+    settings_obj = _gate_or_exit()
+    if settings_obj is None:
+        return 4
+    # Fail-fast BEFORE any BUY: if the cleanup SELL cannot be safely executed,
+    # never acquire a position we cannot flatten (ROB-358).
+    preflight_error = _confirm_cleanup_preflight_error(
+        settings_obj, args.cleanup_reason
+    )
+    if preflight_error is not None:
+        logger.error("cleanup preflight failed; no order placed: %s", preflight_error)
+        logger.info(
+            json.dumps(
+                {
+                    "mode": "confirm",
+                    "symbol": args.symbol,
+                    "preflight": "cleanup_gate_failed",
+                    "error": preflight_error,
+                }
+            )
+        )
         return 4
     import uuid
 
@@ -238,16 +303,32 @@ async def _cleanup_and_verify(
     if bid is None:
         evidence["cleanup"] = "no_bid_for_exit"
         return 3
-    sell = await broker.submit_exit_sell(
-        symbol=args.symbol,
-        price=bid,
-        quantity=delta,
-        exit_reason="smoke_cleanup",
-        strategy_id="kis-mock-v1",
-        correlation_id=cid,
-        confirm=True,
-    )
-    evidence["cleanup_sell_order_id"] = sell.get("odno") or sell.get("order_no")
+    try:
+        sell = await broker.submit_exit_sell(
+            symbol=args.symbol,
+            price=bid,
+            quantity=delta,
+            exit_reason=args.cleanup_reason,
+            strategy_id="kis-mock-v1",
+            correlation_id=cid,
+            confirm=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - submit rejection is a cleanup anomaly, not unexpected
+        # A rejected cleanup SELL leaves a residual position; classify it as an
+        # explicit anomaly (exit 3) instead of leaking out as exit 1 (ROB-358).
+        evidence["cleanup_sell_order_id"] = None
+        evidence["cleanup_error"] = str(exc)[:200]
+        evidence["cleanup"] = "SELL_submit_rejected"
+        evidence["final_position_delta_vs_baseline"] = str(cur_qty - base_qty)
+        return 3
+    order_id = sell.get("odno") or sell.get("order_no")
+    evidence["cleanup_sell_order_id"] = order_id
+    if not order_id:
+        # Missing odno/order_no -> explicit failure with reason; residual stays.
+        evidence["cleanup_error"] = "cleanup SELL response missing odno/order_no"
+        evidence["cleanup"] = "SELL_no_order_id"
+        evidence["final_position_delta_vs_baseline"] = str(cur_qty - base_qty)
+        return 3
     exit_fill = await _await_fill(
         broker, sell, max_poll=args.max_poll, interval=args.poll_interval
     )

--- a/scripts/kis_mock_holdings_delta_smoke.py
+++ b/scripts/kis_mock_holdings_delta_smoke.py
@@ -292,9 +292,18 @@ async def _cleanup_and_verify(
         evidence["cleanup_error"] = str(exc)[:200]
         return 3
     delta = cur_qty - base_qty
-    if delta <= 0:
+    if delta < 0:
+        # Holdings dropped BELOW baseline before we sold (over-flatten / external
+        # mutation). A non-zero negative delta is never a clean exit (ROB-358).
+        evidence["final_position_delta_vs_baseline"] = str(delta)
+        evidence["cleanup"] = "below_baseline_anomaly"
+        evidence["cleanup_error"] = (
+            f"holdings {cur_qty} below baseline {base_qty} before cleanup SELL"
+        )
+        return 3
+    if delta == 0:
         evidence["cleanup"] = "nothing_to_flatten"
-        evidence["final_position_delta_vs_baseline"] = str(cur_qty - base_qty)
+        evidence["final_position_delta_vs_baseline"] = str(delta)
         # If the entry never filled, propagate the fill-unconfirmed code.
         return 0 if entry_fill is not None else 2
 
@@ -333,12 +342,21 @@ async def _cleanup_and_verify(
         broker, sell, max_poll=args.max_poll, interval=args.poll_interval
     )
     final_qty, final_cash = await broker._read_snapshot(args.symbol)
+    final_delta = final_qty - base_qty
     evidence["post_holdings_qty"] = str(final_qty)
     evidence["post_cash"] = str(final_cash) if final_cash is not None else None
-    evidence["final_position_delta_vs_baseline"] = str(final_qty - base_qty)
-    if exit_fill is None or final_qty > base_qty:
+    evidence["final_position_delta_vs_baseline"] = str(final_delta)
+    if exit_fill is None or final_delta > 0:
         evidence["cleanup"] = "UNCONFIRMED_residual_position"
         return 3
+    if final_delta < 0:
+        # Over-flatten: sold past baseline. A clean exit requires delta == 0.
+        evidence["cleanup"] = "over_flattened_anomaly"
+        evidence["cleanup_error"] = (
+            f"final holdings {final_qty} below baseline {base_qty} after cleanup SELL"
+        )
+        return 3
+    # Clean exit only when holdings are back to EXACTLY the baseline.
     evidence["cleanup"] = "flattened"
     return 0
 

--- a/tests/test_kis_mock_holdings_delta_smoke_cleanup.py
+++ b/tests/test_kis_mock_holdings_delta_smoke_cleanup.py
@@ -211,3 +211,71 @@ async def test_cleanup_residual_position_is_explicit_anomaly():
     assert rc == 3
     assert evidence["cleanup"] == "UNCONFIRMED_residual_position"
     assert evidence["final_position_delta_vs_baseline"] == "1"
+
+
+# --- non-zero NEGATIVE delta must never be a clean exit (ROB-358) -----------
+
+
+class _BelowBaselineBroker:
+    async def _read_snapshot(self, _symbol):
+        return Decimal("6"), Decimal("100")  # already below baseline 7
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_below_baseline_at_start_is_anomaly_not_clean():
+    # cur_qty < base_qty at cleanup start: final delta is -1, so even with an
+    # entry fill present this must NOT exit 0.
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        _BelowBaselineBroker(),
+        _FakeClient(),
+        _confirm_args(),
+        "cid",
+        Decimal("7"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["final_position_delta_vs_baseline"] == "-1"
+    assert evidence["cleanup"] != "nothing_to_flatten"
+    assert "cleanup_error" in evidence
+
+
+class _OverFlattenBroker:
+    def __init__(self) -> None:
+        # current (8, residual of 1) then post-sell (6, BELOW baseline 7).
+        self._snapshots = [
+            (Decimal("8"), Decimal("100")),
+            (Decimal("6"), Decimal("120")),
+        ]
+
+    async def _read_snapshot(self, _symbol):
+        return self._snapshots.pop(0)
+
+    async def submit_exit_sell(self, **_kwargs):
+        return {"odno": "0000000777"}
+
+    async def confirm_fill(self, _submit):
+        return object()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_over_flatten_below_baseline_is_anomaly():
+    # final_qty < base_qty after the cleanup SELL: final delta is -1, so it must
+    # be an explicit anomaly and NOT report cleanup="flattened".
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        _OverFlattenBroker(),
+        _FakeClient(),
+        _confirm_args(),
+        "cid",
+        Decimal("7"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup"] != "flattened"
+    assert evidence["final_position_delta_vs_baseline"] == "-1"
+    assert "cleanup_error" in evidence

--- a/tests/test_kis_mock_holdings_delta_smoke_cleanup.py
+++ b/tests/test_kis_mock_holdings_delta_smoke_cleanup.py
@@ -1,0 +1,213 @@
+"""ROB-358 — cleanup gate/reason hardening for the holdings-delta smoke.
+
+These tests prove the ``--confirm`` round trip:
+
+* fail-fast BEFORE any BUY when the cleanup SELL cannot be safely executed
+  (missing ``KIS_MOCK_SCALPING_ENABLED`` or an invalid cleanup exit reason);
+* classifies a cleanup SELL submit rejection as an explicit cleanup anomaly
+  (exit 3) rather than leaking out as an unexpected exception (exit 1);
+* returns the entry/exit happy path to baseline (final delta 0);
+* surfaces a residual position as an explicit anomaly.
+
+stdlib + fakes only; no broker / network / secrets.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest import mock
+
+import pytest
+
+import scripts.kis_mock_holdings_delta_smoke as smoke
+
+
+class _FakeSettings:
+    """Minimal stand-in for the Settings object the gate returns."""
+
+    def __init__(self, *, scalping_enabled: bool) -> None:
+        self.kis_mock_scalping_enabled = scalping_enabled
+        self.kis_mock_scalping_ws_enabled = True
+        self.kis_mock_app_key = "k"
+        self.kis_mock_app_secret = "s"
+        self.kis_mock_account_no = "a"
+
+
+def _confirm_args(extra: list[str] | None = None):
+    argv = [
+        "--confirm",
+        "--symbol",
+        "005930",
+        "--max-poll",
+        "1",
+        "--poll-interval",
+        "0",
+    ]
+    return smoke._parse_args(argv + (extra or []))
+
+
+# --- fail-fast preflight (before any BUY) ----------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fails_fast_when_scalping_enabled_missing(monkeypatch):
+    monkeypatch.setattr(
+        smoke, "_gate_or_exit", lambda: _FakeSettings(scalping_enabled=False)
+    )
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+
+    rc = await smoke.run_confirm(_confirm_args())
+
+    assert rc == 4
+    created.assert_not_called()  # no BUY path was ever constructed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fails_fast_on_invalid_cleanup_reason(monkeypatch):
+    monkeypatch.setattr(
+        smoke, "_gate_or_exit", lambda: _FakeSettings(scalping_enabled=True)
+    )
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+
+    rc = await smoke.run_confirm(_confirm_args(["--cleanup-reason", "bogus_reason"]))
+
+    assert rc == 4
+    created.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_preflight_accepts_default_stop_loss_reason(monkeypatch):
+    # The default cleanup reason must be an allowed scalping-exit reason so the
+    # gate passes and the BUY path is reached (we stop it at client creation).
+    monkeypatch.setattr(
+        smoke, "_gate_or_exit", lambda: _FakeSettings(scalping_enabled=True)
+    )
+    sentinel = RuntimeError("reached BUY path")
+
+    def _boom(*_a, **_k):
+        raise sentinel
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", _boom
+    )
+
+    # main() swallows exceptions; here we call run_confirm directly and assert
+    # the preflight let us through to client construction.
+    with pytest.raises(RuntimeError, match="reached BUY path"):
+        await smoke.run_confirm(_confirm_args())
+
+
+# --- cleanup submit rejection -> explicit anomaly, not exit 1 --------------
+
+
+class _RejectingBroker:
+    async def _read_snapshot(self, _symbol):
+        return Decimal("8"), Decimal("100")
+
+    async def submit_exit_sell(self, **_kwargs):
+        raise ValueError("invalid scalping_exit reason: smoke_cleanup")
+
+
+class _FakeClient:
+    async def inquire_orderbook(self, *_a, **_k):
+        return {"askp1": "100", "bidp1": "99"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_submit_rejection_is_anomaly_not_unexpected():
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        _RejectingBroker(),
+        _FakeClient(),
+        _confirm_args(),
+        "cid",
+        Decimal("7"),  # baseline -> residual of 1
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup_sell_order_id"] is None
+    assert "cleanup_error" in evidence
+    assert evidence["final_position_delta_vs_baseline"] == "1"
+
+
+# --- happy path: flattened back to baseline (final delta 0) ----------------
+
+
+class _SuccessfulBroker:
+    def __init__(self) -> None:
+        # cleanup reads snapshot twice: current (8) then post-sell (7 == base).
+        self._snapshots = [
+            (Decimal("8"), Decimal("100")),
+            (Decimal("7"), Decimal("110")),
+        ]
+
+    async def _read_snapshot(self, _symbol):
+        return self._snapshots.pop(0)
+
+    async def submit_exit_sell(self, **_kwargs):
+        return {"odno": "0000000123"}
+
+    async def confirm_fill(self, _submit):
+        return object()  # non-None fill
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_happy_path_flattens_to_baseline():
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        _SuccessfulBroker(),
+        _FakeClient(),
+        _confirm_args(),
+        "cid",
+        Decimal("7"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 0
+    assert evidence["cleanup"] == "flattened"
+    assert evidence["cleanup_sell_order_id"] == "0000000123"
+    assert evidence["final_position_delta_vs_baseline"] == "0"
+
+
+# --- residual position remains -> explicit anomaly -------------------------
+
+
+class _ResidualBroker:
+    async def _read_snapshot(self, _symbol):
+        return Decimal("8"), Decimal("100")  # stays at 8, never returns to 7
+
+    async def submit_exit_sell(self, **_kwargs):
+        return {"odno": "0000000999"}
+
+    async def confirm_fill(self, _submit):
+        return None  # exit never confirmed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_residual_position_is_explicit_anomaly():
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        _ResidualBroker(),
+        _FakeClient(),
+        _confirm_args(),
+        "cid",
+        Decimal("7"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "UNCONFIRMED_residual_position"
+    assert evidence["final_position_delta_vs_baseline"] == "1"


### PR DESCRIPTION
## Summary

Follow-up to ROB-341. The ROB-341 operator smoke confirmed the entry fill via holdings delta (`005930` `7 -> 8`), but the scripted cleanup left `cleanup_sell_order_id=null` and exited with `UNCONFIRMED_residual_position`. Two root defects:

1. **Cleanup gate not preflighted.** The cleanup SELL flattens through the mock scalping-exit bypass, which requires `KIS_MOCK_SCALPING_ENABLED=true` — but `--confirm` only gated on `KIS_MOCK_SCALPING_WS_ENABLED` + mock creds. The BUY was placed first, then the cleanup SELL failed.
2. **Out-of-band cleanup reason.** The helper passed `exit_reason="smoke_cleanup"`, which `ScalpingExitContext` always rejects (allowed: `stop_loss`/`take_profit`/`time_stop`). The cleanup SELL could never succeed, and the resulting `ValueError` leaked out of the `finally` as **exit 1 (unexpected)** rather than a classified anomaly.

## Changes

- **Fail-fast preflight before any BUY** (`run_confirm`): require `KIS_MOCK_SCALPING_ENABLED=true` **and** an allowed cleanup exit reason. On failure → exit `4`, **no position acquired** (never buy what we can't flatten). The existing WS-enabled + mock-creds gate is unchanged.
- **Reuse `stop_loss`** as the cleanup reason via a new `--cleanup-reason` flag (default `stop_loss`). **No smoke-only synthetic reason is added** to the validator surface, so nothing synthetic lands in `ledger.exit_reason`.
- **Cleanup submit rejection → explicit anomaly (exit 3)**: a rejected `submit_exit_sell` (or a response missing `odno`/`order_no`) is recorded with `cleanup_error` + the residual `final_position_delta_vs_baseline` in the evidence packet, instead of leaking out as exit 1.
- **Runbook**: documented `--confirm` command now sets both gate flags (**ephemeral only**), and documents the fail-fast preflight + anomaly exit codes.

## Tests (`tests/test_kis_mock_holdings_delta_smoke_cleanup.py`)

- missing `KIS_MOCK_SCALPING_ENABLED` → fail-fast before BUY (asserts `_create_kis_client` never called)
- invalid cleanup reason → fail-fast before BUY
- default `stop_loss` reason passes preflight (reaches BUY path)
- `submit_exit_sell` `ValueError` → exit 3 anomaly with `cleanup_sell_order_id=null` + residual delta (not exit 1)
- happy path → final delta `0` (`flattened`)
- residual remains → explicit `UNCONFIRMED_residual_position` anomaly

## Scope / safety

Holdings-delta primary confirmation from ROB-341 preserved; daily-ccld stays supplementary. Changes confined to the smoke script, runbook, and focused tests — the broker / live path / order validator body are untouched. KIS mock only; no live, no market orders, no persistent flags, no scheduler/Prefect/TaskIQ, no DB backfill.

## Verification run

```
uv run ruff check app/ tests/                  # All checks passed
uv run ruff format --check <changed files>     # clean
uv run pytest tests/test_kis_mock_holdings_delta_smoke_cleanup.py \
              tests/test_kis_mock_holdings_delta_smoke_cli.py      # 8 passed
uv run pytest tests/test_kis_mock_scalping_*.py \
              tests/test_kis_mock_holdings_delta_fill.py ...        # 49 passed
```

(Pre-existing unrelated ruff errors in `scripts/debug_economic_calendar.py` and `scripts/test_discord_webhook_e2e.py` are outside the CI `app/ tests/` scope and untouched here.)

**Actual bounded broker smoke NOT run** — it requires separate operator approval, a KRX regular session, and KIS mock creds that are absent on this host. This PR lands the code/tests/docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cleanup-reason` CLI option to customize the cleanup exit reason (default: stop_loss; options: take_profit, time_stop).
  * Enhanced preflight validation to check configuration requirements before executing trades.

* **Documentation**
  * Updated runbook with refined error handling semantics and exit codes for cleanup scenarios.

* **Tests**
  * Added comprehensive test coverage for cleanup scenarios and preflight validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->