### PR TITLE
fix(ROB-374): derive market_session from bundle as_of when no stage run records one (B6)

### DIFF
--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -50,6 +50,7 @@ from app.services.investment_dimensions.sentiment_evidence import (
 from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
+from app.services.investment_stages.market_session import derive_market_session
 from app.services.investment_stages.stages.base import (
     Stage,
     StageContext,
@@ -275,11 +276,16 @@ class HermesContextExporter:
             snapshot_bundle_uuid=bundle.bundle_uuid,
             bundle_status=bundle.status,
             market=bundle.market,
-            # ROB-366 B6 — the bundle has no session column; the persisted
-            # market_session lives on the stage run. Derive it from the latest
-            # run already loaded above (None when no run / none recorded — never
-            # computed from a clock, to avoid inventing a session).
-            market_session=run.market_session if run is not None else None,
+            # ROB-366 B6 / ROB-374 B6 — an operator/Hermes-recorded session on
+            # the latest stage run wins; otherwise derive it from the bundle's
+            # own ``as_of`` (a real captured market moment, not a wall-clock
+            # guess) so ``intraday_action_report_v1`` always carries a session
+            # when one is determinable. Unknown/closed instants stay ``None``.
+            market_session=(
+                run.market_session
+                if run is not None and run.market_session is not None
+                else derive_market_session(bundle.market, bundle.as_of)
+            ),
             account_scope=bundle.account_scope,
             policy_version=bundle.policy_version,
             coverage_summary=dict(bundle.coverage_summary or {}),

--- a/app/services/investment_stages/market_session.py
+++ b/app/services/investment_stages/market_session.py
@@ -1,0 +1,82 @@
+"""Deterministic intraday market-session derivation (ROB-374 B6).
+
+Maps a ``(market, instant)`` pair to the persisted ``MarketSessionLiteral``
+vocabulary (``regular`` / ``pre`` / ``post`` / ``24x7``). The instant is the
+bundle's recorded ``as_of`` — a real, captured market moment — so this is *not*
+a wall-clock guess: ROB-366 B6 deliberately refused to invent a session from
+``datetime.now()``, and that still holds. Deriving from the bundle's own as-of
+time is the missing piece ROB-374 needs for ``intraday_action_report_v1``.
+
+Trading-day classification (weekend / holiday / early-close half-day) comes from
+the fail-closed XNYS / XKRX calendar in
+:mod:`app.services.market_events.session_calendar`. Any instant that cannot be
+positively classified — unknown market, missing timestamp, outside the
+extended-hours envelope, or a non-session day — returns ``None`` rather than a
+fabricated session.
+
+Scope: US (XNYS) is classified across pre / regular / post; KR (XKRX) only
+``regular`` (extended NXT windows are intentionally not fabricated here); crypto
+is always ``24x7``. Anything else is ``None``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
+
+from app.schemas.investment_reports import MarketSessionLiteral
+from app.services.market_events.session_calendar import regular_session_bounds
+
+_UTC = ZoneInfo("UTC")
+_EXCHANGE_TZ: dict[str, ZoneInfo] = {
+    "us": ZoneInfo("America/New_York"),
+    "kr": ZoneInfo("Asia/Seoul"),
+}
+
+# US extended-hours envelope (exchange-local). Regular bounds come from the
+# calendar (so half-day early closes are honored); these frame pre / post.
+_US_PRE_OPEN = time(4, 0)
+_US_POST_CLOSE = time(20, 0)
+
+
+def derive_market_session(
+    market: str, at: datetime | None
+) -> MarketSessionLiteral | None:
+    """Classify ``at`` into the report market-session vocabulary, or ``None``.
+
+    ``at`` is treated as UTC when naive. Returns ``None`` for an unknown market,
+    a missing timestamp, a non-trading day, or an instant outside the supported
+    session windows (fail-closed).
+    """
+    normalized = (market or "").strip().lower()
+    if normalized == "crypto":
+        return "24x7"
+    tz = _EXCHANGE_TZ.get(normalized)
+    if at is None or tz is None:
+        return None
+
+    at_utc = at if at.tzinfo is not None else at.replace(tzinfo=_UTC)
+    local = at_utc.astimezone(tz)
+
+    bounds = regular_session_bounds(normalized, local.date())  # type: ignore[arg-type]
+    if bounds is None:
+        return None  # weekend / holiday / out of range
+    open_utc, close_utc = bounds
+    if open_utc <= at_utc < close_utc:
+        return "regular"
+
+    if normalized == "us":
+        pre_open = local.replace(
+            hour=_US_PRE_OPEN.hour, minute=0, second=0, microsecond=0
+        )
+        post_close = local.replace(
+            hour=_US_POST_CLOSE.hour, minute=0, second=0, microsecond=0
+        )
+        open_local = open_utc.astimezone(tz)
+        close_local = close_utc.astimezone(tz)
+        if pre_open <= local < open_local:
+            return "pre"
+        if close_local <= local < post_close:
+            return "post"
+
+    return None

--- a/app/services/market_events/session_calendar.py
+++ b/app/services/market_events/session_calendar.py
@@ -15,7 +15,7 @@ labeling must never leak across a session it could not confirm is open.
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Literal
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,41 @@ def is_trading_session(market: Market, day: date) -> bool:
             exc_info=True,
         )
         return False
+
+
+def regular_session_bounds(
+    market: Market, day: date
+) -> tuple[datetime, datetime] | None:
+    """UTC ``(open, close)`` of the regular session on ``day``.
+
+    Returns ``None`` when ``day`` is not a confirmed trading session (weekend /
+    holiday / out of the calendar's range) or any calendar/library error occurs
+    (fail-closed, same contract as :func:`is_trading_session`). Early-close
+    half-days are honored — the bounds come straight from the library, which
+    models them (e.g. the day after US Thanksgiving closes at 13:00 ET).
+    """
+    import pandas as pd
+
+    try:
+        cal = _calendar(market)
+        session = pd.Timestamp(day)
+        if not cal.is_session(session):
+            return None
+        open_ts = cal.session_open(session)
+        close_ts = cal.session_close(session)
+    except (ValueError, KeyError):
+        return None
+    except Exception:  # noqa: BLE001 - fail-closed on any calendar/library error
+        logger.warning(
+            "session_calendar: unexpected error reading session bounds for %s %s; "
+            "treating as no session (fail-closed)",
+            market,
+            day,
+            exc_info=True,
+        )
+        return None
+    # ``session_open``/``session_close`` return tz-aware UTC pandas Timestamps.
+    return open_ts.to_pydatetime(), close_ts.to_pydatetime()
 
 
 def next_trading_session(market: Market, day: date) -> date | None:

--- a/tests/services/investment_stages/test_hermes_context.py
+++ b/tests/services/investment_stages/test_hermes_context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -71,6 +72,7 @@ def _make_bundle(*, status: str = "complete") -> SimpleNamespace:
         market="crypto",
         account_scope="upbit_live",
         policy_version="intraday_action_report_v1",
+        as_of=dt.datetime(2026, 5, 29, 19, 39, tzinfo=dt.UTC),
         coverage_summary={"news": {"status": "fresh"}},
         freshness_summary={"overall": "fresh"},
         status=status,

--- a/tests/services/investment_stages/test_hermes_context_market_session.py
+++ b/tests/services/investment_stages/test_hermes_context_market_session.py
@@ -1,9 +1,11 @@
-"""ROB-366 B6 — Hermes context market_session derivation.
+"""ROB-366 B6 / ROB-374 B6 — Hermes context market_session.
 
-The exporter used to hardcode ``market_session=None``; it now derives it from
-the latest InvestmentStageRun for the bundle (the run is where StageRunner
-persists the session). DB-backed because the exporter skips run-loading under a
-mock session.
+An operator/Hermes-recorded session on the latest InvestmentStageRun wins.
+When no run records one, the exporter now derives the session from the bundle's
+own ``as_of`` (ROB-374) instead of leaving it ``None`` — so an
+``intraday_action_report_v1`` carries a session whenever the as-of instant is a
+determinable trading-session moment. Closed/unknown instants stay ``None``.
+DB-backed because the exporter skips run-loading under a mock session.
 """
 
 import datetime as dt
@@ -15,15 +17,20 @@ from app.models.investment_snapshots import InvestmentSnapshotBundle
 from app.models.investment_stages import InvestmentStageRun
 from app.services.investment_stages.hermes_context import HermesContextExporter
 
+# 2026-05-29 19:39 UTC == ET Fri 15:39 -> regular session (the live ROB-374 bundle).
+_REGULAR_AS_OF = dt.datetime(2026, 5, 29, 19, 39, tzinfo=dt.UTC)
+# 2026-05-30 (Sat) -> not a trading session -> derivation yields None.
+_CLOSED_AS_OF = dt.datetime(2026, 5, 30, 17, 0, tzinfo=dt.UTC)
 
-def _bundle() -> InvestmentSnapshotBundle:
+
+def _bundle(*, as_of: dt.datetime = _CLOSED_AS_OF) -> InvestmentSnapshotBundle:
     return InvestmentSnapshotBundle(
         bundle_uuid=uuid.uuid4(),
         purpose="report_generation",
         market="us",
         account_scope="kis_live",
         policy_version="intraday_action_report_v1",
-        as_of=dt.datetime.now(tz=dt.UTC),
+        as_of=as_of,
         status="complete",
         coverage_summary={},
         freshness_summary={},
@@ -51,8 +58,10 @@ def _run(
 
 
 @pytest.mark.asyncio
-async def test_market_session_derived_from_latest_run(db_session) -> None:
-    bundle = _bundle()
+async def test_recorded_run_session_wins_over_derivation(db_session) -> None:
+    # Run records "regular" while the bundle as_of is a closed (weekend) instant:
+    # the explicit run value must win, proving recorded > derived precedence.
+    bundle = _bundle(as_of=_CLOSED_AS_OF)
     db_session.add(bundle)
     await db_session.commit()
     db_session.add(_run(bundle.bundle_uuid, market_session="regular"))
@@ -65,8 +74,20 @@ async def test_market_session_derived_from_latest_run(db_session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_market_session_none_when_no_run(db_session) -> None:
-    bundle = _bundle()
+async def test_session_derived_from_bundle_as_of_when_no_run(db_session) -> None:
+    bundle = _bundle(as_of=_REGULAR_AS_OF)
+    db_session.add(bundle)
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session == "regular"
+
+
+@pytest.mark.asyncio
+async def test_session_none_when_no_run_and_as_of_closed(db_session) -> None:
+    bundle = _bundle(as_of=_CLOSED_AS_OF)
     db_session.add(bundle)
     await db_session.commit()
 
@@ -77,9 +98,25 @@ async def test_market_session_none_when_no_run(db_session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_market_session_uses_latest_run_when_multiple(db_session) -> None:
+async def test_session_derived_when_run_recorded_none(db_session) -> None:
+    # A run that recorded None means "not captured", not "no session": the
+    # exporter falls through to deriving from the bundle as_of.
+    bundle = _bundle(as_of=_REGULAR_AS_OF)
+    db_session.add(bundle)
+    await db_session.commit()
+    db_session.add(_run(bundle.bundle_uuid, market_session=None))
+    await db_session.commit()
+
+    payload = await HermesContextExporter(db_session, stages=[]).export(
+        snapshot_bundle_uuid=bundle.bundle_uuid
+    )
+    assert payload.market_session == "regular"
+
+
+@pytest.mark.asyncio
+async def test_session_uses_latest_run_when_multiple(db_session) -> None:
     # Bundle re-run across sessions: the most recent run (by started_at) wins.
-    bundle = _bundle()
+    bundle = _bundle(as_of=_CLOSED_AS_OF)
     db_session.add(bundle)
     await db_session.commit()
     now = dt.datetime.now(tz=dt.UTC)
@@ -97,17 +134,3 @@ async def test_market_session_uses_latest_run_when_multiple(db_session) -> None:
         snapshot_bundle_uuid=bundle.bundle_uuid
     )
     assert payload.market_session == "regular"
-
-
-@pytest.mark.asyncio
-async def test_market_session_none_when_run_recorded_none(db_session) -> None:
-    bundle = _bundle()
-    db_session.add(bundle)
-    await db_session.commit()
-    db_session.add(_run(bundle.bundle_uuid, market_session=None))
-    await db_session.commit()
-
-    payload = await HermesContextExporter(db_session, stages=[]).export(
-        snapshot_bundle_uuid=bundle.bundle_uuid
-    )
-    assert payload.market_session is None

--- a/tests/services/investment_stages/test_market_session.py
+++ b/tests/services/investment_stages/test_market_session.py
@@ -1,0 +1,95 @@
+"""ROB-374 B6 — deterministic intraday market-session derivation."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.investment_stages.market_session import derive_market_session
+
+UTC = dt.UTC
+
+
+def _utc(y, mo, d, h, mi=0) -> dt.datetime:
+    return dt.datetime(y, mo, d, h, mi, tzinfo=UTC)
+
+
+@pytest.mark.unit
+class TestDeriveMarketSession:
+    # The ROB-374 live bundle: as_of 2026-05-29 19:39 UTC (ET Fri 15:39) -> regular.
+    def test_us_regular_live_bundle_instant(self) -> None:
+        assert derive_market_session("us", _utc(2026, 5, 29, 19, 39)) == "regular"
+
+    def test_us_regular_at_open_boundary_inclusive(self) -> None:
+        # 13:30 UTC == 09:30 ET open (inclusive).
+        assert derive_market_session("us", _utc(2026, 5, 29, 13, 30)) == "regular"
+
+    def test_us_pre_market(self) -> None:
+        # 12:00 UTC == 08:00 ET, within [04:00, 09:30) ET.
+        assert derive_market_session("us", _utc(2026, 5, 29, 12, 0)) == "pre"
+
+    def test_us_pre_at_early_boundary(self) -> None:
+        # 08:00 UTC == 04:00 ET pre-open (inclusive).
+        assert derive_market_session("us", _utc(2026, 5, 29, 8, 0)) == "pre"
+
+    def test_us_post_market_at_close_boundary(self) -> None:
+        # 20:00 UTC == 16:00 ET regular close -> post begins (exclusive regular end).
+        assert derive_market_session("us", _utc(2026, 5, 29, 20, 0)) == "post"
+
+    def test_us_post_market_late(self) -> None:
+        # 23:59 UTC == 19:59 ET, within [16:00, 20:00) ET.
+        assert derive_market_session("us", _utc(2026, 5, 29, 23, 59)) == "post"
+
+    def test_us_closed_overnight(self) -> None:
+        # 04:00 UTC == 00:00 ET, before the 04:00 ET pre-open -> closed.
+        assert derive_market_session("us", _utc(2026, 5, 29, 4, 0)) is None
+
+    def test_us_closed_after_post(self) -> None:
+        # 2026-05-30 00:00 UTC == 2026-05-29 20:00 ET, the exclusive post end -> closed.
+        assert derive_market_session("us", _utc(2026, 5, 30, 0, 0)) is None
+
+    def test_us_weekend_is_none(self) -> None:
+        assert derive_market_session("us", _utc(2026, 5, 30, 17, 0)) is None
+
+    def test_us_holiday_is_none(self) -> None:
+        # 2026-05-25 is Memorial Day (XNYS closed).
+        assert derive_market_session("us", _utc(2026, 5, 25, 17, 0)) is None
+
+    def test_us_half_day_early_close_is_post_not_regular(self) -> None:
+        # 2025-11-28 (day after Thanksgiving) closes early at 13:00 ET (18:00 UTC).
+        # 18:30 UTC == 13:30 ET must be post, NOT regular — proves half-days honored.
+        assert derive_market_session("us", _utc(2025, 11, 28, 18, 30)) == "post"
+        # 15:00 UTC == 10:00 ET is still regular on the half-day.
+        assert derive_market_session("us", _utc(2025, 11, 28, 15, 0)) == "regular"
+
+    def test_kr_regular(self) -> None:
+        # 02:00 UTC == 11:00 KST, within KST 09:00-15:30.
+        assert derive_market_session("kr", _utc(2026, 5, 29, 2, 0)) == "regular"
+
+    def test_kr_outside_regular_is_none_not_fabricated(self) -> None:
+        # 08:00 UTC == 17:00 KST (after 15:30 close). KR extended/NXT is not
+        # fabricated here -> None.
+        assert derive_market_session("kr", _utc(2026, 5, 29, 8, 0)) is None
+
+    def test_kr_weekend_is_none(self) -> None:
+        assert derive_market_session("kr", _utc(2026, 5, 30, 2, 0)) is None
+
+    def test_crypto_is_always_24x7(self) -> None:
+        assert derive_market_session("crypto", _utc(2026, 5, 30, 3, 0)) == "24x7"
+
+    def test_crypto_24x7_even_without_timestamp(self) -> None:
+        assert derive_market_session("crypto", None) == "24x7"
+
+    def test_none_timestamp_is_none(self) -> None:
+        assert derive_market_session("us", None) is None
+
+    def test_unknown_market_is_none(self) -> None:
+        assert derive_market_session("jp", _utc(2026, 5, 29, 19, 39)) is None
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        naive = dt.datetime(2026, 5, 29, 19, 39)
+        assert derive_market_session("us", naive) == "regular"
+
+    def test_market_case_and_whitespace_insensitive(self) -> None:
+        assert derive_market_session("  US ", _utc(2026, 5, 29, 19, 39)) == "regular"

--- a/tests/services/market_events/test_session_calendar.py
+++ b/tests/services/market_events/test_session_calendar.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
 
 import pytest
 
@@ -10,6 +10,7 @@ from app.services.market_events.session_calendar import (
     is_trading_session,
     next_trading_session,
     previous_trading_session,
+    regular_session_bounds,
     trading_sessions_in_range,
 )
 
@@ -82,6 +83,57 @@ def test_trading_sessions_in_range_out_of_bounds_is_empty():
 @pytest.mark.unit
 def test_trading_sessions_in_range_reversed_is_empty():
     assert trading_sessions_in_range("us", date(2025, 7, 8), date(2025, 7, 1)) == []
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_us_returns_utc_open_close():
+    bounds = regular_session_bounds("us", date(2026, 5, 29))
+    assert bounds is not None
+    open_utc, close_utc = bounds
+    # XNYS regular 09:30-16:00 ET == 13:30-20:00 UTC on this date.
+    assert open_utc == datetime(2026, 5, 29, 13, 30, tzinfo=UTC)
+    assert close_utc == datetime(2026, 5, 29, 20, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_honors_half_day_early_close():
+    # Day after US Thanksgiving closes early at 13:00 ET == 18:00 UTC.
+    bounds = regular_session_bounds("us", date(2025, 11, 28))
+    assert bounds is not None
+    _, close_utc = bounds
+    assert close_utc == datetime(2025, 11, 28, 18, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_kr():
+    bounds = regular_session_bounds("kr", date(2026, 5, 29))
+    assert bounds is not None
+    open_utc, close_utc = bounds
+    # XKRX 09:00-15:30 KST == 00:00-06:30 UTC.
+    assert open_utc == datetime(2026, 5, 29, 0, 0, tzinfo=UTC)
+    assert close_utc == datetime(2026, 5, 29, 6, 30, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_weekend_and_holiday_are_none():
+    assert regular_session_bounds("us", date(2026, 5, 30)) is None  # Saturday
+    assert regular_session_bounds("us", date(2026, 5, 25)) is None  # Memorial Day
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_out_of_range_fails_closed():
+    assert regular_session_bounds("us", date(2100, 1, 4)) is None
+
+
+@pytest.mark.unit
+def test_regular_session_bounds_unexpected_error_fails_closed(monkeypatch):
+    import app.services.market_events.session_calendar as sc
+
+    def _boom(_market):
+        raise RuntimeError("calendar load blew up")
+
+    monkeypatch.setattr(sc, "_calendar", _boom)
+    assert sc.regular_session_bounds("us", date(2026, 5, 29)) is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## ROB-374 B6

The `get_hermes_context` payload for bundle `e45544ae-…` (`intraday_action_report_v1`)
returned `market_session=null`. ROB-366 B6 read the session *only* from the latest stage run and
deliberately refused to compute it from a wall clock — but on a first-pull context (no run yet) that
left the session perpetually null, which is exactly the intraday gap ROB-374 reports.

### Fix
When no run records a session, derive it from the bundle's own `as_of` — a **real captured market
moment**, not `datetime.now()`, so this is not the "invented session" ROB-366 rejected. Precedence:
1. operator/Hermes-recorded `run.market_session` (non-None) wins;
2. otherwise derive from `bundle.as_of`;
3. a run that recorded `None` ("not captured") falls through to derivation.

### New helpers
- `derive_market_session(market, at)` (`app/services/investment_stages/market_session.py`) → persisted
  `MarketSessionLiteral`: US (XNYS) across **pre / regular / post**, KR (XKRX) **regular** only
  (extended NXT windows are not fabricated), crypto always **24x7**, everything else **None**
  (fail-closed on unknown market / missing timestamp / non-session day).
- `regular_session_bounds(market, day)` on the ROB-371 `session_calendar` returns the UTC open/close,
  **honoring early-close half-days** (e.g. day after US Thanksgiving closes 13:00 ET) — so a 13:30 ET
  instant that day classifies as `post`, not `regular`.

### Verification
- The live bundle `as_of` 2026-05-29 19:39 UTC (ET Fri 15:39) → `market_session="regular"`.
- 20 pure unit tests for `derive_market_session` (boundaries, weekend/holiday, half-day, KR, crypto,
  naive-as-UTC); 6 for `regular_session_bounds`; exporter DB tests updated to cover recorded-wins,
  derive-when-no-run, derive-when-run-None, and closed→None. Full `investment_stages` suite green (119);
  hermes http/mcp/roundtrip suites green. ruff check / format / ty pass.

### Scope note
Single-point fix at the context export (where the null surfaced). KR extended/NXT sessions are
intentionally **not** fabricated (returns None) since the codebase has no authoritative KR extended
window; the issue is US-centric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)