### PR TITLE
feat(ROB-363): KR double_buy + high_yield_value sourcing + cross-preset merge (PR2/3)

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -11,6 +11,7 @@ read-only and degrades to ``unavailable`` on exception.
 
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
 from collections.abc import Callable, Hashable
 from typing import Any
@@ -113,9 +114,12 @@ def _crypto_row_to_input(row: InvestCryptoScreenerSnapshot) -> dict[str, Any]:
     }
 
 
-def _preset_row_to_input(preset: str, row: dict[str, Any]) -> dict[str, Any]:
+def _preset_row_to_input(row: dict[str, Any]) -> dict[str, Any]:
     """Normalize any KR Toss-parity loader row into builder input, carrying the
-    fundamental fields each preset's builder branch needs (ROB-363)."""
+    fundamental fields each preset's builder branch needs (ROB-363).
+
+    Normalization is uniform across presets — the builder selects which fields
+    to score by the ``preset`` argument it is given separately."""
     return {
         "symbol": row.get("symbol"),
         "name": row.get("name") or row.get("symbol"),
@@ -141,8 +145,6 @@ def _merge_evidence(
     UNIONS ``reasons`` + ``risk_flags`` (order-preserving, deduped) from every
     preset that surfaced the symbol, so per-source provenance is preserved.
     Order-preserving on first occurrence."""
-    import dataclasses
-
     order: list[Hashable] = []
     merged: dict[Hashable, CandidateEvidence] = {}
     for ev in evidence:
@@ -342,7 +344,7 @@ class CandidateUniverseSnapshotCollector:
             built = build_candidate_evidence(
                 market="kr",
                 preset=preset_id,
-                rows=[_preset_row_to_input(preset_id, r) for r in rows],
+                rows=[_preset_row_to_input(r) for r in rows],
             )
             # Map freshness by symbol from the raw loader rows — NOT by zipping
             # against ``built``, which build_candidate_evidence re-sorts by score

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -113,25 +113,6 @@ def _crypto_row_to_input(row: InvestCryptoScreenerSnapshot) -> dict[str, Any]:
     }
 
 
-def _gainers_row_to_input(row: dict[str, Any]) -> dict[str, Any]:
-    """Normalize a consecutive_gainers loader row into builder input.
-
-    The loader emits ``close``/``week_change_rate``/``consecutive_up_days``/
-    ``volume`` plus ``_screener_snapshot_state`` (ROB-363). The builder's
-    momentum branch reads these via the close/volume fallbacks and appends the
-    연속 상승 reason.
-    """
-    return {
-        "symbol": row.get("symbol"),
-        "name": row.get("name") or row.get("symbol"),
-        "source": row.get("source") or "kis",
-        "change_rate": row.get("change_rate"),
-        "close": row.get("close"),
-        "volume": row.get("volume"),
-        "consecutive_up_days": row.get("consecutive_up_days"),
-    }
-
-
 def _preset_row_to_input(preset: str, row: dict[str, Any]) -> dict[str, Any]:
     """Normalize any KR Toss-parity loader row into builder input, carrying the
     fundamental fields each preset's builder branch needs (ROB-363)."""

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -132,23 +132,55 @@ def _gainers_row_to_input(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _dedupe_evidence(
+def _preset_row_to_input(preset: str, row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize any KR Toss-parity loader row into builder input, carrying the
+    fundamental fields each preset's builder branch needs (ROB-363)."""
+    return {
+        "symbol": row.get("symbol"),
+        "name": row.get("name") or row.get("symbol"),
+        "source": row.get("source") or "kis",
+        "change_rate": row.get("change_rate"),
+        "close": row.get("close") or row.get("latest_close"),
+        "latest_close": row.get("latest_close") or row.get("close"),
+        "volume": row.get("volume") or row.get("daily_volume"),
+        "consecutive_up_days": row.get("consecutive_up_days"),
+        "foreign_consecutive_buy_days": row.get("foreign_consecutive_buy_days"),
+        "roe": row.get("roe"),
+        "per": row.get("per"),
+        "pbr": row.get("pbr"),
+    }
+
+
+def _merge_evidence(
     evidence: list[CandidateEvidence], *, key: Callable[[CandidateEvidence], Hashable]
 ) -> list[CandidateEvidence]:
-    """Order-preserving dedupe of CandidateEvidence by ``key`` (ROB-363).
+    """Merge duplicate-symbol CandidateEvidence across presets (ROB-363).
 
-    PR1 keeps the first occurrence (highest-ranked from a single preset). PR2
-    replaces this with a reason-merging variant once multiple presets feed the
-    pool."""
-    seen: set[Any] = set()
-    out: list[CandidateEvidence] = []
+    Keeps the first occurrence's scalar fields (symbol/score/source_preset) and
+    UNIONS ``reasons`` + ``risk_flags`` (order-preserving, deduped) from every
+    preset that surfaced the symbol, so per-source provenance is preserved.
+    Order-preserving on first occurrence."""
+    import dataclasses
+
+    order: list[Hashable] = []
+    merged: dict[Hashable, CandidateEvidence] = {}
     for ev in evidence:
         k = key(ev)
-        if k in seen:
+        if k not in merged:
+            merged[k] = ev
+            order.append(k)
             continue
-        seen.add(k)
-        out.append(ev)
-    return out
+        prev = merged[k]
+        reasons = list(prev.reasons)
+        for r in ev.reasons:
+            if r not in reasons:
+                reasons.append(r)
+        flags = list(prev.risk_flags)
+        for f in ev.risk_flags:
+            if f not in flags:
+                flags.append(f)
+        merged[k] = dataclasses.replace(prev, reasons=reasons, risk_flags=flags)
+    return [merged[k] for k in order]
 
 
 def _toss_parity_status(preset: str, market: str) -> str:
@@ -295,19 +327,33 @@ class CandidateUniverseSnapshotCollector:
     ) -> list[SnapshotCollectResult] | None:
         """KR Toss-parity preset sourcing (ROB-363). Returns None when no preset
         produced any rows, so the caller falls back to top_gainers."""
-        from app.services.invest_view_model.screener_service import (
-            load_consecutive_gainers_from_snapshots,
+        from app.services.invest_view_model import (
+            double_buy_screener,
+            high_yield_value_screener,
+            screener_service,
         )
 
-        # (preset_id, loader) — PR2 adds double_buy + high_yield_value here.
+        # (preset_id, module, attr) — resolved via getattr at loop time so
+        # monkeypatch.setattr(module, attr, fake) is honoured in tests.
         pool_limit = max(limit * 3, limit + 20)
         loaders = [
-            ("consecutive_gainers", load_consecutive_gainers_from_snapshots),
+            (
+                "consecutive_gainers",
+                screener_service,
+                "load_consecutive_gainers_from_snapshots",
+            ),
+            ("double_buy", double_buy_screener, "load_double_buy_from_snapshots"),
+            (
+                "high_yield_value",
+                high_yield_value_screener,
+                "load_high_yield_value_from_snapshots",
+            ),
         ]
         evidence: list[CandidateEvidence] = []
         per_state: dict[str, str] = {}  # db_symbol -> fresh|stale
         any_rows = False
-        for preset_id, loader in loaders:
+        for preset_id, module, attr in loaders:
+            loader = getattr(module, attr)
             rows = await loader(self._session, market="kr", limit=pool_limit)
             if not rows:  # None (missing) or [] (stale-empty)
                 continue
@@ -315,21 +361,23 @@ class CandidateUniverseSnapshotCollector:
             built = build_candidate_evidence(
                 market="kr",
                 preset=preset_id,
-                rows=[_gainers_row_to_input(r) for r in rows],
+                rows=[_preset_row_to_input(preset_id, r) for r in rows],
             )
             # Map freshness by symbol from the raw loader rows — NOT by zipping
             # against ``built``, which build_candidate_evidence re-sorts by score
             # (the positions no longer line up). Keyed by db symbol so it stays
-            # correct once PR2 fans in multiple presets.
+            # correct once PR2 fans in multiple presets. A fresh state from ANY
+            # preset wins over stale (a symbol fresh in one source is fresh).
             for src_row in rows:
-                per_state[to_db_symbol(str(src_row.get("symbol")))] = (
-                    src_row.get("_screener_snapshot_state") or "fresh"
-                )
+                k = to_db_symbol(str(src_row.get("symbol")))
+                state = src_row.get("_screener_snapshot_state") or "fresh"
+                if per_state.get(k) != "fresh":
+                    per_state[k] = state
             evidence.extend(built)
         if not any_rows:
             return None
 
-        evidence = _dedupe_evidence(evidence, key=lambda e: to_db_symbol(e.symbol))
+        evidence = _merge_evidence(evidence, key=lambda e: to_db_symbol(e.symbol))
         # Distinct evaluated symbols (pre-slice) = the candidate universe size,
         # so ``capped`` reflects a pool wider than the displayed limit.
         universe_count = len(per_state)

--- a/app/services/screener_evidence/builder.py
+++ b/app/services/screener_evidence/builder.py
@@ -12,6 +12,8 @@ _MOMENTUM_REASON = "단기 상승 모멘텀 후보"
 _OVERSOLD_REASON = "RSI 저점권 후보"
 _HIGH_VOLUME_REASON = "24시간 KRW 거래대금 상위"
 _WARNING_FLAG = "Upbit 유의 종목"
+_DOUBLE_BUY_REASON = "외국인·기관 쌍끌이 매수"
+_HIGH_YIELD_VALUE_REASON = "고수익 저평가 (ROE 15%↑·PER 0~10)"
 
 
 def _to_float(value: Any) -> float | None:
@@ -81,6 +83,23 @@ def build_candidate_evidence(
                 f"거래대금 {int(volume_value):,}" if volume_value is not None else "-"
             )
             reasons = [_HIGH_VOLUME_REASON]
+        elif preset == "double_buy":
+            score = scoring.momentum_score(change_rate)
+            score_label = f"{change_rate:+.2f}%" if change_rate is not None else "-"
+            reasons = [_DOUBLE_BUY_REASON]
+            fcd = row.get("foreign_consecutive_buy_days")
+            if isinstance(fcd, int) and fcd >= 2:
+                reasons.append(f"외국인 {fcd}일 연속 순매수")
+            volume_value = _to_float(row.get("daily_volume") or row.get("volume"))
+        elif preset == "high_yield_value":
+            roe = _to_float(row.get("roe"))
+            per = _to_float(row.get("per"))
+            score = scoring.high_yield_value_score(roe, per)
+            roe_part = f"ROE {roe:.1f}%" if roe is not None else "ROE -"
+            per_part = f"PER {per:.1f}" if per is not None else "PER -"
+            score_label = f"{roe_part} · {per_part}"
+            reasons = [_HIGH_YIELD_VALUE_REASON]
+            volume_value = _to_float(row.get("daily_volume") or row.get("volume"))
         else:  # crypto_momentum + equity top_gainers
             score = scoring.momentum_score(change_rate)
             score_label = f"{change_rate:+.2f}%" if change_rate is not None else "-"

--- a/app/services/screener_evidence/scoring.py
+++ b/app/services/screener_evidence/scoring.py
@@ -29,3 +29,14 @@ def rank_score(index: int, count: int) -> float:
     if count <= 1:
         return 10.0
     return clamp(10.0 * (1.0 - index / count))
+
+
+def high_yield_value_score(roe: float | None, per: float | None) -> float:
+    """ROE-led value score (ROB-363). Higher ROE and lower PER → higher score.
+
+    Both qualify under the preset (ROE>=15, 0<PER<=10) so both contribute:
+    ROE 15 → +0, ROE 35 → +5 (capped); PER 10 → +0, PER 0 → +5. ``None`` parts
+    contribute 0. Result clamped 0–10."""
+    roe_part = 0.0 if roe is None else clamp((roe - 15.0) / 4.0, 0.0, 5.0)
+    per_part = 0.0 if per is None else clamp((10.0 - per) / 2.0, 0.0, 5.0)
+    return clamp(roe_part + per_part)

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -329,3 +329,64 @@ async def test_kr_preset_pool_wider_than_limit_is_capped(db_session, monkeypatch
     assert payload["capped"] is True
     assert len(payload["candidates"]) == 2
     assert results[0].coverage_json["capped"] is True
+
+
+@pytest.mark.asyncio
+async def test_kr_collector_merges_duplicate_symbol_across_presets(
+    db_session, monkeypatch
+):
+    """ROB-363 — a symbol surfaced by two presets becomes ONE candidate whose
+    reasons union both presets' provenance. Loaders stubbed (no DB dependency)."""
+    import app.services.invest_view_model.double_buy_screener as dbb
+    import app.services.invest_view_model.high_yield_value_screener as hy
+    import app.services.invest_view_model.screener_service as ss
+
+    async def fake_consecutive(session, *, market, limit):
+        return [
+            {
+                "symbol": "005930",
+                "name": "삼성전자",
+                "source": "kis",
+                "change_rate": 2.0,
+                "close": 70000,
+                "consecutive_up_days": 6,
+                "volume": 1,
+                "_screener_snapshot_state": "fresh",
+            }
+        ]
+
+    async def fake_double_buy(session, *, market, limit):
+        return None
+
+    async def fake_high_yield(session, *, market, limit, today_market_date=None):
+        return [
+            {
+                "symbol": "005930",
+                "name": "삼성전자",
+                "source": "kis",
+                "change_rate": 2.0,
+                "latest_close": 70000,
+                "roe": 20.0,
+                "per": 7.0,
+                "volume": 1,
+                "_screener_snapshot_state": "fresh",
+            }
+        ]
+
+    monkeypatch.setattr(ss, "load_consecutive_gainers_from_snapshots", fake_consecutive)
+    monkeypatch.setattr(dbb, "load_double_buy_from_snapshots", fake_double_buy)
+    monkeypatch.setattr(hy, "load_high_yield_value_from_snapshots", fake_high_yield)
+
+    collector = CandidateUniverseSnapshotCollector(db_session)
+    results = await collector.collect(
+        CollectorRequest(
+            market="kr", account_scope=None, symbols=[], policy_snapshot={}
+        )
+    )
+    payload = results[0].payload_json
+    rows_005930 = [c for c in payload["candidates"] if c["symbol"] == "005930"]
+    assert len(rows_005930) == 1, "duplicate symbol must merge to one candidate"
+    merged = rows_005930[0]
+    reason_text = " ".join(merged["reasons"])
+    assert "연속 상승" in reason_text  # from consecutive_gainers
+    assert "저평가" in reason_text or "ROE" in reason_text  # from high_yield_value

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -262,13 +262,18 @@ async def test_kr_collector_falls_back_to_top_gainers_when_no_preset_rows(
 ):
     """ROB-363 — when KR Toss-parity presets yield no rows, the collector falls
     back to the top_gainers momentum ranking (not_toss_parity), deterministically
-    (loader stubbed to None, so this does not depend on DB contents)."""
+    (ALL three preset loaders stubbed to None, so this does not depend on DB
+    contents in investor_flow_snapshots / market_valuation_snapshots either)."""
+    import app.services.invest_view_model.double_buy_screener as dbb
+    import app.services.invest_view_model.high_yield_value_screener as hy
     import app.services.invest_view_model.screener_service as ss
 
-    async def _no_rows(session, *, market, limit):
+    async def _no_rows(session, *, market, limit, **kwargs):
         return None
 
     monkeypatch.setattr(ss, "load_consecutive_gainers_from_snapshots", _no_rows)
+    monkeypatch.setattr(dbb, "load_double_buy_from_snapshots", _no_rows)
+    monkeypatch.setattr(hy, "load_high_yield_value_from_snapshots", _no_rows)
 
     repo = _FakeEquityRepository()
     collector = CandidateUniverseSnapshotCollector(db_session, equity_repository=repo)

--- a/tests/services/screener_evidence/test_builder.py
+++ b/tests/services/screener_evidence/test_builder.py
@@ -141,3 +141,46 @@ def test_consecutive_gainers_preset_reasons_and_score():
     assert ev.price == 70000.0  # reads `close` when `price` absent
     assert any("연속 상승" in r for r in ev.reasons)
     assert ev.score > 5.0  # +2.0% momentum -> above neutral
+
+
+def test_double_buy_preset_reasons():
+    from app.services.screener_evidence.builder import build_candidate_evidence
+
+    rows = [
+        {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "source": "kis",
+            "change_rate": 1.0,
+            "latest_close": 180000,
+            "volume": 500000,
+            "foreign_net": 1_000_000,
+            "institution_net": 500_000,
+            "foreign_consecutive_buy_days": 3,
+        }
+    ]
+    out = build_candidate_evidence(market="kr", preset="double_buy", rows=rows)
+    assert out[0].source_preset == "double_buy"
+    assert any("쌍끌이" in r or "외국인" in r for r in out[0].reasons)
+
+
+def test_high_yield_value_preset_reasons_and_score_label():
+    from app.services.screener_evidence.builder import build_candidate_evidence
+
+    rows = [
+        {
+            "symbol": "005490",
+            "name": "POSCO홀딩스",
+            "source": "kis",
+            "change_rate": 0.5,
+            "latest_close": 400000,
+            "volume": 100000,
+            "roe": 18.0,
+            "per": 6.5,
+            "pbr": 0.8,
+        }
+    ]
+    out = build_candidate_evidence(market="kr", preset="high_yield_value", rows=rows)
+    assert out[0].source_preset == "high_yield_value"
+    assert "ROE" in out[0].score_label or "PER" in out[0].score_label
+    assert any("저평가" in r or "ROE" in r for r in out[0].reasons)


### PR DESCRIPTION
## ROB-363 PR2/3 — fan in all three full-parity presets + symbol merge

Builds on PR1 (#1014, merged). PR1 wired one KR Toss-parity preset (`consecutive_gainers`) into the `candidate_universe` collector with `top_gainers` fallback. PR2 fans in the remaining two full-parity presets and merges duplicate symbols across presets.

Plan: `docs/superpowers/plans/2026-05-30-rob-363-kr-toss-parity-candidate-sourcing.md`. PR3 (next): deterministic cross-source priority ordering + per-candidate stale demotion + acceptance regression coverage.

### Preset sources (all full Toss parity)
- `consecutive_gainers` — `invest_screener_snapshots` (consecutive_up_days ≥ 5)
- `double_buy` — `investor_flow_snapshots` (외국인+기관 순매수)
- `high_yield_value` — `market_valuation_snapshots` (ROE ≥ 15, 0 < PER ≤ 10)

Loaders invoked via `getattr(module, attr)` at loop time; each returns the uniform `list[dict] | None` contract (`None`=missing partition, `[]`=stale-empty, rows=results). If all three yield nothing, the collector falls back to `top_gainers`.

### Builder scoring/reasons
- `double_buy` → momentum score + reason `외국인·기관 쌍끌이 매수` (+ `외국인 N일 연속 순매수` when ≥2).
- `high_yield_value` → new `high_yield_value_score(roe, per)` (ROE-led, PER-discounted, clamped 0–10) + score label `ROE X.X% · PER X.X` + reason `고수익 저평가 (ROE 15%↑·PER 0~10)`.

### Cross-preset merge
`_merge_evidence` replaces the PR1 keep-first dedupe: a symbol surfaced by multiple presets becomes ONE candidate keeping first-occurrence scalar fields (symbol/score/source_preset, ordered by the loaders list) and UNIONing `reasons` + `risk_flags` (order-preserving, deduped) so per-source provenance is preserved. Per-candidate `data_state` is keyed by symbol from raw rows (fresh-wins-over-stale across presets); `universe_count` is captured pre-slice so `capped` stays honest.

### Tests (33 pass, ruff + format clean)
- `tests/services/screener_evidence/test_builder.py` — double_buy + high_yield_value scoring/reasons.
- `tests/services/action_report/test_candidate_universe_collector_evidence.py` — cross-preset merge (monkeypatched loaders), plus PR1 sourcing/fallback/cap/US/crypto tests. Fallback test now stubs all three loaders (deterministic, no live-DB dependency).

### Migration / flags
None.

### No-side-effect boundary
No broker/order/watch/order-intent/trade-journal mutation. Read-only DB. KR-only behavior change; US/crypto paths unchanged. Grep over touched files confirms no order-mutation calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "double-buy" and "high-yield value" screening presets alongside existing consecutive gainers option
  * Enhanced candidate aggregation to intelligently merge candidates across multiple screening methods while preserving selection rationales from each preset

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->