### PR TITLE
fix(ROB-375): narrow Bug 1 — draft_policy admits advisory drafts only, not all drafts

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -420,9 +420,12 @@ async def investment_report_context_get_impl(
     report_type: str | None = None,
     exclude_report_uuid: str | None = None,
     n_prior: int = 3,
-    include_draft: bool = False,
+    draft_policy: str = "exclude",
 ) -> dict:
     capped = max(1, min(int(n_prior), 10))
+    # Fail closed: an unknown policy (incl. a hallucinated "all") falls back to
+    # "exclude" so the tool never over-includes smoke drafts.
+    policy = draft_policy if draft_policy in {"exclude", "advisory_only"} else "exclude"
     exclude_uuid = UUID(exclude_report_uuid) if exclude_report_uuid else None
     async with AsyncSessionLocal() as db:
         service = InvestmentReportQueryService(db)
@@ -433,7 +436,7 @@ async def investment_report_context_get_impl(
             report_type=report_type,
             exclude_report_uuid=exclude_uuid,
             n_prior=capped,
-            include_draft=include_draft,
+            draft_policy=policy,
         )
         # ROB-274 — enrich the response with the pending_orders snapshot so
         # next-report drafters see what's already open at the broker. The
@@ -746,8 +749,12 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
             "Return previous-report context for the next-report generator: "
             "prior_reports, unresolved_deferred_items, active_watches, "
             "triggered_events, recent_decisions. n_prior clamped to 1..10. "
-            "include_draft (optional, default False): include draft reports as prior context. "
-            "advisory reports persist as draft, so set True to chain the next delta report off the latest advisory baseline."
+            "draft_policy (optional, default 'exclude'): 'exclude' drops all draft "
+            "reports; 'advisory_only' admits genuine advisory drafts "
+            "(created_by_profile=HERMES_ADVISOR) as prior context while still "
+            "excluding smoke/test drafts. advisory reports persist as draft, so use "
+            "'advisory_only' to chain the next delta report off the latest advisory "
+            "baseline. (Unknown values fall back to 'exclude'.)"
         ),
     )(investment_report_context_get_impl)
     mcp.tool(

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -34,6 +34,27 @@ from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
 
+# ROB-375 Bug 1 — advisory reports persist as status="draft" (no publish step),
+# but so does smoke/CI boilerplate. ``created_by_profile`` is the reliable
+# discriminator: the Hermes advisory composition path hard-codes
+# "HERMES_ADVISOR" (investment_hermes_handlers / hermes_ingest), and no
+# smoke/test/operator profile ("t", "test", "schedule", "pilot-operator", …)
+# uses it. So a draft counts as an advisory prior iff it carries this profile.
+_ADVISORY_DRAFT_PROFILES: frozenset[str] = frozenset({"HERMES_ADVISOR"})
+
+# Allowed draft policies for ``previous_report_context``. There is intentionally
+# NO "all" policy — admitting every draft would re-introduce smoke boilerplate.
+DRAFT_POLICY_EXCLUDE = "exclude"
+DRAFT_POLICY_ADVISORY_ONLY = "advisory_only"
+_VALID_DRAFT_POLICIES: frozenset[str] = frozenset(
+    {DRAFT_POLICY_EXCLUDE, DRAFT_POLICY_ADVISORY_ONLY}
+)
+
+
+def _is_advisory_draft(report: InvestmentReport) -> bool:
+    """True when a draft report is a genuine advisory baseline (not smoke)."""
+    return report.created_by_profile in _ADVISORY_DRAFT_PROFILES
+
 
 class InvestmentReportQueryService:
     """Read-only queries — list / get / latest / previous-context."""
@@ -248,7 +269,7 @@ class InvestmentReportQueryService:
         exclude_report_uuid: UUID | None = None,
         n_prior: int = 3,
         events_since: datetime | None = None,
-        include_draft: bool = False,
+        draft_policy: str = DRAFT_POLICY_EXCLUDE,
     ) -> dict[str, Any]:
         """Locked refinement #7 — previous context is a query, not a single FK.
 
@@ -256,11 +277,17 @@ class InvestmentReportQueryService:
         the unresolved/deferred items, active watches, triggered watch
         events, and recent decisions that span those reports.
         """
-        # ROB-352 Slice B — fetch a buffer so dropping drafts (smoke
-        # boilerplate ships as draft) + the excluded uuid still yields up to
-        # n_prior published rows. NOTE: silently under-fills (returns < n_prior)
-        # if more than _DRAFT_FETCH_BUFFER consecutive drafts precede the last
-        # wanted published row; raise the buffer if smoke density grows.
+        if draft_policy not in _VALID_DRAFT_POLICIES:
+            raise ValueError(
+                f"draft_policy must be one of {sorted(_VALID_DRAFT_POLICIES)}; "
+                f"got {draft_policy!r}"
+            )
+
+        # ROB-352 Slice B / ROB-375 Bug 1 — fetch a buffer so dropping excluded
+        # drafts + the excluded uuid still yields up to n_prior kept rows. NOTE:
+        # silently under-fills (returns < n_prior) if more than
+        # _DRAFT_FETCH_BUFFER consecutive dropped drafts precede the last wanted
+        # row; raise the buffer if smoke density grows.
         _DRAFT_FETCH_BUFFER = 5
         prior_reports: list[InvestmentReport] = await self._repo.list_reports(
             market=market,
@@ -273,7 +300,13 @@ class InvestmentReportQueryService:
             prior_reports = [
                 r for r in prior_reports if r.report_uuid != exclude_report_uuid
             ]
-        if not include_draft:
+        # Draft handling: 'exclude' drops every draft (default); 'advisory_only'
+        # keeps advisory drafts (HERMES_ADVISOR) but still drops smoke drafts.
+        if draft_policy == DRAFT_POLICY_ADVISORY_ONLY:
+            prior_reports = [
+                r for r in prior_reports if r.status != "draft" or _is_advisory_draft(r)
+            ]
+        else:  # DRAFT_POLICY_EXCLUDE
             prior_reports = [r for r in prior_reports if r.status != "draft"]
         prior_reports = prior_reports[:n_prior]
 

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -513,23 +513,37 @@ async def test_generate_from_bundle_user_id_defaults_to_mcp_user(
 
 
 @pytest.mark.asyncio
-async def test_context_get_includes_draft_when_include_draft_true(
+async def test_context_get_draft_policy_advisory_only(
     session: AsyncSession,
 ) -> None:
-    # 1. Create a draft report (by default status="draft" inside investment_report_create_impl)
-    r = await investment_report_create_impl(
+    """draft_policy='advisory_only' admits an advisory (HERMES_ADVISOR) draft as
+    prior context; the default 'exclude' drops it; a smoke draft stays excluded
+    even under 'advisory_only'."""
+    # 1. An advisory draft (HERMES_ADVISOR) — the genuine baseline.
+    advisory = await investment_report_create_impl(
         items=[_action_item_dict()],
-        **_create_kwargs(kst_date="2026-05-18"),
+        **_create_kwargs(kst_date="2026-05-18", created_by_profile="HERMES_ADVISOR"),
     )
-    # Draft is not published, so status remains "draft"
+    # 2. A smoke/test draft (default test profile) — must never be admitted.
+    await investment_report_create_impl(
+        items=[_action_item_dict("action-2")],
+        **_create_kwargs(kst_date="2026-05-17", created_by_profile="t"),
+    )
 
-    # 2. Get context with default include_draft=False
+    # 3. Default draft_policy='exclude' drops all drafts.
     ctx_default = await investment_report_context_get_impl(market="kr")
     assert len(ctx_default["prior_reports"]) == 0
 
-    # 3. Get context with include_draft=True
-    ctx_include = await investment_report_context_get_impl(
-        market="kr", include_draft=True
+    # 4. draft_policy='advisory_only' admits ONLY the advisory draft.
+    ctx_advisory = await investment_report_context_get_impl(
+        market="kr", draft_policy="advisory_only"
     )
-    assert len(ctx_include["prior_reports"]) == 1
-    assert ctx_include["prior_reports"][0]["report_uuid"] == r["report"]["report_uuid"]
+    uuids = {r["report_uuid"] for r in ctx_advisory["prior_reports"]}
+    assert uuids == {advisory["report"]["report_uuid"]}
+
+    # 5. An unknown policy (e.g. a hallucinated "all") fails closed to 'exclude'
+    #    at the tool boundary — never errors, never over-includes drafts.
+    ctx_unknown = await investment_report_context_get_impl(
+        market="kr", draft_policy="all"
+    )
+    assert len(ctx_unknown["prior_reports"]) == 0

--- a/tests/test_investment_reports_query_prior_drafts.py
+++ b/tests/test_investment_reports_query_prior_drafts.py
@@ -11,7 +11,7 @@ from app.services.investment_reports.query_service import (
 from app.services.investment_reports.repository import InvestmentReportsRepository
 
 
-async def _make_report(repo, *, key, status, title):
+async def _make_report(repo, *, key, status, title, created_by_profile="t"):
     return await repo.insert_report(
         idempotency_key=key,
         report_type="snapshot_backed_advisory_v1",
@@ -19,7 +19,7 @@ async def _make_report(repo, *, key, status, title):
         market_session=None,
         account_scope="kis_live",
         execution_mode="advisory_only",
-        created_by_profile="t",
+        created_by_profile=created_by_profile,
         title=title,
         summary="s",
         status=status,
@@ -28,33 +28,19 @@ async def _make_report(repo, *, key, status, title):
 
 
 @pytest.mark.asyncio
-async def test_prior_reports_excludes_drafts(session: AsyncSession) -> None:
+async def test_prior_reports_excludes_drafts_by_default(session: AsyncSession) -> None:
+    """Default draft_policy='exclude' drops ALL drafts — advisory and smoke alike."""
     repo = InvestmentReportsRepository(session)
     await _make_report(repo, key="pub:1", status="published", title="real-1")
     await _make_report(repo, key="draft:1", status="draft", title="hermes-smoke-1")
-    await _make_report(repo, key="draft:2", status="draft", title="hermes-smoke-2")
-    await _make_report(repo, key="pub:2", status="published", title="real-2")
-
-    svc = InvestmentReportQueryService(session)
-    ctx = await svc.previous_report_context(
-        market="us",
-        account_scope="kis_live",
-        report_type="snapshot_backed_advisory_v1",
-        n_prior=3,
+    # An advisory draft (HERMES_ADVISOR) is ALSO excluded under the default.
+    await _make_report(
+        repo,
+        key="draft:adv",
+        status="draft",
+        title="advisory-1",
+        created_by_profile="HERMES_ADVISOR",
     )
-    titles = {r.title for r in ctx["prior_reports"]}
-    assert titles == {"real-1", "real-2"}
-    assert all(r.status != "draft" for r in ctx["prior_reports"])
-
-
-@pytest.mark.asyncio
-async def test_prior_reports_includes_drafts_if_requested(
-    session: AsyncSession,
-) -> None:
-    repo = InvestmentReportsRepository(session)
-    await _make_report(repo, key="pub:1", status="published", title="real-1")
-    await _make_report(repo, key="draft:1", status="draft", title="hermes-smoke-1")
-    await _make_report(repo, key="draft:2", status="draft", title="hermes-smoke-2")
     await _make_report(repo, key="pub:2", status="published", title="real-2")
 
     svc = InvestmentReportQueryService(session)
@@ -63,7 +49,62 @@ async def test_prior_reports_includes_drafts_if_requested(
         account_scope="kis_live",
         report_type="snapshot_backed_advisory_v1",
         n_prior=4,
-        include_draft=True,
     )
     titles = {r.title for r in ctx["prior_reports"]}
-    assert titles == {"real-1", "real-2", "hermes-smoke-1", "hermes-smoke-2"}
+    assert titles == {"real-1", "real-2"}
+    assert all(r.status != "draft" for r in ctx["prior_reports"])
+
+
+@pytest.mark.asyncio
+async def test_prior_reports_advisory_only_includes_advisory_excludes_smoke(
+    session: AsyncSession,
+) -> None:
+    """draft_policy='advisory_only' admits advisory drafts (HERMES_ADVISOR) as
+    prior context but still drops smoke/test drafts (any other profile)."""
+    repo = InvestmentReportsRepository(session)
+    await _make_report(repo, key="pub:1", status="published", title="real-1")
+    # smoke draft — created by a test/CI profile, must stay excluded.
+    await _make_report(
+        repo,
+        key="draft:smoke",
+        status="draft",
+        title="hermes-smoke-1",
+        created_by_profile="t",
+    )
+    # advisory draft — the genuine Hermes advisory baseline, must be admitted.
+    await _make_report(
+        repo,
+        key="draft:adv",
+        status="draft",
+        title="advisory-1",
+        created_by_profile="HERMES_ADVISOR",
+    )
+    await _make_report(repo, key="pub:2", status="published", title="real-2")
+
+    svc = InvestmentReportQueryService(session)
+    ctx = await svc.previous_report_context(
+        market="us",
+        account_scope="kis_live",
+        report_type="snapshot_backed_advisory_v1",
+        n_prior=4,
+        draft_policy="advisory_only",
+    )
+    titles = {r.title for r in ctx["prior_reports"]}
+    assert titles == {"real-1", "real-2", "advisory-1"}
+    assert "hermes-smoke-1" not in titles
+
+
+@pytest.mark.asyncio
+async def test_prior_reports_rejects_unknown_draft_policy(
+    session: AsyncSession,
+) -> None:
+    """There is no 'all' policy — an unknown value is a hard error at the
+    service layer (the MCP handler fails closed to 'exclude' separately)."""
+    svc = InvestmentReportQueryService(session)
+    with pytest.raises(ValueError, match="draft_policy"):
+        await svc.previous_report_context(
+            market="us",
+            account_scope="kis_live",
+            report_type="snapshot_backed_advisory_v1",
+            draft_policy="all",
+        )


### PR DESCRIPTION
## ROB-375 Bug 1 의미 보정 — advisory draft만 prior 인정

#1047의 `include_draft=True`는 **모든 draft**를 `prior_reports`에 포함시켜, ROB-352가 막으려던 smoke boilerplate를 다시 끌어들였습니다. "advisory draft만 prior 인정, smoke draft는 재유입 방지"라는 의도와 어긋났습니다.

### 변경
`include_draft: bool` → **`draft_policy: "exclude" | "advisory_only"`**로 교체:
- **`"exclude"`** (기본): 모든 draft 제외 — 기존 기본 동작 그대로.
- **`"advisory_only"`**: 진짜 advisory draft(`created_by_profile == "HERMES_ADVISOR"`)만 prior로 인정, smoke/test draft는 계속 제외.

**`"all"` 정책은 만들지 않음.** service는 알 수 없는 값에 `ValueError`, MCP 도구는 fail-closed로 `"exclude"` 폴백(환각성 정책이 draft를 과다 포함하지 않게).

### 구분자 (조사 기반)
`created_by_profile == "HERMES_ADVISOR"` — Hermes advisory 합성 파이프라인의 하드코딩 기본값(`investment_hermes_handlers` / `hermes_ingest`). smoke/test/operator 프로필(`"t"`, `"test"`, `"schedule"`, `"pilot-operator"` 등)과 **0% 겹침**. 단일 필드로 신뢰도 최상 + 유지보수 용이.

### Acceptance 매핑
- ✅ 기본 context_get은 draft 제외 유지 (`draft_policy="exclude"` default)
- ✅ `draft_policy="advisory_only"`에서 advisory draft가 prior_reports에 포함
- ✅ smoke draft는 opt-in 경로에서도 제외
- ✅ #1047의 hermes-smoke 포함 기대 테스트 수정 (advisory vs smoke 구분으로 교체)
- ✅ focused pytest(19 passed) + ruff check + format clean
- ✅ main CI green 전 prod deploy/smoke 안 함

### 테스트
- `test_prior_reports_excludes_drafts_by_default` (advisory draft도 기본 제외 확인)
- `test_prior_reports_advisory_only_includes_advisory_excludes_smoke`
- `test_prior_reports_rejects_unknown_draft_policy` (ValueError, no "all")
- `test_context_get_draft_policy_advisory_only` (+ unknown→exclude fail-closed)

ROB-375 후속 PR 중 하나 (다른 후속: #1051 CI deadlock, Bug 2 holdings_count 별도).

🤖 Generated with [Claude Code](https://claude.com/claude-code)