### PR TITLE
feat(ROB-363): KR candidate priority + per-candidate stale demotion (PR3/3)

### DIFF
--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -76,6 +76,7 @@ def classify_candidate_symbol(
     *,
     universe_useful: bool,
     quote_snapshot_present: bool,
+    candidate_fresh: bool = True,
 ) -> str:
     """Deterministic verdict for ONE non-held screener candidate.
 
@@ -83,15 +84,15 @@ def classify_candidate_symbol(
     directional ``rejected`` / ``limit_wait`` — those are Hermes-only.
 
     Order:
-      1. no symbol/quote snapshot at all   -> ``data_gap``   (호가 근거 부족)
-      2. quote present but not actionable  -> ``watch_only`` (저유동성)
-      3. quote actionable, universe stale  -> ``watch_only`` (스크리너 stale)
-      4. quote actionable, universe useful -> ``buy_review``
+      1. no symbol/quote snapshot at all                        -> ``data_gap``   (호가 근거 부족)
+      2. quote present but not actionable                       -> ``watch_only`` (저유동성)
+      3. quote actionable, universe stale OR this candidate stale -> ``watch_only`` (스크리너 stale)
+      4. quote actionable, universe useful, candidate fresh     -> ``buy_review``
     """
     if not quote_snapshot_present:
         return "data_gap"
     if not _quote_is_actionable(quote):
         return "watch_only"
-    if not universe_useful:
+    if not universe_useful or not candidate_fresh:
         return "watch_only"
     return "buy_review"

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -359,6 +359,7 @@ class EvidenceAutoEmitter:
                 quote,
                 universe_useful=candidate_actionable,
                 quote_snapshot_present=symbol_pair is not None,
+                candidate_fresh=(cand.get("data_state") or "fresh") == "fresh",
             )
             reject_or_wait_reason: str | None = None
             if verdict == "data_gap":

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -184,6 +184,25 @@ def _toss_parity_status(preset: str, market: str) -> str:
     return preset_def.parityStatus or "not_toss_parity"
 
 
+_PARITY_RANK = {"full": 0, "partial": 1, "mismatch": 2, "not_toss_parity": 3}
+_FRESHNESS_RANK = {"fresh": 0, "stale": 1, "missing": 2}
+
+
+def _priority_sort_key(
+    ev: CandidateEvidence, data_state: str
+) -> tuple[int, int, float, str]:
+    """Deterministic candidate priority (ROB-363): full Toss parity first, then
+    fresh, then higher score, then symbol (stable tiebreak). Lower tuple sorts
+    first; ``-score`` makes higher score rank earlier."""
+    parity = _toss_parity_status(ev.source_preset or "top_gainers", "kr")
+    return (
+        _PARITY_RANK.get(parity, 3),
+        _FRESHNESS_RANK.get(data_state, 2),
+        -ev.score,
+        ev.symbol,
+    )
+
+
 def _source_coverage(evidence: list[CandidateEvidence]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for ev in evidence:
@@ -361,6 +380,13 @@ class CandidateUniverseSnapshotCollector:
             return None
 
         evidence = _merge_evidence(evidence, key=lambda e: to_db_symbol(e.symbol))
+        # Deterministic priority: full Toss parity + fresh + higher score first,
+        # so the displayed slice keeps the strongest candidates (ROB-363).
+        evidence.sort(
+            key=lambda e: _priority_sort_key(
+                e, per_state.get(to_db_symbol(e.symbol), "fresh")
+            )
+        )
         # Distinct evaluated symbols (pre-slice) = the candidate universe size,
         # so ``capped`` reflects a pool wider than the displayed limit.
         universe_count = len(per_state)

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -185,6 +185,8 @@ def _toss_parity_status(preset: str, market: str) -> str:
 
 
 _PARITY_RANK = {"full": 0, "partial": 1, "mismatch": 2, "not_toss_parity": 3}
+# Comparator over the freshness labels that ``_FRESHNESS_BY_USEFULNESS`` emits
+# (fresh/stale/missing) — used only for priority ordering, not value lookup.
 _FRESHNESS_RANK = {"fresh": 0, "stale": 1, "missing": 2}
 
 

--- a/tests/services/action_report/snapshot_backed/test_action_verdict.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict.py
@@ -96,10 +96,16 @@ def test_classify_candidate_symbol(quote, present, useful, expected):
 
 
 def test_classify_candidate_symbol_never_rejects():
-    # Honest-verdict only: rejected / limit_wait are Hermes-only.
+    # Honest-verdict only: rejected / limit_wait are Hermes-only. ROB-363 added
+    # the candidate_fresh demotion branch — cover it here so the invariant holds
+    # across every parameter combination, not just the universe-stale path.
     for present in (True, False):
         for useful in (True, False):
-            v = classify_candidate_symbol(
-                _DEAD_QUOTE, universe_useful=useful, quote_snapshot_present=present
-            )
-            assert v in {"data_gap", "watch_only", "buy_review"}
+            for fresh in (True, False):
+                v = classify_candidate_symbol(
+                    _DEAD_QUOTE,
+                    universe_useful=useful,
+                    quote_snapshot_present=present,
+                    candidate_fresh=fresh,
+                )
+                assert v in {"data_gap", "watch_only", "buy_review"}

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -426,9 +426,12 @@ async def test_kr_priority_full_fresh_outranks_partial_and_stale(db_session):
         (ev("A", "consecutive_gainers", 6.0), "stale"),  # full but stale
         (ev("B", "high_yield_value", 5.0), "fresh"),  # full + fresh, lower score
         (ev("C", "high_yield_value", 9.0), "fresh"),  # full + fresh, top score
+        # partial parity + fresh + top score must still rank BELOW any full-parity
+        # candidate (parity dominates freshness and score in the sort key).
+        (ev("D", "cheap_value", 10.0), "fresh"),  # partial parity
     ]
     ordered = sorted(rows, key=lambda pair: _priority_sort_key(pair[0], pair[1]))
-    assert [p[0].symbol for p in ordered] == ["C", "B", "A"]
+    assert [p[0].symbol for p in ordered] == ["C", "B", "A", "D"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -395,3 +395,37 @@ async def test_kr_collector_merges_duplicate_symbol_across_presets(
     reason_text = " ".join(merged["reasons"])
     assert "연속 상승" in reason_text  # from consecutive_gainers
     assert "저평가" in reason_text or "ROE" in reason_text  # from high_yield_value
+
+
+@pytest.mark.asyncio
+async def test_kr_priority_full_fresh_outranks_partial_and_stale(db_session):
+    """ROB-363 — deterministic priority: full+fresh+higher-score first. Internal
+    pool wider than candidate_limit, then sliced."""
+    from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+        _priority_sort_key,
+    )
+    from app.services.screener_evidence.models import CandidateEvidence
+
+    def ev(symbol, preset, score):
+        return CandidateEvidence(
+            symbol=symbol,
+            market="kr",
+            name=symbol,
+            score=score,
+            score_label="",
+            change_rate=None,
+            price=None,
+            volume_value=None,
+            reasons=[],
+            source="kis",
+            risk_flags=[],
+            source_preset=preset,
+        )
+
+    rows = [
+        (ev("A", "consecutive_gainers", 6.0), "stale"),  # full but stale
+        (ev("B", "high_yield_value", 5.0), "fresh"),  # full + fresh, lower score
+        (ev("C", "high_yield_value", 9.0), "fresh"),  # full + fresh, top score
+    ]
+    ordered = sorted(rows, key=lambda pair: _priority_sort_key(pair[0], pair[1]))
+    assert [p[0].symbol for p in ordered] == ["C", "B", "A"]

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -429,3 +429,64 @@ async def test_kr_priority_full_fresh_outranks_partial_and_stale(db_session):
     ]
     ordered = sorted(rows, key=lambda pair: _priority_sort_key(pair[0], pair[1]))
     assert [p[0].symbol for p in ordered] == ["C", "B", "A"]
+
+
+@pytest.mark.asyncio
+async def test_kr_stale_only_preset_not_overstated(db_session, monkeypatch):
+    """ROB-363 — when the only preset rows are stale, the collector payload must
+    report usefulness=stale_only and a non-fresh freshness_status, and stamp each
+    candidate data_state=stale (never fabricate freshness). Loaders stubbed."""
+    import app.services.invest_view_model.double_buy_screener as dbb
+    import app.services.invest_view_model.high_yield_value_screener as hy
+    import app.services.invest_view_model.screener_service as ss
+
+    async def _stale_rows(session, *, market, limit):
+        return [
+            {
+                "symbol": "005930",
+                "name": "삼성전자",
+                "source": "kis",
+                "change_rate": 2.0,
+                "close": 70000,
+                "consecutive_up_days": 6,
+                "volume": 1,
+                "_screener_snapshot_state": "stale",
+            }
+        ]
+
+    async def _none(session, *, market, limit, **kwargs):
+        return None
+
+    monkeypatch.setattr(ss, "load_consecutive_gainers_from_snapshots", _stale_rows)
+    monkeypatch.setattr(dbb, "load_double_buy_from_snapshots", _none)
+    monkeypatch.setattr(hy, "load_high_yield_value_from_snapshots", _none)
+
+    collector = CandidateUniverseSnapshotCollector(db_session)
+    results = await collector.collect(
+        CollectorRequest(
+            market="kr", account_scope=None, symbols=[], policy_snapshot={}
+        )
+    )
+    payload = results[0].payload_json
+    assert payload["usefulness"] == "stale_only"
+    assert payload["freshness_status"] != "fresh"
+    assert payload["candidates"], (
+        "stale candidates are still surfaced (demoted, not dropped)"
+    )
+    assert all(c["data_state"] == "stale" for c in payload["candidates"])
+    # And the bundle-level freshness must not claim fresh for a stale-only universe.
+    assert results[0].coverage_json["usefulness"] == "stale_only"
+
+
+def test_partial_parity_presets_report_partial_status():
+    """ROB-363 — partial Toss-parity presets (cheap_value, steady_dividend) must
+    derive a 'partial' status, never be inflated to 'full' (honesty criterion)."""
+    from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+        _toss_parity_status,
+    )
+
+    assert _toss_parity_status("cheap_value", "kr") == "partial"
+    assert _toss_parity_status("steady_dividend", "kr") == "partial"
+    # full presets stay full; non-toss rankings stay not_toss_parity.
+    assert _toss_parity_status("consecutive_gainers", "kr") == "full"
+    assert _toss_parity_status("top_gainers", "kr") == "not_toss_parity"

--- a/tests/test_auto_emit_candidate_citation.py
+++ b/tests/test_auto_emit_candidate_citation.py
@@ -276,3 +276,53 @@ def test_held_candidate_not_double_emitted():
     # Held name routes through held_and_trending only — no candidate buy/watch row.
     assert all(not k.startswith("auto-cand-") for k in keys)
     assert all(not k.startswith("auto-buy-") for k in keys)
+
+
+def test_stale_candidate_demoted_even_when_universe_useful():
+    """Per-candidate stale data_state must NOT be emitted as buy_review.
+
+    Universe usefulness == "useful", but one candidate has data_state="stale".
+    That candidate must be demoted to watch_only / screener_stale even though
+    the universe overall is useful.  The fresh candidate stays buy_review.
+    """
+    snaps = [
+        _Snap("portfolio", {"primary_source": "kis", "holdings": []}),
+        _Snap("symbol", {"symbol": "000660", "quote": _OK_QUOTE}, symbol="000660"),
+        _Snap("symbol", {"symbol": "005930", "quote": _OK_QUOTE}, symbol="005930"),
+        _Snap(
+            "candidate_universe",
+            {
+                "usefulness": "useful",
+                "candidates": [
+                    {
+                        "symbol": "000660",
+                        "score": 9.0,
+                        "rank": 1,
+                        "source": "kis",
+                        "data_state": "fresh",
+                    },
+                    {
+                        "symbol": "005930",
+                        "score": 8.0,
+                        "rank": 2,
+                        "source": "kis",
+                        "data_state": "stale",
+                    },
+                ],
+            },
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="kr", account_scope=None
+    )
+    by_symbol = {i.symbol: i for i in items}
+
+    # Fresh candidate with actionable quote → buy_review
+    assert by_symbol["000660"].evidence_snapshot["action_verdict"] == "buy_review"
+
+    # Stale candidate with actionable quote → watch_only / screener_stale
+    assert by_symbol["005930"].evidence_snapshot["action_verdict"] == "watch_only"
+    assert (
+        by_symbol["005930"].evidence_snapshot["reject_or_wait_reason"]
+        == "screener_stale"
+    )


### PR DESCRIPTION
## ROB-363 PR3/3 — deterministic priority + per-candidate stale demotion

Final PR of 3 (PR1 #1014, PR2 #1015 both merged). PR1+PR2 wired KR `candidate_universe` to fan in three Toss-parity presets with cross-preset symbol merge. PR3 makes the cap honest and the verdict layer act on per-candidate freshness.

Plan: `docs/superpowers/plans/2026-05-30-rob-363-kr-toss-parity-candidate-sourcing.md`.

### 1. Deterministic cross-preset priority
`_priority_sort_key` = `(parity_rank, freshness_rank, -score, symbol)` applied in `_collect_kr_presets` AFTER merge and BEFORE the `candidate_limit` slice. Full Toss parity > partial > mismatch > not_toss_parity; then fresh > stale; then higher score; then symbol (total deterministic order). The internal pool is gathered wider than the limit, so the strongest candidates survive the cap; `universe_count` is captured pre-slice so `capped` stays honest.

### 2. Per-candidate stale demotion
`classify_candidate_symbol` gains `candidate_fresh: bool = True`; `auto_emit` passes `candidate_fresh=(cand.get("data_state") or "fresh") == "fresh"`. A candidate whose own source is stale is demoted to `watch_only` / `screener_stale` even when the universe overall is useful — so stale rows are never overstated as `buy_review`. Demotion target is `watch_only` (never `rejected` — ROB-350 honest-verdict boundary preserved). Default `True` keeps every existing caller unchanged.

### 3. Regression coverage
- stale-only payload → `usefulness="stale_only"`, non-fresh `freshness_status`, candidates surfaced-but-demoted (not dropped).
- partial-parity presets (`cheap_value`/`steady_dividend`) honestly report `partial`, never inflated to `full`.
- per-candidate stale demotion end-to-end (fresh→buy_review, stale→watch_only/screener_stale, same universe).
- never-rejects invariant extended across `candidate_fresh`; priority test includes a partial-parity cross-tier case.

### Tests (404 pass across action_report + screener_evidence + invest_view_model, ruff + format clean)

### Migration / flags
None.

### No-side-effect boundary
No broker/order/watch/order-intent/trade-journal mutation. Read-only DB. KR candidate sourcing only; US/crypto collector paths unchanged. The `auto_emit` demotion is market-agnostic but only activates on a stale `data_state` (default fresh → no behavior change). Grep over touched files confirms no order-mutation calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)