### PR TITLE
fix(ROB-366): currency-aware portfolio stage + derive market_session (B7/B6)

### DIFF
--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -265,7 +265,11 @@ class HermesContextExporter:
             snapshot_bundle_uuid=bundle.bundle_uuid,
             bundle_status=bundle.status,
             market=bundle.market,
-            market_session=None,
+            # ROB-366 B6 — the bundle has no session column; the persisted
+            # market_session lives on the stage run. Derive it from the latest
+            # run already loaded above (None when no run / none recorded — never
+            # computed from a clock, to avoid inventing a session).
+            market_session=run.market_session if run is not None else None,
             account_scope=bundle.account_scope,
             policy_version=bundle.policy_version,
             coverage_summary=dict(bundle.coverage_summary or {}),

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -13,40 +13,49 @@ from app.services.investment_stages.stages.base import (
 )
 
 
-def _nested_krw(value: object) -> float | None:
-    """Return the KRW amount from a nested ``{"krw": x, "usd": y}`` block.
+def _nested_amount(value: object, currency: str) -> float | None:
+    """Return the amount for ``currency`` from a nested ``{"krw": x, "usd": y}``
+    block, or ``None`` when absent.
 
     The production portfolio collector emits cash / buying power as nested
-    per-currency dicts (``payload["cash"] = {"krw": ..., "usd": ...}``). Returns
-    ``None`` when the block is absent or carries no KRW figure so callers can
-    fall back to the legacy flat key.
+    per-currency dicts. ROB-366 B7: there is NO cross-currency fallback — a USD
+    account whose ``usd`` figure is absent returns ``None`` (unavailable), never
+    the KRW figure, so the report never mixes currencies or fabricates a value.
     """
     if isinstance(value, dict):
-        krw = value.get("krw")
-        if krw is not None:
-            return float(krw)
+        amount = value.get(currency)
+        if amount is not None:
+            return float(amount)
     return None
 
 
-def _portfolio_totals(payload: dict) -> tuple[float, float, float]:
-    """Derive ``(nav_krw, buying_power_krw, cash_krw)`` from a portfolio payload.
+def _select_currency(payload: dict) -> str:
+    """Pick the portfolio currency from the collector-tagged ``market``.
 
-    ROB-314: the production collector's payload is nested (``cash.krw``,
-    ``buying_power.krw``, ``holdings[].value_krw``) and carries no canonical
-    total, so NAV is derived as ``sum(holdings value_krw) + cash.krw``. Legacy
-    flat keys (``nav_krw`` / ``buying_power_krw`` / ``cash_krw``) are honoured as
-    a fallback so older fixtures and manual snapshots keep working.
+    US (overseas) accounts report USD; KR and crypto (Upbit, KRW-denominated)
+    use KRW. The market tag is collector-provided, so the stage needs no
+    StageContext signal.
     """
-    cash_krw = _nested_krw(payload.get("cash"))
+    market = str(payload.get("market") or "kr").strip().lower()
+    return "usd" if market == "us" else "krw"
+
+
+def _krw_totals(payload: dict) -> tuple[float, float, float]:
+    """``(nav_krw, buying_power_krw, cash_krw)`` — unchanged ROB-314 behaviour.
+
+    NAV = ``sum(holdings value_krw) + cash.krw``; legacy flat keys
+    (``nav_krw`` / ``buying_power_krw`` / ``cash_krw``) are honoured as a
+    fallback. All three are floats (absent buying power defaults to 0.0 to
+    preserve the existing KR contract).
+    """
+    cash_krw = _nested_amount(payload.get("cash"), "krw")
     if cash_krw is None:
         cash_krw = float(payload.get("cash_krw") or 0.0)
 
-    buying_power_krw = _nested_krw(payload.get("buying_power"))
+    buying_power_krw = _nested_amount(payload.get("buying_power"), "krw")
     if buying_power_krw is None:
         buying_power_krw = float(payload.get("buying_power_krw") or 0.0)
 
-    # Prefer an explicit total when present (legacy/flat), otherwise derive it
-    # from the holdings evaluation sum plus cash.
     explicit_nav = payload.get("nav_krw")
     if explicit_nav is None:
         explicit_nav = payload.get("total_evaluation_krw")
@@ -62,6 +71,31 @@ def _portfolio_totals(payload: dict) -> tuple[float, float, float]:
     return nav_krw, buying_power_krw, cash_krw
 
 
+def _usd_totals(payload: dict) -> tuple[float | None, float | None, float | None]:
+    """``(nav_usd, buying_power_usd, cash_usd)`` for a US (overseas) account.
+
+    ROB-366 B7: honest, no fabrication and no cross-currency arithmetic. Cash /
+    buying power come from the ``usd`` sub-key only (``None`` when absent —
+    e.g. the documented OPSQ0002 overseas-cash case). NAV is summed from
+    ``holdings[].value_native`` (the native USD value) plus USD cash; if ANY
+    holding lacks ``value_native`` the sum cannot be done honestly so NAV is
+    ``None`` (never falls back to the KRW-normalized ``value_krw``).
+    """
+    cash_usd = _nested_amount(payload.get("cash"), "usd")
+    buying_power_usd = _nested_amount(payload.get("buying_power"), "usd")
+
+    holdings = [h for h in (payload.get("holdings") or []) if isinstance(h, dict)]
+    natives = [h.get("value_native") for h in holdings]
+    if any(n is None for n in natives):
+        nav_usd: float | None = None  # cannot sum honestly — no value_krw fallback
+    elif not holdings and cash_usd is None:
+        nav_usd = None  # nothing to report
+    else:
+        nav_usd = sum(float(n) for n in natives) + (cash_usd or 0.0)
+
+    return nav_usd, buying_power_usd, cash_usd
+
+
 class PortfolioJournalStage:
     stage_type = "portfolio_journal"
 
@@ -70,20 +104,25 @@ class PortfolioJournalStage:
         if not portfolio_snaps:
             raise UnavailableStageError("portfolio snapshot missing — required")
         portfolio = portfolio_snaps[0]
+        payload = portfolio.payload_json or {}
         journal_snaps = context.snapshots_for("journal")
 
-        nav, buying_power, _cash_krw = _portfolio_totals(portfolio.payload_json or {})
-        bp_ratio = (buying_power / nav) if nav > 0 else 0.0
+        currency = _select_currency(payload)
+        if currency == "usd":
+            nav, buying_power, _cash = _usd_totals(payload)
+        else:
+            nav, buying_power, _cash = _krw_totals(payload)
 
         entries = []
         for snap in journal_snaps:
             entries.extend((snap.payload_json or {}).get("entries", []))
+        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
 
         citations = [
             StageCitation(
                 snapshot_uuid=portfolio.snapshot_uuid,
                 snapshot_kind="portfolio",
-                payload_path="$.buying_power.krw",
+                payload_path=f"$.buying_power.{currency}",
             )
         ]
         for snap in journal_snaps:
@@ -95,19 +134,48 @@ class PortfolioJournalStage:
                 )
             )
 
-        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
-        summary = (
-            f"NAV={nav:,.0f}, buying_power_krw={buying_power:,.0f} "
-            f"({bp_ratio:.1%}), open journal: {symbols or 'none'}"
-        )
+        missing_data = [] if journal_snaps else ["journal"]
+        key_points = [e.get("thesis", "") for e in entries[:5] if e.get("thesis")]
+
+        if currency == "krw":
+            # Byte-identical legacy KR contract: buying power is always a float
+            # (flat-key default 0.0) and the ratio is always shown.
+            bp_ratio = (buying_power / nav) if nav > 0 else 0.0
+            summary = (
+                f"NAV={nav:,.0f}, buying_power_krw={buying_power:,.0f} "
+                f"({bp_ratio:.1%}), open journal: {symbols or 'none'}"
+            )
+            confidence = 60 if bp_ratio >= 0.05 else 40
+            risk_evidence = [] if bp_ratio >= 0.05 else ["buying_power < 5% NAV"]
+        else:
+            # USD: surface unavailable explicitly; absence is not a low-buying-
+            # power risk signal and must not punish confidence.
+            nav_str = f"{nav:,.0f}" if nav is not None else "unavailable"
+            if buying_power is None:
+                bp_ratio = None
+                bp_segment = "buying_power_usd=unavailable"
+                missing_data = [*missing_data, "buying_power_usd"]
+            else:
+                bp_ratio = (
+                    (buying_power / nav) if (nav is not None and nav > 0) else None
+                )
+                ratio_str = f" ({bp_ratio:.1%})" if bp_ratio is not None else ""
+                bp_segment = f"buying_power_usd={buying_power:,.0f}{ratio_str}"
+            summary = (
+                f"NAV(USD)={nav_str}, {bp_segment}, open journal: {symbols or 'none'}"
+            )
+            if bp_ratio is not None and bp_ratio < 0.05:
+                confidence, risk_evidence = 40, ["buying_power < 5% NAV"]
+            else:
+                confidence, risk_evidence = 60, []
 
         return StageArtifactPayload(
             stage_type=self.stage_type,
             verdict=StageVerdict.NEUTRAL,
-            confidence=60 if bp_ratio >= 0.05 else 40,
+            confidence=confidence,
             summary=summary,
-            key_points=[e.get("thesis", "") for e in entries[:5] if e.get("thesis")],
-            risk_evidence=[] if bp_ratio >= 0.05 else ["buying_power < 5% NAV"],
+            key_points=key_points,
+            risk_evidence=risk_evidence,
             cited_snapshots=citations,
-            missing_data=[] if journal_snaps else ["journal"],
+            missing_data=missing_data,
         )

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -87,3 +87,137 @@ async def test_portfolio_journal_derives_totals_from_nested_kis_payload():
     assert payload.verdict == StageVerdict.NEUTRAL
     assert payload.confidence == 60
     assert any(c.snapshot_kind == "portfolio" for c in payload.cited_snapshots)
+
+
+# --- ROB-366 B7: currency-aware (US/USD) portfolio --------------------------
+def _us_snap(payload_extra: dict):
+    base = {"market": "us"}
+    base.update(payload_extra)
+    return _snap("portfolio", base)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_us_surfaces_usd_buying_power():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _us_snap(
+                    {
+                        "cash": {"krw": None, "usd": 10_000.0},
+                        "buying_power": {"krw": None, "usd": 8_000.0},
+                        "holdings": [
+                            {
+                                "symbol": "AAPL",
+                                "currency": "USD",
+                                "value_native": 20_000.0,
+                                "value_krw": 27_000_000.0,
+                            }
+                        ],
+                    }
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    # NAV(USD) = value_native 20,000 + cash.usd 10,000 = 30,000 (no value_krw)
+    assert "NAV(USD)=30,000" in (payload.summary or "")
+    assert "buying_power_usd=8,000" in (payload.summary or "")
+    assert "buying_power_krw" not in (payload.summary or "")
+    assert "27,000,000" not in (payload.summary or "")  # no KRW cross-currency leak
+    assert payload.cited_snapshots[0].payload_path == "$.buying_power.usd"
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert payload.confidence == 60  # bp_ratio 8000/30000 ≈ 0.27 → healthy
+    assert payload.risk_evidence == []
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_us_buying_power_absent_is_unavailable_not_zero():
+    # ROB-326: KIS overseas cash often unsupported (OPSQ0002) → usd may be None.
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _us_snap(
+                    {
+                        "cash": {"krw": None, "usd": None},
+                        "buying_power": {"krw": None, "usd": None},
+                        "holdings": [
+                            {
+                                "symbol": "AAPL",
+                                "currency": "USD",
+                                "value_native": 20_000.0,
+                                "value_krw": 27_000_000.0,
+                            }
+                        ],
+                    }
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "buying_power_usd=unavailable" in (payload.summary or "")
+    assert "buying_power_usd" in payload.missing_data
+    assert payload.risk_evidence == []  # absence is not a <5% NAV risk
+    assert payload.confidence == 60  # not punished to 40 for absent data
+    assert "buying_power_krw" not in (payload.summary or "")
+    assert "27,000,000" not in (payload.summary or "")  # never falls back to value_krw
+    assert "NAV(USD)=20,000" in (payload.summary or "")  # value_native only
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_us_nav_unavailable_when_value_native_missing():
+    # No cross-currency fallback: a holding without value_native makes NAV
+    # honestly unavailable rather than summing the KRW-normalized figure.
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _us_snap(
+                    {
+                        "cash": {"krw": None, "usd": 5_000.0},
+                        "buying_power": {"krw": None, "usd": 8_000.0},
+                        "holdings": [
+                            {
+                                "symbol": "AAPL",
+                                "currency": "USD",
+                                "value_native": None,
+                                "value_krw": 27_000_000.0,
+                            }
+                        ],
+                    }
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "NAV(USD)=unavailable" in (payload.summary or "")
+    assert "27,000,000" not in (payload.summary or "")
+    assert "buying_power_usd=8,000," in (payload.summary or "")  # present, no ratio
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_crypto_uses_krw():
+    # Upbit (crypto) is KRW-denominated → KRW path, byte-identical labels.
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap(
+                    "portfolio",
+                    {
+                        "market": "crypto",
+                        "buying_power_krw": 500_000,
+                        "nav_krw": 1_000_000,
+                    },
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "buying_power_krw=500,000" in (payload.summary or "")
+    assert payload.cited_snapshots[0].payload_path == "$.buying_power.krw"

--- a/tests/services/investment_stages/test_hermes_context_market_session.py
+++ b/tests/services/investment_stages/test_hermes_context_market_session.py
@@ -1,0 +1,113 @@
+"""ROB-366 B6 — Hermes context market_session derivation.
+
+The exporter used to hardcode ``market_session=None``; it now derives it from
+the latest InvestmentStageRun for the bundle (the run is where StageRunner
+persists the session). DB-backed because the exporter skips run-loading under a
+mock session.
+"""
+
+import datetime as dt
+import uuid
+
+import pytest
+
+from app.models.investment_snapshots import InvestmentSnapshotBundle
+from app.models.investment_stages import InvestmentStageRun
+from app.services.investment_stages.hermes_context import HermesContextExporter
+
+
+def _bundle() -> InvestmentSnapshotBundle:
+    return InvestmentSnapshotBundle(
+        bundle_uuid=uuid.uuid4(),
+        purpose="report_generation",
+        market="us",
+        account_scope="kis_live",
+        policy_version="intraday_action_report_v1",
+        as_of=dt.datetime.now(tz=dt.UTC),
+        status="complete",
+        coverage_summary={},
+        freshness_summary={},
+        idempotency_key=str(uuid.uuid4()),
+    )
+
+
+def _run(
+    bundle_uuid: uuid.UUID,
+    *,
+    market_session: str | None,
+    started_at: dt.datetime | None = None,
+) -> InvestmentStageRun:
+    return InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle_uuid,
+        market="us",
+        market_session=market_session,
+        account_scope="kis_live",
+        policy_version="v1",
+        generator_version="v1",
+        status="completed",
+        started_at=started_at or dt.datetime.now(tz=dt.UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_session_derived_from_latest_run(db_session) -> None:
+    bundle = _bundle()
+    db_session.add(bundle)
+    await db_session.commit()
+    db_session.add(_run(bundle.bundle_uuid, market_session="regular"))
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session == "regular"
+
+
+@pytest.mark.asyncio
+async def test_market_session_none_when_no_run(db_session) -> None:
+    bundle = _bundle()
+    db_session.add(bundle)
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session is None
+
+
+@pytest.mark.asyncio
+async def test_market_session_uses_latest_run_when_multiple(db_session) -> None:
+    # Bundle re-run across sessions: the most recent run (by started_at) wins.
+    bundle = _bundle()
+    db_session.add(bundle)
+    await db_session.commit()
+    now = dt.datetime.now(tz=dt.UTC)
+    db_session.add(
+        _run(
+            bundle.bundle_uuid,
+            market_session="pre",
+            started_at=now - dt.timedelta(hours=2),
+        )
+    )
+    db_session.add(_run(bundle.bundle_uuid, market_session="regular", started_at=now))
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session == "regular"
+
+
+@pytest.mark.asyncio
+async def test_market_session_none_when_run_recorded_none(db_session) -> None:
+    bundle = _bundle()
+    db_session.add(bundle)
+    await db_session.commit()
+    db_session.add(_run(bundle.bundle_uuid, market_session=None))
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session is None


### PR DESCRIPTION
## What

ROB-366 **B7 + B6**, third PR in the sequence (after #1017 B10, #1020 B5). Independent of #1020 (uses the collector-tagged `payload["market"]`, not `StageContext.market`).

**B7** — `PortfolioJournalStage` was hard-wired to KRW (`cash.krw` / `buying_power.krw` / `holdings[].value_krw`). For a US (overseas) bundle the KIS collector emits `{"krw": None, "usd": <amount>}`, so the stage silently zeroed buying power and surfaced the **KRW domestic orderable** instead of the **USD overseas** buying power — the observed live-trial defect.

**B6** — the Hermes context payload hardcoded `market_session=None` for an intraday report.

## How (no fabrication, no cross-currency arithmetic)

**B7** — currency-aware off `payload["market"]` (US → USD, KR/crypto → KRW):
- `_krw_totals` is the unchanged ROB-314 path → KR output (summary, confidence, risk, citation `$.buying_power.krw`) is **byte-identical**.
- `_usd_totals` reads the `usd` sub-key **only** (`None` when absent — never the `krw` figure). `NAV(USD) = Σ holdings[].value_native + cash.usd`; if **any** holding lacks `value_native`, NAV is **unavailable** (never falls back to the KRW-normalized `value_krw`).
- When `buying_power.usd` is genuinely absent (ROB-326 OPSQ0002 overseas-cash case): surfaces `buying_power_usd=unavailable`, adds it to `missing_data`, emits **no** `<5% NAV` risk, and does **not** punish confidence to 40. Citation path `$.buying_power.usd`.

**B6** — the bundle has no session column; the persisted session lives on `InvestmentStageRun`, which the exporter already loads. Derive `market_session` from that latest run (`None` when no run / none recorded). **Not** computed from a clock — no session classifier exists and inventing one could disagree with the recorded value. The ingest-side mismatch guards key off the envelope's own `run_uuid` (not this context value), so emitting a real session **cannot** trip a dormant guard (confirmed by the round-trip smoke).

## Decisions (confirmed with maintainer)

- US NAV = **Σ value_native** (+ USD cash), gated to unavailable if any holding lacks it — the recommended option.
- Currency from the payload market tag → PR3 is independent of the B5 PR; no stacking.

## Verification

- TDD: 4 new portfolio tests (US surfaces USD / absent→unavailable-not-zero / NAV-unavailable-when-value_native-missing / crypto→KRW) + 4 `market_session` tests (derived / no-run / recorded-none / latest-of-many). The 3 pre-existing KR portfolio tests pass **unmodified**.
- `tests/services/investment_stages/`: **81 passed**. `ruff check` + `ruff format --check` + `ty check`: clean.
- Adversarially reviewed (3 lenses: KR byte-identical / currency-honesty / B6 round-trip) → all **sound**.

## Out of scope (later)

B8 (US news feed) + A1 (rebuild/symbol-expansion) → next PR. US per-symbol fundamentals/sentiment (B2) need a data source and are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-currency support for portfolio metrics, enabling proper calculation for both KRW and USD accounts.
  * Market session information now properly tracked and exported in context payloads.

* **Bug Fixes**
  * Fixed portfolio calculations to avoid inappropriate cross-currency conversions for USD accounts.

* **Tests**
  * Added comprehensive test coverage for currency-aware portfolio metrics and market session tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->