### PR TITLE
fix(ROB-412): sync production schema repair into main

### DIFF
--- a/alembic/versions/20260602_rob412_main_merge.py
+++ b/alembic/versions/20260602_rob412_main_merge.py
@@ -1,0 +1,30 @@
+"""ROB-412 repair branch merge into current main head.
+
+Revision ID: 20260602_rob412_main_merge
+Revises: 20260602_rob398s3, 20260602_rob412_repair
+Create Date: 2026-06-02
+
+Keep the production repair revision identical to the already-deployed production
+revision, then merge it with the current main Alembic lineage so `main` remains a
+single-head graph.
+"""
+
+from collections.abc import Sequence
+
+revision: str = "20260602_rob412_main_merge"
+down_revision: str | Sequence[str] | None = (
+    "20260602_rob398s3",
+    "20260602_rob412_repair",
+)
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """No-op merge revision."""
+    return None
+
+
+def downgrade() -> None:
+    """No-op merge revision."""
+    return None

--- a/alembic/versions/20260602_rob412_prod_watch_schema_repair.py
+++ b/alembic/versions/20260602_rob412_prod_watch_schema_repair.py
@@ -1,0 +1,103 @@
+"""ROB-412 repair prod watch/recommendation schema drift.
+
+Revision ID: 20260602_rob412_repair
+Revises: 2489d4709dec
+Create Date: 2026-06-02
+
+Production reached the ROB-406 merge head while the ROB-337/ROB-403
+ancestor DDL was not physically present.  Keep this migration idempotent so it
+is safe on databases where those ancestor revisions did run normally, and safe
+on the drifted production database that only needs the missing additive shape.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260602_rob412_repair"
+down_revision: str | Sequence[str] | None = "2489d4709dec"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_ALERT_OPERATOR_CONSTRAINTS = (
+    "ck_investment_watch_alerts_operator",
+    "ck_investment_watch_alerts_ck_investment_watch_alerts_operator",
+)
+_ALERT_COMBINE_CONSTRAINTS = (
+    "ck_investment_watch_alerts_combine",
+    "ck_investment_watch_alerts_ck_investment_watch_alerts_combine",
+)
+_EVENT_OPERATOR_CONSTRAINTS = (
+    "ck_investment_watch_events_operator",
+    "ck_investment_watch_events_ck_investment_watch_events_operator",
+)
+
+
+def _drop_constraints(table: str, names: tuple[str, ...]) -> None:
+    for name in names:
+        op.execute(f"ALTER TABLE review.{table} DROP CONSTRAINT IF EXISTS {name}")
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE review.investment_report_items
+        ADD COLUMN IF NOT EXISTS watch_recommendation JSONB
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_alerts
+        ADD COLUMN IF NOT EXISTS threshold_high NUMERIC(20,8)
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_alerts
+        ADD COLUMN IF NOT EXISTS conditions JSONB NOT NULL DEFAULT '[]'::jsonb
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_alerts
+        ADD COLUMN IF NOT EXISTS combine TEXT NOT NULL DEFAULT 'and'
+        """
+    )
+    _drop_constraints("investment_watch_alerts", _ALERT_OPERATOR_CONSTRAINTS)
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_alerts
+        ADD CONSTRAINT ck_investment_watch_alerts_operator
+        CHECK (operator IN ('above','below','between'))
+        """
+    )
+    _drop_constraints("investment_watch_alerts", _ALERT_COMBINE_CONSTRAINTS)
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_alerts
+        ADD CONSTRAINT ck_investment_watch_alerts_combine
+        CHECK (combine IN ('and'))
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_events
+        ADD COLUMN IF NOT EXISTS threshold_high NUMERIC(20,8)
+        """
+    )
+    _drop_constraints("investment_watch_events", _EVENT_OPERATOR_CONSTRAINTS)
+    op.execute(
+        """
+        ALTER TABLE review.investment_watch_events
+        ADD CONSTRAINT ck_investment_watch_events_operator
+        CHECK (operator IN ('above','below','between'))
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: repair is additive/idempotent and preserves production data."""
+    return None


### PR DESCRIPTION
## Summary
- Sync the already-deployed production ROB-412 watch/report schema repair revision into `main` unchanged.
- Add a no-op Alembic merge revision so `main` remains a single-head graph after combining the production repair branch with the current ROB-398 Slice 3 head.

## Why
Production is currently at `20260602_rob412_repair`; `main` had advanced to `20260602_rob398s3` without that production repair revision. Without this sync, a future main→production promotion would carry an avoidable Alembic graph/history mismatch risk.

## Verification
- `cmp` repair migration against deployed production file: identical
- `uv run ruff check alembic/versions/20260602_rob412_prod_watch_schema_repair.py alembic/versions/20260602_rob412_main_merge.py`
- `uv run ruff format --check alembic/versions/20260602_rob412_prod_watch_schema_repair.py alembic/versions/20260602_rob412_main_merge.py`
- `uv run alembic heads` → `20260602_rob412_main_merge (head)`
- `uv run pytest tests/test_watch_validity_review.py tests/test_review_active_watches_cli.py tests/test_watch_condition_evaluation.py tests/test_hermes_context_payload_intraday.py -q` → `15 passed, 2 warnings`

Note: full local fresh-DB `alembic upgrade head` was attempted against an ephemeral Homebrew PostgreSQL, but it stopped in an existing older migration because that local instance does not have TimescaleDB installed (`87541fdbc954_add_kr_candles_timescale.py`). This PR's added files passed graph and targeted checks; CI remains the authoritative full-environment check.

## Safety
- No broker/order/watch/order-intent mutation.
- No prod env/secret changes.
- No direct production DDL; this is graph/code sync for `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database schema inconsistencies affecting investment watch and alert functionality to improve system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->