### PR TITLE
feat(ROB-377): OI + Long/Short ratio MCP tools (Binance USD-M, PR2, Slice 4 A2)

### DIFF
--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -33,6 +33,7 @@ AVAILABLE_TOOL_NAMES = [
     "get_short_interest",
     "get_kimchi_premium",
     "get_funding_rate",
+    "get_open_interest",
     "get_market_index",
     "get_support_resistance",
     "get_sector_peers",

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -34,6 +34,7 @@ AVAILABLE_TOOL_NAMES = [
     "get_kimchi_premium",
     "get_funding_rate",
     "get_open_interest",
+    "get_long_short_ratio",
     "get_market_index",
     "get_support_resistance",
     "get_sector_peers",

--- a/app/mcp_server/tooling/fundamentals/_crypto.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto.py
@@ -7,6 +7,7 @@ from typing import Any
 from app.mcp_server.tooling.fundamentals_sources_binance import (
     _fetch_funding_rate,
     _fetch_funding_rate_batch,
+    _fetch_long_short_ratio,
     _fetch_open_interest,
 )
 from app.mcp_server.tooling.fundamentals_sources_coingecko import (
@@ -99,6 +100,33 @@ async def handle_get_open_interest(
     capped_limit = min(max(limit, 1), 500)
     try:
         return await _fetch_open_interest(normalized_symbol, period, capped_limit)
+    except Exception as exc:
+        return _error_payload(
+            source="binance",
+            message=str(exc),
+            symbol=f"{normalized_symbol}USDT",
+            instrument_type="crypto",
+        )
+
+
+async def handle_get_long_short_ratio(
+    symbol: str | None = None,
+    period: str = "1h",
+    limit: int = 30,
+) -> dict[str, Any]:
+    if symbol is None or not symbol.strip():
+        raise ValueError("symbol is required")
+    period = (period or "").strip().lower()
+    if period not in _ALLOWED_PERIODS:
+        raise ValueError(
+            f"period must be one of: {', '.join(sorted(_ALLOWED_PERIODS))}"
+        )
+    normalized_symbol = _normalize_crypto_base_symbol(symbol)
+    if not normalized_symbol:
+        raise ValueError("symbol is required")
+    capped_limit = min(max(limit, 1), 500)
+    try:
+        return await _fetch_long_short_ratio(normalized_symbol, period, capped_limit)
     except Exception as exc:
         return _error_payload(
             source="binance",

--- a/app/mcp_server/tooling/fundamentals/_crypto.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto.py
@@ -7,6 +7,7 @@ from typing import Any
 from app.mcp_server.tooling.fundamentals_sources_binance import (
     _fetch_funding_rate,
     _fetch_funding_rate_batch,
+    _fetch_open_interest,
 )
 from app.mcp_server.tooling.fundamentals_sources_coingecko import (
     _normalize_crypto_base_symbol,
@@ -14,6 +15,8 @@ from app.mcp_server.tooling.fundamentals_sources_coingecko import (
 )
 from app.mcp_server.tooling.fundamentals_sources_naver import _fetch_kimchi_premium
 from app.mcp_server.tooling.shared import error_payload as _error_payload
+
+_ALLOWED_PERIODS = {"5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"}
 
 
 async def handle_get_kimchi_premium(
@@ -74,5 +77,32 @@ async def handle_get_funding_rate(
             source="binance",
             message=str(exc),
             symbol=f"{normalized_symbol}USDT" if normalized_symbol else None,
+            instrument_type="crypto",
+        )
+
+
+async def handle_get_open_interest(
+    symbol: str | None = None,
+    period: str = "1h",
+    limit: int = 30,
+) -> dict[str, Any]:
+    if symbol is None or not symbol.strip():
+        raise ValueError("symbol is required")
+    period = (period or "").strip().lower()
+    if period not in _ALLOWED_PERIODS:
+        raise ValueError(
+            f"period must be one of: {', '.join(sorted(_ALLOWED_PERIODS))}"
+        )
+    normalized_symbol = _normalize_crypto_base_symbol(symbol)
+    if not normalized_symbol:
+        raise ValueError("symbol is required")
+    capped_limit = min(max(limit, 1), 500)
+    try:
+        return await _fetch_open_interest(normalized_symbol, period, capped_limit)
+    except Exception as exc:
+        return _error_payload(
+            source="binance",
+            message=str(exc),
+            symbol=f"{normalized_symbol}USDT",
             instrument_type="crypto",
         )

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from app.mcp_server.tooling.fundamentals._crypto import (
     handle_get_funding_rate,
     handle_get_kimchi_premium,
+    handle_get_open_interest,
 )
 from app.mcp_server.tooling.fundamentals._financials import (
     handle_get_earnings_calendar,
@@ -53,6 +54,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_short_interest",
     "get_kimchi_premium",
     "get_funding_rate",
+    "get_open_interest",
     "get_market_index",
     "get_support_resistance",
     "get_sector_peers",
@@ -220,6 +222,22 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         limit: int = 10,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         return await handle_get_funding_rate(symbol, limit)
+
+    @mcp.tool(
+        name="get_open_interest",
+        description=(
+            "Get Binance USD-M futures open interest for a crypto symbol: current "
+            "open interest plus recent history (sum OI and notional USD value) and "
+            "the OI change over the window. Read-only public Binance data. "
+            "period in {5m,15m,30m,1h,2h,4h,6h,12h,1d}."
+        ),
+    )
+    async def get_open_interest(
+        symbol: str,
+        period: str = "1h",
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        return await handle_get_open_interest(symbol, period, limit)
 
     @mcp.tool(
         name="get_market_index",

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from app.mcp_server.tooling.fundamentals._crypto import (
     handle_get_funding_rate,
     handle_get_kimchi_premium,
+    handle_get_long_short_ratio,
     handle_get_open_interest,
 )
 from app.mcp_server.tooling.fundamentals._financials import (
@@ -55,6 +56,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_kimchi_premium",
     "get_funding_rate",
     "get_open_interest",
+    "get_long_short_ratio",
     "get_market_index",
     "get_support_resistance",
     "get_sector_peers",
@@ -238,6 +240,23 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         limit: int = 30,
     ) -> dict[str, Any]:
         return await handle_get_open_interest(symbol, period, limit)
+
+    @mcp.tool(
+        name="get_long_short_ratio",
+        description=(
+            "Get Binance USD-M long/short ratio for a crypto symbol: global account "
+            "ratio (retail sentiment) and top-trader position ratio (smart money), "
+            "each with current value, recent history, and a retail-vs-smart-money "
+            "divergence note. Read-only public Binance data. "
+            "period in {5m,15m,30m,1h,2h,4h,6h,12h,1d}."
+        ),
+    )
+    async def get_long_short_ratio(
+        symbol: str,
+        period: str = "1h",
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        return await handle_get_long_short_ratio(symbol, period, limit)
 
     @mcp.tool(
         name="get_market_index",

--- a/app/mcp_server/tooling/fundamentals_sources_binance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_binance.py
@@ -17,6 +17,20 @@ from app.mcp_server.tooling.shared import (
 
 BINANCE_PREMIUM_INDEX_URL = "https://fapi.binance.com/fapi/v1/premiumIndex"
 BINANCE_FUNDING_RATE_URL = "https://fapi.binance.com/fapi/v1/fundingRate"
+BINANCE_OPEN_INTEREST_URL = "https://fapi.binance.com/fapi/v1/openInterest"
+BINANCE_OPEN_INTEREST_HIST_URL = (
+    "https://fapi.binance.com/futures/data/openInterestHist"
+)
+
+
+def _oi_interpretation_text(oi_change_pct: float | None) -> str:
+    if oi_change_pct is None:
+        return "데이터 부족 — OI 추세 판단 불가"
+    if oi_change_pct > 0:
+        return "OI 증가 — 신규 포지션 유입 (추세 강화 가능)"
+    if oi_change_pct < 0:
+        return "OI 감소 — 포지션 청산/이탈"
+    return "OI 변동 없음"
 
 
 def _funding_interpretation_text(rate: float) -> str:
@@ -129,4 +143,62 @@ async def _fetch_funding_rate(symbol: str, limit: int) -> dict[str, Any]:
         }
 
 
-__all__ = ["_fetch_funding_rate", "_fetch_funding_rate_batch"]
+async def _fetch_open_interest(symbol: str, period: str, limit: int) -> dict[str, Any]:
+    pair = f"{symbol.upper()}USDT"
+
+    async with httpx.AsyncClient(timeout=10) as cli:
+        current_resp, hist_resp = await asyncio.gather(
+            cli.get(BINANCE_OPEN_INTEREST_URL, params={"symbol": pair}),
+            cli.get(
+                BINANCE_OPEN_INTEREST_HIST_URL,
+                params={"symbol": pair, "period": period, "limit": limit},
+            ),
+        )
+        current_resp.raise_for_status()
+        hist_resp.raise_for_status()
+        current_data = current_resp.json()
+        hist_data = hist_resp.json()
+
+    current_oi = _to_optional_float((current_data or {}).get("openInterest"))
+
+    history: list[dict[str, Any]] = []
+    for entry in hist_data if isinstance(hist_data, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        ts = _to_optional_int(entry.get("timestamp"))
+        if ts is None:
+            continue
+        history.append(
+            {
+                "_ts": ts,
+                "time": datetime.datetime.fromtimestamp(
+                    ts / 1000, tz=datetime.UTC
+                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "sum_open_interest": _to_optional_float(entry.get("sumOpenInterest")),
+                "sum_open_interest_value_usd": _to_optional_float(
+                    entry.get("sumOpenInterestValue")
+                ),
+            }
+        )
+    history.sort(key=lambda e: e["_ts"])
+    for e in history:
+        del e["_ts"]
+
+    oi_change_pct: float | None = None
+    if len(history) >= 2:
+        first = history[0]["sum_open_interest"]
+        last = history[-1]["sum_open_interest"]
+        if first is not None and last is not None and first != 0:
+            oi_change_pct = round((last - first) / first * 100, 4)
+
+    return {
+        "symbol": pair,
+        "current_open_interest": current_oi,
+        "period": period,
+        "open_interest_history": history,
+        "oi_change_pct": oi_change_pct,
+        "interpretation": _oi_interpretation_text(oi_change_pct),
+    }
+
+
+__all__ = ["_fetch_funding_rate", "_fetch_funding_rate_batch", "_fetch_open_interest"]

--- a/app/mcp_server/tooling/fundamentals_sources_binance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_binance.py
@@ -159,7 +159,9 @@ async def _fetch_open_interest(symbol: str, period: str, limit: int) -> dict[str
         current_data = current_resp.json()
         hist_data = hist_resp.json()
 
-    current_oi = _to_optional_float((current_data or {}).get("openInterest"))
+    current_oi = _to_optional_float(
+        current_data.get("openInterest") if isinstance(current_data, dict) else None
+    )
 
     history: list[dict[str, Any]] = []
     for entry in hist_data if isinstance(hist_data, list) else []:

--- a/app/mcp_server/tooling/fundamentals_sources_binance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_binance.py
@@ -228,6 +228,9 @@ def _build_lsr_leg(data: Any, *, role: str) -> dict[str, Any] | None:
         ts = _to_optional_int(entry.get("timestamp"))
         if ts is None:
             continue
+        # Both globalLongShortAccountRatio and topLongShortPositionRatio return
+        # "longAccount"/"shortAccount" proportion fields; if Binance ever differentiates
+        # field names per endpoint, long_pct/short_pct would degrade to None (fail-soft).
         long_acc = _to_optional_float(entry.get("longAccount"))
         short_acc = _to_optional_float(entry.get("shortAccount"))
         history.append(
@@ -268,6 +271,9 @@ def _lsr_divergence_note(
         or top_leg.get("ratio") is None
     ):
         return "divergence 판단 불가 (일부 데이터 없음)"
+    # ratio == 1.0 is treated as "not long" (> 1 is False), so a rare both-legs-exactly-1.0
+    # case reads as same-side "aligned" — matches the spec's >1/==1/<1 convention; live
+    # float ratios essentially never equal exactly 1.0.
     g_long = global_leg["ratio"] > 1
     t_long = top_leg["ratio"] > 1
     if g_long == t_long:

--- a/app/mcp_server/tooling/fundamentals_sources_binance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_binance.py
@@ -201,4 +201,114 @@ async def _fetch_open_interest(symbol: str, period: str, limit: int) -> dict[str
     }
 
 
-__all__ = ["_fetch_funding_rate", "_fetch_funding_rate_batch", "_fetch_open_interest"]
+BINANCE_GLOBAL_LSR_URL = (
+    "https://fapi.binance.com/futures/data/globalLongShortAccountRatio"
+)
+BINANCE_TOP_POSITION_LSR_URL = (
+    "https://fapi.binance.com/futures/data/topLongShortPositionRatio"
+)
+
+
+def _lsr_leg_interpretation(role: str, ratio: float | None) -> str:
+    if ratio is None:
+        return f"{role}: 데이터 없음"
+    if ratio > 1:
+        return f"{role} 롱 우위 (ratio={ratio:.2f}>1)"
+    if ratio < 1:
+        return f"{role} 숏 우위 (ratio={ratio:.2f}<1)"
+    return f"{role} 롱숏 균형 (ratio=1)"
+
+
+def _build_lsr_leg(data: Any, *, role: str) -> dict[str, Any] | None:
+    rows = data if isinstance(data, list) else []
+    history: list[dict[str, Any]] = []
+    for entry in rows:
+        if not isinstance(entry, dict):
+            continue
+        ts = _to_optional_int(entry.get("timestamp"))
+        if ts is None:
+            continue
+        long_acc = _to_optional_float(entry.get("longAccount"))
+        short_acc = _to_optional_float(entry.get("shortAccount"))
+        history.append(
+            {
+                "_ts": ts,
+                "time": datetime.datetime.fromtimestamp(
+                    ts / 1000, tz=datetime.UTC
+                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ratio": _to_optional_float(entry.get("longShortRatio")),
+                "long_pct": round(long_acc * 100, 2) if long_acc is not None else None,
+                "short_pct": round(short_acc * 100, 2)
+                if short_acc is not None
+                else None,
+            }
+        )
+    if not history:
+        return None
+    history.sort(key=lambda e: e["_ts"])
+    for e in history:
+        del e["_ts"]
+    current = history[-1]
+    return {
+        "ratio": current["ratio"],
+        "long_pct": current["long_pct"],
+        "short_pct": current["short_pct"],
+        "history": history,
+        "interpretation": _lsr_leg_interpretation(role, current["ratio"]),
+    }
+
+
+def _lsr_divergence_note(
+    global_leg: dict[str, Any] | None, top_leg: dict[str, Any] | None
+) -> str:
+    if (
+        not global_leg
+        or not top_leg
+        or global_leg.get("ratio") is None
+        or top_leg.get("ratio") is None
+    ):
+        return "divergence 판단 불가 (일부 데이터 없음)"
+    g_long = global_leg["ratio"] > 1
+    t_long = top_leg["ratio"] > 1
+    if g_long == t_long:
+        side = "롱" if g_long else "숏"
+        return f"리테일·스마트머니 동일 방향 ({side} 우위) — 신호 정렬"
+    if g_long and not t_long:
+        return "리테일 롱 / 스마트머니 숏 — contrarian 주의"
+    return "리테일 숏 / 스마트머니 롱 — contrarian 주의"
+
+
+async def _fetch_long_short_ratio(
+    symbol: str, period: str, limit: int
+) -> dict[str, Any]:
+    pair = f"{symbol.upper()}USDT"
+    params = {"symbol": pair, "period": period, "limit": limit}
+
+    async with httpx.AsyncClient(timeout=10) as cli:
+        global_resp, top_resp = await asyncio.gather(
+            cli.get(BINANCE_GLOBAL_LSR_URL, params=params),
+            cli.get(BINANCE_TOP_POSITION_LSR_URL, params=params),
+        )
+        global_resp.raise_for_status()
+        top_resp.raise_for_status()
+        global_data = global_resp.json()
+        top_data = top_resp.json()
+
+    global_leg = _build_lsr_leg(global_data, role="리테일 계정")
+    top_leg = _build_lsr_leg(top_data, role="상위 트레이더 포지션")
+
+    return {
+        "symbol": pair,
+        "period": period,
+        "global_account": global_leg,
+        "top_position": top_leg,
+        "divergence_note": _lsr_divergence_note(global_leg, top_leg),
+    }
+
+
+__all__ = [
+    "_fetch_funding_rate",
+    "_fetch_funding_rate_batch",
+    "_fetch_long_short_ratio",
+    "_fetch_open_interest",
+]

--- a/docs/superpowers/plans/2026-05-31-rob-377-pr2-oi-lsr.md
+++ b/docs/superpowers/plans/2026-05-31-rob-377-pr2-oi-lsr.md
@@ -1,0 +1,786 @@
+# ROB-377 PR2 — Open Interest + Long/Short Ratio Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two read-only MCP tools — `get_open_interest` and `get_long_short_ratio` — surfacing Binance USD-M futures open interest and long/short positioning from public `fapi.binance.com` endpoints.
+
+**Architecture:** Mirror the existing `get_funding_rate` 4-layer pattern exactly: source fetchers in `fundamentals_sources_binance.py`, handlers in `fundamentals/_crypto.py` (normalize symbol, validate, fail-open via `_error_payload`), `@mcp.tool` registrations in `fundamentals_handlers.py`, tool names in `mcp_server/__init__.py`. No new host (fapi.binance.com already used), no auth/secrets, no mutation, no scheduler.
+
+**Tech Stack:** Python 3.13, async httpx, pytest, uv. No migration, no new dependency.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-rob-377-pr2-oi-lsr-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `app/mcp_server/tooling/fundamentals_sources_binance.py` | Binance derivatives provider | +URL constants, `_fetch_open_interest`, `_fetch_long_short_ratio`, interpretation helpers, `__all__` |
+| `app/mcp_server/tooling/fundamentals/_crypto.py` | crypto tool handlers | +`_ALLOWED_PERIODS`, `handle_get_open_interest`, `handle_get_long_short_ratio` |
+| `app/mcp_server/tooling/fundamentals_handlers.py` | MCP tool registry | +import + 2 `@mcp.tool` registrations |
+| `app/mcp_server/__init__.py` | tool-name surface | +`"get_open_interest"`, `"get_long_short_ratio"` |
+| `tests/test_mcp_fundamentals_tools.py` | tool tests | +`TestGetOpenInterest`, `TestGetLongShortRatio` |
+
+Shared test scaffolding already present in the test module: `build_tools()`,
+`_patch_httpx_async_client(monkeypatch, MockClient)`, and the `MockResponse` /
+`MockClient` shape used by `TestGetFundingRate` (lines ~1235-1364). New test
+classes reuse that exact pattern.
+
+---
+
+## Task 1: `get_open_interest`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/fundamentals_sources_binance.py`
+- Modify: `app/mcp_server/tooling/fundamentals/_crypto.py`
+- Modify: `app/mcp_server/tooling/fundamentals_handlers.py`
+- Modify: `app/mcp_server/__init__.py`
+- Test: `tests/test_mcp_fundamentals_tools.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new test class to `tests/test_mcp_fundamentals_tools.py` (end of file):
+
+```python
+@pytest.mark.asyncio
+class TestGetOpenInterest:
+    """ROB-377 PR2: get_open_interest (Binance USD-M, read-only)."""
+
+    def _patch_binance(self, monkeypatch, current_resp, hist_resp, captured=None):
+        class MockResponse:
+            def __init__(self, data):
+                self._data = data
+                self.status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                if captured is not None:
+                    captured.append({"url": url, "params": params or {}})
+                if "openInterestHist" in url:
+                    return MockResponse(hist_resp)
+                return MockResponse(current_resp)
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+    async def test_successful_fetch(self, monkeypatch):
+        tools = build_tools()
+        current = {"symbol": "BTCUSDT", "openInterest": "120000.0", "time": 1707235200000}
+        hist = [
+            {"symbol": "BTCUSDT", "sumOpenInterest": "100000.0",
+             "sumOpenInterestValue": "7000000000.0", "timestamp": 1707206400000},
+            {"symbol": "BTCUSDT", "sumOpenInterest": "110000.0",
+             "sumOpenInterestValue": "7700000000.0", "timestamp": 1707210000000},
+        ]
+        self._patch_binance(monkeypatch, current, hist)
+
+        result = await tools["get_open_interest"]("BTC")
+
+        assert result["symbol"] == "BTCUSDT"
+        assert result["current_open_interest"] == pytest.approx(120000.0)
+        assert result["period"] == "1h"
+        assert len(result["open_interest_history"]) == 2
+        # history sorted ascending by time; change = (110000-100000)/100000*100
+        assert result["open_interest_history"][0]["sum_open_interest"] == pytest.approx(100000.0)
+        assert result["open_interest_history"][-1]["sum_open_interest"] == pytest.approx(110000.0)
+        assert result["oi_change_pct"] == pytest.approx(10.0)
+        assert "증가" in result["interpretation"]
+
+    async def test_oi_change_null_when_insufficient_history(self, monkeypatch):
+        tools = build_tools()
+        current = {"symbol": "BTCUSDT", "openInterest": "120000.0", "time": 1707235200000}
+        hist = [
+            {"symbol": "BTCUSDT", "sumOpenInterest": "100000.0",
+             "sumOpenInterestValue": "7000000000.0", "timestamp": 1707206400000},
+        ]
+        self._patch_binance(monkeypatch, current, hist)
+
+        result = await tools["get_open_interest"]("BTC")
+
+        assert result["oi_change_pct"] is None
+        assert "판단 불가" in result["interpretation"]
+
+    async def test_empty_symbol_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="symbol is required"):
+            await tools["get_open_interest"]("")
+
+    async def test_invalid_period_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="period"):
+            await tools["get_open_interest"]("BTC", period="7m")
+
+    async def test_limit_is_clamped(self, monkeypatch):
+        tools = build_tools()
+        current = {"symbol": "BTCUSDT", "openInterest": "1.0", "time": 1}
+        hist = []
+        captured: list = []
+        self._patch_binance(monkeypatch, current, hist, captured=captured)
+
+        await tools["get_open_interest"]("BTC", limit=9999)
+        hist_calls = [c for c in captured if "openInterestHist" in c["url"]]
+        assert hist_calls and hist_calls[0]["params"]["limit"] == 500
+
+        captured.clear()
+        await tools["get_open_interest"]("BTC", limit=0)
+        hist_calls = [c for c in captured if "openInterestHist" in c["url"]]
+        assert hist_calls and hist_calls[0]["params"]["limit"] == 1
+
+    async def test_error_handling(self, monkeypatch):
+        tools = build_tools()
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                raise Exception("Binance API down")
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+        result = await tools["get_open_interest"]("BTC")
+        assert result.get("error")
+        assert result.get("source") == "binance"
+        assert "open_interest_history" not in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest "tests/test_mcp_fundamentals_tools.py::TestGetOpenInterest" -v`
+Expected: FAIL — `KeyError: 'get_open_interest'` (tool not registered yet).
+
+- [ ] **Step 3: Add the source fetcher**
+
+In `app/mcp_server/tooling/fundamentals_sources_binance.py`, add URL constants after the existing `BINANCE_FUNDING_RATE_URL` line:
+
+```python
+BINANCE_OPEN_INTEREST_URL = "https://fapi.binance.com/fapi/v1/openInterest"
+BINANCE_OPEN_INTEREST_HIST_URL = (
+    "https://fapi.binance.com/futures/data/openInterestHist"
+)
+```
+
+Add an interpretation helper (near `_funding_interpretation_text`):
+
+```python
+def _oi_interpretation_text(oi_change_pct: float | None) -> str:
+    if oi_change_pct is None:
+        return "데이터 부족 — OI 추세 판단 불가"
+    if oi_change_pct > 0:
+        return "OI 증가 — 신규 포지션 유입 (추세 강화 가능)"
+    if oi_change_pct < 0:
+        return "OI 감소 — 포지션 청산/이탈"
+    return "OI 변동 없음"
+```
+
+Add the fetcher (after `_fetch_funding_rate`):
+
+```python
+async def _fetch_open_interest(symbol: str, period: str, limit: int) -> dict[str, Any]:
+    pair = f"{symbol.upper()}USDT"
+
+    async with httpx.AsyncClient(timeout=10) as cli:
+        current_resp, hist_resp = await asyncio.gather(
+            cli.get(BINANCE_OPEN_INTEREST_URL, params={"symbol": pair}),
+            cli.get(
+                BINANCE_OPEN_INTEREST_HIST_URL,
+                params={"symbol": pair, "period": period, "limit": limit},
+            ),
+        )
+        current_resp.raise_for_status()
+        hist_resp.raise_for_status()
+        current_data = current_resp.json()
+        hist_data = hist_resp.json()
+
+    current_oi = _to_optional_float((current_data or {}).get("openInterest"))
+
+    history: list[dict[str, Any]] = []
+    for entry in hist_data if isinstance(hist_data, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        ts = _to_optional_int(entry.get("timestamp"))
+        if ts is None:
+            continue
+        history.append(
+            {
+                "_ts": ts,
+                "time": datetime.datetime.fromtimestamp(
+                    ts / 1000, tz=datetime.UTC
+                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "sum_open_interest": _to_optional_float(entry.get("sumOpenInterest")),
+                "sum_open_interest_value_usd": _to_optional_float(
+                    entry.get("sumOpenInterestValue")
+                ),
+            }
+        )
+    history.sort(key=lambda e: e["_ts"])
+    for e in history:
+        del e["_ts"]
+
+    oi_change_pct: float | None = None
+    if len(history) >= 2:
+        first = history[0]["sum_open_interest"]
+        last = history[-1]["sum_open_interest"]
+        if first is not None and last is not None and first != 0:
+            oi_change_pct = round((last - first) / first * 100, 4)
+
+    return {
+        "symbol": pair,
+        "current_open_interest": current_oi,
+        "period": period,
+        "open_interest_history": history,
+        "oi_change_pct": oi_change_pct,
+        "interpretation": _oi_interpretation_text(oi_change_pct),
+    }
+```
+
+Update `__all__` to include `"_fetch_open_interest"`.
+
+- [ ] **Step 4: Add the handler**
+
+In `app/mcp_server/tooling/fundamentals/_crypto.py`, extend the import from
+`fundamentals_sources_binance` to also import `_fetch_open_interest`:
+
+```python
+from app.mcp_server.tooling.fundamentals_sources_binance import (
+    _fetch_funding_rate,
+    _fetch_funding_rate_batch,
+    _fetch_open_interest,
+)
+```
+
+Add the allowed-period set near the top of the module (after imports):
+
+```python
+_ALLOWED_PERIODS = {"5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"}
+```
+
+Add the handler (after `handle_get_funding_rate`):
+
+```python
+async def handle_get_open_interest(
+    symbol: str | None = None,
+    period: str = "1h",
+    limit: int = 30,
+) -> dict[str, Any]:
+    if symbol is None or not symbol.strip():
+        raise ValueError("symbol is required")
+    period = (period or "").strip().lower()
+    if period not in _ALLOWED_PERIODS:
+        raise ValueError(
+            f"period must be one of: {', '.join(sorted(_ALLOWED_PERIODS))}"
+        )
+    normalized_symbol = _normalize_crypto_base_symbol(symbol)
+    if not normalized_symbol:
+        raise ValueError("symbol is required")
+    capped_limit = min(max(limit, 1), 500)
+    try:
+        return await _fetch_open_interest(normalized_symbol, period, capped_limit)
+    except Exception as exc:
+        return _error_payload(
+            source="binance",
+            message=str(exc),
+            symbol=f"{normalized_symbol}USDT",
+            instrument_type="crypto",
+        )
+```
+
+- [ ] **Step 5: Register the tool + add the tool name**
+
+In `app/mcp_server/tooling/fundamentals_handlers.py`, extend the import from
+`fundamentals._crypto`:
+
+```python
+from app.mcp_server.tooling.fundamentals._crypto import (
+    handle_get_funding_rate,
+    handle_get_kimchi_premium,
+    handle_get_open_interest,
+)
+```
+
+Add the registration right after the `get_funding_rate` `@mcp.tool` block:
+
+```python
+    @mcp.tool(
+        name="get_open_interest",
+        description=(
+            "Get Binance USD-M futures open interest for a crypto symbol: current "
+            "open interest plus recent history (sum OI and notional USD value) and "
+            "the OI change over the window. Read-only public Binance data. "
+            "period in {5m,15m,30m,1h,2h,4h,6h,12h,1d}."
+        ),
+    )
+    async def get_open_interest(
+        symbol: str,
+        period: str = "1h",
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        return await handle_get_open_interest(symbol, period, limit)
+```
+
+In `app/mcp_server/__init__.py`, add `"get_open_interest"` to
+`AVAILABLE_TOOL_NAMES` immediately after `"get_funding_rate"`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest "tests/test_mcp_fundamentals_tools.py::TestGetOpenInterest" -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 7: Lint + commit**
+
+Run: `uv run ruff check app/mcp_server/tooling/fundamentals_sources_binance.py app/mcp_server/tooling/fundamentals/_crypto.py app/mcp_server/tooling/fundamentals_handlers.py app/mcp_server/__init__.py tests/test_mcp_fundamentals_tools.py` and `uv run ruff format --check` on the same — fix any issues you introduced.
+
+```bash
+git add app/mcp_server/tooling/fundamentals_sources_binance.py app/mcp_server/tooling/fundamentals/_crypto.py app/mcp_server/tooling/fundamentals_handlers.py app/mcp_server/__init__.py tests/test_mcp_fundamentals_tools.py
+git commit -m "feat(ROB-377): add get_open_interest MCP tool (Binance USD-M, read-only)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `get_long_short_ratio`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/fundamentals_sources_binance.py`
+- Modify: `app/mcp_server/tooling/fundamentals/_crypto.py`
+- Modify: `app/mcp_server/tooling/fundamentals_handlers.py`
+- Modify: `app/mcp_server/__init__.py`
+- Test: `tests/test_mcp_fundamentals_tools.py`
+
+> `_ALLOWED_PERIODS` is already defined in `_crypto.py` (Task 1) — reuse it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new test class to `tests/test_mcp_fundamentals_tools.py`:
+
+```python
+@pytest.mark.asyncio
+class TestGetLongShortRatio:
+    """ROB-377 PR2: get_long_short_ratio (Binance USD-M, read-only)."""
+
+    def _patch_binance(self, monkeypatch, global_resp, top_resp, captured=None):
+        class MockResponse:
+            def __init__(self, data):
+                self._data = data
+                self.status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                if captured is not None:
+                    captured.append({"url": url, "params": params or {}})
+                if "globalLongShortAccountRatio" in url:
+                    return MockResponse(global_resp)
+                return MockResponse(top_resp)
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+    def _row(self, ratio, long_acc, short_acc, ts):
+        return {
+            "symbol": "BTCUSDT",
+            "longShortRatio": str(ratio),
+            "longAccount": str(long_acc),
+            "shortAccount": str(short_acc),
+            "timestamp": ts,
+        }
+
+    async def test_successful_fetch_with_divergence(self, monkeypatch):
+        tools = build_tools()
+        # retail (global) long-biased; top traders short-biased -> contrarian
+        global_resp = [
+            self._row(1.5, 0.60, 0.40, 1707206400000),
+            self._row(1.85, 0.649, 0.351, 1707210000000),
+        ]
+        top_resp = [
+            self._row(0.95, 0.487, 0.513, 1707206400000),
+            self._row(0.92, 0.479, 0.521, 1707210000000),
+        ]
+        self._patch_binance(monkeypatch, global_resp, top_resp)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+
+        assert result["symbol"] == "BTCUSDT"
+        assert result["period"] == "1h"
+        # current = latest by timestamp
+        assert result["global_account"]["ratio"] == pytest.approx(1.85)
+        assert result["global_account"]["long_pct"] == pytest.approx(64.9)
+        assert result["global_account"]["short_pct"] == pytest.approx(35.1)
+        assert len(result["global_account"]["history"]) == 2
+        assert "롱 우위" in result["global_account"]["interpretation"]
+        assert result["top_position"]["ratio"] == pytest.approx(0.92)
+        assert "숏 우위" in result["top_position"]["interpretation"]
+        assert "contrarian" in result["divergence_note"]
+
+    async def test_aligned_divergence_note(self, monkeypatch):
+        tools = build_tools()
+        global_resp = [self._row(1.4, 0.58, 0.42, 1707210000000)]
+        top_resp = [self._row(1.2, 0.545, 0.455, 1707210000000)]
+        self._patch_binance(monkeypatch, global_resp, top_resp)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+        assert "정렬" in result["divergence_note"]
+
+    async def test_empty_symbol_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="symbol is required"):
+            await tools["get_long_short_ratio"]("")
+
+    async def test_invalid_period_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="period"):
+            await tools["get_long_short_ratio"]("BTC", period="3m")
+
+    async def test_limit_is_clamped(self, monkeypatch):
+        tools = build_tools()
+        captured: list = []
+        self._patch_binance(
+            monkeypatch,
+            [self._row(1.0, 0.5, 0.5, 1)],
+            [self._row(1.0, 0.5, 0.5, 1)],
+            captured=captured,
+        )
+        await tools["get_long_short_ratio"]("BTC", limit=9999)
+        assert captured and all(c["params"]["limit"] == 500 for c in captured)
+
+    async def test_error_handling(self, monkeypatch):
+        tools = build_tools()
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                raise Exception("Binance API down")
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+        assert result.get("error")
+        assert result.get("source") == "binance"
+        assert "global_account" not in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest "tests/test_mcp_fundamentals_tools.py::TestGetLongShortRatio" -v`
+Expected: FAIL — `KeyError: 'get_long_short_ratio'`.
+
+- [ ] **Step 3: Add the source fetcher + helpers**
+
+In `app/mcp_server/tooling/fundamentals_sources_binance.py`, add URL constants:
+
+```python
+BINANCE_GLOBAL_LSR_URL = (
+    "https://fapi.binance.com/futures/data/globalLongShortAccountRatio"
+)
+BINANCE_TOP_POSITION_LSR_URL = (
+    "https://fapi.binance.com/futures/data/topLongShortPositionRatio"
+)
+```
+
+Add helpers:
+
+```python
+def _lsr_leg_interpretation(role: str, ratio: float | None) -> str:
+    if ratio is None:
+        return f"{role}: 데이터 없음"
+    if ratio > 1:
+        return f"{role} 롱 우위 (ratio={ratio:.2f}>1)"
+    if ratio < 1:
+        return f"{role} 숏 우위 (ratio={ratio:.2f}<1)"
+    return f"{role} 롱숏 균형 (ratio=1)"
+
+
+def _build_lsr_leg(data: Any, *, role: str) -> dict[str, Any] | None:
+    rows = data if isinstance(data, list) else []
+    history: list[dict[str, Any]] = []
+    for entry in rows:
+        if not isinstance(entry, dict):
+            continue
+        ts = _to_optional_int(entry.get("timestamp"))
+        if ts is None:
+            continue
+        long_acc = _to_optional_float(entry.get("longAccount"))
+        short_acc = _to_optional_float(entry.get("shortAccount"))
+        history.append(
+            {
+                "_ts": ts,
+                "time": datetime.datetime.fromtimestamp(
+                    ts / 1000, tz=datetime.UTC
+                ).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "ratio": _to_optional_float(entry.get("longShortRatio")),
+                "long_pct": round(long_acc * 100, 2) if long_acc is not None else None,
+                "short_pct": round(short_acc * 100, 2)
+                if short_acc is not None
+                else None,
+            }
+        )
+    if not history:
+        return None
+    history.sort(key=lambda e: e["_ts"])
+    for e in history:
+        del e["_ts"]
+    current = history[-1]
+    return {
+        "ratio": current["ratio"],
+        "long_pct": current["long_pct"],
+        "short_pct": current["short_pct"],
+        "history": history,
+        "interpretation": _lsr_leg_interpretation(role, current["ratio"]),
+    }
+
+
+def _lsr_divergence_note(
+    global_leg: dict[str, Any] | None, top_leg: dict[str, Any] | None
+) -> str:
+    if (
+        not global_leg
+        or not top_leg
+        or global_leg.get("ratio") is None
+        or top_leg.get("ratio") is None
+    ):
+        return "divergence 판단 불가 (일부 데이터 없음)"
+    g_long = global_leg["ratio"] > 1
+    t_long = top_leg["ratio"] > 1
+    if g_long == t_long:
+        side = "롱" if g_long else "숏"
+        return f"리테일·스마트머니 동일 방향 ({side} 우위) — 신호 정렬"
+    if g_long and not t_long:
+        return "리테일 롱 / 스마트머니 숏 — contrarian 주의"
+    return "리테일 숏 / 스마트머니 롱 — contrarian 주의"
+```
+
+Add the fetcher:
+
+```python
+async def _fetch_long_short_ratio(
+    symbol: str, period: str, limit: int
+) -> dict[str, Any]:
+    pair = f"{symbol.upper()}USDT"
+    params = {"symbol": pair, "period": period, "limit": limit}
+
+    async with httpx.AsyncClient(timeout=10) as cli:
+        global_resp, top_resp = await asyncio.gather(
+            cli.get(BINANCE_GLOBAL_LSR_URL, params=params),
+            cli.get(BINANCE_TOP_POSITION_LSR_URL, params=params),
+        )
+        global_resp.raise_for_status()
+        top_resp.raise_for_status()
+        global_data = global_resp.json()
+        top_data = top_resp.json()
+
+    global_leg = _build_lsr_leg(global_data, role="리테일 계정")
+    top_leg = _build_lsr_leg(top_data, role="상위 트레이더 포지션")
+
+    return {
+        "symbol": pair,
+        "period": period,
+        "global_account": global_leg,
+        "top_position": top_leg,
+        "divergence_note": _lsr_divergence_note(global_leg, top_leg),
+    }
+```
+
+Update `__all__` to also include `"_fetch_long_short_ratio"`.
+
+- [ ] **Step 4: Add the handler**
+
+In `app/mcp_server/tooling/fundamentals/_crypto.py`, extend the binance import to
+include `_fetch_long_short_ratio`:
+
+```python
+from app.mcp_server.tooling.fundamentals_sources_binance import (
+    _fetch_funding_rate,
+    _fetch_funding_rate_batch,
+    _fetch_long_short_ratio,
+    _fetch_open_interest,
+)
+```
+
+Add the handler (after `handle_get_open_interest`):
+
+```python
+async def handle_get_long_short_ratio(
+    symbol: str | None = None,
+    period: str = "1h",
+    limit: int = 30,
+) -> dict[str, Any]:
+    if symbol is None or not symbol.strip():
+        raise ValueError("symbol is required")
+    period = (period or "").strip().lower()
+    if period not in _ALLOWED_PERIODS:
+        raise ValueError(
+            f"period must be one of: {', '.join(sorted(_ALLOWED_PERIODS))}"
+        )
+    normalized_symbol = _normalize_crypto_base_symbol(symbol)
+    if not normalized_symbol:
+        raise ValueError("symbol is required")
+    capped_limit = min(max(limit, 1), 500)
+    try:
+        return await _fetch_long_short_ratio(normalized_symbol, period, capped_limit)
+    except Exception as exc:
+        return _error_payload(
+            source="binance",
+            message=str(exc),
+            symbol=f"{normalized_symbol}USDT",
+            instrument_type="crypto",
+        )
+```
+
+- [ ] **Step 5: Register the tool + add the tool name**
+
+In `app/mcp_server/tooling/fundamentals_handlers.py`, extend the `_crypto` import
+to include `handle_get_long_short_ratio`:
+
+```python
+from app.mcp_server.tooling.fundamentals._crypto import (
+    handle_get_funding_rate,
+    handle_get_kimchi_premium,
+    handle_get_long_short_ratio,
+    handle_get_open_interest,
+)
+```
+
+Add the registration right after the `get_open_interest` `@mcp.tool` block:
+
+```python
+    @mcp.tool(
+        name="get_long_short_ratio",
+        description=(
+            "Get Binance USD-M long/short ratio for a crypto symbol: global account "
+            "ratio (retail sentiment) and top-trader position ratio (smart money), "
+            "each with current value, recent history, and a retail-vs-smart-money "
+            "divergence note. Read-only public Binance data. "
+            "period in {5m,15m,30m,1h,2h,4h,6h,12h,1d}."
+        ),
+    )
+    async def get_long_short_ratio(
+        symbol: str,
+        period: str = "1h",
+        limit: int = 30,
+    ) -> dict[str, Any]:
+        return await handle_get_long_short_ratio(symbol, period, limit)
+```
+
+In `app/mcp_server/__init__.py`, add `"get_long_short_ratio"` to
+`AVAILABLE_TOOL_NAMES` immediately after `"get_open_interest"`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest "tests/test_mcp_fundamentals_tools.py::TestGetLongShortRatio" -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 7: Lint + commit**
+
+Run: `uv run ruff check` + `uv run ruff format --check` on the 5 changed files; fix any issues.
+
+```bash
+git add app/mcp_server/tooling/fundamentals_sources_binance.py app/mcp_server/tooling/fundamentals/_crypto.py app/mcp_server/tooling/fundamentals_handlers.py app/mcp_server/__init__.py tests/test_mcp_fundamentals_tools.py
+git commit -m "feat(ROB-377): add get_long_short_ratio MCP tool (Binance USD-M, read-only)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Lint + type + test gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint**
+
+Run: `uv run ruff check app/ tests/`
+Expected: no errors.
+
+- [ ] **Step 2: Format check**
+
+Run: `uv run ruff format --check app/ tests/`
+Expected: all files already formatted. (If any file is listed, run `uv run ruff format app/ tests/`, re-check, and amend the relevant commit.)
+
+- [ ] **Step 3: Type check**
+
+Run: `uv run ty check app/mcp_server/tooling/fundamentals_sources_binance.py app/mcp_server/tooling/fundamentals/_crypto.py app/mcp_server/tooling/fundamentals_handlers.py`
+Expected: no new type errors.
+
+- [ ] **Step 4: AVAILABLE_TOOL_NAMES regression**
+
+Run: `uv run python -c "from app.mcp_server import AVAILABLE_TOOL_NAMES as n; assert 'get_open_interest' in n and 'get_long_short_ratio' in n, n; print('tool names OK')"`
+Expected: prints `tool names OK`.
+
+- [ ] **Step 5: Targeted tests**
+
+Run: `uv run pytest "tests/test_mcp_fundamentals_tools.py::TestGetOpenInterest" "tests/test_mcp_fundamentals_tools.py::TestGetLongShortRatio" "tests/test_mcp_fundamentals_tools.py::TestGetFundingRate" -q`
+Expected: all PASS (new tools + funding-rate regression).
+
+- [ ] **Step 6: Full fundamentals-module regression**
+
+Run: `uv run pytest tests/test_mcp_fundamentals_tools.py -q`
+Expected: PASS.
+
+> Note: the full `pytest -n auto` suite runs against a shared Postgres in CI;
+> unrelated DB-integration tests can flake across xdist workers (re-run clears).
+> Treat only failures in the touched module as blocking locally; rely on the CI
+> Test workflow for the green-main gate before merge.
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** AC ③ `get_open_interest` → Task 1; `get_long_short_ratio`
+  (global + top-position + divergence) → Task 2; period/limit/symbol validation →
+  both tasks' handlers; fail-open `_error_payload` → both tasks' `test_error_handling`;
+  tool-name surface → Steps 5 + Task 3 Step 4; safety boundary (read-only/no-host/
+  no-secret) → spec-level, no mutation code introduced. ✓
+- **Placeholder scan:** every code step has complete code; no TBD/TODO. ✓
+- **Type consistency:** `_fetch_open_interest(symbol, period, limit)` and
+  `_fetch_long_short_ratio(symbol, period, limit)` signatures identical across
+  source (Tasks 1/2 Step 3) and handler call sites (Step 4). `_ALLOWED_PERIODS`
+  defined once (Task 1) and reused (Task 2). `_to_optional_float`/`_to_optional_int`
+  are already imported in `fundamentals_sources_binance.py`. Row keys
+  (`sum_open_interest`, `sum_open_interest_value_usd`, `oi_change_pct`,
+  `global_account`/`top_position` with `ratio`/`long_pct`/`short_pct`/`history`/
+  `interpretation`, `divergence_note`) match between implementation and tests. ✓
+- **Out of scope (documented):** liquidations (no vendor), Upbit indices (PR3),
+  batch (per-symbol decision), A3. ✓

--- a/docs/superpowers/specs/2026-05-31-rob-377-pr2-oi-lsr-design.md
+++ b/docs/superpowers/specs/2026-05-31-rob-377-pr2-oi-lsr-design.md
@@ -1,0 +1,187 @@
+# ROB-377 PR2 — Derivatives sentiment: Open Interest + Long/Short Ratio (Binance public read-only)
+
+**Date:** 2026-05-31
+**Issue:** ROB-377 §A2 (parent ROB-369 Slice 4)
+**Scope:** PR2 of a 3-PR slicing. PR1 (A1 crypto market index) is MERGED
+(`ef4ae091`). This PR covers **A2** only: surface Binance USD-M open interest
+and long/short ratio as MCP read tools. Liquidations are parked (no archive
+vendor — see ROB-355). Upbit digital-asset indices are a separate follow-up
+(PR3). A3 (on-chain/ETF) is parked.
+
+## Problem
+
+Crypto reports can read funding (`get_funding_rate`) but have no MCP visibility
+into **open interest (OI)** or **long/short positioning (LSR)** — two of the
+core derivatives-sentiment signals. They currently depend on out-of-band
+(9222 Upbit) inspection.
+
+## Goal (acceptance, ROB-377 AC ③)
+
+Two new MCP read tools expose OI and LSR from Binance USD-M futures:
+
+- `get_open_interest(symbol, period, limit)` → current OI + recent OI history +
+  trend.
+- `get_long_short_ratio(symbol, period, limit)` → global-account ratio (retail
+  sentiment) + top-trader position ratio (smart money) + a divergence note.
+
+Both are **public, read-only, no-auth** Binance endpoints on `fapi.binance.com`.
+
+## The A2 gotcha (must be stated in the PR)
+
+ROB-356's funding+OI feature builder consumes `data.binance.vision` **archives**
+(monthly/daily zip, for PIT backtesting). This PR is a **live read client** over
+different endpoints (`fapi.binance.com/futures/data/*` + `/fapi/v1/openInterest`).
+It does **not** reuse ROB-356's archive code — surfacing the archive builder as a
+live tool would be wrong (stale, not real-time).
+
+## Approach — mirror the existing `get_funding_rate` pattern
+
+`get_funding_rate` already implements the exact 4-layer shape we need, against
+the same host. Extend each layer:
+
+1. **Source** — `app/mcp_server/tooling/fundamentals_sources_binance.py`:
+   add `_fetch_open_interest(symbol, period, limit)` and
+   `_fetch_long_short_ratio(symbol, period, limit)`, plus URL constants; export
+   in `__all__`.
+2. **Handler** — `app/mcp_server/tooling/fundamentals/_crypto.py`:
+   add `handle_get_open_interest()` and `handle_get_long_short_ratio()`,
+   mirroring `handle_get_funding_rate` (normalize symbol via
+   `_normalize_crypto_base_symbol`, validate, call source, `except` →
+   `_error_payload(source="binance", instrument_type="crypto")`).
+3. **Registration** — `app/mcp_server/tooling/fundamentals_handlers.py`:
+   add two `@mcp.tool(...)` registrations + import the two handlers.
+4. **Surface** — `app/mcp_server/__init__.py`:
+   add `"get_open_interest"` and `"get_long_short_ratio"` to
+   `AVAILABLE_TOOL_NAMES`.
+
+## Endpoints (all `https://fapi.binance.com`, public, no-auth)
+
+| Tool | Endpoint(s) |
+|------|-------------|
+| OI current | `GET /fapi/v1/openInterest?symbol=BTCUSDT` → `{openInterest, symbol, time}` |
+| OI history | `GET /futures/data/openInterestHist?symbol=&period=&limit=` → `[{sumOpenInterest, sumOpenInterestValue, timestamp}]` |
+| LSR global | `GET /futures/data/globalLongShortAccountRatio?symbol=&period=&limit=` → `[{longShortRatio, longAccount, shortAccount, timestamp}]` |
+| LSR top-position | `GET /futures/data/topLongShortPositionRatio?symbol=&period=&limit=` → `[{longShortRatio, longAccount, shortAccount, timestamp}]` |
+
+`/futures/data/*` history is most-recent-first or oldest-first depending on
+Binance; the implementation sorts the returned history by timestamp ascending
+and takes the latest entry as "current" for the ratio tools.
+
+## Tool contracts
+
+### `get_open_interest(symbol: str, period: str = "1h", limit: int = 30)`
+
+```jsonc
+{
+  "symbol": "BTCUSDT",
+  "current_open_interest": 123456.789,           // contracts, from /fapi/v1/openInterest
+  "period": "1h",
+  "open_interest_history": [
+    {"time": "2026-05-31T00:00:00Z",
+     "sum_open_interest": 123000.0,              // contracts
+     "sum_open_interest_value_usd": 8.1e9}       // notional USD
+  ],
+  "oi_change_pct": 2.34,                          // (last - first) / first * 100 over the window, null if <2 points
+  "interpretation": "OI 증가 — 신규 포지션 유입 (추세 강화 가능)" // by sign of oi_change_pct
+}
+```
+
+### `get_long_short_ratio(symbol: str, period: str = "1h", limit: int = 30)`
+
+```jsonc
+{
+  "symbol": "BTCUSDT",
+  "period": "1h",
+  "global_account": {                             // globalLongShortAccountRatio — retail
+    "ratio": 1.85, "long_pct": 64.9, "short_pct": 35.1,
+    "history": [{"time": "...", "ratio": 1.8, "long_pct": 64.3, "short_pct": 35.7}],
+    "interpretation": "리테일 계정 롱 우위 (ratio>1)"
+  },
+  "top_position": {                               // topLongShortPositionRatio — smart money
+    "ratio": 0.92, "long_pct": 47.9, "short_pct": 52.1,
+    "history": [...],
+    "interpretation": "상위 트레이더 포지션 숏 우위 (ratio<1)"
+  },
+  "divergence_note": "리테일 롱 / 스마트머니 숏 — contrarian 주의" // derived from the two current ratios
+}
+```
+
+`longAccount`/`shortAccount` from Binance are proportions in `[0,1]`; surface as
+percentages (`*100`, rounded). `ratio` = `longShortRatio` passthrough (float).
+
+## Parameter validation
+
+- `symbol` **required** (decision: no batch — `/futures/data/*` is per-symbol and
+  has no all-symbols snapshot). Empty/missing → `ValueError`.
+- `period` ∈ `{"5m","15m","30m","1h","2h","4h","6h","12h","1d"}` (Binance's
+  allowed set) else `ValueError` (mirrors `get_market_index` period validation).
+- `limit` clamped to `[1, 500]` (Binance max), default `30`.
+
+## Interpretation / divergence logic (deterministic, no price coupling)
+
+- OI: `oi_change_pct > 0` → "OI 증가 — 신규 포지션 유입"; `< 0` → "OI 감소 —
+  포지션 청산/이탈"; `== 0` or `null` → neutral/"데이터 부족". No price coupling
+  (we don't fetch price here), so phrasing is about position flow only.
+- LSR per-leg: `ratio > 1` → 롱 우위; `< 1` → 숏 우위; `== 1` → 균형.
+- `divergence_note`: compare `global_account.ratio` vs `top_position.ratio`
+  across the 1.0 boundary — if retail and top traders sit on opposite sides,
+  emit a contrarian-caution note; if same side, emit an alignment note; if a leg
+  is unavailable, emit "divergence 판단 불가 (일부 데이터 없음)".
+
+## Error handling & safety boundary
+
+- **Read-only.** No broker/order/watch/order-intent mutation reachable.
+- **No secrets.** Public endpoints; no API key, no signing, nothing printed or
+  committed.
+- **No new host.** `fapi.binance.com` is already used by `get_funding_rate`
+  (URL constants pinned in the source module).
+- **No scheduler.** No TaskIQ/Prefect/cron activation.
+- **Fail-open**, identical to `get_funding_rate`: `httpx.AsyncClient(timeout=10)`
+  + `.raise_for_status()`; the handler's `try/except` maps any failure to
+  `_error_payload(source="binance", ...)`. A Binance outage degrades only these
+  tools — never crashes a caller or fabricates values.
+
+## Test plan (TDD)
+
+Mirror `TestGetFundingRate` in `tests/test_mcp_fundamentals_tools.py`
+(monkeypatch `httpx.AsyncClient.get`, drive via `build_tools()`):
+
+1. `get_open_interest(symbol="BTC")` happy path → `current_open_interest`,
+   `open_interest_history` rows, `oi_change_pct` computed, `interpretation`
+   matches the change sign, `symbol == "BTCUSDT"`.
+2. `oi_change_pct` is `null` when history has <2 points; interpretation neutral.
+3. `get_long_short_ratio(symbol="BTC")` happy path → `global_account` +
+   `top_position` each with `ratio`/`long_pct`/`short_pct`/`history`, and a
+   `divergence_note` reflecting the two current ratios.
+4. `divergence_note` contrarian vs aligned cases (retail long + top short ⇒
+   contrarian; both long ⇒ aligned).
+5. Missing/empty `symbol` → `ValueError` for both tools.
+6. Invalid `period` → `ValueError` for both tools.
+7. `limit` clamped to `[1, 500]` (e.g. 0 → 1, 9999 → 500) — assert the value
+   passed to the Binance request.
+8. Binance failure (mocked raise) → `_error_payload(source="binance")` for both
+   tools (fail-open; no fabricated rows).
+9. Source-level unit tests for `_fetch_open_interest` / `_fetch_long_short_ratio`
+   (row shape + computed fields) with mocked httpx.
+10. Regression: existing `TestGetFundingRate` and tool-registry tests pass;
+    `AVAILABLE_TOOL_NAMES` includes the two new names.
+
+## Verification
+
+Deterministic unit tests prove AC ③. A live Binance round-trip is
+operator-verifiable but **not a merge gate** (consistent with other slices).
+**Linear Done is gated on main CI green + operator smoke evidence** — do not mark
+Done before then.
+
+CI gate before merge (repo convention): `ruff check app/ tests/` +
+`ruff format --check app/ tests/` + `ty` + the Test workflow green.
+
+## Files touched
+
+- `app/mcp_server/tooling/fundamentals_sources_binance.py` (2 fetchers + URL constants)
+- `app/mcp_server/tooling/fundamentals/_crypto.py` (2 handlers)
+- `app/mcp_server/tooling/fundamentals_handlers.py` (2 registrations + import)
+- `app/mcp_server/__init__.py` (2 tool names)
+- `tests/test_mcp_fundamentals_tools.py` (new `TestGetOpenInterest` + `TestGetLongShortRatio`)
+
+No migration. No new dependency. No new external host.

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4612,3 +4612,148 @@ class TestFetchIndexCryptoCurrent:
             await fundamentals_sources_indices._fetch_index_crypto_current(
                 "unsupported", "x", "X"
             )
+
+
+@pytest.mark.asyncio
+class TestGetOpenInterest:
+    """ROB-377 PR2: get_open_interest (Binance USD-M, read-only)."""
+
+    def _patch_binance(self, monkeypatch, current_resp, hist_resp, captured=None):
+        class MockResponse:
+            def __init__(self, data):
+                self._data = data
+                self.status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                if captured is not None:
+                    captured.append({"url": url, "params": params or {}})
+                if "openInterestHist" in url:
+                    return MockResponse(hist_resp)
+                return MockResponse(current_resp)
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+    async def test_successful_fetch(self, monkeypatch):
+        tools = build_tools()
+        current = {
+            "symbol": "BTCUSDT",
+            "openInterest": "120000.0",
+            "time": 1707235200000,
+        }
+        hist = [
+            {
+                "symbol": "BTCUSDT",
+                "sumOpenInterest": "100000.0",
+                "sumOpenInterestValue": "7000000000.0",
+                "timestamp": 1707206400000,
+            },
+            {
+                "symbol": "BTCUSDT",
+                "sumOpenInterest": "110000.0",
+                "sumOpenInterestValue": "7700000000.0",
+                "timestamp": 1707210000000,
+            },
+        ]
+        self._patch_binance(monkeypatch, current, hist)
+
+        result = await tools["get_open_interest"]("BTC")
+
+        assert result["symbol"] == "BTCUSDT"
+        assert result["current_open_interest"] == pytest.approx(120000.0)
+        assert result["period"] == "1h"
+        assert len(result["open_interest_history"]) == 2
+        assert result["open_interest_history"][0]["sum_open_interest"] == pytest.approx(
+            100000.0
+        )
+        assert result["open_interest_history"][-1][
+            "sum_open_interest"
+        ] == pytest.approx(110000.0)
+        assert result["oi_change_pct"] == pytest.approx(10.0)
+        assert "증가" in result["interpretation"]
+
+    async def test_oi_change_null_when_insufficient_history(self, monkeypatch):
+        tools = build_tools()
+        current = {
+            "symbol": "BTCUSDT",
+            "openInterest": "120000.0",
+            "time": 1707235200000,
+        }
+        hist = [
+            {
+                "symbol": "BTCUSDT",
+                "sumOpenInterest": "100000.0",
+                "sumOpenInterestValue": "7000000000.0",
+                "timestamp": 1707206400000,
+            },
+        ]
+        self._patch_binance(monkeypatch, current, hist)
+
+        result = await tools["get_open_interest"]("BTC")
+
+        assert result["oi_change_pct"] is None
+        assert "판단 불가" in result["interpretation"]
+
+    async def test_empty_symbol_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="symbol is required"):
+            await tools["get_open_interest"]("")
+
+    async def test_invalid_period_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="period"):
+            await tools["get_open_interest"]("BTC", period="7m")
+
+    async def test_limit_is_clamped(self, monkeypatch):
+        tools = build_tools()
+        current = {"symbol": "BTCUSDT", "openInterest": "1.0", "time": 1}
+        hist = []
+        captured: list = []
+        self._patch_binance(monkeypatch, current, hist, captured=captured)
+
+        await tools["get_open_interest"]("BTC", limit=9999)
+        hist_calls = [c for c in captured if "openInterestHist" in c["url"]]
+        assert hist_calls and hist_calls[0]["params"]["limit"] == 500
+
+        captured.clear()
+        await tools["get_open_interest"]("BTC", limit=0)
+        hist_calls = [c for c in captured if "openInterestHist" in c["url"]]
+        assert hist_calls and hist_calls[0]["params"]["limit"] == 1
+
+    async def test_error_handling(self, monkeypatch):
+        tools = build_tools()
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                raise Exception("Binance API down")
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+        result = await tools["get_open_interest"]("BTC")
+        assert result.get("error")
+        assert result.get("source") == "binance"
+        assert "open_interest_history" not in result

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4770,3 +4770,127 @@ class TestGetOpenInterest:
 
         result_suffix = await tools["get_open_interest"]("BTCUSDT")
         assert result_suffix["symbol"] == "BTCUSDT"
+
+
+@pytest.mark.asyncio
+class TestGetLongShortRatio:
+    """ROB-377 PR2: get_long_short_ratio (Binance USD-M, read-only)."""
+
+    def _patch_binance(self, monkeypatch, global_resp, top_resp, captured=None):
+        class MockResponse:
+            def __init__(self, data):
+                self._data = data
+                self.status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._data
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                if captured is not None:
+                    captured.append({"url": url, "params": params or {}})
+                if "globalLongShortAccountRatio" in url:
+                    return MockResponse(global_resp)
+                return MockResponse(top_resp)
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+    def _row(self, ratio, long_acc, short_acc, ts):
+        return {
+            "symbol": "BTCUSDT",
+            "longShortRatio": str(ratio),
+            "longAccount": str(long_acc),
+            "shortAccount": str(short_acc),
+            "timestamp": ts,
+        }
+
+    async def test_successful_fetch_with_divergence(self, monkeypatch):
+        tools = build_tools()
+        global_resp = [
+            self._row(1.5, 0.60, 0.40, 1707206400000),
+            self._row(1.85, 0.649, 0.351, 1707210000000),
+        ]
+        top_resp = [
+            self._row(0.95, 0.487, 0.513, 1707206400000),
+            self._row(0.92, 0.479, 0.521, 1707210000000),
+        ]
+        self._patch_binance(monkeypatch, global_resp, top_resp)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+
+        assert result["symbol"] == "BTCUSDT"
+        assert result["period"] == "1h"
+        assert result["global_account"]["ratio"] == pytest.approx(1.85)
+        assert result["global_account"]["long_pct"] == pytest.approx(64.9)
+        assert result["global_account"]["short_pct"] == pytest.approx(35.1)
+        assert len(result["global_account"]["history"]) == 2
+        assert "롱 우위" in result["global_account"]["interpretation"]
+        assert result["top_position"]["ratio"] == pytest.approx(0.92)
+        assert "숏 우위" in result["top_position"]["interpretation"]
+        assert "contrarian" in result["divergence_note"]
+
+    async def test_aligned_divergence_note(self, monkeypatch):
+        tools = build_tools()
+        global_resp = [self._row(1.4, 0.58, 0.42, 1707210000000)]
+        top_resp = [self._row(1.2, 0.545, 0.455, 1707210000000)]
+        self._patch_binance(monkeypatch, global_resp, top_resp)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+        assert "정렬" in result["divergence_note"]
+
+    async def test_empty_symbol_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="symbol is required"):
+            await tools["get_long_short_ratio"]("")
+
+    async def test_invalid_period_raises(self):
+        tools = build_tools()
+        with pytest.raises(ValueError, match="period"):
+            await tools["get_long_short_ratio"]("BTC", period="3m")
+
+    async def test_limit_is_clamped(self, monkeypatch):
+        tools = build_tools()
+        captured: list = []
+        self._patch_binance(
+            monkeypatch,
+            [self._row(1.0, 0.5, 0.5, 1)],
+            [self._row(1.0, 0.5, 0.5, 1)],
+            captured=captured,
+        )
+        await tools["get_long_short_ratio"]("BTC", limit=9999)
+        assert captured and all(c["params"]["limit"] == 500 for c in captured)
+
+    async def test_error_handling(self, monkeypatch):
+        tools = build_tools()
+
+        class MockClient:
+            def __init__(self, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                pass
+
+            async def get(self, url, params=None, **kw):
+                raise Exception("Binance API down")
+
+        _patch_httpx_async_client(monkeypatch, MockClient)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+        assert result.get("error")
+        assert result.get("source") == "binance"
+        assert "global_account" not in result

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4757,3 +4757,16 @@ class TestGetOpenInterest:
         assert result.get("error")
         assert result.get("source") == "binance"
         assert "open_interest_history" not in result
+
+    async def test_symbol_normalization(self, monkeypatch):
+        tools = build_tools()
+        current = {"symbol": "BTCUSDT", "openInterest": "1.0", "time": 1}
+        hist = []
+        self._patch_binance(monkeypatch, current, hist)
+
+        # KRW- prefix and USDT suffix both normalize to the BTCUSDT pair.
+        result_krw = await tools["get_open_interest"]("KRW-BTC")
+        assert result_krw["symbol"] == "BTCUSDT"
+
+        result_suffix = await tools["get_open_interest"]("BTCUSDT")
+        assert result_suffix["symbol"] == "BTCUSDT"

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4894,3 +4894,16 @@ class TestGetLongShortRatio:
         assert result.get("error")
         assert result.get("source") == "binance"
         assert "global_account" not in result
+
+    async def test_divergence_unavailable_when_a_leg_is_empty(self, monkeypatch):
+        tools = build_tools()
+        # global leg has data; top-position leg returns an empty list -> None leg.
+        global_resp = [self._row(1.5, 0.6, 0.4, 1707210000000)]
+        top_resp = []
+        self._patch_binance(monkeypatch, global_resp, top_resp)
+
+        result = await tools["get_long_short_ratio"]("BTC")
+
+        assert result["global_account"] is not None
+        assert result["top_position"] is None
+        assert "판단 불가" in result["divergence_note"]


### PR DESCRIPTION
## Summary

ROB-377 **PR2 (A2)** — adds two read-only MCP tools surfacing Binance USD-M derivatives sentiment so crypto reports can see open interest and long/short positioning (previously 9222-Upbit-only). Parent: ROB-369 Slice 4. PR1 (A1 crypto market index, #1040) is merged.

- **`get_open_interest(symbol, period="1h", limit=30)`** — current OI (`/fapi/v1/openInterest`) + recent history (`/futures/data/openInterestHist`: sum OI + notional USD) + OI change % over the window + interpretation.
- **`get_long_short_ratio(symbol, period="1h", limit=30)`** — two legs: **global account ratio** (`globalLongShortAccountRatio`, retail sentiment) + **top-trader position ratio** (`topLongShortPositionRatio`, smart money), each with current value + recent history + interpretation, plus a **retail-vs-smart-money divergence note**.

Mirrors the existing `get_funding_rate` 4-layer pattern (source → handler → `@mcp.tool` → tool-name list). All endpoints are public, **no-auth**, on `fapi.binance.com` (already used).

### A2 gotcha (resolved correctly)
ROB-356's funding+OI builder consumes `data.binance.vision` **archives** (PIT backtest). These tools are a **new live read client** over `fapi.binance.com/futures/data/*` + `/fapi/v1/openInterest` — NOT a reuse of the archive builder (which would be stale/wrong for real-time reads).

### Acceptance (ROB-377 AC ③)
- `get_open_interest` + `get_long_short_ratio` expose OI/LSR ✅
- Liquidations parked (no archive vendor — ROB-355); Upbit digital-asset indices = separate follow-up (PR3); A3 parked ✅

### Safety boundary
Read-only public market data. No broker/order/watch/order-intent mutation. No secrets (public endpoints, no API key/signing, nothing printed/committed). No new external host. No scheduler/TaskIQ/Prefect/cron. **Fail-open**: a Binance outage degrades only these tools (`_error_payload`), never crashes a caller or fabricates values. Client errors (missing symbol / invalid period) raise `ValueError`; only fetch failures become error payloads.

## Test plan
- [x] `TestGetOpenInterest` (7): happy path + OI change %, null change on <2 points, empty-symbol ValueError, invalid-period ValueError, limit clamp [1,500] (asserted at HTTP params), fail-open error_payload, symbol normalization
- [x] `TestGetLongShortRatio` (7): happy path + divergence (contrarian), aligned divergence, empty-symbol/invalid-period ValueError, limit clamp, fail-open error_payload, empty-leg → "판단 불가"
- [x] `get_funding_rate` regression + full `tests/test_mcp_fundamentals_tools.py` (184) pass
- [x] `ruff check` + `ruff format --check` (app/ tests/) clean; `ty` clean on touched modules; `AVAILABLE_TOOL_NAMES` includes both new tools
- Note: full `pytest -n auto` runs on a shared Postgres in CI; unrelated DB-integration tests can flake across xdist workers (re-run clears).

Spec: `docs/superpowers/specs/2026-05-31-rob-377-pr2-oi-lsr-design.md`
Plan: `docs/superpowers/plans/2026-05-31-rob-377-pr2-oi-lsr.md`

> Not marking ROB-377 Done: pending main CI green + operator live-Binance smoke evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)