### PR TITLE
test: accept legitimate 'partial' screener state (fix weekend baseline CI flake)

### DIFF
--- a/tests/services/invest_view_model/test_consecutive_gainers_public_loader.py
+++ b/tests/services/invest_view_model/test_consecutive_gainers_public_loader.py
@@ -41,4 +41,12 @@ async def test_public_wrapper_returns_rows_or_none(db_session):
     assert rows is not None
     assert isinstance(rows, list)
     assert rows[0]["symbol"] == "005930"
-    assert rows[0]["_screener_snapshot_state"] in {"fresh", "stale"}
+    # _screener_snapshot_state is the full DataState taxonomy (fresh/partial/
+    # stale). This fixture's closes_window has length 3 (< _PARTIAL_MAX_LEN=5, so
+    # week_change_rate is not computable), so classify_state returns "partial"
+    # whenever the partition is current (snapshot_date == trading baseline) and
+    # "stale" once the baseline rolls past snapshot_date. Both are valid usable
+    # states; asserting the set keeps this date-independent — the prior
+    # {"fresh", "stale"} only passed on weekdays and went red on weekends, when
+    # the KR baseline rolls back to the Friday snapshot_date (ROB-378 baseline).
+    assert rows[0]["_screener_snapshot_state"] in {"fresh", "stale", "partial"}


### PR DESCRIPTION
## Summary

Fixes a **date-dependent baseline CI red** on `main` (predates and is independent of any open feature PR — reproduced on latest `main` 892df430).

`tests/services/invest_view_model/test_consecutive_gainers_public_loader.py::test_public_wrapper_returns_rows_or_none` asserted:

```python
assert rows[0]["_screener_snapshot_state"] in {"fresh", "stale"}
```

But the fixture inserts a snapshot with `closes_window=[1, 2, 3]` (length 3). In `app/services/invest_screener_snapshots/freshness.py::classify_state`, `closes_window_len < _PARTIAL_MAX_LEN` (=5, week_change_rate not computable) classifies the row as **`"partial"`** whenever the partition is *current* (`snapshot_date == trading baseline`).

`"partial"` is a first-class, by-design `DataState` (the `_PRIORITY` map ranks it `stale(2) < partial(3) < fresh(4)`), returned unchanged through the public wrapper and handled gracefully downstream (`candidate_universe` collector). The old assertion was simply too narrow and only passed by date-accident:

- **Weekdays:** trading baseline ≠ `snapshot_date(2026-05-29)` → row reads `"stale"` → assertion passed.
- **Weekends:** baseline rolls back to the Friday `2026-05-29` (= `snapshot_date`) → partition is current → row reads `"partial"` → **assertion failed → red main** (today is Saturday 2026-05-30).

### Fix
Broaden the assertion to the full set of valid usable states (`{"fresh", "stale", "partial"}`) and document why. This makes the test **date-independent**. Test-only change — production behavior is correct.

## Test plan
- [x] `uv run pytest tests/services/invest_view_model/test_consecutive_gainers_public_loader.py` — passes (was failing on `main` today)
- [x] `ruff check` + `ruff format --check` + `ty` clean on the file
- Reproduced the failure on latest `main` (892df430) before the fix; passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)