### PR TITLE
fix(ROB-368): use US mock sell TR ID

### DIFF
--- a/app/services/brokers/kis/constants.py
+++ b/app/services/brokers/kis/constants.py
@@ -116,7 +116,8 @@ OVERSEAS_ORDER_URL = "/uapi/overseas-stock/v1/trading/order"
 OVERSEAS_ORDER_BUY_TR = "TTTT1002U"  # 실전투자 해외주식 매수주문
 OVERSEAS_ORDER_BUY_TR_MOCK = "VTTT1002U"  # 모의투자 해외주식 매수주문
 OVERSEAS_ORDER_SELL_TR = "TTTT1006U"  # 실전투자 해외주식 매도주문
-OVERSEAS_ORDER_SELL_TR_MOCK = "VTTT1006U"  # 모의투자 해외주식 매도주문
+OVERSEAS_ORDER_SELL_TR_MOCK = "VTTT1006U"  # 모의투자 해외주식 매도주문(US 제외)
+OVERSEAS_ORDER_SELL_TR_MOCK_US = "VTTT1001U"  # 모의투자 미국 해외주식 매도주문
 
 OVERSEAS_ORDER_INQUIRY_URL = "/uapi/overseas-stock/v1/trading/inquire-nccs"
 OVERSEAS_ORDER_INQUIRY_TR = "TTTS3018R"  # 해외주식 미체결내역 조회
@@ -143,6 +144,8 @@ INTEGRATED_MARGIN_TR_MOCK = "VTTC0869R"  # 모의투자 통합증거금 조회
 # ============================================================================
 
 # Overseas exchange codes (for API calls)
+OVERSEAS_US_EXCHANGE_CODES = frozenset({"NASD", "NYSE", "AMEX"})
+
 OVERSEAS_EXCHANGE_MAP = {
     "NASD": "NAS",  # 나스닥
     "NYSE": "NYS",  # 뉴욕

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -107,6 +107,10 @@ class OverseasOrderClient:
 
         cano = account_no[:8]
         acnt_prdt_cd = account_no[8:10]
+        exchange_code_normalized = _EXCHANGE_ALIAS_MAP.get(
+            str(exchange_code or "").strip().upper(),
+            str(exchange_code or "").strip().upper(),
+        )
 
         if order_type.lower() == "buy":
             tr_id = (
@@ -116,11 +120,17 @@ class OverseasOrderClient:
             )
             order_type_korean = "매수"
         elif order_type.lower() == "sell":
-            tr_id = (
-                constants.OVERSEAS_ORDER_SELL_TR_MOCK
-                if is_mock
-                else constants.OVERSEAS_ORDER_SELL_TR
-            )
+            if (
+                is_mock
+                and exchange_code_normalized in constants.OVERSEAS_US_EXCHANGE_CODES
+            ):
+                tr_id = constants.OVERSEAS_ORDER_SELL_TR_MOCK_US
+            else:
+                tr_id = (
+                    constants.OVERSEAS_ORDER_SELL_TR_MOCK
+                    if is_mock
+                    else constants.OVERSEAS_ORDER_SELL_TR
+                )
             order_type_korean = "매도"
         else:
             raise ValueError(

--- a/docs/kis-mock-tr-routing-matrix.md
+++ b/docs/kis-mock-tr-routing-matrix.md
@@ -36,7 +36,7 @@ account and order lifecycle for both domestic (KR) and overseas (US) markets.
 | `inquire_overseas_orders` | pending-inquiry, cancel/modify-lookup | `/uapi/overseas-stock/v1/trading/inquire-nccs` | `TTTS3018R` | **mock_unsupported** | fails closed (raises `RuntimeError` with `"mock"` in message) | `errors[].mock_unsupported=true` | `tests/test_kis_overseas_pending_mock.py::test_inquire_overseas_orders_mock_fails_closed` |
 | `inquire_daily_order_overseas` | daily-history | `/uapi/overseas-stock/v1/trading/inquire-ccnl` | `TTTS3035R` | `VTTS3035R` | uses mock TR | — | `tests/test_kis_mock_routing.py::test_inquire_daily_order_mock_uses_mock_tr[overseas]` |
 | `order_overseas_stock` (buy) | order-submit | `/uapi/overseas-stock/v1/trading/order` | `TTTT1002U` | `VTTT1002U` | uses mock TR | — | `tests/test_kis_order_ops.py` |
-| `order_overseas_stock` (sell) | order-submit | `/uapi/overseas-stock/v1/trading/order` | `TTTT1006U` | `VTTT1006U` | uses mock TR | — | `tests/test_kis_order_ops.py` |
+| `order_overseas_stock` (sell) | order-submit | `/uapi/overseas-stock/v1/trading/order` | `TTTT1006U` | `VTTT1001U` for US (`NASD/NYSE/AMEX`); `VTTT1006U` retained for non-US overseas mock until separately verified | uses mock TR | — | `tests/test_kis_overseas_orders_retry.py::test_mock_us_sell_order_uses_portal_tr_id` |
 | `cancel_overseas_order` | cancel-submit | `/uapi/overseas-stock/v1/trading/order-rvsecncl` | `TTTT1004U` | `VTTT1004U` | uses mock TR | — | `tests/test_kis_order_ops.py` |
 | `modify_overseas_order` | modify-submit | `/uapi/overseas-stock/v1/trading/order-rvsecncl` | `TTTT1004U` | `VTTT1004U` | uses mock TR | — | `tests/test_kis_order_ops.py` |
 

--- a/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
+++ b/docs/runbooks/kis-mock-overseas-holdings-delta-smoke.md
@@ -25,7 +25,7 @@ Script: `scripts/kis_mock_overseas_holdings_delta_smoke.py`
 | Account holdings | `KISClient.fetch_my_us_stocks(exchange=…)` | rows keyed `ovrs_pdno` / `ovrs_cblc_qty`; pre-filtered to nonzero |
 | USD cash / margin | `KISClient.inquire_overseas_margin()` | **OPSQ0002** in mock → treated as unavailable (best-effort only) |
 | Quote (sizing) | `KISClient.inquire_overseas_minute_chart(symbol, exchange, n=1)` | latest candle = **last** row (`close`, `datetime`); accepts the 4-digit order code |
-| BUY / SELL | `KISClient.buy_overseas_stock` / `sell_overseas_stock` | limit order when `price>0` (`ORD_DVSN=00`); TRs `VTTT1002U` / `VTTT1006U`; order id at `result["odno"]` |
+| BUY / SELL | `KISClient.buy_overseas_stock` / `sell_overseas_stock` | limit order when `price>0` (`ORD_DVSN=00`); US mock TRs `VTTT1002U` / `VTTT1001U`; order id at `result["odno"]` |
 | CANCEL | `KISClient.cancel_overseas_order(order_number, symbol, exchange, qty)` | `order_number` = prior BUY `odno`; TR `VTTT1004U` |
 | Pending orders | `inquire_overseas_orders` | **RuntimeError in mock** — not used here |
 | Filled history | `inquire_daily_order_overseas` | supplementary / non-gating (may be empty same-day) |

--- a/scripts/kis_mock_overseas_holdings_delta_smoke.py
+++ b/scripts/kis_mock_overseas_holdings_delta_smoke.py
@@ -3,7 +3,7 @@
 
 US counterpart to ``scripts/kis_mock_holdings_delta_smoke.py`` (domestic, ROB-358).
 Two modes, both KIS **mock** only (``is_mock=True`` -> mock host; overseas mock
-order TRs VTTT1002U/VTTT1006U/VTTT1004U):
+order TRs VTTT1002U/VTTT1001U/VTTT1004U):
 
 * ``--preflight`` — READ-ONLY. Resolves the US exchange, reads the mock overseas
   holdings (``fetch_my_us_stocks``) and a best-effort margin snapshot, prints the

--- a/tests/test_kis_overseas_orders_retry.py
+++ b/tests/test_kis_overseas_orders_retry.py
@@ -115,7 +115,6 @@ class TestOverseasOrdersTransientRetry:
             "msg_cd": "SOME_OTHER",
             "msg1": "알 수 없는 오류",
         }
-
         parent._request_with_rate_limit = AsyncMock(return_value=error_response)
 
         with pytest.raises(RuntimeError, match="SOME_OTHER"):
@@ -125,3 +124,58 @@ class TestOverseasOrdersTransientRetry:
 
         # Should fail on first attempt, no retry
         assert parent._request_with_rate_limit.call_count == 1
+
+    @pytest.fixture
+    def _successful_order_response(self):
+        return {
+            "rt_cd": "0",
+            "msg1": "주문 전송 완료",
+            "output": {"ODNO": "0000000001", "ORD_TMD": "093000"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_mock_us_sell_order_uses_portal_tr_id(
+        self, _mock_overseas_orders, _successful_order_response
+    ):
+        """KIS API Portal lists VTTT1001U as US mock sell, not VTTT1006U."""
+        instance, parent = _mock_overseas_orders
+        parent._kis_url = MagicMock(return_value="https://openapivts.example/order")
+        parent._request_with_rate_limit = AsyncMock(
+            return_value=_successful_order_response
+        )
+
+        await instance.sell_overseas_stock(
+            symbol="F",
+            exchange_code="NYSE",
+            quantity=1,
+            price=18.0,
+            is_mock=True,
+        )
+
+        _, kwargs = parent._request_with_rate_limit.call_args
+        assert kwargs["tr_id"] == "VTTT1001U"
+        assert kwargs["headers"]["tr_id"] == "VTTT1001U"
+        assert kwargs["json_body"]["SLL_TYPE"] == "00"
+        assert kwargs["json_body"]["ORD_DVSN"] == "00"
+
+    @pytest.mark.asyncio
+    async def test_non_us_mock_sell_order_keeps_generic_tr_id_until_verified(
+        self, _mock_overseas_orders, _successful_order_response
+    ):
+        instance, parent = _mock_overseas_orders
+        parent._kis_url = MagicMock(return_value="https://openapivts.example/order")
+        parent._request_with_rate_limit = AsyncMock(
+            return_value=_successful_order_response
+        )
+
+        await instance.sell_overseas_stock(
+            symbol="0700",
+            exchange_code="SEHK",
+            quantity=1,
+            price=300.0,
+            is_mock=True,
+        )
+
+        _, kwargs = parent._request_with_rate_limit.call_args
+        assert kwargs["tr_id"] == "VTTT1006U"
+        assert kwargs["headers"]["tr_id"] == "VTTT1006U"


### PR DESCRIPTION
## Summary
- Route KIS official-mock US overseas SELL orders (`NASD`/`NYSE`/`AMEX`) through the portal-documented `VTTT1001U` TR ID.
- Keep the existing generic overseas mock SELL TR (`VTTT1006U`) for non-US overseas markets until separately verified.
- Update the KIS mock TR routing matrix, ROB-364 overseas smoke runbook, and smoke script header comment.
- Add regression coverage for US mock SELL TR routing and non-US fallback behavior.

## Evidence / Test Plan
- `uv run --group test pytest tests/test_kis_overseas_orders_retry.py tests/test_kis_order_ops.py tests/test_kis_mock_routing.py tests/test_kis_mock_overseas_holdings_delta_smoke_cleanup.py -q` → `86 passed, 2 warnings`
- `uv run ruff check app/services/brokers/kis/constants.py app/services/brokers/kis/overseas_orders.py tests/test_kis_overseas_orders_retry.py scripts/kis_mock_overseas_holdings_delta_smoke.py` → `All checks passed!`
- `uv run ruff format --check app/services/brokers/kis/constants.py app/services/brokers/kis/overseas_orders.py tests/test_kis_overseas_orders_retry.py scripts/kis_mock_overseas_holdings_delta_smoke.py` → `4 files already formatted`

## Safety / Non-actions
- No live broker calls.
- No KIS mock confirmed-smoke rerun in this PR.
- No DB migration/backfill, scheduler activation, persistent env/secret changes, or production deploy.

Linear: ROB-368
Related: ROB-364
