### PR TITLE
test(ROB-375): fix mock_preview runner xdist deadlock on main CI

### DIFF
--- a/tests/services/investment_reports/mock_preview/test_runner.py
+++ b/tests/services/investment_reports/mock_preview/test_runner.py
@@ -26,6 +26,17 @@ from app.services.investment_reports.mock_preview.runner import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 
+# These tests use the global ``db_session`` fixture and seed
+# ``review.investment_reports`` rows alongside snapshot/bundle rows. Under
+# xdist that races with the helper ``session`` fixture's per-test
+# ``TRUNCATE ... CASCADE`` on the report family (AccessExclusiveLock),
+# producing an asyncpg ``DeadlockDetectedError`` (observed on main CI). The
+# ``investment_reports_cleanup_lock`` fixture holds the same advisory lock the
+# helper uses for the whole test body, serializing this file's report-table
+# access against those truncates — the established pattern for cross-domain
+# ``db_session`` tests (see test_hermes_roundtrip_smoke / test_run_card_snapshot_ingest).
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 _SEED_SNAPSHOT_UUID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 


### PR DESCRIPTION
## main CI red 복구 — mock_preview runner xdist deadlock

최신 main의 `test (3.13)` run에서 `tests/services/investment_reports/mock_preview/test_runner.py`가 asyncpg `DeadlockDetectedError`로 실패 (reproducible: `test_runner_reuses_live_bundle_account_independent_rows` + `test_runner_isolates_bridge_failure_...`의 setup). 기능 assertion 실패가 아니라 **xdist 병렬 DB isolation** 문제.

### 근본 원인
이 테스트들은 global `db_session` fixture로 `review.investment_reports` + snapshot/bundle 행을 seed하는데, advisory lock(`INVESTMENT_REPORTS_TEST_LOCK_ID`)을 안 잡음. 다른 워커의 helper `session` fixture는 매 테스트 `TRUNCATE review.investment_reports ... CASCADE`(AccessExclusiveLock)를 같은 lock 아래서 수행 → INSERT 트랜잭션 vs TRUNCATE가 AB-BA 데드락.

### 수정
모듈 레벨 `pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")` 추가 — conftest의 **기존 sanctioned 메커니즘**으로, cross-domain `db_session` 테스트(이미 `test_hermes_roundtrip_smoke`, `test_run_card_snapshot_ingest`, `test_investment_stage_runs` 등 5개 파일이 사용)가 helper session의 truncate와 같은 advisory lock 위에서 직렬화되게 함. **프로덕션 코드 변경 없음.**

> payload salt(고정 kst_date/as_of 변경)는 whole-table TRUNCATE의 AccessExclusiveLock 충돌에는 효과가 없어 채택하지 않음 — lock 직렬화가 root-cause 수정.

### 검증
- 로컬 `pytest tests/services/investment_reports/mock_preview/test_runner.py` 7 passed (fixture 적용 후 무회귀). ruff check + format clean.
- cross-worker race는 결정적 로컬 재현 불가 → 최종 검증은 이 PR + post-merge main CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)