### PR TITLE
fix(ROB-374): portfolio USD buying power reads general orderable, not field-1 (B2)

### DIFF
--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -227,7 +227,12 @@ class KISHomeReader:
                     )
                     if us_margin:
                         usd_balance = us_margin.get("frcr_dncl_amt1")
-                        usd_buying_power = us_margin.get("frcr_ord_psbl_amt1")
+                        # ROB-374 (B2): the orderable is the *general* order-possible
+                        # amount, the same field ``get_available_capital`` /
+                        # ``portfolio_cash`` / ``account.service`` read. The field-1
+                        # value (``frcr_ord_psbl_amt1``) can be 0 even when the account
+                        # has buying power, producing a false ``buying_power_usd=0``.
+                        usd_buying_power = us_margin.get("frcr_gnrl_ord_psbl_amt")
                 except Exception as exc:
                     logger.warning("KIS overseas margin fallback failed: %s", exc)
 

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -137,6 +137,7 @@ async def test_kis_reader_overseas_margin_fallback(
                     "crcy_cd": "USD",
                     "frcr_dncl_amt1": 50.0,
                     "frcr_ord_psbl_amt1": 40.0,
+                    "frcr_gnrl_ord_psbl_amt": 40.0,
                 }
             ]
 
@@ -188,6 +189,7 @@ async def test_kis_reader_overseas_margin_fallback_without_us_holdings(
                     "crcy_cd": "USD",
                     "frcr_dncl_amt1": 49.25,
                     "frcr_ord_psbl_amt1": 49.25,
+                    "frcr_gnrl_ord_psbl_amt": 49.25,
                 }
             ]
 
@@ -207,6 +209,71 @@ async def test_kis_reader_overseas_margin_fallback_without_us_holdings(
     account = result.accounts[0]
     assert account.cashBalances.usd == pytest.approx(49.25)
     assert account.buyingPower.usd == pytest.approx(49.25)
+    assert result.warning is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_reader_overseas_margin_uses_general_orderable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-374 (B2): USD buying power must come from ``frcr_gnrl_ord_psbl_amt``.
+
+    The live regression had ``frcr_ord_psbl_amt1 == 0`` while the real orderable
+    (``frcr_gnrl_ord_psbl_amt``) was $3,080.62 — the same value ``get_available_capital``
+    / ``portfolio_cash`` report. Reading the field-1 value produced a false
+    ``buying_power_usd=0`` and a bogus "buying_power < 5% NAV" risk flag.
+    """
+
+    class _FakeKISAccountGeneralOrderable:
+        async def fetch_my_stocks(self, *, is_overseas: bool) -> list[dict[str, Any]]:
+            return []
+
+        async def inquire_integrated_margin(self) -> dict[str, Any]:
+            # Integrated margin reports no USD orderable -> triggers overseas fallback.
+            return {
+                "stck_cash_objt_amt": "100000",
+                "stck_cash100_max_ord_psbl_amt": "50000",
+                "usd_balance": None,
+                "usd_ord_psbl_amt": None,
+            }
+
+        async def fetch_my_overseas_stocks(
+            self, *, exchange_code: str
+        ) -> list[dict[str, Any]]:
+            return [{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "1"}]
+
+        async def inquire_overseas_margin(self) -> list[dict[str, Any]]:
+            # Real KIS rows carry BOTH fields; field-1 can be 0 even when the
+            # general orderable is non-zero.
+            return [
+                {
+                    "natn_name": "미국",
+                    "crcy_cd": "USD",
+                    "frcr_dncl_amt1": 3_080.0,
+                    "frcr_ord_psbl_amt1": 0.0,
+                    "frcr_gnrl_ord_psbl_amt": 3_080.62,
+                }
+            ]
+
+    class _FakeKISClient:
+        def __init__(self) -> None:
+            self.account = _FakeKISAccountGeneralOrderable()
+
+    monkeypatch.setattr(readers, "SafeKISClient", _FakeKISClient)
+
+    async def _fx() -> float:
+        return 1_300.0
+
+    monkeypatch.setattr(readers, "get_usd_krw_rate", _fx)
+
+    result = await readers.KISHomeReader(db=None).fetch(user_id=1)  # type: ignore[arg-type]
+
+    account = result.accounts[0]
+    # Orderable must be the general orderable ($3,080.62), not the zero field-1 value.
+    assert account.buyingPower.usd == pytest.approx(3_080.62)
+    assert account.cashBalances.usd == pytest.approx(3_080.0)
+    # A non-zero orderable means no "USD unavailable" warning.
     assert result.warning is None
 
 


### PR DESCRIPTION
## ROB-374 B2 (🔴 regression)

Post-deploy verification of bundle `e45544ae-…` showed the portfolio stage reporting
`NAV(USD)=30,639, buying_power_usd=0 (0.0%)` with a **false** `risk_evidence:["buying_power < 5% NAV"]`,
while at the same instant `get_available_capital(kis_live).kis_overseas.orderable=$3,080.62`.

### Root cause
`KISHomeReader`'s overseas-margin fallback (`app/services/invest_home_readers.py:230`) read
`frcr_ord_psbl_amt1` — the *field-1* orderable, which is `0` in this account state — instead of
`frcr_gnrl_ord_psbl_amt`, the canonical orderable that **three** other code paths already use:
- `app/mcp_server/tooling/portfolio_cash.py:95` (`get_available_capital`)
- `app/services/account/service.py:118`
- `app/services/brokers/kis/account.py` (debug logging prints both, confirming they can diverge)

USD cash (`frcr_dncl_amt1`) was already read correctly — that is why NAV included the ~$3,080 cash
while orderable wrongly came out `0`. The reader emitted `0.0` (not `None`), so the stage treated it
as a real value, computed `0.0% < 5%`, and raised the bogus risk flag.

### Fix
One-line field correction (`frcr_ord_psbl_amt1` → `frcr_gnrl_ord_psbl_amt`) aligning the home reader
with `get_available_capital`. After the fix the reader emits `$3,080.62` → stage shows `≈10%` → no flag.

### Tests
- New `test_kis_reader_overseas_margin_uses_general_orderable` reproduces the live shape
  (`frcr_ord_psbl_amt1=0`, `frcr_gnrl_ord_psbl_amt=3080.62`) and asserts `buyingPower.usd==3080.62`,
  no warning. Verified RED (`0.0`) before the fix.
- Corrected two existing fallback fixtures that omitted `frcr_gnrl_ord_psbl_amt` (real KIS rows carry
  both; cash accounts report them equal, which had masked the bug).
- Green: `test_invest_home_readers.py` (28), `test_collectors.py` (64), portfolio_journal stage (8),
  adjacent KIS-field suites (91). ruff check / format / ty all pass.

### Scope note
The same field-1 pattern exists in `us/account_snapshot.py:138` (ROB-326 dual-paper) and
`us_dual_paper/kis_mock.py:87`, but those are **separate features with their own live evidence**
(ROB-326 was live-smoke verified) and are intentionally left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)