### PR TITLE
fix(ROB-390): NXT live orderbook evidence를 report bundle에 freeze

### DIFF
--- a/app/schemas/investment_snapshots_mcp.py
+++ b/app/schemas/investment_snapshots_mcp.py
@@ -25,6 +25,7 @@ from app.schemas.investment_snapshots import (
     SourceKind,
 )
 from app.services.investment_snapshots.collectors import SnapshotCollectResult
+from app.schemas.investment_reports import MarketSessionLiteral
 
 EnsureMode = Literal["ensure_fresh", "reuse_only"]
 
@@ -41,6 +42,7 @@ class EnsureBundleRequest(BaseModel):
     policy_version: str = Field(min_length=1)
     mode: EnsureMode = "ensure_fresh"
     symbols: list[str] | None = None
+    market_session: MarketSessionLiteral | None = None
     candidate_limit: Annotated[int | None, Field(ge=1, le=100)] = None
     manual_snapshots: dict[SnapshotKind, list[SnapshotCollectResult]] | None = None
     """Caller-supplied pre-collected snapshots keyed by ``snapshot_kind``.

--- a/app/schemas/investment_snapshots_mcp.py
+++ b/app/schemas/investment_snapshots_mcp.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.schemas.investment_reports import MarketSessionLiteral
 from app.schemas.investment_snapshots import (
     BundleItemRole,
     BundleStatus,
@@ -25,7 +26,6 @@ from app.schemas.investment_snapshots import (
     SourceKind,
 )
 from app.services.investment_snapshots.collectors import SnapshotCollectResult
-from app.schemas.investment_reports import MarketSessionLiteral
 
 EnsureMode = Literal["ensure_fresh", "reuse_only"]
 

--- a/app/services/action_report/common/snapshot_bundle.py
+++ b/app/services/action_report/common/snapshot_bundle.py
@@ -505,6 +505,7 @@ class SnapshotBundleEnsureService:
             candidate_limit=request.candidate_limit,
             policy_snapshot=policy_snapshot,
             user_id=request.user_id,
+            market_session=request.market_session,
         )
         try:
             results = await asyncio.wait_for(

--- a/app/services/action_report/snapshot_backed/collectors/market.py
+++ b/app/services/action_report/snapshot_backed/collectors/market.py
@@ -123,7 +123,9 @@ class MarketEventsSnapshotCollector:
             payload["indices"] = indices
             if request.market == "kr" and request.market_session == "nxt":
                 payload["index_session"] = "regular_closed"
-                payload["index_session_note"] = "KRX 정규장 미개장, 전일 종가 기준(frozen)"
+                payload["index_session_note"] = (
+                    "KRX 정규장 미개장, 전일 종가 기준(frozen)"
+                )
         altseason = await self._collect_altseason(request.market)
         if altseason:
             payload["altseason"] = altseason

--- a/app/services/action_report/snapshot_backed/collectors/market.py
+++ b/app/services/action_report/snapshot_backed/collectors/market.py
@@ -121,6 +121,9 @@ class MarketEventsSnapshotCollector:
         indices = await self._collect_indices(request.market)
         if indices:
             payload["indices"] = indices
+            if request.market == "kr" and request.market_session == "nxt":
+                payload["index_session"] = "regular_closed"
+                payload["index_session_note"] = "KRX 정규장 미개장, 전일 종가 기준(frozen)"
         altseason = await self._collect_altseason(request.market)
         if altseason:
             payload["altseason"] = altseason

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -70,6 +70,10 @@ class _UpbitOpenOrdersAdapter:
         return await _upbit_fetch_open_orders(market=market)
 
 
+# ROB-390 — venue -> KIS domestic market-division code. "J"=KRX, "NX"=NXT.
+_VENUE_TO_KIS_MARKET_CODE = {"krx": "J", "nxt": "NX"}
+
+
 class _KISDomesticQuoteOrderbookAdapter:
     """ROB-278 Phase 2 — read-only adapter wrapping the existing KIS quote
     + orderbook calls. Exposes a single ``fetch_quote_orderbook(symbol)``
@@ -84,13 +88,16 @@ class _KISDomesticQuoteOrderbookAdapter:
     def __init__(self, kis_client: KISClient | None) -> None:
         self._client = kis_client
 
-    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]:
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]:
         if self._client is None:
             raise RuntimeError("kis client unavailable")
         # Two read-only calls — both already exist on the KIS client. No
         # new HTTP surface, no order placement/cancellation paths reached.
+        market_code = _VENUE_TO_KIS_MARKET_CODE.get(venue, "J")
         price_df = await self._client.inquire_price(symbol)
-        orderbook = await self._client.inquire_orderbook(symbol)
+        orderbook = await self._client.inquire_orderbook(symbol, market=market_code)
 
         last_price = float(price_df["close"].iloc[0]) if len(price_df) else 0.0
 
@@ -123,7 +130,7 @@ class _KISDomesticQuoteOrderbookAdapter:
             "best_ask": best_ask,
             "bid_depth": bid_depth,
             "ask_depth": ask_depth,
-            "venue": "krx",
+            "venue": venue if venue in _VENUE_TO_KIS_MARKET_CODE else "krx",
             "as_of": None,  # KIS orderbook payload has no clean as_of; UI uses snapshot.as_of
             "session": "regular" if best_bid > 0 and best_ask > 0 else "closed",
             "nxt_eligible": bool(nxt_eligible),
@@ -142,7 +149,10 @@ class _UpbitQuoteOrderbookAdapter:
     top-of-book is the liquidity signal the symbol stage reads.
     """
 
-    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]:
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]:
+        _ = venue  # Upbit has a single venue; argument kept for protocol parity.
         # Lazy import keeps httpx / the Upbit module out of the registry import
         # graph (mirrors the news / index fns) and narrow to the read function.
         from app.services.upbit_orderbook import fetch_orderbook

--- a/app/services/action_report/snapshot_backed/collectors/symbol.py
+++ b/app/services/action_report/snapshot_backed/collectors/symbol.py
@@ -124,7 +124,8 @@ class SymbolSnapshotCollector:
         * crypto + ``upbit_live`` → Upbit client, NO ``user_id`` (public data).
         """
         if request.market == "kr" and request.account_scope == "kis_live":
-            return (self._kis_quote_client, True, "krx", "kis_live")
+            venue = "nxt" if request.market_session == "nxt" else "krx"
+            return (self._kis_quote_client, True, venue, "kis_live")
         if request.market == "crypto" and request.account_scope == "upbit_live":
             return (self._upbit_quote_client, False, "upbit", "upbit_live")
         return None
@@ -317,7 +318,7 @@ class SymbolSnapshotCollector:
                 ),
             }
         try:
-            raw = await client.fetch_quote_orderbook(symbol)
+            raw = await client.fetch_quote_orderbook(symbol, venue=default_venue)
         except Exception as exc:  # noqa: BLE001 — optional, per-symbol fail-open
             return {
                 "status": "unavailable",

--- a/app/services/action_report/snapshot_backed/collectors/symbol.py
+++ b/app/services/action_report/snapshot_backed/collectors/symbol.py
@@ -65,7 +65,9 @@ class _QuoteOrderbookClient(Protocol):
     not call any broker order-mutation path.
     """
 
-    async def fetch_quote_orderbook(self, symbol: str) -> dict[str, Any]: ...
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]: ...
 
 
 def _is_empty_book(quote: dict[str, Any]) -> bool:

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -339,6 +339,7 @@ class SnapshotBackedReportGenerator:
                 policy_version=request.policy_version,
                 mode="ensure_fresh",
                 symbols=derivation.symbols or None,
+                market_session=request.market_session,
                 candidate_limit=request.candidate_limit,
                 requested_by=request.requested_by,
                 user_id=request.user_id,

--- a/app/services/investment_snapshots/collectors.py
+++ b/app/services/investment_snapshots/collectors.py
@@ -92,6 +92,10 @@ class CollectorRequest(BaseModel):
     live-account read endpoints (e.g. KIS holdings/cash). ``None`` means the
     caller did not supply one; broker-backed collectors must then fail
     closed (``unavailable``) rather than invent a default."""
+    market_session: str | None = None
+    """ROB-390 — venue/session context ("regular"/"nxt"/...). ``None`` = unset.
+    Collectors that switch venue by trading session (e.g. NXT orderbook) read
+    this; left ``None`` for callers that do not distinguish sessions."""
 
 
 @runtime_checkable

--- a/docs/superpowers/plans/2026-06-01-rob-390-nxt-orderbook-freeze.md
+++ b/docs/superpowers/plans/2026-06-01-rob-390-nxt-orderbook-freeze.md
@@ -1,0 +1,635 @@
+# ROB-390 NXT orderbook evidence freeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `market_session="nxt"` 리포트 번들에 NXT live orderbook evidence(venue/session/spread/depth/as_of)를 freeze하고, KRX 정규장 미개장 index가 frozen임을 명시한다.
+
+**Architecture:** Option B — 새 snapshot kind 없이 기존 `symbol` quote enrichment의 venue를 `market_session="nxt"`일 때 `nxt`로 전환. enabling으로 `market_session`을 `EnsureBundleRequest`→`CollectorRequest`로 threading. KIS 어댑터가 venue→KIS market code(`J`/`NX`)를 매핑해 기존 `inquire_orderbook(market=...)`만 사용(신규 HTTP surface 없음). market collector는 nxt 세션에서 index frozen 주석만 첨부.
+
+**Tech Stack:** Python 3.13, pytest (`uv run pytest`), pydantic 요청 모델, 기존 `snapshot_backed/collectors/*` + `market_data` venue 매핑.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-rob-390-nxt-orderbook-freeze-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `app/services/investment_snapshots/collectors.py` — `CollectorRequest`에 `market_session` 필드.
+- **Modify** `app/schemas/investment_snapshots_mcp.py` — `EnsureBundleRequest`에 `market_session` 필드.
+- **Modify** `app/services/action_report/common/snapshot_bundle.py` — `CollectorRequest` 생성 시 market_session 전달.
+- **Modify** `app/services/action_report/snapshot_backed/generator.py` — `EnsureBundleRequest` 생성 시 market_session 전달.
+- **Modify** `app/services/action_report/snapshot_backed/collectors/registry.py` — KIS 어댑터 venue 지원.
+- **Modify** `app/services/action_report/snapshot_backed/collectors/symbol.py` — protocol venue 인자 + plan venue 전환 + enrich 호출.
+- **Modify** `app/services/action_report/snapshot_backed/collectors/market.py` — nxt index frozen 주석.
+- **Test** `tests/services/action_report/snapshot_backed/test_collectors.py` — 신규 + 기존 fake/assert 업데이트.
+
+> 실행 시 모든 명령은 worktree `/Users/mgh3326/work/auto_trader.rob-390`에서 `uv run` 으로 수행.
+> `MarketSessionLiteral = Literal["regular", "nxt", "pre", "post", "24x7"]` (`app/schemas/investment_reports.py:38`).
+
+---
+
+## Task 1: `market_session`을 요청 모델에 추가 (threading enabling)
+
+**Files:**
+- Modify: `app/services/investment_snapshots/collectors.py:77-95` (`CollectorRequest`)
+- Modify: `app/schemas/investment_snapshots_mcp.py:35-45` (`EnsureBundleRequest`)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
+
+```python
+def test_collector_request_carries_market_session_default_none():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    req = CollectorRequest(market="kr", account_scope="kis_live", policy_snapshot={})
+    assert req.market_session is None
+    req2 = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        policy_snapshot={},
+        market_session="nxt",
+    )
+    assert req2.market_session == "nxt"
+
+
+def test_ensure_bundle_request_carries_market_session_default_none():
+    from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+
+    req = EnsureBundleRequest(market="kr", account_scope="kis_live")
+    assert req.market_session is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k market_session_default -v`
+Expected: FAIL — `pydantic ValidationError` (extra="forbid") on `market_session`, or AttributeError.
+
+- [ ] **Step 3: Add the field to `CollectorRequest`**
+
+`app/services/investment_snapshots/collectors.py`, `CollectorRequest` 클래스에 `user_id` 필드 뒤에 추가:
+
+```python
+    market_session: str | None = None
+    """ROB-390 — venue/session context ("regular"/"nxt"/...). ``None`` = unset.
+    Collectors that switch venue by trading session (e.g. NXT orderbook) read
+    this; left ``None`` for callers that do not distinguish sessions."""
+```
+
+> `CollectorRequest`는 lock된 enum 의존을 피하려고 `str | None`을 쓴다(소비 측에서 `== "nxt"` 비교만 함).
+
+- [ ] **Step 4: Add the field to `EnsureBundleRequest`**
+
+`app/schemas/investment_snapshots_mcp.py` 상단 import에 (이미 없으면) 추가:
+
+```python
+from app.schemas.investment_reports import MarketSessionLiteral
+```
+
+`EnsureBundleRequest` 클래스(`symbols` 필드 근처)에 추가:
+
+```python
+    market_session: MarketSessionLiteral | None = None
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k market_session_default -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/investment_snapshots/collectors.py app/schemas/investment_snapshots_mcp.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-390): add market_session to CollectorRequest + EnsureBundleRequest
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `market_session` threading (generator → ensure → CollectorRequest)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py:335` (`EnsureBundleRequest(...)`)
+- Modify: `app/services/action_report/common/snapshot_bundle.py:501` (`CollectorRequest(...)`)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가 (bundle 빌더가 CollectorRequest로 market_session을 전달하는지 fake collector로 검증):
+
+```python
+@pytest.mark.asyncio
+async def test_snapshot_bundle_threads_market_session_into_collector_request():
+    import datetime as dt
+
+    from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+    from app.services.action_report.common.snapshot_bundle import (
+        SnapshotBundleEnsureService,
+    )
+    from app.services.investment_snapshots.collectors import (
+        CollectorRequest,
+        SnapshotCollectResult,
+    )
+
+    captured: dict = {}
+
+    class _CapturingCollector:
+        snapshot_kind = "market"
+
+        async def collect(self, request: CollectorRequest):
+            captured["market_session"] = request.market_session
+            return [
+                SnapshotCollectResult(
+                    snapshot_kind="market",
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={"ok": True},
+                    origin="auto_trader_db",
+                    as_of=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+                    freshness_status="fresh",
+                    coverage={},
+                )
+            ]
+
+    service = SnapshotBundleEnsureService.__new__(SnapshotBundleEnsureService)
+    service._collectors = {"market": _CapturingCollector()}
+
+    from app.services.action_report.snapshot_backed.collectors._base import (
+        SnapshotKindPolicy,
+    )
+
+    # Use the same kind-policy plumbing the service expects; resolve a minimal
+    # policy for the "market" kind via the service helper under test.
+    results, warnings, attempted = await service._collect_for_kind(
+        kind_policy=_market_kind_policy(),
+        request=EnsureBundleRequest(
+            market="kr",
+            account_scope="kis_live",
+            market_session="nxt",
+        ),
+        policy_snapshot={},
+    )
+    assert attempted is True
+    assert captured["market_session"] == "nxt"
+```
+
+> 위 테스트의 `_collect_for_kind` / `_market_kind_policy` / `SnapshotKindPolicy` 경로 이름은 구현 시 `snapshot_bundle.py`의 실제 메서드명·헬퍼와 맞춘다(라인 ~478의 `_collect_for_kind` 시그니처 확인). 핵심 단언은 `captured["market_session"] == "nxt"` 하나다. 만약 kind-policy 구성이 과도하면, 더 단순히 `service` 인스턴스를 정식 생성하지 않고 `_collect_for_kind`에 필요한 최소 `kind_policy` 객체(`snapshot_kind="market"`, `collector_timeout=dt.timedelta(seconds=5)`)를 `types.SimpleNamespace`로 만들어 주입한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k threads_market_session -v`
+Expected: FAIL — `captured["market_session"]` is `None` (snapshot_bundle still builds CollectorRequest without market_session).
+
+- [ ] **Step 3: Thread market_session in `snapshot_bundle.py`**
+
+`app/services/action_report/common/snapshot_bundle.py`, `CollectorRequest(...)` 생성(라인 ~501)에 한 줄 추가:
+
+```python
+        collect_request = CollectorRequest(
+            market=request.market,
+            account_scope=request.account_scope,
+            symbols=request.symbols,
+            candidate_limit=request.candidate_limit,
+            policy_snapshot=policy_snapshot,
+            user_id=request.user_id,
+            market_session=request.market_session,
+        )
+```
+
+- [ ] **Step 4: Thread market_session in `generator.py`**
+
+`app/services/action_report/snapshot_backed/generator.py`, `EnsureBundleRequest(...)` 생성(라인 ~335)에 한 줄 추가:
+
+```python
+            EnsureBundleRequest(
+                market=request.market,
+                ...
+                market_session=request.market_session,
+            )
+```
+
+> `...` 부분은 기존 인자를 그대로 두고 `market_session=request.market_session`만 추가한다. `request`(SnapshotBacked report request)는 이미 `market_session`을 보유(라인 854에서 사용 중).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k threads_market_session -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/action_report/common/snapshot_bundle.py app/services/action_report/snapshot_backed/generator.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-390): thread market_session generator->ensure->CollectorRequest
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: KIS 어댑터 venue 지원 (protocol + adapter)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/symbol.py:71` (`_QuoteOrderbookClient` protocol)
+- Modify: `app/services/action_report/snapshot_backed/collectors/registry.py:73-131` (`_KISDomesticQuoteOrderbookAdapter`); `:133-164` (`_UpbitQuoteOrderbookAdapter`)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
+
+```python
+@pytest.mark.asyncio
+async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
+    import pandas as pd
+    from unittest.mock import AsyncMock
+
+    from app.services.action_report.snapshot_backed.collectors.registry import (
+        _KISDomesticQuoteOrderbookAdapter,
+    )
+
+    captured: dict = {}
+
+    kis_client = MagicMock()
+    kis_client.inquire_price = AsyncMock(
+        return_value=pd.DataFrame({"close": [70_000.0]})
+    )
+
+    async def _inquire_orderbook(code, market="J"):
+        captured["market"] = market
+        return {"askp1": "70100", "bidp1": "69900", "askp_rsqn1": "10", "bidp_rsqn1": "12"}
+
+    kis_client.inquire_orderbook = AsyncMock(side_effect=_inquire_orderbook)
+
+    adapter = _KISDomesticQuoteOrderbookAdapter(kis_client)
+    raw = await adapter.fetch_quote_orderbook("005930", venue="nxt")
+    assert captured["market"] == "NX"
+    assert raw["venue"] == "nxt"
+
+    raw_krx = await adapter.fetch_quote_orderbook("005930")  # default venue
+    assert captured["market"] == "J"
+    assert raw_krx["venue"] == "krx"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k maps_nxt_venue -v`
+Expected: FAIL — `fetch_quote_orderbook()` got an unexpected keyword argument `venue`.
+
+- [ ] **Step 3: Extend the protocol signature**
+
+`app/services/action_report/snapshot_backed/collectors/symbol.py`, `_QuoteOrderbookClient` protocol의 메서드 시그니처를 교체:
+
+```python
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]: ...
+```
+
+- [ ] **Step 4: Add venue mapping to the KIS adapter**
+
+`app/services/action_report/snapshot_backed/collectors/registry.py`, `_KISDomesticQuoteOrderbookAdapter` 클래스 위에 상수 추가:
+
+```python
+# ROB-390 — venue -> KIS domestic market-division code. "J"=KRX, "NX"=NXT.
+_VENUE_TO_KIS_MARKET_CODE = {"krx": "J", "nxt": "NX"}
+```
+
+`fetch_quote_orderbook` 시그니처와 orderbook 호출, 반환 venue를 교체:
+
+```python
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]:
+        if self._client is None:
+            raise RuntimeError("kis client unavailable")
+        market_code = _VENUE_TO_KIS_MARKET_CODE.get(venue, "J")
+        price_df = await self._client.inquire_price(symbol)
+        orderbook = await self._client.inquire_orderbook(symbol, market=market_code)
+        ...
+```
+
+그리고 반환 dict의 `"venue": "krx"`를 `"venue": venue if venue in _VENUE_TO_KIS_MARKET_CODE else "krx",`로 교체. 나머지 로직(`_num`, depth, session, nxt_eligible)은 그대로 유지.
+
+- [ ] **Step 5: Make the Upbit adapter accept (and ignore) venue**
+
+`app/services/action_report/snapshot_backed/collectors/registry.py`, `_UpbitQuoteOrderbookAdapter.fetch_quote_orderbook` 시그니처를 교체(venue 인자만 추가, 본문 불변):
+
+```python
+    async def fetch_quote_orderbook(
+        self, symbol: str, venue: str = "krx"
+    ) -> dict[str, Any]:
+        _ = venue  # Upbit has a single venue; argument kept for protocol parity.
+```
+
+> 기존 본문 첫 줄 앞에 `_ = venue`만 넣고 나머지는 유지.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k maps_nxt_venue -v`
+Expected: PASS (1 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/symbol.py app/services/action_report/snapshot_backed/collectors/registry.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-390): KIS adapter maps venue->market code (krx=J, nxt=NX)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: symbol collector venue 전환 (nxt 세션) + 기존 테스트 갱신
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/symbol.py:115-128` (`_quote_enrichment_plan`); `:317` (`_maybe_enrich_quote` 호출)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py` (신규 + 기존 fake/assert 갱신)
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
+
+```python
+@pytest.mark.asyncio
+async def test_symbol_collector_switches_to_nxt_venue_when_nxt_session():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+
+    captured: dict = {}
+
+    async def fetch_quote(symbol: str, venue: str = "krx") -> dict[str, Any]:
+        captured["venue"] = venue
+        return {
+            "last_price": 70_000.0,
+            "best_bid": 69_900.0,
+            "best_ask": 70_100.0,
+            "bid_depth": 100.0,
+            "ask_depth": 120.0,
+            "venue": venue,
+            "as_of": "2026-06-01T08:30:00+09:00",
+            "session": "nxt",
+            "nxt_eligible": True,
+        }
+
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(side_effect=fetch_quote)
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        policy_snapshot={},
+        user_id=42,
+        market_session="nxt",
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert captured["venue"] == "nxt"
+    assert payload["quote"]["venue"] == "nxt"
+    assert payload["quote"]["session"] == "nxt"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k switches_to_nxt_venue -v`
+Expected: FAIL — `captured["venue"] == "krx"` (plan still hardcodes krx and call passes no venue).
+
+- [ ] **Step 3: Make the enrichment plan venue session-aware**
+
+`app/services/action_report/snapshot_backed/collectors/symbol.py`, `_quote_enrichment_plan`의 KR 분기를 교체:
+
+```python
+    def _quote_enrichment_plan(
+        self, request: CollectorRequest
+    ) -> tuple[_QuoteOrderbookClient | None, bool, str, str] | None:
+        if request.market == "kr" and request.account_scope == "kis_live":
+            venue = "nxt" if request.market_session == "nxt" else "krx"
+            return (self._kis_quote_client, True, venue, "kis_live")
+        if request.market == "crypto" and request.account_scope == "upbit_live":
+            return (self._upbit_quote_client, False, "upbit", "upbit_live")
+        return None
+```
+
+- [ ] **Step 4: Pass the plan venue into the client call**
+
+`app/services/action_report/snapshot_backed/collectors/symbol.py`, `_maybe_enrich_quote` 내부의 client 호출(라인 ~317)을 교체:
+
+```python
+        try:
+            raw = await client.fetch_quote_orderbook(symbol, venue=default_venue)
+```
+
+> 단, crypto 경로의 `default_venue`는 `"upbit"`이고 Upbit 어댑터는 venue를 무시하므로 안전하다.
+
+- [ ] **Step 5: Update existing symbol-collector test fakes for the new signature**
+
+기존 fake quote client들이 `fetch_quote_orderbook(symbol, venue=...)` 호출로 깨지지 않도록 시그니처에 `venue` 인자를 추가한다. 다음 위치를 모두 수정:
+
+`_fake_quote_client_ok` (라인 ~1567):
+```python
+    async def fetch_quote(symbol: str, venue: str = "krx") -> dict[str, Any]:
+```
+
+`test_symbol_collector_quote_exception_marks_unavailable`의 `fetch`(라인 ~1700 부근):
+```python
+    async def fetch(symbol: str, venue: str = "krx"):
+```
+
+`test_symbol_collector_quote_empty_book_marks_no_data_reason`의 `fetch`(라인 ~1740 부근):
+```python
+    async def fetch(symbol: str, venue: str = "krx"):
+```
+
+그리고 기존 단언(라인 ~1622):
+```python
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("005930")
+```
+을 다음으로 교체:
+```python
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("005930", venue="krx")
+```
+
+> `assert_not_called()`를 쓰는 테스트(no-kis-live / no-user-id)는 호출되지 않으므로 시그니처 수정 불필요. 단, `quote_enrichment_cap` 테스트가 `_fake_quote_client_ok`를 재사용하면 위 시그니처 수정으로 자동 호환된다.
+
+- [ ] **Step 6: Run the full symbol-collector suite**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "symbol_collector or switches_to_nxt" -v`
+Expected: 모두 PASS (신규 nxt 테스트 + 갱신된 기존 테스트).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/symbol.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-390): symbol collector switches to nxt venue on nxt session
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: market collector index frozen 주석 (nxt 세션)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/market.py:114-126` (`collect`, payload 구성)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
+
+```python
+@pytest.mark.asyncio
+async def test_market_collector_kr_nxt_marks_index_frozen():
+    async def fake_index_fn(symbols):
+        return [
+            {"symbol": "KOSPI", "name": "코스피", "current": 2700.0, "change_pct": 0.0},
+        ]
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(), query_service=_empty_events_query(), index_quote_fn=fake_index_fn
+    )
+    req = _request(market="kr")
+    req = req.model_copy(update={"market_session": "nxt"})
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["index_session"] == "regular_closed"
+    assert "frozen" in payload["index_session_note"]
+
+
+@pytest.mark.asyncio
+async def test_market_collector_kr_regular_session_has_no_frozen_note():
+    async def fake_index_fn(symbols):
+        return [
+            {"symbol": "KOSPI", "name": "코스피", "current": 2700.0, "change_pct": 0.5},
+        ]
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(), query_service=_empty_events_query(), index_quote_fn=fake_index_fn
+    )
+    results = await collector.collect(_request(market="kr"))
+    payload = results[0].payload_json
+    assert "index_session" not in payload
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "index_frozen or regular_session_has_no_frozen" -v`
+Expected: FAIL — `payload["index_session"]` KeyError (nxt 주석 미구현).
+
+- [ ] **Step 3: Add the frozen annotation in `market.py`**
+
+`app/services/action_report/snapshot_backed/collectors/market.py`, `collect` 메서드의 `indices` 첨부 직후(라인 ~123, `payload["indices"] = indices` 다음)에 추가:
+
+```python
+        if (
+            request.market == "kr"
+            and request.market_session == "nxt"
+            and indices
+        ):
+            payload["index_session"] = "regular_closed"
+            payload["index_session_note"] = (
+                "KRX 정규장 미개장, 전일 종가 기준(frozen)"
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "index_frozen or regular_session_has_no_frozen" -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/market.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-390): annotate KR index as frozen during nxt session
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 전체 검증 + mutation guard + lint + PR + 핸드오프
+
+**Files:** 없음 (검증 전용)
+
+- [ ] **Step 1: Run the collectors + threading suites**
+
+Run:
+```bash
+uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -v
+```
+Expected: 모두 PASS (신규 + 기존 회귀 없음).
+
+- [ ] **Step 2: Run the mutation/import-guard regression (ROB-278)**
+
+Run:
+```bash
+uv run pytest tests/services/action_report/snapshot_backed/test_generator_safety.py tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v
+```
+Expected: 모두 PASS — symbol/registry/market 변경 후에도 order placement/cancel/modify surface import 없음.
+
+- [ ] **Step 3: Lint (CLAUDE.md 게이트)**
+
+Run:
+```bash
+uv run ruff check app/ tests/
+uv run ruff format --check app/ tests/
+```
+Expected: 둘 다 통과. (format 위반이면 `uv run ruff format app/ tests/` 후 재확인·커밋 — `ruff check`만으로는 lint job이 떨어진다.)
+
+- [ ] **Step 4: Push branch and open PR (base: main)**
+
+Run:
+```bash
+git push -u origin rob-390
+gh pr create --base main --title "fix(ROB-390): NXT live orderbook evidence를 report bundle에 freeze" --body "$(cat <<'EOF'
+## 요약
+ROB-390: `market_session="nxt"` 리포트 번들에 NXT live orderbook evidence를 freeze (Option B — 새 snapshot kind 없이 기존 symbol quote enrichment의 venue 전환).
+
+1. `market_session`을 `EnsureBundleRequest`→`CollectorRequest`로 threading (additive, None 기본).
+2. symbol collector: `market_session="nxt"` & kr/kis_live → enrichment venue를 `nxt`로 전환.
+3. KIS 어댑터: venue→KIS market code 매핑(`krx=J`, `nxt=NX`) 후 기존 `inquire_orderbook(market=...)` 호출 (신규 HTTP surface 없음). quote payload의 venue/session/spread/depth/as_of가 NXT 기준으로 freeze.
+4. market collector: kr + nxt 세션 → indices payload에 `index_session="regular_closed"` + frozen note (KRX 정규장 미개장 `+0.00%` 방향 오독 방지).
+
+## 테스트
+- `tests/services/action_report/snapshot_backed/test_collectors.py` — market_session threading / KIS venue→NX / symbol nxt 전환 / market index frozen + 기존 fake·assert 갱신
+- mutation/import-guard 회귀(ROB-278) 유지
+
+## 안전 경계
+read-only. broker/order/watch mutation 없음. 신규 KIS HTTP surface 없음(기존 inquire_orderbook market 파라미터만). DB 마이그레이션 없음(payload + 요청 모델 additive 필드만). scheduler 활성화 없음.
+
+## 잔여 (handoff)
+- index는 frozen 주석만 첨부(데이터 교체 없음). MarketStage의 frozen 해석/합성은 Hermes 측. NXT 전용 지수 소스 도입은 비목표.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+Expected: PR URL 출력. (출력된 URL 확인 후에만 PR 번호 인용.)
+
+- [ ] **Step 5: ROB-394 handoff 코멘트 작성**
+
+ROB-394에 ROB-390 결과(PR 링크 + 검증 결과 + 비목표: NXT 지수 소스/Hermes frozen 해석)를 남기고, 다음 순서가 ROB-392임을 명시한다. (Linear `save_comment`.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 변경1 market_session threading → Task 1(필드) + Task 2(generator/bundle). ✅
+- 변경2 symbol venue 전환 → Task 4. ✅
+- 변경3 KIS 어댑터 venue → Task 3. ✅
+- 변경4 market index frozen → Task 5. ✅
+- 테스트 T1/T2/T3/T4/T5/T6 → Task1/Task4/Task3/Task4/Task5/Task6에 매핑. ✅
+- 안전 경계(read-only, no new HTTP surface, no migration, mutation guard) → Task 3는 기존 inquire_orderbook만, Task 6 guard 회귀. ✅
+- 비목표(새 kind, NXT 지수 소스, Hermes 해석) → 미구현, Task6 handoff 명시. ✅
+
+**Placeholder scan:** 모든 step에 실제 코드/명령. Task 2 Step 1은 헬퍼명 확인 주의 포함하되 핵심 단언은 구체적. ✅
+
+**Type consistency:** `market_session: str | None`(CollectorRequest) / `MarketSessionLiteral | None`(EnsureBundleRequest) — 소비 측은 `== "nxt"` 문자열 비교만(타입 호환). `fetch_quote_orderbook(symbol, venue="krx")`(Task3 protocol+adapter ↔ Task4 호출 ↔ 기존 fake 갱신 ↔ assert venue 인자). `_VENUE_TO_KIS_MARKET_CODE={"krx":"J","nxt":"NX"}`(Task3). payload 키 `index_session`/`index_session_note`(Task5 ↔ T5). ✅
+
+**Commit-별 CI green:** Task3은 protocol/adapter에 venue 기본값 추가(symbol.py는 아직 venue 미전달)라 기존 테스트 무손상. Task4에서 호출 변경과 동시에 기존 fake/assert를 같은 커밋으로 갱신 → 각 커밋 green 유지. ✅

--- a/docs/superpowers/plans/2026-06-01-rob-390-nxt-orderbook-freeze.md
+++ b/docs/superpowers/plans/2026-06-01-rob-390-nxt-orderbook-freeze.md
@@ -35,7 +35,7 @@
 - Modify: `app/schemas/investment_snapshots_mcp.py:35-45` (`EnsureBundleRequest`)
 - Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 `tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
 
@@ -61,12 +61,12 @@ def test_ensure_bundle_request_carries_market_session_default_none():
     assert req.market_session is None
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k market_session_default -v`
 Expected: FAIL — `pydantic ValidationError` (extra="forbid") on `market_session`, or AttributeError.
 
-- [ ] **Step 3: Add the field to `CollectorRequest`**
+- [x] **Step 3: Add the field to `CollectorRequest`**
 
 `app/services/investment_snapshots/collectors.py`, `CollectorRequest` 클래스에 `user_id` 필드 뒤에 추가:
 
@@ -79,7 +79,7 @@ Expected: FAIL — `pydantic ValidationError` (extra="forbid") on `market_sessio
 
 > `CollectorRequest`는 lock된 enum 의존을 피하려고 `str | None`을 쓴다(소비 측에서 `== "nxt"` 비교만 함).
 
-- [ ] **Step 4: Add the field to `EnsureBundleRequest`**
+- [x] **Step 4: Add the field to `EnsureBundleRequest`**
 
 `app/schemas/investment_snapshots_mcp.py` 상단 import에 (이미 없으면) 추가:
 
@@ -93,12 +93,12 @@ from app.schemas.investment_reports import MarketSessionLiteral
     market_session: MarketSessionLiteral | None = None
 ```
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k market_session_default -v`
 Expected: PASS (2 passed).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add app/services/investment_snapshots/collectors.py app/schemas/investment_snapshots_mcp.py tests/services/action_report/snapshot_backed/test_collectors.py
@@ -116,7 +116,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Modify: `app/services/action_report/common/snapshot_bundle.py:501` (`CollectorRequest(...)`)
 - Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 `tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가 (bundle 빌더가 CollectorRequest로 market_session을 전달하는지 fake collector로 검증):
 
@@ -178,12 +178,12 @@ async def test_snapshot_bundle_threads_market_session_into_collector_request():
 
 > 위 테스트의 `_collect_for_kind` / `_market_kind_policy` / `SnapshotKindPolicy` 경로 이름은 구현 시 `snapshot_bundle.py`의 실제 메서드명·헬퍼와 맞춘다(라인 ~478의 `_collect_for_kind` 시그니처 확인). 핵심 단언은 `captured["market_session"] == "nxt"` 하나다. 만약 kind-policy 구성이 과도하면, 더 단순히 `service` 인스턴스를 정식 생성하지 않고 `_collect_for_kind`에 필요한 최소 `kind_policy` 객체(`snapshot_kind="market"`, `collector_timeout=dt.timedelta(seconds=5)`)를 `types.SimpleNamespace`로 만들어 주입한다.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k threads_market_session -v`
 Expected: FAIL — `captured["market_session"]` is `None` (snapshot_bundle still builds CollectorRequest without market_session).
 
-- [ ] **Step 3: Thread market_session in `snapshot_bundle.py`**
+- [x] **Step 3: Thread market_session in `snapshot_bundle.py`**
 
 `app/services/action_report/common/snapshot_bundle.py`, `CollectorRequest(...)` 생성(라인 ~501)에 한 줄 추가:
 
@@ -199,7 +199,7 @@ Expected: FAIL — `captured["market_session"]` is `None` (snapshot_bundle still
         )
 ```
 
-- [ ] **Step 4: Thread market_session in `generator.py`**
+- [x] **Step 4: Thread market_session in `generator.py`**
 
 `app/services/action_report/snapshot_backed/generator.py`, `EnsureBundleRequest(...)` 생성(라인 ~335)에 한 줄 추가:
 
@@ -213,12 +213,12 @@ Expected: FAIL — `captured["market_session"]` is `None` (snapshot_bundle still
 
 > `...` 부분은 기존 인자를 그대로 두고 `market_session=request.market_session`만 추가한다. `request`(SnapshotBacked report request)는 이미 `market_session`을 보유(라인 854에서 사용 중).
 
-- [ ] **Step 5: Run test to verify it passes**
+- [x] **Step 5: Run test to verify it passes**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k threads_market_session -v`
 Expected: PASS (1 passed).
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add app/services/action_report/common/snapshot_bundle.py app/services/action_report/snapshot_backed/generator.py tests/services/action_report/snapshot_backed/test_collectors.py
@@ -236,7 +236,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Modify: `app/services/action_report/snapshot_backed/collectors/registry.py:73-131` (`_KISDomesticQuoteOrderbookAdapter`); `:133-164` (`_UpbitQuoteOrderbookAdapter`)
 - Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 `tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
 
@@ -273,12 +273,12 @@ async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
     assert raw_krx["venue"] == "krx"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k maps_nxt_venue -v`
 Expected: FAIL — `fetch_quote_orderbook()` got an unexpected keyword argument `venue`.
 
-- [ ] **Step 3: Extend the protocol signature**
+- [x] **Step 3: Extend the protocol signature**
 
 `app/services/action_report/snapshot_backed/collectors/symbol.py`, `_QuoteOrderbookClient` protocol의 메서드 시그니처를 교체:
 
@@ -288,7 +288,7 @@ Expected: FAIL — `fetch_quote_orderbook()` got an unexpected keyword argument 
     ) -> dict[str, Any]: ...
 ```
 
-- [ ] **Step 4: Add venue mapping to the KIS adapter**
+- [x] **Step 4: Add venue mapping to the KIS adapter**
 
 `app/services/action_report/snapshot_backed/collectors/registry.py`, `_KISDomesticQuoteOrderbookAdapter` 클래스 위에 상수 추가:
 
@@ -313,7 +313,7 @@ _VENUE_TO_KIS_MARKET_CODE = {"krx": "J", "nxt": "NX"}
 
 그리고 반환 dict의 `"venue": "krx"`를 `"venue": venue if venue in _VENUE_TO_KIS_MARKET_CODE else "krx",`로 교체. 나머지 로직(`_num`, depth, session, nxt_eligible)은 그대로 유지.
 
-- [ ] **Step 5: Make the Upbit adapter accept (and ignore) venue**
+- [x] **Step 5: Make the Upbit adapter accept (and ignore) venue**
 
 `app/services/action_report/snapshot_backed/collectors/registry.py`, `_UpbitQuoteOrderbookAdapter.fetch_quote_orderbook` 시그니처를 교체(venue 인자만 추가, 본문 불변):
 
@@ -326,12 +326,12 @@ _VENUE_TO_KIS_MARKET_CODE = {"krx": "J", "nxt": "NX"}
 
 > 기존 본문 첫 줄 앞에 `_ = venue`만 넣고 나머지는 유지.
 
-- [ ] **Step 6: Run test to verify it passes**
+- [x] **Step 6: Run test to verify it passes**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k maps_nxt_venue -v`
 Expected: PASS (1 passed).
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add app/services/action_report/snapshot_backed/collectors/symbol.py app/services/action_report/snapshot_backed/collectors/registry.py tests/services/action_report/snapshot_backed/test_collectors.py
@@ -348,7 +348,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Modify: `app/services/action_report/snapshot_backed/collectors/symbol.py:115-128` (`_quote_enrichment_plan`); `:317` (`_maybe_enrich_quote` 호출)
 - Test: `tests/services/action_report/snapshot_backed/test_collectors.py` (신규 + 기존 fake/assert 갱신)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 `tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
 
@@ -393,12 +393,12 @@ async def test_symbol_collector_switches_to_nxt_venue_when_nxt_session():
     assert payload["quote"]["session"] == "nxt"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k switches_to_nxt_venue -v`
 Expected: FAIL — `captured["venue"] == "krx"` (plan still hardcodes krx and call passes no venue).
 
-- [ ] **Step 3: Make the enrichment plan venue session-aware**
+- [x] **Step 3: Make the enrichment plan venue session-aware**
 
 `app/services/action_report/snapshot_backed/collectors/symbol.py`, `_quote_enrichment_plan`의 KR 분기를 교체:
 
@@ -414,7 +414,7 @@ Expected: FAIL — `captured["venue"] == "krx"` (plan still hardcodes krx and ca
         return None
 ```
 
-- [ ] **Step 4: Pass the plan venue into the client call**
+- [x] **Step 4: Pass the plan venue into the client call**
 
 `app/services/action_report/snapshot_backed/collectors/symbol.py`, `_maybe_enrich_quote` 내부의 client 호출(라인 ~317)을 교체:
 
@@ -425,7 +425,7 @@ Expected: FAIL — `captured["venue"] == "krx"` (plan still hardcodes krx and ca
 
 > 단, crypto 경로의 `default_venue`는 `"upbit"`이고 Upbit 어댑터는 venue를 무시하므로 안전하다.
 
-- [ ] **Step 5: Update existing symbol-collector test fakes for the new signature**
+- [x] **Step 5: Update existing symbol-collector test fakes for the new signature**
 
 기존 fake quote client들이 `fetch_quote_orderbook(symbol, venue=...)` 호출로 깨지지 않도록 시그니처에 `venue` 인자를 추가한다. 다음 위치를 모두 수정:
 
@@ -455,12 +455,12 @@ Expected: FAIL — `captured["venue"] == "krx"` (plan still hardcodes krx and ca
 
 > `assert_not_called()`를 쓰는 테스트(no-kis-live / no-user-id)는 호출되지 않으므로 시그니처 수정 불필요. 단, `quote_enrichment_cap` 테스트가 `_fake_quote_client_ok`를 재사용하면 위 시그니처 수정으로 자동 호환된다.
 
-- [ ] **Step 6: Run the full symbol-collector suite**
+- [x] **Step 6: Run the full symbol-collector suite**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "symbol_collector or switches_to_nxt" -v`
 Expected: 모두 PASS (신규 nxt 테스트 + 갱신된 기존 테스트).
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add app/services/action_report/snapshot_backed/collectors/symbol.py tests/services/action_report/snapshot_backed/test_collectors.py
@@ -477,7 +477,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Modify: `app/services/action_report/snapshot_backed/collectors/market.py:114-126` (`collect`, payload 구성)
 - Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 `tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
 
@@ -515,12 +515,12 @@ async def test_market_collector_kr_regular_session_has_no_frozen_note():
     assert "index_session" not in payload
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "index_frozen or regular_session_has_no_frozen" -v`
 Expected: FAIL — `payload["index_session"]` KeyError (nxt 주석 미구현).
 
-- [ ] **Step 3: Add the frozen annotation in `market.py`**
+- [x] **Step 3: Add the frozen annotation in `market.py`**
 
 `app/services/action_report/snapshot_backed/collectors/market.py`, `collect` 메서드의 `indices` 첨부 직후(라인 ~123, `payload["indices"] = indices` 다음)에 추가:
 
@@ -536,12 +536,12 @@ Expected: FAIL — `payload["index_session"]` KeyError (nxt 주석 미구현).
             )
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "index_frozen or regular_session_has_no_frozen" -v`
 Expected: PASS (2 passed).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add app/services/action_report/snapshot_backed/collectors/market.py tests/services/action_report/snapshot_backed/test_collectors.py
@@ -556,7 +556,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 **Files:** 없음 (검증 전용)
 
-- [ ] **Step 1: Run the collectors + threading suites**
+- [x] **Step 1: Run the collectors + threading suites**
 
 Run:
 ```bash
@@ -564,7 +564,7 @@ uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -v
 ```
 Expected: 모두 PASS (신규 + 기존 회귀 없음).
 
-- [ ] **Step 2: Run the mutation/import-guard regression (ROB-278)**
+- [x] **Step 2: Run the mutation/import-guard regression (ROB-278)**
 
 Run:
 ```bash
@@ -572,7 +572,7 @@ uv run pytest tests/services/action_report/snapshot_backed/test_generator_safety
 ```
 Expected: 모두 PASS — symbol/registry/market 변경 후에도 order placement/cancel/modify surface import 없음.
 
-- [ ] **Step 3: Lint (CLAUDE.md 게이트)**
+- [x] **Step 3: Lint (CLAUDE.md 게이트)**
 
 Run:
 ```bash
@@ -581,7 +581,7 @@ uv run ruff format --check app/ tests/
 ```
 Expected: 둘 다 통과. (format 위반이면 `uv run ruff format app/ tests/` 후 재확인·커밋 — `ruff check`만으로는 lint job이 떨어진다.)
 
-- [ ] **Step 4: Push branch and open PR (base: main)**
+- [x] **Step 4: Push branch and open PR (base: main)**
 
 Run:
 ```bash
@@ -611,7 +611,7 @@ EOF
 ```
 Expected: PR URL 출력. (출력된 URL 확인 후에만 PR 번호 인용.)
 
-- [ ] **Step 5: ROB-394 handoff 코멘트 작성**
+- [x] **Step 5: ROB-394 handoff 코멘트 작성**
 
 ROB-394에 ROB-390 결과(PR 링크 + 검증 결과 + 비목표: NXT 지수 소스/Hermes frozen 해석)를 남기고, 다음 순서가 ROB-392임을 명시한다. (Linear `save_comment`.)
 

--- a/docs/superpowers/specs/2026-06-01-rob-390-nxt-orderbook-freeze-design.md
+++ b/docs/superpowers/specs/2026-06-01-rob-390-nxt-orderbook-freeze-design.md
@@ -1,0 +1,132 @@
+# ROB-390 — NXT live orderbook evidence를 report bundle에 freeze 설계
+
+- **이슈:** ROB-390 (오케스트레이션 ROB-394의 3번)
+- **날짜:** 2026-06-01
+- **상태:** 설계 승인됨 → 구현 계획 대상
+- **base:** `origin/main` `861d149e` (ROB-389 머지 직후)
+
+## 목표
+
+NXT 세션 리포트가 KRX 정규장 미개장 지수 `+0.00%`만 보고 방향성을 오독하지 않도록, `market_session="nxt"`
+report bundle에 **NXT live orderbook evidence**(top-of-book / spread / depth / venue / session / as_of)를
+freeze하고, KRX 정규장 미개장으로 index가 frozen이면 이를 명시한다. read-only, order mutation 무접촉.
+
+## 설계 결정 (이슈 요구: 선택지 먼저 기록)
+
+**Option B 채택** — 새 snapshot kind를 만들지 않고, `market_session="nxt"`일 때 기존 `symbol` quote
+enrichment의 venue를 `nxt`로 전환한다.
+
+근거: `symbol` collector는 **이미** quote payload로 `venue`/`session`/`best_bid`/`best_ask`/`spread`/
+`spread_bps`/`bid_depth`/`ask_depth`/`as_of`를 내보낸다 — ROB-390 acceptance가 요구하는 evidence 형태와
+동일. 따라서 venue만 전환하면 NXT top-of-book이 그대로 freeze된다.
+
+**Option A 기각** — 별도 `nxt_orderbook` snapshot kind + 전용 collector + registry + freshness + schema는
+symbol enrichment와 중복되고 스키마 표면이 과다하다.
+
+## 코드 현황 (근거)
+
+* `app/services/action_report/snapshot_backed/collectors/symbol.py` — `_quote_enrichment_plan`이
+  KR을 `(kis_client, requires_user_id=True, default_venue="krx", "kis_live")`로 고정 반환. 갭은
+  **venue가 항상 `krx`**. `_maybe_enrich_quote`가 `client.fetch_quote_orderbook(symbol)` 결과를 quote
+  payload(venue/session/spread/depth/as_of 포함)로 직렬화 — evidence 형태는 이미 충분.
+* `app/services/action_report/snapshot_backed/collectors/registry.py:73` —
+  `_KISDomesticQuoteOrderbookAdapter.fetch_quote_orderbook(symbol)`이 `inquire_orderbook(symbol)`
+  (기본 `market="J"`=KRX) 호출 후 `"venue": "krx"` 하드코딩.
+* `app/services/brokers/kis/domestic_market_data.py:228` —
+  `inquire_orderbook(code, market="J")`의 **`market` 파라미터가 venue 셀렉터**. NXT는 KIS market code
+  `"NX"`.
+* `app/services/market_data/service.py:200-204` — `_KR_VENUE_MAP`: `krx→KrOrderbookVenue("krx","J")`,
+  `nxt→("nxt","NX")`, `unified→("unified","UN")`. (이미 `get_orderbook(venue="nxt")` tool이 사용.)
+* `app/services/investment_snapshots/collectors.py:77` `CollectorRequest` — `market`/`account_scope`/
+  `symbols`/`candidate_limit`/`policy_snapshot`/`user_id`만 보유. **`market_session` 없음.**
+* `app/schemas/investment_snapshots_mcp.py:35` `EnsureBundleRequest` — 동일하게 `market_session` 없음.
+* `app/services/action_report/common/snapshot_bundle.py:501` — `EnsureBundleRequest`로부터
+  `CollectorRequest`를 구성(이 지점에 market_session 전달 필요).
+* `app/services/action_report/snapshot_backed/generator.py:335` — `EnsureBundleRequest`를 구성하며
+  `request.market_session`을 이미 보유(라인 854에서 다른 경로로 사용 중).
+* `app/services/action_report/snapshot_backed/collectors/market.py:145` `_collect_indices` — index는
+  세션 비인식. NXT 프리마켓에 KRX 정규장 종가를 그대로 노출(→ `+0.00%` 오독 원인).
+
+## 설계
+
+### 변경 1 — `market_session` threading (enabling)
+
+* `CollectorRequest`(`collectors.py`)와 `EnsureBundleRequest`(`investment_snapshots_mcp.py`)에
+  `market_session: MarketSessionLiteral | None = None` 추가. additive·None 기본이라 기존 호출 무영향.
+  `MarketSessionLiteral`는 `app/services/action_report/snapshot_backed/request.py`에서 import(이미 정의됨).
+* `generator.py:335` `EnsureBundleRequest(...)`에 `market_session=request.market_session` 추가.
+* `snapshot_bundle.py:501` `CollectorRequest(...)`에 `market_session=request.market_session` 추가.
+* 다른 `EnsureBundleRequest` 생성 사이트(7곳)는 None 기본값 사용 — 변경 없음.
+
+### 변경 2 — symbol collector NXT venue 전환
+
+`_quote_enrichment_plan(request)`:
+
+* `market=="kr" & account_scope=="kis_live"`:
+  * `request.market_session == "nxt"` → `default_venue="nxt"`
+  * else → `default_venue="krx"` (기존 동작)
+* crypto/upbit_live는 불변.
+
+enrichment 루프(`collect` → `_maybe_enrich_quote`)가 plan의 venue를 KIS 어댑터 호출에 전달한다
+(아래 변경 3의 확장된 protocol 사용).
+
+### 변경 3 — KIS 어댑터 venue 지원
+
+* `_QuoteOrderbookClient` protocol을 `fetch_quote_orderbook(self, symbol: str, venue: str = "krx")`로 확장
+  (기본값으로 Upbit/back-compat 유지).
+* `symbol.py::_maybe_enrich_quote`가 `client.fetch_quote_orderbook(symbol, venue=default_venue)` 호출.
+* `_KISDomesticQuoteOrderbookAdapter.fetch_quote_orderbook(symbol, venue="krx")`:
+  * venue → KIS market code 매핑: `{"krx": "J", "nxt": "NX"}` (미지원 venue → `"J"` fallback).
+  * `inquire_orderbook(symbol, market=code)` 호출(**신규 HTTP surface 없음**, 기존 메서드의 market 파라미터만).
+  * 반환 payload의 `"venue"`를 실제 venue(`"krx"`/`"nxt"`)로 세팅. `session`/`nxt_eligible`/depth 등은 기존
+    로직 유지.
+* `_UpbitQuoteOrderbookAdapter.fetch_quote_orderbook(symbol, venue="krx")`는 venue 인자를 받되 무시.
+
+### 변경 4 — market collector index frozen 주석 (acceptance #2)
+
+`MarketEventsSnapshotCollector.collect`에서 `request.market=="kr" & request.market_session=="nxt"`이고
+`indices`가 존재하면, payload에 다음을 첨부:
+
+```python
+payload["index_session"] = "regular_closed"
+payload["index_session_note"] = "KRX 정규장 미개장, 전일 종가 기준(frozen)"
+```
+
+새 데이터 fetch 없음. MarketStage가 `+0.00%`를 실제 flat으로 오독하지 않도록 명시만 한다. (market collector도
+변경 1로 `request.market_session`을 받게 됨.)
+
+## 테스트 (fake / unit, read-only)
+
+* **T1 (threading):** `CollectorRequest`/`EnsureBundleRequest`가 `market_session`을 보유하고 기본 None.
+* **T2 (symbol plan):** `_quote_enrichment_plan`이 `market_session="nxt"` → `default_venue="nxt"`;
+  미지정/`"regular"` → `"krx"`.
+* **T3 (KIS 어댑터 venue):** fake KIS client(`inquire_orderbook`의 `market` 인자 캡처)로
+  `fetch_quote_orderbook(symbol, venue="nxt")` → `market="NX"` 호출 + payload `venue="nxt"`;
+  `venue="krx"`(기본) → `market="J"` + `venue="krx"`.
+* **T4 (symbol collect NXT):** fake KIS client를 주입한 symbol collector가
+  `market_session="nxt"` 요청에서 각 심볼 quote에 `venue="nxt"`를 남긴다.
+* **T5 (market index frozen):** kr + `market_session="nxt"` → market payload에
+  `index_session="regular_closed"` + note; 다른 세션/마켓엔 미첨부.
+* **T6 (mutation guard 회귀):** 기존 ROB-278 import-guard 테스트가 여전히 통과(symbol/registry가 order
+  placement/cancel/modify surface를 import 안 함).
+
+## 안전 경계
+
+* read-only. broker/order/watch/order-intent mutation 없음.
+* collector는 order mutation surface를 import/호출하지 않음 — 기존 import-guard 테스트 유지.
+* **신규 KIS HTTP surface 없음** — 기존 `inquire_orderbook(market=...)`의 파라미터만 사용.
+* **DB 마이그레이션 없음** — payload JSON 필드 + 요청 모델 필드(additive)만.
+* scheduler/Prefect 활성화 없음. `recommend_stocks` 무관.
+
+## 산출물 / 핸드오프
+
+* 독립 PR (base `origin/main` `861d149e`, worktree `auto_trader.rob-390`/branch `rob-390`).
+* 검증 명령/결과 → PR + ROB-394 handoff 코멘트.
+* 다음 순서 ROB-392로 인계.
+
+## 비목표 (Out of scope)
+
+* 새 `nxt_orderbook` snapshot kind (Option A 기각).
+* NXT 전용 지수 소스 도입 — index는 frozen 주석만, 데이터 교체 없음.
+* NXT 세션 시간대 판정 로직 — `market_session`은 요청이 명시(이 PR은 그것을 소비만).
+* MarketStage(Hermes 합성 측)의 index frozen 해석 로직 — 본 PR은 evidence/주석만 freeze하고 합성은 Hermes.

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2422,4 +2422,37 @@ async def test_snapshot_bundle_threads_market_session_into_collector_request():
     assert captured["market_session"] == "nxt"
 
 
+@pytest.mark.asyncio
+async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
+    import pandas as pd
+    from unittest.mock import MagicMock, AsyncMock
+
+    from app.services.action_report.snapshot_backed.collectors.registry import (
+        _KISDomesticQuoteOrderbookAdapter,
+    )
+
+    captured: dict = {}
+
+    kis_client = MagicMock()
+    kis_client.inquire_price = AsyncMock(
+        return_value=pd.DataFrame({"close": [70_000.0]})
+    )
+
+    async def _inquire_orderbook(code, market="J"):
+        captured["market"] = market
+        return {"askp1": "70100", "bidp1": "69900", "askp_rsqn1": "10", "bidp_rsqn1": "12"}
+
+    kis_client.inquire_orderbook = AsyncMock(side_effect=_inquire_orderbook)
+
+    adapter = _KISDomesticQuoteOrderbookAdapter(kis_client)
+    raw = await adapter.fetch_quote_orderbook("005930", venue="nxt")
+    assert captured["market"] == "NX"
+    assert raw["venue"] == "nxt"
+
+    raw_krx = await adapter.fetch_quote_orderbook("005930")  # default venue
+    assert captured["market"] == "J"
+    assert raw_krx["venue"] == "krx"
+
+
+
 

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1564,7 +1564,7 @@ def _stock_info_session(rows: list[Any]) -> MagicMock:
 def _fake_quote_client_ok() -> MagicMock:
     """Fake KIS quote/orderbook client returning a full top-of-book."""
 
-    async def fetch_quote(symbol: str) -> dict[str, Any]:
+    async def fetch_quote(symbol: str, venue: str = "krx") -> dict[str, Any]:
         return {
             "last_price": 70_000.0,
             "best_bid": 69_900.0,
@@ -1619,7 +1619,7 @@ async def test_symbol_collector_enriches_with_kis_quote_when_kis_live():
     assert payload["quote"]["nxt_eligible"] is True
     assert payload["quote"]["session"] == "regular"
     assert payload["quote"]["status"] == "ok"
-    quote_client.fetch_quote_orderbook.assert_awaited_once_with("005930")
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("005930", venue="krx")
 
 
 @pytest.mark.asyncio
@@ -1685,7 +1685,7 @@ async def test_symbol_collector_quote_exception_marks_unavailable():
     ]
     session = _stock_info_session(rows)
 
-    async def fetch(symbol: str):
+    async def fetch(symbol: str, venue: str = "krx"):
         if symbol == "005930":
             raise RuntimeError("session closed")
         return {
@@ -1729,7 +1729,7 @@ async def test_symbol_collector_quote_empty_book_marks_no_data_reason():
 
     session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
 
-    async def fetch(symbol: str):
+    async def fetch(symbol: str, venue: str = "krx"):
         return {
             "last_price": 0.0,
             "best_bid": 0.0,
@@ -1825,7 +1825,7 @@ def _upbit_universe_row(market: str = "KRW-BTC", korean_name: str = "비트코�
 def _fake_upbit_quote_client_ok() -> MagicMock:
     """Fake Upbit orderbook adapter returning a full top-of-book (no last_price)."""
 
-    async def fetch(symbol: str) -> dict[str, Any]:
+    async def fetch(symbol: str, venue: str = "upbit") -> dict[str, Any]:
         return {
             "last_price": None,
             "best_bid": 94_900_000.0,
@@ -1899,7 +1899,7 @@ async def test_symbol_collector_crypto_enriches_with_upbit_orderbook_no_user_id(
     assert q["spread_bps"] == pytest.approx(21.05, rel=0.05)
     assert q["venue"] == "upbit"
     assert q["last_price"] is None  # orderbook carries no last trade — honest
-    quote_client.fetch_quote_orderbook.assert_awaited_once_with("KRW-BTC")
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with("KRW-BTC", venue="upbit")
 
 
 @pytest.mark.asyncio
@@ -1941,7 +1941,7 @@ async def test_symbol_collector_crypto_orderbook_failure_is_fail_open():
         ]
     )
 
-    async def fetch(symbol: str):
+    async def fetch(symbol: str, venue: str = "upbit"):
         if symbol == "KRW-BTC":
             raise RuntimeError("upbit timeout")
         return {
@@ -2452,6 +2452,47 @@ async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
     raw_krx = await adapter.fetch_quote_orderbook("005930")  # default venue
     assert captured["market"] == "J"
     assert raw_krx["venue"] == "krx"
+
+
+@pytest.mark.asyncio
+async def test_symbol_collector_switches_to_nxt_venue_when_nxt_session():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    session = _stock_info_session([_stock_info_row("005930", "삼성전자")])
+
+    captured: dict = {}
+
+    async def fetch_quote(symbol: str, venue: str = "krx") -> dict[str, Any]:
+        captured["venue"] = venue
+        return {
+            "last_price": 70_000.0,
+            "best_bid": 69_900.0,
+            "best_ask": 70_100.0,
+            "bid_depth": 100.0,
+            "ask_depth": 120.0,
+            "venue": venue,
+            "as_of": "2026-06-01T08:30:00+09:00",
+            "session": "nxt",
+            "nxt_eligible": True,
+        }
+
+    quote_client = MagicMock()
+    quote_client.fetch_quote_orderbook = AsyncMock(side_effect=fetch_quote)
+    collector = SymbolSnapshotCollector(session, kis_quote_client=quote_client)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        symbols=["005930"],
+        policy_snapshot={},
+        user_id=42,
+        market_session="nxt",
+    )
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert captured["venue"] == "nxt"
+    assert payload["quote"]["venue"] == "nxt"
+    assert payload["quote"]["session"] == "nxt"
+
 
 
 

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2365,3 +2365,61 @@ def test_ensure_bundle_request_carries_market_session_default_none():
     assert req.market_session is None
 
 
+@pytest.mark.asyncio
+async def test_snapshot_bundle_threads_market_session_into_collector_request():
+    import datetime as dt
+    import types
+
+    from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+    from app.services.action_report.common.snapshot_bundle import (
+        SnapshotBundleEnsureService,
+    )
+    from app.services.investment_snapshots.collectors import (
+        CollectorRequest,
+        SnapshotCollectResult,
+    )
+
+    captured: dict = {}
+
+    class _CapturingCollector:
+        snapshot_kind = "market"
+
+        async def collect(self, request: CollectorRequest):
+            captured["market_session"] = request.market_session
+            return [
+                SnapshotCollectResult(
+                    snapshot_kind="market",
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={"ok": True},
+                    origin="auto_trader_db",
+                    as_of=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+                    freshness_status="fresh",
+                    coverage={},
+                )
+            ]
+
+    service = SnapshotBundleEnsureService.__new__(SnapshotBundleEnsureService)
+    service._collectors = {"market": _CapturingCollector()}
+
+    kind_policy = types.SimpleNamespace(
+        snapshot_kind="market",
+        collector_timeout=dt.timedelta(seconds=5),
+    )
+
+    results, warnings, attempted = await service._collect_for_kind(
+        kind_policy=kind_policy,
+        request=EnsureBundleRequest(
+            market="kr",
+            account_scope="kis_live",
+            market_session="nxt",
+            purpose="testing",
+            policy_version="v1",
+        ),
+        policy_snapshot={},
+    )
+    assert attempted is True
+    assert captured["market_session"] == "nxt"
+
+
+

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2494,6 +2494,40 @@ async def test_symbol_collector_switches_to_nxt_venue_when_nxt_session():
     assert payload["quote"]["session"] == "nxt"
 
 
+@pytest.mark.asyncio
+async def test_market_collector_kr_nxt_marks_index_frozen():
+    async def fake_index_fn(symbols):
+        return [
+            {"symbol": "KOSPI", "name": "코스피", "current": 2700.0, "change_pct": 0.0},
+        ]
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(), query_service=_empty_events_query(), index_quote_fn=fake_index_fn
+    )
+    req = _request(market="kr")
+    req = req.model_copy(update={"market_session": "nxt"})
+    results = await collector.collect(req)
+    payload = results[0].payload_json
+    assert payload["index_session"] == "regular_closed"
+    assert "frozen" in payload["index_session_note"]
+
+
+@pytest.mark.asyncio
+async def test_market_collector_kr_regular_session_has_no_frozen_note():
+    async def fake_index_fn(symbols):
+        return [
+            {"symbol": "KOSPI", "name": "코스피", "current": 2700.0, "change_pct": 0.5},
+        ]
+
+    collector = MarketEventsSnapshotCollector(
+        MagicMock(), query_service=_empty_events_query(), index_quote_fn=fake_index_fn
+    )
+    results = await collector.collect(_request(market="kr"))
+    payload = results[0].payload_json
+    assert "index_session" not in payload
+
+
+
 
 
 

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -1899,7 +1899,9 @@ async def test_symbol_collector_crypto_enriches_with_upbit_orderbook_no_user_id(
     assert q["spread_bps"] == pytest.approx(21.05, rel=0.05)
     assert q["venue"] == "upbit"
     assert q["last_price"] is None  # orderbook carries no last trade — honest
-    quote_client.fetch_quote_orderbook.assert_awaited_once_with("KRW-BTC", venue="upbit")
+    quote_client.fetch_quote_orderbook.assert_awaited_once_with(
+        "KRW-BTC", venue="upbit"
+    )
 
 
 @pytest.mark.asyncio
@@ -2375,7 +2377,6 @@ async def test_snapshot_bundle_threads_market_session_into_collector_request():
         SnapshotBundleEnsureService,
     )
     from app.services.investment_snapshots.collectors import (
-        CollectorRequest,
         SnapshotCollectResult,
     )
 
@@ -2424,8 +2425,9 @@ async def test_snapshot_bundle_threads_market_session_into_collector_request():
 
 @pytest.mark.asyncio
 async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
+    from unittest.mock import AsyncMock, MagicMock
+
     import pandas as pd
-    from unittest.mock import MagicMock, AsyncMock
 
     from app.services.action_report.snapshot_backed.collectors.registry import (
         _KISDomesticQuoteOrderbookAdapter,
@@ -2440,7 +2442,12 @@ async def test_kis_adapter_maps_nxt_venue_to_market_code_nx():
 
     async def _inquire_orderbook(code, market="J"):
         captured["market"] = market
-        return {"askp1": "70100", "bidp1": "69900", "askp_rsqn1": "10", "bidp_rsqn1": "12"}
+        return {
+            "askp1": "70100",
+            "bidp1": "69900",
+            "askp_rsqn1": "10",
+            "bidp_rsqn1": "12",
+        }
 
     kis_client.inquire_orderbook = AsyncMock(side_effect=_inquire_orderbook)
 
@@ -2525,9 +2532,3 @@ async def test_market_collector_kr_regular_session_has_no_frozen_note():
     results = await collector.collect(_request(market="kr"))
     payload = results[0].payload_json
     assert "index_session" not in payload
-
-
-
-
-
-

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2337,3 +2337,31 @@ def test_collector_modules_do_not_import_broker_or_activation_paths():
                 f"{name} unexpectedly references {forbidden!r} — "
                 "collectors must remain read-only"
             )
+
+
+def test_collector_request_carries_market_session_default_none():
+    from app.services.investment_snapshots.collectors import CollectorRequest
+
+    req = CollectorRequest(market="kr", account_scope="kis_live", policy_snapshot={})
+    assert req.market_session is None
+    req2 = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        policy_snapshot={},
+        market_session="nxt",
+    )
+    assert req2.market_session == "nxt"
+
+
+def test_ensure_bundle_request_carries_market_session_default_none():
+    from app.schemas.investment_snapshots_mcp import EnsureBundleRequest
+
+    req = EnsureBundleRequest(
+        market="kr",
+        account_scope="kis_live",
+        purpose="testing",
+        policy_version="v1",
+    )
+    assert req.market_session is None
+
+


### PR DESCRIPTION
## 요약
ROB-390: `market_session="nxt"` 리포트 번들에 NXT live orderbook evidence를 freeze (Option B — 새 snapshot kind 없이 기존 symbol quote enrichment의 venue 전환).

1. `market_session`을 `EnsureBundleRequest`→`CollectorRequest`로 threading (additive, None 기본).
2. symbol collector: `market_session="nxt"` & kr/kis_live → enrichment venue를 `nxt`로 전환.
3. KIS 어댑터: venue→KIS market code 매핑(`krx=J`, `nxt=NX`) 후 기존 `inquire_orderbook(market=...)` 호출 (신규 HTTP surface 없음). quote payload의 venue/session/spread/depth/as_of가 NXT 기준으로 freeze.
4. market collector: kr + nxt 세션 → indices payload에 `index_session="regular_closed"` + frozen note (KRX 정규장 미개장 `+0.00%` 방향 오독 방지).

## 테스트
- `tests/services/action_report/snapshot_backed/test_collectors.py` — market_session threading / KIS venue→NX / symbol nxt 전환 / market index frozen + 기존 fake·assert 갱신
- mutation/import-guard 회귀(ROB-278) 유지

## 안전 경계
read-only. broker/order/watch mutation 없음. 신규 KIS HTTP surface 없음(기존 inquire_orderbook market 파라미터만). DB 마이그레이션 없음(payload + 요청 모델 additive 필드만). scheduler 활성화 없음.

## 잔여 (handoff)
- index는 frozen 주석만 첨부(데이터 교체 없음). MarketStage의 frozen 해석/합성은 Hermes 측. NXT 전용 지수 소스 도입은 비목표.

🤖 Generated with Antigravity