### PR TITLE
deploy(ROB-376): promote intraday delta context to production

### DIFF
--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -33,6 +33,7 @@ PRs per the user's Plan B directive).
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,7 @@ from app.services.action_report.common.snapshot_bundle import (
 from app.services.action_report.snapshot_backed.collectors.registry import (
     production_collector_registry,
 )
+from app.services.investment_reports.delta_service import DeltaService
 from app.services.investment_stages.hermes_context import (
     HermesContextExporter,
     HermesContextExportError,
@@ -65,12 +67,19 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
+logger = logging.getLogger(__name__)
+
+
 INVESTMENT_HERMES_TOOL_NAMES: set[str] = {
     "investment_report_prepare_bundle",
     "investment_report_get_hermes_context",
     "investment_report_create_from_hermes_composition",
     "investment_stage_artifacts_ingest_from_hermes",
+    "investment_report_prepare_intraday_context",
 }
+
+
+INTRADAY_UPDATE_REPORT_TYPE = "intraday_update_v1"
 
 
 _DISABLED_PAYLOAD: dict[str, Any] = {
@@ -181,6 +190,75 @@ async def investment_report_get_hermes_context_impl(
                 "detail": str(exc),
             }
     return {"success": True, **payload.model_dump(mode="json")}
+
+
+# ---------------------------------------------------------------------------
+# investment_report_prepare_intraday_context (ROB-376 item 2)
+# ---------------------------------------------------------------------------
+async def investment_report_prepare_intraday_context_impl(
+    snapshot_bundle_uuid: str,
+    baseline_report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict[str, Any]:
+    """Assemble an intraday_update Hermes context: the bundle's deterministic
+    context + an ``intraday_delta_block`` (report-vs-now/prior delta) keyed to
+    ``baseline_report_uuid``. Read-only; no in-process LLM; no broker / order /
+    watch / order-intent mutation. Fail-open: a delta failure leaves the rest
+    of the context intact. Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    parsed_bundle = _parse_bundle_uuid(snapshot_bundle_uuid)
+    if isinstance(parsed_bundle, dict):
+        return parsed_bundle
+
+    from app.core.timezone import now_kst
+
+    base_uuid: uuid.UUID | None = None
+    async with AsyncSessionLocal() as db:
+        exporter = HermesContextExporter(db)
+        try:
+            payload = await exporter.export(snapshot_bundle_uuid=parsed_bundle)
+        except HermesContextExportError as exc:
+            return {
+                "success": False,
+                "error": "snapshot_bundle_not_found",
+                "snapshot_bundle_uuid": snapshot_bundle_uuid,
+                "detail": str(exc),
+            }
+
+        # Delta is fail-open: errors ride inside intraday_delta_block, never
+        # flip the context's success.
+        try:
+            base_uuid = uuid.UUID(baseline_report_uuid)
+        except (ValueError, AttributeError, TypeError):
+            delta_block: dict[str, Any] = {
+                "success": False,
+                "error": "invalid_report_uuid",
+            }
+        else:
+            try:
+                delta_block = await DeltaService(db).compute_delta(
+                    base_uuid,
+                    near_pct=near_pct,
+                    account_type=account_type,
+                    computed_at_kst=now_kst().isoformat(),
+                )
+            except Exception as exc:  # noqa: BLE001 — fail-open
+                logger.exception("intraday delta computation failed")
+                delta_block = {"unavailable": str(exc) or exc.__class__.__name__}
+
+    # Echo baseline only when the delta actually succeeded against it.
+    payload.baseline_report_uuid = base_uuid if delta_block.get("success") else None
+    payload.intraday_delta_block = delta_block
+    return {
+        "success": True,
+        "report_type_hint": INTRADAY_UPDATE_REPORT_TYPE,
+        **payload.model_dump(mode="json"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +473,17 @@ def register_investment_hermes_tools(mcp: FastMCP) -> None:
             "effect. Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
         ),
     )(investment_stage_artifacts_ingest_from_hermes_impl)
+    mcp.tool(
+        name="investment_report_prepare_intraday_context",
+        description=(
+            "ROB-376 — assemble an intraday_update Hermes context: the bundle's "
+            "deterministic context plus an intraday_delta_block (report-vs-now / "
+            "report-vs-prior delta) keyed to baseline_report_uuid, for Hermes to "
+            "compose an intraday_update_v1 report. Read-only, fail-open on the "
+            "delta, no in-process LLM, no broker/order/watch mutation. Gated by "
+            "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_prepare_intraday_context_impl)
 
 
 __all__ = [
@@ -403,5 +492,6 @@ __all__ = [
     "investment_report_get_hermes_context_impl",
     "investment_report_prepare_bundle_impl",
     "investment_stage_artifacts_ingest_from_hermes_impl",
+    "investment_report_prepare_intraday_context_impl",
     "register_investment_hermes_tools",
 ]

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -63,6 +63,7 @@ INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
     "investment_report_decide_item",
     "investment_report_activate_watch",
     "investment_report_context_get",
+    "investment_report_delta_get",
     "investment_report_generate_from_bundle",
     "investment_watch_recommend",
 }
@@ -564,6 +565,32 @@ async def investment_report_context_get_impl(
 
 
 # ---------------------------------------------------------------------------
+# investment_report_delta_get (ROB-376)
+# ---------------------------------------------------------------------------
+async def investment_report_delta_get_impl(
+    report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict:
+    from app.core.timezone import now_kst
+    from app.services.investment_reports.delta_service import DeltaService
+
+    try:
+        parsed = UUID(report_uuid)
+    except (ValueError, AttributeError, TypeError):
+        return {"success": False, "error": "invalid_report_uuid"}
+
+    async with AsyncSessionLocal() as db:
+        service = DeltaService(db)
+        return await service.compute_delta(
+            parsed,
+            near_pct=near_pct,
+            account_type=account_type,
+            computed_at_kst=now_kst().isoformat(),
+        )
+
+
+# ---------------------------------------------------------------------------
 # investment_report_generate_from_bundle (ROB-273)
 # ---------------------------------------------------------------------------
 async def investment_report_generate_from_bundle_impl(
@@ -877,6 +904,19 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         ),
     )(investment_report_context_get_impl)
     mcp.tool(
+        name="investment_report_delta_get",
+        description=(
+            "Read-only intraday delta vs a baseline report. Given report_uuid "
+            "(the open/prior report), returns three deterministic deltas for Hermes "
+            "to compose: levels_delta (journal target/stop touch x live), "
+            "holdings_pnl_delta (per-symbol live P/L vs the baseline snapshot "
+            "bundle's portfolio P/L), and index_delta (live index vs the report's "
+            "frozen market baseline). Per-signal fail-open: a degraded signal is "
+            "null with a reason under 'unavailable'; missing data is never coerced "
+            "to zero. No broker/order/watch mutation."
+        ),
+    )(investment_report_delta_get_impl)
+    mcp.tool(
         name="investment_report_generate_from_bundle",
         description=GENERATE_FROM_BUNDLE_DESCRIPTION,
     )(investment_report_generate_from_bundle_impl)
@@ -900,6 +940,7 @@ __all__ = [
     "investment_report_context_get_impl",
     "investment_report_create_impl",
     "investment_report_decide_item_impl",
+    "investment_report_delta_get_impl",
     "investment_report_generate_from_bundle_impl",
     "investment_report_get_impl",
     "investment_report_list_impl",

--- a/app/schemas/hermes_composition.py
+++ b/app/schemas/hermes_composition.py
@@ -100,6 +100,11 @@ class HermesContextPayload(BaseModel):
     constraints: HermesContextConstraints = Field(
         default_factory=HermesContextConstraints
     )
+    # ROB-376 item 2 — intraday_update report continuity. Optional/additive
+    # (no context_version bump). Populated only by the intraday context tool;
+    # the base get_hermes_context path leaves both None.
+    baseline_report_uuid: uuid.UUID | None = None
+    intraday_delta_block: dict[str, Any] | None = None
 
 
 class HermesCompositionResult(BaseModel):

--- a/app/services/investment_reports/delta_service.py
+++ b/app/services/investment_reports/delta_service.py
@@ -1,0 +1,359 @@
+"""ROB-376 — read-only intraday delta computation for investment reports.
+
+Deterministic baseline-vs-live deltas (target/stop touch, per-symbol holdings P/L,
+index move) for the next/intraday report. No DB writes, no broker/watch mutation,
+no in-process LLM. Every signal is fail-open: one signal's failure never kills the
+others.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+def _is_finite_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _near(current: Any, level: Any, near_pct: float) -> bool:
+    """True when ``current`` is within ``near_pct`` percent of ``level``."""
+    if not _is_finite_number(current) or not _is_finite_number(level) or level == 0:
+        return False
+    return abs(current - level) / abs(level) * 100 <= near_pct
+
+
+def _levels_delta(
+    journal_result: Mapping[str, Any],
+    symbols: set[str],
+    *,
+    near_pct: float,
+) -> dict[str, Any]:
+    """Project the journal's already-computed live enrichment into a delta block.
+
+    Reuses ``target_reached`` / ``stop_reached`` / ``pnl_pct_live`` (computed by
+    ``get_trade_journal(enrich_live=True)``); computes per-entry ``near_*`` flags
+    here. When ``symbols`` is empty, all entries are kept.
+    """
+    entries: list[dict[str, Any]] = []
+    near_target = near_stop = target_hit = stop_hit = 0
+    for entry in journal_result.get("entries") or []:
+        symbol = entry.get("symbol")
+        if symbols and symbol not in symbols:
+            continue
+        current = entry.get("current_price")
+        target = entry.get("target_price")
+        stop = entry.get("stop_loss")
+        is_target_reached = bool(entry.get("target_reached"))
+        is_stop_reached = bool(entry.get("stop_reached"))
+        is_near_target = _near(current, target, near_pct) and not is_target_reached
+        is_near_stop = _near(current, stop, near_pct) and not is_stop_reached
+        near_target += int(is_near_target)
+        near_stop += int(is_near_stop)
+        target_hit += int(is_target_reached)
+        stop_hit += int(is_stop_reached)
+        entries.append(
+            {
+                "symbol": symbol,
+                "side": entry.get("side"),
+                "target_price": target,
+                "stop_loss": stop,
+                "current_price": current,
+                "pnl_pct_live": entry.get("pnl_pct_live"),
+                "target_reached": entry.get("target_reached"),
+                "stop_reached": entry.get("stop_reached"),
+                "near_target": is_near_target,
+                "near_stop": is_near_stop,
+            }
+        )
+    return {
+        "entries": entries,
+        "summary": {
+            "near_target": near_target,
+            "near_stop": near_stop,
+            "target_hit": target_hit,
+            "stop_hit": stop_hit,
+        },
+    }
+
+
+def _baseline_pnl_from_bundle_pairs(
+    pairs: list[tuple[Any, Any]],
+) -> dict[str, float] | None:
+    """Extract ``{ticker: pnl_rate}`` from the bundle's ``portfolio`` snapshot.
+
+    Returns ``None`` when no ``portfolio`` snapshot is present (so the caller can
+    record ``baseline_snapshot_absent`` rather than fabricating an empty baseline).
+    Holdings without a finite ``pnl_rate`` are skipped (missing != zero).
+    """
+    for _item, snapshot in pairs:
+        if getattr(snapshot, "snapshot_kind", None) != "portfolio":
+            continue
+        payload = getattr(snapshot, "payload_json", None) or {}
+        out: dict[str, float] = {}
+        for holding in payload.get("holdings") or []:
+            ticker = holding.get("ticker")
+            rate = holding.get("pnl_rate")
+            if ticker is not None and _is_finite_number(rate):
+                out[str(ticker)] = float(rate)
+        return out
+    return None
+
+
+def _live_pnl_by_symbol(holdings_result: Mapping[str, Any]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for account in holdings_result.get("accounts") or []:
+        for position in account.get("positions") or []:
+            symbol = position.get("symbol")
+            rate = position.get("profit_rate")
+            if symbol is not None and _is_finite_number(rate):
+                out[str(symbol)] = float(rate)
+    return out
+
+
+def _holdings_pnl_delta(
+    baseline_pnl: Mapping[str, float],
+    holdings_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Per-symbol live P/L vs baseline P/L. Only symbols present on BOTH sides get
+    an entry (missing != zero); one-sided symbols are counted in the summary."""
+    live_pnl = _live_pnl_by_symbol(holdings_result)
+    baseline_keys = set(baseline_pnl)
+    live_keys = set(live_pnl)
+    both = baseline_keys & live_keys
+    entries: list[dict[str, Any]] = []
+    for symbol in sorted(both):
+        base = baseline_pnl[symbol]
+        live = live_pnl[symbol]
+        entries.append(
+            {
+                "symbol": symbol,
+                "baseline_pnl_pct": base,
+                "live_pnl_pct": live,
+                "delta_pp": round(live - base, 6),
+            }
+        )
+    return {
+        "entries": entries,
+        "summary": {
+            "symbols_compared": len(both),
+            "symbols_baseline_only": len(baseline_keys - live_keys),
+            "symbols_live_only": len(live_keys - baseline_keys),
+        },
+    }
+
+
+def _baseline_indices(market_snapshot: Any) -> dict[str, Any] | None:
+    """Return the frozen ``baseline.indices`` dict (keyed by index symbol), or
+    ``None`` when the snapshot is the ``unavailable`` shape or lacks indices."""
+    if not isinstance(market_snapshot, Mapping):
+        return None
+    if market_snapshot.get("status") == "unavailable":
+        return None
+    baseline = market_snapshot.get("baseline")
+    if not isinstance(baseline, Mapping):
+        return None
+    indices = baseline.get("indices")
+    if not isinstance(indices, Mapping):
+        return None
+    return dict(indices)
+
+
+def _index_delta(
+    baseline_indices: Mapping[str, Any],
+    market_index_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Live index value vs frozen baseline value, per index symbol. ``change_pct``
+    is computed only when both values are finite and baseline != 0; otherwise it is
+    ``null`` (never fabricated). Indices absent from the live response carry a
+    ``null`` ``live_value``."""
+    live_by_symbol: dict[str, Any] = {}
+    for index in market_index_result.get("indices") or []:
+        symbol = index.get("symbol")
+        if symbol is not None:
+            live_by_symbol[str(symbol)] = index.get("current")
+    entries: list[dict[str, Any]] = []
+    for symbol, baseline in baseline_indices.items():
+        baseline_value = (
+            baseline.get("current") if isinstance(baseline, Mapping) else None
+        )
+        live_value = live_by_symbol.get(symbol)
+        change_pct: float | None = None
+        if (
+            _is_finite_number(baseline_value)
+            and _is_finite_number(live_value)
+            and baseline_value != 0
+        ):
+            change_pct = (live_value - baseline_value) / baseline_value * 100
+        entries.append(
+            {
+                "index_symbol": symbol,
+                "baseline_value": baseline_value,
+                "live_value": live_value,
+                "change_pct": change_pct,
+            }
+        )
+    return {"entries": entries}
+
+
+def _reason(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+class DeltaService:
+    """Orchestrates the three read-only deltas. I/O is injectable so the logic is
+    unit-testable without a DB or live network. Defaults wire the real loaders/tools."""
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        baseline_loader: Callable[[UUID], Awaitable[dict[str, Any] | None]]
+        | None = None,
+        journal_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        holdings_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        market_index_fn: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._session = session
+        self._baseline_loader = baseline_loader
+        self._journal_fn = journal_fn
+        self._holdings_fn = holdings_fn
+        self._market_index_fn = market_index_fn
+
+    async def compute_delta(
+        self,
+        report_uuid: UUID | str,
+        *,
+        near_pct: float = 1.0,
+        account_type: str = "live",
+        computed_at_kst: str | None = None,
+    ) -> dict[str, Any]:
+        parsed = (
+            report_uuid if isinstance(report_uuid, UUID) else UUID(str(report_uuid))
+        )
+        loader = self._baseline_loader or self._default_baseline_loader
+        baseline = await loader(parsed)
+        if baseline is None:
+            return {"success": False, "error": "baseline_not_found"}
+
+        market = baseline["market"]
+        symbols = baseline["symbols"]
+        market_snapshot = baseline["market_snapshot"]
+        baseline_pnl = baseline["baseline_pnl"]
+        unavailable: dict[str, str] = {}
+
+        levels_delta: dict[str, Any] | None = None
+        try:
+            journal_fn = self._journal_fn or _default_journal_fn
+            journal_result = await journal_fn(account_type=account_type, market=market)
+            levels_delta = _levels_delta(journal_result, symbols, near_pct=near_pct)
+        except Exception as exc:  # noqa: BLE001 — fail-open per signal
+            logger.info("levels_delta failed: %r", exc)
+            unavailable["levels"] = _reason(exc)
+
+        holdings_pnl_delta: dict[str, Any] | None = None
+        if baseline_pnl is None:
+            unavailable["holdings"] = "baseline_snapshot_absent"
+        else:
+            try:
+                holdings_fn = self._holdings_fn or _default_holdings_fn
+                holdings_result = await holdings_fn(market=market)
+                holdings_pnl_delta = _holdings_pnl_delta(baseline_pnl, holdings_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("holdings_pnl_delta failed: %r", exc)
+                unavailable["holdings"] = _reason(exc)
+
+        index_delta: dict[str, Any] | None = None
+        baseline_indices = _baseline_indices(market_snapshot)
+        if baseline_indices is None:
+            unavailable["index"] = "baseline_snapshot_absent"
+        else:
+            try:
+                market_index_fn = self._market_index_fn or _default_market_index_fn
+                index_result = await market_index_fn()
+                index_delta = _index_delta(baseline_indices, index_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("index_delta failed: %r", exc)
+                unavailable["index"] = _reason(exc)
+
+        out: dict[str, Any] = {
+            "success": True,
+            "baseline_report_uuid": str(parsed),
+            "market": market,
+            "levels_delta": levels_delta,
+            "holdings_pnl_delta": holdings_pnl_delta,
+            "index_delta": index_delta,
+        }
+        if computed_at_kst is not None:
+            out["computed_at_kst"] = computed_at_kst
+        if unavailable:
+            out["unavailable"] = unavailable
+        return out
+
+    async def _default_baseline_loader(
+        self, report_uuid: UUID
+    ) -> dict[str, Any] | None:
+        from app.services.investment_reports.query_service import (
+            InvestmentReportQueryService,
+        )
+        from app.services.investment_snapshots.repository import (
+            InvestmentSnapshotsRepository,
+        )
+
+        query_service = InvestmentReportQueryService(self._session)
+        bundle = await query_service.get_bundle(report_uuid)
+        if bundle is None:
+            return None
+        report = bundle["report"]
+        symbols = {
+            item.symbol
+            for item in (bundle.get("items") or [])
+            if getattr(item, "symbol", None)
+        }
+        baseline_pnl: dict[str, float] | None = None
+        bundle_uuid = getattr(report, "snapshot_bundle_uuid", None)
+        if bundle_uuid is not None:
+            snapshots_repo = InvestmentSnapshotsRepository(self._session)
+            snapshot_bundle = await snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+            if snapshot_bundle is not None:
+                pairs = await snapshots_repo.list_bundle_items_with_snapshots(
+                    snapshot_bundle.id
+                )
+                baseline_pnl = _baseline_pnl_from_bundle_pairs(pairs)
+        return {
+            "market": report.market,
+            "symbols": symbols,
+            "market_snapshot": report.market_snapshot or {},
+            "baseline_pnl": baseline_pnl,
+        }
+
+
+async def _default_journal_fn(*, account_type: str, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.trade_journal_tools import get_trade_journal
+
+    return await get_trade_journal(
+        enrich_live=True, account_type=account_type, market=market
+    )
+
+
+async def _default_holdings_fn(*, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+
+    return await _get_holdings_impl(market=market, include_current_price=True)
+
+
+async def _default_market_index_fn() -> dict[str, Any]:
+    from app.mcp_server.tooling.fundamentals._market_index import (
+        handle_get_market_index,
+    )
+
+    return await handle_get_market_index()

--- a/docs/superpowers/plans/2026-06-01-rob-376-report-delta.md
+++ b/docs/superpowers/plans/2026-06-01-rob-376-report-delta.md
@@ -1,0 +1,1084 @@
+# investment_report_delta_get Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only MCP tool `investment_report_delta_get` that, given a baseline report, returns three deterministic intraday deltas — target/stop touch, per-symbol holdings P/L delta, and index delta — for Hermes to pull and compose.
+
+**Architecture:** A pure-function transform layer (no I/O) plus a thin `DeltaService` orchestrator that loads the baseline (report row + snapshot-bundle portfolio payload) and calls three injectable live-data fns. Every signal is computed in its own try/except (fail-open). No DB writes, no broker/watch mutation, no migration, no in-process LLM.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, FastMCP tool registration, pytest. Reuses existing tools: `get_trade_journal(enrich_live=True)`, `_get_holdings_impl`, `handle_get_market_index`, `InvestmentReportQueryService.get_bundle`, `InvestmentSnapshotsRepository`.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md`
+
+---
+
+## File Structure
+
+- **Create** `app/services/investment_reports/delta_service.py` — pure helpers
+  (`_levels_delta`, `_holdings_pnl_delta`, `_baseline_pnl_from_bundle_pairs`, `_index_delta`,
+  `_baseline_indices`), the `DeltaService` orchestrator, and module-level default I/O fns.
+- **Modify** `app/mcp_server/tooling/investment_reports_handlers.py` — add
+  `investment_report_delta_get_impl`, register it, add its name to
+  `INVESTMENT_REPORT_TOOL_NAMES` and `__all__`.
+- **Create** `tests/services/investment_reports/test_delta_service.py` — pure-helper unit tests
+  + orchestrator tests with injected fakes (no DB).
+- **Create** `tests/services/investment_reports/test_delta_service_db.py` — one DB-integration
+  test for the default baseline loader (seeds a report row only) + `baseline_not_found`.
+- **Create** `tests/mcp_server/test_investment_report_delta_tool.py` — handler + registration test.
+
+### Key data shapes (verified against current code)
+
+- `get_trade_journal(enrich_live=True, account_type=..., market=...)` →
+  `{"success": True, "entries": [{"symbol", "side", "target_price", "stop_loss",
+  "current_price", "pnl_pct_live", "target_reached", "stop_reached", ...}], "summary": {...}}`.
+- `_get_holdings_impl(market=..., include_current_price=True)` →
+  `{"accounts": [{"positions": [{"symbol", "profit_rate", ...}]}], ...}`.
+- `handle_get_market_index()` (no symbol) → `{"indices": [{"symbol", "current", "change_pct", ...}]}`.
+- Report row `market_snapshot` = `{"provenance": {...}, "baseline": {"market", "from_date",
+  "to_date", "indices": {"<sym>": {"change_percent", "name", "current"}}}}`
+  **or** `{"status": "unavailable", "reason": ...}`.
+- Snapshot-bundle `portfolio` payload `holdings[]` entries carry `ticker` + `pnl_rate`.
+- `InvestmentReportQueryService.get_bundle(uuid)` → `{"report", "items", ...}` or `None`;
+  `report.snapshot_bundle_uuid`, `report.market`, `report.market_snapshot`; each item has `.symbol`.
+- `InvestmentSnapshotsRepository.get_bundle_by_uuid(uuid)` → bundle row (has `.id`) or `None`;
+  `.list_bundle_items_with_snapshots(bundle_id)` → `[(item, snapshot), ...]`, each `snapshot`
+  has `.snapshot_kind` and `.payload_json`.
+
+---
+
+## Task 1: Pure helper `_levels_delta`
+
+**Files:**
+- Create: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_delta_service.py
+from __future__ import annotations
+
+from app.services.investment_reports.delta_service import _levels_delta
+
+
+def test_levels_delta_filters_to_symbols_and_projects_flags():
+    journal = {
+        "entries": [
+            {"symbol": "AAPL", "side": "buy", "target_price": 230.0, "stop_loss": 200.0,
+             "current_price": 231.0, "pnl_pct_live": 4.1,
+             "target_reached": True, "stop_reached": False},
+            {"symbol": "MSFT", "side": "buy", "target_price": 500.0, "stop_loss": 400.0,
+             "current_price": 401.0, "pnl_pct_live": -1.0,
+             "target_reached": False, "stop_reached": False},
+            {"symbol": "ZZZZ", "side": "buy", "target_price": 1.0, "stop_loss": 0.5,
+             "current_price": 0.9, "pnl_pct_live": 0.0,
+             "target_reached": False, "stop_reached": False},
+        ]
+    }
+    out = _levels_delta(journal, {"AAPL", "MSFT"}, near_pct=1.0)
+    syms = [e["symbol"] for e in out["entries"]]
+    assert syms == ["AAPL", "MSFT"]  # ZZZZ filtered out
+    aapl = out["entries"][0]
+    assert aapl["target_reached"] is True
+    assert aapl["pnl_pct_live"] == 4.1
+    # MSFT current 401 is within 1% of stop 400 -> near_stop True
+    msft = out["entries"][1]
+    assert msft["near_stop"] is True
+    assert msft["near_target"] is False
+    assert out["summary"] == {
+        "near_target": 0, "near_stop": 1, "target_hit": 1, "stop_hit": 0
+    }
+
+
+def test_levels_delta_empty_symbols_keeps_all_entries():
+    journal = {"entries": [
+        {"symbol": "AAPL", "side": "buy", "target_price": None, "stop_loss": None,
+         "current_price": 10.0, "pnl_pct_live": 1.0,
+         "target_reached": None, "stop_reached": None},
+    ]}
+    out = _levels_delta(journal, set(), near_pct=1.0)
+    assert [e["symbol"] for e in out["entries"]] == ["AAPL"]
+    assert out["entries"][0]["near_target"] is False  # no target -> not near
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `ImportError` / `cannot import name '_levels_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/investment_reports/delta_service.py
+"""ROB-376 — read-only intraday delta computation for investment reports.
+
+Deterministic baseline-vs-live deltas (target/stop touch, per-symbol holdings P/L,
+index move) for the next/intraday report. No DB writes, no broker/watch mutation,
+no in-process LLM. Every signal is fail-open: one signal's failure never kills the
+others.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _near(current: Any, level: Any, near_pct: float) -> bool:
+    """True when ``current`` is within ``near_pct`` percent of ``level``."""
+    if not _is_finite_number(current) or not _is_finite_number(level) or level == 0:
+        return False
+    return abs(current - level) / abs(level) * 100 <= near_pct
+
+
+def _levels_delta(
+    journal_result: Mapping[str, Any],
+    symbols: set[str],
+    *,
+    near_pct: float,
+) -> dict[str, Any]:
+    """Project the journal's already-computed live enrichment into a delta block.
+
+    Reuses ``target_reached`` / ``stop_reached`` / ``pnl_pct_live`` (computed by
+    ``get_trade_journal(enrich_live=True)``); computes per-entry ``near_*`` flags
+    here. When ``symbols`` is empty, all entries are kept.
+    """
+    entries: list[dict[str, Any]] = []
+    near_target = near_stop = target_hit = stop_hit = 0
+    for entry in journal_result.get("entries") or []:
+        symbol = entry.get("symbol")
+        if symbols and symbol not in symbols:
+            continue
+        current = entry.get("current_price")
+        target = entry.get("target_price")
+        stop = entry.get("stop_loss")
+        is_near_target = _near(current, target, near_pct)
+        is_near_stop = _near(current, stop, near_pct)
+        is_target_reached = bool(entry.get("target_reached"))
+        is_stop_reached = bool(entry.get("stop_reached"))
+        near_target += int(is_near_target)
+        near_stop += int(is_near_stop)
+        target_hit += int(is_target_reached)
+        stop_hit += int(is_stop_reached)
+        entries.append({
+            "symbol": symbol,
+            "side": entry.get("side"),
+            "target_price": target,
+            "stop_loss": stop,
+            "current_price": current,
+            "pnl_pct_live": entry.get("pnl_pct_live"),
+            "target_reached": entry.get("target_reached"),
+            "stop_reached": entry.get("stop_reached"),
+            "near_target": is_near_target,
+            "near_stop": is_near_stop,
+        })
+    return {
+        "entries": entries,
+        "summary": {
+            "near_target": near_target,
+            "near_stop": near_stop,
+            "target_hit": target_hit,
+            "stop_hit": stop_hit,
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): _levels_delta pure helper for report delta tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: Pure helpers `_holdings_pnl_delta` + `_baseline_pnl_from_bundle_pairs`
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+import types
+
+from app.services.investment_reports.delta_service import (
+    _baseline_pnl_from_bundle_pairs,
+    _holdings_pnl_delta,
+)
+
+
+def _snap(kind, payload):
+    return types.SimpleNamespace(snapshot_kind=kind, payload_json=payload)
+
+
+def test_baseline_pnl_from_bundle_pairs_reads_portfolio_holdings():
+    pairs = [
+        (object(), _snap("market", {"indices": {}})),
+        (object(), _snap("portfolio", {"holdings": [
+            {"ticker": "AAPL", "pnl_rate": 1.0},
+            {"ticker": "MSFT", "pnl_rate": -2.0},
+            {"ticker": "NOPNL"},  # missing pnl_rate -> skipped, not fabricated
+        ]})),
+    ]
+    assert _baseline_pnl_from_bundle_pairs(pairs) == {"AAPL": 1.0, "MSFT": -2.0}
+
+
+def test_baseline_pnl_from_bundle_pairs_none_when_no_portfolio_kind():
+    pairs = [(object(), _snap("market", {"indices": {}}))]
+    assert _baseline_pnl_from_bundle_pairs(pairs) is None
+
+
+def test_holdings_pnl_delta_joins_baseline_and_live_missing_not_zero():
+    baseline = {"AAPL": 1.0, "MSFT": -2.0, "ONLYBASE": 5.0}
+    live = {
+        "accounts": [
+            {"positions": [
+                {"symbol": "AAPL", "profit_rate": 4.1},
+                {"symbol": "MSFT", "profit_rate": -1.0},
+                {"symbol": "ONLYLIVE", "profit_rate": 9.0},
+                {"symbol": "NORATE"},  # missing profit_rate -> skipped
+            ]},
+        ]
+    }
+    out = _holdings_pnl_delta(baseline, live)
+    by_symbol = {e["symbol"]: e for e in out["entries"]}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # only symbols in BOTH
+    assert by_symbol["AAPL"]["delta_pp"] == 3.1
+    assert by_symbol["MSFT"]["delta_pp"] == 1.0
+    assert out["summary"] == {
+        "symbols_compared": 2, "symbols_baseline_only": 1, "symbols_live_only": 1
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name '_holdings_pnl_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+
+def _baseline_pnl_from_bundle_pairs(
+    pairs: list[tuple[Any, Any]],
+) -> dict[str, float] | None:
+    """Extract ``{ticker: pnl_rate}`` from the bundle's ``portfolio`` snapshot.
+
+    Returns ``None`` when no ``portfolio`` snapshot is present (so the caller can
+    record ``baseline_snapshot_absent`` rather than fabricating an empty baseline).
+    Holdings without a finite ``pnl_rate`` are skipped (missing != zero).
+    """
+    for _item, snapshot in pairs:
+        if getattr(snapshot, "snapshot_kind", None) != "portfolio":
+            continue
+        payload = getattr(snapshot, "payload_json", None) or {}
+        out: dict[str, float] = {}
+        for holding in payload.get("holdings") or []:
+            ticker = holding.get("ticker")
+            rate = holding.get("pnl_rate")
+            if ticker is not None and _is_finite_number(rate):
+                out[str(ticker)] = float(rate)
+        return out
+    return None
+
+
+def _live_pnl_by_symbol(holdings_result: Mapping[str, Any]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for account in holdings_result.get("accounts") or []:
+        for position in account.get("positions") or []:
+            symbol = position.get("symbol")
+            rate = position.get("profit_rate")
+            if symbol is not None and _is_finite_number(rate):
+                out[str(symbol)] = float(rate)
+    return out
+
+
+def _holdings_pnl_delta(
+    baseline_pnl: Mapping[str, float],
+    holdings_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Per-symbol live P/L vs baseline P/L. Only symbols present on BOTH sides get
+    an entry (missing != zero); one-sided symbols are counted in the summary."""
+    live_pnl = _live_pnl_by_symbol(holdings_result)
+    baseline_keys = set(baseline_pnl)
+    live_keys = set(live_pnl)
+    both = baseline_keys & live_keys
+    entries: list[dict[str, Any]] = []
+    for symbol in sorted(both):
+        base = baseline_pnl[symbol]
+        live = live_pnl[symbol]
+        entries.append({
+            "symbol": symbol,
+            "baseline_pnl_pct": base,
+            "live_pnl_pct": live,
+            "delta_pp": live - base,
+        })
+    return {
+        "entries": entries,
+        "summary": {
+            "symbols_compared": len(both),
+            "symbols_baseline_only": len(baseline_keys - live_keys),
+            "symbols_live_only": len(live_keys - baseline_keys),
+        },
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (5 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): holdings P/L delta helpers (bundle baseline vs live)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: Pure helpers `_index_delta` + `_baseline_indices`
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+from app.services.investment_reports.delta_service import (
+    _baseline_indices,
+    _index_delta,
+)
+
+
+def test_baseline_indices_extracts_dict_or_none():
+    ok = {"provenance": {}, "baseline": {"indices": {"^GSPC": {"current": 5500.0}}}}
+    assert _baseline_indices(ok) == {"^GSPC": {"current": 5500.0}}
+    assert _baseline_indices({"status": "unavailable", "reason": "x"}) is None
+    assert _baseline_indices({"baseline": {}}) is None  # no indices key
+    assert _baseline_indices({}) is None
+
+
+def test_index_delta_change_pct_and_null_guards():
+    baseline = {
+        "^GSPC": {"current": 5500.0},
+        "^VIX": {"current": 0.0},      # baseline 0 -> change_pct null, no div-by-zero
+        "MISSINGLIVE": {"current": 100.0},
+    }
+    live = {"indices": [
+        {"symbol": "^GSPC", "current": 5533.0},
+        {"symbol": "^VIX", "current": 15.0},
+        # MISSINGLIVE absent from live
+    ]}
+    out = _index_delta(baseline, live)
+    by_symbol = {e["index_symbol"]: e for e in out["entries"]}
+    assert round(by_symbol["^GSPC"]["change_pct"], 4) == 0.6
+    assert by_symbol["^VIX"]["change_pct"] is None     # baseline 0 -> null
+    assert by_symbol["MISSINGLIVE"]["live_value"] is None
+    assert by_symbol["MISSINGLIVE"]["change_pct"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name '_index_delta'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+
+def _baseline_indices(market_snapshot: Any) -> dict[str, Any] | None:
+    """Return the frozen ``baseline.indices`` dict (keyed by index symbol), or
+    ``None`` when the snapshot is the ``unavailable`` shape or lacks indices."""
+    if not isinstance(market_snapshot, Mapping):
+        return None
+    if market_snapshot.get("status") == "unavailable":
+        return None
+    baseline = market_snapshot.get("baseline")
+    if not isinstance(baseline, Mapping):
+        return None
+    indices = baseline.get("indices")
+    if not isinstance(indices, Mapping):
+        return None
+    return dict(indices)
+
+
+def _index_delta(
+    baseline_indices: Mapping[str, Any],
+    market_index_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Live index value vs frozen baseline value, per index symbol. ``change_pct``
+    is computed only when both values are finite and baseline != 0; otherwise it is
+    ``null`` (never fabricated). Indices absent from the live response carry a
+    ``null`` ``live_value``."""
+    live_by_symbol: dict[str, Any] = {}
+    for index in market_index_result.get("indices") or []:
+        symbol = index.get("symbol")
+        if symbol is not None:
+            live_by_symbol[str(symbol)] = index.get("current")
+    entries: list[dict[str, Any]] = []
+    for symbol, baseline in baseline_indices.items():
+        baseline_value = baseline.get("current") if isinstance(baseline, Mapping) else None
+        live_value = live_by_symbol.get(symbol)
+        change_pct: float | None = None
+        if (
+            _is_finite_number(baseline_value)
+            and _is_finite_number(live_value)
+            and baseline_value != 0
+        ):
+            change_pct = (live_value - baseline_value) / baseline_value * 100
+        entries.append({
+            "index_symbol": symbol,
+            "baseline_value": baseline_value,
+            "live_value": live_value,
+            "change_pct": change_pct,
+        })
+    return {"entries": entries}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): index delta helpers (frozen baseline vs live, null guards)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 4: `DeltaService.compute_delta` orchestrator (injected fakes)
+
+**Files:**
+- Modify: `app/services/investment_reports/delta_service.py`
+- Test: `tests/services/investment_reports/test_delta_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/services/investment_reports/test_delta_service.py
+import pytest
+
+from app.services.investment_reports.delta_service import DeltaService
+
+
+def _baseline(*, market="us", symbols=None, market_snapshot=None, baseline_pnl=None):
+    return {
+        "market": market,
+        "symbols": symbols if symbols is not None else {"AAPL"},
+        "market_snapshot": market_snapshot if market_snapshot is not None
+        else {"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        "baseline_pnl": baseline_pnl if baseline_pnl is not None else {"AAPL": 1.0},
+    }
+
+
+def _service(*, baseline, journal=None, holdings=None, index=None):
+    async def loader(_uuid):
+        return baseline
+
+    async def journal_fn(*, account_type, market):
+        if journal is None:
+            raise RuntimeError("journal boom")
+        return journal
+
+    async def holdings_fn(*, market):
+        if holdings is None:
+            raise RuntimeError("holdings boom")
+        return holdings
+
+    async def index_fn():
+        if index is None:
+            raise RuntimeError("index boom")
+        return index
+
+    return DeltaService(
+        session=None,
+        baseline_loader=loader,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_happy_path_all_three():
+    svc = _service(
+        baseline=_baseline(),
+        journal={"entries": [{"symbol": "AAPL", "side": "buy", "target_price": 230.0,
+                              "stop_loss": 200.0, "current_price": 231.0,
+                              "pnl_pct_live": 4.1, "target_reached": True,
+                              "stop_reached": False}]},
+        holdings={"accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 4.1}]}]},
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta(
+        "11111111-1111-1111-1111-111111111111", computed_at_kst="2026-06-01T13:00:00+09:00"
+    )
+    assert out["success"] is True
+    assert out["market"] == "us"
+    assert out["computed_at_kst"] == "2026-06-01T13:00:00+09:00"
+    assert out["levels_delta"]["summary"]["target_hit"] == 1
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 3.1
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+    assert "unavailable" not in out
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_fail_open_isolates_each_signal():
+    # journal raises; holdings + index still populate
+    svc = _service(
+        baseline=_baseline(),
+        journal=None,  # -> RuntimeError
+        holdings={"accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 2.0}]}]},
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["levels_delta"] is None
+    assert out["unavailable"]["levels"]  # reason string present
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 1.0
+    assert out["index_delta"]["entries"][0]["live_value"] == 5533.0
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_absent_marks_unavailable():
+    svc = _service(
+        baseline=_baseline(
+            market_snapshot={"status": "unavailable", "reason": "not_collected"},
+            baseline_pnl=None,
+        ),
+        journal={"entries": []},
+        holdings={"accounts": []},
+        index={"indices": []},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    assert out["index_delta"] is None
+    assert out["unavailable"]["index"] == "baseline_snapshot_absent"
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_not_found():
+    async def loader(_uuid):
+        return None
+
+    svc = DeltaService(session=None, baseline_loader=loader)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: FAIL with `cannot import name 'DeltaService'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to app/services/investment_reports/delta_service.py
+import logging
+from collections.abc import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def _reason(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}"
+
+
+class DeltaService:
+    """Orchestrates the three read-only deltas. I/O is injectable so the logic is
+    unit-testable without a DB or live network. Defaults wire the real loaders/tools."""
+
+    def __init__(
+        self,
+        session: Any,
+        *,
+        baseline_loader: Callable[[UUID], Awaitable[dict[str, Any] | None]] | None = None,
+        journal_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        holdings_fn: Callable[..., Awaitable[dict[str, Any]]] | None = None,
+        market_index_fn: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._session = session
+        self._baseline_loader = baseline_loader
+        self._journal_fn = journal_fn
+        self._holdings_fn = holdings_fn
+        self._market_index_fn = market_index_fn
+
+    async def compute_delta(
+        self,
+        report_uuid: UUID | str,
+        *,
+        near_pct: float = 1.0,
+        account_type: str = "live",
+        computed_at_kst: str | None = None,
+    ) -> dict[str, Any]:
+        parsed = report_uuid if isinstance(report_uuid, UUID) else UUID(str(report_uuid))
+        loader = self._baseline_loader or self._default_baseline_loader
+        baseline = await loader(parsed)
+        if baseline is None:
+            return {"success": False, "error": "baseline_not_found"}
+
+        market = baseline["market"]
+        symbols = baseline["symbols"]
+        market_snapshot = baseline["market_snapshot"]
+        baseline_pnl = baseline["baseline_pnl"]
+        unavailable: dict[str, str] = {}
+
+        levels_delta: dict[str, Any] | None = None
+        try:
+            journal_fn = self._journal_fn or _default_journal_fn
+            journal_result = await journal_fn(account_type=account_type, market=market)
+            levels_delta = _levels_delta(journal_result, symbols, near_pct=near_pct)
+        except Exception as exc:  # noqa: BLE001 — fail-open per signal
+            logger.info("levels_delta failed: %r", exc)
+            unavailable["levels"] = _reason(exc)
+
+        holdings_pnl_delta: dict[str, Any] | None = None
+        if baseline_pnl is None:
+            unavailable["holdings"] = "baseline_snapshot_absent"
+        else:
+            try:
+                holdings_fn = self._holdings_fn or _default_holdings_fn
+                holdings_result = await holdings_fn(market=market)
+                holdings_pnl_delta = _holdings_pnl_delta(baseline_pnl, holdings_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("holdings_pnl_delta failed: %r", exc)
+                unavailable["holdings"] = _reason(exc)
+
+        index_delta: dict[str, Any] | None = None
+        baseline_indices = _baseline_indices(market_snapshot)
+        if baseline_indices is None:
+            unavailable["index"] = "baseline_snapshot_absent"
+        else:
+            try:
+                market_index_fn = self._market_index_fn or _default_market_index_fn
+                index_result = await market_index_fn()
+                index_delta = _index_delta(baseline_indices, index_result)
+            except Exception as exc:  # noqa: BLE001 — fail-open per signal
+                logger.info("index_delta failed: %r", exc)
+                unavailable["index"] = _reason(exc)
+
+        out: dict[str, Any] = {
+            "success": True,
+            "baseline_report_uuid": str(parsed),
+            "market": market,
+            "levels_delta": levels_delta,
+            "holdings_pnl_delta": holdings_pnl_delta,
+            "index_delta": index_delta,
+        }
+        if computed_at_kst is not None:
+            out["computed_at_kst"] = computed_at_kst
+        if unavailable:
+            out["unavailable"] = unavailable
+        return out
+
+    async def _default_baseline_loader(self, report_uuid: UUID) -> dict[str, Any] | None:
+        from app.services.investment_reports.query_service import (
+            InvestmentReportQueryService,
+        )
+        from app.services.investment_snapshots.repository import (
+            InvestmentSnapshotsRepository,
+        )
+
+        query_service = InvestmentReportQueryService(self._session)
+        bundle = await query_service.get_bundle(report_uuid)
+        if bundle is None:
+            return None
+        report = bundle["report"]
+        symbols = {
+            item.symbol
+            for item in (bundle.get("items") or [])
+            if getattr(item, "symbol", None)
+        }
+        baseline_pnl: dict[str, float] | None = None
+        bundle_uuid = getattr(report, "snapshot_bundle_uuid", None)
+        if bundle_uuid is not None:
+            snapshots_repo = InvestmentSnapshotsRepository(self._session)
+            snapshot_bundle = await snapshots_repo.get_bundle_by_uuid(bundle_uuid)
+            if snapshot_bundle is not None:
+                pairs = await snapshots_repo.list_bundle_items_with_snapshots(
+                    snapshot_bundle.id
+                )
+                baseline_pnl = _baseline_pnl_from_bundle_pairs(pairs)
+        return {
+            "market": report.market,
+            "symbols": symbols,
+            "market_snapshot": report.market_snapshot or {},
+            "baseline_pnl": baseline_pnl,
+        }
+
+
+async def _default_journal_fn(*, account_type: str, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.trade_journal_tools import get_trade_journal
+
+    return await get_trade_journal(
+        enrich_live=True, account_type=account_type, market=market
+    )
+
+
+async def _default_holdings_fn(*, market: str) -> dict[str, Any]:
+    from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+
+    return await _get_holdings_impl(market=market, include_current_price=True)
+
+
+async def _default_market_index_fn() -> dict[str, Any]:
+    from app.mcp_server.tooling.fundamentals._market_index import (
+        handle_get_market_index,
+    )
+
+    return await handle_get_market_index()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service.py -q`
+Expected: PASS (11 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/delta_service.py tests/services/investment_reports/test_delta_service.py
+git commit -m "feat(ROB-376): DeltaService orchestrator with injectable I/O + fail-open
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 5: DB-integration test for the default baseline loader
+
+**Files:**
+- Test: `tests/services/investment_reports/test_delta_service_db.py`
+
+This exercises the real `_default_baseline_loader` against a seeded report row (no bundle),
+verifying market/symbols extraction, `baseline_pnl=None` when no bundle, and `baseline_not_found`.
+Per the ROB-375 follow-up, investment-report DB tests serialize under the cleanup-lock fixture to
+avoid the xdist shared-Postgres deadlock.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_delta_service_db.py
+"""ROB-376 — default baseline loader against a seeded report row (no bundle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.delta_service import DeltaService
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+
+@pytest.mark.asyncio
+async def test_default_loader_reads_report_market_and_marks_pnl_absent(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await repo.insert_report(
+        idempotency_key="rob376:delta:1",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="baseline",
+        summary="s",
+        status="published",
+        report_metadata={},
+        market_snapshot={"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        portfolio_snapshot={},
+    )
+    await session.commit()
+
+    # Inject only the live fns so no network is hit; loader is the real default.
+    async def journal_fn(*, account_type, market):
+        return {"entries": []}
+
+    async def holdings_fn(*, market):
+        return {"accounts": []}
+
+    async def index_fn():
+        return {"indices": [{"symbol": "^GSPC", "current": 5533.0}]}
+
+    svc = DeltaService(
+        session=session,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+    out = await svc.compute_delta(report.report_uuid)
+    assert out["success"] is True
+    assert out["market"] == "us"
+    # No snapshot_bundle_uuid on the seeded row -> per-symbol P/L baseline absent.
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    # Index baseline IS present on the row -> index delta computed.
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+
+
+@pytest.mark.asyncio
+async def test_default_loader_baseline_not_found(session: AsyncSession) -> None:
+    svc = DeltaService(session=session)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_delta_service_db.py -q`
+Expected: PASS (2 passed) — the implementation from Task 4 already supports this. If the
+`session` fixture or `investment_reports_cleanup_lock` fixture name differs, check
+`tests/conftest.py` and adjust the import/fixture name. (Both are confirmed present in
+`tests/conftest.py`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/investment_reports/test_delta_service_db.py
+git commit -m "test(ROB-376): DB-integration test for default delta baseline loader
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 6: MCP handler + registration
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` (add impl ~after line 448;
+  register in `register_investment_report_tools` ~line 760; add name to
+  `INVESTMENT_REPORT_TOOL_NAMES` line 50-58 and to `__all__` line 766+)
+- Test: `tests/mcp_server/test_investment_report_delta_tool.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_investment_report_delta_tool.py
+"""ROB-376 — investment_report_delta_get handler + registration."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.mcp_server.tooling.investment_reports_handlers as handlers
+
+
+def test_delta_tool_name_registered():
+    assert "investment_report_delta_get" in handlers.INVESTMENT_REPORT_TOOL_NAMES
+
+
+def test_register_investment_report_tools_includes_delta():
+    registered: list[str] = []
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            registered.append(name)
+            return lambda fn: fn
+
+    handlers.register_investment_report_tools(_FakeMCP())
+    assert "investment_report_delta_get" in registered
+
+
+@pytest.mark.asyncio
+async def test_delta_impl_invalid_uuid_returns_error():
+    out = await handlers.investment_report_delta_get_impl(report_uuid="not-a-uuid")
+    assert out == {"success": False, "error": "invalid_report_uuid"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_investment_report_delta_tool.py -q`
+Expected: FAIL — `investment_report_delta_get` not in the name set / no
+`investment_report_delta_get_impl` attribute.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/mcp_server/tooling/investment_reports_handlers.py`:
+
+(3a) Add the name to the set (line 50-58):
+
+```python
+INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
+    "investment_report_create",
+    "investment_report_list",
+    "investment_report_get",
+    "investment_report_decide_item",
+    "investment_report_activate_watch",
+    "investment_report_context_get",
+    "investment_report_delta_get",
+    "investment_report_generate_from_bundle",
+}
+```
+
+(3b) Add the handler (immediately after `investment_report_context_get_impl`, ~line 449).
+`now_kst` is the project KST clock used elsewhere in the tooling layer:
+
+```python
+# ---------------------------------------------------------------------------
+# investment_report_delta_get (ROB-376)
+# ---------------------------------------------------------------------------
+async def investment_report_delta_get_impl(
+    report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict:
+    from app.core.timezone import now_kst
+    from app.services.investment_reports.delta_service import DeltaService
+
+    try:
+        parsed = UUID(report_uuid)
+    except (ValueError, AttributeError, TypeError):
+        return {"success": False, "error": "invalid_report_uuid"}
+
+    async with AsyncSessionLocal() as db:
+        service = DeltaService(db)
+        return await service.compute_delta(
+            parsed,
+            near_pct=near_pct,
+            account_type=account_type,
+            computed_at_kst=now_kst().isoformat(),
+        )
+```
+
+> CONFIRMED: `now_kst` lives at `app/core/timezone.py:14`; `trade_journal_tools.py:15` imports it
+> as `from app.core.timezone import now_kst`. Use exactly that import.
+
+(3c) Register it (in `register_investment_report_tools`, after the `context_get` block ~line 759):
+
+```python
+    mcp.tool(
+        name="investment_report_delta_get",
+        description=(
+            "Read-only intraday delta vs a baseline report. Given report_uuid "
+            "(the open/prior report), returns three deterministic deltas for Hermes "
+            "to compose: levels_delta (journal target/stop touch x live), "
+            "holdings_pnl_delta (per-symbol live P/L vs the baseline snapshot "
+            "bundle's portfolio P/L), and index_delta (live index vs the report's "
+            "frozen market baseline). Per-signal fail-open: a degraded signal is "
+            "null with a reason under 'unavailable'; missing data is never coerced "
+            "to zero. No broker/order/watch mutation."
+        ),
+    )(investment_report_delta_get_impl)
+```
+
+(3d) Add to `__all__` (line 766+), keeping alphabetical-ish order near the other impls:
+
+```python
+    "investment_report_delta_get_impl",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_investment_report_delta_tool.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/investment_reports_handlers.py tests/mcp_server/test_investment_report_delta_tool.py
+git commit -m "feat(ROB-376): register investment_report_delta_get MCP tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 7: Lint, format, typecheck, full-suite gate, final commit
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format + lint (exact CI commands)**
+
+Run:
+```bash
+uv run ruff format app/ tests/
+uv run ruff format --check app/ tests/
+uv run ruff check app/ tests/
+```
+Expected: `ruff format --check` reports "X files already formatted"; `ruff check` reports
+"All checks passed!". Fix any reported issue and re-run.
+
+- [ ] **Step 2: Typecheck the new module**
+
+Run: `uv run ty check app/services/investment_reports/delta_service.py`
+Expected: no errors. (If `ty` flags the injected-callable defaults, ensure the type hints match
+the `Callable[..., Awaitable[...]]` signatures above.)
+
+- [ ] **Step 3: Run the full new-test set**
+
+Run:
+```bash
+uv run pytest tests/services/investment_reports/test_delta_service.py \
+  tests/services/investment_reports/test_delta_service_db.py \
+  tests/mcp_server/test_investment_report_delta_tool.py -q
+```
+Expected: all pass (16 total).
+
+- [ ] **Step 4: Import-guard sanity (no in-process LLM / broker mutation pulled in)**
+
+Run: `uv run python -c "import app.services.investment_reports.delta_service"`
+Expected: imports cleanly with no heavy/broker/LLM side-effect (defaults import lazily inside fns).
+
+- [ ] **Step 5: Final commit (if Step 1 reformatted anything)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-376): format + lint pass for delta tool
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** levels_delta (Task 1), holdings_pnl_delta from bundle baseline (Task 2),
+  index_delta from report baseline (Task 3), orchestrator + fail-open + baseline_not_found
+  (Task 4), default loader DB path (Task 5), MCP tool surface + registration + invalid_uuid
+  (Task 6), CI gates (Task 7). All §3 contract fields and §5 error rows are covered.
+- **Non-goals honored:** no `intraday_update` policy, no screener/news signals, no new migration,
+  no persisted per-report level snapshot, MCP-only (no HTTP).
+- **Type consistency:** `_levels_delta(journal_result, symbols, *, near_pct)`,
+  `_holdings_pnl_delta(baseline_pnl, holdings_result)`,
+  `_baseline_pnl_from_bundle_pairs(pairs)`, `_index_delta(baseline_indices, market_index_result)`,
+  `_baseline_indices(market_snapshot)`, `DeltaService.compute_delta(report_uuid, *, near_pct,
+  account_type, computed_at_kst)` — names/signatures consistent across tasks and tests.
+- **All imports pinned:** `now_kst` = `app.core.timezone` (confirmed); the `session` and
+  `investment_reports_cleanup_lock` fixtures are globally registered via
+  `tests/conftest.py` `pytest_plugins = [..., "tests._investment_reports_helpers"]` (confirmed).
+  No open confirmations remain.

--- a/docs/superpowers/plans/2026-06-02-rob-376-item2-intraday-update-context.md
+++ b/docs/superpowers/plans/2026-06-02-rob-376-item2-intraday-update-context.md
@@ -1,0 +1,451 @@
+# ROB-376 item 2 — intraday_update context tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hermes가 단일 pull로 (현재 번들 context + baseline 리포트 대비 델타)를 받아 `intraday_update_v1` 리포트를 compose할 수 있도록, 신규 read-only MCP 도구 `investment_report_prepare_intraday_context`와 `HermesContextPayload`의 델타 블록 필드를 추가한다.
+
+**Architecture:** PR1의 `DeltaService.compute_delta`(델타) + 기존 `HermesContextExporter.export`(번들 context)를 결합하는 얇은 핸들러. `HermesContextPayload`에 optional `baseline_report_uuid`/`intraday_delta_block`(additive) 추가. 신호별 fail-open(델타 실패가 context를 죽이지 않음). gate=기존 `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`. migration 0, no LLM, no broker/watch mutation.
+
+**Tech Stack:** Python 3.13, Pydantic v2, FastMCP, pytest. 재사용: `HermesContextExporter`, `DeltaService`, `_disabled_check`/`_parse_bundle_uuid`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-rob-376-item2-intraday-update-context-design.md`
+
+---
+
+## File Structure
+
+- `app/schemas/hermes_composition.py` — `HermesContextPayload`에 `baseline_report_uuid`/`intraday_delta_block` optional 필드 추가.
+- `app/mcp_server/tooling/investment_hermes_handlers.py` — `INTRADAY_UPDATE_REPORT_TYPE` 상수 + `investment_report_prepare_intraday_context_impl` + 등록 + `INVESTMENT_HERMES_TOOL_NAMES` + `__all__`.
+- `tests/mcp_server/test_investment_hermes_tools.py` — tool-names set 단언 갱신 + 신규 도구 동작 테스트.
+- (신규) `tests/test_hermes_context_payload_intraday.py` — 스키마 additive 단위.
+
+---
+
+## Task 1: 스키마 additive 필드 (TDD)
+
+**Files:**
+- Create: `tests/test_hermes_context_payload_intraday.py`
+- Modify: `app/schemas/hermes_composition.py` (`HermesContextPayload`, 현 라인 88-101 필드 블록)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+새 파일 `tests/test_hermes_context_payload_intraday.py`:
+
+```python
+"""ROB-376 item 2 — HermesContextPayload intraday delta fields (additive)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.schemas.hermes_composition import HermesContextPayload
+
+
+def _minimal(**kw) -> HermesContextPayload:
+    base = dict(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        bundle_status="ready",
+        market="us",
+        policy_version="intraday_action_report_v1",
+    )
+    base.update(kw)
+    return HermesContextPayload(**base)
+
+
+def test_intraday_fields_default_none() -> None:
+    payload = _minimal()
+    assert payload.baseline_report_uuid is None
+    assert payload.intraday_delta_block is None
+    # context_version unchanged (additive, no version bump)
+    assert payload.context_version == "hermes-context.v1"
+
+
+def test_intraday_fields_roundtrip() -> None:
+    base = uuid.uuid4()
+    block = {"success": True, "levels_delta": {"summary": {"target_hit": 1}}}
+    payload = _minimal(baseline_report_uuid=base, intraday_delta_block=block)
+    dumped = payload.model_dump(mode="json")
+    assert dumped["baseline_report_uuid"] == str(base)
+    assert dumped["intraday_delta_block"] == block
+```
+
+- [ ] **Step 2: 실행 → 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-376 && uv run pytest tests/test_hermes_context_payload_intraday.py -p no:randomly -q`
+Expected: FAIL — `ValidationError` (extra="forbid"라 `baseline_report_uuid`/`intraday_delta_block` 미정의 키 거부).
+
+- [ ] **Step 3: 스키마 필드 추가**
+
+`app/schemas/hermes_composition.py`의 `HermesContextPayload`에서 `constraints: HermesContextConstraints = Field(...)` 정의(현 라인 100-102) **다음 줄**에 추가:
+
+```python
+    # ROB-376 item 2 — intraday_update report continuity. Optional/additive
+    # (no context_version bump). Populated only by the intraday context tool;
+    # the base get_hermes_context path leaves both None.
+    baseline_report_uuid: uuid.UUID | None = None
+    intraday_delta_block: dict[str, Any] | None = None
+```
+
+(`uuid`, `Any` 이미 import 되어 있음.)
+
+- [ ] **Step 4: 실행 → 통과 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-376 && uv run pytest tests/test_hermes_context_payload_intraday.py -p no:randomly -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-376
+git add app/schemas/hermes_composition.py tests/test_hermes_context_payload_intraday.py
+git commit -m "feat(ROB-376): HermesContextPayload baseline_report_uuid + intraday_delta_block (additive)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 2: intraday context 도구 (TDD)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_hermes_handlers.py`
+- Test: `tests/mcp_server/test_investment_hermes_tools.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/mcp_server/test_investment_hermes_tools.py`의 tool-names 단언(현 라인 78)에 신규 도구 추가:
+
+```python
+    assert INVESTMENT_HERMES_TOOL_NAMES == {
+        "investment_report_prepare_bundle",
+        "investment_report_get_hermes_context",
+        "investment_report_create_from_hermes_composition",
+        "investment_stage_artifacts_ingest_from_hermes",
+        "investment_report_prepare_intraday_context",
+    }
+```
+
+그리고 파일 하단에 동작 테스트 추가 (import 블록에 핸들러 추가):
+
+```python
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_disabled(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False)
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    assert out["success"] is False
+    assert out["error"] == "snapshot_backed_report_generator_disabled"
+
+
+def _fake_payload() -> object:
+    from app.schemas.hermes_composition import HermesContextPayload
+
+    return HermesContextPayload(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        bundle_status="ready",
+        market="us",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_attaches_delta(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+    base_uuid = uuid.uuid4()
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            return {"success": True, "baseline_report_uuid": str(report_uuid),
+                    "levels_delta": {"summary": {"target_hit": 1}}}
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(base_uuid),
+    )
+    assert out["success"] is True
+    assert out["report_type_hint"] == "intraday_update_v1"
+    assert out["baseline_report_uuid"] == str(base_uuid)
+    assert out["intraday_delta_block"]["success"] is True
+    assert out["intraday_delta_block"]["levels_delta"]["summary"]["target_hit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_failopen_bad_baseline(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            return {"success": False, "error": "baseline_not_found"}
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    # fail-open: context still success, delta block carries the reason
+    assert out["success"] is True
+    assert out["intraday_delta_block"]["success"] is False
+    assert out["intraday_delta_block"]["error"] == "baseline_not_found"
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_failopen_delta_raises(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    assert out["success"] is True
+    assert "unavailable" in out["intraday_delta_block"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_invalid_baseline_uuid(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid="not-a-uuid",
+    )
+    assert out["success"] is True
+    assert out["intraday_delta_block"]["error"] == "invalid_report_uuid"
+```
+
+(파일 상단 import에 `investment_report_prepare_intraday_context_impl`을 `from app.mcp_server.tooling.investment_hermes_handlers import (...)` 묶음에 추가. `uuid`/`pytest`는 기존 테스트에서 이미 import.)
+
+- [ ] **Step 2: 실행 → 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-376 && uv run pytest tests/mcp_server/test_investment_hermes_tools.py -p no:randomly -q`
+Expected: FAIL — `ImportError`(핸들러 미정의) + names-set 단언 불일치.
+
+- [ ] **Step 3: 상수 + 핸들러 구현**
+
+`app/mcp_server/tooling/investment_hermes_handlers.py`에서 `DeltaService` import를 상단에 추가 (현 import 블록):
+
+```python
+from app.services.investment_reports.delta_service import DeltaService
+```
+
+(`HermesContextExporter`는 이미 import. `settings`, `AsyncSessionLocal`, `uuid`, `Any`도 이미 import.)
+
+`INVESTMENT_HERMES_TOOL_NAMES` set(현 라인 68-73)에 추가:
+
+```python
+    "investment_report_prepare_intraday_context",
+```
+
+상수 추가 (`_DISABLED_PAYLOAD` 부근, 모듈 상단):
+
+```python
+INTRADAY_UPDATE_REPORT_TYPE = "intraday_update_v1"
+```
+
+`investment_report_get_hermes_context_impl` 함수 정의 **다음**에 신규 핸들러 추가:
+
+```python
+# ---------------------------------------------------------------------------
+# investment_report_prepare_intraday_context (ROB-376 item 2)
+# ---------------------------------------------------------------------------
+async def investment_report_prepare_intraday_context_impl(
+    snapshot_bundle_uuid: str,
+    baseline_report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict[str, Any]:
+    """Assemble an intraday_update Hermes context: the bundle's deterministic
+    context + an ``intraday_delta_block`` (report-vs-now/prior delta) keyed to
+    ``baseline_report_uuid``. Read-only; no in-process LLM; no broker / order /
+    watch / order-intent mutation. Fail-open: a delta failure leaves the rest
+    of the context intact. Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED.
+    """
+    disabled = _disabled_check()
+    if disabled is not None:
+        return disabled
+
+    parsed_bundle = _parse_bundle_uuid(snapshot_bundle_uuid)
+    if isinstance(parsed_bundle, dict):
+        return parsed_bundle
+
+    from app.core.timezone import now_kst
+
+    base_uuid: uuid.UUID | None = None
+    async with AsyncSessionLocal() as db:
+        exporter = HermesContextExporter(db)
+        try:
+            payload = await exporter.export(snapshot_bundle_uuid=parsed_bundle)
+        except HermesContextExportError as exc:
+            return {
+                "success": False,
+                "error": "snapshot_bundle_not_found",
+                "snapshot_bundle_uuid": snapshot_bundle_uuid,
+                "detail": str(exc),
+            }
+
+        # Delta is fail-open: errors ride inside intraday_delta_block, never
+        # flip the context's success.
+        try:
+            base_uuid = uuid.UUID(baseline_report_uuid)
+        except (ValueError, AttributeError, TypeError):
+            delta_block: dict[str, Any] = {
+                "success": False,
+                "error": "invalid_report_uuid",
+            }
+        else:
+            try:
+                delta_block = await DeltaService(db).compute_delta(
+                    base_uuid,
+                    near_pct=near_pct,
+                    account_type=account_type,
+                    computed_at_kst=now_kst().isoformat(),
+                )
+            except Exception as exc:  # noqa: BLE001 — fail-open
+                logger.exception("intraday delta computation failed")
+                delta_block = {"unavailable": str(exc) or exc.__class__.__name__}
+
+    # Echo baseline only when the delta actually succeeded against it.
+    payload.baseline_report_uuid = base_uuid if delta_block.get("success") else None
+    payload.intraday_delta_block = delta_block
+    return {
+        "success": True,
+        "report_type_hint": INTRADAY_UPDATE_REPORT_TYPE,
+        **payload.model_dump(mode="json"),
+    }
+```
+
+(`logger`는 hermes_handlers 모듈에 이미 정의되어 있음 — 없으면 `import logging; logger = logging.getLogger(__name__)` 추가.)
+
+- [ ] **Step 4: 등록 + __all__**
+
+`register_investment_hermes_tools`의 마지막 `mcp.tool(...)(investment_stage_artifacts_ingest_from_hermes_impl)` 다음에 추가:
+
+```python
+    mcp.tool(
+        name="investment_report_prepare_intraday_context",
+        description=(
+            "ROB-376 — assemble an intraday_update Hermes context: the bundle's "
+            "deterministic context plus an intraday_delta_block (report-vs-now / "
+            "report-vs-prior delta) keyed to baseline_report_uuid, for Hermes to "
+            "compose an intraday_update_v1 report. Read-only, fail-open on the "
+            "delta, no in-process LLM, no broker/order/watch mutation. Gated by "
+            "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_prepare_intraday_context_impl)
+```
+
+`__all__`에 `"investment_report_prepare_intraday_context_impl"` 추가.
+
+- [ ] **Step 5: 실행 → 통과 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-376 && uv run pytest tests/mcp_server/test_investment_hermes_tools.py tests/test_hermes_context_payload_intraday.py -p no:randomly -q`
+Expected: PASS (기존 hermes + 신규 5 + 스키마 2).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-376
+git add app/mcp_server/tooling/investment_hermes_handlers.py tests/mcp_server/test_investment_hermes_tools.py
+git commit -m "feat(ROB-376): investment_report_prepare_intraday_context tool (delta-backed intraday context)
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Task 3: 전체 검증 + lint
+
+**Files:** 없음 (품질 게이트만)
+
+- [ ] **Step 1: 관련 + 회귀 테스트**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-376
+uv run pytest tests/mcp_server/test_investment_hermes_tools.py tests/test_hermes_context_payload_intraday.py tests/mcp_server/test_investment_report_delta_tool.py tests/test_investment_reports_mcp.py tests/test_us_candles_sync.py::test_revision_graph_has_single_final_head -p no:randomly -q
+```
+Expected: 전부 PASS (신규 + hermes/delta 회귀 + 단일 alembic head).
+
+- [ ] **Step 2: lint (CI 게이트와 동일)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-376 && uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/`
+Expected: 둘 다 통과. (format 실패 시 `uv run ruff format app/ tests/` 후 amend.)
+
+- [ ] **Step 3: 타입 체크 + no-mutation 확인**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-376
+uv run ty check app/mcp_server/tooling/investment_hermes_handlers.py app/schemas/hermes_composition.py
+grep -nE "commit\(|insert_|update_alert|activate_watch|decide_item|\.add\(" app/mcp_server/tooling/investment_hermes_handlers.py | grep -i intraday || echo "no mutation in intraday handler"
+```
+Expected: 본 변경 신규 타입 에러 없음; intraday 핸들러에 mutation 없음.
+
+- [ ] **Step 4: 정리 커밋 (필요 시)**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-376
+git add -A && git commit -m "chore(ROB-376): lint/format item 2
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+---
+
+## Post-implementation (PR 외 수동 단계)
+
+- PR 전 사전-머지 full-CI 게이트: `ruff check app/ tests/` + GitHub Test 워크플로우 green 확인 후 머지. ⚠️ alembic 단일-head 사전 확인(최근 병렬 마이그레이션 머지로 main이 일시 two-head가 되는 사례 반복 — `uv run alembic heads`로 점검, 필요 시 `git merge origin/main` 후 재실행).
+- Linear ROB-376 댓글: item 2 완료 → PR1(델타 도구)+본 PR(intraday context 결합)로 **auto_trader 측 ROB-376 종료**; no broker/scheduler/LLM 경계 + 테스트/CI evidence. 실 Hermes intraday 합성 라운드트립은 operator-gated 후속(별도). ROB-376 Done 처리 여부는 operator 판단(레포 밖 합성 미검증).
+
+## 비범위 (재확인)
+
+- 실제 Hermes intraday 합성/푸시(레포 밖, operator-gated). report_type은 자유 문자열 규약(`intraday_update_v1`)일 뿐 enum/CHECK/migration 없음.
+- 급변주/뉴스 신규 신호(델타는 PR1의 levels/holdings_pnl/index 3신호 유지).

--- a/docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md
+++ b/docs/superpowers/specs/2026-05-31-rob-376-report-delta-design.md
@@ -1,0 +1,191 @@
+# ROB-376 PR1 — `investment_report_delta_get` (read-only 장중 델타 도구)
+
+**Status:** Design approved 2026-05-31
+**Issue:** ROB-376 (split from ROB-375). This spec covers **PR1 only** — the read-only
+delta MCP tool. The `intraday_update` report policy/type (issue item 2) is a deferred
+follow-up issue, out of scope here.
+
+## 1. Problem & context
+
+ROB-375 (a bug umbrella, all merged) fixed report **continuity** (advisory drafts now flow
+into `investment_report_context_get`, journal `enrich_live`, frozen numeric baselines).
+ROB-376 is the **feature** layer: an intraday follow-up report should automatically surface
+what changed vs the open/prior report — "무엇이 목표/손절/트리거를 터치했고, 지수·보유 P/L이
+어떻게 변했나".
+
+### Verified current state (code-checked)
+
+- `investment_report_context_get` returns `triggered_events`, `active_watches`,
+  `recent_decisions` (`app/services/investment_reports/query_service.py:262`). `triggered_events`
+  is **only** populated by the background `InvestmentWatchScanner` job
+  (`app/jobs/investment_watch_scanner.py`); advisory drafts never activate a watch, so it is
+  effectively always empty for them. This is a **side-effect-job dependency**, not a hard
+  "advisory is forbidden" guard.
+- **Correction to the issue's premise:** advisory flows are **not** code-barred from
+  `activate_watch`/`decide_item`. `decide_item` has no service guard; `activate_watch` guards
+  only on item kind/status/condition. `draft_policy` (`"exclude"` | `"advisory_only"`,
+  discriminated by `created_by_profile == "HERMES_ADVISOR"`) only selects which prior drafts
+  are returned as context — it does not gate calls. Therefore the delta must be derived from
+  baseline-snapshot-vs-live and must **not** depend on scanner/watch state.
+- `previous_report_uuid` is a **trace hint only** — no consumer computes a delta today.
+- `get_trade_journal(enrich_live=True)` (`app/mcp_server/tooling/trade_journal_tools.py:240`)
+  **already** computes per-entry `target_reached`, `stop_reached`, `pnl_pct_live`,
+  `current_price` from live quotes (ROB-375 Bug3). The delta tool **reuses** these — it does
+  not recompute level touches.
+- Reports carry frozen `market_snapshot` and `portfolio_snapshot` dicts
+  (`app/schemas/investment_reports.py:344-345`), built by
+  `generator.py::_section_snapshot_descriptors` as `{ "provenance": {...}, "baseline": {...} }`
+  (or `{ "status": "unavailable", "reason": ... }`), frozen at row-snapshot time by
+  ROB-375 Bug2. **Critical asymmetry (code-verified):**
+  - `market_snapshot["baseline"]["indices"]` IS present — a dict keyed by index symbol:
+    `{ "<symbol>": { "change_percent": float, "name": str|None, "current": float|None } }`
+    (`generator.py:80,89` whitelist `("market","from_date","to_date","indices")`). Usable
+    baseline for the **index delta**.
+  - `portfolio_snapshot["baseline"]` whitelists **aggregates only**
+    (`primary_source`, `cash`, `buying_power`, `sellable_summary`, `holdings_count`) and
+    **deliberately omits the per-symbol `holdings` list** (`generator.py:81-106`). So there is
+    **no per-symbol P/L baseline on the report row**.
+- The per-symbol P/L baseline lives in the **snapshot bundle's** `portfolio` payload, reachable
+  via `report.snapshot_bundle_uuid`. Each `holdings[]` entry carries `ticker` + `pnl_rate`
+  (`collectors/portfolio.py:144-168`, `_reader_holding_to_dict`). Live `get_holdings` positions
+  carry `symbol` + `profit_rate` (`portfolio_helpers.py`). The holdings-P/L delta joins
+  baseline `pnl_rate` (by `ticker`) to live `profit_rate` (by `symbol`).
+- Input tools all exist: `get_trade_journal`, `get_holdings`
+  (`portfolio_holdings.py:1215`), `get_market_index` (`fundamentals_handlers.py:271`,
+  returns `{"indices": [{symbol, current, change_pct, ...}]}`),
+  `investment_report_get`/`get_bundle`. Bundle payloads are read via
+  `InvestmentSnapshotsRepository.list_bundle_items_with_snapshots` (the same read path the
+  generator uses) — `investment_snapshots` are reusable evidence artifacts.
+
+## 2. Goals & non-goals
+
+**Goals**
+- One new read-only MCP tool that, given a baseline report, returns 3 deterministic deltas:
+  1. **levels_delta** — target/stop touch (journal × live), reusing `get_trade_journal` output.
+  2. **holdings_pnl_delta** — current holdings P/L vs baseline `portfolio_snapshot` P/L.
+  3. **index_delta** — current `get_market_index` vs baseline `market_snapshot` index.
+- Per-signal fail-open: one signal's failure never kills the others.
+- `migration 0`; no broker/order/watch/order-intent mutation; no in-process LLM.
+
+**Non-goals (deferred)**
+- `intraday_update` report policy / `report_type` / freshness policy (issue item 2 → separate issue).
+- New 급변주 (`screen_stocks`) and 뉴스 이슈 (`get_market_issues`) signals (the "5종" option; not chosen).
+- Persisting per-report expected-level snapshots (would need a migration; rejected in favor of
+  journal-derived levels).
+- HTTP transport surface (MCP tool only for PR1).
+
+## 3. Tool contract
+
+```
+investment_report_delta_get(
+    report_uuid: str,            # baseline = 개장/직전 리포트
+    near_pct: float = 1.0,       # 목표/손절 근접 임계(%), passed through to journal near-flags
+    account_type: str = "live",  # 저널 조회 스코프 ("live" | "paper")
+) -> dict
+```
+
+Return (deterministic; snake_case keys, serialized `by_alias`/`mode="json"`):
+
+```jsonc
+{
+  "success": true,
+  "baseline_report_uuid": "<uuid>",
+  "market": "us",                       // echoed from baseline report
+  "computed_at_kst": "2026-05-31T13:05:00+09:00",
+  "levels_delta": {
+    "entries": [
+      { "symbol": "AAPL", "side": "buy", "target_price": 230.0, "stop_loss": 200.0,
+        "current_price": 231.2, "pnl_pct_live": 4.1,
+        "target_reached": true, "stop_reached": false,
+        "near_target": false, "near_stop": false }
+    ],
+    "summary": { "near_target": 1, "near_stop": 0, "target_hit": 1, "stop_hit": 0 }
+  },
+  "holdings_pnl_delta": {                 // baseline = snapshot-bundle portfolio payload
+    "entries": [
+      { "symbol": "AAPL", "baseline_pnl_pct": 1.0, "live_pnl_pct": 4.1, "delta_pp": 3.1 }
+    ],
+    "summary": { "symbols_compared": 1, "symbols_baseline_only": 0, "symbols_live_only": 0 }
+  },
+  "index_delta": {                        // baseline = report market_snapshot["baseline"]["indices"]
+    "entries": [
+      { "index_symbol": "^GSPC", "baseline_value": 5500.0, "live_value": 5533.0, "change_pct": 0.6 }
+    ]
+  },
+  "unavailable": { "holdings": "baseline_snapshot_absent" }   // present only when a signal degraded
+}
+```
+
+- `success:false` only for top-level failures: `{ "error": "baseline_not_found" }` (bad/missing
+  `report_uuid`) or `{ "error": "invalid_report_uuid" }` (unparseable).
+- Per-signal degradation does **not** flip `success`; the block is set to `null` and the reason
+  recorded under `unavailable[<signal>]`.
+
+## 4. Components & data flow
+
+New file: `app/services/investment_reports/delta_service.py` (one focused service, one public
+method `compute_delta(...)`). Handler in
+`app/mcp_server/tooling/investment_reports_handlers.py` (`investment_report_delta_get_impl`),
+registered alongside the other investment-report tools.
+
+Flow inside `compute_delta`:
+
+1. **Baseline load** — `InvestmentReportQueryService.get_bundle(report_uuid)` (returns a dict
+   `{report, items, decisions_by_item, alerts, events}` or `None`). If `None` →
+   `baseline_not_found`. From `bundle["report"]` read `market`, `market_snapshot`,
+   `snapshot_bundle_uuid`. The **symbol set** = de-duped non-null `item.symbol` over
+   `bundle["items"]`.
+2. **levels_delta** — call `get_trade_journal(enrich_live=True, account_type=account_type,
+   market=<baseline market>)`; filter `entries` to the baseline symbol set; project the already-
+   computed `target_reached`/`stop_reached`/`pnl_pct_live`/`current_price` plus `near_*` flags.
+3. **holdings_pnl_delta** — baseline P/L from the **snapshot bundle**: load the bundle's
+   `portfolio` payload via `InvestmentSnapshotsRepository.list_bundle_items_with_snapshots(
+   bundle.id)` (bundle resolved from `snapshot_bundle_uuid`), build `{ticker → pnl_rate}` from
+   `payload["holdings"]`. Live P/L from `get_holdings(...)` → `{symbol → profit_rate}` over all
+   `accounts[].positions[]`. `delta_pp = live_profit_rate − baseline_pnl_rate` for symbols
+   present in **both**; count `symbols_baseline_only` / `symbols_live_only` in `summary`.
+   **Missing ≠ zero** — never fabricate a 0 P/L for a symbol absent on one side (ROB-375 Bug2
+   lesson). If `snapshot_bundle_uuid` is null or no `portfolio` payload is present →
+   `unavailable["holdings"]="baseline_snapshot_absent"`.
+4. **index_delta** — baseline from `market_snapshot["baseline"]["indices"]` (dict keyed by index
+   symbol; per-symbol `current`). If `market_snapshot` is the `{"status":"unavailable"}` shape or
+   lacks `baseline.indices` → `unavailable["index"]="baseline_snapshot_absent"`. Live from
+   `get_market_index(market=<baseline market>)` → match `indices[].symbol`, take `current`.
+   `change_pct = (live_current − baseline_current) / baseline_current * 100` only when both
+   finite and `baseline_current != 0`; otherwise `change_pct` is `null` (never fabricated).
+
+Each of steps 2–4 is wrapped in its own `try/except` (fail-open). Live-data helpers and the
+snapshots repository are imported lazily inside the service to keep the handler/CLI import path
+free of heavy/Settings-backed modules.
+
+## 5. Error handling
+
+| Condition | Behavior |
+|---|---|
+| Unparseable `report_uuid` | `{success:false, error:"invalid_report_uuid"}` |
+| Baseline report not found | `{success:false, error:"baseline_not_found"}` |
+| A signal's collector raises | That block `null`, `unavailable[signal]=<short reason>`, others continue |
+| Baseline snapshot key absent (legacy report) | `unavailable[signal]="baseline_snapshot_absent"` |
+| Symbol present on only one side (P/L) | Counted in summary; **no** fabricated entry |
+| Non-finite / divide-by-zero in a numeric delta | Field `null`, never `NaN`/`Infinity` in JSON |
+
+## 6. Testing (pytest, DB-integration where a report row is needed)
+
+- **Happy path:** seed a baseline report (bundle items + frozen snapshots) + active journals;
+  mock live quotes/holdings/index → all 3 deltas populated with correct values.
+- **Fail-open isolation:** force each signal's collector to raise; assert the other two still
+  populate and `unavailable[<signal>]` is set, `success` stays `true`.
+- **Missing ≠ zero:** baseline `portfolio_snapshot` lacks symbol X present live (and vice-versa)
+  → no fabricated P/L entry; counted in `summary`.
+- **Legacy report:** empty `market_snapshot`/`portfolio_snapshot` → `unavailable` path, no crash.
+- **Top-level errors:** bad UUID → `invalid_report_uuid`; unknown UUID → `baseline_not_found`.
+- **Registration/schema:** tool is registered and its response round-trips serialization.
+
+## 7. Safety boundaries (recap)
+
+- Read-only: no broker/order/watch/order-intent mutation; does not touch the scanner or
+  `activate_watch`/`decide_item` paths.
+- `migration 0`.
+- No in-process LLM — output is deterministic evidence for Hermes to pull/compose/push
+  (consistent with `/invest/reports has no internal LLM`).
+- Independent of watch/scanner state — derives purely from baseline snapshot vs live.

--- a/docs/superpowers/specs/2026-06-02-rob-376-item2-intraday-update-context-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob-376-item2-intraday-update-context-design.md
@@ -1,0 +1,77 @@
+# ROB-376 item 2 — `intraday_update` 리포트 타입 + 델타 consumer (설계)
+
+- **이슈**: ROB-376 (오케스트레이션 ROB-412 D라인 마지막). PR1(`investment_report_delta_get` 델타 도구) MERGED(`0b52d266`). 본 문서 = **item 2** = intraday 리포트 타입 + 델타를 Hermes가 pull하도록 결합.
+- **날짜**: 2026-06-02
+- **상태**: 설계 승인됨 → 플랜 작성 단계
+- **범위 경계**: read-only. broker/order/watch/order-intent mutation 없음. no in-process LLM(Hermes compose). migration 0. gate = 기존 `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`.
+
+## 1. 배경 / 현재 상태 (코드 검증)
+
+- `report_type`은 **자유 문자열**(model `investment_reports.report_type: Mapped[str]`, schema `IngestReportRequest.report_type: str` — enum/CHECK 없음). → `intraday_update_v1` 도입에 마이그레이션 불필요.
+- 델타 도구 `DeltaService.compute_delta(report_uuid, *, near_pct=1.0, account_type="live", computed_at_kst=None)`는 PR1로 존재. 반환: `{success, baseline_report_uuid, market, levels_delta, holdings_pnl_delta, index_delta, computed_at_kst, unavailable?}` 또는 `{success:false, error:"baseline_not_found"|"invalid_report_uuid"}`.
+- Hermes context는 `HermesContextExporter.export(*, snapshot_bundle_uuid) -> HermesContextPayload`가 결정적으로 생성(차원 evidence/진단/coverage). 현재 baseline 리포트/델타 개념 없음.
+- `HermesContextPayload`(`app/schemas/hermes_composition.py`)는 `context_version: Literal["hermes-context.v1"]` + 다수 dict 필드. **델타 블록 없음**(자유롭게 additive 확장 가능).
+- Hermes 경로 gate: `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`(기본 False), `prepare_bundle`/`get_hermes_context`/`create_from_hermes_composition` 등에서 enforce.
+- `create_from_hermes_composition`은 `report_type` free 수용(기본 `snapshot_backed_advisory_v1`, override 자유).
+
+## 2. 결정 (Option A — 전용 intraday context 조립 도구)
+
+신규 read-only MCP 도구가 (기존 번들 context) + (baseline 대비 델타 블록)을 **하나의 pullable 봉투**로 조립한다. Hermes는 단일 context pull로 intraday_update 리포트를 compose한다.
+
+## 3. 변경
+
+### 3.1 스키마 (additive)
+`app/schemas/hermes_composition.py` `HermesContextPayload`에 optional 필드 2개 추가:
+```python
+baseline_report_uuid: uuid.UUID | None = None
+intraday_delta_block: dict[str, Any] | None = None
+```
+- `context_version="hermes-context.v1"` 유지(필드 additive·optional → 하위호환). 기존 `investment_report_get_hermes_context`는 둘 다 `None`으로 직렬화 → 회귀 없음.
+
+### 3.2 신규 MCP 도구
+`app/mcp_server/tooling/investment_hermes_handlers.py`:
+```python
+async def investment_report_prepare_intraday_context_impl(
+    snapshot_bundle_uuid: str,
+    baseline_report_uuid: str,
+    near_pct: float = 1.0,
+    account_type: str = "live",
+) -> dict: ...
+```
+흐름:
+1. **gate**: `settings.SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED` False → `{"success": False, "error": "snapshot_backed_report_generator_disabled"}` (기존 Hermes 도구 메시지 패턴 따름).
+2. `payload = await HermesContextExporter(...).export(snapshot_bundle_uuid=UUID(...))` — 현재 번들 결정적 context.
+3. 델타: `DeltaService(db).compute_delta(baseline_report_uuid, near_pct=near_pct, account_type=account_type)`.
+   - **fail-open**: `compute_delta`가 `success:false`면 그 dict를 그대로 `intraday_delta_block`에 담아 **이유 노출**(예: `{"success": false, "error": "baseline_not_found"}`). `DeltaService`/exporter 예외는 try/except로 잡아 `intraday_delta_block = {"unavailable": "<reason>"}`. **context 자체는 success 유지.**
+4. `payload.baseline_report_uuid = <UUID>`, `payload.intraday_delta_block = <delta or error/unavailable>`.
+5. 반환: `{"success": True, "report_type_hint": "intraday_update_v1", "context": payload.model_dump(mode="json", by_alias=True)}` (기존 `get_hermes_context` 반환 envelope과 일관되게; 실제 형태는 기존 도구 반환을 미러).
+6. 등록: `register_*`에 `mcp.tool(name="investment_report_prepare_intraday_context", ...)`, `__all__` + 해당 도구-네임 set(있으면)에 추가.
+
+### 3.3 report_type 규약
+모듈 상수 `INTRADAY_UPDATE_REPORT_TYPE = "intraday_update_v1"` (hermes handlers 또는 인접 상수 위치). `create_from_hermes_composition`은 free `report_type` 수용하므로 Hermes가 이 값으로 ingest. baseline 연결은 ingest 시 `previous_report_uuid`로 기록 가능(기존 필드). enum/CHECK/마이그레이션 없음.
+
+## 4. 테스트
+
+`tests/mcp_server/test_investment_hermes_tools.py`(또는 신규 `test_investment_report_intraday_context.py`):
+- **gate off** → `{"success": False, "error": "...disabled"}`.
+- **정상 baseline** → 반환 context에 `intraday_delta_block`이 델타(success:true) + `baseline_report_uuid` 세팅. (exporter + DeltaService를 주입/모킹하거나, 기존 hermes 테스트의 시드 패턴 재사용.)
+- **bad baseline**(unknown/invalid uuid) → `intraday_delta_block`에 error dict, context `success` 유지(fail-open).
+- **예외 격리** → exporter는 정상이고 delta가 raise → `intraday_delta_block={"unavailable":...}`, context success.
+- **스키마 회귀**: `HermesContextPayload`에 두 필드 additive; 기존 `investment_report_get_hermes_context`는 None 직렬화.
+- **report_type round-trip**: `create_from_hermes_composition(report_type="intraday_update_v1", ...)`가 자유 문자열 수용·저장.
+- registration(도구 등록) + 단일 alembic head(마이그레이션 없음) + no-mutation(broker/order grep 0).
+
+## 5. 안전경계 / 비범위
+
+- read-only: broker/order/watch/order-intent mutation 없음. scanner/activate/decide 무접촉.
+- **no in-process LLM** — 결정적 evidence만 조립; Hermes가 compose/push.
+- **migration 0**(report_type 자유 문자열, 스키마 필드 additive).
+- gate = 기존 `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`(신규 env 없음).
+- **비범위**: 실제 Hermes intraday 합성 라운드트립(레포 밖, operator-gated, ROB-287/413 계열). 급변주(`screen_stocks`)/뉴스(`get_market_issues`) 신규 신호(델타는 PR1의 3신호 유지).
+
+## 6. 완료 기준 (ROB-376 item 2)
+
+- ✅ intraday_update 리포트 타입 규약(`intraday_update_v1`, 자유 문자열) 도입.
+- ✅ 델타가 Hermes가 pull 가능한 단일 context evidence(`intraday_delta_block`)로 결합 — report-vs-now/prior 델타 consumer 성립.
+- ✅ read-only/gated/migration 0, no LLM.
+- → PR1(델타 도구) + 본 PR(intraday context 결합)으로 **ROB-376 auto_trader 측 작업 종료**. 실 Hermes 합성은 operator-gated 후속.

--- a/tests/mcp_server/test_investment_hermes_tools.py
+++ b/tests/mcp_server/test_investment_hermes_tools.py
@@ -80,6 +80,7 @@ def test_investment_hermes_tool_names_lock() -> None:
         "investment_report_get_hermes_context",
         "investment_report_create_from_hermes_composition",
         "investment_stage_artifacts_ingest_from_hermes",
+        "investment_report_prepare_intraday_context",
     }
 
 
@@ -664,3 +665,139 @@ async def test_create_from_hermes_composition_zero_items_partial_data(_flag_on) 
 
     assert result["success"] is True
     assert result["items_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_disabled(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", False)
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    assert out["success"] is False
+    assert out["error"] == "snapshot_backed_report_generator_disabled"
+
+
+def _fake_payload() -> object:
+    from app.schemas.hermes_composition import HermesContextPayload
+
+    return HermesContextPayload(
+        snapshot_bundle_uuid=uuid.uuid4(),
+        bundle_status="ready",
+        market="us",
+        policy_version="intraday_action_report_v1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_attaches_delta(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+    base_uuid = uuid.uuid4()
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            return {
+                "success": True,
+                "baseline_report_uuid": str(report_uuid),
+                "levels_delta": {"summary": {"target_hit": 1}},
+            }
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(base_uuid),
+    )
+    assert out["success"] is True
+    assert out["report_type_hint"] == "intraday_update_v1"
+    assert out["baseline_report_uuid"] == str(base_uuid)
+    assert out["intraday_delta_block"]["success"] is True
+    assert out["intraday_delta_block"]["levels_delta"]["summary"]["target_hit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_failopen_bad_baseline(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            return {"success": False, "error": "baseline_not_found"}
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    # fail-open: context still success, delta block carries the reason
+    assert out["success"] is True
+    assert out["intraday_delta_block"]["success"] is False
+    assert out["intraday_delta_block"]["error"] == "baseline_not_found"
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_failopen_delta_raises(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    class _FakeDelta:
+        def __init__(self, db): ...
+        async def compute_delta(self, report_uuid, **kw):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+    monkeypatch.setattr(h, "DeltaService", _FakeDelta)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid=str(uuid.uuid4()),
+    )
+    assert out["success"] is True
+    assert "unavailable" in out["intraday_delta_block"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_intraday_context_invalid_baseline_uuid(monkeypatch) -> None:
+    from app.mcp_server.tooling import investment_hermes_handlers as h
+
+    monkeypatch.setattr(h.settings, "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", True)
+
+    class _FakeExporter:
+        def __init__(self, db): ...
+        async def export(self, *, snapshot_bundle_uuid):
+            return _fake_payload()
+
+    monkeypatch.setattr(h, "HermesContextExporter", _FakeExporter)
+
+    out = await h.investment_report_prepare_intraday_context_impl(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        baseline_report_uuid="not-a-uuid",
+    )
+    assert out["success"] is True
+    assert out["intraday_delta_block"]["error"] == "invalid_report_uuid"

--- a/tests/mcp_server/test_investment_report_delta_tool.py
+++ b/tests/mcp_server/test_investment_report_delta_tool.py
@@ -1,0 +1,30 @@
+# tests/mcp_server/test_investment_report_delta_tool.py
+"""ROB-376 — investment_report_delta_get handler + registration."""
+
+from __future__ import annotations
+
+import pytest
+
+import app.mcp_server.tooling.investment_reports_handlers as handlers
+
+
+def test_delta_tool_name_registered():
+    assert "investment_report_delta_get" in handlers.INVESTMENT_REPORT_TOOL_NAMES
+
+
+def test_register_investment_report_tools_includes_delta():
+    registered: list[str] = []
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            registered.append(name)
+            return lambda fn: fn
+
+    handlers.register_investment_report_tools(_FakeMCP())
+    assert "investment_report_delta_get" in registered
+
+
+@pytest.mark.asyncio
+async def test_delta_impl_invalid_uuid_returns_error():
+    out = await handlers.investment_report_delta_get_impl(report_uuid="not-a-uuid")
+    assert out == {"success": False, "error": "invalid_report_uuid"}

--- a/tests/services/investment_reports/test_delta_service.py
+++ b/tests/services/investment_reports/test_delta_service.py
@@ -1,0 +1,299 @@
+# tests/services/investment_reports/test_delta_service.py
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from app.services.investment_reports.delta_service import (
+    DeltaService,
+    _baseline_indices,
+    _baseline_pnl_from_bundle_pairs,
+    _holdings_pnl_delta,
+    _index_delta,
+    _levels_delta,
+)
+
+
+def test_levels_delta_filters_to_symbols_and_projects_flags():
+    journal = {
+        "entries": [
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "target_price": 230.0,
+                "stop_loss": 200.0,
+                "current_price": 231.0,
+                "pnl_pct_live": 4.1,
+                "target_reached": True,
+                "stop_reached": False,
+            },
+            {
+                "symbol": "MSFT",
+                "side": "buy",
+                "target_price": 500.0,
+                "stop_loss": 400.0,
+                "current_price": 401.0,
+                "pnl_pct_live": -1.0,
+                "target_reached": False,
+                "stop_reached": False,
+            },
+            {
+                "symbol": "ZZZZ",
+                "side": "buy",
+                "target_price": 1.0,
+                "stop_loss": 0.5,
+                "current_price": 0.9,
+                "pnl_pct_live": 0.0,
+                "target_reached": False,
+                "stop_reached": False,
+            },
+        ]
+    }
+    out = _levels_delta(journal, {"AAPL", "MSFT"}, near_pct=1.0)
+    syms = [e["symbol"] for e in out["entries"]]
+    assert syms == ["AAPL", "MSFT"]  # ZZZZ filtered out
+    aapl = out["entries"][0]
+    assert aapl["target_reached"] is True
+    assert aapl["pnl_pct_live"] == 4.1
+    # MSFT current 401 is within 1% of stop 400 -> near_stop True
+    msft = out["entries"][1]
+    assert msft["near_stop"] is True
+    assert msft["near_target"] is False
+    assert out["summary"] == {
+        "near_target": 0,
+        "near_stop": 1,
+        "target_hit": 1,
+        "stop_hit": 0,
+    }
+
+
+def test_levels_delta_empty_symbols_keeps_all_entries():
+    journal = {
+        "entries": [
+            {
+                "symbol": "AAPL",
+                "side": "buy",
+                "target_price": None,
+                "stop_loss": None,
+                "current_price": 10.0,
+                "pnl_pct_live": 1.0,
+                "target_reached": None,
+                "stop_reached": None,
+            },
+        ]
+    }
+    out = _levels_delta(journal, set(), near_pct=1.0)
+    assert [e["symbol"] for e in out["entries"]] == ["AAPL"]
+    assert out["entries"][0]["near_target"] is False  # no target -> not near
+
+
+def _snap(kind, payload):
+    return types.SimpleNamespace(snapshot_kind=kind, payload_json=payload)
+
+
+def test_baseline_pnl_from_bundle_pairs_reads_portfolio_holdings():
+    pairs = [
+        (object(), _snap("market", {"indices": {}})),
+        (
+            object(),
+            _snap(
+                "portfolio",
+                {
+                    "holdings": [
+                        {"ticker": "AAPL", "pnl_rate": 1.0},
+                        {"ticker": "MSFT", "pnl_rate": -2.0},
+                        {
+                            "ticker": "NOPNL"
+                        },  # missing pnl_rate -> skipped, not fabricated
+                    ]
+                },
+            ),
+        ),
+    ]
+    assert _baseline_pnl_from_bundle_pairs(pairs) == {"AAPL": 1.0, "MSFT": -2.0}
+
+
+def test_baseline_pnl_from_bundle_pairs_none_when_no_portfolio_kind():
+    pairs = [(object(), _snap("market", {"indices": {}}))]
+    assert _baseline_pnl_from_bundle_pairs(pairs) is None
+
+
+def test_holdings_pnl_delta_joins_baseline_and_live_missing_not_zero():
+    baseline = {"AAPL": 1.0, "MSFT": -2.0, "ONLYBASE": 5.0}
+    live = {
+        "accounts": [
+            {
+                "positions": [
+                    {"symbol": "AAPL", "profit_rate": 4.1},
+                    {"symbol": "MSFT", "profit_rate": -1.0},
+                    {"symbol": "ONLYLIVE", "profit_rate": 9.0},
+                    {"symbol": "NORATE"},  # missing profit_rate -> skipped
+                ]
+            },
+        ]
+    }
+    out = _holdings_pnl_delta(baseline, live)
+    by_symbol = {e["symbol"]: e for e in out["entries"]}
+    assert set(by_symbol) == {"AAPL", "MSFT"}  # only symbols in BOTH
+    assert by_symbol["AAPL"]["delta_pp"] == 3.1
+    assert by_symbol["MSFT"]["delta_pp"] == 1.0
+    assert out["summary"] == {
+        "symbols_compared": 2,
+        "symbols_baseline_only": 1,
+        "symbols_live_only": 1,
+    }
+
+
+def test_baseline_indices_extracts_dict_or_none():
+    ok = {"provenance": {}, "baseline": {"indices": {"^GSPC": {"current": 5500.0}}}}
+    assert _baseline_indices(ok) == {"^GSPC": {"current": 5500.0}}
+    assert _baseline_indices({"status": "unavailable", "reason": "x"}) is None
+    assert _baseline_indices({"baseline": {}}) is None  # no indices key
+    assert _baseline_indices({}) is None
+
+
+def test_index_delta_change_pct_and_null_guards():
+    baseline = {
+        "^GSPC": {"current": 5500.0},
+        "^VIX": {"current": 0.0},  # baseline 0 -> change_pct null, no div-by-zero
+        "MISSINGLIVE": {"current": 100.0},
+    }
+    live = {
+        "indices": [
+            {"symbol": "^GSPC", "current": 5533.0},
+            {"symbol": "^VIX", "current": 15.0},
+            # MISSINGLIVE absent from live
+        ]
+    }
+    out = _index_delta(baseline, live)
+    by_symbol = {e["index_symbol"]: e for e in out["entries"]}
+    assert round(by_symbol["^GSPC"]["change_pct"], 4) == 0.6
+    assert by_symbol["^VIX"]["change_pct"] is None  # baseline 0 -> null
+    assert by_symbol["MISSINGLIVE"]["live_value"] is None
+    assert by_symbol["MISSINGLIVE"]["change_pct"] is None
+
+
+def _baseline(
+    *, market="us", symbols=None, market_snapshot=None, baseline_pnl="default"
+):
+    return {
+        "market": market,
+        "symbols": symbols if symbols is not None else {"AAPL"},
+        "market_snapshot": market_snapshot
+        if market_snapshot is not None
+        else {"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        "baseline_pnl": {"AAPL": 1.0} if baseline_pnl == "default" else baseline_pnl,
+    }
+
+
+def _service(*, baseline, journal=None, holdings=None, index=None):
+    async def loader(_uuid):
+        return baseline
+
+    async def journal_fn(*, account_type, market):
+        if journal is None:
+            raise RuntimeError("journal boom")
+        return journal
+
+    async def holdings_fn(*, market):
+        if holdings is None:
+            raise RuntimeError("holdings boom")
+        return holdings
+
+    async def index_fn():
+        if index is None:
+            raise RuntimeError("index boom")
+        return index
+
+    return DeltaService(
+        session=None,
+        baseline_loader=loader,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_happy_path_all_three():
+    svc = _service(
+        baseline=_baseline(),
+        journal={
+            "entries": [
+                {
+                    "symbol": "AAPL",
+                    "side": "buy",
+                    "target_price": 230.0,
+                    "stop_loss": 200.0,
+                    "current_price": 231.0,
+                    "pnl_pct_live": 4.1,
+                    "target_reached": True,
+                    "stop_reached": False,
+                }
+            ]
+        },
+        holdings={
+            "accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 4.1}]}]
+        },
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta(
+        "11111111-1111-1111-1111-111111111111",
+        computed_at_kst="2026-06-01T13:00:00+09:00",
+    )
+    assert out["success"] is True
+    assert out["market"] == "us"
+    assert out["computed_at_kst"] == "2026-06-01T13:00:00+09:00"
+    assert out["levels_delta"]["summary"]["target_hit"] == 1
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 3.1
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+    assert "unavailable" not in out
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_fail_open_isolates_each_signal():
+    # journal raises; holdings + index still populate
+    svc = _service(
+        baseline=_baseline(),
+        journal=None,  # -> RuntimeError
+        holdings={
+            "accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 2.0}]}]
+        },
+        index={"indices": [{"symbol": "^GSPC", "current": 5533.0}]},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["levels_delta"] is None
+    assert out["unavailable"]["levels"]  # reason string present
+    assert out["holdings_pnl_delta"]["entries"][0]["delta_pp"] == 1.0
+    assert out["index_delta"]["entries"][0]["live_value"] == 5533.0
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_absent_marks_unavailable():
+    svc = _service(
+        baseline=_baseline(
+            market_snapshot={"status": "unavailable", "reason": "not_collected"},
+            baseline_pnl=None,
+        ),
+        journal={"entries": []},
+        holdings={"accounts": []},
+        index={"indices": []},
+    )
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out["success"] is True
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    assert out["index_delta"] is None
+    assert out["unavailable"]["index"] == "baseline_snapshot_absent"
+
+
+@pytest.mark.asyncio
+async def test_compute_delta_baseline_not_found():
+    async def loader(_uuid):
+        return None
+
+    svc = DeltaService(session=None, baseline_loader=loader)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}

--- a/tests/services/investment_reports/test_delta_service_db.py
+++ b/tests/services/investment_reports/test_delta_service_db.py
@@ -1,0 +1,65 @@
+# tests/services/investment_reports/test_delta_service_db.py
+"""ROB-376 — default baseline loader against a seeded report row (no bundle)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_reports.delta_service import DeltaService
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+@pytest.mark.asyncio
+async def test_default_loader_reads_report_market_and_marks_pnl_absent(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await repo.insert_report(
+        idempotency_key="rob376:delta:1",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="baseline",
+        summary="s",
+        status="published",
+        report_metadata={},
+        market_snapshot={"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},
+        portfolio_snapshot={},
+    )
+    await session.commit()
+
+    # Inject only the live fns so no network is hit; loader is the real default.
+    async def journal_fn(*, account_type, market):
+        return {"entries": []}
+
+    async def holdings_fn(*, market):
+        return {"accounts": []}
+
+    async def index_fn():
+        return {"indices": [{"symbol": "^GSPC", "current": 5533.0}]}
+
+    svc = DeltaService(
+        session=session,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    )
+    out = await svc.compute_delta(report.report_uuid)
+    assert out["success"] is True
+    assert out["market"] == "us"
+    # No snapshot_bundle_uuid on the seeded row -> per-symbol P/L baseline absent.
+    assert out["holdings_pnl_delta"] is None
+    assert out["unavailable"]["holdings"] == "baseline_snapshot_absent"
+    # Index baseline IS present on the row -> index delta computed.
+    assert round(out["index_delta"]["entries"][0]["change_pct"], 4) == 0.6
+
+
+@pytest.mark.asyncio
+async def test_default_loader_baseline_not_found(session: AsyncSession) -> None:
+    svc = DeltaService(session=session)
+    out = await svc.compute_delta("11111111-1111-1111-1111-111111111111")
+    assert out == {"success": False, "error": "baseline_not_found"}

--- a/tests/test_hermes_context_payload_intraday.py
+++ b/tests/test_hermes_context_payload_intraday.py
@@ -1,0 +1,35 @@
+"""ROB-376 item 2 — HermesContextPayload intraday delta fields (additive)."""
+
+from __future__ import annotations
+
+import uuid
+
+from app.schemas.hermes_composition import HermesContextPayload
+
+
+def _minimal(**kw) -> HermesContextPayload:
+    base = {
+        "snapshot_bundle_uuid": uuid.uuid4(),
+        "bundle_status": "ready",
+        "market": "us",
+        "policy_version": "intraday_action_report_v1",
+    }
+    base.update(kw)
+    return HermesContextPayload(**base)
+
+
+def test_intraday_fields_default_none() -> None:
+    payload = _minimal()
+    assert payload.baseline_report_uuid is None
+    assert payload.intraday_delta_block is None
+    # context_version unchanged (additive, no version bump)
+    assert payload.context_version == "hermes-context.v1"
+
+
+def test_intraday_fields_roundtrip() -> None:
+    base = uuid.uuid4()
+    block = {"success": True, "levels_delta": {"summary": {"target_hit": 1}}}
+    payload = _minimal(baseline_report_uuid=base, intraday_delta_block=block)
+    dumped = payload.model_dump(mode="json")
+    assert dumped["baseline_report_uuid"] == str(base)
+    assert dumped["intraday_delta_block"] == block

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -119,6 +119,7 @@ def test_tool_names_match_registered_set() -> None:
         # ROB-273 — opt-in snapshot-backed advisory generator.
         "investment_report_generate_from_bundle",
         "investment_watch_recommend",
+        "investment_report_delta_get",
     }
 
 


### PR DESCRIPTION
## Summary
- Promote ROB-376 production-safe intraday delta surface onto `production` without pulling the rest of `main`.
- Cherry-picks the two already-merged/read-only ROB-376 commits:
  - #1083 `investment_report_delta_get`
  - #1088 `investment_report_prepare_intraday_context` / `intraday_update_v1` context payload

## Safety boundary
- Read-only MCP/report-context functionality only.
- No broker/order/order-intent mutation.
- No scheduler/recurring activation.
- No prod env/secret change.
- Builds on the already-promoted ROB-412 schema repair head.

## Verification
- `uv run ruff check app/ tests/ alembic/versions/20260602_rob412_prod_watch_schema_repair.py`
- `uv run ruff format --check app/ tests/ alembic/versions/20260602_rob412_prod_watch_schema_repair.py`
- `uv run alembic heads` → single head `20260602_rob412_repair`
- `uv run pytest tests/mcp_server/test_investment_report_delta_tool.py tests/services/investment_reports/test_delta_service.py tests/services/investment_reports/test_delta_service_db.py tests/test_hermes_context_payload_intraday.py -q` → 18 passed
