### PR TITLE
feat(ROB-381): get_upbit_index + get_upbit_altseason MCP read tools (PR2)

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_upbit_index.py
+++ b/app/mcp_server/tooling/fundamentals/_upbit_index.py
@@ -1,0 +1,68 @@
+"""Handlers for get_upbit_index and get_upbit_altseason tools (ROB-381 PR2).
+
+Read-only public market-data. Indices from robots-clean datalab-static; 24h
+breadth from the official Open API ticker. 4-layer fail-open: validate →
+normalize → fetch → catch & return error_payload. No broker/order/account API.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.services.external import upbit_index
+
+_ALLOWED_CATEGORIES = {"market", "sector", "strategy", "theme"}
+
+
+async def handle_get_upbit_index(
+    category: str | None = None,
+) -> dict[str, Any]:
+    normalized_category: str | None = None
+    if category is not None and category.strip():
+        normalized_category = category.strip().lower()
+        if normalized_category not in _ALLOWED_CATEGORIES:
+            raise ValueError(
+                f"category must be one of: {', '.join(sorted(_ALLOWED_CATEGORIES))}"
+            )
+
+    try:
+        payload = await upbit_index.fetch_upbit_indices()
+        if payload is None:
+            return _error_payload(
+                source="upbit_datalab",
+                message="Upbit index data unavailable",
+                instrument_type="crypto",
+            )
+        if normalized_category is None:
+            return payload
+        filtered = {
+            code: row
+            for code, row in payload.get("indices", {}).items()
+            if row.get("category_type") == normalized_category
+        }
+        return {**payload, "indices": filtered, "category": normalized_category}
+    except Exception as exc:
+        return _error_payload(
+            source="upbit_datalab",
+            message=str(exc),
+            instrument_type="crypto",
+        )
+
+
+async def handle_get_upbit_altseason() -> dict[str, Any]:
+    try:
+        payload = await upbit_index.fetch_upbit_altseason()
+        if payload is None:
+            return _error_payload(
+                source="upbit_datalab+upbit_open_api",
+                message="Upbit altseason data unavailable",
+                instrument_type="crypto",
+            )
+        return payload
+    except Exception as exc:
+        return _error_payload(
+            source="upbit_datalab+upbit_open_api",
+            message=str(exc),
+            instrument_type="crypto",
+        )

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -32,6 +32,10 @@ from app.mcp_server.tooling.fundamentals._support_resistance import (
 from app.mcp_server.tooling.fundamentals._support_resistance import (
     get_support_resistance_impl as _get_support_resistance_impl,
 )
+from app.mcp_server.tooling.fundamentals._upbit_index import (
+    handle_get_upbit_altseason,
+    handle_get_upbit_index,
+)
 from app.mcp_server.tooling.fundamentals._valuation import (
     handle_get_investment_opinions,
     handle_get_investor_trends,
@@ -58,6 +62,8 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_open_interest",
     "get_long_short_ratio",
     "get_market_index",
+    "get_upbit_index",
+    "get_upbit_altseason",
     "get_support_resistance",
     "get_sector_peers",
 }
@@ -274,6 +280,35 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         count: int = 20,
     ) -> dict[str, Any]:
         return await handle_get_market_index(symbol, period, count)
+
+    @mcp.tool(
+        name="get_upbit_index",
+        description=(
+            "Get Upbit digital-asset indices (디지털 자산 지수): market indices "
+            "(UBMI=Upbit Market Index, UBAI=Upbit Altcoin Index, top-10/30) plus "
+            "sector/strategy/theme indices, each with current value, 24h change, "
+            "and yield/risk stats (daily~yearly yield, beta, sharpe, winRate). "
+            "Read-only public data from datalab-static. Optional category in "
+            "{market,sector,strategy,theme} filters the result."
+        ),
+    )
+    async def get_upbit_index(
+        category: str | None = None,
+    ) -> dict[str, Any]:
+        return await handle_get_upbit_index(category)
+
+    @mcp.tool(
+        name="get_upbit_altseason",
+        description=(
+            "Get an Upbit altseason snapshot: the UBAI/UBMI ratio (altcoin index "
+            "vs market index) and 24h breadth (fraction of KRW-quoted alts beating "
+            "BTC over 24h, derived from the official Upbit ticker). Higher ratio + "
+            "higher breadth lean altseason. Read-only public data. Note: breadth is "
+            "24h only (multi-period breadth is a separate follow-up)."
+        ),
+    )
+    async def get_upbit_altseason() -> dict[str, Any]:
+        return await handle_get_upbit_altseason()
 
     @mcp.tool(
         name="get_support_resistance",

--- a/app/services/external/upbit_index.py
+++ b/app/services/external/upbit_index.py
@@ -1,0 +1,269 @@
+"""Upbit digital-asset-index / altseason data source (ROB-381 PR2).
+
+Read-only public market-data. Two data planes, deliberately split by robots policy
+(see ``docs/runbooks/rob-381-upbit-index-altseason-recon.md``):
+
+- **Indices** come from ``datalab-static.upbit.com`` — an S3-hosted public data
+  product with no robots restriction. We merge index/master (catalog) +
+  index/recent (live value) + index/summary (yield/risk stats).
+- **24h breadth** (alts beating BTC) is derived from the **official** Open API
+  ``api.upbit.com/v1/ticker`` (``signed_change_rate`` is 24h only). We do NOT use
+  the robots-disallowed ``crix-api-cdn`` trends endpoints.
+
+7/30/90d breadth is intentionally out of scope here (official ``/v1/ticker`` has no
+multi-period change rate); that is a separate follow-up over ``/v1/candles/days``.
+
+Fail-open: every fetch returns ``None`` (or a partial dict) on failure rather than
+raising, so report generation is never blocked. No broker/order/account API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+
+from app.core.timezone import now_kst
+
+logger = logging.getLogger(__name__)
+
+# datalab-static: robots-clean S3 public data product.
+_DATALAB_BASE = "https://datalab-static.upbit.com/platform/v1/index"
+INDEX_MASTER_URL = f"{_DATALAB_BASE}/master"
+INDEX_RECENT_URL = f"{_DATALAB_BASE}/recent"
+INDEX_SUMMARY_URL = f"{_DATALAB_BASE}/summary"
+
+# Official Open API (documented, robots-allowed for these data endpoints).
+_OPEN_API_BASE = "https://api.upbit.com/v1"
+MARKET_ALL_URL = f"{_OPEN_API_BASE}/market/all"
+TICKER_URL = f"{_OPEN_API_BASE}/ticker"
+
+# Composite/market index codes used for the altseason ratio.
+ALTCOIN_INDEX_CODE = "IDX.UPBIT.UBAI"  # Upbit Altcoin Index
+MARKET_INDEX_CODE = "IDX.UPBIT.UBMI"  # Upbit Market Index
+
+_INDEX_TTL = timedelta(seconds=60)  # datalab responses carry max-age=60
+_ALTSEASON_TTL = timedelta(minutes=5)
+_HTTP_TIMEOUT = 10.0
+
+_indices_cache: dict[str, Any] | None = None
+_indices_cache_expires: datetime | None = None
+_altseason_cache: dict[str, Any] | None = None
+_altseason_cache_expires: datetime | None = None
+_cache_lock = asyncio.Lock()
+
+
+def _clear_caches() -> None:
+    """Clear in-memory caches (for tests)."""
+    global _indices_cache, _indices_cache_expires
+    global _altseason_cache, _altseason_cache_expires
+    _indices_cache = None
+    _indices_cache_expires = None
+    _altseason_cache = None
+    _altseason_cache_expires = None
+
+
+async def _get_json(url: str, params: dict[str, Any] | None = None) -> Any:
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def _normalize_index_row(
+    master: dict[str, Any],
+    recent: dict[str, Any] | None,
+    summary_stats: dict[str, Any] | None,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "code": master.get("code"),
+        "symbol": master.get("symbol"),
+        "korean_name": master.get("koreanName"),
+        "category_type": master.get("categoryType"),
+        "index_type": master.get("indexType"),
+        "value": None,
+        "signed_change_rate_24h": None,
+    }
+    if recent:
+        row["value"] = recent.get("tradePrice")
+        row["signed_change_rate_24h"] = recent.get("signedChangeRate")
+        row["as_of"] = recent.get("candleDateTime")
+    if summary_stats:
+        # Pass through the regime-relevant stats only (not the whole blob).
+        for key in (
+            "dailyYield",
+            "weeklyYield",
+            "monthlyYield",
+            "quarterlyYield",
+            "yearlyYield",
+            "winningRate",
+            "volatility",
+            "beta",
+            "sharpeRatio",
+        ):
+            if key in summary_stats:
+                row[key] = summary_stats[key]
+    return row
+
+
+async def fetch_upbit_indices() -> dict[str, Any] | None:
+    """Fetch + merge Upbit digital-asset indices from datalab-static.
+
+    Returns ``{"source", "as_of", "provenance", "indices": {code: {...}}}`` or
+    ``None`` if the catalog fetch fails. Recent/summary are best-effort overlays.
+    """
+    global _indices_cache, _indices_cache_expires
+
+    async with _cache_lock:
+        if (
+            _indices_cache is not None
+            and _indices_cache_expires
+            and now_kst() < _indices_cache_expires
+        ):
+            return _indices_cache.copy()
+
+    try:
+        master = await _get_json(INDEX_MASTER_URL)
+    except Exception as exc:
+        logger.warning("Failed to fetch Upbit index master: %s", exc)
+        return None
+    if not isinstance(master, list) or not master:
+        logger.warning("Unexpected Upbit index master payload")
+        return None
+
+    # Recent + summary are overlays — fail-open to {} so the catalog still returns.
+    try:
+        recent_rows = await _get_json(INDEX_RECENT_URL)
+    except Exception as exc:
+        logger.warning("Failed to fetch Upbit index recent: %s", exc)
+        recent_rows = []
+    try:
+        summary_rows = await _get_json(INDEX_SUMMARY_URL)
+    except Exception as exc:
+        logger.warning("Failed to fetch Upbit index summary: %s", exc)
+        summary_rows = []
+
+    recent_by_code = {
+        r.get("code"): r for r in recent_rows if isinstance(r, dict) and r.get("code")
+    }
+    summary_by_code = {
+        s.get("code"): (s.get("stats") or {})
+        for s in summary_rows
+        if isinstance(s, dict) and s.get("code")
+    }
+
+    indices: dict[str, Any] = {}
+    for m in master:
+        if not isinstance(m, dict) or not m.get("code"):
+            continue
+        code = m["code"]
+        indices[code] = _normalize_index_row(
+            m, recent_by_code.get(code), summary_by_code.get(code)
+        )
+
+    result = {
+        "source": "upbit_datalab",
+        "provenance": "unofficial_web_endpoint",
+        "as_of": now_kst().isoformat(),
+        "indices": indices,
+    }
+
+    async with _cache_lock:
+        _indices_cache = result.copy()
+        _indices_cache_expires = now_kst() + _INDEX_TTL
+    return result.copy()
+
+
+async def _fetch_krw_breadth_24h() -> dict[str, Any] | None:
+    """24h alt-vs-BTC breadth from the official Open API ticker.
+
+    breadth = fraction of KRW-quoted non-BTC markets whose 24h change exceeds
+    KRW-BTC's 24h change. ``None`` if the official data is unavailable.
+    """
+    try:
+        markets = await _get_json(MARKET_ALL_URL)
+        krw = [
+            m["market"]
+            for m in markets
+            if isinstance(m, dict) and str(m.get("market", "")).startswith("KRW-")
+        ]
+        if "KRW-BTC" not in krw:
+            return None
+        tickers = await _get_json(TICKER_URL, params={"markets": ",".join(krw)})
+    except Exception as exc:
+        logger.warning("Failed to fetch Upbit KRW breadth: %s", exc)
+        return None
+
+    rate_by_market = {
+        t["market"]: t.get("signed_change_rate")
+        for t in tickers
+        if isinstance(t, dict) and t.get("market")
+    }
+    btc_rate = rate_by_market.get("KRW-BTC")
+    if btc_rate is None:
+        return None
+
+    alt_rates = [
+        rate
+        for market, rate in rate_by_market.items()
+        if market != "KRW-BTC" and rate is not None
+    ]
+    if not alt_rates:
+        return None
+
+    beating = sum(1 for rate in alt_rates if rate > btc_rate)
+    return {
+        "window": "24h",
+        "method": "open_api_ticker_24h_derived",
+        "alts_total": len(alt_rates),
+        "alts_beating_btc": beating,
+        "alts_beating_btc_pct": round(beating / len(alt_rates), 4),
+        "btc_change_24h": btc_rate,
+    }
+
+
+async def fetch_upbit_altseason() -> dict[str, Any] | None:
+    """Altseason snapshot: UBAI/UBMI ratio + 24h alt-vs-BTC breadth.
+
+    Returns a partial dict if one plane is unavailable; ``None`` only if both the
+    index ratio and the breadth are unavailable.
+    """
+    global _altseason_cache, _altseason_cache_expires
+
+    async with _cache_lock:
+        if (
+            _altseason_cache is not None
+            and _altseason_cache_expires
+            and now_kst() < _altseason_cache_expires
+        ):
+            return _altseason_cache.copy()
+
+    indices_payload = await fetch_upbit_indices()
+    ratio: float | None = None
+    if indices_payload:
+        idx = indices_payload.get("indices", {})
+        ubai = (idx.get(ALTCOIN_INDEX_CODE) or {}).get("value")
+        ubmi = (idx.get(MARKET_INDEX_CODE) or {}).get("value")
+        if ubai is not None and ubmi:
+            ratio = round(float(ubai) / float(ubmi), 6)
+
+    breadth = await _fetch_krw_breadth_24h()
+
+    if ratio is None and breadth is None:
+        return None
+
+    result = {
+        "source": "upbit_datalab+upbit_open_api",
+        "provenance": "unofficial_web_endpoint+official_open_api",
+        "as_of": now_kst().isoformat(),
+        "ubai_ubmi_ratio": ratio,
+        "breadth": breadth,
+    }
+
+    async with _cache_lock:
+        _altseason_cache = result.copy()
+        _altseason_cache_expires = now_kst() + _ALTSEASON_TTL
+    return result.copy()

--- a/docs/runbooks/rob-381-upbit-index-altseason-recon.md
+++ b/docs/runbooks/rob-381-upbit-index-altseason-recon.md
@@ -1,6 +1,8 @@
 # ROB-381 — Upbit 디지털자산지수·알트시즌 데이터 소스 정찰 (reconnaissance spike)
 
-**Status:** PR1 reconnaissance only. No production MCP tool / collector built here.
+**Status:** PR1 reconnaissance (merged #1054). **PR2 implements** `get_upbit_index` /
+`get_upbit_altseason` MCP read tools (`app/services/external/upbit_index.py` +
+`app/mcp_server/tooling/fundamentals/_upbit_index.py`). Collector wiring = PR3.
 **Parent:** ROB-377 (코인 마켓레짐·파생심리 데이터 소스 — A1/A2 완료) · ROB-369 (crypto 리포트 데이터 공백)
 **Verdict:** `implement` — **분할 권장** (아래 [Final verdict](#final-verdict) 참고).
 **Date:** 2026-05-31

--- a/tests/test_upbit_index_service.py
+++ b/tests/test_upbit_index_service.py
@@ -1,0 +1,215 @@
+"""ROB-381 PR2 — Upbit index/altseason service + MCP handlers.
+
+Mocks httpx by routing on URL. Indices come from datalab-static fixtures (the
+PR1 recon samples); 24h breadth is derived from a synthetic official-ticker
+response. No network. No broker/order/account API.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import httpx
+import pytest
+
+from app.mcp_server.tooling.fundamentals._upbit_index import (
+    handle_get_upbit_altseason,
+    handle_get_upbit_index,
+)
+from app.services.external import upbit_index
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures" / "upbit_index"
+
+
+def _fx(name: str):
+    return json.loads((_FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def _route(mapping: dict[str, object], *, fail_substrings: tuple[str, ...] = ()):
+    """Build a fake httpx.AsyncClient.get that routes by URL substring."""
+
+    async def fake_get(self_cli, url, *args, **kwargs):
+        for sub in fail_substrings:
+            if sub in url:
+                raise httpx.ConnectError(f"boom: {sub}")
+        for sub, payload in mapping.items():
+            if sub in url:
+                return _FakeResponse(payload)
+        raise AssertionError(f"unexpected URL: {url}")
+
+    return fake_get
+
+
+# Index value overlays so UBAI/UBMI ratio is deterministic.
+_RECENT = [
+    {"code": "IDX.UPBIT.UBAI", "tradePrice": 7100.0, "signedChangeRate": -0.002},
+    {"code": "IDX.UPBIT.UBMI", "tradePrice": 15600.0, "signedChangeRate": -0.001},
+]
+_SUMMARY = [
+    {
+        "code": "IDX.UPBIT.UBAI",
+        "stats": {"weeklyYield": 0.07, "beta": 1.2, "sharpeRatio": -0.03},
+    }
+]
+_MARKET_ALL = [
+    {"market": "KRW-BTC"},
+    {"market": "KRW-ETH"},
+    {"market": "KRW-XRP"},
+    {"market": "BTC-ETH"},  # non-KRW, must be ignored
+]
+_TICKER = [
+    {"market": "KRW-BTC", "signed_change_rate": 0.01},
+    {"market": "KRW-ETH", "signed_change_rate": 0.05},  # beats BTC
+    {"market": "KRW-XRP", "signed_change_rate": -0.02},  # loses to BTC
+]
+
+
+def _datalab_mapping():
+    return {
+        "/index/master": _fx("index_master.json"),
+        "/index/recent": _RECENT,
+        "/index/summary": _SUMMARY,
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_indices_merges_master_recent_summary(monkeypatch):
+    upbit_index._clear_caches()
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(_datalab_mapping()))
+
+    payload = await upbit_index.fetch_upbit_indices()
+
+    assert payload is not None
+    assert payload["source"] == "upbit_datalab"
+    ubai = payload["indices"]["IDX.UPBIT.UBAI"]
+    assert ubai["symbol"] == "UBAI"
+    assert ubai["category_type"] == "market"
+    assert ubai["value"] == 7100.0  # recent overlay
+    assert ubai["weeklyYield"] == 0.07  # summary overlay
+    assert ubai["beta"] == 1.2
+
+
+@pytest.mark.asyncio
+async def test_fetch_indices_failopen_when_master_unavailable(monkeypatch):
+    upbit_index._clear_caches()
+    monkeypatch.setattr(
+        httpx.AsyncClient,
+        "get",
+        _route(_datalab_mapping(), fail_substrings=("/index/master",)),
+    )
+
+    assert await upbit_index.fetch_upbit_indices() is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_indices_recent_overlay_is_best_effort(monkeypatch):
+    """If recent/summary fail, the catalog still returns (value=None)."""
+    upbit_index._clear_caches()
+    monkeypatch.setattr(
+        httpx.AsyncClient,
+        "get",
+        _route(
+            _datalab_mapping(),
+            fail_substrings=("/index/recent", "/index/summary"),
+        ),
+    )
+
+    payload = await upbit_index.fetch_upbit_indices()
+    assert payload is not None
+    assert payload["indices"]["IDX.UPBIT.UBAI"]["value"] is None
+
+
+@pytest.mark.asyncio
+async def test_altseason_ratio_and_breadth(monkeypatch):
+    upbit_index._clear_caches()
+    mapping = {
+        **_datalab_mapping(),
+        "/market/all": _MARKET_ALL,
+        "/ticker": _TICKER,
+    }
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(mapping))
+
+    payload = await upbit_index.fetch_upbit_altseason()
+
+    assert payload is not None
+    assert payload["ubai_ubmi_ratio"] == pytest.approx(7100.0 / 15600.0, rel=1e-6)
+    breadth = payload["breadth"]
+    assert breadth["window"] == "24h"
+    assert breadth["alts_total"] == 2  # ETH + XRP (BTC excluded, BTC-ETH ignored)
+    assert breadth["alts_beating_btc"] == 1  # ETH only
+    assert breadth["alts_beating_btc_pct"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_altseason_partial_when_breadth_unavailable(monkeypatch):
+    """Ratio survives even if the official ticker plane is down."""
+    upbit_index._clear_caches()
+    monkeypatch.setattr(
+        httpx.AsyncClient,
+        "get",
+        _route(_datalab_mapping(), fail_substrings=("/market/all", "/ticker")),
+    )
+
+    payload = await upbit_index.fetch_upbit_altseason()
+    assert payload is not None
+    assert payload["ubai_ubmi_ratio"] is not None
+    assert payload["breadth"] is None
+
+
+@pytest.mark.asyncio
+async def test_handle_get_upbit_index_category_filter(monkeypatch):
+    upbit_index._clear_caches()
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(_datalab_mapping()))
+
+    result = await handle_get_upbit_index(category="market")
+    assert result["category"] == "market"
+    assert all(row["category_type"] == "market" for row in result["indices"].values())
+    assert "IDX.UPBIT.UBAI" in result["indices"]
+
+
+@pytest.mark.asyncio
+async def test_handle_get_upbit_index_rejects_bad_category():
+    with pytest.raises(ValueError):
+        await handle_get_upbit_index(category="bogus")
+
+
+@pytest.mark.asyncio
+async def test_handle_get_upbit_index_failopen_returns_error_payload(monkeypatch):
+    upbit_index._clear_caches()
+    monkeypatch.setattr(
+        httpx.AsyncClient,
+        "get",
+        _route(_datalab_mapping(), fail_substrings=("/index/master",)),
+    )
+
+    result = await handle_get_upbit_index()
+    assert "error" in result
+    assert result["source"] == "upbit_datalab"
+
+
+@pytest.mark.asyncio
+async def test_handle_get_upbit_altseason_failopen(monkeypatch):
+    upbit_index._clear_caches()
+    monkeypatch.setattr(
+        httpx.AsyncClient,
+        "get",
+        _route(
+            _datalab_mapping(),
+            fail_substrings=("/index/", "/market/all", "/ticker"),
+        ),
+    )
+
+    result = await handle_get_upbit_altseason()
+    assert "error" in result


### PR DESCRIPTION
## What

PR2 of ROB-381 — implements the recon verdict (SPLIT) as two read-only MCP tools.

Linear: ROB-381 · follows PR1 #1054 (recon doc + fixtures, merged)

- **`get_upbit_index`** — Upbit digital-asset indices (UBMI/UBAI/top-10·30, sector/strategy/theme) with current value, 24h change, and yield/risk stats (daily~yearly yield, beta, sharpe, winRate). Optional `category` filter ∈ {market,sector,strategy,theme}.
- **`get_upbit_altseason`** — UBAI/UBMI ratio + 24h breadth (fraction of KRW alts beating BTC over 24h).

## Source split (per recon verdict)

| Plane | Source | robots |
|---|---|---|
| Indices (value + stats) | `datalab-static.upbit.com` index/master+recent+summary | clean (S3) |
| 24h breadth | **official** `api.upbit.com/v1/market/all` + `/v1/ticker` (`signed_change_rate`) | allowed |
| crix-api-cdn trends | **not used** | Disallow |

7/30/90d breadth (official `/v1/candles/days` fanout) stays a separate follow-up — `/v1/ticker` is 24h only. 체결강도 parked.

## Design
- `app/services/external/upbit_index.py` — `fetch_upbit_indices()` / `fetch_upbit_altseason()`, in-memory cache (indices 60s = datalab `max-age`, altseason 5m), fail-open to `None`/partial, httpx 10s. Mirrors `btc_dominance.py`.
- `app/mcp_server/tooling/fundamentals/_upbit_index.py` — ROB-377 4-layer fail-open returning `error_payload`.
- Registered in `fundamentals_handlers.py` (`FUNDAMENTALS_TOOL_NAMES` + `@mcp.tool` wrappers).

## Verification
- `tests/test_upbit_index_service.py` — **9 passed** (merge overlay, category filter, ratio+breadth math, every fail-open branch; reuses PR1 datalab fixtures).
- `tests/test_mcp_fundamentals_tools.py` — **185 passed** (no inventory break).
- `ruff check` + `ruff format --check` + `ty check` all green.

## Boundaries
Read-only public market-data. No broker/order/watch/order-intent mutation, no Upbit private/account/order API, no scheduler/TaskIQ/Prefect/cron, no production DB write/backfill, no robots-disallowed `crix-api-cdn`, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve and filter Upbit market indices by category to focus analysis on specific market segments.
  * Access Upbit altseason metrics combining market indices with 24-hour market breadth analysis for comprehensive market seasonality assessment.

* **Documentation**
  * Updated project documentation and runbooks reflecting implementation of Upbit altseason data retrieval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->