### PR TITLE
feat(ROB-381): enrich crypto market snapshot with Upbit altseason (PR3)

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/market.py
+++ b/app/services/action_report/snapshot_backed/collectors/market.py
@@ -53,6 +53,12 @@ _MARKET_TO_INDEX_SYMBOLS: dict[str, list[str]] = {
 # deterministic fundamentals index source so this module imports no MCP tooling.
 IndexQuoteFn = Callable[[list[str]], Awaitable[list[dict[str, Any]]]]
 
+# ROB-381 PR3 — read-only callable returning the Upbit altseason snapshot
+# (UBAI/UBMI ratio + 24h alt-vs-BTC breadth) or ``None``. Wired in registry.py
+# over ``fetch_upbit_altseason`` and only consulted for the crypto market, so the
+# Hermes crypto market dimension gains an altseason signal. Best-effort.
+AltseasonFn = Callable[[], Awaitable[dict[str, Any] | None]]
+
 
 class MarketEventsSnapshotCollector:
     """Required-kind ``market`` collector backed by ``market_events``."""
@@ -65,12 +71,14 @@ class MarketEventsSnapshotCollector:
         *,
         query_service: MarketEventsQueryService | None = None,
         index_quote_fn: IndexQuoteFn | None = None,
+        altseason_fn: AltseasonFn | None = None,
         lookback_days: int = 0,
         lookahead_days: int = 1,
     ) -> None:
         self._session = session
         self._query = query_service or MarketEventsQueryService(session)
         self._index_quote_fn = index_quote_fn
+        self._altseason_fn = altseason_fn
         self._lookback = max(0, lookback_days)
         self._lookahead = max(0, lookahead_days)
 
@@ -113,6 +121,9 @@ class MarketEventsSnapshotCollector:
         indices = await self._collect_indices(request.market)
         if indices:
             payload["indices"] = indices
+        altseason = await self._collect_altseason(request.market)
+        if altseason:
+            payload["altseason"] = altseason
         return [
             build_result(
                 snapshot_kind=self.snapshot_kind,
@@ -126,6 +137,7 @@ class MarketEventsSnapshotCollector:
                     "from_date": from_date.isoformat(),
                     "to_date": to_date.isoformat(),
                     "index_count": len(payload.get("indices", {})),
+                    "has_altseason": bool(altseason),
                 },
             )
         ]
@@ -169,3 +181,19 @@ class MarketEventsSnapshotCollector:
                 "current": row.get("current"),
             }
         return indices
+
+    async def _collect_altseason(self, market: str) -> dict[str, Any] | None:
+        """Attach the Upbit altseason snapshot to the crypto market dimension.
+
+        Crypto-only and best-effort: returns ``None`` for non-crypto markets, when
+        no altseason source is wired, or on any fetch error — the rest of the
+        market snapshot is emitted regardless (never fabricated).
+        """
+        if market != "crypto" or self._altseason_fn is None:
+            return None
+        try:
+            altseason = await self._altseason_fn()
+        except Exception as exc:  # noqa: BLE001 — altseason is best-effort
+            _logger.info("altseason fetch failed for %s: %r", market, exc)
+            return None
+        return altseason if isinstance(altseason, dict) else None

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -23,6 +23,7 @@ from app.services.action_report.snapshot_backed.collectors.journal import (
     JournalSnapshotCollector,
 )
 from app.services.action_report.snapshot_backed.collectors.market import (
+    AltseasonFn,
     IndexQuoteFn,
     MarketEventsSnapshotCollector,
 )
@@ -198,6 +199,25 @@ def _build_market_index_quote_fn() -> IndexQuoteFn:
     return _index_quote_fn
 
 
+def _build_altseason_fn() -> AltseasonFn:
+    """Read-only adapter over the Upbit altseason source (ROB-381 PR3).
+
+    Returns the UBAI/UBMI ratio + 24h alt-vs-BTC breadth snapshot, or ``None`` on
+    any failure. Imported lazily and already fail-open inside the service, so the
+    crypto market snapshot degrades gracefully. No order/mutation surface.
+    """
+
+    async def _altseason_fn() -> dict[str, Any] | None:
+        from app.services.external.upbit_index import fetch_upbit_altseason
+
+        try:
+            return await fetch_upbit_altseason()
+        except Exception:  # noqa: BLE001 — best-effort altseason signal
+            return None
+
+    return _altseason_fn
+
+
 def _build_news_fetch_fn() -> NewsFetchFn:
     """Read-only adapter over the deterministic, market-aware news source.
 
@@ -267,7 +287,9 @@ def production_collector_registry(session: AsyncSession) -> SnapshotCollectorReg
     registry.register(WatchContextSnapshotCollector(session))
     registry.register(
         MarketEventsSnapshotCollector(
-            session, index_quote_fn=_build_market_index_quote_fn()
+            session,
+            index_quote_fn=_build_market_index_quote_fn(),
+            altseason_fn=_build_altseason_fn(),
         )
     )
 

--- a/docs/runbooks/rob-381-upbit-index-altseason-recon.md
+++ b/docs/runbooks/rob-381-upbit-index-altseason-recon.md
@@ -1,8 +1,12 @@
 # ROB-381 — Upbit 디지털자산지수·알트시즌 데이터 소스 정찰 (reconnaissance spike)
 
-**Status:** PR1 reconnaissance (merged #1054). **PR2 implements** `get_upbit_index` /
-`get_upbit_altseason` MCP read tools (`app/services/external/upbit_index.py` +
-`app/mcp_server/tooling/fundamentals/_upbit_index.py`). Collector wiring = PR3.
+**Status:** PR1 reconnaissance (merged #1054). PR2 (merged #1056) implements
+`get_upbit_index` / `get_upbit_altseason` MCP read tools
+(`app/services/external/upbit_index.py` +
+`app/mcp_server/tooling/fundamentals/_upbit_index.py`). **PR3 wires altseason into
+the crypto `market` snapshot** (`collectors/market.py` + `registry.py`) so the
+Hermes crypto market dimension gains an altseason signal — no new SnapshotKind, no
+migration (enriches the existing `market` payload, fail-open).
 **Parent:** ROB-377 (코인 마켓레짐·파생심리 데이터 소스 — A1/A2 완료) · ROB-369 (crypto 리포트 데이터 공백)
 **Verdict:** `implement` — **분할 권장** (아래 [Final verdict](#final-verdict) 참고).
 **Date:** 2026-05-31

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1189,6 +1189,33 @@ async def test_market_collector_altseason_none_is_omitted():
     assert results[0].coverage_json["has_altseason"] is False
 
 
+@pytest.mark.asyncio
+async def test_build_altseason_fn_returns_payload(monkeypatch):
+    # ROB-381 PR3: registry adapter passes through the upbit altseason service.
+    from app.services.action_report.snapshot_backed.collectors import registry
+
+    async def fake_fetch():
+        return {"ubai_ubmi_ratio": 0.47}
+
+    monkeypatch.setattr(
+        "app.services.external.upbit_index.fetch_upbit_altseason", fake_fetch
+    )
+    fn = registry._build_altseason_fn()
+    assert await fn() == {"ubai_ubmi_ratio": 0.47}
+
+
+@pytest.mark.asyncio
+async def test_build_altseason_fn_failopen_on_error(monkeypatch):
+    from app.services.action_report.snapshot_backed.collectors import registry
+
+    async def boom():
+        raise RuntimeError("upbit down")
+
+    monkeypatch.setattr("app.services.external.upbit_index.fetch_upbit_altseason", boom)
+    fn = registry._build_altseason_fn()
+    assert await fn() is None
+
+
 # ---------------------------------------------------------------------------
 # News collector
 # ---------------------------------------------------------------------------

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1115,6 +1115,80 @@ async def test_market_collector_no_index_fn_emits_no_indices():
     assert "indices" not in results[0].payload_json
 
 
+@pytest.mark.asyncio
+async def test_market_collector_crypto_attaches_altseason():
+    # ROB-381 PR3: crypto market dimension gains an Upbit altseason snapshot.
+    called = {"hit": False}
+
+    async def fake_altseason_fn():
+        called["hit"] = True
+        return {"ubai_ubmi_ratio": 0.455, "breadth": {"alts_beating_btc_pct": 0.42}}
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(),
+        query_service=_empty_events_query(),
+        altseason_fn=fake_altseason_fn,
+    )
+    results = await collector.collect(_request(market="crypto"))
+    payload = results[0].payload_json
+    assert called["hit"] is True
+    assert payload["altseason"]["ubai_ubmi_ratio"] == 0.455
+    assert results[0].coverage_json["has_altseason"] is True
+
+
+@pytest.mark.asyncio
+async def test_market_collector_altseason_only_for_crypto():
+    # Non-crypto markets never call the altseason source.
+    called = {"hit": False}
+
+    async def fake_altseason_fn():
+        called["hit"] = True
+        return {"ubai_ubmi_ratio": 0.5}
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(),
+        query_service=_empty_events_query(),
+        altseason_fn=fake_altseason_fn,
+    )
+    results = await collector.collect(_request(market="us"))
+    assert called["hit"] is False
+    assert "altseason" not in results[0].payload_json
+    assert results[0].coverage_json["has_altseason"] is False
+
+
+@pytest.mark.asyncio
+async def test_market_collector_altseason_failure_is_soft():
+    # Altseason is best-effort: a fetch error leaves the rest of the snapshot.
+    async def fake_altseason_fn():
+        raise RuntimeError("upbit down")
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(),
+        query_service=_empty_events_query(),
+        altseason_fn=fake_altseason_fn,
+    )
+    results = await collector.collect(_request(market="crypto"))
+    assert results[0].freshness_status == "fresh"
+    assert "events" in results[0].payload_json
+    assert "altseason" not in results[0].payload_json
+
+
+@pytest.mark.asyncio
+async def test_market_collector_altseason_none_is_omitted():
+    # Source returning None (both planes down) → no altseason key, not fabricated.
+    async def fake_altseason_fn():
+        return None
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(),
+        query_service=_empty_events_query(),
+        altseason_fn=fake_altseason_fn,
+    )
+    results = await collector.collect(_request(market="crypto"))
+    assert "altseason" not in results[0].payload_json
+    assert results[0].coverage_json["has_altseason"] is False
+
+
 # ---------------------------------------------------------------------------
 # News collector
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

PR3 (final) of ROB-381 — wires the PR2 Upbit altseason source into the snapshot pipeline so the **Hermes crypto `market` dimension gains an altseason signal**.

Linear: ROB-381 · follows PR1 #1054 (recon) + PR2 #1056 (MCP tools)

**No new `SnapshotKind`, no migration.** It enriches the existing `market` snapshot payload (crypto-only), per the recon doc's "no migration preferred" constraint.

## How
- `collectors/market.py` — `MarketEventsSnapshotCollector` gains an optional `altseason_fn` (mirroring the existing `index_quote_fn` injection). For `market=="crypto"` it attaches `payload["altseason"]` (UBAI/UBMI ratio + 24h alt-vs-BTC breadth) and `coverage.has_altseason`.
- `collectors/registry.py` — `_build_altseason_fn()` lazily wraps `fetch_upbit_altseason` (keeps the snapshot_backed no-LLM / no-heavy-import guard satisfied) and is passed to the market collector registration.

Best-effort throughout: non-crypto markets skip it, a fetch error or `None` is omitted (never fabricated 0), and the rest of the market snapshot is emitted regardless.

## Verification
- `tests/.../test_collectors.py` — **+4 tests** (crypto attaches altseason, non-crypto skips, fetch failure soft, None omitted). Full collectors suite **69 passed**.
- `test_no_internal_llm_imports.py` import guard — **41 passed**.
- PR2 service tests **9 passed**; `ruff check` + `ruff format --check` + `ty check` all green.

## Boundaries
Read-only public market-data. No broker/order/watch/order-intent mutation, no private/account API, no scheduler/TaskIQ/Prefect/cron, no production DB write/backfill, no robots-disallowed `crix-api-cdn`, no secrets. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)