### PR TITLE
research(binance-1m-spike): bounded 1m gross-edge falsification probe

### DIFF
--- a/research/binance_1m_spike/.gitignore
+++ b/research/binance_1m_spike/.gitignore
@@ -1,0 +1,7 @@
+# Spike-local data + artifacts: never commit raw bars or result dumps.
+data/
+results/
+__pycache__/
+*.pyc
+_run.*
+_*.txt

--- a/research/binance_1m_spike/README.md
+++ b/research/binance_1m_spike/README.md
@@ -1,0 +1,65 @@
+# Binance USD-M 1m gross-edge spike
+
+A **bounded, reproducible falsification probe**, not a strategy and not a
+validator. It answers one cheap question before any heavier backtest work:
+
+> On a 1-minute timeframe, does a canonical z-score mean-reversion *fade* have any
+> **GROSS** per-trade edge (before fees) above the economic-triviality floor, on a
+> tiny bounded sample of Binance USD-M futures data?
+
+## Why this shape
+
+The repo has already concluded that trend / momentum / reversal scalping is
+**net-negative, and mostly gross-negative**, on this venue:
+
+- `docs/runbooks/rob-353-pr2-empirical-verdict.md` — families 1/2/3 all
+  `screened_out` on **gross** (−70.99 / −27.53 / −39.38 bps), before fees.
+- `docs/runbooks/binance-demo-scalping.md` — ROB-316 trend micro-breakout
+  net-negative at realistic fees and gross-negative out-of-sample.
+
+So the honest job here is **falsification on the cheapest possible path**, not a
+search for profit. The full validator (walk-forward, bootstrap CI, MC
+permutation, maker-fill model) already exists in `research/nautilus_scalping/`
+and requires a NautilusTrader build; this spike intentionally avoids that and
+runs under a bare `python3`.
+
+## What it does
+
+1. `binance_1m_data.py` — read-only download of one `SYMBOL-1m-YYYY-MM.zip` from
+   the public `data.binance.vision` USD-M archive → close prices. (The existing
+   `nautilus_scalping/pit_klines_fetcher.py` only supports 1d/1h; this adds the
+   1m path in isolation.)
+2. `meanrev_probe.py` — rolling z-score; **non-overlapping** fade trades (open,
+   hold N bars, close, skip past exit) → independent gross per-trade returns.
+3. `fees.py` — frozen Binance USD-M Demo envelope (taker 4.0 / maker 2.0 bps per
+   leg; gross floor 0.5 bps), mirroring `nautilus_scalping/frozen_config.py`.
+4. `run.py` — fetch → probe → emit a **counts-only** JSON artifact.
+
+## Run
+
+```bash
+cd research/binance_1m_spike
+python3 run.py --out          # default: 2026-04, XRPUSDT + BTCUSDT, one param set
+python3 test_spike.py         # pure unit tests, no network
+```
+
+`data/` and `results/` are gitignored — no raw bars or result dumps are committed.
+
+## Verdict space (mirrors the funnel labels)
+
+- `needs_more_data` — fewer than 30 trades; sample can't support a read.
+- `screened_out_gross` — mean gross ≤ 0.5 bps floor; no edge even before fees → reject.
+- `gross_edge_present_needs_full_validation` — gross edge above the floor; this
+  spike does **not** validate it (net + statistics are the Nautilus gate's job).
+
+## Hard non-goals / stop conditions
+
+- No parameter sweep (one fixed param set).
+- No profitability claim from a tiny sample.
+- No live execution; no order mutation; read-only public data only.
+- `net_*` columns subtract a flat round-trip fee for **context only** — a real
+  net verdict requires the full gate.
+- BTCUSDT is **data-only**: it is excluded from the futures-demo execution
+  allowlist (`app/services/brokers/binance/futures_demo/sizing.py`), so its
+  result does not map to anything the demo loop could trade. XRPUSDT is the demo
+  default.

--- a/research/binance_1m_spike/binance_1m_data.py
+++ b/research/binance_1m_spike/binance_1m_data.py
@@ -1,0 +1,58 @@
+"""Read-only fetch + parse of Binance USD-M Futures 1m monthly klines.
+
+Source: ``data.binance.vision`` public archive (no auth, no secrets). This is
+the same host the existing ``research/nautilus_scalping/pit_klines_fetcher.py``
+uses for 1d/1h; that fetcher hard-codes ``SUPPORTED_INTERVALS = ("1d","1h")``,
+so this spike adds the missing 1m path in isolation rather than touching it.
+
+Downloads one ``<SYMBOL>-1m-<YYYY>-<MM>.zip`` to a gitignored ``data/`` cache and
+returns a list of close prices (floats). Pure stdlib — no pandas, no repo deps.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import urllib.request
+import zipfile
+from pathlib import Path
+
+_BASE = "https://data.binance.vision/data/futures/um/monthly/klines"
+_DATA_ROOT = Path(__file__).resolve().parent / "data"
+
+# Binance kline CSV column order (no header in the archive files).
+_OPEN_TIME, _OPEN, _HIGH, _LOW, _CLOSE = 0, 1, 2, 3, 4
+
+
+def _zip_url(symbol: str, year: int, month: int) -> str:
+    stem = f"{symbol}-1m-{year:04d}-{month:02d}"
+    return f"{_BASE}/{symbol}/1m/{stem}.zip"
+
+
+def fetch_month_closes(
+    symbol: str, year: int, month: int
+) -> tuple[list[int], list[float]]:
+    """Return (open_times_ms, closes) for one symbol-month of 1m USD-M klines.
+
+    Caches the raw zip under ``data/`` (gitignored). Read-only network access.
+    """
+    _DATA_ROOT.mkdir(parents=True, exist_ok=True)
+    stem = f"{symbol}-1m-{year:04d}-{month:02d}"
+    zip_path = _DATA_ROOT / f"{stem}.zip"
+    if not zip_path.exists():
+        url = _zip_url(symbol, year, month)
+        with urllib.request.urlopen(url, timeout=120) as resp:  # noqa: S310 (trusted host)
+            zip_path.write_bytes(resp.read())
+
+    open_times: list[int] = []
+    closes: list[float] = []
+    with zipfile.ZipFile(zip_path) as zf:
+        name = zf.namelist()[0]
+        with zf.open(name) as fh:
+            text = io.TextIOWrapper(fh, encoding="utf-8")
+            for row in csv.reader(text):
+                if not row or not row[_OPEN].replace(".", "", 1).isdigit():
+                    continue  # skip a stray header row if the archive adds one
+                open_times.append(int(row[_OPEN_TIME]))
+                closes.append(float(row[_CLOSE]))
+    return open_times, closes

--- a/research/binance_1m_spike/fees.py
+++ b/research/binance_1m_spike/fees.py
@@ -1,0 +1,29 @@
+"""Frozen Binance USD-M Futures Demo cost envelope for the 1m gross-edge spike.
+
+These mirror the committed campaign envelope in
+``research/nautilus_scalping/frozen_config.py`` (``taker_bps=4.0``,
+``achievable_maker_bps=2.0``, ``economic_triviality_floor_bps=0.5``). They are
+re-declared here — not imported — so this spike stays standalone and runs under a
+bare ``python3`` with no repo/Nautilus dependency.
+
+``test_spike.py::test_fee_envelope_matches_frozen_config`` pins these literals,
+so an accidental edit to *this* file is caught by the tests. It does NOT import
+``frozen_config`` (that would break standalone), so keeping the two in sync if
+the canonical envelope ever changes is a MANUAL step — update both.
+
+Per-leg fees; a round trip (entry + exit) pays two legs.
+"""
+
+from __future__ import annotations
+
+TAKER_BPS_PER_LEG = 4.0
+MAKER_BPS_PER_LEG = 2.0
+ECONOMIC_TRIVIALITY_FLOOR_BPS = 0.5  # a gross mean below this is "no edge"
+
+TAKER_ROUND_TRIP_BPS = 2 * TAKER_BPS_PER_LEG  # 8.0
+MAKER_ROUND_TRIP_BPS = 2 * MAKER_BPS_PER_LEG  # 4.0
+
+
+def net_bps(gross_bps: float, *, round_trip_bps: float) -> float:
+    """Net per-trade bps after one round-trip commission (taker fills assumed)."""
+    return gross_bps - round_trip_bps

--- a/research/binance_1m_spike/meanrev_probe.py
+++ b/research/binance_1m_spike/meanrev_probe.py
@@ -1,0 +1,161 @@
+"""Pure-stdlib GROSS per-trade edge probe for a 1m mean-reversion fade.
+
+This is a *falsification* probe, not a validator. It measures whether a canonical
+1m z-score fade (the reversal family the repo has repeatedly studied) has any
+GROSS per-trade edge above the economic-triviality floor — BEFORE fees — on a
+tiny bounded sample. It deliberately reuses the reversal idea behind
+``research/nautilus_scalping/meanrev_signal.py`` but in ~stdlib so it runs with no
+Nautilus build.
+
+Trades are NON-OVERLAPPING (open, hold ``hold`` bars, close, skip past the exit)
+so each trade return is independent — no double-counting inflating the sample.
+
+Verdict mirrors the funnel label space already in the repo
+(``screened_out`` / ``needs_more_data`` / promote-to-full-validation). A positive
+gross result does NOT claim profitability: net (after fees) and statistical
+validation are explicitly left to the full Nautilus gate.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import asdict, dataclass
+
+from fees import (
+    ECONOMIC_TRIVIALITY_FLOOR_BPS,
+    MAKER_ROUND_TRIP_BPS,
+    TAKER_ROUND_TRIP_BPS,
+    net_bps,
+)
+
+MIN_TRADES = 30  # below this, the sample can't support any read -> needs_more_data
+
+
+@dataclass(frozen=True)
+class ProbeParams:
+    lookback: int = 20
+    z_entry: float = 2.0
+    hold: int = 10
+
+
+@dataclass(frozen=True)
+class SymbolResult:
+    symbol: str
+    demo_executable: bool
+    n_bars: int
+    n_trades: int
+    mean_gross_bps: float
+    median_gross_bps: float
+    stdev_gross_bps: float
+    t_stat: float
+    win_rate_pct: float
+    mean_net_taker_bps: float
+    mean_net_maker_bps: float
+    verdict: str
+
+
+def _rolling_z(closes: list[float], lookback: int) -> list[float | None]:
+    z: list[float | None] = [None] * len(closes)
+    for i in range(lookback, len(closes)):
+        window = closes[i - lookback : i]
+        mean = statistics.fmean(window)
+        sd = statistics.pstdev(window)
+        if sd > 0:
+            z[i] = (closes[i] - mean) / sd
+    return z
+
+
+def trade_records(
+    closes: list[float], z: list[float | None], p: ProbeParams
+) -> list[tuple[int, int, float]]:
+    """Non-overlapping fade trades -> list of (entry_idx, exit_idx, gross_bps).
+
+    Non-overlapping: after a trade opened at ``i`` and held ``p.hold`` bars, the
+    scan resumes at ``exit_i + 1``, so consecutive entries are always more than
+    ``p.hold`` apart and no bar is counted in two trades.
+    """
+    out: list[tuple[int, int, float]] = []
+    n = len(closes)
+    i = 0
+    while i < n:
+        zi = z[i]
+        if zi is None:
+            i += 1
+            continue
+        if zi <= -p.z_entry:
+            direction = 1  # oversold -> fade up (go long)
+        elif zi >= p.z_entry:
+            direction = -1  # overbought -> fade down (go short)
+        else:
+            i += 1
+            continue
+        exit_i = i + p.hold
+        if exit_i >= n:
+            break
+        entry, exitp = closes[i], closes[exit_i]
+        if entry > 0:
+            ret = (exitp - entry) / entry * 10_000.0 * direction
+            out.append((i, exit_i, ret))
+        i = exit_i + 1  # non-overlapping
+    return out
+
+
+def _trade_returns_bps(
+    closes: list[float], z: list[float | None], p: ProbeParams
+) -> list[float]:
+    """Non-overlapping fade trades -> list of GROSS per-trade returns in bps."""
+    return [ret for (_entry, _exit, ret) in trade_records(closes, z, p)]
+
+
+def _verdict(n_trades: int, mean_gross: float) -> str:
+    if n_trades < MIN_TRADES:
+        return "needs_more_data"
+    if mean_gross <= ECONOMIC_TRIVIALITY_FLOOR_BPS:
+        return "screened_out_gross"  # no gross edge above the floor; reject
+    return "gross_edge_present_needs_full_validation"
+
+
+def probe_symbol(
+    symbol: str, closes: list[float], *, demo_executable: bool, params: ProbeParams
+) -> SymbolResult:
+    z = _rolling_z(closes, params.lookback)
+    rets = _trade_returns_bps(closes, z, params)
+    n = len(rets)
+    if n == 0:
+        return SymbolResult(
+            symbol,
+            demo_executable,
+            len(closes),
+            0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            "needs_more_data",
+        )
+    mean = statistics.fmean(rets)
+    median = statistics.median(rets)
+    sd = statistics.pstdev(rets)
+    t_stat = (mean / (sd / (n**0.5))) if (sd > 0 and n > 1) else 0.0
+    win_rate = 100.0 * sum(1 for r in rets if r > 0) / n
+    return SymbolResult(
+        symbol=symbol,
+        demo_executable=demo_executable,
+        n_bars=len(closes),
+        n_trades=n,
+        mean_gross_bps=round(mean, 4),
+        median_gross_bps=round(median, 4),
+        stdev_gross_bps=round(sd, 4),
+        t_stat=round(t_stat, 4),
+        win_rate_pct=round(win_rate, 2),
+        mean_net_taker_bps=round(net_bps(mean, round_trip_bps=TAKER_ROUND_TRIP_BPS), 4),
+        mean_net_maker_bps=round(net_bps(mean, round_trip_bps=MAKER_ROUND_TRIP_BPS), 4),
+        verdict=_verdict(n, mean),
+    )
+
+
+def result_to_dict(r: SymbolResult) -> dict:
+    return asdict(r)

--- a/research/binance_1m_spike/run.py
+++ b/research/binance_1m_spike/run.py
@@ -1,0 +1,109 @@
+"""Run the bounded 1m gross-edge spike and emit a counts-only artifact.
+
+Bounded by construction: ONE month, ONE parameter set, a fixed symbol list. No
+parameter sweep (that is an explicit non-goal). The artifact carries only
+counts/metrics — never raw bars.
+
+Usage (standalone, no repo deps):
+    python3 run.py                          # default: 2026-04, XRPUSDT + BTCUSDT
+    python3 run.py --year 2026 --month 4 --out
+
+Symbols: XRPUSDT is the Binance USD-M Futures Demo default (executable). BTCUSDT
+is included as a liquid DATA reference only — it is explicitly excluded from the
+demo execution allowlist (MIN_NOTIONAL=50 > 10 USDT cap; see
+``app/services/brokers/binance/futures_demo/sizing.py``), so its result does NOT
+map to anything the demo loop could trade.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from binance_1m_data import fetch_month_closes
+from fees import (
+    ECONOMIC_TRIVIALITY_FLOOR_BPS,
+    MAKER_BPS_PER_LEG,
+    TAKER_BPS_PER_LEG,
+)
+from meanrev_probe import ProbeParams, probe_symbol, result_to_dict
+
+_SCHEMA = "binance_1m_gross_edge_spike.v1"
+_RESULTS = Path(__file__).resolve().parent / "results"
+
+# (symbol, demo_executable)
+_SYMBOLS = [("XRPUSDT", True), ("BTCUSDT", False)]
+
+
+def _parse(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--year", type=int, default=2026)
+    ap.add_argument("--month", type=int, default=4)
+    ap.add_argument("--lookback", type=int, default=20)
+    ap.add_argument("--z-entry", type=float, default=2.0, dest="z_entry")
+    ap.add_argument("--hold", type=int, default=10)
+    ap.add_argument(
+        "--out", action="store_true", help="also write results/<schema>.json"
+    )
+    return ap.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse(argv)
+    params = ProbeParams(lookback=args.lookback, z_entry=args.z_entry, hold=args.hold)
+
+    symbols_out = []
+    for symbol, demo_exec in _SYMBOLS:
+        _times, closes = fetch_month_closes(symbol, args.year, args.month)
+        res = probe_symbol(symbol, closes, demo_executable=demo_exec, params=params)
+        symbols_out.append(result_to_dict(res))
+
+    any_gross = any(
+        s["verdict"] == "gross_edge_present_needs_full_validation" for s in symbols_out
+    )
+    all_screened = symbols_out and all(
+        s["verdict"] == "screened_out_gross" for s in symbols_out
+    )
+    overall = (
+        "gross_edge_candidate_found"
+        if any_gross
+        else ("screened_out_gross_all" if all_screened else "needs_more_data")
+    )
+
+    artifact = {
+        "schema_version": _SCHEMA,
+        "window": {"year": args.year, "month": args.month, "interval": "1m"},
+        "market": "binance_usdm_futures",
+        "params": {
+            "lookback": params.lookback,
+            "z_entry": params.z_entry,
+            "hold": params.hold,
+            "signal": "zscore_meanrev_fade_nonoverlapping",
+        },
+        "fees_bps_per_leg": {
+            "taker": TAKER_BPS_PER_LEG,
+            "maker": MAKER_BPS_PER_LEG,
+            "economic_triviality_floor_gross": ECONOMIC_TRIVIALITY_FLOOR_BPS,
+        },
+        "symbols": symbols_out,
+        "overall_verdict": overall,
+        "caveats": [
+            "Tiny single-month sample; NOT a profitability claim and NOT a validation.",
+            "GROSS edge only; net columns subtract a flat round-trip fee for context.",
+            "Single parameter set; no sweep (explicit non-goal).",
+            "BTCUSDT is data-only (excluded from futures-demo execution).",
+        ],
+    }
+
+    print(json.dumps(artifact, indent=2))
+    if args.out:
+        _RESULTS.mkdir(parents=True, exist_ok=True)
+        path = _RESULTS / f"{_SCHEMA}.json"
+        path.write_text(json.dumps(artifact, indent=2))
+        print(f"\nartifact written: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/research/binance_1m_spike/test_spike.py
+++ b/research/binance_1m_spike/test_spike.py
@@ -1,0 +1,94 @@
+"""Pure unit tests for the 1m gross-edge spike (no network, no repo deps).
+
+Run: ``python3 -m pytest test_spike.py`` from this directory, or
+``python3 test_spike.py`` for a dependency-free smoke check.
+"""
+
+from __future__ import annotations
+
+import fees
+from meanrev_probe import (
+    MIN_TRADES,
+    ProbeParams,
+    _rolling_z,
+    _verdict,
+    probe_symbol,
+    trade_records,
+)
+
+
+def test_fee_envelope_matches_frozen_config():
+    # Mirrors research/nautilus_scalping/frozen_config.py (taker 4 / maker 2 / floor 0.5).
+    assert fees.TAKER_BPS_PER_LEG == 4.0
+    assert fees.MAKER_BPS_PER_LEG == 2.0
+    assert fees.ECONOMIC_TRIVIALITY_FLOOR_BPS == 0.5
+    assert fees.TAKER_ROUND_TRIP_BPS == 8.0
+    assert fees.MAKER_ROUND_TRIP_BPS == 4.0
+
+
+def test_net_bps_subtracts_round_trip():
+    assert fees.net_bps(10.0, round_trip_bps=8.0) == 2.0
+    assert fees.net_bps(3.0, round_trip_bps=8.0) == -5.0
+
+
+def test_rolling_z_warmup_is_none():
+    z = _rolling_z([1.0] * 10, lookback=5)
+    assert z[:5] == [None] * 5
+    # flat series -> zero stdev -> None (no signal)
+    assert all(v is None for v in z)
+
+
+def test_nonoverlapping_trades_do_not_double_count():
+    # V-shape: a steady decline then recovery guarantees z crossings both ways,
+    # so multiple fade trades fire. The key property under test is that no two
+    # trades overlap (each entry is more than `hold` bars after the previous).
+    closes = [100.0 - i for i in range(40)] + [60.0 + i for i in range(40)]
+    z = _rolling_z(closes, lookback=20)
+    params = ProbeParams(lookback=20, z_entry=1.5, hold=5)
+    records = trade_records(closes, z, params)
+    assert len(records) >= 1
+    entries = [entry for (entry, _exit, _ret) in records]
+    # Index iteration over consecutive pairs (no zip): avoids the B905
+    # explicit-strict rule and keeps the standalone runner working on the
+    # system's older python3.
+    for k in range(len(entries) - 1):
+        assert entries[k + 1] - entries[k] > params.hold  # non-overlapping
+    # entry/exit indices are consistent with the hold horizon
+    for entry, exit_i, _ret in records:
+        assert exit_i == entry + params.hold
+
+
+def test_verdict_needs_more_data_on_tiny_sample():
+    r = probe_symbol(
+        "TESTUSDT",
+        [100.0, 101.0, 102.0],
+        demo_executable=True,
+        params=ProbeParams(),
+    )
+    assert r.n_trades == 0
+    assert r.verdict == "needs_more_data"
+
+
+def test_verdict_screens_out_at_or_below_floor_else_promotes():
+    # Deterministic check of the screening rule itself (no data dependence).
+    # With enough trades, the floor (0.5 bps, inclusive) decides screened_out vs
+    # promote; below MIN_TRADES it is always needs_more_data.
+    assert _verdict(100, 0.4) == "screened_out_gross"  # below floor
+    assert (
+        _verdict(100, fees.ECONOMIC_TRIVIALITY_FLOOR_BPS) == "screened_out_gross"
+    )  # AT floor (<=)
+    assert (
+        _verdict(100, 0.6) == "gross_edge_present_needs_full_validation"
+    )  # above floor
+    assert _verdict(MIN_TRADES - 1, 5.0) == "needs_more_data"  # too few trades wins
+    assert (
+        _verdict(MIN_TRADES, 0.4) == "screened_out_gross"
+    )  # at threshold, floor applies
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok: {fn.__name__}")
+    print(f"\n{len(fns)} tests passed")


### PR DESCRIPTION
## Bounded Binance USD-M 1m gross-edge falsification spike

Research infrastructure + a cheap falsification, **not** a strategy and **not** live trading. Adds a standalone `research/binance_1m_spike/` (stdlib-only, ~260 LOC, runs under bare `python3` — no NautilusTrader build) that measures the **GROSS** per-trade edge (before fees) of a canonical 1m z-score mean-reversion *fade* on Binance USD-M futures, on a tiny bounded sample.

### Why this shape
The repo already concluded trend/momentum/reversal scalping is net-negative and **mostly gross-negative** on this venue — `docs/runbooks/rob-353-pr2-empirical-verdict.md` (families 1/2/3 `screened_out` on gross: −70.99 / −27.53 / −39.38 bps) and ROB-316 (net-neg + gross-neg OOS). The 1m timeframe hadn't been explicitly probed. This is the cheapest extension of that question. The full validator (`research/nautilus_scalping/`) needs a NautilusTrader build; this spike avoids it so it runs today.

### Run evidence (2026-04, one param set `z=2.0 / lookback=20 / hold=10`, no sweep, full month = 43,200 1m bars each)
| symbol | demo-exec | trades | mean gross bps | t | win% | net taker bps | net maker bps | verdict |
|---|---|---|---|---|---|---|---|---|
| XRPUSDT | ✅ | 2,111 | **+0.1182** | 0.275 | 50.50 | −7.88 | −3.88 | `screened_out_gross` |
| BTCUSDT | ❌ data-only | 2,065 | **+0.4139** | 1.072 | 53.51 | −7.59 | −3.59 | `screened_out_gross` |

**Overall: `screened_out_gross_all`.** Both gross means sit **below the 0.5 bps economic-triviality floor** and are **statistically indistinguishable from zero** (t < 1.1), and both are **deeply net-negative** after fees (≈ −7.6 to −7.9 bps/trade taker). No edge. **Not a profitability claim, and no backtest issue is warranted.** Consistent with the prior crypto-scalping verdict, now extended to the 1m timeframe.

> Note: median gross is mildly positive (0.70 / 0.93 bps) while the mean is ~0 with a large stdev (~18–20 bps) — a left-skewed distribution where a few large losers offset many small winners. Neither the mean edge nor the t-stat supports pursuing this.

> BTCUSDT is **data-only** — excluded from the futures-demo execution allowlist (`app/services/brokers/binance/futures_demo/sizing.py:29`, MIN_NOTIONAL>cap). XRPUSDT is the demo default.

### Tests
6 pure unit tests pass (`python3 test_spike.py` → `6 tests passed`, exit 0; no network).

### Reusable vs dead-end
- **Reusable infra:** the 1m USD-M kline fetcher (the existing `pit_klines_fetcher` is 1d/1h-only) + the counts-only probe/artifact pattern — drop-in for any future 1m signal.
- **Dead-end (this signal):** 1m mean-rev fade shows no edge → no strategy/backtest issue opened. If a *different* 1m signal is worth testing, the harness is ready; a real verdict would still need the full Nautilus gate (walk-forward + bootstrap + MC permutation + maker-fill).

### Safety
Read-only public market data only; no real orders; no broker/order/watch/order-intent mutation; no scheduler/cron; no secrets; no production DB writes; no parameter sweep. `data/` + `results/` gitignored (no raw bars or result dumps committed). `research/` is outside CI lint/test scope, so this does not affect main CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added research toolkit for analyzing mean-reversion patterns in Binance USD-M Futures 1-minute data.
  * Implemented automated data fetching and analysis probe with configurable parameters and JSON output reporting.
  * Included per-symbol results with gross and net edge metrics across different fee tiers.

* **Documentation**
  * Added comprehensive README documenting probe capabilities, scope, and limitations.

* **Tests**
  * Added full test suite validating fee calculations, trading logic, and verdict criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->