### PR TITLE
fix(ROB-395): dedupe KIS daily fill evidence rows

### DIFF
--- a/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
+++ b/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
@@ -58,6 +58,26 @@ def _lower_keys(row: dict[str, Any]) -> dict[str, Any]:
     return {str(k).lower(): v for k, v in row.items()}
 
 
+def _dedupe_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop byte-for-byte duplicate broker rows after key normalization.
+
+    KIS daily-order inquiry can return the same order row more than once across
+    pages / query shapes.  The filled-quantity fields are then cumulative for
+    the order, not independent fills, so counting exact duplicates would
+    overstate fills and could over-book live journals.
+    """
+
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    unique: list[dict[str, Any]] = []
+    for row in rows:
+        key = tuple(sorted((str(k), str(v)) for k, v in row.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(row)
+    return unique
+
+
 def _get_field(lowered: dict[str, Any], candidates: tuple[str, ...]) -> Any:
     for c in candidates:
         if c in lowered and lowered[c] not in (None, ""):
@@ -108,11 +128,11 @@ def classify_fill_evidence(
             "no order number to match",
         )
 
-    matched = [
+    matched = _dedupe_rows(
         _lower_keys(r)
         for r in rows
         if _order_no_matches(target, _get_field(_lower_keys(r), _ORDER_NO_KEYS))
-    ]
+    )
     if not matched:
         return FillEvidence(
             FillVerdict.NONE,

--- a/tests/brokers/kis/mock_scalping_exec/test_fill_evidence.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_fill_evidence.py
@@ -96,6 +96,32 @@ def test_split_fill_rows_aggregate() -> None:
 
 
 @pytest.mark.unit
+def test_duplicate_daily_rows_are_not_double_counted() -> None:
+    rows = [
+        _row(
+            odno="123456",
+            ord_qty="10",
+            tot_ccld_qty="10",
+            avg_prvs="38500",
+            tot_ccld_amt="385000",
+            ord_tmd="085745",
+        ),
+        _row(
+            odno="123456",
+            ord_qty="10",
+            tot_ccld_qty="10",
+            avg_prvs="38500",
+            tot_ccld_amt="385000",
+            ord_tmd="085745",
+        ),
+    ]
+    ev = classify_fill_evidence(order_no="123456", rows=rows)
+    assert ev.verdict is FillVerdict.FILLED
+    assert ev.filled_qty == Decimal("10")
+    assert ev.avg_price == Decimal("38500")
+
+
+@pytest.mark.unit
 def test_uppercase_keys_resolved() -> None:
     rows = [
         {"ODNO": "123456", "ORD_QTY": "1", "TOT_CCLD_QTY": "1", "AVG_PRVS": "70000"}


### PR DESCRIPTION
## Summary
- Deduplicate identical KIS daily-order rows before classifying fill evidence.
- Prevent live reconcile from double-counting duplicated broker inquiry rows and over-booking journals/PnL.
- Add regression coverage using the duplicated live smoke shape from ROB-395 follow-up.

## Test Plan
- `uv run pytest tests/brokers/kis/mock_scalping_exec/test_fill_evidence.py -q`
- `uv run pytest tests/mcp_server/tooling/test_kis_live_ledger.py tests/mcp_server/tooling/test_order_execution_live_routing.py -q`
- `uv run ruff check app/services/brokers/kis/mock_scalping_exec/fill_evidence.py tests/brokers/kis/mock_scalping_exec/test_fill_evidence.py`

## Safety
- No broker/order submission path changes.
- No DB migration/backfill/scheduler changes.
- Reconcile remains evidence-gated; this only prevents duplicated read-only broker rows from being counted twice.

Fixes ROB-395 follow-up smoke blocker.
