### PR TITLE
fix(ROB-369): crypto crash-filter recovers BTC reference when absent (B4-residual)

### DIFF
--- a/app/mcp_server/tooling/screening/crypto.py
+++ b/app/mcp_server/tooling/screening/crypto.py
@@ -14,6 +14,7 @@ import app.services.brokers.upbit.client as upbit_service
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling.analysis_screen_crypto import finalize_crypto_screen
 from app.mcp_server.tooling.screening.common import (
+    DROP_THRESHOLD,
     MarketCapCache,
     _clean_text,
     _compute_rsi_bucket,
@@ -318,14 +319,49 @@ async def _normalize_crypto_results(
     )
     btc_change_24h: float | None = None
     if btc_item is None:
-        if not pure_market_snapshot:
-            logger.warning(
-                "KRW-BTC ticker not found in Upbit KRW crypto screener rows; "
-                "crash filter uses btc_change_24h=0.0 fallback"
+        # ROB-369 B4 — KRW-BTC can be absent from the tvscreener rows, leaving
+        # the crash filter with a btc_change_24h=0.0 fallback that mistakes a
+        # market-wide crash for an isolated drop (wrongly filtering deep losers).
+        # Recover the reference with a direct Upbit ticker fetch — but only when
+        # it can change the outcome: a crash candidate (≤ DROP_THRESHOLD) exists
+        # and we're in interactive screening (the filter is skipped for snapshot
+        # builds). This avoids an extra Upbit call on calm screens.
+        has_crash_candidate = not pure_market_snapshot and any(
+            (
+                _to_optional_float(
+                    item.get("signed_change_rate")
+                    if item.get("signed_change_rate") is not None
+                    else item.get("change_rate")
+                )
+                or 0.0
             )
-            warnings.append(
-                "BTC 기준 데이터가 없어 급락 방어 필터를 기본값으로 적용했습니다."
-            )
+            <= DROP_THRESHOLD
+            for item in raw_results
+        )
+        if has_crash_candidate:
+            try:
+                btc_rows = await upbit_service.fetch_multiple_tickers(["KRW-BTC"])
+            except Exception as exc:  # noqa: BLE001 — best-effort, degrade to 0.0
+                logger.warning(
+                    "KRW-BTC crash-filter fallback fetch failed (%s: %s)",
+                    type(exc).__name__,
+                    exc,
+                )
+                btc_rows = []
+            if btc_rows:
+                btc_change_24h = _to_optional_float(
+                    btc_rows[0].get("signed_change_rate")
+                    or btc_rows[0].get("change_rate")
+                )
+            if btc_change_24h is None:
+                logger.warning(
+                    "KRW-BTC ticker not found in Upbit KRW crypto screener rows "
+                    "and fallback fetch yielded no change rate; crash filter uses "
+                    "btc_change_24h=0.0 fallback"
+                )
+                warnings.append(
+                    "BTC 기준 데이터가 없어 급락 방어 필터를 기본값으로 적용했습니다."
+                )
     else:
         btc_change_24h = _to_optional_float(
             btc_item.get("signed_change_rate") or btc_item.get("change_rate")

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -269,6 +269,167 @@ class TestScreenStocksCrypto:
         assert first["trade_amount_24h"] == pytest.approx(146_153_871_600.0)
         assert first["volume_24h"] == pytest.approx(12_345.0)
 
+    def _btc_absent_tv_service(self):
+        """tvscreener result omitting KRW-BTC (only KRW-ETH, down 35% — a crash
+        candidate ≤ DROP_THRESHOLD of -30%)."""
+        tv_service = AsyncMock()
+        tv_service.query_crypto_screener.return_value = pd.DataFrame(
+            {
+                "symbol": ["UPBIT:ETHKRW"],
+                "name": ["ETHKRW"],
+                "description": ["Ethereum TV"],
+                "price": [5_000_000.0],
+                "change_percent": [-0.35],  # 35% drop → crash candidate
+                "relative_strength_index_14": [28.0],
+                "average_directional_index_14": [30.0],
+                "volume_24h_in_usd": [95_000_000.0],
+                "value_traded": [None],
+                "market_cap": [500_000_000_000_000.0],
+                "exchange": ["UPBIT"],
+            }
+        )
+        return tv_service
+
+    async def _empty_cache_get(self):
+        return {
+            "data": {},
+            "cached": True,
+            "age_seconds": 1.0,
+            "stale": False,
+            "error": None,
+        }
+
+    @pytest.mark.asyncio
+    async def test_crypto_crash_filter_recovers_btc_reference_via_ticker_fallback(
+        self, fake_crypto_tvscreener_module, monkeypatch
+    ):
+        """ROB-369 B4 — when tvscreener omits KRW-BTC, the crash filter fell back
+        to btc_change_24h=0.0, so a market-wide crash looked like an isolated
+        drop and the deep loser was wrongly filtered. The screener now fetches
+        the KRW-BTC ticker directly; with BTC down 15% (panic), the ETH 35% drop
+        is a market crash (not isolated) and survives."""
+        tv_service = self._btc_absent_tv_service()
+        calls: list[list[str]] = []
+
+        async def mock_fetch_multiple_tickers(market_codes):
+            calls.append(list(market_codes))
+            if list(market_codes) == ["KRW-BTC"]:
+                return [{"market": "KRW-BTC", "signed_change_rate": -0.15}]
+            return [{"market": "KRW-ETH", "acc_trade_volume_24h": 54_321.0}]
+
+        async def mock_warning_markets(db=None, *, quote_currency: str) -> set[str]:
+            return set()
+
+        monkeypatch.setattr(
+            screening_crypto,
+            "_import_tvscreener",
+            lambda: fake_crypto_tvscreener_module,
+        )
+        monkeypatch.setattr(
+            screening_crypto, "TvScreenerService", lambda timeout=30.0: tv_service
+        )
+        monkeypatch.setattr(
+            upbit_service, "fetch_multiple_tickers", mock_fetch_multiple_tickers
+        )
+        monkeypatch.setattr(
+            screening_crypto, "get_upbit_warning_markets", mock_warning_markets
+        )
+        monkeypatch.setattr(
+            screening_crypto._CRYPTO_MARKET_CAP_CACHE, "get", self._empty_cache_get
+        )
+        monkeypatch.setattr(
+            screening_crypto,
+            "get_upbit_market_display_names",
+            AsyncMock(
+                return_value={
+                    "KRW-ETH": {"korean_name": "이더리움", "english_name": "Ethereum"}
+                }
+            ),
+            raising=False,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="crypto",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_order="desc",
+            limit=5,
+        )
+        # The KRW-BTC fallback ticker fetch was attempted.
+        assert ["KRW-BTC"] in calls
+        # ETH survives — BTC down 15% means this is a market crash, not isolated.
+        assert len(result["results"]) == 1
+        assert result["results"][0]["symbol"] == "KRW-ETH"
+        assert result["meta"]["filtered_by_crash"] == 0
+        # No "BTC 기준 데이터가 없어" warning — the reference was recovered.
+        assert not any("BTC 기준" in w for w in result.get("warnings", []))
+
+    @pytest.mark.asyncio
+    async def test_crypto_crash_filter_btc_fallback_failure_degrades_gracefully(
+        self, fake_crypto_tvscreener_module, monkeypatch
+    ):
+        """ROB-369 B4 — when the KRW-BTC fallback fetch also fails, the screener
+        degrades to btc_change_24h=0.0 with the warning (the prior behaviour),
+        never crashing."""
+        tv_service = self._btc_absent_tv_service()
+        calls: list[list[str]] = []
+
+        async def mock_fetch_multiple_tickers(market_codes):
+            calls.append(list(market_codes))
+            if list(market_codes) == ["KRW-BTC"]:
+                raise RuntimeError("upbit ticker timeout")
+            return [{"market": "KRW-ETH", "acc_trade_volume_24h": 54_321.0}]
+
+        async def mock_warning_markets(db=None, *, quote_currency: str) -> set[str]:
+            return set()
+
+        monkeypatch.setattr(
+            screening_crypto,
+            "_import_tvscreener",
+            lambda: fake_crypto_tvscreener_module,
+        )
+        monkeypatch.setattr(
+            screening_crypto, "TvScreenerService", lambda timeout=30.0: tv_service
+        )
+        monkeypatch.setattr(
+            upbit_service, "fetch_multiple_tickers", mock_fetch_multiple_tickers
+        )
+        monkeypatch.setattr(
+            screening_crypto, "get_upbit_warning_markets", mock_warning_markets
+        )
+        monkeypatch.setattr(
+            screening_crypto._CRYPTO_MARKET_CAP_CACHE, "get", self._empty_cache_get
+        )
+        monkeypatch.setattr(
+            screening_crypto,
+            "get_upbit_market_display_names",
+            AsyncMock(return_value={}),
+            raising=False,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="crypto",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_order="desc",
+            limit=5,
+        )
+        # The fallback was attempted even though it failed.
+        assert ["KRW-BTC"] in calls
+        # Degrades to 0.0 reference → ETH 35% drop looks isolated → filtered.
+        assert result["meta"]["filtered_by_crash"] == 1
+        assert any("BTC 기준" in w for w in result.get("warnings", []))
+
     @pytest.mark.asyncio
     async def test_crypto_coingecko_span_wraps_actual_fetch(
         self, fake_crypto_tvscreener_module, monkeypatch

--- a/tests/test_screening_crypto.py
+++ b/tests/test_screening_crypto.py
@@ -146,7 +146,8 @@ class TestCryptoScreeningPhases:
         assert all(row["symbol"].startswith("KRW-") for row in payload["results"])
         warnings = payload.get("warnings", [])
         assert not any("KRW-BTC ticker not found" in warning for warning in warnings)
-        assert (
-            "BTC 기준 데이터가 없어 급락 방어 필터를 기본값으로 적용했습니다."
-            in warnings
-        )
+        # ROB-369 B4 — the BTC-default crash-filter warning is only emitted when
+        # a crash candidate (≤ -30%) is present AND the KRW-BTC reference can't be
+        # recovered. KRW-IMX here is +36% (no crash candidate), so the reference
+        # is irrelevant and no warning is raised (previously it was noise).
+        assert not any("BTC 기준 데이터가 없어" in warning for warning in warnings)


### PR DESCRIPTION
## ROB-369 B4-residual — crypto crash-filter recovers the BTC reference

Part of [ROB-369](https://linear.app/mgh3326/issue/ROB-369), built on the merged Slice 3 (#1033). Screener-only change.

### The bug
The crypto screener's "급락 방어" (crash) filter drops a coin iff `coin ≤ -30% AND btc > -10%` (isolated drop, not a market-wide panic). When **KRW-BTC is absent** from the tvscreener rows, `btc_change_24h` fell back to **`0.0`** — so a `0.0` reference makes *every* deep loser look isolated. During a market-wide crash (BTC also down hard), the screener **wrongly filters out the very coins it should surface**, and it spammed a `"BTC 기준 데이터가 없어..."` warning even when nothing was actually being crash-filtered.

### The fix
When KRW-BTC is absent, recover the reference with a direct Upbit ticker fetch (`signed_change_rate`) — but **only when it can change the outcome**: a crash candidate (some row `≤ DROP_THRESHOLD = -30%`) exists *and* we're in interactive screening (the filter is skipped for snapshot builds). This:
- bounds the cost to a **single extra Upbit call** in the rare deep-crash + BTC-absent case (zero on calm screens — aligns with the operator's latency preference);
- emits the `"BTC 기준"` warning **only** when a crash candidate exists *and* the reference still couldn't be recovered (previously noise on every BTC-absent screen);
- **degrades gracefully** to `btc_change_24h=0.0` + warning on fetch failure (the prior behaviour), never crashes.

### Scope (operator decision)
B4's `plus_di`/`minus_di` + `volume_ratio` are **intentionally not included**. The investigation showed they're **not a parity fix** — tvscreener exposes ADX but **not ±DI for any market**, and **KR/US screeners don't compute `volume_ratio` either** — so filling them for crypto is a crypto-only feature that requires adding a per-symbol OHLCV fetch to the single-call screener (latency). Deferred per operator decision.

### Safety
Read-only — public Upbit ticker fetch only; no broker/order mutation. Bounded extra call, fail-open. No migration. Import-contract guard green.

### Testing
- KRW-BTC absent + crash candidate → fallback fetch recovers BTC; a -35% ETH **survives** when BTC is down 15% (market crash, not isolated).
- Fallback failure → degrades to `0.0` + warning.
- No crash candidate → **no fetch, no warning** (the prior always-warn behaviour updated to suppress the now-irrelevant noise).
- 1289 crypto/screener tests + import-contract guard green; `ruff check` + `ruff format --check` clean.

### Adversarially reviewed
A 2-lens review (correctness + regression/perf) found **nothing actionable** — confirmed the crash-candidate gate is a sound, documented latency optimization and all three paths (recover / degrade / no-op) are correctly tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of crypto crash-filtering when market reference data is unavailable
  * Enhanced crash detection accuracy with intelligent fallback mechanisms for missing critical data
  * Better handling of edge cases to reduce false positives in market crash identification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->