### PR TITLE
fix(ROB-369): upbit_live portfolio reads the live Upbit account (E9)

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -3,8 +3,8 @@
 For the ROB-278 lockdown the collector emits a v2 payload that is
 **additive** over the legacy ``holdings``/``count``/``market`` shape:
 
-* ``primary_source``: ``"kis" | "manual" | "none"`` — explicit label so the
-  viewer/audit can tell which source backs the holdings.
+* ``primary_source``: ``"kis" | "upbit" | "manual" | "none"`` — explicit label
+  so the viewer/audit can tell which source backs the holdings.
 * ``reference_holdings``: manual rows surfaced when KIS live is primary, so
   manual/Toss entries remain visible for cross-check without being mislabeled
   as KIS live.
@@ -24,6 +24,14 @@ Policy invariants:
   default).
 * Non-(kis_live) combos preserve the v1 manual-primary behaviour and add
   the ``primary_source="manual"`` label only.
+
+ROB-369 E9 — ``market="crypto" + account_scope="upbit_live"`` reads the live
+Upbit account via ``UpbitHomeReader`` (``primary_source="upbit"``), mirroring
+the KIS-live path: live holdings + KRW cash/orderable are primary, manual
+``CRYPTO`` rows stay reference-only, and an Upbit failure yields
+``primary_source="none"`` / ``freshness="unavailable"``. Provenance uses
+``upbit_fetch_status``. Crypto has no sellable/pending-sell concept, so
+``sellable_summary`` is ``None``.
 
 ROB-297 — ``market="us" + account_scope="kis_live"`` is the canonical KIS
 overseas combo and takes the same KIS-live path as ``market="kr"``. The KR/US
@@ -98,7 +106,48 @@ def _manual_row_to_dict(row: Any) -> dict[str, Any]:
     }
 
 
-def _kis_holding_to_dict(h: Holding) -> dict[str, Any]:
+def _classify_fetch_status(
+    holdings_dicts: list[dict[str, Any]],
+    account: Any | None,
+    fetch_warnings: list[str],
+) -> str:
+    """Classify a live read-only fetch as ``ok`` / ``partial`` / ``failed``.
+
+    Shared by the KIS-live and Upbit-live paths so they stay in lockstep:
+
+    * ``failed`` — nothing usable returned (no holdings AND no account), or
+      warnings present with no holdings (data-quality gate).
+    * ``partial`` — holdings present but the reader flagged a warning.
+    * ``ok`` — holdings (and/or account) present with no warnings.
+    """
+    if not holdings_dicts and account is None:
+        return "failed"
+    if fetch_warnings and not holdings_dicts:
+        return "failed"
+    if fetch_warnings:
+        return "partial"
+    return "ok"
+
+
+def _krw_or_zero(value: float | None) -> float:
+    """Coerce an Upbit KRW figure to an explicit float.
+
+    The Upbit reader reports a missing KRW row as ``None``, which for Upbit
+    means the account genuinely holds 0 KRW (distinct from the KIS-overseas
+    case where ``None`` means cash is *unsupported*/unknown). Emitting an
+    explicit ``0.0`` keeps the portfolio stage's ``$.buying_power.krw`` citation
+    pointed at a real value instead of a null.
+    """
+    return float(value) if value is not None else 0.0
+
+
+def _reader_holding_to_dict(h: Holding) -> dict[str, Any]:
+    """Map a read-only :class:`Holding` to the snapshot dict shape.
+
+    Used by both the KIS-live (``h.source == "kis"``) and the Upbit-live
+    (``h.source == "upbit"``) paths; ``source`` is taken from the holding so
+    the audit trail records the real provenance rather than a hard-coded label.
+    """
     return {
         "ticker": h.symbol,
         "market": h.market,
@@ -115,7 +164,7 @@ def _kis_holding_to_dict(h: Holding) -> dict[str, Any]:
         "pnl_rate": h.pnlRate,
         "sellable_quantity": h.sellableQuantity,
         "pending_sell_quantity": h.pendingSellQuantity,
-        "source": "kis",
+        "source": h.source,
     }
 
 
@@ -130,11 +179,13 @@ class PortfolioSnapshotCollector:
         session: AsyncSession,
         *,
         kis_reader: Any | None = None,
+        upbit_reader: Any | None = None,
     ) -> None:
         self._session = session
-        # KISHomeReader is imported lazily to avoid pulling broker module
-        # graph into call sites that don't need KIS (tests, unit imports).
+        # Home readers are imported lazily to avoid pulling the broker module
+        # graph into call sites that don't need them (tests, unit imports).
         self._kis_reader = kis_reader
+        self._upbit_reader = upbit_reader
 
     def _get_kis_reader(self) -> Any:
         if self._kis_reader is not None:
@@ -143,6 +194,14 @@ class PortfolioSnapshotCollector:
 
         self._kis_reader = KISHomeReader(self._session)
         return self._kis_reader
+
+    def _get_upbit_reader(self) -> Any:
+        if self._upbit_reader is not None:
+            return self._upbit_reader
+        from app.services.invest_home_readers import UpbitHomeReader
+
+        self._upbit_reader = UpbitHomeReader(self._session)
+        return self._upbit_reader
 
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         market_types = _MARKET_TO_TYPES.get(request.market)
@@ -168,6 +227,11 @@ class PortfolioSnapshotCollector:
             "us",
         ):
             return await self._collect_kis_live(request, market_types, now=now)
+        # ROB-369 E9 — crypto + upbit_live reads the live Upbit account so the
+        # portfolio stage gets real NAV / cash / orderable instead of the
+        # manual-primary empty payload that produced "NAV=0".
+        if request.account_scope == "upbit_live" and request.market == "crypto":
+            return await self._collect_upbit_live(request, market_types, now=now)
         return await self._collect_manual_primary(request, market_types, now=now)
 
     async def _collect_manual_primary(
@@ -307,7 +371,7 @@ class PortfolioSnapshotCollector:
                 for h in (kis_result.holdings or [])
                 if h.market == holding_market_filter
             ]
-            kis_holdings_dicts = [_kis_holding_to_dict(h) for h in market_holdings]
+            kis_holdings_dicts = [_reader_holding_to_dict(h) for h in market_holdings]
             if kis_result.warning is not None:
                 fetch_warnings.append(
                     f"{kis_result.warning.source}: {kis_result.warning.message}"
@@ -337,14 +401,9 @@ class PortfolioSnapshotCollector:
                 "sellable_count": sellable_count,
                 "pending_sell_count": pending_sell_count,
             }
-            if not kis_holdings_dicts and account is None:
-                kis_fetch_status = "failed"
-            elif fetch_warnings and not kis_holdings_dicts:
-                kis_fetch_status = "failed"
-            elif fetch_warnings:
-                kis_fetch_status = "partial"
-            else:
-                kis_fetch_status = "ok"
+            kis_fetch_status = _classify_fetch_status(
+                kis_holdings_dicts, account, fetch_warnings
+            )
 
         if kis_fetch_status == "failed":
             primary_source = "none"
@@ -396,6 +455,149 @@ class PortfolioSnapshotCollector:
                     errors={
                         "reason_code": "kis_fetch_failed",
                         "reason": "KIS live portfolio fetch failed",
+                        "warnings": fetch_warnings,
+                        "errors": fetch_errors,
+                    },
+                )
+            ]
+
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="auto_trader_db",
+                as_of=now,
+                freshness_status=freshness,
+                coverage=coverage,
+            )
+        ]
+
+    async def _collect_upbit_live(
+        self,
+        request: CollectorRequest,
+        market_types: tuple[MarketType, ...],
+        *,
+        now: dt.datetime,
+    ) -> list[SnapshotCollectResult]:
+        """Upbit live path for ``crypto + upbit_live`` (ROB-369 E9).
+
+        Mirrors ``_collect_kis_live``: live Upbit holdings + KRW cash/orderable
+        become ``primary_source="upbit"``; any manual ``CRYPTO`` rows surface
+        only via ``reference_holdings`` and are NEVER promoted to primary. An
+        Upbit fetch failure yields ``primary_source="none"`` with
+        ``freshness="unavailable"`` so the report's stale gate handles it.
+
+        Unlike KIS, Upbit uses global env credentials rather than a per-user
+        account, so ``user_id`` does not select an account and is not required
+        (passed through as ``0`` when absent, matching ``UpbitHomeReader``
+        usage in ``symbol_derivation``). Crypto positions are continuously
+        liquid, so there is no sellable/pending-sell concept — the payload
+        carries ``sellable_summary=None``.
+        """
+        manual_rows = await self._read_manual_rows(market_types)
+        reference_holdings = [_manual_row_to_dict(r) for r in manual_rows]
+
+        reader = self._get_upbit_reader()
+        fetch_warnings: list[str] = []
+        fetch_errors: list[str] = []
+        upbit_result: Any = None
+        try:
+            upbit_result = await reader.fetch(user_id=request.user_id or 0)
+        except Exception as exc:  # noqa: BLE001 — collector must never crash
+            logger.warning("Upbit read-only fetch failed: %s", exc, exc_info=True)
+            fetch_errors.append(f"{type(exc).__name__}: {exc}")
+
+        upbit_holdings_dicts: list[dict[str, Any]] = []
+        cash_payload: dict[str, Any] | None = None
+        buying_power_payload: dict[str, Any] | None = None
+        upbit_fetch_status: str
+        if upbit_result is None:
+            upbit_fetch_status = "failed"
+        else:
+            holdings = list(upbit_result.holdings or [])
+            upbit_holdings_dicts = [_reader_holding_to_dict(h) for h in holdings]
+            if upbit_result.warning is not None:
+                fetch_warnings.append(
+                    f"{upbit_result.warning.source}: {upbit_result.warning.message}"
+                )
+            account = next(iter(upbit_result.accounts or []), None)
+            if account is not None:
+                # Upbit reports a KRW-only account (no USD leg); surface both
+                # keys so the consumer contract matches the KIS payload shape.
+                # KRW is coerced to an explicit 0.0 (Upbit None = 0 KRW) so the
+                # portfolio citation never points at a null.
+                cash_payload = {
+                    "krw": _krw_or_zero(account.cashBalances.krw),
+                    "usd": account.cashBalances.usd,
+                }
+                buying_power_payload = {
+                    "krw": _krw_or_zero(account.buyingPower.krw),
+                    "usd": account.buyingPower.usd,
+                }
+            upbit_fetch_status = _classify_fetch_status(
+                upbit_holdings_dicts, account, fetch_warnings
+            )
+
+        if upbit_fetch_status == "failed":
+            primary_source = "none"
+            holdings_out: list[dict[str, Any]] = []
+            cash_payload = None
+            buying_power_payload = None
+            freshness = "unavailable"
+        else:
+            primary_source = "upbit"
+            holdings_out = upbit_holdings_dicts
+            freshness = "fresh" if upbit_fetch_status == "ok" else "partial"
+
+        payload: dict[str, Any] = {
+            "holdings": holdings_out,
+            "count": len(holdings_out),
+            "market": request.market,
+            "primary_source": primary_source,
+            "reference_holdings": reference_holdings,
+            "cash": cash_payload,
+            "buying_power": buying_power_payload,
+            "sellable_summary": None,
+            "provenance": {
+                "upbit_fetch_status": upbit_fetch_status,
+                "account_scope": request.account_scope,
+                "fetched_at": _iso(now),
+                "warnings": fetch_warnings,
+                "errors": fetch_errors,
+            },
+        }
+
+        coverage = {
+            "holdings_count": len(holdings_out),
+            "reference_count": len(reference_holdings),
+            "upbit_fetch_status": upbit_fetch_status,
+        }
+        # Surface the reader's dust (<5000 KRW) / inactive filtering so the
+        # snapshot NAV's divergence from the raw Upbit eval is auditable rather
+        # than a silent drop.
+        hidden_counts = getattr(upbit_result, "hidden_counts", None)
+        if hidden_counts is not None:
+            coverage["hidden_dust_count"] = getattr(hidden_counts, "upbitDust", 0)
+            coverage["hidden_inactive_count"] = getattr(
+                hidden_counts, "upbitInactive", 0
+            )
+
+        if freshness == "unavailable":
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload=payload,
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="unavailable",
+                    coverage=coverage,
+                    errors={
+                        "reason_code": "upbit_fetch_failed",
+                        "reason": "Upbit live portfolio fetch failed",
                         "warnings": fetch_warnings,
                         "errors": fetch_errors,
                     },

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -331,46 +331,269 @@ async def test_portfolio_v2_kr_kis_live_exception_is_fail_closed():
     assert "boom" in payload["provenance"]["errors"][0]
 
 
-@pytest.mark.asyncio
-async def test_portfolio_v2_crypto_upbit_live_preserves_v1_manual_primary():
-    """ROB-278 — non-(kr+kis_live) combos unchanged: manual still primary."""
-    from app.models.manual_holdings import MarketType
-
-    class _CryptoRow:
-        ticker = "KRW-BTC"
-        market_type = MarketType.CRYPTO
-        quantity = 0.1
-        avg_price = 50_000_000
-        display_name = "비트코인"
-        updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
-
-    session = MagicMock()
-    scalars = MagicMock(all=MagicMock(return_value=[_CryptoRow()]))
-    session.execute = AsyncMock(
-        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
-    )
-    # KIS reader MUST NOT be called for upbit_live.
-    reader = MagicMock()
-    reader.fetch = AsyncMock(
-        side_effect=AssertionError("KIS reader called for non-kis_live request")
-    )
-    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
-    req = CollectorRequest(
+# ---------------------------------------------------------------------------
+# Portfolio v2 — ROB-369 E9: crypto + upbit_live reads the live Upbit account.
+#
+# Before ROB-369 the crypto/upbit_live combo fell through to the v1
+# manual-primary path, so the portfolio snapshot carried no live NAV / cash /
+# buying power. The Hermes portfolio stage then reported "NAV=0,
+# buying_power_krw=0" for a real Upbit account (eval ~25.75M KRW) and misfired
+# a "buying_power < 5% NAV" risk on a 0/0 artifact. The collector now routes
+# crypto+upbit_live to ``UpbitHomeReader`` (mirroring the KIS-live path): live
+# holdings + KRW cash/orderable become primary; manual CRYPTO rows stay
+# reference-only and are never promoted.
+# ---------------------------------------------------------------------------
+def _crypto_upbit_request(user_id: int | None = 1) -> CollectorRequest:
+    return CollectorRequest(
         market="crypto",
         account_scope="upbit_live",
         symbols=None,
         candidate_limit=None,
         policy_snapshot={},
-        user_id=None,
+        user_id=user_id,
     )
-    results = await collector.collect(req)
+
+
+def _manual_crypto_session(rows: list[Any] | None = None) -> MagicMock:
+    from app.models.manual_holdings import MarketType
+
+    class _ManualCryptoRow:
+        def __init__(
+            self,
+            ticker: str = "KRW-BTC",
+            quantity: float = 0.01,
+            avg_price: float = 40_000_000.0,
+        ) -> None:
+            self.ticker = ticker
+            self.market_type = MarketType.CRYPTO
+            self.quantity = quantity
+            self.avg_price = avg_price
+            self.display_name = ticker
+            self.updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
+
+    rows = rows if rows is not None else [_ManualCryptoRow()]
+    session = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=rows))
+    session.execute = AsyncMock(
+        return_value=MagicMock(scalars=MagicMock(return_value=scalars))
+    )
+    return session
+
+
+def _upbit_reader_with_holdings(
+    *,
+    warning: Any | None = None,
+    cash_krw: float | None = 365_342.0,
+    hidden_dust: int = 0,
+    hidden_inactive: int = 0,
+) -> MagicMock:
+    """UpbitHomeReader stub: one live BTC holding + KRW cash/orderable.
+
+    Upbit reports the same KRW figure for cash balance and buying power
+    (orderable), and never carries a USD leg — mirrors the real reader.
+    ``cash_krw=None`` models a KRW-less (all-coin) account; ``hidden_*`` model
+    the reader's dust/inactive filtering.
+    """
+    from app.schemas.invest_home import (
+        Account,
+        CashAmounts,
+        Holding,
+        InvestHomeHiddenCounts,
+    )
+    from app.services.invest_home_service import _SourceFetchResult
+
+    holding_btc = Holding(
+        holdingId="upbit:BTC",
+        accountId="upbit_account",
+        source="upbit",
+        accountKind="live",
+        symbol="BTC",
+        market="CRYPTO",
+        assetType="crypto",
+        assetCategory="crypto",
+        displayName="BTC",
+        quantity=0.235,
+        averageCost=90_000_000.0,
+        costBasis=21_150_000.0,
+        currency="KRW",
+        valueNative=25_384_658.0,
+        valueKrw=25_384_658.0,
+        pnlKrw=4_234_658.0,
+        pnlRate=0.20,
+        priceState="live",
+    )
+    account = Account(
+        accountId="upbit_account",
+        displayName="Upbit",
+        source="upbit",
+        accountKind="live",
+        includedInHome=True,
+        valueKrw=25_384_658.0,
+        costBasisKrw=21_150_000.0,
+        pnlKrw=4_234_658.0,
+        pnlRate=0.20,
+        cashBalances=CashAmounts(krw=cash_krw, usd=None),
+        buyingPower=CashAmounts(krw=cash_krw, usd=None),
+    )
+    hidden_counts = InvestHomeHiddenCounts()
+    hidden_counts.upbitDust = hidden_dust
+    hidden_counts.upbitInactive = hidden_inactive
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[account],
+            holdings=[holding_btc],
+            warning=warning,
+            hidden_counts=hidden_counts,
+        )
+    )
+    return reader
+
+
+def _upbit_reader_failed() -> MagicMock:
+    from app.schemas.invest_home import InvestHomeWarning
+    from app.services.invest_home_service import _SourceFetchResult
+
+    reader = MagicMock()
+    reader.fetch = AsyncMock(
+        return_value=_SourceFetchResult(
+            accounts=[],
+            holdings=[],
+            warning=InvestHomeWarning(source="upbit", message="upbit auth refused"),
+        )
+    )
+    return reader
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_success_populates_upbit_primary():
+    """ROB-369 E9 — Upbit live success: primary_source=upbit, live KRW NAV/cash,
+    manual CRYPTO rows surface as reference only (never promoted)."""
+    session = _manual_crypto_session()
+    upbit_reader = _upbit_reader_with_holdings()
+    # KIS reader MUST NOT be touched for upbit_live.
+    kis_reader = MagicMock()
+    kis_reader.fetch = AsyncMock(
+        side_effect=AssertionError("KIS reader called for upbit_live request")
+    )
+    collector = PortfolioSnapshotCollector(
+        session, kis_reader=kis_reader, upbit_reader=upbit_reader
+    )
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    assert len(results) == 1
     payload = results[0].payload_json
     assert results[0].freshness_status == "fresh"
+    assert payload["primary_source"] == "upbit"
     assert payload["count"] == 1
-    assert payload["holdings"][0]["ticker"] == "KRW-BTC"
-    # New label is "manual" for non-KIS combos so payload always says where data came from.
-    assert payload.get("primary_source") == "manual"
-    reader.fetch.assert_not_called()
+    assert payload["holdings"][0]["ticker"] == "BTC"
+    assert payload["holdings"][0]["source"] == "upbit"
+    assert payload["holdings"][0]["value_krw"] == 25_384_658.0
+    # KRW cash + orderable surfaced — the E9 fix (not None/0).
+    assert payload["cash"]["krw"] == 365_342.0
+    assert payload["buying_power"]["krw"] == 365_342.0
+    # Crypto has no pending-sell concept on the reader.
+    assert payload["sellable_summary"] is None
+    # Manual CRYPTO row visible as reference, never promoted to primary.
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["ticker"] == "KRW-BTC"
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    # Provenance.
+    assert payload["provenance"]["upbit_fetch_status"] == "ok"
+    assert payload["provenance"]["account_scope"] == "upbit_live"
+    upbit_reader.fetch.assert_awaited_once_with(user_id=1)
+    kis_reader.fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_failure_does_not_promote_manual():
+    """ROB-369 E9 — Upbit fetch failure: primary_source=none, manual stays reference."""
+    session = _manual_crypto_session()
+    upbit_reader = _upbit_reader_failed()
+    collector = PortfolioSnapshotCollector(session, upbit_reader=upbit_reader)
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    assert len(results) == 1
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert payload["holdings"] == []
+    assert payload["count"] == 0
+    assert payload["cash"] is None
+    assert payload["buying_power"] is None
+    # Manual remains visible as reference, never promoted to primary.
+    assert len(payload["reference_holdings"]) == 1
+    assert payload["reference_holdings"][0]["source"] == "manual"
+    assert payload["provenance"]["upbit_fetch_status"] == "failed"
+    assert "upbit" in str(payload["provenance"]["warnings"]).lower()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_exception_is_fail_closed():
+    """ROB-369 E9 — UpbitHomeReader raising is treated like 'failed', not a crash."""
+    session = _manual_crypto_session()
+    upbit_reader = MagicMock()
+    upbit_reader.fetch = AsyncMock(side_effect=RuntimeError("boom"))
+    collector = PortfolioSnapshotCollector(session, upbit_reader=upbit_reader)
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "unavailable"
+    assert payload["primary_source"] == "none"
+    assert "boom" in payload["provenance"]["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_price_warning_is_partial():
+    """ROB-369 E9 — a price warning with live holdings → partial, still upbit primary."""
+    from app.schemas.invest_home import InvestHomeWarning
+
+    session = _manual_crypto_session()
+    upbit_reader = _upbit_reader_with_holdings(
+        warning=InvestHomeWarning(
+            source="upbit",
+            message="일부 코인은 현재가가 없어 평가금액에서 제외했습니다.",
+        )
+    )
+    collector = PortfolioSnapshotCollector(session, upbit_reader=upbit_reader)
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    payload = results[0].payload_json
+    assert results[0].freshness_status == "partial"
+    assert payload["primary_source"] == "upbit"
+    assert payload["provenance"]["upbit_fetch_status"] == "partial"
+    assert payload["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_krw_less_account_emits_explicit_zero():
+    """ROB-369 E9 — a KRW-less (all-coin) Upbit account reports krw=None on the
+    reader. The collector must coerce to an explicit 0.0 (the honest value for
+    Upbit, unlike KIS-overseas None=unsupported) so the portfolio citation
+    ``$.buying_power.krw`` resolves to a real number, not null."""
+    session = _manual_crypto_session()
+    upbit_reader = _upbit_reader_with_holdings(cash_krw=None)
+    collector = PortfolioSnapshotCollector(session, upbit_reader=upbit_reader)
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    payload = results[0].payload_json
+    # Successful fetch — a 0-KRW coin-only account is a complete, valid state.
+    assert results[0].freshness_status == "fresh"
+    assert payload["primary_source"] == "upbit"
+    # Explicit 0.0, never None — the citation must point at a real value.
+    assert payload["cash"]["krw"] == 0.0
+    assert payload["buying_power"]["krw"] == 0.0
+    assert payload["cash"]["krw"] is not None
+    assert payload["buying_power"]["krw"] is not None
+
+
+@pytest.mark.asyncio
+async def test_portfolio_v2_crypto_upbit_live_surfaces_hidden_dust_count():
+    """ROB-369 E9 — the reader hides dust (<5000 KRW) and inactive coins, so the
+    snapshot NAV undercounts the raw Upbit eval. Surface the hidden counts in
+    coverage so the divergence is auditable rather than silent."""
+    session = _manual_crypto_session()
+    upbit_reader = _upbit_reader_with_holdings(hidden_dust=3, hidden_inactive=2)
+    collector = PortfolioSnapshotCollector(session, upbit_reader=upbit_reader)
+    results = await collector.collect(_crypto_upbit_request(user_id=1))
+    coverage = results[0].coverage_json
+    assert coverage["hidden_dust_count"] == 3
+    assert coverage["hidden_inactive_count"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -221,3 +221,41 @@ async def test_portfolio_journal_crypto_uses_krw():
     payload = await PortfolioJournalStage().run(ctx)
     assert "buying_power_krw=500,000" in (payload.summary or "")
     assert payload.cited_snapshots[0].payload_path == "$.buying_power.krw"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_crypto_nested_upbit_payload_yields_live_nav():
+    """ROB-369 E9 — the upbit_live collector now emits a *nested* payload
+    (cash.krw, buying_power.krw, holdings[].value_krw). NAV must reflect the
+    live Upbit eval instead of defaulting to 0 (the pre-fix bug that reported
+    "NAV=0, buying_power_krw=0" for a real ~25.75M KRW account)."""
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap(
+                    "portfolio",
+                    {
+                        "market": "crypto",
+                        "primary_source": "upbit",
+                        "cash": {"krw": 365_342.0, "usd": None},
+                        "buying_power": {"krw": 365_342.0, "usd": None},
+                        "holdings": [
+                            {"symbol": "BTC", "value_krw": 25_384_658.0},
+                        ],
+                    },
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    # NAV = holdings 25,384,658 + cash 365,342 = 25,750,000 (live eval, not 0).
+    assert "NAV=25,750,000" in (payload.summary or "")
+    assert "NAV=0," not in (payload.summary or "")
+    assert "buying_power_krw=365,342" in (payload.summary or "")
+    assert payload.cited_snapshots[0].payload_path == "$.buying_power.krw"
+    # Low orderable vs a 25.75M book is now a TRUE signal (~1.4% < 5%),
+    # not the pre-fix 0/0 artifact.
+    assert payload.risk_evidence == ["buying_power < 5% NAV"]
+    assert payload.confidence == 40


### PR DESCRIPTION
## ROB-369 Slice 2a — E9: `upbit_live` portfolio NAV=0

Part of the crypto-report data-gap issue [ROB-369](https://linear.app/mgh3326/issue/ROB-369). Follows the ROB-366 (US path) fixes merged in #1017/#1020/#1021/#1022 — this is the **crypto/upbit_live** counterpart for the bundle portfolio stage.

### The bug (E9)
For `market="crypto" + account_scope="upbit_live"` the portfolio collector fell through to the v1 **manual-primary** path, emitting `cash=None`, `buying_power=None`, empty `holdings`. The Hermes portfolio stage then reported **`NAV=0, buying_power_krw=0`** for a real ~25.75M KRW Upbit account and misfired a **`buying_power < 5% NAV`** risk on a 0/0 artifact. `report_quality.grade` could still read `high_confidence` over it.

The defect was entirely in the **collector** — `PortfolioJournalStage` already routes `market="crypto"` to the KRW path correctly (post-ROB-366 #1021).

### The fix (read-only, deterministic, no fabrication)
- `PortfolioSnapshotCollector` routes `crypto+upbit_live` to a new `_collect_upbit_live` that reads the sanctioned read-only `UpbitHomeReader` (same abstraction the KIS path uses), **mirroring `_collect_kis_live`**:
  - live holdings + KRW cash/orderable → `primary_source="upbit"`
  - manual `CRYPTO` rows stay **reference-only**, never promoted (ROB-278/297 invariant)
  - Upbit failure → `primary_source="none"` / `freshness="unavailable"` (stale gate handles it)
  - provenance `upbit_fetch_status`; `sellable_summary=None` (crypto has no pending-sell concept)
- **Null-citation fix:** Upbit reports a missing KRW row as `None`, which for Upbit means the account genuinely holds **0 KRW** (unlike KIS-overseas `None`=unsupported). The KRW figure is coerced to an explicit `0.0` so the stage's `$.buying_power.krw` citation points at a real value, never a null.
- **No silent caps:** the reader hides dust (<5000 KRW) / inactive coins, so snapshot NAV undercounts the raw Upbit eval; `hidden_dust_count` / `hidden_inactive_count` are surfaced in coverage so the divergence is auditable.
- Extracted `_classify_fetch_status` (shared ok/partial/failed classifier for KIS + Upbit) and `_kis_holding_to_dict` → `_reader_holding_to_dict` (source from the holding). **KIS output stays byte-identical** — proven by the unchanged KIS test suite.

`primary_source="upbit"` (was `"manual"`) remains outside the KIS-only `auto_emit` sell-readiness gate (`!= "kis"`), so crypto is not pulled into that path — no behavioral change there.

### Safety
Read-only throughout — no broker/order/watch/order-intent mutation. The Upbit reader is the same one used by `symbol_derivation` (ROB-357). No migration. Lazy `UpbitHomeReader` import keeps the import-contract guard green.

### Testing
- New collector tests: success / failure / exception / price-warning→partial / KRW-less→explicit-zero / hidden-dust coverage.
- New `portfolio_journal` acceptance test: NAV reflects the live eval (25,750,000), not 0; low orderable is now a **true** `buying_power < 5% NAV` signal, not a 0/0 artifact.
- `action_report` + `investment_stages` + evidence + import-contract suites green (**494 passed**); `ruff check` + `ruff format --check` clean.

### Verification adversarially reviewed
A multi-lens adversarial review (correctness / policy-regression / edge-robustness / reuse) surfaced the null-KRW-citation, dust-divergence, and duplicated-classifier issues — all addressed in this PR.

### Not in this PR (ROB-369 follow-ups)
- E11/E12 crypto `dimension_evidence` + per-symbol stage synthesis (architectural, shared with US/ROB-366 #2)
- B4/B5 screener `trade_amount_24h`/`market_cap`; A1/A2 crypto market index + OI/LSR/liquidations (new data sources)
- Pre-existing nit: `_collect_manual_primary` provenance key is named `kis_fetch_status` even with no KIS involved — left untouched here to avoid churning unrelated tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
