### PR TITLE
fix(ROB-393): watch 생성-활성화 계약 모순 해소 — review-watch activate 조건 주입 + actionable 거부

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -388,12 +388,16 @@ async def investment_report_activate_watch_impl(
     item_uuid: str,
     actor: str,
     idempotency_key: str | None = None,
+    watch_condition: dict | None = None,
+    valid_until: str | None = None,
 ) -> dict:
     request = ActivateWatchRequest.model_validate(
         {
             "item_uuid": item_uuid,
             "actor": actor,
             "idempotency_key": idempotency_key,
+            "watch_condition": watch_condition,
+            "valid_until": valid_until,
         }
     )
     async with AsyncSessionLocal() as db:
@@ -408,6 +412,7 @@ async def investment_report_activate_watch_impl(
             item=InvestmentReportItemResponse.model_validate(item_row),
         )
     return response.model_dump(mode="json", by_alias=True)
+
 
 
 # ---------------------------------------------------------------------------
@@ -740,7 +745,11 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         name="investment_report_activate_watch",
         description=(
             "Activate an approved watch item into investment_watch_alerts "
-            "as an immutable activation snapshot. Idempotent per source item."
+            "as an immutable activation snapshot. Idempotent per source item. "
+            "For operation='review' watches created without a condition, pass "
+            "watch_condition (metric/operator/threshold) and valid_until to arm "
+            "them; activating such a watch without a condition fails with an "
+            "actionable error rather than 'corrupt state'."
         ),
     )(investment_report_activate_watch_impl)
     mcp.tool(

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -414,7 +414,6 @@ async def investment_report_activate_watch_impl(
     return response.model_dump(mode="json", by_alias=True)
 
 
-
 # ---------------------------------------------------------------------------
 # investment_report_context_get
 # ---------------------------------------------------------------------------

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -321,7 +321,6 @@ class ActivateWatchRequest(BaseModel):
     valid_until: datetime | None = None
 
 
-
 # ---------------------------------------------------------------------------
 # Response models (Plan 3 — HTTP / MCP read surface)
 # ---------------------------------------------------------------------------

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -313,6 +313,13 @@ class ActivateWatchRequest(BaseModel):
     item_uuid: UUID
     actor: str
     idempotency_key: str | None = None
+    # ROB-393 — operation='review' watches are created without a condition
+    # (schema + DB CHECK both exempt them). Allow supplying the condition /
+    # expiry at activation time so such a watch can still be armed. Auto
+    # derivation of the condition is out of scope (ROB-337 seam).
+    watch_condition: WatchConditionPayload | None = None
+    valid_until: datetime | None = None
+
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -204,7 +204,6 @@ class InvestmentReportsRepository:
             .values(**values)
         )
 
-
     async def delete_items_for_report(self, report_id: int) -> None:
         """ROB-352 — remove every item of one report (overwrite path).
 

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -181,6 +181,30 @@ class InvestmentReportsRepository:
             .values(status=status)
         )
 
+    async def update_item_watch_condition(
+        self,
+        item_id: int,
+        watch_condition: dict | None,
+        valid_until: datetime | None,
+    ) -> None:
+        """ROB-393 — persist a watch_condition / valid_until injected at
+        activation time onto a review-watch item. Only non-None values are
+        written; a None field is left unchanged. Flushes but never commits
+        (caller owns the transaction)."""
+        values: dict[str, Any] = {}
+        if watch_condition is not None:
+            values["watch_condition"] = watch_condition
+        if valid_until is not None:
+            values["valid_until"] = valid_until
+        if not values:
+            return
+        await self._session.execute(
+            sa.update(InvestmentReportItem)
+            .where(InvestmentReportItem.id == item_id)
+            .values(**values)
+        )
+
+
     async def delete_items_for_report(self, report_id: int) -> None:
         """ROB-352 — remove every item of one report (overwrite path).
 

--- a/app/services/investment_reports/watch_activation.py
+++ b/app/services/investment_reports/watch_activation.py
@@ -65,18 +65,56 @@ class WatchActivationService:
             raise ValueError(
                 f"only approved items can be activated; status={item.status}"
             )
-        if item.watch_condition is None:
-            raise ValueError("watch_condition missing on item (corrupt state)")
-        if item.valid_until is None:
-            raise ValueError("valid_until missing on watch item (corrupt state)")
+        # ROB-393 — operation='review' watches are created without a
+        # watch_condition/valid_until (schema + DB CHECK both exempt them).
+        # Allow supplying them at activation time; persist back onto the item
+        # so the item stays the source of truth and re-activation is idempotent.
+        watch_condition = item.watch_condition
+        valid_until = item.valid_until
+
+        if request.watch_condition is not None:
+            if watch_condition is not None:
+                raise ValueError(
+                    "watch_condition already set on item; refusing to override "
+                    "at activation"
+                )
+            watch_condition = request.watch_condition.model_dump(mode="json")
+        if request.valid_until is not None:
+            if valid_until is not None:
+                raise ValueError(
+                    "valid_until already set on item; refusing to override "
+                    "at activation"
+                )
+            valid_until = request.valid_until
+
+        if watch_condition is None:
+            raise ValueError(
+                "watch_condition not set (operation='review' watch); pass "
+                "watch_condition to activate, or recreate the watch with a "
+                "condition"
+            )
+        if valid_until is None:
+            raise ValueError(
+                "valid_until not set (operation='review' watch); pass "
+                "valid_until to activate, or recreate the watch with an expiry"
+            )
         if item.symbol is None:
             raise ValueError("symbol missing on watch item")
+
+        # Persist any injected fields before building the alert.
+        await self._repo.update_item_watch_condition(
+            item.id,
+            watch_condition=(
+                watch_condition if item.watch_condition is None else None
+            ),
+            valid_until=(valid_until if item.valid_until is None else None),
+        )
 
         report = await self._repo.get_report_by_id(item.report_id)
         if report is None:
             raise ValueError(f"report not found for item: {item.report_id}")
 
-        condition: dict[str, Any] = item.watch_condition
+        condition: dict[str, Any] = watch_condition
         threshold = _to_decimal(condition.get("threshold"))
         threshold_key = condition.get("threshold_key") or str(threshold)
 
@@ -97,8 +135,9 @@ class WatchActivationService:
             rationale=item.rationale,
             trigger_checklist=list(item.trigger_checklist),
             max_action=dict(item.max_action),
-            valid_until=item.valid_until,
+            valid_until=valid_until,
         )
+
 
         await self._repo.update_item_status(item.id, "activated")
         await self._session.flush()

--- a/app/services/investment_reports/watch_activation.py
+++ b/app/services/investment_reports/watch_activation.py
@@ -104,9 +104,7 @@ class WatchActivationService:
         # Persist any injected fields before building the alert.
         await self._repo.update_item_watch_condition(
             item.id,
-            watch_condition=(
-                watch_condition if item.watch_condition is None else None
-            ),
+            watch_condition=(watch_condition if item.watch_condition is None else None),
             valid_until=(valid_until if item.valid_until is None else None),
         )
 
@@ -137,7 +135,6 @@ class WatchActivationService:
             max_action=dict(item.max_action),
             valid_until=valid_until,
         )
-
 
         await self._repo.update_item_status(item.id, "activated")
         await self._session.flush()

--- a/docs/superpowers/plans/2026-06-01-rob-393-watch-activation-contract.md
+++ b/docs/superpowers/plans/2026-06-01-rob-393-watch-activation-contract.md
@@ -1,0 +1,508 @@
+# ROB-393 Watch Activation Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** review-operation watch 항목이 `watch_condition` 없이 생성·승인된 뒤 `activate_watch`에서 `"corrupt state"`로 영구 활성화 불가가 되는 계약 모순을, 활성화 시점 조건 주입 + actionable 거부로 해소한다.
+
+**Architecture:** `ActivateWatchRequest`에 선택적 `watch_condition`/`valid_until`를 추가하고, `WatchActivationService.activate`가 item에 조건이 없을 때 (1) request로 주입되면 item에 영속화 후 진행, (2) 없으면 actionable 메시지로 거부, (3) 이미 있는데 또 주면 충돌 거부한다. 생성·승인 경로와 DB 스키마는 변경하지 않는다(마이그레이션 없음). 조건 자동 파생은 ROB-337 seam으로 남긴다.
+
+**Tech Stack:** Python 3.13, FastMCP, Pydantic v2, SQLAlchemy async, pytest (`-n auto` shared Postgres).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-rob-393-watch-activation-contract-design.md`
+
+---
+
+## File Structure
+
+- `app/schemas/investment_reports.py` — `ActivateWatchRequest`에 `watch_condition`/`valid_until` 추가 (재사용: `WatchConditionPayload`).
+- `app/services/investment_reports/repository.py` — `update_item_watch_condition` DAO 메서드 추가.
+- `app/services/investment_reports/watch_activation.py` — `activate()`의 condition/valid_until 가드 블록 교체.
+- `app/mcp_server/tooling/investment_reports_handlers.py` — `investment_report_activate_watch_impl` 파라미터 패스스루 + 툴 description 갱신.
+- `tests/test_investment_reports_mcp.py` — 재현/주입/충돌/회귀 테스트.
+
+---
+
+## Task 1: 재현 테스트 + review-watch 헬퍼 (RED)
+
+**Files:**
+- Test: `tests/test_investment_reports_mcp.py` (헬퍼 추가 ~라인 92 부근, 테스트 추가 ~라인 238 `test_activate_watch_copies_snapshot` 다음)
+
+- [ ] **Step 1: review-watch 헬퍼 추가**
+
+`_watch_item_dict`(라인 78-91) 바로 아래에 추가:
+
+```python
+def _review_watch_item_dict(client_item_key: str = "review-watch-1") -> dict:
+    """operation='review' watch — 생성 시 watch_condition/valid_until 면제(ROB-274).
+
+    ROB-393 재현용: 이 항목은 condition 없이 approve까지 도달하지만 종전
+    activate_watch에서 'corrupt state'로 막혔다.
+    """
+    return {
+        "client_item_key": client_item_key,
+        "item_kind": "watch",
+        "operation": "review",
+        "symbol": "005930",
+        "intent": "trend_recovery_review",
+        "rationale": "r",
+    }
+```
+
+- [ ] **Step 2: 재현 테스트 추가**
+
+`test_activate_watch_copies_snapshot`(라인 220-237) 다음에 추가:
+
+```python
+@pytest.mark.asyncio
+async def test_activate_review_watch_without_condition_is_actionable(
+    session: AsyncSession,
+) -> None:
+    """ROB-393 재현: operation='review' watch는 condition 없이 approve되지만,
+    인자 없이 activate하면 'corrupt state'가 아니라 actionable 에러여야 한다."""
+    created = await investment_report_create_impl(
+        items=[_review_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await investment_report_activate_watch_impl(
+            item_uuid=watch_uuid, actor="operator"
+        )
+    message = str(exc_info.value)
+    assert "corrupt state" not in message
+    assert "watch_condition not set" in message
+```
+
+- [ ] **Step 3: 재현 테스트 실행 → 실패 확인**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py::test_activate_review_watch_without_condition_is_actionable -p no:randomly -v`
+Expected: FAIL — 현재 메시지가 `"watch_condition missing on item (corrupt state)"`라 `"corrupt state" not in message` 어서션이 깨진다.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add tests/test_investment_reports_mcp.py
+git commit -m "test(ROB-393): failing repro — review-watch activate must be actionable, not 'corrupt state'
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: 스키마 — `ActivateWatchRequest` 확장
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py:310-315`
+
+- [ ] **Step 1: 필드 추가**
+
+`ActivateWatchRequest`(현 라인 310-315)를 교체:
+
+```python
+class ActivateWatchRequest(BaseModel):
+    """Activate an approved watch item into ``investment_watch_alerts``."""
+
+    item_uuid: UUID
+    actor: str
+    idempotency_key: str | None = None
+    # ROB-393 — operation='review' watches are created without a condition
+    # (schema + DB CHECK both exempt them). Allow supplying the condition /
+    # expiry at activation time so such a watch can still be armed. Auto
+    # derivation of the condition is out of scope (ROB-337 seam).
+    watch_condition: WatchConditionPayload | None = None
+    valid_until: datetime | None = None
+```
+
+(`WatchConditionPayload`와 `datetime`은 이 파일 상단에 이미 import/정의되어 있음 — 추가 import 불필요.)
+
+- [ ] **Step 2: 임포트/구문 확인**
+
+Run: `uv run python -c "from app.schemas.investment_reports import ActivateWatchRequest; ActivateWatchRequest(item_uuid='00000000-0000-0000-0000-000000000000', actor='x')"`
+Expected: 에러 없이 종료(필드 기본값으로 인스턴스화 성공).
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/schemas/investment_reports.py
+git commit -m "feat(ROB-393): ActivateWatchRequest accepts optional watch_condition/valid_until
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: 리포지토리 — `update_item_watch_condition`
+
+**Files:**
+- Modify: `app/services/investment_reports/repository.py` (`update_item_status` 다음, 현 라인 182 뒤)
+
+- [ ] **Step 1: DAO 메서드 추가**
+
+`update_item_status`(라인 177-182) 바로 다음에 추가:
+
+```python
+    async def update_item_watch_condition(
+        self,
+        item_id: int,
+        watch_condition: dict | None,
+        valid_until: datetime | None,
+    ) -> None:
+        """ROB-393 — persist a watch_condition / valid_until injected at
+        activation time onto a review-watch item. Only non-None values are
+        written; a None field is left unchanged. Flushes but never commits
+        (caller owns the transaction)."""
+        values: dict[str, Any] = {}
+        if watch_condition is not None:
+            values["watch_condition"] = watch_condition
+        if valid_until is not None:
+            values["valid_until"] = valid_until
+        if not values:
+            return
+        await self._session.execute(
+            sa.update(InvestmentReportItem)
+            .where(InvestmentReportItem.id == item_id)
+            .values(**values)
+        )
+```
+
+(`datetime`, `Any`, `sa`, `InvestmentReportItem`는 이미 import 되어 있음.)
+
+- [ ] **Step 2: 임포트/구문 확인**
+
+Run: `uv run python -c "from app.services.investment_reports.repository import InvestmentReportsRepository; print(hasattr(InvestmentReportsRepository, 'update_item_watch_condition'))"`
+Expected: `True`
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/services/investment_reports/repository.py
+git commit -m "feat(ROB-393): repo.update_item_watch_condition to persist injected watch condition
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: 서비스 — `activate()` 조건 가드 교체 (Task 1 GREEN)
+
+**Files:**
+- Modify: `app/services/investment_reports/watch_activation.py:68-100`
+
+- [ ] **Step 1: condition/valid_until 가드 블록 교체**
+
+현재 라인 68-73:
+
+```python
+        if item.watch_condition is None:
+            raise ValueError("watch_condition missing on item (corrupt state)")
+        if item.valid_until is None:
+            raise ValueError("valid_until missing on watch item (corrupt state)")
+        if item.symbol is None:
+            raise ValueError("symbol missing on watch item")
+```
+
+를 아래로 교체:
+
+```python
+        # ROB-393 — operation='review' watches are created without a
+        # watch_condition/valid_until (schema + DB CHECK both exempt them).
+        # Allow supplying them at activation time; persist back onto the item
+        # so the item stays the source of truth and re-activation is idempotent.
+        watch_condition = item.watch_condition
+        valid_until = item.valid_until
+
+        if request.watch_condition is not None:
+            if watch_condition is not None:
+                raise ValueError(
+                    "watch_condition already set on item; refusing to override "
+                    "at activation"
+                )
+            watch_condition = request.watch_condition.model_dump(mode="json")
+        if request.valid_until is not None:
+            if valid_until is not None:
+                raise ValueError(
+                    "valid_until already set on item; refusing to override "
+                    "at activation"
+                )
+            valid_until = request.valid_until
+
+        if watch_condition is None:
+            raise ValueError(
+                "watch_condition not set (operation='review' watch); pass "
+                "watch_condition to activate, or recreate the watch with a "
+                "condition"
+            )
+        if valid_until is None:
+            raise ValueError(
+                "valid_until not set (operation='review' watch); pass "
+                "valid_until to activate, or recreate the watch with an expiry"
+            )
+        if item.symbol is None:
+            raise ValueError("symbol missing on watch item")
+
+        # Persist any injected fields before building the alert.
+        await self._repo.update_item_watch_condition(
+            item.id,
+            watch_condition=(
+                watch_condition if item.watch_condition is None else None
+            ),
+            valid_until=(valid_until if item.valid_until is None else None),
+        )
+```
+
+- [ ] **Step 2: alert-build에서 주입값 사용**
+
+현재 라인 79-101 블록에서 `item.watch_condition` / `item.valid_until` 참조를 위에서 만든 지역변수로 교체.
+
+현재:
+```python
+        condition: dict[str, Any] = item.watch_condition
+        threshold = _to_decimal(condition.get("threshold"))
+```
+→
+```python
+        condition: dict[str, Any] = watch_condition
+        threshold = _to_decimal(condition.get("threshold"))
+```
+
+그리고 `insert_alert(...)` 호출의 마지막 인자:
+```python
+            valid_until=item.valid_until,
+```
+→
+```python
+            valid_until=valid_until,
+```
+
+(나머지 `insert_alert` 인자는 그대로 둔다.)
+
+- [ ] **Step 3: 재현 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py::test_activate_review_watch_without_condition_is_actionable -p no:randomly -v`
+Expected: PASS — 인자 없는 activate가 `"watch_condition not set ..."` actionable 에러를 낸다(`"corrupt state"` 미포함).
+
+- [ ] **Step 4: 기존 정상경로 회귀 확인**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py::test_activate_watch_copies_snapshot -p no:randomly -v`
+Expected: PASS — condition 있는 watch는 종전과 동일하게 활성화(인자 없이).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/investment_reports/watch_activation.py
+git commit -m "fix(ROB-393): activate review-watch via injected condition + actionable refusal
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: 주입/충돌 테스트 (RED — 핸들러 파라미터 필요)
+
+**Files:**
+- Test: `tests/test_investment_reports_mcp.py` (Task 1 테스트 다음)
+
+- [ ] **Step 1: 주입 성공 + 영속화 테스트 추가**
+
+```python
+@pytest.mark.asyncio
+async def test_activate_review_watch_with_injected_condition_succeeds(
+    session: AsyncSession,
+) -> None:
+    """ROB-393: review-watch도 activate 시 watch_condition/valid_until을 주면
+    활성화되고, 주입된 조건이 item에 영속화된다."""
+    created = await investment_report_create_impl(
+        items=[_review_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+    )
+    assert response["success"] is True
+    assert response["alert"]["metric"] == "price"
+    assert response["alert"]["operator"] == "below"
+    assert response["item"]["status"] == "activated"
+
+    # 주입 조건이 item에 영속화되었는지 확인.
+    bundle_post = await investment_report_get_impl(created["report"]["report_uuid"])
+    item_post = bundle_post["items"][0]
+    assert item_post["watch_condition"]["metric"] == "price"
+    assert item_post["valid_until"] is not None
+```
+
+- [ ] **Step 2: 충돌(override 거부) 테스트 추가**
+
+```python
+@pytest.mark.asyncio
+async def test_activate_watch_rejects_condition_override(
+    session: AsyncSession,
+) -> None:
+    """ROB-393: condition이 이미 있는 watch에 activate로 또 주면 silent override
+    하지 않고 거부한다."""
+    created = await investment_report_create_impl(
+        items=[_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await investment_report_activate_watch_impl(
+            item_uuid=watch_uuid,
+            actor="operator",
+            watch_condition={"metric": "price", "operator": "below", "threshold": 1},
+        )
+    assert "already set" in str(exc_info.value)
+```
+
+- [ ] **Step 3: 실행 → 실패 확인**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py::test_activate_review_watch_with_injected_condition_succeeds tests/test_investment_reports_mcp.py::test_activate_watch_rejects_condition_override -p no:randomly -v`
+Expected: 주입 테스트는 FAIL — `investment_report_activate_watch_impl`가 아직 `watch_condition` kwarg를 받지 않아 `TypeError: unexpected keyword argument`. (충돌 테스트는 kwarg를 넘기므로 동일 `TypeError`.)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add tests/test_investment_reports_mcp.py
+git commit -m "test(ROB-393): failing injection + override-refusal tests for activate_watch
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: MCP 핸들러 패스스루 (Task 5 GREEN)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py:387-398` (impl), `:739-745` (description)
+
+- [ ] **Step 1: impl 시그니처 + request 매핑 교체**
+
+현재 라인 387-398:
+
+```python
+async def investment_report_activate_watch_impl(
+    item_uuid: str,
+    actor: str,
+    idempotency_key: str | None = None,
+) -> dict:
+    request = ActivateWatchRequest.model_validate(
+        {
+            "item_uuid": item_uuid,
+            "actor": actor,
+            "idempotency_key": idempotency_key,
+        }
+    )
+```
+
+를 교체:
+
+```python
+async def investment_report_activate_watch_impl(
+    item_uuid: str,
+    actor: str,
+    idempotency_key: str | None = None,
+    watch_condition: dict | None = None,
+    valid_until: str | None = None,
+) -> dict:
+    request = ActivateWatchRequest.model_validate(
+        {
+            "item_uuid": item_uuid,
+            "actor": actor,
+            "idempotency_key": idempotency_key,
+            "watch_condition": watch_condition,
+            "valid_until": valid_until,
+        }
+    )
+```
+
+- [ ] **Step 2: 툴 description 갱신**
+
+현재 라인 739-745의 `activate_watch` 등록 description을 교체:
+
+```python
+    mcp.tool(
+        name="investment_report_activate_watch",
+        description=(
+            "Activate an approved watch item into investment_watch_alerts "
+            "as an immutable activation snapshot. Idempotent per source item. "
+            "For operation='review' watches created without a condition, pass "
+            "watch_condition (metric/operator/threshold) and valid_until to arm "
+            "them; activating such a watch without a condition fails with an "
+            "actionable error rather than 'corrupt state'."
+        ),
+    )(investment_report_activate_watch_impl)
+```
+
+- [ ] **Step 3: 주입/충돌 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py::test_activate_review_watch_with_injected_condition_succeeds tests/test_investment_reports_mcp.py::test_activate_watch_rejects_condition_override -p no:randomly -v`
+Expected: PASS (둘 다).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add app/mcp_server/tooling/investment_reports_handlers.py
+git commit -m "feat(ROB-393): pass watch_condition/valid_until through activate_watch MCP tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: 전체 검증 + lint
+
+**Files:** 없음 (검증/품질 게이트만)
+
+- [ ] **Step 1: 투자리포트 테스트 전체 실행**
+
+Run: `uv run pytest tests/test_investment_reports_mcp.py tests/test_investment_reports_model.py -p no:randomly -v`
+Expected: 전부 PASS (신규 4 테스트 + 기존 회귀 무손상; model 테스트 불변).
+
+- [ ] **Step 2: lint (CI 게이트와 동일하게)**
+
+Run: `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/`
+Expected: 둘 다 통과. (format 실패 시 `uv run ruff format app/ tests/` 후 재확인하고 변경분 amend 커밋.)
+
+- [ ] **Step 3: import guard / 타입 체크**
+
+Run: `uv run ty check app/services/investment_reports app/schemas/investment_reports.py app/mcp_server/tooling/investment_reports_handlers.py`
+Expected: 신규 변경 관련 에러 없음. (기존 베이스라인 노이즈는 무시하되, 본 변경이 새로 만든 에러는 없어야 함.)
+
+- [ ] **Step 4: (정리 커밋 필요 시)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-393): lint/format
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Post-implementation (PR 외 수동 단계)
+
+- PR 생성 전: 사전-머지 full-CI 게이트 — `ruff check app/ tests/` + import guards 통과 및 GitHub Test 워크플로우 green 확인 후에만 머지(`feedback_premerge_full_ci_gate`).
+- Linear ROB-393 댓글: no broker/order/order-intent mutation + no scheduler activation 경계와 테스트/CI evidence, 그리고 ROB-337(조건 자동 파생) seam을 명시.
+- ROB-412 완료 기준의 "scheduler/automation 비활성 유지"는 본 변경에 자동화 배선이 전혀 없음을 근거로 충족.
+
+## 비범위 (재확인)
+
+- DB migration 없음 (컬럼·CHECK 불변).
+- approve 상태머신 변경 없음.
+- 조건 자동 파생/매수가 정책 = ROB-337.
+- live/mock 자동집행 = ROB-402.

--- a/docs/superpowers/specs/2026-06-01-rob-393-watch-activation-contract-design.md
+++ b/docs/superpowers/specs/2026-06-01-rob-393-watch-activation-contract-design.md
@@ -1,0 +1,112 @@
+# ROB-393 — watch 항목 생성–활성화 계약 모순 해소 (설계)
+
+- **이슈**: ROB-393 (오케스트레이션 D라인 ROB-412의 우선 처리 항목)
+- **날짜**: 2026-06-01
+- **상태**: 설계 승인됨 → 플랜 작성 단계
+- **범위**: advisory/report/watch metadata 정합성. broker/order/order-intent mutation·scheduler activation·자동집행 배선 **없음**.
+
+## 1. 문제
+
+`/invest/reports` watch 항목의 생성–승인–활성화 3단계 계약이 비대칭이다.
+
+| 단계 | watch_condition / valid_until | 강제 위치 |
+|---|---|---|
+| **생성** `operation="review"` | **면제** | `app/schemas/investment_reports.py:179` (`_validate_watch_invariants`가 `operation in (None,"create","modify")`에만 적용); DB CHECK도 `operation IN ('cancel','keep','review')`는 NULL 허용 (ROB-274 마이그레이션 `20260520_rob274_p1_*`) |
+| **승인** approve | **검증 없음** | `app/services/investment_reports/decisions.py` — 그냥 `approved`로 전이 |
+| **활성화** activate | **필수 (하드 raise)** | `app/services/investment_reports/watch_activation.py:68-71` |
+
+결과: `operation="review"`로 정상 생성한 watch는 condition 없이 `approved`까지 도달하지만, `activate_watch`에서
+`"watch_condition missing on item (corrupt state)"`로 **영구히 활성화 불가**.
+2026-06-01 NXT 개장 리포트(`report_uuid=4e20c131-...`, 삼성전자 005930 / SK하이닉스 000660)에서 실제 재현됨.
+"corrupt state" 문구는 운영자에게 데이터 손상으로 오인을 유발하나 실제로는 **정상 생성 결과**다.
+
+## 2. 결정한 방향 — (b)+(c)
+
+ROB-274가 `review/keep/cancel`을 의도적으로 condition-면제로 완화한 설계를 **보존**한다.
+따라서 비대칭은 **생성 시 강제(a)** 가 아니라 **활성화 시점에서 메운다**:
+
+- **(b)** `activate_watch`가 명시적 `watch_condition`(+`valid_until`) 인자를 받아 review-watch를 활성화할 수 있게 한다.
+- **(c)** 조건 없이 활성화 시도 시 `"corrupt state"`가 아니라 **actionable** 메시지로 거부한다.
+- **approve 단계는 변경하지 않는다.** condition 없는 review-watch의 approve는 audit 기록으로 그대로 허용.
+
+조건 **자동 파생**(매수가 기준·유효기간 정책)은 본 이슈 범위가 아니며 **ROB-337**의 seam으로 남긴다.
+
+## 3. 변경 단위
+
+### 3.1 스키마 — `ActivateWatchRequest` 확장
+`app/schemas/investment_reports.py` (현 라인 310)
+
+```python
+class ActivateWatchRequest(BaseModel):
+    item_uuid: UUID
+    actor: str
+    idempotency_key: str | None = None
+    # ROB-393 — review-watch는 생성 시 condition 면제. 활성화 시 주입 허용.
+    watch_condition: WatchConditionPayload | None = None
+    valid_until: datetime | None = None
+```
+
+기존 `WatchConditionPayload`를 재사용 → metric/operator/threshold/action_mode Literal 검증이 그대로 적용된다.
+
+### 3.2 서비스 — `WatchActivationService.activate`
+`app/services/investment_reports/watch_activation.py` (현 라인 68-71)
+
+`item.watch_condition` / `item.valid_until`가 `None`일 때:
+
+1. **request에 해당 값이 제공됨** → 그 값을 **item에 영속화**한 뒤 진행.
+   - items = source of truth 원칙 유지. 재활성화(idempotent) 시에도 item이 일관된 상태.
+   - 영속화 후 기존 alert-build 로직(`condition["metric"]` 등)이 그대로 동작.
+2. **제공 안 됨** → actionable `ValueError`:
+   - `watch_condition`: `"watch_condition not set (operation='review' watch); pass watch_condition to activate, or recreate the watch with a condition"`
+   - `valid_until`: `"valid_until not set (operation='review' watch); pass valid_until to activate, or recreate the watch with an expiry"`
+   - 문구에 `"corrupt state"` 미포함.
+3. **충돌 가드**: `item.watch_condition`이 **이미 not-null인데** request에도 `watch_condition`이 오면 → 거부
+   (`"watch_condition already set on item; refusing to override at activation"`). silent override 금지.
+   `valid_until`도 동일.
+
+`item_kind != "watch"` / `status != "approved"` 기존 가드는 condition 체크보다 **앞에** 유지(순서 불변).
+
+### 3.3 리포지토리 — 영속화 메서드 추가
+`app/services/investment_reports/repository.py`
+
+```python
+async def update_item_watch_condition(
+    self, item_id: int,
+    watch_condition: dict | None,
+    valid_until: datetime | None,
+) -> None
+```
+
+주입된 condition/valid_until을 item 행에 기록. 둘 중 주어진 값만 갱신(None은 미변경). DB CHECK는 review에 not-null을 허용하므로 안전.
+
+### 3.4 MCP 핸들러 — 파라미터 패스스루
+`app/mcp_server/tooling/investment_reports_handlers.py` (현 라인 387 `investment_report_activate_watch_impl`)
+
+`watch_condition: dict | None = None`, `valid_until: str | None = None` 파라미터 추가 → `ActivateWatchRequest.model_validate`로 전달. MCP 툴 등록부 시그니처/스키마도 동기화.
+
+## 4. 테스트 (TDD — 재현 우선)
+
+`tests/test_investment_reports_mcp.py`:
+
+1. **재현(RED)**: review-watch(condition 없음) 생성 → approve → activate **인자 없이** → `ValueError`이고 메시지에 `"corrupt state"` **미포함**, actionable 문구 포함.
+2. **주입(GREEN)**: 같은 경로 + activate에 `watch_condition`/`valid_until` 제공 → 성공, alert 생성 + **item에 condition 영속화** 확인.
+3. **충돌**: item에 이미 condition 있는 정상 watch에 activate로 또 condition 주면 거부.
+4. **회귀**: 기존 `test_activate_watch_copies_snapshot`(정상 경로, 인자 없이 활성화) 무손상.
+
+모델 단 CHECK 테스트(`tests/test_investment_reports_model.py`)는 변경 없음(스키마/제약 불변).
+
+## 5. 안전 경계 / 비범위
+
+- **마이그레이션 없음** — 컬럼(`watch_condition`/`valid_until` nullable)·CHECK 제약 모두 그대로 활용.
+- broker/order/order-intent mutation 없음. live/mock 자동집행 배선 없음(ROB-402와 분리).
+- recurring scheduler activation 없음.
+- approve 상태머신 변경 없음.
+- **조건 자동 파생은 ROB-337 seam**: activate가 "명시 인자 수용 또는 명확한 거부"까지만 책임진다.
+
+## 6. 완료 기준 매핑 (ROB-412)
+
+- ✅ watch 생성/승인/활성화 계약 모순이 **재현 테스트와 함께** 해결 (§4-1,2).
+- ✅ 활성화 불가 상태가 **명확한 actionable reason**으로 표현 (§3.2-2). (approve 차단 대신 activate 시점 해소 — 완료기준의 "또는" 절 충족.)
+- ✅ ROB-337/376으로 넘어갈 **contract seam 문서화** (§2, §5).
+- ✅ scheduler/automation 비활성 상태 유지 명시 (§5).
+- ✅ no broker/order/order-intent mutation + no scheduler activation 경계 → Linear 댓글에 테스트/CI evidence와 함께 기록.

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -91,6 +91,23 @@ def _watch_item_dict(client_item_key: str = "watch-1") -> dict:
     }
 
 
+def _review_watch_item_dict(client_item_key: str = "review-watch-1") -> dict:
+    """operation='review' watch — 생성 시 watch_condition/valid_until 면제(ROB-274).
+
+    ROB-393 재현용: 이 항목은 condition 없이 approve까지 도달하지만 종전
+    activate_watch에서 'corrupt state'로 막혔다.
+    """
+    return {
+        "client_item_key": client_item_key,
+        "item_kind": "watch",
+        "operation": "review",
+        "symbol": "005930",
+        "intent": "trend_recovery_review",
+        "rationale": "r",
+    }
+
+
+
 def test_tool_names_match_registered_set() -> None:
     assert INVESTMENT_REPORT_TOOL_NAMES == {
         "investment_report_create",
@@ -235,6 +252,31 @@ async def test_activate_watch_copies_snapshot(session: AsyncSession) -> None:
     assert response["alert"]["metric"] == "rsi"
     assert response["alert"]["operator"] == "below"
     assert response["item"]["status"] == "activated"
+
+
+@pytest.mark.asyncio
+async def test_activate_review_watch_without_condition_is_actionable(
+    session: AsyncSession,
+) -> None:
+    """ROB-393 재현: operation='review' watch는 condition 없이 approve되지만,
+    인자 없이 activate하면 'corrupt state'가 아니라 actionable 에러여야 한다."""
+    created = await investment_report_create_impl(
+        items=[_review_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await investment_report_activate_watch_impl(
+            item_uuid=watch_uuid, actor="operator"
+        )
+    message = str(exc_info.value)
+    assert "corrupt state" not in message
+    assert "watch_condition not set" in message
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -107,7 +107,6 @@ def _review_watch_item_dict(client_item_key: str = "review-watch-1") -> dict:
     }
 
 
-
 def test_tool_names_match_registered_set() -> None:
     assert INVESTMENT_REPORT_TOOL_NAMES == {
         "investment_report_create",

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -278,6 +278,62 @@ async def test_activate_review_watch_without_condition_is_actionable(
     assert "watch_condition not set" in message
 
 
+@pytest.mark.asyncio
+async def test_activate_review_watch_with_injected_condition_succeeds(
+    session: AsyncSession,
+) -> None:
+    """ROB-393: review-watch도 activate 시 watch_condition/valid_until을 주면
+    활성화되고, 주입된 조건이 item에 영속화된다."""
+    created = await investment_report_create_impl(
+        items=[_review_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+    )
+    assert response["success"] is True
+    assert response["alert"]["metric"] == "price"
+    assert response["alert"]["operator"] == "below"
+    assert response["item"]["status"] == "activated"
+
+    # 주입 조건이 item에 영속화되었는지 확인.
+    bundle_post = await investment_report_get_impl(created["report"]["report_uuid"])
+    item_post = bundle_post["items"][0]
+    assert item_post["watch_condition"]["metric"] == "price"
+    assert item_post["valid_until"] is not None
+
+
+@pytest.mark.asyncio
+async def test_activate_watch_rejects_condition_override(
+    session: AsyncSession,
+) -> None:
+    """ROB-393: condition이 이미 있는 watch에 activate로 또 주면 silent override
+    하지 않고 거부한다."""
+    created = await investment_report_create_impl(
+        items=[_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await investment_report_activate_watch_impl(
+            item_uuid=watch_uuid,
+            actor="operator",
+            watch_condition={"metric": "price", "operator": "below", "threshold": 1},
+        )
+    assert "already set" in str(exc_info.value)
+
 
 @pytest.mark.asyncio
 async def test_context_get_aggregates_across_prior_reports(


### PR DESCRIPTION
## 배경 (ROB-393 / 오케스트레이션 ROB-412 D라인 우선 항목)

`/invest/reports` watch 항목의 **생성–승인–활성화 계약이 비대칭**이었다.

| 단계 | watch_condition/valid_until | 위치 |
|---|---|---|
| 생성 `operation="review"` | **면제** | `schemas/investment_reports.py` `_validate_watch_invariants` + DB CHECK (ROB-274) |
| 승인 approve | 검증 없음 | `decisions.py` |
| 활성화 activate | **필수 하드 raise** | `watch_activation.py` |

→ `operation="review"`로 정상 생성한 watch가 condition 없이 `approved`까지 도달하지만, `activate_watch`에서 `"watch_condition missing on item (corrupt state)"`로 **영구 활성화 불가**. 2026-06-01 NXT 개장 리포트(삼성전자 005930 / SK하이닉스 000660)에서 실제 재현됨. "corrupt state" 문구는 정상 생성 결과를 데이터 손상으로 오인하게 만든다.

## 변경 — (b)+(c)

ROB-274가 의도한 `review/keep/cancel` condition-면제 설계를 **보존**하고, 비대칭을 **활성화 시점**에서 메운다.

- **스키마**: `ActivateWatchRequest`에 선택적 `watch_condition`(`WatchConditionPayload` 재사용) / `valid_until` 추가.
- **서비스** `WatchActivationService.activate`:
  - item에 condition 없음 + request로 주입됨 → **item에 영속화** 후 활성화 (items=source of truth, 재활성화 idempotent).
  - 주입 안 됨 → `"corrupt state"`가 아닌 **actionable** 거부(`"watch_condition not set ... pass watch_condition to activate, or recreate ..."`).
  - item에 이미 condition 있는데 또 주면 → **override 거부**(silent 덮어쓰기 금지).
- **리포지토리**: `update_item_watch_condition` (주입값 영속화, 주어진 필드만 갱신).
- **MCP 핸들러**: `investment_report_activate_watch_impl` 파라미터 패스스루 + 툴 description 갱신.

**approve 상태머신은 변경하지 않음.** 조건 **자동 파생**(매수가 기준·유효기간 정책)은 본 PR 범위가 아니며 **ROB-337 seam**으로 남김.

## 테스트

`tests/test_investment_reports_mcp.py`:
- 재현: review-watch → approve → activate(인자 없음) → actionable 에러(`"corrupt state"` 미포함)
- 주입: activate에 condition/valid_until 제공 → 활성화 성공 + item에 영속화 확인
- 충돌: 기존 condition 있는 watch에 override 시도 → 거부
- 회귀: 기존 `test_activate_watch_copies_snapshot`(정상 경로) 무손상

로컬: `test_investment_reports_mcp.py` + `_model.py` **44 passed**, `ruff check app/ tests/` All passed, `ruff format --check` OK.

## 안전 경계

- **DB migration 없음** (컬럼·CHECK 불변).
- broker/order/order-intent mutation 없음. live/mock 자동집행 배선 없음 (ROB-402와 분리).
- recurring scheduler activation 없음.

## 완료 기준 (ROB-412)

- ✅ 생성/승인/활성화 계약 모순이 재현 테스트와 함께 해결
- ✅ 활성화 불가 상태가 actionable reason으로 표현 (activate 시점 해소)
- ✅ ROB-337/376 contract seam 문서화 (design doc)
- ✅ scheduler/automation 비활성 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Watch activation requests now accept optional conditions and expiry dates, allowing them to be set at activation time.

* **Bug Fixes**
  * Watch activation now provides clear, actionable error messages when required conditions are missing instead of generic error states.

* **Documentation**
  * Added design specification and implementation plan for watch activation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->