### PR TITLE
fix(ROB-375): freeze numeric baseline into report row snapshots (Bug 2)

### DIFF
--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -77,6 +77,31 @@ from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
 
+_MARKET_BASELINE_KEYS = ("market", "from_date", "to_date", "indices")
+_PORTFOLIO_BASELINE_KEYS = (
+    "primary_source",
+    "cash",
+    "buying_power",
+    "sellable_summary",
+)
+
+
+def _market_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Whitelist the small delta-relevant numerics from a market snapshot
+    payload. Never copies the heavy ``events`` list. Missing keys are skipped
+    (no fabrication)."""
+    return {k: payload[k] for k in _MARKET_BASELINE_KEYS if k in payload}
+
+
+def _portfolio_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Whitelist cash/buying_power/sellable_summary + a holdings count.
+    Never copies the heavy ``holdings`` list."""
+    base = {k: payload[k] for k in _PORTFOLIO_BASELINE_KEYS if k in payload}
+    holdings = payload.get("holdings")
+    base["holdings_count"] = len(holdings) if isinstance(holdings, list) else 0
+    return base
+
+
 _MARKET_ACCOUNT_PAIRS: dict[str, str] = {
     "kr": "kis_live",
     "us": "kis_live",  # ROB-297 — KIS overseas (US) stock account.
@@ -545,14 +570,17 @@ class SnapshotBackedReportGenerator:
                 reason = str(info.get("reason") or info.get("status") or reason)
             return {"status": "unavailable", "reason": reason}
 
-        def _descriptor(snapshot: Any) -> dict[str, Any]:
+        def _section(snapshot: Any, baseline: dict[str, Any]) -> dict[str, Any]:
             as_of = getattr(snapshot, "as_of", None)
             return {
-                "snapshot_uuid": str(snapshot.snapshot_uuid),
-                "snapshot_kind": snapshot.snapshot_kind,
-                "as_of": as_of.isoformat() if as_of is not None else None,
-                "freshness_status": getattr(snapshot, "freshness_status", None),
-                "coverage": getattr(snapshot, "coverage_json", None) or {},
+                "provenance": {
+                    "snapshot_uuid": str(snapshot.snapshot_uuid),
+                    "snapshot_kind": snapshot.snapshot_kind,
+                    "as_of": as_of.isoformat() if as_of is not None else None,
+                    "freshness_status": getattr(snapshot, "freshness_status", None),
+                    "coverage": getattr(snapshot, "coverage_json", None) or {},
+                },
+                "baseline": baseline,
             }
 
         market = _unavailable("market")
@@ -562,10 +590,11 @@ class SnapshotBackedReportGenerator:
             return market, portfolio
         pairs = await self._snapshots_repo.list_bundle_items_with_snapshots(bundle.id)
         for _item, snapshot in pairs:
+            payload = getattr(snapshot, "payload_json", None) or {}
             if snapshot.snapshot_kind == "market":
-                market = _descriptor(snapshot)
+                market = _section(snapshot, _market_numeric_baseline(payload))
             elif snapshot.snapshot_kind == "portfolio":
-                portfolio = _descriptor(snapshot)
+                portfolio = _section(snapshot, _portfolio_numeric_baseline(payload))
         return market, portfolio
 
     async def _build_classifier_context(

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1493,10 +1493,12 @@ async def test_market_portfolio_descriptors_from_bundle() -> None:
     )
     await gen.generate(_make_request())
     sent = ingest.calls[0]
-    assert sent.market_snapshot["snapshot_uuid"] == str(market.snapshot_uuid)
-    assert sent.market_snapshot["freshness_status"] == "fresh"
-    assert sent.portfolio_snapshot["snapshot_kind"] == "portfolio"
-    assert "payload_json" not in sent.market_snapshot
+    assert sent.market_snapshot["provenance"]["snapshot_uuid"] == str(
+        market.snapshot_uuid
+    )
+    assert sent.market_snapshot["provenance"]["freshness_status"] == "fresh"
+    assert sent.portfolio_snapshot["provenance"]["snapshot_kind"] == "portfolio"
+    assert "payload_json" not in sent.market_snapshot["provenance"]
 
 
 @pytest.mark.asyncio
@@ -1550,16 +1552,78 @@ async def test_crypto_descriptors_are_pointers_not_empty() -> None:
     # Non-empty pointer descriptors.
     assert sent.market_snapshot != {}
     assert sent.portfolio_snapshot != {}
-    assert sent.market_snapshot["snapshot_uuid"] == str(market.snapshot_uuid)
-    assert sent.portfolio_snapshot["snapshot_uuid"] == str(portfolio.snapshot_uuid)
-    assert sent.market_snapshot["freshness_status"] == "fresh"
-    assert sent.portfolio_snapshot["coverage"] == {"rows": 3}
+    assert sent.market_snapshot["provenance"]["snapshot_uuid"] == str(
+        market.snapshot_uuid
+    )
+    assert sent.portfolio_snapshot["provenance"]["snapshot_uuid"] == str(
+        portfolio.snapshot_uuid
+    )
+    assert sent.market_snapshot["provenance"]["freshness_status"] == "fresh"
+    assert sent.portfolio_snapshot["provenance"]["coverage"] == {"rows": 3}
+    assert sent.market_snapshot["baseline"] == {}
+    assert sent.portfolio_snapshot["baseline"] == {"holdings_count": 0}
 
     # Pointer, NOT payload — the snapshot body must never be copied in.
-    for descriptor in (sent.market_snapshot, sent.portfolio_snapshot):
+    for descriptor in (
+        sent.market_snapshot["provenance"],
+        sent.portfolio_snapshot["provenance"],
+    ):
         assert "payload_json" not in descriptor
         assert "holdings" not in descriptor
         assert "events" not in descriptor
+
+
+@pytest.mark.asyncio
+async def test_descriptors_freeze_numeric_baseline_from_payload() -> None:
+    """ROB-375 Bug 2 — when the market/portfolio snapshot payloads carry the
+    delta-relevant numerics, the report row freezes them under ``baseline``
+    (indices for market; cash/buying_power/sellable_summary + holdings_count
+    for portfolio) while still never copying the heavy lists into provenance.
+    """
+    market = _FakeSnap(kind="market")
+    market.payload_json = {
+        "market": "us",
+        "from_date": "2026-05-30",
+        "to_date": "2026-05-30",
+        "indices": {"SPX": {"price": 5300.0, "change_pct": 0.4}},
+        "events": [{"big": "blob"}],  # heavy list must NOT be frozen
+    }
+    portfolio = _FakeSnap(kind="portfolio")
+    portfolio.payload_json = {
+        "primary_source": "kis_live",
+        "cash": {"usd_cash": 3095.26, "usd_orderable": 3078.32},
+        "buying_power": {"usd": 3078.32},
+        "sellable_summary": {"count": 4},
+        "holdings": [{"ticker": "BAC"}, {"ticker": "TMUS"}],  # heavy list excluded
+    }
+    repo = _FakeSnapshotsRepository(
+        bundle=type("B", (), {"id": 7})(),
+        items=[(object(), market), (object(), portfolio)],
+    )
+    ensure = _FakeEnsureService(_ensure_response())
+    ingest = _FakeIngestionService()
+    gen = SnapshotBackedReportGenerator(
+        session=object(),
+        ensure_service=ensure,
+        ingestion_service=ingest,
+        snapshots_repository=repo,
+    )
+    await gen.generate(_make_request())
+    sent = ingest.calls[0]
+
+    assert sent.market_snapshot["baseline"]["indices"] == {
+        "SPX": {"price": 5300.0, "change_pct": 0.4}
+    }
+    assert sent.market_snapshot["baseline"]["market"] == "us"
+    assert "events" not in sent.market_snapshot["baseline"]
+
+    pb = sent.portfolio_snapshot["baseline"]
+    assert pb["cash"] == {"usd_cash": 3095.26, "usd_orderable": 3078.32}
+    assert pb["buying_power"] == {"usd": 3078.32}
+    assert pb["sellable_summary"] == {"count": 4}
+    assert pb["primary_source"] == "kis_live"
+    assert pb["holdings_count"] == 2
+    assert "holdings" not in pb
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_snapshot_baseline.py
+++ b/tests/services/test_snapshot_baseline.py
@@ -1,0 +1,39 @@
+# tests/services/test_snapshot_baseline.py
+from app.services.action_report.snapshot_backed import generator as gen
+
+
+def test_market_baseline_whitelists_indices():
+    payload = {
+        "market": "us",
+        "from_date": "2026-05-30",
+        "to_date": "2026-05-30",
+        "event_count": 3,
+        "events": [{"big": "blob"}],  # excluded
+        "indices": {"SPX": {"price": 5300.0, "change_pct": 0.4}},
+    }
+    base = gen._market_numeric_baseline(payload)
+    assert base["indices"] == {"SPX": {"price": 5300.0, "change_pct": 0.4}}
+    assert base["market"] == "us"
+    assert "events" not in base  # heavy list not copied
+
+
+def test_portfolio_baseline_whitelists_cash_and_summary():
+    payload = {
+        "holdings": [{"ticker": "BAC"}],  # excluded heavy list
+        "primary_source": "kis_live",
+        "cash": {"usd_cash": 3095.26, "usd_orderable": 3078.32},
+        "buying_power": {"usd": 3078.32},
+        "sellable_summary": {"count": 4},
+    }
+    base = gen._portfolio_numeric_baseline(payload)
+    assert base["cash"] == {"usd_cash": 3095.26, "usd_orderable": 3078.32}
+    assert base["buying_power"] == {"usd": 3078.32}
+    assert base["sellable_summary"] == {"count": 4}
+    assert base["primary_source"] == "kis_live"
+    assert base["holdings_count"] == 1
+    assert "holdings" not in base
+
+
+def test_baselines_handle_missing_keys():
+    assert gen._market_numeric_baseline({}) == {}
+    assert gen._portfolio_numeric_baseline({}) == {"holdings_count": 0}


### PR DESCRIPTION
## ROB-375 Bug 2 — snapshot-backed report row의 `market_snapshot`/`portfolio_snapshot`이 비거나 pointer-only

ROB-352 Slice B의 "pointer not payload" 원칙대로 report row가 provenance descriptor만 들고 있어, 델타 계산용 개장 베이스라인(지수·USD현금·비중)을 row만으로 회수 불가 → 번들 우회 필요. (구 수동 리포트는 `portfolio_snapshot{usd_cash, usd_orderable, ...}`를 직접 동결했었음.)

### 변경
- `_section_snapshot_descriptors`가 각 섹션을 `{"provenance": <descriptor>, "baseline": <numeric>}` 구조로 기록 (pointer 보존 + 델타 numeric 추가).
- `snapshot.payload_json`에서 **화이트리스트** numeric만 추출:
  - market: `indices`/`market`/`from_date`/`to_date` (heavy `events` 리스트 제외)
  - portfolio: `cash`/`buying_power`/`sellable_summary`/`primary_source` + `holdings_count` (heavy `holdings` 리스트 제외)
- payload에 키 없으면 skip(fabricate 금지). 마이그레이션 0건(JSONB 컬럼 재사용).

### 소비자 영향
- flat descriptor 형태(`market_snapshot["snapshot_uuid"]`)를 읽는 downstream 소비자 없음 확인. 기존 generator 테스트는 `["provenance"]`로 갱신.

### 테스트
- `tests/services/test_snapshot_baseline.py` (신규): 순수 추출기 단위(indices/cash 화이트리스트, missing-key, heavy 리스트 제외).
- `test_descriptors_freeze_numeric_baseline_from_payload` (신규 통합): payload 채워진 번들 → baseline에 indices/cash 동결, holdings_count=2, events/holdings 미복사.
- 기존 pointer-not-payload 가드 유지. (44 passed)

3개 독립 PR 중 3/3 (우선순위 Bug3 → Bug1 → Bug2). 설계/플랜 문서는 #1046 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)