### PR TITLE
feat(ROB-405 Slice B): trade_journal verdict (good/neutral/bad, default-off)

### DIFF
--- a/alembic/versions/6e1ed781fc56_rob405b_trade_journal_reviews.py
+++ b/alembic/versions/6e1ed781fc56_rob405b_trade_journal_reviews.py
@@ -1,0 +1,73 @@
+"""rob405b trade_journal_reviews
+
+Revision ID: 6e1ed781fc56
+Revises: 075d44e505b9
+Create Date: 2026-06-02 06:52:39.363719
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6e1ed781fc56'
+down_revision: Union[str, Sequence[str], None] = '075d44e505b9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trade_journal_reviews",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("journal_id", sa.BigInteger(), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("verdict_source", sa.Text(), nullable=False),
+        sa.Column("pnl_pct", sa.Numeric(8, 4), nullable=True),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["journal_id"], ["review.trade_journals.id"], ondelete="CASCADE"
+        ),
+        sa.CheckConstraint(
+            "verdict IN ('good','neutral','bad')",
+            name="ck_trade_journal_reviews_verdict",
+        ),
+        sa.CheckConstraint(
+            "verdict_source IN ('auto','manual')",
+            name="ck_trade_journal_reviews_source",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journal_reviews_journal_id",
+        "trade_journal_reviews",
+        ["journal_id"],
+        schema="review",
+    )
+    op.create_index(
+        "uq_trade_journal_reviews_auto",
+        "trade_journal_reviews",
+        ["journal_id"],
+        schema="review",
+        unique=True,
+        postgresql_where=sa.text("verdict_source = 'auto'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_trade_journal_reviews_auto", "trade_journal_reviews", schema="review"
+    )
+    op.drop_index(
+        "ix_trade_journal_reviews_journal_id", "trade_journal_reviews", schema="review"
+    )
+    op.drop_table("trade_journal_reviews", schema="review")
+

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -474,6 +474,9 @@ class Settings(BaseSettings):
     # ROB-405 Slice A — mock roundtrip → trade_journal bridge. Default off:
     # no journals are created until an operator flips this.
     MOCK_ROUNDTRIP_JOURNAL_BRIDGE_ENABLED: bool = False
+    # ROB-405 Slice B — auto journal verdict. Default off.
+    JOURNAL_VERDICT_AUTO_ENABLED: bool = False
+
     # ROB-269 Phase 2 — gates BOTH the 4 MCP snapshot tools AND the
     # /trading/api/investment-snapshots/* GET router. Default off: code is
     # importable but unreachable from caller surfaces until flipped post-merge.

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -738,4 +738,3 @@ class TradeJournalReview(Base):
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )
-

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -698,3 +698,44 @@ class WatchOrderIntentLedger(Base):
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+class TradeJournalReview(Base):
+    """ROB-405 Slice B — verdict (good/neutral/bad) for a trade_journal.
+
+    Separate from TradeReview (which FKs review.trades). auto verdicts come from
+    pnl_pct thresholds on closed mock journals; manual verdicts are overrides.
+    """
+
+    __tablename__ = "trade_journal_reviews"
+    __table_args__ = (
+        CheckConstraint(
+            "verdict IN ('good','neutral','bad')",
+            name="ck_trade_journal_reviews_verdict",
+        ),
+        CheckConstraint(
+            "verdict_source IN ('auto','manual')",
+            name="ck_trade_journal_reviews_source",
+        ),
+        Index("ix_trade_journal_reviews_journal_id", "journal_id"),
+        Index(
+            "uq_trade_journal_reviews_auto",
+            "journal_id",
+            unique=True,
+            postgresql_where=text("verdict_source = 'auto'"),
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    journal_id: Mapped[int] = mapped_column(
+        ForeignKey("review.trade_journals.id", ondelete="CASCADE"), nullable=False
+    )
+    verdict: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict_source: Mapped[str] = mapped_column(Text, nullable=False)
+    pnl_pct: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    comment: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+

--- a/app/services/trade_journal/journal_verdict_policy.py
+++ b/app/services/trade_journal/journal_verdict_policy.py
@@ -1,0 +1,19 @@
+"""ROB-405 Slice B — deterministic auto-verdict from pnl_pct."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+GOOD_PNL_PCT = Decimal("1.0")
+BAD_PNL_PCT = Decimal("-1.0")
+
+
+def classify_journal_verdict(pnl_pct: Decimal | None) -> str:
+    """good if pnl_pct >= +1.0%, bad if <= -1.0%, else neutral (None → neutral)."""
+    if pnl_pct is None:
+        return "neutral"
+    if pnl_pct >= GOOD_PNL_PCT:
+        return "good"
+    if pnl_pct <= BAD_PNL_PCT:
+        return "bad"
+    return "neutral"

--- a/app/services/trade_journal/journal_verdict_service.py
+++ b/app/services/trade_journal/journal_verdict_service.py
@@ -1,0 +1,81 @@
+"""ROB-405 Slice B — record verdicts for closed mock trade_journals.
+
+Auto verdicts (pnl_pct policy) for closed account_type='mock' journals lacking
+one; manual verdicts are operator overrides. Idempotent via partial-unique
+(journal_id) WHERE verdict_source='auto'. Default off.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models.review import TradeJournalReview
+from app.models.trade_journal import TradeJournal
+from app.services.trade_journal.journal_verdict_policy import (
+    classify_journal_verdict,
+)
+
+logger = logging.getLogger(__name__)
+
+_VALID_VERDICTS = frozenset({"good", "neutral", "bad"})
+
+
+async def sync_journal_verdicts(db, *, force: bool = False) -> dict[str, Any]:
+    """Record auto verdicts for closed mock journals without one."""
+    if not force and not settings.JOURNAL_VERDICT_AUTO_ENABLED:
+        return {"status": "disabled", "created": 0}
+
+    journals = (
+        await db.execute(
+            select(TradeJournal).where(
+                TradeJournal.status == "closed",
+                TradeJournal.account_type == "mock",
+            )
+        )
+    ).scalars().all()
+
+    created = 0
+    for j in journals:
+        existing = (
+            await db.execute(
+                select(TradeJournalReview.id).where(
+                    TradeJournalReview.journal_id == j.id,
+                    TradeJournalReview.verdict_source == "auto",
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            continue
+        db.add(
+            TradeJournalReview(
+                journal_id=j.id,
+                verdict=classify_journal_verdict(j.pnl_pct),
+                verdict_source="auto",
+                pnl_pct=j.pnl_pct,
+            )
+        )
+        created += 1
+    await db.commit()
+    return {"status": "ok", "created": created}
+
+
+async def record_manual_verdict(
+    db, *, journal_id: int, verdict: str, comment: str | None = None
+) -> dict[str, Any]:
+    """Record an operator (manual) verdict override."""
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(f"invalid verdict: {verdict!r}")
+    db.add(
+        TradeJournalReview(
+            journal_id=journal_id,
+            verdict=verdict,
+            verdict_source="manual",
+            comment=comment,
+        )
+    )
+    await db.commit()
+    return {"status": "ok"}

--- a/app/services/trade_journal/journal_verdict_service.py
+++ b/app/services/trade_journal/journal_verdict_service.py
@@ -30,13 +30,17 @@ async def sync_journal_verdicts(db, *, force: bool = False) -> dict[str, Any]:
         return {"status": "disabled", "created": 0}
 
     journals = (
-        await db.execute(
-            select(TradeJournal).where(
-                TradeJournal.status == "closed",
-                TradeJournal.account_type == "mock",
+        (
+            await db.execute(
+                select(TradeJournal).where(
+                    TradeJournal.status == "closed",
+                    TradeJournal.account_type == "mock",
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     created = 0
     for j in journals:

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -12,6 +12,7 @@ from app.tasks import (
     market_quote_snapshot_tasks,
     market_valuation_snapshot_tasks,
     mock_roundtrip_journal_tasks,
+    journal_verdict_tasks,
     pending_orders,
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
@@ -33,6 +34,7 @@ TASKIQ_TASK_MODULES = (
     market_quote_snapshot_tasks,
     market_valuation_snapshot_tasks,
     mock_roundtrip_journal_tasks,
+    journal_verdict_tasks,
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
     watch_scan_tasks,
@@ -43,3 +45,4 @@ TASKIQ_TASK_MODULES = (
     us_candles_tasks,
     us_symbol_universe_tasks,
 )
+

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -7,12 +7,12 @@ from app.tasks import (
     invest_momentum_event_tasks,
     invest_screener_snapshot_tasks,
     investor_flow_snapshot_tasks,
+    journal_verdict_tasks,
     kr_candles_tasks,
     kr_symbol_universe_tasks,
     market_quote_snapshot_tasks,
     market_valuation_snapshot_tasks,
     mock_roundtrip_journal_tasks,
-    journal_verdict_tasks,
     pending_orders,
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
@@ -45,4 +45,3 @@ TASKIQ_TASK_MODULES = (
     us_candles_tasks,
     us_symbol_universe_tasks,
 )
-

--- a/app/tasks/journal_verdict_tasks.py
+++ b/app/tasks/journal_verdict_tasks.py
@@ -1,0 +1,24 @@
+"""ROB-405 Slice B — paused taskiq task for auto journal verdicts.
+NO schedule: paused; operator flips JOURNAL_VERDICT_AUTO_ENABLED + adds cron.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.core.taskiq_broker import broker
+from app.services.trade_journal.journal_verdict_service import (
+    sync_journal_verdicts,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@broker.task(task_name="journal_verdict.sync")  # no schedule → paused
+async def journal_verdict_sync() -> dict:
+    if not settings.JOURNAL_VERDICT_AUTO_ENABLED:
+        return {"status": "disabled", "created": 0}
+    async with AsyncSessionLocal() as db:
+        return await sync_journal_verdicts(db)

--- a/docs/superpowers/plans/2026-06-02-rob-405-sliceB-journal-verdict.md
+++ b/docs/superpowers/plans/2026-06-02-rob-405-sliceB-journal-verdict.md
@@ -1,0 +1,752 @@
+# ROB-405 Slice B — trade_journal verdict Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** closed mock trade_journal(Slice A)에 verdict(good/neutral/bad)를 pnl_pct 임계값으로 자동 기록하고 수동 override를 지원하는 신규 `trade_journal_reviews` 테이블 + default-off 서비스를 추가한다.
+
+**Architecture:** 순수함수 `classify_journal_verdict(pnl_pct)` + 서비스 `sync_journal_verdicts(db)`(closed mock journal 스캔→auto verdict insert, partial-unique 멱등) + `record_manual_verdict`(반자동). Slice A 브리지와 독립. default-off flag + paused taskiq + CLI.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, Postgres, alembic, taskiq, pytest.
+
+**의존**: Slice A(#1086, merged) — trade_journals.account_type 'mock' + correlation_id + closed 상태. origin/main 기준.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-rob-405-sliceB-journal-verdict-design.md`
+
+---
+
+## File Structure
+| 파일 | 역할 | 변경 |
+|---|---|---|
+| `app/core/config.py` | 게이트 | `JOURNAL_VERDICT_AUTO_ENABLED=False` |
+| `app/models/review.py` | ORM | `TradeJournalReview` 테이블 |
+| `alembic/versions/<rev>_rob405b_*.py` | 마이그레이션 | create_table + partial-unique |
+| `app/services/trade_journal/journal_verdict_policy.py` | 순수정책 | `classify_journal_verdict` |
+| `app/services/trade_journal/journal_verdict_service.py` | 서비스 | `sync_journal_verdicts`/`record_manual_verdict` |
+| `app/tasks/journal_verdict_tasks.py` | paused task | env-gated |
+| `scripts/sync_journal_verdicts.py` | operator CLI | sync / manual |
+| `tests/test_journal_verdict_policy.py` / `tests/test_journal_verdict_service.py` / `tests/test_journal_verdict_task.py` | | 신규 |
+
+---
+
+## Task 1: 모델 `TradeJournalReview` + config + 마이그레이션
+
+**Files:**
+- Modify: `app/models/review.py` (ORM 추가), `app/core/config.py:476`
+- Create: `alembic/versions/<rev>_rob405b_journal_verdict.py`
+- Test: `tests/test_journal_verdict_service.py` (모델 insert/CHECK)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/test_journal_verdict_service.py` 생성:
+
+```python
+"""ROB-405 Slice B — trade_journal verdict."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeJournalReview
+from app.models.trade_journal import TradeJournal
+
+
+async def _closed_mock_journal(db, *, pnl_pct, cid=None):
+    j = TradeJournal(
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        entry_price=Decimal("50000"),
+        quantity=Decimal("10"),
+        thesis="t",
+        account_type="mock",
+        account="kis_mock",
+        correlation_id=cid or f"corr-{uuid4().hex}",
+        status="closed",
+        exit_price=Decimal("55000"),
+        exit_date=datetime(2026, 6, 2, tzinfo=UTC),
+        pnl_pct=Decimal(pnl_pct),
+    )
+    db.add(j)
+    await db.commit()
+    return j
+
+
+@pytest.mark.asyncio
+async def test_journal_review_inserts_and_checks(db_session: AsyncSession):
+    j = await _closed_mock_journal(db_session, pnl_pct="10")
+    r = TradeJournalReview(
+        journal_id=j.id, verdict="good", verdict_source="auto", pnl_pct=Decimal("10")
+    )
+    db_session.add(r)
+    await db_session.commit()
+    assert r.id is not None
+
+
+@pytest.mark.asyncio
+async def test_journal_review_verdict_check_rejects(db_session: AsyncSession):
+    j = await _closed_mock_journal(db_session, pnl_pct="1")
+    db_session.add(
+        TradeJournalReview(journal_id=j.id, verdict="great", verdict_source="auto")
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_service.py -k "review_inserts or verdict_check" -v`
+Expected: FAIL — `ImportError: cannot import name 'TradeJournalReview'`.
+
+- [ ] **Step 3-a: config 플래그**
+
+`app/core/config.py` — `MOCK_ROUNDTRIP_JOURNAL_BRIDGE_ENABLED`(476행) 다음에:
+
+```python
+    # ROB-405 Slice B — auto journal verdict. Default off.
+    JOURNAL_VERDICT_AUTO_ENABLED: bool = False
+```
+
+- [ ] **Step 3-b: ORM 추가**
+
+`app/models/review.py` — `TradeReview` 클래스 다음에 추가:
+
+```python
+class TradeJournalReview(Base):
+    """ROB-405 Slice B — verdict (good/neutral/bad) for a trade_journal.
+
+    Separate from TradeReview (which FKs review.trades). auto verdicts come from
+    pnl_pct thresholds on closed mock journals; manual verdicts are overrides.
+    """
+
+    __tablename__ = "trade_journal_reviews"
+    __table_args__ = (
+        CheckConstraint(
+            "verdict IN ('good','neutral','bad')",
+            name="ck_trade_journal_reviews_verdict",
+        ),
+        CheckConstraint(
+            "verdict_source IN ('auto','manual')",
+            name="ck_trade_journal_reviews_source",
+        ),
+        Index("ix_trade_journal_reviews_journal_id", "journal_id"),
+        Index(
+            "uq_trade_journal_reviews_auto",
+            "journal_id",
+            unique=True,
+            postgresql_where=text("verdict_source = 'auto'"),
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    journal_id: Mapped[int] = mapped_column(
+        ForeignKey("review.trade_journals.id", ondelete="CASCADE"), nullable=False
+    )
+    verdict: Mapped[str] = mapped_column(Text, nullable=False)
+    verdict_source: Mapped[str] = mapped_column(Text, nullable=False)
+    pnl_pct: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    comment: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+> 상단 import에 `Numeric`, `BigInteger`, `Text`, `ForeignKey`, `Index`, `CheckConstraint`, `TIMESTAMP`, `func`, `text`, `Mapped`, `mapped_column`이 모두 이미 있으면 추가 불필요(review.py에 존재 확인됨).
+
+- [ ] **Step 3-c: alembic 마이그레이션**
+
+```bash
+uv run alembic heads
+uv run alembic revision -m "rob405b trade_journal_reviews"
+```
+
+생성 파일 본문:
+
+```python
+"""rob405b trade_journal_reviews
+
+Revision ID: <자동생성>
+Revises: <현재 head>
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "<자동생성>"
+down_revision = "<현재 head>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trade_journal_reviews",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("journal_id", sa.BigInteger(), nullable=False),
+        sa.Column("verdict", sa.Text(), nullable=False),
+        sa.Column("verdict_source", sa.Text(), nullable=False),
+        sa.Column("pnl_pct", sa.Numeric(8, 4), nullable=True),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["journal_id"], ["review.trade_journals.id"], ondelete="CASCADE"
+        ),
+        sa.CheckConstraint(
+            "verdict IN ('good','neutral','bad')",
+            name="ck_trade_journal_reviews_verdict",
+        ),
+        sa.CheckConstraint(
+            "verdict_source IN ('auto','manual')",
+            name="ck_trade_journal_reviews_source",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journal_reviews_journal_id",
+        "trade_journal_reviews",
+        ["journal_id"],
+        schema="review",
+    )
+    op.create_index(
+        "uq_trade_journal_reviews_auto",
+        "trade_journal_reviews",
+        ["journal_id"],
+        unique=True,
+        schema="review",
+        postgresql_where=sa.text("verdict_source = 'auto'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_trade_journal_reviews_auto", "trade_journal_reviews", schema="review"
+    )
+    op.drop_index(
+        "ix_trade_journal_reviews_journal_id", "trade_journal_reviews", schema="review"
+    )
+    op.drop_table("trade_journal_reviews", schema="review")
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_service.py -k "review_inserts or verdict_check" -v`
+Expected: PASS (신규 테이블 create_all로 생성됨).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/core/config.py app/models/review.py alembic/versions tests/test_journal_verdict_service.py
+git commit -m "feat(ROB-405): trade_journal_reviews table + verdict auto flag"
+```
+
+---
+
+## Task 2: 자동 verdict 정책 (순수함수)
+
+**Files:**
+- Create: `app/services/trade_journal/journal_verdict_policy.py`
+- Test: `tests/test_journal_verdict_policy.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/test_journal_verdict_policy.py` 생성:
+
+```python
+"""ROB-405 Slice B — verdict policy."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.trade_journal.journal_verdict_policy import (
+    classify_journal_verdict,
+)
+
+
+@pytest.mark.parametrize(
+    "pnl_pct,expected",
+    [
+        (Decimal("2.0"), "good"),
+        (Decimal("1.0"), "good"),  # boundary inclusive
+        (Decimal("0.5"), "neutral"),
+        (Decimal("-0.5"), "neutral"),
+        (Decimal("-1.0"), "bad"),  # boundary inclusive
+        (Decimal("-2.0"), "bad"),
+        (None, "neutral"),
+    ],
+)
+def test_classify_journal_verdict(pnl_pct, expected):
+    assert classify_journal_verdict(pnl_pct) == expected
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_policy.py -v`
+Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3: 구현**
+
+`app/services/trade_journal/journal_verdict_policy.py` 생성:
+
+```python
+"""ROB-405 Slice B — deterministic auto-verdict from pnl_pct."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+GOOD_PNL_PCT = Decimal("1.0")
+BAD_PNL_PCT = Decimal("-1.0")
+
+
+def classify_journal_verdict(pnl_pct: Decimal | None) -> str:
+    """good if pnl_pct >= +1.0%, bad if <= -1.0%, else neutral (None → neutral)."""
+    if pnl_pct is None:
+        return "neutral"
+    if pnl_pct >= GOOD_PNL_PCT:
+        return "good"
+    if pnl_pct <= BAD_PNL_PCT:
+        return "bad"
+    return "neutral"
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_policy.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/journal_verdict_policy.py tests/test_journal_verdict_policy.py
+git commit -m "feat(ROB-405): journal verdict pnl_pct policy"
+```
+
+---
+
+## Task 3: verdict 서비스 (sync + manual)
+
+**Files:**
+- Create: `app/services/trade_journal/journal_verdict_service.py`
+- Test: `tests/test_journal_verdict_service.py` (추가)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/test_journal_verdict_service.py`에 추가:
+
+```python
+from app.services.trade_journal import journal_verdict_service as svc
+
+
+async def _reviews_for(db, journal_id):
+    return (
+        await db.execute(
+            select(TradeJournalReview).where(
+                TradeJournalReview.journal_id == journal_id
+            )
+        )
+    ).scalars().all()
+
+
+@pytest.mark.asyncio
+async def test_sync_records_auto_verdict(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    j = await _closed_mock_journal(db_session, pnl_pct="2.0")
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["created"] == 1
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict == "good"
+    assert rows[0].verdict_source == "auto"
+
+
+@pytest.mark.asyncio
+async def test_sync_idempotent(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    j = await _closed_mock_journal(db_session, pnl_pct="-2.0")
+    await svc.sync_journal_verdicts(db_session)
+    out2 = await svc.sync_journal_verdicts(db_session)
+    assert out2["created"] == 0
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict == "bad"
+
+
+@pytest.mark.asyncio
+async def test_sync_ignores_non_closed_and_non_mock(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    # active mock journal
+    j_active = TradeJournal(
+        symbol="A", instrument_type="equity_kr", side="buy",
+        thesis="t", account_type="mock", account="kis_mock",
+        correlation_id=f"c-{uuid4().hex}", status="active",
+    )
+    # closed live journal
+    j_live = TradeJournal(
+        symbol="B", instrument_type="equity_kr", side="buy",
+        thesis="t", account_type="live", status="closed", pnl_pct=Decimal("5"),
+    )
+    db_session.add_all([j_active, j_live])
+    await db_session.commit()
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["created"] == 0
+
+
+@pytest.mark.asyncio
+async def test_flag_off_disables(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", False)
+    j = await _closed_mock_journal(db_session, pnl_pct="2.0")
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["status"] == "disabled"
+    assert await _reviews_for(db_session, j.id) == []
+
+
+@pytest.mark.asyncio
+async def test_record_manual_verdict(db_session):
+    j = await _closed_mock_journal(db_session, pnl_pct="0.0")
+    out = await svc.record_manual_verdict(
+        db_session, journal_id=j.id, verdict="bad", comment="thesis broke"
+    )
+    assert out["status"] == "ok"
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict_source == "manual"
+    with pytest.raises(ValueError):
+        await svc.record_manual_verdict(db_session, journal_id=j.id, verdict="great")
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_service.py -k "sync or manual or flag_off" -v`
+Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3: 구현**
+
+`app/services/trade_journal/journal_verdict_service.py` 생성:
+
+```python
+"""ROB-405 Slice B — record verdicts for closed mock trade_journals.
+
+Auto verdicts (pnl_pct policy) for closed account_type='mock' journals lacking
+one; manual verdicts are operator overrides. Idempotent via partial-unique
+(journal_id) WHERE verdict_source='auto'. Default off.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.models.review import TradeJournalReview
+from app.models.trade_journal import TradeJournal
+from app.services.trade_journal.journal_verdict_policy import (
+    classify_journal_verdict,
+)
+
+logger = logging.getLogger(__name__)
+
+_VALID_VERDICTS = frozenset({"good", "neutral", "bad"})
+
+
+async def sync_journal_verdicts(db, *, force: bool = False) -> dict[str, Any]:
+    """Record auto verdicts for closed mock journals without one."""
+    if not force and not settings.JOURNAL_VERDICT_AUTO_ENABLED:
+        return {"status": "disabled", "created": 0}
+
+    journals = (
+        await db.execute(
+            select(TradeJournal).where(
+                TradeJournal.status == "closed",
+                TradeJournal.account_type == "mock",
+            )
+        )
+    ).scalars().all()
+
+    created = 0
+    for j in journals:
+        existing = (
+            await db.execute(
+                select(TradeJournalReview.id).where(
+                    TradeJournalReview.journal_id == j.id,
+                    TradeJournalReview.verdict_source == "auto",
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            continue
+        db.add(
+            TradeJournalReview(
+                journal_id=j.id,
+                verdict=classify_journal_verdict(j.pnl_pct),
+                verdict_source="auto",
+                pnl_pct=j.pnl_pct,
+            )
+        )
+        created += 1
+    await db.commit()
+    return {"status": "ok", "created": created}
+
+
+async def record_manual_verdict(
+    db, *, journal_id: int, verdict: str, comment: str | None = None
+) -> dict[str, Any]:
+    """Record an operator (manual) verdict override."""
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(f"invalid verdict: {verdict!r}")
+    db.add(
+        TradeJournalReview(
+            journal_id=journal_id,
+            verdict=verdict,
+            verdict_source="manual",
+            comment=comment,
+        )
+    )
+    await db.commit()
+    return {"status": "ok"}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_service.py -v`
+Expected: PASS (전체).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/journal_verdict_service.py tests/test_journal_verdict_service.py
+git commit -m "feat(ROB-405): journal verdict service (auto sync + manual override)"
+```
+
+---
+
+## Task 4: paused taskiq task + CLI
+
+**Files:**
+- Create: `app/tasks/journal_verdict_tasks.py`, `scripts/sync_journal_verdicts.py`
+- Test: `tests/test_journal_verdict_task.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/test_journal_verdict_task.py` 생성:
+
+```python
+"""ROB-405 Slice B — paused taskiq task gating."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.tasks.journal_verdict_tasks as task_mod
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_flag_off(monkeypatch):
+    monkeypatch.setattr(task_mod.settings, "JOURNAL_VERDICT_AUTO_ENABLED", False)
+    called = {"n": 0}
+
+    async def _fake(db, **kw):
+        called["n"] += 1
+        return {"status": "ok", "created": 0}
+
+    monkeypatch.setattr(task_mod, "sync_journal_verdicts", _fake)
+    result = await task_mod.journal_verdict_sync()
+    assert result["status"] == "disabled"
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_runs_when_enabled(monkeypatch):
+    monkeypatch.setattr(task_mod.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    captured = {"n": 0}
+
+    async def _fake(db, **kw):
+        captured["n"] += 1
+        return {"status": "ok", "created": 3}
+
+    monkeypatch.setattr(task_mod, "sync_journal_verdicts", _fake)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(task_mod, "AsyncSessionLocal", lambda: _FakeSession())
+    result = await task_mod.journal_verdict_sync()
+    assert result["created"] == 3
+    assert captured["n"] == 1
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_journal_verdict_task.py -v`
+Expected: FAIL — `ModuleNotFoundError`.
+
+- [ ] **Step 3-a: taskiq task**
+
+`app/tasks/journal_verdict_tasks.py` 생성:
+
+```python
+"""ROB-405 Slice B — paused taskiq task for auto journal verdicts.
+NO schedule: paused; operator flips JOURNAL_VERDICT_AUTO_ENABLED + adds cron.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.core.taskiq_broker import broker
+from app.services.trade_journal.journal_verdict_service import (
+    sync_journal_verdicts,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@broker.task(task_name="journal_verdict.sync")  # no schedule → paused
+async def journal_verdict_sync() -> dict:
+    if not settings.JOURNAL_VERDICT_AUTO_ENABLED:
+        return {"status": "disabled", "created": 0}
+    async with AsyncSessionLocal() as db:
+        return await sync_journal_verdicts(db)
+```
+
+- [ ] **Step 3-b: operator CLI**
+
+`scripts/sync_journal_verdicts.py` 생성:
+
+```python
+"""ROB-405 Slice B — operator CLI for journal verdicts.
+``sync`` runs auto verdicts (force). ``manual`` records an override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="trade_journal verdict bridge")
+    sub = p.add_subparsers(dest="mode", required=True)
+    sub.add_parser("sync")
+    m = sub.add_parser("manual")
+    m.add_argument("--journal-id", type=int, required=True)
+    m.add_argument("--verdict", choices=["good", "neutral", "bad"], required=True)
+    m.add_argument("--comment", default=None)
+    return p
+
+
+async def _amain(args) -> int:
+    from app.core.db import AsyncSessionLocal
+    from app.services.trade_journal.journal_verdict_service import (
+        record_manual_verdict,
+        sync_journal_verdicts,
+    )
+
+    async with AsyncSessionLocal() as db:
+        if args.mode == "sync":
+            result = await sync_journal_verdicts(db, force=True)
+        else:
+            result = await record_manual_verdict(
+                db,
+                journal_id=args.journal_id,
+                verdict=args.verdict,
+                comment=args.comment,
+            )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    return asyncio.run(_amain(_build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run:
+```bash
+uv run pytest tests/test_journal_verdict_task.py -v
+uv run python scripts/sync_journal_verdicts.py --help
+```
+Expected: 테스트 PASS, `--help`는 secret 없이 usage 출력.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/tasks/journal_verdict_tasks.py scripts/sync_journal_verdicts.py tests/test_journal_verdict_task.py
+git commit -m "feat(ROB-405): paused taskiq task + CLI for journal verdicts"
+```
+
+---
+
+## Task 5: 회귀 + lint/format/typecheck
+
+- [ ] **Step 1: 관련 스위트 회귀**
+
+Run:
+```bash
+uv run pytest tests/test_journal_verdict_policy.py tests/test_journal_verdict_service.py tests/test_journal_verdict_task.py tests/test_trade_journal_model.py tests/test_mock_roundtrip_journal_bridge.py -p no:randomly -v
+```
+Expected: 전부 PASS (Slice A 회귀 포함).
+
+- [ ] **Step 2: lint + format**
+
+Run:
+```bash
+uv run ruff check app/ tests/
+uv run ruff format --check app/ tests/ scripts/sync_journal_verdicts.py
+```
+Expected: 통과(필요 시 `uv run ruff format ...`).
+
+- [ ] **Step 3: typecheck**
+
+Run:
+```bash
+uv run ty check app/services/trade_journal/journal_verdict_policy.py app/services/trade_journal/journal_verdict_service.py app/models/review.py app/tasks/journal_verdict_tasks.py
+```
+Expected: 통과.
+
+- [ ] **Step 4: 커밋(필요 시 format)**
+
+```bash
+git add -A && git commit -m "style(ROB-405): ruff format" || echo "nothing to format"
+```
+
+---
+
+## 검증 / 인수 기준
+- closed mock journal → auto verdict(pnl_pct: good ≥+1%, bad ≤-1%, else neutral), 멱등(partial-unique).
+- non-closed/non-mock 무시, flag off→disabled. manual override 기록(복수), 잘못된 verdict 거부.
+- 신규 trade_journal_reviews 테이블 CHECK + FK CASCADE. Slice A 무변경.
+
+## 범위 밖 (후속)
+C counterfactual / D 사이클 read API(verdict 집계) / E follow_up. MCP verdict 도구 / thesis-target 보정 / operator flip.

--- a/docs/superpowers/specs/2026-06-02-rob-405-sliceB-journal-verdict-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob-405-sliceB-journal-verdict-design.md
@@ -1,0 +1,86 @@
+# ROB-405 Slice B — trade_journal verdict (good/neutral/bad)
+
+- **이슈**: ROB-405 (G4) 회고 배선 — **Slice B (verdict)**
+- **부모 에픽**: ROB-401, 트래커 ROB-410 Wave 3
+- **선행**: Slice A (mock roundtrip→trade_journal, merged #1086 41d12c06)
+- **작성일**: 2026-06-02
+- **상태**: 설계 승인됨 → 구현 계획 수립 단계
+
+## 1. 배경 / 현 상태
+
+Slice A가 reconciled kis_mock roundtrip을 `trade_journal`(account_type='mock', correlation_id, entry/exit/pnl_pct)로 마감한다. Slice B는 그 closed journal에 **verdict(good/neutral/bad)** 를 pnl_pct 임계값으로 **자동** 기록하고 **수동 override(반자동)** 를 지원한다.
+
+### 코드 매핑
+- `app/models/trade_journal.py::TradeJournal`: status(draft|active|closed|stopped|expired), account_type(live|paper|**mock** — Slice A), pnl_pct(Numeric(8,4)), correlation_id(Slice A). closed mock journal이 verdict 대상.
+- `app/models/review.py::TradeReview`(99–129): **`review.trades` FK**(journal 아님), verdict CHECK good|neutral|bad, review_type, comment, pnl_pct. → journal verdict은 **신규 테이블** 필요(기존 TradeReview 재사용 불가).
+- Slice A 패턴: `app/services/trade_journal/`(브리지), config flag + paused taskiq + CLI, default-off.
+
+## 2. 목표 / 비목표
+**목표**: closed mock journal → verdict 자동 기록(pnl_pct 임계값) + 수동 override. 신규 `trade_journal_reviews` 테이블. default-off, 멱등, mock 전용 auto.
+**비목표**: C counterfactual / D 사이클 read API(verdict 집계) / E follow_up. thesis/target-stop 보정. live journal auto-verdict(수동만).
+
+## 3. 설계
+
+### 3.1 데이터 모델 (신규 테이블 + 마이그레이션)
+`review.trade_journal_reviews`:
+- `id` BigInteger PK
+- `journal_id` BigInteger FK→`review.trade_journals.id`(ondelete CASCADE), NOT NULL
+- `verdict` Text NOT NULL — CHECK `verdict IN ('good','neutral','bad')`
+- `verdict_source` Text NOT NULL — CHECK `verdict_source IN ('auto','manual')`
+- `pnl_pct` Numeric(8,4) nullable (기록 시점 journal.pnl_pct)
+- `comment` Text nullable
+- `created_at` TIMESTAMP server_default now()
+- Index `(journal_id)`. **Partial-unique** `(journal_id) WHERE verdict_source='auto'` (journal당 auto verdict 1개 → 멱등). manual은 복수 허용.
+- 신규 테이블 → `Base.metadata.create_all`이 테스트 DB에 생성(conftest drift 패치 불요). alembic migration 추가.
+
+### 3.2 자동 verdict 정책 (순수함수)
+`app/services/trade_journal/journal_verdict_policy.py`:
+```python
+GOOD_PNL_PCT = Decimal("1.0")
+BAD_PNL_PCT = Decimal("-1.0")
+
+def classify_journal_verdict(pnl_pct: Decimal | None) -> str:
+    if pnl_pct is None:
+        return "neutral"
+    if pnl_pct >= GOOD_PNL_PCT:
+        return "good"
+    if pnl_pct <= BAD_PNL_PCT:
+        return "bad"
+    return "neutral"
+```
+결정적. 임계값=모듈 상수(향후 config화 가능).
+
+### 3.3 verdict 서비스 (`journal_verdict_service.py`)
+- `sync_journal_verdicts(db, *, force=False) -> dict`: gate(`force or JOURNAL_VERDICT_AUTO_ENABLED`) → `status='closed'` + `account_type='mock'` + auto verdict 미존재 journal 스캔 → `classify_journal_verdict(journal.pnl_pct)` verdict insert(verdict_source='auto', pnl_pct, partial-unique로 멱등). 반환 `{status, created}`. **Slice A 브리지와 독립**(closed journal 스캔, A 무수정).
+- `record_manual_verdict(db, *, journal_id, verdict, comment=None) -> dict`: verdict_source='manual' insert. verdict 값 검증(good|neutral|bad). 반자동 override(복수 허용).
+
+### 3.4 발화 (default-off)
+- `JOURNAL_VERDICT_AUTO_ENABLED: bool = False` (config). False면 auto sync `{"status":"disabled"}`.
+- paused taskiq `journal_verdict.sync` + operator CLI(auto sync / manual record).
+
+## 4. 컴포넌트
+| 단위 | 위치 | 책임 |
+|---|---|---|
+| 모델/마이그레이션 | `app/models/review.py` + alembic | `trade_journal_reviews` 테이블 |
+| 정책 | `app/services/trade_journal/journal_verdict_policy.py` | `classify_journal_verdict` 순수함수 |
+| 서비스 | `app/services/trade_journal/journal_verdict_service.py` | `sync_journal_verdicts` + `record_manual_verdict` |
+| config | `app/core/config.py` | `JOURNAL_VERDICT_AUTO_ENABLED=False` |
+| task/CLI | `app/tasks/journal_verdict_tasks.py` + `scripts/sync_journal_verdicts.py` | paused + operator |
+
+## 5. 안전 경계
+- auto는 mock journal 전용(account_type='mock'). verdict 기록=DB-only(broker/order mutation 없음). default-off inert. 멱등(partial-unique). live journal verdict는 manual만.
+
+## 6. 테스트
+1. `classify_journal_verdict`: +1.5→good, -1.5→bad, 0.5→neutral, None→neutral, 경계값(±1.0 포함).
+2. `sync_journal_verdicts`: closed mock journal(pnl_pct=+2)→auto 'good' row.
+3. 멱등: 재실행 중복 auto verdict 없음(partial-unique).
+4. non-closed / non-mock journal 무시.
+5. `record_manual_verdict`: manual row(복수 허용), 잘못된 verdict 값 거부.
+6. flag off → `disabled`, verdict 0.
+7. 테이블 CHECK(verdict/verdict_source) + FK CASCADE.
+
+## 7. 미해결 / 후속
+- C counterfactual / D 사이클 read API(armed/triggered/filled/PnL/hit-miss, verdict 집계) / E follow_up_report_item_id.
+- MCP verdict 도구(수동 override surface)는 D read API와 함께/별도.
+- thesis/target-stop 보정, 임계값 config화, operator flag flip.
+- 구현 시 origin/main(Slice A merged) 기준.

--- a/scripts/sync_journal_verdicts.py
+++ b/scripts/sync_journal_verdicts.py
@@ -1,0 +1,51 @@
+"""ROB-405 Slice B — operator CLI for journal verdicts.
+``sync`` runs auto verdicts (force). ``manual`` records an override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="trade_journal verdict bridge")
+    sub = p.add_subparsers(dest="mode", required=True)
+    sub.add_parser("sync")
+    m = sub.add_parser("manual")
+    m.add_argument("--journal-id", type=int, required=True)
+    m.add_argument("--verdict", choices=["good", "neutral", "bad"], required=True)
+    m.add_argument("--comment", default=None)
+    return p
+
+
+async def _amain(args) -> int:
+    from app.core.db import AsyncSessionLocal
+    from app.services.trade_journal.journal_verdict_service import (
+        record_manual_verdict,
+        sync_journal_verdicts,
+    )
+
+    async with AsyncSessionLocal() as db:
+        if args.mode == "sync":
+            result = await sync_journal_verdicts(db, force=True)
+        else:
+            result = await record_manual_verdict(
+                db,
+                journal_id=args.journal_id,
+                verdict=args.verdict,
+                comment=args.comment,
+            )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO)
+    return asyncio.run(_amain(_build_parser().parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_journal_verdict_policy.py
+++ b/tests/test_journal_verdict_policy.py
@@ -1,0 +1,27 @@
+"""ROB-405 Slice B — verdict policy."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.trade_journal.journal_verdict_policy import (
+    classify_journal_verdict,
+)
+
+
+@pytest.mark.parametrize(
+    "pnl_pct,expected",
+    [
+        (Decimal("2.0"), "good"),
+        (Decimal("1.0"), "good"),  # boundary inclusive
+        (Decimal("0.5"), "neutral"),
+        (Decimal("-0.5"), "neutral"),
+        (Decimal("-1.0"), "bad"),  # boundary inclusive
+        (Decimal("-2.0"), "bad"),
+        (None, "neutral"),
+    ],
+)
+def test_classify_journal_verdict(pnl_pct, expected):
+    assert classify_journal_verdict(pnl_pct) == expected

--- a/tests/test_journal_verdict_service.py
+++ b/tests/test_journal_verdict_service.py
@@ -7,17 +7,14 @@ from decimal import Decimal
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
+import pytest_asyncio
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from sqlalchemy import delete
-
 from app.models.review import TradeJournalReview
 from app.models.trade_journal import TradeJournal
-
-
-import pytest_asyncio
+from app.services.trade_journal import journal_verdict_service as svc
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -49,7 +46,6 @@ async def _closed_mock_journal(db, *, pnl_pct, cid=None):
     return j
 
 
-
 @pytest.mark.asyncio
 async def test_journal_review_inserts_and_checks(db_session: AsyncSession):
     j = await _closed_mock_journal(db_session, pnl_pct="10")
@@ -72,17 +68,18 @@ async def test_journal_review_verdict_check_rejects(db_session: AsyncSession):
     await db_session.rollback()
 
 
-from app.services.trade_journal import journal_verdict_service as svc
-
-
 async def _reviews_for(db, journal_id):
     return (
-        await db.execute(
-            select(TradeJournalReview).where(
-                TradeJournalReview.journal_id == journal_id
+        (
+            await db.execute(
+                select(TradeJournalReview).where(
+                    TradeJournalReview.journal_id == journal_id
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
 
 @pytest.mark.asyncio
@@ -114,14 +111,24 @@ async def test_sync_ignores_non_closed_and_non_mock(db_session, monkeypatch):
     monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
     # active mock journal
     j_active = TradeJournal(
-        symbol="A", instrument_type="equity_kr", side="buy",
-        thesis="t", account_type="mock", account="kis_mock",
-        correlation_id=f"c-{uuid4().hex}", status="active",
+        symbol="A",
+        instrument_type="equity_kr",
+        side="buy",
+        thesis="t",
+        account_type="mock",
+        account="kis_mock",
+        correlation_id=f"c-{uuid4().hex}",
+        status="active",
     )
     # closed live journal
     j_live = TradeJournal(
-        symbol="B", instrument_type="equity_kr", side="buy",
-        thesis="t", account_type="live", status="closed", pnl_pct=Decimal("5"),
+        symbol="B",
+        instrument_type="equity_kr",
+        side="buy",
+        thesis="t",
+        account_type="live",
+        status="closed",
+        pnl_pct=Decimal("5"),
     )
     db_session.add_all([j_active, j_live])
     await db_session.commit()
@@ -150,4 +157,3 @@ async def test_record_manual_verdict(db_session):
     assert rows[0].verdict_source == "manual"
     with pytest.raises(ValueError):
         await svc.record_manual_verdict(db_session, journal_id=j.id, verdict="great")
-

--- a/tests/test_journal_verdict_service.py
+++ b/tests/test_journal_verdict_service.py
@@ -11,11 +11,24 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import delete
+
 from app.models.review import TradeJournalReview
 from app.models.trade_journal import TradeJournal
 
 
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def cleanup_journal_tables(db_session: AsyncSession):
+    await db_session.execute(delete(TradeJournalReview))
+    await db_session.execute(delete(TradeJournal))
+    await db_session.commit()
+
+
 async def _closed_mock_journal(db, *, pnl_pct, cid=None):
+
     j = TradeJournal(
         symbol="005930",
         instrument_type="equity_kr",
@@ -32,8 +45,9 @@ async def _closed_mock_journal(db, *, pnl_pct, cid=None):
         pnl_pct=Decimal(pnl_pct),
     )
     db.add(j)
-    await db.commit()
+    await db.flush()
     return j
+
 
 
 @pytest.mark.asyncio
@@ -56,3 +70,84 @@ async def test_journal_review_verdict_check_rejects(db_session: AsyncSession):
     with pytest.raises(IntegrityError):
         await db_session.commit()
     await db_session.rollback()
+
+
+from app.services.trade_journal import journal_verdict_service as svc
+
+
+async def _reviews_for(db, journal_id):
+    return (
+        await db.execute(
+            select(TradeJournalReview).where(
+                TradeJournalReview.journal_id == journal_id
+            )
+        )
+    ).scalars().all()
+
+
+@pytest.mark.asyncio
+async def test_sync_records_auto_verdict(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    j = await _closed_mock_journal(db_session, pnl_pct="2.0")
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["created"] == 1
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict == "good"
+    assert rows[0].verdict_source == "auto"
+
+
+@pytest.mark.asyncio
+async def test_sync_idempotent(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    j = await _closed_mock_journal(db_session, pnl_pct="-2.0")
+    await svc.sync_journal_verdicts(db_session)
+    out2 = await svc.sync_journal_verdicts(db_session)
+    assert out2["created"] == 0
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict == "bad"
+
+
+@pytest.mark.asyncio
+async def test_sync_ignores_non_closed_and_non_mock(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    # active mock journal
+    j_active = TradeJournal(
+        symbol="A", instrument_type="equity_kr", side="buy",
+        thesis="t", account_type="mock", account="kis_mock",
+        correlation_id=f"c-{uuid4().hex}", status="active",
+    )
+    # closed live journal
+    j_live = TradeJournal(
+        symbol="B", instrument_type="equity_kr", side="buy",
+        thesis="t", account_type="live", status="closed", pnl_pct=Decimal("5"),
+    )
+    db_session.add_all([j_active, j_live])
+    await db_session.commit()
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["created"] == 0
+
+
+@pytest.mark.asyncio
+async def test_flag_off_disables(db_session, monkeypatch):
+    monkeypatch.setattr(svc.settings, "JOURNAL_VERDICT_AUTO_ENABLED", False)
+    j = await _closed_mock_journal(db_session, pnl_pct="2.0")
+    out = await svc.sync_journal_verdicts(db_session)
+    assert out["status"] == "disabled"
+    assert await _reviews_for(db_session, j.id) == []
+
+
+@pytest.mark.asyncio
+async def test_record_manual_verdict(db_session):
+    j = await _closed_mock_journal(db_session, pnl_pct="0.0")
+    out = await svc.record_manual_verdict(
+        db_session, journal_id=j.id, verdict="bad", comment="thesis broke"
+    )
+    assert out["status"] == "ok"
+    rows = await _reviews_for(db_session, j.id)
+    assert len(rows) == 1
+    assert rows[0].verdict_source == "manual"
+    with pytest.raises(ValueError):
+        await svc.record_manual_verdict(db_session, journal_id=j.id, verdict="great")
+

--- a/tests/test_journal_verdict_service.py
+++ b/tests/test_journal_verdict_service.py
@@ -1,0 +1,58 @@
+"""ROB-405 Slice B — trade_journal verdict."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeJournalReview
+from app.models.trade_journal import TradeJournal
+
+
+async def _closed_mock_journal(db, *, pnl_pct, cid=None):
+    j = TradeJournal(
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        entry_price=Decimal("50000"),
+        quantity=Decimal("10"),
+        thesis="t",
+        account_type="mock",
+        account="kis_mock",
+        correlation_id=cid or f"corr-{uuid4().hex}",
+        status="closed",
+        exit_price=Decimal("55000"),
+        exit_date=datetime(2026, 6, 2, tzinfo=UTC),
+        pnl_pct=Decimal(pnl_pct),
+    )
+    db.add(j)
+    await db.commit()
+    return j
+
+
+@pytest.mark.asyncio
+async def test_journal_review_inserts_and_checks(db_session: AsyncSession):
+    j = await _closed_mock_journal(db_session, pnl_pct="10")
+    r = TradeJournalReview(
+        journal_id=j.id, verdict="good", verdict_source="auto", pnl_pct=Decimal("10")
+    )
+    db_session.add(r)
+    await db_session.commit()
+    assert r.id is not None
+
+
+@pytest.mark.asyncio
+async def test_journal_review_verdict_check_rejects(db_session: AsyncSession):
+    j = await _closed_mock_journal(db_session, pnl_pct="1")
+    db_session.add(
+        TradeJournalReview(journal_id=j.id, verdict="great", verdict_source="auto")
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()

--- a/tests/test_journal_verdict_task.py
+++ b/tests/test_journal_verdict_task.py
@@ -1,0 +1,46 @@
+"""ROB-405 Slice B — paused taskiq task gating."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.tasks.journal_verdict_tasks as task_mod
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_flag_off(monkeypatch):
+    monkeypatch.setattr(task_mod.settings, "JOURNAL_VERDICT_AUTO_ENABLED", False)
+    called = {"n": 0}
+
+    async def _fake(db, **kw):
+        called["n"] += 1
+        return {"status": "ok", "created": 0}
+
+    monkeypatch.setattr(task_mod, "sync_journal_verdicts", _fake)
+    result = await task_mod.journal_verdict_sync()
+    assert result["status"] == "disabled"
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_runs_when_enabled(monkeypatch):
+    monkeypatch.setattr(task_mod.settings, "JOURNAL_VERDICT_AUTO_ENABLED", True)
+    captured = {"n": 0}
+
+    async def _fake(db, **kw):
+        captured["n"] += 1
+        return {"status": "ok", "created": 3}
+
+    monkeypatch.setattr(task_mod, "sync_journal_verdicts", _fake)
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(task_mod, "AsyncSessionLocal", lambda: _FakeSession())
+    result = await task_mod.journal_verdict_sync()
+    assert result["created"] == 3
+    assert captured["n"] == 1


### PR DESCRIPTION
## 요약 (ROB-405 Slice B / ROB-410 Wave 3)

closed mock trade_journal(Slice A #1086)에 verdict(good/neutral/bad)를 pnl_pct 임계값으로 **자동** 기록 + **수동 override(반자동)**. 신규 `trade_journal_reviews` 테이블. 회고 배선 Slice B.

## 변경

- **신규 테이블** `review.trade_journal_reviews`: journal_id FK→trade_journals(CASCADE), verdict(CHECK good|neutral|bad), verdict_source(CHECK auto|manual), pnl_pct, comment, created_at. **partial-unique `(journal_id) WHERE verdict_source='auto'`** → journal당 auto verdict 1개(멱등). (기존 trade_reviews는 review.trades FK라 재사용 불가)
- **순수 정책** `classify_journal_verdict(pnl_pct)`: good ≥+1% / bad ≤-1% / 그 외 neutral / None→neutral (경계 inclusive).
- **서비스** `sync_journal_verdicts(db, force=False)`: `status='closed'` + `account_type='mock'` + auto verdict 미존재 journal 스캔 → auto verdict insert(멱등). `record_manual_verdict(journal_id, verdict, comment)`: 반자동 override(verdict 값 검증).
- **발화(default-off)**: `JOURNAL_VERDICT_AUTO_ENABLED`(default False) + paused taskiq `journal_verdict.sync` + operator CLI(sync/manual).

## 안전 경계

- auto는 mock journal 전용(account_type='mock'). verdict 기록=DB-only(broker/order mutation 없음). default-off inert. 멱등(partial-unique). live journal verdict는 manual만. Slice A 무변경.

## 테스트

- classify(good/bad/neutral/None/경계) / sync(closed mock→auto verdict) / 멱등(재실행 중복 없음) / non-closed·non-mock 무시 / flag off→disabled / manual override(복수, 잘못된 verdict 거부) / 테이블 CHECK+FK + paused task gating.
- 17 passed(single-head 포함), `app/ tests/` ruff clean, 단일 alembic head.
- origin/main(ROB-398 #1085 등) 머지 clean(충돌 없음, head 분기 없음). diff=Slice B only.

## 의존 / 후속

- 선행 Slice A #1086 merged. origin/main 기준.
- 후속: **C** counterfactual / **D** 사이클 read API(verdict 집계) / **E** follow_up_report_item_id. MCP verdict 도구 / thesis-target 보정 / operator flip(`JOURNAL_VERDICT_AUTO_ENABLED`).

설계: `docs/superpowers/specs/2026-06-02-rob-405-sliceB-journal-verdict-design.md`
계획: `docs/superpowers/plans/2026-06-02-rob-405-sliceB-journal-verdict.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)