### PR TITLE
fix(ROB-361): funding+OI metrics CSV parser handles quoted-empty cells

### DIFF
--- a/research/nautilus_scalping/funding_oi_archive.py
+++ b/research/nautilus_scalping/funding_oi_archive.py
@@ -18,7 +18,7 @@ Confirmed archive schemas (read-only public probe, ROB-356):
         count_long_short_ratio,sum_taker_long_short_vol_ratio
         - create_time: STRING UTC datetime ("YYYY-MM-DD HH:MM:SS"), 5-min grid
         - duplicate (symbol, create_time) rows occur -> deduped (first wins)
-        - ratio columns may be blank -> None (OI columns still parse)
+        - ratio columns may be blank OR CSV-quoted-empty ("") -> None (OI still parses)
 
 No OHLCV/volume/wick proxy is ever used for OI: ``sum_open_interest`` comes straight
 from the metrics archive.
@@ -26,6 +26,7 @@ from the metrics archive.
 
 from __future__ import annotations
 
+import csv
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -69,17 +70,22 @@ def _float_or_none(cell: str) -> float | None:
     return float(cell) if cell else None
 
 
-def _data_lines(text: str, header_token: str) -> list[str]:
-    """Non-blank lines minus a possible header row."""
-    out: list[str] = []
+def _data_rows(text: str, header_token: str):
+    """Yield parsed CSV field-lists for non-blank, non-header rows.
+
+    Uses ``csv.reader`` (not ``str.split(",")``) so CSV-quoted-empty cells (``""``,
+    common for ratio columns on low-liquidity / delisted symbols) unquote to ``""``
+    rather than surviving as the literal 2-char string — see ROB-360/ROB-361.
+    """
+    lines: list[str] = []
     for raw in text.splitlines():
         line = raw.strip()
         if not line:
             continue
         if line.split(",", 1)[0] == header_token:  # header
             continue
-        out.append(line)
-    return out
+        lines.append(line)
+    return csv.reader(lines)
 
 
 def parse_funding_csv(text: str) -> list[FundingRow]:
@@ -90,7 +96,7 @@ def parse_funding_csv(text: str) -> list[FundingRow]:
             funding_interval_hours=int(c[1]),
             last_funding_rate=float(c[2]),
         )
-        for c in (line.split(",") for line in _data_lines(text, _FUNDING_HEADER))
+        for c in _data_rows(text, _FUNDING_HEADER)
     ]
     return sorted(rows, key=lambda r: r.calc_time)
 
@@ -100,7 +106,7 @@ def parse_metrics_csv(text: str) -> list[MetricRow]:
     sorted ascending by ``create_time``."""
     seen: set[tuple[str, int]] = set()
     rows: list[MetricRow] = []
-    for c in (line.split(",") for line in _data_lines(text, _METRICS_HEADER)):
+    for c in _data_rows(text, _METRICS_HEADER):
         ts = _metrics_time_to_epoch_ms(c[0])
         symbol = c[1].strip()
         key = (symbol, ts)

--- a/research/nautilus_scalping/tests/test_funding_oi_archive.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_archive.py
@@ -133,3 +133,22 @@ def test_parse_metrics_csv_empty_ratio_field_is_none():
     assert r.sum_open_interest == 39080.231
     assert r.count_toptrader_long_short_ratio is None
     assert r.sum_taker_long_short_vol_ratio is None
+
+
+def test_parse_metrics_csv_quoted_empty_ratio_field_is_none():
+    # REAL archives (ROB-360 finding) encode empty ratio columns as CSV-quoted empty
+    # fields ("") rather than bare blanks. A naive split(",") leaves the literal 2-char
+    # string '""' and float('""') raises -> the whole symbol was being SKIP'd, which
+    # disproportionately killed 2022-era delisted symbols (ROB-349 survivorship). The
+    # parser must treat a quoted-empty cell as None and still parse populated columns.
+    csv = METRICS_HEADER + (
+        '2022-01-26 03:35:00,1000BTTCUSDT,2023567.00000000,4176.01498223,"","",8.5,""\n'
+    )
+    (r,) = foa.parse_metrics_csv(csv)
+    assert r.symbol == "1000BTTCUSDT"
+    assert r.sum_open_interest == 2023567.0
+    assert r.sum_open_interest_value == 4176.01498223
+    assert r.count_toptrader_long_short_ratio is None
+    assert r.sum_toptrader_long_short_ratio is None
+    assert r.count_long_short_ratio == 8.5
+    assert r.sum_taker_long_short_vol_ratio is None


### PR DESCRIPTION
## What

ROB-361 — bounded fix-only follow-up split out of **ROB-360** (post-merge operator RUN/evidence closure for ROB-356).

`data.binance.vision` USD-M **daily metrics** CSVs encode empty ratio columns as CSV-quoted empty fields (`""`), e.g.:

```
2022-01-26 03:35:00,1000BTTCUSDT,2023567.00000000,4176.01498223,"","",8.5,""
```

`funding_oi_archive.py::parse_metrics_csv` parsed rows with a naive `line.split(",")`, so a quoted-empty field survived as the literal 2-char string `""` → `_float_or_none('""')` → `float('""')` → **ValueError** → whole symbol `SKIP`'d.

## Why it mattered

The `""` empties cluster in low-liquidity periods, so this disproportionately killed **2022-era delisted/dead symbols** — exactly the population ROB-349 survivorship-safe coverage validation depends on. ROB-360's smoke `needs_more_data` verdict was therefore a **parser-induced false negative**, not a real coverage gap.

## Fix

- `parse_metrics_csv` **and** `parse_funding_csv` now parse via `csv.reader` (shared `_data_rows` helper) instead of `str.split(",")`. Quoted-empty cells unquote to `""` and map to `None`.
- Added a quoted-empty regression fixture mirroring the real archive line (`test_parse_metrics_csv_quoted_empty_ratio_field_is_none`).
- No change to readiness thresholds, verdict logic, or the `funding_oi_coverage.v1` schema.

## Verification

- **Unit:** `tests/test_funding_oi_archive.py` + `tests/test_funding_oi_features.py` → **22 passed** (pure stdlib; `uv run --no-project --with pytest`). The 7 unrelated collection errors in the dir are pre-existing `ModuleNotFoundError: numpy`/nautilus (research `--no-project` venv), not touched by this change.
- **End-to-end against public archive:** limit-6 smoke went from **5/6 SKIP → 6/6 parsed**; all five 2022-era dead symbols (`1000BTTCUSDT`, `AKROUSDT`, `ANCUSDT`, `ANTUSDT`, `AUDIOUSDT`) now yield rows with survivorship intact. Verdict now operates on real parsed data.
- `ruff check` on changed files: clean.

## Scope / safety

`research/` only (outside app CI ruff scope). No strategy/backtest/parameter sweep; no raw Binance market data committed; no broker/order/watch/order-intent mutation; no Demo `confirm=true`; no live/mainnet endpoints; no scheduler/daemon; no prod DB write.

## Follow-up

After this lands, **ROB-360** resumes the closure RUN. If the post-fix full `--limit 0` RUN proves too heavy (`--limit 40` already timed out at 480s), a **separate** resumability / stratified-selection follow-up should be opened — not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSV parsing for funding and metrics data to properly handle empty ratio fields, improving data import reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->