### PR TITLE
fix(ROB-374): news dimension reads the bundle's article snapshot, matching the stage (B3)

### DIFF
--- a/app/services/investment_dimensions/news_evidence.py
+++ b/app/services/investment_dimensions/news_evidence.py
@@ -1,9 +1,16 @@
 """Deterministic News dimension evidence bundle (ROB-310).
 
-Assembles recent research-report citations into a market-wide News evidence
-bundle, mirroring ``market_evidence``. No prose, no LLM — raw material for the
-Hermes News dimension report. ``research_reports`` is empty until ingestion is
-enabled (operator gate); this degrades gracefully to zero citations.
+Assembles a market-wide News evidence bundle, mirroring ``market_evidence``. No
+prose, no LLM — raw material for the Hermes News dimension report.
+
+Source preference (ROB-374 B3): when the snapshot bundle carries a news-article
+snapshot — the *same* articles ``NewsStage`` summarizes for ``stage_inputs`` —
+the evidence is built from it so ``dimension_evidence.news`` and
+``stage_inputs.news`` can no longer disagree (the live bug: stage "20 articles"
+vs dimension count 0). Only when no article snapshot is present does this fall
+back to the ``research_reports`` query (older citation-path bundles / no news
+kind). ``research_reports`` is empty until ingestion is enabled (operator gate),
+so the fallback degrades gracefully to zero citations.
 """
 
 from __future__ import annotations
@@ -20,10 +27,24 @@ async def build_news_evidence(
     query_service: ResearchReportsQueryService,
     *,
     market: str,
+    snapshot_payload: dict[str, Any] | None = None,
     lookback_hours: int = 24,
     now: dt.datetime | None = None,
 ) -> dict[str, Any]:
     now_dt = now or dt.datetime.now(tz=dt.UTC)
+
+    # ROB-374 B3 — prefer the bundle's own news-article snapshot. A present-but-
+    # empty ``articles`` list is authoritative ("queried, nothing in window") and
+    # must NOT silently fall back to the research_reports query — otherwise the
+    # dimension would again diverge from the stage.
+    if snapshot_payload is not None and snapshot_payload.get("articles") is not None:
+        return _evidence_from_articles(
+            market,
+            snapshot_payload.get("articles") or [],
+            now_dt=now_dt,
+            lookback_hours=lookback_hours,
+        )
+
     # ROB-366 B8 — scope to the bundle market via the per-candidate market tag so
     # KR research does not bleed into a US bundle. No ``since`` so freshness
     # (fresh vs stale) is meaningful rather than always-fresh.
@@ -47,6 +68,96 @@ async def build_news_evidence(
         ):
             latest_published = c.published_at
 
+    return _build_result(
+        market,
+        citations,
+        latest_published,
+        now_dt=now_dt,
+        lookback_hours=lookback_hours,
+        source="research_reports",
+    )
+
+
+def _evidence_from_articles(
+    market: str,
+    articles: list[Any],
+    *,
+    now_dt: dt.datetime,
+    lookback_hours: int,
+) -> dict[str, Any]:
+    """Build the evidence bundle from the news snapshot's ``articles`` payload.
+
+    Mirrors the ``research_reports`` citation schema so Hermes sees one shape
+    regardless of source; ``analyst`` is ``None`` (articles have no analyst).
+    """
+    citations: list[dict[str, Any]] = []
+    latest_published: dt.datetime | None = None
+    for article in articles:
+        if not isinstance(article, dict):
+            continue
+        published_at = _parse_published_at(article.get("published_at"))
+        source = article.get("source") or article.get("feed_source")
+        symbol_candidates: list[dict[str, Any]] = []
+        symbol = article.get("stock_symbol")
+        if symbol:
+            candidate: dict[str, Any] = {
+                "symbol": str(symbol),
+                "market": market,
+                "source": source,
+            }
+            name = article.get("stock_name")
+            if name:
+                candidate["name"] = name
+            symbol_candidates.append(candidate)
+        citations.append(
+            {
+                "title": article.get("title"),
+                "source": source,
+                "analyst": None,
+                "published_at": (
+                    published_at.isoformat() if published_at is not None else None
+                ),
+                "excerpt": article.get("summary"),
+                "symbol_candidates": symbol_candidates,
+            }
+        )
+        if published_at is not None and (
+            latest_published is None or published_at > latest_published
+        ):
+            latest_published = published_at
+
+    return _build_result(
+        market,
+        citations,
+        latest_published,
+        now_dt=now_dt,
+        lookback_hours=lookback_hours,
+        source="news_articles",
+    )
+
+
+def _parse_published_at(value: Any) -> dt.datetime | None:
+    """Coerce an ISO string / datetime to a tz-aware UTC datetime, or ``None``."""
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=dt.UTC)
+    if isinstance(value, str):
+        try:
+            parsed = dt.datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=dt.UTC)
+    return None
+
+
+def _build_result(
+    market: str,
+    citations: list[dict[str, Any]],
+    latest_published: dt.datetime | None,
+    *,
+    now_dt: dt.datetime,
+    lookback_hours: int,
+    source: str,
+) -> dict[str, Any]:
     if not citations:
         status = "unavailable"
     elif latest_published is not None and latest_published >= now_dt - dt.timedelta(
@@ -66,5 +177,5 @@ async def build_news_evidence(
             if latest_published
             else None,
         },
-        "data_health": {"available_count": len(citations)},
+        "data_health": {"available_count": len(citations), "source": source},
     }

--- a/app/services/investment_stages/hermes_context.py
+++ b/app/services/investment_stages/hermes_context.py
@@ -158,8 +158,25 @@ class HermesContextExporter:
                 dimension_evidence["market"] = {"unavailable": str(exc)}
 
             try:
+                # ROB-374 B3 — feed the dimension the SAME news-article snapshot
+                # NewsStage reads so stage_inputs.news and dimension_evidence.news
+                # agree. A present (even empty) ``articles`` payload is
+                # authoritative; absent it, build_news_evidence falls back to the
+                # research_reports query.
+                news_articles: list[Any] = []
+                has_news_article_snapshot = False
+                for snap in snapshots_by_kind.get("news", []):
+                    snap_payload = snap.payload_json or {}
+                    if "articles" in snap_payload:
+                        has_news_article_snapshot = True
+                        news_articles.extend(snap_payload.get("articles") or [])
+                news_snapshot_payload = (
+                    {"articles": news_articles} if has_news_article_snapshot else None
+                )
                 news_evidence = await build_news_evidence(
-                    ResearchReportsQueryService(self._session), market=bundle.market
+                    ResearchReportsQueryService(self._session),
+                    market=bundle.market,
+                    snapshot_payload=news_snapshot_payload,
                 )
                 dimension_evidence["news"] = news_evidence
             except Exception as exc:  # noqa: BLE001 — best-effort, like market

--- a/tests/services/investment_dimensions/test_news_evidence.py
+++ b/tests/services/investment_dimensions/test_news_evidence.py
@@ -123,3 +123,145 @@ async def test_build_news_evidence_empty_is_unavailable(db_session):
     assert bundle["count"] == 0
     assert bundle["citations"] == []
     assert bundle["freshness"]["status"] == "unavailable"
+
+
+# --- ROB-374 B3: snapshot-article-preferred source --------------------------
+
+
+def _article(title, *, symbol=None, name=None, published_at=None, summary="snippet"):
+    return {
+        "title": title,
+        "url": f"https://news.example/{title}",
+        "source": "finnhub",
+        "feed_source": "rss_finnhub",
+        "summary": summary,
+        "stock_symbol": symbol,
+        "stock_name": name,
+        "published_at": published_at.isoformat() if published_at else None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_prefers_snapshot_articles_over_db(db_session):
+    # The live ROB-374 mismatch: stage reads N article snapshots while the
+    # dimension queried an empty research_reports table and reported 0. With a
+    # news snapshot present the dimension must reflect it — even if the DB also
+    # has rows, the snapshot wins (so it can never disagree with the stage).
+    await _clear(db_session)
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    db_session.add(
+        _report("db1", published_at=now, title="DB-only report", symbols=["IBM"])
+    )
+    await db_session.commit()
+
+    snapshot_payload = {
+        "articles": [
+            _article("Apple climbs", published_at=now - dt.timedelta(hours=1)),
+            _article("Nvidia rallies", published_at=now - dt.timedelta(hours=3)),
+        ]
+    }
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session),
+        market="us",
+        snapshot_payload=snapshot_payload,
+        now=now,
+    )
+    assert bundle["count"] == 2
+    assert {c["title"] for c in bundle["citations"]} == {
+        "Apple climbs",
+        "Nvidia rallies",
+    }
+    assert all(c["title"] != "DB-only report" for c in bundle["citations"])
+    assert bundle["data_health"]["source"] == "news_articles"
+    assert bundle["freshness"]["status"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_empty_snapshot_is_authoritative_no_db_bleed(
+    db_session,
+):
+    # A present-but-empty article snapshot ("queried, nothing in window") must
+    # NOT fall back to research_reports — that would re-introduce the divergence.
+    await _clear(db_session)
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    db_session.add(
+        _report("db1", published_at=now, title="Recent DB report", symbols=["IBM"])
+    )
+    await db_session.commit()
+
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session),
+        market="us",
+        snapshot_payload={"articles": []},
+        now=now,
+    )
+    assert bundle["count"] == 0
+    assert bundle["freshness"]["status"] == "unavailable"
+    assert bundle["data_health"]["source"] == "news_articles"
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_snapshot_articles_stale_when_old(db_session):
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    snapshot_payload = {
+        "articles": [_article("Old news", published_at=now - dt.timedelta(days=5))]
+    }
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session),
+        market="us",
+        snapshot_payload=snapshot_payload,
+        lookback_hours=24,
+        now=now,
+    )
+    assert bundle["count"] == 1
+    assert bundle["freshness"]["status"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_snapshot_maps_symbol_and_excerpt(db_session):
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    snapshot_payload = {
+        "articles": [
+            _article(
+                "Apple earnings",
+                symbol="AAPL",
+                name="Apple Inc.",
+                summary="Apple beat estimates.",
+                published_at=now - dt.timedelta(hours=1),
+            )
+        ]
+    }
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session),
+        market="us",
+        snapshot_payload=snapshot_payload,
+        now=now,
+    )
+    citation = bundle["citations"][0]
+    assert citation["excerpt"] == "Apple beat estimates."
+    assert citation["analyst"] is None
+    assert citation["symbol_candidates"][0]["symbol"] == "AAPL"
+    assert citation["symbol_candidates"][0]["market"] == "us"
+    assert citation["symbol_candidates"][0]["name"] == "Apple Inc."
+
+
+@pytest.mark.asyncio
+async def test_build_news_evidence_falls_back_to_db_when_no_snapshot(db_session):
+    # No article snapshot -> the research_reports query path is used (back-compat).
+    await _clear(db_session)
+    now = dt.datetime(2026, 5, 24, 12, 0, tzinfo=dt.UTC)
+    db_session.add(
+        _report(
+            "k1",
+            published_at=now - dt.timedelta(hours=2),
+            title="삼성전자 목표가 상향",
+            symbols=["005930"],
+        )
+    )
+    await db_session.commit()
+    bundle = await build_news_evidence(
+        ResearchReportsQueryService(db_session), market="kr", now=now
+    )
+    assert bundle["count"] == 1
+    assert bundle["citations"][0]["title"] == "삼성전자 목표가 상향"
+    assert bundle["data_health"]["source"] == "research_reports"

--- a/tests/services/investment_stages/test_hermes_context_news_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_news_dimension.py
@@ -6,6 +6,15 @@ import pytest
 from app.models.investment_snapshots import InvestmentSnapshotBundle
 from app.models.investment_stages import InvestmentStageRun
 from app.models.research_reports import ResearchReport
+from app.schemas.investment_snapshots import (
+    BundleCreate,
+    BundleItemCreate,
+    SnapshotCreate,
+    SnapshotRunCreate,
+)
+from app.services.investment_snapshots.repository import (
+    InvestmentSnapshotsRepository,
+)
 from app.services.investment_stages.hermes_context import HermesContextExporter
 
 
@@ -89,3 +98,95 @@ async def test_exporter_attaches_news_evidence_bundle(db_session) -> None:
     assert news_ev["citations"][0]["title"] == "삼성전자 실적 전망"
     assert news_ev["citations"][0]["symbol_candidates"][0]["symbol"] == "005930"
     assert news_ev["freshness"]["status"] == "fresh"
+    # No news-article snapshot present -> research_reports fallback path.
+    assert news_ev["data_health"]["source"] == "research_reports"
+
+
+@pytest.mark.asyncio
+async def test_news_dimension_reads_article_snapshot_not_db(db_session) -> None:
+    """ROB-374 B3 — when the bundle has a news-article snapshot, the dimension is
+    built from it (matching stage_inputs.news), not from research_reports.
+
+    A research report is also seeded to prove the snapshot wins over the DB.
+    """
+    await _clear(db_session)
+    now = dt.datetime.now(tz=dt.UTC)
+    db_session.add(
+        _report("db1", published_at=now, title="DB-only report", symbols=["IBM"])
+    )
+    await db_session.commit()
+
+    repo = InvestmentSnapshotsRepository(db_session)
+    run = await repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            requested_by="user",
+            policy_version="intraday_action_report_v1",
+            policy_snapshot_json={},
+        )
+    )
+    news_snap = await repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="news",
+            market="us",
+            source_kind="news_ingestor",
+            payload_json={
+                "source": "news_articles",
+                "count": 2,
+                "articles": [
+                    {
+                        "title": "Apple climbs on earnings",
+                        "source": "finnhub",
+                        "summary": "Beat estimates.",
+                        "stock_symbol": "AAPL",
+                        "stock_name": "Apple Inc.",
+                        "published_at": now.isoformat(),
+                    },
+                    {
+                        "title": "Nvidia rallies",
+                        "source": "finnhub",
+                        "summary": "AI demand.",
+                        "stock_symbol": "NVDA",
+                        "stock_name": "NVIDIA",
+                        "published_at": now.isoformat(),
+                    },
+                ],
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    bundle = await repo.insert_bundle(
+        BundleCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+            coverage_summary={},
+            freshness_summary={},
+        )
+    )
+    await repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=news_snap.snapshot_uuid, role="optional"),
+    )
+    await db_session.commit()
+
+    exporter = HermesContextExporter(db_session, stages=[])
+    payload = await exporter.export(snapshot_bundle_uuid=bundle.bundle_uuid)
+
+    news_ev = payload.dimension_evidence["news"]
+    assert news_ev["count"] == 2
+    assert {c["title"] for c in news_ev["citations"]} == {
+        "Apple climbs on earnings",
+        "Nvidia rallies",
+    }
+    # The seeded DB report must NOT appear — the snapshot is authoritative.
+    assert all(c["title"] != "DB-only report" for c in news_ev["citations"])
+    assert news_ev["data_health"]["source"] == "news_articles"
+    assert news_ev["citations"][0]["symbol_candidates"][0]["market"] == "us"


### PR DESCRIPTION
## ROB-374 B3 (news layer)

The Hermes context disagreed with itself for bundle `e45544ae-…`:
- `stage_inputs.news` → **"20 articles"** (read from the bundle's news-article snapshot)
- `dimension_evidence.news` → **count=0 / unavailable**

…because `build_news_evidence` ignored the snapshot and re-queried the `research_reports` table,
which is empty for US (ingestion gate off). Two layers, two sources, guaranteed to diverge.

### Fix
`build_news_evidence` now **prefers the bundle's own news-article snapshot** — the same `articles`
payload `NewsStage` summarizes — so the layers can't disagree. A present (even empty) `articles`
payload is **authoritative**; only when the bundle carries no article snapshot does it fall back to
the `research_reports` query (older citation-path bundles / no news kind). Articles map into the
existing citation schema (`analyst=None`), and `data_health.source` records the path
(`news_articles` vs `research_reports`) for provenance.

`HermesContextExporter` merges articles from the bundle's `news` snapshots and passes them through.

### Tests
- `build_news_evidence` units: snapshot wins over a seeded DB report; empty snapshot is authoritative
  (no DB bleed); freshness from article timestamps; symbol/excerpt mapping; DB fallback when no
  snapshot (back-compat).
- Exporter DB test seeds a real `news` snapshot + a research report and asserts the dimension reflects
  the snapshot, not the DB.
- Existing research-fallback exporter test still green (no news snapshot → research path).
- Full `investment_stages` + `investment_dimensions` suites green; hermes http/mcp/roundtrip green.
  ruff check / format / ty pass.

### Scope note
The **market** half of B3 (stage `unavailable` while dimension has breadth/top_movers) is tied to
ITEM 1 (US index, operator-RUN) and needs a strict-vs-degrade product decision — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * News evidence now prioritizes article snapshots when available, ensuring authoritative sourcing of news data.
  * Added source tracking to data health, indicating whether news originates from articles or reports.
  * Enhanced fallback behavior with graceful degradation when snapshots are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->