### PR TITLE
feat(ROB-398) Slice 1: 뉴스-종목 매핑 read-model + KR 별칭 확장

### DIFF
--- a/app/services/kr_news_symbol_mapping/__init__.py
+++ b/app/services/kr_news_symbol_mapping/__init__.py
@@ -1,0 +1,25 @@
+"""KR 뉴스-종목 매핑 read-model (ROB-398 Slice 1)."""
+
+from app.services.kr_news_symbol_mapping.contract import (
+    ArticleView,
+    CandidateRow,
+    Freshness,
+    MappedArticle,
+    MappedSymbol,
+    SymbolNewsMapping,
+)
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+from app.services.kr_news_symbol_mapping.query_service import get_symbol_news_mapping
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+
+__all__ = [
+    "ArticleView",
+    "CandidateRow",
+    "Freshness",
+    "MappedArticle",
+    "MappedSymbol",
+    "SymbolNewsMapping",
+    "derive_freshness",
+    "get_symbol_news_mapping",
+    "resolve_article_symbols",
+]

--- a/app/services/kr_news_symbol_mapping/contract.py
+++ b/app/services/kr_news_symbol_mapping/contract.py
@@ -1,0 +1,77 @@
+"""뉴스-종목 매핑 read-model 계약 — provenance-rich 통합 뷰 (ROB-398 Slice 1).
+
+기존 데이터(article.stock_symbol / news_article_related_symbols / 별칭 matcher)
+위의 read-only 뷰. write/migration 없음.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+# mapping_source 우선순위 (작을수록 우선). naver_code = 확정, ner = 최약.
+MAPPING_SOURCE_PRIORITY: dict[str, int] = {
+    "naver_code": 0,
+    "candidate": 1,
+    "ner": 2,
+}
+
+NER_CONFIDENCE: float = 0.5
+CANDIDATE_DEFAULT_CONFIDENCE: float = 0.7  # candidate row.score 부재 시
+FRESHNESS_TTL_HOURS: int = 24
+
+
+@dataclass(frozen=True)
+class CandidateRow:
+    """news_article_related_symbols 한 행의 read-only 뷰 (candidate source)."""
+
+    symbol: str
+    source: str
+    score: float | None = None
+    rank: int | None = None
+    matched_term: str | None = None
+
+
+@dataclass(frozen=True)
+class MappedSymbol:
+    symbol: str
+    market: str
+    mapping_source: str  # "naver_code" | "candidate" | "ner"
+    confidence: float  # 0.0..1.0
+    is_primary: bool
+    matched_term: str | None
+
+
+@dataclass(frozen=True)
+class ArticleView:
+    """resolver/query_service 입력용 기사 뷰 (DB ORM 비의존, 테스트 친화)."""
+
+    market: str
+    stock_symbol: str | None
+    related_rows: tuple[CandidateRow, ...]
+    title: str | None
+    summary: str | None
+    keywords: tuple[str, ...]
+    as_of: datetime
+
+
+@dataclass(frozen=True)
+class MappedArticle:
+    as_of: datetime
+    title: str | None
+    mapped_symbols: tuple[MappedSymbol, ...]
+
+
+@dataclass(frozen=True)
+class Freshness:
+    overall: str  # "fresh" | "stale" | "unavailable"
+    latest_as_of: datetime | None
+    stale_reason: str | None
+
+
+@dataclass(frozen=True)
+class SymbolNewsMapping:
+    symbol: str
+    market: str
+    articles: tuple[MappedArticle, ...]
+    freshness: Freshness

--- a/app/services/kr_news_symbol_mapping/freshness.py
+++ b/app/services/kr_news_symbol_mapping/freshness.py
@@ -1,0 +1,33 @@
+"""뉴스-종목 매핑 freshness 파생 (ROB-398 Slice 1, 순수 함수).
+
+가장 신선한 매핑 기사 as_of 가 TTL 내면 fresh, 초과면 stale, 0건이면
+unavailable. reason 을 동봉해 숨김 없이 노출한다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+
+from app.services.kr_news_symbol_mapping.contract import (
+    FRESHNESS_TTL_HOURS,
+    Freshness,
+)
+
+
+def derive_freshness(
+    as_ofs: Sequence[datetime],
+    *,
+    now: datetime,
+    ttl_hours: int = FRESHNESS_TTL_HOURS,
+) -> Freshness:
+    if not as_ofs:
+        return Freshness(
+            overall="unavailable", latest_as_of=None, stale_reason="no_mapped_news"
+        )
+    latest = max(as_ofs)
+    if now - latest <= timedelta(hours=ttl_hours):
+        return Freshness(overall="fresh", latest_as_of=latest, stale_reason=None)
+    return Freshness(
+        overall="stale", latest_as_of=latest, stale_reason="older_than_ttl"
+    )

--- a/app/services/kr_news_symbol_mapping/query_service.py
+++ b/app/services/kr_news_symbol_mapping/query_service.py
@@ -1,0 +1,75 @@
+"""뉴스-종목 매핑 read-model query_service (ROB-398 Slice 1).
+
+article-provider(DI)로 ArticleView 들을 받아 per-article provenance 를 resolve 하고
+target symbol 을 매핑한 기사만 모아 freshness 와 함께 반환. read-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+
+from app.services.kr_news_symbol_mapping.contract import (
+    FRESHNESS_TTL_HOURS,
+    ArticleView,
+    MappedArticle,
+    SymbolNewsMapping,
+)
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+from app.services.news_entity_matcher import match_symbols_for_article
+
+ArticleProvider = Callable[[str, str, int, int], Awaitable[Sequence[ArticleView]]]
+
+
+async def _empty_provider(
+    symbol: str, market: str, hours: int, limit: int
+) -> list[ArticleView]:
+    # 기본 provider: DB 연결은 후속 슬라이스. 미연결 시 honest 빈 결과.
+    return []
+
+
+async def get_symbol_news_mapping(
+    symbol: str,
+    *,
+    market: str = "kr",
+    hours: int = 24,
+    limit: int = 20,
+    now: datetime | None = None,
+    ttl_hours: int = FRESHNESS_TTL_HOURS,
+    article_provider: ArticleProvider | None = None,
+) -> SymbolNewsMapping:
+    now = now or datetime.now(UTC)
+    provider = article_provider or _empty_provider
+    target = symbol.upper()
+
+    raw_articles = await provider(symbol, market, hours, limit)
+
+    mapped_articles: list[MappedArticle] = []
+    as_ofs: list[datetime] = []
+    for av in raw_articles:
+        ner_matches = match_symbols_for_article(
+            title=av.title, summary=av.summary, keywords=av.keywords, market=market
+        )
+        mapped = resolve_article_symbols(
+            market=market,
+            stock_symbol=av.stock_symbol,
+            related_rows=av.related_rows,
+            ner_matches=ner_matches,
+        )
+        if not any(m.symbol == target for m in mapped):
+            continue
+        # target 매핑을 앞으로 정렬(소비자 편의), 결정적 순서 유지.
+        ordered = tuple(sorted(mapped, key=lambda m: (m.symbol != target, m.symbol)))
+        mapped_articles.append(
+            MappedArticle(as_of=av.as_of, title=av.title, mapped_symbols=ordered)
+        )
+        as_ofs.append(av.as_of)
+
+    freshness = derive_freshness(as_ofs, now=now, ttl_hours=ttl_hours)
+    return SymbolNewsMapping(
+        symbol=target,
+        market=market,
+        articles=tuple(mapped_articles),
+        freshness=freshness,
+    )

--- a/app/services/kr_news_symbol_mapping/resolver.py
+++ b/app/services/kr_news_symbol_mapping/resolver.py
@@ -1,0 +1,78 @@
+"""provenance 통합 + is_primary 파생 (ROB-398 Slice 1, 순수 함수).
+
+우선순위 naver_code(1.0) > candidate > ner. is_primary 는 확정 소스(naver_code)
+또는 단일 후보일 때만 True; 그 외(복수 후보, 확정 없음)면 전부 False(모호성 보류).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.services.kr_news_symbol_mapping.contract import (
+    CANDIDATE_DEFAULT_CONFIDENCE,
+    MAPPING_SOURCE_PRIORITY,
+    NER_CONFIDENCE,
+    CandidateRow,
+    MappedSymbol,
+)
+from app.services.news_entity_matcher import SymbolMatch
+
+
+def _candidate_confidence(score: float | None) -> float:
+    if score is None:
+        return CANDIDATE_DEFAULT_CONFIDENCE
+    return max(0.0, min(1.0, float(score)))
+
+
+def resolve_article_symbols(
+    *,
+    market: str,
+    stock_symbol: str | None,
+    related_rows: Sequence[CandidateRow],
+    ner_matches: Sequence[SymbolMatch],
+) -> list[MappedSymbol]:
+    # symbol -> (priority, mapping_source, confidence, matched_term)
+    best: dict[str, tuple[int, str, float, str | None]] = {}
+
+    def _offer(
+        symbol: str, source: str, confidence: float, matched_term: str | None
+    ) -> None:
+        symbol = symbol.upper()
+        priority = MAPPING_SOURCE_PRIORITY[source]
+        existing = best.get(symbol)
+        if existing is None or priority < existing[0]:
+            best[symbol] = (priority, source, confidence, matched_term)
+
+    if stock_symbol:
+        _offer(stock_symbol, "naver_code", 1.0, None)
+    for row in related_rows:
+        _offer(
+            row.symbol, "candidate", _candidate_confidence(row.score), row.matched_term
+        )
+    for match in ner_matches:
+        _offer(match.symbol, "ner", NER_CONFIDENCE, match.matched_term)
+
+    if not best:
+        return []
+
+    confirmed_symbol = stock_symbol.upper() if stock_symbol else None
+    only_one = len(best) == 1
+
+    out: list[MappedSymbol] = []
+    for symbol in sorted(best):
+        _priority, source, confidence, matched_term = best[symbol]
+        if confirmed_symbol is not None:
+            is_primary = symbol == confirmed_symbol
+        else:
+            is_primary = only_one
+        out.append(
+            MappedSymbol(
+                symbol=symbol,
+                market=market,
+                mapping_source=source,
+                confidence=confidence,
+                is_primary=is_primary,
+                matched_term=matched_term,
+            )
+        )
+    return out

--- a/app/services/news_entity_alias_data.py
+++ b/app/services/news_entity_alias_data.py
@@ -24,11 +24,19 @@ class AliasEntry:
 
 
 KR_ALIASES: tuple[AliasEntry, ...] = (
-    AliasEntry("005930", "kr", "삼성전자", ("삼성전자", "삼전", "삼전닉스", "Samsung Electronics")),
+    AliasEntry(
+        "005930",
+        "kr",
+        "삼성전자",
+        ("삼성전자", "삼전", "삼전닉스", "Samsung Electronics"),
+    ),
     # ROB-130: "닉스" is a 2-char alias requested by the spec; accepts some
     # false-positive risk for higher recall on KR market chatter.
     AliasEntry(
-        "000660", "kr", "SK하이닉스", ("SK하이닉스", "하이닉스", "닉스", "삼전닉스", "SK Hynix")
+        "000660",
+        "kr",
+        "SK하이닉스",
+        ("SK하이닉스", "하이닉스", "닉스", "삼전닉스", "SK Hynix"),
     ),
     AliasEntry("035420", "kr", "NAVER", ("네이버", "NAVER")),
     AliasEntry("035720", "kr", "카카오", ("카카오",)),

--- a/app/services/news_entity_alias_data.py
+++ b/app/services/news_entity_alias_data.py
@@ -24,11 +24,11 @@ class AliasEntry:
 
 
 KR_ALIASES: tuple[AliasEntry, ...] = (
-    AliasEntry("005930", "kr", "삼성전자", ("삼성전자", "삼전", "Samsung Electronics")),
+    AliasEntry("005930", "kr", "삼성전자", ("삼성전자", "삼전", "삼전닉스", "Samsung Electronics")),
     # ROB-130: "닉스" is a 2-char alias requested by the spec; accepts some
     # false-positive risk for higher recall on KR market chatter.
     AliasEntry(
-        "000660", "kr", "SK하이닉스", ("SK하이닉스", "하이닉스", "닉스", "SK Hynix")
+        "000660", "kr", "SK하이닉스", ("SK하이닉스", "하이닉스", "닉스", "삼전닉스", "SK Hynix")
     ),
     AliasEntry("035420", "kr", "NAVER", ("네이버", "NAVER")),
     AliasEntry("035720", "kr", "카카오", ("카카오",)),
@@ -38,6 +38,11 @@ KR_ALIASES: tuple[AliasEntry, ...] = (
     AliasEntry("005380", "kr", "현대차", ("현대차", "현대자동차", "Hyundai Motor")),
     AliasEntry("005490", "kr", "POSCO홀딩스", ("POSCO", "포스코")),
     AliasEntry("373220", "kr", "LG에너지솔루션", ("LG에너지솔루션", "LG엔솔")),
+    AliasEntry("000270", "kr", "기아", ("기아", "기아차", "Kia")),
+    AliasEntry("006400", "kr", "삼성SDI", ("삼성SDI", "삼성에스디아이")),
+    AliasEntry("068270", "kr", "셀트리온", ("셀트리온",)),
+    AliasEntry("066570", "kr", "LG전자", ("LG전자", "엘지전자", "LG Electronics")),
+    AliasEntry("105560", "kr", "KB금융", ("KB금융", "KB금융지주")),
 )
 
 US_ALIASES: tuple[AliasEntry, ...] = (

--- a/docs/superpowers/plans/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel.md
+++ b/docs/superpowers/plans/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel.md
@@ -1,0 +1,882 @@
+# ROB-398 Slice 1 — 뉴스-종목 매핑 read-model + 별칭 확장 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 기존 데이터(article.stock_symbol + news_article_related_symbols + 별칭 matcher) 위에 provenance·is_primary·모호성·freshness를 통합하는 read-only read-model을 만들고 `KR_ALIASES`를 큐레이티드 확장한다.
+
+**Architecture:** 신규 패키지 `app/services/kr_news_symbol_mapping/`. 핵심 로직(provenance 통합·is_primary 파생·freshness)은 **순수 함수**(`resolver.py`/`freshness.py`)로 두어 DB 없이 단위테스트한다. `query_service.py`는 article-provider 의존성 주입으로 조립만 하며 DB는 기본 provider에만 둔다. migration/write/scheduler 없음.
+
+**Tech Stack:** Python 3.13, `@dataclass(frozen=True)`, pytest. 기존 `news_entity_matcher.match_symbols_for_article`/`SymbolMatch`, `news_entity_alias_data.AliasEntry/KR_ALIASES` 재사용. 새 의존성 없음.
+
+**참조 스펙:** `docs/superpowers/specs/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel-design.md`
+
+기존 시그니처(확인됨):
+- `AliasEntry(symbol, market, canonical_name, aliases: tuple[str,...])` — `app/services/news_entity_alias_data.py`
+- `SymbolMatch(symbol, market, canonical_name, matched_term, reason)`; `match_symbols_for_article(*, title, summary=None, keywords=None, market=None) -> list[SymbolMatch]` (symbol별 dedup, 정렬) — `app/services/news_entity_matcher.py`
+- `NewsArticleRelatedSymbol(symbol, source, score, rank, matched_term, ...)`, `NewsArticle(stock_symbol, published_at, scraped_at, title, summary, keywords, market, ...)` — `app/models/news.py`
+
+---
+
+## File Structure
+
+- Create `app/services/kr_news_symbol_mapping/__init__.py` — 공개 표면 re-export
+- Create `app/services/kr_news_symbol_mapping/contract.py` — frozen dataclass(`MappedSymbol`, `CandidateRow`, `MappedArticle`, `Freshness`, `SymbolNewsMapping`, `ArticleView`) + 상수(`MAPPING_SOURCE_PRIORITY`, `NER_CONFIDENCE`, `CANDIDATE_DEFAULT_CONFIDENCE`, `FRESHNESS_TTL_HOURS`)
+- Create `app/services/kr_news_symbol_mapping/resolver.py` — 순수 `resolve_article_symbols(...)`
+- Create `app/services/kr_news_symbol_mapping/freshness.py` — 순수 `derive_freshness(...)`
+- Create `app/services/kr_news_symbol_mapping/query_service.py` — DI 기반 `get_symbol_news_mapping(...)`
+- Modify `app/services/news_entity_alias_data.py` — `KR_ALIASES` 큐레이티드 확장 + 복합별칭
+- Create tests: `tests/test_kr_news_symbol_mapping_resolver.py`, `tests/test_kr_news_symbol_mapping_freshness.py`, `tests/test_kr_news_symbol_mapping_query.py`, `tests/test_kr_aliases_extension.py`
+
+---
+
+## Task 1: contract dataclasses + 상수 (`contract.py`)
+
+**Files:**
+- Create: `app/services/kr_news_symbol_mapping/__init__.py` (빈 docstring; Task 6에서 re-export)
+- Create: `app/services/kr_news_symbol_mapping/contract.py`
+- Test: `tests/test_kr_news_symbol_mapping_resolver.py` (Task 2에서 채움; Task 1은 contract import만 검증)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_news_symbol_mapping_resolver.py
+import dataclasses
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.contract import (
+    CandidateRow,
+    Freshness,
+    MappedSymbol,
+    MAPPING_SOURCE_PRIORITY,
+    NER_CONFIDENCE,
+)
+
+
+@pytest.mark.unit
+def test_mapped_symbol_is_frozen():
+    m = MappedSymbol(
+        symbol="005930",
+        market="kr",
+        mapping_source="naver_code",
+        confidence=1.0,
+        is_primary=True,
+        matched_term=None,
+    )
+    assert m.confidence == 1.0
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        m.is_primary = False  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_priority_order_and_ner_confidence_constants():
+    assert MAPPING_SOURCE_PRIORITY["naver_code"] < MAPPING_SOURCE_PRIORITY["candidate"]
+    assert MAPPING_SOURCE_PRIORITY["candidate"] < MAPPING_SOURCE_PRIORITY["ner"]
+    assert 0.0 < NER_CONFIDENCE < 1.0
+
+
+@pytest.mark.unit
+def test_candidate_row_holds_score_rank():
+    row = CandidateRow(symbol="000660", source="news_ingestor", score=0.8, rank=1, matched_term="하이닉스")
+    assert row.symbol == "000660"
+    assert row.score == 0.8
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.services.kr_news_symbol_mapping.contract`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/kr_news_symbol_mapping/__init__.py
+"""KR 뉴스-종목 매핑 read-model (ROB-398 Slice 1)."""
+```
+
+```python
+# app/services/kr_news_symbol_mapping/contract.py
+"""뉴스-종목 매핑 read-model 계약 — provenance-rich 통합 뷰 (ROB-398 Slice 1).
+
+기존 데이터(article.stock_symbol / news_article_related_symbols / 별칭 matcher)
+위의 read-only 뷰. write/migration 없음.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+# mapping_source 우선순위 (작을수록 우선). naver_code = 확정, ner = 최약.
+MAPPING_SOURCE_PRIORITY: dict[str, int] = {
+    "naver_code": 0,
+    "candidate": 1,
+    "ner": 2,
+}
+
+NER_CONFIDENCE: float = 0.5
+CANDIDATE_DEFAULT_CONFIDENCE: float = 0.7  # candidate row.score 부재 시
+FRESHNESS_TTL_HOURS: int = 24
+
+
+@dataclass(frozen=True)
+class CandidateRow:
+    """news_article_related_symbols 한 행의 read-only 뷰 (candidate source)."""
+
+    symbol: str
+    source: str
+    score: float | None = None
+    rank: int | None = None
+    matched_term: str | None = None
+
+
+@dataclass(frozen=True)
+class MappedSymbol:
+    symbol: str
+    market: str
+    mapping_source: str        # "naver_code" | "candidate" | "ner"
+    confidence: float          # 0.0..1.0
+    is_primary: bool
+    matched_term: str | None
+
+
+@dataclass(frozen=True)
+class ArticleView:
+    """resolver/query_service 입력용 기사 뷰 (DB ORM 비의존, 테스트 친화)."""
+
+    market: str
+    stock_symbol: str | None
+    related_rows: tuple[CandidateRow, ...]
+    title: str | None
+    summary: str | None
+    keywords: tuple[str, ...]
+    as_of: datetime
+
+
+@dataclass(frozen=True)
+class MappedArticle:
+    as_of: datetime
+    title: str | None
+    mapped_symbols: tuple[MappedSymbol, ...]
+
+
+@dataclass(frozen=True)
+class Freshness:
+    overall: str               # "fresh" | "stale" | "unavailable"
+    latest_as_of: datetime | None
+    stale_reason: str | None
+
+
+@dataclass(frozen=True)
+class SymbolNewsMapping:
+    symbol: str
+    market: str
+    articles: tuple[MappedArticle, ...]
+    freshness: Freshness
+```
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_resolver.py -v && uv run ruff check app/services/kr_news_symbol_mapping/`
+Expected: PASS (3 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/kr_news_symbol_mapping/__init__.py app/services/kr_news_symbol_mapping/contract.py tests/test_kr_news_symbol_mapping_resolver.py
+git commit -m "feat(ROB-398): 뉴스-종목 매핑 read-model 계약 dataclass + 상수
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: provenance 통합 + is_primary 파생 (`resolver.py`)
+
+**Files:**
+- Create: `app/services/kr_news_symbol_mapping/resolver.py`
+- Test: `tests/test_kr_news_symbol_mapping_resolver.py` (Task 1 파일에 추가)
+
+- [ ] **Step 1: Write the failing test (append)**
+
+`tests/test_kr_news_symbol_mapping_resolver.py` 에 추가:
+
+```python
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+from app.services.news_entity_matcher import SymbolMatch
+
+
+def _ner(symbol, term="x"):
+    return SymbolMatch(symbol=symbol, market="kr", canonical_name=symbol, matched_term=term, reason="alias_dict")
+
+
+@pytest.mark.unit
+def test_naver_code_is_confirmed_primary():
+    out = resolve_article_symbols(
+        market="kr", stock_symbol="005930", related_rows=(), ner_matches=()
+    )
+    assert len(out) == 1
+    assert out[0].symbol == "005930"
+    assert out[0].mapping_source == "naver_code"
+    assert out[0].confidence == 1.0
+    assert out[0].is_primary is True
+
+
+@pytest.mark.unit
+def test_candidate_source_uses_score_and_matched_term():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(CandidateRow(symbol="000660", source="news_ingestor", score=0.8, rank=1, matched_term="하이닉스"),),
+        ner_matches=(),
+    )
+    assert len(out) == 1
+    assert out[0].mapping_source == "candidate"
+    assert out[0].confidence == 0.8
+    assert out[0].is_primary is True  # 단일 후보
+
+
+@pytest.mark.unit
+def test_candidate_missing_score_uses_default_confidence():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(CandidateRow(symbol="000660", source="x", score=None, rank=2),),
+        ner_matches=(),
+    )
+    assert out[0].confidence == 0.7  # CANDIDATE_DEFAULT_CONFIDENCE
+
+
+@pytest.mark.unit
+def test_ner_single_match_is_primary():
+    out = resolve_article_symbols(
+        market="kr", stock_symbol=None, related_rows=(), ner_matches=(_ner("035420", "네이버"),)
+    )
+    assert out[0].mapping_source == "ner"
+    assert out[0].confidence == 0.5
+    assert out[0].is_primary is True
+
+
+@pytest.mark.unit
+def test_ner_ambiguity_holds_back_is_primary():
+    # 이름충돌(복합 별칭 "삼전닉스" → 005930 + 000660), 확정/후보 disambiguator 없음.
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(),
+        ner_matches=(_ner("005930", "삼전닉스"), _ner("000660", "삼전닉스")),
+    )
+    assert {m.symbol for m in out} == {"005930", "000660"}
+    assert all(m.is_primary is False for m in out)  # 강제 단일 금지
+
+
+@pytest.mark.unit
+def test_higher_priority_source_wins_per_symbol():
+    # 같은 symbol이 candidate + ner 둘 다 → candidate(우선)로 합쳐짐.
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(CandidateRow(symbol="035420", source="x", score=0.9),),
+        ner_matches=(_ner("035420", "네이버"),),
+    )
+    assert len(out) == 1
+    assert out[0].mapping_source == "candidate"
+    assert out[0].confidence == 0.9
+
+
+@pytest.mark.unit
+def test_naver_code_present_makes_other_symbols_non_primary():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol="005930",
+        related_rows=(),
+        ner_matches=(_ner("000660", "하이닉스"),),
+    )
+    by_symbol = {m.symbol: m for m in out}
+    assert by_symbol["005930"].is_primary is True
+    assert by_symbol["000660"].is_primary is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_resolver.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...resolver`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/kr_news_symbol_mapping/resolver.py
+"""provenance 통합 + is_primary 파생 (ROB-398 Slice 1, 순수 함수).
+
+우선순위 naver_code(1.0) > candidate > ner. is_primary 는 확정 소스(naver_code)
+또는 단일 후보일 때만 True; 그 외(복수 후보, 확정 없음)면 전부 False(모호성 보류).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.services.kr_news_symbol_mapping.contract import (
+    CANDIDATE_DEFAULT_CONFIDENCE,
+    MAPPING_SOURCE_PRIORITY,
+    NER_CONFIDENCE,
+    CandidateRow,
+    MappedSymbol,
+)
+from app.services.news_entity_matcher import SymbolMatch
+
+
+def _candidate_confidence(score: float | None) -> float:
+    if score is None:
+        return CANDIDATE_DEFAULT_CONFIDENCE
+    return max(0.0, min(1.0, float(score)))
+
+
+def resolve_article_symbols(
+    *,
+    market: str,
+    stock_symbol: str | None,
+    related_rows: Sequence[CandidateRow],
+    ner_matches: Sequence[SymbolMatch],
+) -> list[MappedSymbol]:
+    # symbol -> (priority, mapping_source, confidence, matched_term)
+    best: dict[str, tuple[int, str, float, str | None]] = {}
+
+    def _offer(symbol: str, source: str, confidence: float, matched_term: str | None) -> None:
+        symbol = symbol.upper()
+        priority = MAPPING_SOURCE_PRIORITY[source]
+        existing = best.get(symbol)
+        if existing is None or priority < existing[0]:
+            best[symbol] = (priority, source, confidence, matched_term)
+
+    if stock_symbol:
+        _offer(stock_symbol, "naver_code", 1.0, None)
+    for row in related_rows:
+        _offer(row.symbol, "candidate", _candidate_confidence(row.score), row.matched_term)
+    for match in ner_matches:
+        _offer(match.symbol, "ner", NER_CONFIDENCE, match.matched_term)
+
+    if not best:
+        return []
+
+    confirmed_symbol = stock_symbol.upper() if stock_symbol else None
+    only_one = len(best) == 1
+
+    out: list[MappedSymbol] = []
+    for symbol in sorted(best):
+        _priority, source, confidence, matched_term = best[symbol]
+        if confirmed_symbol is not None:
+            is_primary = symbol == confirmed_symbol
+        else:
+            is_primary = only_one
+        out.append(
+            MappedSymbol(
+                symbol=symbol,
+                market=market,
+                mapping_source=source,
+                confidence=confidence,
+                is_primary=is_primary,
+                matched_term=matched_term,
+            )
+        )
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_resolver.py -v && uv run ruff check app/services/kr_news_symbol_mapping/resolver.py`
+Expected: PASS (10 passed total in file); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/kr_news_symbol_mapping/resolver.py tests/test_kr_news_symbol_mapping_resolver.py
+git commit -m "feat(ROB-398): provenance 통합 resolver + 모호시 is_primary 보류
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: freshness 파생 (`freshness.py`)
+
+**Files:**
+- Create: `app/services/kr_news_symbol_mapping/freshness.py`
+- Test: `tests/test_kr_news_symbol_mapping_freshness.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_news_symbol_mapping_freshness.py
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+
+NOW = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.unit
+def test_no_articles_is_unavailable():
+    f = derive_freshness([], now=NOW, ttl_hours=24)
+    assert f.overall == "unavailable"
+    assert f.latest_as_of is None
+    assert f.stale_reason == "no_mapped_news"
+
+
+@pytest.mark.unit
+def test_recent_is_fresh():
+    f = derive_freshness([NOW - timedelta(hours=2)], now=NOW, ttl_hours=24)
+    assert f.overall == "fresh"
+    assert f.latest_as_of == NOW - timedelta(hours=2)
+    assert f.stale_reason is None
+
+
+@pytest.mark.unit
+def test_older_than_ttl_is_stale():
+    f = derive_freshness(
+        [NOW - timedelta(hours=30), NOW - timedelta(hours=48)], now=NOW, ttl_hours=24
+    )
+    assert f.overall == "stale"
+    assert f.latest_as_of == NOW - timedelta(hours=30)  # 가장 신선한 것 기준
+    assert f.stale_reason == "older_than_ttl"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_freshness.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...freshness`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/kr_news_symbol_mapping/freshness.py
+"""뉴스-종목 매핑 freshness 파생 (ROB-398 Slice 1, 순수 함수).
+
+가장 신선한 매핑 기사 as_of 가 TTL 내면 fresh, 초과면 stale, 0건이면
+unavailable. reason 을 동봉해 숨김 없이 노출한다.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+
+from app.services.kr_news_symbol_mapping.contract import (
+    FRESHNESS_TTL_HOURS,
+    Freshness,
+)
+
+
+def derive_freshness(
+    as_ofs: Sequence[datetime],
+    *,
+    now: datetime,
+    ttl_hours: int = FRESHNESS_TTL_HOURS,
+) -> Freshness:
+    if not as_ofs:
+        return Freshness(overall="unavailable", latest_as_of=None, stale_reason="no_mapped_news")
+    latest = max(as_ofs)
+    if now - latest <= timedelta(hours=ttl_hours):
+        return Freshness(overall="fresh", latest_as_of=latest, stale_reason=None)
+    return Freshness(overall="stale", latest_as_of=latest, stale_reason="older_than_ttl")
+```
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_freshness.py -v && uv run ruff check app/services/kr_news_symbol_mapping/freshness.py`
+Expected: PASS (3 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/kr_news_symbol_mapping/freshness.py tests/test_kr_news_symbol_mapping_freshness.py
+git commit -m "feat(ROB-398): 뉴스 매핑 freshness 파생(fresh/stale/unavailable + reason)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 별칭 큐레이티드 확장 + 복합별칭 (`news_entity_alias_data.py`)
+
+**Files:**
+- Modify: `app/services/news_entity_alias_data.py` (`KR_ALIASES` 튜플)
+- Test: `tests/test_kr_aliases_extension.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_aliases_extension.py
+import pytest
+
+from app.services.news_entity_matcher import match_symbols
+
+
+def _symbols(text):
+    return {m.symbol for m in match_symbols(text, market="kr")}
+
+
+@pytest.mark.unit
+def test_new_curated_aliases_match():
+    assert "000270" in _symbols("기아 신차 출시")          # 기아
+    assert "006400" in _symbols("삼성SDI 배터리 수주")       # 삼성SDI
+    assert "068270" in _symbols("셀트리온 바이오시밀러 허가")  # 셀트리온
+
+
+@pytest.mark.unit
+def test_compound_alias_maps_to_multiple_symbols_ambiguous():
+    # "삼전닉스" → 삼성전자(005930) + SK하이닉스(000660) 동시 매칭(이름충돌 시연).
+    syms = _symbols("오늘 삼전닉스 강세")
+    assert "005930" in syms
+    assert "000660" in syms
+
+
+@pytest.mark.unit
+def test_no_false_positive_on_unrelated_text():
+    # 무관 텍스트는 매칭되지 않아야 한다(precision 회귀).
+    assert _symbols("점심 삼겹살 맛집 추천") == set()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_aliases_extension.py -v`
+Expected: FAIL — 신규 별칭/복합별칭 미존재로 `000270`/`006400`/`068270`/`삼전닉스` 매칭 실패.
+
+- [ ] **Step 3: Modify `KR_ALIASES`**
+
+`app/services/news_entity_alias_data.py` 의 `KR_ALIASES` 튜플에서:
+
+1. 기존 `005930`(삼성전자)·`000660`(SK하이닉스) 엔트리의 `aliases` 에 복합별칭 `"삼전닉스"` 를 **양쪽 모두** 추가:
+
+```python
+    AliasEntry("005930", "kr", "삼성전자", ("삼성전자", "삼전", "삼전닉스", "Samsung Electronics")),
+    AliasEntry(
+        "000660", "kr", "SK하이닉스", ("SK하이닉스", "하이닉스", "닉스", "삼전닉스", "SK Hynix")
+    ),
+```
+
+2. 튜플 끝(`373220` 다음)에 큐레이티드 신규 엔트리 추가(고신호·precision 우선, 모호한 짧은 토큰 회피):
+
+```python
+    AliasEntry("000270", "kr", "기아", ("기아", "기아차", "Kia")),
+    AliasEntry("006400", "kr", "삼성SDI", ("삼성SDI", "삼성에스디아이")),
+    AliasEntry("068270", "kr", "셀트리온", ("셀트리온",)),
+    AliasEntry("066570", "kr", "LG전자", ("LG전자", "엘지전자", "LG Electronics")),
+    AliasEntry("105560", "kr", "KB금융", ("KB금융", "KB금융지주")),
+```
+
+(주의: `"기아"`는 2글자지만 KR 한글 substring 매칭이라 "기아차/기아자동차" 등에서 안전. 짧은 영문 토큰은 추가 금지 — word-boundary라도 오탐 위험.)
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_aliases_extension.py -v && uv run ruff check app/services/news_entity_alias_data.py tests/test_kr_aliases_extension.py`
+Expected: PASS (3 passed); ruff clean.
+
+- [ ] **Step 5: 기존 별칭/엔티티 테스트 회귀 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/ -k "alias or entity_match or news_entity" -q`
+Expected: PASS (기존 매처 테스트 무회귀). 실패 시 신규 별칭이 기존 기대값과 충돌하는지 확인 후 조정.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/news_entity_alias_data.py tests/test_kr_aliases_extension.py
+git commit -m "feat(ROB-398): KR_ALIASES 큐레이티드 확장 + 복합별칭(삼전닉스) 모호성 시연
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: query_service 조립 (DI, `query_service.py`)
+
+**Files:**
+- Create: `app/services/kr_news_symbol_mapping/query_service.py`
+- Test: `tests/test_kr_news_symbol_mapping_query.py`
+
+`get_symbol_news_mapping` 은 article-provider(콜러블)로 `ArticleView` 시퀀스를 받아 per-article resolve → target symbol 포함 기사만 모아 freshness 파생. 기본 provider는 DB(후속에서 실 연결); 본 슬라이스는 DI로 테스트하고 기본 provider는 미연결 시 빈 결과를 honest 반환.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_news_symbol_mapping_query.py
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.contract import ArticleView, CandidateRow
+from app.services.kr_news_symbol_mapping.query_service import get_symbol_news_mapping
+
+NOW = datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_assembles_mapping_for_target_symbol_with_freshness():
+    articles = [
+        ArticleView(
+            market="kr",
+            stock_symbol="005930",  # naver_code 확정
+            related_rows=(),
+            title="삼성전자 신규 투자",
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=1),
+        ),
+        ArticleView(
+            market="kr",
+            stock_symbol=None,
+            related_rows=(),
+            title="네이버 실적 발표",  # NER로 035420 매핑 → target과 무관
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=2),
+        ),
+    ]
+
+    async def provider(symbol, market, hours, limit):
+        return articles
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", hours=24, limit=20, now=NOW, article_provider=provider
+    )
+
+    assert result.symbol == "005930"
+    # target symbol(005930)을 매핑한 기사만 포함
+    assert len(result.articles) == 1
+    primary = result.articles[0].mapped_symbols[0]
+    assert primary.symbol == "005930"
+    assert primary.mapping_source == "naver_code"
+    assert primary.is_primary is True
+    assert result.freshness.overall == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_no_matching_articles_is_unavailable():
+    async def provider(symbol, market, hours, limit):
+        return []
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", now=NOW, article_provider=provider
+    )
+    assert result.articles == ()
+    assert result.freshness.overall == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_candidate_row_article_maps_target():
+    articles = [
+        ArticleView(
+            market="kr",
+            stock_symbol=None,
+            related_rows=(CandidateRow(symbol="000660", source="news_ingestor", score=0.8, rank=1),),
+            title="반도체 업황",
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=3),
+        )
+    ]
+
+    async def provider(symbol, market, hours, limit):
+        return articles
+
+    result = await get_symbol_news_mapping(
+        "000660", market="kr", now=NOW, article_provider=provider
+    )
+    assert len(result.articles) == 1
+    m = result.articles[0].mapped_symbols[0]
+    assert m.mapping_source == "candidate"
+    assert m.confidence == 0.8
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_query.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...query_service`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/kr_news_symbol_mapping/query_service.py
+"""뉴스-종목 매핑 read-model query_service (ROB-398 Slice 1).
+
+article-provider(DI)로 ArticleView 들을 받아 per-article provenance 를 resolve 하고
+target symbol 을 매핑한 기사만 모아 freshness 와 함께 반환. read-only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import datetime, timezone
+
+from app.services.kr_news_symbol_mapping.contract import (
+    FRESHNESS_TTL_HOURS,
+    ArticleView,
+    MappedArticle,
+    SymbolNewsMapping,
+)
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+from app.services.news_entity_matcher import match_symbols_for_article
+
+ArticleProvider = Callable[[str, str, int, int], Awaitable[Sequence[ArticleView]]]
+
+
+async def _empty_provider(symbol: str, market: str, hours: int, limit: int) -> list[ArticleView]:
+    # 기본 provider: DB 연결은 후속 슬라이스. 미연결 시 honest 빈 결과.
+    return []
+
+
+async def get_symbol_news_mapping(
+    symbol: str,
+    *,
+    market: str = "kr",
+    hours: int = 24,
+    limit: int = 20,
+    now: datetime | None = None,
+    ttl_hours: int = FRESHNESS_TTL_HOURS,
+    article_provider: ArticleProvider | None = None,
+) -> SymbolNewsMapping:
+    now = now or datetime.now(timezone.utc)
+    provider = article_provider or _empty_provider
+    target = symbol.upper()
+
+    raw_articles = await provider(symbol, market, hours, limit)
+
+    mapped_articles: list[MappedArticle] = []
+    as_ofs: list[datetime] = []
+    for av in raw_articles:
+        ner_matches = match_symbols_for_article(
+            title=av.title, summary=av.summary, keywords=av.keywords, market=market
+        )
+        mapped = resolve_article_symbols(
+            market=market,
+            stock_symbol=av.stock_symbol,
+            related_rows=av.related_rows,
+            ner_matches=ner_matches,
+        )
+        if not any(m.symbol == target for m in mapped):
+            continue
+        # target 매핑을 앞으로 정렬(소비자 편의), 결정적 순서 유지.
+        ordered = tuple(
+            sorted(mapped, key=lambda m: (m.symbol != target, m.symbol))
+        )
+        mapped_articles.append(
+            MappedArticle(as_of=av.as_of, title=av.title, mapped_symbols=ordered)
+        )
+        as_ofs.append(av.as_of)
+
+    freshness = derive_freshness(as_ofs, now=now, ttl_hours=ttl_hours)
+    return SymbolNewsMapping(
+        symbol=target,
+        market=market,
+        articles=tuple(mapped_articles),
+        freshness=freshness,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes + lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/test_kr_news_symbol_mapping_query.py -v && uv run ruff check app/services/kr_news_symbol_mapping/query_service.py`
+Expected: PASS (3 passed); ruff clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/kr_news_symbol_mapping/query_service.py tests/test_kr_news_symbol_mapping_query.py
+git commit -m "feat(ROB-398): 뉴스-종목 매핑 query_service(DI provider + freshness 조립)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: 패키지 공개 표면 + 전체 검증
+
+**Files:**
+- Modify: `app/services/kr_news_symbol_mapping/__init__.py`
+
+- [ ] **Step 1: __init__ re-export**
+
+```python
+# app/services/kr_news_symbol_mapping/__init__.py
+"""KR 뉴스-종목 매핑 read-model (ROB-398 Slice 1)."""
+
+from app.services.kr_news_symbol_mapping.contract import (
+    ArticleView,
+    CandidateRow,
+    Freshness,
+    MappedArticle,
+    MappedSymbol,
+    SymbolNewsMapping,
+)
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+from app.services.kr_news_symbol_mapping.query_service import get_symbol_news_mapping
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+
+__all__ = [
+    "ArticleView",
+    "CandidateRow",
+    "Freshness",
+    "MappedArticle",
+    "MappedSymbol",
+    "SymbolNewsMapping",
+    "derive_freshness",
+    "get_symbol_news_mapping",
+    "resolve_article_symbols",
+]
+```
+
+- [ ] **Step 2: 전체 모듈 테스트 + lint + format + import-contract**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+uv run pytest tests/test_kr_news_symbol_mapping_resolver.py tests/test_kr_news_symbol_mapping_freshness.py tests/test_kr_news_symbol_mapping_query.py tests/test_kr_aliases_extension.py -v
+uv run ruff check app/services/kr_news_symbol_mapping/ app/services/news_entity_alias_data.py tests/test_kr_news_symbol_mapping_*.py tests/test_kr_aliases_extension.py
+uv run ruff format --check app/services/kr_news_symbol_mapping/ tests/test_kr_news_symbol_mapping_*.py tests/test_kr_aliases_extension.py
+uv run pytest tests/test_import_contracts.py -q
+```
+Expected: 전부 PASS; ruff clean. (kr_news_symbol_mapping 은 services 내부 + news_entity_matcher 만 import → import-contract 위반 없음.)
+
+- [ ] **Step 3: 별칭 변경 인접 회귀 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-398 && uv run pytest tests/ -k "alias or entity_match or news_entity or news" -q`
+Expected: PASS. (KR_ALIASES 확장이 기존 뉴스/매처 테스트를 깨지 않음 확인.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-398
+git add app/services/kr_news_symbol_mapping/__init__.py
+git commit -m "feat(ROB-398): kr_news_symbol_mapping 패키지 공개 표면 re-export
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (작성자 체크)
+
+**Spec coverage:**
+- §3 아키텍처(패키지 + 순수 resolver/freshness + DI query_service) → Task 1/2/3/5 ✅
+- §3 mapping_source 3소스(naver_code/candidate/ner) + confidence → Task 2 ✅
+- §4 우선순위 + is_primary 파생 + 모호성 보류 → Task 2 (`test_ner_ambiguity_holds_back_is_primary`) ✅
+- §5 freshness(fresh/stale/unavailable + reason) → Task 3 ✅
+- §6 별칭 큐레이티드 확장 + 복합별칭 + false-positive 회귀 → Task 4 ✅
+- §7 테스트 6종 → Task 2/3/4/5 전반 ✅
+- §2 migration 0 / read-only / write 없음 → 어떤 Task도 모델/마이그레이션/ingest write 미추가 ✅
+
+**Placeholder scan:** 모든 step 에 실제 코드/명령/기대 출력. placeholder 없음.
+
+**Type consistency:** `MappedSymbol`/`CandidateRow`/`ArticleView`/`MappedArticle`/`Freshness`/`SymbolNewsMapping`(Task1) → `resolve_article_symbols`(Task2)/`derive_freshness`(Task3)/`get_symbol_news_mapping`(Task5)에서 일관 사용. `MAPPING_SOURCE_PRIORITY`/`NER_CONFIDENCE`/`CANDIDATE_DEFAULT_CONFIDENCE`/`FRESHNESS_TTL_HOURS` 상수 일관. `SymbolMatch`(기존, symbol/market/canonical_name/matched_term/reason) 필드 정확.
+
+**검증 시 주의:**
+- Task 4 의 신규 별칭이 기존 매처 테스트(`tests/` 의 alias/entity 테스트)와 충돌하면 Step 5에서 표면화 → 조정.
+- `match_symbols_for_article` 의 keywords 인자는 Iterable; `ArticleView.keywords`는 tuple 로 전달(정상).

--- a/docs/superpowers/specs/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel-design.md
@@ -1,0 +1,115 @@
+# ROB-398 Slice 1 — 뉴스-종목 매핑 read-model + 별칭 확장 설계
+
+- **이슈**: ROB-398 (오케스트레이션 ROB-411 C라인) — Slice 1 of 4
+- **상태**: design (브레인스토밍 승인 완료)
+- **날짜**: 2026-06-02
+- **선행/관련**: ROB-397(symbol_analysis 계약), ROB-396(analyze 결정성). 관련 ROB-389(candidate_universe), ROB-391(naver collector 승격).
+
+---
+
+## 0. ROB-398 분해 (4 슬라이스)
+
+ROB-398은 단일 spec에 너무 커서 독립 출하 가능한 슬라이스로 나눈다:
+
+1. **Slice 1 (본 문서)** — 뉴스-종목 매핑 read-model + 별칭 확장.
+2. Slice 2 — Naver sise 랭킹 snapshot collector (greenfield, screen_stocks/stale momentum 대체).
+3. Slice 3 — 투자자 매매동향 collector (외인/기관 순매수·체결강도, 397 flow 피드).
+4. Slice 4 — Toss screener (내부 API 선확보 후).
+
+## 1. 배경 — 기존 인프라와 갭
+
+탐색 결과 매핑 백본의 상당 부분이 이미 존재한다:
+
+- `KR_ALIASES`(`app/services/news_entity_alias_data.py`, 9개) + `news_entity_matcher.match_symbols_for_article`(NER/별칭, `reason∈{alias_dict,candidate_metadata,exact_symbol}`, 모호 시 종목별 dedup 다중 반환).
+- `news_articles` + 다대다 `news_article_related_symbols`(`article_id,market,symbol,source,matched_term,score,rank,raw`, UNIQUE `(article_id,market,symbol,source)`). `is_primary`/명시적 `mapping_source`/`confidence` 컬럼은 없음(`source`/`score`가 근사).
+- Naver 종목뉴스 fetcher `naver_finance.news.fetch_news(code)`(`&code=` = 매핑전략①, 확정). durable 적재 주경로는 news-ingestor 브리지(`/trading/api/.../ingest/bulk`, `raw.stock_candidates`→related_symbols).
+
+**갭**: 매핑 provenance가 한 곳에 통합돼 있지 않다. ① `naver_code` 확정매핑은 `article.stock_symbol`에만, ② ingestor 후보는 `related_symbols`에, ③ 별칭 matcher는 **조회 시점에만**(영속 X). 소비자가 "이 기사/종목 매핑의 출처·신뢰도·일차성·모호성·신선도"를 일관되게 못 본다.
+
+## 2. 목표·범위
+
+기존 데이터 위 **read-model 뷰**로 매핑 provenance를 통합한다. **migration 0, read-only, backfill/scheduler 없음, 신규 ingest write 없음.** ROB-398 완료기준(종목 코드 매핑·뉴스 매핑·별칭 충돌 처리·freshness metadata)을 read 레이어에서 충족.
+
+**안전 경계** (ROB-411 상속): broker/order/watch/order-intent mutation 없음, production DB backfill/commit ingest 없음, scheduler activation 없음, Toss/Naver는 reference/calibration, stale/부재는 숨기지 않고 노출.
+
+## 3. 아키텍처 — 신규 `app/services/kr_news_symbol_mapping/`
+
+기존 3개 매핑 신호를 provenance-rich 통합 뷰로 합치는 read-only query_service.
+
+| mapping_source | 출처 | confidence |
+|---|---|---|
+| `naver_code` | `article.stock_symbol`(Naver `&code=` 등 확정) | 1.0 |
+| `candidate` | 영속 `news_article_related_symbols`(ingestor 후보) | `row.score` 정규화(없으면 rank 파생) |
+| `ner` | 조회시점 `match_symbols_for_article`(KR_ALIASES) | 고정 밴드 0.5 |
+
+핵심 단위:
+
+- `resolve_article_symbols(article) -> list[MappedSymbol]` — per-article provenance (세 소스 통합, dedup by symbol, source별 최고 conf 유지).
+- `get_symbol_news_mapping(symbol, *, market="kr", hours=24, limit=20) -> SymbolNewsMapping` — symbol-centric, freshness 포함.
+
+frozen dataclass:
+
+```python
+@dataclass(frozen=True)
+class MappedSymbol:
+    symbol: str
+    market: str
+    mapping_source: str        # "naver_code" | "candidate" | "ner"
+    confidence: float          # 0.0..1.0
+    is_primary: bool
+    matched_term: str | None
+
+@dataclass(frozen=True)
+class Freshness:
+    overall: str               # "fresh" | "stale" | "unavailable"
+    latest_as_of: datetime | None
+    stale_reason: str | None
+
+@dataclass(frozen=True)
+class SymbolNewsMapping:
+    symbol: str
+    market: str
+    articles: tuple[MappedArticle, ...]   # 기사별 매핑 + as_of
+    freshness: Freshness
+```
+
+## 4. provenance·is_primary·모호성 (확정 의미론)
+
+- mapping_source 우선순위: `naver_code(1.0) > candidate > ner`.
+- **is_primary 파생** (per article, 결정적):
+  - 확정 소스(`naver_code`)가 있으면 그 매핑이 `is_primary=True` (모호성 없음).
+  - 그 외, 단일 후보만 있으면 그 후보가 `is_primary=True`.
+  - **NER 모호**(한 기사가 이름충돌로 ner 다중 종목 매칭, 확정/후보 disambiguator 없음): **is_primary 전부 False** — 후보 N개 + confidence 그대로 노출, 강제 단일 금지.
+- 같은 symbol이 여러 source로 매핑되면 최고 우선순위 source의 confidence로 합치되 `raw`에 출처별 보존.
+
+## 5. freshness
+
+- per-article `as_of` = `article.published_at`(없으면 `scraped_at`).
+- `SymbolNewsMapping.freshness`:
+  - 매핑 기사 0건 → `overall="unavailable"`, `stale_reason="no_mapped_news"`.
+  - 가장 신선한 매핑 기사 `as_of`가 TTL(기본 24h, 모듈 상수) 내 → `fresh`.
+  - TTL 초과 → `stale`, `stale_reason="older_than_ttl"`.
+- machine-readable. 소비자가 Korean-facing copy에 활용하도록 reason 동봉. 숨김 없음.
+
+## 6. 별칭 확장 (큐레이티드, precision-first)
+
+- `KR_ALIASES`에 주요 KR 종목·약칭·영문·그룹명 고정탐지 추가(현 9개 → 확장; 시총 상위/뉴스 빈출 위주, false-positive 회피 위해 모호한 짧은 토큰 제외).
+- **복합/그룹 별칭 시연**: "삼전닉스" → 005930·000660 두 엔트리가 같은 alias를 공유 → matcher가 둘 다 반환 → §4 모호성 경로(is_primary 보류)로 연결.
+- DB `stock_aliases`(StockAliasService) matcher 와이어링은 **후속**(범위 억제, false-positive 검증 부담).
+
+## 7. 테스트 (TDD)
+
+1. `naver_code` 확정(article.stock_symbol==symbol) → mapping_source="naver_code", confidence=1.0, is_primary=True.
+2. `candidate`(related_symbols row) → mapping_source/confidence(score 파생)/rank 반영.
+3. `ner` 단일 매칭 → mapped, 모호성 없으면 is_primary=True.
+4. **NER 모호성**(예 "삼전닉스"→005930+000660, 확정/후보 없음) → 후보 2개, **is_primary 전부 False**.
+5. freshness: 최근 as_of→fresh, TTL 초과→stale(reason), 0건→unavailable(reason).
+6. 별칭 확장: 신규 큐레이티드 별칭 매칭(positive) + 무관 텍스트 미매칭(false-positive 회귀).
+- DB는 기존 테스트 패턴(fake/in-memory article objects)으로, 실 네트워크 없음.
+
+## 8. 비목표 (YAGNI)
+
+- ingest 시점 영속화 / migration / `is_primary`·`mapping_source` 컬럼 (read-time 파생).
+- 새 snapshot_kind / 번들 통합 (기존 `news` collector가 후속 슬라이스에서 이 read-model 소비 가능).
+- Naver 랭킹·투자자 매매동향·Toss screener (Slice 2~4).
+- DB `stock_aliases` matcher 와이어링.

--- a/tests/test_kr_aliases_extension.py
+++ b/tests/test_kr_aliases_extension.py
@@ -1,0 +1,29 @@
+# tests/test_kr_aliases_extension.py
+import pytest
+
+from app.services.news_entity_matcher import match_symbols
+
+
+def _symbols(text):
+    return {m.symbol for m in match_symbols(text, market="kr")}
+
+
+@pytest.mark.unit
+def test_new_curated_aliases_match():
+    assert "000270" in _symbols("기아 신차 출시")  # 기아
+    assert "006400" in _symbols("삼성SDI 배터리 수주")  # 삼성SDI
+    assert "068270" in _symbols("셀트리온 바이오시밀러 허가")  # 셀트리온
+
+
+@pytest.mark.unit
+def test_compound_alias_maps_to_multiple_symbols_ambiguous():
+    # "삼전닉스" → 삼성전자(005930) + SK하이닉스(000660) 동시 매칭(이름충돌 시연).
+    syms = _symbols("오늘 삼전닉스 강세")
+    assert "005930" in syms
+    assert "000660" in syms
+
+
+@pytest.mark.unit
+def test_no_false_positive_on_unrelated_text():
+    # 무관 텍스트는 매칭되지 않아야 한다(precision 회귀).
+    assert _symbols("점심 삼겹살 맛집 추천") == set()

--- a/tests/test_kr_news_symbol_mapping_freshness.py
+++ b/tests/test_kr_news_symbol_mapping_freshness.py
@@ -1,0 +1,33 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.freshness import derive_freshness
+
+NOW = datetime(2026, 6, 2, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_no_articles_is_unavailable():
+    f = derive_freshness([], now=NOW, ttl_hours=24)
+    assert f.overall == "unavailable"
+    assert f.latest_as_of is None
+    assert f.stale_reason == "no_mapped_news"
+
+
+@pytest.mark.unit
+def test_recent_is_fresh():
+    f = derive_freshness([NOW - timedelta(hours=2)], now=NOW, ttl_hours=24)
+    assert f.overall == "fresh"
+    assert f.latest_as_of == NOW - timedelta(hours=2)
+    assert f.stale_reason is None
+
+
+@pytest.mark.unit
+def test_older_than_ttl_is_stale():
+    f = derive_freshness(
+        [NOW - timedelta(hours=30), NOW - timedelta(hours=48)], now=NOW, ttl_hours=24
+    )
+    assert f.overall == "stale"
+    assert f.latest_as_of == NOW - timedelta(hours=30)  # 가장 신선한 것 기준
+    assert f.stale_reason == "older_than_ttl"

--- a/tests/test_kr_news_symbol_mapping_query.py
+++ b/tests/test_kr_news_symbol_mapping_query.py
@@ -1,0 +1,91 @@
+# tests/test_kr_news_symbol_mapping_query.py
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.contract import ArticleView, CandidateRow
+from app.services.kr_news_symbol_mapping.query_service import get_symbol_news_mapping
+
+NOW = datetime(2026, 6, 2, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_assembles_mapping_for_target_symbol_with_freshness():
+    articles = [
+        ArticleView(
+            market="kr",
+            stock_symbol="005930",  # naver_code 확정
+            related_rows=(),
+            title="삼성전자 신규 투자",
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=1),
+        ),
+        ArticleView(
+            market="kr",
+            stock_symbol=None,
+            related_rows=(),
+            title="네이버 실적 발표",  # NER로 035420 매핑 → target과 무관
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=2),
+        ),
+    ]
+
+    async def provider(symbol, market, hours, limit):
+        return articles
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", hours=24, limit=20, now=NOW, article_provider=provider
+    )
+
+    assert result.symbol == "005930"
+    # target symbol(005930)을 매핑한 기사만 포함
+    assert len(result.articles) == 1
+    primary = result.articles[0].mapped_symbols[0]
+    assert primary.symbol == "005930"
+    assert primary.mapping_source == "naver_code"
+    assert primary.is_primary is True
+    assert result.freshness.overall == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_no_matching_articles_is_unavailable():
+    async def provider(symbol, market, hours, limit):
+        return []
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", now=NOW, article_provider=provider
+    )
+    assert result.articles == ()
+    assert result.freshness.overall == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_candidate_row_article_maps_target():
+    articles = [
+        ArticleView(
+            market="kr",
+            stock_symbol=None,
+            related_rows=(
+                CandidateRow(
+                    symbol="000660", source="news_ingestor", score=0.8, rank=1
+                ),
+            ),
+            title="반도체 업황",
+            summary=None,
+            keywords=(),
+            as_of=NOW - timedelta(hours=3),
+        )
+    ]
+
+    async def provider(symbol, market, hours, limit):
+        return articles
+
+    result = await get_symbol_news_mapping(
+        "000660", market="kr", now=NOW, article_provider=provider
+    )
+    assert len(result.articles) == 1
+    m = result.articles[0].mapped_symbols[0]
+    assert m.mapping_source == "candidate"
+    assert m.confidence == 0.8

--- a/tests/test_kr_news_symbol_mapping_resolver.py
+++ b/tests/test_kr_news_symbol_mapping_resolver.py
@@ -1,0 +1,155 @@
+import dataclasses
+
+import pytest
+
+from app.services.kr_news_symbol_mapping.contract import (
+    MAPPING_SOURCE_PRIORITY,
+    NER_CONFIDENCE,
+    CandidateRow,
+    MappedSymbol,
+)
+from app.services.kr_news_symbol_mapping.resolver import resolve_article_symbols
+from app.services.news_entity_matcher import SymbolMatch
+
+
+@pytest.mark.unit
+def test_mapped_symbol_is_frozen():
+    m = MappedSymbol(
+        symbol="005930",
+        market="kr",
+        mapping_source="naver_code",
+        confidence=1.0,
+        is_primary=True,
+        matched_term=None,
+    )
+    assert m.confidence == 1.0
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        m.is_primary = False  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_priority_order_and_ner_confidence_constants():
+    assert MAPPING_SOURCE_PRIORITY["naver_code"] < MAPPING_SOURCE_PRIORITY["candidate"]
+    assert MAPPING_SOURCE_PRIORITY["candidate"] < MAPPING_SOURCE_PRIORITY["ner"]
+    assert 0.0 < NER_CONFIDENCE < 1.0
+
+
+@pytest.mark.unit
+def test_candidate_row_holds_score_rank():
+    row = CandidateRow(
+        symbol="000660",
+        source="news_ingestor",
+        score=0.8,
+        rank=1,
+        matched_term="하이닉스",
+    )
+    assert row.symbol == "000660"
+    assert row.score == 0.8
+
+
+def _ner(symbol, term="x"):
+    return SymbolMatch(
+        symbol=symbol,
+        market="kr",
+        canonical_name=symbol,
+        matched_term=term,
+        reason="alias_dict",
+    )
+
+
+@pytest.mark.unit
+def test_naver_code_is_confirmed_primary():
+    out = resolve_article_symbols(
+        market="kr", stock_symbol="005930", related_rows=(), ner_matches=()
+    )
+    assert len(out) == 1
+    assert out[0].symbol == "005930"
+    assert out[0].mapping_source == "naver_code"
+    assert out[0].confidence == 1.0
+    assert out[0].is_primary is True
+
+
+@pytest.mark.unit
+def test_candidate_source_uses_score_and_matched_term():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(
+            CandidateRow(
+                symbol="000660",
+                source="news_ingestor",
+                score=0.8,
+                rank=1,
+                matched_term="하이닉스",
+            ),
+        ),
+        ner_matches=(),
+    )
+    assert len(out) == 1
+    assert out[0].mapping_source == "candidate"
+    assert out[0].confidence == 0.8
+    assert out[0].is_primary is True  # 단일 후보
+
+
+@pytest.mark.unit
+def test_candidate_missing_score_uses_default_confidence():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(CandidateRow(symbol="000660", source="x", score=None, rank=2),),
+        ner_matches=(),
+    )
+    assert out[0].confidence == 0.7  # CANDIDATE_DEFAULT_CONFIDENCE
+
+
+@pytest.mark.unit
+def test_ner_single_match_is_primary():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(),
+        ner_matches=(_ner("035420", "네이버"),),
+    )
+    assert out[0].mapping_source == "ner"
+    assert out[0].confidence == 0.5
+    assert out[0].is_primary is True
+
+
+@pytest.mark.unit
+def test_ner_ambiguity_holds_back_is_primary():
+    # 이름충돌(복합 별칭 "삼전닉스" → 005930 + 000660), 확정/후보 disambiguator 없음.
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(),
+        ner_matches=(_ner("005930", "삼전닉스"), _ner("000660", "삼전닉스")),
+    )
+    assert {m.symbol for m in out} == {"005930", "000660"}
+    assert all(m.is_primary is False for m in out)  # 강제 단일 금지
+
+
+@pytest.mark.unit
+def test_higher_priority_source_wins_per_symbol():
+    # 같은 symbol이 candidate + ner 둘 다 → candidate(우선)로 합쳐짐.
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol=None,
+        related_rows=(CandidateRow(symbol="035420", source="x", score=0.9),),
+        ner_matches=(_ner("035420", "네이버"),),
+    )
+    assert len(out) == 1
+    assert out[0].mapping_source == "candidate"
+    assert out[0].confidence == 0.9
+
+
+@pytest.mark.unit
+def test_naver_code_present_makes_other_symbols_non_primary():
+    out = resolve_article_symbols(
+        market="kr",
+        stock_symbol="005930",
+        related_rows=(),
+        ner_matches=(_ner("000660", "하이닉스"),),
+    )
+    by_symbol = {m.symbol: m for m in out}
+    assert by_symbol["005930"].is_primary is True
+    assert by_symbol["000660"].is_primary is False


### PR DESCRIPTION
## 요약 (ROB-411 C라인, ROB-398 Slice 1 of 4)

기존 데이터(article.stock_symbol / `news_article_related_symbols` / 별칭 matcher) 위에 **provenance·is_primary·모호성·freshness**를 통합하는 read-only read-model을 추가하고 `KR_ALIASES`를 큐레이티드 확장. **migration 0, write/ingest/scheduler 없음.**

ROB-398 분해: **Slice 1(본 PR)** = 뉴스매핑 read-model / Slice 2 = Naver 랭킹 / Slice 3 = 투자자 매매동향 / Slice 4 = Toss screener.

## 변경 (신규 `app/services/kr_news_symbol_mapping/`)

- **contract.py** — `MappedSymbol`/`CandidateRow`/`ArticleView`/`MappedArticle`/`Freshness`/`SymbolNewsMapping` + 상수
- **resolver.py** (순수) — provenance 우선순위 `naver_code(1.0) > candidate > ner`, symbol별 최고우선 source 채택. **is_primary**=확정(naver_code) 또는 단일 후보만 True; 복수+미확정이면 전부 False(이름충돌 모호성 보류, 강제 단일 금지)
- **freshness.py** (순수) — fresh/stale/unavailable + reason (TTL 24h)
- **query_service.py** — DI article-provider로 per-article resolve→target 매핑 기사 수집→freshness 조립 (read-only; 기본 provider는 DB 연결 후속, 미연결 시 honest 빈 결과)
- **KR_ALIASES 확장** — 기아/삼성SDI/셀트리온/LG전자/KB금융 + 복합별칭 "삼전닉스"→005930·000660 (모호성 시연)

## 검증

- 19 신규 테스트 passed (resolver/freshness/query/alias)
- 별칭·뉴스 인접 회귀 105 passed (KR_ALIASES 확장 무회귀)
- import-contracts pass, ruff check/format clean
- migration 0, broker/order/watch mutation 없음, scheduler 없음, prod backfill 없음

## 비목표 (후속)

ingest 시점 영속화/`is_primary` 컬럼(read-time 파생), 새 snapshot_kind/번들 통합, DB `stock_aliases` matcher 와이어링, Slice 2~4.

## 설계/계획

- spec: `docs/superpowers/specs/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel-design.md`
- plan: `docs/superpowers/plans/2026-06-02-rob398-slice1-news-symbol-mapping-readmodel.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)