### PR TITLE
fix(ROB-369): surface Upbit altseason in crypto report baseline

### DIFF
--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -78,6 +78,13 @@ from app.services.investment_snapshots.repository import (
 )
 
 _MARKET_BASELINE_KEYS = ("market", "from_date", "to_date", "indices")
+_MARKET_ALTSEASON_BASELINE_KEYS = ("ubai_ubmi_ratio",)
+_MARKET_ALTSEASON_BREADTH_BASELINE_KEYS = (
+    "alts_beating_btc_pct",
+    "alts_beating_btc",
+    "alts_total",
+    "btc_change_24h",
+)
 _PORTFOLIO_BASELINE_KEYS = (
     "primary_source",
     "cash",
@@ -86,11 +93,46 @@ _PORTFOLIO_BASELINE_KEYS = (
 )
 
 
+def _is_json_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool)
+
+
+def _altseason_numeric_baseline(altseason: Any) -> dict[str, Any]:
+    """Freeze only compact numeric altseason fields.
+
+    Upbit altseason payloads also carry provenance/source/as_of strings and
+    breadth method/window metadata. Those stay in snapshot provenance; the report
+    descriptor baseline keeps only delta-relevant numbers.
+    """
+    if not isinstance(altseason, Mapping):
+        return {}
+
+    base = {
+        key: altseason[key]
+        for key in _MARKET_ALTSEASON_BASELINE_KEYS
+        if _is_json_number(altseason.get(key))
+    }
+    breadth = altseason.get("breadth")
+    if isinstance(breadth, Mapping):
+        breadth_base = {
+            key: breadth[key]
+            for key in _MARKET_ALTSEASON_BREADTH_BASELINE_KEYS
+            if _is_json_number(breadth.get(key))
+        }
+        if breadth_base:
+            base["breadth"] = breadth_base
+    return base
+
+
 def _market_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:
     """Whitelist the small delta-relevant numerics from a market snapshot
     payload. Never copies the heavy ``events`` list. Missing keys are skipped
     (no fabrication)."""
-    return {k: payload[k] for k in _MARKET_BASELINE_KEYS if k in payload}
+    base = {k: payload[k] for k in _MARKET_BASELINE_KEYS if k in payload}
+    altseason = _altseason_numeric_baseline(payload.get("altseason"))
+    if altseason:
+        base["altseason"] = altseason
+    return base
 
 
 def _portfolio_numeric_baseline(payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/app/services/investment_stages/stages/market.py
+++ b/app/services/investment_stages/stages/market.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from app.schemas.investment_stages import (
     StageArtifactPayload,
     StageCitation,
@@ -47,6 +49,46 @@ def _select_index(indices: dict, market: str) -> tuple[str, float] | None:
     return None
 
 
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _altseason_points(altseason: Any) -> tuple[list[str], list[str]]:
+    """Return compact Upbit altseason summary/key-point strings.
+
+    The market snapshot stores Upbit altseason as best-effort optional data.
+    Missing/non-numeric fields are skipped rather than fabricated, so the
+    CRYPTO index remains the only hard gate for the market stage.
+    """
+    if not isinstance(altseason, dict):
+        return [], []
+
+    summary_parts: list[str] = []
+    key_points: list[str] = []
+
+    ratio = _coerce_float(altseason.get("ubai_ubmi_ratio"))
+    if ratio is not None:
+        ratio_text = f"{ratio:.3f}"
+        summary_parts.append(f"UBAI/UBMI={ratio_text}")
+        key_points.append(f"Upbit altseason UBAI/UBMI={ratio_text}")
+
+    breadth = altseason.get("breadth")
+    breadth_pct = None
+    if isinstance(breadth, dict):
+        breadth_pct = _coerce_float(breadth.get("alts_beating_btc_pct"))
+    if breadth_pct is not None:
+        breadth_text = f"{breadth_pct * 100:.1f}%"
+        summary_parts.append(f"alts_beating_btc={breadth_text}")
+        key_points.append(f"Upbit breadth alts beating BTC {breadth_text}")
+
+    return summary_parts, key_points
+
+
 class MarketStage:
     stage_type = "market"
 
@@ -77,23 +119,60 @@ class MarketStage:
 
         confidence = min(int(abs(change) * 30), 90)
 
+        summary = f"{symbol} change_percent={change:+.2f}%"
+        key_points = [f"{symbol} {change:+.2f}%"]
+        cited_snapshots = [
+            StageCitation(
+                snapshot_uuid=snapshot.snapshot_uuid,
+                snapshot_kind="market",
+                payload_path=f"$.indices.{symbol}.change_percent",
+            )
+        ]
+        if market == "crypto":
+            altseason = (snapshot.payload_json or {}).get("altseason")
+            altseason_summary_parts, altseason_key_points = _altseason_points(altseason)
+            if altseason_summary_parts:
+                summary = (
+                    f"{summary}; Upbit altseason {', '.join(altseason_summary_parts)}"
+                )
+                key_points.extend(altseason_key_points)
+                if (
+                    isinstance(altseason, dict)
+                    and _coerce_float(altseason.get("ubai_ubmi_ratio")) is not None
+                ):
+                    cited_snapshots.append(
+                        StageCitation(
+                            snapshot_uuid=snapshot.snapshot_uuid,
+                            snapshot_kind="market",
+                            payload_path="$.altseason.ubai_ubmi_ratio",
+                        )
+                    )
+                breadth = (
+                    altseason.get("breadth") if isinstance(altseason, dict) else None
+                )
+                if (
+                    isinstance(breadth, dict)
+                    and _coerce_float(breadth.get("alts_beating_btc_pct")) is not None
+                ):
+                    cited_snapshots.append(
+                        StageCitation(
+                            snapshot_uuid=snapshot.snapshot_uuid,
+                            snapshot_kind="market",
+                            payload_path="$.altseason.breadth.alts_beating_btc_pct",
+                        )
+                    )
+
         return StageArtifactPayload(
             stage_type=self.stage_type,
             verdict=verdict,
             confidence=max(confidence, 30 if verdict != StageVerdict.NEUTRAL else 20),
-            summary=f"{symbol} change_percent={change:+.2f}%",
-            key_points=[f"{symbol} {change:+.2f}%"],
+            summary=summary,
+            key_points=key_points,
             buy_evidence=[f"{symbol} 상승 {change:+.2f}%"]
             if verdict == StageVerdict.BULL
             else [],
             sell_evidence=[f"{symbol} 하락 {change:+.2f}%"]
             if verdict == StageVerdict.BEAR
             else [],
-            cited_snapshots=[
-                StageCitation(
-                    snapshot_uuid=snapshot.snapshot_uuid,
-                    snapshot_kind="market",
-                    payload_path=f"$.indices.{symbol}.change_percent",
-                )
-            ],
+            cited_snapshots=cited_snapshots,
         )

--- a/tests/services/action_report/snapshot_backed/test_generator.py
+++ b/tests/services/action_report/snapshot_backed/test_generator.py
@@ -1589,6 +1589,10 @@ async def test_descriptors_freeze_numeric_baseline_from_payload() -> None:
         "from_date": "2026-05-30",
         "to_date": "2026-05-30",
         "indices": {"SPX": {"price": 5300.0, "change_pct": 0.4}},
+        "altseason": {
+            "ubai_ubmi_ratio": 0.455,
+            "breadth": {"alts_beating_btc_pct": 0.42},
+        },
         "events": [{"big": "blob"}],  # heavy list must NOT be frozen
     }
     portfolio = _FakeSnap(kind="portfolio")
@@ -1618,6 +1622,10 @@ async def test_descriptors_freeze_numeric_baseline_from_payload() -> None:
         "SPX": {"price": 5300.0, "change_pct": 0.4}
     }
     assert sent.market_snapshot["baseline"]["market"] == "us"
+    assert sent.market_snapshot["baseline"]["altseason"] == {
+        "ubai_ubmi_ratio": 0.455,
+        "breadth": {"alts_beating_btc_pct": 0.42},
+    }
     assert "events" not in sent.market_snapshot["baseline"]
 
     pb = sent.portfolio_snapshot["baseline"]

--- a/tests/services/investment_stages/stages/test_market.py
+++ b/tests/services/investment_stages/stages/test_market.py
@@ -182,6 +182,45 @@ async def test_market_stage_crypto_selects_crypto_bull():
 
 
 @pytest.mark.asyncio
+async def test_market_stage_crypto_summarizes_upbit_altseason_with_citations():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "market": [
+                _snapshot(
+                    {
+                        "indices": {"CRYPTO": {"change_percent": 0.4}},
+                        "altseason": {
+                            "ubai_ubmi_ratio": 0.455,
+                            "breadth": {
+                                "alts_beating_btc_pct": 0.42,
+                                "alts_beating_btc": 84,
+                                "alts_total": 200,
+                            },
+                        },
+                    }
+                )
+            ]
+        },
+        bundle_metadata={},
+        market="crypto",
+    )
+    payload = await MarketStage().run(ctx)
+
+    assert payload.summary == (
+        "CRYPTO change_percent=+0.40%; Upbit altseason "
+        "UBAI/UBMI=0.455, alts_beating_btc=42.0%"
+    )
+    assert "Upbit altseason UBAI/UBMI=0.455" in payload.key_points
+    assert "Upbit breadth alts beating BTC 42.0%" in payload.key_points
+    assert [c.payload_path for c in payload.cited_snapshots] == [
+        "$.indices.CRYPTO.change_percent",
+        "$.altseason.ubai_ubmi_ratio",
+        "$.altseason.breadth.alts_beating_btc_pct",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_market_stage_crypto_selects_crypto_bear():
     ctx = StageContext(
         bundle_uuid=uuid.uuid4(),


### PR DESCRIPTION
## Summary
- Surface Upbit altseason enrichment in the crypto `MarketStage` summary/key points with snapshot citations for UBAI/UBMI and alt-vs-BTC breadth.
- Freeze compact numeric altseason baseline fields in snapshot-backed market descriptors while keeping provenance pointer-only and excluding heavy payloads.
- Add regression coverage for both the market-stage report text/citations and descriptor baseline filtering.

## Test Plan
- `uv run --group test pytest tests/services/investment_stages/stages/test_market.py tests/services/action_report/snapshot_backed/test_generator.py -q`
- `uv run --group test ruff check app/services/investment_stages/stages/market.py app/services/action_report/snapshot_backed/generator.py tests/services/investment_stages/stages/test_market.py tests/services/action_report/snapshot_backed/test_generator.py`
- `uv run --group test ruff format --check app/services/investment_stages/stages/market.py app/services/action_report/snapshot_backed/generator.py tests/services/investment_stages/stages/test_market.py tests/services/action_report/snapshot_backed/test_generator.py`

Refs ROB-369.
