### PR TITLE
fix(ROB-396): analyze_stock_batch 비결정성(source flip) + KR stale current_price 해소

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -125,7 +125,6 @@ async def _resolve_kr_quote(
     return fallback
 
 
-
 async def _get_indicators_impl(
     symbol: str,
     indicators: list[str],
@@ -458,7 +457,6 @@ def _apply_recommendation(
     analysis["recommendation"] = recommendation
 
 
-
 async def analyze_stock_impl(
     symbol: str,
     market: str | None = None,
@@ -475,8 +473,6 @@ async def analyze_stock_impl(
             f"Unsupported symbol format: '{symbol}'. "
             "Use ticker codes (e.g., AAPL, 005930, KRW-BTC)."
         )
-
-
 
     analysis = _build_analysis_payload(normalized_symbol, market_type)
     loop = asyncio.get_running_loop()

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -7,11 +7,7 @@ from typing import Any
 import pandas as pd
 import sentry_sdk
 import yfinance as yf
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 
-from app.core.config import settings
-from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling.fundamentals_sources_finnhub import (
     _fetch_company_profile_finnhub,
     _fetch_news_finnhub,
@@ -42,7 +38,6 @@ from app.mcp_server.tooling.shared import (
     normalize_symbol_input as _normalize_symbol_input,
 )
 from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market_type
-from app.models.research_pipeline import ResearchSession, ResearchSummary
 from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 
 logger = logging.getLogger(__name__)
@@ -400,142 +395,6 @@ def _apply_recommendation(
         analysis["recommendation"] = recommendation
 
 
-def _map_confidence_score(score: int) -> str:
-    if score >= 70:
-        return "high"
-    if score >= 40:
-        return "medium"
-    return "low"
-
-
-def _map_pipeline_to_analysis(
-    session: ResearchSession,
-    summary: ResearchSummary,
-    symbol: str,
-    market_type: str,
-) -> dict[str, Any]:
-    # Extract price analysis fields
-    pa = summary.price_analysis or {}
-
-    buy_zones = []
-    if (
-        pa.get("appropriate_buy_min") is not None
-        or pa.get("appropriate_buy_max") is not None
-    ):
-        buy_zones.append(
-            {
-                "price": pa.get("appropriate_buy_max") or pa.get("appropriate_buy_min"),
-                "type": "appropriate_buy",
-                "reasoning": f"Appropriate buy range: {pa.get('appropriate_buy_min')} - {pa.get('appropriate_buy_max')}",
-            }
-        )
-    if pa.get("buy_hope_min") is not None or pa.get("buy_hope_max") is not None:
-        buy_zones.append(
-            {
-                "price": pa.get("buy_hope_max") or pa.get("buy_hope_min"),
-                "type": "buy_hope",
-                "reasoning": f"Buy hope range: {pa.get('buy_hope_min')} - {pa.get('buy_hope_max')}",
-            }
-        )
-
-    sell_targets = []
-    if (
-        pa.get("appropriate_sell_min") is not None
-        or pa.get("appropriate_sell_max") is not None
-    ):
-        sell_targets.append(
-            {
-                "price": pa.get("appropriate_sell_min")
-                or pa.get("appropriate_sell_max"),
-                "type": "appropriate_sell",
-                "reasoning": f"Appropriate sell range: {pa.get('appropriate_sell_min')} - {pa.get('appropriate_sell_max')}",
-            }
-        )
-    if pa.get("sell_target_min") is not None or pa.get("sell_target_max") is not None:
-        sell_targets.append(
-            {
-                "price": pa.get("sell_target_min") or pa.get("sell_target_max"),
-                "type": "sell_target",
-                "reasoning": f"Sell target range: {pa.get('sell_target_min')} - {pa.get('sell_target_max')}",
-            }
-        )
-
-    # Sort and limit
-    buy_zones.sort(key=lambda x: x["price"] if x["price"] is not None else 0)
-    sell_targets.sort(key=lambda x: x["price"] if x["price"] is not None else 0)
-
-    # Recommendation
-    recommendation = {
-        "action": (
-            summary.decision.value
-            if hasattr(summary.decision, "value")
-            else str(summary.decision)
-        ),
-        "confidence": _map_confidence_score(summary.confidence),
-        "buy_zones": buy_zones[:3],
-        "sell_targets": sell_targets[:3],
-        "stop_loss": None,  # PriceAnalysis doesn't have it explicitly yet
-        "reasoning": "; ".join(summary.reasons) if summary.reasons else "",
-        "detailed_text": summary.detailed_text,
-        "bull_arguments": summary.bull_arguments,
-        "bear_arguments": summary.bear_arguments,
-    }
-
-    # Map stages back to indicators/news/etc if possible
-    analysis = {
-        "symbol": symbol,
-        "market_type": market_type,
-        "source": "research_pipeline",
-        "session_id": session.id,
-        "recommendation": recommendation,
-        "errors": summary.warnings or [],
-        "pipeline_metadata": {
-            "model_name": summary.model_name,
-            "prompt_version": summary.prompt_version,
-            "executed_at": (
-                summary.executed_at.isoformat() if summary.executed_at else None
-            ),
-        },
-    }
-
-    # Try to extract some quote/indicators from stages if available
-    for stage in session.stage_analyses:
-        if stage.stage_type == "market":
-            analysis["quote"] = {
-                "price": stage.signals.get("last_close"),
-                "change_pct": stage.signals.get("change_pct"),
-                "symbol": symbol,
-                "instrument_type": market_type,
-                "source": "research_pipeline",
-            }
-            analysis["indicators"] = stage.signals
-        elif stage.stage_type == "news":
-            analysis["news"] = stage.signals
-        elif stage.stage_type == "fundamentals":
-            analysis["valuation"] = stage.signals
-
-    return analysis
-
-
-async def _get_pipeline_result(
-    session_id: int, symbol: str, market_type: str
-) -> dict[str, Any]:
-    async with AsyncSessionLocal() as db:
-        result = await db.execute(
-            select(ResearchSession)
-            .where(ResearchSession.id == session_id)
-            .options(
-                selectinload(ResearchSession.summaries),
-                selectinload(ResearchSession.stage_analyses),
-            )
-        )
-        session = result.scalar_one_or_none()
-        if not session or not session.summaries:
-            return {}
-
-        summary = max(session.summaries, key=lambda s: s.executed_at)
-        return _map_pipeline_to_analysis(session, summary, symbol, market_type)
-
 
 async def analyze_stock_impl(
     symbol: str,
@@ -554,27 +413,7 @@ async def analyze_stock_impl(
             "Use ticker codes (e.g., AAPL, 005930, KRW-BTC)."
         )
 
-    # ROB-112: Research Pipeline Integration
-    if (
-        settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED
-        and settings.RESEARCH_PIPELINE_ENABLED
-    ):
-        try:
-            from app.analysis.pipeline import run_research_session
 
-            async with AsyncSessionLocal() as db:
-                session_id = await run_research_session(
-                    db=db,
-                    symbol=normalized_symbol,
-                    name=normalized_symbol,
-                    instrument_type=market_type,
-                )
-            return await _get_pipeline_result(
-                session_id, normalized_symbol, market_type
-            )
-        except Exception as exc:
-            logger.warning("research_pipeline.analyze_stock fallback: %s", exc)
-            # Fall through to legacy path
 
     analysis = _build_analysis_payload(normalized_symbol, market_type)
     loop = asyncio.get_running_loop()

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 import sentry_sdk
@@ -27,6 +29,7 @@ from app.mcp_server.tooling.fundamentals_sources_yfinance import (
 )
 from app.mcp_server.tooling.market_data_indicators import _fetch_ohlcv_for_indicators
 from app.mcp_server.tooling.market_data_quotes import (
+    _fetch_kr_live_quote,
     _fetch_quote_crypto,
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
@@ -40,6 +43,7 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market_type
 from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
+from app.services.symbol_analysis.freshness import compute_is_stale
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +94,38 @@ def _build_kr_quote_from_ohlcv(
     }
 
 
+_KST = ZoneInfo("Asia/Seoul")
+
+
+async def _resolve_kr_quote(
+    symbol: str, ohlcv_df: pd.DataFrame
+) -> dict[str, Any] | None:
+    """KR analyze quote: 라이브 inquire_price 우선, 실패 시 일봉 종가 fallback.
+    두 경로 모두 price_as_of + is_stale_price 를 정직하게 태그한다."""
+    trading_date = datetime.now(_KST).date()
+
+    live = await _fetch_kr_live_quote(symbol)
+    if live is not None:
+        as_of_raw = live.get("price_as_of")
+        as_of_dt = datetime.fromisoformat(as_of_raw) if as_of_raw else None
+        live["is_stale_price"] = compute_is_stale(
+            "price", as_of_dt, trading_date=trading_date
+        )
+        return live
+
+    fallback = _build_kr_quote_from_ohlcv(symbol, ohlcv_df)
+    if fallback is None:
+        return None
+    last_idx = ohlcv_df.index[-1]
+    as_of_dt = pd.Timestamp(last_idx).to_pydatetime()
+    fallback["price_as_of"] = as_of_dt.isoformat()
+    fallback["is_stale_price"] = compute_is_stale(
+        "price", as_of_dt, trading_date=trading_date
+    )
+    return fallback
+
+
+
 async def _get_indicators_impl(
     symbol: str,
     indicators: list[str],
@@ -137,17 +173,13 @@ def _prepare_quote_tasks(
     named_tasks: list[tuple[str, asyncio.Task[Any]]] = []
 
     if market_type == "equity_kr":
-        preloaded_quote = _build_kr_quote_from_ohlcv(normalized_symbol, ohlcv_df)
-        if preloaded_quote is None:
-            named_tasks.append(
-                (
-                    "quote",
-                    asyncio.create_task(
-                        _get_quote_impl(normalized_symbol, market_type)
-                    ),
-                )
+        named_tasks.append(
+            (
+                "quote",
+                asyncio.create_task(_resolve_kr_quote(normalized_symbol, ohlcv_df)),
             )
-        return preloaded_quote, named_tasks
+        )
+        return None, named_tasks
 
     named_tasks.append(
         (

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -39,6 +39,7 @@ from app.mcp_server.tooling.shared import (
 )
 from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market_type
 from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
+from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
 
 logger = logging.getLogger(__name__)
 
@@ -390,9 +391,39 @@ def _apply_recommendation(
 ) -> None:
     if market_type not in ("equity_kr", "equity_us"):
         return
+
     recommendation = _build_recommendation_for_equity(analysis, market_type)
-    if recommendation:
-        analysis["recommendation"] = recommendation
+
+    quote = analysis.get("quote") or {}
+    price_present = quote.get("price") is not None
+    consensus_present = bool((analysis.get("opinions") or {}).get("consensus"))
+
+    if recommendation is None:
+        # price/quote 부재 → unavailable floor 레코멘데이션을 정직하게 부착.
+        recommendation = {
+            "action": "hold",
+            "confidence": "low",
+            "rsi14": None,
+            "buy_zones": [],
+            "sell_targets": [],
+            "stop_loss": None,
+            "reasoning": "",
+        }
+    rsi_present = recommendation.get("rsi14") is not None
+
+    missing = insufficient_inputs(
+        price_present=price_present,
+        rsi_present=rsi_present,
+        consensus_present=consensus_present,
+    )
+    action, confidence = floored_action(
+        recommendation["action"], recommendation["confidence"], insufficient=missing
+    )
+    recommendation["action"] = action
+    recommendation["confidence"] = confidence
+    recommendation["insufficient_inputs"] = missing
+
+    analysis["recommendation"] = recommendation
 
 
 

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -438,6 +438,45 @@ async def _fetch_quote_equity_kr(symbol: str) -> dict[str, Any]:
     }
 
 
+async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
+    """analyze 전용: KR 라이브 현재가(KIS inquire_price, stck_prpr) + as_of.
+
+    공유 _fetch_quote_equity_kr(orders/portfolio 사용)는 건드리지 않는다.
+    실패/빈응답이면 None (호출자가 일봉으로 fallback).
+    """
+    kis = KISClient()
+    try:
+        df = await kis.inquire_price(code=symbol, market="J")
+    except Exception:
+        return None
+    if df.empty:
+        return None
+
+    row = df.iloc[0].to_dict()  # index=종목코드
+    as_of: datetime.datetime | None = None
+    date_val = row.get("date")
+    time_val = row.get("time")
+    if date_val is not None:
+        d = pd.Timestamp(date_val).to_pydatetime()
+        if time_val is not None:
+            as_of = datetime.datetime.combine(d.date(), time_val)
+        else:
+            as_of = d
+
+    return {
+        "symbol": symbol,
+        "instrument_type": "equity_kr",
+        "price": row.get("close"),  # stck_prpr → close
+        "open": row.get("open"),
+        "high": row.get("high"),
+        "low": row.get("low"),
+        "volume": row.get("volume"),
+        "value": row.get("value"),
+        "source": "kis",
+        "price_as_of": as_of.isoformat() if as_of is not None else None,
+    }
+
+
 async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
     """Fetch US equity quote from Yahoo Finance."""
     normalized_symbol = str(symbol or "").strip().upper()
@@ -1168,6 +1207,7 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
 __all__ = [
     "_fetch_quote_crypto",
     "_fetch_quote_equity_kr",
+    "_fetch_kr_live_quote",
     "_fetch_quote_equity_us",
     "_fetch_ohlcv_crypto",
     "_fetch_ohlcv_equity_kr",

--- a/app/services/symbol_analysis/floor.py
+++ b/app/services/symbol_analysis/floor.py
@@ -1,0 +1,36 @@
+"""fail-closed insufficient-data floor 헬퍼 (ROB-396, ROB-397 정책 재사용).
+
+core 입력(price/rsi14/consensus)이 부족하면 확신적 buy/sell 을 금지한다.
+price 부재면 unavailable, 그 외 부족이면 hold 로 내린다.
+"""
+
+from __future__ import annotations
+
+# floor 가 검사하는 core 입력 순서 (insufficient_inputs 출력 순서 고정 → 결정적).
+_CORE_FIELDS: tuple[str, ...] = ("price", "rsi14", "consensus")
+
+
+def insufficient_inputs(
+    *, price_present: bool, rsi_present: bool, consensus_present: bool
+) -> list[str]:
+    """부재한 core 입력 이름 리스트 (고정 순서)."""
+
+    present = {
+        "price": price_present,
+        "rsi14": rsi_present,
+        "consensus": consensus_present,
+    }
+    return [field for field in _CORE_FIELDS if not present[field]]
+
+
+def floored_action(
+    action: str, confidence: str, *, insufficient: list[str]
+) -> tuple[str, str]:
+    """(action, confidence). price 부재→(unavailable, low); 그 외 부족→(hold, low);
+    부족 없으면 입력 그대로 통과."""
+
+    if "price" in insufficient:
+        return "unavailable", "low"
+    if insufficient:
+        return "hold", "low"
+    return action, confidence

--- a/docs/superpowers/plans/2026-06-01-rob396-analyze-stock-determinism-stale-price.md
+++ b/docs/superpowers/plans/2026-06-01-rob396-analyze-stock-determinism-stale-price.md
@@ -1,0 +1,690 @@
+# ROB-396 — analyze_stock_batch 결정성 + stale price Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `analyze_stock_impl`의 source·판정 flip(증상1)과 KR stale current_price(증상2)를 ROB-397 계약 원칙으로 결정적·정직하게 고친다.
+
+**Architecture:** (1) `analyze_stock_impl`의 research_pipeline↔legacy 비결정 분기를 제거해 항상 legacy KIS-rich 경로로 고정한다(전 시장). (2) `_apply_recommendation`에 ROB-397 fail-closed floor(`app/services/symbol_analysis/floor.py`)를 적용해 core 입력 부족 시 확신적 buy/sell을 금지한다. (3) KR current_price를 analyze 전용 라이브 오버레이(`inquire_price`)로 전환하고 `price_as_of`/`is_stale_price`를 정직하게 태그한다. 공유 `_fetch_quote_equity_kr`(orders/portfolio/screening 사용)는 건드리지 않는다.
+
+**Tech Stack:** Python 3.13, pytest, `unittest.mock` patch, KIS `inquire_price`, ROB-397 `app/services/symbol_analysis/`(`compute_is_stale`). 새 의존성/마이그레이션 없음. `mcp_server → services` import는 허용 방향.
+
+**참조 스펙:** `docs/superpowers/specs/2026-06-01-rob396-analyze-stock-determinism-stale-price-design.md`
+
+---
+
+## File Structure
+
+- Create `app/services/symbol_analysis/floor.py` — 순수 fail-closed floor 헬퍼 (`insufficient_inputs`, `floored_action`)
+- Create `tests/test_symbol_analysis_floor.py`
+- Modify `app/mcp_server/tooling/analysis_analyze.py` — pipeline 분기 + dead code 제거(Task 2), `_apply_recommendation` floor 적용(Task 3), KR 라이브 quote 오버레이 배선(Task 4)
+- Modify `app/mcp_server/tooling/market_data_quotes.py` — analyze 전용 `_fetch_kr_live_quote` 추가(Task 4)
+- Rewrite `tests/mcp_server/test_analyze_stock_pipeline_compat.py` — 결정성 회귀로 재작성(Task 2)
+- Create `tests/test_analyze_stock_floor.py` (Task 3)
+- Create `tests/test_analyze_stock_kr_live_price.py` (Task 4)
+
+---
+
+## Task 1: fail-closed floor 헬퍼 (`floor.py`)
+
+**Files:**
+- Create: `app/services/symbol_analysis/floor.py`
+- Test: `tests/test_symbol_analysis_floor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_symbol_analysis_floor.py
+import pytest
+
+from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
+
+
+@pytest.mark.unit
+def test_insufficient_inputs_lists_missing_core_fields():
+    assert insufficient_inputs(
+        price_present=True, rsi_present=True, consensus_present=True
+    ) == []
+    assert insufficient_inputs(
+        price_present=True, rsi_present=True, consensus_present=False
+    ) == ["consensus"]
+    assert insufficient_inputs(
+        price_present=False, rsi_present=False, consensus_present=False
+    ) == ["price", "rsi14", "consensus"]
+
+
+@pytest.mark.unit
+def test_floored_action_price_absent_is_unavailable():
+    assert floored_action("buy", "high", insufficient=["price", "rsi14", "consensus"]) == (
+        "unavailable",
+        "low",
+    )
+
+
+@pytest.mark.unit
+def test_floored_action_insufficient_floors_to_hold():
+    assert floored_action("buy", "high", insufficient=["consensus"]) == ("hold", "low")
+    assert floored_action("sell", "medium", insufficient=["rsi14"]) == ("hold", "low")
+
+
+@pytest.mark.unit
+def test_floored_action_complete_inputs_passthrough():
+    assert floored_action("buy", "high", insufficient=[]) == ("buy", "high")
+    assert floored_action("hold", "low", insufficient=[]) == ("hold", "low")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_symbol_analysis_floor.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.services.symbol_analysis.floor`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/symbol_analysis/floor.py
+"""fail-closed insufficient-data floor 헬퍼 (ROB-396, ROB-397 정책 재사용).
+
+core 입력(price/rsi14/consensus)이 부족하면 확신적 buy/sell 을 금지한다.
+price 부재면 unavailable, 그 외 부족이면 hold 로 내린다.
+"""
+
+from __future__ import annotations
+
+# floor 가 검사하는 core 입력 순서 (insufficient_inputs 출력 순서 고정 → 결정적).
+_CORE_FIELDS: tuple[str, ...] = ("price", "rsi14", "consensus")
+
+
+def insufficient_inputs(
+    *, price_present: bool, rsi_present: bool, consensus_present: bool
+) -> list[str]:
+    """부재한 core 입력 이름 리스트 (고정 순서)."""
+
+    present = {
+        "price": price_present,
+        "rsi14": rsi_present,
+        "consensus": consensus_present,
+    }
+    return [field for field in _CORE_FIELDS if not present[field]]
+
+
+def floored_action(
+    action: str, confidence: str, *, insufficient: list[str]
+) -> tuple[str, str]:
+    """(action, confidence). price 부재→(unavailable, low); 그 외 부족→(hold, low);
+    부족 없으면 입력 그대로 통과."""
+
+    if "price" in insufficient:
+        return "unavailable", "low"
+    if insufficient:
+        return "hold", "low"
+    return action, confidence
+```
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_symbol_analysis_floor.py -v && uv run ruff check app/services/symbol_analysis/floor.py tests/test_symbol_analysis_floor.py`
+Expected: PASS (4 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+git add app/services/symbol_analysis/floor.py tests/test_symbol_analysis_floor.py
+git commit -m "feat(ROB-396): fail-closed insufficient-data floor 헬퍼 (397 정책 재사용)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: source 결정성 — pipeline 분기 + dead code 제거
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_analyze.py`
+- Rewrite: `tests/mcp_server/test_analyze_stock_pipeline_compat.py`
+
+기존 `test_analyze_stock_pipeline_compat.py`는 pipeline 분기 동작을 검증한다(`source == "research_pipeline"`). 분기 제거 후 이 파일을 **결정성 회귀**로 재작성한다: pipeline 플래그가 켜져 있어도 legacy source 가 결정적으로 나오고 판정이 안 뒤집힌다.
+
+- [ ] **Step 1: Write the failing test (재작성)**
+
+`tests/mcp_server/test_analyze_stock_pipeline_compat.py` 전체를 아래로 교체:
+
+```python
+# tests/mcp_server/test_analyze_stock_pipeline_compat.py
+"""ROB-396: pipeline 플래그가 켜져 있어도 analyze_stock_impl 은 결정적으로
+legacy 경로(source)를 사용하며 판정이 호출마다 뒤집히지 않는다."""
+
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
+
+
+@pytest.fixture
+def mock_ohlcv_df():
+    return pd.DataFrame(
+        {
+            "open": [100.0],
+            "high": [110.0],
+            "low": [90.0],
+            "close": [105.0],
+            "volume": [1000],
+            "value": [105000.0],
+        },
+        index=[pd.Timestamp.now()],
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_flags_do_not_flip_source(mock_ohlcv_df):
+    """RESEARCH_PIPELINE 플래그 True 라도 legacy source 로 결정적."""
+
+    with patch("app.mcp_server.tooling.analysis_analyze.settings") as mock_settings:
+        mock_settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED = True
+        mock_settings.RESEARCH_PIPELINE_ENABLED = True
+
+        with patch(
+            "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
+            new_callable=AsyncMock,
+            return_value=mock_ohlcv_df,
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_quote_impl",
+            new_callable=AsyncMock,
+            return_value={
+                "price": 105.0,
+                "symbol": "AAPL",
+                "instrument_type": "equity_us",
+                "source": "yahoo",
+            },
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
+            new_callable=AsyncMock,
+            return_value={"rsi": {"value": 50}},
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            first = await analyze_stock_impl("AAPL")
+            second = await analyze_stock_impl("AAPL")
+
+    assert first["source"] == "yahoo"
+    assert first["source"] != "research_pipeline"
+    # 결정적: 반복 호출에 source/판정 불변
+    assert first["source"] == second["source"]
+    assert first["recommendation"]["action"] == second["recommendation"]["action"]
+
+
+@pytest.mark.asyncio
+async def test_no_research_pipeline_symbols_in_module():
+    """분기 제거 회귀: 모듈에서 pipeline 합성 헬퍼가 사라졌다."""
+
+    import app.mcp_server.tooling.analysis_analyze as mod
+
+    assert not hasattr(mod, "_get_pipeline_result")
+    assert not hasattr(mod, "_map_pipeline_to_analysis")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/mcp_server/test_analyze_stock_pipeline_compat.py -v`
+Expected: FAIL — `test_no_research_pipeline_symbols_in_module` fails (`_get_pipeline_result` still exists); `test_pipeline_flags_do_not_flip_source` may fail because the live branch still returns `research_pipeline`.
+
+- [ ] **Step 3: Remove the pipeline branch + dead code**
+
+In `app/mcp_server/tooling/analysis_analyze.py`:
+
+1. In `analyze_stock_impl`, delete the entire research-pipeline block (the `if settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED and settings.RESEARCH_PIPELINE_ENABLED:` ... `# Fall through to legacy path` block, currently ~lines 551-578). After deletion the function flows straight from the `market_type, normalized_symbol = _resolve_market_type(...)` try/except into `analysis = _build_analysis_payload(...)`.
+
+2. Delete the functions `_get_pipeline_result` and `_map_pipeline_to_analysis` (and any private helper used ONLY by them — confirm via grep, e.g. `_map_confidence_score`):
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+grep -rn "_map_confidence_score" app/   # if only inside analysis_analyze.py and only used by _map_pipeline_to_analysis → delete it too
+```
+
+3. Remove now-unused imports at the top of the file:
+   - `from sqlalchemy import select`
+   - `from sqlalchemy.orm import selectinload`
+   - `from app.models.research_pipeline import ResearchSession, ResearchSummary`
+
+4. Run ruff to confirm nothing unused remains:
+
+```bash
+uv run ruff check app/mcp_server/tooling/analysis_analyze.py
+```
+If ruff reports any remaining unused import (e.g. another pipeline-only symbol), remove it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/mcp_server/test_analyze_stock_pipeline_compat.py -v && uv run ruff check app/mcp_server/tooling/analysis_analyze.py`
+Expected: PASS (2 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+git add app/mcp_server/tooling/analysis_analyze.py tests/mcp_server/test_analyze_stock_pipeline_compat.py
+git commit -m "fix(ROB-396): analyze_stock_batch source flip 제거 — pipeline 분기 삭제(legacy 결정성)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: verdict fail-closed floor 배선
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_analyze.py` (`_apply_recommendation`)
+- Test: `tests/test_analyze_stock_floor.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_analyze_stock_floor.py
+import pytest
+
+from app.mcp_server.tooling.analysis_analyze import _apply_recommendation
+
+
+@pytest.mark.unit
+def test_floor_holds_when_consensus_absent():
+    # price + rsi 있으나 consensus 없음 → 확신적 buy 금지(hold).
+    analysis = {
+        "quote": {"price": 1000.0},
+        "indicators": {"rsi": {"14": 25.0}},
+        "support_resistance": {"supports": [{"price": 950.0}]},
+        "opinions": {},  # consensus 없음
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "hold"
+    assert rec["confidence"] == "low"
+    assert "consensus" in rec["insufficient_inputs"]
+
+
+@pytest.mark.unit
+def test_floor_unavailable_when_price_absent():
+    analysis = {
+        "quote": {"price": None},
+        "indicators": {},
+        "opinions": {},
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "unavailable"
+    assert rec["confidence"] == "low"
+    assert "price" in rec["insufficient_inputs"]
+
+
+@pytest.mark.unit
+def test_no_floor_when_inputs_complete():
+    # bullish RSI + bullish consensus → buy 통과, insufficient 없음.
+    analysis = {
+        "quote": {"price": 1000.0},
+        "indicators": {"rsi": {"14": 25.0}},
+        "support_resistance": {"supports": [{"price": 950.0}]},
+        "opinions": {
+            "consensus": {
+                "buy_count": 8,
+                "sell_count": 1,
+                "strong_buy_count": 5,
+                "total_count": 10,
+            }
+        },
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "buy"
+    assert rec["insufficient_inputs"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_analyze_stock_floor.py -v`
+Expected: FAIL — `KeyError: 'insufficient_inputs'` (and `test_floor_unavailable_when_price_absent` fails because current `_apply_recommendation` returns no `recommendation` when price absent).
+
+- [ ] **Step 3: Apply floor in `_apply_recommendation`**
+
+`app/mcp_server/tooling/analysis_analyze.py` 상단 import 에 추가:
+
+```python
+from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
+```
+
+`_apply_recommendation` 를 아래로 교체:
+
+```python
+def _apply_recommendation(
+    analysis: dict[str, Any],
+    market_type: str,
+) -> None:
+    if market_type not in ("equity_kr", "equity_us"):
+        return
+
+    recommendation = _build_recommendation_for_equity(analysis, market_type)
+
+    quote = analysis.get("quote") or {}
+    price_present = quote.get("price") is not None
+    consensus_present = bool((analysis.get("opinions") or {}).get("consensus"))
+
+    if recommendation is None:
+        # price/quote 부재 → unavailable floor 레코멘데이션을 정직하게 부착.
+        recommendation = {
+            "action": "hold",
+            "confidence": "low",
+            "rsi14": None,
+            "buy_zones": [],
+            "sell_targets": [],
+            "stop_loss": None,
+            "reasoning": "",
+        }
+    rsi_present = recommendation.get("rsi14") is not None
+
+    missing = insufficient_inputs(
+        price_present=price_present,
+        rsi_present=rsi_present,
+        consensus_present=consensus_present,
+    )
+    action, confidence = floored_action(
+        recommendation["action"], recommendation["confidence"], insufficient=missing
+    )
+    recommendation["action"] = action
+    recommendation["confidence"] = confidence
+    recommendation["insufficient_inputs"] = missing
+
+    analysis["recommendation"] = recommendation
+```
+
+Note: equity 에 대해 `recommendation` 이 항상 부착된다(이전엔 price 부재 시 누락). additive 변경 — 소비자는 `unavailable` 을 정직하게 받는다.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_analyze_stock_floor.py tests/mcp_server/test_analyze_stock_pipeline_compat.py -v && uv run ruff check app/mcp_server/tooling/analysis_analyze.py tests/test_analyze_stock_floor.py`
+Expected: PASS; ruff clean. (compat 테스트도 여전히 green — bullish 입력이면 floor 통과.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+git add app/mcp_server/tooling/analysis_analyze.py tests/test_analyze_stock_floor.py
+git commit -m "fix(ROB-396): verdict fail-closed floor — core 입력 부족 시 hold/unavailable + insufficient_inputs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 라이브 KR price + 정직 태그
+
+**Files:**
+- Modify: `app/mcp_server/tooling/market_data_quotes.py` (`_fetch_kr_live_quote` 추가)
+- Modify: `app/mcp_server/tooling/analysis_analyze.py` (`_resolve_kr_quote` 추가 + `_prepare_quote_tasks` KR 배선)
+- Test: `tests/test_analyze_stock_kr_live_price.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_analyze_stock_kr_live_price.py
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import analysis_analyze
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _ohlcv():
+    # 전일 일봉(어제 날짜) — fallback 경로용
+    yesterday = pd.Timestamp(datetime.now(KST).date() - timedelta(days=1))
+    return pd.DataFrame(
+        {"open": [100.0], "high": [110.0], "low": [90.0], "close": [105.0],
+         "volume": [1000], "value": [105000.0]},
+        index=[yesterday],
+    )
+
+
+@pytest.mark.asyncio
+async def test_kr_live_price_today_is_not_stale(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol, "instrument_type": "equity_kr",
+            "price": 1225000.0, "open": 1200000.0, "high": 1230000.0,
+            "low": 1190000.0, "volume": 5, "value": 6,
+            "source": "kis", "price_as_of": today.isoformat(),
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["price"] == 1225000.0
+    assert quote["is_stale_price"] is False
+
+
+@pytest.mark.asyncio
+async def test_kr_prev_day_quote_is_stale(monkeypatch):
+    prev = datetime.now(KST) - timedelta(days=1)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol, "instrument_type": "equity_kr",
+            "price": 1173000.0, "open": 1.0, "high": 1.0, "low": 1.0,
+            "volume": 1, "value": 1, "source": "kis",
+            "price_as_of": prev.isoformat(),
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["is_stale_price"] is True
+
+
+@pytest.mark.asyncio
+async def test_kr_live_failure_falls_back_to_ohlcv_stale(monkeypatch):
+    async def fake_live(symbol):
+        return None  # inquire_price 실패/빈응답
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["price"] == 105.0  # 일봉 종가 fallback
+    assert quote["is_stale_price"] is True
+    assert quote["price_as_of"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_analyze_stock_kr_live_price.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_fetch_kr_live_quote'` / `_resolve_kr_quote`.
+
+- [ ] **Step 3: Implement live quote + resolver + wiring**
+
+(a) `app/mcp_server/tooling/market_data_quotes.py` 에 추가 (KISClient 는 이 모듈에 이미 import 됨):
+
+```python
+async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
+    """analyze 전용: KR 라이브 현재가(KIS inquire_price, stck_prpr) + as_of.
+
+    공유 _fetch_quote_equity_kr(orders/portfolio 사용)는 건드리지 않는다.
+    실패/빈응답이면 None (호출자가 일봉으로 fallback).
+    """
+    kis = KISClient()
+    try:
+        df = await kis.inquire_price(code=symbol, market="J")
+    except Exception:
+        return None
+    if df.empty:
+        return None
+
+    row = df.iloc[0].to_dict()  # index=종목코드
+    as_of: datetime | None = None
+    date_val = row.get("date")
+    time_val = row.get("time")
+    if date_val is not None:
+        d = pd.Timestamp(date_val).to_pydatetime()
+        if time_val is not None:
+            as_of = datetime.combine(d.date(), time_val)
+        else:
+            as_of = d
+
+    return {
+        "symbol": symbol,
+        "instrument_type": "equity_kr",
+        "price": row.get("close"),  # stck_prpr → close
+        "open": row.get("open"),
+        "high": row.get("high"),
+        "low": row.get("low"),
+        "volume": row.get("volume"),
+        "value": row.get("value"),
+        "source": "kis",
+        "price_as_of": as_of.isoformat() if as_of is not None else None,
+    }
+```
+
+market_data_quotes.py 상단에 `datetime` import 가 없으면 추가:
+```python
+from datetime import datetime
+```
+그리고 `__all__` 가 있으면 `"_fetch_kr_live_quote"` 를 추가한다(다른 export 패턴을 따름).
+
+(b) `app/mcp_server/tooling/analysis_analyze.py` 상단 import 추가:
+
+```python
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.mcp_server.tooling.market_data_quotes import _fetch_kr_live_quote
+from app.services.symbol_analysis.freshness import compute_is_stale
+```
+
+(기존 `market_data_quotes` import 블록에 `_fetch_kr_live_quote` 를 합쳐도 된다.)
+
+analyze 에 resolver 추가 (`_build_kr_quote_from_ohlcv` 정의 근처):
+
+```python
+_KST = ZoneInfo("Asia/Seoul")
+
+
+async def _resolve_kr_quote(
+    symbol: str, ohlcv_df: pd.DataFrame
+) -> dict[str, Any] | None:
+    """KR analyze quote: 라이브 inquire_price 우선, 실패 시 일봉 종가 fallback.
+    두 경로 모두 price_as_of + is_stale_price 를 정직하게 태그한다."""
+    trading_date = datetime.now(_KST).date()
+
+    live = await _fetch_kr_live_quote(symbol)
+    if live is not None:
+        as_of_raw = live.get("price_as_of")
+        as_of_dt = datetime.fromisoformat(as_of_raw) if as_of_raw else None
+        live["is_stale_price"] = compute_is_stale(
+            "price", as_of_dt, trading_date=trading_date
+        )
+        return live
+
+    fallback = _build_kr_quote_from_ohlcv(symbol, ohlcv_df)
+    if fallback is None:
+        return None
+    last_idx = ohlcv_df.index[-1]
+    as_of_dt = pd.Timestamp(last_idx).to_pydatetime()
+    fallback["price_as_of"] = as_of_dt.isoformat()
+    fallback["is_stale_price"] = compute_is_stale(
+        "price", as_of_dt, trading_date=trading_date
+    )
+    return fallback
+```
+
+`_prepare_quote_tasks` 의 KR 분기를 라이브 resolver task 로 교체:
+
+```python
+    if market_type == "equity_kr":
+        named_tasks.append(
+            (
+                "quote",
+                asyncio.create_task(_resolve_kr_quote(normalized_symbol, ohlcv_df)),
+            )
+        )
+        return None, named_tasks
+```
+
+(기존 `_build_kr_quote_from_ohlcv` preload + `if preloaded_quote is None` task 분기를 위 한 블록으로 대체. `_build_kr_quote_from_ohlcv` 함수 자체는 `_resolve_kr_quote` 의 fallback 으로 계속 사용되므로 유지.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-396 && uv run pytest tests/test_analyze_stock_kr_live_price.py -v && uv run ruff check app/mcp_server/tooling/analysis_analyze.py app/mcp_server/tooling/market_data_quotes.py tests/test_analyze_stock_kr_live_price.py`
+Expected: PASS (3 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+git add app/mcp_server/tooling/analysis_analyze.py app/mcp_server/tooling/market_data_quotes.py tests/test_analyze_stock_kr_live_price.py
+git commit -m "fix(ROB-396): KR current_price 라이브 inquire_price + price_as_of/is_stale_price 태그
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 전체 검증
+
+**Files:** (없음 — 검증/회귀만)
+
+- [ ] **Step 1: 신규/변경 테스트 전체 실행**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+uv run pytest tests/test_symbol_analysis_floor.py tests/test_analyze_stock_floor.py \
+  tests/test_analyze_stock_kr_live_price.py tests/mcp_server/test_analyze_stock_pipeline_compat.py \
+  tests/test_symbol_analysis_contract.py tests/test_symbol_analysis_authority.py \
+  tests/test_symbol_analysis_freshness.py tests/test_symbol_analysis_derived.py -v
+```
+Expected: 전부 PASS.
+
+- [ ] **Step 2: 인접 회귀 (analyze/quote 소비자) + import-contract + lint/format**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+uv run pytest tests/test_mcp_fundamentals_tools.py tests/test_import_contracts.py -q
+uv run ruff check app/ tests/
+uv run ruff format --check app/services/symbol_analysis/ app/mcp_server/tooling/analysis_analyze.py app/mcp_server/tooling/market_data_quotes.py tests/test_symbol_analysis_floor.py tests/test_analyze_stock_floor.py tests/test_analyze_stock_kr_live_price.py tests/mcp_server/test_analyze_stock_pipeline_compat.py
+```
+Expected: PASS; ruff check/format clean. (import-contracts: analyze 가 `app.services.symbol_analysis` 를 import 하는 것은 `mcp_server → services` 허용 방향이므로 위반 아님.)
+
+- [ ] **Step 3: (변경 없으면) 커밋 불필요**
+
+검증만 통과하면 Task 5 는 커밋이 없다. lint/format 수정이 필요하면 해당 파일을 고치고:
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-396
+git add -A && git commit -m "chore(ROB-396): lint/format 정리
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (작성자 체크)
+
+**Spec coverage:**
+- 스펙 §3 source 결정성(pipeline 분기 제거, 전 시장) → Task 2 ✅
+- 스펙 §4 verdict fail-closed floor(shape 불변 + insufficient_inputs) → Task 1(헬퍼) + Task 3(배선) ✅
+- 스펙 §5 라이브 KR price + price_as_of/is_stale_price + graceful fallback → Task 4 ✅
+- 스펙 §6 additive 필드(quote.price_as_of/is_stale_price, recommendation.insufficient_inputs) → Task 3/4 ✅
+- 스펙 §7 두 증상 TDD 회귀 → Task 2(증상1) + Task 4(증상2) + Task 3(floor) ✅
+- 스펙 §8 비목표(공유 _fetch_quote_equity_kr 불변, US/crypto price 제외) → Task 4 가 analyze 전용 _fetch_kr_live_quote 만 추가, 공유 함수 미변경 ✅
+
+**Placeholder scan:** 모든 step 에 실제 코드/명령/기대 출력 포함. dead-code 제거는 grep 확인 단계를 명시(라인 드리프트 회피). placeholder 없음.
+
+**Type consistency:** `insufficient_inputs`/`floored_action`(Task 1 정의, Task 3 사용) 시그니처 일치. `_fetch_kr_live_quote`(Task 4 정의, 테스트/`_resolve_kr_quote` 사용), `_resolve_kr_quote`(Task 4 정의, `_prepare_quote_tasks` 사용), `compute_is_stale`(ROB-397 기존, `compute_is_stale(category, as_of, *, trading_date)`) 일치. recommendation dict 키(action/confidence/rsi14/buy_zones/sell_targets/stop_loss/reasoning/insufficient_inputs) 일관.
+
+**검증 시 주의:**
+- Task 2 dead-code 제거 후 ruff 가 잡는 미사용 import 를 모두 제거(`select`/`selectinload`/`ResearchSession`/`ResearchSummary`, 그리고 `_map_confidence_score` 가 pipeline 전용이면 함께).
+- `inquire_price` 반환 DataFrame 컬럼은 date/time/open/high/low/close/volume/value, index=종목코드 (`domestic_market_data.py:175-215` 확인).

--- a/docs/superpowers/specs/2026-06-01-rob396-analyze-stock-determinism-stale-price-design.md
+++ b/docs/superpowers/specs/2026-06-01-rob396-analyze-stock-determinism-stale-price-design.md
@@ -1,0 +1,86 @@
+# ROB-396 — analyze_stock_batch 비결정성 + stale price 해소 설계
+
+- **이슈**: ROB-396 (오케스트레이션 ROB-411 C라인, 397 다음 순서)
+- **상태**: design (브레인스토밍 승인 완료)
+- **날짜**: 2026-06-01
+- **선행**: ROB-397 (`app/services/symbol_analysis/` 계약 — main c34c79e3). 관련 ROB-392(스코프), ROB-411(오케스트레이션).
+
+---
+
+## 1. 문제 (ROB-396 실증, 2026-06-01)
+
+`analyze_stock_batch`(코어 `analyze_stock_impl`)를 같은 날 같은 종목에 두 번 호출했더니:
+
+- **증상 1 — source·판정 flip**: `analysis_analyze.py:559-576`의 `RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED` + `RESEARCH_PIPELINE_ENABLED` 게이트 아래 `run_research_session()` → `_get_pipeline_result()` 분기. 파이프라인이 성공하면 sparse한 `source:"research_pipeline"`(rsi/consensus null, sell 가능), 예외면 `except`로 legacy `source:"kis"`(rich, buy)로 폴백. 즉 파이프라인 성공 여부에 따라 **source와 매매 판정이 비결정적으로 뒤집힘**. (부수 결함: `_get_pipeline_result`가 summaries 없을 때 `{}`를 그대로 반환.)
+- **증상 2 — stale current_price**: KR 경로는 `_build_kr_quote_from_ohlcv`(일봉 df의 마지막 종가) 또는 `_fetch_quote_equity_kr`(`inquire_daily_itemchartprice n=1`)로 current_price를 만든다 — 둘 다 **일봉 종가**. 정규장 중에도 전일/당일 종가를 반환해 라이브 체결가와 어긋남(012450 1,173,000 vs 실제 ~1,225,000 등).
+
+## 2. 목표·범위
+
+호출 시점 합성을 **결정적·정직**하게 만든다 (ROB-397 계약 원칙 재사용). 397 snapshot read-model 런타임 전환은 후속(ROB-398+collector)이고 본 건이 아니다.
+
+**범위**: KR 경로 중심. 단 §3 source 결정성(파이프라인 분기 제거)은 분기가 market-agnostic이라 전 시장 적용. US/crypto의 라이브 price는 이미 존재(US `fetch_us_live_last_price`, crypto Upbit)하므로 §5 price 수정은 KR 한정.
+
+**안전 경계**: broker/order/watch/order-intent mutation 없음, production DB backfill 없음, scheduler activation 없음, secret/env 변경 없음. 마이그레이션 0. 응답은 read-only.
+
+## 3. 증상 1 수정 — source 결정성 (pipeline 분기 제거)
+
+`analyze_stock_impl`에서 `RESEARCH_PIPELINE_*` 게이트 + `run_research_session` → `_get_pipeline_result` 분기(약 `analysis_analyze.py:551-578`)를 **통째로 제거**. 항상 legacy KIS-rich 합성 경로를 탄다.
+
+- flip 경로 소멸 + `{}` 반환 부수 결함 소멸.
+- 전 시장 적용 (clean-cut). `run_research_session`은 `research_pipeline_service.py` 등 다른 사용처가 있으므로 보존; 제거 대상은 **이 도구 내 분기**뿐.
+- `_get_pipeline_result` / `_map_pipeline_to_analysis`는 본 파일에서만 사용(grep 확인) → 분기 제거 후 dead code로 함께 삭제. 관련 import(`run_research_session`, `ResearchSession`, `selectinload` 등) 미사용분 정리.
+
+## 4. verdict fail-closed floor (397 정책 재사용)
+
+`_apply_recommendation(analysis, market_type)` 직후 floor post-step을 추가한다. 기존 `recommendation` dict **shape는 불변**(reasoning/rsi14/buy_zones/sell_targets/stop_loss 유지) — Hermes/리포트 소비자 비파괴.
+
+floor 규칙 (ROB-397 `derived` 정책과 동일 정신):
+
+- `quote`의 current_price 부재 → `recommendation["action"]="unavailable"`, `confidence="low"`.
+- core 입력 부족 — rsi14 null **또는** consensus 부재/null — 이면 확신적 buy/sell 금지: `action="hold"`, `confidence="low"`.
+- `recommendation["insufficient_inputs"]`(list[str]) 추가로 사유 명시(예: `["consensus"]`, `["rsi14","consensus"]`, `["price"]`).
+
+`mcp_server → services` import는 허용 방향이므로, 397 패키지에 작은 순수 헬퍼를 두고 재사용하는 것을 우선한다. 헬퍼 시그니처(안):
+
+```python
+# app/services/symbol_analysis/floor.py (신규, 작은 순수 함수)
+def insufficient_inputs(*, price_present: bool, rsi_present: bool,
+                        consensus_present: bool) -> list[str]: ...
+def floored_action(action: str, *, price_present: bool,
+                   insufficient: list[str]) -> tuple[str, str]:
+    """(action, confidence). price 부재→unavailable/low;
+    insufficient 있으면→hold/low; 아니면 입력 그대로."""
+```
+
+(헬퍼 추가 시 ROB-397 패키지에 단위테스트 동반. 인라인+인용으로 할지 헬퍼로 뺄지는 plan에서 확정하되, 중복 로직을 피하는 헬퍼를 기본으로 한다.)
+
+## 5. 증상 2 수정 — 라이브 KR price + 정직 태그
+
+KR current_price 소스를 일봉 종가 → **라이브 `inquire_price`**(`app/services/brokers/kis/domestic_market_data.py:175`, `stck_prpr`)로 전환한다. 일봉 df(`ohlcv_df`)는 지표 계산용으로 그대로 사용. US가 `fetch_us_live_last_price`로 오버레이하는 패턴(`market_data_quotes.py:875` 부근)을 미러링한다.
+
+- KR quote 조립 시 current_price를 `inquire_price.stck_prpr`로 채운다.
+- `quote["price_as_of"]`: `inquire_price`의 `stck_bsop_date` + `stck_cntg_hour`(체결 일자·시각)로 구성한 timestamp.
+- `quote["is_stale_price"]`: ROB-397 `compute_is_stale("price", price_as_of, trading_date=<KST 영업일>)`. 장외엔 `inquire_price`가 마지막 종가를 주므로 as_of 날짜 기준으로 정직하게 stale=true.
+- **graceful fallback**: `inquire_price` 실패/빈 응답 시 기존 일봉 종가로 폴백하되 `is_stale_price=true` + price_as_of=일봉 날짜. (숨김 금지 — 라이브 확인 불가를 표면화.)
+- 배치 시 종목당 `inquire_price` +1 read 콜. (broker mutation 아님.)
+
+## 6. 응답 shape 변경 (additive, 비파괴)
+
+- `analysis["quote"]` += `price_as_of`(ISO8601|null), `is_stale_price`(bool).
+- `analysis["recommendation"]` += `insufficient_inputs`(list[str], 기본 `[]`).
+- 기존 키 제거/타입 변경 없음.
+
+## 7. 테스트 (TDD, 두 증상 회귀)
+
+1. **증상1 회귀**: `RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED=true`로 설정해도 `analyze_stock_impl`이 결정적으로 legacy `source`(kis 계열)를 반환하고, 반복 호출에 `recommendation.action`이 뒤집히지 않음. (pipeline 분기 제거 검증.)
+2. **증상2 회귀 (live)**: `inquire_price` mock이 당일 체결(stck_bsop_date=오늘) 반환 → `quote.price`=라이브가, `is_stale_price=false`. 전일 날짜 반환 → `is_stale_price=true`.
+3. **증상2 fallback**: `inquire_price` 예외 → 일봉 종가 폴백 + `is_stale_price=true`.
+4. **floor 회귀**: consensus 부재 + rsi만 존재 → `action="hold"`(buy/sell 아님) + `insufficient_inputs=["consensus"]`; price 부재 → `action="unavailable"`, `insufficient_inputs=["price"]`.
+5. KIS 호출은 기존 테스트 패턴대로 fake/mock (실 네트워크 없음).
+
+## 8. 비목표 (YAGNI)
+
+- ROB-397 snapshot read-model 런타임 전환 (후속 398+collector).
+- US/crypto price 경로 (이미 라이브) — §3 source 결정성만 전 시장.
+- 별칭/뉴스/이벤트 캘린더 (ROB-398/408).
+- analyze_stock 응답을 397 `SymbolAnalysis` 타입으로 재구성 (소비자 비파괴 위해 dict shape 유지).

--- a/tests/mcp_server/test_analyze_stock_pipeline_compat.py
+++ b/tests/mcp_server/test_analyze_stock_pipeline_compat.py
@@ -1,11 +1,13 @@
-from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+# tests/mcp_server/test_analyze_stock_pipeline_compat.py
+"""ROB-396: pipeline 플래그가 켜져 있어도 analyze_stock_impl 은 결정적으로
+legacy 경로(source)를 사용하며 판정이 호출마다 뒤집히지 않는다."""
+
+from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 import pytest
 
 from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
-from app.models.research_pipeline import ResearchSession, ResearchSummary, StageAnalysis
 
 
 @pytest.fixture
@@ -24,123 +26,50 @@ def mock_ohlcv_df():
 
 
 @pytest.mark.asyncio
-async def test_analyze_stock_pipeline_compat_success():
-    """Verify analyze_stock_impl uses pipeline and returns compatible structure."""
-
-    mock_session_id = 123
-
-    # We need real or realistic MagicMocks that can be used by _map_pipeline_to_analysis
-    mock_summary = MagicMock(spec=ResearchSummary)
-    mock_summary.decision = MagicMock()
-    mock_summary.decision.value = "buy"
-    mock_summary.confidence = 80
-    mock_summary.reasons = ["Reason 1", "Reason 2"]
-    mock_summary.detailed_text = "Detailed reasoning"
-    mock_summary.bull_arguments = ["Bull 1"]
-    mock_summary.bear_arguments = ["Bear 1"]
-    mock_summary.price_analysis = {
-        "appropriate_buy_min": 100,
-        "appropriate_buy_max": 110,
-        "appropriate_sell_min": 150,
-        "appropriate_sell_max": 160,
-    }
-    mock_summary.warnings = []
-    mock_summary.model_name = "test-model"
-    mock_summary.prompt_version = "1.0"
-    mock_summary.executed_at = datetime.now(UTC)
-
-    mock_stage = MagicMock(spec=StageAnalysis)
-    mock_stage.stage_type = "market"
-    mock_stage.signals = {
-        "last_close": 105.0,
-        "change_pct": 1.5,
-    }
-
-    mock_session = MagicMock(spec=ResearchSession)
-    mock_session.id = mock_session_id
-    mock_session.summaries = [mock_summary]
-    mock_session.stage_analyses = [mock_stage]
+async def test_pipeline_flags_do_not_flip_source(mock_ohlcv_df):
+    """RESEARCH_PIPELINE 플래그 True 라도 legacy source 로 결정적."""
 
     with patch("app.mcp_server.tooling.analysis_analyze.settings") as mock_settings:
         mock_settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED = True
         mock_settings.RESEARCH_PIPELINE_ENABLED = True
 
-        # Patch the source module since it's imported locally in analyze_stock_impl
         with patch(
-            "app.analysis.pipeline.run_research_session", new_callable=AsyncMock
-        ) as mock_run:
-            mock_run.return_value = mock_session_id
+            "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
+            new_callable=AsyncMock,
+            return_value=mock_ohlcv_df,
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_quote_impl",
+            new_callable=AsyncMock,
+            return_value={
+                "price": 105.0,
+                "symbol": "AAPL",
+                "instrument_type": "equity_us",
+                "source": "yahoo",
+            },
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
+            new_callable=AsyncMock,
+            return_value={"rsi": {"value": 50}},
+        ), patch(
+            "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            first = await analyze_stock_impl("AAPL")
+            second = await analyze_stock_impl("AAPL")
 
-            with patch(
-                "app.mcp_server.tooling.analysis_analyze.AsyncSessionLocal"
-            ) as mock_db_factory:
-                mock_db = AsyncMock()
-                mock_db_factory.return_value.__aenter__.return_value = mock_db
-
-                # Mock result for _get_pipeline_result's query
-                mock_result = MagicMock()
-                mock_result.scalar_one_or_none.return_value = mock_session
-                mock_db.execute.return_value = mock_result
-
-                result = await analyze_stock_impl("AAPL")
-
-                assert result["symbol"] == "AAPL"
-                assert result["source"] == "research_pipeline"
-                assert "recommendation" in result
-                assert result["recommendation"]["action"] == "buy"
-                assert result["recommendation"]["confidence"] == "high"
-                assert len(result["recommendation"]["buy_zones"]) > 0
-                assert result["quote"]["price"] == pytest.approx(105.0)
+    assert first["source"] == "yahoo"
+    assert first["source"] != "research_pipeline"
+    # 결정적: 반복 호출에 source/판정 불변
+    assert first["source"] == second["source"]
+    assert first["recommendation"]["action"] == second["recommendation"]["action"]
 
 
 @pytest.mark.asyncio
-async def test_analyze_stock_pipeline_compat_fallback(mock_ohlcv_df):
-    """Verify fallback to legacy path on pipeline error."""
+async def test_no_research_pipeline_symbols_in_module():
+    """분기 제거 회귀: 모듈에서 pipeline 합성 헬퍼가 사라졌다."""
 
-    with patch("app.mcp_server.tooling.analysis_analyze.settings") as mock_settings:
-        mock_settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED = True
-        mock_settings.RESEARCH_PIPELINE_ENABLED = True
+    import app.mcp_server.tooling.analysis_analyze as mod
 
-        # Force an error in the pipeline path
-        with patch(
-            "app.analysis.pipeline.run_research_session",
-            side_effect=Exception("Pipeline Crash"),
-        ):
-            # We need to mock the legacy path components to avoid real API calls
-            with patch(
-                "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
-                new_callable=AsyncMock,
-            ) as mock_ohlcv:
-                mock_ohlcv.return_value = mock_ohlcv_df
-
-                with patch(
-                    "app.mcp_server.tooling.analysis_analyze._get_quote_impl",
-                    new_callable=AsyncMock,
-                ) as mock_quote:
-                    mock_quote.return_value = {
-                        "price": 105.0,
-                        "symbol": "AAPL",
-                        "instrument_type": "equity_us",
-                        "source": "yahoo",
-                    }
-
-                    with patch(
-                        "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
-                        new_callable=AsyncMock,
-                    ) as mock_ind:
-                        mock_ind.return_value = {"rsi": {"value": 50}}
-
-                        with patch(
-                            "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
-                            new_callable=AsyncMock,
-                        ) as mock_sr:
-                            mock_sr.return_value = {}
-
-                            # Execute
-                            result = await analyze_stock_impl("AAPL")
-
-                            # Verify result comes from legacy path
-                            assert result["symbol"] == "AAPL"
-                            assert result["source"] == "yahoo"  # Default for US stock
-                            assert "quote" in result
-                            assert "indicators" in result
+    assert not hasattr(mod, "_get_pipeline_result")
+    assert not hasattr(mod, "_map_pipeline_to_analysis")

--- a/tests/mcp_server/test_analyze_stock_pipeline_compat.py
+++ b/tests/mcp_server/test_analyze_stock_pipeline_compat.py
@@ -29,31 +29,36 @@ def mock_ohlcv_df():
 async def test_pipeline_flags_do_not_flip_source(mock_ohlcv_df):
     """RESEARCH_PIPELINE 플래그 True 라도 legacy source 로 결정적."""
 
-    with patch("app.mcp_server.tooling.analysis_analyze.settings") as mock_settings:
+    with patch("app.core.config.settings") as mock_settings:
         mock_settings.RESEARCH_PIPELINE_ANALYZE_STOCK_ENABLED = True
         mock_settings.RESEARCH_PIPELINE_ENABLED = True
 
-        with patch(
-            "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
-            new_callable=AsyncMock,
-            return_value=mock_ohlcv_df,
-        ), patch(
-            "app.mcp_server.tooling.analysis_analyze._get_quote_impl",
-            new_callable=AsyncMock,
-            return_value={
-                "price": 105.0,
-                "symbol": "AAPL",
-                "instrument_type": "equity_us",
-                "source": "yahoo",
-            },
-        ), patch(
-            "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
-            new_callable=AsyncMock,
-            return_value={"rsi": {"value": 50}},
-        ), patch(
-            "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
-            new_callable=AsyncMock,
-            return_value={},
+        with (
+            patch(
+                "app.mcp_server.tooling.analysis_analyze._fetch_ohlcv_for_indicators",
+                new_callable=AsyncMock,
+                return_value=mock_ohlcv_df,
+            ),
+            patch(
+                "app.mcp_server.tooling.analysis_analyze._get_quote_impl",
+                new_callable=AsyncMock,
+                return_value={
+                    "price": 105.0,
+                    "symbol": "AAPL",
+                    "instrument_type": "equity_us",
+                    "source": "yahoo",
+                },
+            ),
+            patch(
+                "app.mcp_server.tooling.analysis_analyze._get_indicators_impl",
+                new_callable=AsyncMock,
+                return_value={"rsi": {"value": 50}},
+            ),
+            patch(
+                "app.mcp_server.tooling.analysis_analyze._get_support_resistance_impl",
+                new_callable=AsyncMock,
+                return_value={},
+            ),
         ):
             first = await analyze_stock_impl("AAPL")
             second = await analyze_stock_impl("AAPL")

--- a/tests/test_analyze_stock_floor.py
+++ b/tests/test_analyze_stock_floor.py
@@ -1,0 +1,59 @@
+# tests/test_analyze_stock_floor.py
+import pytest
+
+from app.mcp_server.tooling.analysis_analyze import _apply_recommendation
+
+
+@pytest.mark.unit
+def test_floor_holds_when_consensus_absent():
+    # price + rsi 있으나 consensus 없음 → 확신적 buy 금지(hold).
+    analysis = {
+        "quote": {"price": 1000.0},
+        "indicators": {"rsi": {"14": 25.0}},
+        "support_resistance": {"supports": [{"price": 950.0}]},
+        "opinions": {},  # consensus 없음
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "hold"
+    assert rec["confidence"] == "low"
+    assert "consensus" in rec["insufficient_inputs"]
+
+
+@pytest.mark.unit
+def test_floor_unavailable_when_price_absent():
+    analysis = {
+        "quote": {"price": None},
+        "indicators": {},
+        "opinions": {},
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "unavailable"
+    assert rec["confidence"] == "low"
+    assert "price" in rec["insufficient_inputs"]
+
+
+@pytest.mark.unit
+def test_no_floor_when_inputs_complete():
+    # bullish RSI + bullish consensus → buy 통과, insufficient 없음.
+    analysis = {
+        "quote": {"price": 1000.0},
+        "indicators": {"rsi": {"14": 25.0}},
+        "support_resistance": {"supports": [{"price": 950.0}]},
+        "opinions": {
+            "consensus": {
+                "buy_count": 8,
+                "sell_count": 1,
+                "strong_buy_count": 5,
+                "total_count": 10,
+            }
+        },
+        "valuation": {},
+    }
+    _apply_recommendation(analysis, "equity_kr")
+    rec = analysis["recommendation"]
+    assert rec["action"] == "buy"
+    assert rec["insufficient_inputs"] == []

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -14,8 +14,14 @@ def _ohlcv():
     # 전일 일봉(어제 날짜) — fallback 경로용
     yesterday = pd.Timestamp(datetime.now(KST).date() - timedelta(days=1))
     return pd.DataFrame(
-        {"open": [100.0], "high": [110.0], "low": [90.0], "close": [105.0],
-         "volume": [1000], "value": [105000.0]},
+        {
+            "open": [100.0],
+            "high": [110.0],
+            "low": [90.0],
+            "close": [105.0],
+            "volume": [1000],
+            "value": [105000.0],
+        },
         index=[yesterday],
     )
 
@@ -26,10 +32,16 @@ async def test_kr_live_price_today_is_not_stale(monkeypatch):
 
     async def fake_live(symbol):
         return {
-            "symbol": symbol, "instrument_type": "equity_kr",
-            "price": 1225000.0, "open": 1200000.0, "high": 1230000.0,
-            "low": 1190000.0, "volume": 5, "value": 6,
-            "source": "kis", "price_as_of": today.isoformat(),
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 1225000.0,
+            "open": 1200000.0,
+            "high": 1230000.0,
+            "low": 1190000.0,
+            "volume": 5,
+            "value": 6,
+            "source": "kis",
+            "price_as_of": today.isoformat(),
         }
 
     monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
@@ -44,9 +56,15 @@ async def test_kr_prev_day_quote_is_stale(monkeypatch):
 
     async def fake_live(symbol):
         return {
-            "symbol": symbol, "instrument_type": "equity_kr",
-            "price": 1173000.0, "open": 1.0, "high": 1.0, "low": 1.0,
-            "volume": 1, "value": 1, "source": "kis",
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 1173000.0,
+            "open": 1.0,
+            "high": 1.0,
+            "low": 1.0,
+            "volume": 1,
+            "value": 1,
+            "source": "kis",
             "price_as_of": prev.isoformat(),
         }
 

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -1,0 +1,67 @@
+# tests/test_analyze_stock_kr_live_price.py
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import analysis_analyze
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+def _ohlcv():
+    # 전일 일봉(어제 날짜) — fallback 경로용
+    yesterday = pd.Timestamp(datetime.now(KST).date() - timedelta(days=1))
+    return pd.DataFrame(
+        {"open": [100.0], "high": [110.0], "low": [90.0], "close": [105.0],
+         "volume": [1000], "value": [105000.0]},
+        index=[yesterday],
+    )
+
+
+@pytest.mark.asyncio
+async def test_kr_live_price_today_is_not_stale(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol, "instrument_type": "equity_kr",
+            "price": 1225000.0, "open": 1200000.0, "high": 1230000.0,
+            "low": 1190000.0, "volume": 5, "value": 6,
+            "source": "kis", "price_as_of": today.isoformat(),
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["price"] == 1225000.0
+    assert quote["is_stale_price"] is False
+
+
+@pytest.mark.asyncio
+async def test_kr_prev_day_quote_is_stale(monkeypatch):
+    prev = datetime.now(KST) - timedelta(days=1)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol, "instrument_type": "equity_kr",
+            "price": 1173000.0, "open": 1.0, "high": 1.0, "low": 1.0,
+            "volume": 1, "value": 1, "source": "kis",
+            "price_as_of": prev.isoformat(),
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["is_stale_price"] is True
+
+
+@pytest.mark.asyncio
+async def test_kr_live_failure_falls_back_to_ohlcv_stale(monkeypatch):
+    async def fake_live(symbol):
+        return None  # inquire_price 실패/빈응답
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    quote = await analysis_analyze._resolve_kr_quote("012450", _ohlcv())
+    assert quote["price"] == 105.0  # 일봉 종가 fallback
+    assert quote["is_stale_price"] is True
+    assert quote["price_as_of"] is not None

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -3647,8 +3647,8 @@ async def test_analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver(monkeyp
 
     _patch_runtime_attr(monkeypatch, "_fetch_ohlcv_for_indicators", mock_fetch_ohlcv)
 
-    quote_mock = AsyncMock(side_effect=AssertionError("unexpected KR quote fetch"))
-    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", quote_mock)
+    quote_mock = AsyncMock(return_value=None)
+    _patch_runtime_attr(monkeypatch, "_fetch_kr_live_quote", quote_mock)
 
     standalone_valuation_mock = AsyncMock(
         side_effect=AssertionError("unexpected standalone KR valuation fetch")
@@ -3738,7 +3738,7 @@ async def test_analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver(monkeyp
     result = await tools["analyze_stock"]("005930", market="kr")
 
     assert ohlcv_fetches == [("005930", "equity_kr", 250)]
-    quote_mock.assert_not_awaited()
+    quote_mock.assert_awaited_once_with("005930")
     standalone_valuation_mock.assert_not_awaited()
     standalone_news_mock.assert_not_awaited()
     standalone_opinions_mock.assert_not_awaited()
@@ -3756,6 +3756,8 @@ async def test_analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver(monkeyp
         "volume": 1000000,
         "value": 75000000000.0,
         "source": "kis",
+        "price_as_of": "1970-01-01T00:00:00",
+        "is_stale_price": True,
     }
     assert result["valuation"]["instrument_type"] == "equity_kr"
     assert result["news"]["source"] == "naver"
@@ -3788,9 +3790,10 @@ async def test_analyze_stock_kr_falls_back_to_quote_helper_when_ohlcv_empty(
             "volume": 1100000,
             "value": 76000000000.0,
             "source": "kis",
+            "price_as_of": pd.Timestamp.now().isoformat(),
         }
     )
-    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", quote_mock)
+    _patch_runtime_attr(monkeypatch, "_fetch_kr_live_quote", quote_mock)
 
     standalone_valuation_mock = AsyncMock(
         side_effect=AssertionError("unexpected standalone KR valuation fetch")

--- a/tests/test_symbol_analysis_floor.py
+++ b/tests/test_symbol_analysis_floor.py
@@ -5,9 +5,12 @@ from app.services.symbol_analysis.floor import floored_action, insufficient_inpu
 
 @pytest.mark.unit
 def test_insufficient_inputs_lists_missing_core_fields():
-    assert insufficient_inputs(
-        price_present=True, rsi_present=True, consensus_present=True
-    ) == []
+    assert (
+        insufficient_inputs(
+            price_present=True, rsi_present=True, consensus_present=True
+        )
+        == []
+    )
     assert insufficient_inputs(
         price_present=True, rsi_present=True, consensus_present=False
     ) == ["consensus"]
@@ -18,7 +21,9 @@ def test_insufficient_inputs_lists_missing_core_fields():
 
 @pytest.mark.unit
 def test_floored_action_price_absent_is_unavailable():
-    assert floored_action("buy", "high", insufficient=["price", "rsi14", "consensus"]) == (
+    assert floored_action(
+        "buy", "high", insufficient=["price", "rsi14", "consensus"]
+    ) == (
         "unavailable",
         "low",
     )

--- a/tests/test_symbol_analysis_floor.py
+++ b/tests/test_symbol_analysis_floor.py
@@ -1,0 +1,36 @@
+import pytest
+
+from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
+
+
+@pytest.mark.unit
+def test_insufficient_inputs_lists_missing_core_fields():
+    assert insufficient_inputs(
+        price_present=True, rsi_present=True, consensus_present=True
+    ) == []
+    assert insufficient_inputs(
+        price_present=True, rsi_present=True, consensus_present=False
+    ) == ["consensus"]
+    assert insufficient_inputs(
+        price_present=False, rsi_present=False, consensus_present=False
+    ) == ["price", "rsi14", "consensus"]
+
+
+@pytest.mark.unit
+def test_floored_action_price_absent_is_unavailable():
+    assert floored_action("buy", "high", insufficient=["price", "rsi14", "consensus"]) == (
+        "unavailable",
+        "low",
+    )
+
+
+@pytest.mark.unit
+def test_floored_action_insufficient_floors_to_hold():
+    assert floored_action("buy", "high", insufficient=["consensus"]) == ("hold", "low")
+    assert floored_action("sell", "medium", insufficient=["rsi14"]) == ("hold", "low")
+
+
+@pytest.mark.unit
+def test_floored_action_complete_inputs_passthrough():
+    assert floored_action("buy", "high", insufficient=[]) == ("buy", "high")
+    assert floored_action("hold", "low", insufficient=[]) == ("hold", "low")


### PR DESCRIPTION
## 요약 (ROB-411 C라인, 397 다음)

같은 날 같은 종목 `analyze_stock_batch` 호출이 **source·판정 flip**(증상1) 되고 **current_price가 전일 종가로 고정**(증상2) 되던 문제를 ROB-397 계약 원칙으로 결정적·정직하게 해소.

## 변경

- **source 결정성 (증상1)**: `analyze_stock_impl`의 `RESEARCH_PIPELINE_*` 게이트 하 research_pipeline↔legacy 비결정 분기를 통째 제거 → 항상 legacy KIS-rich 경로(전 시장). dead-code(`_get_pipeline_result`/`_map_pipeline_to_analysis`/미사용 import) 정리. `run_research_session`은 타 사용처 있어 보존.
- **verdict fail-closed floor**: `_apply_recommendation`에 ROB-397 floor 적용(`app/services/symbol_analysis/floor.py`). core 입력(price/rsi14/consensus) 부족 시 확신적 buy/sell 금지 — price 부재→`unavailable`, 그 외 부족→`hold`, `recommendation.insufficient_inputs[]` 명시. 기존 recommendation shape는 additive(비파괴).
- **라이브 KR price (증상2)**: analyze 전용 `_fetch_kr_live_quote`(KIS `inquire_price`, `stck_prpr`) + `_resolve_kr_quote`(라이브 우선 / 일봉 fallback). `quote.price_as_of` + `quote.is_stale_price`(397 `compute_is_stale`) 정직 태그. 공유 `_fetch_quote_equity_kr`(orders/portfolio/screening)는 **미변경**.

## 검증

- 220 passed (신규 floor/floor-wiring/kr-live + 증상1 회귀 + 397 + 인접 fundamentals/import-contracts)
- ruff check / format clean
- import-contracts pass (`mcp_server → services` 허용 방향)
- 마이그레이션 0, broker/order/watch mutation 없음, scheduler 변경 없음

## 비목표

- 397 snapshot read-model 런타임 전환 (후속 398+collector)
- US/crypto price (이미 라이브) — source 결정성만 전 시장
- analyze 응답의 397 SymbolAnalysis 타입 재구성 (소비자 비파괴 위해 dict shape 유지)

## 설계/계획

- spec: `docs/superpowers/specs/2026-06-01-rob396-analyze-stock-determinism-stale-price-design.md`
- plan: `docs/superpowers/plans/2026-06-01-rob396-analyze-stock-determinism-stale-price.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)