### PR TITLE
fix(ROB-378): exclude intraday earnings from daily coverage gate + readiness docs

### DIFF
--- a/app/services/market_events/coverage_gate.py
+++ b/app/services/market_events/coverage_gate.py
@@ -4,17 +4,25 @@ Pure classifier: a :class:`CoverageMeasurement` (counts/ratios only, no raw
 bars) in, a :class:`GateResult` (overall PASS/FAIL + per-criterion breakdown)
 out. No I/O, no DB.
 
-The verdict explicitly distinguishes three FAIL shapes so an unbuilt dev store
+The verdict explicitly distinguishes four FAIL shapes so an unbuilt dev store
 is never mis-reported as a data-quality problem:
 * ``realized_events == 0``                          -> "no earnings in range"
-* events present but every window empty             -> "coverage not materialized"
+* events present but all intraday/excluded          -> "no eligible population"
+* eligible events present but every window empty     -> "coverage not materialized"
 * a §5 threshold genuinely missed                   -> "thresholds not met"
 
 The §5 criteria mirror ``docs/runbooks/rob-367-event-driven-equity-data-feasibility.md``
 section 5. ``date_only_ratio`` / ``unknown_time_ratio`` are recorded for
 transparency but do NOT independently gate: per §5, any ratio is accepted for
-equities once intraday labeling is forbidden, which the ``no_intraday_labeling``
-criterion enforces directly.
+equities once intraday labeling is forbidden.
+
+Intraday (``during_market``) earnings cannot be labeled at daily granularity
+(ROB-367 hard boundary), so they are **excluded** from the eligible
+daily-granularity population rather than hard-failing the whole gate (ROB-378).
+``aggregate_coverage`` reports their count in ``intraday_excluded_events`` and
+the gate evaluates join quality against ``eligible_events`` (= realized minus
+intraday-excluded). The ``intraday_excluded`` criterion surfaces the count for
+transparency but never gates.
 """
 
 from __future__ import annotations
@@ -28,6 +36,10 @@ class CoverageMeasurement:
     bar-date collections — so serializing it can never leak raw data."""
 
     realized_events: int
+    # Daily-granularity study population = realized_events - intraday_excluded_events.
+    # All join-quality criteria (ratio denominator, materialization, window p50)
+    # are measured against this, not the raw realized total (ROB-378).
+    eligible_events: int
     events_with_bars_present: int
     events_with_zero_bars: int
     joinable_events: int
@@ -35,7 +47,9 @@ class CoverageMeasurement:
     window_coverage_p50: float
     date_only_ratio: float
     unknown_time_ratio: float
-    intraday_labeled_events: int
+    # ``during_market`` events excluded from the eligible population: counted for
+    # transparency, never measured/joined, never hard-fails the gate (ROB-378).
+    intraday_excluded_events: int
     dup_ambiguous_ratio: float
     tradability_coverage: float
     benchmark_coverage: float
@@ -80,9 +94,12 @@ def _ratio(numer: int, denom: int) -> float:
 
 
 def evaluate_section5_gate(m: CoverageMeasurement, t: Section5Thresholds) -> GateResult:
-    joinable_event_ratio = _ratio(m.joinable_events, m.realized_events)
+    # Join quality is measured against the eligible (non-intraday) population so
+    # excluded intraday events never depress the ratio (ROB-378).
+    joinable_event_ratio = _ratio(m.joinable_events, m.eligible_events)
     no_events = m.realized_events == 0
-    not_materialized = m.realized_events > 0 and m.events_with_bars_present == 0
+    no_eligible_events = m.realized_events > 0 and m.eligible_events == 0
+    not_materialized = m.eligible_events > 0 and m.events_with_bars_present == 0
 
     criteria = [
         GateCriterion(
@@ -102,14 +119,18 @@ def evaluate_section5_gate(m: CoverageMeasurement, t: Section5Thresholds) -> Gat
             round(joinable_event_ratio, 4),
             t.min_joinable_event_ratio,
             joinable_event_ratio >= t.min_joinable_event_ratio,
-            note="fraction of realized events with >=90% window join coverage",
+            note="fraction of ELIGIBLE (non-intraday) events with >=90% window join coverage",
         ),
         GateCriterion(
-            "no_intraday_labeling",
-            m.intraday_labeled_events,
+            "intraday_excluded",
+            m.intraday_excluded_events,
             0,
-            m.intraday_labeled_events == 0,
-            note="intraday labeling is forbidden (ROB-367 boundary)",
+            # Never gates: intraday (during_market) events are excluded from the
+            # eligible daily-granularity population (ROB-367 forbids intraday
+            # labeling), not a coverage failure. Reported for transparency; the
+            # count also lives in measurement.intraday_excluded_events (ROB-378).
+            True,
+            note="during_market events excluded from the eligible population (reported, not gated)",
         ),
         GateCriterion(
             "max_dup_ambiguous",
@@ -140,7 +161,12 @@ def evaluate_section5_gate(m: CoverageMeasurement, t: Section5Thresholds) -> Gat
         ),
     ]
 
-    passed = all(c.passed for c in criteria) and not not_materialized and not no_events
+    passed = (
+        all(c.passed for c in criteria)
+        and not not_materialized
+        and not no_events
+        and not no_eligible_events
+    )
 
     # NOTE: verdict keywords PASS / FAIL are machine-parsed by operators and log
     # dashboards; do not refactor the prefixes without updating the runbook.
@@ -149,10 +175,17 @@ def evaluate_section5_gate(m: CoverageMeasurement, t: Section5Thresholds) -> Gat
             "FAIL — no earnings events found in the date range. Extend the "
             "window or wait for events to release; this is not a quality failure."
         )
+    elif no_eligible_events:
+        verdict = (
+            f"FAIL — all {m.realized_events} realized events are intraday/excluded; "
+            "the eligible daily-granularity population is empty. Intraday "
+            "(during_market) earnings cannot be labeled at daily granularity "
+            "(ROB-367 boundary); this is a scope limit, not a join-quality failure."
+        )
     elif not_materialized:
         verdict = (
             "FAIL — coverage not materialized: "
-            f"{m.realized_events} realized events but 0 have daily bars. "
+            f"{m.eligible_events} eligible events but 0 have daily bars. "
             "If backfill is pending, materialize the window with "
             "scripts/backfill_daily_candles.py --market us against a dev DB and "
             "re-probe. Otherwise some symbols (delisted / penny) may lack "

--- a/app/services/market_events/us_earnings_coverage.py
+++ b/app/services/market_events/us_earnings_coverage.py
@@ -35,8 +35,11 @@ from app.services.market_events.session_calendar import (
 
 logger = logging.getLogger(__name__)
 
-# US benchmark set: SPY + GICS sector SPDRs. Fetched directly (NOT via the
-# common-stock universe — ETFs are is_common_stock=False/NULL and may be absent).
+# US benchmark set: SPY + GICS sector SPDRs. The symbols are an explicit
+# hard-coded list (NOT resolved from the common-stock universe — ETFs are
+# is_common_stock=False/NULL and may be absent from it). Their bars are READ from
+# the pre-materialized us_candles_1d store below (the probe never live-fetches bar
+# data during the gate), so each benchmark symbol must already be backfilled.
 BENCHMARK_SYMBOLS: tuple[str, ...] = (
     "SPY",
     "XLK",
@@ -100,7 +103,14 @@ def aggregate_coverage(
     Expected sessions are the -5..+20 window around the decision session (the
     next tradable session for AMC/unknown), so date-only earnings are never
     treated as intraday-tradable on event_date. Unmappable events are counted and
-    fail closed."""
+    fail closed.
+
+    Intraday (``during_market``) events are **excluded** from the eligible
+    daily-granularity population (ROB-378): they are counted in
+    ``intraday_excluded_events`` but never measured, joined, or placed in the
+    coverage/benchmark denominator. ``eligible_events`` = realized minus
+    intraday-excluded; all join-quality counts are over the eligible set. The
+    labeling logic is untouched, so lookahead safety is preserved."""
     realized_events = len(events)
     null_symbol_count = max(total_released - realized_events, 0)
     dup_ambiguous_ratio = (
@@ -108,7 +118,8 @@ def aggregate_coverage(
     )
 
     labels = [label_earnings_decision_time(ed, th, market) for (_s, ed, th) in events]
-    intraday_labeled_events = sum(1 for lbl in labels if lbl.is_intraday_rejected)
+    intraday_excluded_events = sum(1 for lbl in labels if lbl.is_intraday_rejected)
+    eligible_events = realized_events - intraday_excluded_events
     unmappable_events = sum(1 for lbl in labels if lbl.decision_session is None)
     unknown_count = sum(
         1 for (_s, _ed, th) in events if th not in (_BMO, _AMC, _INTRADAY)
@@ -142,6 +153,12 @@ def aggregate_coverage(
     symbol_has_volume: dict[str, bool] = {}
 
     for (sym, ed, _th), label in zip(events, labels, strict=True):
+        if label.is_intraday_rejected:
+            # Excluded from the eligible daily-granularity population (ROB-378):
+            # intraday timing cannot be pinned to a lookahead-safe daily bar, so
+            # it is counted in intraday_excluded_events but never measured,
+            # joined, or placed in the coverage denominator.
+            continue
         decision = label.decision_session
         if decision is None:
             # Unmappable: no lookahead-safe window -> fail closed (0.0 coverage,
@@ -160,7 +177,7 @@ def aggregate_coverage(
         has_vol = bool(volume & expected)
         symbol_has_volume[sym] = symbol_has_volume.get(sym, False) or has_vol
 
-    events_with_zero_bars = realized_events - events_with_bars_present
+    events_with_zero_bars = eligible_events - events_with_bars_present
     window_coverage_p50 = median(coverages) if coverages else 0.0
 
     if joinable_symbols:
@@ -171,6 +188,10 @@ def aggregate_coverage(
 
     benchmark_covered = 0
     for (_sym, _ed, _th), label in zip(events, labels, strict=True):
+        if label.is_intraday_rejected:
+            # Excluded from the eligible population (ROB-378), so also excluded
+            # from the benchmark-coverage denominator below.
+            continue
         decision = label.decision_session
         if decision is None:
             continue
@@ -181,12 +202,13 @@ def aggregate_coverage(
             if len(expected & bdates) / len(expected) >= MIN_WINDOW_COVERAGE:
                 benchmark_covered += 1
                 break
-    benchmark_coverage = benchmark_covered / realized_events if realized_events else 0.0
+    benchmark_coverage = benchmark_covered / eligible_events if eligible_events else 0.0
 
     delisted_events = sum(1 for (sym, _ed, _th) in events if sym in delisted_symbols)
 
     return CoverageMeasurement(
         realized_events=realized_events,
+        eligible_events=eligible_events,
         events_with_bars_present=events_with_bars_present,
         events_with_zero_bars=events_with_zero_bars,
         joinable_events=joinable_events,
@@ -194,7 +216,7 @@ def aggregate_coverage(
         window_coverage_p50=round(window_coverage_p50, 4),
         date_only_ratio=date_only_ratio,
         unknown_time_ratio=round(unknown_time_ratio, 4),
-        intraday_labeled_events=intraday_labeled_events,
+        intraday_excluded_events=intraday_excluded_events,
         dup_ambiguous_ratio=round(dup_ambiguous_ratio, 4),
         tradability_coverage=round(tradability_coverage, 4),
         benchmark_coverage=round(benchmark_coverage, 4),

--- a/docs/runbooks/rob-371-us-earnings-coverage-probe.md
+++ b/docs/runbooks/rob-371-us-earnings-coverage-probe.md
@@ -20,21 +20,29 @@ The probe measures, for realized Finnhub US earnings events
 
 1. **Lookahead-safe labeling** — each date-only event is mapped to its first
    tradable daily bar (`before_open`→next-open, `after_close`→next-close,
-   `during_market`→whole-day-uncertain *and rejected*, `unknown/None`→next
-   session conservatively). Intraday labeling is forbidden and counted; any
-   intraday-labeled event hard-fails the gate.
+   `during_market`→whole-day-uncertain *and excluded*, `unknown/None`→next
+   session conservatively). Intraday (`during_market`) earnings cannot be
+   labeled at daily granularity (ROB-367 boundary), so they are **excluded**
+   from the eligible daily-granularity population — counted in
+   `intraday_excluded_events` and reported, but never measured/joined and never
+   hard-failing the gate (ROB-378).
 2. **`-5..+20d` window join coverage** against `us_candles_1d` (KIS primary +
    Yahoo fallback), measured against the fail-closed NYSE (XNYS) session
    calendar — counts only, never raw bars. The window is anchored on each
    event's **lookahead-safe decision session** (the next tradable session for
    AMC/unknown), not the raw `event_date`, so date-only earnings are never
-   treated as intraday-tradable on the announcement day. Events with no
-   mappable decision session (out of calendar range) are counted as
-   `unmappable_events` and fail closed (never joinable).
+   treated as intraday-tradable on the announcement day. Join-quality counts are
+   measured against the **eligible** population (`eligible_events` = realized −
+   intraday-excluded). Events with no mappable decision session (out of calendar
+   range) are counted as `unmappable_events` and fail closed (never joinable).
 3. **Survivorship** — delisted symbols (`us_symbol_universe.is_active=false`)
    are counted; with `--measure-delisted-recoverability` a bounded Yahoo probe
    measures (does not assume) delisted-bar recoverability.
-4. **Benchmark** — SPY + GICS sector SPDRs window coverage per event.
+4. **Benchmark** — SPY + GICS sector SPDRs window coverage per eligible event.
+   The benchmark symbol list is an explicit hard-coded constant (not resolved
+   from a universe); its bars are READ from the pre-materialized `us_candles_1d`
+   store — the probe does NOT live-fetch benchmark bars during the gate, so each
+   benchmark symbol must already be backfilled (see §8).
 5. **§5 gate** — a deterministic PASS/FAIL verdict + per-criterion breakdown.
 
 **It never** writes to any database, mutates broker/order/watch/approval state,
@@ -49,16 +57,25 @@ Yahoo delisted-recoverability probe (read-only).
 |---|---|---|
 | `min_realized_events` | ≥ 500 | `realized_events` |
 | `min_joinable_symbols` | ≥ 200 | `joinable_symbols` (distinct symbols with ≥1 joinable event) |
-| `min_joinable_event_ratio` | ≥ 0.90 | `joinable_events / realized_events` (event joinable iff window coverage ≥ 90%) |
-| `no_intraday_labeling` | == 0 | `intraday_labeled_events` |
+| `min_joinable_event_ratio` | ≥ 0.90 | `joinable_events / eligible_events` (event joinable iff window coverage ≥ 90%) |
+| `intraday_excluded` | reported, **not gated** | `intraday_excluded_events` |
 | `max_dup_ambiguous` | ≤ 0.01 | `dup_ambiguous_ratio` (US Finnhub: NULL-symbol ratio) |
 | `min_tradability` | ≥ 0.90 | `tradability_coverage` (joinable symbols with ≥1 `volume>0` bar) |
-| `min_benchmark` | ≥ 0.90 | `benchmark_coverage` (events with ≥1 benchmark window ≥ 90%) |
+| `min_benchmark` | ≥ 0.90 | `benchmark_coverage` (eligible events with ≥1 benchmark window ≥ 90%) |
 | `session_calendar_present` | true | XNYS calendar resolvable |
 
 `date_only_ratio` and `unknown_time_ratio` are **recorded but not gated** — per
-§5 any ratio is accepted for equities once intraday labeling is forbidden (which
-`no_intraday_labeling` enforces directly).
+§5 any ratio is accepted for equities once intraday labeling is forbidden.
+
+**Intraday-exclude policy (ROB-378).** `during_market` earnings cannot be
+labeled at daily granularity, so they are **excluded** from the eligible
+population rather than hard-failing the gate. They are surfaced via the
+non-gating `intraday_excluded` criterion and the `intraday_excluded_events` /
+`eligible_events` measurement fields. **Thresholds are unchanged** — exclusion
+only moves intraday events out of the denominators (`eligible_events` = realized
+− intraday-excluded), it does not relax any bar. If *every* realized event is
+intraday (`eligible_events == 0`), the verdict is the dedicated `FAIL — all …
+intraday/excluded` shape (a scope limit, not a quality failure).
 
 ---
 
@@ -95,18 +112,23 @@ uv run python -m scripts.probe_us_earnings_coverage \
 
 ## 4. Interpreting the verdict
 
-The verdict prefix is machine-parsed (`PASS` / `FAIL`). There are three FAIL
-shapes — only the third is a true data-quality failure:
+The verdict prefix is machine-parsed (`PASS` / `FAIL`). There are four FAIL
+shapes — only the last is a true data-quality failure:
 
 1. **`FAIL — no earnings events found in the date range.`** The window has no
    realized events. Widen `--from-date`/`--to-date` or wait for ingestion. Not a
    quality failure.
-2. **`FAIL — coverage not materialized: N realized events but 0 have daily
-   bars.`** Events exist but `us_candles_1d` has no bars for them. Materialize a
-   dev-DB window (§5 below) and re-probe. A **build gap**, not a join failure.
-3. **`FAIL — §5 thresholds not met: <criteria>.`** Genuine coverage shortfall;
+2. **`FAIL — all N realized events are intraday/excluded …`** Events exist but
+   every one is `during_market` (excluded from the eligible daily-granularity
+   population), so `eligible_events == 0`. A scope limit (intraday labeling is
+   forbidden), not a join-quality or build failure.
+3. **`FAIL — coverage not materialized: N eligible events but 0 have daily
+   bars.`** Eligible events exist but `us_candles_1d` has no bars for them.
+   Materialize a dev-DB window (§5 below) and re-probe. A **build gap**, not a
+   join failure.
+4. **`FAIL — §5 thresholds not met: <criteria>.`** Genuine coverage shortfall;
    the named criteria say what is missing.
-4. **`PASS — §5 thresholds met; a bounded US event-response backtest issue MAY
+5. **`PASS — §5 thresholds met; a bounded US event-response backtest issue MAY
    be opened.`** Record the artifact in Linear; opening the backtest issue is a
    separate, explicit decision (this probe does not open it).
 
@@ -156,3 +178,144 @@ production is out of scope for ROB-371.
 - §5 gate: `app/services/market_events/coverage_gate.py`
 - Artifact root: `research/event_coverage/artifact_paths.py`
 - CLI: `scripts/probe_us_earnings_coverage.py`
+- Finnhub ingest CLI: `scripts/ingest_market_events.py`
+- Daily-candle backfill CLI: `scripts/backfill_daily_candles.py`
+
+---
+
+## 8. Operator checklist — ROB-378 (historical-window materialization + re-run)
+
+ROB-371 built the probe; **ROB-378 executes it** against a historical window and
+ends with a deterministic PASS/FAIL artifact + a decision on whether a bounded
+backtest issue is justified. This section is the full operator journey. It is
+**dev/research-DB only** — never production. The probe and this checklist make
+**no** broker/order/watch/order-intent mutation and activate **no** scheduler.
+
+> **Why this exists.** The first ROB-371 operator run FAILed only on missing
+> dev/research data (benchmark ETF bars absent → benchmark join 0.0; no
+> historical Finnhub earnings → only recent partially-materialized windows;
+> intraday events tripping the old hard gate). None of those are infeasibility
+> verdicts. ROB-378 removes the data prerequisites and re-runs.
+
+### 8.0 Pre-flight — confirm a DEV/RESEARCH database
+
+```bash
+echo "$DATABASE_URL"   # MUST be a dev/research DB. Never production.
+```
+
+Stop here if this is not a dev/research DB. All steps below write candles/events
+to whatever `DATABASE_URL` points at.
+
+### 8.1 SPY one-symbol eligibility check (no-write, then bounded live)
+
+Benchmark ETFs (SPY + sector SPDRs) are NYSE-Arca listed. The US backfill
+defaults to `--partition NASD`; the KIS overseas fetcher only maps
+`NASD/NYSE/AMEX` (unknown codes fall back to the first 3 chars, which KIS may
+reject). **Validate SPY before committing to a full backfill.**
+
+```bash
+# (a) No-write dry-run: confirms the CLI builds the SyncTarget (no API, no write).
+uv run python scripts/backfill_daily_candles.py \
+    --market us --symbols SPY --partition NYSE --dry-run
+
+# (b) Bounded LIVE single-symbol probe (writes ~50 SPY bars to the DEV DB only).
+#     This is the real eligibility test — it proves KIS/Yahoo returns ETF bars
+#     for the chosen --partition. Try NYSE first; if KIS returns 0 rows the sync
+#     logs a Yahoo-fallback attempt (Yahoo is partition-agnostic for SPY).
+uv run python scripts/backfill_daily_candles.py \
+    --market us --symbols SPY --partition NYSE --horizon-bars 50
+```
+
+If (b) reports `upserted=0 fallback=...` for every partition tried, record that
+benchmark ETF bars are not retrievable on this host and treat benchmark coverage
+as a remaining prerequisite (do **not** fudge it). `ARCA` is **not** in the KIS
+exchange map — prefer `NYSE` (or rely on the Yahoo fallback) over passing `ARCA`.
+
+### 8.2 Choose a trailing `--horizon-bars` for the historical window
+
+`backfill_daily_candles.py` is **trailing-horizon** (counts back from *today*);
+it has no `--from/--to`. To cover the earliest event's `-5d` lookback through its
+`+20d` lookahead, size the horizon to reach the earliest `event_date` plus
+margin:
+
+```
+trading_days ≈ (today − earliest_event_date in calendar days) / 365 × 252
+horizon_bars = trading_days + 25   # -5d..+20d window margin, rounded up
+```
+
+For an earliest event of **2023-01-01** measured on **~2026-05-30**
+(~1,245 calendar days): `1245/365×252 ≈ 857` + margin → **use `--horizon-bars 900`**
+(round up; over-fetching dev bars is harmless).
+
+### 8.3 Ingest historical Finnhub US earnings (DEV/RESEARCH only)
+
+Events must exist before you know which symbols to backfill. Requires the
+`FINNHUB_API_KEY` env var (name only — never print the value). One Finnhub API
+call per invocation; quota exhaustion fails closed (`finnhub_quota_exceeded`).
+
+```bash
+uv run python scripts/ingest_market_events.py \
+    --source finnhub --category earnings --market us \
+    --from-date 2023-01-01 --to-date 2025-12-31 --dry-run   # inspect first
+
+uv run python scripts/ingest_market_events.py \
+    --source finnhub --category earnings --market us \
+    --from-date 2023-01-01 --to-date 2025-12-31             # writes events
+```
+
+Only rows with realized `eps_actual`/`revenue_actual` normalize to
+`status="released"` (the probe filters on that), so the populated count may be
+below the raw calendar count — expected.
+
+### 8.4 Backfill event-symbol + benchmark windows (DEV/RESEARCH only)
+
+Backfill **all 12 benchmark symbols** plus the event symbols you intend to
+measure, at the §8.2 horizon:
+
+```bash
+# Benchmarks (all 12 — partition per §8.1 finding):
+uv run python scripts/backfill_daily_candles.py \
+    --market us --partition NYSE --horizon-bars 900 \
+    --symbols SPY,XLK,XLF,XLE,XLV,XLI,XLY,XLP,XLU,XLB,XLRE,XLC
+
+# Event symbols (derive the symbol list from the ingested events; common stocks
+# default to --partition NASD, override per-symbol as needed):
+uv run python scripts/backfill_daily_candles.py \
+    --market us --partition NASD --horizon-bars 900 \
+    --symbols <comma-separated event symbols>
+```
+
+### 8.5 Re-run the probe with UNCHANGED thresholds
+
+```bash
+uv run python -m scripts.probe_us_earnings_coverage \
+    --from-date 2023-01-01 --to-date 2025-12-31 --run --out
+```
+
+**Do NOT edit `Section5Thresholds()` or the gate logic to manufacture a PASS.**
+The probe always constructs the default thresholds; the gate must stay
+apples-to-apples with the recorded §5 table (§2). The intraday-exclude policy is
+already built in — `during_market` events are reported in
+`intraday_excluded_events`, not hard-failed.
+
+### 8.6 Record the counts-only artifact + verdict
+
+`--out` writes `us_earnings_coverage.json` (counts-only scalars). Record in the
+ROB-378 Linear issue:
+
+- the artifact path (or its JSON — it is counts-only and safe to paste);
+- the machine-parsed verdict string;
+- the §5 per-criterion table (observed vs threshold);
+- `eligible_events` and `intraday_excluded_events` so the intraday exclusion is
+  auditable.
+
+**Never** paste raw bars/events, symbol lists, or secret values.
+
+### 8.7 Decision
+
+- **PASS** → a bounded US event-response backtest issue **may** be opened as a
+  separate, explicit decision. This issue does not open it.
+- **FAIL** → do **not** open a backtest issue. List the remaining prerequisites
+  from the verdict shape (no events / no eligible population / not materialized /
+  thresholds not met) and stop. A FAIL here is a data/scope gap, not an
+  infeasibility verdict for event-driven equity research.

--- a/tests/scripts/test_probe_us_earnings_coverage_cli.py
+++ b/tests/scripts/test_probe_us_earnings_coverage_cli.py
@@ -30,7 +30,7 @@ def _measurement(**overrides) -> CoverageMeasurement:
         "window_coverage_p50": 0.98,
         "date_only_ratio": 1.0,
         "unknown_time_ratio": 0.05,
-        "intraday_labeled_events": 0,
+        "intraday_excluded_events": 0,
         "dup_ambiguous_ratio": 0.0,
         "tradability_coverage": 0.95,
         "benchmark_coverage": 0.97,
@@ -39,6 +39,9 @@ def _measurement(**overrides) -> CoverageMeasurement:
         "session_calendar_present": True,
     }
     base.update(overrides)
+    base.setdefault(
+        "eligible_events", base["realized_events"] - base["intraday_excluded_events"]
+    )
     return CoverageMeasurement(**base)
 
 

--- a/tests/services/market_events/test_coverage_gate.py
+++ b/tests/services/market_events/test_coverage_gate.py
@@ -21,7 +21,7 @@ def _passing_measurement(**overrides) -> CoverageMeasurement:
         "window_coverage_p50": 0.98,
         "date_only_ratio": 1.0,
         "unknown_time_ratio": 0.05,
-        "intraday_labeled_events": 0,
+        "intraday_excluded_events": 0,
         "dup_ambiguous_ratio": 0.0,
         "tradability_coverage": 0.95,
         "benchmark_coverage": 0.97,
@@ -30,6 +30,11 @@ def _passing_measurement(**overrides) -> CoverageMeasurement:
         "session_calendar_present": True,
     }
     base.update(overrides)
+    # eligible_events defaults to the (post-intraday-exclusion) realized total so
+    # callers that only tweak realized/joinable stay self-consistent (ROB-378).
+    base.setdefault(
+        "eligible_events", base["realized_events"] - base["intraday_excluded_events"]
+    )
     return CoverageMeasurement(**base)
 
 
@@ -76,14 +81,64 @@ def test_too_few_joinable_symbols_fails():
 
 
 @pytest.mark.unit
-def test_intraday_labeled_events_hard_fail():
+def test_intraday_excluded_does_not_hard_fail():
+    # ROB-378: intraday (during_market) events are excluded from the eligible
+    # population and reported, NOT a hard gate failure. With a healthy eligible
+    # population the gate still PASSes.
     result = evaluate_section5_gate(
-        _passing_measurement(intraday_labeled_events=3), Section5Thresholds()
+        _passing_measurement(
+            realized_events=618,
+            intraday_excluded_events=18,
+            eligible_events=600,
+            joinable_events=560,
+        ),
+        Section5Thresholds(),
     )
+    assert result.passed is True
+    crit = {c.name: c for c in result.criteria}
+    assert "intraday_excluded" in crit
+    assert crit["intraday_excluded"].passed is True
+    assert crit["intraday_excluded"].observed == 18
+    # The legacy hard-fail criterion no longer exists.
+    assert "no_intraday_labeling" not in crit
+
+
+@pytest.mark.unit
+def test_intraday_excluded_from_joinable_ratio_denominator():
+    # 600 eligible events, 540 joinable -> 540/600 = 0.90 passes. The 200 excluded
+    # intraday events must NOT enter the denominator (else 540/800 = 0.675 fails).
+    result = evaluate_section5_gate(
+        _passing_measurement(
+            realized_events=800,
+            intraday_excluded_events=200,
+            eligible_events=600,
+            joinable_events=540,
+        ),
+        Section5Thresholds(),
+    )
+    ratio = next(c for c in result.criteria if c.name == "min_joinable_event_ratio")
+    assert ratio.observed == pytest.approx(0.90)
+    assert ratio.passed is True
+
+
+@pytest.mark.unit
+def test_all_intraday_reports_no_eligible_population_not_quality_failure():
+    # FALSE-FAIL guard: events exist but every one is intraday-excluded -> the
+    # eligible daily-granularity population is empty (a scope limit, not a
+    # join-quality or materialization failure).
+    m = _passing_measurement(
+        realized_events=600,
+        intraday_excluded_events=600,
+        eligible_events=0,
+        events_with_bars_present=0,
+        events_with_zero_bars=0,
+        joinable_events=0,
+        joinable_symbols=0,
+    )
+    result = evaluate_section5_gate(m, Section5Thresholds())
     assert result.passed is False
-    assert any(
-        c.name == "no_intraday_labeling" and not c.passed for c in result.criteria
-    )
+    assert "eligible" in result.verdict.lower()
+    assert "not materialized" not in result.verdict.lower()
 
 
 @pytest.mark.unit

--- a/tests/services/market_events/test_us_earnings_coverage.py
+++ b/tests/services/market_events/test_us_earnings_coverage.py
@@ -57,12 +57,13 @@ def test_full_coverage_single_event():
         session_calendar_present=True,
     )
     assert m.realized_events == 1
+    assert m.eligible_events == 1
     assert m.events_with_bars_present == 1
     assert m.events_with_zero_bars == 0
     assert m.joinable_events == 1
     assert m.joinable_symbols == 1
     assert m.window_coverage_p50 == pytest.approx(1.0)
-    assert m.intraday_labeled_events == 0
+    assert m.intraday_excluded_events == 0
     assert m.benchmark_coverage == pytest.approx(1.0)
     assert m.tradability_coverage == pytest.approx(1.0)
     assert m.date_only_ratio == 1.0
@@ -89,7 +90,10 @@ def test_zero_bars_event_counts_as_zero_not_joinable():
 
 
 @pytest.mark.unit
-def test_intraday_event_is_counted():
+def test_intraday_event_is_excluded_not_measured():
+    # ROB-378: a during_market event is counted in intraday_excluded_events but
+    # excluded from the eligible population — never measured, joined, or counted
+    # as having bars (even though full bars are supplied here).
     expected = set(_expected_sessions(_EVENT_DATE))
     m = aggregate_coverage(
         events=[("INTC", _EVENT_DATE, "during_market")],
@@ -100,7 +104,43 @@ def test_intraday_event_is_counted():
         delisted_recoverable=0,
         session_calendar_present=True,
     )
-    assert m.intraday_labeled_events == 1
+    assert m.intraday_excluded_events == 1
+    assert m.realized_events == 1
+    assert m.eligible_events == 0
+    assert m.events_with_bars_present == 0
+    assert m.joinable_events == 0
+    assert m.joinable_symbols == 0
+    assert m.benchmark_coverage == pytest.approx(0.0)
+
+
+@pytest.mark.unit
+def test_intraday_mixed_with_eligible_excludes_only_intraday():
+    # One eligible BMO event (full coverage) + one intraday event. The intraday
+    # event is excluded from every join-quality count; the eligible one is
+    # measured normally.
+    expected = set(_expected_sessions(_EVENT_DATE))
+    m = aggregate_coverage(
+        events=[
+            ("AAPL", _EVENT_DATE, "before_open"),
+            ("INTC", _EVENT_DATE, "during_market"),
+        ],
+        total_released=2,
+        window_present={
+            ("AAPL", _EVENT_DATE): (set(expected), set(expected)),
+            ("INTC", _EVENT_DATE): (set(expected), set(expected)),
+        },
+        benchmark_present={"SPY": set(expected)},
+        delisted_symbols=set(),
+        delisted_recoverable=0,
+        session_calendar_present=True,
+    )
+    assert m.realized_events == 2
+    assert m.intraday_excluded_events == 1
+    assert m.eligible_events == 1
+    assert m.joinable_events == 1
+    assert m.joinable_symbols == 1
+    # benchmark denominator is the eligible population (1), fully covered.
+    assert m.benchmark_coverage == pytest.approx(1.0)
 
 
 @pytest.mark.unit
@@ -412,11 +452,12 @@ async def test_measure_counts_released_event_with_full_window(db_session):
         today=date(2025, 8, 31),
     )
     assert m.realized_events == 1
+    assert m.eligible_events == 1
     assert m.events_with_bars_present == 1
     assert m.events_with_zero_bars == 0
     assert m.window_coverage_p50 >= MIN_WINDOW_COVERAGE
     assert m.joinable_symbols == 1
-    assert m.intraday_labeled_events == 0
+    assert m.intraday_excluded_events == 0
     assert m.date_only_ratio == 1.0
     assert m.session_calendar_present is True
 


### PR DESCRIPTION
## ROB-378 readiness PR (no data writes)

Removes the code/doc prerequisites found during review **before** the operator-run historical materialization + ROB-371 §5 gate re-run. ROB-371 built the probe; ROB-378 executes it. This PR does **not** materialize data or run the gate — it locks the one design decision (intraday-exclude) and writes the operator checklist.

### The one design decision: intraday-exclude policy
`during_market` earnings cannot be labeled at daily granularity (ROB-367 boundary). They previously **HARD-FAILED the whole §5 gate** via `no_intraday_labeling == 0` — so the 18 intraday events in the first operator run could sink thousands of otherwise-joinable events as a false negative.

Now they are **excluded** from the eligible daily-granularity population and reported, never hard-failing:
- `aggregate_coverage` skips `is_intraday_rejected` events in the coverage + benchmark loops; counts them in `intraday_excluded_events`; computes `eligible_events = realized − intraday_excluded`.
- All join-quality denominators (joinable ratio, `events_with_zero_bars`, `benchmark_coverage`) are over `eligible_events`, not raw realized.
- The gate's `no_intraday_labeling` hard-fail criterion becomes the **non-gating** `intraday_excluded` report criterion; a new `no_eligible_events` verdict covers the all-intraday case.
- **Thresholds are UNCHANGED** (`Section5Thresholds` untouched) — exclusion only moves intraday events out of the denominators, it relaxes no bar.
- **Lookahead safety preserved**: the labeler is untouched; intraday events are still mapped to the next session, just not measured.

### Docs / readiness
- Clarify the misleading *"benchmarks fetched directly"* wording (code comment + runbook §1/§4 + plan D5): the symbol set is hard-coded, but the **bars are READ** from the pre-materialized `us_candles_1d` store (not live-fetched during the gate), so benchmark ETFs must be backfilled first.
- Add runbook **§8: full ROB-378 operator checklist** — dev-DB pre-flight, SPY partition eligibility check, trailing `--horizon-bars` derivation, historical Finnhub ingest, all-12 benchmark + event-symbol backfill, re-run with UNCHANGED thresholds, counts-only artifact recording, PASS/FAIL decision.

### Tests
Invert the intraday hard-fail test → no-hard-fail; rewrite intraday-counted → excluded-from-eligible; add ratio-denominator-excludes-intraday, gate-passes-with-intraday-present, all-intraday→`no_eligible_events`, mixed eligible+intraday, artifact-carries-new-fields. **44 focused unit tests pass; ruff check + format clean.**

### Safety boundaries
- ✅ No DB writes; no ingest/backfill executed; no `--commit`.
- ✅ No scheduler/TaskIQ/Prefect/cron activation.
- ✅ No broker/order/watch/order-intent/approval/trade-journal mutation.
- ✅ No production DB write/backfill/delete.
- ✅ No secrets printed/committed; no raw market/event data committed.
- ✅ ROB-372 untouched.

**ROB-378 stays open** until the operator-run materialization + gate re-run produce a final PASS/FAIL artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
