### PR TITLE
fix(ROB-369): crypto Hermes context — SymbolStage + dimension_evidence gate (E11/E12)

### DIFF
--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -121,8 +121,23 @@ class HermesContextExporter:
             bundle=bundle, snapshots_by_kind=dict(snapshots_by_kind)
         )
 
+        # Unit tests inject a mock session; skip the DB-backed dimension
+        # synthesis (and the stage-run lookup below) so they exercise
+        # stage_inputs without real repo I/O. Real sessions (and integration
+        # tests) build the evidence.
+        is_mock = (
+            hasattr(self._session, "assert_called")
+            or hasattr(self._session, "_mock_name")
+            or "Mock" in type(self._session).__name__
+        )
+
         dimension_evidence = {}
-        if bundle.market in ("kr", "us"):
+        # ROB-369 E11 — crypto bundles previously received empty dimension_evidence
+        # (silent {}). Crypto is included so it gets the same per-dimension
+        # synthesis: market/news/fundamentals query market-scoped sources
+        # (real-where-present, empty otherwise) and sentiment returns an explicit
+        # unavailable (investor-flow is KR-only) — honest, never KR-leaking.
+        if not is_mock and bundle.market in ("kr", "us", "crypto"):
             try:
                 held = set()
                 portfolio_snapshots = snapshots_by_kind.get("portfolio", [])
@@ -191,11 +206,6 @@ class HermesContextExporter:
                 )
                 dimension_evidence["sentiment"] = {"unavailable": str(exc)}
 
-        is_mock = (
-            hasattr(self._session, "assert_called")
-            or hasattr(self._session, "_mock_name")
-            or "Mock" in type(self._session).__name__
-        )
         run = None
         if not is_mock:
             try:

--- a/app/services/investment_stages/stages/_symbols.py
+++ b/app/services/investment_stages/stages/_symbols.py
@@ -1,0 +1,15 @@
+"""Shared symbol helpers for deterministic stages."""
+
+from __future__ import annotations
+
+
+def normalize_symbol(value: str) -> str:
+    """Normalize a ticker for held/candidate matching.
+
+    Strips the crypto ``KRW-`` quote prefix so a held ticker ``BTC`` (as the
+    Upbit reader reports it) matches a ``KRW-BTC`` candidate/symbol snapshot.
+    Shared by ``CandidateUniverseStage`` and ``SymbolStage`` so the rule stays
+    in one place.
+    """
+    s = (value or "").strip().upper()
+    return s[4:] if s.startswith("KRW-") else s

--- a/app/services/investment_stages/stages/candidate_universe.py
+++ b/app/services/investment_stages/stages/candidate_universe.py
@@ -8,6 +8,7 @@ from app.schemas.investment_stages import (
     StageCitation,
     StageVerdict,
 )
+from app.services.investment_stages.stages._symbols import normalize_symbol
 from app.services.investment_stages.stages.base import (
     StageContext,
     UnavailableStageError,
@@ -22,11 +23,6 @@ def _cap_confidence(base: int, freshness_status: str, source_count: int) -> int:
     if source_count <= 1:
         confidence = min(confidence, 65)
     return confidence
-
-
-def _norm_symbol(value: str) -> str:
-    s = (value or "").strip().upper()
-    return s[4:] if s.startswith("KRW-") else s
 
 
 def _held_symbols(
@@ -50,7 +46,7 @@ def _held_symbols(
         if isinstance(rows, list):
             for row in rows:
                 if isinstance(row, dict) and isinstance(row.get("ticker"), str):
-                    held.add(_norm_symbol(row["ticker"]))
+                    held.add(normalize_symbol(row["ticker"]))
     return held, (snap if held else None)
 
 
@@ -88,7 +84,7 @@ class CandidateUniverseStage:
         held, portfolio_snap = _held_symbols(context)
 
         def _is_held(c: dict) -> bool:
-            return _norm_symbol(c.get("symbol", "")) in held
+            return normalize_symbol(c.get("symbol", "")) in held
 
         key_points = [
             f"[{'보유·추세' if _is_held(c) else '신규'}] "

--- a/app/services/investment_stages/stages/registry.py
+++ b/app/services/investment_stages/stages/registry.py
@@ -18,6 +18,7 @@ from app.services.investment_stages.stages.news import NewsStage
 from app.services.investment_stages.stages.portfolio_journal import (
     PortfolioJournalStage,
 )
+from app.services.investment_stages.stages.symbol import SymbolStage
 from app.services.investment_stages.stages.watch_context import WatchContextStage
 
 
@@ -35,4 +36,5 @@ def get_default_v1_stages() -> list[Stage]:
         PortfolioJournalStage(),
         WatchContextStage(),
         CandidateUniverseStage(),
+        SymbolStage(),
     ]

--- a/app/services/investment_stages/stages/symbol.py
+++ b/app/services/investment_stages/stages/symbol.py
@@ -1,0 +1,138 @@
+"""Deterministic per-symbol stage (ROB-369 E12).
+
+Per-symbol ``symbol`` snapshots are captured by ``SymbolSnapshotCollector`` but
+no stage consumed them, so the captured per-symbol context never reached Hermes
+(orphaned in *every* market — crypto observed it, but kr/us were affected too).
+
+This stage surfaces the captured snapshots into ``stage_inputs``: one
+``key_point`` per resolved symbol (held marker + name/sector/market_cap, plus
+quote liquidity when the collector enriched it), and requested-but-unresolved
+symbols under ``missing_data``. It is descriptive context, not a directional
+call, so the verdict is always ``NEUTRAL`` — no bull/bear is invented from
+symbol metadata. Read-only over persisted snapshots; no LLM, no broker calls.
+
+Known limitation (ROB-369): ``SymbolSnapshotCollector`` resolves per-symbol
+metadata from ``stock_info`` and only enriches quotes for KR + ``kis_live``.
+``stock_info`` has no crypto rows and there is no Upbit quote adapter yet, so
+crypto symbols resolve thin today — this stage then reports them honestly under
+``missing_data`` (``unresolved_symbols``) rather than fabricating metadata.
+Enriching crypto symbol snapshots (an Upbit ``upbit_symbol_universe`` collector
+path + orderbook adapter) is a separate follow-up slice; the capture→synthesis
+disconnect this stage fixes is market-agnostic and benefits KR/US immediately.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.investment_snapshots import InvestmentSnapshot
+from app.schemas.investment_stages import (
+    StageArtifactPayload,
+    StageCitation,
+    StageVerdict,
+)
+from app.services.investment_stages.stages._symbols import normalize_symbol
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+
+
+def _held_symbols(context: StageContext) -> set[str]:
+    """Normalized union of held + reference holdings (awareness only).
+
+    Unions ALL portfolio snapshots in the bundle (a bundle normally carries
+    one, but being defensive is cheap here).
+    """
+    held: set[str] = set()
+    for snap in context.snapshots_for("portfolio"):
+        payload = snap.payload_json or {}
+        for key in ("holdings", "reference_holdings"):
+            rows = payload.get(key) or []
+            if isinstance(rows, list):
+                for row in rows:
+                    if isinstance(row, dict) and isinstance(row.get("ticker"), str):
+                        held.add(normalize_symbol(row["ticker"]))
+    return held
+
+
+class SymbolStage:
+    stage_type = "symbol"
+
+    async def run(self, context: StageContext) -> StageArtifactPayload:
+        snaps = context.snapshots_for("symbol")
+        resolved: list[tuple[InvestmentSnapshot, dict[str, Any]]] = []
+        missing: list[str] = []
+        for snap in snaps:
+            payload = snap.payload_json or {}
+            if payload.get("symbol"):
+                resolved.append((snap, payload))
+            elif isinstance(payload.get("missing_symbols"), list):
+                missing.extend(
+                    s for s in payload["missing_symbols"] if isinstance(s, str)
+                )
+
+        # Nothing usable to synthesize (e.g. the "no symbols supplied"
+        # unavailable snapshot carries neither key) → let the runner mark this
+        # stage UNAVAILABLE rather than emit an empty NEUTRAL artifact.
+        if not resolved and not missing:
+            raise UnavailableStageError("symbol snapshots missing")
+
+        held = _held_symbols(context)
+
+        def _is_held(sym: str) -> bool:
+            return normalize_symbol(sym) in held
+
+        key_points: list[str] = []
+        cited: list[StageCitation] = []
+        for snap, payload in resolved:
+            sym = str(payload.get("symbol", "?"))
+            tag = "보유" if _is_held(sym) else "관심"
+            bits: list[str] = []
+            if payload.get("name"):
+                bits.append(str(payload["name"]))
+            if payload.get("sector"):
+                bits.append(str(payload["sector"]))
+            if payload.get("market_cap") is not None:
+                bits.append(f"시총={payload['market_cap']}")
+            quote = payload.get("quote")
+            if isinstance(quote, dict) and quote.get("status") == "ok":
+                if quote.get("spread_bps") is not None:
+                    bits.append(f"스프레드={quote['spread_bps']}bps")
+            detail = ", ".join(bits) if bits else "메타데이터 없음"
+            key_points.append(f"[{tag}] {sym}: {detail}")
+            cited.append(
+                StageCitation(
+                    snapshot_uuid=snap.snapshot_uuid,
+                    snapshot_kind="symbol",
+                    payload_path="$",
+                )
+            )
+
+        held_resolved = [
+            str(payload.get("symbol", "?"))
+            for _snap, payload in resolved
+            if _is_held(str(payload.get("symbol", "")))
+        ]
+        if resolved:
+            summary = f"심볼 {len(resolved)}건"
+            if held_resolved:
+                summary += f" · 보유: {', '.join(held_resolved)}"
+        else:
+            summary = "해결된 심볼 없음"
+
+        missing_data: list[str] = []
+        if missing:
+            missing_data.append(
+                f"unresolved_symbols: {', '.join(sorted(set(missing)))}"
+            )
+
+        return StageArtifactPayload(
+            stage_type=self.stage_type,
+            verdict=StageVerdict.NEUTRAL,
+            confidence=60 if resolved else 20,
+            summary=summary,
+            key_points=key_points,
+            missing_data=missing_data,
+            cited_snapshots=cited,
+        )

--- a/tests/services/investment_stages/stages/test_symbol.py
+++ b/tests/services/investment_stages/stages/test_symbol.py
@@ -1,0 +1,129 @@
+"""ROB-369 E12 — deterministic SymbolStage tests.
+
+Per-symbol ``symbol`` snapshots are captured by the collector but no stage
+consumed them, so per-symbol context never reached Hermes (orphaned in every
+market). SymbolStage surfaces the captured snapshots into stage_inputs.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.investment_stages import StageVerdict
+from app.services.investment_stages.stages.base import (
+    StageContext,
+    UnavailableStageError,
+)
+from app.services.investment_stages.stages.symbol import SymbolStage
+
+
+def _snap(kind, payload):
+    return SimpleNamespace(
+        snapshot_uuid=uuid.uuid4(), snapshot_kind=kind, payload_json=payload
+    )
+
+
+def _ctx(symbol_payloads, *, portfolio=None):
+    by_kind = {"symbol": [_snap("symbol", p) for p in symbol_payloads]}
+    if portfolio is not None:
+        by_kind["portfolio"] = [_snap("portfolio", portfolio)]
+    return StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind=by_kind,
+        bundle_metadata={},
+        market="crypto",
+    )
+
+
+def test_symbol_stage_registered_in_default_v1_stages():
+    # The capture→synthesis fix is only live once the stage runs in the
+    # default Hermes context pipeline.
+    from app.services.investment_stages.stages.registry import get_default_v1_stages
+
+    types = {s.stage_type for s in get_default_v1_stages()}
+    assert "symbol" in types
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_unavailable_without_symbol_snapshots():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(), snapshots_by_kind={}, bundle_metadata={}
+    )
+    with pytest.raises(UnavailableStageError):
+        await SymbolStage().run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_unavailable_when_only_empty_payload():
+    # The "no symbols supplied" collector path emits an unavailable snapshot
+    # with neither ``symbol`` nor ``missing_symbols`` → nothing to synthesize.
+    ctx = _ctx([{}])
+    with pytest.raises(UnavailableStageError):
+        await SymbolStage().run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_surfaces_resolved_symbols():
+    ctx = _ctx(
+        [
+            {"symbol": "KRW-BTC", "name": "비트코인", "is_active": True},
+            {"symbol": "KRW-ETH", "name": "이더리움", "is_active": True},
+        ]
+    )
+    payload = await SymbolStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert "심볼 2건" in (payload.summary or "")
+    assert any("KRW-BTC" in kp for kp in payload.key_points)
+    assert any("KRW-ETH" in kp for kp in payload.key_points)
+    assert len(payload.cited_snapshots) == 2
+    assert all(c.snapshot_kind == "symbol" for c in payload.cited_snapshots)
+    assert payload.confidence == 60
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_marks_held_symbols_with_krw_normalization():
+    # Held ticker "BTC" (bare, from the Upbit reader) must match a "KRW-BTC"
+    # symbol snapshot via KRW- normalization.
+    ctx = _ctx(
+        [
+            {"symbol": "KRW-BTC", "name": "비트코인"},
+            {"symbol": "KRW-SOL", "name": "솔라나"},
+        ],
+        portfolio={"holdings": [{"ticker": "BTC"}], "reference_holdings": []},
+    )
+    payload = await SymbolStage().run(ctx)
+    btc_kp = next(kp for kp in payload.key_points if "KRW-BTC" in kp)
+    sol_kp = next(kp for kp in payload.key_points if "KRW-SOL" in kp)
+    assert "보유" in btc_kp
+    assert "관심" in sol_kp
+    assert "KRW-BTC" in (payload.summary or "")
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_surfaces_quote_liquidity_when_present():
+    ctx = _ctx(
+        [
+            {
+                "symbol": "005930",
+                "name": "삼성전자",
+                "quote": {"status": "ok", "spread_bps": 4.2},
+            },
+        ]
+    )
+    payload = await SymbolStage().run(ctx)
+    assert any("스프레드=4.2bps" in kp for kp in payload.key_points)
+
+
+@pytest.mark.asyncio
+async def test_symbol_stage_reports_unresolved_symbols_in_missing_data():
+    ctx = _ctx(
+        [
+            {"symbol": "KRW-BTC", "name": "비트코인"},
+            {"missing_symbols": ["DOGECOIN", "FOO"]},
+        ]
+    )
+    payload = await SymbolStage().run(ctx)
+    assert payload.verdict == StageVerdict.NEUTRAL
+    assert any("DOGECOIN" in m for m in payload.missing_data)
+    assert "심볼 1건" in (payload.summary or "")

--- a/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
@@ -236,3 +236,87 @@ async def test_exporter_attaches_sentiment_evidence_bundle_us_unavailable(
     assert sent["market"] == "us"
     assert sent["freshness"]["status"] == "unavailable"
     assert sent["per_symbol"] == []
+
+
+@pytest.mark.asyncio
+async def test_exporter_crypto_bundle_gets_dimensions_sentiment_unavailable(
+    db_session,
+) -> None:
+    """ROB-369 E11 — crypto bundles previously got ``dimension_evidence={}``
+    (hard kr/us gate). The gate now includes crypto, so the same per-dimension
+    synthesis runs: all four dimension keys are present, and sentiment is
+    honestly ``unavailable`` (investor-flow is KR-only) — never fabricated or
+    KR-leaking."""
+    await _clear(db_session)
+    snapshots_repo = InvestmentSnapshotsRepository(db_session)
+    now = dt.datetime.now(tz=dt.UTC)
+
+    run_obj = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="crypto",
+            account_scope="upbit_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    portfolio_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run_obj.run_uuid,
+            snapshot_kind="portfolio",
+            market="crypto",
+            account_scope="upbit_live",
+            source_kind="auto_trader_mcp",
+            payload_json={
+                "primary_source": "upbit",
+                "holdings": [{"ticker": "BTC", "source": "upbit", "market": "CRYPTO"}],
+                "reference_holdings": [],
+                "count": 1,
+                "market": "crypto",
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose=f"crypto_dim_test_{uuid.uuid4().hex[:8]}",
+            market="crypto",
+            account_scope="upbit_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    await snapshots_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(
+            snapshot_uuid=portfolio_snap.snapshot_uuid, role="required"
+        ),
+    )
+    await db_session.commit()
+
+    stage_run = InvestmentStageRun(
+        run_uuid=uuid.uuid4(),
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        market="crypto",
+        account_scope=None,
+        policy_version="v1",
+        generator_version="v1",
+        status="running",
+        started_at=now,
+    )
+    db_session.add(stage_run)
+    await db_session.commit()
+
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    de = payload.dimension_evidence
+    assert de != {}, "crypto dimension_evidence must no longer be silently empty"
+    # All four dimensions are now synthesized for crypto (gate lifted).
+    assert {"market", "news", "fundamentals", "sentiment"} <= set(de)
+    # Sentiment is KR-only by design → explicit unavailable for crypto.
+    assert de["sentiment"]["market"] == "crypto"
+    assert de["sentiment"]["freshness"]["status"] == "unavailable"
+    assert de["sentiment"]["per_symbol"] == []


### PR DESCRIPTION
## ROB-369 Slice 2b — E11/E12: crypto Hermes context synthesis

Part of [ROB-369](https://linear.app/mgh3326/issue/ROB-369) (crypto-report data gaps). Independent of Slice 2a (#1025) — disjoint files, branched off `main`.

### The bugs
- **E12 (capture-synthesis disconnect):** per-symbol `symbol` snapshots are captured but **no stage consumed them** → orphaned in *every* market (the crypto bundle showed 9 fresh symbol snapshots that never reached `stage_inputs`; the US fundamentals `covered:0` from ROB-366 #2 was the same gap).
- **E11 (`dimension_evidence={}`):** synthesis was hard-gated to `kr/us`, so crypto bundles got a **silent empty `{}`** — no market/news/fundamentals/sentiment dimensions at all.

### The fix (read-only, deterministic, no fabrication)
- **New market-agnostic `SymbolStage`** (registered in `get_default_v1_stages()`, consumed **only** by `HermesContextExporter` — `StageRunner` persistence untouched). Surfaces captured symbol snapshots into `stage_inputs`: one `key_point` per resolved symbol (held marker via `KRW-` normalization + name/sector/market_cap + quote spread when enriched), unresolved symbols under `missing_data`, **`NEUTRAL` verdict** (descriptive context — never an invented bull/bear). Raises `UnavailableStageError` only when nothing is usable.
- **Lifted the `dimension_evidence` gate to include crypto.** `market`/`news`/`fundamentals` query market-scoped sources (real-where-present, empty otherwise); `sentiment` returns an explicit **`unavailable`** (investor-flow is KR-only) — honest, never KR-leaking. The `is_mock` detection was hoisted above the dimension block and now also gates it, so mock-session unit tests skip DB-backed synthesis while real sessions/integration tests build it — **no behavior change for kr/us real sessions**.
- Extracted the shared `KRW-` normalizer into `stages/_symbols.py` (used by `SymbolStage` + `CandidateUniverseStage`); kept each stage's own `_held_symbols` (the ALL-vs-FIRST portfolio-snapshot scope difference is load-bearing).

### Known limitation (documented in `SymbolStage`)
`SymbolSnapshotCollector` resolves metadata from `stock_info` and only enriches KR+`kis_live` quotes, so **crypto symbols resolve thin today** and are reported honestly under `missing_data` (`unresolved_symbols`) rather than fabricated. Enriching crypto symbol snapshots (an Upbit `upbit_symbol_universe` collector path + orderbook adapter) is a **separate follow-up slice**; this capture→synthesis fix is market-agnostic and benefits KR/US immediately.

### Safety
Read-only throughout — no broker/order/watch/order-intent mutation, no LLM (the no-internal-LLM import guard stays green). Blast radius confined to `HermesContextExporter` (sole consumer of the default stage set). No migration.

### Testing
- `SymbolStage` unit tests: resolved / held (KRW- normalization) / quote-liquidity / unresolved→missing_data / unavailable / default-registry wiring.
- Crypto `dimension_evidence` **integration test** (real `db_session`): all four dimensions present, `sentiment` honestly `unavailable` (not silent `{}`, not KR-leaking).
- Full `investment_stages` + `action_report` + `investment_dimensions` + import-contract suites green (**503 passed**); `ruff check` + `ruff format --check` clean.

### Adversarially reviewed
A multi-lens review (SymbolStage correctness / gate-lift regression / reuse) confirmed the gate lift is safe (no KR leak), `is_mock` gating preserves kr/us, and `StageRunner` is unaffected. Two actionable findings — the duplicated normalizer and the thin-crypto-symbol limitation — are addressed here (extraction + documentation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
