### PR TITLE
docs: add KR staged report workflow contracts

### DIFF
--- a/docs/invest/data-source-contract.md
+++ b/docs/invest/data-source-contract.md
@@ -36,6 +36,7 @@ Phase 4  push (ingest)
 ```
 
 - **공식 생성 MCP** (canonical): 위 4개 (`prepare_bundle` / `get_hermes_context` / `..._ingest_from_hermes` / `..._create_from_hermes_composition`).
+- **KR staged report 계약**: `docs/invest/report-workflows/`에 `pre` → `nxt` → `regular` 단계형 리포트와 sanitized composer template을 둔다. 운영 프롬프트는 이 계약을 private operator workspace에서 감싸되, public repo에는 비밀값·계좌 상태·generated report를 넣지 않는다.
 - **보조 MCP** (`get_quote` / `get_orderbook` / `get_indicators` / `get_valuation` / `get_financials` / `screen_stocks` / `get_top_stocks` / `get_news` / `search_news` / `get_holdings` / `get_cash_balance` / `get_order_history` / …)는 **read-only 진단**이다. UI/diagnostics 용도이며, 그 직접 호출 결과는 리포트 근거가 아니다.
 
 ## 보조 MCP는 언제 collector로 흡수되나 (이슈 질문 6)

--- a/docs/invest/report-workflows/README.md
+++ b/docs/invest/report-workflows/README.md
@@ -1,0 +1,53 @@
+# /invest report workflow contracts
+
+This directory contains public-safe contracts and prompt templates for staged
+`/invest/reports` generation. These documents describe what the application
+contract should guarantee; private operator workspaces may wrap these contracts
+with local MCP routing, credentials, browser sessions, and generated reports.
+
+## Documents
+
+- [`kr-staged-report-workflow.md`](kr-staged-report-workflow.md) — KR market
+  staged report flow for pre-market, NXT open, regular open, and later intraday
+  extensions.
+- [`kr-report-composer-template.md`](kr-report-composer-template.md) — sanitized
+  Hermes composer prompt template that can be copied into private operator
+  prompts without committing private account state or credentials.
+- [`candidate-lineage-contract.md`](candidate-lineage-contract.md) — candidate
+  status, transition, and evidence-lineage vocabulary used across stages.
+
+## Boundary
+
+`auto_trader` owns deterministic data preparation, bundle freezing, context
+export, ingest, persistence, and UI contracts. Hermes or an external agent owns
+LLM reasoning and composition. The application must not import or call an LLM
+provider in-process to compose investment advice.
+
+Canonical flow:
+
+```text
+investment_report_prepare_bundle
+  -> investment_report_get_hermes_context
+  -> Hermes compose stage artifacts + final composition
+  -> investment_stage_artifacts_ingest_from_hermes
+  -> investment_report_create_from_hermes_composition
+```
+
+Direct read-only MCP calls are useful for diagnosis and gap discovery. Once a
+piece of direct-tool evidence is repeatedly required for a report, it should be
+promoted into a durable read model and a snapshot collector so it can be frozen
+inside a bundle.
+
+## Public-safety rules
+
+Do not commit:
+
+- secrets, bearer tokens, cookies, browser profile paths, or MCP authorization
+  values;
+- generated private reports containing account balances, holdings, or realized
+  PnL;
+- local `.mcp.json` files or operator-specific routing;
+- live order, watch, order-intent, scheduler, or broker-mutation instructions.
+
+These docs are safe to keep in the public repository because they describe
+contracts, stage vocabulary, and sanitized prompt structure only.

--- a/docs/invest/report-workflows/candidate-lineage-contract.md
+++ b/docs/invest/report-workflows/candidate-lineage-contract.md
@@ -1,0 +1,115 @@
+# Candidate lineage contract
+
+Staged KR reports must not silently drop or rename candidates between sessions.
+This contract defines the public vocabulary for carrying candidate decisions from
+pre-market planning through NXT and regular-session confirmation.
+
+## Candidate identity
+
+A candidate should have a stable key within a report day and account scope:
+
+```text
+<market>:<account_scope>:<kst_date>:<symbol_or_asset_id>:<intent>
+```
+
+For UI display, a shorter `client_item_key` may be used, but it should remain
+stable across re-composition attempts for the same bundle/report key.
+
+Recommended identity fields:
+
+- `symbol` or target asset identifier;
+- `market`;
+- `account_scope`;
+- `intent` such as `buy_review`, `sell_review`, `risk_review`,
+  `trend_recovery_review`, or `rebalance_review`;
+- `lineage_source_stage` and prior candidate key when the item was carried from
+  an earlier stage.
+
+## Status vocabulary
+
+| Status | Meaning | Typical next transition |
+|---|---|---|
+| `seeded` | Candidate introduced before sufficient live-session confirmation. | `confirmed`, `downgraded`, `rejected`, `deferred` |
+| `confirmed` | Later session evidence supports keeping the candidate active. | Remain active or become final report item |
+| `downgraded` | Evidence weakened the candidate, but it remains worth monitoring. | `deferred`, `rejected`, or risk watch |
+| `rejected` | Evidence invalidated the candidate for this report cycle. | Terminal for the cycle |
+| `deferred` | Evidence is missing/stale/conflicting, so no action-oriented review should be made. | Re-evaluate in a later session |
+| `new_session_candidate` | Candidate first appeared in the current live session rather than in the earlier plan. | `confirmed`, `downgraded`, `deferred` |
+| `risk_watch` | Candidate is primarily a risk-management item, not a buy/sell opportunity. | Remain watch or become sell/risk review |
+
+A candidate may be absent from the final recommendation list, but it should still
+appear in lineage or limitations if it was material in an earlier stage.
+
+## Transition rules
+
+1. `seeded` candidates from `pre` must be accounted for in `nxt` or `regular`.
+2. `nxt` candidates carried into `regular` must retain their prior status and
+   explain any change.
+3. A `rejected` candidate must include at least one invalidation reason and a
+   citation or missing-data explanation.
+4. A `deferred` candidate must include the missing/stale/conflicting evidence
+   that prevented a decision.
+5. A `new_session_candidate` must explain why it was not visible in the earlier
+   stage and must not erase earlier carried candidates.
+6. `risk_watch` items must not be conflated with buy/sell conviction.
+7. No lineage transition may imply an order was placed, previewed, or approved.
+
+## Evidence requirements
+
+Every material candidate transition should cite one or more of:
+
+- frozen snapshot UUIDs or stable JSON paths;
+- prior stage artifact IDs;
+- report context coverage/freshness summaries;
+- explicit unavailable-source records.
+
+Do not cite operator-private artifacts such as browser profile paths, cookies,
+raw generated private reports, or credential-bearing MCP config.
+
+## Example transition record
+
+```json
+{
+  "candidate_key": "kr:kis_live:YYYY-MM-DD:005930:buy_review",
+  "symbol": "005930",
+  "intent": "buy_review",
+  "previous_stage": "pre",
+  "current_stage": "nxt",
+  "previous_status": "seeded",
+  "current_status": "downgraded",
+  "transition_reason": "NXT evidence was unavailable, so the pre-market thesis was not confirmed.",
+  "confirmation_needed": [
+    "regular-session price/volume confirmation",
+    "fresh screener or orderbook snapshot"
+  ],
+  "invalidation_triggers": [
+    "break below cited support level",
+    "fresh negative account/news conflict"
+  ],
+  "cited_snapshots": [
+    "snapshot_uuid_or_stable_path"
+  ],
+  "missing_data": [
+    "nxt_orderbook unavailable"
+  ],
+  "advisory_only": true
+}
+```
+
+## Relationship to report items
+
+Final report items should reference lineage rather than recomputing it in prose.
+Suggested fields when schemas allow:
+
+- `lineage_status`
+- `lineage_source_stage`
+- `previous_candidate_key`
+- `transition_reason`
+- `confirmation_needed`
+- `invalidation_triggers`
+- `cited_snapshot_uuids`
+- `missing_data`
+
+If the current schema cannot store these fields directly, keep them in the stage
+artifact payload or report metadata until a follow-up schema/UI issue promotes
+them to first-class fields.

--- a/docs/invest/report-workflows/kr-report-composer-template.md
+++ b/docs/invest/report-workflows/kr-report-composer-template.md
@@ -1,0 +1,179 @@
+# KR report composer prompt template
+
+This is a public-safe template for Hermes or another external composer. Private
+operator prompts may import or adapt it, but must keep credentials, account
+amounts, generated reports, and local MCP routing out of the public repository.
+
+## Role
+
+You are the `/invest/reports` composer for Korean equity advisory reports. Use
+only the provided frozen Hermes context and explicitly allowed read-only
+diagnostics. Produce structured stage artifacts and a final composition for
+`auto_trader` ingest.
+
+`auto_trader` is the deterministic evidence and persistence layer. You are the
+out-of-process LLM reasoning layer.
+
+## Absolute constraints
+
+- Advisory only. Do not place, preview, cancel, modify, or simulate an order.
+- Do not mutate watches, order intents, schedulers, user preferences, or broker
+  state.
+- Do not ask the operator questions in unattended runs. If data is unavailable,
+  continue with a `missing_data` entry and lower confidence.
+- Do not use `market_session=preopen`; use `pre`, `nxt`, or `regular`.
+- Do not treat Toss/Naver/browser/community observations as account or market
+  authority. Use them only as supplementary attention/calibration signals.
+- If direct diagnostics repeatedly supply decisive evidence, record a collector
+  gap instead of depending on that diagnostic path long-term.
+
+## Canonical inputs
+
+The primary input is the result of:
+
+```text
+investment_report_get_hermes_context
+```
+
+The context should identify:
+
+- `snapshot_bundle_uuid`
+- `bundle_status`
+- `market`
+- `market_session`
+- `account_scope`
+- `policy_version`
+- `coverage_summary`
+- `freshness_summary`
+- `unavailable_sources`
+- `source_conflicts`
+- deterministic stage inputs
+- cited snapshots
+- constraints
+
+If the context lacks required evidence, do not invent it. Mark it as unavailable
+or stale.
+
+## Session-specific instruction blocks
+
+### `market_session=pre`
+
+Compose a pre-market plan:
+
+1. Summarize market/news/portfolio context.
+2. Seed candidates from frozen screener, holdings, watch-context, and journal
+   evidence.
+3. For each candidate, define confirmation evidence needed at NXT or regular
+   open.
+4. Provide invalidation triggers and missing-data notes.
+5. Avoid final execution language; use review language.
+
+### `market_session=nxt`
+
+Compose an NXT open confirmation report:
+
+1. Compare carried pre-market candidates against NXT evidence in the bundle.
+2. Assign each carried candidate a lineage status: `confirmed`, `downgraded`,
+   `rejected`, or `deferred`.
+3. Separate any newly observed NXT candidate as `new_session_candidate`.
+4. Explain absent/stale NXT data instead of implying live confirmation.
+5. Keep the final result advisory-only.
+
+### `market_session=regular`
+
+Compose a regular-open report:
+
+1. Re-check carried pre/NXT candidates against regular-session evidence.
+2. Preserve status transitions and rationale.
+3. Group final items into buy review, sell review, risk watch, and deferred
+   no-action.
+4. Cite frozen snapshots or stage artifacts for every material claim.
+5. End with a concise Korean summary and explicit data limitations.
+
+## Required output shape
+
+Produce two logical payloads: stage artifacts and final composition. Field names
+should stay close to the existing `HermesCompositionResult` and
+`StageArtifactPayload` schemas.
+
+### Stage artifact sketch
+
+```json
+{
+  "stage_type": "candidate_universe",
+  "verdict": "mixed",
+  "confidence": 0.62,
+  "summary": "후보군은 형성됐지만 일부 NXT/정규장 확인이 필요하다.",
+  "key_points": [
+    "보유 종목 A는 전일 대비 리스크 확인 필요",
+    "신규 후보 B는 거래대금 조건 확인 전까지 deferred"
+  ],
+  "buy_evidence": [],
+  "sell_evidence": [],
+  "risk_evidence": [],
+  "missing_data": [
+    "NXT 호가 snapshot unavailable"
+  ],
+  "cited_snapshots": [
+    "snapshot_uuid_or_stable_path"
+  ],
+  "freshness_summary": {
+    "stale_sources": [],
+    "unavailable_sources": ["nxt_orderbook"]
+  },
+  "model_name": "external-composer",
+  "prompt_version": "kr-staged-report-v1"
+}
+```
+
+### Final composition sketch
+
+```json
+{
+  "report_type": "kr_regular_open_report_v1",
+  "market": "kr",
+  "market_session": "regular",
+  "account_scope": "kis_live",
+  "summary": "정규장 개장 기준 advisory-only 리포트 요약",
+  "items": [
+    {
+      "client_item_key": "regular:005930:buy_review",
+      "target_kind": "asset",
+      "symbol": "005930",
+      "decision_bucket": "new_buy_candidate",
+      "intent": "buy_review",
+      "lineage_status": "confirmed",
+      "lineage_source_stage": "nxt",
+      "rationale": "frozen bundle evidence에 근거한 요약",
+      "cited_snapshot_uuids": ["snapshot_uuid_or_stable_path"],
+      "missing_data": []
+    }
+  ],
+  "limitations": [
+    "실주문 없음",
+    "일부 supplementary source unavailable"
+  ],
+  "safety_notes": [
+    "advisory only",
+    "no broker/order/watch/order-intent mutation"
+  ]
+}
+```
+
+The sketch is intentionally illustrative. Keep the implementation aligned with
+current application schemas when building the actual ingest payload.
+
+## Direct diagnostic gap log
+
+When a private operator run uses direct read-only MCP tools or browser/CDP data
+because the frozen bundle lacks evidence, record a gap in this form:
+
+```text
+Gap: <evidence needed>
+Observed via: <read-only diagnostic class, no credential/path>
+Needed by stage: <pre|nxt|regular|intraday>
+Recommended product fix: <durable table/read-model + collector + bundle kind>
+Safety: read-only; no order/watch/scheduler mutation
+```
+
+This converts prompt discoveries into future `/invest/reports` product work.

--- a/docs/invest/report-workflows/kr-staged-report-workflow.md
+++ b/docs/invest/report-workflows/kr-staged-report-workflow.md
@@ -1,0 +1,168 @@
+# KR staged `/invest/reports` workflow
+
+This contract defines the Korean equity report sequence that should be supported
+by `/invest/reports` and private operator prompts. The goal is to preserve a
+stage-by-stage decision lineage from early context to live-session confirmation,
+without turning the application into an in-process LLM runner.
+
+## Scope
+
+Initial stages:
+
+| Stage | Suggested report key | `market_session` | Purpose | Side effects |
+|---|---|---:|---|---|
+| Pre-market plan | `kr-pre-report` | `pre` | Build a read-only plan before NXT/regular liquidity confirms candidates. | None |
+| NXT open check | `kr-nxt-open-report` | `nxt` | Confirm, downgrade, or reject the pre-market plan using NXT orderbook/trade context when available. | None |
+| Regular open report | `kr-regular-open-report` | `regular` | Convert the carried plan into a regular-session advisory report after KRX liquidity opens. | None |
+| Intraday delta, later | `kr-intraday-report` | `regular` | Update existing candidates from new evidence and explicitly record changed rationale. | None |
+
+Do not introduce a new `preopen` `market_session` value. Use the existing
+vocabulary: `pre`, `nxt`, `regular`, `post`, and `24x7` where applicable.
+
+## Canonical generation flow
+
+The official stored report path is bundle-backed and Hermes-composed:
+
+```text
+Phase 1: prepare bundle in auto_trader
+  investment_report_prepare_bundle
+
+Phase 2: expose frozen context
+  investment_report_get_hermes_context
+
+Phase 3: compose outside auto_trader
+  Hermes reads the frozen context and writes structured stage artifacts and a
+  final composition.
+
+Phase 4: ingest in auto_trader
+  investment_stage_artifacts_ingest_from_hermes
+  investment_report_create_from_hermes_composition
+```
+
+`auto_trader` should provide deterministic evidence and persist the result. It
+must not import an LLM provider or compose the investment narrative in-process.
+
+## Stage responsibilities
+
+### 1. Pre-market plan (`market_session=pre`)
+
+Purpose:
+
+- summarize market context, overnight/news themes, stale-data warnings, and
+  holdings/cash availability at an abstract advisory level;
+- seed buy/sell/risk candidates that need live-session confirmation;
+- define the exact evidence that would confirm or invalidate each candidate;
+- avoid previewing or placing orders.
+
+Expected output:
+
+- market context summary;
+- portfolio/journal/watch context summary;
+- candidate universe seed list;
+- per-candidate `confirmation_needed[]`, `invalidation_triggers[]`, and
+  `missing_data[]`;
+- explicit `advisory_only` constraints.
+
+### 2. NXT open check (`market_session=nxt`)
+
+Purpose:
+
+- compare pre-market candidates against NXT orderbook/trade evidence when the
+  bundle contains it;
+- carry forward only candidates with live-session support;
+- mark candidates as downgraded/rejected/deferred rather than silently dropping
+  them;
+- keep the result advisory-only.
+
+Expected output:
+
+- NXT liquidity/price-action summary;
+- transition records for each pre-market candidate;
+- newly observed candidates, if any, marked as `new_session_candidate` and
+  clearly separated from pre-market carried candidates;
+- missing-data notes when NXT evidence is absent or stale.
+
+### 3. Regular open report (`market_session=regular`)
+
+Purpose:
+
+- re-check carried pre/NXT candidates after regular-market liquidity opens;
+- preserve why a candidate changed status;
+- rank advisory buy/sell/risk candidates with source citations and uncertainty;
+- state what remains unverified.
+
+Expected output:
+
+- market/session summary;
+- holdings/account-scope summary without leaking private balances into public
+  docs or templates;
+- candidate tables grouped by buy review, sell review, risk watch, and deferred
+  no-action;
+- per-item citations to frozen snapshots and stage artifacts;
+- final Korean summary suitable for `/invest/reports` display.
+
+### 4. Intraday delta, later (`market_session=regular`)
+
+Purpose:
+
+- update existing candidates from changed evidence, not regenerate an unrelated
+  list;
+- make additions rare and explain why they were not visible earlier;
+- record deltas against the most recent stored report or stage artifact.
+
+This is a follow-up extension. The initial contract should leave room for it but
+not require intraday scheduling or automation.
+
+## Evidence hierarchy
+
+Use this hierarchy when evidence conflicts:
+
+1. `auto_trader`/KIS/account-owned data and frozen bundle snapshots.
+2. Durable product read models such as screener, market events, journals,
+   watch-context, and news-ingestor data.
+3. Read-only live diagnostics that are frozen into the bundle at report time.
+4. Toss/Naver/browser/community observations as supplementary or low-trust
+   attention signals only.
+
+Toss, Naver, and browser observations must not become final authority for
+account truth, order state, or buy/sell conviction. If they repeatedly matter,
+create a collector/read-model follow-up rather than depending on operator-local
+scraping.
+
+## Required safety constraints
+
+Every stage must preserve these constraints:
+
+- advisory-only unless a separate, explicit operator-approved execution workflow
+  consumes the result later;
+- no broker/order/watch/order-intent mutation;
+- no scheduler or recurring automation activation;
+- no production DB backfill/migration as part of report composition;
+- no private credential, token, cookie, browser profile, or generated private
+  account report committed to the public repository;
+- stale, unavailable, and conflicting sources are reported explicitly instead of
+  guessed.
+
+## Stage artifact guidance
+
+A Hermes stage artifact should include, at minimum:
+
+- `stage_type` from the existing stage catalog where possible;
+- `verdict`, `confidence`, `summary`, and `key_points`;
+- buy/sell/risk evidence groups;
+- `missing_data`, `freshness_summary`, and `source_conflicts`;
+- cited snapshot UUIDs or stable citation paths;
+- model/prompt metadata such as `model_name` and `prompt_version`.
+
+Recommended stage catalog for the KR flow:
+
+- `market`
+- `news`
+- `portfolio_journal`
+- `watch_context`
+- `candidate_universe`
+- `bull_reducer`
+- `bear_reducer`
+- `risk_review`
+
+Add new stage types only after the source snapshots or collectors exist.


### PR DESCRIPTION
## Summary
- Add public-safe `/invest` report workflow contract docs under `docs/invest/report-workflows/`.
- Define KR staged report flow for `pre` → `nxt` → `regular`, plus later intraday extension seam.
- Add sanitized Hermes composer template and candidate-lineage vocabulary for future schema/UI/operator prompt alignment.
- Link the new workflow contract from the existing `/invest` data-source contract narrative.

## Validation
- `git diff --cached --check`
- `git diff --check`
- custom secret/path sanity scan over `docs/invest/data-source-contract.md` and `docs/invest/report-workflows/*.md`
- `uv run --group test pytest tests/test_invest_data_source_contract.py -q` — 11 passed, 2 existing Pydantic deprecation warnings

## Safety / non-actions
- Docs-only change.
- No broker, order, watch, order-intent, scheduler, deployment, DB migration, or production runtime side effects.
- No generated private reports, secrets, account balances, local MCP authorization values, browser cookies, or operator-local credential paths committed.

Linear: ROB-385
