### PR TITLE
feat(ROB-362): resumable + stratified funding+OI coverage RUN (PR1)

### DIFF
--- a/research/nautilus_scalping/build_funding_oi_features.py
+++ b/research/nautilus_scalping/build_funding_oi_features.py
@@ -17,7 +17,10 @@ See the durable report at ``docs/runbooks/rob-356-funding-oi-pit-features.md``.
 
 Usage (operator):
     cd research/nautilus_scalping
-    uv run --no-project python build_funding_oi_features.py --run --limit 40 --out
+    # representative coverage verdict in minutes (stratified across delisted+active):
+    uv run --no-project python build_funding_oi_features.py --run --stratified 40 --out
+    # resume a crashed/partial RUN (skips already-built symbols):
+    uv run --no-project python build_funding_oi_features.py --run --stratified 40 --out --resume
 """
 
 from __future__ import annotations
@@ -34,6 +37,7 @@ import urllib.request
 import zipfile
 from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime
+from pathlib import Path
 
 import funding_oi_features as fof
 import pit_universe as pu
@@ -121,6 +125,71 @@ def survivorship_ok(last_day: str | None, delisted_at: int | None) -> bool:
     if last_day is None:
         return False
     return last_day >= _day_str(delisted_at - 1)  # delisted_at is exclusive
+
+
+# --------------------------------------------------------------------------- #
+# ROB-362 — stratified subset + resumable progress checkpoint (pure; unit-tested)
+#   The full 552-symbol RUN is ~4.6h, non-resumable. A stratified subset returns a
+#   representative coverage verdict in minutes; the progress jsonl lets a crashed RUN
+#   resume by skipping already-built symbols. Both are pure/path-based for testability.
+# --------------------------------------------------------------------------- #
+def _evenly_spaced(seq: list, k: int) -> list:
+    """``k`` distinct, evenly-spread elements of ``seq`` (deterministic). Spreading
+    beats first-``k`` truncation, which alphabetically clusters short-lived symbols."""
+    if k <= 0:
+        return []
+    if k >= len(seq):
+        return list(seq)
+    return [seq[i * len(seq) // k] for i in range(k)]
+
+
+def stratified_sample(listings: list, n: int) -> list:
+    """Pick ~``n`` listings stratified across delisted (survivorship-critical, scarce)
+    and active strata, evenly spread within each. ``n<=0`` or ``n>=total`` -> all.
+    The scarce delisted stratum gets at least half of ``n``; active backfills the rest."""
+    if n <= 0 or n >= len(listings):
+        return list(listings)
+    delisted = sorted(
+        (x for x in listings if x.delisted_at is not None), key=lambda x: x.symbol
+    )
+    active = sorted(
+        (x for x in listings if x.delisted_at is None), key=lambda x: x.symbol
+    )
+    n_del = min(len(delisted), max(1, n // 2)) if delisted else 0
+    n_act = min(len(active), n - n_del)
+    n_del = min(len(delisted), n - n_act)  # backfill delisted if active ran short
+    return _evenly_spaced(delisted, n_del) + _evenly_spaced(active, n_act)
+
+
+def load_progress(path) -> list[dict]:
+    """Per-symbol coverage stats persisted by a prior RUN (one JSON object per line).
+    Tolerates a torn final line from a crash mid-write (that symbol is simply re-run)."""
+    p = Path(path)
+    if not p.exists():
+        return []
+    out: list[dict] = []
+    for line in p.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue  # partial trailing line from an interrupted write -> skip
+    return out
+
+
+def append_progress(path, record: dict) -> None:
+    """Atomically append one completed symbol's stats as a JSON line (resume checkpoint)."""
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def completed_symbols(records: list[dict]) -> set:
+    """Symbols already built (skip their network fetch on resume)."""
+    return {r["symbol"] for r in records if "symbol" in r}
 
 
 # --------------------------------------------------------------------------- #
@@ -261,7 +330,37 @@ def main(argv: list[str] | None = None) -> int:
         help="PIT universe manifest path.",
     )
     parser.add_argument(
-        "--limit", type=int, default=0, help="Cap symbols processed (0 = all)."
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap symbols to the first N of the manifest (0 = all). See --stratified.",
+    )
+    parser.add_argument(
+        "--stratified",
+        type=int,
+        default=0,
+        help=(
+            "Pick N symbols stratified across the delisted + active strata (a representative "
+            "coverage verdict in minutes instead of the ~4.6h full RUN). Takes precedence "
+            "over --limit. 0 = off."
+        ),
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "With --out: skip symbols already in the progress checkpoint and append new "
+            "ones (resume a crashed/partial RUN). Without it the RUN starts a fresh slate."
+        ),
+    )
+    parser.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=10,
+        help=(
+            "With --out: rewrite the coverage summary every N processed symbols so a crash "
+            "leaves an inspectable partial verdict (0 = only at completion)."
+        ),
     )
     parser.add_argument(
         "--out",
@@ -276,7 +375,9 @@ def main(argv: list[str] | None = None) -> int:
 
     manifest = pu.PITManifest.load(args.manifest).strict_usdt_perp()
     syms = list(manifest.listings)
-    if args.limit:
+    if args.stratified:
+        syms = stratified_sample(syms, args.stratified)
+    elif args.limit:
         syms = syms[: args.limit]
 
     if not args.run:
@@ -290,36 +391,61 @@ def main(argv: list[str] | None = None) -> int:
 
     from artifact_paths import resolve_artifact_path
 
+    thr = ReadinessThresholds()
     feat_dir = resolve_artifact_path("discovery", "rob356", "features")
+    summary_path = resolve_artifact_path(
+        "discovery", "rob356", "funding_oi_coverage.v1.json"
+    )
+    progress_path = resolve_artifact_path("discovery", "rob356", "_progress.jsonl")
+
+    def _write_summary(s: dict) -> None:
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(s, indent=2))
+
+    # Resume: skip symbols a prior RUN already built; otherwise start a fresh slate.
+    done: dict[str, dict] = {}
+    if args.out and args.resume:
+        done = {r["symbol"]: r for r in load_progress(progress_path)}
+        if done:
+            print(f"resume: {len(done)} symbols already built; skipping their fetch")
+    elif args.out:
+        Path(progress_path).unlink(missing_ok=True)
+
     stats: list[dict] = []
     for i, listing in enumerate(syms, 1):
+        if listing.symbol in done:
+            stats.append(done[listing.symbol])
+            print(f"  [{i}/{len(syms)}] {listing.symbol:14} resumed (cached)")
+            continue
         try:
             s = build_symbol(listing)
         except Exception as exc:  # noqa: BLE001 — coverage probe must be resilient per-symbol
             print(f"  [{i}/{len(syms)}] {listing.symbol}: SKIP ({type(exc).__name__})")
             continue
         feats = s.pop("_feats")
-        if args.out:  # --out gates ALL disk writes (feature CSVs + summary)
+        if args.out:  # --out gates ALL disk writes (feature CSVs + progress + summary)
             _write_feature_csv(feat_dir / f"{s['symbol']}.csv", feats)
+            append_progress(progress_path, s)  # checkpoint this symbol for resume
         stats.append(s)
         print(
             f"  [{i}/{len(syms)}] {s['symbol']:14} rows={s['feature_rows']:6} "
             f"oi={s['oi_first_day']}..{s['oi_last_day']} cov={s['oi_coverage']} "
             f"surv={int(s['survivorship_ok'])}"
         )
+        if args.out and args.checkpoint_every > 0 and i % args.checkpoint_every == 0:
+            _write_summary(summarize(stats, thr))  # partial verdict survives a crash
 
-    summary = summarize(stats, ReadinessThresholds())
+    summary = summarize(stats, thr)
     print("\nverdict:", summary["verdict"])
     for r in summary["verdict_reasons"]:
         print("  -", r)
 
     if args.out:
-        out = resolve_artifact_path(
-            "discovery", "rob356", "funding_oi_coverage.v1.json"
+        _write_summary(summary)
+        print(
+            "\nsummary + per-symbol feature CSVs written (gitignored): "
+            f"{summary_path.parent}"
         )
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(summary, indent=2))
-        print(f"\nsummary + per-symbol feature CSVs written (gitignored): {out.parent}")
     else:
         print("\n(no --out: nothing written to disk)")
     return 0

--- a/research/nautilus_scalping/build_funding_oi_features.py
+++ b/research/nautilus_scalping/build_funding_oi_features.py
@@ -180,16 +180,13 @@ def load_progress(path) -> list[dict]:
 
 
 def append_progress(path, record: dict) -> None:
-    """Atomically append one completed symbol's stats as a JSON line (resume checkpoint)."""
+    """Append one completed symbol's stats as a JSON line (resume checkpoint). A hard
+    kill mid-write can leave a torn final line; ``load_progress`` skips it and that one
+    symbol is simply re-built on the next resume."""
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     with open(p, "a") as fh:
         fh.write(json.dumps(record) + "\n")
-
-
-def completed_symbols(records: list[dict]) -> set:
-    """Symbols already built (skip their network fetch on resume)."""
-    return {r["symbol"] for r in records if "symbol" in r}
 
 
 # --------------------------------------------------------------------------- #
@@ -372,6 +369,12 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    if args.resume and not args.out:
+        parser.error(
+            "--resume requires --out (it reads the on-disk progress checkpoint)"
+        )
+    if args.checkpoint_every < 0:
+        parser.error("--checkpoint-every must be >= 0")
 
     manifest = pu.PITManifest.load(args.manifest).strict_usdt_perp()
     syms = list(manifest.listings)
@@ -396,13 +399,19 @@ def main(argv: list[str] | None = None) -> int:
     summary_path = resolve_artifact_path(
         "discovery", "rob356", "funding_oi_coverage.v1.json"
     )
+    partial_path = resolve_artifact_path(
+        "discovery", "rob356", "_partial_coverage.json"
+    )
     progress_path = resolve_artifact_path("discovery", "rob356", "_progress.jsonl")
 
-    def _write_summary(s: dict) -> None:
-        summary_path.parent.mkdir(parents=True, exist_ok=True)
-        summary_path.write_text(json.dumps(s, indent=2))
+    def _write_json(path, s: dict) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(s, indent=2))
 
-    # Resume: skip symbols a prior RUN already built; otherwise start a fresh slate.
+    # Resume: seed the verdict with EVERY symbol a prior RUN already built (not only those
+    # in the current selection) so resuming with a different --stratified/--limit can never
+    # drop on-disk coverage and flip a true `ready` to `needs_more_data`. Fresh (no
+    # --resume) starts a clean slate, clearing stale progress + partial artifacts.
     done: dict[str, dict] = {}
     if args.out and args.resume:
         done = {r["symbol"]: r for r in load_progress(progress_path)}
@@ -410,11 +419,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"resume: {len(done)} symbols already built; skipping their fetch")
     elif args.out:
         Path(progress_path).unlink(missing_ok=True)
+        Path(partial_path).unlink(missing_ok=True)
 
-    stats: list[dict] = []
+    stats: list[dict] = list(
+        done.values()
+    )  # all prior-built coverage counts in the verdict
     for i, listing in enumerate(syms, 1):
         if listing.symbol in done:
-            stats.append(done[listing.symbol])
             print(f"  [{i}/{len(syms)}] {listing.symbol:14} resumed (cached)")
             continue
         try:
@@ -432,8 +443,10 @@ def main(argv: list[str] | None = None) -> int:
             f"oi={s['oi_first_day']}..{s['oi_last_day']} cov={s['oi_coverage']} "
             f"surv={int(s['survivorship_ok'])}"
         )
+        # Interim verdict goes to a clearly-partial sidecar — NEVER the canonical file,
+        # so `funding_oi_coverage.v1.json` existing always means a COMPLETE RUN.
         if args.out and args.checkpoint_every > 0 and i % args.checkpoint_every == 0:
-            _write_summary(summarize(stats, thr))  # partial verdict survives a crash
+            _write_json(partial_path, summarize(stats, thr))
 
     summary = summarize(stats, thr)
     print("\nverdict:", summary["verdict"])
@@ -441,7 +454,8 @@ def main(argv: list[str] | None = None) -> int:
         print("  -", r)
 
     if args.out:
-        _write_summary(summary)
+        _write_json(summary_path, summary)  # canonical artifact = full completion only
+        Path(partial_path).unlink(missing_ok=True)  # drop the now-superseded partial
         print(
             "\nsummary + per-symbol feature CSVs written (gitignored): "
             f"{summary_path.parent}"

--- a/research/nautilus_scalping/tests/test_funding_oi_readiness.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_readiness.py
@@ -7,6 +7,7 @@ the builder must stop rather than hand off to a backtest.
 """
 
 import build_funding_oi_features as b
+import pit_universe as pu
 
 
 def _ready_inputs(**over):
@@ -117,3 +118,82 @@ def test_summarize_drops_internal_feats_and_emits_verdict():
     assert (
         out["verdict"] == "needs_more_data"
     )  # 9 rows < 1000 -> not usable -> 0 usable symbols
+
+
+# --------------------------------------------------------------------------- #
+# ROB-362 PR1 — stratified subset selection (pure; makes the coverage RUN cheap)
+# --------------------------------------------------------------------------- #
+def _mk(sym: str, delisted: bool = False) -> pu.SymbolListing:
+    return pu.SymbolListing(
+        symbol=sym,
+        listed_from=0,
+        delisted_at=(100 if delisted else None),
+        status=("dead" if delisted else "live"),
+    )
+
+
+def test_stratified_sample_respects_n_and_represents_both_strata():
+    listings = [_mk(f"D{i:02d}", delisted=True) for i in range(10)] + [
+        _mk(f"L{i:02d}") for i in range(30)
+    ]
+    sel = b.stratified_sample(listings, 12)
+    assert len(sel) == 12
+    assert sum(1 for x in sel if x.delisted_at is not None) >= 1  # delisted present
+    assert sum(1 for x in sel if x.delisted_at is None) >= 1  # active present
+
+
+def test_stratified_sample_favors_scarce_delisted_stratum():
+    # delisted symbols are the survivorship-critical, scarcer stratum -> >= half of n
+    listings = [_mk(f"D{i:02d}", delisted=True) for i in range(20)] + [
+        _mk(f"L{i:02d}") for i in range(20)
+    ]
+    sel = b.stratified_sample(listings, 10)
+    assert sum(1 for x in sel if x.delisted_at is not None) >= 5
+
+
+def test_stratified_sample_is_deterministic():
+    listings = [_mk(f"D{i:02d}", delisted=True) for i in range(20)] + [
+        _mk(f"L{i:02d}") for i in range(20)
+    ]
+    a = [x.symbol for x in b.stratified_sample(listings, 8)]
+    c = [x.symbol for x in b.stratified_sample(listings, 8)]
+    assert a == c
+    assert len(set(a)) == len(a)  # no duplicates
+
+
+def test_stratified_sample_n_ge_total_or_zero_returns_all():
+    listings = [_mk("D0", delisted=True), _mk("L0")]
+    assert len(b.stratified_sample(listings, 99)) == 2
+    assert len(b.stratified_sample(listings, 0)) == 2
+
+
+def test_stratified_sample_backfills_when_one_stratum_short():
+    # only 1 delisted available -> remaining slots backfill from active, n still honored
+    listings = [_mk("D0", delisted=True)] + [_mk(f"L{i:02d}") for i in range(20)]
+    sel = b.stratified_sample(listings, 10)
+    assert len(sel) == 10
+    assert sum(1 for x in sel if x.delisted_at is not None) == 1
+
+
+# --------------------------------------------------------------------------- #
+# ROB-362 PR1 — resumable progress checkpoint (crash-safe, skip-completed)
+# --------------------------------------------------------------------------- #
+def test_progress_roundtrip(tmp_path):
+    p = tmp_path / "discovery" / "rob356" / "_progress.jsonl"
+    b.append_progress(p, {"symbol": "AAA", "feature_rows": 5})
+    b.append_progress(p, {"symbol": "BBB", "feature_rows": 9})
+    recs = b.load_progress(p)
+    assert [r["symbol"] for r in recs] == ["AAA", "BBB"]
+    assert b.completed_symbols(recs) == {"AAA", "BBB"}
+
+
+def test_load_progress_missing_file_is_empty(tmp_path):
+    assert b.load_progress(tmp_path / "nope.jsonl") == []
+
+
+def test_load_progress_tolerates_torn_final_line(tmp_path):
+    # a crash mid-write leaves a partial last line; resume must not choke on it
+    p = tmp_path / "_progress.jsonl"
+    p.write_text('{"symbol": "AAA"}\n{"symbol": "BBB"}\n{"symbol": "CC')
+    recs = b.load_progress(p)
+    assert [r["symbol"] for r in recs] == ["AAA", "BBB"]

--- a/research/nautilus_scalping/tests/test_funding_oi_readiness.py
+++ b/research/nautilus_scalping/tests/test_funding_oi_readiness.py
@@ -6,6 +6,11 @@ ANY threshold (or unproven survivorship) -> ``needs_more_data`` with named reaso
 the builder must stop rather than hand off to a backtest.
 """
 
+import json
+import types
+
+import pytest
+
 import build_funding_oi_features as b
 import pit_universe as pu
 
@@ -184,7 +189,6 @@ def test_progress_roundtrip(tmp_path):
     b.append_progress(p, {"symbol": "BBB", "feature_rows": 9})
     recs = b.load_progress(p)
     assert [r["symbol"] for r in recs] == ["AAA", "BBB"]
-    assert b.completed_symbols(recs) == {"AAA", "BBB"}
 
 
 def test_load_progress_missing_file_is_empty(tmp_path):
@@ -197,3 +201,113 @@ def test_load_progress_tolerates_torn_final_line(tmp_path):
     p.write_text('{"symbol": "AAA"}\n{"symbol": "BBB"}\n{"symbol": "CC')
     recs = b.load_progress(p)
     assert [r["symbol"] for r in recs] == ["AAA", "BBB"]
+
+
+# --------------------------------------------------------------------------- #
+# ROB-362 PR1 — main() resume wiring (offline seam: stub network + manifest)
+# --------------------------------------------------------------------------- #
+def _fake_build(listing):
+    """Stand-in for the network ``build_symbol``: a usable, survivorship-ok symbol."""
+    return {
+        "symbol": listing.symbol,
+        "status": listing.status,
+        "delisted": listing.delisted_at is not None,
+        "feature_rows": 1000,
+        "oi_first_day": "2022-01-01",
+        "oi_last_day": "2024-01-01",
+        "oi_coverage": 1.0,
+        "missingness": 0.0,
+        "survivorship_ok": True,
+        "_feats": [],
+    }
+
+
+def _patch_run(monkeypatch, tmp_path, listings):
+    monkeypatch.setenv("AUTO_TRADER_RESEARCH_ARTIFACT_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        b.pu.PITManifest,
+        "load",
+        lambda path: types.SimpleNamespace(
+            strict_usdt_perp=lambda: types.SimpleNamespace(listings=listings)
+        ),
+    )
+
+
+def _coverage(tmp_path):
+    return json.loads(
+        (tmp_path / "discovery" / "rob356" / "funding_oi_coverage.v1.json").read_text()
+    )
+
+
+def test_main_resume_without_out_errors(monkeypatch, tmp_path):
+    _patch_run(monkeypatch, tmp_path, [_mk("L00")])
+    monkeypatch.setattr(b, "build_symbol", _fake_build)
+    with pytest.raises(SystemExit):  # --resume requires --out (no silent no-op)
+        b.main(["--run", "--resume"])
+
+
+def test_main_resume_keeps_all_prior_coverage_with_narrower_selection(
+    monkeypatch, tmp_path
+):
+    # A1 regression: resuming with a NARROWER selection must not drop on-disk coverage
+    # (which would flip a true `ready` to `needs_more_data`).
+    listings = [_mk(f"D{i:02d}", delisted=True) for i in range(6)] + [
+        _mk(f"L{i:02d}") for i in range(30)
+    ]
+    _patch_run(monkeypatch, tmp_path, listings)
+
+    built: list[str] = []
+
+    def _counting_build(listing):
+        built.append(listing.symbol)
+        return _fake_build(listing)
+
+    monkeypatch.setattr(b, "build_symbol", _counting_build)
+
+    assert b.main(["--run", "--out"]) == 0  # fresh full RUN over all 36
+    assert _coverage(tmp_path)["symbols_attempted"] == 36
+    assert len(built) == 36
+
+    built.clear()
+    assert b.main(["--run", "--out", "--limit", "4", "--resume"]) == 0
+    # all 36 prior-built symbols still counted; nothing re-fetched
+    assert _coverage(tmp_path)["symbols_attempted"] == 36
+    assert built == []
+
+
+def test_main_fresh_run_clears_stale_progress(monkeypatch, tmp_path):
+    listings = [_mk(f"L{i:02d}") for i in range(5)]
+    _patch_run(monkeypatch, tmp_path, listings)
+    monkeypatch.setattr(b, "build_symbol", _fake_build)
+
+    assert b.main(["--run", "--out"]) == 0
+    assert _coverage(tmp_path)["symbols_attempted"] == 5
+    # a second fresh (no --resume) run starts a clean slate, not double-counted
+    assert b.main(["--run", "--out"]) == 0
+    assert _coverage(tmp_path)["symbols_attempted"] == 5
+
+
+def test_main_canonical_file_only_on_completion_partial_goes_to_sidecar(
+    monkeypatch, tmp_path
+):
+    # checkpoint writes the sidecar, NOT the canonical file -> canonical existing
+    # always means a complete RUN.
+    listings = [_mk(f"L{i:02d}") for i in range(4)]
+    _patch_run(monkeypatch, tmp_path, listings)
+
+    seen = {"canonical_during_checkpoint": None}
+    real_build = _fake_build
+    canonical = tmp_path / "discovery" / "rob356" / "funding_oi_coverage.v1.json"
+
+    def _build_checking_canonical(listing):
+        # at the first checkpoint (after 2 symbols) the canonical file must not exist yet
+        if listing.symbol == "L03" and seen["canonical_during_checkpoint"] is None:
+            seen["canonical_during_checkpoint"] = canonical.exists()
+        return real_build(listing)
+
+    monkeypatch.setattr(b, "build_symbol", _build_checking_canonical)
+    assert b.main(["--run", "--out", "--checkpoint-every", "2"]) == 0
+    assert seen["canonical_during_checkpoint"] is False  # not written mid-run
+    assert canonical.exists()  # written at completion
+    # partial sidecar cleared once the canonical (final) verdict exists
+    assert not (tmp_path / "discovery" / "rob356" / "_partial_coverage.json").exists()


### PR DESCRIPTION
## What

PR1 of **ROB-362** — the fork-B "close the crypto strategy book" plan. Makes the ROB-356 funding+OI coverage RUN practical so the ROB-360 closure RUN can actually complete.

Today: `build_funding_oi_features.py` is **~30s/symbol × 552 ≈ 4.6h+**, **non-resumable**, and writes its verdict **only at full completion** — a crash/sleep/network blip loses everything (confirmed in ROB-360 `e8ccc500`, which is exactly what blocks the closure RUN).

## Changes (`build_funding_oi_features.py`)

- **`stratified_sample(listings, n)`** — pick ~N symbols evenly spread across the **delisted** (survivorship-critical, scarce → gets ≥ half) and **active** strata. A representative coverage verdict in minutes instead of 4.6h. Even-spread beats first-N truncation (which alphabetically clusters short-lived symbols).
- **`load_progress` / `append_progress` / `completed_symbols`** — per-symbol stats checkpoint (one JSON line each) under the gitignored artifact root; tolerates a torn final line from a crash.
- **`main()` flags**: `--stratified N` (precedence over `--limit`), `--resume` (skip already-built symbols, reuse their feature CSV), `--checkpoint-every N` (rewrite the coverage summary mid-run so a crash leaves an inspectable partial verdict).

No change to readiness thresholds, verdict logic, or the `funding_oi_coverage.v1` schema. Pure-stdlib; research/ outside app CI ruff scope.

## Verification

- **Unit (TDD):** 8 new tests (stratified: both strata represented, ≥half delisted, deterministic/no-dups, n≥total/0→all, backfill; progress: roundtrip, missing-file, torn-final-line). `tests/test_funding_oi_readiness.py` + archive + features → **42 passed**.
- **End-to-end against public archive:** `--stratified 4` selected 2 delisted (1000BTTCUSDT, FOOTBALLUSDT) + 2 active (0GUSDT, KITEUSDT); a `--resume` re-run skipped all 4 with **zero network fetch in 0.22s** (vs minutes fresh), identical verdict, no duplicate progress appends. `--checkpoint-every 2` wrote the summary mid-run.
- `ruff check` + `ruff format --check` on changed files: clean.

## Next (separate slices, gated)

- **PR2 (RUN):** run the stratified coverage pass → produce/verify `funding_oi_coverage.v1.json`.
- **PR3 (conditional on coverage=`ready`):** ONE gross-triage on the OI-crowding signal via the existing cost-blind screen, ROB-342 pre-registered as the skeptical prior; if gross ≤ 0.5bps floor → write the auditable negative and **close the crypto strategy line**.

## Safety

`research/` only. No strategy/backtest/sweep, no broker/order/watch mutation, no Demo `confirm=true`, no live/mainnet endpoints, no scheduler/DB, no raw market data committed, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--stratified` flag to sample representative subsets across delisted and active listings.
  * Added `--resume` flag to reuse progress checkpoints and skip already-completed symbols.
  * Added `--checkpoint-every` flag for periodic intermediate summary reports during long runs.
  * Introduced JSONL-based progress tracking with end-of-run and intermediate summaries.

* **Tests**
  * Added comprehensive test coverage for stratified sampling and progress checkpoint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->