### PR TITLE
test(ROB-396): _fetch_kr_live_quote 직접 커버리지

### DIFF
--- a/tests/test_kr_live_quote.py
+++ b/tests/test_kr_live_quote.py
@@ -1,0 +1,93 @@
+"""ROB-396 follow-up: direct coverage for `_fetch_kr_live_quote`.
+
+The analyze-path tests monkeypatch `_fetch_kr_live_quote` out, so its real body
+(KIS `inquire_price` call + row parsing + as_of composition) was uncovered.
+These tests exercise the body directly with a faked `KISClient.inquire_price`.
+"""
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import market_data_quotes
+
+
+def _make_kis(df=None, *, raises=False):
+    class _FakeKIS:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def inquire_price(self, code, market="J"):
+            if raises:
+                raise RuntimeError("kis down")
+            return df
+
+    return _FakeKIS
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_live_quote_parses_price_and_as_of(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": pd.Timestamp("2026-06-01"),
+                "time": datetime.time(9, 30, 0),
+                "open": 1200000.0,
+                "high": 1230000.0,
+                "low": 1190000.0,
+                "close": 1225000.0,
+                "volume": 5,
+                "value": 6,
+            }
+        ],
+        index=["012450"],
+    )
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(df))
+
+    quote = await market_data_quotes._fetch_kr_live_quote("012450")
+
+    assert quote is not None
+    assert quote["price"] == 1225000.0  # stck_prpr → close (live, not prev close)
+    assert quote["source"] == "kis"
+    assert quote["instrument_type"] == "equity_kr"
+    assert quote["price_as_of"] == "2026-06-01T09:30:00"
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_live_quote_as_of_without_time_uses_date(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "date": pd.Timestamp("2026-06-01"),
+                "time": None,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1225000.0,
+                "volume": 1,
+                "value": 1,
+            }
+        ],
+        index=["012450"],
+    )
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(df))
+
+    quote = await market_data_quotes._fetch_kr_live_quote("012450")
+
+    assert quote is not None
+    assert quote["price_as_of"] == "2026-06-01T00:00:00"
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_live_quote_empty_df_returns_none(monkeypatch):
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(pd.DataFrame()))
+
+    assert await market_data_quotes._fetch_kr_live_quote("012450") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_live_quote_swallows_kis_error_returns_none(monkeypatch):
+    monkeypatch.setattr(market_data_quotes, "KISClient", _make_kis(raises=True))
+
+    assert await market_data_quotes._fetch_kr_live_quote("012450") is None


### PR DESCRIPTION
## 요약

ROB-396(#1078) 후속. analyze-path 테스트가 `_fetch_kr_live_quote`를 monkeypatch로 대체해 함수 본문(KIS `inquire_price` 호출 + row 파싱 + as_of 합성 + 실패/빈응답 분기)이 codecov patch에서 미커버였다. 이를 직접 단위테스트로 해소.

## 변경

- `tests/test_kr_live_quote.py` 신규 4 케이스:
  - 정상: `stck_prpr`→price(라이브), `price_as_of`=date+time 합성
  - time 없음 → as_of=date(자정)
  - 빈 df → None
  - KIS 예외 → None (graceful)

테스트 전용, 프로덕션 코드 변경 없음. 마이그레이션 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)