### PR TITLE
fix(ROB-365): harden US index current quote against yfinance fast_info crashes

### DIFF
--- a/app/mcp_server/tooling/fundamentals_sources_indices.py
+++ b/app/mcp_server/tooling/fundamentals_sources_indices.py
@@ -128,16 +128,85 @@ async def _fetch_index_kr_history(
     return history
 
 
+def _safe_fast_info_attr(info: Any, name: str) -> Any:
+    """Read a yfinance ``fast_info`` attribute without propagating its internals.
+
+    ROB-365 hotfix: ``getattr(info, name, default)`` only shields against
+    ``AttributeError``. yfinance's ``FastInfo`` computes values lazily on access
+    and can raise ``TypeError: 'NoneType' object is not subscriptable`` (and
+    similar) when the underlying price frame is missing — that propagates out of
+    ``getattr`` and crashes the caller. Treat any such failure as "unavailable".
+    """
+    if info is None:
+        return None
+    try:
+        return getattr(info, name, None)
+    except Exception:  # noqa: BLE001 — FastInfo internals can raise non-AttributeError
+        return None
+
+
+async def _index_current_from_history(yf_ticker: str) -> dict[str, Any] | None:
+    """Latest-history-row fallback for a US index current quote (ROB-365 hotfix).
+
+    Returns ``{current, previous_close, open, high, low, volume}`` from the most
+    recent daily history row (``previous_close`` from the prior row when present),
+    or ``None`` when history is empty/unavailable. Never raises.
+    """
+    try:
+        rows = await _fetch_index_us_history(yf_ticker, 2, "day")
+    except Exception:  # noqa: BLE001 — fallback must never raise
+        return None
+    if not rows:
+        return None
+    latest = rows[-1]
+    current = latest.get("close")
+    if current is None:
+        return None
+    return {
+        "current": current,
+        "previous_close": rows[-2].get("close") if len(rows) >= 2 else None,
+        "open": latest.get("open"),
+        "high": latest.get("high"),
+        "low": latest.get("low"),
+        "volume": latest.get("volume"),
+    }
+
+
 async def _fetch_index_us_current(
     yf_ticker: str, name: str, symbol: str
 ) -> dict[str, Any]:
     loop = asyncio.get_running_loop()
-    with yfinance_tracing_session() as session:
-        ticker_obj = yf.Ticker(yf_ticker, session=session)
-        info = await loop.run_in_executor(None, lambda: ticker_obj.fast_info)
+    # fast_info acquisition itself can fail (network / yfinance internals); never
+    # let it crash the current-quote path.
+    info: Any = None
+    try:
+        with yfinance_tracing_session() as session:
+            ticker_obj = yf.Ticker(yf_ticker, session=session)
+            info = await loop.run_in_executor(None, lambda: ticker_obj.fast_info)
+    except Exception:  # noqa: BLE001 — degrade to history fallback below
+        info = None
 
-    current = getattr(info, "last_price", None)
-    previous_close = getattr(info, "regular_market_previous_close", None)
+    current = _safe_fast_info_attr(info, "last_price")
+    previous_close = _safe_fast_info_attr(info, "regular_market_previous_close")
+    open_ = _safe_fast_info_attr(info, "open")
+    high = _safe_fast_info_attr(info, "day_high")
+    low = _safe_fast_info_attr(info, "day_low")
+    volume = _safe_fast_info_attr(info, "last_volume")
+    source = "yfinance"
+
+    # ROB-365 hotfix: when fast_info yields no current price (failed internally or
+    # returned None), fall back to the latest daily history row.
+    if current is None:
+        fallback = await _index_current_from_history(yf_ticker)
+        if fallback is not None:
+            current = fallback["current"]
+            if previous_close is None:
+                previous_close = fallback["previous_close"]
+            open_ = open_ if open_ is not None else fallback["open"]
+            high = high if high is not None else fallback["high"]
+            low = low if low is not None else fallback["low"]
+            volume = volume if volume is not None else fallback["volume"]
+            source = "yfinance_history_fallback"
 
     change: float | None = None
     change_pct: float | None = None
@@ -145,18 +214,26 @@ async def _fetch_index_us_current(
         change = round(current - previous_close, 2)
         change_pct = round((current - previous_close) / previous_close * 100, 2)
 
-    return {
+    result: dict[str, Any] = {
         "symbol": symbol,
         "name": name,
         "current": current,
         "change": change,
         "change_pct": change_pct,
-        "open": getattr(info, "open", None),
-        "high": getattr(info, "day_high", None),
-        "low": getattr(info, "day_low", None),
-        "volume": getattr(info, "last_volume", None),
-        "source": "yfinance",
+        "open": open_,
+        "high": high,
+        "low": low,
+        "volume": volume,
+        "source": source,
     }
+    # Fail-closed: neither fast_info nor history yielded a price -> explicit
+    # degraded result instead of raising.
+    if current is None:
+        result["unavailable"] = True
+        result["degraded_reason"] = (
+            "current quote unavailable: fast_info failed and no history fallback"
+        )
+    return result
 
 
 async def _fetch_index_us_history(

--- a/tests/test_us_index_current_quote_hardening.py
+++ b/tests/test_us_index_current_quote_hardening.py
@@ -1,0 +1,155 @@
+"""ROB-365 hotfix — US index current-quote hardening.
+
+``_fetch_index_us_current`` reads ``yfinance`` ``fast_info`` attributes via
+``getattr(info, name, None)``. That only shields against ``AttributeError`` —
+but yfinance's ``FastInfo`` computes values lazily and can raise
+``TypeError: 'NoneType' object is not subscriptable`` (subscripting a missing
+price frame) when a ticker has no fetchable fast data. That exception propagates
+out of ``getattr`` and crashes the current-quote path, while the history path
+(``yf.download`` → empty DataFrame) keeps working.
+
+These tests pin the hardened contract: the current path must never raise, fall
+back to the latest history row when fast_info is unusable, and fail closed to a
+degraded result when even history is unavailable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import fundamentals_sources_indices as idx
+
+pytestmark = pytest.mark.asyncio
+
+
+class _BrokenFastInfo:
+    """fast_info whose attribute access raises like yfinance does when the
+    underlying price frame is ``None`` — a ``TypeError``, not ``AttributeError``."""
+
+    def __getattr__(self, name: str):
+        raise TypeError("'NoneType' object is not subscriptable")
+
+
+def _patch_ticker(monkeypatch, fast_info_value, *, raise_on_acquire=False):
+    class _Ticker:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        @property
+        def fast_info(self):
+            if raise_on_acquire:
+                raise TypeError("'NoneType' object is not subscriptable")
+            return fast_info_value
+
+    monkeypatch.setattr("yfinance.Ticker", lambda symbol, session=None: _Ticker())
+
+
+def _patch_download(monkeypatch, df: pd.DataFrame):
+    monkeypatch.setattr("yfinance.download", lambda *args, **kwargs: df)
+
+
+def _history_df(closes: list[float]) -> pd.DataFrame:
+    n = len(closes)
+    dates = pd.date_range("2026-05-26", periods=n, freq="D")
+    return pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": [c - 5 for c in closes],
+            "High": [c + 5 for c in closes],
+            "Low": [c - 8 for c in closes],
+            "Close": closes,
+            "Volume": [1_000_000 + i for i in range(n)],
+        }
+    ).set_index("Date")
+
+
+async def test_fast_info_typeerror_falls_back_to_history(monkeypatch):
+    _patch_ticker(monkeypatch, _BrokenFastInfo())
+    _patch_download(monkeypatch, _history_df([5490.0, 5500.0]))
+
+    res = await idx._fetch_index_us_current("^GSPC", "S&P 500", "SPX")
+
+    assert res["symbol"] == "SPX"
+    assert res["current"] == pytest.approx(5500.0)  # latest history close
+    assert res["change"] == pytest.approx(10.0)  # vs prior row close 5490
+    assert res["change_pct"] == pytest.approx(0.18, abs=0.01)  # 10/5490*100
+    assert res["source"] == "yfinance_history_fallback"
+    assert "unavailable" not in res
+
+
+async def test_fast_info_typeerror_no_history_returns_degraded(monkeypatch):
+    _patch_ticker(monkeypatch, _BrokenFastInfo())
+    _patch_download(monkeypatch, pd.DataFrame())  # empty -> history []
+
+    res = await idx._fetch_index_us_current("^VIX", "CBOE Volatility Index", "VIX")
+
+    assert res["symbol"] == "VIX"
+    assert res["current"] is None
+    assert res["change"] is None
+    assert res["change_pct"] is None
+    assert res["unavailable"] is True
+    assert "degraded_reason" in res
+
+
+async def test_fast_info_acquisition_raising_is_handled(monkeypatch):
+    # Even ``ticker.fast_info`` property access raising must not crash.
+    _patch_ticker(monkeypatch, None, raise_on_acquire=True)
+    _patch_download(monkeypatch, _history_df([100.0, 101.0, 102.0]))
+
+    res = await idx._fetch_index_us_current("^DJI", "Dow Jones", "DJI")
+
+    assert res["current"] == pytest.approx(102.0)
+    assert res["source"] == "yfinance_history_fallback"
+    assert "unavailable" not in res
+
+
+async def test_normal_fast_info_preserved_no_history_fetch(monkeypatch):
+    # Regression: a healthy fast_info path is unchanged and must NOT trigger the
+    # history fallback (source stays 'yfinance').
+    @dataclasses.dataclass(frozen=True)
+    class _FastInfo:
+        last_price: float = 5500.0
+        regular_market_previous_close: float = 5450.0
+        open: float = 5460.0
+        day_high: float = 5510.0
+        day_low: float = 5430.0
+        last_volume: int = 3_000_000
+
+    _patch_ticker(monkeypatch, _FastInfo())
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("history fallback must not run when fast_info works")
+
+    monkeypatch.setattr("yfinance.download", _boom)
+
+    res = await idx._fetch_index_us_current("^GSPC", "S&P 500", "SPX")
+
+    assert res["current"] == pytest.approx(5500.0)
+    assert res["change"] == pytest.approx(50.0)
+    assert res["source"] == "yfinance"
+    assert "unavailable" not in res
+
+
+async def test_single_missing_attr_does_not_block_other_fields(monkeypatch):
+    # fast_info present but missing one attribute (AttributeError path) must still
+    # work via getattr default — and a present last_price means no fallback.
+    @dataclasses.dataclass(frozen=True)
+    class _PartialFastInfo:
+        last_price: float = 18.5
+        regular_market_previous_close: float = 17.2
+
+    _patch_ticker(monkeypatch, _PartialFastInfo())
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("history fallback must not run when last_price exists")
+
+    monkeypatch.setattr("yfinance.download", _boom)
+
+    res = await idx._fetch_index_us_current("^VIX", "CBOE Volatility Index", "VIX")
+
+    assert res["current"] == pytest.approx(18.5)
+    assert res["source"] == "yfinance"
+    assert res["open"] is None  # missing attr -> None, not a crash


### PR DESCRIPTION
## Problem

`_fetch_index_us_current` (used for SPX/NASDAQ/DJI/VIX) crashed with
**`TypeError: 'NoneType' object is not subscriptable`** on the current-quote path,
while `_fetch_index_us_history(..., count=3)` returned rows fine.

## Root cause

The function read fast_info via `getattr(info, "last_price", None)`. `getattr(obj, name, default)`
**only swallows `AttributeError`** — but yfinance's `FastInfo` computes values lazily on
attribute access and raises `TypeError: 'NoneType' object is not subscriptable` (it subscripts a
missing/`None` price frame) for tickers with no fetchable fast data. That `TypeError` propagated
straight out of `getattr` and crashed the function. The history path uses `yf.download`, which
returns an empty `DataFrame` on failure (already handled) — so only the *current* path broke.

## Fix (scope: US index current quote / yfinance hardening only)

- **`_safe_fast_info_attr(info, name)`** — reads each fast_info attribute, swallowing *any*
  non-`AttributeError` raised by FastInfo internals (→ `None`).
- **fast_info acquisition wrapped** — a raising `fast_info` property degrades to `info=None`.
- **history fallback** — when no current price results, use the latest daily history row
  (`previous_close` from the prior row); `source` becomes `"yfinance_history_fallback"`.
- **fail-closed** — if history is also empty/unavailable, return an explicit degraded result
  (`current=None`, `unavailable=True`, `degraded_reason`) instead of raising.

KR path (`_fetch_index_kr_current`) is **untouched**; VIX (`^VIX`, ROB-365 #1031) is **preserved**
(it flows through the same hardened US path). No new features, no DB writes, no migrations.

## Tests — `tests/test_us_index_current_quote_hardening.py`

Reproduces the crash and pins the contract:
- fast_info attribute access raising `TypeError` → **falls back to latest history row** (no raise).
- fast_info raising + **no history** → **degraded result** (`unavailable=True`), no raise.
- fast_info **property** raising on acquisition → handled (history fallback).
- healthy fast_info path **unchanged** (`source="yfinance"`, history fallback NOT invoked).
- missing single attr (`AttributeError`) → `None`, not a crash.

Verified RED before the fix (3 scenarios crashed with the exact `TypeError`), GREEN after.

## Verification

```
uv run pytest tests/test_us_index_current_quote_hardening.py            # 5 passed
uv run pytest tests/test_mcp_fundamentals_tools.py \
              tests/analysis/stages/test_market_stage.py                # 175 passed (KR/US/VIX/default)
uv run ruff check  app/mcp_server/tooling/fundamentals_sources_indices.py tests/test_us_index_current_quote_hardening.py   # pass
uv run ruff format --check ...                                          # pass
uv run ty check app/mcp_server/tooling/fundamentals_sources_indices.py  # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and resilience when fetching US index current quotes, preventing crashes when live data is unavailable
  * Implemented automatic fallback to historical data when current quotes cannot be retrieved
  * Enhanced transparency with explicit status indicators for unavailable or degraded index data

* **Tests**
  * Added comprehensive test coverage for index quote retrieval failure scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->