### PR TITLE
fix(ROB-365): US tools report live current_price, not previous close (bug 1)

### DIFF
--- a/app/analysis/stages/market_stage.py
+++ b/app/analysis/stages/market_stage.py
@@ -9,6 +9,7 @@ from app.mcp_server.tooling.market_data_indicators import (
     _calculate_sma,
     _fetch_ohlcv_for_indicators,
 )
+from app.mcp_server.tooling.market_data_quotes import fetch_us_live_last_price
 from app.schemas.research_pipeline import (
     MarketSignals,
     SourceFreshness,
@@ -33,6 +34,14 @@ async def _fetch_market_snapshot(symbol: str, instrument_type: str) -> dict[str,
 
     # Latest values
     last_close = close.iloc[-1]
+    last_close_source = "ohlcv_close"
+    if instrument_type == "equity_us":
+        # ROB-365 bug 1: use the live intraday last price (not the previous daily
+        # close) for the reported price/change/trend; indicators stay historical.
+        live = await fetch_us_live_last_price(symbol)
+        if live is not None:
+            last_close = live
+            last_close_source = "yahoo_live"
     prev_close = close.iloc[-2]
     change_pct = (last_close - prev_close) / prev_close * 100
 
@@ -61,6 +70,7 @@ async def _fetch_market_snapshot(symbol: str, instrument_type: str) -> dict[str,
 
     return {
         "last_close": float(last_close),
+        "last_close_source": last_close_source,
         "change_pct": round(float(change_pct), 2),
         "rsi_14": rsi_14 if rsi_14 is not None else 50.0,
         "atr_14": atr_14 if atr_14 is not None else 0.0,

--- a/app/mcp_server/tooling/fundamentals/_support_resistance.py
+++ b/app/mcp_server/tooling/fundamentals/_support_resistance.py
@@ -15,6 +15,7 @@ from app.mcp_server.tooling.market_data_indicators import (
     _format_fibonacci_source,
     _split_support_resistance_levels,
 )
+from app.mcp_server.tooling.market_data_quotes import fetch_us_live_last_price
 from app.mcp_server.tooling.shared import (
     error_payload as _error_payload,
 )
@@ -56,6 +57,14 @@ async def get_support_resistance_impl(
                 raise ValueError(f"Missing required column: {col}")
 
         current_price = round(float(df["close"].iloc[-1]), 2)
+        current_price_source = "ohlcv_close"
+        if market_type == "equity_us":
+            # ROB-365 bug 1: position levels against the live intraday price,
+            # not the previous daily close (levels themselves stay historical).
+            live = await fetch_us_live_last_price(normalized_symbol)
+            if live is not None:
+                current_price = round(live, 2)
+                current_price_source = "yahoo_live"
         fib_result = _calculate_fibonacci(df, current_price)
         fib_result["symbol"] = normalized_symbol
 
@@ -122,12 +131,16 @@ async def get_support_resistance_impl(
             current_price,
         )
 
-        return {
+        result: dict[str, Any] = {
             "symbol": normalized_symbol,
             "current_price": round(current_price, 2),
             "supports": supports,
             "resistances": resistances,
         }
+        if market_type == "equity_us":
+            result["current_price_source"] = current_price_source
+            result["current_price_stale"] = current_price_source != "yahoo_live"
+        return result
     except Exception as exc:
         return _error_payload(
             source=source,

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -497,6 +497,32 @@ async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
     }
 
 
+async def fetch_us_live_last_price(symbol: str) -> float | None:
+    """Live US last-price scalar (15-min delayed). Never raises.
+
+    Returns the live intraday last-price for a US equity (from Yahoo fast_info
+    last_price/regularMarketPrice), or ``None`` when no live source is reachable
+    (delisted/after-hours/Yahoo failure). Callers overlay this onto the OHLCV
+    close so the reported ``current_price`` is live during regular trading,
+    falling back to the OHLCV close when ``None`` (ROB-365 bug 1).
+    """
+    try:
+        quote = await _fetch_quote_equity_us(symbol)
+    except Exception:
+        # ValueError (missing/zero price) or RuntimeError (Yahoo fetch failed,
+        # incl. the 'NoneType' object is not subscriptable yfinance flake).
+        return None
+
+    price = quote.get("price")
+    if price is None:
+        return None
+    try:
+        value = float(price)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 # ---------------------------------------------------------------------------
 # OHLCV Fetching
 # ---------------------------------------------------------------------------
@@ -836,6 +862,7 @@ async def _get_indicators_impl(
             float(df["close"].iloc[-1]) if "close" in df.columns else None
         )
         current_price = close_fallback_price
+        current_price_source = "ohlcv_close"
         if market_type == "crypto":
             try:
                 prices = await upbit_service.fetch_multiple_current_prices([symbol])
@@ -844,6 +871,11 @@ async def _get_indicators_impl(
                     current_price = float(ticker_price)
             except Exception:
                 current_price = close_fallback_price
+        elif market_type == "equity_us":
+            live = await fetch_us_live_last_price(symbol)
+            if live is not None:
+                current_price = live
+                current_price_source = "yahoo_live"
 
         indicator_results = _compute_indicators(df, normalized_indicators)
 
@@ -852,13 +884,17 @@ async def _get_indicators_impl(
             if realtime_rsi is not None:
                 indicator_results.setdefault("rsi", {})["14"] = realtime_rsi
 
-        return {
+        result = {
             "symbol": symbol,
             "price": current_price,
             "instrument_type": market_type,
             "source": source,
             "indicators": indicator_results,
         }
+        if market_type == "equity_us":
+            result["current_price_source"] = current_price_source
+            result["current_price_stale"] = current_price_source != "yahoo_live"
+        return result
 
     except Exception as exc:
         return _error_payload_from_exception(

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -23,6 +23,7 @@ from app.mcp_server.tooling.market_data_indicators import (
 from app.mcp_server.tooling.market_data_quotes import (
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
+    fetch_us_live_last_price,
 )
 from app.mcp_server.tooling.portfolio_avg_cost import (
     simulate_avg_cost_impl,
@@ -810,6 +811,7 @@ async def _get_indicators_impl(
             float(df["close"].iloc[-1]) if "close" in df.columns else None
         )
         current_price = close_fallback_price
+        current_price_source = "ohlcv_close"
         if market_type == "crypto":
             try:
                 prices = await upbit_service.fetch_multiple_current_prices([symbol])
@@ -818,6 +820,11 @@ async def _get_indicators_impl(
                     current_price = float(ticker_price)
             except Exception:
                 current_price = close_fallback_price
+        elif market_type == "equity_us":
+            live = await fetch_us_live_last_price(symbol)
+            if live is not None:
+                current_price = live
+                current_price_source = "yahoo_live"
 
         indicator_results = _compute_indicators(df, indicators)
 
@@ -828,13 +835,17 @@ async def _get_indicators_impl(
             if realtime_rsi is not None:
                 indicator_results.setdefault("rsi", {})["14"] = realtime_rsi
 
-        return {
+        result = {
             "symbol": symbol,
             "price": current_price,
             "instrument_type": market_type,
             "source": source,
             "indicators": indicator_results,
         }
+        if market_type == "equity_us":
+            result["current_price_source"] = current_price_source
+            result["current_price_stale"] = current_price_source != "yahoo_live"
+        return result
     except Exception as exc:
         return {
             "error": str(exc),

--- a/tests/analysis/stages/test_market_stage.py
+++ b/tests/analysis/stages/test_market_stage.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock
 
+import pandas as pd
 import pytest
 
+import app.services.brokers.yahoo.client as yahoo_service
 from app.analysis.stages.base import StageContext
 from app.analysis.stages.market_stage import MarketStageAnalyzer
 from app.schemas.research_pipeline import MarketSignals, StageVerdict
@@ -77,3 +79,81 @@ async def test_fetch_market_snapshot(monkeypatch):
     assert "atr_14" in res
     assert res["volume_ratio_20d"] == pytest.approx(1.0)  # (1000 / 1000)
     assert res["trend"] == "uptrend"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_market_snapshot_us_overlays_live_last_close(monkeypatch):
+    """US research-pipeline market stage must overlay the live last price onto the
+    OHLCV close so quote.price is live, not the previous daily close (ROB-365 bug 1)."""
+    dates = pd.date_range(end="2026-05-05", periods=70)
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [143.0] * 70,
+            "high": [144.0] * 70,
+            "low": [142.0] * 70,
+            "close": [143.31] * 70,  # stale previous daily close
+            "volume": [1000] * 70,
+        }
+    )
+    monkeypatch.setattr(
+        "app.analysis.stages.market_stage._fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=df),
+    )
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(
+            return_value={
+                "symbol": "PLTR",
+                "close": 157.24,  # live intraday last price
+                "previous_close": 143.34,
+                "open": 144.0,
+                "high": 158.0,
+                "low": 143.0,
+                "volume": 1,
+            }
+        ),
+    )
+
+    from app.analysis.stages.market_stage import _fetch_market_snapshot
+
+    res = await _fetch_market_snapshot("PLTR", "equity_us")
+
+    assert res["last_close"] == pytest.approx(157.24)
+    assert res["last_close_source"] == "yahoo_live"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_market_snapshot_us_degrades_to_close(monkeypatch):
+    """When the live US source is unreachable, the pipeline market stage falls back to
+    the OHLCV close with an explicit stale source label (ROB-365 bug 1)."""
+    dates = pd.date_range(end="2026-05-05", periods=70)
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": [143.0] * 70,
+            "high": [144.0] * 70,
+            "low": [142.0] * 70,
+            "close": [143.31] * 70,
+            "volume": [1000] * 70,
+        }
+    )
+    monkeypatch.setattr(
+        "app.analysis.stages.market_stage._fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=df),
+    )
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=RuntimeError("'NoneType' object is not subscriptable")),
+    )
+
+    from app.analysis.stages.market_stage import _fetch_market_snapshot
+
+    res = await _fetch_market_snapshot("PLTR", "equity_us")
+
+    assert res["last_close"] == pytest.approx(143.31)
+    assert res["last_close_source"] == "ohlcv_close"

--- a/tests/test_mcp_indicator_tools.py
+++ b/tests/test_mcp_indicator_tools.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 
 import app.services.brokers.upbit.client as upbit_service
+import app.services.brokers.yahoo.client as yahoo_service
 from app.mcp_server.tooling import (
     market_data_indicators,
     portfolio_holdings,
@@ -837,3 +838,157 @@ async def test_fetch_ohlcv_for_volume_profile_kr_warm_cache_avoids_kis_call(
 
     assert len(result) == 1
     assert not kis_called, "KIS should not be called when cache is warm"
+
+
+# ---------------------------------------------------------------------------
+# ROB-365 bug 1: US live-price convergence (get_indicators / get_support_resistance)
+# ---------------------------------------------------------------------------
+
+
+def _flat_us_ohlcv(close_value: float, rows: int = 80) -> pd.DataFrame:
+    close = pd.Series([close_value] * rows)
+    return pd.DataFrame(
+        {
+            "close": close,
+            "high": close + 1.5,
+            "low": close - 1.5,
+            "volume": pd.Series([1000.0] * rows),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_indicators_us_uses_live_price_not_prev_close(monkeypatch):
+    """US get_indicators must report the live last price, not the OHLCV prev close (ROB-365 bug 1)."""
+    tools = build_tools()
+
+    # OHLCV last close = 143.31 (yesterday's close, the stale value the bug returns)
+    _patch_runtime_attr(
+        monkeypatch,
+        "_fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=_flat_us_ohlcv(143.31)),
+    )
+    # Live intraday last price = 157.24 (Naver/KIS live at observation time)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(
+            return_value={
+                "symbol": "PLTR",
+                "close": 157.24,
+                "previous_close": 143.34,
+                "open": 144.0,
+                "high": 158.0,
+                "low": 143.0,
+                "volume": 123,
+            }
+        ),
+    )
+
+    result = await tools["get_indicators"]("PLTR", indicators=["rsi"], market="us")
+
+    assert "error" not in result
+    assert result["price"] == pytest.approx(157.24)
+    assert result["current_price_source"] == "yahoo_live"
+    assert result["current_price_stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_indicators_us_degrades_to_close_with_stale_flag(monkeypatch):
+    """When the live US source is unreachable, fall back to the OHLCV close with a stale flag (ROB-365 bug 1)."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=_flat_us_ohlcv(143.31)),
+    )
+    # Mirror the observed bug-2 failure: Yahoo raises 'NoneType' object is not subscriptable
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=RuntimeError("'NoneType' object is not subscriptable")),
+    )
+
+    result = await tools["get_indicators"]("PLTR", indicators=["rsi"], market="us")
+
+    assert "error" not in result  # graceful degradation, never crash
+    assert result["price"] == pytest.approx(143.31)
+    assert result["current_price_source"] == "ohlcv_close"
+    assert result["current_price_stale"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_support_resistance_us_positions_levels_against_live_price(monkeypatch):
+    """US get_support_resistance must position levels against the live price, not the OHLCV close (ROB-365 bug 1)."""
+    from app.mcp_server.tooling.fundamentals import _support_resistance
+
+    tools = build_tools()
+
+    async def mock_fetch_ohlcv(symbol, market_type, count):
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=60, freq="D"),
+                "open": [100.0] * 60,
+                "high": [105.0] * 60,
+                "low": [95.0] * 60,
+                "close": [102.0] * 60,
+                "volume": [1000] * 60,
+            }
+        )
+
+    monkeypatch.setattr(
+        _support_resistance, "_fetch_ohlcv_for_indicators", mock_fetch_ohlcv
+    )
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(
+            return_value={
+                "symbol": "AAPL",
+                "close": 150.0,
+                "previous_close": 102.0,
+                "open": 101.0,
+                "high": 151.0,
+                "low": 100.0,
+                "volume": 1,
+            }
+        ),
+    )
+
+    result = await tools["get_support_resistance"]("AAPL", market="us")
+
+    assert result["current_price"] == pytest.approx(150.0)
+    assert result["current_price_source"] == "yahoo_live"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_get_indicators_impl_us_uses_live_price(monkeypatch):
+    """The analyze-path indicators impl (portfolio_holdings) must report the live US price (ROB-365 bug 1)."""
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=_flat_us_ohlcv(143.31)),
+    )
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(
+            return_value={
+                "symbol": "PLTR",
+                "close": 157.24,
+                "previous_close": 143.34,
+                "open": 144.0,
+                "high": 158.0,
+                "low": 143.0,
+                "volume": 1,
+            }
+        ),
+    )
+
+    result = await portfolio_holdings._get_indicators_impl("PLTR", ["rsi"], market="us")
+
+    assert "error" not in result
+    assert result["price"] == pytest.approx(157.24)
+    assert result["current_price_source"] == "yahoo_live"
+    assert result["current_price_stale"] is False

--- a/tests/test_mcp_indicator_tools.py
+++ b/tests/test_mcp_indicator_tools.py
@@ -919,7 +919,9 @@ async def test_get_indicators_us_degrades_to_close_with_stale_flag(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_support_resistance_us_positions_levels_against_live_price(monkeypatch):
+async def test_get_support_resistance_us_positions_levels_against_live_price(
+    monkeypatch,
+):
     """US get_support_resistance must position levels against the live price, not the OHLCV close (ROB-365 bug 1)."""
     from app.mcp_server.tooling.fundamentals import _support_resistance
 


### PR DESCRIPTION
## ROB-365 bug 1 — US live-price convergence

Part of [ROB-365](https://linear.app/mgh3326/issue/ROB-365) (US MCP tool data defects, 5 bugs). This PR fixes **bug 1**: `analyze_stock_batch` / `get_support_resistance` / `get_indicators` returned the **previous daily close** as `current_price` during regular US trading.

### Problem
All three tools (the registered `get_indicators`, the analyze-path indicators impl, `get_support_resistance`) and the research-pipeline market stage derived US `current_price` from the OHLCV daily frame's last close (`df["close"].iloc[-1]`) — which intraday is yesterday's close. Observed: PLTR `143.31` vs live `157.24` (~9% off), corrupting distance-to-support/resistance math.

### Fix
- New fail-soft helper `fetch_us_live_last_price` (wraps the existing `_fetch_quote_equity_us` Yahoo fast_info path; **never raises**).
- Overlay it onto the reported `current_price` **scalar** for `equity_us` only — mirroring the existing crypto override. Historical OHLCV-derived levels/indicators (fib, volume profile, bollinger, RSI/ATR/SMA) are intentionally left unchanged; only the reported price and its price-relative distances become live.
- When no live source is reachable: fall back to the OHLCV close and flag it via additive `current_price_source` / `current_price_stale` keys (US results only).
- Research-pipeline `market_stage` overlays `last_close` the same way (+ `last_close_source`).

KR and crypto paths are **byte-for-byte unchanged** (all branches gated on `equity_us`).

### Testing
- 6 new tests: live-price convergence for the registered `get_indicators` tool, the analyze-path `portfolio_holdings._get_indicators_impl`, `get_support_resistance`, and the `market_stage` pipeline; plus graceful-degradation-with-stale-flag cases.
- `ruff check app/ tests/` clean; broad MCP + analysis + import-guard suites green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * US equity market analysis now incorporates live intraday prices for improved accuracy
  * Added price source tracking to indicate when live data is used vs. historical fallbacks
  * Support and resistance levels are now calculated against live prices for US equities
  * Graceful fallback to historical prices when live data is unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->