### PR TITLE
fix(ROB-369): crypto symbol enrichment — upbit_symbol_universe + Upbit orderbook (2c)

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -129,6 +129,40 @@ class _KISDomesticQuoteOrderbookAdapter:
         }
 
 
+class _UpbitQuoteOrderbookAdapter:
+    """ROB-369 2c — read-only adapter wrapping the public Upbit orderbook read
+    for per-symbol crypto liquidity. Exposes the same
+    ``fetch_quote_orderbook(symbol)`` contract as the KIS adapter so the symbol
+    collector treats venues uniformly.
+
+    Public market-data only — no Upbit account/auth surface and no order
+    placement/cancel paths are reachable. ``last_price`` is left ``None`` (the
+    orderbook carries no last trade); the spread/depth derived from the
+    top-of-book is the liquidity signal the symbol stage reads.
+    """
+
+    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]:
+        # Lazy import keeps httpx / the Upbit module out of the registry import
+        # graph (mirrors the news / index fns) and narrow to the read function.
+        from app.services.upbit_orderbook import fetch_orderbook
+
+        raw = await fetch_orderbook(symbol)
+        units = (raw or {}).get("orderbook_units") or []
+        top = units[0] if units else {}
+        timestamp = (raw or {}).get("timestamp")
+        return {
+            "last_price": None,
+            "best_bid": top.get("bid_price"),
+            "best_ask": top.get("ask_price"),
+            "bid_depth": top.get("bid_size"),
+            "ask_depth": top.get("ask_size"),
+            "venue": "upbit",
+            "as_of": str(timestamp) if timestamp else None,
+            "session": "24h",
+            "nxt_eligible": False,
+        }
+
+
 def _build_market_index_quote_fn() -> IndexQuoteFn:
     """Read-only adapter over the deterministic fundamentals index source.
 
@@ -247,12 +281,15 @@ def production_collector_registry(session: AsyncSession) -> SnapshotCollectorReg
     # requests get per-symbol quote evidence. Construction is wrapped (the
     # KIS client can be None when credentials are absent) so the collector
     # cleanly emits per-symbol unavailable rather than crashing.
+    # ROB-369 2c — also wire the public Upbit orderbook adapter so crypto +
+    # upbit_live requests get per-symbol liquidity evidence.
     registry.register(
         SymbolSnapshotCollector(
             session,
             kis_quote_client=_KISDomesticQuoteOrderbookAdapter(
                 _build_kis_client_safely()
             ),
+            upbit_quote_client=_UpbitQuoteOrderbookAdapter(),
         )
     )
     registry.register(CandidateUniverseSnapshotCollector(session))

--- a/app/services/action_report/snapshot_backed/collectors/symbol.py
+++ b/app/services/action_report/snapshot_backed/collectors/symbol.py
@@ -1,9 +1,18 @@
 """Symbol snapshot collector (read-only, optional).
 
-Reads ``stock_info`` master rows for the symbols the caller asked about,
-and for ``(market=kr, account_scope=kis_live)`` with an explicit
-``user_id``, enriches each resolved symbol with read-only KIS
-quote/orderbook evidence (last price, best bid/ask, spread, depth, venue).
+Resolves per-symbol metadata for the symbols the caller asked about and,
+where a venue is wired, enriches each resolved symbol with read-only
+quote/orderbook evidence (best bid/ask, spread, depth, venue):
+
+* KR equities: metadata from ``stock_info``; quote enrichment for
+  ``(market=kr, account_scope=kis_live)`` with an explicit ``user_id``
+  via the KIS domestic quote/orderbook adapter.
+* Crypto (ROB-369 2c): metadata from ``upbit_symbol_universe`` (crypto is
+  not in ``stock_info``); quote enrichment for
+  ``(market=crypto, account_scope=upbit_live)`` via the Upbit orderbook
+  adapter. Upbit market-data is public, so NO ``user_id`` is required and
+  ``last_price`` is left ``None`` (the orderbook carries no last trade —
+  spread/depth is the liquidity signal).
 
 Lockdown invariants (ROB-278):
 
@@ -34,6 +43,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analysis import StockInfo
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
 from app.services.action_report.snapshot_backed.collectors._base import (
     build_result,
     unavailable_result,
@@ -47,11 +57,12 @@ from app.services.investment_snapshots.collectors import (
 _DEFAULT_QUOTE_ENRICHMENT_LIMIT = 25
 
 
-class _KISQuoteOrderbookClient(Protocol):
-    """Read-only adapter contract for per-symbol KIS quote/orderbook reads.
+class _QuoteOrderbookClient(Protocol):
+    """Read-only adapter contract for per-symbol quote/orderbook reads.
 
-    The default production wiring lives in the collector registry; tests
-    inject fakes. Implementations MUST not call any broker mutation path.
+    Implemented per venue (KIS domestic for KR equities, Upbit for crypto) and
+    wired in the collector registry; tests inject fakes. Implementations MUST
+    not call any broker order-mutation path.
     """
 
     async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]: ...
@@ -79,10 +90,11 @@ def _derive_spread(quote: dict[str, Any]) -> tuple[float | None, float | None]:
 
 
 class SymbolSnapshotCollector:
-    """Optional ``symbol`` collector backed by ``stock_info``.
+    """Optional ``symbol`` collector backed by ``stock_info`` (KR/US) or
+    ``upbit_symbol_universe`` (crypto).
 
-    The collector also performs read-only KIS quote/orderbook enrichment
-    on the resolved symbols when the request targets KR live trading.
+    The collector also performs read-only per-venue quote/orderbook enrichment
+    on the resolved symbols: KIS for KR live trading, Upbit for crypto.
     """
 
     snapshot_kind: str = "symbol"
@@ -91,12 +103,70 @@ class SymbolSnapshotCollector:
         self,
         session: AsyncSession,
         *,
-        kis_quote_client: _KISQuoteOrderbookClient | None = None,
+        kis_quote_client: _QuoteOrderbookClient | None = None,
+        upbit_quote_client: _QuoteOrderbookClient | None = None,
         quote_enrichment_limit: int = _DEFAULT_QUOTE_ENRICHMENT_LIMIT,
     ) -> None:
         self._session = session
         self._kis_quote_client = kis_quote_client
+        self._upbit_quote_client = upbit_quote_client
         self._quote_enrichment_limit = quote_enrichment_limit
+
+    def _quote_enrichment_plan(
+        self, request: CollectorRequest
+    ) -> tuple[_QuoteOrderbookClient | None, bool, str, str] | None:
+        """Per-venue enrichment plan, or ``None`` when no enrichment applies.
+
+        Returns ``(client, requires_user_id, default_venue, scope_label)``:
+        * KR + ``kis_live`` → KIS client, ``user_id`` required (broker auth).
+        * crypto + ``upbit_live`` → Upbit client, NO ``user_id`` (public data).
+        """
+        if request.market == "kr" and request.account_scope == "kis_live":
+            return (self._kis_quote_client, True, "krx", "kis_live")
+        if request.market == "crypto" and request.account_scope == "upbit_live":
+            return (self._upbit_quote_client, False, "upbit", "upbit_live")
+        return None
+
+    async def _resolve_symbol_payloads(
+        self, market: str, symbols: list[str]
+    ) -> list[dict[str, Any]]:
+        """Resolve per-symbol base metadata from the market's master source.
+
+        Crypto reads ``upbit_symbol_universe`` (keyed by the ``KRW-XXX`` market
+        code); KR/US read ``stock_info``. Both return the same payload shape so
+        the enrichment loop is venue-uniform.
+        """
+        if market == "crypto":
+            stmt = select(UpbitSymbolUniverse).where(
+                UpbitSymbolUniverse.market.in_(symbols)
+            )
+            rows = (await self._session.execute(stmt)).scalars().all()
+            return [
+                {
+                    "symbol": row.market,
+                    "name": row.korean_name,
+                    "instrument_type": "crypto",
+                    "exchange": "upbit",
+                    "sector": None,
+                    "market_cap": None,
+                    "is_active": row.is_active,
+                }
+                for row in rows
+            ]
+        stmt = select(StockInfo).where(StockInfo.symbol.in_(symbols))
+        rows = (await self._session.execute(stmt)).scalars().all()
+        return [
+            {
+                "symbol": row.symbol,
+                "name": row.name,
+                "instrument_type": row.instrument_type,
+                "exchange": row.exchange,
+                "sector": row.sector,
+                "market_cap": row.market_cap,
+                "is_active": row.is_active,
+            }
+            for row in rows
+        ]
 
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
@@ -114,8 +184,7 @@ class SymbolSnapshotCollector:
             ]
 
         try:
-            stmt = select(StockInfo).where(StockInfo.symbol.in_(symbols))
-            rows = (await self._session.execute(stmt)).scalars().all()
+            base_payloads = await self._resolve_symbol_payloads(request.market, symbols)
         except Exception as exc:  # noqa: BLE001 — optional, fail open
             return [
                 unavailable_result(
@@ -123,42 +192,43 @@ class SymbolSnapshotCollector:
                     market=request.market,
                     account_scope=request.account_scope,
                     origin="auto_trader_db",
-                    reason=f"stock_info query failed: {type(exc).__name__}: {exc}",
+                    reason=(
+                        f"symbol query failed ({request.market}): "
+                        f"{type(exc).__name__}: {exc}"
+                    ),
                     as_of=now,
                 )
             ]
 
-        # Quote enrichment policy (ROB-278 Phase 2).
-        wants_quote = request.market == "kr" and request.account_scope == "kis_live"
-        quote_status_default: dict[str, Any] | None
-        if wants_quote and request.user_id is None:
-            # Fail-closed: never invent a default user_id for broker calls.
-            quote_status_default = {
-                "status": "unavailable",
-                "unavailable_reason": (
-                    "kis_live quote enrichment requires explicit user_id"
-                ),
-            }
-        else:
-            quote_status_default = None
+        # Per-venue quote enrichment plan (KIS for KR live, Upbit for crypto).
+        plan = self._quote_enrichment_plan(request)
+        quote_status_default: dict[str, Any] | None = None
+        if plan is not None:
+            _client, requires_user_id, _venue, scope_label = plan
+            if requires_user_id and request.user_id is None:
+                # Fail-closed: never invent a default user_id for broker calls.
+                quote_status_default = {
+                    "status": "unavailable",
+                    "unavailable_reason": (
+                        f"{scope_label} quote enrichment requires explicit user_id"
+                    ),
+                }
 
         results: list[SnapshotCollectResult] = []
         seen_symbols: set[str] = set()
         enriched_count = 0
-        for row in rows:
-            seen_symbols.add(row.symbol)
-            payload: dict[str, Any] = {
-                "symbol": row.symbol,
-                "name": row.name,
-                "instrument_type": row.instrument_type,
-                "exchange": row.exchange,
-                "sector": row.sector,
-                "market_cap": row.market_cap,
-                "is_active": row.is_active,
-            }
-            if wants_quote:
+        for base in base_payloads:
+            symbol = base["symbol"]
+            seen_symbols.add(symbol)
+            payload: dict[str, Any] = dict(base)
+            if plan is not None:
+                client, requires_user_id, default_venue, scope_label = plan
                 quote_payload = await self._maybe_enrich_quote(
-                    symbol=row.symbol,
+                    symbol=symbol,
+                    client=client,
+                    requires_user_id=requires_user_id,
+                    default_venue=default_venue,
+                    scope_label=scope_label,
                     user_id_present=request.user_id is not None,
                     enriched_count=enriched_count,
                     quote_status_default=quote_status_default,
@@ -174,7 +244,7 @@ class SymbolSnapshotCollector:
                     payload=payload,
                     origin="auto_trader_db",
                     as_of=now,
-                    symbol=row.symbol,
+                    symbol=symbol,
                     coverage={"resolved": True},
                 )
             )
@@ -215,23 +285,27 @@ class SymbolSnapshotCollector:
         self,
         *,
         symbol: str,
+        client: _QuoteOrderbookClient | None,
+        requires_user_id: bool,
+        default_venue: str,
+        scope_label: str,
         user_id_present: bool,
         enriched_count: int,
         quote_status_default: dict[str, Any] | None,
     ) -> dict[str, Any]:
         if quote_status_default is not None:
             return dict(quote_status_default)
-        if not user_id_present:
+        if requires_user_id and not user_id_present:
             return {
                 "status": "unavailable",
                 "unavailable_reason": (
-                    "kis_live quote enrichment requires explicit user_id"
+                    f"{scope_label} quote enrichment requires explicit user_id"
                 ),
             }
-        if self._kis_quote_client is None:
+        if client is None:
             return {
                 "status": "unavailable",
-                "unavailable_reason": "no KIS quote client configured",
+                "unavailable_reason": f"no quote client configured ({default_venue})",
             }
         if enriched_count >= self._quote_enrichment_limit:
             return {
@@ -241,16 +315,19 @@ class SymbolSnapshotCollector:
                 ),
             }
         try:
-            raw = await self._kis_quote_client.fetch_quote_orderbook(symbol)
+            raw = await client.fetch_quote_orderbook(symbol)
         except Exception as exc:  # noqa: BLE001 — optional, per-symbol fail-open
             return {
                 "status": "unavailable",
-                "unavailable_reason": f"kis_error: {type(exc).__name__}: {exc}",
+                # Venue-tagged so ops can distinguish KIS vs Upbit fetch failures.
+                "unavailable_reason": (
+                    f"{scope_label}_error: {type(exc).__name__}: {exc}"
+                ),
             }
         if not isinstance(raw, dict):
             return {
                 "status": "unavailable",
-                "unavailable_reason": "kis returned non-dict quote payload",
+                "unavailable_reason": "quote client returned non-dict payload",
             }
         if _is_empty_book(raw):
             session = raw.get("session")
@@ -273,7 +350,7 @@ class SymbolSnapshotCollector:
             "spread_bps": spread_bps,
             "bid_depth": raw.get("bid_depth"),
             "ask_depth": raw.get("ask_depth"),
-            "venue": raw.get("venue") or "krx",
+            "venue": raw.get("venue") or default_venue,
             "nxt_eligible": bool(raw.get("nxt_eligible")),
             "session": raw.get("session"),
             "as_of": raw.get("as_of"),

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1448,6 +1448,183 @@ async def test_symbol_collector_quote_respects_enrichment_cap():
 
 
 # ---------------------------------------------------------------------------
+# Symbol collector — crypto enrichment (ROB-369 Slice 2c).
+#
+# Crypto symbols are NOT in stock_info; they live in upbit_symbol_universe.
+# For (market=crypto, account_scope=upbit_live) the collector resolves metadata
+# from that universe and enriches each symbol with read-only Upbit orderbook
+# liquidity (best bid/ask, spread, depth). Public market-data → no user_id
+# required (unlike KIS). Per-symbol fail-open + the shared enrichment cap.
+# ---------------------------------------------------------------------------
+def _upbit_universe_row(market: str = "KRW-BTC", korean_name: str = "비트코인"):
+    class _Row:
+        def __init__(self) -> None:
+            self.market = market
+            self.korean_name = korean_name
+            self.english_name = "Bitcoin"
+            self.base_currency = market.split("-")[-1]
+            self.quote_currency = "KRW"
+            self.is_active = True
+
+    return _Row()
+
+
+def _fake_upbit_quote_client_ok() -> MagicMock:
+    """Fake Upbit orderbook adapter returning a full top-of-book (no last_price)."""
+
+    async def fetch(symbol: str) -> dict[str, Any]:
+        return {
+            "last_price": None,
+            "best_bid": 94_900_000.0,
+            "best_ask": 95_100_000.0,
+            "bid_depth": 0.5,
+            "ask_depth": 0.3,
+            "venue": "upbit",
+            "session": "24h",
+            "nxt_eligible": False,
+            "as_of": "1716200000000",
+        }
+
+    client = MagicMock()
+    client.fetch_quote_orderbook = AsyncMock(side_effect=fetch)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_crypto_resolves_metadata_from_upbit_universe():
+    """ROB-369 2c — crypto symbols resolve from upbit_symbol_universe (not
+    stock_info); metadata is populated even when no quote adapter is wired."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_upbit_universe_row("KRW-ETH", "이더리움")])
+    collector = SymbolSnapshotCollector(session)  # no upbit quote client wired
+    req = CollectorRequest(
+        market="crypto",
+        account_scope="upbit_live",
+        symbols=["KRW-ETH"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=1,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["symbol"] == "KRW-ETH"
+    assert payload["name"] == "이더리움"
+    assert payload["instrument_type"] == "crypto"
+    assert payload["exchange"] == "upbit"
+    assert payload["is_active"] is True
+    # Enrichment is wanted (crypto+upbit_live) but no client → honest unavailable.
+    assert payload["quote"]["status"] == "unavailable"
+    assert "no quote client" in payload["quote"]["unavailable_reason"]
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_crypto_enriches_with_upbit_orderbook_no_user_id():
+    """ROB-369 2c — crypto+upbit_live enriches via the Upbit orderbook adapter;
+    public market-data requires NO user_id (unlike KIS)."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_upbit_universe_row("KRW-BTC", "비트코인")])
+    quote_client = _fake_upbit_quote_client_ok()
+    collector = SymbolSnapshotCollector(session, upbit_quote_client=quote_client)
+    req = CollectorRequest(
+        market="crypto",
+        account_scope="upbit_live",
+        symbols=["KRW-BTC"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=None,  # no user_id — Upbit market-data is public
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["symbol"] == "KRW-BTC"
+    q = payload["quote"]
+    assert q["status"] == "ok"
+    assert q["best_bid"] == 94_900_000.0
+    assert q["best_ask"] == 95_100_000.0
+    assert q["spread"] == 200_000.0
+    assert q["spread_bps"] == pytest.approx(21.05, rel=0.05)
+    assert q["venue"] == "upbit"
+    assert q["last_price"] is None  # orderbook carries no last trade — honest
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("KRW-BTC")
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_crypto_skips_quote_when_not_upbit_live():
+    """ROB-369 2c — crypto without upbit_live scope must not call the quote client."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_upbit_universe_row("KRW-BTC", "비트코인")])
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(
+        side_effect=AssertionError("upbit quote client must not be called")
+    )
+    collector = SymbolSnapshotCollector(session, upbit_quote_client=quote_client)
+    req = CollectorRequest(
+        market="crypto",
+        account_scope=None,
+        symbols=["KRW-BTC"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=1,
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["symbol"] == "KRW-BTC"
+    assert "quote" not in payload or payload.get("quote") is None
+    quote_client.fetch_quote_orderbook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_crypto_orderbook_failure_is_fail_open():
+    """ROB-369 2c — an Upbit orderbook error marks that symbol unavailable
+    without crashing others (per-symbol fail-open)."""
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session(
+        [
+            _upbit_universe_row("KRW-BTC", "비트코인"),
+            _upbit_universe_row("KRW-XRP", "리플"),
+        ]
+    )
+
+    async def fetch(symbol: str):
+        if symbol == "KRW-BTC":
+            raise RuntimeError("upbit timeout")
+        return {
+            "last_price": None,
+            "best_bid": 800.0,
+            "best_ask": 801.0,
+            "bid_depth": 100.0,
+            "ask_depth": 120.0,
+            "venue": "upbit",
+            "session": "24h",
+            "nxt_eligible": False,
+            "as_of": None,
+        }
+
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(side_effect=fetch)
+    collector = SymbolSnapshotCollector(session, upbit_quote_client=quote_client)
+    req = CollectorRequest(
+        market="crypto",
+        account_scope="upbit_live",
+        symbols=["KRW-BTC", "KRW-XRP"],
+        candidate_limit=None,
+        policy_snapshot={},
+        user_id=None,
+    )
+    results = await collector.collect(req)
+    by_symbol = {r.symbol: r for r in results if r.symbol}
+    assert by_symbol["KRW-BTC"].payload_json["quote"]["status"] == "unavailable"
+    assert (
+        "upbit timeout"
+        in by_symbol["KRW-BTC"].payload_json["quote"]["unavailable_reason"]
+    )
+    assert by_symbol["KRW-XRP"].payload_json["quote"]["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
 # Candidate-universe collector
 # ---------------------------------------------------------------------------
 @pytest.mark.asyncio
@@ -1681,6 +1858,82 @@ def test_production_registry_registers_pending_orders():
     """ROB-274 — pending_orders collector is wired into the production registry."""
     registry = production_collector_registry(session=MagicMock())
     assert "pending_orders" in registry.list_kinds()
+
+
+def test_production_registry_wires_upbit_quote_client_into_symbol_collector():
+    """ROB-369 2c — the symbol collector gets the Upbit orderbook adapter so
+    crypto + upbit_live requests can be enriched."""
+    registry = production_collector_registry(session=MagicMock())
+    symbol_collector = registry.get("symbol")
+    assert symbol_collector is not None
+    assert symbol_collector._upbit_quote_client is not None
+    assert symbol_collector._kis_quote_client is not None
+
+
+@pytest.mark.asyncio
+async def test_upbit_quote_adapter_maps_orderbook_top_of_book(monkeypatch):
+    """ROB-369 2c — the Upbit adapter maps the orderbook top-of-book into the
+    shared quote contract (last_price None — orderbook has no last trade)."""
+    from app.services.action_report.snapshot_backed.collectors import (
+        registry as registry_mod,
+    )
+
+    async def fake_fetch_orderbook(market: str):
+        assert market == "KRW-BTC"
+        return {
+            "market": "KRW-BTC",
+            "timestamp": 1716200000000,
+            "total_ask_size": 1.0,
+            "total_bid_size": 2.0,
+            "orderbook_units": [
+                {
+                    "ask_price": 95_100_000.0,
+                    "bid_price": 94_900_000.0,
+                    "ask_size": 0.3,
+                    "bid_size": 0.5,
+                },
+                {
+                    "ask_price": 95_200_000.0,
+                    "bid_price": 94_800_000.0,
+                    "ask_size": 1.0,
+                    "bid_size": 1.0,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.services.upbit_orderbook.fetch_orderbook", fake_fetch_orderbook
+    )
+    adapter = registry_mod._UpbitQuoteOrderbookAdapter()
+    quote = await adapter.fetch_quote_orderbook("KRW-BTC")
+    assert quote["best_bid"] == 94_900_000.0
+    assert quote["best_ask"] == 95_100_000.0
+    assert quote["bid_depth"] == 0.5
+    assert quote["ask_depth"] == 0.3
+    assert quote["last_price"] is None
+    assert quote["venue"] == "upbit"
+    assert quote["as_of"] == "1716200000000"
+
+
+@pytest.mark.asyncio
+async def test_upbit_quote_adapter_empty_orderbook_yields_none_top(monkeypatch):
+    """ROB-369 2c — empty/missing orderbook → None top-of-book, which the
+    collector's empty-book branch then marks unavailable."""
+    from app.services.action_report.snapshot_backed.collectors import (
+        registry as registry_mod,
+    )
+
+    async def fake_fetch_orderbook(market: str):
+        return {}
+
+    monkeypatch.setattr(
+        "app.services.upbit_orderbook.fetch_orderbook", fake_fetch_orderbook
+    )
+    adapter = registry_mod._UpbitQuoteOrderbookAdapter()
+    quote = await adapter.fetch_quote_orderbook("KRW-FOO")
+    assert quote["best_bid"] is None
+    assert quote["best_ask"] is None
+    assert quote["venue"] == "upbit"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## ROB-369 Slice 2c — crypto symbol enrichment

Part of [ROB-369](https://linear.app/mgh3326/issue/ROB-369). Collector-layer change, **disjoint from 2a (#1025) and 2b (#1026)** — branched off `main`, mergeable in any order. Composes with **2b's `SymbolStage`**: once both land, crypto bundles get rich per-symbol `stage_inputs`.

### The gap
2b's `SymbolStage` surfaces per-symbol `symbol` snapshots, but for crypto those were **thin**: `SymbolSnapshotCollector` resolved metadata only from `stock_info` (which has no crypto rows) and only enriched quotes for KR + `kis_live`. So crypto symbols landed in `missing_data` with no name and no liquidity context.

### The fix (read-only, deterministic, no fabrication)
- **Dual symbol resolution:** crypto reads `upbit_symbol_universe` (keyed by the `KRW-XXX` market code → `name=korean_name`, `instrument_type="crypto"`, `exchange="upbit"`, `is_active`); KR/US keep `stock_info`. Both return the same base-payload shape so the enrichment loop is venue-uniform.
- **Per-venue quote-enrichment plan:** KR+`kis_live` → KIS adapter (`user_id` required, venue `krx`); crypto+`upbit_live` → Upbit adapter (**public market-data, NO `user_id`**, venue `upbit`). `_maybe_enrich_quote` generalized over `(client, requires_user_id, default_venue, scope_label)` — **KIS behavior is byte-equivalent** (verified by the unchanged KIS suite). Fetch errors are venue-tagged (`kis_live_error` / `upbit_live_error`) for ops diagnostics.
- **New `_UpbitQuoteOrderbookAdapter`** wraps the public Upbit orderbook read (lazy-imports `app.services.upbit_orderbook.fetch_orderbook` — no broker client, the static-import guard stays green), mapping top-of-book bid/ask/depth into the shared quote contract. **`last_price` is left `None`** (the orderbook carries no last trade; spread/depth is the liquidity signal `SymbolStage` reads). Wired as `upbit_quote_client` in the production registry.

### Safety
Read-only throughout — public Upbit `GET /orderbook` only; no Upbit account/auth/order-mutation surface. The collector-module static-import guard (`forbids "upbit.client"` + order-mutation verbs) stays green via the lazy import. Per-symbol fail-open; bounded by the existing `quote_enrichment_limit=25` (≤25 orderbook calls/report). No migration.

### Testing
- Crypto resolution from `upbit_symbol_universe`; Upbit orderbook enrichment with no `user_id`; skip when not `upbit_live`; per-symbol fail-open; `_UpbitQuoteOrderbookAdapter` top-of-book mapping + empty-orderbook; production-registry Upbit wiring.
- The full **KIS symbol-enrichment suite is unchanged and green** (generalization preserved behavior).
- `action_report` + import-contract suites green (**397 passed**); `ruff check` + `ruff format --check` clean.

### Adversarially reviewed
A multi-lens review (KIS regression / crypto correctness / safety+import-guard) confirmed no KIS drift, correct crypto mapping/scope-gating, and an intact import guard. Three diagnostic-clarity fixes were applied (venue-tagged error prefix, market context in query-failure message, `as_of` falsy-guard); the rest were "correct, no fix."

### Not in this PR
crypto `market_cap` (would need a CoinGecko join) is left `None` — separate from this resolution/liquidity slice. Remaining ROB-369: Slice 3 (B4/B5 screener source bugs), Slice 4 (A1/A2 crypto index + derivatives), D8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
