### PR TITLE
feat(ROB-359): /invest/reports new-buy candidate screener-evidence lineage (Scope E, PR5)

### DIFF
--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -162,6 +162,11 @@ def _candidate_item(
         "candidate_score": cand.get("score"),
         "candidate_reasons": cand.get("reasons"),
         "candidate_source": cand.get("source"),
+        # ROB-359 Scope E — screener evidence lineage so the report can show why
+        # a new-buy candidate surfaced (preset hit / freshness / Toss parity).
+        "candidate_source_preset": cand.get("source_preset"),
+        "candidate_data_state": cand.get("data_state"),
+        "candidate_toss_parity_status": cand.get("toss_parity_status"),
         "news_matches": news_match_count,
         "quote_status": q.get("status") if quote is not None else "no_snapshot",
         "best_bid": q.get("best_bid"),

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -113,6 +113,24 @@ def _crypto_row_to_input(row: InvestCryptoScreenerSnapshot) -> dict[str, Any]:
     }
 
 
+def _toss_parity_status(preset: str, market: str) -> str:
+    """ROB-359 Scope E — map the candidate ranking/preset to its Toss-parity
+    status so the report can state honestly where a candidate came from.
+
+    The current collector sources candidates from a top-movers ranking
+    (``top_gainers`` / ``crypto_momentum``), which is NOT a Toss-parity preset,
+    so this returns ``not_toss_parity``. When candidate sourcing is wired to the
+    actual Toss-parity catalog presets (candidate strategy — ROB-346), a real
+    ``full``/``partial``/``mismatch`` status flows through automatically.
+    """
+    from app.services.invest_view_model.screener_presets import get_preset
+
+    preset_def = get_preset(preset, market="crypto" if market == "crypto" else "kr")
+    if preset_def is None or preset_def.presetOrigin != "toss_parity":
+        return "not_toss_parity"
+    return preset_def.parityStatus or "not_toss_parity"
+
+
 def _source_coverage(evidence: list[CandidateEvidence]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for ev in evidence:
@@ -273,8 +291,18 @@ class CandidateUniverseSnapshotCollector:
         usefulness: str,
     ) -> SnapshotCollectResult:
         freshness_status = _FRESHNESS_BY_USEFULNESS.get(usefulness, "partial")
+        # ROB-359 Scope E — stamp universe-level lineage onto each candidate dict
+        # so a new-buy report item is self-describing (preset hit / freshness /
+        # Toss parity status) without needing the universe payload for context.
+        toss_parity_status = _toss_parity_status(preset, market)
         candidates = [
-            {**e.to_payload_dict(), "rank": rank, "candidate_rank": rank}
+            {
+                **e.to_payload_dict(),
+                "rank": rank,
+                "candidate_rank": rank,
+                "data_state": freshness_status,
+                "toss_parity_status": toss_parity_status,
+            }
             for rank, e in enumerate(evidence, start=1)
         ]
         universe_count = fresh_count + stale_count

--- a/app/services/screener_evidence/builder.py
+++ b/app/services/screener_evidence/builder.py
@@ -103,6 +103,7 @@ def build_candidate_evidence(
                 reasons=reasons,
                 source=_source_of(row, market),
                 risk_flags=_risk_flags(row),
+                source_preset=preset,
             )
         )
 

--- a/app/services/screener_evidence/models.py
+++ b/app/services/screener_evidence/models.py
@@ -20,6 +20,12 @@ class CandidateEvidence:
     reasons: list[str]  # Korean reason strings
     source: str  # provenance: tvscreener_upbit / upbit_official / kis / yahoo / ...
     risk_flags: list[str]  # Korean risk labels, e.g. "Upbit 유의 종목"
+    # ROB-359 Scope E — provenance lineage so /invest/reports can explain why a
+    # new-buy candidate surfaced. ``source_preset`` is the ranking/preset that
+    # produced this candidate (e.g. "top_gainers", "crypto_momentum"). Universe-
+    # level descriptors (freshness/parity) are stamped onto the payload candidate
+    # dict by the collector, not here, to keep this transformer pure.
+    source_preset: str | None = None
 
     def to_payload_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -109,6 +109,11 @@ async def test_crypto_collector_emits_candidate_evidence(db_session):
     assert top["reasons"] == ["단기 상승 모멘텀 후보"]
     assert payload["source_coverage"] == {"tvscreener_upbit": 1}
     assert payload["usefulness"] == "useful"
+    # ROB-359 Scope E — per-candidate lineage so a new-buy item is self-describing.
+    assert top["source_preset"] == "crypto_momentum"
+    assert top["data_state"] == "fresh"  # usefulness "useful" → fresh
+    # crypto_momentum is an auto_trader-original preset, not a Toss-parity one.
+    assert top["toss_parity_status"] == "not_toss_parity"
 
 
 @pytest.mark.asyncio

--- a/tests/services/screener_evidence/test_builder.py
+++ b/tests/services/screener_evidence/test_builder.py
@@ -15,6 +15,7 @@ def test_candidate_evidence_to_payload_dict_round_trips():
         reasons=["단기 상승 모멘텀 후보"],
         source="tvscreener_upbit",
         risk_flags=[],
+        source_preset="crypto_momentum",
     )
     payload = ev.to_payload_dict()
     assert payload == {
@@ -29,6 +30,7 @@ def test_candidate_evidence_to_payload_dict_round_trips():
         "reasons": ["단기 상승 모멘텀 후보"],
         "source": "tvscreener_upbit",
         "risk_flags": [],
+        "source_preset": "crypto_momentum",
     }
 
 
@@ -106,6 +108,8 @@ def test_builder_equity_top_gainers_uses_change_rate_and_source():
     assert out[0].score_label == "+3.00%"
     assert out[0].reasons == ["단기 상승 모멘텀 후보", "3일 연속 상승"]
     assert out[0].volume_value == 14_000_000.0
+    # ROB-359 Scope E — provenance lineage records which ranking surfaced it.
+    assert out[0].source_preset == "top_gainers"
 
 
 def test_builder_empty_rows_returns_empty():

--- a/tests/test_auto_emit_candidate_citation.py
+++ b/tests/test_auto_emit_candidate_citation.py
@@ -33,6 +33,9 @@ def test_buy_item_cites_candidate_evidence():
                         "score": 8.0,
                         "reasons": ["단기 상승 모멘텀 후보"],
                         "source": "kis",
+                        "source_preset": "top_gainers",
+                        "data_state": "fresh",
+                        "toss_parity_status": "not_toss_parity",
                     },
                 ],
             },
@@ -47,6 +50,10 @@ def test_buy_item_cites_candidate_evidence():
     assert ev["candidate_score"] == 8.0
     assert ev["candidate_source"] == "kis"
     assert ev["candidate_reasons"] == ["단기 상승 모멘텀 후보"]
+    # ROB-359 Scope E — screener evidence lineage on the new-buy item.
+    assert ev["candidate_source_preset"] == "top_gainers"
+    assert ev["candidate_data_state"] == "fresh"
+    assert ev["candidate_toss_parity_status"] == "not_toss_parity"
 
 
 def test_buy_candidates_follow_candidate_rank_and_limit():


### PR DESCRIPTION
## ROB-359 PR5 — Scope E (`/invest/reports` ↔ screener evidence lineage)

Attaches screener-evidence **lineage** to `/invest/reports` new-buy candidates so the report can explain *why* a candidate surfaced.

### Key finding (one half of Scope E was already done)
The `candidate_universe` collector (ROB-352 Slice C) already sources candidates **deterministically from `invest_screener_snapshots` / `invest_crypto_screener_snapshots`** — **not** from the MCP `recommend_stocks` tool. So "consume `/invest/screener` evidence, not `recommend_stocks`" was already satisfied, and PR1's registry-hiding of `recommend_stocks` did **not** break the report path (verified: 0 references in the report/bundle prep).

### What this PR adds (deterministic, in-process)
- `CandidateEvidence` gains **`source_preset`** (the ranking/preset that produced the candidate), set in the pure builder.
- The collector stamps universe-level **`data_state`** (freshness) and **`toss_parity_status`** onto each payload candidate dict, so a single new-buy item is self-describing without the universe payload.
- `auto_emit` surfaces **`candidate_source_preset` / `candidate_data_state` / `candidate_toss_parity_status`** into each `buy_review` item's `evidence_snapshot` (alongside the existing `candidate_usefulness` / score / reasons / source).

### Honest scoping + concrete follow-up (per the AC)
The collector currently sources from a **top-movers ranking** (`top_gainers` / `crypto_momentum`), which is **not** a Toss-parity preset — so `toss_parity_status` resolves to `not_toss_parity` today (derived from the screener catalog via `get_preset`; auto_trader-original/unknown presets are honestly *not* parity). Wiring candidate **sourcing** to the actual Toss-parity catalog presets (`consecutive_gainers` / `double_buy` / `high_yield_value`) so the field becomes `full`/`partial` is the **candidate-strategy follow-up → ROB-346**. The AC explicitly allows leaving a concrete follow-up for the not-yet-wired part; the lineage *plumbing* lands here so ROB-346 only changes the source.

### Boundaries
- **No Hermes-side change required** — unknown evidence keys are ignored; rendering the lineage in the report UI is a Hermes follow-up that can activate incrementally.
- No migration (JSONB `payload_json` / `evidence_snapshot`). No broker/order/watch/order-intent mutation. Held-position actions vs new-buy discovery stay separated (unchanged `classify_candidate_symbol`).

### Tests
- builder `source_preset`; collector per-candidate `data_state` + `toss_parity_status`; `auto_emit` evidence_snapshot lineage; payload round-trip updated.
- Local: **209 passed** across candidate/evidence/auto_emit suites; `ruff check` + `ruff format --check` clean.

### ROB-359 umbrella status after this PR
- A (matrix) PR2 ✅ · B (catalog provenance) PR3 ✅ · D (recommend_stocks registry-hidden) PR1 ✅ · E (reports lineage) **this PR** · bonus 고수익 저평가 PR4 ✅.
- C (재무제표 fundamentals source for the 4 remaining missing presets) and ROB-346 (candidate sourcing strategy / real parity hits) remain as separate follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)