### PR TITLE
fix(ROB-415): report_quality_summary grade가 candidate_universe stale partial 번들에서 과대평가되는 문제 강등

### DIFF
--- a/app/services/action_report/common/diagnostics.py
+++ b/app/services/action_report/common/diagnostics.py
@@ -288,8 +288,9 @@ def build_report_quality_summary(
     * ``no_action`` — bundle failed or fell back to stale data.
     * ``informational_only`` — a critical kind is degrading, OR (ROB-366 B10)
       the core is not fully fresh, OR internal coverage is below
-      ``HIGH_CONFIDENCE_MIN_COVERAGE_PCT`` with no usable external cross-check to
-      corroborate (a degrading cross-check does not count).
+      ``HIGH_CONFIDENCE_MIN_COVERAGE_PCT``, OR (ROB-415) ``candidate_universe``
+      (the buy-candidate source) is non-fresh — the latter two only when no usable
+      external cross-check corroborates (a degrading cross-check does not count).
     * ``high_confidence`` — core fully fresh AND (ample internal coverage OR a
       usable external cross-check). A genuinely complete bundle is internally
       all-fresh (the producer's invariant), so it satisfies both checks and is
@@ -304,6 +305,8 @@ def build_report_quality_summary(
     critical_statuses: list[str | None] = []
     core_fresh = core_total = 0
     optional_fresh = optional_total = 0
+    candidate_universe_present = False
+    candidate_universe_status: str | None = None
     for kind, info in summary.items():
         if kind == "overall" or not isinstance(info, Mapping):
             continue
@@ -320,6 +323,9 @@ def build_report_quality_summary(
             optional_total += 1
             if status == "fresh":
                 optional_fresh += 1
+            if kind == "candidate_universe":
+                candidate_universe_present = True
+                candidate_universe_status = status
 
     total = sum(counts.values())
     fresh = counts.get("fresh", 0)
@@ -352,6 +358,14 @@ def build_report_quality_summary(
         )
         core_incomplete = core_total > 0 and core_fresh < core_total
         thin_coverage = internal_pct < HIGH_CONFIDENCE_MIN_COVERAGE_PCT
+        # ROB-415 — candidate_universe is the buy-candidate source: a stale one
+        # degrades the report's core purpose even when other optional kinds keep
+        # aggregate coverage above the thin threshold. Gated like thin_coverage
+        # (a usable cross-check can still rescue), so ROB-323's external fail-open
+        # holds: an un-run external probe alone never demotes.
+        candidate_universe_non_fresh = (
+            candidate_universe_present and candidate_universe_status != "fresh"
+        )
         # A cross-check only corroborates when it is present and not itself
         # degrading — a hard_stale/unavailable/failed probe is stale-expired
         # evidence and must not rescue thin coverage.
@@ -359,7 +373,9 @@ def build_report_quality_summary(
             external_status is None
             or external_status in CRITICAL_KIND_DEGRADING_STATUSES
         )
-        if core_incomplete or (thin_coverage and no_cross_check):
+        if core_incomplete or (
+            (thin_coverage or candidate_universe_non_fresh) and no_cross_check
+        ):
             grade = "informational_only"
 
     return {

--- a/docs/superpowers/plans/2026-06-02-rob-415-report-quality-grade-partial-demotion.md
+++ b/docs/superpowers/plans/2026-06-02-rob-415-report-quality-grade-partial-demotion.md
@@ -1,0 +1,352 @@
+# ROB-415 report_quality_summary grade partial 강등 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `build_report_quality_summary`가 `candidate_universe`(매수 후보 소스)가 stale이고 usable external cross-check가 없을 때 집계 커버리지 %와 무관하게 `high_confidence`를 `informational_only`로 강등하도록 한다.
+
+**Architecture:** 기존 강등 조건 `core_incomplete OR (thin_coverage AND no_cross_check)`에 `candidate_universe_non_fresh`를 thin_coverage와 동일한 rescue 게이트로 OR 추가. `candidate_universe` 상태는 기존 집계 루프에서 캡처(추가 순회 없음). ROB-323 외부 fail-open 보존, migration 0, read-only.
+
+**Tech Stack:** Python 3.13, pytest. 순수 함수(`app/services/action_report/common/diagnostics.py`), DB/IO 없음 — 테스트는 dict in/out.
+
+---
+
+## File Structure
+
+- Modify: `app/services/action_report/common/diagnostics.py` — `build_report_quality_summary` (그레이드 데모션 조건 + candidate_universe 상태 캡처)
+- Test: `tests/services/action_report/common/test_diagnostics.py` — 신규 3 케이스
+
+단일 함수 변경. 신규 파일 없음.
+
+---
+
+## Task 1: candidate_universe stale + no-cross-check 데모션 (repro)
+
+**Files:**
+- Modify: `app/services/action_report/common/diagnostics.py`
+- Test: `tests/services/action_report/common/test_diagnostics.py`
+
+배경: 현재 데모션은 집계 internal % (`thin_coverage`)에만 의존(`diagnostics.py:362`). `candidate_universe`가 단일 stale이어도 다른 optional이 fresh면 %가 ≥70으로 희석되어 강등 안 됨. repro: core fresh + candidate_universe stale + news/symbol fresh(%≥70) + 외부 unavailable → 잘못된 high_confidence.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/services/action_report/common/test_diagnostics.py` 끝(파일 마지막 테스트 뒤)에 추가. `build_report_quality_summary`는 파일 상단(라인 7-11)에서 이미 import됨:
+
+```python
+def test_quality_grade_demotes_when_candidate_universe_stale_no_cross_check() -> None:
+    # ROB-415: candidate_universe (the buy-candidate source) is stale while other
+    # optional kinds are fresh, so aggregate internal coverage stays >=70% and the
+    # old thin_coverage rule never fired. With no usable external cross-check, a
+    # stale candidate_universe must demote high_confidence → informational_only.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "symbol": {"status": "fresh"},
+            "invest_page": {"status": "fresh"},
+            "candidate_universe": {"status": "soft_stale"},
+            "toss_remote_debug": {"status": "unavailable"},  # external, no rescue
+        },
+        bundle_status="partial",
+    )
+    # Core fully fresh and internal coverage is high (7/8 ≈ 88%), so the old rule
+    # left it high_confidence — the bug.
+    assert out["core_fresh_coverage_pct"] == 100
+    assert out["grade"] == "informational_only"
+    assert out["external_cross_check_status"] == "unavailable"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/action_report/common/test_diagnostics.py::test_quality_grade_demotes_when_candidate_universe_stale_no_cross_check -v`
+Expected: FAIL — `grade == "high_confidence"` (데모션 미발화).
+
+- [ ] **Step 3: Write minimal implementation**
+
+`app/services/action_report/common/diagnostics.py`:
+
+(a) 집계 루프에서 `candidate_universe` 상태 캡처. 현재 루프(라인 307-322)는:
+
+```python
+    summary = freshness_summary or {}
+    counts: dict[str, int] = {}
+    critical_statuses: list[str | None] = []
+    core_fresh = core_total = 0
+    optional_fresh = optional_total = 0
+    for kind, info in summary.items():
+        if kind == "overall" or not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        counts[str(status)] = counts.get(str(status), 0) + 1
+        if kind in EXTERNAL_AUDIT_KINDS:
+            continue  # surfaced via external_cross_check_status, not coverage
+        if kind in CRITICAL_SNAPSHOT_KINDS:
+            critical_statuses.append(status)
+            core_total += 1
+            if status == "fresh":
+                core_fresh += 1
+        else:
+            optional_total += 1
+            if status == "fresh":
+                optional_fresh += 1
+```
+
+이것을 다음으로 교체(루프 앞에 `candidate_universe` 캡처 변수 2개 추가, 루프 안에서 세팅):
+
+```python
+    summary = freshness_summary or {}
+    counts: dict[str, int] = {}
+    critical_statuses: list[str | None] = []
+    core_fresh = core_total = 0
+    optional_fresh = optional_total = 0
+    candidate_universe_present = False
+    candidate_universe_status: str | None = None
+    for kind, info in summary.items():
+        if kind == "overall" or not isinstance(info, Mapping):
+            continue
+        status = info.get("status")
+        counts[str(status)] = counts.get(str(status), 0) + 1
+        if kind in EXTERNAL_AUDIT_KINDS:
+            continue  # surfaced via external_cross_check_status, not coverage
+        if kind in CRITICAL_SNAPSHOT_KINDS:
+            critical_statuses.append(status)
+            core_total += 1
+            if status == "fresh":
+                core_fresh += 1
+        else:
+            optional_total += 1
+            if status == "fresh":
+                optional_fresh += 1
+            if kind == "candidate_universe":
+                candidate_universe_present = True
+                candidate_universe_status = status
+```
+
+(b) 데모션 조건(라인 353-363)을 교체. 현재:
+
+```python
+        core_incomplete = core_total > 0 and core_fresh < core_total
+        thin_coverage = internal_pct < HIGH_CONFIDENCE_MIN_COVERAGE_PCT
+        # A cross-check only corroborates when it is present and not itself
+        # degrading — a hard_stale/unavailable/failed probe is stale-expired
+        # evidence and must not rescue thin coverage.
+        no_cross_check = (
+            external_status is None
+            or external_status in CRITICAL_KIND_DEGRADING_STATUSES
+        )
+        if core_incomplete or (thin_coverage and no_cross_check):
+            grade = "informational_only"
+```
+
+교체:
+
+```python
+        core_incomplete = core_total > 0 and core_fresh < core_total
+        thin_coverage = internal_pct < HIGH_CONFIDENCE_MIN_COVERAGE_PCT
+        # ROB-415 — candidate_universe is the buy-candidate source: a stale one
+        # degrades the report's core purpose even when other optional kinds keep
+        # aggregate coverage above the thin threshold. Gated like thin_coverage
+        # (a usable cross-check can still rescue), so ROB-323's external fail-open
+        # holds: an un-run external probe alone never demotes.
+        candidate_universe_non_fresh = (
+            candidate_universe_present and candidate_universe_status != "fresh"
+        )
+        # A cross-check only corroborates when it is present and not itself
+        # degrading — a hard_stale/unavailable/failed probe is stale-expired
+        # evidence and must not rescue thin coverage.
+        no_cross_check = (
+            external_status is None
+            or external_status in CRITICAL_KIND_DEGRADING_STATUSES
+        )
+        if core_incomplete or (
+            (thin_coverage or candidate_universe_non_fresh) and no_cross_check
+        ):
+            grade = "informational_only"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/action_report/common/test_diagnostics.py::test_quality_grade_demotes_when_candidate_universe_stale_no_cross_check -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-415
+git add app/services/action_report/common/diagnostics.py tests/services/action_report/common/test_diagnostics.py
+git commit -m "fix(ROB-415): candidate_universe stale + no cross-check면 grade 강등
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: candidate_universe stale라도 passing cross-check면 high 유지 (rescue 가드)
+
+**Files:**
+- Test: `tests/services/action_report/common/test_diagnostics.py`
+
+ROB-323 보존: usable external cross-check(fresh/soft_stale 등 비-degrading)가 있으면 candidate_universe stale이어도 rescue되어 high_confidence 유지. Task 1 구현의 `no_cross_check` 게이트가 이를 보장(회귀 가드).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_quality_grade_candidate_universe_stale_rescued_by_cross_check() -> None:
+    # ROB-415 / ROB-323: a usable external cross-check still corroborates a stale
+    # candidate_universe, so the bundle stays high_confidence. Guards the demotion
+    # from over-firing when there IS fresh external evidence.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "symbol": {"status": "fresh"},
+            "invest_page": {"status": "fresh"},
+            "candidate_universe": {"status": "soft_stale"},
+            "toss_remote_debug": {"status": "fresh"},  # usable cross-check
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["external_cross_check_status"] == "fresh"
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/action_report/common/test_diagnostics.py::test_quality_grade_candidate_universe_stale_rescued_by_cross_check -v`
+Expected: PASS (Task 1의 `no_cross_check=False` → 데모션 미발화).
+
+- [ ] **Step 3: (구현 변경 없음 — Task 1로 충족)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-415
+git add tests/services/action_report/common/test_diagnostics.py
+git commit -m "test(ROB-415): candidate_universe stale라도 passing cross-check면 high 유지
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: candidate_universe fresh면 데모션 미발화 (over-fire 가드)
+
+**Files:**
+- Test: `tests/services/action_report/common/test_diagnostics.py`
+
+candidate_universe가 fresh면 `candidate_universe_non_fresh=False` → 데모션 미발화, high_confidence 유지. 데모션이 candidate_universe 존재만으로 발화하지 않음을 가드.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_quality_grade_candidate_universe_fresh_stays_high() -> None:
+    # candidate_universe present and fresh must NOT trigger the ROB-415 demotion.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "candidate_universe": {"status": "fresh"},
+            "toss_remote_debug": {"status": "unavailable"},  # external, no rescue
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/action_report/common/test_diagnostics.py::test_quality_grade_candidate_universe_fresh_stays_high -v`
+Expected: PASS.
+
+- [ ] **Step 3: (구현 변경 없음 — Task 1로 충족)**
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-415
+git add tests/services/action_report/common/test_diagnostics.py
+git commit -m "test(ROB-415): candidate_universe fresh면 데모션 미발화 가드
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 전체 회귀 + lint 검증
+
+**Files:**
+- (없음 — 검증만)
+
+- [ ] **Step 1: diagnostics 테스트 전체 (기존 회귀 무변경 확인)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/action_report/common/test_diagnostics.py -v`
+Expected: PASS — 신규 3 + 기존 전부 green. 특히 `test_quality_summary_splits_core_optional_external_coverage`(high_confidence 유지), `test_quality_grade_thin_coverage_stays_high_with_soft_stale_cross_check`(high_confidence 유지) 무변경.
+
+- [ ] **Step 2: grade 소비자 회귀 (hermes_context / snapshot metadata)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run pytest tests/services/investment_stages/test_hermes_context.py tests/test_investment_reports_snapshot_metadata.py -q`
+Expected: PASS — grade 소비자 무영향.
+
+- [ ] **Step 3: Lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-415 && uv run ruff check app/services/action_report/common/diagnostics.py && uv run ruff format --check app/services/action_report/common/diagnostics.py`
+Expected: All checks passed / already formatted.
+
+- [ ] **Step 4: docstring 갱신 + commit**
+
+`build_report_quality_summary` docstring(라인 287-296 부근)의 grade 설명에 ROB-415 데모션을 한 줄 반영. 현재 `informational_only` 불릿:
+
+```python
+    * ``informational_only`` — a critical kind is degrading, OR (ROB-366 B10)
+      the core is not fully fresh, OR internal coverage is below
+      ``HIGH_CONFIDENCE_MIN_COVERAGE_PCT`` with no usable external cross-check to
+      corroborate (a degrading cross-check does not count).
+```
+
+교체:
+
+```python
+    * ``informational_only`` — a critical kind is degrading, OR (ROB-366 B10)
+      the core is not fully fresh, OR internal coverage is below
+      ``HIGH_CONFIDENCE_MIN_COVERAGE_PCT``, OR (ROB-415) ``candidate_universe``
+      (the buy-candidate source) is non-fresh — the latter two only when no usable
+      external cross-check corroborates (a degrading cross-check does not count).
+```
+
+그 후:
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-415
+uv run ruff format app/services/action_report/common/diagnostics.py
+git add app/services/action_report/common/diagnostics.py
+git commit -m "docs(ROB-415): grade docstring에 candidate_universe 데모션 반영
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review 결과
+
+**Spec 커버리지:**
+- 데모션 규칙(candidate_universe_non_fresh OR thin_coverage, no_cross_check 게이트) → Task 1 ✅
+- ROB-323 rescue 보존 → Task 2 ✅
+- candidate fresh over-fire 가드 → Task 3 ✅
+- 기존 회귀 무변경 + 소비자 + lint + docstring → Task 4 ✅
+
+**Placeholder 스캔:** 없음 — 모든 코드 step에 실제 코드 포함.
+
+**Type 일관성:** `candidate_universe_present: bool`, `candidate_universe_status: str | None`, `candidate_universe_non_fresh: bool` 변수명 Task 1 내에서 일관. 기존 `no_cross_check`/`thin_coverage`/`core_incomplete` 재사용. 시그니처/반환 dict 키 무변경(`grade`/`external_cross_check_status` 등 그대로).
+
+**안전 경계 재확인:** grade는 display/audit 메타데이터(백엔드 게이팅 안 함), 강등 단방향, migration 0, broker/order/watch/order-intent mutation 없음, read-only. fundamentals/sentiment per-symbol 입력 미추가(scope 고정).

--- a/docs/superpowers/specs/2026-06-02-rob-415-report-quality-grade-partial-demotion-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob-415-report-quality-grade-partial-demotion-design.md
@@ -1,0 +1,83 @@
+# ROB-415 — report_quality_summary.grade partial 번들 과대평가 강등
+
+- **이슈**: ROB-415 (E라인 E1, read-only report surface)
+- **유형**: Bug fix
+- **작성일**: 2026-06-02
+- **연관**: ROB-421(오케스트레이션), ROB-414(E1 선행, candidate 해소), ROB-323(grade core-vs-external 정책), ROB-366 B10(honesty demotion)
+
+## 증상 / 근본 원인
+
+`build_report_quality_summary`가 `bundle_status="partial"`이고 `candidate_universe`가 stale인 번들에서도 `grade="high_confidence"`로 보고함.
+
+재현(bundle_uuid `7bee448a...`, 2026-06-01): `bundle_status=partial`, `fresh_coverage_pct=67`, `external_cross_check_status=unavailable`, `candidate_universe` stale(partition_date 2026-05-29, stale_count 66054/fresh 0), 그럼에도 `grade=high_confidence`.
+
+근본 원인: 현재 강등 규칙은
+```
+core_incomplete OR (thin_coverage AND no_cross_check)
+```
+이고 `thin_coverage`는 **집계 internal 커버리지 %**(`internal_pct < HIGH_CONFIDENCE_MIN_COVERAGE_PCT=70`)에만 의존한다. `candidate_universe`(매수 후보의 소스 = 리포트의 핵심 목적)가 단일 stale 상태여도, 다른 optional 내부 kind(news/symbol/invest_page 등)가 fresh면 집계 %가 70 이상으로 희석되어 강등이 발화하지 않는다. 외부 audit kind는 분모에서 제외되므로 % 희석이 더 커진다.
+
+`fundamentals`/`sentiment`의 0/32 커버는 per-symbol 커버리지로, `freshness_summary`의 kind가 아니라 grade 입력에 아예 들어오지 않는다(별도 결정으로 본 PR 범위 밖, 아래 Non-goals 참조).
+
+## 기대 동작 (이슈 Acceptance)
+
+`candidate_universe` stale + 외부 cross-check unavailable 등이 겹치면 grade가 `high_confidence`에서 강등되어야 한다. 현재 grade는 다운스트림(stale_gate/리포트 신뢰표시)을 오도할 수 있다.
+
+## 설계
+
+### 변경 표면
+
+- `app/services/action_report/common/diagnostics.py` — `build_report_quality_summary` 단일 함수.
+- migration 0, read-only, 새 입력 파라미터 없음(`freshness_summary` + `bundle_status`만 사용). broker/order/watch/order-intent mutation 없음.
+
+### 정책 (ROB-323 보존)
+
+ROB-323 불변식: **외부 audit probe 미실행(absence)만으로는 grade를 깎지 않는다**(un-run operator probe가 fresh 리포트를 tank하면 안 됨). 강등은 internal 신호 기반, 외부는 *보상* cross-check로만 진입.
+
+`candidate_universe`는 optional internal kind이지만 매수 후보의 소스라 staleness가 리포트의 핵심 목적을 직접 훼손한다. 따라서 강등 규칙에 `candidate_universe` non-fresh를 `thin_coverage`와 **동일한 rescue 게이트**로 추가한다(usable cross-check가 있으면 rescue 가능, 외부 미실행이면 강등):
+
+```
+candidate_universe_non_fresh = (candidate_universe present in summary) and (status != "fresh")
+demote (high_confidence → informational_only) if:
+    core_incomplete
+    OR ((thin_coverage OR candidate_universe_non_fresh) AND no_cross_check)
+```
+
+- non-fresh = `soft_stale` / `hard_stale` / `partial` / `unavailable` / `failed` 등 `"fresh"`가 아닌 모든 상태.
+- `no_cross_check`(기존 정의 유지) = external_status is None OR external_status in `CRITICAL_KIND_DEGRADING_STATUSES`(hard_stale/unavailable/failed). 즉 fresh/soft_stale 등 usable cross-check는 rescue.
+- 집계 % 무관하게 발화 → repro(희석된 ≥70%)를 정확히 잡음.
+
+### 구현 디테일
+
+- 기존 `for kind, info in summary.items()` 루프 내에서 `candidate_universe` 상태를 캡처(별도 쿼리/순회 없음): `kind == "candidate_universe"`일 때 `candidate_universe_present = True`, `candidate_universe_status = status`. 루프는 이미 `isinstance(info, Mapping)`을 통과한 항목만 처리하므로 malformed candidate_universe는 absent로 취급(fail-open).
+- `candidate_universe_non_fresh = candidate_universe_present and candidate_universe_status != "fresh"`.
+- `else`(grade 후보 = high_confidence) 블록의 기존 데모션 조건에 `candidate_universe_non_fresh`를 OR로 추가.
+
+### 기존 테스트 영향 (검산)
+
+| 테스트 | candidate_universe | 외부 | 결과 |
+|---|---|---|---|
+| `splits_core_optional_external_coverage` | 부재 | unavailable | high_confidence 유지 (non_fresh=False, %=80) ✓ |
+| `demotes_on_thin_optional_coverage_without_cross_check` | unavailable | 없음 | informational_only 유지 ✓ |
+| `thin_coverage_stays_high_with_passing_cross_check` | unavailable | fresh | high_confidence 유지 (rescue) ✓ |
+| `thin_coverage_stays_high_with_soft_stale_cross_check` | unavailable | soft_stale | high_confidence 유지 (soft_stale=usable rescue, ROB-323 의미 보존) ✓ |
+| `demotes_when_external_cross_check_hard_stale` | unavailable | hard_stale | informational_only 유지 ✓ |
+
+→ 기존 테스트는 무변경. 변경은 **새 케이스**(희석된 ≥70%에서 candidate stale + no cross-check)에서만 발생.
+
+## 테스트 (TDD)
+
+`tests/services/action_report/common/test_diagnostics.py`:
+
+1. **repro 케이스**: core 4종 fresh + candidate_universe `soft_stale`(또는 hard_stale) + news/symbol/invest_page fresh(internal_pct ≥70) + 외부 unavailable → `informational_only` (이전 high_confidence). `core_fresh_coverage_pct == 100` 확인.
+2. **candidate stale + passing cross-check**: 같은 구성 + toss_remote_debug fresh → `high_confidence` 유지(rescue).
+3. **candidate fresh**: candidate_universe fresh + 나머지 fresh → `high_confidence` 유지(데모션 미발화).
+4. 기존 회귀 전건 green.
+
+## 안전 경계 / Non-goals
+
+- grade는 display/audit 메타데이터 — 백엔드 게이팅이 읽지 않음. 강등은 단방향(high_confidence → informational_only).
+- migration 0, broker/order/watch/order-intent mutation 없음, read-only.
+- `fundamentals`/`sentiment` per-symbol 0커버를 grade 입력으로 추가하지 않음(시그니처/모든 호출부/커버리지 집계 변경 = scope creep). candidate_universe staleness가 후보-데이터 빈약의 대리 신호. 후보가 stale이면 그 fundamentals/sentiment도 fresh일 수 없으므로 동일 강등으로 귀결.
+- ROB-323 외부 fail-open 불변식 보존(외부 probe absence 단독으로는 강등 안 함).
+- `HIGH_CONFIDENCE_MIN_COVERAGE_PCT`/`thin_coverage` 임계 자체는 변경하지 않음.

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -569,6 +569,3 @@ def test_quality_grade_candidate_universe_fresh_stays_high() -> None:
         bundle_status="partial",
     )
     assert out["grade"] == "high_confidence"
-
-
-

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -501,3 +501,31 @@ def test_report_diagnostics_includes_data_quality_audit() -> None:
     )
     assert "data_quality_audit" in out
     assert out["data_quality_audit"]["snapshot_bundle_uuid"] == "b-1"
+
+
+def test_quality_grade_demotes_when_candidate_universe_stale_no_cross_check() -> None:
+    # ROB-415: candidate_universe (the buy-candidate source) is stale while other
+    # optional kinds are fresh, so aggregate internal coverage stays >=70% and the
+    # old thin_coverage rule never fired. With no usable external cross-check, a
+    # stale candidate_universe must demote high_confidence → informational_only.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "symbol": {"status": "fresh"},
+            "invest_page": {"status": "fresh"},
+            "candidate_universe": {"status": "soft_stale"},
+            "toss_remote_debug": {"status": "unavailable"},  # external, no rescue
+        },
+        bundle_status="partial",
+    )
+    # Core fully fresh and internal coverage is high (7/8 ≈ 88%), so the old rule
+    # left it high_confidence — the bug.
+    assert out["core_fresh_coverage_pct"] == 100
+    assert out["grade"] == "informational_only"
+    assert out["external_cross_check_status"] == "unavailable"
+

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -553,3 +553,22 @@ def test_quality_grade_candidate_universe_stale_rescued_by_cross_check() -> None
     assert out["external_cross_check_status"] == "fresh"
 
 
+def test_quality_grade_candidate_universe_fresh_stays_high() -> None:
+    # candidate_universe present and fresh must NOT trigger the ROB-415 demotion.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "candidate_universe": {"status": "fresh"},
+            "toss_remote_debug": {"status": "unavailable"},  # external, no rescue
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+
+
+

--- a/tests/services/action_report/common/test_diagnostics.py
+++ b/tests/services/action_report/common/test_diagnostics.py
@@ -529,3 +529,27 @@ def test_quality_grade_demotes_when_candidate_universe_stale_no_cross_check() ->
     assert out["grade"] == "informational_only"
     assert out["external_cross_check_status"] == "unavailable"
 
+
+def test_quality_grade_candidate_universe_stale_rescued_by_cross_check() -> None:
+    # ROB-415 / ROB-323: a usable external cross-check still corroborates a stale
+    # candidate_universe, so the bundle stays high_confidence. Guards the demotion
+    # from over-firing when there IS fresh external evidence.
+    out = build_report_quality_summary(
+        freshness_summary={
+            "overall": "partial",
+            "portfolio": {"status": "fresh"},
+            "journal": {"status": "fresh"},
+            "watch_context": {"status": "fresh"},
+            "market": {"status": "fresh"},
+            "news": {"status": "fresh"},
+            "symbol": {"status": "fresh"},
+            "invest_page": {"status": "fresh"},
+            "candidate_universe": {"status": "soft_stale"},
+            "toss_remote_debug": {"status": "fresh"},  # usable cross-check
+        },
+        bundle_status="partial",
+    )
+    assert out["grade"] == "high_confidence"
+    assert out["external_cross_check_status"] == "fresh"
+
+


### PR DESCRIPTION
## 요약 (ROB-415, E라인 E1 / read-only report surface)

`build_report_quality_summary`가 `bundle_status="partial"`이고 `candidate_universe`(매수 후보 소스)가 stale인 번들에서도 `grade="high_confidence"`로 과대평가하던 문제를 수정합니다.

근본 원인: 기존 강등 규칙 `core_incomplete OR (thin_coverage AND no_cross_check)`의 `thin_coverage`가 **집계 internal 커버리지 %**에만 의존 → `candidate_universe` 하나가 stale이어도 다른 optional이 fresh면 %가 ≥70으로 희석되어 강등 미발화. repro(bundle_uuid `7bee448a...`): partial / fresh_coverage_pct 67 / external unavailable / candidate_universe stale인데 grade=high_confidence.

## 변경 (단일 함수, migration 0, read-only)

`app/services/action_report/common/diagnostics.py` — 강등 조건에 `candidate_universe_non_fresh`를 `thin_coverage`와 **동일한 rescue 게이트**로 OR 추가:

```
candidate_universe_non_fresh = present and status != "fresh"
demote if: core_incomplete OR ((thin_coverage OR candidate_universe_non_fresh) AND no_cross_check)
```

- candidate_universe가 present & non-fresh(soft/hard_stale/partial/unavailable/failed)이고 usable external cross-check가 없으면 집계 % 무관하게 `high_confidence → informational_only`.
- 상태는 기존 집계 루프에서 캡처(추가 순회/쿼리 없음).

## ROB-323 불변식 보존

- 외부 audit probe 미실행(absence)만으로는 강등하지 않음 — usable cross-check(fresh/soft_stale 등 비-degrading)가 있으면 candidate stale이어도 rescue.
- grade는 display/audit 메타데이터(백엔드 게이팅 안 함), 강등 단방향.

## 테스트

- 신규 3종: repro(희석된 %에도 강등) / passing cross-check rescue / candidate fresh over-fire 가드.
- diagnostics 44 passed(단일-head 포함), grade 소비자(hermes_context/snapshot_metadata) 22 passed, 기존 회귀(splits_core_optional, soft_stale_cross_check 등) 무변경. ruff clean.

## Non-goals

- `fundamentals`/`sentiment` per-symbol 0커버는 freshness kind가 아니라 grade 입력 미추가(scope creep 회피) — candidate_universe staleness가 후보-데이터 빈약의 대리 신호.
- `HIGH_CONFIDENCE_MIN_COVERAGE_PCT`/thin_coverage 임계 자체 무변경.

## 충돌 경계 (ROB-421 E라인)

- E1 read-only. ROB-414(#1084 머지됨) 후속. broker/order/watch/order-intent mutation 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Report quality grades are now properly adjusted based on internal data freshness when external cross-checks are unavailable, while preserving rescue behavior when external verification is available.

* **Documentation**
  * Added comprehensive planning and design documentation for report quality grading adjustments.

* **Tests**
  * Added new test cases for report quality grading validation across various freshness and verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->