### PR TITLE
fix(ROB-375): get_trade_journal enrich_live opt-in for target/stop touch (Bug 3)

### DIFF
--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -45,7 +45,8 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "account_type defaults to 'live'; set to 'paper' for paper journals, "
             "or None to query both. "
             "account (optional) filters to a specific account name. "
-            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID."
+            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID. "
+            "enrich_live (optional, default False): fetch live quotes to compute current_price/pnl_pct_live/target_reached/stop_reached and near_target/near_stop. Slower (one quote per returned entry); fail-open per entry."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -62,6 +62,46 @@ def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
     }
 
 
+_LONG_SIDES = {"buy", "long"}
+_QUOTE_MARKET_BY_INSTRUMENT = {
+    InstrumentType.equity_us: "us",
+    InstrumentType.equity_kr: "kr",
+    InstrumentType.crypto: "crypto",
+}
+_NEAR_PCT = 1.5  # within ±1.5% of target/stop counts as "near"
+
+
+def _apply_live_enrich(
+    entry: dict[str, Any], *, current_price: float, side: str | None
+) -> None:
+    """Mutate ``entry`` in place with live target/stop/pnl judgements.
+
+    Pure: takes an already-fetched ``current_price`` so it is trivially
+    testable without network. Leaves a field ``None`` when its inputs are
+    missing rather than fabricating a value.
+    """
+    is_long = (side or "buy").strip().lower() in _LONG_SIDES
+    entry["current_price"] = current_price
+
+    entry_price = entry.get("entry_price")
+    if entry_price:
+        raw_pct = (current_price - entry_price) / entry_price * 100.0
+        entry["pnl_pct_live"] = raw_pct if is_long else -raw_pct
+    else:
+        entry["pnl_pct_live"] = None
+
+    target = entry.get("target_price")
+    if target is not None:
+        entry["target_reached"] = (
+            current_price >= target if is_long else current_price <= target
+        )
+    stop = entry.get("stop_loss")
+    if stop is not None:
+        entry["stop_reached"] = (
+            current_price <= stop if is_long else current_price >= stop
+        )
+
+
 async def save_trade_journal(
     symbol: str,
     thesis: str,
@@ -208,6 +248,7 @@ async def get_trade_journal(
     account_type: str | None = "live",
     account: str | None = None,
     paperclip_issue_id: str | None = None,
+    enrich_live: bool = False,
 ) -> dict[str, Any]:
     """Query trade journals. Call before any sell decision to check thesis and hold periods.
 
@@ -299,12 +340,41 @@ async def get_trade_journal(
                     entry["hold_remaining_days"] = None
                     entry["hold_expired"] = None
 
-                # Current price not fetched here (too slow for bulk queries)
-                # Caller can use get_quote separately
+                # Live enrichment is opt-in (per-entry quote is slow for bulk).
                 entry["current_price"] = None
                 entry["pnl_pct_live"] = None
                 entry["target_reached"] = None
                 entry["stop_reached"] = None
+                if enrich_live:
+                    market_alias = _QUOTE_MARKET_BY_INSTRUMENT.get(j.instrument_type)
+                    if market_alias is not None:
+                        from app.services.market_data.service import get_quote
+
+                        try:
+                            quote = await get_quote(j.symbol, market_alias)
+                        except Exception:  # fail-open per entry
+                            logger.debug(
+                                "enrich_live quote failed for %s",
+                                j.symbol,
+                                exc_info=True,
+                            )
+                        else:
+                            _apply_live_enrich(
+                                entry, current_price=quote.price, side=j.side
+                            )
+                            if j.status == JournalStatus.active:
+                                tgt = entry.get("target_price")
+                                stp = entry.get("stop_loss")
+                                if (
+                                    tgt
+                                    and abs(quote.price - tgt) / tgt * 100 <= _NEAR_PCT
+                                ):
+                                    near_target += 1
+                                if (
+                                    stp
+                                    and abs(quote.price - stp) / stp * 100 <= _NEAR_PCT
+                                ):
+                                    near_stop += 1
 
                 if j.status == JournalStatus.active:
                     total_active += 1

--- a/docs/superpowers/plans/2026-05-31-rob-375-report-continuity-delta.md
+++ b/docs/superpowers/plans/2026-05-31-rob-375-report-continuity-delta.md
@@ -1,0 +1,622 @@
+# ROB-375 리포트 연속성/델타 레이어 버그 3건 구현 플랜
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** advisory(항상-draft) 플로우에서 리포트 연속성/델타 신호를 회수할 수 있게 3개 조회·저장 버그를 수정한다.
+
+**Architecture:** 3개 독립 슬라이스(각 1 PR), 우선순위 순서 Slice 1(Bug 3) → Slice 2(Bug 1) → Slice 3(Bug 2). 모두 opt-in/하위호환, 마이그레이션 0건, read-only.
+
+**Tech Stack:** Python 3.13, FastAPI/SQLAlchemy async, pytest, MCP tooling, JSONB.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-rob-375-report-continuity-delta-design.md`
+
+**공통 검증 (각 슬라이스 머지 전):** `uv run ruff check app/ tests/` + `uv run ruff format --check app/ tests/` + 해당 테스트 green + Test 워크플로 green.
+
+---
+
+## File Structure
+
+- **Slice 1:** `app/mcp_server/tooling/trade_journal_tools.py` (enrich 로직), `app/mcp_server/tooling/trade_journal_registration.py` (파라미터/docstring), `tests/mcp/test_trade_journal_enrich.py` (신규).
+- **Slice 2:** `app/services/investment_reports/query_service.py` (`include_draft`), `app/mcp_server/tooling/investment_reports_handlers.py` (도구 노출), `tests/` 해당 테스트.
+- **Slice 3:** `app/services/action_report/snapshot_backed/generator.py` (numeric baseline 동결), `tests/` 해당 테스트.
+
+---
+
+## Slice 1 — Bug 3: `get_trade_journal` opt-in 라이브 enrich
+
+### Task 1.1: enrich 헬퍼 + `enrich_live` 파라미터 (failing test 먼저)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_journal_tools.py`
+- Test: `tests/mcp/test_trade_journal_enrich.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp/test_trade_journal_enrich.py
+import pytest
+
+from app.mcp_server.tooling import trade_journal_tools as tjt
+
+
+def test_enrich_entry_long_target_reached(monkeypatch):
+    # long position, current >= target -> target_reached True, stop False
+    entry = {"entry_price": 100.0, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=112.0, side="buy")
+    assert entry["current_price"] == 112.0
+    assert entry["pnl_pct_live"] == pytest.approx(12.0)
+    assert entry["target_reached"] is True
+    assert entry["stop_reached"] is False
+
+
+def test_enrich_entry_long_stop_reached(monkeypatch):
+    entry = {"entry_price": 100.0, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=88.0, side="buy")
+    assert entry["stop_reached"] is True
+    assert entry["target_reached"] is False
+    assert entry["pnl_pct_live"] == pytest.approx(-12.0)
+
+
+def test_enrich_entry_short_inverts(monkeypatch):
+    # short: target below entry, current <= target -> target_reached
+    entry = {"entry_price": 100.0, "target_price": 90.0, "stop_loss": 110.0}
+    tjt._apply_live_enrich(entry, current_price=88.0, side="sell")
+    assert entry["target_reached"] is True
+    assert entry["stop_reached"] is False
+    # short pnl positive when price falls
+    assert entry["pnl_pct_live"] == pytest.approx(12.0)
+
+
+def test_enrich_entry_missing_entry_price_leaves_pnl_null():
+    entry = {"entry_price": None, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=112.0, side="buy")
+    assert entry["current_price"] == 112.0
+    assert entry["pnl_pct_live"] is None
+    assert entry["target_reached"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp/test_trade_journal_enrich.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_apply_live_enrich'`
+
+- [ ] **Step 3: Add the pure enrich helper**
+
+`app/mcp_server/tooling/trade_journal_tools.py` — add near the top (after `_serialize_journal`):
+
+```python
+_LONG_SIDES = {"buy", "long"}
+
+
+def _apply_live_enrich(
+    entry: dict[str, Any], *, current_price: float, side: str | None
+) -> None:
+    """Mutate ``entry`` in place with live target/stop/pnl judgements.
+
+    Pure: takes an already-fetched ``current_price`` so it is trivially
+    testable without network. Leaves a field ``None`` when its inputs are
+    missing rather than fabricating a value.
+    """
+    is_long = (side or "buy").strip().lower() in _LONG_SIDES
+    entry["current_price"] = current_price
+
+    entry_price = entry.get("entry_price")
+    if entry_price:
+        raw_pct = (current_price - entry_price) / entry_price * 100.0
+        entry["pnl_pct_live"] = raw_pct if is_long else -raw_pct
+    else:
+        entry["pnl_pct_live"] = None
+
+    target = entry.get("target_price")
+    if target is not None:
+        entry["target_reached"] = (
+            current_price >= target if is_long else current_price <= target
+        )
+    stop = entry.get("stop_loss")
+    if stop is not None:
+        entry["stop_reached"] = (
+            current_price <= stop if is_long else current_price >= stop
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp/test_trade_journal_enrich.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/trade_journal_tools.py tests/mcp/test_trade_journal_enrich.py
+git commit -m "feat(ROB-375): pure live-enrich helper for trade journal (Bug 3)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 1.2: wire `enrich_live` into `get_trade_journal`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_journal_tools.py:200-324`
+- Test: `tests/mcp/test_trade_journal_enrich.py`
+
+- [ ] **Step 1: Write the failing test (quote stub, near-target summary)**
+
+```python
+async def test_get_trade_journal_enrich_live_summary(monkeypatch, journal_factory):
+    # journal_factory creates one active US journal: entry 100, target 110, stop 90
+    j = await journal_factory(symbol="BAC", entry_price=100.0,
+                              target_price=110.0, stop_loss=90.0,
+                              instrument_type="equity_us", side="buy")
+
+    async def _fake_quote(symbol, market):
+        from app.services.market_data.contracts import Quote
+        return Quote(symbol=symbol, market="equity_us", price=109.5, source="test")
+
+    monkeypatch.setattr(
+        "app.services.market_data.service.get_quote", _fake_quote
+    )
+    res = await tjt.get_trade_journal(market="us", enrich_live=True)
+    assert res["success"] is True
+    e = res["entries"][0]
+    assert e["current_price"] == 109.5
+    assert e["target_reached"] is False
+    # within 1.5% of target (109.5 vs 110) -> near_target counted
+    assert res["summary"]["near_target"] == 1
+
+
+async def test_get_trade_journal_enrich_false_is_unchanged(journal_factory):
+    await journal_factory(symbol="BAC", instrument_type="equity_us")
+    res = await tjt.get_trade_journal(market="us")  # enrich_live defaults False
+    e = res["entries"][0]
+    assert e["current_price"] is None
+    assert e["pnl_pct_live"] is None
+    assert res["summary"]["near_target"] == 0
+```
+
+> Note: if no `journal_factory` fixture exists, add a minimal one to `tests/mcp/conftest.py` (or the test file) that inserts a `TradeJournal` row via the test session. Follow the existing trade-journal test fixtures in `tests/` (grep `TradeJournal(` under `tests/`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp/test_trade_journal_enrich.py -k enrich_live -v`
+Expected: FAIL — `get_trade_journal() got an unexpected keyword argument 'enrich_live'`
+
+- [ ] **Step 3: Add param + market map + enrich loop**
+
+In `trade_journal_tools.py`, add the instrument→market map near `_LONG_SIDES`:
+
+```python
+_QUOTE_MARKET_BY_INSTRUMENT = {
+    InstrumentType.equity_us: "us",
+    InstrumentType.equity_kr: "kr",
+    InstrumentType.crypto: "crypto",
+}
+_NEAR_PCT = 1.5  # within ±1.5% of target/stop counts as "near"
+```
+
+Add `enrich_live: bool = False` to the signature (after `paperclip_issue_id`):
+
+```python
+    paperclip_issue_id: str | None = None,
+    enrich_live: bool = False,
+) -> dict[str, Any]:
+```
+
+Replace the hardcoded null block (currently lines ~302-307) with:
+
+```python
+                # Live enrichment is opt-in (per-entry quote is slow for bulk).
+                entry["current_price"] = None
+                entry["pnl_pct_live"] = None
+                entry["target_reached"] = None
+                entry["stop_reached"] = None
+                if enrich_live:
+                    market_alias = _QUOTE_MARKET_BY_INSTRUMENT.get(j.instrument_type)
+                    if market_alias is not None:
+                        from app.services.market_data.service import get_quote
+
+                        try:
+                            quote = await get_quote(j.symbol, market_alias)
+                        except Exception:  # fail-open per entry
+                            logger.debug(
+                                "enrich_live quote failed for %s", j.symbol,
+                                exc_info=True,
+                            )
+                        else:
+                            _apply_live_enrich(
+                                entry, current_price=quote.price, side=j.side
+                            )
+                            if j.status == JournalStatus.active:
+                                tgt = entry.get("target_price")
+                                stp = entry.get("stop_loss")
+                                if tgt and abs(quote.price - tgt) / tgt * 100 <= _NEAR_PCT:
+                                    near_target += 1
+                                if stp and abs(quote.price - stp) / stp * 100 <= _NEAR_PCT:
+                                    near_stop += 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/mcp/test_trade_journal_enrich.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/trade_journal_tools.py tests/mcp/test_trade_journal_enrich.py
+git commit -m "feat(ROB-375): get_trade_journal enrich_live opt-in (Bug 3)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 1.3: expose `enrich_live` in MCP registration + docstring
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_journal_registration.py`
+
+- [ ] **Step 1: Inspect registration**
+
+Run: `grep -n "enrich\|get_trade_journal\|def \|param" app/mcp_server/tooling/trade_journal_registration.py | head -40`
+
+- [ ] **Step 2: Add `enrich_live` to the registered signature**
+
+Mirror the `get_trade_journal` parameter list in the registration wrapper (add `enrich_live: bool = False`) and pass it through to the impl. Update the docstring to add:
+> `enrich_live` (optional, default False): fetch live quotes to compute current_price/pnl_pct_live/target_reached/stop_reached and near_target/near_stop. Slower (one quote per returned entry); fail-open per entry.
+
+- [ ] **Step 3: Run the full trade-journal test module**
+
+Run: `uv run pytest tests/ -k trade_journal -v`
+Expected: PASS (no regressions)
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/
+git add app/mcp_server/tooling/trade_journal_registration.py
+git commit -m "feat(ROB-375): register enrich_live param for get_trade_journal (Bug 3)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+> **Slice 1 PR gate:** push branch, open PR, confirm full CI green before merge.
+
+---
+
+## Slice 2 — Bug 1: `include_draft` for report context
+
+### Task 2.1: `include_draft` on `previous_report_context`
+
+**Files:**
+- Modify: `app/services/investment_reports/query_service.py:258-276`
+- Test: existing query_service test module (grep `previous_report_context` under `tests/`) or new `tests/services/test_report_context_include_draft.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_report_context_include_draft.py
+import pytest
+
+# Use the project's report-ingest test helpers to insert reports.
+# (grep tests/ for an existing fixture that inserts InvestmentReport rows,
+#  e.g. publish_report / ingest helper used by ROB-352 Slice B tests.)
+
+
+async def test_include_draft_true_returns_draft_priors(report_ctx_env):
+    # report_ctx_env inserts two reports for (market=us, account_scope=kis_live):
+    #   one status=draft (newer), one status=active (older)
+    svc = report_ctx_env.service
+    excl = False
+
+    default_ctx = await svc.previous_report_context(
+        market="us", account_scope="kis_live"
+    )
+    # default drops drafts -> only the active one
+    assert [r.status for r in default_ctx["prior_reports"]] == ["active"]
+
+    incl_ctx = await svc.previous_report_context(
+        market="us", account_scope="kis_live", include_draft=True
+    )
+    statuses = sorted(r.status for r in incl_ctx["prior_reports"])
+    assert statuses == ["active", "draft"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_report_context_include_draft.py -v`
+Expected: FAIL — `previous_report_context() got an unexpected keyword argument 'include_draft'`
+
+- [ ] **Step 3: Add the parameter and guard the filter**
+
+`app/services/investment_reports/query_service.py` — add to signature:
+
+```python
+        exclude_report_uuid: UUID | None = None,
+        n_prior: int = 3,
+        events_since: datetime | None = None,
+        include_draft: bool = False,
+    ) -> dict[str, Any]:
+```
+
+Replace the unconditional draft drop (line ~275):
+
+```python
+        if not include_draft:
+            prior_reports = [r for r in prior_reports if r.status != "draft"]
+        prior_reports = prior_reports[:n_prior]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_report_context_include_draft.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/query_service.py tests/services/test_report_context_include_draft.py
+git commit -m "feat(ROB-375): include_draft opt-in for previous_report_context (Bug 1)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 2.2: expose `include_draft` on the MCP tool
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py:416-435`
+- Modify: MCP registration for `investment_report_context_get` (grep `investment_report_context_get` in the registration module)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+async def test_context_get_impl_forwards_include_draft(report_ctx_env, monkeypatch):
+    captured = {}
+
+    async def _spy(self, **kwargs):
+        captured.update(kwargs)
+        return report_ctx_env.empty_ctx  # a valid empty context dict
+
+    monkeypatch.setattr(
+        "app.services.investment_reports.query_service.InvestmentReportQueryService.previous_report_context",
+        _spy,
+    )
+    from app.mcp_server.tooling.investment_reports_handlers import (
+        investment_report_context_get_impl,
+    )
+    await investment_report_context_get_impl(
+        market="us", account_scope="kis_live", include_draft=True
+    )
+    assert captured["include_draft"] is True
+```
+
+> If mocking the bound method is awkward, instead assert end-to-end: insert a draft prior, call the impl with `include_draft=True`, and assert `prior_reports` is non-empty in the returned dict.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/ -k context_get_impl_forwards_include_draft -v`
+Expected: FAIL — unexpected keyword argument `include_draft`
+
+- [ ] **Step 3: Add the parameter and forward it**
+
+In `investment_report_context_get_impl` add `include_draft: bool = False` to the signature and pass `include_draft=include_draft` into `service.previous_report_context(...)`.
+
+Update the registration wrapper for `investment_report_context_get` to accept and forward `include_draft: bool = False`, with docstring:
+> `include_draft` (optional, default False): include draft reports as prior context. advisory reports persist as draft, so set True to chain the next delta report off the latest advisory baseline.
+
+- [ ] **Step 4: Run test + regression**
+
+Run: `uv run pytest tests/ -k "context_get or previous_report_context" -v`
+Expected: PASS
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/
+git add app/mcp_server/tooling/investment_reports_handlers.py app/mcp_server/tooling/*registration*.py tests/
+git commit -m "feat(ROB-375): expose include_draft on investment_report_context_get (Bug 1)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+> **Slice 2 PR gate:** push branch, open PR, confirm full CI green before merge.
+
+---
+
+## Slice 3 — Bug 2: freeze numeric baseline into report row snapshots
+
+### Task 3.0: confirm the empty-`{}` write path (investigation, no code)
+
+- [ ] **Step 1: Identify which path wrote `market_snapshot:{}` for the repro rows**
+
+Run:
+```bash
+grep -rn "market_snapshot\|portfolio_snapshot" app/services/investment_reports/mock_preview/ app/services/investment_stages/ app/services/action_report/snapshot_backed/
+```
+Determine whether the repro rows (dfda9a04/7004e783) came from `generator.py` (descriptor path) or `mock_preview/runner.py` / `hermes_ingest.py` (which may pass `{}`). Record the finding as a comment in the PR description. The fix below targets `generator.py`; if mock_preview/hermes also emit empty snapshots and are in scope, apply the same baseline helper there. **Do not** widen scope into ROB-376 feature paths.
+
+### Task 3.1: numeric baseline extraction helper (pure, failing test first)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py`
+- Test: `tests/services/test_snapshot_baseline.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_snapshot_baseline.py
+from app.services.action_report.snapshot_backed import generator as gen
+
+
+def test_market_baseline_whitelists_indices():
+    payload = {
+        "market": "us",
+        "from_date": "2026-05-30",
+        "to_date": "2026-05-30",
+        "event_count": 3,
+        "events": [{"big": "blob"}],  # excluded
+        "indices": {"SPX": {"price": 5300.0, "change_pct": 0.4}},
+    }
+    base = gen._market_numeric_baseline(payload)
+    assert base["indices"] == {"SPX": {"price": 5300.0, "change_pct": 0.4}}
+    assert base["market"] == "us"
+    assert "events" not in base  # heavy list not copied
+
+
+def test_portfolio_baseline_whitelists_cash_and_summary():
+    payload = {
+        "holdings": [{"ticker": "BAC"}],  # excluded heavy list
+        "primary_source": "kis_live",
+        "cash": {"usd_cash": 3095.26, "usd_orderable": 3078.32},
+        "buying_power": {"usd": 3078.32},
+        "sellable_summary": {"count": 4},
+    }
+    base = gen._portfolio_numeric_baseline(payload)
+    assert base["cash"] == {"usd_cash": 3095.26, "usd_orderable": 3078.32}
+    assert base["buying_power"] == {"usd": 3078.32}
+    assert base["sellable_summary"] == {"count": 4}
+    assert base["primary_source"] == "kis_live"
+    assert base["holdings_count"] == 1
+    assert "holdings" not in base
+
+
+def test_baselines_handle_missing_keys():
+    assert gen._market_numeric_baseline({}) == {}
+    assert gen._portfolio_numeric_baseline({}) == {"holdings_count": 0}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_snapshot_baseline.py -v`
+Expected: FAIL — `module ... has no attribute '_market_numeric_baseline'`
+
+- [ ] **Step 3: Add the two pure helpers**
+
+In `generator.py` (module level):
+
+```python
+_MARKET_BASELINE_KEYS = ("market", "from_date", "to_date", "indices")
+_PORTFOLIO_BASELINE_KEYS = (
+    "primary_source",
+    "cash",
+    "buying_power",
+    "sellable_summary",
+)
+
+
+def _market_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Whitelist the small delta-relevant numerics from a market snapshot
+    payload. Never copies the heavy ``events`` list. Missing keys are skipped
+    (no fabrication)."""
+    return {k: payload[k] for k in _MARKET_BASELINE_KEYS if k in payload}
+
+
+def _portfolio_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Whitelist cash/buying_power/sellable_summary + a holdings count.
+    Never copies the heavy ``holdings`` list."""
+    base = {k: payload[k] for k in _PORTFOLIO_BASELINE_KEYS if k in payload}
+    holdings = payload.get("holdings")
+    base["holdings_count"] = len(holdings) if isinstance(holdings, list) else 0
+    return base
+```
+
+(`Mapping` and `Any` are already imported in this module — verify with `grep -n "from typing import\|Mapping" app/services/action_report/snapshot_backed/generator.py`; add to the import if absent.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_snapshot_baseline.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/generator.py tests/services/test_snapshot_baseline.py
+git commit -m "feat(ROB-375): numeric baseline extractors for report snapshots (Bug 2)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 3.2: fold baseline into `_section_snapshot_descriptors`
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py:528-569`
+- Test: existing generator test module (grep `_section_snapshot_descriptors` under `tests/`) or extend `tests/services/test_snapshot_baseline.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Extend the report row to carry provenance + baseline.
+# Insert a bundle with a 'market' snapshot whose payload has indices and a
+# 'portfolio' snapshot whose payload has cash, then assert the descriptor
+# dict now has shape {"provenance": {...}, "baseline": {...}}.
+async def test_section_descriptors_carry_baseline(snapshot_backed_env):
+    market, portfolio = await snapshot_backed_env.generator._section_snapshot_descriptors(
+        bundle_uuid=snapshot_backed_env.bundle_uuid,
+        unavailable_sources={},
+    )
+    assert market["provenance"]["snapshot_kind"] == "market"
+    assert "indices" in market["baseline"]
+    assert portfolio["provenance"]["snapshot_kind"] == "portfolio"
+    assert "cash" in portfolio["baseline"]
+```
+
+> Reuse the existing snapshot-backed generator fixtures (grep `_section_snapshot_descriptors` / `SnapshotBackedReportGenerator(` under `tests/` for the setup helper that builds a bundle with market/portfolio snapshots).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/ -k section_descriptors_carry_baseline -v`
+Expected: FAIL — `KeyError: 'provenance'` (current code returns flat descriptor)
+
+- [ ] **Step 3: Wrap descriptor + add baseline from `payload_json`**
+
+In `_section_snapshot_descriptors`, change `_descriptor` and the kind loop so each section becomes `{"provenance": <descriptor>, "baseline": <numeric>}`, and `_unavailable` stays as the unavailable marker:
+
+```python
+        def _section(snapshot: Any, baseline: dict[str, Any]) -> dict[str, Any]:
+            as_of = getattr(snapshot, "as_of", None)
+            return {
+                "provenance": {
+                    "snapshot_uuid": str(snapshot.snapshot_uuid),
+                    "snapshot_kind": snapshot.snapshot_kind,
+                    "as_of": as_of.isoformat() if as_of is not None else None,
+                    "freshness_status": getattr(snapshot, "freshness_status", None),
+                    "coverage": getattr(snapshot, "coverage_json", None) or {},
+                },
+                "baseline": baseline,
+            }
+
+        market = _unavailable("market")
+        portfolio = _unavailable("portfolio")
+        bundle = await self._snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+        if bundle is None:
+            return market, portfolio
+        pairs = await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
+        for _item, snapshot in pairs:
+            payload = getattr(snapshot, "payload_json", None) or {}
+            if snapshot.snapshot_kind == "market":
+                market = _section(snapshot, _market_numeric_baseline(payload))
+            elif snapshot.snapshot_kind == "portfolio":
+                portfolio = _section(snapshot, _portfolio_numeric_baseline(payload))
+        return market, portfolio
+```
+
+- [ ] **Step 4: Run test + the generator regression module**
+
+Run: `uv run pytest tests/ -k "section_descriptors or snapshot_backed" -v`
+Expected: PASS. If any existing test asserted the old flat descriptor shape, update it to read `["provenance"]` (these are provenance-shape assertions, not behavior changes).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/
+git add app/services/action_report/snapshot_backed/generator.py tests/
+git commit -m "feat(ROB-375): freeze numeric baseline in report row snapshots (Bug 2)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+> **Slice 3 PR gate:** push branch, open PR, confirm full CI green before merge.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Slice 1 ↔ Bug 3 (Tasks 1.1–1.3); Slice 2 ↔ Bug 1 (Tasks 2.1–2.2); Slice 3 ↔ Bug 2 (Tasks 3.0–3.2). All spec sections mapped.
+- **Hidden assumptions flagged for the implementer:** (a) test fixture names (`journal_factory`, `report_ctx_env`, `snapshot_backed_env`) are illustrative — reuse the project's existing report/journal test fixtures; grep before inventing. (b) Slice 3 row-shape change (`{provenance, baseline}`) is a NEW consumer contract — if any reader downstream reads `market_snapshot["snapshot_uuid"]` flat, update it (grep `market_snapshot[` / `portfolio_snapshot[`). (c) Task 3.0 must confirm the actual empty-`{}` path before assuming generator.py is the only writer.

--- a/docs/superpowers/specs/2026-05-31-rob-375-report-continuity-delta-design.md
+++ b/docs/superpowers/specs/2026-05-31-rob-375-report-continuity-delta-design.md
@@ -1,0 +1,107 @@
+# ROB-375 — 리포트 연속성/델타 레이어 버그 3건 설계
+
+- **이슈:** ROB-375 (Bug, Medium). `market="us"`, `account_scope="kis_live"`. ROB-287 계열.
+- **분리:** 기능성 항목(advisory watch/decision → triggered_events, intraday 델타 리포트 타입/API)은 ROB-376으로 분리됨. 본 작업은 **조회/저장 버그만** 다룬다.
+- **패키징:** 3개 독립 PR(슬라이스), 우선순위 순서 **Slice 1(Bug 3) → Slice 2(Bug 1) → Slice 3(Bug 2)**.
+
+## 공통 원칙 / 제약
+
+- 순수 조회·저장 버그만 수정. ROB-376 기능 영역(watch/decision 기록, intraday_update 타입)은 손대지 않는다.
+- **마이그레이션 0건** — 관련 컬럼(`market_snapshot`/`portfolio_snapshot` JSONB, `status`)은 이미 존재.
+- read-mostly. 어떤 경로도 broker/order/watch mutation에 도달하지 않는다.
+- **하위호환:** 기존 기본 동작을 보존. 새 동작은 전부 opt-in 파라미터(기본값 = 현행 동작).
+
+---
+
+## Slice 1 — Bug 3: `get_trade_journal` opt-in 라이브 enrich (최우선)
+
+### 문제
+`app/mcp_server/tooling/trade_journal_tools.py:302-307` — `current_price`/`pnl_pct_live`/`target_reached`/`stop_reached`가 하드코딩 `None`("too slow for bulk queries"). `target_price`/`stop_loss`는 저널 행에 존재하지만 라이브 판정을 못 해 가장 강한 델타 신호("목표/손절 터치")를 못 뽑음. summary의 `near_target`/`near_stop`도 항상 0.
+
+### 변경
+- `get_trade_journal(...)`에 파라미터 `enrich_live: bool = False` 추가.
+- `enrich_live=True`일 때만 entry별 라이브 시세 조회·계산. `False`(기본)면 현행과 100% 동일(필드 null 유지).
+- **시세 소스:** `app/services/market_data/service.py::get_quote(symbol, market)` 재사용. `market`은 `instrument_type`에서 파생:
+  - `equity_us → "us"`, `equity_kr → "kr"`, `crypto → "crypto"`.
+- **계산 (side 고려):**
+  - `current_price` = quote.price
+  - `pnl_pct_live` = `(current - entry_price) / entry_price * 100` (entry_price 존재 시; side가 sell/short면 부호 반전)
+  - `target_reached`: long이면 `target_price is not None and current >= target_price`; short면 `current <= target_price`
+  - `stop_reached`: long이면 `stop_loss is not None and current <= stop_loss`; short면 `current >= stop_loss`
+  - summary `near_target`/`near_stop`: 임계 근접(목표/손절 가격의 ±1.5% 이내)인 active entry 카운트
+- **안전/graceful:** quote 조회 실패·심볼 미해석·entry_price 없음 → 해당 entry 필드는 null로 두고 계속 진행(전체 호출 실패 금지). enrich는 조회된 journals(이미 `limit`로 bounded)에 대해서만 수행.
+
+### 영향 범위
+- `app/mcp_server/tooling/trade_journal_tools.py` (핸들러 + 필요한 헬퍼)
+- `app/mcp_server/tooling/trade_journal_registration.py` (docstring/파라미터 노출)
+
+### 테스트
+- quote stub으로: target_reached True/False, stop_reached True/False, near_target/near_stop 집계, side=sell 부호/판정 반전, quote 실패 graceful(필드 null + success True), `enrich_live=False` 시 현행 동일.
+
+---
+
+## Slice 2 — Bug 1: `investment_report_context_get`의 draft 제외로 컨텍스트가 항상 빈 배열
+
+### 문제
+`app/services/investment_reports/query_service.py:275`:
+```python
+prior_reports = [r for r in prior_reports if r.status != "draft"]
+```
+ROB-352 Slice B에서 smoke boilerplate(항상 draft) 제거 목적으로 추가됨. 그러나 advisory 플로우는 리포트가 **항상 `status="draft"`**(publish 단계 없음, `status` 서버 기본값 `'draft'`)라 이 필터가 prior_reports를 통째로 비우고, 이어서 `unresolved_deferred_items`/`active_watches`/`triggered_events`/`recent_decisions`(모두 prior_report_ids 의존)까지 연쇄로 빈 배열이 됨.
+
+### 변경 — `include_draft` 파라미터 (결정됨)
+- `ReportQueryService.previous_report_context(...)`에 `include_draft: bool = False` 추가.
+  - `include_draft=False`(기본): 현행대로 `status != "draft"` 필터 적용(smoke-safe).
+  - `include_draft=True`: draft 제외 필터를 건너뛰어 최신 draft도 prior로 인정.
+- `exclude_report_uuid` 제외와 `[:n_prior]` 슬라이스는 그대로. `_DRAFT_FETCH_BUFFER` 버퍼 로직 유지(include_draft=True에서는 불필요하지만 무해).
+- MCP 도구 `investment_report_context_get`(`app/mcp_server/tooling/investment_reports_handlers.py`)에 `include_draft` 파라미터를 노출하고 `previous_report_context`로 전달. docstring에 advisory(항상-draft) 연속성 용도임을 명시.
+
+### 스코프 경계
+- prior_reports를 비우던 근본만 수정. `active_watches`/`triggered_events`/`recent_decisions`의 **내용 채움**은 ROB-376 기능 영역 — 본 슬라이스는 prior_reports가 비지 않게 만들어 배선이 동작하게만 함.
+
+### 영향 범위
+- `app/services/investment_reports/query_service.py`
+- `app/mcp_server/tooling/investment_reports_handlers.py`
+
+### 테스트
+- 전부 draft인 prior 집합 + `include_draft=True` → prior_reports 비지 않음; `include_draft=False`(기본) → 현행대로 빈 배열.
+- 혼합(draft + active) → False는 active만, True는 둘 다(최신순 n_prior).
+- `exclude_report_uuid`가 draft를 제외해도 정상.
+
+---
+
+## Slice 3 — Bug 2: snapshot-backed report row의 `market_snapshot`/`portfolio_snapshot`이 빈/포인터-only
+
+### 문제
+`app/services/action_report/snapshot_backed/generator.py:528-569` `_section_snapshot_descriptors`는 ROB-352 Slice B 원칙("pointer not payload")대로 **포인터 descriptor**(`snapshot_uuid`/`as_of`/`freshness`/`coverage`)만 기록하고 numeric payload는 안 뽑음. 결과적으로 델타 계산용 개장 베이스라인(지수·NAV·USD현금·비중·종목 종가)을 report row만으로 회수 불가 → 번들로 우회 필요. 구 수동 리포트(6d805c85)는 `portfolio_snapshot{usd_cash, usd_orderable, unrealized_pl_pct, concentration_notes}`를 직접 동결 저장했었음.
+
+### 사전 조사 (구현 1단계)
+- 재현 행(dfda9a04·7004e783)이 `{}`(빈)인지, descriptor(`{"status":"unavailable",...}`)인지 실제 write 경로 확인. descriptor 코드상 최소 unavailable dict가 들어가야 하므로 `{}`는 (a) Slice B 이전 행이거나 (b) 다른 생성 경로(mock_preview 등) 가능성. 어느 경로가 `market_snapshot`/`portfolio_snapshot`을 비우는지 특정한 뒤 설계 확정.
+
+### 변경 — descriptor 유지 + numeric baseline 동결
+- pointer/freshness descriptor는 **그대로 유지**(Slice B 원칙 보존). 거기에 델타용 **소수 numeric baseline**을 추가.
+- bundle item의 `snapshot.payload_json`(generator는 이미 line 607 등에서 접근)에서 market/portfolio kind payload를 읽어 작은 화이트리스트 필드만 추출:
+  - **market:** 주요 지수 값(가능 시), as_of.
+  - **portfolio:** `usd_cash`, `usd_orderable`, `unrealized_pl_pct`, `concentration_notes`, (가능 시) per-symbol 종가/평가액.
+- 저장 구조(예): `market_snapshot = {"provenance": <descriptor>, "baseline": <numeric subset>}` / `portfolio_snapshot` 동일. 정확한 키 네이밍은 기존 소비자(있다면)와의 호환을 조사 후 확정.
+- payload에 해당 numeric이 없으면 baseline은 부분/빈으로 두되 fabricate 금지(없는 값 만들지 않음).
+
+### 스코프 경계
+- 전체 payload 복사 금지(Slice B 위반). 델타에 필요한 화이트리스트 numeric만.
+- 마이그레이션 없음(JSONB 컬럼 재사용).
+
+### 영향 범위
+- `app/services/action_report/snapshot_backed/generator.py` (+ 필요 시 mock_preview/runner 경로)
+
+### 테스트
+- market/portfolio payload가 있는 번들 → row의 baseline에 numeric 동결, provenance 유지.
+- payload에 numeric 없음 → fabricate 없이 부분/빈 baseline.
+- 재현 경로 회귀(빈 `{}`가 더 이상 나오지 않음 확인).
+
+---
+
+## 통합 검증 (각 슬라이스 공통)
+
+- `ruff check app/ tests/` + `ruff format --check app/ tests/` + import guards.
+- 관련 단위 테스트 통과, Test 워크플로 green 확인 후 머지(pre-merge full-CI gate).
+- 운영 활성화·라이브 render smoke는 operator-gated(별도). 본 작업 범위는 코드 + 테스트.

--- a/tests/mcp/test_trade_journal_enrich.py
+++ b/tests/mcp/test_trade_journal_enrich.py
@@ -1,0 +1,121 @@
+# tests/mcp/test_trade_journal_enrich.py
+import pytest
+
+from app.mcp_server.tooling import trade_journal_tools as tjt
+
+
+def test_enrich_entry_long_target_reached(monkeypatch):
+    # long position, current >= target -> target_reached True, stop False
+    entry = {"entry_price": 100.0, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=112.0, side="buy")
+    assert entry["current_price"] == 112.0
+    assert entry["pnl_pct_live"] == pytest.approx(12.0)
+    assert entry["target_reached"] is True
+    assert entry["stop_reached"] is False
+
+
+def test_enrich_entry_long_stop_reached(monkeypatch):
+    entry = {"entry_price": 100.0, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=88.0, side="buy")
+    assert entry["stop_reached"] is True
+    assert entry["target_reached"] is False
+    assert entry["pnl_pct_live"] == pytest.approx(-12.0)
+
+
+def test_enrich_entry_short_inverts(monkeypatch):
+    # short: target below entry, current <= target -> target_reached
+    entry = {"entry_price": 100.0, "target_price": 90.0, "stop_loss": 110.0}
+    tjt._apply_live_enrich(entry, current_price=88.0, side="sell")
+    assert entry["target_reached"] is True
+    assert entry["stop_reached"] is False
+    # short pnl positive when price falls
+    assert entry["pnl_pct_live"] == pytest.approx(12.0)
+
+
+def test_enrich_entry_missing_entry_price_leaves_pnl_null():
+    entry = {"entry_price": None, "target_price": 110.0, "stop_loss": 90.0}
+    tjt._apply_live_enrich(entry, current_price=112.0, side="buy")
+    assert entry["current_price"] == 112.0
+    assert entry["pnl_pct_live"] is None
+    assert entry["target_reached"] is True
+
+
+@pytest.fixture
+def journal_factory(db_session, monkeypatch):
+    async def _factory(**kwargs):
+        from decimal import Decimal
+
+        from app.models.trade_journal import TradeJournal
+        from app.models.trading import InstrumentType
+
+        # Default some fields
+        kwargs.setdefault("symbol", "BAC")
+        kwargs.setdefault("thesis", "Test thesis")
+        kwargs.setdefault("status", "active")
+        kwargs.setdefault("account_type", "live")
+        kwargs.setdefault("side", "buy")
+
+        # Map type if it's string
+        if isinstance(kwargs.get("instrument_type"), str):
+            kwargs["instrument_type"] = InstrumentType(kwargs["instrument_type"])
+
+        # Decimalize prices
+        for price_field in ("entry_price", "target_price", "stop_loss"):
+            if kwargs.get(price_field) is not None:
+                kwargs[price_field] = Decimal(str(kwargs[price_field]))
+
+        j = TradeJournal(**kwargs)
+        db_session.add(j)
+        await db_session.flush()
+
+        # Monkeypatch the session factory in trade_journal_tools
+        import contextlib
+
+        @contextlib.asynccontextmanager
+        async def _fake_session_cm():
+            yield db_session
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: _fake_session_cm,
+        )
+        return j
+
+    return _factory
+
+
+@pytest.mark.asyncio
+async def test_get_trade_journal_enrich_live_summary(monkeypatch, journal_factory):
+    # journal_factory creates one active US journal: entry 100, target 110, stop 90
+    await journal_factory(
+        symbol="BAC",
+        entry_price=100.0,
+        target_price=110.0,
+        stop_loss=90.0,
+        instrument_type="equity_us",
+        side="buy",
+    )
+
+    async def _fake_quote(symbol, market):
+        from app.services.market_data.contracts import Quote
+
+        return Quote(symbol=symbol, market="equity_us", price=109.5, source="test")
+
+    monkeypatch.setattr("app.services.market_data.service.get_quote", _fake_quote)
+    res = await tjt.get_trade_journal(market="us", enrich_live=True)
+    assert res["success"] is True
+    e = res["entries"][0]
+    assert e["current_price"] == 109.5
+    assert e["target_reached"] is False
+    # within 1.5% of target (109.5 vs 110) -> near_target counted
+    assert res["summary"]["near_target"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_trade_journal_enrich_false_is_unchanged(journal_factory):
+    await journal_factory(symbol="BAC", instrument_type="equity_us")
+    res = await tjt.get_trade_journal(market="us")  # enrich_live defaults False
+    e = res["entries"][0]
+    assert e["current_price"] is None
+    assert e["pnl_pct_live"] is None
+    assert res["summary"]["near_target"] == 0


### PR DESCRIPTION
## ROB-375 Bug 3 — `get_trade_journal` 라이브 미enrich

저널이 가장 강한 델타 신호("목표/손절 터치")를 들고 있는데도 라이브 판정을 못 해(`current_price`/`pnl_pct_live`/`target_reached`/`stop_reached`가 항상 null, summary `near_target`/`near_stop`=0) 외부 holdings/quote 조인이 필요했음.

### 변경
- `get_trade_journal(...)`에 `enrich_live: bool = False` opt-in 파라미터 추가.
- `enrich_live=True`일 때만 entry별 `market_data.get_quote(symbol, market)` 재사용으로 라이브 시세 조회 후 `current_price`/`pnl_pct_live`/`target_reached`/`stop_reached` 계산 + `near_target`/`near_stop`(±1.5%) 집계.
- `instrument_type → "us"/"kr"/"crypto"` 매핑. side(long/short) 고려한 판정.
- **fail-open per entry**: quote 실패/미해석/entry_price 없음 → 해당 필드 null, 전체 호출은 성공. 기본값 False면 현행과 100% 동일(bulk 속도 보존).

### 안전 경계
- read-only. broker/order/watch mutation 없음. 마이그레이션 0건.

### 테스트
- `tests/mcp/test_trade_journal_enrich.py` (신규): long target/stop reached, short 부호/판정 반전, entry_price 없음 graceful, near 집계, `enrich_live=False` 무변화. (6 passed)

### 문서
- 설계·구현 플랜 문서 포함 (ROB-375 3-bug 전체 커버, 이 PR이 시리즈 첫 PR).

3개 독립 PR 중 1/3 (우선순위 Bug3 → Bug1 → Bug2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)