### PR TITLE
fix(ROB-337): merge alembic heads (single-head test red on main)

### DIFF
--- a/alembic/versions/rob337_rob403_merge_heads.py
+++ b/alembic/versions/rob337_rob403_merge_heads.py
@@ -1,0 +1,30 @@
+"""merge rob337_add_watch_recommendation + c6358fdef6fd (ROB-403) heads
+
+Revision ID: rob337_rob403_merge_heads
+Revises: rob337_add_watch_recommendation, c6358fdef6fd
+Create Date: 2026-06-01
+
+Both revisions branched from 14fa36b85d0a and merged to main in parallel
+(ROB-337 Slice 1 watch_recommendation column + ROB-403 watch_conditions
+zone), producing two alembic heads. This merge revision unifies them so
+the revision graph has a single final head. No schema change.
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "rob337_rob403_merge_heads"
+down_revision: Union[str, Sequence[str], None] = (
+    "rob337_add_watch_recommendation",
+    "c6358fdef6fd",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No-op: pure merge of two heads."""
+
+
+def downgrade() -> None:
+    """No-op: pure merge of two heads."""


### PR DESCRIPTION
## 문제

main이 alembic **두 head**로 red:
`test_revision_graph_has_single_final_head — Expected single head, got: {'c6358fdef6fd', 'rob337_add_watch_recommendation'}`

`rob337_add_watch_recommendation`(ROB-337 Slice 1 watch_recommendation 컬럼, #1076)과 `c6358fdef6fd`(ROB-403 watch_conditions zone, #1075)가 **둘 다 `14fa36b85d0a`에서 분기**해 병렬 머지되며 head가 둘이 됨. (각 PR의 머지 후 main Test는 단발로는 green이었으나, 둘이 함께 올라온 뒤 single-head 불변식 위반.)

## 수정

no-op **merge 마이그레이션** `rob337_rob403_merge_heads` (`down_revision=(rob337_add_watch_recommendation, c6358fdef6fd)`)로 두 head를 단일 head로 통합. **스키마 변경 없음.**

## 검증
- `tests/test_us_candles_sync.py::test_revision_graph_has_single_final_head` **1 passed** (로컬).
- `alembic heads` → 단일 `rob337_rob403_merge_heads`.
- `ruff check app/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)