### PR TITLE
feat(ROB-364): KIS mock overseas/US holdings-delta confirmed-smoke (PR1)

### DIFF
--- a/app/services/brokers/kis/mock_scalping_exec/overseas_holdings_confirm.py
+++ b/app/services/brokers/kis/mock_scalping_exec/overseas_holdings_confirm.py
@@ -1,0 +1,118 @@
+"""ROB-364 — pure normalization helpers for the KIS mock **overseas/US**
+holdings-delta confirmed-smoke.
+
+The overseas smoke (``scripts/kis_mock_overseas_holdings_delta_smoke.py``) is the
+US counterpart to the domestic ROB-358 smoke. It cannot reuse the domestic
+``KisMockBroker`` (which reads ``fetch_domestic_balance_snapshot`` and routes the
+cleanup SELL through the KR-only scalping-exit validator), so it talks to the
+overseas order client directly and layers these small, broker-free helpers on
+top of the shared, market-agnostic ``classify_fill_by_delta`` /
+``derive_fill_price`` kernel:
+
+* :func:`extract_overseas_holdings_qty` — per-symbol share count from KIS
+  overseas holdings rows (``ovrs_pdno`` / ``ovrs_cblc_qty``), symbol-normalized
+  so a KIS-format ``BRK/B`` matches the DB-format ``BRK.B`` the smoke passes.
+  Returns ``0`` when the symbol is absent (the holdings read pre-filters to
+  nonzero positions, so absence means "we hold zero"); a *read failure* raises
+  upstream and the caller fails closed to ``None``.
+* :func:`latest_close_from_minute_frame` / :func:`latest_timestamp_from_minute_frame`
+  — read the most-recent candle from an overseas minute frame. The frame is
+  sorted ascending by ``datetime`` (see ``_base_market_data._build_ohlcv_dataframe``),
+  so the latest candle is the LAST row.
+* :func:`quote_is_fresh` — fail-closed wall-clock staleness gate (absolute skew,
+  so a stale-because-closed bar AND a future-skewed bar both read as not fresh).
+
+USD cash/margin is OPSQ0002-blocked in KIS mock overseas, so the cash-delta
+branch of ``derive_fill_price`` is never available here; the smoke passes
+``cash=None`` and the fill price is always the submitted limit (``limit_fallback``).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping, Sequence
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.symbol import to_db_symbol
+
+
+def extract_overseas_holdings_qty(
+    rows: Sequence[Mapping[str, Any]], symbol: str
+) -> Decimal:
+    """Sum the held quantity for ``symbol`` across KIS overseas holdings rows.
+
+    Rows come from ``fetch_my_us_stocks`` / ``fetch_my_overseas_stocks`` and carry
+    ``ovrs_pdno`` (KIS-format symbol) and ``ovrs_cblc_qty`` (share count). Both the
+    row symbol and the requested ``symbol`` are normalized via ``to_db_symbol`` so
+    ``BRK/B`` (KIS) matches ``BRK.B`` (DB). Returns ``Decimal("0")`` when the symbol
+    is not present (the holdings read pre-filters to nonzero positions, so absence
+    means a zero position — a read *failure* is a raised exception handled by the
+    caller, never an empty list).
+    """
+    target = to_db_symbol(str(symbol))
+    total = Decimal("0")
+    for row in rows:
+        pdno = row.get("ovrs_pdno")
+        if pdno is None:
+            continue
+        if to_db_symbol(str(pdno)) != target:
+            continue
+        raw = str(row.get("ovrs_cblc_qty", "0")).replace(",", "").strip() or "0"
+        total += Decimal(raw)
+    return total
+
+
+def latest_close_from_minute_frame(frame: Any) -> Decimal | None:
+    """Return the latest candle's close as a positive ``Decimal``, else ``None``.
+
+    ``None`` (no usable quote) when the frame is empty, lacks a ``close`` column,
+    or the latest close is non-positive / unparseable.
+    """
+    if frame is None or len(frame) == 0 or "close" not in getattr(frame, "columns", []):
+        return None
+    raw = frame.iloc[-1]["close"]
+    try:
+        close = Decimal(str(raw))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return close if close > 0 else None
+
+
+def latest_timestamp_from_minute_frame(frame: Any) -> dt.datetime | None:
+    """Return the latest candle's ``datetime`` as a python ``datetime``, else ``None``."""
+    if (
+        frame is None
+        or len(frame) == 0
+        or "datetime" not in getattr(frame, "columns", [])
+    ):
+        return None
+    raw = frame.iloc[-1]["datetime"]
+    to_pydatetime = getattr(raw, "to_pydatetime", None)
+    if callable(to_pydatetime):
+        return to_pydatetime()
+    return raw if isinstance(raw, dt.datetime) else None
+
+
+def quote_is_fresh(
+    latest_ts: dt.datetime,
+    now: dt.datetime,
+    *,
+    max_staleness_seconds: float,
+) -> bool:
+    """Fail-closed quote freshness gate.
+
+    Fresh iff the latest candle is within ``max_staleness_seconds`` of ``now`` in
+    *absolute* terms, so both a market-closed (far-past) bar and a clock/tz-skewed
+    (far-future) bar read as not fresh. ``latest_ts`` and ``now`` must both be
+    tz-aware or both naive (the caller localizes the naive exchange timestamp).
+    """
+    return abs((now - latest_ts).total_seconds()) <= max_staleness_seconds
+
+
+__all__ = [
+    "extract_overseas_holdings_qty",
+    "latest_close_from_minute_frame",
+    "latest_timestamp_from_minute_frame",
+    "quote_is_fresh",
+]

--- a/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
+++ b/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
@@ -1,0 +1,129 @@
+# KIS mock overseas/US holdings-delta smoke (ROB-364)
+
+Operator runbook for the KIS official-mock **overseas/US stock** holdings-delta
+fill-confirmation smoke — the US counterpart to the domestic ROB-358 smoke
+(`docs/runbooks/kis-mock-scalping-smoke.md` / `scripts/kis_mock_holdings_delta_smoke.py`).
+**Mock/paper only, default-disabled, no automatic submit.** This validates the
+US *execution + cleanup plumbing*; it is **not** a live-trading recommendation.
+
+Script: `scripts/kis_mock_overseas_holdings_delta_smoke.py`
+
+## Why this is a separate smoke (not the domestic one with a US symbol)
+
+| Concern | Domestic (ROB-358) | Overseas/US (this smoke) |
+|---|---|---|
+| Execution path | `KisMockBroker` (`mock_scalping_exec/adapters.py`) | overseas order client **directly** (`buy/sell/cancel_overseas_stock`) — there is **no** overseas `KisMockBroker` |
+| Cleanup SELL gate | `KIS_MOCK_SCALPING_ENABLED` + an allowed `ScalpingExitContext` reason | **none** — that validator is KR-only; cleanup is a plain overseas SELL/CANCEL |
+| Cash / fill price | mock domestic cash **is** readable → cash-delta price | USD margin is **OPSQ0002-blocked** → cash-delta unavailable → `fill_price_source="limit_fallback"` |
+| Same-day history | domestic daily-ccld empty (non-gating) | overseas daily-ccld likely empty + pending-orders (TTTS3018R) **unavailable in mock** → both non-gating |
+| Fill gate | holdings delta (primary) | holdings delta (**sole** gate) |
+
+## Capability surfaces (inventory)
+
+| Capability | Surface (`is_mock=True`) | Notes |
+|---|---|---|
+| Account holdings | `KISClient.fetch_my_us_stocks(exchange=…)` | rows keyed `ovrs_pdno` / `ovrs_cblc_qty`; pre-filtered to nonzero |
+| USD cash / margin | `KISClient.inquire_overseas_margin()` | **OPSQ0002** in mock → treated as unavailable (best-effort only) |
+| Quote (sizing) | `KISClient.inquire_overseas_minute_chart(symbol, exchange, n=1)` | latest candle = **last** row (`close`, `datetime`); accepts the 4-digit order code |
+| BUY / SELL | `KISClient.buy_overseas_stock` / `sell_overseas_stock` | limit order when `price>0` (`ORD_DVSN=00`); TRs `VTTT1002U` / `VTTT1006U`; order id at `result["odno"]` |
+| CANCEL | `KISClient.cancel_overseas_order(order_number, symbol, exchange, qty)` | `order_number` = prior BUY `odno`; TR `VTTT1004U` |
+| Pending orders | `inquire_overseas_orders` | **RuntimeError in mock** — not used here |
+| Filled history | `inquire_daily_order_overseas` | supplementary / non-gating (may be empty same-day) |
+| Exchange resolution | `us_symbol_universe_service.get_us_exchange_by_symbol` | order/cancel use 4-digit `NASD/NYSE/AMEX` |
+
+## Fill-evidence hierarchy
+
+1. **GATING — overseas holdings delta.** Baseline `fetch_my_us_stocks` qty vs
+   post-submit qty, matched per-symbol (`to_db_symbol` normalizes `BRK/B`↔`BRK.B`),
+   via the shared `classify_fill_by_delta` kernel. Only a **full** directional
+   delta confirms; partial / zero / wrong-direction fail closed.
+2. **PRICE only (not gating) — `derive_fill_price`.** Cash is OPSQ2-blocked, so
+   `cash=None` → `(limit_price, "limit_fallback")`.
+3. **DIAGNOSTIC (not gating) — `inquire_daily_order_overseas`.** Best-effort,
+   attached if present; empty neither confirms nor denies.
+
+## Gates (all default off)
+
+| env | effect |
+|-----|--------|
+| `KIS_MOCK_OVERSEAS_SMOKE_ENABLED` | runs the smoke at all (read directly from env — **not** a persistent Settings flag); unset → no-op exit 4 |
+| `KIS_MOCK_APP_KEY` / `KIS_MOCK_APP_SECRET` / `KIS_MOCK_ACCOUNT_NO` | KIS mock credentials (existing) |
+
+There is intentionally **no** new persistent config field and **no**
+`KIS_MOCK_SCALPING_*` reuse — set the enable flag ephemerally for one run.
+
+## Pre-BUY fail-closed gates (`--confirm` stops before any order if any fail)
+
+- smoke disabled / KIS mock not configured → exit 4
+- `KIS_MOCK_ACCOUNT_NO` < 10 digits (cleanup SELL/CANCEL un-submittable) → exit 4
+- US market not open right now (`is_market_open("us")`, XNYS) → exit 4
+- exchange unresolved → exit 2
+- no quote / stale quote / size zero / baseline read failed → exit 2
+
+## Step 1 — read-only preflight (no order)
+
+```bash
+KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true uv run python -m \
+    scripts.kis_mock_overseas_holdings_delta_smoke --preflight --symbol AAPL
+```
+
+Expect a JSON line with `mode=preflight`, resolved `exchange`, `holdings_qty`,
+and `cash_usd=null` / `cash_source=unavailable_opsq0002` (expected in mock).
+**No order is placed.** Run this first and confirm the symbol/exchange/holdings.
+
+## Step 2 — small confirmed round trip (operator-gated, US RTH only)
+
+Run only during US regular trading hours (so a marketable limit can fill), on an
+**idle** symbol with no concurrent manual activity (see attribution caveat).
+
+```bash
+KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true uv run python -m \
+    scripts.kis_mock_overseas_holdings_delta_smoke \
+    --confirm --symbol AAPL --exchange NASD --notional-usd 20
+```
+
+The script: sizes a marketable limit from the latest minute close → BUY →
+bounded holdings-delta poll → **cleanup in a `finally`** (SELL a filled residual,
+or CANCEL an unfilled resting BUY) → final open-position/delta verification. It
+prints a JSON evidence packet including symbol, exchange, side(s), order id(s),
+baseline/post holdings, selected fill signal, cleanup result, and final position
+delta vs baseline.
+
+## Exit codes
+
+| code | meaning |
+|---|---|
+| 0 | success — preflight printed, or confirmed round trip flattened to baseline (final delta 0) |
+| 1 | unexpected exception |
+| 2 | pre-BUY blocked (no/stale quote, unresolved exchange, size zero, baseline read failed) **or** fill unconfirmed but flat |
+| 3 | anomaly — residual position / pending order could not be cleaned up (SELL/CANCEL rejected, missing order id, residual, over-flatten) |
+| 4 | disabled / KIS mock not configured / account un-submittable / US market closed (no order placed) |
+
+## Safety boundaries
+
+- KIS official **mock** overseas/US only. No KIS live. No market orders. No
+  shorting. No automatic submit. No scheduler / Prefect / TaskIQ / cron / launchd.
+  No persistent env / flag / secret changes. No production DB backfill/delete.
+- Cleanup goes through the overseas order client directly; SELL/CANCEL responses
+  are inspected — a missing `odno` or a submit rejection is an explicit anomaly
+  (exit 3), never a silent success.
+- Negative / below-baseline / over-flatten deltas are **always** anomalies, never
+  a clean exit (final clean exit requires delta exactly 0).
+- **Alpaca Paper is a separate broker** (`account_scope=alpaca_paper`,
+  `scripts/smoke/*alpaca*`). Do not mix its ledger/preflight semantics into this
+  KIS-mock evidence; this smoke never touches the dual-paper preview packet.
+
+## Caveats / known unknowns (operator must verify on the confirmed run)
+
+- **Mock fill reflection is unverified.** Whether KIS mock actually fills overseas
+  orders and reflects them in `fetch_my_us_stocks(is_mock=True)` is the central
+  unknown. If mock does **not** populate overseas holdings on fill, every run is
+  fill-unconfirmed (exit 2) — the smoke fails closed and never fabricates a fill.
+- **Quote freshness tz.** Minute-chart timestamps are treated as US/Eastern; the
+  freshness gate is coarse. `is_market_open("us")` is the primary session gate and
+  the CANCEL cleanup is the real safety net for an unfilled resting limit.
+- **Attribution boundary (inherited from ROB-341).** Holdings delta attributes any
+  same-symbol qty change in the poll window to this order; there is no WS
+  serialization here, so keep the confirmed smoke to idle symbols.
+- **Overseas mock cancel fields** (forwarding-org code, partial-qty rules) are
+  unvalidated until the confirmed run; a cancel rejection is classified exit 3.

--- a/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
+++ b/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
@@ -83,20 +83,50 @@ KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true uv run python -m \
 ```
 
 The script: sizes a marketable limit from the latest minute close → BUY →
-bounded holdings-delta poll → **cleanup in a `finally`** (SELL a filled residual,
-or CANCEL an unfilled resting BUY) → final open-position/delta verification. It
-prints a JSON evidence packet including symbol, exchange, side(s), order id(s),
-baseline/post holdings, selected fill signal, cleanup result, and final position
-delta vs baseline.
+bounded holdings-delta poll → **cleanup in a `finally`** → final open-position /
+delta verification. It prints a JSON evidence packet (see *Evidence packet* below).
+
+## Fill verdict & cleanup policy (fail-closed)
+
+The entry fill verdict is one of `filled` (full directional delta — the **only**
+confirmation), `partial` (some but not the full ordered qty), `none`, or
+`read_failed`. The cleanup branches on whether the entry was a **confirmed full
+fill**:
+
+- **Confirmed full fill** → no resting remainder exists; SELL the delta to flatten.
+  A clean flatten to baseline (final delta 0) is the **only** path to **exit 0**.
+- **Partial / unconfirmed entry with a positive delta** → the original BUY may
+  have an unfilled resting remainder. KIS overseas mock has **no authoritative
+  open-order query** (`inquire_overseas_orders` raises in mock), so the smoke
+  **cancels the original BUY** to remove that risk, then SELLs the filled delta.
+  Even when it ends flat, this is **exit 2 (never exit 0)** — the entry was never
+  a clean confirmed full fill.
+- **Cannot authoritatively cancel the resting BUY** (cancel rejected or response
+  missing `odno`) → **fail closed, exit 3**, and the smoke does **not** SELL.
+- **No fill / nothing acked** → exit 2 (fill-unconfirmed) — never exit 0.
+
+So a partial fill can never be silently reported as success, and a flat-but-
+unconfirmed run is never mistaken for a clean round trip.
+
+## Evidence packet (every `--confirm` run logs these)
+
+`symbol`, `exchange`, `buy_limit_price`, `baseline_holdings_qty`, `quantity`,
+`buy_order_id` / `entry_order_id`, `entry_fill_verdict`, `entry_fill_confirmed`,
+`entry_filled`, `fill_price_source`, `cleanup_current_delta`,
+`buy_cancel_attempted`, `buy_cancel_order_id` / `buy_cancel_status`,
+`open_order_check_status`, `cleanup_sell_order_id` / `cleanup_sell_status`,
+`cleanup`, `final_position_delta_vs_baseline`, `final_exit_reason`, `exit_code`.
+On a BUY submit failure: `entry="BUY_submit_rejected"` + `buy_submit_exception`
++ `entry_order_id=null`, with a non-zero `exit_code` consistent with the process.
 
 ## Exit codes
 
 | code | meaning |
 |---|---|
-| 0 | success — preflight printed, or confirmed round trip flattened to baseline (final delta 0) |
+| 0 | **confirmed full fill** flattened to baseline (final delta 0) — the only clean success; or `--preflight` printed |
 | 1 | unexpected exception |
-| 2 | pre-BUY blocked (no/stale quote, unresolved exchange, size zero, baseline read failed) **or** fill unconfirmed but flat |
-| 3 | anomaly — residual position / pending order could not be cleaned up (SELL/CANCEL rejected, missing order id, residual, over-flatten) |
+| 2 | pre-BUY blocked (no/stale quote, unresolved exchange, size zero, baseline read failed); **or** partial/unconfirmed fill that ended flat (resting BUY cancelled but entry never confirmed full); **or** BUY submit rejected with nothing acquired |
+| 3 | anomaly — could not authoritatively clean up: resting BUY un-cancellable, residual after SELL, over-flatten/below-baseline, missing SELL/CANCEL order id |
 | 4 | disabled / KIS mock not configured / account un-submittable / US market closed (no order placed) |
 
 ## Safety boundaries
@@ -109,16 +139,30 @@ delta vs baseline.
   (exit 3), never a silent success.
 - Negative / below-baseline / over-flatten deltas are **always** anomalies, never
   a clean exit (final clean exit requires delta exactly 0).
+- A **partial / unconfirmed** entry never reports exit 0: the resting BUY is
+  cancelled (fail-closed if that cancel can't be authoritatively confirmed) and a
+  flat outcome is exit 2, not exit 0.
+- **Confirmed smoke is operator-approved only**, after the read-only `--preflight`
+  passes — one-off, minimal, LIMIT-only, on an idle symbol. No automatic `--confirm`.
 - **Alpaca Paper is a separate broker** (`account_scope=alpaca_paper`,
   `scripts/smoke/*alpaca*`). Do not mix its ledger/preflight semantics into this
   KIS-mock evidence; this smoke never touches the dual-paper preview packet.
 
 ## Caveats / known unknowns (operator must verify on the confirmed run)
 
+- **Open-order query is NOT authoritative in mock.** `inquire_overseas_orders`
+  (pending, TTTS3018R) raises in mock, so the smoke cannot *read* whether a resting
+  BUY exists. Instead it removes the risk by **cancelling** the BUY whenever the
+  entry was not a confirmed full fill; if that cancel can't be confirmed, it fails
+  closed (exit 3). `open_order_check_status` in the evidence records which applied.
 - **Mock fill reflection is unverified.** Whether KIS mock actually fills overseas
   orders and reflects them in `fetch_my_us_stocks(is_mock=True)` is the central
   unknown. If mock does **not** populate overseas holdings on fill, every run is
   fill-unconfirmed (exit 2) — the smoke fails closed and never fabricates a fill.
+- **ROB-364 is NOT Done until the operator confirmed run.** This PR hardens the
+  code/tests/docs only; the issue stays open until an operator-approved confirmed
+  smoke (creds + US RTH) actually exercises the round trip and resolves the
+  unknowns above. This runbook makes no live-trading recommendation.
 - **Quote freshness tz.** Minute-chart timestamps are treated as US/Eastern; the
   freshness gate is coarse. `is_market_open("us")` is the primary session gate and
   the CANCEL cleanup is the real safety net for an unfilled resting limit.

--- a/scripts/kis_mock_overseas_holdings_delta_smoke.py
+++ b/scripts/kis_mock_overseas_holdings_delta_smoke.py
@@ -38,12 +38,20 @@ environment, NOT a persistent Settings flag) plus KIS mock config. ``--confirm``
 must be passed explicitly. Prints only missing env var NAMES, never secret
 values. Always attempts cleanup in a ``finally`` block.
 
+Fill verdict & cleanup policy (fail-closed): a CONFIRMED FULL fill is the only
+path to exit 0. A partial/unconfirmed entry with a positive delta may leave a
+resting BUY remainder; since KIS overseas mock has no authoritative open-order
+query, the smoke CANCELS the original BUY (fail-closed exit 3 if that cancel
+cannot be confirmed) and even a flat outcome is exit 2 — never exit 0.
+
 Exit codes:
-    0  - success (preflight printed, or confirmed round trip cleaned up to baseline)
+    0  - CONFIRMED full fill flattened to baseline (final delta 0); or --preflight
     1  - unexpected exception
     2  - pre-BUY blocked (no/stale quote, unresolved exchange, size zero, baseline
-         read failed) OR fill could not be confirmed in the poll window (but flat)
-    3  - anomaly: residual position / pending order could not be cleaned up
+         read failed); OR partial/unconfirmed fill that ended flat (resting BUY
+         cancelled but entry never confirmed full); OR BUY submit rejected
+    3  - anomaly: resting BUY un-cancellable, residual after SELL, over-flatten /
+         below-baseline, or missing SELL/CANCEL order id
     4  - disabled, KIS mock not configured, cleanup path not submittable, or US
          market closed (no order placed)
 
@@ -98,6 +106,21 @@ class _EntryFill:
     price: Decimal
     quantity: Decimal
     price_source: str
+
+
+@dataclass
+class _EntryOutcome:
+    """Result of the bounded entry-fill poll.
+
+    ``fill`` is non-None ONLY on a confirmed **full** fill. ``verdict`` is the
+    last poll verdict — ``"filled" | "partial" | "none" | "read_failed"`` — so a
+    partial fill is explicitly distinguished from no fill at all (a ``partial``
+    leaves a resting BUY remainder that cleanup must cancel).
+    """
+
+    fill: _EntryFill | None
+    verdict: str
+    observed_delta: Decimal | None
 
 
 def _env_truthy(value: str | None) -> bool:
@@ -257,14 +280,22 @@ async def _await_entry_fill(
     base_qty: Decimal,
     ordered_qty: Decimal,
     limit_price: Decimal,
-) -> _EntryFill | None:
+) -> _EntryOutcome:
+    """Poll holdings for a confirmed FULL fill. Returns an :class:`_EntryOutcome`
+    whose ``fill`` is non-None only on a full fill; a ``partial`` / ``none`` /
+    ``read_failed`` outcome reports the last verdict so the caller can apply the
+    partial-fill cleanup policy (cancel the resting BUY remainder)."""
+    last_verdict = "none"
+    last_delta: Decimal | None = None
     for _ in range(max(args.max_poll, 1)):
         cur = await _read_holdings_qty(client, symbol, exchange)
         if cur is None:
-            return None
+            return _EntryOutcome(fill=None, verdict="read_failed", observed_delta=None)
         decision = classify_fill_by_delta(
             side="buy", ordered_qty=ordered_qty, baseline_qty=base_qty, observed_qty=cur
         )
+        last_verdict = decision.verdict
+        last_delta = decision.delta
         if decision.verdict == "filled":
             price, source = derive_fill_price(
                 side="buy",
@@ -273,11 +304,16 @@ async def _await_entry_fill(
                 cash_observed=None,
                 limit_price=limit_price,
             )
-            return _EntryFill(
-                price=price, quantity=decision.filled_qty, price_source=source
+            return _EntryOutcome(
+                fill=_EntryFill(
+                    price=price, quantity=decision.filled_qty, price_source=source
+                ),
+                verdict="filled",
+                observed_delta=decision.delta,
             )
         await asyncio.sleep(args.poll_interval)
-    return None
+    # Timed out without a full fill: "partial" (some directional delta) or "none".
+    return _EntryOutcome(fill=None, verdict=last_verdict, observed_delta=last_delta)
 
 
 async def _await_flat(
@@ -307,6 +343,7 @@ async def _cancel_resting_buy(
     Inspects the cancel response order id explicitly; a rejection or a missing id
     is an explicit anomaly (exit 3), never a silent success.
     """
+    evidence["buy_cancel_attempted"] = True
     try:
         cancel = await client.cancel_overseas_order(
             order_number=buy_odno,
@@ -316,12 +353,14 @@ async def _cancel_resting_buy(
             is_mock=True,
         )
     except Exception as exc:  # noqa: BLE001 - submit rejection is a cleanup anomaly
-        evidence["cleanup_cancel_order_id"] = None
+        evidence["buy_cancel_order_id"] = None
+        evidence["buy_cancel_status"] = "submit_rejected"
         evidence["cleanup_error"] = str(exc)[:200]
         evidence["cleanup"] = "CANCEL_submit_rejected"
         return 3
     cancel_id = cancel.get("odno") if isinstance(cancel, Mapping) else None
-    evidence["cleanup_cancel_order_id"] = cancel_id
+    evidence["buy_cancel_order_id"] = cancel_id
+    evidence["buy_cancel_status"] = "acked" if cancel_id else "no_order_id"
     if not cancel_id:
         evidence["cleanup_error"] = "cleanup CANCEL response missing odno"
         evidence["cleanup"] = "CANCEL_no_order_id"
@@ -339,13 +378,33 @@ async def _cleanup_and_verify(
     evidence: dict,
     entry_fill,
 ) -> int:
-    """Return holdings to baseline. Returns the process exit code (0 clean, 2
-    fill-unconfirmed-but-flat, 3 anomaly/residual)."""
+    """Return holdings to baseline. Returns the process exit code.
+
+    Exit policy (load-bearing safety contract):
+    * 0 — ONLY a **confirmed full fill** that flattened to baseline (or a
+      confirmed full fill already flat). A clean confirmed round trip.
+    * 2 — flat / nothing to flatten but the entry was **not** a confirmed full
+      fill (partial / unconfirmed) — never a clean success even if flat.
+    * 3 — anomaly: cannot authoritatively cancel a resting BUY, residual after
+      SELL, over-flatten, below-baseline, missing SELL/CANCEL id, read failure.
+
+    KIS overseas mock has NO authoritative open-order query
+    (``inquire_overseas_orders`` raises in mock), so for any entry that is not a
+    confirmed full fill the original BUY may have an unfilled resting remainder.
+    We therefore CANCEL that BUY to remove the risk; if the cancel cannot be
+    authoritatively confirmed, we fail closed (3) and do not SELL.
+    """
     symbol = args.symbol
+    entry_confirmed = entry_fill is not None  # confirmed FULL fill only
+    evidence["entry_fill_confirmed"] = entry_confirmed
+    evidence.setdefault("buy_cancel_attempted", False)
+
     cur = await _read_holdings_qty(client, symbol, exchange)
     if cur is None:
         evidence["cleanup"] = "holdings_read_failed"
         evidence["cleanup_error"] = "post-buy holdings read failed"
+        evidence["open_order_check_status"] = "unknown_holdings_read_failed"
+        evidence["final_exit_reason"] = "post-buy holdings read failed"
         return 3
     delta = cur - base_qty
     evidence["cleanup_current_delta"] = str(delta)
@@ -356,44 +415,73 @@ async def _cleanup_and_verify(
             f"holdings {cur} below baseline {base_qty} before cleanup"
         )
         evidence["final_position_delta_vs_baseline"] = str(delta)
+        evidence["open_order_check_status"] = "not_checked_below_baseline"
+        evidence["final_exit_reason"] = "holdings below baseline before cleanup"
         return 3
 
-    if delta == 0:
-        # No filled shares. A resting unfilled BUY could still fill later -> cancel it.
-        if buy_odno:
-            cancel_rc = await _cancel_resting_buy(
-                client, args, exchange, buy_odno, buy_qty, evidence
+    # A confirmed full fill leaves nothing resting. Any other outcome (partial, or
+    # an unconfirmed entry that nonetheless moved holdings) may leave a resting
+    # BUY -> cancel it authoritatively (mock has no open-order query), else fail
+    # closed.
+    if not entry_confirmed and buy_odno:
+        cancel_rc = await _cancel_resting_buy(
+            client, args, exchange, buy_odno, buy_qty, evidence
+        )
+        if cancel_rc != 0:
+            evidence["open_order_check_status"] = "resting_buy_cancel_failed"
+            evidence.setdefault("final_position_delta_vs_baseline", str(delta))
+            evidence["final_exit_reason"] = (
+                "could not authoritatively cancel the resting BUY; fail closed"
             )
-            if cancel_rc != 0:
-                return cancel_rc
-            cur = await _read_holdings_qty(client, symbol, exchange)
-            if cur is None:
-                evidence["cleanup"] = "holdings_read_failed"
-                evidence["cleanup_error"] = "post-cancel holdings read failed"
-                return 3
-            delta = cur - base_qty
-            evidence["post_cancel_delta"] = str(delta)
-            if delta < 0:
-                evidence["cleanup"] = "below_baseline_anomaly"
-                evidence["cleanup_error"] = (
-                    f"holdings {cur} below baseline {base_qty} after cancel"
-                )
-                evidence["final_position_delta_vs_baseline"] = str(delta)
-                return 3
-        if delta == 0:
-            evidence["cleanup"] = (
-                "flat_after_cancel" if buy_odno else "nothing_to_flatten"
+            return cancel_rc
+        evidence["open_order_check_status"] = "resting_buy_cancelled"
+        cur = await _read_holdings_qty(client, symbol, exchange)
+        if cur is None:
+            evidence["cleanup"] = "holdings_read_failed"
+            evidence["cleanup_error"] = "post-cancel holdings read failed"
+            evidence["final_exit_reason"] = "post-cancel holdings read failed"
+            return 3
+        delta = cur - base_qty
+        evidence["post_cancel_delta"] = str(delta)
+        if delta < 0:
+            evidence["cleanup"] = "below_baseline_anomaly"
+            evidence["cleanup_error"] = (
+                f"holdings {cur} below baseline {base_qty} after cancel"
             )
-            evidence["final_position_delta_vs_baseline"] = "0"
-            return 0 if entry_fill is not None else 2
-        # else: a late fill landed during the cancel -> fall through to SELL.
+            evidence["final_position_delta_vs_baseline"] = str(delta)
+            evidence["final_exit_reason"] = "holdings below baseline after cancel"
+            return 3
+    elif entry_confirmed:
+        evidence["open_order_check_status"] = "full_fill_no_resting_order"
+    else:  # not confirmed and no acked BUY id -> nothing could be resting
+        evidence["open_order_check_status"] = "no_order_acked"
 
-    # delta > 0: residual filled shares -> SELL flatten.
+    if delta == 0:
+        evidence["final_position_delta_vs_baseline"] = "0"
+        if entry_confirmed:
+            evidence["cleanup"] = "flat_full_fill"
+            evidence["final_exit_reason"] = (
+                "confirmed full fill, holdings already flat vs baseline"
+            )
+            return 0
+        evidence["cleanup"] = (
+            "flat_entry_unconfirmed" if buy_odno else "nothing_to_flatten"
+        )
+        evidence["final_exit_reason"] = (
+            "flat after cancelling the resting BUY, but entry fill was never "
+            "confirmed full"
+            if buy_odno
+            else "no fill and no order acked; entry never confirmed"
+        )
+        return 2
+
+    # delta > 0: filled shares to flatten via SELL.
     sell_close = await _latest_close(client, symbol, exchange)
     if sell_close is None:
         evidence["cleanup"] = "no_quote_for_exit"
         evidence["cleanup_error"] = "no usable close to price the cleanup SELL"
         evidence["final_position_delta_vs_baseline"] = str(delta)
+        evidence["final_exit_reason"] = "no quote to price the cleanup SELL"
         return 3
     try:
         sell = await client.sell_overseas_stock(
@@ -405,37 +493,55 @@ async def _cleanup_and_verify(
         )
     except Exception as exc:  # noqa: BLE001 - submit rejection is a cleanup anomaly
         evidence["cleanup_sell_order_id"] = None
+        evidence["cleanup_sell_status"] = "submit_rejected"
         evidence["cleanup_error"] = str(exc)[:200]
         evidence["cleanup"] = "SELL_submit_rejected"
         evidence["final_position_delta_vs_baseline"] = str(delta)
+        evidence["final_exit_reason"] = "cleanup SELL submit rejected"
         return 3
     order_id = sell.get("odno") if isinstance(sell, Mapping) else None
     evidence["cleanup_sell_order_id"] = order_id
+    evidence["cleanup_sell_status"] = "acked" if order_id else "no_order_id"
     if not order_id:
         evidence["cleanup_error"] = "cleanup SELL response missing odno"
         evidence["cleanup"] = "SELL_no_order_id"
         evidence["final_position_delta_vs_baseline"] = str(delta)
+        evidence["final_exit_reason"] = "cleanup SELL response missing order id"
         return 3
 
     final_qty = await _await_flat(client, args, symbol, exchange, base_qty)
     if final_qty is None:
         evidence["cleanup"] = "holdings_read_failed"
         evidence["cleanup_error"] = "post-sell holdings read failed"
+        evidence["final_exit_reason"] = "post-sell holdings read failed"
         return 3
     final_delta = final_qty - base_qty
     evidence["post_holdings_qty"] = str(final_qty)
     evidence["final_position_delta_vs_baseline"] = str(final_delta)
     if final_delta > 0:
         evidence["cleanup"] = "UNCONFIRMED_residual_position"
+        evidence["final_exit_reason"] = "residual position remains after cleanup SELL"
         return 3
     if final_delta < 0:
         evidence["cleanup"] = "over_flattened_anomaly"
         evidence["cleanup_error"] = (
             f"final holdings {final_qty} below baseline {base_qty} after cleanup SELL"
         )
+        evidence["final_exit_reason"] = "over-flattened below baseline"
         return 3
-    evidence["cleanup"] = "flattened"
-    return 0
+    # Flattened to baseline. Exit 0 ONLY for a confirmed full fill; a partial /
+    # unconfirmed entry that we flattened + cancelled is a safe cleanup but NOT a
+    # clean confirmed round trip (blocker 2).
+    if entry_confirmed:
+        evidence["cleanup"] = "flattened"
+        evidence["final_exit_reason"] = "confirmed full fill flattened to baseline"
+        return 0
+    evidence["cleanup"] = "flattened_entry_unconfirmed"
+    evidence["final_exit_reason"] = (
+        "filled delta flattened and resting BUY handled, but entry fill was never "
+        "confirmed full"
+    )
+    return 2
 
 
 def _parse_usd_cash(margin_rows) -> tuple[Decimal | None, str]:
@@ -598,37 +704,62 @@ async def run_confirm(args: argparse.Namespace) -> int:
         return 2
     evidence["quantity"] = str(qty)
 
+    evidence["confirmation_signal"] = "holdings_delta"
+    evidence.setdefault("buy_cancel_attempted", False)
     buy_odno: str | None = None
     entry_fill: _EntryFill | None = None
+    buy_submit_error: str | None = None
     try:
-        buy = await client.buy_overseas_stock(
-            symbol=args.symbol,
-            exchange_code=exchange,
-            quantity=qty,
-            price=float(close),
-            is_mock=True,
-        )
-        buy_odno = buy.get("odno") if isinstance(buy, Mapping) else None
-        evidence["buy_order_id"] = buy_odno
-        evidence["confirmation_signal"] = "holdings_delta"
-        if not buy_odno:
-            evidence["entry"] = "BUY_no_order_id"
-            evidence["note"] = "buy response missing odno; nothing acked to flatten"
-        else:
-            entry_fill = await _await_entry_fill(
-                client, args, args.symbol, exchange, base_qty, Decimal(qty), close
+        try:
+            buy = await client.buy_overseas_stock(
+                symbol=args.symbol,
+                exchange_code=exchange,
+                quantity=qty,
+                price=float(close),
+                is_mock=True,
             )
-            if entry_fill is None:
+        except Exception as exc:  # noqa: BLE001 - classify a BUY submit failure
+            # A BUY submit exception must not leak out as a generic exit 1 with an
+            # inconsistent evidence packet; classify it and keep exit consistent.
+            buy_submit_error = str(exc)[:200]
+            buy = None
+            evidence["entry"] = "BUY_submit_rejected"
+            evidence["buy_submit_exception"] = buy_submit_error
+            evidence["buy_order_id"] = None
+            evidence["entry_order_id"] = None
+            evidence["entry_filled"] = False
+            evidence["entry_fill_verdict"] = "buy_submit_rejected"
+            evidence["entry_fill_confirmed"] = False
+            logger.error("overseas BUY submit failed: %s", buy_submit_error)
+        if buy is not None:
+            buy_odno = buy.get("odno") if isinstance(buy, Mapping) else None
+            evidence["buy_order_id"] = buy_odno
+            evidence["entry_order_id"] = buy_odno
+            if not buy_odno:
+                evidence["entry"] = "BUY_no_order_id"
                 evidence["entry_filled"] = False
-                evidence["note"] = (
-                    "entry fill UNCONFIRMED within poll window — holdings did not "
-                    "reflect a same-day mock fill (ROB-364 STOP condition)"
-                )
+                evidence["entry_fill_verdict"] = "no_order_id"
+                evidence["entry_fill_confirmed"] = False
+                evidence["note"] = "buy response missing odno; nothing acked to flatten"
             else:
-                evidence["entry_filled"] = True
-                evidence["entry_fill_price"] = str(entry_fill.price)
-                evidence["entry_fill_qty"] = str(entry_fill.quantity)
-                evidence["fill_price_source"] = entry_fill.price_source
+                outcome = await _await_entry_fill(
+                    client, args, args.symbol, exchange, base_qty, Decimal(qty), close
+                )
+                entry_fill = outcome.fill
+                evidence["entry_fill_verdict"] = outcome.verdict
+                evidence["entry_fill_confirmed"] = entry_fill is not None
+                if entry_fill is None:
+                    evidence["entry_filled"] = False
+                    evidence["note"] = (
+                        f"entry fill UNCONFIRMED (verdict={outcome.verdict}) within "
+                        "poll window — no confirmed full same-day mock fill "
+                        "(ROB-364 STOP condition)"
+                    )
+                else:
+                    evidence["entry_filled"] = True
+                    evidence["entry_fill_price"] = str(entry_fill.price)
+                    evidence["entry_fill_qty"] = str(entry_fill.quantity)
+                    evidence["fill_price_source"] = entry_fill.price_source
     finally:
         result = await _cleanup_and_verify(
             client,
@@ -640,6 +771,11 @@ async def run_confirm(args: argparse.Namespace) -> int:
             evidence,
             entry_fill,
         )
+        # A BUY submit failure is never a clean success even if cleanup found
+        # nothing to flatten; keep the process exit non-zero AND consistent with
+        # the logged evidence.
+        if buy_submit_error is not None and result == 0:
+            result = 2
         evidence["exit_code"] = result
         logger.info(json.dumps(evidence))
     return result

--- a/scripts/kis_mock_overseas_holdings_delta_smoke.py
+++ b/scripts/kis_mock_overseas_holdings_delta_smoke.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""KIS mock **overseas/US** holdings-delta fill-confirmation smoke (ROB-364).
+
+US counterpart to ``scripts/kis_mock_holdings_delta_smoke.py`` (domestic, ROB-358).
+Two modes, both KIS **mock** only (``is_mock=True`` -> mock host; overseas mock
+order TRs VTTT1002U/VTTT1006U/VTTT1004U):
+
+* ``--preflight`` — READ-ONLY. Resolves the US exchange, reads the mock overseas
+  holdings (``fetch_my_us_stocks``) and a best-effort margin snapshot, prints the
+  per-symbol holdings + cash availability. Places NO order. Run this first.
+* ``--confirm``   — operator-gated bounded round trip: one small marketable-limit
+  BUY, holdings-delta fill confirmation, then cleanup (SELL a filled residual, or
+  CANCEL an unfilled resting BUY) to return to baseline. Prints a JSON evidence
+  packet.
+
+Why this is NOT the domestic smoke with a different symbol:
+
+* There is no overseas ``KisMockBroker`` — the domestic one reads
+  ``fetch_domestic_balance_snapshot`` and routes its cleanup SELL through the
+  KR-only scalping-exit validator. This smoke talks to the overseas order client
+  directly, so there is NO ``KIS_MOCK_SCALPING_ENABLED`` gate and NO scalping-exit
+  reason — those are KR-only surfaces.
+* USD cash/margin is OPSQ0002-blocked in KIS mock overseas, so cash-delta is
+  unavailable: holdings delta is the SOLE fill gate and the fill price always
+  falls back to the submitted limit (``fill_price_source="limit_fallback"``).
+* ``inquire_overseas_orders`` (pending) is unavailable in mock and
+  ``inquire_daily_order_overseas`` can be empty for same-day mock fills, so
+  neither gates the verdict — holdings delta does.
+
+Same-day fill confirmation is the baseline-vs-post **holdings delta** (load
+bearing). A full directional delta is the only confirmation; partial / zero /
+wrong-direction fails closed.
+
+Safety: KIS mock only (no live), limit orders only (no market), no shorting, no
+scheduler, no automatic submit, no persistent env/flag changes. Default-disabled
+— requires ``KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true`` (read directly from the
+environment, NOT a persistent Settings flag) plus KIS mock config. ``--confirm``
+must be passed explicitly. Prints only missing env var NAMES, never secret
+values. Always attempts cleanup in a ``finally`` block.
+
+Exit codes:
+    0  - success (preflight printed, or confirmed round trip cleaned up to baseline)
+    1  - unexpected exception
+    2  - pre-BUY blocked (no/stale quote, unresolved exchange, size zero, baseline
+         read failed) OR fill could not be confirmed in the poll window (but flat)
+    3  - anomaly: residual position / pending order could not be cleaned up
+    4  - disabled, KIS mock not configured, cleanup path not submittable, or US
+         market closed (no order placed)
+
+Usage:
+    KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true uv run python -m \
+        scripts.kis_mock_overseas_holdings_delta_smoke --preflight --symbol AAPL
+    KIS_MOCK_OVERSEAS_SMOKE_ENABLED=true uv run python -m \
+        scripts.kis_mock_overseas_holdings_delta_smoke \
+        --confirm --symbol AAPL --exchange NASD --notional-usd 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import ROUND_DOWN, Decimal
+from zoneinfo import ZoneInfo
+
+from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
+    derive_fill_price,
+)
+from app.services.brokers.kis.mock_scalping_exec.overseas_holdings_confirm import (
+    extract_overseas_holdings_qty,
+    latest_close_from_minute_frame,
+    latest_timestamp_from_minute_frame,
+    quote_is_fresh,
+)
+from app.services.brokers.kis.overseas_orders import _normalize_kis_exchange_code
+from app.services.kis_mock_holdings_reconciler import classify_fill_by_delta
+
+logger = logging.getLogger(__name__)
+
+# KIS overseas minute-chart timestamps are exchange-local (US/Eastern) and naive;
+# localize to this zone before comparing to wall-clock UTC for the freshness gate.
+_QUOTE_TZ = ZoneInfo("America/New_York")
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class _ExchangeResolutionError(RuntimeError):
+    """The US listing exchange could not be resolved for the smoke symbol."""
+
+
+@dataclass
+class _EntryFill:
+    price: Decimal
+    quantity: Decimal
+    price_source: str
+
+
+def _env_truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() in _TRUTHY
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="KIS mock overseas/US holdings-delta fill-confirmation smoke"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--preflight",
+        action="store_true",
+        help="read-only: print holdings + cash for --symbol, place no order",
+    )
+    mode.add_argument(
+        "--confirm",
+        action="store_true",
+        help="operator-gated bounded round trip (one small limit buy + cleanup)",
+    )
+    parser.add_argument("--symbol", required=True, help="US ticker, e.g. AAPL")
+    parser.add_argument(
+        "--exchange",
+        default="",
+        help="KIS exchange code (NASD/NYSE/AMEX); resolved from the universe if omitted",
+    )
+    parser.add_argument(
+        "--notional-usd",
+        type=float,
+        default=20.0,
+        help="max buy notional in USD (default 20)",
+    )
+    parser.add_argument("--max-poll", type=int, default=10)
+    parser.add_argument("--poll-interval", type=float, default=1.0)
+    parser.add_argument(
+        "--max-quote-staleness-min",
+        type=float,
+        default=10.0,
+        help="reject the marketable limit if the latest candle is older than this",
+    )
+    return parser.parse_args(argv)
+
+
+def _gate_or_exit() -> object | None:
+    """Lazy import + env gate. Returns the settings object, or None if disabled.
+
+    Top-level enable is the dedicated ``KIS_MOCK_OVERSEAS_SMOKE_ENABLED`` env var,
+    read directly (NOT a persistent Settings flag) so this smoke cannot be turned
+    on by the unrelated WS-scalping flag and so the repo grows no new config field.
+    """
+    if not _env_truthy(os.environ.get("KIS_MOCK_OVERSEAS_SMOKE_ENABLED")):
+        logger.info(
+            "KIS_MOCK_OVERSEAS_SMOKE_ENABLED is not set; smoke disabled (no-op)."
+        )
+        return None
+    from app.core.config import settings
+
+    missing = [
+        name
+        for name, value in (
+            ("KIS_MOCK_APP_KEY", settings.kis_mock_app_key),
+            ("KIS_MOCK_APP_SECRET", settings.kis_mock_app_secret),
+            ("KIS_MOCK_ACCOUNT_NO", settings.kis_mock_account_no),
+        )
+        if not value
+    ]
+    if missing:
+        logger.error("KIS mock not configured. Missing (names only): %s", missing)
+        return None
+    return settings
+
+
+def _cleanup_path_preflight_error(settings_obj: object) -> str | None:
+    """Fail-fast check that the cleanup SELL/CANCEL is submittable, BEFORE any BUY.
+
+    The overseas order client derives CANO/ACNT_PRDT_CD from a >=10-digit account
+    number; if it cannot, the cleanup SELL/CANCEL would raise and we would be left
+    holding a position we cannot flatten. There is no scalping-exit reason gate for
+    overseas (that is KR-only).
+    """
+    acct = getattr(settings_obj, "kis_mock_account_no", None)
+    digits = str(acct or "").replace("-", "")
+    if len(digits) < 10:
+        return (
+            "KIS_MOCK_ACCOUNT_NO must be >=10 digits to form CANO/ACNT_PRDT_CD for "
+            "the cleanup SELL/CANCEL; refusing to BUY a position we cannot flatten"
+        )
+    return None
+
+
+def _us_market_open() -> bool:
+    """True iff the US equity market is open right now (XNYS trading minute)."""
+    from app.jobs.watch_market_data import is_market_open
+
+    return bool(is_market_open("us"))
+
+
+async def _resolve_exchange(args: argparse.Namespace) -> str:
+    """Resolve the canonical 4-digit KIS exchange code for the smoke symbol.
+
+    Prefers an explicit ``--exchange`` (operator-authoritative); otherwise looks the
+    symbol up in ``us_symbol_universe``. Raises :class:`_ExchangeResolutionError`
+    rather than guessing — for a real order, the wrong exchange can be rejected.
+    """
+    explicit = (args.exchange or "").strip()
+    if explicit:
+        try:
+            return _normalize_kis_exchange_code(explicit)
+        except ValueError as exc:
+            raise _ExchangeResolutionError(str(exc)) from exc
+    try:
+        from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+        code = await get_us_exchange_by_symbol(args.symbol)
+        return _normalize_kis_exchange_code(code)
+    except Exception as exc:  # noqa: BLE001 - any resolution fault fails closed
+        raise _ExchangeResolutionError(
+            f"could not resolve exchange for {args.symbol!r}: {str(exc)[:200]}"
+        ) from exc
+
+
+async def _read_holdings_qty(client, symbol: str, exchange: str) -> Decimal | None:
+    """Return the mock overseas held quantity for ``symbol``, or None on read fault.
+
+    A successful read that does not list the symbol means a zero position (the read
+    pre-filters to nonzero holdings); only a raised exception is a read failure.
+    """
+    try:
+        rows = await client.fetch_my_us_stocks(is_mock=True, exchange=exchange)
+    except Exception as exc:  # noqa: BLE001 - read fault fails closed
+        logger.error("overseas holdings read failed: %s", str(exc)[:200])
+        return None
+    return extract_overseas_holdings_qty(rows, symbol)
+
+
+async def _latest_close(client, symbol: str, exchange: str) -> Decimal | None:
+    try:
+        page = await client.inquire_overseas_minute_chart(symbol, exchange, n=1)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("overseas minute-chart read failed: %s", str(exc)[:200])
+        return None
+    return latest_close_from_minute_frame(page.frame)
+
+
+def _localize_quote_ts(naive_or_aware: dt.datetime) -> dt.datetime:
+    if naive_or_aware.tzinfo is None:
+        return naive_or_aware.replace(tzinfo=_QUOTE_TZ).astimezone(dt.UTC)
+    return naive_or_aware.astimezone(dt.UTC)
+
+
+async def _await_entry_fill(
+    client,
+    args: argparse.Namespace,
+    symbol: str,
+    exchange: str,
+    base_qty: Decimal,
+    ordered_qty: Decimal,
+    limit_price: Decimal,
+) -> _EntryFill | None:
+    for _ in range(max(args.max_poll, 1)):
+        cur = await _read_holdings_qty(client, symbol, exchange)
+        if cur is None:
+            return None
+        decision = classify_fill_by_delta(
+            side="buy", ordered_qty=ordered_qty, baseline_qty=base_qty, observed_qty=cur
+        )
+        if decision.verdict == "filled":
+            price, source = derive_fill_price(
+                side="buy",
+                filled_qty=decision.filled_qty,
+                cash_baseline=None,  # OPSQ0002: cash unavailable in mock overseas
+                cash_observed=None,
+                limit_price=limit_price,
+            )
+            return _EntryFill(
+                price=price, quantity=decision.filled_qty, price_source=source
+            )
+        await asyncio.sleep(args.poll_interval)
+    return None
+
+
+async def _await_flat(
+    client, args: argparse.Namespace, symbol: str, exchange: str, base_qty: Decimal
+) -> Decimal | None:
+    final_qty: Decimal | None = None
+    for _ in range(max(args.max_poll, 1)):
+        final_qty = await _read_holdings_qty(client, symbol, exchange)
+        if final_qty is None:
+            return None
+        if final_qty - base_qty <= 0:
+            return final_qty
+        await asyncio.sleep(args.poll_interval)
+    return final_qty
+
+
+async def _cancel_resting_buy(
+    client,
+    args: argparse.Namespace,
+    exchange: str,
+    buy_odno: str,
+    buy_qty: Decimal,
+    evidence: dict,
+) -> int:
+    """Cancel an unfilled resting BUY so it cannot fill after the smoke exits.
+
+    Inspects the cancel response order id explicitly; a rejection or a missing id
+    is an explicit anomaly (exit 3), never a silent success.
+    """
+    try:
+        cancel = await client.cancel_overseas_order(
+            order_number=buy_odno,
+            symbol=args.symbol,
+            exchange_code=exchange,
+            quantity=int(buy_qty),
+            is_mock=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - submit rejection is a cleanup anomaly
+        evidence["cleanup_cancel_order_id"] = None
+        evidence["cleanup_error"] = str(exc)[:200]
+        evidence["cleanup"] = "CANCEL_submit_rejected"
+        return 3
+    cancel_id = cancel.get("odno") if isinstance(cancel, Mapping) else None
+    evidence["cleanup_cancel_order_id"] = cancel_id
+    if not cancel_id:
+        evidence["cleanup_error"] = "cleanup CANCEL response missing odno"
+        evidence["cleanup"] = "CANCEL_no_order_id"
+        return 3
+    return 0
+
+
+async def _cleanup_and_verify(
+    client,
+    args: argparse.Namespace,
+    exchange: str,
+    base_qty: Decimal,
+    buy_odno: str | None,
+    buy_qty: Decimal,
+    evidence: dict,
+    entry_fill,
+) -> int:
+    """Return holdings to baseline. Returns the process exit code (0 clean, 2
+    fill-unconfirmed-but-flat, 3 anomaly/residual)."""
+    symbol = args.symbol
+    cur = await _read_holdings_qty(client, symbol, exchange)
+    if cur is None:
+        evidence["cleanup"] = "holdings_read_failed"
+        evidence["cleanup_error"] = "post-buy holdings read failed"
+        return 3
+    delta = cur - base_qty
+    evidence["cleanup_current_delta"] = str(delta)
+    if delta < 0:
+        # Holdings below baseline before we sold (over-flatten / external mutation).
+        evidence["cleanup"] = "below_baseline_anomaly"
+        evidence["cleanup_error"] = (
+            f"holdings {cur} below baseline {base_qty} before cleanup"
+        )
+        evidence["final_position_delta_vs_baseline"] = str(delta)
+        return 3
+
+    if delta == 0:
+        # No filled shares. A resting unfilled BUY could still fill later -> cancel it.
+        if buy_odno:
+            cancel_rc = await _cancel_resting_buy(
+                client, args, exchange, buy_odno, buy_qty, evidence
+            )
+            if cancel_rc != 0:
+                return cancel_rc
+            cur = await _read_holdings_qty(client, symbol, exchange)
+            if cur is None:
+                evidence["cleanup"] = "holdings_read_failed"
+                evidence["cleanup_error"] = "post-cancel holdings read failed"
+                return 3
+            delta = cur - base_qty
+            evidence["post_cancel_delta"] = str(delta)
+            if delta < 0:
+                evidence["cleanup"] = "below_baseline_anomaly"
+                evidence["cleanup_error"] = (
+                    f"holdings {cur} below baseline {base_qty} after cancel"
+                )
+                evidence["final_position_delta_vs_baseline"] = str(delta)
+                return 3
+        if delta == 0:
+            evidence["cleanup"] = (
+                "flat_after_cancel" if buy_odno else "nothing_to_flatten"
+            )
+            evidence["final_position_delta_vs_baseline"] = "0"
+            return 0 if entry_fill is not None else 2
+        # else: a late fill landed during the cancel -> fall through to SELL.
+
+    # delta > 0: residual filled shares -> SELL flatten.
+    sell_close = await _latest_close(client, symbol, exchange)
+    if sell_close is None:
+        evidence["cleanup"] = "no_quote_for_exit"
+        evidence["cleanup_error"] = "no usable close to price the cleanup SELL"
+        evidence["final_position_delta_vs_baseline"] = str(delta)
+        return 3
+    try:
+        sell = await client.sell_overseas_stock(
+            symbol=symbol,
+            exchange_code=exchange,
+            quantity=int(delta),
+            price=float(sell_close),
+            is_mock=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - submit rejection is a cleanup anomaly
+        evidence["cleanup_sell_order_id"] = None
+        evidence["cleanup_error"] = str(exc)[:200]
+        evidence["cleanup"] = "SELL_submit_rejected"
+        evidence["final_position_delta_vs_baseline"] = str(delta)
+        return 3
+    order_id = sell.get("odno") if isinstance(sell, Mapping) else None
+    evidence["cleanup_sell_order_id"] = order_id
+    if not order_id:
+        evidence["cleanup_error"] = "cleanup SELL response missing odno"
+        evidence["cleanup"] = "SELL_no_order_id"
+        evidence["final_position_delta_vs_baseline"] = str(delta)
+        return 3
+
+    final_qty = await _await_flat(client, args, symbol, exchange, base_qty)
+    if final_qty is None:
+        evidence["cleanup"] = "holdings_read_failed"
+        evidence["cleanup_error"] = "post-sell holdings read failed"
+        return 3
+    final_delta = final_qty - base_qty
+    evidence["post_holdings_qty"] = str(final_qty)
+    evidence["final_position_delta_vs_baseline"] = str(final_delta)
+    if final_delta > 0:
+        evidence["cleanup"] = "UNCONFIRMED_residual_position"
+        return 3
+    if final_delta < 0:
+        evidence["cleanup"] = "over_flattened_anomaly"
+        evidence["cleanup_error"] = (
+            f"final holdings {final_qty} below baseline {base_qty} after cleanup SELL"
+        )
+        return 3
+    evidence["cleanup"] = "flattened"
+    return 0
+
+
+def _parse_usd_cash(margin_rows) -> tuple[Decimal | None, str]:
+    """Best-effort USD cash from an overseas margin response (None in mock OPSQ0002)."""
+    if not isinstance(margin_rows, list):
+        return None, "unavailable"
+    for row in margin_rows:
+        if not isinstance(row, Mapping):
+            continue
+        if str(row.get("crcy_cd", "")).upper() != "USD":
+            continue
+        # `inquire_overseas_margin` normalizes the USD row to `frcr_dncl_amt1`
+        # (raw `frcr_dncl_amt_2` kept as a fallback for raw payloads).
+        for key in ("frcr_dncl_amt1", "frcr_dncl_amt_2"):
+            raw = row.get(key)
+            if raw in (None, ""):
+                continue
+            try:
+                return Decimal(str(raw).replace(",", "").strip()), key
+            except Exception:  # noqa: BLE001
+                continue
+    return None, "unavailable"
+
+
+async def run_preflight(args: argparse.Namespace) -> int:
+    if _gate_or_exit() is None:
+        return 4
+    from app.mcp_server.tooling.order_execution import _create_kis_client
+
+    client = _create_kis_client(is_mock=True)
+    try:
+        exchange = await _resolve_exchange(args)
+    except _ExchangeResolutionError as exc:
+        logger.error("%s", exc)
+        logger.info(
+            json.dumps(
+                {
+                    "mode": "preflight",
+                    "symbol": args.symbol,
+                    "error": "exchange_unresolved",
+                }
+            )
+        )
+        return 2
+    try:
+        rows = await client.fetch_my_us_stocks(is_mock=True, exchange=exchange)
+    except Exception as exc:  # noqa: BLE001 - read-only preflight, classify the fault
+        logger.error("overseas balance snapshot read failed: %s", str(exc)[:300])
+        return 2
+    holdings_qty = extract_overseas_holdings_qty(rows, args.symbol)
+
+    cash: Decimal | None = None
+    cash_source = "unavailable_opsq0002"
+    try:
+        margin = await client.inquire_overseas_margin(is_mock=True)
+        cash, cash_source = _parse_usd_cash(margin)
+    except Exception as exc:  # noqa: BLE001 - OPSQ0002 expected in mock overseas
+        logger.info(
+            "overseas margin unavailable (expected in mock): %s", str(exc)[:160]
+        )
+
+    logger.info(
+        json.dumps(
+            {
+                "mode": "preflight",
+                "symbol": args.symbol,
+                "exchange": exchange,
+                "holdings_qty": str(holdings_qty),
+                "cash_usd": (str(cash) if cash is not None else None),
+                "cash_source": cash_source,
+            }
+        )
+    )
+    return 0
+
+
+async def run_confirm(args: argparse.Namespace) -> int:
+    settings_obj = _gate_or_exit()
+    if settings_obj is None:
+        return 4
+    # Fail-fast BEFORE any BUY: never acquire a position we cannot flatten.
+    cleanup_error = _cleanup_path_preflight_error(settings_obj)
+    if cleanup_error is not None:
+        logger.error("cleanup preflight failed; no order placed: %s", cleanup_error)
+        logger.info(
+            json.dumps(
+                {
+                    "mode": "confirm",
+                    "symbol": args.symbol,
+                    "preflight": "cleanup_path_unsubmittable",
+                    "error": cleanup_error,
+                }
+            )
+        )
+        return 4
+    if not _us_market_open():
+        logger.error("US market is not open right now; no order placed.")
+        logger.info(
+            json.dumps(
+                {
+                    "mode": "confirm",
+                    "symbol": args.symbol,
+                    "preflight": "us_market_closed",
+                }
+            )
+        )
+        return 4
+
+    from app.mcp_server.tooling.order_execution import _create_kis_client
+
+    client = _create_kis_client(is_mock=True)
+    evidence: dict = {"mode": "confirm", "symbol": args.symbol}
+
+    try:
+        exchange = await _resolve_exchange(args)
+    except _ExchangeResolutionError as exc:
+        evidence["error"] = "exchange_unresolved"
+        evidence["detail"] = str(exc)[:200]
+        logger.info(json.dumps(evidence))
+        return 2
+    evidence["exchange"] = exchange
+
+    # Single minute-chart read: derive BOTH the marketable-limit price and the
+    # freshness timestamp from the SAME candle (no second read that could pick a
+    # different last row).
+    try:
+        page = await client.inquire_overseas_minute_chart(args.symbol, exchange, n=1)
+    except Exception as exc:  # noqa: BLE001 - quote read fault blocks the BUY
+        evidence["error"] = "no_quote"
+        evidence["detail"] = str(exc)[:200]
+        logger.info(json.dumps(evidence))
+        return 2
+    close = latest_close_from_minute_frame(page.frame)
+    if close is None:
+        evidence["error"] = "no_quote"
+        logger.info(json.dumps(evidence))
+        return 2
+    latest_ts = latest_timestamp_from_minute_frame(page.frame)
+    if latest_ts is None or not quote_is_fresh(
+        _localize_quote_ts(latest_ts),
+        dt.datetime.now(dt.UTC),
+        max_staleness_seconds=args.max_quote_staleness_min * 60,
+    ):
+        evidence["error"] = "stale_quote"
+        logger.info(json.dumps(evidence))
+        return 2
+    evidence["buy_limit_price"] = str(close)
+
+    base_qty = await _read_holdings_qty(client, args.symbol, exchange)
+    if base_qty is None:
+        evidence["error"] = "baseline_read_failed"
+        logger.info(json.dumps(evidence))
+        return 2
+    evidence["baseline_holdings_qty"] = str(base_qty)
+
+    qty = int((Decimal(str(args.notional_usd)) / close).to_integral_value(ROUND_DOWN))
+    if qty <= 0:
+        evidence["error"] = "size_zero"
+        logger.info(json.dumps(evidence))
+        return 2
+    evidence["quantity"] = str(qty)
+
+    buy_odno: str | None = None
+    entry_fill: _EntryFill | None = None
+    try:
+        buy = await client.buy_overseas_stock(
+            symbol=args.symbol,
+            exchange_code=exchange,
+            quantity=qty,
+            price=float(close),
+            is_mock=True,
+        )
+        buy_odno = buy.get("odno") if isinstance(buy, Mapping) else None
+        evidence["buy_order_id"] = buy_odno
+        evidence["confirmation_signal"] = "holdings_delta"
+        if not buy_odno:
+            evidence["entry"] = "BUY_no_order_id"
+            evidence["note"] = "buy response missing odno; nothing acked to flatten"
+        else:
+            entry_fill = await _await_entry_fill(
+                client, args, args.symbol, exchange, base_qty, Decimal(qty), close
+            )
+            if entry_fill is None:
+                evidence["entry_filled"] = False
+                evidence["note"] = (
+                    "entry fill UNCONFIRMED within poll window — holdings did not "
+                    "reflect a same-day mock fill (ROB-364 STOP condition)"
+                )
+            else:
+                evidence["entry_filled"] = True
+                evidence["entry_fill_price"] = str(entry_fill.price)
+                evidence["entry_fill_qty"] = str(entry_fill.quantity)
+                evidence["fill_price_source"] = entry_fill.price_source
+    finally:
+        result = await _cleanup_and_verify(
+            client,
+            args,
+            exchange,
+            base_qty,
+            buy_odno,
+            Decimal(qty),
+            evidence,
+            entry_fill,
+        )
+        evidence["exit_code"] = result
+        logger.info(json.dumps(evidence))
+    return result
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.preflight:
+        return await run_preflight(args)
+    return await run_confirm(args)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    try:
+        return asyncio.run(_run(_parse_args(argv)))
+    except KeyboardInterrupt:
+        return 1
+    except Exception:  # noqa: BLE001
+        logger.exception("unexpected error in overseas holdings-delta smoke")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kis_mock_overseas_holdings_confirm.py
+++ b/tests/test_kis_mock_overseas_holdings_confirm.py
@@ -1,0 +1,146 @@
+"""ROB-364 — pure helpers for the KIS mock **overseas/US** holdings-delta smoke.
+
+Unit tests for the normalization helpers the overseas smoke layers on top of
+the shared ``classify_fill_by_delta`` / ``derive_fill_price`` kernel:
+
+* ``extract_overseas_holdings_qty`` — per-symbol qty from KIS overseas holdings
+  rows (``ovrs_pdno`` / ``ovrs_cblc_qty``), symbol-normalized so a KIS-format
+  ``BRK/B`` matches a DB-format ``BRK.B``;
+* ``latest_close_from_minute_frame`` / ``latest_timestamp_from_minute_frame`` —
+  read the most-recent candle from an ascending-sorted overseas minute frame;
+* ``quote_is_fresh`` — fail-closed wall-clock staleness gate.
+
+stdlib + pandas + fakes only; no broker / network / secrets.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from app.services.brokers.kis.mock_scalping_exec.overseas_holdings_confirm import (
+    extract_overseas_holdings_qty,
+    latest_close_from_minute_frame,
+    latest_timestamp_from_minute_frame,
+    quote_is_fresh,
+)
+
+# --- extract_overseas_holdings_qty -----------------------------------------
+
+
+@pytest.mark.unit
+def test_extract_holdings_qty_symbol_present():
+    rows = [
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "5"},
+        {"ovrs_pdno": "TSLA", "ovrs_cblc_qty": "3"},
+    ]
+    assert extract_overseas_holdings_qty(rows, "AAPL") == Decimal("5")
+
+
+@pytest.mark.unit
+def test_extract_holdings_qty_symbol_absent_is_zero():
+    # fetch_my_us_stocks pre-filters to nonzero holdings, so an absent symbol
+    # means we hold zero of it (NOT a read failure — that raises upstream).
+    rows = [{"ovrs_pdno": "TSLA", "ovrs_cblc_qty": "3"}]
+    assert extract_overseas_holdings_qty(rows, "AAPL") == Decimal("0")
+
+
+@pytest.mark.unit
+def test_extract_holdings_qty_empty_rows_is_zero():
+    assert extract_overseas_holdings_qty([], "AAPL") == Decimal("0")
+
+
+@pytest.mark.unit
+def test_extract_holdings_qty_normalizes_kis_slash_symbol():
+    # KIS holdings return ovrs_pdno in KIS format (BRK/B); the smoke passes the
+    # DB-format symbol (BRK.B). Both must normalize to the same key.
+    rows = [{"ovrs_pdno": "BRK/B", "ovrs_cblc_qty": "2"}]
+    assert extract_overseas_holdings_qty(rows, "BRK.B") == Decimal("2")
+
+
+@pytest.mark.unit
+def test_extract_holdings_qty_sums_duplicate_rows():
+    rows = [
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "5"},
+        {"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "1"},
+    ]
+    assert extract_overseas_holdings_qty(rows, "AAPL") == Decimal("6")
+
+
+# --- latest_close_from_minute_frame ----------------------------------------
+
+
+def _minute_frame(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows, columns=["datetime", "close"])
+
+
+@pytest.mark.unit
+def test_latest_close_uses_last_row():
+    # The overseas minute frame is sorted ascending by datetime, so the latest
+    # candle is the LAST row.
+    frame = _minute_frame(
+        [
+            {"datetime": dt.datetime(2026, 5, 29, 9, 30), "close": 100.0},
+            {"datetime": dt.datetime(2026, 5, 29, 9, 31), "close": 101.5},
+        ]
+    )
+    assert latest_close_from_minute_frame(frame) == Decimal("101.5")
+
+
+@pytest.mark.unit
+def test_latest_close_empty_frame_is_none():
+    assert latest_close_from_minute_frame(_minute_frame([])) is None
+
+
+@pytest.mark.unit
+def test_latest_close_nonpositive_is_none():
+    frame = _minute_frame([{"datetime": dt.datetime(2026, 5, 29, 9, 31), "close": 0.0}])
+    assert latest_close_from_minute_frame(frame) is None
+
+
+# --- latest_timestamp_from_minute_frame ------------------------------------
+
+
+@pytest.mark.unit
+def test_latest_timestamp_uses_last_row():
+    frame = _minute_frame(
+        [
+            {"datetime": dt.datetime(2026, 5, 29, 9, 30), "close": 100.0},
+            {"datetime": dt.datetime(2026, 5, 29, 9, 31), "close": 101.5},
+        ]
+    )
+    assert latest_timestamp_from_minute_frame(frame) == dt.datetime(2026, 5, 29, 9, 31)
+
+
+@pytest.mark.unit
+def test_latest_timestamp_empty_frame_is_none():
+    assert latest_timestamp_from_minute_frame(_minute_frame([])) is None
+
+
+# --- quote_is_fresh --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_quote_is_fresh_within_window():
+    now = dt.datetime(2026, 5, 29, 14, 0, tzinfo=dt.UTC)
+    latest = now - dt.timedelta(minutes=2)
+    assert quote_is_fresh(latest, now, max_staleness_seconds=600) is True
+
+
+@pytest.mark.unit
+def test_quote_is_stale_beyond_window():
+    now = dt.datetime(2026, 5, 29, 14, 0, tzinfo=dt.UTC)
+    # 14h stale: market closed, or an Eastern/UTC tz mismatch -> fail closed.
+    latest = now - dt.timedelta(hours=14)
+    assert quote_is_fresh(latest, now, max_staleness_seconds=600) is False
+
+
+@pytest.mark.unit
+def test_quote_freshness_uses_absolute_skew():
+    # A bar timestamped in the future (clock/tz skew) is also not fresh.
+    now = dt.datetime(2026, 5, 29, 14, 0, tzinfo=dt.UTC)
+    latest = now + dt.timedelta(hours=5)
+    assert quote_is_fresh(latest, now, max_staleness_seconds=600) is False

--- a/tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py
+++ b/tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py
@@ -80,6 +80,7 @@ class _FakeOverseasClient:
         cancel: dict | None = None,
         cancel_exc: Exception | None = None,
         buy: dict | None = None,
+        buy_exc: Exception | None = None,
         fetch_exc: bool = False,
     ) -> None:
         self._holdings_seq = list(holdings_seq or [[]])
@@ -90,6 +91,7 @@ class _FakeOverseasClient:
         self._cancel = cancel
         self._cancel_exc = cancel_exc
         self._buy = buy
+        self._buy_exc = buy_exc
         self._fetch_exc = fetch_exc
         self.sell_calls: list[dict] = []
         self.cancel_calls: list[dict] = []
@@ -124,6 +126,8 @@ class _FakeOverseasClient:
         self.buy_calls.append(
             {"symbol": symbol, "exchange_code": exchange_code, "quantity": quantity}
         )
+        if self._buy_exc is not None:
+            raise self._buy_exc
         return self._buy or {"odno": "BUY0000001"}
 
     async def sell_overseas_stock(
@@ -478,7 +482,9 @@ async def test_cleanup_unfilled_resting_buy_is_cancelled():
     )
     assert client.cancel_calls[0]["exchange_code"] == "NASD"
     assert client.sell_calls == []  # nothing to flatten
-    assert evidence["cleanup_cancel_order_id"] == "CANCEL00001"
+    assert evidence["buy_cancel_attempted"] is True
+    assert evidence["buy_cancel_order_id"] == "CANCEL00001"
+    assert evidence["open_order_check_status"] == "resting_buy_cancelled"
 
 
 @pytest.mark.unit
@@ -502,7 +508,11 @@ async def test_cleanup_cancel_submit_rejection_is_anomaly():
     )
     assert rc == 3
     assert evidence["cleanup"] == "CANCEL_submit_rejected"
-    assert evidence["cleanup_cancel_order_id"] is None
+    assert evidence["buy_cancel_order_id"] is None
+    assert evidence["open_order_check_status"] == "resting_buy_cancel_failed"
+    assert (
+        client.sell_calls == []
+    )  # fail-closed: no SELL after an un-cancellable resting BUY
 
 
 @pytest.mark.unit
@@ -553,6 +563,8 @@ async def test_cleanup_nothing_to_flatten_no_buy_odno_is_fill_unconfirmed():
 async def test_cleanup_late_fill_during_cancel_falls_through_to_sell():
     # delta 0 at cleanup start -> cancel the resting BUY -> a late fill lands
     # (delta 1 on the post-cancel re-read) -> fall through to SELL -> flatten.
+    # The entry was NEVER a confirmed full fill, so even flat this is exit 2,
+    # NOT exit 0 (blocker 2).
     client = _FakeOverseasClient(
         holdings_seq=[_holdings(None, 0), _holdings("AAPL", 1), _holdings(None, 0)],
         close=100.0,
@@ -568,10 +580,10 @@ async def test_cleanup_late_fill_during_cancel_falls_through_to_sell():
         evidence,
         entry_fill=None,  # poll missed it; it filled during the cancel window
     )
-    assert rc == 0
+    assert rc == 2
     assert client.cancel_calls and client.sell_calls
     assert client.sell_calls[0]["quantity"] == 1
-    assert evidence["cleanup"] == "flattened"
+    assert evidence["cleanup"] == "flattened_entry_unconfirmed"
     assert evidence["final_position_delta_vs_baseline"] == "0"
 
 
@@ -620,7 +632,9 @@ async def test_confirm_entry_unconfirmed_but_flat_is_exit_2(monkeypatch):
     _confirm_env(monkeypatch, client)
 
     async def _no_fill(*_a, **_k):
-        return None
+        return smoke._EntryOutcome(
+            fill=None, verdict="none", observed_delta=Decimal("0")
+        )
 
     monkeypatch.setattr(smoke, "_await_entry_fill", _no_fill)
     rc = await smoke.run_confirm(_confirm_args(["--notional-usd", "100"]))
@@ -670,18 +684,30 @@ async def test_confirm_happy_path_evidence_has_required_fields(monkeypatch, capl
         "baseline_holdings_qty",
         "quantity",
         "buy_order_id",
+        "entry_order_id",
         "confirmation_signal",
+        "entry_fill_verdict",
+        "entry_fill_confirmed",
         "entry_filled",
         "fill_price_source",
+        "buy_cancel_attempted",
+        "open_order_check_status",
         "cleanup",
         "cleanup_sell_order_id",
         "final_position_delta_vs_baseline",
+        "final_exit_reason",
         "exit_code",
     ):
         assert key in ev, f"missing evidence field: {key}"
     assert ev["exit_code"] == 0
     assert ev["final_position_delta_vs_baseline"] == "0"
     assert ev["fill_price_source"] == "limit_fallback"  # cash OPSQ0002 in mock
+    assert ev["entry_fill_verdict"] == "filled"
+    assert ev["entry_fill_confirmed"] is True
+    assert ev["open_order_check_status"] == "full_fill_no_resting_order"
+    assert (
+        ev["buy_cancel_attempted"] is False
+    )  # full fill -> no resting order to cancel
 
 
 # --- run_preflight (read-only mode) ----------------------------------------
@@ -820,3 +846,121 @@ def test_parse_usd_cash_invalid_decimal_falls_back_to_next_key():
     cash, source = smoke._parse_usd_cash(rows)
     assert cash == Decimal("50")
     assert source == "frcr_dncl_amt_2"
+
+
+# --- partial / unconfirmed fill must cancel the resting BUY + never exit 0 ---
+# (safety-review blockers 1 & 2)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_partial_fill_cancels_resting_buy_and_is_not_exit_0():
+    # entry never confirmed FULL (entry_fill=None) but holdings moved (+1) -> the
+    # original BUY may have an unfilled resting remainder. Cancel it first, SELL
+    # the filled delta, and even though flat, this is exit 2 (NOT 0).
+    client = _FakeOverseasClient(
+        holdings_seq=[
+            _holdings("AAPL", 1),  # cleanup current (partial fill landed)
+            _holdings("AAPL", 1),  # post-cancel re-read (still held)
+            _holdings(None, 0),  # post-sell flat
+        ],
+        close=100.0,
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("2"),  # ordered 2, only 1 filled -> resting remainder
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 2  # flat but entry never confirmed full -> NOT a clean exit 0
+    assert (
+        client.cancel_calls and client.cancel_calls[0]["order_number"] == "BUY0000001"
+    )
+    assert client.sell_calls and client.sell_calls[0]["quantity"] == 1
+    assert evidence["buy_cancel_attempted"] is True
+    assert evidence["open_order_check_status"] == "resting_buy_cancelled"
+    assert evidence["cleanup"] == "flattened_entry_unconfirmed"
+    assert evidence["final_position_delta_vs_baseline"] == "0"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_partial_fill_cancel_rejected_is_fail_closed():
+    # entry unconfirmed + positive delta, but the resting BUY cancel is rejected:
+    # we cannot authoritatively remove the resting-order risk -> fail closed (3),
+    # and we do NOT proceed to SELL.
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 1)],
+        close=100.0,
+        cancel_exc=RuntimeError("cancel rejected"),
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("2"),
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "CANCEL_submit_rejected"
+    assert evidence["open_order_check_status"] == "resting_buy_cancel_failed"
+    assert client.sell_calls == []  # never SELL when the resting BUY is un-cancellable
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_unconfirmed_positive_delta_no_odno_is_not_exit_0():
+    # positive delta with an unconfirmed entry and NO acked BUY odno (nothing to
+    # cancel): flatten the delta but still never exit 0.
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 1), _holdings(None, 0)], close=100.0
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        None,  # no acked BUY order id
+        Decimal("1"),
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 2
+    assert client.cancel_calls == []
+    assert client.sell_calls and client.sell_calls[0]["quantity"] == 1
+    assert evidence["open_order_check_status"] == "no_order_acked"
+    assert evidence["cleanup"] == "flattened_entry_unconfirmed"
+
+
+# --- BUY submit exception: explicit evidence + consistent non-zero exit ------
+# (safety-review blocker 3)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_buy_submit_exception_is_consistent_nonzero(monkeypatch, caplog):
+    client = _FakeOverseasClient(
+        close=100.0, buy_exc=RuntimeError("APBK0918 buy rejected")
+    )
+    _confirm_env(monkeypatch, client)
+    with caplog.at_level(logging.INFO, logger=smoke.__name__):
+        rc = await smoke.run_confirm(_confirm_args(["--notional-usd", "100"]))
+    assert rc != 0  # a BUY submit failure is never a clean success
+    ev = _last_json_with(caplog, "exit_code")
+    assert ev is not None
+    assert ev["entry"] == "BUY_submit_rejected"
+    assert "buy_submit_exception" in ev
+    assert ev["entry_order_id"] is None
+    assert ev["entry_fill_confirmed"] is False
+    # evidence exit_code is consistent with the actual process exit code
+    assert ev["exit_code"] == rc

--- a/tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py
+++ b/tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py
@@ -1,0 +1,822 @@
+"""ROB-364 — cleanup gate/reason hardening for the KIS mock **overseas/US**
+holdings-delta smoke (the US counterpart to ROB-358's domestic smoke).
+
+These tests prove the ``--confirm`` round trip for overseas/US KIS mock:
+
+* fail-fast BEFORE any BUY when the smoke is disabled, the account cannot
+  satisfy the SELL/CANCEL cleanup path, or the US market is closed — the BUY
+  path (client construction) is never reached;
+* fail-fast BEFORE any BUY on a missing/stale quote (no marketable limit) or an
+  unresolved exchange;
+* the cleanup SELL flattens a filled residual back to baseline (final delta 0);
+* an unfilled resting BUY is CANCELLED (not left to fill later);
+* every off-baseline / rejected / id-less cleanup outcome is an explicit anomaly
+  (exit 3), never a silent success or a leaked exception (exit 1).
+
+Unlike the domestic smoke there is NO scalping-exit validator and NO overseas
+``KisMockBroker`` — cleanup goes through the overseas order client directly, so
+the fakes here implement that client surface (``fetch_my_us_stocks`` /
+``sell_overseas_stock`` / ``cancel_overseas_order`` / ``inquire_overseas_minute_chart``).
+
+stdlib + pandas + fakes only; no broker / network / secrets.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from decimal import Decimal
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+import scripts.kis_mock_overseas_holdings_delta_smoke as smoke
+
+
+class _FakeSettings:
+    """Minimal stand-in for the Settings object the gate returns."""
+
+    def __init__(self, *, account_no: str = "12345678-01") -> None:
+        self.kis_mock_app_key = "k"
+        self.kis_mock_app_secret = "s"
+        self.kis_mock_account_no = account_no
+
+
+def _holdings(symbol: str | None, qty: int) -> list[dict]:
+    """A KIS overseas holdings row list (pre-filtered to nonzero positions)."""
+    if symbol is None or qty == 0:
+        return []
+    return [{"ovrs_pdno": symbol, "ovrs_cblc_qty": str(qty)}]
+
+
+class _Page:
+    def __init__(self, frame: pd.DataFrame) -> None:
+        self.frame = frame
+
+
+def _fresh_minute_frame(close: float) -> pd.DataFrame:
+    # A candle stamped at "now" in US/Eastern (the tz the smoke localizes to)
+    # so the freshness gate passes deterministically.
+    now_et = dt.datetime.now(ZoneInfo("America/New_York")).replace(
+        tzinfo=None, microsecond=0
+    )
+    return pd.DataFrame([{"datetime": now_et, "close": close}])
+
+
+class _FakeOverseasClient:
+    """Fake KIS overseas client covering only the surfaces the smoke calls."""
+
+    def __init__(
+        self,
+        *,
+        holdings_seq: list[list[dict]] | None = None,
+        close: float | None = 100.0,
+        stale: bool = False,
+        sell: dict | None = None,
+        sell_exc: Exception | None = None,
+        cancel: dict | None = None,
+        cancel_exc: Exception | None = None,
+        buy: dict | None = None,
+        fetch_exc: bool = False,
+    ) -> None:
+        self._holdings_seq = list(holdings_seq or [[]])
+        self._close = close
+        self._stale = stale
+        self._sell = sell
+        self._sell_exc = sell_exc
+        self._cancel = cancel
+        self._cancel_exc = cancel_exc
+        self._buy = buy
+        self._fetch_exc = fetch_exc
+        self.sell_calls: list[dict] = []
+        self.cancel_calls: list[dict] = []
+        self.buy_calls: list[dict] = []
+
+    async def fetch_my_us_stocks(self, is_mock: bool = False, exchange: str = "NASD"):
+        if self._fetch_exc:
+            raise RuntimeError("overseas balance read failed")
+        if len(self._holdings_seq) > 1:
+            return self._holdings_seq.pop(0)
+        return self._holdings_seq[0] if self._holdings_seq else []
+
+    async def inquire_overseas_minute_chart(
+        self, symbol, exchange_code="NASD", n=1, keyb=""
+    ):
+        if self._close is None:
+            return _Page(pd.DataFrame(columns=["datetime", "close"]))
+        if self._stale:
+            return _Page(
+                pd.DataFrame(
+                    [{"datetime": dt.datetime(2020, 1, 1, 9, 31), "close": self._close}]
+                )
+            )
+        return _Page(_fresh_minute_frame(self._close))
+
+    async def inquire_overseas_margin(self, is_mock: bool = False):
+        raise RuntimeError("OPSQ0002 no such service code")
+
+    async def buy_overseas_stock(
+        self, symbol, exchange_code, quantity, price=0.0, is_mock=False
+    ):
+        self.buy_calls.append(
+            {"symbol": symbol, "exchange_code": exchange_code, "quantity": quantity}
+        )
+        return self._buy or {"odno": "BUY0000001"}
+
+    async def sell_overseas_stock(
+        self, symbol, exchange_code, quantity, price=0.0, is_mock=False
+    ):
+        self.sell_calls.append(
+            {"symbol": symbol, "exchange_code": exchange_code, "quantity": quantity}
+        )
+        if self._sell_exc is not None:
+            raise self._sell_exc
+        return self._sell if self._sell is not None else {"odno": "SELL0000001"}
+
+    async def cancel_overseas_order(
+        self, order_number, symbol, exchange_code, quantity, is_mock=False
+    ):
+        self.cancel_calls.append(
+            {
+                "order_number": order_number,
+                "symbol": symbol,
+                "exchange_code": exchange_code,
+                "quantity": quantity,
+            }
+        )
+        if self._cancel_exc is not None:
+            raise self._cancel_exc
+        return self._cancel if self._cancel is not None else {"odno": "CANCEL00001"}
+
+
+def _confirm_args(extra: list[str] | None = None):
+    argv = [
+        "--confirm",
+        "--symbol",
+        "AAPL",
+        "--exchange",
+        "NASD",
+        "--max-poll",
+        "2",
+        "--poll-interval",
+        "0",
+    ]
+    return smoke._parse_args(argv + (extra or []))
+
+
+# --- fail-fast preflight (before any BUY / client construction) ------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fails_fast_when_smoke_disabled(monkeypatch):
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: None)
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 4
+    created.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fails_fast_when_account_cannot_clean_up(monkeypatch):
+    # account_no too short to form CANO/ACNT_PRDT_CD -> SELL/CANCEL would fail,
+    # so we must never acquire a position. Stop before any BUY.
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings(account_no="123"))
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: True)
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 4
+    created.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_fails_fast_when_us_market_closed(monkeypatch):
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: False)
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 4
+    created.assert_not_called()
+
+
+# --- pre-BUY quote / exchange gates (client built, BUY never sent) ---------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_no_quote_blocks_before_buy(monkeypatch):
+    client = _FakeOverseasClient(close=None)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: True)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 2
+    assert client.buy_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_stale_quote_blocks_before_buy(monkeypatch):
+    client = _FakeOverseasClient(close=100.0, stale=True)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: True)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 2
+    assert client.buy_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_unresolved_exchange_blocks_before_buy(monkeypatch):
+    client = _FakeOverseasClient(close=100.0)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: True)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+
+    async def _boom(*_a, **_k):
+        raise smoke._ExchangeResolutionError("AAPL not registered")
+
+    monkeypatch.setattr(smoke, "_resolve_exchange", _boom)
+    rc = await smoke.run_confirm(_confirm_args(["--exchange", ""]))
+    assert rc == 2
+    assert client.buy_calls == []
+
+
+# --- happy path: buy fills, cleanup flattens to baseline (final delta 0) ----
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_happy_path_buys_fills_and_flattens(monkeypatch):
+    # baseline 0 -> buy fills to 1 -> cleanup SELL -> back to 0.
+    client = _FakeOverseasClient(
+        holdings_seq=[
+            _holdings(None, 0),  # baseline
+            _holdings("AAPL", 1),  # entry fill poll
+            _holdings("AAPL", 1),  # cleanup current
+            _holdings(None, 0),  # post-sell
+        ],
+        close=100.0,
+    )
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: True)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+    rc = await smoke.run_confirm(_confirm_args(["--notional-usd", "100"]))
+    assert rc == 0
+    assert client.buy_calls and client.buy_calls[0]["exchange_code"] == "NASD"
+    assert client.sell_calls and client.sell_calls[0]["quantity"] == 1
+
+
+# --- cleanup matrix (call _cleanup_and_verify directly) --------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_happy_path_flattens_to_baseline():
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 1), _holdings(None, 0)], close=100.0
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 0
+    assert evidence["cleanup"] == "flattened"
+    assert evidence["cleanup_sell_order_id"] == "SELL0000001"
+    assert evidence["final_position_delta_vs_baseline"] == "0"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_residual_position_is_explicit_anomaly():
+    client = _FakeOverseasClient(holdings_seq=[_holdings("AAPL", 1)], close=100.0)
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "UNCONFIRMED_residual_position"
+    assert evidence["final_position_delta_vs_baseline"] == "1"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_sell_submit_rejection_is_anomaly_not_unexpected():
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 1)],
+        close=100.0,
+        sell_exc=RuntimeError("APBK0918 rejected"),
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup_sell_order_id"] is None
+    assert "cleanup_error" in evidence
+    assert evidence["cleanup"] == "SELL_submit_rejected"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_sell_missing_order_id_is_anomaly():
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 1)], close=100.0, sell={"odno": None}
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "SELL_no_order_id"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_below_baseline_at_start_is_anomaly():
+    # current holdings (0) below baseline (1): final delta -1, never a clean exit.
+    client = _FakeOverseasClient(holdings_seq=[_holdings(None, 0)], close=100.0)
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("1"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["final_position_delta_vs_baseline"] == "-1"
+    assert evidence["cleanup"] != "flattened"
+    assert "cleanup_error" in evidence
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_over_flatten_below_baseline_is_anomaly():
+    # baseline 1 -> current 2 (delta 1) -> SELL -> post 0 (below baseline): delta -1.
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings("AAPL", 2), _holdings(None, 0)], close=100.0
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("1"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "over_flattened_anomaly"
+    assert evidence["final_position_delta_vs_baseline"] == "-1"
+    assert "cleanup_error" in evidence
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_holdings_read_failure_is_anomaly():
+    client = _FakeOverseasClient(fetch_exc=True, close=100.0)
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=object(),
+    )
+    assert rc == 3
+    assert "cleanup_error" in evidence
+
+
+# --- unfilled resting BUY -> CANCEL (not left to fill later) ----------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_unfilled_resting_buy_is_cancelled():
+    # delta 0 at cleanup but a BUY odno is live -> cancel it; stays flat -> exit 2.
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings(None, 0), _holdings(None, 0)], close=100.0
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=None,  # never filled
+    )
+    assert rc == 2  # fill-unconfirmed but flat
+    assert (
+        client.cancel_calls and client.cancel_calls[0]["order_number"] == "BUY0000001"
+    )
+    assert client.cancel_calls[0]["exchange_code"] == "NASD"
+    assert client.sell_calls == []  # nothing to flatten
+    assert evidence["cleanup_cancel_order_id"] == "CANCEL00001"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_cancel_submit_rejection_is_anomaly():
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings(None, 0)],
+        close=100.0,
+        cancel_exc=RuntimeError("cancel rejected"),
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "CANCEL_submit_rejected"
+    assert evidence["cleanup_cancel_order_id"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_cancel_missing_order_id_is_anomaly():
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings(None, 0)], close=100.0, cancel={"odno": None}
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 3
+    assert evidence["cleanup"] == "CANCEL_no_order_id"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_nothing_to_flatten_no_buy_odno_is_fill_unconfirmed():
+    # delta 0 and no BUY odno (submit never acked): nothing to cancel/sell -> exit 2.
+    client = _FakeOverseasClient(holdings_seq=[_holdings(None, 0)], close=100.0)
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        None,  # no buy odno
+        Decimal("1"),
+        evidence,
+        entry_fill=None,
+    )
+    assert rc == 2
+    assert evidence["cleanup"] == "nothing_to_flatten"
+    assert client.cancel_calls == []
+    assert client.sell_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_late_fill_during_cancel_falls_through_to_sell():
+    # delta 0 at cleanup start -> cancel the resting BUY -> a late fill lands
+    # (delta 1 on the post-cancel re-read) -> fall through to SELL -> flatten.
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings(None, 0), _holdings("AAPL", 1), _holdings(None, 0)],
+        close=100.0,
+    )
+    evidence: dict[str, object] = {}
+    rc = await smoke._cleanup_and_verify(
+        client,
+        _confirm_args(),
+        "NASD",
+        Decimal("0"),
+        "BUY0000001",
+        Decimal("1"),
+        evidence,
+        entry_fill=None,  # poll missed it; it filled during the cancel window
+    )
+    assert rc == 0
+    assert client.cancel_calls and client.sell_calls
+    assert client.sell_calls[0]["quantity"] == 1
+    assert evidence["cleanup"] == "flattened"
+    assert evidence["final_position_delta_vs_baseline"] == "0"
+
+
+# --- pre-BUY baseline / size gates (run_confirm, BUY never sent) -----------
+
+
+def _confirm_env(monkeypatch, client, *, market_open=True):
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(smoke, "_us_market_open", lambda: market_open)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_baseline_read_failed_blocks_before_buy(monkeypatch):
+    # quote passes (inquire ok) but the baseline holdings read raises -> no BUY.
+    client = _FakeOverseasClient(close=100.0, fetch_exc=True)
+    _confirm_env(monkeypatch, client)
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 2
+    assert client.buy_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_size_zero_blocks_before_buy(monkeypatch):
+    # notional 20 / close 100000 floors to 0 shares -> size_zero, no BUY.
+    client = _FakeOverseasClient(close=100000.0)
+    _confirm_env(monkeypatch, client)
+    rc = await smoke.run_confirm(_confirm_args())
+    assert rc == 2
+    assert client.buy_calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_entry_unconfirmed_but_flat_is_exit_2(monkeypatch):
+    # BUY acked but the entry never confirms a fill; holdings stay flat -> the
+    # resting BUY is cancelled and the run reports fill-unconfirmed (exit 2).
+    client = _FakeOverseasClient(
+        holdings_seq=[_holdings(None, 0), _holdings(None, 0)], close=100.0
+    )
+    _confirm_env(monkeypatch, client)
+
+    async def _no_fill(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(smoke, "_await_entry_fill", _no_fill)
+    rc = await smoke.run_confirm(_confirm_args(["--notional-usd", "100"]))
+    assert rc == 2
+    assert client.buy_calls  # the BUY was placed
+    assert client.cancel_calls  # the resting BUY was cancelled
+
+
+# --- final evidence packet structure (AC5) ---------------------------------
+
+
+def _last_json_with(caplog, key: str) -> dict | None:
+    found = None
+    for rec in caplog.records:
+        try:
+            obj = json.loads(rec.getMessage())
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and key in obj:
+            found = obj
+    return found
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_happy_path_evidence_has_required_fields(monkeypatch, caplog):
+    client = _FakeOverseasClient(
+        holdings_seq=[
+            _holdings(None, 0),  # baseline
+            _holdings("AAPL", 1),  # entry fill poll
+            _holdings("AAPL", 1),  # cleanup current
+            _holdings(None, 0),  # post-sell
+        ],
+        close=100.0,
+    )
+    _confirm_env(monkeypatch, client)
+    with caplog.at_level(logging.INFO, logger=smoke.__name__):
+        rc = await smoke.run_confirm(_confirm_args(["--notional-usd", "100"]))
+    assert rc == 0
+    ev = _last_json_with(caplog, "exit_code")
+    assert ev is not None
+    for key in (
+        "mode",
+        "symbol",
+        "exchange",
+        "buy_limit_price",
+        "baseline_holdings_qty",
+        "quantity",
+        "buy_order_id",
+        "confirmation_signal",
+        "entry_filled",
+        "fill_price_source",
+        "cleanup",
+        "cleanup_sell_order_id",
+        "final_position_delta_vs_baseline",
+        "exit_code",
+    ):
+        assert key in ev, f"missing evidence field: {key}"
+    assert ev["exit_code"] == 0
+    assert ev["final_position_delta_vs_baseline"] == "0"
+    assert ev["fill_price_source"] == "limit_fallback"  # cash OPSQ0002 in mock
+
+
+# --- run_preflight (read-only mode) ----------------------------------------
+
+
+def _preflight_args(extra: list[str] | None = None):
+    argv = ["--preflight", "--symbol", "AAPL", "--exchange", "NASD"]
+    return smoke._parse_args(argv + (extra or []))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preflight_disabled_is_noop(monkeypatch):
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: None)
+    created = mock.Mock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client", created
+    )
+    rc = await smoke.run_preflight(_preflight_args())
+    assert rc == 4
+    created.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preflight_exchange_unresolved_is_exit_2(monkeypatch):
+    client = _FakeOverseasClient(close=100.0)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+
+    async def _boom(*_a, **_k):
+        raise smoke._ExchangeResolutionError("AAPL not registered")
+
+    monkeypatch.setattr(smoke, "_resolve_exchange", _boom)
+    rc = await smoke.run_preflight(_preflight_args(["--exchange", ""]))
+    assert rc == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preflight_holdings_read_failure_is_exit_2(monkeypatch):
+    client = _FakeOverseasClient(fetch_exc=True, close=100.0)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+    rc = await smoke.run_preflight(_preflight_args())
+    assert rc == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preflight_success_reports_holdings_and_opsq2_cash(monkeypatch, caplog):
+    # margin raises OPSQ0002 (the fake default) -> cash null + opsq2 source.
+    client = _FakeOverseasClient(holdings_seq=[_holdings("AAPL", 4)], close=100.0)
+    monkeypatch.setattr(smoke, "_gate_or_exit", lambda: _FakeSettings())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_execution._create_kis_client",
+        lambda *a, **k: client,
+    )
+    with caplog.at_level(logging.INFO, logger=smoke.__name__):
+        rc = await smoke.run_preflight(_preflight_args())
+    assert rc == 0
+    ev = _last_json_with(caplog, "holdings_qty")
+    assert ev is not None
+    assert ev["mode"] == "preflight"
+    assert ev["exchange"] == "NASD"
+    assert ev["holdings_qty"] == "4"
+    assert ev["cash_usd"] is None
+    assert ev["cash_source"] == "unavailable_opsq0002"
+
+
+# --- pure smoke-script helpers ---------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", " on "])
+def test_env_truthy_accepts(value):
+    assert smoke._env_truthy(value) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["0", "false", "", "no", "maybe", None])
+def test_env_truthy_rejects(value):
+    assert smoke._env_truthy(value) is False
+
+
+@pytest.mark.unit
+def test_localize_quote_ts_naive_is_eastern_to_utc():
+    naive = dt.datetime(2026, 5, 29, 9, 31)  # 09:31 US/Eastern
+    out = smoke._localize_quote_ts(naive)
+    assert out.utcoffset() == dt.timedelta(0)
+    assert out == naive.replace(tzinfo=ZoneInfo("America/New_York")).astimezone(dt.UTC)
+
+
+@pytest.mark.unit
+def test_localize_quote_ts_aware_utc_passthrough():
+    aware = dt.datetime(2026, 5, 29, 13, 31, tzinfo=dt.UTC)
+    assert smoke._localize_quote_ts(aware) == aware
+
+
+@pytest.mark.unit
+def test_localize_quote_ts_aware_other_tz_to_utc():
+    seoul = dt.datetime(2026, 5, 29, 22, 31, tzinfo=ZoneInfo("Asia/Seoul"))
+    out = smoke._localize_quote_ts(seoul)
+    assert out.utcoffset() == dt.timedelta(0)
+    assert out == seoul.astimezone(dt.UTC)
+
+
+@pytest.mark.unit
+def test_parse_usd_cash_non_list_is_unavailable():
+    assert smoke._parse_usd_cash(None) == (None, "unavailable")
+
+
+@pytest.mark.unit
+def test_parse_usd_cash_reads_usd_row():
+    rows = [{"crcy_cd": "USD", "frcr_dncl_amt1": "123.45"}]
+    cash, source = smoke._parse_usd_cash(rows)
+    assert cash == Decimal("123.45")
+    assert source == "frcr_dncl_amt1"
+
+
+@pytest.mark.unit
+def test_parse_usd_cash_no_usd_row_is_unavailable():
+    rows = [{"crcy_cd": "KRW", "frcr_dncl_amt1": "1000"}]
+    assert smoke._parse_usd_cash(rows) == (None, "unavailable")
+
+
+@pytest.mark.unit
+def test_parse_usd_cash_invalid_decimal_falls_back_to_next_key():
+    rows = [{"crcy_cd": "USD", "frcr_dncl_amt1": "abc", "frcr_dncl_amt_2": "50"}]
+    cash, source = smoke._parse_usd_cash(rows)
+    assert cash == Decimal("50")
+    assert source == "frcr_dncl_amt_2"


### PR DESCRIPTION
## Summary

PR1 for **ROB-364** — the US/overseas counterpart to the domestic ROB-358 KIS-mock holdings-delta confirmed-smoke. Default-disabled, operator-gated, **mock-only**. It proves the US execution + cleanup plumbing; the actual confirmed BUY **run** is deferred to operator (needs creds + US RTH) → **NOT Done until run** (same posture as ROB-341/358).

Linear: https://linear.app/mgh3326/issue/ROB-364

## Why this is NOT the domestic smoke with a US symbol

Verified by reading the overseas client/account/quote surfaces:

| Concern | Domestic (ROB-358) | Overseas/US (this PR) |
|---|---|---|
| Execution path | `KisMockBroker` | overseas order client **directly** (`buy/sell/cancel_overseas_stock`, `is_mock=True`) — there is **no** overseas `KisMockBroker` |
| Cleanup SELL gate | `KIS_MOCK_SCALPING_ENABLED` + allowed scalping-exit reason | **dropped** (KR-only); pre-BUY gate asserts account_no ≥ 10 digits + US market open |
| Cash / fill price | mock cash readable → cash-delta | USD margin **OPSQ0002-blocked** → cash-delta dead → `fill_price_source="limit_fallback"` |
| Same-day history | daily-ccld empty (non-gating) | pending-orders **raises in mock** + daily-ccld empty same-day → both non-gating |
| Fill gate | holdings delta (primary) | holdings delta (**sole** gate) |

## Files

- `scripts/kis_mock_overseas_holdings_delta_smoke.py` — `--preflight` (read-only) + operator-gated `--confirm` (marketable LIMIT BUY → bounded holdings-delta poll → cleanup in `finally`: SELL a filled residual / CANCEL an unfilled resting BUY → final delta verification). Exit codes 0/1/2/3/4.
- `app/services/brokers/kis/mock_scalping_exec/overseas_holdings_confirm.py` — pure helpers; reuses the shared `classify_fill_by_delta` + `derive_fill_price` kernel.
- `tests/test_kis_mock_overseas_holdings_confirm.py` + `tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py` — **59 tests**, fake-client only, **no broker mutation**.
- `docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md` — capability-surfaces inventory + exit-code table + caveats.

## Safety boundaries

KIS mock overseas only; no live; LIMIT only; no shorting; no automatic submit; enable flag `KIS_MOCK_OVERSEAS_SMOKE_ENABLED` read directly from `os.environ` (**not** a persistent `Settings` flag); no scheduler/Prefect/TaskIQ/cron; secrets never printed (names only); **Alpaca Paper semantics kept separate**; cleanup always attempted in `finally`; negative / below-baseline / over-flatten deltas are **always** anomalies (never a clean exit).

## Central operator-gated unknown

Whether KIS mock actually *fills* overseas orders and reflects them in `fetch_my_us_stocks(is_mock=True)`. If it does not, every confirmed run is fill-unconfirmed (exit 2) — the smoke **fails closed and never fabricates a fill**. This is what the live RUN must resolve.

## Test plan

- [x] CI-scope `ruff check app/ tests/` + `ruff format --check app/ tests/` clean
- [x] 59 new tests pass (pure helpers + cleanup matrix + pre-BUY gates + preflight + evidence structure + late-fill-during-cancel)
- [x] Import guards (`test_import_contracts`, `test_kis_imports`) + adjacent KIS-mock suites green — no regressions
- [x] A 4-dimension adversarial review pass was run; confirmed findings folded in (consolidated a redundant double quote-read, fixed an invalid KIS margin field name, added the coverage above)
- [ ] Operator confirmed RUN (creds + US RTH) — deferred, NOT Done until run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
