### PR TITLE
fix(ROB-375): include_draft so advisory drafts count as prior context (Bug 1)

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -420,6 +420,7 @@ async def investment_report_context_get_impl(
     report_type: str | None = None,
     exclude_report_uuid: str | None = None,
     n_prior: int = 3,
+    include_draft: bool = False,
 ) -> dict:
     capped = max(1, min(int(n_prior), 10))
     exclude_uuid = UUID(exclude_report_uuid) if exclude_report_uuid else None
@@ -432,6 +433,7 @@ async def investment_report_context_get_impl(
             report_type=report_type,
             exclude_report_uuid=exclude_uuid,
             n_prior=capped,
+            include_draft=include_draft,
         )
         # ROB-274 — enrich the response with the pending_orders snapshot so
         # next-report drafters see what's already open at the broker. The
@@ -743,7 +745,9 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         description=(
             "Return previous-report context for the next-report generator: "
             "prior_reports, unresolved_deferred_items, active_watches, "
-            "triggered_events, recent_decisions. n_prior clamped to 1..10."
+            "triggered_events, recent_decisions. n_prior clamped to 1..10. "
+            "include_draft (optional, default False): include draft reports as prior context. "
+            "advisory reports persist as draft, so set True to chain the next delta report off the latest advisory baseline."
         ),
     )(investment_report_context_get_impl)
     mcp.tool(

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -248,6 +248,7 @@ class InvestmentReportQueryService:
         exclude_report_uuid: UUID | None = None,
         n_prior: int = 3,
         events_since: datetime | None = None,
+        include_draft: bool = False,
     ) -> dict[str, Any]:
         """Locked refinement #7 — previous context is a query, not a single FK.
 
@@ -272,7 +273,8 @@ class InvestmentReportQueryService:
             prior_reports = [
                 r for r in prior_reports if r.report_uuid != exclude_report_uuid
             ]
-        prior_reports = [r for r in prior_reports if r.status != "draft"]
+        if not include_draft:
+            prior_reports = [r for r in prior_reports if r.status != "draft"]
         prior_reports = prior_reports[:n_prior]
 
         prior_report_uuids = [r.report_uuid for r in prior_reports]

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -510,3 +510,26 @@ async def test_generate_from_bundle_user_id_defaults_to_mcp_user(
     assert result["success"] is True
     assert result["resolved_user_id"] == expected
     assert captured["request"].user_id == expected
+
+
+@pytest.mark.asyncio
+async def test_context_get_includes_draft_when_include_draft_true(
+    session: AsyncSession,
+) -> None:
+    # 1. Create a draft report (by default status="draft" inside investment_report_create_impl)
+    r = await investment_report_create_impl(
+        items=[_action_item_dict()],
+        **_create_kwargs(kst_date="2026-05-18"),
+    )
+    # Draft is not published, so status remains "draft"
+
+    # 2. Get context with default include_draft=False
+    ctx_default = await investment_report_context_get_impl(market="kr")
+    assert len(ctx_default["prior_reports"]) == 0
+
+    # 3. Get context with include_draft=True
+    ctx_include = await investment_report_context_get_impl(
+        market="kr", include_draft=True
+    )
+    assert len(ctx_include["prior_reports"]) == 1
+    assert ctx_include["prior_reports"][0]["report_uuid"] == r["report"]["report_uuid"]

--- a/tests/test_investment_reports_query_prior_drafts.py
+++ b/tests/test_investment_reports_query_prior_drafts.py
@@ -45,3 +45,25 @@ async def test_prior_reports_excludes_drafts(session: AsyncSession) -> None:
     titles = {r.title for r in ctx["prior_reports"]}
     assert titles == {"real-1", "real-2"}
     assert all(r.status != "draft" for r in ctx["prior_reports"])
+
+
+@pytest.mark.asyncio
+async def test_prior_reports_includes_drafts_if_requested(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    await _make_report(repo, key="pub:1", status="published", title="real-1")
+    await _make_report(repo, key="draft:1", status="draft", title="hermes-smoke-1")
+    await _make_report(repo, key="draft:2", status="draft", title="hermes-smoke-2")
+    await _make_report(repo, key="pub:2", status="published", title="real-2")
+
+    svc = InvestmentReportQueryService(session)
+    ctx = await svc.previous_report_context(
+        market="us",
+        account_scope="kis_live",
+        report_type="snapshot_backed_advisory_v1",
+        n_prior=4,
+        include_draft=True,
+    )
+    titles = {r.title for r in ctx["prior_reports"]}
+    assert titles == {"real-1", "real-2", "hermes-smoke-1", "hermes-smoke-2"}


### PR DESCRIPTION
## ROB-375 Bug 1 — `investment_report_context_get`가 draft 제외 → 항상 빈 컨텍스트

advisory 플로우는 리포트가 **항상 `status="draft"`**(publish 단계 없음)인데, ROB-352 Slice B에서 smoke boilerplate 제거용으로 추가한 `status != "draft"` 필터가 prior_reports를 통째로 비우고 `unresolved_deferred_items`/`active_watches`/`triggered_events`/`recent_decisions`(모두 prior 의존)까지 연쇄로 빈 배열이 됨 → 후속 델타 리포트가 개장 베이스라인을 못 끌어옴.

### 변경
- `InvestmentReportQueryService.previous_report_context(...)`에 `include_draft: bool = False` 추가.
  - `False`(기본): 현행대로 draft 제외 → smoke-safe.
  - `True`: draft 제외 필터 skip → 최신 advisory draft를 prior로 인정.
- MCP 도구 `investment_report_context_get`에 `include_draft` 노출 + docstring 갱신.

### 스코프
- prior_reports를 비우던 근본만 수정. `active_watches`/`triggered_events`/`recent_decisions` **내용 채움**은 ROB-376 기능 영역 — 본 PR은 배선이 동작하게만 함. 마이그레이션 0건, read-only.

### 테스트
- `test_prior_reports_includes_drafts_if_requested` (service): `include_draft=True`면 draft 포함, 기본은 제외.
- `test_context_get_includes_draft_when_include_draft_true` (MCP): 기본 0건 vs `include_draft=True` 1건. (18 passed)

3개 독립 PR 중 2/3 (우선순위 Bug3 → Bug1 → Bug2). 설계/플랜 문서는 #1046 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)