### PR TITLE
fix: merge alembic heads (ROB-398 Slice2 + ROB-405 Slice C)

### DIFF
--- a/alembic/versions/bb4fb793a865_merge_heads_rob398s2_rob405c.py
+++ b/alembic/versions/bb4fb793a865_merge_heads_rob398s2_rob405c.py
@@ -1,0 +1,25 @@
+"""merge heads rob398s2 + rob405c
+
+Revision ID: bb4fb793a865
+Revises: 20260602_rob398s2, 91097f38827e
+Create Date: 2026-06-02 08:09:06.071625
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "bb4fb793a865"
+down_revision: str | Sequence[str] | None = ("20260602_rob398s2", "91097f38827e")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## 요약

`origin/main`이 alembic **2-head**로 분기되어 `test_revision_graph_has_single_final_head`가 실패(모든 PR CI 차단):
- `20260602_rob398s2` (ROB-398 Slice 2, #1090)
- `91097f38827e` (ROB-405 Slice C, #1091)

둘 다 `down_revision=6e1ed781fc56`에서 분기. 빈 merge revision `bb4fb793a865`(down_revision=두 head)로 단일 head 복원. **스키마 변경 없음**(upgrade/downgrade pass).

선례: #1082(ROB-337/403 merge), `2489d4709dec`(ROB-406 merge). 머지 treadmill 반복 대응.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>