### PR TITLE
fix(ROB-366): report_quality grade honestly demotes partial/thin-coverage bundles (B10)

### DIFF
--- a/app/services/action_report/common/diagnostics.py
+++ b/app/services/action_report/common/diagnostics.py
@@ -210,6 +210,12 @@ def _why(kind: WhyNoActionKind, blocking_sources: list[str]) -> dict[str, Any]:
 
 ReportQualityGrade = Literal["high_confidence", "informational_only", "no_action"]
 
+# ROB-366 B10 — minimum internal (core + optional, external-excluded) fresh
+# coverage for a non-complete bundle to honestly read as high_confidence. Below
+# this, with no passing external cross-check, the grade is demoted to
+# informational_only (display/audit only — never blocks generation).
+HIGH_CONFIDENCE_MIN_COVERAGE_PCT = 70
+
 
 def build_data_sufficiency_by_source(
     freshness_summary: Mapping[str, Any] | None,
@@ -278,10 +284,20 @@ def build_report_quality_summary(
     * ``external_cross_check_status`` — worst status across the external audit
       kinds present, or ``None`` if none were attempted.
 
-    Grade (unchanged basis — critical kinds + bundle_status):
+    Grade:
     * ``no_action`` — bundle failed or fell back to stale data.
-    * ``informational_only`` — a critical kind is degrading.
-    * ``high_confidence`` — all critical kinds usable.
+    * ``informational_only`` — a critical kind is degrading, OR (ROB-366 B10)
+      the core is not fully fresh, OR internal coverage is below
+      ``HIGH_CONFIDENCE_MIN_COVERAGE_PCT`` with no usable external cross-check to
+      corroborate (a degrading cross-check does not count).
+    * ``high_confidence`` — core fully fresh AND (ample internal coverage OR a
+      usable external cross-check). A genuinely complete bundle is internally
+      all-fresh (the producer's invariant), so it satisfies both checks and is
+      never demoted — no completeness special-case is needed.
+
+    The demotion is one-directional (only ``high_confidence`` →
+    ``informational_only``) and the grade is display/audit metadata only, so it
+    never blocks report generation (ROB-323 external fail-open preserved).
     """
     summary = freshness_summary or {}
     counts: dict[str, int] = {}
@@ -321,6 +337,30 @@ def build_report_quality_summary(
         grade = "informational_only"
     else:
         grade = "high_confidence"
+        # ROB-366 B10 — honesty demotion. The grade is display/audit metadata
+        # (no backend gating reads it), so demoting it never blocks generation
+        # and the ROB-323 external fail-open invariant is preserved: external
+        # probes are excluded from the coverage denominator and only ever enter
+        # as a *compensating* cross-check, never as a hard gate. Computed over
+        # internal kinds only so an un-run operator probe cannot tank an
+        # otherwise-fresh report. A genuinely complete bundle is fresh across all
+        # internal kinds (coverage 100%, core fully fresh) so it never demotes.
+        internal_total = core_total + optional_total
+        internal_fresh = core_fresh + optional_fresh
+        internal_pct = (
+            round(100 * internal_fresh / internal_total) if internal_total else 0
+        )
+        core_incomplete = core_total > 0 and core_fresh < core_total
+        thin_coverage = internal_pct < HIGH_CONFIDENCE_MIN_COVERAGE_PCT
+        # A cross-check only corroborates when it is present and not itself
+        # degrading — a hard_stale/unavailable/failed probe is stale-expired
+        # evidence and must not rescue thin coverage.
+        no_cross_check = (
+            external_status is None
+            or external_status in CRITICAL_KIND_DEGRADING_STATUSES
+        )
+        if core_incomplete or (thin_coverage and no_cross_check):
+            grade = "informational_only"
 
     return {
         "grade": grade,

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -305,6 +305,145 @@ def test_quality_summary_external_status_none_when_absent() -> None:
     assert out["core_fresh_coverage_pct"] == 100
 
 
+# --- build_report_quality_summary: ROB-366 B10 honesty demotion --------------
+def test_quality_grade_demotes_when_core_kind_soft_stale_on_partial() -> None:
+    # ROB-366 B10: the real bundle had core_fresh_coverage_pct=75 — one critical
+    # kind ('market') was non-fresh but only soft_stale, which is NOT in
+    # CRITICAL_KIND_DEGRADING_STATUSES, so the old grade fell through to
+    # high_confidence. A non-fully-fresh core on a non-complete bundle is now an
+    # honest informational_only.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "soft_stale"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "informational_only"
+    assert out["core_fresh_coverage_pct"] == 75
+
+
+def test_quality_grade_demotes_on_thin_optional_coverage_without_cross_check() -> None:
+    # ROB-366 B10: core fully fresh but news/candidate/symbol all empty and no
+    # external cross-check to compensate → internal coverage (4/7 ≈ 57%) is too
+    # thin to honestly read as high_confidence.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "unavailable"},
+            "candidate_universe": {"status": "unavailable"},
+            "symbol": {"status": "unavailable"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "informational_only"
+    assert out["core_fresh_coverage_pct"] == 100
+
+
+def test_quality_grade_thin_coverage_stays_high_with_passing_cross_check() -> None:
+    # A passing external cross-check is the one signal that legitimately rescues a
+    # thin-but-core-fresh bundle: it stays high_confidence. Guards against the
+    # demotion over-firing when there IS corroborating evidence.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "unavailable"},
+            "candidate_universe": {"status": "unavailable"},
+            "symbol": {"status": "unavailable"},
+            "toss_remote_debug": {"status": "fresh"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["external_cross_check_status"] == "fresh"
+
+
+def test_quality_grade_demotes_when_external_cross_check_hard_stale() -> None:
+    # A hard_stale external probe is a degrading status
+    # (CRITICAL_KIND_DEGRADING_STATUSES) — stale-expired evidence must NOT count
+    # as a usable cross-check that rescues thin coverage back to high_confidence.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "unavailable"},
+            "candidate_universe": {"status": "unavailable"},
+            "symbol": {"status": "unavailable"},
+            "toss_remote_debug": {"status": "hard_stale"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "informational_only"
+    assert out["external_cross_check_status"] == "hard_stale"
+
+
+def test_quality_grade_thin_coverage_stays_high_with_soft_stale_cross_check() -> None:
+    # soft_stale is a non-degrading status, so a soft_stale external cross-check
+    # still corroborates and lets a thin-but-core-fresh bundle stay high.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "unavailable"},
+            "candidate_universe": {"status": "unavailable"},
+            "symbol": {"status": "unavailable"},
+            "toss_remote_debug": {"status": "soft_stale"},
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["external_cross_check_status"] == "soft_stale"
+
+
+def test_quality_grade_complete_bundle_stays_high_without_external() -> None:
+    # An external probe that was simply never run must never tank an otherwise
+    # complete bundle — ROB-323 fail-open preserved in the grade. internal
+    # coverage is 100% so no demotion fires regardless of the absent probe.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "fresh",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+        },
+        bundle_status="complete",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["external_cross_check_status"] is None
+
+
+def test_quality_grade_no_action_on_stale_fallback_precedence_unchanged() -> None:
+    # The honesty demotion only ever moves high_confidence → informational_only;
+    # it must never interfere with the top-precedence no_action branch.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "hard_stale",
+            "market": {"status": "hard_stale"},
+        },
+        bundle_status="stale_fallback",
+    )
+    assert out["grade"] == "no_action"
+
+
 def test_build_data_quality_audit_shape() -> None:
     from app.services.action_report.common.diagnostics import build_data_quality_audit
 


### PR DESCRIPTION
## What

ROB-366 is a 10-defect collection from a live US-open trial of the snapshot-backed report bundle / Hermes context (ROB-287 lineage). This PR fixes **B10** — the most urgent — and is the first in the proposed sequence (B10 → B5 market US-ification → B7/B6 currency+session → B8 news + A1 rebuild).

`build_report_quality_summary` stamped `high_confidence` whenever the 4 critical kinds were non-degrading and the bundle wasn't `failed`/`stale_fallback`, **ignoring fresh coverage and the external cross-check entirely**. The observed US bundle (`status=partial`, `core_fresh_coverage_pct=75`, `fresh_coverage_pct=33`, `external_cross_check_status=unavailable`, news=0, candidate stale) was graded `high_confidence` — a dishonest reassurance that masks the rest of the US-path defects.

## How

A one-directional honesty demotion (only `high_confidence` → `informational_only`) inside the `else` branch, computed over **internal kinds only** (core + optional, external-excluded):

- core not fully fresh on the bundle → demote
- internal coverage `< 70%` **and** no usable external cross-check → demote

Design choices (improved over the initial plan via an adversarial-review pass):

- **Internal-only coverage** (not the external-inclusive `fresh_coverage_pct`): a genuinely complete bundle is 100% internally fresh and never demotes — no completeness special-case needed — and a low-coverage **reused** bundle is now judged honestly (closes a reuse gap the guard-based approach would have left open). Honors ROB-323 (external probes never gate).
- **Usable cross-check = present and non-degrading.** `hard_stale`/`unavailable`/`failed`/absent do not corroborate (caught by adversarial review — `hard_stale` is a degrading status, so a stale-expired probe must not rescue thin coverage).
- The grade is **display/audit metadata only** (no backend gating reads it; the real gate is `derive_generator_constraints`), so the demotion never blocks generation — ROB-323 external fail-open preserved.

## Blast radius

- Return dict shape and the 3 grade values are **unchanged** — no schema, no DB migration, no frontend change.
- All **5 pre-existing** quality tests pass **unchanged** (the locked split-coverage test re-derives to internal 80% ≥ 70 → stays `high_confidence`).
- **7 new** tests pin: the demotion (core soft_stale / thin optional), the cross-check rescue (`fresh`/`soft_stale` yes, `hard_stale` no), the complete-bundle and passing-cross-check over-demotion guards, and `no_action` precedence.

## Verification

- `tests/services/action_report/` + Hermes-context + report-metadata downstream: **395 passed**
- `ruff check app/ tests/`: clean · `ty check` (changed file): clean

## Out of scope (later PRs)

The KOSPI-for-US market mis-citation, US news feed, portfolio currency, and rebuild/symbol-expansion modes are tracked as B5/B8/B7/A1 in the issue and handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)