### PR TITLE
fix(ROB-400): kis_mock reconciler delta-budget attribution + lifecycle/status 정합

### DIFF
--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -114,6 +114,7 @@ async def run_kis_mock_reconciliation(
                 else None
             ),
             accepted_at=row.trade_date,
+            price=_to_decimal(row.price),
         )
         for row in open_rows
     ]
@@ -139,6 +140,11 @@ async def run_kis_mock_reconciliation(
             "observed_delta": (
                 str(proposal.observed_delta)
                 if proposal.observed_delta is not None
+                else None
+            ),
+            "attributed_fill_qty": (
+                str(proposal.attributed_fill_qty)
+                if proposal.attributed_fill_qty is not None
                 else None
             ),
         }

--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -131,6 +131,10 @@ async def run_kis_mock_reconciliation(
     events: list[dict[str, Any]] = []
 
     for proposal in proposals:
+        # ``observed_delta`` is the raw un-apportioned per-order delta (diagnostic
+        # only — a pending sibling in a same-symbol group may show a non-zero
+        # delta it did NOT receive). ``attributed_fill_qty`` is the authoritative
+        # apportioned quantity that drives lifecycle and order-history status.
         detail = {
             "observed_holdings_qty": (
                 str(proposal.observed_holdings_qty)

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -94,7 +94,9 @@ def _decimal_to_float(value: Any) -> float:
     return _to_float(value, default=0.0)
 
 
-def _derive_shadow_fill(row: KISMockOrderLedger, ordered_qty: float) -> tuple[float, float, str]:
+def _derive_shadow_fill(
+    row: KISMockOrderLedger, ordered_qty: float
+) -> tuple[float, float, str]:
     """Derive (filled_qty, remaining_qty, status) consistent with lifecycle_state.
 
     A row in ``fill`` must never report status=pending/filled_qty=0. When the

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -106,19 +106,25 @@ def _derive_shadow_fill(
     if row.lifecycle_state != "fill":
         return 0.0, ordered_qty, "pending"
 
+    # Compare in Decimal so a fractional-share fill (e.g. 9.9999999 vs 10) is not
+    # mislabeled partial by float rounding; the reconciler emits Decimal values.
+    ordered_dec = Decimal(str(ordered_qty))
     detail = row.last_reconcile_detail or {}
     raw = detail.get("attributed_fill_qty")
     if raw is None:
-        filled = ordered_qty
+        filled_dec = ordered_dec
     else:
         try:
-            filled = float(raw)
-        except (TypeError, ValueError):
-            filled = ordered_qty
-        filled = max(0.0, min(filled, ordered_qty))
-    remaining = ordered_qty - filled
-    status = "filled" if filled >= ordered_qty else "partial"
-    return filled, remaining, status
+            filled_dec = Decimal(str(raw))
+        except (InvalidOperation, TypeError, ValueError):
+            filled_dec = ordered_dec
+        if filled_dec < 0:
+            filled_dec = Decimal("0")
+        elif filled_dec > ordered_dec:
+            filled_dec = ordered_dec
+    remaining_dec = ordered_dec - filled_dec
+    status = "filled" if filled_dec >= ordered_dec else "partial"
+    return float(filled_dec), float(remaining_dec), status
 
 
 def _shadow_row_to_order(row: KISMockOrderLedger) -> dict[str, Any]:

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -94,8 +94,35 @@ def _decimal_to_float(value: Any) -> float:
     return _to_float(value, default=0.0)
 
 
+def _derive_shadow_fill(row: KISMockOrderLedger, ordered_qty: float) -> tuple[float, float, str]:
+    """Derive (filled_qty, remaining_qty, status) consistent with lifecycle_state.
+
+    A row in ``fill`` must never report status=pending/filled_qty=0. When the
+    reconciler recorded ``attributed_fill_qty`` (ROB-400) we honor it; legacy
+    fill rows without it fall back to a full fill so lifecycle and status agree.
+    """
+    if row.lifecycle_state != "fill":
+        return 0.0, ordered_qty, "pending"
+
+    detail = row.last_reconcile_detail or {}
+    raw = detail.get("attributed_fill_qty")
+    if raw is None:
+        filled = ordered_qty
+    else:
+        try:
+            filled = float(raw)
+        except (TypeError, ValueError):
+            filled = ordered_qty
+        filled = max(0.0, min(filled, ordered_qty))
+    remaining = ordered_qty - filled
+    status = "filled" if filled >= ordered_qty else "partial"
+    return filled, remaining, status
+
+
 def _shadow_row_to_order(row: KISMockOrderLedger) -> dict[str, Any]:
     ordered_at = row.trade_date.isoformat() if row.trade_date else None
+    ordered_qty = _decimal_to_float(row.quantity)
+    filled_qty, remaining_qty, status = _derive_shadow_fill(row, ordered_qty)
     return {
         "order_id": row.order_no or f"ledger:{row.id}",
         "ledger_id": row.id,
@@ -104,11 +131,11 @@ def _shadow_row_to_order(row: KISMockOrderLedger) -> dict[str, Any]:
         "instrument_type": row.instrument_type,
         "side": row.side,
         "order_type": row.order_type,
-        "status": "pending",
+        "status": status,
         "lifecycle_state": row.lifecycle_state,
-        "ordered_qty": _decimal_to_float(row.quantity),
-        "remaining_qty": _decimal_to_float(row.quantity),
-        "filled_qty": 0.0,
+        "ordered_qty": ordered_qty,
+        "remaining_qty": remaining_qty,
+        "filled_qty": filled_qty,
         "ordered_price": _decimal_to_float(row.price),
         "amount": _decimal_to_float(row.amount),
         "currency": row.currency,

--- a/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
+++ b/app/services/brokers/kis/mock_scalping_exec/holdings_delta_confirm.py
@@ -113,6 +113,11 @@ async def confirm_fill_from_holdings_delta(
         )
         return None
 
+    # NOTE (ROB-400 / ROB-404): this synchronous per-order confirm shares the
+    # holdings-delta root cause fixed for the batch reconciler — two concurrent
+    # same-symbol confirms could each claim the same delta. It is narrower here
+    # (baseline captured immediately pre-submit), and true order-unit attribution
+    # awaits the execution-event correlation source in ROB-404.
     decision = classify_fill_by_delta(
         side=baseline.side,
         ordered_qty=baseline.ordered_qty,

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -11,6 +11,7 @@ in `reason_code`.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -102,6 +103,21 @@ _TERMINAL: frozenset[str] = frozenset({"reconciled", "failed", "stale"})
 _RECONCILABLE_INPUTS: frozenset[str] = frozenset({"accepted", "pending", "fill"})
 
 
+def _anomaly(
+    order: LedgerOrderInput, reason: ReasonCode
+) -> LifecycleTransitionProposal:
+    return LifecycleTransitionProposal(
+        ledger_id=order.ledger_id,
+        symbol=order.symbol,
+        prior_state=order.lifecycle_state,
+        next_state="anomaly",
+        reason_code=reason,
+        observed_holdings_qty=None,
+        observed_delta=None,
+        attributed_fill_qty=None,
+    )
+
+
 def classify_orders(
     *,
     orders: Sequence[LedgerOrderInput],
@@ -110,100 +126,114 @@ def classify_orders(
     now: datetime,
 ) -> list[LifecycleTransitionProposal]:
     proposals: list[LifecycleTransitionProposal] = []
+    groups: dict[tuple[str, str], list[LedgerOrderInput]] = defaultdict(list)
+
     for order in orders:
         if order.lifecycle_state in _TERMINAL:
             continue
         if order.lifecycle_state not in _RECONCILABLE_INPUTS:
             # planned/previewed/submitted/anomaly are out of scope here.
             continue
-
         if order.holdings_baseline_qty is None:
-            proposals.append(
-                LifecycleTransitionProposal(
-                    ledger_id=order.ledger_id,
-                    symbol=order.symbol,
-                    prior_state=order.lifecycle_state,
-                    next_state="anomaly",
-                    reason_code="baseline_missing",
-                    observed_holdings_qty=None,
-                    observed_delta=None,
-                )
-            )
+            proposals.append(_anomaly(order, "baseline_missing"))
             continue
-
-        snapshot = holdings.get(order.symbol)
-        if snapshot is None:
-            proposals.append(
-                LifecycleTransitionProposal(
-                    ledger_id=order.ledger_id,
-                    symbol=order.symbol,
-                    prior_state=order.lifecycle_state,
-                    next_state="anomaly",
-                    reason_code="holdings_snapshot_missing",
-                    observed_holdings_qty=None,
-                    observed_delta=None,
-                )
-            )
+        if holdings.get(order.symbol) is None:
+            proposals.append(_anomaly(order, "holdings_snapshot_missing"))
             continue
+        groups[(order.symbol, order.side)].append(order)
 
-        delta = snapshot.quantity - order.holdings_baseline_qty
-
-        if order.lifecycle_state == "fill":
-            expected = order.ordered_qty if order.side == "buy" else -order.ordered_qty
-            if (order.side == "buy" and delta >= expected) or (
-                order.side == "sell" and delta <= expected
-            ):
-                proposals.append(
-                    LifecycleTransitionProposal(
-                        ledger_id=order.ledger_id,
-                        symbol=order.symbol,
-                        prior_state=order.lifecycle_state,
-                        next_state="reconciled",
-                        reason_code="position_reconciled",
-                        observed_holdings_qty=snapshot.quantity,
-                        observed_delta=delta,
-                    )
-                )
-            else:
-                proposals.append(
-                    LifecycleTransitionProposal(
-                        ledger_id=order.ledger_id,
-                        symbol=order.symbol,
-                        prior_state=order.lifecycle_state,
-                        next_state="anomaly",
-                        reason_code="holdings_mismatch",
-                        observed_holdings_qty=snapshot.quantity,
-                        observed_delta=delta,
-                    )
-                )
-            continue
-
-        # accepted / pending paths — delegate the delta decision to the kernel.
-        decision = classify_fill_by_delta(
-            side=order.side,
-            ordered_qty=order.ordered_qty,
-            baseline_qty=order.holdings_baseline_qty,
-            observed_qty=snapshot.quantity,
-        )
-        if decision.verdict == "filled":
-            next_state, reason = "fill", "fill_detected"
-        elif decision.verdict == "partial":
-            next_state, reason = "fill", "partial_fill_detected"
-        else:
-            next_state, reason = _pending_or_stale(order, now, thresholds)
-
-        proposals.append(
-            LifecycleTransitionProposal(
-                ledger_id=order.ledger_id,
-                symbol=order.symbol,
-                prior_state=order.lifecycle_state,
-                next_state=next_state,
-                reason_code=reason,
-                observed_holdings_qty=snapshot.quantity,
-                observed_delta=delta,
+    for (symbol, side), group in groups.items():
+        snapshot = holdings[symbol]
+        proposals.extend(
+            _apportion_group(
+                group=group,
+                snapshot=snapshot,
+                side=side,
+                now=now,
+                thresholds=thresholds,
             )
         )
+
     return proposals
+
+
+def _apportion_group(
+    *,
+    group: list[LedgerOrderInput],
+    snapshot: HoldingsSnapshot,
+    side: str,
+    now: datetime,
+    thresholds: ReconcilerThresholds,
+) -> list[LifecycleTransitionProposal]:
+    # Reference = position just before this competing batch. Terminal orders
+    # already dropped out, so their fills are baked into later baselines.
+    reference = min(o.holdings_baseline_qty for o in group)  # type: ignore[type-var]
+    raw_budget = (
+        snapshot.quantity - reference
+        if side == "buy"
+        else reference - snapshot.quantity
+    )
+    budget = raw_budget if raw_budget > 0 else Decimal("0")
+
+    # Priority: already-fill first (consume prior attribution), then aggressive
+    # price (buy DESC / sell ASC), then oldest order (accepted_at, ledger_id).
+    def _key(o: LedgerOrderInput) -> tuple[int, Decimal, datetime, int]:
+        already_fill = 0 if o.lifecycle_state == "fill" else 1
+        price_key = -o.price if side == "buy" else o.price
+        return (already_fill, price_key, o.accepted_at, o.ledger_id)
+
+    out: list[LifecycleTransitionProposal] = []
+    for order in sorted(group, key=_key):
+        take = min(budget, order.ordered_qty) if budget > 0 else Decimal("0")
+        budget -= take
+        out.append(
+            _proposal_for(
+                order=order,
+                snapshot=snapshot,
+                take=take,
+                now=now,
+                thresholds=thresholds,
+            )
+        )
+    return out
+
+
+def _proposal_for(
+    *,
+    order: LedgerOrderInput,
+    snapshot: HoldingsSnapshot,
+    take: Decimal,
+    now: datetime,
+    thresholds: ReconcilerThresholds,
+) -> LifecycleTransitionProposal:
+    # Per-order diagnostic delta keeps its historical meaning; attributed_fill_qty
+    # is the authoritative apportioned quantity.
+    per_order_delta = snapshot.quantity - order.holdings_baseline_qty  # type: ignore[operator]
+
+    if order.lifecycle_state == "fill":
+        if take >= order.ordered_qty:
+            next_state: OrderLifecycleState = "reconciled"
+            reason: ReasonCode = "position_reconciled"
+        else:
+            next_state = "anomaly"
+            reason = "holdings_mismatch"
+    elif take >= order.ordered_qty:
+        next_state, reason = "fill", "fill_detected"
+    elif take > 0:
+        next_state, reason = "fill", "partial_fill_detected"
+    else:
+        next_state, reason = _pending_or_stale(order, now, thresholds)
+
+    return LifecycleTransitionProposal(
+        ledger_id=order.ledger_id,
+        symbol=order.symbol,
+        prior_state=order.lifecycle_state,
+        next_state=next_state,
+        reason_code=reason,
+        observed_holdings_qty=snapshot.quantity,
+        observed_delta=per_order_delta,
+        attributed_fill_qty=take,
+    )
 
 
 def _pending_or_stale(

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -40,6 +40,7 @@ class LedgerOrderInput:
     lifecycle_state: OrderLifecycleState
     holdings_baseline_qty: Decimal | None
     accepted_at: datetime
+    price: Decimal = Decimal("0")
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,6 +65,7 @@ class LifecycleTransitionProposal:
     reason_code: ReasonCode
     observed_holdings_qty: Decimal | None
     observed_delta: Decimal | None
+    attributed_fill_qty: Decimal | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/docs/superpowers/plans/2026-06-01-rob-400-kis-mock-reconciler-delta-attribution.md
+++ b/docs/superpowers/plans/2026-06-01-rob-400-kis-mock-reconciler-delta-attribution.md
@@ -1,0 +1,842 @@
+# ROB-400 kis_mock reconciler delta-attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** kis_mock reconciler가 동일종목 다중주문의 단일 보유 델타를 한 번만 배분하도록 고치고(이중계상 제거), order-history의 `lifecycle_state`와 `status/filled_qty`를 정합시킨다.
+
+**Architecture:** 순수 함수 `classify_orders`를 "주문 독립 평가"에서 "종목+side별 델타 예산(budget) 배분"으로 재작성한다. 매수=고가 우선/매도=저가 우선, 동가는 (trade_date,id) 오래된 주문 우선, 이미 `fill`인 주문이 예산을 최우선 소진. 각 주문에 귀속된 수량 `attributed_fill_qty`를 proposal·`last_reconcile_detail`(JSONB)에 실어, shadow order-history가 이 값으로 status/filled_qty를 파생한다. 새 lifecycle 상태·DB 컬럼·마이그레이션 없음.
+
+**Tech Stack:** Python 3.13, dataclasses(frozen/slots), Decimal, pytest(`@pytest.mark.unit`), `uv run pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-rob-400-kis-mock-reconciler-delta-attribution-design.md`
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 변경 |
+|------|------|------|
+| `app/services/kis_mock_holdings_reconciler.py` | 순수 결정 로직 | `LedgerOrderInput`에 `price` 추가, `LifecycleTransitionProposal`에 `attributed_fill_qty` 추가, `classify_orders` 재작성 + 헬퍼 `_apportion_group`/`_proposal_for`. 커널 `classify_fill_by_delta` 보존. |
+| `app/jobs/kis_mock_reconciliation_job.py` | DB↔reconciler 합성 | `LedgerOrderInput(price=...)` 전달, `detail`에 `attributed_fill_qty` 기록. |
+| `app/mcp_server/tooling/kis_mock_ledger.py` | shadow order-history/exposure 투영 | `_shadow_row_to_order`가 status/filled_qty/remaining_qty를 lifecycle_state+attributed_fill_qty에서 파생(헬퍼 `_derive_shadow_fill`). |
+| `tests/services/test_kis_mock_holdings_reconciler.py` | 순수 단위 테스트 | 신규 배분 케이스 추가. |
+| `tests/mcp_server/test_kis_mock_shadow_order_history.py` (신규) | shadow 파생 정합 테스트 | 신규 파일. |
+
+---
+
+## Task 1: dataclass 확장 (price, attributed_fill_qty)
+
+**Files:**
+- Modify: `app/services/kis_mock_holdings_reconciler.py:34-66`
+- Test: `tests/services/test_kis_mock_holdings_reconciler.py`
+
+- [ ] **Step 1: 실패하는 테스트 추가**
+
+`tests/services/test_kis_mock_holdings_reconciler.py` 맨 아래에 추가:
+
+```python
+@pytest.mark.unit
+def test_ledger_order_input_has_price_default():
+    from app.services.kis_mock_holdings_reconciler import LedgerOrderInput
+
+    order = LedgerOrderInput(
+        ledger_id=1,
+        symbol="005930",
+        side="buy",
+        ordered_qty=Decimal("10"),
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("0"),
+        accepted_at=_now(),
+    )
+    assert order.price == Decimal("0")  # default keeps existing call sites working
+
+    priced = LedgerOrderInput(
+        ledger_id=2,
+        symbol="005930",
+        side="buy",
+        ordered_qty=Decimal("10"),
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("0"),
+        accepted_at=_now(),
+        price=Decimal("15900"),
+    )
+    assert priced.price == Decimal("15900")
+
+
+@pytest.mark.unit
+def test_proposal_attributed_fill_qty_defaults_none():
+    from app.services.kis_mock_holdings_reconciler import LifecycleTransitionProposal
+
+    p = LifecycleTransitionProposal(
+        ledger_id=1,
+        symbol="005930",
+        prior_state="accepted",
+        next_state="pending",
+        reason_code="pending_unconfirmed",
+        observed_holdings_qty=Decimal("0"),
+        observed_delta=Decimal("0"),
+    )
+    assert p.attributed_fill_qty is None
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py::test_ledger_order_input_has_price_default tests/services/test_kis_mock_holdings_reconciler.py::test_proposal_attributed_fill_qty_defaults_none -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'price'` / AttributeError.
+
+- [ ] **Step 3: dataclass에 필드 추가**
+
+`app/services/kis_mock_holdings_reconciler.py` — `LedgerOrderInput`에 `price` 필드를 **맨 끝(default 포함)** 으로 추가:
+
+```python
+@dataclass(frozen=True, slots=True)
+class LedgerOrderInput:
+    ledger_id: int
+    symbol: str
+    side: Literal["buy", "sell"]
+    ordered_qty: Decimal
+    lifecycle_state: OrderLifecycleState
+    holdings_baseline_qty: Decimal | None
+    accepted_at: datetime
+    price: Decimal = Decimal("0")
+```
+
+같은 파일 `LifecycleTransitionProposal`에 `attributed_fill_qty` 필드 추가(default None):
+
+```python
+@dataclass(frozen=True, slots=True)
+class LifecycleTransitionProposal:
+    ledger_id: int
+    symbol: str
+    prior_state: OrderLifecycleState
+    next_state: OrderLifecycleState
+    reason_code: ReasonCode
+    observed_holdings_qty: Decimal | None
+    observed_delta: Decimal | None
+    attributed_fill_qty: Decimal | None = None
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py::test_ledger_order_input_has_price_default tests/services/test_kis_mock_holdings_reconciler.py::test_proposal_attributed_fill_qty_defaults_none -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: 기존 reconciler 테스트 회귀 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py -v`
+Expected: 기존 테스트 전부 PASS (single-order 케이스는 group=1이라 동작 불변).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/kis_mock_holdings_reconciler.py tests/services/test_kis_mock_holdings_reconciler.py
+git commit -m "feat(ROB-400): add price + attributed_fill_qty fields to reconciler dataclasses
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: classify_orders를 종목별 델타 예산 배분으로 재작성 (데모 재현 케이스)
+
+**Files:**
+- Modify: `app/services/kis_mock_holdings_reconciler.py:103-204` (classify_orders 본문 + 헬퍼/임포트)
+- Test: `tests/services/test_kis_mock_holdings_reconciler.py`
+
+- [ ] **Step 1: 데모 재현 실패 테스트 추가**
+
+`tests/services/test_kis_mock_holdings_reconciler.py`에 추가. 동일종목 2 매수, 보유 +10 → 고가 1건만 fill:
+
+```python
+def _buy(
+    *,
+    ledger_id: int,
+    price: Decimal,
+    ordered_qty: Decimal = Decimal("10"),
+    baseline: Decimal = Decimal("0"),
+    state: str = "accepted",
+    accepted_age_sec: int = 0,
+) -> LedgerOrderInput:
+    return LedgerOrderInput(
+        ledger_id=ledger_id,
+        symbol="0148J0",
+        side="buy",
+        ordered_qty=ordered_qty,
+        lifecycle_state=state,
+        holdings_baseline_qty=baseline,
+        accepted_at=_now() - timedelta(seconds=accepted_age_sec),
+        price=price,
+    )
+
+
+@pytest.mark.unit
+def test_same_symbol_double_buy_single_delta_attributed_to_higher_price():
+    # ROB-400 demo: ledger23 @15,500 / ledger24 @15,900, actual holdings +10 (one fill)
+    orders = [
+        _buy(ledger_id=23, price=Decimal("15500"), accepted_age_sec=120),
+        _buy(ledger_id=24, price=Decimal("15900"), accepted_age_sec=60),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    # higher price (15,900) wins the single +10 budget
+    assert by_id[24].next_state == "fill"
+    assert by_id[24].reason_code == "fill_detected"
+    assert by_id[24].attributed_fill_qty == Decimal("10")
+    # the other stays pending — no double count
+    assert by_id[23].next_state == "pending"
+    assert by_id[23].reason_code == "pending_unconfirmed"
+    assert by_id[23].attributed_fill_qty == Decimal("0")
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py::test_same_symbol_double_buy_single_delta_attributed_to_higher_price -v`
+Expected: FAIL — 현재 로직은 ledger23도 `fill`(observed_delta +10)로 판정.
+
+- [ ] **Step 3: classify_orders 재작성 + 헬퍼 추가**
+
+`app/services/kis_mock_holdings_reconciler.py` 상단 import에 `defaultdict` 추가(line 14 근처):
+
+```python
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+```
+
+`classify_orders`(현재 103~204행) 전체를 아래로 교체. `classify_fill_by_delta`(76~96) 및 `_pending_or_stale`(207~215)는 그대로 둔다:
+
+```python
+def _anomaly(
+    order: LedgerOrderInput, reason: ReasonCode
+) -> LifecycleTransitionProposal:
+    return LifecycleTransitionProposal(
+        ledger_id=order.ledger_id,
+        symbol=order.symbol,
+        prior_state=order.lifecycle_state,
+        next_state="anomaly",
+        reason_code=reason,
+        observed_holdings_qty=None,
+        observed_delta=None,
+        attributed_fill_qty=None,
+    )
+
+
+def classify_orders(
+    *,
+    orders: Sequence[LedgerOrderInput],
+    holdings: Mapping[str, HoldingsSnapshot],
+    thresholds: ReconcilerThresholds,
+    now: datetime,
+) -> list[LifecycleTransitionProposal]:
+    proposals: list[LifecycleTransitionProposal] = []
+    groups: dict[tuple[str, str], list[LedgerOrderInput]] = defaultdict(list)
+
+    for order in orders:
+        if order.lifecycle_state in _TERMINAL:
+            continue
+        if order.lifecycle_state not in _RECONCILABLE_INPUTS:
+            # planned/previewed/submitted/anomaly are out of scope here.
+            continue
+        if order.holdings_baseline_qty is None:
+            proposals.append(_anomaly(order, "baseline_missing"))
+            continue
+        if holdings.get(order.symbol) is None:
+            proposals.append(_anomaly(order, "holdings_snapshot_missing"))
+            continue
+        groups[(order.symbol, order.side)].append(order)
+
+    for (symbol, side), group in groups.items():
+        snapshot = holdings[symbol]
+        proposals.extend(
+            _apportion_group(
+                group=group,
+                snapshot=snapshot,
+                side=side,
+                now=now,
+                thresholds=thresholds,
+            )
+        )
+
+    return proposals
+
+
+def _apportion_group(
+    *,
+    group: list[LedgerOrderInput],
+    snapshot: HoldingsSnapshot,
+    side: str,
+    now: datetime,
+    thresholds: ReconcilerThresholds,
+) -> list[LifecycleTransitionProposal]:
+    # Reference = position just before this competing batch. Terminal orders
+    # already dropped out, so their fills are baked into later baselines.
+    reference = min(o.holdings_baseline_qty for o in group)  # type: ignore[type-var]
+    raw_budget = (
+        snapshot.quantity - reference
+        if side == "buy"
+        else reference - snapshot.quantity
+    )
+    budget = raw_budget if raw_budget > 0 else Decimal("0")
+
+    # Priority: already-fill first (consume prior attribution), then aggressive
+    # price (buy DESC / sell ASC), then oldest order (accepted_at, ledger_id).
+    def _key(o: LedgerOrderInput) -> tuple[int, Decimal, datetime, int]:
+        already_fill = 0 if o.lifecycle_state == "fill" else 1
+        price_key = -o.price if side == "buy" else o.price
+        return (already_fill, price_key, o.accepted_at, o.ledger_id)
+
+    out: list[LifecycleTransitionProposal] = []
+    for order in sorted(group, key=_key):
+        take = min(budget, order.ordered_qty) if budget > 0 else Decimal("0")
+        budget -= take
+        out.append(
+            _proposal_for(
+                order=order,
+                snapshot=snapshot,
+                take=take,
+                now=now,
+                thresholds=thresholds,
+            )
+        )
+    return out
+
+
+def _proposal_for(
+    *,
+    order: LedgerOrderInput,
+    snapshot: HoldingsSnapshot,
+    take: Decimal,
+    now: datetime,
+    thresholds: ReconcilerThresholds,
+) -> LifecycleTransitionProposal:
+    # Per-order diagnostic delta keeps its historical meaning; attributed_fill_qty
+    # is the authoritative apportioned quantity.
+    per_order_delta = snapshot.quantity - order.holdings_baseline_qty  # type: ignore[operator]
+
+    if order.lifecycle_state == "fill":
+        if take >= order.ordered_qty:
+            next_state: OrderLifecycleState = "reconciled"
+            reason: ReasonCode = "position_reconciled"
+        else:
+            next_state = "anomaly"
+            reason = "holdings_mismatch"
+    elif take >= order.ordered_qty:
+        next_state, reason = "fill", "fill_detected"
+    elif take > 0:
+        next_state, reason = "fill", "partial_fill_detected"
+    else:
+        next_state, reason = _pending_or_stale(order, now, thresholds)
+
+    return LifecycleTransitionProposal(
+        ledger_id=order.ledger_id,
+        symbol=order.symbol,
+        prior_state=order.lifecycle_state,
+        next_state=next_state,
+        reason_code=reason,
+        observed_holdings_qty=snapshot.quantity,
+        observed_delta=per_order_delta,
+        attributed_fill_qty=take,
+    )
+```
+
+`__all__`(218~227행)에 헬퍼는 추가하지 않는다(내부 전용). 기존 export 유지.
+
+- [ ] **Step 4: 데모 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py::test_same_symbol_double_buy_single_delta_attributed_to_higher_price -v`
+Expected: PASS.
+
+- [ ] **Step 5: 기존 reconciler 테스트 회귀 확인**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py -v`
+Expected: 전부 PASS. (single-order 케이스는 group=1, budget = snap−baseline 으로 종전과 동일.)
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/kis_mock_holdings_reconciler.py tests/services/test_kis_mock_holdings_reconciler.py
+git commit -m "fix(ROB-400): apportion symbol holdings delta as a single budget across orders
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: 배분 엣지 케이스 테스트 (tiebreaker / partial / external excess / sell)
+
+**Files:**
+- Test: `tests/services/test_kis_mock_holdings_reconciler.py`
+
+이 태스크는 Task 2 구현을 검증하는 케이스들을 추가한다. 통과해야 정상이며, 실패 시 Task 2 구현을 고친다.
+
+- [ ] **Step 1: 케이스 테스트 추가**
+
+```python
+@pytest.mark.unit
+def test_same_price_tiebreak_oldest_order_wins():
+    orders = [
+        _buy(ledger_id=30, price=Decimal("15500"), accepted_age_sec=60),
+        _buy(ledger_id=31, price=Decimal("15500"), accepted_age_sec=600),  # older
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[31].next_state == "fill"          # oldest wins the budget
+    assert by_id[30].next_state == "pending"
+
+
+@pytest.mark.unit
+def test_partial_budget_goes_to_priority_order_only():
+    orders = [
+        _buy(ledger_id=40, price=Decimal("15900")),
+        _buy(ledger_id=41, price=Decimal("15500")),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("6"), taken_at=_now()
+        )},  # +6 budget, each ordered 10
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[40].next_state == "fill"
+    assert by_id[40].reason_code == "partial_fill_detected"
+    assert by_id[40].attributed_fill_qty == Decimal("6")
+    assert by_id[41].next_state == "pending"
+    assert by_id[41].attributed_fill_qty == Decimal("0")
+
+
+@pytest.mark.unit
+def test_external_holdings_excess_not_flagged_anomaly():
+    orders = [_buy(ledger_id=50, price=Decimal("15900"))]  # ordered 10
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
+        )},  # +15 > ordered 10 (manual/external position)
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "fill_detected"
+    assert proposals[0].attributed_fill_qty == Decimal("10")  # capped, leftover ignored
+
+
+@pytest.mark.unit
+def test_already_fill_pair_only_one_reconciles_other_anomaly():
+    orders = [
+        _buy(ledger_id=60, price=Decimal("15900"), state="fill"),
+        _buy(ledger_id=61, price=Decimal("15500"), state="fill"),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},  # only +10 supports a single 10-share fill
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[60].next_state == "reconciled"
+    assert by_id[60].reason_code == "position_reconciled"
+    assert by_id[61].next_state == "anomaly"
+    assert by_id[61].reason_code == "holdings_mismatch"
+
+
+@pytest.mark.unit
+def test_sell_lower_price_wins_budget():
+    def _sell(ledger_id, price):
+        return LedgerOrderInput(
+            ledger_id=ledger_id,
+            symbol="005930",
+            side="sell",
+            ordered_qty=Decimal("10"),
+            lifecycle_state="accepted",
+            holdings_baseline_qty=Decimal("10"),  # held 10 before selling
+            accepted_at=_now(),
+            price=price,
+        )
+
+    proposals = classify_orders(
+        orders=[_sell(70, Decimal("16000")), _sell(71, Decimal("15500"))],
+        holdings={"005930": _snap(Decimal("0"))},  # sold 10 (delta -10)
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[71].next_state == "fill"          # lower ask (15,500) fills first
+    assert by_id[70].next_state == "pending"
+```
+
+- [ ] **Step 2: 케이스 테스트 실행**
+
+Run: `uv run pytest tests/services/test_kis_mock_holdings_reconciler.py -v -k "tiebreak or partial_budget or external_holdings or already_fill_pair or sell_lower_price"`
+Expected: 5 passed. 실패 시 Task 2의 `_apportion_group`/`_proposal_for`를 수정해 통과시킨다(설계 §4.2 규칙 기준).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add tests/services/test_kis_mock_holdings_reconciler.py
+git commit -m "test(ROB-400): cover delta-budget tiebreak/partial/excess/sell cases
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: job이 price를 전달하고 attributed_fill_qty를 detail에 기록
+
+**Files:**
+- Modify: `app/jobs/kis_mock_reconciliation_job.py:104-144`
+- Test: `tests/jobs/test_kis_mock_reconciliation_job.py`
+
+- [ ] **Step 1: 기존 job 테스트 패턴 확인**
+
+Run: `sed -n '1,60p' tests/jobs/test_kis_mock_reconciliation_job.py`
+Expected: fake lifecycle 서비스/holdings로 `run_kis_mock_reconciliation`을 호출하는 패턴 파악(아래 Step 2 테스트를 이 파일 컨벤션에 맞춰 작성).
+
+- [ ] **Step 2: 실패 테스트 추가**
+
+`tests/jobs/test_kis_mock_reconciliation_job.py` 맨 아래에 추가. 두 매수 ledger(23 @15,500 / 24 @15,900), 보유 +10 → dry_run transition에서 24만 fill·attributed 10, 23은 pending·attributed 0이 detail에 실리는지 검증. (이 파일에 이미 있는 fake/factory 헬퍼 이름을 재사용한다; 없으면 기존 테스트의 fake 구성 그대로 복제한다.)
+
+```python
+@pytest.mark.unit
+async def test_reconciliation_attributes_single_delta_and_records_attributed_qty():
+    rows = [
+        _make_ledger_row(
+            ledger_id=23, symbol="0148J0", side="buy", quantity=Decimal("10"),
+            price=Decimal("15500"), lifecycle_state="accepted",
+            holdings_baseline_qty=Decimal("0"),
+        ),
+        _make_ledger_row(
+            ledger_id=24, symbol="0148J0", side="buy", quantity=Decimal("10"),
+            price=Decimal("15900"), lifecycle_state="accepted",
+            holdings_baseline_qty=Decimal("0"),
+        ),
+    ]
+    fake_db = _FakeSession()
+    svc_rows = rows
+    kis_client = _FakeKISClient(kr_holdings=[{"pdno": "0148J0", "hldg_qty": "10"}])
+
+    result = await run_kis_mock_reconciliation(
+        fake_db, dry_run=True, kis_client=kis_client,
+        # inject open rows via the same mechanism existing tests use
+    )
+
+    transitions = {t["ledger_id"]: t for t in result["transitions"]}
+    assert transitions[24]["next_state"] == "fill"
+    assert transitions[23]["next_state"] == "pending"
+    # attributed_fill_qty is recorded in the applied detail / event payload
+    events = {e["detail"]["ledger_id"]: e["detail"] for e in result["events"]}
+    assert events[24]["attributed_fill_qty"] == "10"
+    assert events[23]["attributed_fill_qty"] == "0"
+```
+
+> 주의: `run_kis_mock_reconciliation`은 `lifecycle_svc.list_open_orders`로 행을 읽는다. 위 테스트의 `_make_ledger_row`/`_FakeSession`/`_FakeKISClient`/open-rows 주입은 **이 테스트 파일에 이미 존재하는 헬퍼와 동일한 방식**으로 작성한다(Step 1에서 확인). 새 픽스처를 발명하지 말 것.
+
+- [ ] **Step 2b: 테스트 실패 확인**
+
+Run: `uv run pytest tests/jobs/test_kis_mock_reconciliation_job.py::test_reconciliation_attributes_single_delta_and_records_attributed_qty -v`
+Expected: FAIL — `attributed_fill_qty` 키가 detail/event에 없음(또는 ledger23이 fill).
+
+- [ ] **Step 3: job 구현 수정**
+
+`app/jobs/kis_mock_reconciliation_job.py` — `LedgerOrderInput` 생성에 `price` 추가(104-119 블록):
+
+```python
+    order_inputs: list[LedgerOrderInput] = [
+        LedgerOrderInput(
+            ledger_id=row.id,
+            symbol=row.symbol,
+            side=row.side,
+            ordered_qty=_to_decimal(row.quantity),
+            lifecycle_state=row.lifecycle_state,
+            holdings_baseline_qty=(
+                Decimal(str(row.holdings_baseline_qty))
+                if row.holdings_baseline_qty is not None
+                else None
+            ),
+            accepted_at=row.trade_date,
+            price=_to_decimal(row.price),
+        )
+        for row in open_rows
+    ]
+```
+
+같은 파일 `detail` 딕셔너리(132-144 블록)에 `attributed_fill_qty` 추가:
+
+```python
+        detail = {
+            "observed_holdings_qty": (
+                str(proposal.observed_holdings_qty)
+                if proposal.observed_holdings_qty is not None
+                else None
+            ),
+            "observed_delta": (
+                str(proposal.observed_delta)
+                if proposal.observed_delta is not None
+                else None
+            ),
+            "attributed_fill_qty": (
+                str(proposal.attributed_fill_qty)
+                if proposal.attributed_fill_qty is not None
+                else None
+            ),
+        }
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/jobs/test_kis_mock_reconciliation_job.py -v`
+Expected: 신규 테스트 PASS + 기존 전부 PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/jobs/kis_mock_reconciliation_job.py tests/jobs/test_kis_mock_reconciliation_job.py
+git commit -m "fix(ROB-400): pass order price + persist attributed_fill_qty in reconcile detail
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: shadow order-history가 lifecycle+attributed_fill_qty에서 status/filled_qty 파생 (Fix #3)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/kis_mock_ledger.py:97-120`
+- Test: `tests/mcp_server/test_kis_mock_shadow_order_history.py` (신규)
+
+- [ ] **Step 1: 신규 테스트 파일 작성(실패)**
+
+`tests/mcp_server/test_kis_mock_shadow_order_history.py`:
+
+```python
+"""ROB-400: shadow order-history must not contradict lifecycle_state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.mcp_server.tooling.kis_mock_ledger import _shadow_row_to_order
+
+
+def _row(*, lifecycle_state, quantity, detail):
+    return SimpleNamespace(
+        id=24,
+        order_no=None,
+        symbol="0148J0",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=Decimal(str(quantity)),
+        price=Decimal("15900"),
+        amount=Decimal("159000"),
+        currency="KRW",
+        trade_date=datetime(2026, 6, 1, 9, 30, tzinfo=UTC),
+        lifecycle_state=lifecycle_state,
+        last_reconcile_detail=detail,
+    )
+
+
+@pytest.mark.unit
+def test_pending_row_is_unfilled():
+    out = _shadow_row_to_order(
+        _row(lifecycle_state="pending", quantity=10, detail=None)
+    )
+    assert out["status"] == "pending"
+    assert out["filled_qty"] == 0.0
+    assert out["remaining_qty"] == 10.0
+
+
+@pytest.mark.unit
+def test_fill_row_with_full_attribution_reports_filled():
+    out = _shadow_row_to_order(
+        _row(
+            lifecycle_state="fill",
+            quantity=10,
+            detail={"attributed_fill_qty": "10"},
+        )
+    )
+    assert out["status"] == "filled"
+    assert out["filled_qty"] == 10.0
+    assert out["remaining_qty"] == 0.0
+
+
+@pytest.mark.unit
+def test_fill_row_with_partial_attribution_reports_partial():
+    out = _shadow_row_to_order(
+        _row(
+            lifecycle_state="fill",
+            quantity=10,
+            detail={"attributed_fill_qty": "6"},
+        )
+    )
+    assert out["status"] == "partial"
+    assert out["filled_qty"] == 6.0
+    assert out["remaining_qty"] == 4.0
+
+
+@pytest.mark.unit
+def test_fill_row_without_attribution_falls_back_to_full_fill():
+    # legacy/confirm-path fill rows lacking attributed_fill_qty must still not
+    # contradict lifecycle="fill" (never status=pending with filled_qty=0).
+    out = _shadow_row_to_order(
+        _row(lifecycle_state="fill", quantity=10, detail=None)
+    )
+    assert out["status"] == "filled"
+    assert out["filled_qty"] == 10.0
+    assert out["remaining_qty"] == 0.0
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/mcp_server/test_kis_mock_shadow_order_history.py -v`
+Expected: FAIL — fill 행이 status="pending"/filled 0으로 나옴(현 하드코딩).
+
+- [ ] **Step 3: `_derive_shadow_fill` 헬퍼 추가 + `_shadow_row_to_order` 수정**
+
+`app/mcp_server/tooling/kis_mock_ledger.py` — `_shadow_row_to_order`(97행) 바로 위에 헬퍼 추가:
+
+```python
+def _derive_shadow_fill(row: KISMockOrderLedger, ordered_qty: float) -> tuple[float, float, str]:
+    """Derive (filled_qty, remaining_qty, status) consistent with lifecycle_state.
+
+    A row in ``fill`` must never report status=pending/filled_qty=0. When the
+    reconciler recorded ``attributed_fill_qty`` (ROB-400) we honor it; legacy
+    fill rows without it fall back to a full fill so lifecycle and status agree.
+    """
+    if row.lifecycle_state != "fill":
+        return 0.0, ordered_qty, "pending"
+
+    detail = row.last_reconcile_detail or {}
+    raw = detail.get("attributed_fill_qty")
+    if raw is None:
+        filled = ordered_qty
+    else:
+        try:
+            filled = float(raw)
+        except (TypeError, ValueError):
+            filled = ordered_qty
+        filled = max(0.0, min(filled, ordered_qty))
+    remaining = ordered_qty - filled
+    status = "filled" if filled >= ordered_qty else "partial"
+    return filled, remaining, status
+```
+
+`_shadow_row_to_order`(97-120행) 본문을 아래로 교체:
+
+```python
+def _shadow_row_to_order(row: KISMockOrderLedger) -> dict[str, Any]:
+    ordered_at = row.trade_date.isoformat() if row.trade_date else None
+    ordered_qty = _decimal_to_float(row.quantity)
+    filled_qty, remaining_qty, status = _derive_shadow_fill(row, ordered_qty)
+    return {
+        "order_id": row.order_no or f"ledger:{row.id}",
+        "ledger_id": row.id,
+        "symbol": row.symbol,
+        "market": "kr" if row.instrument_type == "equity_kr" else "us",
+        "instrument_type": row.instrument_type,
+        "side": row.side,
+        "order_type": row.order_type,
+        "status": status,
+        "lifecycle_state": row.lifecycle_state,
+        "ordered_qty": ordered_qty,
+        "remaining_qty": remaining_qty,
+        "filled_qty": filled_qty,
+        "ordered_price": _decimal_to_float(row.price),
+        "amount": _decimal_to_float(row.amount),
+        "currency": row.currency,
+        "ordered_at": ordered_at,
+        "created_at": ordered_at,
+        "source": KIS_MOCK_SHADOW_PENDING_SOURCE,
+        "confidence": KIS_MOCK_SHADOW_PENDING_CONFIDENCE,
+        "warning": KIS_MOCK_SHADOW_PENDING_WARNING,
+    }
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/mcp_server/test_kis_mock_shadow_order_history.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5: shadow exposure 회귀 확인**
+
+`_get_kis_mock_shadow_exposure`는 sell_reserved에 `remaining_qty`를 쓴다. fill된 sell의 remaining이 줄어드는 것은 의도된 개선이다. 기존 exposure 테스트가 깨지지 않는지 확인:
+
+Run: `uv run pytest tests/ -v -k "shadow_exposure or shadow_pending or kis_mock_ledger"`
+Expected: PASS (없으면 0 selected — 무방).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/mcp_server/tooling/kis_mock_ledger.py tests/mcp_server/test_kis_mock_shadow_order_history.py
+git commit -m "fix(ROB-400): derive shadow order status/filled_qty from lifecycle+attributed_fill_qty
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 전체 검증 + lint/typecheck
+
+**Files:** (변경 없음 — 검증 단계)
+
+- [ ] **Step 1: 관련 테스트 일괄 실행**
+
+Run:
+```bash
+uv run pytest tests/services/test_kis_mock_holdings_reconciler.py \
+  tests/jobs/test_kis_mock_reconciliation_job.py \
+  tests/mcp_server/test_kis_mock_shadow_order_history.py \
+  tests/test_kis_mock_holdings_delta_fill.py \
+  tests/test_kis_mock_overseas_holdings_confirm.py -v
+```
+Expected: 전부 PASS.
+
+- [ ] **Step 2: lint (ruff check + format) + typecheck**
+
+Run:
+```bash
+uv run ruff check app/services/kis_mock_holdings_reconciler.py app/jobs/kis_mock_reconciliation_job.py app/mcp_server/tooling/kis_mock_ledger.py tests/services/test_kis_mock_holdings_reconciler.py tests/jobs/test_kis_mock_reconciliation_job.py tests/mcp_server/test_kis_mock_shadow_order_history.py
+uv run ruff format --check app/services/kis_mock_holdings_reconciler.py app/jobs/kis_mock_reconciliation_job.py app/mcp_server/tooling/kis_mock_ledger.py tests/services/test_kis_mock_holdings_reconciler.py tests/jobs/test_kis_mock_reconciliation_job.py tests/mcp_server/test_kis_mock_shadow_order_history.py
+make typecheck
+```
+Expected: clean. (format --check 실패 시 `uv run ruff format <files>` 후 재커밋.)
+
+- [ ] **Step 3: 정합 커밋(필요 시)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-400): lint/format fixes
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review 노트 (작성자 확인)
+
+- **Spec §4.2 배분 규칙** → Task 2/3 (예산, 우선순위, 이미-fill 최우선, pending 유지, anomaly 모순만). ✅
+- **Spec §4.3 lifecycle↔status 정합** → Task 5. ✅
+- **Spec §5 영향 범위 3파일** → Task 2/4/5. 마이그레이션 0, 새 상태 0. ✅
+- **Spec §7 테스트 8케이스** → Task 2(데모) + Task 3(tiebreak/partial/excess/already-fill/sell) + Task 5(정합 4) + Task 1(dataclass) + Task 6(회귀). ✅
+- 타입/시그니처 일관: `attributed_fill_qty`(Proposal), `price`(LedgerOrderInput), `_apportion_group`/`_proposal_for`/`_derive_shadow_fill` 이름 통일. ✅
+- Out-of-scope(ROB-404 correlation, live ROB-395, ROB-406)는 Task 없음(의도). ✅

--- a/docs/superpowers/specs/2026-06-01-rob-400-kis-mock-reconciler-delta-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-01-rob-400-kis-mock-reconciler-delta-attribution-design.md
@@ -1,0 +1,132 @@
+# ROB-400 — kis_mock reconciler fill 이중계상 + lifecycle/status 정합 (설계)
+
+- **Linear**: ROB-400 (High, Backlog) — `[모의/버그] kis_mock reconciler가 동일종목 다중주문 시 보유 델타를 중복 귀속(fill 이중계상) + 주문이력 lifecycle 모순`
+- **Branch**: `rob-400`
+- **관련**: ROB-395(live 선반영), ROB-404(체결 이벤트 correlation 소스), ROB-401(자율매매 에픽), ROB-406(취소·정정 미지원)
+- **마이그레이션**: 0 (새 lifecycle 상태/컬럼 없음)
+
+## 1. 문제
+
+2026-06-01 모의 자율매매 데모: 0148J0 매수 2건(ledger 23 @15,500·10주, ledger 24 @15,900·10주) 후
+`kis_mock_reconciliation_run(dry_run=false, confirm=true)`.
+
+**증상 1 — fill 이중계상.** reconcile 결과 ledger 23·24 둘 다 `next_state=fill`(각 `fill_detected`,
+`observed_delta=+10`). 그러나 실제 보유 증가는 **0148J0 총 +10주**. 하나의 +10 델타가 두 주문에 각각
+귀속되어 체결이 2배 계상됨.
+
+**증상 2 — lifecycle/status 모순.** `kis_mock_get_order_history(symbol=0148J0)`가 두 건 모두
+`status="pending"`, `filled_qty=0`, `remaining_qty=10` 인데 `lifecycle_state="fill"`. 같은 주문이
+"체결됨(lifecycle)" + "미체결 0주(status)"로 동시 표기됨.
+
+## 2. 루트코즈 (코드 검증 완료)
+
+`app/services/kis_mock_holdings_reconciler.py::classify_orders` (line 111~) 가 주문을 **독립적으로** 평가:
+
+```python
+for order in orders:
+    snapshot = holdings.get(order.symbol)          # 종목당 단일 스냅샷
+    delta = snapshot.quantity - order.holdings_baseline_qty
+    decision = classify_fill_by_delta(...)          # 주문마다 같은 델타 재적용
+```
+
+데모 추적: ledger 23·24 모두 `baseline=0`(주문 시점 0보유, 24 주문 시점에도 23 미체결), `snapshot=10`
+→ 각각 `delta=+10 ≥ ordered 10` → 둘 다 `filled`. 종목 레벨에서 "이미 소비된 델타"를 차감하는 중재가 없음.
+
+추가로 `fill` 재검증 경로(line 149~177)도 같은 단일 스냅샷을 쓰므로, 다음 reconcile에서 두 fill 모두
+`delta >= expected`를 만족 → 둘 다 `reconciled`로 굳어져 이중계상이 영구 확정됨.
+
+증상 2는 구조적: `status`/`filled_qty`/`remaining_qty`는 broker(또는 shadow) 소스에서, `lifecycle_state`는
+ledger에서 오며 둘이 정합되지 않음. `app/mcp_server/tooling/kis_mock_ledger.py::_shadow_row_to_order` 가
+shadow pending 행에 `status="pending"`, `filled_qty=0.0`, `remaining_qty=전량` 을 **하드코딩**하면서
+ledger의 `lifecycle_state`(reconciler가 `fill`로 올린 값)를 그대로 첨부.
+
+## 3. 결정 사항
+
+- **배분 우선순위**: 매수 = 가격 DESC(고가 우선), 매도 = 가격 ASC(저가 우선) — 시장에서 더 공격적인 호가가
+  먼저 체결될 가능성 반영. 동가는 `(trade_date, id)` ASC(오래된 주문) tiebreaker. `price` 컬럼은 NOT NULL.
+- **잔여/모순 표기**: 예산을 못 받은 주문은 **pending 유지**. 새 lifecycle 상태(`unknown`) 추가하지 않음
+  (DB CHECK 제약 + 마이그레이션 회피). 물리적으로 불가능한 경우만 기존 `anomaly`("operator review 필요").
+- **수량 비례 분배는 채택하지 않음**: 모의에는 주문단위 체결 증거가 없어 임의 partial을 만들면 평단·PnL을 더 왜곡.
+
+## 4. 설계
+
+### 4.1 핵심 전환 — 종목별 델타 예산(budget) 배분
+
+`classify_orders`를 주문 독립 평가에서 **종목별 예산 배분**으로 재작성. 종목당 단일 보유 델타는 한 번만 소진.
+
+`classify_fill_by_delta` 순수 커널(ROB-341 공유, line 76~96)은 **보존**한다. budget을 인자로 받는 얇은
+배분 호출부만 상위에 추가한다.
+
+### 4.2 배분 알고리즘 (종목 + side 단위)
+
+1. reconcilable 주문(`accepted`/`pending`/`fill`)을 **종목 + side(buy/sell)** 로 그룹핑.
+   baseline_missing / holdings_snapshot_missing 은 기존대로 그룹 진입 전 `anomaly` 처리.
+2. **기준 baseline** = 해당 그룹 reconcilable 주문들의 `holdings_baseline_qty` **최소값**.
+   이 경쟁 배치 직전의 포지션을 뜻한다. 종료(terminal: reconciled/failed/stale) 주문은 그룹에서 빠지며,
+   그 체결 효과는 후속 주문의 baseline에 이미 반영되어 있어 정합이 유지된다.
+3. **directional budget** = 매수 `snapshot.qty − 기준baseline`, 매도 `기준baseline − snapshot.qty`.
+   0 이하이면 0.
+4. 우선순위 정렬: 매수 = `price` DESC, 매도 = `price` ASC, 동가는 `(trade_date, id)` ASC.
+   **단, 이미 `fill` 상태인 주문이 예산을 최우선으로 소진**한다(과거 귀속분을 먼저 차감 →
+   fill→reconciled 경로의 이중계상 차단).
+5. 우선순위대로 greedy 소진: `fill_q = min(잔여예산, ordered_qty)`.
+   - `fill_q ≥ ordered_qty` → `filled` (accepted/pending → `fill`; 기존 `fill` → `reconciled`)
+   - `0 < fill_q < ordered_qty` → `partial` (→ `fill`, `partial_fill_detected`)
+   - `fill_q == 0` → none → 기존 `_pending_or_stale(order, now, thresholds)` 재사용
+   - 소진할 때마다 잔여예산 차감.
+6. 예산을 못 받은 주문 → **pending 유지**. 모든 주문 충족 후 남은 양의 예산(주문 합보다 보유가 더 큼 =
+   외부/수동 보유 추정) → 귀속하지 않음, anomaly 아님.
+7. **물리적 모순만 anomaly**: 이미 `fill`인데 예산이 그 귀속을 받치지 못함(보유가 fill 요구량 밑) →
+   `holdings_mismatch` anomaly. 기존 fill-revalidation의 mismatch 의미를 budget 기준으로 재정의.
+
+각 주문에 대해 기존과 동일한 `LifecycleTransitionProposal`(`observed_holdings_qty`, `observed_delta`)을
+반환하되, **`attributed_fill_qty`(이 주문에 귀속된 수량)와 배분 컨텍스트(기준baseline, 우선순위)** 를 함께
+싣는다.
+
+### 4.3 Fix #3 — lifecycle ↔ status 정합
+
+- reconciler가 `last_reconcile_detail`(기존 JSONB)에 **주문별 `attributed_fill_qty`** 를 기록한다
+  (현재는 aggregate `observed_delta`만). 컬럼 추가 없음.
+- `_shadow_row_to_order` (및 history 정규화 경로)가 하드코딩 `filled_qty=0`/`status="pending"` 대신
+  **`lifecycle_state` + `attributed_fill_qty`에서 파생**한다:
+  - `fill` + 귀속 q: `status = "filled"`(q ≥ ordered) | `"partial"`, `filled_qty = q`,
+    `remaining_qty = ordered − q`.
+  - `accepted`/`pending`(귀속 없음): 기존대로 pending, filled 0.
+  → "체결됨 + 미체결 0주" 모순 제거. shadow warning 텍스트(미지원 엔드포인트 한계 고지)는 유지.
+
+## 5. 영향 범위 (마이그레이션 0)
+
+| 파일 | 변경 |
+|------|------|
+| `app/services/kis_mock_holdings_reconciler.py` | `classify_orders` 재작성(그룹핑/예산 배분). `classify_fill_by_delta` 커널 보존. `attributed_fill_qty` 산출. |
+| `app/jobs/kis_mock_reconciliation_job.py` | 그룹 입력 전달 + `last_reconcile_detail`에 `attributed_fill_qty` 기록. |
+| `app/mcp_server/tooling/kis_mock_ledger.py` | `_shadow_row_to_order` 파생 로직(status/filled_qty/remaining_qty). |
+
+- 새 lifecycle 상태/enum/CHECK 변경 없음. ledger 컬럼 추가 없음.
+- read-only 경로 외 브로커/주문 mutation 없음. dry_run 기본, apply는 `dry_run=False`+`confirm=True` 유지.
+
+## 6. 안전 / 에러 처리
+
+- 데이터 부족(baseline/snapshot missing) → 기존 `anomaly` 유지(fill 단정 금지 원칙 강화).
+- dry_run 기본값·confirm 게이트·fail-closed(config missing) 모두 불변.
+- 한계 명시: holdings-delta 만으로 주문단위 귀속은 원리적 추정. 진짜 주문단위 correlation 은 ROB-404
+  (Redis `execution:{market}` 체결 이벤트)에 의존 — 본 설계는 그 전까지의 결정적 best-effort 배분이며,
+  주석/런북에 이 한계를 남긴다.
+
+## 7. 테스트 (TDD, 순수 함수 중심)
+
+1. **데모 재현**: 동일종목 매수 2건(15,500/15,900), 보유 +10 → ledger24(고가) `filled`, ledger23 `pending`.
+2. **동가 tiebreaker**: 동가 2주문, 보유 +10 → 오래된 주문(trade_date,id) `filled`, 나머지 `pending`.
+3. **부분 배분**: 보유 +6, 두 주문 각 10 → 우선순위 1건 `partial`(6), 2건째 `pending`.
+4. **이미 fill 2건 + 보유 1건분만 받침**: 1건 `reconciled`, 1건 `anomaly`(`holdings_mismatch`).
+5. **외부 보유 초과**: 보유 +15, 주문 합 10 → 10 귀속, 잔여 5 무시(anomaly 아님).
+6. **매도 대칭**: 저가 우선 배분.
+7. **Fix #3 정합**: lifecycle=`fill` + attributed 6, ordered 10 → history `status=partial`,
+   `filled_qty=6`, `remaining_qty=4`.
+8. baseline_missing / snapshot_missing → `anomaly` (회귀 방지).
+
+## 8. 비범위 (Out of scope)
+
+- 주문단위 체결조회(ccld) 보강 / Redis 체결 이벤트 correlation → ROB-404.
+- live 경로(ROB-395). 취소·정정 미지원(ROB-406).
+- 새 lifecycle 상태 도입.

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
+from app.mcp_server.tooling.kis_mock_ledger import _shadow_row_to_order
 from app.models.review import KISMockOrderLedger
 
 
@@ -198,3 +199,63 @@ async def test_reconciliation_attributes_single_delta_and_records_attributed_qty
     # attributed_fill_qty is recorded in the applied detail / event payload
     assert events[24]["detail"]["attributed_fill_qty"] == "10"
     assert events[23]["detail"]["attributed_fill_qty"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_attributed_fill_qty_roundtrips_into_shadow_order_history(monkeypatch):
+    """Cross-seam (ROB-400 Fix #3): the exact detail the job hands the
+    persistence layer (str(Decimal) ``attributed_fill_qty``) is read back by the
+    shadow order-history reader without contradicting ``lifecycle_state``.
+
+    This closes the writer/reader contract — a rename on either side breaks it,
+    whereas the isolated reconciler and shadow tests would each still pass.
+    """
+    row24 = _ledger_row(
+        ledger_id=24,
+        symbol="0148J0",
+        side="buy",
+        qty=Decimal("10"),
+        state="accepted",
+        baseline=Decimal("0"),
+        accepted_age_sec=60,
+    )
+    row24.price = Decimal("15900")
+
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [row24]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[{"pdno": "0148J0", "hldg_qty": "10"}])
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=False, kis_client=fake_kis)
+
+    # Reconstruct exactly what KISMockLifecycleService.apply_lifecycle_transition
+    # persists into row.last_reconcile_detail: {"reason_code", **detail}.
+    call = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    persisted_detail = {"reason_code": call["reason_code"], **call["detail"]}
+
+    shadow_row = MagicMock(spec=KISMockOrderLedger)
+    shadow_row.id = 24
+    shadow_row.order_no = None
+    shadow_row.symbol = "0148J0"
+    shadow_row.instrument_type = "equity_kr"
+    shadow_row.side = "buy"
+    shadow_row.order_type = "limit"
+    shadow_row.quantity = Decimal("10")
+    shadow_row.price = Decimal("15900")
+    shadow_row.amount = Decimal("159000")
+    shadow_row.currency = "KRW"
+    shadow_row.trade_date = datetime.now(UTC)
+    shadow_row.lifecycle_state = call["next_state"]
+    shadow_row.last_reconcile_detail = persisted_detail
+
+    out = _shadow_row_to_order(shadow_row)
+    assert out["lifecycle_state"] == "fill"
+    assert out["status"] == "filled"
+    assert out["filled_qty"] == 10.0
+    assert out["remaining_qty"] == 0.0

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -151,16 +151,28 @@ async def test_reconciliation_job_no_open_orders(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reconciliation_attributes_single_delta_and_records_attributed_qty(monkeypatch):
+async def test_reconciliation_attributes_single_delta_and_records_attributed_qty(
+    monkeypatch,
+):
     row23 = _ledger_row(
-        ledger_id=23, symbol="0148J0", side="buy", qty=Decimal("10"),
-        state="accepted", baseline=Decimal("0"), accepted_age_sec=120
+        ledger_id=23,
+        symbol="0148J0",
+        side="buy",
+        qty=Decimal("10"),
+        state="accepted",
+        baseline=Decimal("0"),
+        accepted_age_sec=120,
     )
     row23.price = Decimal("15500")
 
     row24 = _ledger_row(
-        ledger_id=24, symbol="0148J0", side="buy", qty=Decimal("10"),
-        state="accepted", baseline=Decimal("0"), accepted_age_sec=60
+        ledger_id=24,
+        symbol="0148J0",
+        side="buy",
+        qty=Decimal("10"),
+        state="accepted",
+        baseline=Decimal("0"),
+        accepted_age_sec=60,
     )
     row24.price = Decimal("15900")
 
@@ -186,4 +198,3 @@ async def test_reconciliation_attributes_single_delta_and_records_attributed_qty
     # attributed_fill_qty is recorded in the applied detail / event payload
     assert events[24]["detail"]["attributed_fill_qty"] == "10"
     assert events[23]["detail"]["attributed_fill_qty"] == "0"
-

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -148,3 +148,42 @@ async def test_reconciliation_job_no_open_orders(monkeypatch):
     )
     assert result["orders_processed"] == 0
     fake_kis.fetch_my_stocks.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_attributes_single_delta_and_records_attributed_qty(monkeypatch):
+    row23 = _ledger_row(
+        ledger_id=23, symbol="0148J0", side="buy", qty=Decimal("10"),
+        state="accepted", baseline=Decimal("0"), accepted_age_sec=120
+    )
+    row23.price = Decimal("15500")
+
+    row24 = _ledger_row(
+        ledger_id=24, symbol="0148J0", side="buy", qty=Decimal("10"),
+        state="accepted", baseline=Decimal("0"), accepted_age_sec=60
+    )
+    row24.price = Decimal("15900")
+
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [row23, row24]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[{"pdno": "0148J0", "hldg_qty": "10"}])
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, dry_run=True, kis_client=fake_kis
+    )
+
+    events = {e["detail"]["ledger_id"]: e for e in result["events"]}
+    assert events[24]["state"] == "fill"
+    assert events[23]["state"] == "pending"
+
+    # attributed_fill_qty is recorded in the applied detail / event payload
+    assert events[24]["detail"]["attributed_fill_qty"] == "10"
+    assert events[23]["detail"]["attributed_fill_qty"] == "0"
+

--- a/tests/mcp_server/test_kis_mock_shadow_order_history.py
+++ b/tests/mcp_server/test_kis_mock_shadow_order_history.py
@@ -71,9 +71,7 @@ def test_fill_row_with_partial_attribution_reports_partial():
 def test_fill_row_without_attribution_falls_back_to_full_fill():
     # legacy/confirm-path fill rows lacking attributed_fill_qty must still not
     # contradict lifecycle="fill" (never status=pending with filled_qty=0).
-    out = _shadow_row_to_order(
-        _row(lifecycle_state="fill", quantity=10, detail=None)
-    )
+    out = _shadow_row_to_order(_row(lifecycle_state="fill", quantity=10, detail=None))
     assert out["status"] == "filled"
     assert out["filled_qty"] == 10.0
     assert out["remaining_qty"] == 0.0

--- a/tests/mcp_server/test_kis_mock_shadow_order_history.py
+++ b/tests/mcp_server/test_kis_mock_shadow_order_history.py
@@ -1,0 +1,79 @@
+"""ROB-400: shadow order-history must not contradict lifecycle_state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.mcp_server.tooling.kis_mock_ledger import _shadow_row_to_order
+
+
+def _row(*, lifecycle_state, quantity, detail):
+    return SimpleNamespace(
+        id=24,
+        order_no=None,
+        symbol="0148J0",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=Decimal(str(quantity)),
+        price=Decimal("15900"),
+        amount=Decimal("159000"),
+        currency="KRW",
+        trade_date=datetime(2026, 6, 1, 9, 30, tzinfo=UTC),
+        lifecycle_state=lifecycle_state,
+        last_reconcile_detail=detail,
+    )
+
+
+@pytest.mark.unit
+def test_pending_row_is_unfilled():
+    out = _shadow_row_to_order(
+        _row(lifecycle_state="pending", quantity=10, detail=None)
+    )
+    assert out["status"] == "pending"
+    assert out["filled_qty"] == 0.0
+    assert out["remaining_qty"] == 10.0
+
+
+@pytest.mark.unit
+def test_fill_row_with_full_attribution_reports_filled():
+    out = _shadow_row_to_order(
+        _row(
+            lifecycle_state="fill",
+            quantity=10,
+            detail={"attributed_fill_qty": "10"},
+        )
+    )
+    assert out["status"] == "filled"
+    assert out["filled_qty"] == 10.0
+    assert out["remaining_qty"] == 0.0
+
+
+@pytest.mark.unit
+def test_fill_row_with_partial_attribution_reports_partial():
+    out = _shadow_row_to_order(
+        _row(
+            lifecycle_state="fill",
+            quantity=10,
+            detail={"attributed_fill_qty": "6"},
+        )
+    )
+    assert out["status"] == "partial"
+    assert out["filled_qty"] == 6.0
+    assert out["remaining_qty"] == 4.0
+
+
+@pytest.mark.unit
+def test_fill_row_without_attribution_falls_back_to_full_fill():
+    # legacy/confirm-path fill rows lacking attributed_fill_qty must still not
+    # contradict lifecycle="fill" (never status=pending with filled_qty=0).
+    out = _shadow_row_to_order(
+        _row(lifecycle_state="fill", quantity=10, detail=None)
+    )
+    assert out["status"] == "filled"
+    assert out["filled_qty"] == 10.0
+    assert out["remaining_qty"] == 0.0

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -214,3 +214,48 @@ def test_reconciler_does_not_import_db_or_broker():
     ]
     for tok in forbidden:
         assert tok not in src, f"forbidden import in reconciler: {tok}"
+
+
+@pytest.mark.unit
+def test_ledger_order_input_has_price_default():
+    from app.services.kis_mock_holdings_reconciler import LedgerOrderInput
+
+    order = LedgerOrderInput(
+        ledger_id=1,
+        symbol="005930",
+        side="buy",
+        ordered_qty=Decimal("10"),
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("0"),
+        accepted_at=_now(),
+    )
+    assert order.price == Decimal("0")  # default keeps existing call sites working
+
+    priced = LedgerOrderInput(
+        ledger_id=2,
+        symbol="005930",
+        side="buy",
+        ordered_qty=Decimal("10"),
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("0"),
+        accepted_at=_now(),
+        price=Decimal("15900"),
+    )
+    assert priced.price == Decimal("15900")
+
+
+@pytest.mark.unit
+def test_proposal_attributed_fill_qty_defaults_none():
+    from app.services.kis_mock_holdings_reconciler import LifecycleTransitionProposal
+
+    p = LifecycleTransitionProposal(
+        ledger_id=1,
+        symbol="005930",
+        prior_state="accepted",
+        next_state="pending",
+        reason_code="pending_unconfirmed",
+        observed_holdings_qty=Decimal("0"),
+        observed_delta=Decimal("0"),
+    )
+    assert p.attributed_fill_qty is None
+

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -307,3 +307,107 @@ def test_same_symbol_double_buy_single_delta_attributed_to_higher_price():
     assert by_id[23].attributed_fill_qty == Decimal("0")
 
 
+@pytest.mark.unit
+def test_same_price_tiebreak_oldest_order_wins():
+    orders = [
+        _buy(ledger_id=30, price=Decimal("15500"), accepted_age_sec=60),
+        _buy(ledger_id=31, price=Decimal("15500"), accepted_age_sec=600),  # older
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[31].next_state == "fill"          # oldest wins the budget
+    assert by_id[30].next_state == "pending"
+
+
+@pytest.mark.unit
+def test_partial_budget_goes_to_priority_order_only():
+    orders = [
+        _buy(ledger_id=40, price=Decimal("15900")),
+        _buy(ledger_id=41, price=Decimal("15500")),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("6"), taken_at=_now()
+        )},  # +6 budget, each ordered 10
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[40].next_state == "fill"
+    assert by_id[40].reason_code == "partial_fill_detected"
+    assert by_id[40].attributed_fill_qty == Decimal("6")
+    assert by_id[41].next_state == "pending"
+    assert by_id[41].attributed_fill_qty == Decimal("0")
+
+
+@pytest.mark.unit
+def test_external_holdings_excess_not_flagged_anomaly():
+    orders = [_buy(ledger_id=50, price=Decimal("15900"))]  # ordered 10
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
+        )},  # +15 > ordered 10 (manual/external position)
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "fill_detected"
+    assert proposals[0].attributed_fill_qty == Decimal("10")  # capped, leftover ignored
+
+
+@pytest.mark.unit
+def test_already_fill_pair_only_one_reconciles_other_anomaly():
+    orders = [
+        _buy(ledger_id=60, price=Decimal("15900"), state="fill"),
+        _buy(ledger_id=61, price=Decimal("15500"), state="fill"),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},  # only +10 supports a single 10-share fill
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[60].next_state == "reconciled"
+    assert by_id[60].reason_code == "position_reconciled"
+    assert by_id[61].next_state == "anomaly"
+    assert by_id[61].reason_code == "holdings_mismatch"
+
+
+@pytest.mark.unit
+def test_sell_lower_price_wins_budget():
+    def _sell(ledger_id, price):
+        return LedgerOrderInput(
+            ledger_id=ledger_id,
+            symbol="005930",
+            side="sell",
+            ordered_qty=Decimal("10"),
+            lifecycle_state="accepted",
+            holdings_baseline_qty=Decimal("10"),  # held 10 before selling
+            accepted_at=_now(),
+            price=price,
+        )
+
+    proposals = classify_orders(
+        orders=[_sell(70, Decimal("16000")), _sell(71, Decimal("15500"))],
+        holdings={"005930": _snap(Decimal("0"))},  # sold 10 (delta -10)
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[71].next_state == "fill"          # lower ask (15,500) fills first
+    assert by_id[70].next_state == "pending"
+
+
+

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -259,3 +259,51 @@ def test_proposal_attributed_fill_qty_defaults_none():
     )
     assert p.attributed_fill_qty is None
 
+
+def _buy(
+    *,
+    ledger_id: int,
+    price: Decimal,
+    ordered_qty: Decimal = Decimal("10"),
+    baseline: Decimal = Decimal("0"),
+    state: str = "accepted",
+    accepted_age_sec: int = 0,
+) -> LedgerOrderInput:
+    return LedgerOrderInput(
+        ledger_id=ledger_id,
+        symbol="0148J0",
+        side="buy",
+        ordered_qty=ordered_qty,
+        lifecycle_state=state,
+        holdings_baseline_qty=baseline,
+        accepted_at=_now() - timedelta(seconds=accepted_age_sec),
+        price=price,
+    )
+
+
+@pytest.mark.unit
+def test_same_symbol_double_buy_single_delta_attributed_to_higher_price():
+    # ROB-400 demo: ledger23 @15,500 / ledger24 @15,900, actual holdings +10 (one fill)
+    orders = [
+        _buy(ledger_id=23, price=Decimal("15500"), accepted_age_sec=120),
+        _buy(ledger_id=24, price=Decimal("15900"), accepted_age_sec=60),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"0148J0": HoldingsSnapshot(
+            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+        )},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    # higher price (15,900) wins the single +10 budget
+    assert by_id[24].next_state == "fill"
+    assert by_id[24].reason_code == "fill_detected"
+    assert by_id[24].attributed_fill_qty == Decimal("10")
+    # the other stays pending — no double count
+    assert by_id[23].next_state == "pending"
+    assert by_id[23].reason_code == "pending_unconfirmed"
+    assert by_id[23].attributed_fill_qty == Decimal("0")
+
+

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -290,9 +290,11 @@ def test_same_symbol_double_buy_single_delta_attributed_to_higher_price():
     ]
     proposals = classify_orders(
         orders=orders,
-        holdings={"0148J0": HoldingsSnapshot(
-            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
-        )},
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+            )
+        },
         thresholds=ReconcilerThresholds(),
         now=_now(),
     )
@@ -315,14 +317,16 @@ def test_same_price_tiebreak_oldest_order_wins():
     ]
     proposals = classify_orders(
         orders=orders,
-        holdings={"0148J0": HoldingsSnapshot(
-            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
-        )},
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+            )
+        },
         thresholds=ReconcilerThresholds(),
         now=_now(),
     )
     by_id = {p.ledger_id: p for p in proposals}
-    assert by_id[31].next_state == "fill"          # oldest wins the budget
+    assert by_id[31].next_state == "fill"  # oldest wins the budget
     assert by_id[30].next_state == "pending"
 
 
@@ -334,9 +338,11 @@ def test_partial_budget_goes_to_priority_order_only():
     ]
     proposals = classify_orders(
         orders=orders,
-        holdings={"0148J0": HoldingsSnapshot(
-            symbol="0148J0", quantity=Decimal("6"), taken_at=_now()
-        )},  # +6 budget, each ordered 10
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("6"), taken_at=_now()
+            )
+        },  # +6 budget, each ordered 10
         thresholds=ReconcilerThresholds(),
         now=_now(),
     )
@@ -353,9 +359,11 @@ def test_external_holdings_excess_not_flagged_anomaly():
     orders = [_buy(ledger_id=50, price=Decimal("15900"))]  # ordered 10
     proposals = classify_orders(
         orders=orders,
-        holdings={"0148J0": HoldingsSnapshot(
-            symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
-        )},  # +15 > ordered 10 (manual/external position)
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
+            )
+        },  # +15 > ordered 10 (manual/external position)
         thresholds=ReconcilerThresholds(),
         now=_now(),
     )
@@ -372,9 +380,11 @@ def test_already_fill_pair_only_one_reconciles_other_anomaly():
     ]
     proposals = classify_orders(
         orders=orders,
-        holdings={"0148J0": HoldingsSnapshot(
-            symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
-        )},  # only +10 supports a single 10-share fill
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("10"), taken_at=_now()
+            )
+        },  # only +10 supports a single 10-share fill
         thresholds=ReconcilerThresholds(),
         now=_now(),
     )
@@ -406,8 +416,5 @@ def test_sell_lower_price_wins_budget():
         now=_now(),
     )
     by_id = {p.ledger_id: p for p in proposals}
-    assert by_id[71].next_state == "fill"          # lower ask (15,500) fills first
+    assert by_id[71].next_state == "fill"  # lower ask (15,500) fills first
     assert by_id[70].next_state == "pending"
-
-
-


### PR DESCRIPTION
## ROB-400 — kis_mock reconciler fill 이중계상 + lifecycle/status 정합

모의 자율매매 데모에서 발견된 2개 버그를 고칩니다. 0148J0 매수 2건(@15,500·10주 / @15,900·10주) 후 reconcile 시 실제 보유는 +10주뿐인데 두 주문 모두 `fill`로 판정되어 체결이 2배 계상되고, order-history가 `lifecycle_state="fill"` 인데 `status="pending"`/`filled_qty=0` 으로 자기모순을 보였습니다.

### 루트코즈
`classify_orders`가 동일종목 다중주문을 **독립 평가**해 하나의 보유 델타를 각 주문에 통째로 귀속. `fill` 재검증 경로도 같은 단일 스냅샷을 써서 두 fill이 모두 `reconciled`로 굳어짐. order-history는 ledger의 `lifecycle_state` 와 하드코딩된 `status="pending"`/`filled_qty=0` 이 정합되지 않음.

### 변경
1. **종목+side별 델타 예산(budget) 배분** — 종목당 단일 보유 델타를 한 번만 소진. 우선순위: 이미 `fill`인 주문 최우선 → 공격적 가격(매수 고가/매도 저가) → 오래된 주문(`accepted_at`, `ledger_id`). 예산 못 받은 주문은 `pending` 유지, 물리적 모순만 `anomaly`. 공유 커널 `classify_fill_by_delta` 보존.
2. `LedgerOrderInput.price` + `LifecycleTransitionProposal.attributed_fill_qty` 추가(안전 default).
3. job이 `price` 전달 + `attributed_fill_qty` 를 `last_reconcile_detail`(JSONB)·이벤트에 기록.
4. **Fix #3** — `_derive_shadow_fill` 이 order-history `status`/`filled_qty`/`remaining_qty` 를 `lifecycle_state` + `attributed_fill_qty` 에서 파생. `fill` 행은 절대 `pending`/0 으로 안 나옴. attributed 없는 legacy fill 행은 full-fill fallback.

### 안전 경계
- **마이그레이션 0**, 새 lifecycle 상태 0, ledger 컬럼 추가 0 (귀속 수량은 기존 JSONB에 저장).
- read-only 외 브로커/주문 mutation 없음. dry_run 기본·`confirm=True` 게이트·fail-closed 불변.

### 한계 / 후속
holdings-delta 만으로 주문단위 귀속은 결정적 best-effort 추정. 진짜 order-unit correlation 은 **ROB-404**(Redis `execution:{market}` 체결 이벤트)에 의존 — 동기 confirm-path(`holdings_delta_confirm.py`)의 동일 잠재 케이스도 해당 코드에 NOTE로 명시. live 경로는 ROB-395.

### 테스트 / 검증
- 신규/기존 **60 passed** (reconciler 순수 단위 + job 합성 + shadow 파생 + cross-seam round-trip + delta-fill + overseas-confirm).
- 커버: 데모 재현, 동가 tiebreaker, 부분 배분, 외부보유 초과, 이미-fill 2건→1 reconciled/1 anomaly, 매도 대칭, baseline/snapshot-missing 회귀, lifecycle↔status 정합.
- `ruff check app/ tests/` clean · `ruff format --check` clean · `make typecheck` clean · import-contract guards green.

### 코드리뷰
Senior reviewer 디스패치 → Critical 0. Important 1건(writer/reader seam 미검증)은 cross-seam round-trip 테스트로 해소. Minor 3건(Decimal 비교, observed_delta 주석, ROB-404 follow-up 주석) 반영.

설계: `docs/superpowers/specs/2026-06-01-rob-400-...-design.md`
계획: `docs/superpowers/plans/2026-06-01-rob-400-...md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Holdings delta budget is now apportioned across multiple orders with the same symbol and side to prevent double attribution.
  * Fill attribution is tracked and recorded in reconciliation event details.

* **Bug Fixes**
  * Shadow order status and fill quantities now consistently reflect lifecycle state and attributed quantities.

* **Documentation**
  * Added design specification and implementation plan documentation.

* **Tests**
  * Added comprehensive test coverage for delta apportionment, shadow order consistency, and attribution tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->