### PR TITLE
fix(ROB-365): add VIX (^VIX) as a supported market index (bug 4)

### DIFF
--- a/app/mcp_server/tooling/fundamentals_sources_indices.py
+++ b/app/mcp_server/tooling/fundamentals_sources_indices.py
@@ -20,6 +20,7 @@ _INDEX_META: dict[str, dict[str, str]] = {
     "NASDAQ": {"name": "NASDAQ Composite", "source": "yfinance", "yf_ticker": "^IXIC"},
     "DJI": {"name": "다우존스", "source": "yfinance", "yf_ticker": "^DJI"},
     "DOW": {"name": "다우존스", "source": "yfinance", "yf_ticker": "^DJI"},
+    "VIX": {"name": "CBOE 변동성지수(VIX)", "source": "yfinance", "yf_ticker": "^VIX"},
 }
 
 _DEFAULT_INDICES = ["KOSPI", "KOSDAQ", "SPX", "NASDAQ"]

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -1715,6 +1715,23 @@ class TestGetMarketIndex:
         assert "history" in result
         assert len(result["history"]) == 5
 
+    async def test_single_us_index_vix(self, monkeypatch):
+        """VIX (^VIX) must be a supported index symbol so volatility can be read
+        through the MCP (ROB-365 bug 4)."""
+        tools = build_tools()
+        self._patch_yfinance(monkeypatch, last_price=18.5, prev_close=17.2)
+        self._patch_yf_download(monkeypatch, rows=3)
+
+        result = await tools["get_market_index"](symbol="VIX")
+
+        assert "indices" in result
+        assert len(result["indices"]) == 1
+        idx = result["indices"][0]
+        assert idx["symbol"] == "VIX"
+        assert idx["source"] == "yfinance"
+        assert idx["current"] == pytest.approx(18.5)
+        assert "history" in result
+
     async def test_all_indices_no_symbol(self, monkeypatch):
         """Test fetching all major indices when no symbol specified."""
         tools = build_tools()


### PR DESCRIPTION
## ROB-365 bug 4 — VIX support

Part of [ROB-365](https://linear.app/mgh3326/issue/ROB-365). Fixes **bug 4**: `get_market_index(symbol="VIX")` returned `Unknown index symbol 'VIX'. Supported: DJI, DOW, KOSDAQ, KOSPI, NASDAQ, SP500, SPX`, so the CBOE volatility index could not be read through the MCP.

### Fix
Add a `VIX` entry to `_INDEX_META` (`source=yfinance`, `yf_ticker=^VIX`). It routes through the existing US index fetch path (current + history) — no other code changes.

- Deliberately **not** added to `_DEFAULT_INDICES`, so the no-arg `get_market_index()` dashboard output is unchanged. Query it explicitly via `symbol="VIX"`.

### Out of scope
The separately-observed `get_quote("VIX")` `Session is closed` failure is a distinct yfinance `fast_info` session-lifecycle issue (partially mitigated by the ROB-365 bug-2 `fast_info` hardening in #1030) and is not addressed here.

### Testing
- New `TestGetMarketIndex::test_single_us_index_vix`; existing `TestIndexMeta` schema validation auto-covers the new entry.
- `tests/test_mcp_fundamentals_tools.py` + `tests/test_invest_market_dashboard.py` green (165 passed); `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)