### PR TITLE
fix(ROB-369): crypto screener field bugs — trade_amount_24h + get_top_stocks market_cap (B4/B5)

### DIFF
--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import pandas as pd
@@ -56,6 +57,8 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     to_optional_float as _to_optional_float,
 )
+
+logger = logging.getLogger(__name__)
 
 _normalize_symbol_input = _normalize_symbol_input_impl
 _resolve_market_type = _resolve_market_type_impl
@@ -181,10 +184,49 @@ async def _get_us_rankings(
     return await _get_us_rankings_impl(ranking_type, limit, _map_us_row)
 
 
+async def _enrich_crypto_rankings_market_cap(rankings: list[dict[str, Any]]) -> None:
+    """ROB-369 B5 — fill ``market_cap`` from the shared CoinGecko cache.
+
+    Upbit rankings carry no market cap, so ``_map_crypto_row`` leaves it None.
+    This reuses the same cached CoinGecko source ``screen_stocks`` uses, matched
+    by the bare coin symbol (``KRW-BTC`` → ``BTC``). Best-effort: any failure
+    leaves ``market_cap`` None (honest, never fabricated). Only ``market_cap`` is
+    touched — the ranking row contract has no ``market_cap_rank`` field.
+    """
+    if not rankings:
+        return
+    try:
+        # Lazy imports avoid any module-load import cycle with the screener pkg.
+        from app.mcp_server.tooling.analysis_screen_crypto import (
+            _extract_market_symbol,
+        )
+        from app.mcp_server.tooling.screening.crypto import (
+            _run_crypto_coingecko_fetch,
+        )
+
+        payload = await _run_crypto_coingecko_fetch()
+        coingecko_data = payload.get("data") or {}
+        for row in rankings:
+            symbol = _extract_market_symbol(row.get("symbol"))
+            cap_data = coingecko_data.get(symbol) if symbol else None
+            if cap_data and cap_data.get("market_cap") is not None:
+                row["market_cap"] = cap_data.get("market_cap")
+    except Exception as exc:  # noqa: BLE001 — best-effort enrichment, fail open
+        logger.warning(
+            "crypto market_cap enrichment failed; market_cap left null (%s: %s)",
+            type(exc).__name__,
+            exc,
+        )
+
+
 async def _get_crypto_rankings(
     ranking_type: str, limit: int
 ) -> tuple[list[dict[str, Any]], str]:
-    return await _get_crypto_rankings_impl(ranking_type, limit, _map_crypto_row)
+    rankings, source = await _get_crypto_rankings_impl(
+        ranking_type, limit, _map_crypto_row
+    )
+    await _enrich_crypto_rankings_market_cap(rankings)
+    return rankings, source
 
 
 def _calculate_pearson_correlation(x: list[float], y: list[float]) -> float:

--- a/app/mcp_server/tooling/screening/crypto.py
+++ b/app/mcp_server/tooling/screening/crypto.py
@@ -283,18 +283,24 @@ async def _normalize_crypto_results(
     finally:
         await _db.close()
 
-    # Fetch Upbit 24h volumes
+    # Fetch Upbit 24h volume + trade amount (거래대금). ROB-369 B4: tvscreener
+    # VALUE_TRADED is null in production, so the live Upbit ``acc_trade_price_24h``
+    # (already returned by this same ticker call) is the real trade-amount source.
     ticker_volume_map: dict[str, float] = {}
+    ticker_trade_amount_map: dict[str, float] = {}
     if market_codes:
         try:
             ticker_rows = await upbit_service.fetch_multiple_tickers(market_codes)
-            ticker_volume_map = {
-                str(row.get("market") or "").strip().upper(): (
+            for row in ticker_rows:
+                code = str(row.get("market") or "").strip().upper()
+                if not code:
+                    continue
+                ticker_volume_map[code] = (
                     _to_optional_float(row.get("acc_trade_volume_24h")) or 0.0
                 )
-                for row in ticker_rows
-                if str(row.get("market") or "").strip()
-            }
+                amount = _to_optional_float(row.get("acc_trade_price_24h"))
+                if amount is not None:
+                    ticker_trade_amount_map[code] = amount
         except Exception as exc:
             warnings.append(
                 "Upbit 24h volume enrichment failed; volume_24h defaulted to 0.0 "
@@ -356,9 +362,13 @@ async def _normalize_crypto_results(
             filtered_by_crash += 1
             continue
 
-        trade_amount_24h = _to_optional_float(
-            raw_item.get("acc_trade_price_24h") or raw_item.get("trade_amount_24h")
-        )
+        # Prefer the live Upbit 거래대금; fall back to tvscreener VALUE_TRADED
+        # only when Upbit did not return a trade amount for this market.
+        trade_amount_24h = ticker_trade_amount_map.get(market_code)
+        if trade_amount_24h is None:
+            trade_amount_24h = _to_optional_float(
+                raw_item.get("acc_trade_price_24h") or raw_item.get("trade_amount_24h")
+            )
         item = {
             "symbol": market_code,
             "original_market": market_code,

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -172,6 +172,104 @@ class TestScreenStocksCrypto:
         assert "volume" not in first
 
     @pytest.mark.asyncio
+    async def test_crypto_trade_amount_uses_upbit_value_when_tvscreener_null(
+        self, fake_crypto_tvscreener_module, monkeypatch
+    ):
+        """ROB-369 B4 — tvscreener VALUE_TRADED is null in production, so
+        ``trade_amount_24h`` defaulted to 0 for every crypto row. The Upbit
+        ticker's ``acc_trade_price_24h`` (거래대금) IS available and already
+        fetched; the screener now prefers it."""
+        tv_service = AsyncMock()
+        tv_service.query_crypto_screener.return_value = pd.DataFrame(
+            {
+                "symbol": ["UPBIT:BTCKRW"],
+                "name": ["BTCKRW"],
+                "description": ["Bitcoin TV"],
+                "price": [150_000_000.0],
+                "change_percent": [0.01],
+                "relative_strength_index_14": [45.5],
+                "average_directional_index_14": [25.3],
+                "volume_24h_in_usd": [156_000_000.0],
+                "value_traded": [None],  # tvscreener VALUE_TRADED null (the bug)
+                "market_cap": [2_500_000_000_000_000.0],
+                "exchange": ["UPBIT"],
+            }
+        )
+
+        async def mock_fetch_multiple_tickers(
+            market_codes: list[str],
+        ) -> list[dict[str, object]]:
+            assert market_codes == ["KRW-BTC"]
+            return [
+                {
+                    "market": "KRW-BTC",
+                    "acc_trade_volume_24h": 12_345.0,
+                    # Upbit 거래대금(24H) in KRW — confirmed present on the venue.
+                    "acc_trade_price_24h": 146_153_871_600.0,
+                }
+            ]
+
+        async def mock_warning_markets(db=None, *, quote_currency: str) -> set[str]:
+            return set()
+
+        async def mock_market_cap_cache_get() -> dict[str, object]:
+            return {
+                "data": {},
+                "cached": True,
+                "age_seconds": 1.0,
+                "stale": False,
+                "error": None,
+            }
+
+        monkeypatch.setattr(
+            screening_crypto,
+            "_import_tvscreener",
+            lambda: fake_crypto_tvscreener_module,
+        )
+        monkeypatch.setattr(
+            screening_crypto,
+            "TvScreenerService",
+            lambda timeout=30.0: tv_service,
+        )
+        monkeypatch.setattr(
+            upbit_service, "fetch_multiple_tickers", mock_fetch_multiple_tickers
+        )
+        monkeypatch.setattr(
+            screening_crypto, "get_upbit_warning_markets", mock_warning_markets
+        )
+        monkeypatch.setattr(
+            screening_crypto._CRYPTO_MARKET_CAP_CACHE, "get", mock_market_cap_cache_get
+        )
+        monkeypatch.setattr(
+            screening_crypto,
+            "get_upbit_market_display_names",
+            AsyncMock(
+                return_value={
+                    "KRW-BTC": {"korean_name": "비트코인", "english_name": "Bitcoin"}
+                }
+            ),
+            raising=False,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="crypto",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_order="desc",
+            limit=1,
+        )
+        first = result["results"][0]
+        assert first["symbol"] == "KRW-BTC"
+        # Upbit 거래대금 is used instead of the null tvscreener value (was 0.0).
+        assert first["trade_amount_24h"] == pytest.approx(146_153_871_600.0)
+        assert first["volume_24h"] == pytest.approx(12_345.0)
+
+    @pytest.mark.asyncio
     async def test_crypto_coingecko_span_wraps_actual_fetch(
         self, fake_crypto_tvscreener_module, monkeypatch
     ):

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -582,6 +582,61 @@ class TestMCPTopStocks:
         assert result["total_count"] == 2
         assert result["rankings"][0]["symbol"] == "KRW-BTC"
 
+    async def test_crypto_rankings_fills_market_cap_from_coingecko(self, monkeypatch):
+        """ROB-369 B5 — get_top_stocks(crypto) left market_cap=null for every
+        row; it now enriches from the same CoinGecko cache screen_stocks uses."""
+        from app.mcp_server.tooling.screening import crypto as screening_crypto
+
+        tools = build_tools()
+
+        async def mock_fetch_top_traded_coins():
+            return [
+                {
+                    "market": "KRW-BTC",
+                    "trade_price": "80000000",
+                    "signed_change_rate": "0.025",
+                    "acc_trade_volume_24h": "100",
+                    "acc_trade_price_24h": "8000000000000",
+                },
+                {
+                    "market": "KRW-ETH",
+                    "trade_price": "4000000",
+                    "signed_change_rate": "0.03",
+                    "acc_trade_volume_24h": "80",
+                    "acc_trade_price_24h": "320000000000",
+                },
+            ]
+
+        async def mock_coingecko_fetch():
+            return {
+                "data": {
+                    "BTC": {"market_cap": 3_000_000_000_000_000, "market_cap_rank": 1},
+                    "ETH": {"market_cap": 500_000_000_000_000, "market_cap_rank": 2},
+                },
+                "cached": True,
+                "age_seconds": 1.0,
+                "stale": False,
+                "error": None,
+            }
+
+        monkeypatch.setattr(
+            upbit_service, "fetch_top_traded_coins", mock_fetch_top_traded_coins
+        )
+        monkeypatch.setattr(
+            screening_crypto, "_run_crypto_coingecko_fetch", mock_coingecko_fetch
+        )
+
+        result = await tools["get_top_stocks"](
+            market="crypto", ranking_type="volume", limit=2
+        )
+        rankings = result["rankings"]
+        btc = next(r for r in rankings if r["symbol"] == "KRW-BTC")
+        eth = next(r for r in rankings if r["symbol"] == "KRW-ETH")
+        assert btc["market_cap"] == 3_000_000_000_000_000
+        assert eth["market_cap"] == 500_000_000_000_000
+        # trade_amount stays populated (was never the bug).
+        assert btc["trade_amount"] == pytest.approx(8_000_000_000_000.0)
+
     async def test_crypto_rankings_gainers_sort(self, monkeypatch):
         tools = build_tools()
 


### PR DESCRIPTION
## ROB-369 Slice 3 — crypto screener field bugs (B4/B5)

Part of [ROB-369](https://linear.app/mgh3326/issue/ROB-369). Screener-tooling change, **disjoint from 2a/2b/2c** (#1025/#1026/#1028) — branched off `main`, independent.

Two crypto screener fields were null/0 for **every** row despite the data being available:

### B4 — `screen_stocks(crypto)` `trade_amount_24h=0` (all rows)
Sourced from tvscreener `VALUE_TRADED`, which is **null in production**. The Upbit ticker call the screener already makes (`fetch_multiple_tickers`) returns `acc_trade_price_24h` (거래대금, confirmed present on the venue via the 9222 cross-check) but only `acc_trade_volume_24h` was extracted.
**Fix:** also build `ticker_trade_amount_map` from `acc_trade_price_24h` and prefer it for `trade_amount_24h`, falling back to tvscreener `VALUE_TRADED` only when Upbit didn't return a value.

### B5 — `get_top_stocks(crypto)` `market_cap=null` (all rows)
`_map_crypto_row` hard-codes `market_cap=None` and the rankings path never enriched it, while `screen_stocks` does via the CoinGecko cache.
**Fix:** `_get_crypto_rankings` now calls a new `_enrich_crypto_rankings_market_cap` that reuses the **same cached CoinGecko source** (`_run_crypto_coingecko_fetch`) `screen_stocks` uses, matched by bare coin symbol (`KRW-BTC → BTC`). Best-effort **fail-open** — any error leaves `market_cap` None (honest, never fabricated). Only `market_cap` is set (ranking rows have no `market_cap_rank` field → kr/us parity preserved). Lazy imports avoid any module-load import cycle.

### Deferred (documented follow-ups — need new infra, not in scope)
- B4 `plus_di`/`minus_di` + `volume_ratio`: tvscreener lacks the fields; needs TA-Lib + OHLCV history.
- B4 crash-filter BTC-reference recovery: uncertain root cause + interacts with the subtle crash-filter logic.

### Safety
Read-only throughout — no broker/order/watch mutation. Reuses the existing public Upbit ticker fetch + the existing cached CoinGecko source (no new external surface). No migration. Import-contract guard green.

### Testing
- `screen_stocks(crypto)` with null tvscreener `VALUE_TRADED` + Upbit `acc_trade_price_24h` → `trade_amount_24h` uses the live 거래대금 (was 0).
- `get_top_stocks(crypto)` fills `market_cap` from the CoinGecko cache for every row (BTC + ETH).
- The canonical crypto screener/ranking suites are unchanged and green. **751 crypto/screener tests + import-contract guard green**; `ruff check` + `ruff format --check` clean.

### Adversarially reviewed
A multi-lens review (B4a regression/edge + B5 cycles/fail-open/symbol-match) confirmed correct behavior; the only finding was a one-token clarity nit (redundant `or ""`), applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
