### PR TITLE
feat(ROB-376) PR1: investment_report_delta_get (read-only 장중 델타 도구)

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -63,6 +63,7 @@ INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
     "investment_report_decide_item",
     "investment_report_activate_watch",
     "investment_report_context_get",
+    "investment_report_delta_get",
     "investment_report_generate_from_bundle",
     "investment_watch_recommend",
 }
@@ -564,6 +565,32 @@ async def investment_report_context_get_impl(
 
 
 # ---------------------------------------------------------------------------
+# investment_report_delta_get (ROB-376)
+# ---------------------------------------------------------------------------
+async def investment_report_delta_get_impl(
+    report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict:
+    from app.core.timezone import now_kst
+    from app.services.investment_reports.delta_service import DeltaService
+
+    try:
+        parsed = UUID(report_uuid)
+    except (ValueError, AttributeError, TypeError):
+        return {"success": False, "error": "invalid_report_uuid"}
+
+    async with AsyncSessionLocal() as db:
+        service = DeltaService(db)
+        return await service.compute_delta(
+            parsed,
+            near_pct=near_pct,
+            account_type=account_type,
+            computed_at_kst=now_kst().isoformat(),
+        )
+
+
+# ---------------------------------------------------------------------------
 # investment_report_generate_from_bundle (ROB-273)
 # ---------------------------------------------------------------------------
 async def investment_report_generate_from_bundle_impl(
@@ -877,6 +904,19 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         ),
     )(investment_report_context_get_impl)
     mcp.tool(
+        name="investment_report_delta_get",
+        description=(
+            "Read-only intraday delta vs a baseline report. Given report_uuid "
+            "(the open/prior report), returns three deterministic deltas for Hermes "
+            "to compose: levels_delta (journal target/stop touch x live), "
+            "holdings_pnl_delta (per-symbol live P/L vs the baseline snapshot "
+            "bundle's portfolio P/L), and index_delta (live index vs the report's "
+            "frozen market baseline). Per-signal fail-open: a degraded signal is "
+            "null with a reason under 'unavailable'; missing data is never coerced "
+            "to zero. No broker/order/watch mutation."
+        ),
+    )(investment_report_delta_get_impl)
+    mcp.tool(
         name="investment_report_generate_from_bundle",
         description=GENERATE_FROM_BUNDLE_DESCRIPTION,
     )(investment_report_generate_from_bundle_impl)
@@ -900,6 +940,7 @@ __all__ = [
     "investment_report_context_get_impl",
     "investment_report_create_impl",
     "investment_report_decide_item_impl",
+    "investment_report_delta_get_impl",
     "investment_report_generate_from_bundle_impl",
     "investment_report_get_impl",
     "investment_report_list_impl",

--- a/app/services/investment_reports/delta_service.py
+++ b/app/services/investment_reports/delta_service.py
@@ -1,0 +1,359 @@
+"""ROB-376 — read-only intraday delta computation for investment reports.
+
+Deterministic baseline-vs-live deltas (target/stop touch, per-symbol holdings P/L,
+index move) for the next/intraday report. No DB writes, no broker/watch mutation,
+no in-process LLM. Every signal is fail-open: one signal's failure never kills the
+others.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _near(current: Any, level: Any, near_pct: float) -> bool:
+    """True when ``current`` is within ``near_pct`` percent of ``level``."""
+    if not _is_finite_number(current) or not _is_finite_number(level) or level == 0:
+        return False
+    return abs(current - level) / abs(level) * 100 <= near_pct
+
+
+def _levels_delta(
+    journal_result: Mapping[str, Any],
+    symbols: set[str],
+    *,
+    near_pct: float,
+) -> dict[str, Any]:
+    """Project the journal's already-computed live enrichment into a delta block.
+
+    Reuses ``target_reached`` / ``stop_reached`` / ``pnl_pct_live`` (computed by
+    ``get_trade_journal(enrich_live=True)``); computes per-entry ``near_*`` flags
+    here. When ``symbols`` is empty, all entries are kept.
+    """
+    entries: list[dict[str, Any]] = []
+    near_target = near_stop = target_hit = stop_hit = 0
+    for entry in journal_result.get("entries") or []:
+        symbol = entry.get("symbol")
+        if symbols and symbol not in symbols:
+            continue
+        current = entry.get("current_price")
+        target = entry.get("target_price")
+        stop = entry.get("stop_loss")
+        is_target_reached = bool(entry.get("target_reached"))
+        is_stop_reached = bool(entry.get("stop_reached"))
+        is_near_target = _near(current, target, near_pct) and not is_target_reached
+        is_near_stop = _near(current, stop, near_pct) and not is_stop_reached
+        near_target += int(is_near_target)
+        near_stop += int(is_near_stop)
+        target_hit += int(is_target_reached)
+        stop_hit += int(is_stop_reached)
+        entries.append(
+            {
+                "symbol": symbol,
+                "side": entry.get("side"),
+                "target_price": target,
+                "stop_loss": stop,
+                "current_price": current,
+                "pnl_pct_live": entry.get("pnl_pct_live"),
+                "target_reached": entry.get("target_reached"),
+                "stop_reached": entry.get("stop_reached"),
+                "near_target": is_near_target,
+                "near_stop": is_near_stop,
+            }
+        )
+    return {
+        "entries": entries,
+        "summary": {
+            "near_target": near_target,
+            "near_stop": near_stop,
+            "target_hit": target_hit,
+            "stop_hit": stop_hit,
+        },
+    }
+
+
+def _baseline_pnl_from_bundle_pairs(
+    pairs: list[tuple[Any, Any]],
+) -> dict[str, float] | None:
+    """Extract ``{ticker: pnl_rate}`` from the bundle's ``portfolio`` snapshot.
+
+    Returns ``None`` when no ``portfolio`` snapshot is present (so the caller can
+    record ``baseline_snapshot_absent`` rather than fabricating an empty baseline).
+    Holdings without a finite ``pnl_rate`` are skipped (missing != zero).
+    """
+    for _item, snapshot in pairs:
+        if getattr(snapshot, "snapshot_kind", None) != "portfolio":
+            continue
+        payload = getattr(snapshot, "payload_json", None) or {}
+        out: dict[str, float] = {}
+        for holding in payload.get("holdings") or []:
+            ticker = holding.get("ticker")
+            rate = holding.get("pnl_rate")
+            if ticker is not None and _is_finite_number(rate):
+                out[str(ticker)] = float(rate)
+        return out
+    return None
+
+
+def _live_pnl_by_symbol(holdings_result: Mapping[str, Any]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for account in holdings_result.get("accounts") or []:
+        for position in account.get("positions") or []:
+            symbol = position.get("symbol")
+            rate = position.get("profit_rate")
+            if symbol is not None and _is_finite_number(rate):
+                out[str(symbol)] = float(rate)
+    return out
+
+
+def _holdings_pnl_delta(
+    baseline_pnl: Mapping[str, float],
+    holdings_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Per-symbol live P/L vs baseline P/L. Only symbols present on BOTH sides get
+    an entry (missing != zero); one-sided symbols are counted in the summary."""
+    live_pnl = _live_pnl_by_symbol(holdings_result)
+    baseline_keys = set(baseline_pnl)
+    live_keys = set(live_pnl)
+    both = baseline_keys & live_keys
+    entries: list[dict[str, Any]] = []
+    for symbol in sorted(both):
+        base = baseline_pnl[symbol]
+        live = live_pnl[symbol]
+        entries.append(
+            {
+                "symbol": symbol,
+                "baseline_pnl_pct": base,
+                "live_pnl_pct": live,
+                "delta_pp": round(live - base, 6),
+            }
+        )
+    return {
+        "entries": entries,
+        "summary": {
+            "symbols_compared": len(both),
+            "symbols_baseline_only": len(baseline_keys - live_keys),
+            "symbols_live_only": len(live_keys - baseline_keys),
+        },
+    }
+
+
+def _baseline_indices(market_snapshot: Any) -> dict[str, Any] | None:
+    """Return the frozen ``baseline.indices`` dict (keyed by index symbol), or
+    ``None`` when the snapshot is the ``unavailable`` shape or lacks indices."""
+    if not isinstance(market_snapshot, Mapping):
+        return None
+    if market_snapshot.get("status") == "unavailable":
+        return None
+    baseline = market_snapshot.get("baseline")
+    if not isinstance(baseline, Mapping):
+        return None
+    indices = baseline.get("indices")
+    if not isinstance(indices, Mapping):
+        return None
+    return dict(indices)
+
+
+def _index_delta(
+    baseline_indices: Mapping[str, Any],
+    market_index_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Live index value vs frozen baseline value, per index symbol. ``change_pct``
+    is computed only when both values are finite and baseline != 0; otherwise it is
+    ``null`` (never fabricated). Indices absent from the live response carry a
+    ``null`` ``live_value``."""
+    live_by_symbol: dict[str, Any] = {}
+    for index in market_index_result.get("indices") or []:
+        symbol = index.get("symbol")
+        if symbol is not None:
+            live_by_symbol[str(symbol)] = index.get("current")
+    entries: list[dict[str, Any]] = []
+    for symbol, baseline in baseline_indices.items():
+        baseline_value = (
+            baseline.get("current") if isinstance(baseline, Mapping) else None
+        )
+        live_value = live_by_symbol.get(symbol)
+        change_pct: float | None = None
+        if (
+            _is_finite_number(baseline_value)
+            and _is_finite_number(live_value)
+            and baseline_value != 0
+        ):
+            change_pct = (live_value - baseline_value) / baseline_value * 100
+        entries.append(
+            {
+                "index_symbol": symbol,
+                "baseline_value": baseline_value,
+                "live_value": live_value,
+                "change_pct": change_pct,
+            }
+        )
+    return {"entries": entries}
+
+
+def _reason(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+class DeltaService:
+    """Orchestrates the three read-only deltas. I/O is injectable so the logic is
+    unit-testable without a DB or live network. Defaults wire the real loaders/tools."""
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        baseline_loader: Callable[[UUID], Awaitable[dict[str, Any] | None]]
+        | None = None,
+        journal_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        holdings_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        market_index_fn: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._session = session
+        self._baseline_loader = baseline_loader
+        self._journal_fn = journal_fn
+        self._holdings_fn = holdings_fn
+        self._market_index_fn = market_index_fn
+
+    async def compute_delta(
+        self,
+        report_uuid: UUID | str,
+        *,
+        near_pct: float = 1.0,
+        account_type: str = "live",
+        computed_at_kst: str | None = None,
+    ) -> dict[str, Any]:
+        parsed = (
+            report_uuid if isinstance(report_uuid, UUID) else UUID(str(report_uuid))
+        )
+        loader = self._baseline_loader or self._default_baseline_loader
+        baseline = await loader(parsed)
+        if baseline is None:
+            return {"success": False, "error": "baseline_not_found"}
+
+        market = baseline["market"]
+        symbols = baseline["symbols"]
+        market_snapshot = baseline["market_snapshot"]
+        baseline_pnl = baseline["baseline_pnl"]
+        unavailable: dict[str, str] = {}
+
+        levels_delta: dict[str, Any] | None = None
+        try:
+            journal_fn = self._journal_fn or _default_journal_fn
+            journal_result = await journal_fn(account_type=account_type, market=market)
+            levels_delta = _levels_delta(journal_result, symbols, near_pct=near_pct)
+        except Exception as exc:  # noqa: BLE001 — fail-open per signal
+            logger.info("levels_delta failed: %r", exc)
+            unavailable["levels"] = _reason(exc)
+
+        holdings_pnl_delta: dict[str, Any] | None = None
+        if baseline_pnl is None:
+            unavailable["holdings"] = "baseline_snapshot_absent"
+        else:
+            try:
+                holdings_fn = self._holdings_fn or _default_holdings_fn
+                holdings_result = await holdings_fn(market=market)
+                holdings_pnl_delta = _holdings_pnl_delta(baseline_pnl, holdings_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("holdings_pnl_delta failed: %r", exc)
+                unavailable["holdings"] = _reason(exc)
+
+        index_delta: dict[str, Any] | None = None
+        baseline_indices = _baseline_indices(market_snapshot)
+        if baseline_indices is None:
+            unavailable["index"] = "baseline_snapshot_absent"
+        else:
+            try:
+                market_index_fn = self._market_index_fn or _default_market_index_fn
+                index_result = await market_index_fn()
+                index_delta = _index_delta(baseline_indices, index_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("index_delta failed: %r", exc)
+                unavailable["index"] = _reason(exc)
+
+        out: dict[str, Any] = {
+            "success": True,
+            "baseline_report_uuid": str(parsed),
+            "market": market,
+            "levels_delta": levels_delta,
+            "holdings_pnl_delta": holdings_pnl_delta,
+            "index_delta": index_delta,
+        }
+        if computed_at_kst is not None:
+            out["computed_at_kst"] = computed_at_kst
+        if unavailable:
+            out["unavailable"] = unavailable
+        return out
+
+    async def _default_baseline_loader(
+        self, report_uuid: UUID
+    ) -> dict[str, Any] | None:
+        from app.services.investment_reports.query_service import (
+            InvestmentReportQueryService,
+        )
+        from app.services.investment_snapshots.repository import (
+            InvestmentSnapshotsRepository,
+        )
+
+        query_service = InvestmentReportQueryService(self._session)
+        bundle = await query_service.get_bundle(report_uuid)
+        if bundle is None:
+            return None
+        report = bundle["report"]
+        symbols = {
+            item.symbol
+            for item in (bundle.get("items") or [])
+            if getattr(item, "symbol", None)
+        }
+        baseline_pnl: dict[str, float] | None = None
+        bundle_uuid = getattr(report, "snapshot_bundle_uuid", None)
+        if bundle_uuid is not None:
+            snapshots_repo = InvestmentSnapshotsRepository(self._session)
+            snapshot_bundle = await snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+            if snapshot_bundle is not None:
+                pairs = await snapshots_repo.list_bundle_items_with_snapshots(
+                    snapshot_bundle.id
+                )
+                baseline_pnl = _baseline_pnl_from_bundle_pairs(pairs)
+        return {
+            "market": report.market,
+            "symbols": symbols,
+            "market_snapshot": report.market_snapshot or {},
+            "baseline_pnl": baseline_pnl,
+        }
+
+
+async def _default_journal_fn(*, account_type: str, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.trade_journal_tools import get_trade_journal
+
+    return await get_trade_journal(
+        enrich_live=True, account_type=account_type, market=market
+    )
+
+
+async def _default_holdings_fn(*, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+
+    return await _get_holdings_impl(market=market, include_current_price=True)
+
+
+async def _default_market_index_fn() -> dict[str, Any]:
+    from app.mcp_server.tooling.fundamentals._market_index import (
+        handle_get_market_index,
+    )
+
+    return await handle_get_market_index()

--- a/docs/superpowers/plans/2026-06-01-rob-376-report-delta.md
+++ b/docs/superpowers/plans/2026-06-01-rob-376-report-delta.md
@@ -1,0 +1,1084 @@
+# investment_report_delta_get Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only MCP tool `investment_report_delta_get` that, given a baseline report, returns three deterministic intraday deltas — target/stop touch, per-symbol holdings P/L delta, and index delta — for Hermes to pull and compose.
+
+**Architecture:** A pure-function transform layer (no I/O) plus a thin `DeltaService` orchestrator that loads the baseline (report row + snapshot-bundle portfolio payload) and calls three injectable live-data fns. Every signal is computed in its own try/except (fail-open). No DB writes, no broker/watch mutation, no migration, no in-process LLM.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, FastMCP tool registration, pytest. Reuses existing tools: `get_trade_journal(enrich_live=True)`, `_get_holdings_impl`, `handle_get_market_index`, `InvestmentReportQueryService.get_bundle`, `InvestmentSnapshotsRepository`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md`
+
+---
+
+## File Structure
+
+- **Create** `app/services/investment_reports/delta_service.py` — pure helpers
+  (`_levels_delta`, `_holdings_pnl_delta`, `_baseline_pnl_from_bundle_pairs`, `_index_delta`,
+  `_baseline_indices`), the `DeltaService` orchestrator, and module-level default I/O fns.
+- **Modify** `app/mcp_server/tooling/investment_reports_handlers.py` — add
+  `investment_report_delta_get_impl`, register it, add its name to
+  `INVESTMENT_REPORT_TOOL_NAMES` and `__all__`.
+- **Create** `tests/services/investment_reports/test_delta_service.py` — pure-helper unit tests
+  + orchestrator tests with injected fakes (no DB).
+- **Create** `tests/services/investment_reports/test_delta_service_db.py` — one DB-integration
+  test for the default baseline loader (seeds a report row only) + `baseline_not_found`.
+- **Create** `tests/mcp_server/test_investment_report_delta_tool.py` — handler + registration test.
+
+### Key data shapes (verified against current code)
+
+- `get_trade_journal(enrich_live=True, account_type=..., market=...)` →
+  `{"success": True, "entries": [{"symbol", "side", "target_price", "stop_loss",
+  "current_price", "pnl_pct_live", "target_reached", "stop_reached", ...}], "summary": {...}}`.
+- `_get_holdings_impl(market=..., include_current_price=True)` →
+  `{"accounts": [{"positions": [{"symbol", "profit_rate", ...}]}], ...}`.
+- `handle_get_market_index()` (no symbol) → `{"indices": [{"symbol", "current", "change_pct", ...}]}`.
+- Report row `market_snapshot` = `{"provenance": {...}, "baseline": {"market", "from_date",
+  "to_date", "indices": {"<sym>": {"change_percent", "name", "current"}}}}`
+  **or** `{"status": "unavailable", "reason": ...}`.
+- Snapshot-bundle `portfolio` payload `holdings[]` entries carry `ticker` + `pnl_rate`.
+- `InvestmentReportQueryService.get_bundle(uuid)` → `{"report", "items", ...}` or `None`;
+  `report.snapshot_bundle_uuid`, `report.market`, `report.market_snapshot`; each item has `.symbol`.
+- `InvestmentSnapshotsRepository.get_bundle_by_uuid(uuid)` → bundle row (has `.id`) or `None`;
+  `.list_bundle_items_with_snapshots(bundle_id)` → `[(item, snapshot), ...]`, each `snapshot`
+  has `.snapshot_kind` and `.payload_json`.
+
+---
+
+## Task 1: Pure helper `_levels_delta`
+
+**Files:**
+- Create: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_delta_service.py
+from __future__ import annotations
+
+from app.services.investment_reports.delta_service import _levels_delta
+
+
+def test_levels_delta_filters_to_symbols_and_projects_flags():
+    journal = {
+        "entries": [
+            {"symbol": "AAPL", "side": "buy", "target_price": 230.0, "stop_loss": 200.0,
+             "current_price": 231.0, "pnl_pct_live": 4.1,
+             "target_reached": True, "stop_reached": False},
+            {"symbol": "MSFT", "side": "buy", "target_price": 500.0, "stop_loss": 400.0,
+             "current_price": 401.0, "pnl_pct_live": -1.0,
+             "target_reached": False, "stop_reached": False},
+            {"symbol": "ZZZZ", "side": "buy", "target_price": 1.0, "stop_loss": 0.5,
+             "current_price": 0.9, "pnl_pct_live": 0.0,
+             "target_reached": False, "stop_reached": False},
+        ]
+    }
+    out = _levels_delta(journal, {"AAPL", "MSFT"}, near_pct=1.0)
+    syms = [e["symbol"] for e in out["entries"]]
+    assert syms == ["AAPL", "MSFT"]  # ZZZZ filtered out
+    aapl = out["entries"][0]
+    assert aapl["target_reached"] is True
+    assert aapl["pnl_pct_live"] == 4.1
+    # MSFT current 401 is within 1% of stop 400 -> near_stop True
+    msft = out["entries"][1]
+    assert msft["near_stop"] is True
+    assert msft["near_target"] is False
+    assert out["summary"] == {
+        "near_target": 0, "near_stop": 1, "target_hit": 1, "stop_hit": 0
+    }
+
+
+def test_levels_delta_empty_symbols_keeps_all_entries():
+    journal = {"entries": [
+        {"symbol": "AAPL", "side": "buy", "target_price": None, "stop_loss": None,
+         "current_price": 10.0, "pnl_pct_live": 1.0,
+         "target_reached": None, "stop_reached": None},
+    ]}
+    out = _levels_delta(journal, set(), near_pct=1.0)
+    assert [e["symbol"] for e in out["entries"]] == ["AAPL"]
+    assert out["entries"][0]["near_target"] is False  # no target -> not near
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `ImportError` / `cannot import name '_levels_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/investment_reports/delta_service.py
+"""ROB-376 — read-only intraday delta computation for investment reports.
+
+Deterministic baseline-vs-live deltas (target/stop touch, per-symbol holdings P/L,
+index move) for the next/intraday report. No DB writes, no broker/watch mutation,
+no in-process LLM. Every signal is fail-open: one signal's failure never kills the
+others.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _near(current: Any, level: Any, near_pct: float) -> bool:
+    """True when ``current`` is within ``near_pct`` percent of ``level``."""
+    if not _is_finite_number(current) or not _is_finite_number(level) or level == 0:
+        return False
+    return abs(current - level) / abs(level) * 100 <= near_pct
+
+
+def _levels_delta(
+    journal_result: Mapping[str, Any],
+    symbols: set[str],
+    *,
+    near_pct: float,
+) -> dict[str, Any]:
+    """Project the journal's already-computed live enrichment into a delta block.
+
+    Reuses ``target_reached`` / ``stop_reached`` / ``pnl_pct_live`` (computed by
+    ``get_trade_journal(enrich_live=True)``); computes per-entry ``near_*`` flags
+    here. When ``symbols`` is empty, all entries are kept.
+    """
+    entries: list[dict[str, Any]] = []
+    near_target = near_stop = target_hit = stop_hit = 0
+    for entry in journal_result.get("entries") or []:
+        symbol = entry.get("symbol")
+        if symbols and symbol not in symbols:
+            continue
+        current = entry.get("current_price")
+        target = entry.get("target_price")
+        stop = entry.get("stop_loss")
+        is_near_target = _near(current, target, near_pct)
+        is_near_stop = _near(current, stop, near_pct)
+        is_target_reached = bool(entry.get("target_reached"))
+        is_stop_reached = bool(entry.get("stop_reached"))
+        near_target += int(is_near_target)
+        near_stop += int(is_near_stop)
+        target_hit += int(is_target_reached)
+        stop_hit += int(is_stop_reached)
+        entries.append({
+            "symbol": symbol,
+            "side": entry.get("side"),
+            "target_price": target,
+            "stop_loss": stop,
+            "current_price": current,
+            "pnl_pct_live": entry.get("pnl_pct_live"),
+            "target_reached": entry.get("target_reached"),
+            "stop_reached": entry.get("stop_reached"),
+            "near_target": is_near_target,
+            "near_stop": is_near_stop,
+        })
+    return {
+        "entries": entries,
+        "summary": {
+            "near_target": near_target,
+            "near_stop": near_stop,
+            "target_hit": target_hit,
+            "stop_hit": stop_hit,
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): _levels_delta pure helper for report delta tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Pure helpers `_holdings_pnl_delta` + `_baseline_pnl_from_bundle_pairs`
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+import types
+
+from app.services.investment_reports.delta_service import (
+    _baseline_pnl_from_bundle_pairs,
+    _holdings_pnl_delta,
+)
+
+
+def _snap(kind, payload):
+    return types.SimpleNamespace(snapshot_kind=kind, payload_json=payload)
+
+
+def test_baseline_pnl_from_bundle_pairs_reads_portfolio_holdings():
+    pairs = [
+        (object(), _snap("market", {"indices": {}})),
+        (object(), _snap("portfolio", {"holdings": [
+            {"ticker": "AAPL", "pnl_rate": 1.0},
+            {"ticker": "MSFT", "pnl_rate": -2.0},
+            {"ticker": "NOPNL"},  # missing pnl_rate -> skipped, not fabricated
+        ]})),
+    ]
+    assert _baseline_pnl_from_bundle_pairs(pairs) == {"AAPL": 1.0, "MSFT": -2.0}
+
+
+def test_baseline_pnl_from_bundle_pairs_none_when_no_portfolio_kind():
+    pairs = [(object(), _snap("market", {"indices": {}}))]
+    assert _baseline_pnl_from_bundle_pairs(pairs) is None
+
+
+def test_holdings_pnl_delta_joins_baseline_and_live_missing_not_zero():
+    baseline = {"AAPL": 1.0, "MSFT": -2.0, "ONLYBASE": 5.0}
+    live = {
+        "accounts": [
+            {"positions": [
+                {"symbol": "AAPL", "profit_rate": 4.1},
+                {"symbol": "MSFT", "profit_rate": -1.0},
+                {"symbol": "ONLYLIVE", "profit_rate": 9.0},
+                {"symbol": "NORATE"},  # missing profit_rate -> skipped
+            ]},
+        ]
+    }
+    out = _holdings_pnl_delta(baseline, live)
+    by_symbol = {e["symbol"]: e for e in out["entries"]}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # only symbols in BOTH
+    assert by_symbol["AAPL"]["delta_pp"] == 3.1
+    assert by_symbol["MSFT"]["delta_pp"] == 1.0
+    assert out["summary"] == {
+        "symbols_compared": 2, "symbols_baseline_only": 1, "symbols_live_only": 1
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name '_holdings_pnl_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+
+def _baseline_pnl_from_bundle_pairs(
+    pairs: list[tuple[Any, Any]],
+) -> dict[str, float] | None:
+    """Extract ``{ticker: pnl_rate}`` from the bundle's ``portfolio`` snapshot.
+
+    Returns ``None`` when no ``portfolio`` snapshot is present (so the caller can
+    record ``baseline_snapshot_absent`` rather than fabricating an empty baseline).
+    Holdings without a finite ``pnl_rate`` are skipped (missing != zero).
+    """
+    for _item, snapshot in pairs:
+        if getattr(snapshot, "snapshot_kind", None) != "portfolio":
+            continue
+        payload = getattr(snapshot, "payload_json", None) or {}
+        out: dict[str, float] = {}
+        for holding in payload.get("holdings") or []:
+            ticker = holding.get("ticker")
+            rate = holding.get("pnl_rate")
+            if ticker is not None and _is_finite_number(rate):
+                out[str(ticker)] = float(rate)
+        return out
+    return None
+
+
+def _live_pnl_by_symbol(holdings_result: Mapping[str, Any]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for account in holdings_result.get("accounts") or []:
+        for position in account.get("positions") or []:
+            symbol = position.get("symbol")
+            rate = position.get("profit_rate")
+            if symbol is not None and _is_finite_number(rate):
+                out[str(symbol)] = float(rate)
+    return out
+
+
+def _holdings_pnl_delta(
+    baseline_pnl: Mapping[str, float],
+    holdings_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Per-symbol live P/L vs baseline P/L. Only symbols present on BOTH sides get
+    an entry (missing != zero); one-sided symbols are counted in the summary."""
+    live_pnl = _live_pnl_by_symbol(holdings_result)
+    baseline_keys = set(baseline_pnl)
+    live_keys = set(live_pnl)
+    both = baseline_keys & live_keys
+    entries: list[dict[str, Any]] = []
+    for symbol in sorted(both):
+        base = baseline_pnl[symbol]
+        live = live_pnl[symbol]
+        entries.append({
+            "symbol": symbol,
+            "baseline_pnl_pct": base,
+            "live_pnl_pct": live,
+            "delta_pp": live - base,
+        })
+    return {
+        "entries": entries,
+        "summary": {
+            "symbols_compared": len(both),
+            "symbols_baseline_only": len(baseline_keys - live_keys),
+            "symbols_live_only": len(live_keys - baseline_keys),
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): holdings P/L delta helpers (bundle baseline vs live)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Pure helpers `_index_delta` + `_baseline_indices`
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+from app.services.investment_reports.delta_service import (
+    _baseline_indices,
+    _index_delta,
+)
+
+
+def test_baseline_indices_extracts_dict_or_none():
+    ok = {"provenance": {}, "baseline": {"indices": {"^GSPC": {"current": 5500.0}}}}
+    assert _baseline_indices(ok) == {"^GSPC": {"current": 5500.0}}
+    assert _baseline_indices({"status": "unavailable", "reason": "x"}) is None
+    assert _baseline_indices({"baseline": {}}) is None  # no indices key
+    assert _baseline_indices({}) is None
+
+
+def test_index_delta_change_pct_and_null_guards():
+    baseline = {
+        "^GSPC": {"current": 5500.0},
+        "^VIX": {"current": 0.0},      # baseline 0 -> change_pct null, no div-by-zero
+        "MISSINGLIVE": {"current": 100.0},
+    }
+    live = {"indices": [
+        {"symbol": "^GSPC", "current": 5533.0},
+        {"symbol": "^VIX", "current": 15.0},
+        # MISSINGLIVE absent from live
+    ]}
+    out = _index_delta(baseline, live)
+    by_symbol = {e["index_symbol"]: e for e in out["entries"]}
+    assert round(by_symbol["^GSPC"]["change_pct"], 4) == 0.6
+    assert by_symbol["^VIX"]["change_pct"] is None     # baseline 0 -> null
+    assert by_symbol["MISSINGLIVE"]["live_value"] is None
+    assert by_symbol["MISSINGLIVE"]["change_pct"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name '_index_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+
+def _baseline_indices(market_snapshot: Any) -> dict[str, Any] | None:
+    """Return the frozen ``baseline.indices`` dict (keyed by index symbol), or
+    ``None`` when the snapshot is the ``unavailable`` shape or lacks indices."""
+    if not isinstance(market_snapshot, Mapping):
+        return None
+    if market_snapshot.get("status") == "unavailable":
+        return None
+    baseline = market_snapshot.get("baseline")
+    if not isinstance(baseline, Mapping):
+        return None
+    indices = baseline.get("indices")
+    if not isinstance(indices, Mapping):
+        return None
+    return dict(indices)
+
+
+def _index_delta(
+    baseline_indices: Mapping[str, Any],
+    market_index_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Live index value vs frozen baseline value, per index symbol. ``change_pct``
+    is computed only when both values are finite and baseline != 0; otherwise it is
+    ``null`` (never fabricated). Indices absent from the live response carry a
+    ``null`` ``live_value``."""
+    live_by_symbol: dict[str, Any] = {}
+    for index in market_index_result.get("indices") or []:
+        symbol = index.get("symbol")
+        if symbol is not None:
+            live_by_symbol[str(symbol)] = index.get("current")
+    entries: list[dict[str, Any]] = []
+    for symbol, baseline in baseline_indices.items():
+        baseline_value = baseline.get("current") if isinstance(baseline, Mapping) else None
+        live_value = live_by_symbol.get(symbol)
+        change_pct: float | None = None
+        if (
+            _is_finite_number(baseline_value)
+            and _is_finite_number(live_value)
+            and baseline_value != 0
+        ):
+            change_pct = (live_value - baseline_value) / baseline_value * 100
+        entries.append({
+            "index_symbol": symbol,
+            "baseline_value": baseline_value,
+            "live_value": live_value,
+            "change_pct": change_pct,
+        })
+    return {"entries": entries}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): index delta helpers (frozen baseline vs live, null guards)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: `DeltaService.compute_delta` orchestrator (injected fakes)
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+import pytest
+
+from app.services.investment_reports.delta_service import DeltaService
+
+
+def _baseline(*, market="us", symbols=None, market_snapshot=None, baseline_pnl=None):
+    return {
+        "market": market,
+        "symbols": symbols if symbols is not None else {"AAPL"},
+        "market_snapshot": market_snapshot if market_snapshot is not None
+        else {"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        "baseline_pnl": baseline_pnl if baseline_pnl is not None else {"AAPL": 1.0},
+    }
+
+
+def _service(*, baseline, journal=None, holdings=None, index=None):
+    async def loader(_uuid):
+        return baseline
+
+    async def journal_fn(*, account_type, market):
+        if journal is None:
+            raise RuntimeError("journal boom")
+        return journal
+
+    async def holdings_fn(*, market):
+        if holdings is None:
+            raise RuntimeError("holdings boom")
+        return holdings
+
+    async def index_fn():
+        if index is None:
+            raise RuntimeError("index boom")
+        return index
+
+    return DeltaService(
+        session=None,
+        baseline_loader=loader,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_happy_path_all_three():
+    svc = _service(
+        baseline=_baseline(),
+        journal={"entries": [{"symbol": "AAPL", "side": "buy", "target_price": 230.0,
+                              "stop_loss": 200.0, "current_price": 231.0,
+                              "pnl_pct_live": 4.1, "target_reached": True,
+                              "stop_reached": False}]},
+        holdings={"accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 4.1}]}]},
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta(
+        "11111111-1111-1111-1111-111111111111", computed_at_kst="2026-06-01T13:00:00+09:00"
+    )
+    assert out["success"] is True
+    assert out["market"] == "us"
+    assert out["computed_at_kst"] == "2026-06-01T13:00:00+09:00"
+    assert out["levels_delta"]["summary"]["target_hit"] == 1
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 3.1
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+    assert "unavailable" not in out
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_fail_open_isolates_each_signal():
+    # journal raises; holdings + index still populate
+    svc = _service(
+        baseline=_baseline(),
+        journal=None,  # -> RuntimeError
+        holdings={"accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 2.0}]}]},
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["levels_delta"] is None
+    assert out["unavailable"]["levels"]  # reason string present
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 1.0
+    assert out["index_delta"]["entries"][0]["live_value"] == 5533.0
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_absent_marks_unavailable():
+    svc = _service(
+        baseline=_baseline(
+            market_snapshot={"status": "unavailable", "reason": "not_collected"},
+            baseline_pnl=None,
+        ),
+        journal={"entries": []},
+        holdings={"accounts": []},
+        index={"indices": []},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    assert out["index_delta"] is None
+    assert out["unavailable"]["index"] == "baseline_snapshot_absent"
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_not_found():
+    async def loader(_uuid):
+        return None
+
+    svc = DeltaService(session=None, baseline_loader=loader)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name 'DeltaService'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+import logging
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _reason(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+class DeltaService:
+    """Orchestrates the three read-only deltas. I/O is injectable so the logic is
+    unit-testable without a DB or live network. Defaults wire the real loaders/tools."""
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        baseline_loader: Callable[[UUID], Awaitable[dict[str, Any] | None]] | None = None,
+        journal_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        holdings_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        market_index_fn: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._session = session
+        self._baseline_loader = baseline_loader
+        self._journal_fn = journal_fn
+        self._holdings_fn = holdings_fn
+        self._market_index_fn = market_index_fn
+
+    async def compute_delta(
+        self,
+        report_uuid: UUID | str,
+        *,
+        near_pct: float = 1.0,
+        account_type: str = "live",
+        computed_at_kst: str | None = None,
+    ) -> dict[str, Any]:
+        parsed = report_uuid if isinstance(report_uuid, UUID) else UUID(str(report_uuid))
+        loader = self._baseline_loader or self._default_baseline_loader
+        baseline = await loader(parsed)
+        if baseline is None:
+            return {"success": False, "error": "baseline_not_found"}
+
+        market = baseline["market"]
+        symbols = baseline["symbols"]
+        market_snapshot = baseline["market_snapshot"]
+        baseline_pnl = baseline["baseline_pnl"]
+        unavailable: dict[str, str] = {}
+
+        levels_delta: dict[str, Any] | None = None
+        try:
+            journal_fn = self._journal_fn or _default_journal_fn
+            journal_result = await journal_fn(account_type=account_type, market=market)
+            levels_delta = _levels_delta(journal_result, symbols, near_pct=near_pct)
+        except Exception as exc:  # noqa: BLE001 — fail-open per signal
+            logger.info("levels_delta failed: %r", exc)
+            unavailable["levels"] = _reason(exc)
+
+        holdings_pnl_delta: dict[str, Any] | None = None
+        if baseline_pnl is None:
+            unavailable["holdings"] = "baseline_snapshot_absent"
+        else:
+            try:
+                holdings_fn = self._holdings_fn or _default_holdings_fn
+                holdings_result = await holdings_fn(market=market)
+                holdings_pnl_delta = _holdings_pnl_delta(baseline_pnl, holdings_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("holdings_pnl_delta failed: %r", exc)
+                unavailable["holdings"] = _reason(exc)
+
+        index_delta: dict[str, Any] | None = None
+        baseline_indices = _baseline_indices(market_snapshot)
+        if baseline_indices is None:
+            unavailable["index"] = "baseline_snapshot_absent"
+        else:
+            try:
+                market_index_fn = self._market_index_fn or _default_market_index_fn
+                index_result = await market_index_fn()
+                index_delta = _index_delta(baseline_indices, index_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("index_delta failed: %r", exc)
+                unavailable["index"] = _reason(exc)
+
+        out: dict[str, Any] = {
+            "success": True,
+            "baseline_report_uuid": str(parsed),
+            "market": market,
+            "levels_delta": levels_delta,
+            "holdings_pnl_delta": holdings_pnl_delta,
+            "index_delta": index_delta,
+        }
+        if computed_at_kst is not None:
+            out["computed_at_kst"] = computed_at_kst
+        if unavailable:
+            out["unavailable"] = unavailable
+        return out
+
+    async def _default_baseline_loader(self, report_uuid: UUID) -> dict[str, Any] | None:
+        from app.services.investment_reports.query_service import (
+            InvestmentReportQueryService,
+        )
+        from app.services.investment_snapshots.repository import (
+            InvestmentSnapshotsRepository,
+        )
+
+        query_service = InvestmentReportQueryService(self._session)
+        bundle = await query_service.get_bundle(report_uuid)
+        if bundle is None:
+            return None
+        report = bundle["report"]
+        symbols = {
+            item.symbol
+            for item in (bundle.get("items") or [])
+            if getattr(item, "symbol", None)
+        }
+        baseline_pnl: dict[str, float] | None = None
+        bundle_uuid = getattr(report, "snapshot_bundle_uuid", None)
+        if bundle_uuid is not None:
+            snapshots_repo = InvestmentSnapshotsRepository(self._session)
+            snapshot_bundle = await snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+            if snapshot_bundle is not None:
+                pairs = await snapshots_repo.list_bundle_items_with_snapshots(
+                    snapshot_bundle.id
+                )
+                baseline_pnl = _baseline_pnl_from_bundle_pairs(pairs)
+        return {
+            "market": report.market,
+            "symbols": symbols,
+            "market_snapshot": report.market_snapshot or {},
+            "baseline_pnl": baseline_pnl,
+        }
+
+
+async def _default_journal_fn(*, account_type: str, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.trade_journal_tools import get_trade_journal
+
+    return await get_trade_journal(
+        enrich_live=True, account_type=account_type, market=market
+    )
+
+
+async def _default_holdings_fn(*, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+
+    return await _get_holdings_impl(market=market, include_current_price=True)
+
+
+async def _default_market_index_fn() -> dict[str, Any]:
+    from app.mcp_server.tooling.fundamentals._market_index import (
+        handle_get_market_index,
+    )
+
+    return await handle_get_market_index()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (11 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): DeltaService orchestrator with injectable I/O + fail-open
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: DB-integration test for the default baseline loader
+
+**Files:**
+- Test: `tests/services/investment_reports/test_delta_service_db.py`
+
+This exercises the real `_default_baseline_loader` against a seeded report row (no bundle),
+verifying market/symbols extraction, `baseline_pnl=None` when no bundle, and `baseline_not_found`.
+Per the ROB-375 follow-up, investment-report DB tests serialize under the cleanup-lock fixture to
+avoid the xdist shared-Postgres deadlock.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_delta_service_db.py
+"""ROB-376 — default baseline loader against a seeded report row (no bundle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.delta_service import DeltaService
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+
+@pytest.mark.asyncio
+async def test_default_loader_reads_report_market_and_marks_pnl_absent(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await repo.insert_report(
+        idempotency_key="rob376:delta:1",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="baseline",
+        summary="s",
+        status="published",
+        report_metadata={},
+        market_snapshot={"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        portfolio_snapshot={},
+    )
+    await session.commit()
+
+    # Inject only the live fns so no network is hit; loader is the real default.
+    async def journal_fn(*, account_type, market):
+        return {"entries": []}
+
+    async def holdings_fn(*, market):
+        return {"accounts": []}
+
+    async def index_fn():
+        return {"indices": [{"symbol": "^GSPC", "current": 5533.0}]}
+
+    svc = DeltaService(
+        session=session,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+    out = await svc.compute_delta(report.report_uuid)
+    assert out["success"] is True
+    assert out["market"] == "us"
+    # No snapshot_bundle_uuid on the seeded row -> per-symbol P/L baseline absent.
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    # Index baseline IS present on the row -> index delta computed.
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+
+
+@pytest.mark.asyncio
+async def test_default_loader_baseline_not_found(session: AsyncSession) -> None:
+    svc = DeltaService(session=session)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service_db.py -q`
+Expected: PASS (2 passed) — the implementation from Task 4 already supports this. If the
+`session` fixture or `investment_reports_cleanup_lock` fixture name differs, check
+`tests/conftest.py` and adjust the import/fixture name. (Both are confirmed present in
+`tests/conftest.py`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/investment_reports/test_delta_service_db.py
+git commit -m "test(ROB-376): DB-integration test for default delta baseline loader
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: MCP handler + registration
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` (add impl ~after line 448;
+  register in `register_investment_report_tools` ~line 760; add name to
+  `INVESTMENT_REPORT_TOOL_NAMES` line 50-58 and to `__all__` line 766+)
+- Test: `tests/mcp_server/test_investment_report_delta_tool.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_investment_report_delta_tool.py
+"""ROB-376 — investment_report_delta_get handler + registration."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.mcp_server.tooling.investment_reports_handlers as handlers
+
+
+def test_delta_tool_name_registered():
+    assert "investment_report_delta_get" in handlers.INVESTMENT_REPORT_TOOL_NAMES
+
+
+def test_register_investment_report_tools_includes_delta():
+    registered: list[str] = []
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            registered.append(name)
+            return lambda fn: fn
+
+    handlers.register_investment_report_tools(_FakeMCP())
+    assert "investment_report_delta_get" in registered
+
+
+@pytest.mark.asyncio
+async def test_delta_impl_invalid_uuid_returns_error():
+    out = await handlers.investment_report_delta_get_impl(report_uuid="not-a-uuid")
+    assert out == {"success": False, "error": "invalid_report_uuid"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_investment_report_delta_tool.py -q`
+Expected: FAIL — `investment_report_delta_get` not in the name set / no
+`investment_report_delta_get_impl` attribute.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/mcp_server/tooling/investment_reports_handlers.py`:
+
+(3a) Add the name to the set (line 50-58):
+
+```python
+INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
+    "investment_report_create",
+    "investment_report_list",
+    "investment_report_get",
+    "investment_report_decide_item",
+    "investment_report_activate_watch",
+    "investment_report_context_get",
+    "investment_report_delta_get",
+    "investment_report_generate_from_bundle",
+}
+```
+
+(3b) Add the handler (immediately after `investment_report_context_get_impl`, ~line 449).
+`now_kst` is the project KST clock used elsewhere in the tooling layer:
+
+```python
+# ---------------------------------------------------------------------------
+# investment_report_delta_get (ROB-376)
+# ---------------------------------------------------------------------------
+async def investment_report_delta_get_impl(
+    report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict:
+    from app.core.timezone import now_kst
+    from app.services.investment_reports.delta_service import DeltaService
+
+    try:
+        parsed = UUID(report_uuid)
+    except (ValueError, AttributeError, TypeError):
+        return {"success": False, "error": "invalid_report_uuid"}
+
+    async with AsyncSessionLocal() as db:
+        service = DeltaService(db)
+        return await service.compute_delta(
+            parsed,
+            near_pct=near_pct,
+            account_type=account_type,
+            computed_at_kst=now_kst().isoformat(),
+        )
+```
+
+> CONFIRMED: `now_kst` lives at `app/core/timezone.py:14`; `trade_journal_tools.py:15` imports it
+> as `from app.core.timezone import now_kst`. Use exactly that import.
+
+(3c) Register it (in `register_investment_report_tools`, after the `context_get` block ~line 759):
+
+```python
+    mcp.tool(
+        name="investment_report_delta_get",
+        description=(
+            "Read-only intraday delta vs a baseline report. Given report_uuid "
+            "(the open/prior report), returns three deterministic deltas for Hermes "
+            "to compose: levels_delta (journal target/stop touch x live), "
+            "holdings_pnl_delta (per-symbol live P/L vs the baseline snapshot "
+            "bundle's portfolio P/L), and index_delta (live index vs the report's "
+            "frozen market baseline). Per-signal fail-open: a degraded signal is "
+            "null with a reason under 'unavailable'; missing data is never coerced "
+            "to zero. No broker/order/watch mutation."
+        ),
+    )(investment_report_delta_get_impl)
+```
+
+(3d) Add to `__all__` (line 766+), keeping alphabetical-ish order near the other impls:
+
+```python
+    "investment_report_delta_get_impl",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_investment_report_delta_tool.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/investment_reports_handlers.py tests/mcp_server/test_investment_report_delta_tool.py
+git commit -m "feat(ROB-376): register investment_report_delta_get MCP tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: Lint, format, typecheck, full-suite gate, final commit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format + lint (exact CI commands)**
+
+Run:
+```bash
+uv run ruff format app/ tests/
+uv run ruff format --check app/ tests/
+uv run ruff check app/ tests/
+```
+Expected: `ruff format --check` reports "X files already formatted"; `ruff check` reports
+"All checks passed!". Fix any reported issue and re-run.
+
+- [ ] **Step 2: Typecheck the new module**
+
+Run: `uv run ty check app/services/investment_reports/delta_service.py`
+Expected: no errors. (If `ty` flags the injected-callable defaults, ensure the type hints match
+the `Callable[..., Awaitable[...]]` signatures above.)
+
+- [ ] **Step 3: Run the full new-test set**
+
+Run:
+```bash
+uv run pytest tests/services/investment_reports/test_delta_service.py \
+  tests/services/investment_reports/test_delta_service_db.py \
+  tests/mcp_server/test_investment_report_delta_tool.py -q
+```
+Expected: all pass (16 total).
+
+- [ ] **Step 4: Import-guard sanity (no in-process LLM / broker mutation pulled in)**
+
+Run: `uv run python -c "import app.services.investment_reports.delta_service"`
+Expected: imports cleanly with no heavy/broker/LLM side-effect (defaults import lazily inside fns).
+
+- [ ] **Step 5: Final commit (if Step 1 reformatted anything)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-376): format + lint pass for delta tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** levels_delta (Task 1), holdings_pnl_delta from bundle baseline (Task 2),
+  index_delta from report baseline (Task 3), orchestrator + fail-open + baseline_not_found
+  (Task 4), default loader DB path (Task 5), MCP tool surface + registration + invalid_uuid
+  (Task 6), CI gates (Task 7). All §3 contract fields and §5 error rows are covered.
+- **Non-goals honored:** no `intraday_update` policy, no screener/news signals, no new migration,
+  no persisted per-report level snapshot, MCP-only (no HTTP).
+- **Type consistency:** `_levels_delta(journal_result, symbols, *, near_pct)`,
+  `_holdings_pnl_delta(baseline_pnl, holdings_result)`,
+  `_baseline_pnl_from_bundle_pairs(pairs)`, `_index_delta(baseline_indices, market_index_result)`,
+  `_baseline_indices(market_snapshot)`, `DeltaService.compute_delta(report_uuid, *, near_pct,
+  account_type, computed_at_kst)` — names/signatures consistent across tasks and tests.
+- **All imports pinned:** `now_kst` = `app.core.timezone` (confirmed); the `session` and
+  `investment_reports_cleanup_lock` fixtures are globally registered via
+  `tests/conftest.py` `pytest_plugins = [..., "tests._investment_reports_helpers"]` (confirmed).
+  No open confirmations remain.

--- a/docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md
+++ b/docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md
@@ -1,0 +1,191 @@
+# ROB-376 PR1 — `investment_report_delta_get` (read-only 장중 델타 도구)
+
+**Status:** Design approved 2026-05-31
+**Issue:** ROB-376 (split from ROB-375). This spec covers **PR1 only** — the read-only
+delta MCP tool. The `intraday_update` report policy/type (issue item 2) is a deferred
+follow-up issue, out of scope here.
+
+## 1. Problem & context
+
+ROB-375 (a bug umbrella, all merged) fixed report **continuity** (advisory drafts now flow
+into `investment_report_context_get`, journal `enrich_live`, frozen numeric baselines).
+ROB-376 is the **feature** layer: an intraday follow-up report should automatically surface
+what changed vs the open/prior report — "무엇이 목표/손절/트리거를 터치했고, 지수·보유 P/L이
+어떻게 변했나".
+
+### Verified current state (code-checked)
+
+- `investment_report_context_get` returns `triggered_events`, `active_watches`,
+  `recent_decisions` (`app/services/investment_reports/query_service.py:262`). `triggered_events`
+  is **only** populated by the background `InvestmentWatchScanner` job
+  (`app/jobs/investment_watch_scanner.py`); advisory drafts never activate a watch, so it is
+  effectively always empty for them. This is a **side-effect-job dependency**, not a hard
+  "advisory is forbidden" guard.
+- **Correction to the issue's premise:** advisory flows are **not** code-barred from
+  `activate_watch`/`decide_item`. `decide_item` has no service guard; `activate_watch` guards
+  only on item kind/status/condition. `draft_policy` (`"exclude"` | `"advisory_only"`,
+  discriminated by `created_by_profile == "HERMES_ADVISOR"`) only selects which prior drafts
+  are returned as context — it does not gate calls. Therefore the delta must be derived from
+  baseline-snapshot-vs-live and must **not** depend on scanner/watch state.
+- `previous_report_uuid` is a **trace hint only** — no consumer computes a delta today.
+- `get_trade_journal(enrich_live=True)` (`app/mcp_server/tooling/trade_journal_tools.py:240`)
+  **already** computes per-entry `target_reached`, `stop_reached`, `pnl_pct_live`,
+  `current_price` from live quotes (ROB-375 Bug3). The delta tool **reuses** these — it does
+  not recompute level touches.
+- Reports carry frozen `market_snapshot` and `portfolio_snapshot` dicts
+  (`app/schemas/investment_reports.py:344-345`), built by
+  `generator.py::_section_snapshot_descriptors` as `{ "provenance": {...}, "baseline": {...} }`
+  (or `{ "status": "unavailable", "reason": ... }`), frozen at row-snapshot time by
+  ROB-375 Bug2. **Critical asymmetry (code-verified):**
+  - `market_snapshot["baseline"]["indices"]` IS present — a dict keyed by index symbol:
+    `{ "<symbol>": { "change_percent": float, "name": str|None, "current": float|None } }`
+    (`generator.py:80,89` whitelist `("market","from_date","to_date","indices")`). Usable
+    baseline for the **index delta**.
+  - `portfolio_snapshot["baseline"]` whitelists **aggregates only**
+    (`primary_source`, `cash`, `buying_power`, `sellable_summary`, `holdings_count`) and
+    **deliberately omits the per-symbol `holdings` list** (`generator.py:81-106`). So there is
+    **no per-symbol P/L baseline on the report row**.
+- The per-symbol P/L baseline lives in the **snapshot bundle's** `portfolio` payload, reachable
+  via `report.snapshot_bundle_uuid`. Each `holdings[]` entry carries `ticker` + `pnl_rate`
+  (`collectors/portfolio.py:144-168`, `_reader_holding_to_dict`). Live `get_holdings` positions
+  carry `symbol` + `profit_rate` (`portfolio_helpers.py`). The holdings-P/L delta joins
+  baseline `pnl_rate` (by `ticker`) to live `profit_rate` (by `symbol`).
+- Input tools all exist: `get_trade_journal`, `get_holdings`
+  (`portfolio_holdings.py:1215`), `get_market_index` (`fundamentals_handlers.py:271`,
+  returns `{"indices": [{symbol, current, change_pct, ...}]}`),
+  `investment_report_get`/`get_bundle`. Bundle payloads are read via
+  `InvestmentSnapshotsRepository.list_bundle_items_with_snapshots` (the same read path the
+  generator uses) — `investment_snapshots` are reusable evidence artifacts.
+
+## 2. Goals & non-goals
+
+**Goals**
+- One new read-only MCP tool that, given a baseline report, returns 3 deterministic deltas:
+  1. **levels_delta** — target/stop touch (journal × live), reusing `get_trade_journal` output.
+  2. **holdings_pnl_delta** — current holdings P/L vs baseline `portfolio_snapshot` P/L.
+  3. **index_delta** — current `get_market_index` vs baseline `market_snapshot` index.
+- Per-signal fail-open: one signal's failure never kills the others.
+- `migration 0`; no broker/order/watch/order-intent mutation; no in-process LLM.
+
+**Non-goals (deferred)**
+- `intraday_update` report policy / `report_type` / freshness policy (issue item 2 → separate issue).
+- New 급변주 (`screen_stocks`) and 뉴스 이슈 (`get_market_issues`) signals (the "5종" option; not chosen).
+- Persisting per-report expected-level snapshots (would need a migration; rejected in favor of
+  journal-derived levels).
+- HTTP transport surface (MCP tool only for PR1).
+
+## 3. Tool contract
+
+```
+investment_report_delta_get(
+    report_uuid: str,            # baseline = 개장/직전 리포트
+    near_pct: float = 1.0,       # 목표/손절 근접 임계(%), passed through to journal near-flags
+    account_type: str = "live",  # 저널 조회 스코프 ("live" | "paper")
+) -> dict
+```
+
+Return (deterministic; snake_case keys, serialized `by_alias`/`mode="json"`):
+
+```jsonc
+{
+  "success": true,
+  "baseline_report_uuid": "<uuid>",
+  "market": "us",                       // echoed from baseline report
+  "computed_at_kst": "2026-05-31T13:05:00+09:00",
+  "levels_delta": {
+    "entries": [
+      { "symbol": "AAPL", "side": "buy", "target_price": 230.0, "stop_loss": 200.0,
+        "current_price": 231.2, "pnl_pct_live": 4.1,
+        "target_reached": true, "stop_reached": false,
+        "near_target": false, "near_stop": false }
+    ],
+    "summary": { "near_target": 1, "near_stop": 0, "target_hit": 1, "stop_hit": 0 }
+  },
+  "holdings_pnl_delta": {                 // baseline = snapshot-bundle portfolio payload
+    "entries": [
+      { "symbol": "AAPL", "baseline_pnl_pct": 1.0, "live_pnl_pct": 4.1, "delta_pp": 3.1 }
+    ],
+    "summary": { "symbols_compared": 1, "symbols_baseline_only": 0, "symbols_live_only": 0 }
+  },
+  "index_delta": {                        // baseline = report market_snapshot["baseline"]["indices"]
+    "entries": [
+      { "index_symbol": "^GSPC", "baseline_value": 5500.0, "live_value": 5533.0, "change_pct": 0.6 }
+    ]
+  },
+  "unavailable": { "holdings": "baseline_snapshot_absent" }   // present only when a signal degraded
+}
+```
+
+- `success:false` only for top-level failures: `{ "error": "baseline_not_found" }` (bad/missing
+  `report_uuid`) or `{ "error": "invalid_report_uuid" }` (unparseable).
+- Per-signal degradation does **not** flip `success`; the block is set to `null` and the reason
+  recorded under `unavailable[<signal>]`.
+
+## 4. Components & data flow
+
+New file: `app/services/investment_reports/delta_service.py` (one focused service, one public
+method `compute_delta(...)`). Handler in
+`app/mcp_server/tooling/investment_reports_handlers.py` (`investment_report_delta_get_impl`),
+registered alongside the other investment-report tools.
+
+Flow inside `compute_delta`:
+
+1. **Baseline load** — `InvestmentReportQueryService.get_bundle(report_uuid)` (returns a dict
+   `{report, items, decisions_by_item, alerts, events}` or `None`). If `None` →
+   `baseline_not_found`. From `bundle["report"]` read `market`, `market_snapshot`,
+   `snapshot_bundle_uuid`. The **symbol set** = de-duped non-null `item.symbol` over
+   `bundle["items"]`.
+2. **levels_delta** — call `get_trade_journal(enrich_live=True, account_type=account_type,
+   market=<baseline market>)`; filter `entries` to the baseline symbol set; project the already-
+   computed `target_reached`/`stop_reached`/`pnl_pct_live`/`current_price` plus `near_*` flags.
+3. **holdings_pnl_delta** — baseline P/L from the **snapshot bundle**: load the bundle's
+   `portfolio` payload via `InvestmentSnapshotsRepository.list_bundle_items_with_snapshots(
+   bundle.id)` (bundle resolved from `snapshot_bundle_uuid`), build `{ticker → pnl_rate}` from
+   `payload["holdings"]`. Live P/L from `get_holdings(...)` → `{symbol → profit_rate}` over all
+   `accounts[].positions[]`. `delta_pp = live_profit_rate − baseline_pnl_rate` for symbols
+   present in **both**; count `symbols_baseline_only` / `symbols_live_only` in `summary`.
+   **Missing ≠ zero** — never fabricate a 0 P/L for a symbol absent on one side (ROB-375 Bug2
+   lesson). If `snapshot_bundle_uuid` is null or no `portfolio` payload is present →
+   `unavailable["holdings"]="baseline_snapshot_absent"`.
+4. **index_delta** — baseline from `market_snapshot["baseline"]["indices"]` (dict keyed by index
+   symbol; per-symbol `current`). If `market_snapshot` is the `{"status":"unavailable"}` shape or
+   lacks `baseline.indices` → `unavailable["index"]="baseline_snapshot_absent"`. Live from
+   `get_market_index(market=<baseline market>)` → match `indices[].symbol`, take `current`.
+   `change_pct = (live_current − baseline_current) / baseline_current * 100` only when both
+   finite and `baseline_current != 0`; otherwise `change_pct` is `null` (never fabricated).
+
+Each of steps 2–4 is wrapped in its own `try/except` (fail-open). Live-data helpers and the
+snapshots repository are imported lazily inside the service to keep the handler/CLI import path
+free of heavy/Settings-backed modules.
+
+## 5. Error handling
+
+| Condition | Behavior |
+|---|---|
+| Unparseable `report_uuid` | `{success:false, error:"invalid_report_uuid"}` |
+| Baseline report not found | `{success:false, error:"baseline_not_found"}` |
+| A signal's collector raises | That block `null`, `unavailable[signal]=<short reason>`, others continue |
+| Baseline snapshot key absent (legacy report) | `unavailable[signal]="baseline_snapshot_absent"` |
+| Symbol present on only one side (P/L) | Counted in summary; **no** fabricated entry |
+| Non-finite / divide-by-zero in a numeric delta | Field `null`, never `NaN`/`Infinity` in JSON |
+
+## 6. Testing (pytest, DB-integration where a report row is needed)
+
+- **Happy path:** seed a baseline report (bundle items + frozen snapshots) + active journals;
+  mock live quotes/holdings/index → all 3 deltas populated with correct values.
+- **Fail-open isolation:** force each signal's collector to raise; assert the other two still
+  populate and `unavailable[<signal>]` is set, `success` stays `true`.
+- **Missing ≠ zero:** baseline `portfolio_snapshot` lacks symbol X present live (and vice-versa)
+  → no fabricated P/L entry; counted in `summary`.
+- **Legacy report:** empty `market_snapshot`/`portfolio_snapshot` → `unavailable` path, no crash.
+- **Top-level errors:** bad UUID → `invalid_report_uuid`; unknown UUID → `baseline_not_found`.
+- **Registration/schema:** tool is registered and its response round-trips serialization.
+
+## 7. Safety boundaries (recap)
+
+- Read-only: no broker/order/watch/order-intent mutation; does not touch the scanner or
+  `activate_watch`/`decide_item` paths.
+- `migration 0`.
+- No in-process LLM — output is deterministic evidence for Hermes to pull/compose/push
+  (consistent with `/invest/reports has no internal LLM`).
+- Independent of watch/scanner state — derives purely from baseline snapshot vs live.

--- a/tests/mcp_server/test_investment_report_delta_tool.py
+++ b/tests/mcp_server/test_investment_report_delta_tool.py
@@ -1,0 +1,30 @@
+# tests/mcp_server/test_investment_report_delta_tool.py
+"""ROB-376 — investment_report_delta_get handler + registration."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.mcp_server.tooling.investment_reports_handlers as handlers
+
+
+def test_delta_tool_name_registered():
+    assert "investment_report_delta_get" in handlers.INVESTMENT_REPORT_TOOL_NAMES
+
+
+def test_register_investment_report_tools_includes_delta():
+    registered: list[str] = []
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            registered.append(name)
+            return lambda fn: fn
+
+    handlers.register_investment_report_tools(_FakeMCP())
+    assert "investment_report_delta_get" in registered
+
+
+@pytest.mark.asyncio
+async def test_delta_impl_invalid_uuid_returns_error():
+    out = await handlers.investment_report_delta_get_impl(report_uuid="not-a-uuid")
+    assert out == {"success": False, "error": "invalid_report_uuid"}

--- a/tests/services/investment_reports/test_delta_service.py
+++ b/tests/services/investment_reports/test_delta_service.py
@@ -1,0 +1,299 @@
+# tests/services/investment_reports/test_delta_service.py
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from app.services.investment_reports.delta_service import (
+    DeltaService,
+    _baseline_indices,
+    _baseline_pnl_from_bundle_pairs,
+    _holdings_pnl_delta,
+    _index_delta,
+    _levels_delta,
+)
+
+
+def test_levels_delta_filters_to_symbols_and_projects_flags():
+    journal = {
+        "entries": [
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "target_price": 230.0,
+                "stop_loss": 200.0,
+                "current_price": 231.0,
+                "pnl_pct_live": 4.1,
+                "target_reached": True,
+                "stop_reached": False,
+            },
+            {
+                "symbol": "MSFT",
+                "side": "buy",
+                "target_price": 500.0,
+                "stop_loss": 400.0,
+                "current_price": 401.0,
+                "pnl_pct_live": -1.0,
+                "target_reached": False,
+                "stop_reached": False,
+            },
+            {
+                "symbol": "ZZZZ",
+                "side": "buy",
+                "target_price": 1.0,
+                "stop_loss": 0.5,
+                "current_price": 0.9,
+                "pnl_pct_live": 0.0,
+                "target_reached": False,
+                "stop_reached": False,
+            },
+        ]
+    }
+    out = _levels_delta(journal, {"AAPL", "MSFT"}, near_pct=1.0)
+    syms = [e["symbol"] for e in out["entries"]]
+    assert syms == ["AAPL", "MSFT"]  # ZZZZ filtered out
+    aapl = out["entries"][0]
+    assert aapl["target_reached"] is True
+    assert aapl["pnl_pct_live"] == 4.1
+    # MSFT current 401 is within 1% of stop 400 -> near_stop True
+    msft = out["entries"][1]
+    assert msft["near_stop"] is True
+    assert msft["near_target"] is False
+    assert out["summary"] == {
+        "near_target": 0,
+        "near_stop": 1,
+        "target_hit": 1,
+        "stop_hit": 0,
+    }
+
+
+def test_levels_delta_empty_symbols_keeps_all_entries():
+    journal = {
+        "entries": [
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "target_price": None,
+                "stop_loss": None,
+                "current_price": 10.0,
+                "pnl_pct_live": 1.0,
+                "target_reached": None,
+                "stop_reached": None,
+            },
+        ]
+    }
+    out = _levels_delta(journal, set(), near_pct=1.0)
+    assert [e["symbol"] for e in out["entries"]] == ["AAPL"]
+    assert out["entries"][0]["near_target"] is False  # no target -> not near
+
+
+def _snap(kind, payload):
+    return types.SimpleNamespace(snapshot_kind=kind, payload_json=payload)
+
+
+def test_baseline_pnl_from_bundle_pairs_reads_portfolio_holdings():
+    pairs = [
+        (object(), _snap("market", {"indices": {}})),
+        (
+            object(),
+            _snap(
+                "portfolio",
+                {
+                    "holdings": [
+                        {"ticker": "AAPL", "pnl_rate": 1.0},
+                        {"ticker": "MSFT", "pnl_rate": -2.0},
+                        {
+                            "ticker": "NOPNL"
+                        },  # missing pnl_rate -> skipped, not fabricated
+                    ]
+                },
+            ),
+        ),
+    ]
+    assert _baseline_pnl_from_bundle_pairs(pairs) == {"AAPL": 1.0, "MSFT": -2.0}
+
+
+def test_baseline_pnl_from_bundle_pairs_none_when_no_portfolio_kind():
+    pairs = [(object(), _snap("market", {"indices": {}}))]
+    assert _baseline_pnl_from_bundle_pairs(pairs) is None
+
+
+def test_holdings_pnl_delta_joins_baseline_and_live_missing_not_zero():
+    baseline = {"AAPL": 1.0, "MSFT": -2.0, "ONLYBASE": 5.0}
+    live = {
+        "accounts": [
+            {
+                "positions": [
+                    {"symbol": "AAPL", "profit_rate": 4.1},
+                    {"symbol": "MSFT", "profit_rate": -1.0},
+                    {"symbol": "ONLYLIVE", "profit_rate": 9.0},
+                    {"symbol": "NORATE"},  # missing profit_rate -> skipped
+                ]
+            },
+        ]
+    }
+    out = _holdings_pnl_delta(baseline, live)
+    by_symbol = {e["symbol"]: e for e in out["entries"]}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # only symbols in BOTH
+    assert by_symbol["AAPL"]["delta_pp"] == 3.1
+    assert by_symbol["MSFT"]["delta_pp"] == 1.0
+    assert out["summary"] == {
+        "symbols_compared": 2,
+        "symbols_baseline_only": 1,
+        "symbols_live_only": 1,
+    }
+
+
+def test_baseline_indices_extracts_dict_or_none():
+    ok = {"provenance": {}, "baseline": {"indices": {"^GSPC": {"current": 5500.0}}}}
+    assert _baseline_indices(ok) == {"^GSPC": {"current": 5500.0}}
+    assert _baseline_indices({"status": "unavailable", "reason": "x"}) is None
+    assert _baseline_indices({"baseline": {}}) is None  # no indices key
+    assert _baseline_indices({}) is None
+
+
+def test_index_delta_change_pct_and_null_guards():
+    baseline = {
+        "^GSPC": {"current": 5500.0},
+        "^VIX": {"current": 0.0},  # baseline 0 -> change_pct null, no div-by-zero
+        "MISSINGLIVE": {"current": 100.0},
+    }
+    live = {
+        "indices": [
+            {"symbol": "^GSPC", "current": 5533.0},
+            {"symbol": "^VIX", "current": 15.0},
+            # MISSINGLIVE absent from live
+        ]
+    }
+    out = _index_delta(baseline, live)
+    by_symbol = {e["index_symbol"]: e for e in out["entries"]}
+    assert round(by_symbol["^GSPC"]["change_pct"], 4) == 0.6
+    assert by_symbol["^VIX"]["change_pct"] is None  # baseline 0 -> null
+    assert by_symbol["MISSINGLIVE"]["live_value"] is None
+    assert by_symbol["MISSINGLIVE"]["change_pct"] is None
+
+
+def _baseline(
+    *, market="us", symbols=None, market_snapshot=None, baseline_pnl="default"
+):
+    return {
+        "market": market,
+        "symbols": symbols if symbols is not None else {"AAPL"},
+        "market_snapshot": market_snapshot
+        if market_snapshot is not None
+        else {"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        "baseline_pnl": {"AAPL": 1.0} if baseline_pnl == "default" else baseline_pnl,
+    }
+
+
+def _service(*, baseline, journal=None, holdings=None, index=None):
+    async def loader(_uuid):
+        return baseline
+
+    async def journal_fn(*, account_type, market):
+        if journal is None:
+            raise RuntimeError("journal boom")
+        return journal
+
+    async def holdings_fn(*, market):
+        if holdings is None:
+            raise RuntimeError("holdings boom")
+        return holdings
+
+    async def index_fn():
+        if index is None:
+            raise RuntimeError("index boom")
+        return index
+
+    return DeltaService(
+        session=None,
+        baseline_loader=loader,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_happy_path_all_three():
+    svc = _service(
+        baseline=_baseline(),
+        journal={
+            "entries": [
+                {
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "target_price": 230.0,
+                    "stop_loss": 200.0,
+                    "current_price": 231.0,
+                    "pnl_pct_live": 4.1,
+                    "target_reached": True,
+                    "stop_reached": False,
+                }
+            ]
+        },
+        holdings={
+            "accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 4.1}]}]
+        },
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta(
+        "11111111-1111-1111-1111-111111111111",
+        computed_at_kst="2026-06-01T13:00:00+09:00",
+    )
+    assert out["success"] is True
+    assert out["market"] == "us"
+    assert out["computed_at_kst"] == "2026-06-01T13:00:00+09:00"
+    assert out["levels_delta"]["summary"]["target_hit"] == 1
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 3.1
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+    assert "unavailable" not in out
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_fail_open_isolates_each_signal():
+    # journal raises; holdings + index still populate
+    svc = _service(
+        baseline=_baseline(),
+        journal=None,  # -> RuntimeError
+        holdings={
+            "accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 2.0}]}]
+        },
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["levels_delta"] is None
+    assert out["unavailable"]["levels"]  # reason string present
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 1.0
+    assert out["index_delta"]["entries"][0]["live_value"] == 5533.0
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_absent_marks_unavailable():
+    svc = _service(
+        baseline=_baseline(
+            market_snapshot={"status": "unavailable", "reason": "not_collected"},
+            baseline_pnl=None,
+        ),
+        journal={"entries": []},
+        holdings={"accounts": []},
+        index={"indices": []},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    assert out["index_delta"] is None
+    assert out["unavailable"]["index"] == "baseline_snapshot_absent"
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_not_found():
+    async def loader(_uuid):
+        return None
+
+    svc = DeltaService(session=None, baseline_loader=loader)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}

--- a/tests/services/investment_reports/test_delta_service_db.py
+++ b/tests/services/investment_reports/test_delta_service_db.py
@@ -1,0 +1,65 @@
+# tests/services/investment_reports/test_delta_service_db.py
+"""ROB-376 — default baseline loader against a seeded report row (no bundle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.delta_service import DeltaService
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+@pytest.mark.asyncio
+async def test_default_loader_reads_report_market_and_marks_pnl_absent(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await repo.insert_report(
+        idempotency_key="rob376:delta:1",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="baseline",
+        summary="s",
+        status="published",
+        report_metadata={},
+        market_snapshot={"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        portfolio_snapshot={},
+    )
+    await session.commit()
+
+    # Inject only the live fns so no network is hit; loader is the real default.
+    async def journal_fn(*, account_type, market):
+        return {"entries": []}
+
+    async def holdings_fn(*, market):
+        return {"accounts": []}
+
+    async def index_fn():
+        return {"indices": [{"symbol": "^GSPC", "current": 5533.0}]}
+
+    svc = DeltaService(
+        session=session,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+    out = await svc.compute_delta(report.report_uuid)
+    assert out["success"] is True
+    assert out["market"] == "us"
+    # No snapshot_bundle_uuid on the seeded row -> per-symbol P/L baseline absent.
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    # Index baseline IS present on the row -> index delta computed.
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+
+
+@pytest.mark.asyncio
+async def test_default_loader_baseline_not_found(session: AsyncSession) -> None:
+    svc = DeltaService(session=session)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -119,6 +119,7 @@ def test_tool_names_match_registered_set() -> None:
         # ROB-273 — opt-in snapshot-backed advisory generator.
         "investment_report_generate_from_bundle",
         "investment_watch_recommend",
+        "investment_report_delta_get",
     }
 
 


### PR DESCRIPTION
## 배경 (ROB-376 PR1 / 오케스트레이션 ROB-412 D라인)

ROB-375(연속성 **버그**, 머지 완료)에 이어, 장중 후속 리포트가 개장/직전 리포트 대비 **무엇이 변했나**를 자동 산출하는 **기능 레이어**의 PR1. read-only MCP 도구 하나로 3개 결정적 델타를 제공한다.

**전제 교정(코드 검증)**: advisory가 activate/decide 금지라는 이슈 전제는 코드상 사실이 아님 → 델타는 **baseline-snapshot-vs-live 파생**으로 계산하며 scanner/watch 상태에 **독립**.

## 변경

신규 `investment_report_delta_get(report_uuid, near_pct=1.0, account_type="live")`:
- **levels_delta** — `get_trade_journal(enrich_live=True)`의 target/stop 터치·`pnl_pct_live`를 baseline 리포트 심볼셋으로 필터·투영(재계산 안 함).
- **holdings_pnl_delta** — 스냅샷 번들 portfolio payload의 `pnl_rate`(ticker) baseline vs 라이브 `get_holdings` `profit_rate`(symbol). **missing≠zero**(한쪽만 존재 시 날조 금지, summary에 카운트).
- **index_delta** — 리포트 `market_snapshot.baseline.indices` vs `get_market_index`. 분모 0/비유한 → `change_pct=null`(NaN/Inf 금지).
- **신호별 fail-open**: 한 신호 실패가 나머지를 죽이지 않음(`unavailable[signal]`에 사유, `success`는 유지). top-level만 `invalid_report_uuid`/`baseline_not_found`.

`app/services/investment_reports/delta_service.py`(순수 헬퍼 + `DeltaService.compute_delta`) + `investment_report_delta_get_impl` 핸들러/등록.

## 테스트

- 순수 헬퍼 단위(levels/holdings/index, missing≠zero, 비유한) + 오케스트레이터(주입 fake, fail-open 격리) + DB통합(기본 baseline 로더, baseline_not_found) + 핸들러/등록.
- tool-names set 단언에 신규 도구 등록(다른 세션 누락분 보완).
- 로컬 **39 passed**, `ruff check app/ tests/` + `format --check` clean, 단일 alembic head(마이그레이션 없음).

## 안전 경계

- **read-only**: broker/order/watch/order-intent mutation 0(코드 grep 확인). scanner/activate_watch/decide_item 경로 무접촉.
- **migration 0**, in-process LLM 없음(Hermes가 pull/compose하는 결정적 evidence).

## 범위 / 비범위

- ✅ ROB-376 **item 1+2 중 델타 도구**(read-only).
- ↪ **item 2(`intraday_update` 리포트 정책/타입)는 별도 후속 이슈로 분리** — 이 PR로 ROB-376 전체가 Done은 아님.
- 비범위: 급변주(`screen_stocks`)/뉴스(`get_market_issues`) 신호, expected-level 영속화(migration 필요), HTTP transport.

7개 코드 앵커는 머지 전 최신 main 대비 재검증(drift 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)