### PR TITLE
fix(ROB-392) Slice A: portfolio NAV scope 라벨 + KR code-as-name 매핑

### DIFF
--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -65,6 +65,7 @@ from app.services.investment_snapshots.collectors import (
     CollectorRequest,
     SnapshotCollectResult,
 )
+from app.services.kr_symbol_universe_service import get_kr_names_by_symbols
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +167,24 @@ def _reader_holding_to_dict(h: Holding) -> dict[str, Any]:
         "pending_sell_quantity": h.pendingSellQuantity,
         "source": h.source,
     }
+
+
+def _apply_kr_name_fallback(
+    rows: list[dict[str, Any]], name_map: dict[str, str]
+) -> None:
+    """Fill ``display_name`` for rows whose name is missing or equals the code.
+
+    In-place. A row is fixed only when ``name_map`` has a real name for its
+    ``ticker``; otherwise the code is kept (never fabricate a name).
+    """
+    for row in rows:
+        ticker = row.get("ticker")
+        if not isinstance(ticker, str):
+            continue
+        current = row.get("display_name")
+        is_code_as_name = not current or current == ticker
+        if is_code_as_name and ticker in name_map:
+            row["display_name"] = name_map[ticker]
 
 
 class PortfolioSnapshotCollector:
@@ -416,6 +435,30 @@ class PortfolioSnapshotCollector:
             primary_source = "kis"
             holdings_out = kis_holdings_dicts
             freshness = "fresh" if kis_fetch_status == "ok" else "partial"
+
+        # ROB-392 — resolve KR rows whose ``display_name`` is missing or equals
+        # the code (e.g. "035420") to the universe name. Best-effort: a lookup
+        # failure keeps the code (never fabricate a name). In-place on the dicts
+        # shared by ``holdings_out`` / ``reference_holdings`` → reflected below.
+        if request.market == "kr":
+            name_rows = [*holdings_out, *reference_holdings]
+            need = sorted(
+                {
+                    r["ticker"]
+                    for r in name_rows
+                    if isinstance(r.get("ticker"), str)
+                    and (
+                        not r.get("display_name")
+                        or r.get("display_name") == r["ticker"]
+                    )
+                }
+            )
+            if need:
+                try:
+                    name_map = await get_kr_names_by_symbols(need, db=self._session)
+                except Exception:  # noqa: BLE001 — name fallback is best-effort
+                    name_map = {}
+                _apply_kr_name_fallback(name_rows, name_map)
 
         payload = {
             "holdings": holdings_out,

--- a/app/services/action_report/snapshot_backed/collectors/portfolio.py
+++ b/app/services/action_report/snapshot_backed/collectors/portfolio.py
@@ -435,6 +435,16 @@ class PortfolioSnapshotCollector:
             },
         }
 
+        # ROB-392 — label the NAV scope so the report makes explicit that the
+        # number is KIS-primary (sellable) holdings + cash, with ISA/Toss
+        # reference rows excluded (ROB-297). KR-only wording; numbers unchanged.
+        if request.market == "kr":
+            payload["nav_scope"] = "kis_primary_sellable"
+            payload["nav_scope_label"] = (
+                "NAV는 KIS 실거래(매도가능) 보유 + 현금 기준 · "
+                "ISA/Toss 참조분(reference_holdings)은 제외"
+            )
+
         coverage = {
             "holdings_count": len(holdings_out),
             "reference_count": len(reference_holdings),

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -136,6 +136,11 @@ class PortfolioJournalStage:
 
         missing_data = [] if journal_snaps else ["journal"]
         key_points = [e.get("thesis", "") for e in entries[:5] if e.get("thesis")]
+        # ROB-392 — surface the NAV scope label (byte-identical summary stays
+        # unchanged; the label rides only in key_points).
+        nav_scope_label = payload.get("nav_scope_label")
+        if isinstance(nav_scope_label, str) and nav_scope_label:
+            key_points = [nav_scope_label, *key_points]
 
         if currency == "krw":
             # Byte-identical legacy KR contract: buying power is always a float

--- a/docs/superpowers/plans/2026-06-01-rob-392-sliceA-portfolio-scope-name.md
+++ b/docs/superpowers/plans/2026-06-01-rob-392-sliceA-portfolio-scope-name.md
@@ -1,0 +1,347 @@
+# ROB-392 Slice A — portfolio NAV scope 라벨 + code-as-name 매핑 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** portfolio NAV의 scope를 명시 라벨링하고(수치 불변), KR holdings/reference 행의 code-as-name(예: 035420)을 universe 이름으로 폴백 해석한다.
+
+**Architecture:** portfolio collector payload에 `nav_scope`/`nav_scope_label`(additive) 추가 → portfolio_journal stage가 byte-identical summary는 그대로 두고 key_points에 라벨 surface. 이름은 `display_name`이 falsy/코드와 동일한 KR 행에 한해 `get_kr_names_by_symbols`(DB universe)로 폴백 해석(실패 시 코드 유지). read-only, 신규 HTTP surface 없음.
+
+**Tech Stack:** Python 3.13, pytest (`uv run pytest`), 기존 `snapshot_backed/collectors/portfolio.py` + `investment_stages/stages/portfolio_journal.py` + `kr_symbol_universe_service`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-rob-392-sliceA-portfolio-scope-name-design.md`
+
+---
+
+## File Structure
+
+- **Modify** `app/services/action_report/snapshot_backed/collectors/portfolio.py` — KIS-live payload에 `nav_scope`/`nav_scope_label`; KR 이름 폴백 헬퍼 + 호출.
+- **Modify** `app/services/investment_stages/stages/portfolio_journal.py` — `nav_scope_label`을 key_points에 surface.
+- **Test** `tests/services/action_report/snapshot_backed/test_collectors.py` — NAV scope 라벨 + 이름 폴백 헬퍼.
+- **Test** `tests/services/investment_stages/stages/test_portfolio_journal.py` — key_points scope 라벨 surface.
+
+> 실행 시 모든 명령은 worktree `/Users/mgh3326/work/auto_trader.rob-392`에서 `uv run` 으로 수행.
+> `get_kr_names_by_symbols(symbols: list[str], db: AsyncSession | None = None) -> dict[str, str]`
+> (`app/services/kr_symbol_universe_service.py:484`) — 누락/비활성 심볼은 결과에서 생략.
+
+---
+
+## Task 1: portfolio NAV scope 라벨 (증상4)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/portfolio.py` (KIS-live payload, 라인 ~420-436)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가. 기존 KIS-live 성공 테스트가 어떻게 collector를 구성하는지(`test_portfolio_v2_kr_kis_live_success_populates_kis_primary`, 라인 ~266)를 참고해 동일 픽스처를 재사용한다:
+
+```python
+@pytest.mark.asyncio
+async def test_kr_kis_live_payload_carries_nav_scope_label():
+    # Reuse the same fixture wiring as
+    # test_portfolio_v2_kr_kis_live_success_populates_kis_primary.
+    payload = await _run_kr_kis_live_portfolio_collect()  # helper from that test
+    assert payload["primary_source"] == "kis"
+    assert payload["nav_scope"] == "kis_primary_sellable"
+    assert "ISA/Toss" in payload["nav_scope_label"]
+    # 수치 회귀: holdings/count는 라벨 추가와 무관하게 유지.
+    assert payload["count"] == len(payload["holdings"])
+```
+
+> 만약 `_run_kr_kis_live_portfolio_collect` 같은 공유 헬퍼가 없으면, `test_portfolio_v2_kr_kis_live_success_populates_kis_primary`(라인 ~266)의 collector 구성·`collect()` 호출을 그대로 복사해 `payload = results[0].payload_json`을 얻은 뒤 위 단언만 적용한다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k nav_scope_label -v`
+Expected: FAIL — `payload["nav_scope"]` KeyError.
+
+- [ ] **Step 3: Add nav_scope fields to the KIS-live payload**
+
+`app/services/action_report/snapshot_backed/collectors/portfolio.py`, KIS-live `payload = {...}`(라인 ~420)에 `sellable_summary` 뒤·`provenance` 앞에 두 키 추가:
+
+```python
+            "sellable_summary": sellable_summary,
+            "nav_scope": "kis_primary_sellable",
+            "nav_scope_label": (
+                "NAV는 KIS 실거래(매도가능) 보유 + 현금 기준 · "
+                "ISA/Toss 참조분(reference_holdings)은 제외"
+            ),
+            "provenance": {
+```
+
+> 이 두 키는 KIS-live KR 경로 payload에만 추가한다(수치 로직·다른 경로 불변).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k nav_scope_label -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/portfolio.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-392): label portfolio NAV scope (kis_primary_sellable)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: portfolio_journal stage가 nav_scope_label을 key_points에 surface
+
+**Files:**
+- Modify: `app/services/investment_stages/stages/portfolio_journal.py` (`run`, 라인 ~138 `key_points` 직후)
+- Test: `tests/services/investment_stages/stages/test_portfolio_journal.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/investment_stages/stages/test_portfolio_journal.py` 끝에 추가. 기존 KR 성공 테스트의 portfolio payload 픽스처를 참고해 `nav_scope_label`을 넣고 key_points에 노출되는지 확인:
+
+```python
+@pytest.mark.asyncio
+async def test_portfolio_journal_surfaces_nav_scope_label_in_key_points():
+    # 기존 KR 케이스와 동일하게 StageContext를 구성하되 portfolio payload에
+    # nav_scope_label을 추가한다(아래는 그 핵심만; 기존 헬퍼/픽스처 재사용).
+    label = "NAV는 KIS 실거래(매도가능) 보유 + 현금 기준 · ISA/Toss 참조분(reference_holdings)은 제외"
+    context = _kr_context_with_portfolio_payload(
+        {
+            "holdings": [{"ticker": "005930", "value_krw": 1_000_000}],
+            "cash": {"krw": 500_000},
+            "buying_power": {"krw": 500_000},
+            "nav_scope_label": label,
+        }
+    )
+    artifact = await PortfolioJournalStage().run(context)
+    assert label in artifact.key_points
+```
+
+> `_kr_context_with_portfolio_payload` / `PortfolioJournalStage` 임포트·StageContext 구성은 이 테스트 파일의 기존 KR 테스트(예: NAV/summary를 검증하는 케이스)의 픽스처를 그대로 재사용한다. 핵심 단언은 `label in artifact.key_points` 하나다.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -k surfaces_nav_scope_label -v`
+Expected: FAIL — label이 key_points에 없음.
+
+- [ ] **Step 3: Surface the label in key_points (summary는 불변)**
+
+`app/services/investment_stages/stages/portfolio_journal.py`, `run`의 `key_points = [...]`(라인 ~138) 직후에 추가:
+
+```python
+        key_points = [e.get("thesis", "") for e in entries[:5] if e.get("thesis")]
+        nav_scope_label = payload.get("nav_scope_label")
+        if isinstance(nav_scope_label, str) and nav_scope_label:
+            key_points = [nav_scope_label, *key_points]
+```
+
+> byte-identical KR `summary` 문자열은 변경하지 않는다(라벨은 key_points로만 노출).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -k surfaces_nav_scope_label -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full portfolio_journal suite (byte-identical summary 회귀)**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+Expected: 모두 PASS (summary contract 무손상).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/investment_stages/stages/portfolio_journal.py tests/services/investment_stages/stages/test_portfolio_journal.py
+git commit -m "feat(ROB-392): surface NAV scope label in portfolio_journal key_points
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: KR code-as-name 폴백 (증상5)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/portfolio.py` (모듈 헬퍼 `_apply_kr_name_fallback` + KR 경로 호출)
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+- [ ] **Step 1: Write the failing test (pure helper)**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py` 끝에 추가:
+
+```python
+def test_apply_kr_name_fallback_fills_code_as_name_rows():
+    from app.services.action_report.snapshot_backed.collectors.portfolio import (
+        _apply_kr_name_fallback,
+    )
+
+    rows = [
+        {"ticker": "035420", "display_name": None},      # missing
+        {"ticker": "035720", "display_name": "035720"},  # code-as-name
+        {"ticker": "005930", "display_name": "삼성전자"},  # already good
+    ]
+    _apply_kr_name_fallback(rows, {"035420": "NAVER", "035720": "카카오"})
+    assert rows[0]["display_name"] == "NAVER"
+    assert rows[1]["display_name"] == "카카오"
+    assert rows[2]["display_name"] == "삼성전자"  # untouched
+
+
+def test_apply_kr_name_fallback_keeps_code_when_unresolved():
+    from app.services.action_report.snapshot_backed.collectors.portfolio import (
+        _apply_kr_name_fallback,
+    )
+
+    rows = [{"ticker": "999999", "display_name": None}]
+    _apply_kr_name_fallback(rows, {})  # lookup returned nothing
+    assert rows[0]["display_name"] is None  # no fabricated name
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k apply_kr_name_fallback -v`
+Expected: FAIL — `ImportError: cannot import name '_apply_kr_name_fallback'`.
+
+- [ ] **Step 3: Add the pure helper**
+
+`app/services/action_report/snapshot_backed/collectors/portfolio.py`, 모듈 레벨(다른 `_*_to_dict` 헬퍼 근처)에 추가:
+
+```python
+def _apply_kr_name_fallback(
+    rows: list[dict[str, Any]], name_map: dict[str, str]
+) -> None:
+    """Fill ``display_name`` for rows whose name is missing or equals the code.
+
+    In-place. A row is fixed only when ``name_map`` has a real name for its
+    ``ticker``; otherwise the code is kept (never fabricate a name).
+    """
+    for row in rows:
+        ticker = row.get("ticker")
+        if not isinstance(ticker, str):
+            continue
+        current = row.get("display_name")
+        is_code_as_name = not current or current == ticker
+        if is_code_as_name and ticker in name_map:
+            row["display_name"] = name_map[ticker]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k apply_kr_name_fallback -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Wire the fallback into the KR collect path**
+
+`app/services/action_report/snapshot_backed/collectors/portfolio.py` 상단 import에 추가:
+
+```python
+from app.services.kr_symbol_universe_service import get_kr_names_by_symbols
+```
+
+KIS-live `payload = {...}` 구성 **직전**(라인 ~420, `holdings_out`/`reference_holdings`가 확정된 지점), KR 시장일 때만 이름 폴백을 적용:
+
+```python
+        if request.market == "kr":
+            name_rows = [*holdings_out, *reference_holdings]
+            need = sorted(
+                {
+                    r["ticker"]
+                    for r in name_rows
+                    if isinstance(r.get("ticker"), str)
+                    and (not r.get("display_name") or r.get("display_name") == r["ticker"])
+                }
+            )
+            if need:
+                try:
+                    name_map = await get_kr_names_by_symbols(need, db=self._session)
+                except Exception:  # noqa: BLE001 — name fallback is best-effort
+                    name_map = {}
+                _apply_kr_name_fallback(name_rows, name_map)
+```
+
+> `self._session`은 collector가 이미 보유. lookup 실패는 fail-open(코드 유지). `holdings_out`/`reference_holdings`의 dict는 참조로 공유되므로 in-place 수정이 payload에 반영된다.
+
+- [ ] **Step 6: Run the portfolio collector suite for regressions**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k "portfolio or apply_kr_name or nav_scope" -v`
+Expected: 모두 PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/portfolio.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-392): fallback-resolve KR code-as-name portfolio rows
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 전체 검증 + lint + PR + 핸드오프
+
+**Files:** 없음 (검증 전용)
+
+- [ ] **Step 1: Run the touched suites**
+
+Run:
+```bash
+uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py tests/services/investment_stages/stages/test_portfolio_journal.py -v
+```
+Expected: 모두 PASS (신규 + 기존 회귀 없음, 특히 byte-identical KR summary).
+
+- [ ] **Step 2: Lint (CLAUDE.md 게이트)**
+
+Run:
+```bash
+uv run ruff check app/ tests/
+uv run ruff format --check app/ tests/
+```
+Expected: 둘 다 통과. (format 위반이면 `uv run ruff format app/ tests/` 후 재확인·커밋 — `ruff check`만으로는 lint job이 떨어진다.)
+
+- [ ] **Step 3: Push branch and open PR (base: main)**
+
+Run:
+```bash
+git push -u origin rob-392
+gh pr create --base main --title "fix(ROB-392) Slice A: portfolio NAV scope 라벨 + KR code-as-name 매핑" --body "$(cat <<'EOF'
+## 요약
+ROB-392 **Slice A** (증상4 + 증상5만; 증상1/2는 별도 이슈, 증상3은 by-design Hermes).
+
+1. **NAV scope 라벨 (증상4)** — portfolio collector payload에 `nav_scope="kis_primary_sellable"` + `nav_scope_label`(ISA/Toss 참조분 제외 명시) 추가. portfolio_journal stage가 byte-identical summary는 그대로 두고 key_points에 라벨 surface. **수치 로직 불변** — NAV는 여전히 KIS primary holdings + cash(reference 미합산, ROB-297 유지).
+2. **KR code-as-name 매핑 (증상5)** — holdings/reference 행의 `display_name`이 null이거나 코드와 같으면 `get_kr_names_by_symbols`(DB universe)로 폴백 해석. 해석 실패 시 코드 유지(거짓 이름 금지).
+
+## 증상1 전제 정정 (integrity)
+증상1은 "symbol 스냅샷에 KIS RSI/컨센서스/레벨이 있는데 stage가 평탄화"라고 했으나, 실측 결과 `SymbolSnapshotCollector`는 그 evidence를 **전혀 담지 않음**(quote만; evidence는 `analyze_stock_batch` 생성, 미캡처). "승격"이 아니라 "캡처"가 필요한 큰 작업 → **별도 이슈로 분리**.
+
+## 테스트
+- `tests/services/action_report/snapshot_backed/test_collectors.py` — NAV scope 라벨 + 이름 폴백 헬퍼(해석 성공/실패)
+- `tests/services/investment_stages/stages/test_portfolio_journal.py` — key_points scope 라벨 surface (summary 회귀 무손상)
+
+## 안전 경계
+read-only. broker/order/watch mutation 없음. 신규 HTTP surface 없음(DB universe lookup). NAV 수치/merge 로직 불변. DB 마이그레이션 없음(payload additive). deterministic이 LLM 합성 대체 안 함(라벨/이름만).
+
+## 잔여 (handoff)
+- 증상1/2 (KIS RSI/consensus/level을 symbol evidence로 캡처) = 별도 큰 이슈 (collector enrichment + 신규 HTTP surface 검토).
+- 증상3 (news 합성) = by-design Hermes compose.
+- US/crypto 이름 폴백, symbol stage key_points 코드 노출(universe-sync 갭) = 비목표.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+Expected: PR URL 출력. (출력된 URL 확인 후에만 PR 번호 인용.)
+
+- [ ] **Step 4: ROB-394 handoff 코멘트 + 증상1/2 별도 이슈 메모**
+
+ROB-394에 ROB-392 Slice A 결과(PR 링크 + 검증 + 증상1 전제 정정 + 증상1/2 별도 이슈 필요)를 남기고, 다음 순서가 ROB-391임을 명시한다. (Linear `save_comment`.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 변경1 NAV scope 라벨 → Task 1(payload) + Task 2(stage surface). ✅
+- 변경2 code-as-name 폴백 → Task 3(helper + wiring). ✅
+- 테스트 T1/T2/T3/T4 → Task1/Task2/Task3(2건). ✅
+- 안전 경계(read-only, no HTTP, NAV 불변, no migration) → payload/stage additive, 수치 미변경. ✅
+- 비목표(증상1/2/3, US/crypto 이름, symbol stage) → 미구현, Task4 handoff 명시. ✅
+
+**Placeholder scan:** 코드 step은 실제 코드 포함. Task1/2 Step1은 기존 픽스처 재사용을 명시하되 핵심 단언은 구체적(픽스처 헬퍼명은 파일 기존 테스트에서 확정). ✅
+
+**Type consistency:** `_apply_kr_name_fallback(rows: list[dict], name_map: dict[str,str]) -> None`(Task3 정의 ↔ 호출 ↔ T3/T4); payload 키 `nav_scope`/`nav_scope_label`(Task1 정의 ↔ T1 ↔ Task2 소비 ↔ T2); `get_kr_names_by_symbols(need, db=self._session)`(시그니처 `(symbols, db=None)`와 일치). ✅

--- a/docs/superpowers/specs/2026-06-01-rob-392-sliceA-portfolio-scope-name-design.md
+++ b/docs/superpowers/specs/2026-06-01-rob-392-sliceA-portfolio-scope-name-design.md
@@ -1,0 +1,114 @@
+# ROB-392 Slice A — portfolio NAV scope 라벨 + code-as-name 매핑 설계
+
+- **이슈:** ROB-392 (오케스트레이션 ROB-394의 4번) — **Slice A만**
+- **날짜:** 2026-06-01
+- **상태:** 설계 승인됨 → 구현 계획 대상
+- **base:** `origin/main` `dcac00ef` (ROB-390 머지 직후)
+
+## 목표
+
+"invest_report 결과 = 운영자가 MCP로 직접 분석한 결과" 목표에서, 번들이 이미 정확히 담은 portfolio 수치가
+**scope 라벨 부재**로 더 넓은 `get_holdings` total과 혼동되고, 일부 종목이 **코드=이름**으로 노출되는 두
+정합성 결함을 좁게 고친다. read-only, 신규 HTTP surface 없음, 수치 로직 불변.
+
+## 범위 결정 (분해)
+
+ROB-392는 5개 증상의 멀티파트 이슈다. 본 PR은 **Slice A = 증상4 + 증상5**만 다룬다.
+
+* **증상4 (portfolio NAV scope 불일치)** — IN. 라벨/metadata 정리.
+* **증상5 (종목명=코드)** — IN. 이름 매핑 보정.
+* **증상1/2 (KIS RSI/consensus/level을 symbol evidence로)** — OUT → **별도 이슈**. (아래 "증상1 전제
+  정정" 참고: 큰 작업.)
+* **증상3 (news pos/neg 합성)** — OUT. 이슈가 명시한 대로 by-design Hermes(out-of-process LLM) 담당.
+
+### 증상1 전제 정정 (integrity)
+
+증상1은 "012450 symbol **스냅샷에** KIS RSI 33.2·컨센서스·레벨이 **있는데** stage가 평탄화"라고 기술하나,
+실측 결과 **`SymbolSnapshotCollector`는 RSI/consensus/support/resistance/upside를 전혀 담지 않는다**
+(`quote`=bid/ask/spread/depth/venue만). 그 KIS evidence는 별도 MCP tool `analyze_stock_batch`가 생성하며
+symbol 스냅샷으로 캡처되지 않는다. 따라서 "이미 있는 evidence를 승격"이 아니라 "evidence를 먼저 캡처"가
+필요하며(collector enrichment + 신규 HTTP surface 가능성 + 안전 검토), 이는 Slice A 밖의 큰 작업이다.
+ROB-389 candidate_universe와 동일한 "증상 전제 부정확" 패턴. → 별도 이슈로 분리하고 ROB-392/394에 기록.
+
+## 코드 현황 (근거)
+
+* `app/services/investment_stages/stages/portfolio_journal.py:43` `_krw_totals` —
+  NAV = `sum(holdings[].value_krw) + cash.krw`. **`holdings`(KIS primary/매도가능)만 포함**,
+  `reference_holdings`(ISA/Toss)는 NAV에서 제외(ROB-297 "no sellable merge"와 일치). 즉 NAV=30.9M은
+  정확하나 scope 라벨이 없어 `get_holdings(kr)` total=51.5M(ISA+Toss 31종목)과 혼동된다.
+* `app/services/action_report/snapshot_backed/collectors/portfolio.py` —
+  `holdings`(KIS primary) / `reference_holdings`(manual·Toss) 분리, payload에 `count`/`reference_count`/
+  `provenance.account_scope` 존재. 행 dict는 `display_name`을 담음(`_manual_row_to_dict`:row.display_name,
+  `_reader_holding_to_dict`:h.displayName). display_name이 null이거나 ticker와 같으면 코드=이름 노출.
+* `app/services/kr_symbol_universe_service.py:484` `get_kr_names_by_symbols(db, symbols)` — 심볼→이름 배치
+  조회(DB universe). 이름 폴백의 정규 헬퍼. (신규 HTTP 없음.)
+
+## 설계
+
+### 변경 1 — portfolio NAV scope 라벨 (증상4)
+
+수치 로직은 **전혀 건드리지 않는다**. portfolio collector payload(live KIS-primary 경로)에 scope metadata만
+추가:
+
+```python
+"nav_scope": "kis_primary_sellable",
+"nav_scope_label": (
+    "NAV는 KIS 실거래(매도가능) 보유 + 현금 기준 · "
+    "ISA/Toss 참조분(reference_holdings)은 제외"
+),
+```
+
+`portfolio_journal` stage가 NAV를 surface할 때 이 라벨을 key_point(또는 summary 접미)로 함께 노출해,
+운영자가 `get_holdings` total과의 차이를 scope 차이로 이해하게 한다. `reference_count`가 >0이면 "참조분 N건
+별도"를 덧붙인다.
+
+> crypto(upbit_live)/US 경로는 동일 라벨 키를 추가하되 라벨 문구는 시장에 맞게(또는 KR 전용으로 한정).
+> 1차 구현은 **KR kis_live 경로에 집중**하고, 타 시장은 키 부재 시 stage가 라벨 없이 기존대로 동작(안전).
+
+### 변경 2 — code-as-name 매핑 (증상5)
+
+portfolio collector에서 행 dict(holdings + reference_holdings)를 만든 뒤, `display_name`이 falsy이거나
+ticker와 동일한 행들을 모아 `get_kr_names_by_symbols(session, symbols)`로 이름을 폴백 해석하여 `display_name`을
+채운다.
+
+* 해석된 이름이 있으면 채우고, 없으면 **코드 유지**(거짓 이름 금지).
+* KR 시장에 한정(`get_kr_names_by_symbols`는 KR universe). US/crypto는 이번 범위 밖.
+* 신규 HTTP 없음(DB universe 조회). collector는 이미 `self._session`을 보유.
+
+> symbol stage key_points의 코드 노출은 symbol 스냅샷 `name`(stock_info 유래) 부재 시 발생 →
+> universe-sync 데이터 갭이므로 본 Slice 밖(비목표).
+
+## 테스트 (fake/unit, read-only)
+
+* **T1 (NAV scope 라벨):** KIS-live portfolio collect payload에 `nav_scope=="kis_primary_sellable"` +
+  `nav_scope_label`(문자열) 존재. holdings/cash 수치는 라벨 추가 전후 동일(회귀).
+* **T2 (portfolio_journal surface):** NAV가 있는 payload에 scope 라벨이 들어오면 stage의 key_points/summary에
+  scope 문구가 노출된다(fake payload).
+* **T3 (name 폴백 - 해석 성공):** reference 행 `display_name=None`(또는 ticker와 동일) + fake
+  `get_kr_names_by_symbols`가 `{"035420": "NAVER"}` 반환 → 행 `display_name=="NAVER"`.
+* **T4 (name 폴백 - 해석 실패):** lookup이 빈 dict 반환 → 행 `display_name`은 코드 유지(거짓 이름 없음).
+
+## 안전 경계
+
+* read-only. broker/order/watch/order-intent mutation 없음.
+* **신규 HTTP surface 없음** — DB universe lookup(`get_kr_names_by_symbols`)만.
+* **NAV 수치/merge 로직 불변** — 라벨/metadata만 추가. reference는 여전히 NAV에 미합산(ROB-297 유지).
+* **DB 마이그레이션 없음** — payload additive 필드만.
+* deterministic stage가 LLM 합성을 대체하지 않음 — 라벨/이름 보정만, 방향 판정(bull/bear) 생성 없음.
+* `recommend_stocks` 무관.
+
+## 산출물 / 핸드오프
+
+* 독립 PR (base `origin/main` `dcac00ef`, worktree `auto_trader.rob-392`/branch `rob-392`).
+* 검증 명령/결과 → PR + ROB-394 handoff 코멘트.
+* **증상1/2(KIS evidence 캡처)는 별도 이슈로 분리** + 증상1 전제 부정확을 ROB-392/394에 명시.
+* 다음 순서 ROB-391로 인계.
+
+## 비목표 (Out of scope)
+
+* 증상1/2 — symbol collector에 KIS RSI/consensus/support/resistance/upside 캡처 (별도 큰 이슈, 신규 HTTP
+  surface 검토 필요).
+* 증상3 — news 테마/감성 합성 (by-design Hermes compose).
+* symbol stage key_points의 코드 노출 (universe-sync 데이터 갭).
+* NAV 계산/merge 로직 변경 (수치 불변).
+* US/crypto 이름 폴백 (KR 한정).

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2551,3 +2551,29 @@ async def test_kr_kis_live_payload_carries_nav_scope_label():
     assert "ISA/Toss" in payload["nav_scope_label"]
     # 수치 회귀: holdings/count는 라벨 추가와 무관하게 유지.
     assert payload["count"] == len(payload["holdings"])
+
+
+def test_apply_kr_name_fallback_fills_code_as_name_rows():
+    from app.services.action_report.snapshot_backed.collectors.portfolio import (
+        _apply_kr_name_fallback,
+    )
+
+    rows = [
+        {"ticker": "035420", "display_name": None},      # missing
+        {"ticker": "035720", "display_name": "035720"},  # code-as-name
+        {"ticker": "005930", "display_name": "삼성전자"},  # already good
+    ]
+    _apply_kr_name_fallback(rows, {"035420": "NAVER", "035720": "카카오"})
+    assert rows[0]["display_name"] == "NAVER"
+    assert rows[1]["display_name"] == "카카오"
+    assert rows[2]["display_name"] == "삼성전자"  # untouched
+
+
+def test_apply_kr_name_fallback_keeps_code_when_unresolved():
+    from app.services.action_report.snapshot_backed.collectors.portfolio import (
+        _apply_kr_name_fallback,
+    )
+
+    rows = [{"ticker": "999999", "display_name": None}]
+    _apply_kr_name_fallback(rows, {})  # lookup returned nothing
+    assert rows[0]["display_name"] is None  # no fabricated name

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2532,3 +2532,22 @@ async def test_market_collector_kr_regular_session_has_no_frozen_note():
     results = await collector.collect(_request(market="kr"))
     payload = results[0].payload_json
     assert "index_session" not in payload
+
+
+# ---------------------------------------------------------------------------
+# ROB-392 Slice A — NAV scope label + KR code-as-name fallback.
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_kr_kis_live_payload_carries_nav_scope_label():
+    # Reuse the same fixture wiring as
+    # test_portfolio_v2_kr_kis_live_success_populates_kis_primary.
+    session = _manual_kr_session()
+    reader = _kis_reader_with_holdings()
+    collector = PortfolioSnapshotCollector(session, kis_reader=reader)
+    results = await collector.collect(_kr_kis_request(user_id=42))
+    payload = results[0].payload_json
+    assert payload["primary_source"] == "kis"
+    assert payload["nav_scope"] == "kis_primary_sellable"
+    assert "ISA/Toss" in payload["nav_scope_label"]
+    # 수치 회귀: holdings/count는 라벨 추가와 무관하게 유지.
+    assert payload["count"] == len(payload["holdings"])

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -2559,7 +2559,7 @@ def test_apply_kr_name_fallback_fills_code_as_name_rows():
     )
 
     rows = [
-        {"ticker": "035420", "display_name": None},      # missing
+        {"ticker": "035420", "display_name": None},  # missing
         {"ticker": "035720", "display_name": "035720"},  # code-as-name
         {"ticker": "005930", "display_name": "삼성전자"},  # already good
     ]

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -259,3 +259,35 @@ async def test_portfolio_journal_crypto_nested_upbit_payload_yields_live_nav():
     # not the pre-fix 0/0 artifact.
     assert payload.risk_evidence == ["buying_power < 5% NAV"]
     assert payload.confidence == 40
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_surfaces_nav_scope_label_in_key_points():
+    """ROB-392 — portfolio collector's nav_scope_label is surfaced in
+    key_points so the report makes the NAV scope explicit. The byte-identical
+    KR summary string is unchanged (label rides only in key_points)."""
+    label = (
+        "NAV는 KIS 실거래(매도가능) 보유 + 현금 기준 · "
+        "ISA/Toss 참조분(reference_holdings)은 제외"
+    )
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap(
+                    "portfolio",
+                    {
+                        "nav_krw": 1_000_000,
+                        "buying_power_krw": 500_000,
+                        "nav_scope_label": label,
+                    },
+                )
+            ],
+            "journal": [
+                _snap("journal", {"entries": [{"symbol": "005930", "thesis": "tech"}]})
+            ],
+        },
+        bundle_metadata={},
+    )
+    artifact = await PortfolioJournalStage().run(ctx)
+    assert label in artifact.key_points


### PR DESCRIPTION
## 요약
ROB-392 **Slice A** (증상4 + 증상5만; 증상1/2는 별도 이슈, 증상3은 by-design Hermes).

1. **NAV scope 라벨 (증상4)** — portfolio collector payload(KR KIS-live 경로)에 `nav_scope="kis_primary_sellable"` + `nav_scope_label`(ISA/Toss 참조분 제외 명시) 추가. portfolio_journal stage가 byte-identical summary는 그대로 두고 key_points에 라벨 surface. **수치 로직 불변** — NAV는 여전히 KIS primary holdings + cash(reference 미합산, ROB-297 유지).
2. **KR code-as-name 매핑 (증상5)** — holdings/reference 행의 `display_name`이 null이거나 코드와 같으면 `get_kr_names_by_symbols`(DB universe)로 폴백 해석. 해석 실패 시 코드 유지(거짓 이름 금지, fail-open).

## 증상1 전제 정정 (integrity)
증상1은 "symbol 스냅샷에 KIS RSI/컨센서스/레벨이 있는데 stage가 평탄화"라고 했으나, 실측 결과 `SymbolSnapshotCollector`는 그 evidence를 **전혀 담지 않음**(quote만; evidence는 `analyze_stock_batch` 생성, 미캡처). "승격"이 아니라 "캡처"가 필요한 큰 작업 → **별도 이슈로 분리**.

## 테스트
- `tests/services/action_report/snapshot_backed/test_collectors.py` — NAV scope 라벨 + 이름 폴백 헬퍼(해석 성공/실패)
- `tests/services/investment_stages/stages/test_portfolio_journal.py` — key_points scope 라벨 surface (summary 회귀 무손상; 전체 9 passed)

## 안전 경계
read-only. broker/order/watch mutation 없음. 신규 HTTP surface 없음(DB universe lookup). NAV 수치/merge 로직 불변. DB 마이그레이션 없음(payload additive). deterministic이 LLM 합성 대체 안 함(라벨/이름만).

## 잔여 (handoff)
- 증상1/2 (KIS RSI/consensus/level을 symbol evidence로 캡처) = 별도 큰 이슈 (collector enrichment + 신규 HTTP surface 검토).
- 증상3 (news 합성) = by-design Hermes compose.
- US/crypto 이름 폴백, symbol stage key_points 코드 노출(universe-sync 갭) = 비목표.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Korean security name resolution fallback for holdings with missing display names
  * Added NAV scope labels to portfolio payloads for better categorization of holdings types

* **Documentation**
  * Added implementation plan and design specification for portfolio scope naming feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->