### PR TITLE
fix(ROB-375): portfolio holdings_count only when holdings is a list (Bug 2 minor)

### DIFF
--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -95,10 +95,14 @@ def _market_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 def _portfolio_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Whitelist cash/buying_power/sellable_summary + a holdings count.
-    Never copies the heavy ``holdings`` list."""
+    Never copies the heavy ``holdings`` list. ``holdings_count`` is emitted ONLY
+    when ``holdings`` is an actual list — a missing/non-list value leaves it out
+    rather than coercing to 0, so "no holdings data" is not confused with
+    "zero holdings" by a downstream delta reader."""
     base = {k: payload[k] for k in _PORTFOLIO_BASELINE_KEYS if k in payload}
     holdings = payload.get("holdings")
-    base["holdings_count"] = len(holdings) if isinstance(holdings, list) else 0
+    if isinstance(holdings, list):
+        base["holdings_count"] = len(holdings)
     return base
 
 

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1560,8 +1560,11 @@ async def test_crypto_descriptors_are_pointers_not_empty() -> None:
     )
     assert sent.market_snapshot["provenance"]["freshness_status"] == "fresh"
     assert sent.portfolio_snapshot["provenance"]["coverage"] == {"rows": 3}
+    # Payload {"x": 1} has no whitelisted numerics and no ``holdings`` key, so
+    # the baseline is empty — holdings_count is NOT fabricated as 0 (missing !=
+    # zero).
     assert sent.market_snapshot["baseline"] == {}
-    assert sent.portfolio_snapshot["baseline"] == {"holdings_count": 0}
+    assert sent.portfolio_snapshot["baseline"] == {}
 
     # Pointer, NOT payload — the snapshot body must never be copied in.
     for descriptor in (

--- a/tests/services/test_snapshot_baseline.py
+++ b/tests/services/test_snapshot_baseline.py
@@ -35,5 +35,15 @@ def test_portfolio_baseline_whitelists_cash_and_summary():
 
 
 def test_baselines_handle_missing_keys():
+    # Missing keys are skipped entirely (no fabrication). Critically, a missing
+    # ``holdings`` must NOT become holdings_count=0 — "we have no holdings data"
+    # is not the same as "zero holdings".
     assert gen._market_numeric_baseline({}) == {}
-    assert gen._portfolio_numeric_baseline({}) == {"holdings_count": 0}
+    assert gen._portfolio_numeric_baseline({}) == {}
+
+
+def test_portfolio_baseline_zero_holdings_is_explicit_empty_list():
+    # An explicit empty holdings list DOES mean "zero holdings" -> count 0.
+    assert gen._portfolio_numeric_baseline({"holdings": []}) == {"holdings_count": 0}
+    # A non-list holdings value is treated as missing (no count emitted).
+    assert gen._portfolio_numeric_baseline({"holdings": None}) == {}


### PR DESCRIPTION
## ROB-375 Bug 2 minor — holdings_count: missing ≠ zero

#1048의 `_portfolio_numeric_baseline`는 `holdings` 키가 없거나 list가 아닐 때 `holdings_count=0`을 넣어, **"holdings 데이터 없음"과 "보유 0개"를 혼동**시켰습니다. 델타 리더가 0을 실제 잔고 0으로 오해할 수 있습니다.

### 변경
`holdings_count`는 `holdings`가 **실제 list일 때만** emit:
- `holdings=[...]` → `holdings_count=len(...)`
- `holdings=[]` (명시적 빈 리스트) → `holdings_count=0` (진짜 0)
- `holdings` 누락/비-list → **키 자체를 안 넣음** (fabricate 금지)

### 테스트
- `test_baselines_handle_missing_keys`: `_portfolio_numeric_baseline({}) == {}` (was `{"holdings_count": 0}`)
- `test_portfolio_baseline_zero_holdings_is_explicit_empty_list` (신규): 빈 리스트→0, None→키 부재
- `test_crypto_descriptors_are_pointers_not_empty`: empty-payload baseline `== {}` 갱신
- 45 passed, ruff check + format clean

ROB-375 후속 PR 중 하나 (다른 후속: #1051 CI deadlock, #1052 Bug 1 draft_policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)