### PR TITLE
fix(ROB-366): US news dimension serves market-scoped articles, no KR bleed (B8)

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -16,6 +16,7 @@ than infer signal from absence.
 from __future__ import annotations
 
 import datetime as dt
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,6 +31,11 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 from app.services.research_reports.query_service import ResearchReportsQueryService
+
+# ROB-366 B8 — read-only market-scoped news article fetch (market, hours, limit)
+# → list of article dicts. Wired in registry.py over the deterministic
+# get_news_articles source so this module imports no MCP tooling.
+NewsFetchFn = Callable[[str, int, int], Awaitable[list[dict[str, Any]]]]
 
 
 def _citation_symbols(citation: Any) -> set[str]:
@@ -52,17 +58,26 @@ class NewsSnapshotCollector:
         session: AsyncSession,
         *,
         query_service: ResearchReportsQueryService | None = None,
+        news_fetch_fn: NewsFetchFn | None = None,
         lookback_hours: int = 24,
         limit: int = 20,
     ) -> None:
         self._session = session
         self._query = query_service or ResearchReportsQueryService(session)
+        self._news_fetch_fn = news_fetch_fn
         self._lookback_hours = max(1, lookback_hours)
         self._limit = max(1, limit)
 
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
         since = now - dt.timedelta(hours=self._lookback_hours)
+
+        # ROB-366 B8 — when a market-aware article source is wired, the news
+        # dimension serves real (market-scoped) articles in the shape NewsStage
+        # reads (``articles``). Falls back to the research_reports citation path
+        # when no source is injected (back-compat / tests).
+        if self._news_fetch_fn is not None:
+            return await self._collect_articles(request, now=now, since=since)
 
         try:
             response = await self._query.find_relevant(
@@ -138,5 +153,50 @@ class NewsSnapshotCollector:
                 origin="news",
                 as_of=now,
                 coverage={"citation_count": len(citations_payload)},
+            )
+        ]
+
+    async def _collect_articles(
+        self, request: CollectorRequest, *, now: dt.datetime, since: dt.datetime
+    ) -> list[SnapshotCollectResult]:
+        """Market-scoped news articles path (ROB-366 B8). Fail-open like the
+        research path: a fetch error degrades the optional ``news`` kind to
+        ``unavailable`` rather than blocking the bundle. An empty result is
+        ``partial`` (queried, nothing within the window) — never fabricated."""
+        assert self._news_fetch_fn is not None
+        try:
+            articles = await self._news_fetch_fn(
+                request.market, self._lookback_hours, self._limit
+            )
+        except Exception as exc:  # noqa: BLE001 — optional, fail open
+            return [
+                unavailable_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    origin="news",
+                    reason=f"news article fetch failed: {type(exc).__name__}: {exc}",
+                    as_of=now,
+                )
+            ]
+
+        articles_payload = [a for a in (articles or []) if isinstance(a, dict)]
+        payload: dict[str, Any] = {
+            "since": since.isoformat(),
+            "count": len(articles_payload),
+            "articles": articles_payload,
+            "source": "news_articles",
+            "market": request.market,
+        }
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="news",
+                as_of=now,
+                freshness_status="fresh" if articles_payload else "partial",
+                coverage={"article_count": len(articles_payload)},
             )
         ]

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -27,6 +27,7 @@ from app.services.action_report.snapshot_backed.collectors.market import (
     MarketEventsSnapshotCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.news import (
+    NewsFetchFn,
     NewsSnapshotCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.optional_stubs import (
@@ -163,6 +164,45 @@ def _build_market_index_quote_fn() -> IndexQuoteFn:
     return _index_quote_fn
 
 
+def _build_news_fetch_fn() -> NewsFetchFn:
+    """Read-only adapter over the deterministic, market-aware news source.
+
+    ROB-366 B8: given (market, hours, limit), returns recent market-scoped
+    ``NewsArticle`` rows mapped to plain dicts in the shape NewsStage reads
+    (``articles``). ``get_news_articles`` is imported lazily and uses its own
+    read-only session; this stays a thin pass-through with no order/mutation
+    surface. The collector wraps the call so a fetch error degrades the
+    optional ``news`` kind to ``unavailable``.
+    """
+
+    async def _news_fetch_fn(
+        market: str, hours: int, limit: int
+    ) -> list[dict[str, Any]]:
+        from app.services.llm_news_service import get_news_articles
+
+        articles, _total = await get_news_articles(
+            market=market, hours=hours, limit=limit
+        )
+        out: list[dict[str, Any]] = []
+        for a in articles:
+            published = getattr(a, "article_published_at", None)
+            out.append(
+                {
+                    "title": a.title,
+                    "url": a.url,
+                    "source": a.source,
+                    "feed_source": a.feed_source,
+                    "summary": a.summary,
+                    "stock_symbol": a.stock_symbol,
+                    "stock_name": a.stock_name,
+                    "published_at": published.isoformat() if published else None,
+                }
+            )
+        return out
+
+    return _news_fetch_fn
+
+
 def _build_kis_client_safely() -> KISClient | None:
     """Construct the KIS client used by the pending-orders collector.
 
@@ -197,8 +237,12 @@ def production_collector_registry(session: AsyncSession) -> SnapshotCollectorReg
         )
     )
 
-    # Optional kinds — DB-backed where possible.
-    registry.register(NewsSnapshotCollector(session))
+    # Optional kinds — DB-backed where possible. ROB-366 B8 — wire the
+    # market-aware news article source so US (and KR) bundles serve real
+    # market-scoped news instead of an empty/KR-bleeding research feed.
+    registry.register(
+        NewsSnapshotCollector(session, news_fetch_fn=_build_news_fetch_fn())
+    )
     # ROB-278 Phase 2 — wire the KIS quote/orderbook adapter so KR + kis_live
     # requests get per-symbol quote evidence. Construction is wrapped (the
     # KIS client can be None when credentials are absent) so the collector

--- a/app/services/investment_dimensions/news_evidence.py
+++ b/app/services/investment_dimensions/news_evidence.py
@@ -24,11 +24,10 @@ async def build_news_evidence(
     now: dt.datetime | None = None,
 ) -> dict[str, Any]:
     now_dt = now or dt.datetime.now(tz=dt.UTC)
-    # research_reports rows are multi-symbol mentions, not market-scoped, and the
-    # query surface has no market filter — take the most recent reports and pass
-    # symbol_candidates through so Hermes can scope per market. No ``since`` so
-    # freshness (fresh vs stale) is meaningful rather than always-fresh.
-    response = await query_service.find_relevant(limit=CITATION_LIMIT)
+    # ROB-366 B8 — scope to the bundle market via the per-candidate market tag so
+    # KR research does not bleed into a US bundle. No ``since`` so freshness
+    # (fresh vs stale) is meaningful rather than always-fresh.
+    response = await query_service.find_relevant(limit=CITATION_LIMIT, market=market)
 
     citations: list[dict[str, Any]] = []
     latest_published: dt.datetime | None = None

--- a/app/services/research_reports/query_service.py
+++ b/app/services/research_reports/query_service.py
@@ -60,6 +60,7 @@ class ResearchReportsQueryService:
         source: str | None = None,
         since: datetime | None = None,
         until: datetime | None = None,
+        market: str | None = None,
         limit: int | None = None,
     ) -> ResearchReportCitationListResponse:
         effective_limit = min(
@@ -83,6 +84,15 @@ class ResearchReportsQueryService:
             stmt = stmt.where(
                 ResearchReport.symbol_candidates.cast(JSONB).op("@>")(
                     [{"symbol": symbol}]
+                )
+            )
+
+        if market is not None:
+            # ROB-366 B8 — scope to a market via the per-candidate market tag so
+            # KR research does not bleed into a US bundle. Mirrors find_feed_page.
+            stmt = stmt.where(
+                ResearchReport.symbol_candidates.cast(JSONB).op("@>")(
+                    [{"market": market}]
                 )
             )
 

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -904,6 +904,54 @@ async def test_news_collector_failure_is_fail_open():
     assert results[0].freshness_status == "unavailable"
 
 
+# --- ROB-366 B8: market-scoped news articles via injected fetch fn ----------
+@pytest.mark.asyncio
+async def test_news_collector_articles_from_news_fetch_fn():
+    captured: dict = {}
+
+    async def fake_news_fn(market, hours, limit):
+        captured["market"] = market
+        return [
+            {"title": "Apple beats earnings", "url": "u1", "stock_symbol": "AAPL"},
+            {"title": "Fed holds rates", "url": "u2", "stock_symbol": None},
+        ]
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
+    results = await collector.collect(_request(market="us"))
+    payload = results[0].payload_json
+    # The articles key (what NewsStage reads) is populated, market-scoped.
+    assert payload["count"] == 2
+    assert [a["title"] for a in payload["articles"]] == [
+        "Apple beats earnings",
+        "Fed holds rates",
+    ]
+    assert captured["market"] == "us"
+    assert results[0].freshness_status == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_news_collector_articles_empty_is_partial():
+    async def fake_news_fn(market, hours, limit):
+        return []
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
+    results = await collector.collect(_request(market="us"))
+    assert results[0].payload_json["count"] == 0
+    assert results[0].payload_json["articles"] == []
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_news_collector_articles_fetch_failure_is_fail_open():
+    async def fake_news_fn(market, hours, limit):
+        raise RuntimeError("news feed down")
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
+    results = await collector.collect(_request(market="us"))
+    assert len(results) == 1
+    assert results[0].freshness_status == "unavailable"
+
+
 def _make_citation(*, report_uuid: str, symbols: list[str]):
     from app.schemas.research_reports import (
         ResearchReportCitation,

--- a/tests/services/investment_dimensions/test_news_evidence.py
+++ b/tests/services/investment_dimensions/test_news_evidence.py
@@ -14,7 +14,7 @@ async def _clear(db_session):
     await db_session.commit()
 
 
-def _report(dedup_key, *, published_at, title, symbols):
+def _report(dedup_key, *, published_at, title, symbols, market="kr"):
     return ResearchReport(
         dedup_key=dedup_key,
         report_type="research-reports.v1",
@@ -26,7 +26,7 @@ def _report(dedup_key, *, published_at, title, symbols):
         published_at=published_at,
         published_at_text=published_at.isoformat(),
         symbol_candidates=[
-            {"symbol": s, "market": "kr", "source": "naver_research"} for s in symbols
+            {"symbol": s, "market": market, "source": "naver_research"} for s in symbols
         ],
     )
 
@@ -76,6 +76,40 @@ async def test_build_news_evidence_stale_when_old(db_session):
     )
     assert bundle["count"] == 1
     assert bundle["freshness"]["status"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_scopes_to_market_no_kr_bleed(db_session):
+    # ROB-366 B8: a US bundle must NOT surface KR research (kis_truefriend bleed).
+    await _clear(db_session)
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    db_session.add(
+        _report(
+            "kr1",
+            published_at=now - dt.timedelta(hours=1),
+            title="엔비디아 KR 노트",
+            symbols=["NVDA"],
+            market="kr",
+        )
+    )
+    db_session.add(
+        _report(
+            "us1",
+            published_at=now - dt.timedelta(hours=2),
+            title="Apple US note",
+            symbols=["AAPL"],
+            market="us",
+        )
+    )
+    await db_session.commit()
+
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session), market="us", now=now
+    )
+    assert bundle["count"] == 1
+    assert bundle["citations"][0]["title"] == "Apple US note"
+    # The newer KR report must be excluded despite being more recent.
+    assert all(c["title"] != "엔비디아 KR 노트" for c in bundle["citations"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

ROB-366 **B8**, final implementation PR (after #1017 B10, #1020 B5, #1021 B7/B6). The news dimension had **three stacked defects**:

1. **Shape mismatch:** `NewsStage` reads `payload["articles"]` but `NewsSnapshotCollector` wrote `"citations"` → the stage **always** saw `0` ("0 articles") regardless of source.
2. **KR bleed:** `build_news_evidence` called `find_relevant` with no market filter → the newest `research_reports` (KR `kis_truefriend`) bled into a US bundle's news evidence.
3. **Wrong source:** both news paths read `research_reports` (empty in prod, KR-centric); the real market-aware feed (`NewsArticle` / `get_news_articles`, with US RSS sources) was never wired in.

## How (read-only, deterministic, no fabrication)

- `find_relevant` gains an optional `market` kwarg filtering `symbol_candidates @> [{"market": market}]` (mirrors `find_feed_page`); `build_news_evidence` passes the bundle market → KR research no longer bleeds into US (research being empty in prod now yields an honest empty US news dimension, not KR rows).
- `NewsSnapshotCollector` takes an injected read-only `news_fetch_fn`; when present it emits a market-scoped **`articles`** payload (the shape `NewsStage` reads) — fixing the "0 articles" shape mismatch **and** delivering real US news. Empty → freshness `partial` (queried, none in window), never fabricated; fetch error → `unavailable` (fail-open). The research-citations path is unchanged back-compat.
- `registry` wires `_build_news_fetch_fn` over `get_news_articles(market, hours, limit)`, **lazy-imported** (no LLM/broker/order surface — both import guards stay green), forwarding `summary` (never the `article_content` body — copyright boundary intact).
- **Sentiment is not fabricated:** `NewsArticle` carries no sentiment (it lives in `NewsAnalysisResult`), so `NewsStage` scores count-only → `NEUTRAL` conf 30 with N real articles, an honest signal rather than a fake bull/bear.

## Decisions (confirmed with maintainer)

- Source = wire `get_news_articles` (the populated, market-aware feed) — the recommended option; matches the issue's "get_market_news 미반영" note.
- **A1 (rebuild/symbol-expansion) split to a separate scoped issue:** its premise ("same-day reuse") is actually a **5-minute hard-TTL window** (after which a new bundle is built and picks up new symbols), and the only safe remedy touches the bundle ensure/reuse + idempotency contract — making symbols part of bundle identity would break the globally-reusable-evidence invariant. Out of scope here.

## Verification

- TDD: 3 collector articles tests (fetch fn / empty→partial / fail-open) + 1 market-scoping `news_evidence` test; the 3 pre-existing KR `news_evidence` tests and the research-citations collector tests pass **unmodified**.
- 343 tests across news/dimension/snapshot suites + the no-internal-LLM import guard + data-source-contract drift guard. `ruff check` + `ruff format --check` + `ty check`: clean. Adversarially reviewed (3 lenses) → all **sound**.

## Remaining for ROB-366 closure

- **A1** → separate issue (rebuild mode design + TTL-window doc).
- **B2** (US per-symbol fundamentals/sentiment) → needs a US data source; deferred.
- **B9/A3** (candidate screener US freshness) → entangled with ROB-204 US activation.
- **A4** (external probe intentionally-not-wired) → doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)