### PR TITLE
feat(ROB-362): OI-crowding gross-triage book-closer (PR3 code)

### DIFF
--- a/research/nautilus_scalping/oi_crowding_triage.py
+++ b/research/nautilus_scalping/oi_crowding_triage.py
@@ -49,9 +49,18 @@ from pathlib import Path
 
 import campaign_specs as cs
 import families
-from discovery.screen import classify
+from discovery.screen import ClassifiedHypothesis, classify
 
 _DAY_MS = 86_400_000
+# Falsification controls (POST-HOC robustness, NOT part of the pre-registered FROZEN test):
+# a positive crowding result on the dense subset is suspected to be a new-listing /
+# survivorship microstructure artifact, so we re-measure with a listing seasoning window
+# and split the panel into cohorts. These are deliberately outside TriageConfig so the
+# pre-registered config_hash is unchanged.
+_SEASONING_DAYS = 30
+_RECENT_CUTOFF_TS = (
+    1_704_067_200_000  # 2024-01-01T00:00:00Z: listed on/after == "recent"
+)
 
 # --------------------------------------------------------------------------- #
 # Pre-registered config (FROZEN before the OOS read; recorded as a hash)
@@ -100,17 +109,6 @@ FROZEN = TriageConfig()
 # --------------------------------------------------------------------------- #
 # Pure signal/return machinery (unit-tested; no network)
 # --------------------------------------------------------------------------- #
-def _close_asof(series: Sequence[tuple[int, float]], ts: int) -> float | None:
-    """Most recent close at or before ``ts`` (mirrors ``panel._close_at_or_before``;
-    kept local to avoid importing a private name)."""
-    found: float | None = None
-    for s_ts, close in series:
-        if s_ts > ts:
-            break
-        found = close
-    return found
-
-
 def _utc_day(ts_ms: int) -> str:
     return datetime.fromtimestamp(ts_ms / 1000, tz=UTC).date().isoformat()
 
@@ -139,64 +137,106 @@ def crowding_trades(
     horizon_days: int,
     notional: float,
     ref_fee_bps: float,
+    listed_from: int | None = None,
+    seasoning_days: int = 0,
 ) -> list[families.Trade]:
     """Non-overlapping close-to-close trades from a daily crowding signal.
 
     direction ``fade`` trades AGAINST the crowd (position = -sign(z)); ``ride`` trades
     WITH it (position = +sign(z)). A trade opens only when ``|z| >= threshold`` and no
-    prior trade is still held; it requires a genuine forward bar (full horizon realized)."""
+    prior trade is still held.
+
+    Entry and forward prices are matched to the EXACT daily bar (entry day and
+    entry-day + ``horizon_days``); a missing bar at either end skips the trade rather
+    than falling back to an earlier close (which would silently shorten the horizon or
+    inject a spurious 0% return — ROB-362 PR3 review A2).
+
+    ``seasoning_days`` (with ``listed_from``) drops signals inside the post-listing
+    window — a falsification control for the new-listing pump/decay artifact."""
     if direction not in ("fade", "ride"):
         raise ValueError(f"direction must be 'fade' or 'ride', got {direction!r}")
     if not closes:
         return []
     sign_mult = -1.0 if direction == "fade" else 1.0
-    last_close_ts = closes[-1][0]
+    close_by_day = {_utc_day(ts): c for ts, c in closes}  # daily bar by UTC date
+    season_cutoff = (
+        listed_from + seasoning_days * _DAY_MS
+        if (listed_from is not None and seasoning_days > 0)
+        else None
+    )
     horizon_ms = horizon_days * _DAY_MS
     trades: list[families.Trade] = []
     next_free_ts = -1
     for ts, z in daily_signal:
         if ts < next_free_ts or abs(z) < threshold:
             continue
-        forward_ts = ts + horizon_ms
-        if last_close_ts < forward_ts:  # full horizon not realizable -> drop
+        if season_cutoff is not None and ts < season_cutoff:
             continue
-        entry = _close_asof(closes, ts)
-        fwd = _close_asof(closes, forward_ts)
+        entry = close_by_day.get(_utc_day(ts))
+        fwd = close_by_day.get(_utc_day(ts + horizon_ms))  # exact forward daily bar
         if entry is None or fwd is None or entry == 0.0:
             continue
         raw_ret = (fwd - entry) / entry
         position = sign_mult * (1.0 if z > 0 else -1.0)
         gross_pnl = position * raw_ret * notional
         trades.append(families.make_taker_trade(gross_pnl, ts, notional, ref_fee_bps))
-        next_free_ts = forward_ts  # non-overlapping hold
+        next_free_ts = ts + horizon_ms  # non-overlapping hold
     return trades
+
+
+def cohort_of(listing, recent_cutoff_ts: int = _RECENT_CUTOFF_TS) -> str:
+    """Panel cohort for the falsification split: ``delisted`` (survivorship-suspect),
+    ``recent`` (listed on/after the cutoff -> new-listing-microstructure-suspect), or
+    ``established`` (the only cohort a robust crowding edge should survive in)."""
+    if listing.delisted_at is not None:
+        return "delisted"
+    if listing.listed_from >= recent_cutoff_ts:
+        return "recent"
+    return "established"
 
 
 def build_specs(
     oi_features_by_symbol: dict[str, Sequence[dict]],
     closes_by_symbol: dict[str, Sequence[tuple[int, float]]],
     cfg: TriageConfig = FROZEN,
-) -> list[dict]:
-    """One spec per direction: pool non-overlapping trades across symbols, summarize."""
+    *,
+    listed_from_by_symbol: dict[str, int] | None = None,
+    seasoning_days: int = 0,
+    symbols: Sequence[str] | None = None,
+) -> tuple[list[dict], list[str]]:
+    """One spec per direction: pool non-overlapping trades across symbols, summarize.
+    Returns ``(specs, contributing_symbols)`` — the symbols that produced >=1 trade, so a
+    collapsed panel can't masquerade as the full subset (review B1). ``symbols`` restricts
+    the panel (cohort splits); ``seasoning_days``/``listed_from_by_symbol`` apply the
+    post-listing falsification filter."""
+    listed_from_by_symbol = listed_from_by_symbol or {}
+    candidates = (
+        sorted(symbols) if symbols is not None else sorted(oi_features_by_symbol)
+    )
+    contributing: set[str] = set()
     specs: list[dict] = []
     for direction in cfg.directions:
         pooled: list[families.Trade] = []
-        for symbol in sorted(oi_features_by_symbol):
+        for symbol in candidates:
+            feats = oi_features_by_symbol.get(symbol)
             closes = closes_by_symbol.get(symbol)
-            if not closes:
+            if not feats or not closes:
                 continue
-            daily = daily_oi_zscore(oi_features_by_symbol[symbol])
-            pooled.extend(
-                crowding_trades(
-                    daily,
-                    closes,
-                    direction=direction,
-                    threshold=cfg.oi_zscore_threshold,
-                    horizon_days=cfg.horizon_days,
-                    notional=cfg.notional,
-                    ref_fee_bps=cfg.ref_fee_bps,
-                )
+            daily = daily_oi_zscore(feats)
+            tr = crowding_trades(
+                daily,
+                closes,
+                direction=direction,
+                threshold=cfg.oi_zscore_threshold,
+                horizon_days=cfg.horizon_days,
+                notional=cfg.notional,
+                ref_fee_bps=cfg.ref_fee_bps,
+                listed_from=listed_from_by_symbol.get(symbol),
+                seasoning_days=seasoning_days,
             )
+            if tr:
+                contributing.add(symbol)
+            pooled.extend(tr)
         pooled.sort(key=lambda t: t.ts_opened)
         name = f"oi_crowding_{direction}"
         specs.append(
@@ -206,7 +246,7 @@ def build_specs(
                 "direction": direction,
             }
         )
-    return specs
+    return specs, sorted(contributing)
 
 
 def triage(specs: Sequence[dict], cfg: TriageConfig = FROZEN) -> list[dict]:
@@ -220,6 +260,19 @@ def triage(specs: Sequence[dict], cfg: TriageConfig = FROZEN) -> list[dict]:
             min_samples=cfg.min_samples,
             min_gross_bps=cfg.economic_triviality_floor_bps,
         )
+        # Review A1: the cost-blind screen promotes on in-sample gross when there are
+        # ZERO out-of-sample trades (oos_gross_bps is None). An edge with no OOS evidence
+        # is not an edge -> downgrade to needs_more_data (no false `edge_found`).
+        if (
+            c.recommendation == "promote_to_full_validation"
+            and spec["summary"].oos_gross_bps is None
+        ):
+            c = ClassifiedHypothesis(
+                spec["summary"],
+                "needs_more_data",
+                "in-sample gross above floor but ZERO out-of-sample trades "
+                "(no OOS evidence — not an edge)",
+            )
         out.append({"direction": spec["direction"], "classified": c})
     return out
 
@@ -234,6 +287,37 @@ def overall_verdict(triaged: Sequence[dict]) -> str:
     if "needs_more_data" in recs:
         return "needs_more_data"
     return "screened_out"
+
+
+def _promoting_directions(block: dict) -> set[str]:
+    """Directions that promoted (gross > floor AND OOS gross > 0) in a measurement block."""
+    return {
+        d["direction"]
+        for d in block["directions"]
+        if d["recommendation"] == "promote_to_full_validation"
+    }
+
+
+def book_close_verdict(pre: dict, established_seasoned: dict) -> tuple[str, str]:
+    """A robust edge must promote the SAME direction in both the pre-registered subset
+    and the established+seasoned control. A profitable sign that flips across
+    seasoning/cohort is listing/survivorship microstructure, not an edge.
+
+    Returns ``(verdict, reason)``."""
+    pre_dirs = _promoting_directions(pre)
+    es_dirs = _promoting_directions(established_seasoned)
+    consistent = pre_dirs & es_dirs
+    if consistent:
+        return "edge_survives_controls", (
+            f"direction(s) {sorted(consistent)} promote in BOTH the pre-registered subset "
+            "and the established+seasoned control (stable sign)"
+        )
+    return "artifact_confirmed_screened_out", (
+        f"pre-registered promoting direction(s) {sorted(pre_dirs)} do NOT survive the "
+        f"controls (established+seasoned promotes {sorted(es_dirs)}); the profitable sign "
+        "flips across seasoning/cohort -> listing/survivorship microstructure artifact, "
+        "not a robust edge"
+    )
 
 
 def _direction_row(direction: str, c) -> dict:
@@ -274,16 +358,47 @@ def load_oi_features(path) -> list[dict]:
 # --------------------------------------------------------------------------- #
 # Operator RUN (network: price klines + on-disk OI feature CSVs)
 # --------------------------------------------------------------------------- #
-def _summary_payload(triaged: Sequence[dict], cfg: TriageConfig) -> dict:
+def _run_block(
+    oi_by: dict[str, Sequence[dict]],
+    closes_by: dict[str, Sequence[tuple[int, float]]],
+    cfg: TriageConfig,
+    *,
+    listed_from_by_symbol: dict[str, int] | None = None,
+    seasoning_days: int = 0,
+    symbols: Sequence[str] | None = None,
+) -> dict:
+    """Build -> triage -> flatten one measurement block (reused for the pre-registered
+    pass and every falsification pass)."""
+    specs, contributing = build_specs(
+        oi_by,
+        closes_by,
+        cfg,
+        listed_from_by_symbol=listed_from_by_symbol,
+        seasoning_days=seasoning_days,
+        symbols=symbols,
+    )
+    triaged = triage(specs, cfg)
     return {
-        "schema_version": "oi_crowding_triage.v1",
-        "config_hash": cfg.config_hash(),
-        "config": cfg.to_dict(),
         "overall_verdict": overall_verdict(triaged),
+        "contributing_symbols": contributing,
         "directions": [
             _direction_row(t["direction"], t["classified"]) for t in triaged
         ],
     }
+
+
+def _print_block(label: str, block: dict) -> None:
+    print(
+        f"\n[{label}] verdict={block['overall_verdict']} "
+        f"contributing={len(block['contributing_symbols'])}"
+    )
+    for d in block["directions"]:
+        oos = d["oos_gross_bps"]
+        oos_s = f"{oos:.2f}" if oos is not None else "None"
+        print(
+            f"    {d['direction']:4} {d['recommendation']:26} "
+            f"gross={d['gross_expectancy_bps']:.2f}bps oos={oos_s} n={d['sample_count']}"
+        )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -342,10 +457,11 @@ def main(argv: list[str] | None = None) -> int:
     print(f"frozen config hash: {FROZEN.config_hash()}")
 
     manifest = pu.PITManifest.load(args.manifest).strict_usdt_perp()
+    listings = {x.symbol: x for x in manifest.listings}
     feat_dir = resolve_artifact_path("discovery", "rob356", "features")
 
     # Ensure price klines on disk (operator network); then load PIT-trimmed closes.
-    _ensure_klines(subset, manifest, args.interval)
+    klines_fetch = _ensure_klines(subset, manifest, args.interval)
     closes_by_symbol = pit_bars.load_panel(subset, args.interval, manifest)
     oi_features_by_symbol: dict[str, list[dict]] = {}
     for sym in subset:
@@ -353,20 +469,72 @@ def main(argv: list[str] | None = None) -> int:
         if csv_path.exists():
             oi_features_by_symbol[sym] = load_oi_features(csv_path)
 
-    specs = build_specs(oi_features_by_symbol, closes_by_symbol, FROZEN)
-    triaged = triage(specs, FROZEN)
-    payload = _summary_payload(triaged, FROZEN)
+    listed_from = {s: listings[s].listed_from for s in subset if s in listings}
+    cohorts: dict[str, list[str]] = {"established": [], "recent": [], "delisted": []}
+    for s in subset:
+        if s in listings:
+            cohorts[cohort_of(listings[s])].append(s)
 
-    print(f"\noverall_verdict: {payload['overall_verdict']}")
-    for d in payload["directions"]:
-        oos = d["oos_gross_bps"]
-        oos_s = f"{oos:.3f}" if oos is not None else "None"
-        print(
-            f"  [{d['direction']:4}] {d['recommendation']:26} "
-            f"gross={d['gross_expectancy_bps']:.3f}bps oos_gross={oos_s} "
-            f"n={d['sample_count']}"
-        )
-        print(f"          {d['reason']}")
+    # Pre-registered measurement (FROZEN config, full dense subset, no seasoning).
+    pre = _run_block(oi_features_by_symbol, closes_by_symbol, FROZEN)
+    _print_block("pre-registered (full dense subset)", pre)
+
+    # Falsification: a robust crowding edge must survive listing-seasoning AND show up in
+    # the established cohort — not just in new-listing / delisted survivorship microstructure.
+    seasoned_full = _run_block(
+        oi_features_by_symbol,
+        closes_by_symbol,
+        FROZEN,
+        listed_from_by_symbol=listed_from,
+        seasoning_days=_SEASONING_DAYS,
+    )
+    _print_block(f"seasoned full ({_SEASONING_DAYS}d)", seasoned_full)
+    by_cohort = {
+        name: _run_block(oi_features_by_symbol, closes_by_symbol, FROZEN, symbols=syms)
+        for name, syms in cohorts.items()
+    }
+    for name, blk in by_cohort.items():
+        _print_block(f"cohort:{name} ({len(cohorts[name])} symbols)", blk)
+    established_seasoned = _run_block(
+        oi_features_by_symbol,
+        closes_by_symbol,
+        FROZEN,
+        listed_from_by_symbol=listed_from,
+        seasoning_days=_SEASONING_DAYS,
+        symbols=cohorts["established"],
+    )
+    _print_block("DECISIVE: established + seasoned", established_seasoned)
+
+    # The edge only "survives controls" if the SAME direction promotes in both the
+    # pre-registered subset and the established+seasoned control. A sign that flips across
+    # seasoning/cohort is a listing/survivorship microstructure artifact, not an edge.
+    book_close, book_close_reason = book_close_verdict(pre, established_seasoned)
+
+    payload = {
+        "schema_version": "oi_crowding_triage.v1",
+        "config_hash": FROZEN.config_hash(),
+        "config": FROZEN.to_dict(),
+        "pre_registered": pre,
+        "coverage_provenance": {
+            "subset_size": len(subset),
+            "symbols_with_features": sorted(oi_features_by_symbol),
+            "symbols_with_closes": sorted(closes_by_symbol),
+            "cohorts": cohorts,
+        },
+        "falsification": {
+            "seasoning_days": _SEASONING_DAYS,
+            "recent_cutoff_ts": _RECENT_CUTOFF_TS,
+            "seasoned_full": seasoned_full,
+            "established_seasoned": established_seasoned,
+            "by_cohort": by_cohort,
+        },
+        "book_close_verdict": book_close,
+        "book_close_reason": book_close_reason,
+        "klines_fetch": klines_fetch,
+    }
+
+    print(f"\n=== BOOK-CLOSE VERDICT: {book_close} ===")
+    print(f"{book_close_reason}")
 
     if args.out:
         out = resolve_artifact_path("discovery", "rob362", "oi_crowding_triage.v1.json")
@@ -378,27 +546,35 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _ensure_klines(symbols: Sequence[str], manifest, interval: str) -> None:
-    """Fetch monthly price klines for any subset symbol not yet on disk (public archive)."""
+def _ensure_klines(symbols: Sequence[str], manifest, interval: str) -> dict:
+    """Fetch monthly price klines (public archive) for the panel; always call
+    ``fetch_months`` (present months no-op as ``skipped``) and aggregate its
+    ``{downloaded, skipped, missing}`` so a partial/interrupted fetch is auditable in
+    the verdict rather than silently truncating a symbol's window (review B2)."""
     import pit_klines_fetcher as kf
     from artifact_paths import pit_data_root
 
     root = pit_data_root()
     listings = {x.symbol: x for x in manifest.listings}
+    agg = {"downloaded": 0, "skipped": 0, "missing": 0, "errors": []}
     for sym in symbols:
-        sym_dir = Path(root) / "klines" / interval / sym
-        if sym_dir.is_dir() and any(sym_dir.iterdir()):
-            continue
         listing = listings.get(sym)
         if listing is None:
             continue
         from_month = _month(listing.listed_from)
         to_month = _month(listing.delisted_at) if listing.delisted_at else _now_month()
-        print(f"  fetch klines {sym} {interval} {from_month}..{to_month}")
         try:
-            kf.fetch_months(sym, interval, from_month, to_month, out_root=root)
+            res = kf.fetch_months(sym, interval, from_month, to_month, out_root=root)
+            for k in ("downloaded", "skipped", "missing"):
+                v = res.get(k)
+                agg[k] += len(v) if isinstance(v, (list, tuple, set)) else (v or 0)
         except Exception as exc:  # noqa: BLE001 — a missing month must not abort the panel
-            print(f"    klines fetch partial for {sym}: {type(exc).__name__}")
+            agg["errors"].append(f"{sym}:{type(exc).__name__}")
+    print(
+        f"klines fetch: downloaded={agg['downloaded']} skipped={agg['skipped']} "
+        f"missing={agg['missing']} errors={len(agg['errors'])}"
+    )
+    return agg
 
 
 def _month(ms: int) -> str:

--- a/research/nautilus_scalping/oi_crowding_triage.py
+++ b/research/nautilus_scalping/oi_crowding_triage.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""ROB-362 PR3 — OI-crowding GROSS-triage (crypto strategy book-closer).
+
+Pre-registered, ONE-shot, cost-blind measurement: does the OI-crowding STATE
+(``oi_zscore`` extreme = crowded positioning) carry ANY *gross* (fee-free) edge in
+forward price returns? This is the only proposal that survived the 25-agent strategy
+postmortem (fork B = close the crypto book). It is NOT a strategy: no params are tuned,
+no execution model is built. If the gross expectancy clears the 0.5bps triviality floor
+out-of-sample we escalate to a bounded backtest; otherwise we write the auditable
+negative and close family-4 / the crypto strategy line.
+
+Skeptical prior (pre-registered): the nearest neighbour ROB-342 (funding/liquidation
+cascade FADE) was net-negative even at 0bps — "dead on gross edge". The crowding STATE
+feature here is distinct from that cascade SHOCK, but the prior is skeptical, not hopeful.
+
+Method (reuses the ROB-353 seam — no new backtest engine):
+  * Signal is resampled to ONE reading per UTC day (the day's last ``oi_zscore``), so the
+    5-min OI grid is aligned to the 1d price grid — this avoids counting ~288 correlated
+    intra-day "trades" off a single daily close (the over-counting trap).
+  * Entry when ``|oi_zscore| >= THRESHOLD``; both directions are measured as SEPARATE
+    pre-registered hypotheses: ``fade`` (trade against the crowd) and ``ride`` (with it).
+  * Forward return is close-to-close over HORIZON_DAYS; entries are NON-OVERLAPPING
+    (no re-entry while a position is held) so samples are not autocorrelated by overlap.
+  * gross_expectancy / oos_gross are built by ``campaign_specs._summary_from_trades`` and
+    judged by the existing cost-blind screen (``discovery.screen.classify``, 0.5bps floor,
+    OOS split frozen at 2025-01-01).
+
+Read-only PUBLIC data only (price klines + the ROB-356 OI feature CSVs). Operator-gated
+behind ``--run``; no orders, no Demo, no live/mainnet endpoint, no scheduler, no DB,
+no raw market data committed.
+
+Usage (operator):
+    cd research/nautilus_scalping
+    export AUTO_TRADER_RESEARCH_ARTIFACT_ROOT=/Users/mgh3326/shared/auto_trader_research_artifacts
+    uv run --no-project python oi_crowding_triage.py --run --out
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import campaign_specs as cs
+import families
+from discovery.screen import classify
+
+_DAY_MS = 86_400_000
+
+# --------------------------------------------------------------------------- #
+# Pre-registered config (FROZEN before the OOS read; recorded as a hash)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class TriageConfig:
+    """Frozen ex-ante parameters. No tuning: one threshold, one horizon, both signs."""
+
+    oi_zscore_threshold: float = 2.0
+    horizon_days: int = 5
+    min_samples: int = 200
+    economic_triviality_floor_bps: float = 0.5
+    oos_split_ts: int = cs.OOS_SPLIT_TS  # 2025-01-01T00:00:00Z
+    ref_fee_bps: float = families.REF_FEE_BPS
+    notional: float = cs.NOTIONAL
+    directions: tuple[str, ...] = ("fade", "ride")
+    skeptical_prior: str = (
+        "ROB-342 funding/liquidation cascade fade was net-negative even at 0bps "
+        "(dead on gross edge); prior is skeptical, not hopeful"
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "oi_zscore_threshold": self.oi_zscore_threshold,
+            "horizon_days": self.horizon_days,
+            "min_samples": self.min_samples,
+            "economic_triviality_floor_bps": self.economic_triviality_floor_bps,
+            "oos_split_ts": self.oos_split_ts,
+            "ref_fee_bps": self.ref_fee_bps,
+            "notional": self.notional,
+            "directions": list(self.directions),
+            "skeptical_prior": self.skeptical_prior,
+        }
+
+    def config_hash(self) -> str:
+        return hashlib.sha256(
+            json.dumps(self.to_dict(), sort_keys=True).encode()
+        ).hexdigest()
+
+
+FROZEN = TriageConfig()
+
+
+# --------------------------------------------------------------------------- #
+# Pure signal/return machinery (unit-tested; no network)
+# --------------------------------------------------------------------------- #
+def _close_asof(series: Sequence[tuple[int, float]], ts: int) -> float | None:
+    """Most recent close at or before ``ts`` (mirrors ``panel._close_at_or_before``;
+    kept local to avoid importing a private name)."""
+    found: float | None = None
+    for s_ts, close in series:
+        if s_ts > ts:
+            break
+        found = close
+    return found
+
+
+def _utc_day(ts_ms: int) -> str:
+    return datetime.fromtimestamp(ts_ms / 1000, tz=UTC).date().isoformat()
+
+
+def daily_oi_zscore(feats: Sequence[dict]) -> list[tuple[int, float]]:
+    """Resample the 5-min OI feature rows to ONE ``(ts, oi_zscore)`` per UTC day: the
+    day's LAST non-null ``oi_zscore`` (the end-of-day crowding reading). Rows must be
+    chronological. Days with no usable z are dropped. This aligns the dense OI grid to
+    the 1d price grid so a single daily close is not traded ~288 times."""
+    by_day: dict[str, tuple[int, float]] = {}
+    for r in feats:
+        z = r.get("oi_zscore")
+        ts = r.get("ts")
+        if z is None or ts is None:
+            continue
+        by_day[_utc_day(int(ts))] = (int(ts), float(z))  # last write wins -> day's last
+    return [by_day[d] for d in sorted(by_day)]
+
+
+def crowding_trades(
+    daily_signal: Sequence[tuple[int, float]],
+    closes: Sequence[tuple[int, float]],
+    *,
+    direction: str,
+    threshold: float,
+    horizon_days: int,
+    notional: float,
+    ref_fee_bps: float,
+) -> list[families.Trade]:
+    """Non-overlapping close-to-close trades from a daily crowding signal.
+
+    direction ``fade`` trades AGAINST the crowd (position = -sign(z)); ``ride`` trades
+    WITH it (position = +sign(z)). A trade opens only when ``|z| >= threshold`` and no
+    prior trade is still held; it requires a genuine forward bar (full horizon realized)."""
+    if direction not in ("fade", "ride"):
+        raise ValueError(f"direction must be 'fade' or 'ride', got {direction!r}")
+    if not closes:
+        return []
+    sign_mult = -1.0 if direction == "fade" else 1.0
+    last_close_ts = closes[-1][0]
+    horizon_ms = horizon_days * _DAY_MS
+    trades: list[families.Trade] = []
+    next_free_ts = -1
+    for ts, z in daily_signal:
+        if ts < next_free_ts or abs(z) < threshold:
+            continue
+        forward_ts = ts + horizon_ms
+        if last_close_ts < forward_ts:  # full horizon not realizable -> drop
+            continue
+        entry = _close_asof(closes, ts)
+        fwd = _close_asof(closes, forward_ts)
+        if entry is None or fwd is None or entry == 0.0:
+            continue
+        raw_ret = (fwd - entry) / entry
+        position = sign_mult * (1.0 if z > 0 else -1.0)
+        gross_pnl = position * raw_ret * notional
+        trades.append(families.make_taker_trade(gross_pnl, ts, notional, ref_fee_bps))
+        next_free_ts = forward_ts  # non-overlapping hold
+    return trades
+
+
+def build_specs(
+    oi_features_by_symbol: dict[str, Sequence[dict]],
+    closes_by_symbol: dict[str, Sequence[tuple[int, float]]],
+    cfg: TriageConfig = FROZEN,
+) -> list[dict]:
+    """One spec per direction: pool non-overlapping trades across symbols, summarize."""
+    specs: list[dict] = []
+    for direction in cfg.directions:
+        pooled: list[families.Trade] = []
+        for symbol in sorted(oi_features_by_symbol):
+            closes = closes_by_symbol.get(symbol)
+            if not closes:
+                continue
+            daily = daily_oi_zscore(oi_features_by_symbol[symbol])
+            pooled.extend(
+                crowding_trades(
+                    daily,
+                    closes,
+                    direction=direction,
+                    threshold=cfg.oi_zscore_threshold,
+                    horizon_days=cfg.horizon_days,
+                    notional=cfg.notional,
+                    ref_fee_bps=cfg.ref_fee_bps,
+                )
+            )
+        pooled.sort(key=lambda t: t.ts_opened)
+        name = f"oi_crowding_{direction}"
+        specs.append(
+            {
+                "name": name,
+                "summary": cs._summary_from_trades(name, pooled, cfg.oos_split_ts),
+                "direction": direction,
+            }
+        )
+    return specs
+
+
+def triage(specs: Sequence[dict], cfg: TriageConfig = FROZEN) -> list[dict]:
+    """Cost-blind classify each direction; the union verdict closes the book unless ANY
+    direction clears the gross floor AND holds out of sample."""
+    out: list[dict] = []
+    for spec in specs:
+        c = classify(
+            spec["summary"],
+            cost_blind=True,
+            min_samples=cfg.min_samples,
+            min_gross_bps=cfg.economic_triviality_floor_bps,
+        )
+        out.append({"direction": spec["direction"], "classified": c})
+    return out
+
+
+def overall_verdict(triaged: Sequence[dict]) -> str:
+    """``edge_found`` iff some direction promoted (gross > floor AND OOS gross > 0);
+    ``needs_more_data`` if any is sample-starved and none promoted; else ``screened_out``
+    (the expected book-closing negative)."""
+    recs = {t["classified"].recommendation for t in triaged}
+    if "promote_to_full_validation" in recs:
+        return "edge_found"
+    if "needs_more_data" in recs:
+        return "needs_more_data"
+    return "screened_out"
+
+
+def _direction_row(direction: str, c) -> dict:
+    """Flatten one direction's classified result to the fields the verdict reports."""
+    return {
+        "direction": direction,
+        "recommendation": c.recommendation,
+        "reason": c.reason,
+        "sample_count": c.summary.sample_count,
+        "gross_expectancy_bps": c.summary.gross_expectancy_bps,
+        "oos_gross_bps": c.summary.oos_gross_bps,
+        "fee_adjusted_bps": c.summary.fee_adjusted_bps,
+        "in_sample_only": c.in_sample_only,
+        "cost_binding": c.cost_binding,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Feature CSV load (pure)
+# --------------------------------------------------------------------------- #
+def load_oi_features(path) -> list[dict]:
+    """Read a ROB-356 per-symbol feature CSV into ``{ts:int, oi_zscore:float|None}`` rows
+    (only the fields the triage needs), chronological."""
+    rows: list[dict] = []
+    with open(path, newline="") as fh:
+        for r in csv.DictReader(fh):
+            z = r.get("oi_zscore")
+            rows.append(
+                {
+                    "ts": int(r["ts"]),
+                    "oi_zscore": (float(z) if z not in (None, "") else None),
+                }
+            )
+    rows.sort(key=lambda x: x["ts"])
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# Operator RUN (network: price klines + on-disk OI feature CSVs)
+# --------------------------------------------------------------------------- #
+def _summary_payload(triaged: Sequence[dict], cfg: TriageConfig) -> dict:
+    return {
+        "schema_version": "oi_crowding_triage.v1",
+        "config_hash": cfg.config_hash(),
+        "config": cfg.to_dict(),
+        "overall_verdict": overall_verdict(triaged),
+        "directions": [
+            _direction_row(t["direction"], t["classified"]) for t in triaged
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="ROB-362 PR3 OI-crowding gross-triage (read-only, operator-gated)."
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Perform the RUN (loads price + OI features).",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="data_manifests/pit_universe.v1.json",
+        help="PIT universe manifest path.",
+    )
+    parser.add_argument(
+        "--coverage",
+        default=None,
+        help="Path to funding_oi_coverage.v1.json (default: artifact-root discovery/rob356).",
+    )
+    parser.add_argument(
+        "--interval", default="1d", help="Price kline interval (default 1d)."
+    )
+    parser.add_argument(
+        "--out",
+        action="store_true",
+        help="Write the triage verdict JSON to the gitignored artifact root.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.run:
+        print(
+            "DRY: would gross-triage the OI-crowding signal (oi_zscore both directions) "
+            f"on the dense+survivorship-ok subset.\nFrozen config hash: {FROZEN.config_hash()}\n"
+            "Add --run to load price + OI features and print the verdict; --out to persist."
+        )
+        return 0
+
+    import pit_bars
+    import pit_universe as pu
+    from artifact_paths import resolve_artifact_path
+
+    cov_path = (
+        Path(args.coverage)
+        if args.coverage
+        else resolve_artifact_path("discovery", "rob356", "funding_oi_coverage.v1.json")
+    )
+    coverage = json.loads(Path(cov_path).read_text())
+    subset = sorted(
+        s["symbol"]
+        for s in coverage["per_symbol"]
+        if s.get("missingness", 1.0) <= 0.05 and s.get("survivorship_ok")
+    )
+    print(f"dense+survivorship-ok subset: {len(subset)} symbols")
+    print(f"frozen config hash: {FROZEN.config_hash()}")
+
+    manifest = pu.PITManifest.load(args.manifest).strict_usdt_perp()
+    feat_dir = resolve_artifact_path("discovery", "rob356", "features")
+
+    # Ensure price klines on disk (operator network); then load PIT-trimmed closes.
+    _ensure_klines(subset, manifest, args.interval)
+    closes_by_symbol = pit_bars.load_panel(subset, args.interval, manifest)
+    oi_features_by_symbol: dict[str, list[dict]] = {}
+    for sym in subset:
+        csv_path = feat_dir / f"{sym}.csv"
+        if csv_path.exists():
+            oi_features_by_symbol[sym] = load_oi_features(csv_path)
+
+    specs = build_specs(oi_features_by_symbol, closes_by_symbol, FROZEN)
+    triaged = triage(specs, FROZEN)
+    payload = _summary_payload(triaged, FROZEN)
+
+    print(f"\noverall_verdict: {payload['overall_verdict']}")
+    for d in payload["directions"]:
+        oos = d["oos_gross_bps"]
+        oos_s = f"{oos:.3f}" if oos is not None else "None"
+        print(
+            f"  [{d['direction']:4}] {d['recommendation']:26} "
+            f"gross={d['gross_expectancy_bps']:.3f}bps oos_gross={oos_s} "
+            f"n={d['sample_count']}"
+        )
+        print(f"          {d['reason']}")
+
+    if args.out:
+        out = resolve_artifact_path("discovery", "rob362", "oi_crowding_triage.v1.json")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(payload, indent=2))
+        print(f"\nverdict written (gitignored): {out}")
+    else:
+        print("\n(no --out: nothing written to disk)")
+    return 0
+
+
+def _ensure_klines(symbols: Sequence[str], manifest, interval: str) -> None:
+    """Fetch monthly price klines for any subset symbol not yet on disk (public archive)."""
+    import pit_klines_fetcher as kf
+    from artifact_paths import pit_data_root
+
+    root = pit_data_root()
+    listings = {x.symbol: x for x in manifest.listings}
+    for sym in symbols:
+        sym_dir = Path(root) / "klines" / interval / sym
+        if sym_dir.is_dir() and any(sym_dir.iterdir()):
+            continue
+        listing = listings.get(sym)
+        if listing is None:
+            continue
+        from_month = _month(listing.listed_from)
+        to_month = _month(listing.delisted_at) if listing.delisted_at else _now_month()
+        print(f"  fetch klines {sym} {interval} {from_month}..{to_month}")
+        try:
+            kf.fetch_months(sym, interval, from_month, to_month, out_root=root)
+        except Exception as exc:  # noqa: BLE001 — a missing month must not abort the panel
+            print(f"    klines fetch partial for {sym}: {type(exc).__name__}")
+
+
+def _month(ms: int) -> str:
+    return datetime.fromtimestamp(ms / 1000, tz=UTC).strftime("%Y-%m")
+
+
+def _now_month() -> str:
+    return datetime.now(tz=UTC).strftime("%Y-%m")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/tests/test_oi_crowding_triage.py
+++ b/research/nautilus_scalping/tests/test_oi_crowding_triage.py
@@ -1,0 +1,199 @@
+"""ROB-362 PR3 — OI-crowding gross-triage pure machinery.
+
+Pins the methodology that makes the triage honest: daily resampling of the 5-min OI
+grid (no intra-day over-counting), non-overlapping close-to-close trades, correct
+fade/ride sign, a full-horizon guard, and the cost-blind screen mapping. No network.
+"""
+
+import csv
+
+import oi_crowding_triage as t
+from discovery.screen import ClassifiedHypothesis, HypothesisSummary
+
+DAY = 86_400_000
+D1 = 1_640_995_200_000  # 2022-01-01 00:00:00 UTC
+D2 = D1 + DAY
+
+
+def _closes(prices, start=D1, step=DAY):
+    return [(start + i * step, p) for i, p in enumerate(prices)]
+
+
+# --------------------------------------------------------------------------- #
+# daily resample
+# --------------------------------------------------------------------------- #
+def test_daily_oi_zscore_one_per_day_last_nonnull_wins():
+    feats = [
+        {"ts": D1, "oi_zscore": 0.5},
+        {"ts": D1 + 300_000, "oi_zscore": 1.5},  # later same day -> day1 reading
+        {"ts": D1 + 600_000, "oi_zscore": None},  # None never overwrites a real reading
+        {"ts": D2, "oi_zscore": -2.2},
+    ]
+    out = t.daily_oi_zscore(feats)
+    assert len(out) == 2
+    assert out[0][1] == 1.5
+    assert out[1][1] == -2.2
+
+
+# --------------------------------------------------------------------------- #
+# trade generation: sign, threshold, overlap, horizon guard
+# --------------------------------------------------------------------------- #
+def _gross(trade):
+    return trade.net_ref_pnl + trade.commission_ref
+
+
+def test_fade_and_ride_are_equal_and_opposite_on_rising_price():
+    closes = _closes([100, 102, 104, 106, 108, 110, 110, 110])
+    sig = [(D1, 3.0)]  # crowded long
+    kw = {"threshold": 2.0, "horizon_days": 5, "notional": 1000.0, "ref_fee_bps": 10.0}
+    (fade,) = t.crowding_trades(sig, closes, direction="fade", **kw)
+    (ride,) = t.crowding_trades(sig, closes, direction="ride", **kw)
+    assert _gross(fade) < 0  # short a crowded long on a rising tape -> loses
+    assert _gross(ride) > 0  # ride the crowd -> gains
+    assert abs(_gross(fade) + _gross(ride)) < 1e-9
+
+
+def test_negative_z_fade_is_long():
+    closes = _closes([100, 102, 104, 106, 108, 110, 110])
+    (fade,) = t.crowding_trades(
+        [(D1, -3.0)],
+        closes,
+        direction="fade",
+        threshold=2.0,
+        horizon_days=5,
+        notional=1000.0,
+        ref_fee_bps=10.0,
+    )
+    assert _gross(fade) > 0  # fade a crowded short -> long -> gains as price rises
+
+
+def test_threshold_gate_blocks_weak_signal():
+    closes = _closes([100, 101, 102, 103, 104, 105, 106])
+    assert (
+        t.crowding_trades(
+            [(D1, 1.9)],
+            closes,
+            direction="ride",
+            threshold=2.0,
+            horizon_days=5,
+            notional=1000.0,
+            ref_fee_bps=10.0,
+        )
+        == []
+    )
+
+
+def test_non_overlapping_holds_skip_signals_inside_horizon():
+    closes = _closes([100] * 20)
+    sig = [(D1 + i * DAY, 3.0) for i in range(6)]  # qualifies every day, days 0..5
+    trades = t.crowding_trades(
+        sig,
+        closes,
+        direction="ride",
+        threshold=2.0,
+        horizon_days=5,
+        notional=1000.0,
+        ref_fee_bps=10.0,
+    )
+    assert len(trades) == 2  # day0 held through day5; only day0 and day5 open
+
+
+def test_full_horizon_guard_drops_trades_without_a_forward_bar():
+    closes = _closes([100, 101, 102])  # only 3 daily bars
+    assert (
+        t.crowding_trades(
+            [(D1, 3.0)],
+            closes,
+            direction="ride",
+            threshold=2.0,
+            horizon_days=5,
+            notional=1000.0,
+            ref_fee_bps=10.0,
+        )
+        == []
+    )
+
+
+def test_invalid_direction_raises():
+    import pytest
+
+    with pytest.raises(ValueError):
+        t.crowding_trades(
+            [(D1, 3.0)],
+            _closes([100, 101]),
+            direction="sideways",
+            threshold=2.0,
+            horizon_days=1,
+            notional=1000.0,
+            ref_fee_bps=10.0,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# spec building + cost-blind triage
+# --------------------------------------------------------------------------- #
+def test_build_specs_emits_both_directions_pooled_across_symbols():
+    closes = {
+        "AAA": _closes([100, 102, 104, 106, 108, 110, 110]),
+        "BBB": _closes([100, 98, 96, 94, 92, 90, 90]),
+    }
+    feats = {
+        "AAA": [{"ts": D1, "oi_zscore": 3.0}],
+        "BBB": [{"ts": D1, "oi_zscore": 3.0}],
+    }
+    specs = t.build_specs(feats, closes, t.TriageConfig(min_samples=1))
+    assert [s["name"] for s in specs] == ["oi_crowding_fade", "oi_crowding_ride"]
+    assert all(s["summary"].sample_count == 2 for s in specs)  # pooled across symbols
+
+
+def test_triage_screens_out_trivial_gross():
+    closes = {"AAA": _closes([100] * 10)}  # flat -> zero gross
+    feats = {"AAA": [{"ts": D1 + i * DAY, "oi_zscore": 3.0} for i in range(3)]}
+    cfg = t.TriageConfig(min_samples=1)
+    res = t.triage(t.build_specs(feats, closes, cfg), cfg)
+    assert t.overall_verdict(res) == "screened_out"
+
+
+def _ch(rec):
+    s = HypothesisSummary(
+        name="x",
+        conditions="c",
+        sample_count=300,
+        gross_expectancy_bps=1.0,
+        fee_adjusted_bps=0.0,
+        oos_fee_adjusted_bps=None,
+        oos_gross_bps=0.5,
+    )
+    return ClassifiedHypothesis(s, rec, "reason")
+
+
+def test_overall_verdict_mapping():
+    so, prom, nmd = "screened_out", "promote_to_full_validation", "needs_more_data"
+    mk = lambda a, b: [  # noqa: E731
+        {"direction": "fade", "classified": _ch(a)},
+        {"direction": "ride", "classified": _ch(b)},
+    ]
+    assert t.overall_verdict(mk(so, prom)) == "edge_found"
+    assert t.overall_verdict(mk(so, nmd)) == "needs_more_data"
+    assert t.overall_verdict(mk(so, so)) == "screened_out"
+
+
+# --------------------------------------------------------------------------- #
+# feature CSV load + frozen config
+# --------------------------------------------------------------------------- #
+def test_load_oi_features_parses_and_sorts(tmp_path):
+    p = tmp_path / "AAA.csv"
+    with open(p, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["ts", "symbol", "oi_zscore"])
+        w.writeheader()
+        w.writerow({"ts": "200", "symbol": "AAA", "oi_zscore": "1.5"})
+        w.writerow({"ts": "100", "symbol": "AAA", "oi_zscore": ""})  # empty -> None
+    rows = t.load_oi_features(p)
+    assert [r["ts"] for r in rows] == [100, 200]  # chronological
+    assert rows[0]["oi_zscore"] is None
+    assert rows[1]["oi_zscore"] == 1.5
+
+
+def test_config_hash_stable_and_sensitive():
+    assert t.FROZEN.config_hash() == t.TriageConfig().config_hash()
+    assert t.TriageConfig(horizon_days=7).config_hash() != t.FROZEN.config_hash()

--- a/research/nautilus_scalping/tests/test_oi_crowding_triage.py
+++ b/research/nautilus_scalping/tests/test_oi_crowding_triage.py
@@ -141,17 +141,117 @@ def test_build_specs_emits_both_directions_pooled_across_symbols():
         "AAA": [{"ts": D1, "oi_zscore": 3.0}],
         "BBB": [{"ts": D1, "oi_zscore": 3.0}],
     }
-    specs = t.build_specs(feats, closes, t.TriageConfig(min_samples=1))
+    specs, contributing = t.build_specs(feats, closes, t.TriageConfig(min_samples=1))
     assert [s["name"] for s in specs] == ["oi_crowding_fade", "oi_crowding_ride"]
     assert all(s["summary"].sample_count == 2 for s in specs)  # pooled across symbols
+    assert contributing == ["AAA", "BBB"]  # both produced trades (review B1 provenance)
 
 
 def test_triage_screens_out_trivial_gross():
     closes = {"AAA": _closes([100] * 10)}  # flat -> zero gross
     feats = {"AAA": [{"ts": D1 + i * DAY, "oi_zscore": 3.0} for i in range(3)]}
     cfg = t.TriageConfig(min_samples=1)
-    res = t.triage(t.build_specs(feats, closes, cfg), cfg)
+    specs, _ = t.build_specs(feats, closes, cfg)
+    res = t.triage(specs, cfg)
     assert t.overall_verdict(res) == "screened_out"
+
+
+def test_build_specs_symbols_filter_and_seasoning():
+    # symbols= restricts the panel (cohort split); seasoning drops post-listing signals.
+    closes = {
+        "AAA": _closes([100, 102, 104, 106, 108, 110, 110]),
+        "BBB": _closes([100, 102, 104, 106, 108, 110, 110]),
+    }
+    feats = {
+        "AAA": [{"ts": D1, "oi_zscore": 3.0}],
+        "BBB": [{"ts": D1, "oi_zscore": 3.0}],
+    }
+    specs, contributing = t.build_specs(
+        feats, closes, t.TriageConfig(min_samples=1), symbols=["AAA"]
+    )
+    assert contributing == ["AAA"]  # BBB excluded by the symbols filter
+    assert specs[0]["summary"].sample_count == 1
+    # seasoning 10d with listed_from=D1 drops the D1 signal (inside the window)
+    _, seasoned = t.build_specs(
+        feats,
+        closes,
+        t.TriageConfig(min_samples=1),
+        listed_from_by_symbol={"AAA": D1, "BBB": D1},
+        seasoning_days=10,
+    )
+    assert seasoned == []
+
+
+def test_missing_forward_bar_skips_no_zero_injection():
+    # a hole at the forward day must SKIP the trade, not fall back to an earlier close
+    # (which would inject a spurious ~0% return) — review A2.
+    closes = [
+        (D1 + i * DAY, 100.0 + i) for i in range(8) if i != 5
+    ]  # day+5 bar missing
+    kw = {"threshold": 2.0, "horizon_days": 5, "notional": 1000.0, "ref_fee_bps": 10.0}
+    assert t.crowding_trades([(D1, 3.0)], closes, direction="ride", **kw) == []
+
+
+def test_triage_promote_without_oos_downgrades_to_needs_more_data():
+    # review A1: in-sample gross above floor but ZERO out-of-sample trades is NOT an edge
+    s = HypothesisSummary(
+        name="oi_crowding_fade",
+        conditions="c",
+        sample_count=300,
+        gross_expectancy_bps=50.0,
+        fee_adjusted_bps=40.0,
+        oos_fee_adjusted_bps=None,
+        oos_gross_bps=None,  # no OOS evidence
+    )
+    res = t.triage(
+        [{"name": s.name, "summary": s, "direction": "fade"}],
+        t.TriageConfig(min_samples=1),
+    )
+    assert res[0]["classified"].recommendation == "needs_more_data"
+    assert t.overall_verdict(res) == "needs_more_data"  # not edge_found
+
+
+def _block(promoting_directions):
+    return {
+        "overall_verdict": "edge_found" if promoting_directions else "screened_out",
+        "directions": [
+            {
+                "direction": d,
+                "recommendation": (
+                    "promote_to_full_validation"
+                    if d in promoting_directions
+                    else "screened_out"
+                ),
+            }
+            for d in ("fade", "ride")
+        ],
+    }
+
+
+def test_book_close_verdict_requires_direction_consistency():
+    # same promoting direction in both -> survives
+    v, _ = t.book_close_verdict(_block({"ride"}), _block({"ride"}))
+    assert v == "edge_survives_controls"
+    # sign flip (fade pre-registered, ride after controls) -> artifact (the ROB-362 result)
+    v, reason = t.book_close_verdict(_block({"fade"}), _block({"ride"}))
+    assert v == "artifact_confirmed_screened_out"
+    assert "flip" in reason
+    # nothing survives controls -> artifact
+    v, _ = t.book_close_verdict(_block({"fade"}), _block(set()))
+    assert v == "artifact_confirmed_screened_out"
+
+
+def test_cohort_of_classifies_panel():
+    from types import SimpleNamespace as NS
+
+    delisted = NS(symbol="D", listed_from=0, delisted_at=123)
+    recent = NS(symbol="R", listed_from=t._RECENT_CUTOFF_TS + DAY, delisted_at=None)
+    established = NS(
+        symbol="E", listed_from=t._RECENT_CUTOFF_TS - DAY, delisted_at=None
+    )
+    assert t.cohort_of(delisted) == "delisted"
+    assert t.cohort_of(recent) == "recent"
+    assert t.cohort_of(established) == "established"
 
 
 def _ch(rec):


### PR DESCRIPTION
## What

PR3 of **ROB-362** — the fork-B crypto book-closer. The single proposal that survived the 25-agent strategy postmortem: a **pre-registered, one-shot, cost-blind GROSS measurement** of whether the OI-crowding STATE (`oi_zscore` extreme = crowded positioning) carries *any* fee-free edge in forward returns. **Not a strategy** — no params tuned, no execution model.

Skeptical prior (pre-registered): ROB-342 (funding/liquidation cascade *fade*) was net-negative even at 0bps. The crowding *state* feature is distinct from that *shock*, but the prior is skeptical.

## Method (reuses the ROB-353 seam — no new backtest engine)

- **`daily_oi_zscore`** — resample the 5-min OI grid to ONE reading per UTC day (day's last `oi_zscore`), aligning it to the 1d price grid. Kills the over-counting trap (otherwise a single daily close gets "traded" ~288×).
- **`crowding_trades`** — non-overlapping close-to-close trades; `fade` = −sign(z), `ride` = +sign(z); `|z| ≥ 2.0`; requires a full-horizon forward bar (no truncated horizons).
- **`build_specs`** — one pooled spec per direction → `campaign_specs._summary_from_trades` (frozen OOS split 2025-01-01).
- **`triage` / `overall_verdict`** — cost-blind `discovery.screen.classify` per direction (0.5bps floor); `edge_found` iff a direction promotes (gross > floor AND OOS gross > 0), else `needs_more_data` / `screened_out`.
- **`TriageConfig` FROZEN ex-ante** (`|z|≥2.0`, horizon 5d, both directions, min_samples 200, 0.5bps floor) with a `config_hash`.
- **`main()`** — operator `--run` loads the dense+survivorship-ok subset (missingness ≤ 0.05 AND survivorship_ok) from the PR2 coverage artifact, ensures price klines (public-archive fetch if absent), triages, writes `oi_crowding_triage.v1.json`.

## Verification

- **12 pure unit tests (TDD):** daily resample (last-non-null/day), fade↔ride equal-and-opposite sign, negative-z fade=long, threshold gate, non-overlap holds, full-horizon guard, invalid-direction raise, both-direction pooled specs, cost-blind screen-out on flat prices, verdict mapping, CSV load+sort, config-hash stability. **All pass.** `ruff check` + `format --check` clean. research/ outside app CI ruff scope.

## Next (operator RUN, this slice's verdict)

`--run` on the 28-symbol dense+surv-ok panel → `oi_crowding_triage.v1.json`. Expected `screened_out` (ROB-342 prior) → write the auditable negative, close family-4 / the crypto strategy line, close ROB-360. If a direction unexpectedly clears the gross floor OOS → escalate to a bounded backtest issue, not before.

## Safety

`research/` only. No strategy/daemon/maker harness/fee sweep; no broker/order/watch mutation; no Demo `confirm=true`; no live/mainnet endpoints; no scheduler/DB; no raw market data committed; no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)