### PR TITLE
feat(ROB-359): screener preset catalog provenance + Toss parity honesty (Scope B, PR3)

### DIFF
--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -41,6 +41,12 @@ ScreenerSourceState = Literal[
     "fallback",
 ]
 ScreenerRiskSeverity = Literal["info", "warning", "danger"]
+# ROB-359 Scope B — catalog provenance + Toss parity honesty.
+# presetOrigin distinguishes a Toss 골라보기 baseline preset from an
+# auto_trader-original preset; parityStatus marks how closely a toss_parity
+# preset matches Toss semantics (auto_trader_original presets leave it None).
+ScreenerPresetOrigin = Literal["toss_parity", "auto_trader_original"]
+ScreenerParityStatus = Literal["full", "partial", "mismatch"]
 
 
 class ScreenerInvestorFlowChip(BaseModel):
@@ -66,6 +72,13 @@ class ScreenerPreset(BaseModel):
     filterChips: list[ScreenerFilterChip] = Field(default_factory=list)
     metricLabel: str
     market: ScreenerMarket = "kr"
+    # ROB-359 Scope B (additive, optional). presetOrigin lets the catalog
+    # separate Toss-parity presets from auto_trader-original ones; parityStatus
+    # + parityNote surface honest divergence (partial/mismatch) without
+    # fabricating results. None defaults keep existing constructions valid.
+    presetOrigin: ScreenerPresetOrigin | None = None
+    parityStatus: ScreenerParityStatus | None = None
+    parityNote: str | None = None
 
 
 class ScreenerSourceContext(BaseModel):

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -7,7 +7,19 @@ via the OHLCV-backed enrichment pipeline."""
 
 from __future__ import annotations
 
-from app.schemas.invest_screener import ScreenerFilterChip, ScreenerPreset
+from app.schemas.invest_screener import (
+    ScreenerFilterChip,
+    ScreenerParityStatus,
+    ScreenerPreset,
+    ScreenerPresetOrigin,
+)
+
+# ROB-359 Scope B — short aliases for catalog provenance metadata.
+_TOSS: ScreenerPresetOrigin = "toss_parity"
+_AT_OWN: ScreenerPresetOrigin = "auto_trader_original"
+_FULL: ScreenerParityStatus = "full"
+_PARTIAL: ScreenerParityStatus = "partial"
+_MISMATCH: ScreenerParityStatus = "mismatch"
 
 DEFAULT_PRESET_ID = "consecutive_gainers"
 CONSECUTIVE_GAINERS_LIMIT = 80
@@ -28,6 +40,8 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="주가등락률",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_FULL,
     ),
     ScreenerPreset(
         id="cheap_value",
@@ -41,6 +55,12 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="PER",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_PARTIAL,
+        parityNote=(
+            "Toss '아직 저렴한 가치주'의 PER·PBR 조건만 반영. "
+            "3년 평균 순이익 증감률(≥0%) 조건은 재무제표 데이터 소스 부재로 미적용(확인 불가)."
+        ),
     ),
     ScreenerPreset(
         id="steady_dividend",
@@ -53,6 +73,12 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="배당수익률",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_PARTIAL,
+        parityNote=(
+            "배당수익률 임계가 Toss(3% 이상)와 달리 2% 이상이며, "
+            "배당성향·배당 연속지급·순이익 연속증가 조건은 재무제표 데이터 소스 부재로 미적용(확인 불가)."
+        ),
     ),
     ScreenerPreset(
         id="oversold_recovery",
@@ -65,6 +91,12 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="RSI",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_MISMATCH,
+        parityNote=(
+            "현재 구현은 RSI ≤ 30 과매도 기반. "
+            "Toss '저평가 탈출'(PER 0~10 + PBR 0~1 + 신고가)과 의미가 다름."
+        ),
     ),
     ScreenerPreset(
         id="kr_high_volume_surge",
@@ -77,6 +109,8 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="거래량",
         market="kr",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 프리셋 (Toss 기본 골라보기에 없음).",
     ),
     ScreenerPreset(
         id="investor_flow_momentum",
@@ -90,6 +124,11 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="외국인 순매수",
         market="kr",
+        presetOrigin=_AT_OWN,
+        parityNote=(
+            "auto_trader 자체 프리셋 (Toss 기본 골라보기에 없음). "
+            "외국인 연속 순매수 중심으로, '쌍끌이 매수'(double_buy)와는 별개."
+        ),
     ),
     ScreenerPreset(
         id="double_buy",
@@ -105,6 +144,8 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="주가등락률",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_FULL,
     ),
     ScreenerPreset(
         id="growth_expectation",
@@ -118,6 +159,12 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="주가등락률",
         market="kr",
+        presetOrigin=_TOSS,
+        parityStatus=_MISMATCH,
+        parityNote=(
+            "현재 구현은 시가총액(≥1조)·등락률 상위 기반. "
+            "Toss '성장 기대주'(3년 평균 순이익 증감률 + 직전분기 대비 순이익 증감률)와 의미가 다름."
+        ),
     ),
 ]
 
@@ -134,6 +181,8 @@ CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="거래대금",
         market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (Toss 국내주식 골라보기 대상 아님).",
     ),
     ScreenerPreset(
         id="crypto_oversold",
@@ -146,6 +195,8 @@ CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="RSI",
         market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (Toss 국내주식 골라보기 대상 아님).",
     ),
     ScreenerPreset(
         id="crypto_momentum",
@@ -158,6 +209,8 @@ CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
         ],
         metricLabel="등락률",
         market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (Toss 국내주식 골라보기 대상 아님).",
     ),
 ]
 

--- a/frontend/invest/src/__tests__/ScreenerPresetSidebar.test.tsx
+++ b/frontend/invest/src/__tests__/ScreenerPresetSidebar.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { test, expect, vi } from "vitest";
+
+import { ScreenerPresetSidebar } from "../desktop/screener/ScreenerPresetSidebar";
+import type { ScreenerPreset } from "../types/screener";
+
+function preset(p: Partial<ScreenerPreset> & Pick<ScreenerPreset, "id" | "name">): ScreenerPreset {
+  return {
+    description: "",
+    badges: [],
+    filterChips: [],
+    metricLabel: "",
+    market: "kr",
+    ...p,
+  };
+}
+
+const PRESETS: ScreenerPreset[] = [
+  preset({ id: "consecutive_gainers", name: "연속 상승세", presetOrigin: "toss_parity", parityStatus: "full" }),
+  preset({
+    id: "oversold_recovery",
+    name: "저평가 탈출",
+    presetOrigin: "toss_parity",
+    parityStatus: "mismatch",
+    parityNote: "현재 구현은 RSI 기반.",
+  }),
+  preset({
+    id: "kr_high_volume_surge",
+    name: "거래량 급증",
+    presetOrigin: "auto_trader_original",
+  }),
+];
+
+test("groups Toss-parity and auto_trader-original presets under separate headings", () => {
+  render(<ScreenerPresetSidebar presets={PRESETS} selectedId={null} onSelect={vi.fn()} />);
+
+  expect(screen.getByText("토스증권이 만든")).toBeInTheDocument();
+  expect(screen.getByText("auto_trader가 만든")).toBeInTheDocument();
+  // All presets still render their selectable button regardless of group.
+  expect(screen.getByTestId("screener-preset-consecutive_gainers")).toBeInTheDocument();
+  expect(screen.getByTestId("screener-preset-kr_high_volume_surge")).toBeInTheDocument();
+});
+
+test("shows a parity marker for mismatch/partial presets only", () => {
+  render(<ScreenerPresetSidebar presets={PRESETS} selectedId={null} onSelect={vi.fn()} />);
+
+  // mismatch preset surfaces the "차이" marker; full preset does not.
+  expect(screen.getByText("차이")).toBeInTheDocument();
+  const full = screen.getByTestId("screener-preset-consecutive_gainers");
+  expect(full.textContent).not.toContain("차이");
+});
+
+test("omits the auto_trader heading when there are no original presets", () => {
+  const tossOnly = PRESETS.filter((p) => p.presetOrigin !== "auto_trader_original");
+  render(<ScreenerPresetSidebar presets={tossOnly} selectedId={null} onSelect={vi.fn()} />);
+
+  expect(screen.queryByText("auto_trader가 만든")).not.toBeInTheDocument();
+});

--- a/frontend/invest/src/desktop/screener/ScreenerPresetSidebar.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerPresetSidebar.tsx
@@ -7,7 +7,57 @@ interface Props {
   onSelect: (id: string) => void;
 }
 
+function PresetItem({
+  preset,
+  active,
+  onSelect,
+}: {
+  preset: ScreenerPreset;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  // ROB-359 Scope B: surface honest divergence from Toss without fabricating it.
+  const parityLabel =
+    preset.parityStatus === "partial"
+      ? "일부"
+      : preset.parityStatus === "mismatch"
+        ? "차이"
+        : null;
+  return (
+    <li>
+      <button
+        type="button"
+        data-testid={`screener-preset-${preset.id}`}
+        className={active ? "screener-preset-item-active" : "screener-preset-item"}
+        onClick={() => onSelect(preset.id)}
+        aria-current={active ? "true" : undefined}
+        title={preset.parityNote ?? undefined}
+      >
+        <span>{preset.name}</span>
+        <span className="screener-preset-tags">
+          {preset.badges.includes("인기") && (
+            <span className="screener-preset-badge">인기</span>
+          )}
+          {parityLabel && (
+            <span
+              className="screener-preset-parity"
+              data-parity={preset.parityStatus ?? undefined}
+            >
+              {parityLabel}
+            </span>
+          )}
+        </span>
+      </button>
+    </li>
+  );
+}
+
 export function ScreenerPresetSidebar({ presets, selectedId, onSelect }: Props) {
+  // auto_trader-original presets are NOT made by Toss; group them separately so
+  // the "토스증권이 만든" heading stays truthful. Unknown origin defaults to the
+  // Toss group to preserve prior behavior during the additive rollout.
+  const tossPresets = presets.filter((p) => p.presetOrigin !== "auto_trader_original");
+  const ownPresets = presets.filter((p) => p.presetOrigin === "auto_trader_original");
   return (
     <div className="screener-sidebar" aria-label="주식 골라보기 목록">
       <div className="screener-sidebar-section">
@@ -16,30 +66,36 @@ export function ScreenerPresetSidebar({ presets, selectedId, onSelect }: Props) 
           직접 만들기 (준비중)
         </button>
       </div>
-      <div className="screener-sidebar-section">
-        <div className="screener-sidebar-heading">토스증권이 만든</div>
-        <ul className="screener-preset-list">
-          {presets.map((p) => {
-            const active = p.id === selectedId;
-            return (
-              <li key={p.id}>
-                <button
-                  type="button"
-                  data-testid={`screener-preset-${p.id}`}
-                  className={active ? "screener-preset-item-active" : "screener-preset-item"}
-                  onClick={() => onSelect(p.id)}
-                  aria-current={active ? "true" : undefined}
-                >
-                  <span>{p.name}</span>
-                  {p.badges.includes("인기") && (
-                    <span className="screener-preset-badge">인기</span>
-                  )}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+      {tossPresets.length > 0 && (
+        <div className="screener-sidebar-section">
+          <div className="screener-sidebar-heading">토스증권이 만든</div>
+          <ul className="screener-preset-list">
+            {tossPresets.map((p) => (
+              <PresetItem
+                key={p.id}
+                preset={p}
+                active={p.id === selectedId}
+                onSelect={onSelect}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+      {ownPresets.length > 0 && (
+        <div className="screener-sidebar-section">
+          <div className="screener-sidebar-heading">auto_trader가 만든</div>
+          <ul className="screener-preset-list">
+            {ownPresets.map((p) => (
+              <PresetItem
+                key={p.id}
+                preset={p}
+                active={p.id === selectedId}
+                onSelect={onSelect}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -7,6 +7,9 @@
 .screener-preset-item:hover { background: var(--surface-2); }
 .screener-preset-item-active { background: var(--surface-2); color: var(--fg); font-weight: 700; }
 .screener-preset-badge { font-size: 10px; background: var(--accent-soft); color: var(--accent-press); border-radius: 4px; padding: 2px 6px; font-weight: 600; }
+.screener-preset-tags { display: inline-flex; gap: 4px; align-items: center; }
+.screener-preset-parity { font-size: 10px; border-radius: 4px; padding: 2px 6px; font-weight: 600; background: var(--surface-2); color: var(--fg-3); }
+.screener-preset-parity[data-parity="mismatch"] { color: var(--danger, #c0392b); }
 
 .screener-filter-bar { display: flex; flex-direction: column; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--divider); margin-bottom: 16px; }
 .screener-filter-title { font-size: 22px; margin: 0; color: var(--fg); font-weight: 800; letter-spacing: -0.02em; }

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -22,6 +22,9 @@ export interface ScreenerFilterChip {
   detail: string | null;
 }
 
+export type ScreenerPresetOrigin = "toss_parity" | "auto_trader_original";
+export type ScreenerParityStatus = "full" | "partial" | "mismatch";
+
 export interface ScreenerPreset {
   id: string;
   name: string;
@@ -30,6 +33,10 @@ export interface ScreenerPreset {
   filterChips: ScreenerFilterChip[];
   metricLabel: string;
   market: ScreenerMarket;
+  // ROB-359 Scope B (additive, optional during transition).
+  presetOrigin?: ScreenerPresetOrigin;
+  parityStatus?: ScreenerParityStatus | null;
+  parityNote?: string | null;
 }
 
 export interface ScreenerPresetsResponse {

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -86,6 +86,13 @@ def test_screener_presets_endpoint_returns_catalog() -> None:
     assert len(body["presets"]) >= 6
     assert body["selectedPresetId"] == "consecutive_gainers"
     assert any(p["id"] == "consecutive_gainers" for p in body["presets"])
+    # ROB-359 Scope B — catalog provenance flows through the API contract.
+    by_id = {p["id"]: p for p in body["presets"]}
+    assert by_id["consecutive_gainers"]["presetOrigin"] == "toss_parity"
+    assert by_id["consecutive_gainers"]["parityStatus"] == "full"
+    assert by_id["kr_high_volume_surge"]["presetOrigin"] == "auto_trader_original"
+    assert by_id["oversold_recovery"]["parityStatus"] == "mismatch"
+    assert by_id["oversold_recovery"]["parityNote"]
 
 
 @pytest.mark.unit

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -100,6 +100,60 @@ def test_crypto_preset_definitions_are_crypto_scoped() -> None:
 
 
 @pytest.mark.unit
+def test_every_kr_preset_declares_origin() -> None:
+    # ROB-359 Scope B: the catalog must separate Toss-parity presets from
+    # auto_trader-original ones; no KR preset may leave presetOrigin unset.
+    for p in preset_definitions("kr"):
+        assert p.presetOrigin in {"toss_parity", "auto_trader_original"}, p.id
+
+
+@pytest.mark.unit
+def test_auto_trader_original_presets_are_flagged() -> None:
+    by_id = {p.id: p for p in preset_definitions("kr")}
+    for pid in ("kr_high_volume_surge", "investor_flow_momentum"):
+        assert by_id[pid].presetOrigin == "auto_trader_original", pid
+        # Parity status is meaningless for auto_trader-original presets.
+        assert by_id[pid].parityStatus is None, pid
+
+
+@pytest.mark.unit
+def test_toss_parity_presets_have_a_parity_status() -> None:
+    for p in preset_definitions("kr"):
+        if p.presetOrigin == "toss_parity":
+            assert p.parityStatus in {"full", "partial", "mismatch"}, p.id
+
+
+@pytest.mark.unit
+def test_already_implemented_presets_marked_full() -> None:
+    by_id = {p.id: p for p in preset_definitions("kr")}
+    # ROB-170 / ROB-276 shipped real Toss parity for these.
+    assert by_id["consecutive_gainers"].parityStatus == "full"
+    assert by_id["double_buy"].parityStatus == "full"
+
+
+@pytest.mark.unit
+def test_partial_and_mismatch_presets_explain_the_gap() -> None:
+    by_id = {p.id: p for p in preset_definitions("kr")}
+    assert by_id["cheap_value"].parityStatus == "partial"
+    assert by_id["steady_dividend"].parityStatus == "partial"
+    assert by_id["oversold_recovery"].parityStatus == "mismatch"
+    assert by_id["growth_expectation"].parityStatus == "mismatch"
+    # Honest divergence must be explained, not silently approximated.
+    for pid in ("cheap_value", "steady_dividend", "oversold_recovery", "growth_expectation"):
+        assert by_id[pid].parityNote, pid
+    # partial presets specifically flag the un-implementable conditions.
+    for pid in ("cheap_value", "steady_dividend"):
+        assert "확인 불가" in (by_id[pid].parityNote or ""), pid
+
+
+@pytest.mark.unit
+def test_crypto_presets_are_auto_trader_original() -> None:
+    for p in preset_definitions("crypto"):
+        assert p.presetOrigin == "auto_trader_original", p.id
+        assert p.parityStatus is None, p.id
+
+
+@pytest.mark.unit
 def test_crypto_screening_filters_are_read_only_market_filters() -> None:
     high_volume = screening_filters_for("crypto_high_volume", "crypto")
     oversold = screening_filters_for("crypto_oversold", "crypto")

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -139,7 +139,12 @@ def test_partial_and_mismatch_presets_explain_the_gap() -> None:
     assert by_id["oversold_recovery"].parityStatus == "mismatch"
     assert by_id["growth_expectation"].parityStatus == "mismatch"
     # Honest divergence must be explained, not silently approximated.
-    for pid in ("cheap_value", "steady_dividend", "oversold_recovery", "growth_expectation"):
+    for pid in (
+        "cheap_value",
+        "steady_dividend",
+        "oversold_recovery",
+        "growth_expectation",
+    ):
         assert by_id[pid].parityNote, pid
     # partial presets specifically flag the un-implementable conditions.
     for pid in ("cheap_value", "steady_dividend"):


### PR DESCRIPTION
## ROB-359 PR3 — Scope B (preset catalog 정리)

Third slice of the ROB-359 umbrella. Adds **additive, optional** catalog metadata so `/invest/screener` distinguishes Toss 골라보기 baseline presets from auto_trader-original ones, and **honestly marks parity divergence** (partial/mismatch) instead of silently approximating Toss semantics.

Satisfies the Scope B acceptance criteria:
- KR preset catalog separates Toss-parity presets from auto_trader 자체 presets.
- The mismatch/partial presets (저평가 탈출, 성장 기대주, 꾸준한 배당주, 아직 저렴한 가치주) are explicitly marked `partial`/`mismatch` with a `확인 불가` note rather than rewritten to fake conditions.

### Backend
- `ScreenerPreset` gains optional `presetOrigin` (`toss_parity` | `auto_trader_original`), `parityStatus` (`full` | `partial` | `mismatch`), `parityNote`. All `None`-default → non-breaking against `extra="forbid"` and existing constructions/tests.
- Populated for all 8 KR + 3 crypto presets:
  | status | presets |
  |---|---|
  | full | `consecutive_gainers` (ROB-170), `double_buy` (ROB-276) |
  | partial | `cheap_value`, `steady_dividend` — parityNote names the un-implementable conditions as `확인 불가` |
  | mismatch | `oversold_recovery` (RSI vs PER/PBR/신고가), `growth_expectation` (market_cap/등락률 vs 순이익 성장) |
  | auto_trader_original | `kr_high_volume_surge`, `investor_flow_momentum`, crypto presets |
- `GET /invest/api/screener/presets` passes the fields through (FastAPI auto-serialize); no route change needed.

### Frontend
- Sidebar groups presets by origin: auto_trader-original presets move out of the **"토스증권이 만든"** heading into a new **"auto_trader가 만든"** section — fixes the prior mislabeling of `거래량 급증` / `수급 모멘텀` as Toss-made. Empty sections are not rendered.
- partial/mismatch presets show a small marker (`일부`/`차이`) with `parityNote` as tooltip.
- `ScreenerPreset` TS type extended with the optional fields. Unknown origin defaults to the Toss group during rollout.

### Tests
- backend: preset catalog parity-metadata assertions (`tests/test_invest_screener_presets.py`) + API contract assertion (`tests/test_invest_api_screener_router.py`). **36 passed**, `ruff check app/ tests/` clean.
- frontend: `ScreenerPresetSidebar.test.tsx` (grouping + parity marker + empty-section). typecheck clean, **vitest 9 passed** (`--pool=forks`).

### Scope boundaries
- **No filter/behavior change** — presets still screen the same rows; this is metadata + display only.
- No migration. No broker/order/watch/order-intent mutation.
- Honest `partial`/`mismatch` + `확인 불가` labeling, no fabricated results. Toss/Naver remain benchmark references, not production source-of-truth.

### Not in this PR (follow-up)
- 고수익 저평가 (ROE≥15 + PER 0~10) — implementable now from existing `market_valuation_snapshots`; candidate next PR.
- The other missing presets + partial residual conditions need a new 재무제표 source → separate issue (Scope C).
- Snapshot freshness cadence stays with ROB-280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)