### PR TITLE
fix(ROB-365): screen_stocks(us) uses is_common_stock authority for classification (bug 5)

### DIFF
--- a/app/mcp_server/tooling/screening/instrument_type.py
+++ b/app/mcp_server/tooling/screening/instrument_type.py
@@ -57,8 +57,20 @@ def classify_us_instrument(
     name: object,
     tvscreener_type: object,
     tvscreener_subtype: object,
+    is_common_stock: bool | None = None,
 ) -> InstrumentType:
-    """Classify US instruments into the public screen_stocks taxonomy."""
+    """Classify US instruments into the public screen_stocks taxonomy.
+
+    ``is_common_stock`` is the authoritative NASDAQ-Trader flag from
+    ``us_symbol_universe`` (ROB-204). When it is ``True`` it overrides the
+    yfinance-derived tokens, which intermittently mislabel a common stock as an
+    ETF/fund (ROB-365 bug 5, e.g. NFLX). ``False``/``None`` fall through to the
+    token-based classification (so genuine ETFs/preferred/REITs stay correct,
+    and unknown symbols are still best-effort classified).
+    """
+    if is_common_stock is True:
+        return "common"
+
     symbol_text = str(symbol or "").strip().upper()
     name_text = str(name or "").strip()
     type_text = str(tvscreener_type or "").strip()

--- a/app/mcp_server/tooling/screening/us.py
+++ b/app/mcp_server/tooling/screening/us.py
@@ -43,6 +43,7 @@ from app.services.tvscreener_service import (
     TvScreenerService,
     _import_tvscreener,
 )
+from app.services.us_symbol_universe_service import get_us_common_stock_flags
 
 logger = logging.getLogger(__name__)
 
@@ -208,6 +209,18 @@ async def _screen_us(
                     return value
             return None
 
+        # ROB-365 bug 5: load the authoritative NASDAQ-Trader is_common_stock
+        # flags once, to correct yfinance type glitches (e.g. NFLX tagged ETF).
+        # Fail-soft: if the universe DB is unavailable, fall back to algorithmic
+        # classification (unchanged behavior).
+        try:
+            common_flags = await get_us_common_stock_flags(
+                [s for q in quotes if (s := q.get("symbol"))]
+            )
+        except Exception as exc:
+            logger.debug("US common-stock flag lookup failed: %s", exc)
+            common_flags = {}
+
         results = []
         for quote in quotes:
             mapped = {
@@ -255,6 +268,7 @@ async def _screen_us(
                 mapped.get("name"),
                 _first_value(quote, "quoteType", "type"),
                 _first_value(quote, "typeDisp", "subtype"),
+                is_common_stock=common_flags.get(mapped.get("code")),
             )
             market_cap = _to_optional_float(mapped.get("market_cap"))
             if market_cap is not None:
@@ -696,6 +710,20 @@ async def _screen_us_via_tvscreener(
             market=market,
             usd_krw_rate=usd_krw_rate,
         )
+
+        # ROB-365 bug 5: apply the authoritative NASDAQ-Trader is_common_stock
+        # flag (correcting tvscreener type glitches, e.g. NFLX tagged ETF) BEFORE
+        # instrument-type filtering. Fail-soft: skip on universe-DB error.
+        try:
+            common_flags = await get_us_common_stock_flags(
+                [s.get("symbol") for s in stocks if s.get("symbol")]
+            )
+        except Exception as exc:
+            logger.debug("US common-stock flag lookup failed: %s", exc)
+            common_flags = {}
+        for stock in stocks:
+            if common_flags.get(stock.get("symbol")) is True:
+                stock["instrument_type"] = "common"
 
         stocks = _filter_by_min_analyst_buy(stocks, min_analyst_buy)
 

--- a/app/services/us_symbol_universe_service.py
+++ b/app/services/us_symbol_universe_service.py
@@ -264,6 +264,50 @@ async def get_us_exchange_by_symbol(
         return row.exchange
 
 
+async def get_us_common_stock_flags(
+    symbols: list[str],
+    db: AsyncSession | None = None,
+) -> dict[str, bool | None]:
+    """Return ``{input_symbol: is_common_stock}`` for active US symbols (ROB-365 bug 5).
+
+    ``is_common_stock`` is the authoritative NASDAQ-Trader flag (ROB-204). The
+    returned dict is keyed by the caller's original symbol string for easy
+    lookup. Symbols absent from the active universe are omitted; a present but
+    un-synced symbol maps to ``None`` (the flag column is nullable). Callers
+    treat both missing and ``None`` as "use algorithmic classification".
+    """
+    canon_to_original: dict[str, str] = {}
+    for raw in symbols:
+        if not raw:
+            continue
+        canon = to_db_symbol(_normalize_symbol(raw))
+        if canon:
+            canon_to_original.setdefault(canon, raw)
+    if not canon_to_original:
+        return {}
+
+    async def _run(session: AsyncSession) -> dict[str, bool | None]:
+        stmt = select(
+            USSymbolUniverse.symbol, USSymbolUniverse.is_common_stock
+        ).where(
+            USSymbolUniverse.symbol.in_(list(canon_to_original)),
+            USSymbolUniverse.is_active.is_(True),
+        )
+        result = await session.execute(stmt)
+        flags: dict[str, bool | None] = {}
+        for canon_symbol, is_common in result.all():
+            original = canon_to_original.get(canon_symbol)
+            if original is not None:
+                flags[original] = is_common
+        return flags
+
+    if db is not None:
+        return await _run(db)
+
+    async with AsyncSessionLocal() as session:  # pyright: ignore[reportGeneralTypeIssues]
+        return await _run(session)
+
+
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
     normalized_name = normalize_name(name)
     if not normalized_name:

--- a/app/services/us_symbol_universe_service.py
+++ b/app/services/us_symbol_universe_service.py
@@ -287,9 +287,7 @@ async def get_us_common_stock_flags(
         return {}
 
     async def _run(session: AsyncSession) -> dict[str, bool | None]:
-        stmt = select(
-            USSymbolUniverse.symbol, USSymbolUniverse.is_common_stock
-        ).where(
+        stmt = select(USSymbolUniverse.symbol, USSymbolUniverse.is_common_stock).where(
             USSymbolUniverse.symbol.in_(list(canon_to_original)),
             USSymbolUniverse.is_active.is_(True),
         )

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -942,3 +942,46 @@ class TestScreenStocksPhase2Spec:
         assert result["market"] == "crypto"
         assert result["filters_applied"]["sort_by"] == "trade_amount"
         assert result["filters_applied"]["sort_order"] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_us_screen_is_common_stock_overrides_etf_misclassification(monkeypatch):
+    """ROB-365 bug 5: a common stock mis-tagged ETF by the yfinance screener is
+    corrected to 'common' when the us_symbol_universe.is_common_stock authority
+    says so."""
+    import yfinance as yf
+
+    def screen_func(query, size, sortField, sortAsc, session=None):
+        assert session is not None
+        return {
+            "quotes": [
+                {
+                    "symbol": "NFLX",
+                    "shortname": "Netflix Inc.",
+                    "lastprice": 1000.0,
+                    "quoteType": "ETF",  # yfinance glitch — NFLX is common stock
+                    "typeDisp": "ETF",
+                    "percentchange": 1.0,
+                    "dayvolume": 5_000_000,
+                    "intradaymarketcap": 400_000_000_000,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(yf, "screen", screen_func)
+    # Force the legacy yfinance path (the surface this test exercises).
+    monkeypatch.setattr(
+        screening_us, "_can_use_tvscreener_stock_path", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        screening_us,
+        "get_us_common_stock_flags",
+        AsyncMock(return_value={"NFLX": True}),
+    )
+
+    tools = build_tools()
+    result = await tools["screen_stocks"](market="us", limit=10)
+
+    assert "error" not in result, f"Unexpected error: {result.get('error')}"
+    nflx = next(r for r in result["results"] if r.get("code") == "NFLX")
+    assert nflx["instrument_type"] == "common"

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -985,3 +985,44 @@ async def test_us_screen_is_common_stock_overrides_etf_misclassification(monkeyp
     assert "error" not in result, f"Unexpected error: {result.get('error')}"
     nflx = next(r for r in result["results"] if r.get("code") == "NFLX")
     assert nflx["instrument_type"] == "common"
+
+
+@pytest.mark.asyncio
+async def test_us_screen_is_common_stock_lookup_is_fail_soft(monkeypatch):
+    """If the is_common_stock universe lookup raises, the yfinance path falls back
+    to algorithmic classification rather than erroring (ROB-365 bug 5)."""
+    import yfinance as yf
+
+    def screen_func(query, size, sortField, sortAsc, session=None):
+        assert session is not None
+        return {
+            "quotes": [
+                {
+                    "symbol": "SPY",
+                    "shortname": "SPDR S&P 500 ETF Trust",
+                    "lastprice": 500.0,
+                    "quoteType": "ETF",
+                    "typeDisp": "ETF",
+                    "percentchange": 0.3,
+                    "dayvolume": 50_000_000,
+                    "intradaymarketcap": 500_000_000_000,
+                }
+            ]
+        }
+
+    monkeypatch.setattr(yf, "screen", screen_func)
+    monkeypatch.setattr(
+        screening_us, "_can_use_tvscreener_stock_path", lambda *a, **k: False
+    )
+    monkeypatch.setattr(
+        screening_us,
+        "get_us_common_stock_flags",
+        AsyncMock(side_effect=RuntimeError("universe DB unavailable")),
+    )
+
+    tools = build_tools()
+    result = await tools["screen_stocks"](market="us", limit=10)
+
+    assert "error" not in result, f"Unexpected error: {result.get('error')}"
+    spy = next(r for r in result["results"] if r.get("code") == "SPY")
+    assert spy["instrument_type"] == "etf"  # algorithmic classification preserved

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -1511,3 +1511,75 @@ class TestScreenStocksTvScreenerContract:
 
         assert result["market"] == "us"
         assert "results" in result
+
+
+@pytest.mark.asyncio
+async def test_us_tvscreener_applies_is_common_stock_authority(monkeypatch):
+    """ROB-365 bug 5: the tvscreener (primary) US path corrects a yfinance/tvscreener
+    ETF mistag to 'common' using the us_symbol_universe.is_common_stock authority."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "NFLX",
+                "name": "Netflix Inc.",
+                "price": 1000.0,
+                "type": "fund",  # tvscreener glitch — NFLX is common stock
+                "subtype": "ETF",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        screening_us,
+        "_build_us_filters",
+        lambda **kwargs: {"columns": [], "where_conditions": [], "Market": object()},
+    )
+    monkeypatch.setattr(screening_us, "_execute_us_query", AsyncMock(return_value=df))
+    monkeypatch.setattr(
+        screening_us,
+        "get_us_common_stock_flags",
+        AsyncMock(return_value={"NFLX": True}),
+    )
+
+    result = await screening_us._screen_us_via_tvscreener(market="us", limit=10)
+
+    assert result.get("error") is None
+    nflx = next(s for s in result["stocks"] if s.get("symbol") == "NFLX")
+    assert nflx["instrument_type"] == "common"
+
+
+@pytest.mark.asyncio
+async def test_us_tvscreener_is_common_stock_lookup_is_fail_soft(monkeypatch):
+    """If the is_common_stock universe lookup raises, the tvscreener path falls back
+    to algorithmic classification rather than crashing (ROB-365 bug 5)."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "SPY",
+                "name": "SPDR S&P 500 ETF Trust",
+                "price": 500.0,
+                "type": "fund",
+                "subtype": "ETF",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        screening_us,
+        "_build_us_filters",
+        lambda **kwargs: {"columns": [], "where_conditions": [], "Market": object()},
+    )
+    monkeypatch.setattr(screening_us, "_execute_us_query", AsyncMock(return_value=df))
+    monkeypatch.setattr(
+        screening_us,
+        "get_us_common_stock_flags",
+        AsyncMock(side_effect=RuntimeError("universe DB unavailable")),
+    )
+
+    result = await screening_us._screen_us_via_tvscreener(market="us", limit=10)
+
+    assert result.get("error") is None
+    spy = next(s for s in result["stocks"] if s.get("symbol") == "SPY")
+    assert spy["instrument_type"] == "etf"  # algorithmic classification preserved

--- a/tests/test_screening_instrument_type.py
+++ b/tests/test_screening_instrument_type.py
@@ -75,7 +75,14 @@ def test_classify_us_instrument_cases(symbol, name, type_, subtype, expected):
         # is_common_stock=False / None preserve the algorithmic classification.
         ("SPY", "SPDR S&P 500 ETF Trust", "fund", "ETF", False, "etf"),
         ("SPY", "SPDR S&P 500 ETF Trust", "fund", "ETF", None, "etf"),
-        ("BAC.PR.K", "Bank of America Preferred Series K", "stock", "", False, "preferred"),
+        (
+            "BAC.PR.K",
+            "Bank of America Preferred Series K",
+            "stock",
+            "",
+            False,
+            "preferred",
+        ),
         ("AAPL", "Apple Inc.", "stock", "common stock", None, "common"),
     ],
 )

--- a/tests/test_screening_instrument_type.py
+++ b/tests/test_screening_instrument_type.py
@@ -64,3 +64,25 @@ def test_classify_kr_instrument_cases(symbol, name, subtype, expected):
 )
 def test_classify_us_instrument_cases(symbol, name, type_, subtype, expected):
     assert classify_us_instrument(symbol, name, type_, subtype) == expected
+
+
+@pytest.mark.parametrize(
+    ("symbol", "name", "type_", "subtype", "is_common", "expected"),
+    [
+        # NASDAQ-Trader authority (is_common_stock=True) overrides a wrong yfinance
+        # ETF/fund signal — the ROB-365 bug 5 NFLX-classified-as-etf case.
+        ("NFLX", "Netflix Inc.", "fund", "ETF", True, "common"),
+        # is_common_stock=False / None preserve the algorithmic classification.
+        ("SPY", "SPDR S&P 500 ETF Trust", "fund", "ETF", False, "etf"),
+        ("SPY", "SPDR S&P 500 ETF Trust", "fund", "ETF", None, "etf"),
+        ("BAC.PR.K", "Bank of America Preferred Series K", "stock", "", False, "preferred"),
+        ("AAPL", "Apple Inc.", "stock", "common stock", None, "common"),
+    ],
+)
+def test_classify_us_instrument_is_common_stock_authority(
+    symbol, name, type_, subtype, is_common, expected
+):
+    assert (
+        classify_us_instrument(symbol, name, type_, subtype, is_common_stock=is_common)
+        == expected
+    )

--- a/tests/test_us_symbol_universe_sync.py
+++ b/tests/test_us_symbol_universe_sync.py
@@ -515,3 +515,19 @@ async def test_get_us_common_stock_flags_returns_authoritative_flags(tmp_path: P
     assert "MISSING" not in flags  # symbols absent from the universe are omitted
     # input keyed; separator variant (BRK-B) resolves to the canonical BRK.B row
     assert flags["BRK-B"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_us_common_stock_flags_empty_input_returns_empty(tmp_path: Path):
+    """Empty / blank-only symbol lists short-circuit to an empty mapping without a
+    DB round-trip (ROB-365 bug 5)."""
+    async with _search_session(tmp_path / "empty-flags.db", []) as db:
+        assert (
+            await us_symbol_universe_service.get_us_common_stock_flags([], db=db) == {}
+        )
+        assert (
+            await us_symbol_universe_service.get_us_common_stock_flags(
+                ["", "   "], db=db
+            )
+            == {}
+        )

--- a/tests/test_us_symbol_universe_sync.py
+++ b/tests/test_us_symbol_universe_sync.py
@@ -453,3 +453,65 @@ async def test_search_us_symbols_keeps_name_search_behavior(
         )
 
     assert [result["symbol"] for result in results] == ["BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_get_us_common_stock_flags_returns_authoritative_flags(tmp_path: Path):
+    """ROB-365 bug 5: the batch loader returns is_common_stock for active symbols,
+    keyed by the caller's input symbol; inactive/missing are omitted and an
+    un-synced (NULL) flag maps to None."""
+    rows = [
+        USSymbolUniverse(
+            symbol="NFLX",
+            exchange="NASD",
+            name_kr="넷플릭스",
+            name_en="Netflix Inc.",
+            is_active=True,
+            is_common_stock=True,
+        ),
+        USSymbolUniverse(
+            symbol="SPY",
+            exchange="NYSE",
+            name_kr="SPY",
+            name_en="SPDR S&P 500 ETF Trust",
+            is_active=True,
+            is_common_stock=False,
+        ),
+        USSymbolUniverse(
+            symbol="TSM",
+            exchange="NYSE",
+            name_kr="TSM",
+            name_en="Taiwan Semiconductor",
+            is_active=True,
+            is_common_stock=None,  # present but not yet synced
+        ),
+        USSymbolUniverse(
+            symbol="DEAD",
+            exchange="NASD",
+            name_kr="상폐",
+            name_en="Delisted Co",
+            is_active=False,
+            is_common_stock=True,
+        ),
+        USSymbolUniverse(
+            symbol="BRK.B",
+            exchange="NYSE",
+            name_kr="버크셔B",
+            name_en="Berkshire Hathaway B",
+            is_active=True,
+            is_common_stock=True,
+        ),
+    ]
+
+    async with _search_session(tmp_path / "common-flags.db", rows) as db:
+        flags = await us_symbol_universe_service.get_us_common_stock_flags(
+            ["NFLX", "SPY", "TSM", "DEAD", "MISSING", "BRK-B"], db=db
+        )
+
+    assert flags["NFLX"] is True
+    assert flags["SPY"] is False
+    assert flags["TSM"] is None
+    assert "DEAD" not in flags  # inactive rows are omitted
+    assert "MISSING" not in flags  # symbols absent from the universe are omitted
+    # input keyed; separator variant (BRK-B) resolves to the canonical BRK.B row
+    assert flags["BRK-B"] is True


### PR DESCRIPTION
## ROB-365 bug 5 — screen_stocks(us) classification

Part of [ROB-365](https://linear.app/mgh3326/issue/ROB-365). Fixes **bug 5**: `screen_stocks(market="us")` mislabeled a common stock as an ETF (observed `NFLX → instrument_type="etf"`) because classification keyed purely off yfinance/tvscreener type tokens, which intermittently glitch.

### Fix
Make the NASDAQ-Trader `is_common_stock` flag (`us_symbol_universe`, ROB-204) the classification authority:

- `classify_us_instrument()` gains an optional `is_common_stock` arg — `True` forces `"common"` (overriding a wrong ETF/fund token); `False`/`None` fall through to the existing token-based logic (genuine ETFs/preferred/REITs stay correct).
- New batch loader `us_symbol_universe_service.get_us_common_stock_flags()` — flags keyed by the caller's input symbol; active rows only; canonical (dot-form) symbol match; un-synced → `None`.
- **Both** US screener paths consult it, **fail-soft** (universe-DB error → algorithmic classification): the yfinance `_screen_us` path passes the flag into `classify_us_instrument`; the tvscreener path applies it as a post-normalize override **before** instrument-type filtering (so `instrument_types=["common"]` sees the corrected type).

Preferred-share mixing (JPM/PK, BAC/PE) is already handled by the existing preferred-symbol regex + `instrument_types=["common"]` filtering, now reinforced by the authority.

### Scope / honesty notes
- `is_common_stock` is nullable and populated by the **operator-gated** `sync_us_common_stock_flags` (ROB-204). The correction is architecturally in place but **inert for a symbol until that sync runs** — running the sync is the operational follow-up.
- The **abnormal-but-plausible price** (NFLX `close=86.32`) is a yfinance screener data-quality issue that the screener **cannot detect deterministically without a reference quote**. Rather than ship a false sanity check, this is left as a separate cross-source-validation follow-up.

### Testing
- Pure classifier authority cases (`test_classify_us_instrument_is_common_stock_authority`).
- Batch-loader unit test against a real (sqlite) DB: active/inactive/missing/un-synced + separator-variant keying.
- End-to-end screener integration test: a yfinance-tagged-ETF NFLX is corrected to `"common"` via the authority.
- `ruff check app/ tests/` clean; 841 passed across all screening/universe/screener suites, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)