### PR TITLE
fix(ROB-365): get_holdings US uses KIS-primary refresh + harden Yahoo fast_info (bug 2)

### DIFF
--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -10,6 +10,7 @@ import pandas as pd
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import validate_kis_mock_config
 from app.core.db import AsyncSessionLocal
+from app.core.symbol import to_kis_symbol
 from app.mcp_server.env_utils import _env_int
 from app.mcp_server.tooling.account_modes import (
     apply_account_routing_metadata,
@@ -589,23 +590,54 @@ async def _fetch_price_map_for_positions(
 
     async def fetch_equity_price(
         instrument_type: str, symbol: str
-    ) -> tuple[str, str, float | None, str | None]:
-        try:
-            if instrument_type == "equity_kr":
+    ) -> tuple[str, str, float | None, str | None, str | None]:
+        if instrument_type == "equity_kr":
+            try:
                 quote = await _fetch_quote_equity_kr(symbol)
-            else:
-                quote = await _fetch_quote_equity_us(symbol)
-            price = quote.get("price")
-            return (
-                instrument_type,
-                symbol,
-                float(price) if price is not None else None,
-                None,
-            )
+                price = quote.get("price")
+                return (
+                    instrument_type,
+                    symbol,
+                    float(price) if price is not None else None,
+                    None,
+                    "kis",
+                )
+            except Exception as exc:
+                error_msg = str(exc)
+                logger.debug(
+                    "Failed to fetch equity price for %s: %s", symbol, error_msg
+                )
+                return instrument_type, symbol, None, error_msg, "kis"
+
+        # equity_us (ROB-365 bug 2): KIS overseas daily close is the PRIMARY refresh
+        # source (reliable, no Yahoo fast_info session flakiness); Yahoo fast_info is
+        # the secondary live source; fail-closed (no fabricated price) if both miss.
+        kis_error: str | None = None
+        try:
+            kis = KISClient()
+            frame = await kis.inquire_overseas_daily_price(to_kis_symbol(symbol), n=2)
+            if frame is not None and not frame.empty and "close" in frame.columns:
+                last_close = float(frame["close"].iloc[-1])
+                if last_close > 0:
+                    return (instrument_type, symbol, last_close, None, "kis")
+            kis_error = "KIS overseas daily price unavailable"
         except Exception as exc:
-            error_msg = str(exc)
-            logger.debug("Failed to fetch equity price for %s: %s", symbol, error_msg)
-            return instrument_type, symbol, None, error_msg
+            kis_error = str(exc)
+            logger.debug("KIS US daily price failed for %s: %s", symbol, kis_error)
+
+        yahoo_error: str
+        try:
+            quote = await _fetch_quote_equity_us(symbol)
+            price = quote.get("price")
+            if price is not None:
+                return (instrument_type, symbol, float(price), None, "yahoo")
+            yahoo_error = "Yahoo quote returned no price"
+        except Exception as exc:
+            yahoo_error = str(exc)
+            logger.debug("Failed to fetch equity price for %s: %s", symbol, yahoo_error)
+
+        combined = "; ".join(part for part in (kis_error, yahoo_error) if part)
+        return instrument_type, symbol, None, combined, "kis+yahoo"
 
     equity_tasks = [
         fetch_equity_price(instrument_type, symbol)
@@ -621,14 +653,15 @@ async def _fetch_price_map_for_positions(
 
     if equity_tasks:
         results = await asyncio.gather(*equity_tasks)
-        for instrument_type, symbol, price, error in results:
+        for instrument_type, symbol, price, error, source in results:
             if price is not None:
                 price_map[(instrument_type, symbol)] = price
             elif error is not None:
                 error_map[(instrument_type, symbol)] = error
                 price_errors.append(
                     {
-                        "source": "yahoo" if instrument_type == "equity_us" else "kis",
+                        "source": source
+                        or ("yahoo" if instrument_type == "equity_us" else "kis"),
                         "market": "us" if instrument_type == "equity_us" else "kr",
                         "symbol": symbol,
                         "stage": "current_price",

--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -41,7 +41,17 @@ def _bucket_key(period: str, bucket_date) -> tuple[int, int, int]:
 
 def _fast_info_get(info: Any, *keys: str) -> Any:
     for key in keys:
-        value = getattr(info, key, None)
+        try:
+            value = getattr(info, key, None)
+        except Exception as exc:
+            # yfinance fast_info computes fields lazily on attribute access; a
+            # transient internal failure (e.g. "'NoneType' object is not
+            # subscriptable") must degrade this field to None rather than crash
+            # the whole quote (ROB-365 bug 2). Crumb/auth errors still bubble so
+            # the caller's fresh-session retry can fire.
+            if _is_crumb_auth_error(exc):
+                raise
+            value = None
         if value is None and hasattr(info, "get"):
             try:
                 value = info.get(key)

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 
 import app.services.brokers.upbit.client as upbit_service
-from app.mcp_server.tooling import paper_portfolio_handler
+from app.mcp_server.tooling import paper_portfolio_handler, portfolio_holdings
 from app.services.upbit_symbol_universe_service import (
     UpbitSymbolInactiveError,
     UpbitSymbolNotRegisteredError,
@@ -1943,6 +1943,13 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
                 },
             ]
 
+        async def inquire_overseas_daily_price(
+            self, symbol, exchange_code="NASD", n=200, period="D"
+        ):
+            # ROB-365 bug 2: KIS daily close is the primary refresh source; here it
+            # is also unavailable, so the position must fall back / fail-closed.
+            return pd.DataFrame()
+
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
     _patch_runtime_attr(
         monkeypatch,
@@ -1970,7 +1977,7 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
     assert amzn["quantity"] == pytest.approx(10.0)
     assert amzn["avg_buy_price"] == pytest.approx(150.0)
     assert amzn["current_price"] is None
-    assert amzn["price_error"] == "Symbol 'AMZN' not found"
+    assert "not found" in amzn["price_error"]
     assert amzn["evaluation_amount"] == pytest.approx(1600.0)
     assert amzn["profit_loss"] == pytest.approx(100.0)
     assert amzn["profit_rate"] == pytest.approx(6.67)
@@ -1980,7 +1987,7 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
     assert aapl["quantity"] == pytest.approx(5.0)
     assert aapl["avg_buy_price"] == pytest.approx(180.0)
     assert aapl["current_price"] is None
-    assert aapl["price_error"] == "Symbol 'AAPL' not found"
+    assert "not found" in aapl["price_error"]
     assert aapl["evaluation_amount"] == pytest.approx(9500.0)
     assert aapl["profit_loss"] == pytest.approx(-500.0)
     assert aapl["profit_rate"] == pytest.approx(-5.26)
@@ -1990,7 +1997,8 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
     assert "AMZN" in error_symbols
     assert "AAPL" in error_symbols
     for error in result["errors"]:
-        assert error["source"] == "yahoo"
+        # KIS daily close is tried first, then Yahoo; both unavailable here.
+        assert error["source"] == "kis+yahoo"
         assert error["market"] == "us"
         assert error["stage"] == "current_price"
         # Check that error message is in expected format (contains the symbol)
@@ -2395,6 +2403,12 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
                 }
             ]
 
+        async def inquire_overseas_daily_price(
+            self, symbol, exchange_code="NASD", n=200, period="D"
+        ):
+            # KIS daily close (primary refresh source) also unavailable here.
+            return pd.DataFrame()
+
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
     _patch_runtime_attr(
         monkeypatch,
@@ -2445,17 +2459,17 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
     assert manual_aapl["evaluation_amount"] is None
     assert manual_aapl["profit_loss"] is None
     assert manual_aapl["profit_rate"] is None
-    assert manual_aapl["price_error"] == "Symbol 'AAPL' not found"
+    assert "not found" in manual_aapl["price_error"]
 
-    assert result["errors"] == [
-        {
-            "source": "yahoo",
-            "market": "us",
-            "symbol": "AAPL",
-            "stage": "current_price",
-            "error": "Symbol 'AAPL' not found",
-        }
-    ]
+    # A single deduped error for the symbol; KIS daily close is tried before Yahoo,
+    # both unavailable here, so the source reflects both providers (ROB-365 bug 2).
+    assert len(result["errors"]) == 1
+    error = result["errors"][0]
+    assert error["source"] == "kis+yahoo"
+    assert error["market"] == "us"
+    assert error["symbol"] == "AAPL"
+    assert error["stage"] == "current_price"
+    assert "not found" in error["error"]
 
 
 @pytest.mark.asyncio
@@ -3309,3 +3323,110 @@ async def test_get_available_capital_paper(monkeypatch):
     # paper USD row must have krw_equivalent injected
     usd_row = next(r for r in result["accounts"] if r["currency"] == "USD")
     assert usd_row["krw_equivalent"] == pytest.approx(700_000.0)
+
+
+# ---------------------------------------------------------------------------
+# ROB-365 bug 2: get_holdings US current-price refresh — KIS-primary, fail-closed
+# ---------------------------------------------------------------------------
+
+
+def _us_refresh_position(symbol: str = "AAPL") -> dict:
+    """A US position whose KIS snapshot is incomplete, so the refresh path fires.
+
+    source != "kis_api" makes _has_valid_kis_equity_us_snapshot() return False.
+    """
+    return {
+        "instrument_type": "equity_us",
+        "symbol": symbol,
+        "source": "manual",
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+
+def _kis_daily_frame(last_close: float) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=2, freq="D"),
+            "open": [last_close - 2, last_close - 1],
+            "high": [last_close + 2, last_close + 2],
+            "low": [last_close - 3, last_close - 2],
+            "close": [last_close - 1, last_close],
+            "volume": [1000, 1100],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_price_map_us_uses_kis_daily_close_primary(monkeypatch):
+    """US current-price refresh resolves from KIS daily close first; Yahoo not called (ROB-365 bug 2)."""
+
+    class DummyKISClient:
+        async def inquire_overseas_daily_price(
+            self, symbol, exchange_code="NASD", n=200, period="D"
+        ):
+            return _kis_daily_frame(208.0)
+
+    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
+    us_quote_mock = AsyncMock(return_value={"price": 220.0})
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
+
+    price_map, price_errors, error_map = (
+        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    )
+
+    assert price_map[("equity_us", "AAPL")] == pytest.approx(208.0)
+    assert ("equity_us", "AAPL") not in error_map
+    us_quote_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_price_map_us_falls_back_to_yahoo_when_kis_empty(monkeypatch):
+    """When KIS daily close is unavailable, fall back to the Yahoo live quote (ROB-365 bug 2)."""
+
+    class DummyKISClient:
+        async def inquire_overseas_daily_price(
+            self, symbol, exchange_code="NASD", n=200, period="D"
+        ):
+            return pd.DataFrame()  # no data (e.g. a NYSE/AMEX symbol under NASD)
+
+    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
+    us_quote_mock = AsyncMock(return_value={"price": 215.0})
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
+
+    price_map, price_errors, error_map = (
+        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    )
+
+    assert price_map[("equity_us", "AAPL")] == pytest.approx(215.0)
+    us_quote_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fetch_price_map_us_fail_closed_when_all_sources_fail(monkeypatch):
+    """When both KIS and Yahoo fail, no price is fabricated and the error records the
+    actual source (not the previously hardcoded 'yahoo') (ROB-365 bug 2)."""
+
+    class DummyKISClient:
+        async def inquire_overseas_daily_price(
+            self, symbol, exchange_code="NASD", n=200, period="D"
+        ):
+            raise RuntimeError("KIS overseas daily unavailable")
+
+    monkeypatch.setattr(portfolio_holdings, "KISClient", DummyKISClient)
+    us_quote_mock = AsyncMock(
+        side_effect=RuntimeError("'NoneType' object is not subscriptable")
+    )
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
+
+    price_map, price_errors, error_map = (
+        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    )
+
+    assert ("equity_us", "AAPL") not in price_map  # no fabricated price
+    assert ("equity_us", "AAPL") in error_map
+    us_error = next(e for e in price_errors if e.get("symbol") == "AAPL")
+    assert us_error["source"] == "kis+yahoo"
+    assert us_error["market"] == "us"

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -3373,8 +3373,12 @@ async def test_fetch_price_map_us_uses_kis_daily_close_primary(monkeypatch):
     us_quote_mock = AsyncMock(return_value={"price": 220.0})
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
-    price_map, price_errors, error_map = (
-        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    (
+        price_map,
+        price_errors,
+        error_map,
+    ) = await portfolio_holdings._fetch_price_map_for_positions(
+        [_us_refresh_position()]
     )
 
     assert price_map[("equity_us", "AAPL")] == pytest.approx(208.0)
@@ -3396,8 +3400,12 @@ async def test_fetch_price_map_us_falls_back_to_yahoo_when_kis_empty(monkeypatch
     us_quote_mock = AsyncMock(return_value={"price": 215.0})
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
-    price_map, price_errors, error_map = (
-        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    (
+        price_map,
+        price_errors,
+        error_map,
+    ) = await portfolio_holdings._fetch_price_map_for_positions(
+        [_us_refresh_position()]
     )
 
     assert price_map[("equity_us", "AAPL")] == pytest.approx(215.0)
@@ -3421,8 +3429,12 @@ async def test_fetch_price_map_us_fail_closed_when_all_sources_fail(monkeypatch)
     )
     monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_us", us_quote_mock)
 
-    price_map, price_errors, error_map = (
-        await portfolio_holdings._fetch_price_map_for_positions([_us_refresh_position()])
+    (
+        price_map,
+        price_errors,
+        error_map,
+    ) = await portfolio_holdings._fetch_price_map_for_positions(
+        [_us_refresh_position()]
     )
 
     assert ("equity_us", "AAPL") not in price_map  # no fabricated price

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -101,6 +101,76 @@ class TestYahooService:
         assert mock_ticker_class.call_args.kwargs["session"] is tracing_session
 
     @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.Ticker")
+    async def test_fetch_fast_info_degrades_nonetype_flake_to_none(
+        self, mock_ticker_class, monkeypatch
+    ):
+        """A yfinance internal "'NoneType' object is not subscriptable" raised on lazy
+        fast_info attribute access must degrade that field to None, not crash the whole
+        quote (ROB-365 bug 2). .get() still works, so it is the attribute path that flakes.
+        """
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: object(),
+        )
+
+        class _FlakyFastInfo:
+            def __getattr__(self, name):
+                raise TypeError("'NoneType' object is not subscriptable")
+
+            def get(self, key, default=None):
+                return default
+
+        mock_ticker = MagicMock()
+        mock_ticker.fast_info = _FlakyFastInfo()
+        mock_ticker_class.return_value = mock_ticker
+
+        from app.services.brokers.yahoo.client import fetch_fast_info
+
+        result = await fetch_fast_info("AAPL")
+
+        assert result["symbol"] == "AAPL"
+        assert result["close"] is None
+        assert result["previous_close"] is None
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.Ticker")
+    async def test_fetch_fast_info_still_retries_and_raises_on_crumb_error(
+        self, mock_ticker_class, monkeypatch
+    ):
+        """Crumb/auth errors must still bubble (and trigger the fresh-session retry),
+        not be swallowed by the NoneType-flake hardening (ROB-365 bug 2 regression guard)."""
+        sessions: list[object] = []
+
+        def _build():
+            session = object()
+            sessions.append(session)
+            return session
+
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            _build,
+        )
+
+        class _CrumbFastInfo:
+            def __getattr__(self, name):
+                raise RuntimeError("invalid crumb")
+
+            def get(self, key, default=None):
+                raise RuntimeError("invalid crumb")
+
+        mock_ticker = MagicMock()
+        mock_ticker.fast_info = _CrumbFastInfo()
+        mock_ticker_class.return_value = mock_ticker
+
+        from app.services.brokers.yahoo.client import fetch_fast_info
+
+        with pytest.raises(RuntimeError, match="invalid crumb"):
+            await fetch_fast_info("AAPL")
+
+        assert len(sessions) == 2  # original attempt + one fresh-session crumb retry
+
+    @pytest.mark.asyncio
     async def test_fetch_price_offloads_blocking_call_to_thread(self, monkeypatch):
         import app.services.brokers.yahoo.client as yahoo
 


### PR DESCRIPTION
## ROB-365 bug 2 — get_holdings US Yahoo failure / KIS-primary

Part of [ROB-365](https://linear.app/mgh3326/issue/ROB-365). Fixes **bug 2**: `get_holdings(market="us")` returned `errors[]` entries `Yahoo quote fetch failed ... 'NoneType' object is not subscriptable` for all US symbols.

> Independent of #1029 (bug 1) — both branch from `main`. They both touch `portfolio_holdings.py` in different regions, so whichever merges second may need a trivial rebase.

### Problem
US holdings prices come primarily from the KIS `now_pric2` snapshot, but when that snapshot is incomplete the current-price **refresh** fell back to Yahoo `fast_info`, which flaked for every symbol — polluting `errors[]` and risking a price gap if KIS also failed.

### Fix
1. **Holdings US refresh is now KIS-primary** (`portfolio_holdings.py`): the `equity_us` refresh resolves from the KIS overseas daily close (`inquire_overseas_daily_price`) **first**, then the Yahoo live quote as a secondary source, then **fail-closed** (no fabricated price — evaluation/profit fields stay null). The error-`source` label is now derived from the provider actually attempted (`kis` / `yahoo` / `kis+yahoo`) instead of being hardcoded `"yahoo"`.
2. **Yahoo `fast_info` hardening** (`yahoo/client.py`): `_fast_info_get` degrades a yfinance-internal `'NoneType' object is not subscriptable` raised during lazy attribute access to `None` for that field instead of crashing the whole quote. **Crumb/auth errors still bubble** so the existing fresh-session retry fires. Benefits every fast_info caller (holdings, analyze, order-validation, paper trading).

`now_pric2` remains the primary price whenever the KIS snapshot is complete (unchanged).

### Caveats
- KIS daily-close fallback covers NASDAQ; NYSE/AMEX (under the `NASD` default) fall through to Yahoo secondary — noted as a follow-up (per-symbol exchange resolution).
- **KIS field names / exchange codes await operator live smoke** (no creds on host; consistent with the ROB-358/364 operator-gated pattern).

### Testing
- 5 new tests (3 holdings refresh: KIS-primary / Yahoo-secondary / fail-closed-with-accurate-source; 2 yahoo: NoneType-flake → None, crumb-error still retries+raises) + 2 existing holdings tests updated to the new KIS-primary contract.
- `ruff check app/ tests/` clean; 1847 passed in the broad sweep (the 2 failures are pre-existing local env artifacts — `portfolio_links` public_base_url, `kis_mock_lifecycle` DB drift — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)