### PR TITLE
fix(ROB-417): kis_mock US 매수 미지원 명확화 — capability 조기 가드(mock_unsupported)

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -823,6 +823,18 @@ async def _validate_sell_side(
     return order_quantity, avg_price, None
 
 
+def _kis_mock_us_orderable_unsupported() -> bool:
+    """KIS 모의투자가 해외(USD) orderable-cash 서비스를 제공하지 않는지 여부.
+
+    OPSQ0002 "없는 서비스 코드" — 2026-05-27 live smoke로 확정. capability_matrix를
+    권위 소스로 사용하므로, 미래에 US mock cash 어댑터가 생겨 account_cash_read=True가
+    되면 이 가드는 자동으로 완화된다.
+    """
+    from app.services.us_dual_paper.capability_matrix import get_capability_matrix
+
+    return get_capability_matrix().get("kis_mock", {}).get("account_cash_read") is False
+
+
 async def _check_balance_and_warn(
     *,
     market_type: str,
@@ -838,6 +850,27 @@ async def _check_balance_and_warn(
     Returns (warning_message_or_None, error_dict_or_None).
     If error_dict is not None, the caller should return it immediately.
     """
+    # ROB-417 — KIS 모의투자는 해외 orderable-cash 서비스가 없어(OPSQ0002) US mock
+    # 매수의 주문가능현금을 검증할 수 없다. capability_matrix 기반으로 KIS 호출 전
+    # 결정적으로 fail-closed 처리하고, 구조적 미지원을 mock_unsupported로 명시한다.
+    if (
+        is_mock
+        and market_type == "equity_us"
+        and side == "buy"
+        and _kis_mock_us_orderable_unsupported()
+    ):
+        message = (
+            "US mock buy unsupported: KIS 모의투자 provides no overseas "
+            "orderable-cash service (OPSQ0002), so orderable cash cannot be "
+            "verified. Use alpaca_paper for US paper buys; kis_mock supports KR."
+        )
+        if dry_run:
+            return f"Preview warning: {message}", None
+        err = order_error_fn(message)
+        err["mock_unsupported"] = True
+        err["capability"] = "kis_mock_us_orderable_cash_unsupported"
+        return None, err
+
     try:
         balance = await _get_balance_for_order(market_type, is_mock=is_mock)
     except Exception as balance_exc:

--- a/docs/superpowers/plans/2026-06-02-rob-417-us-mock-buy-unsupported.md
+++ b/docs/superpowers/plans/2026-06-02-rob-417-us-mock-buy-unsupported.md
@@ -1,0 +1,289 @@
+# ROB-417 US mock 매수 미지원 명확화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** US `kis_mock` 매수가 KIS 모의투자의 해외 orderable-cash 미지원(OPSQ0002)으로 원천 불가임을 capability_matrix 기반 조기 가드로 명확히(`mock_unsupported` 태그 + 명시 메시지) fail-closed 표면화한다.
+
+**Architecture:** `_check_balance_and_warn` 맨 앞에 US-mock-buy 조기 가드를 추가 — `capability_matrix`의 kis_mock `account_cash_read=False`를 권위 소스로 사용해 KIS 네트워크 호출 전 결정적으로 차단. dry_run은 명확 warning + 프리뷰 유지, 실주문은 `mock_unsupported` 태그 에러. KR/live/crypto 무영향, broker/order mutation 없음.
+
+**Tech Stack:** Python 3.13, pytest(asyncio). 순수 함수 + async 헬퍼, DB/네트워크 없음(테스트는 stub order_error_fn + monkeypatch spy).
+
+---
+
+## File Structure
+
+- Modify: `app/mcp_server/tooling/order_validation.py` — `_kis_mock_us_orderable_unsupported` 헬퍼 + `_check_balance_and_warn` 조기 가드
+- Create: `tests/test_order_us_mock_buy_unsupported.py` — 헬퍼 + 가드 단위 테스트
+
+---
+
+## Task 1: capability_matrix 헬퍼 + US mock buy 조기 가드
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py`
+- Test: `tests/test_order_us_mock_buy_unsupported.py`
+
+배경: US mock buy는 `_get_balance_for_order`가 OPSQ0002로 raise → `_check_balance_and_warn` 예외 분기가 generic 메시지로 뭉갬(`mock_unsupported` 미태깅, 구조적 미지원 vs 일시실패 미구분). capability_matrix(`account_cash_read=False`)를 권위 소스로 조기 차단.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_order_us_mock_buy_unsupported.py` 신규 생성:
+
+```python
+"""ROB-417 — US kis_mock buy is fail-closed unsupported (OPSQ0002), made explicit."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import (
+    _check_balance_and_warn,
+    _kis_mock_us_orderable_unsupported,
+)
+
+
+def _order_error(message: str) -> dict:
+    return {"success": False, "error": message}
+
+
+def test_kis_mock_us_orderable_unsupported_reflects_capability_matrix():
+    # capability_matrix documents kis_mock account_cash_read=False (OPSQ0002).
+    assert _kis_mock_us_orderable_unsupported() is True
+
+
+@pytest.mark.asyncio
+async def test_us_mock_buy_non_dry_run_blocked_with_mock_unsupported(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(*_a, **_k):
+        called["balance"] = True
+        return 0.0
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert warning is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["mock_unsupported"] is True
+    assert error["capability"] == "kis_mock_us_orderable_cash_unsupported"
+    assert "unsupported" in error["error"].lower()
+    # Early guard short-circuits BEFORE any KIS network call.
+    assert called["balance"] is False
+
+
+@pytest.mark.asyncio
+async def test_us_mock_buy_dry_run_returns_clear_warning_keeps_preview(monkeypatch):
+    async def spy_balance(*_a, **_k):
+        raise AssertionError("must not be called for US mock buy guard")
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert error is None  # preview not blocked
+    assert warning is not None
+    assert "US mock buy unsupported" in warning
+
+
+@pytest.mark.asyncio
+async def test_kr_mock_buy_not_guarded_enters_balance_path(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(market_type, is_mock=False):
+        called["balance"] = True
+        return 10_000_000.0  # ample KRW
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+    # KR mock has a DB-shadow-exposure guard; stub it to the pass-through state.
+    async def fake_exposure(*_a, **_k):
+        return {"confidence": "db_shadow_pending", "buy_reserved_amount": 0.0}
+
+    monkeypatch.setattr(
+        order_validation, "_get_kis_mock_shadow_exposure", fake_exposure
+    )
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_kr",
+        normalized_symbol="005930",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert error is None
+    assert called["balance"] is True  # guard did NOT short-circuit KR
+
+
+@pytest.mark.asyncio
+async def test_us_live_buy_not_guarded(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(*_a, **_k):
+        called["balance"] = True
+        return 10_000.0
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,  # live
+    )
+    assert error is None
+    assert called["balance"] is True  # live enters the real precheck
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run pytest tests/test_order_us_mock_buy_unsupported.py -v`
+Expected: FAIL — `ImportError: cannot import name '_kis_mock_us_orderable_unsupported'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`app/mcp_server/tooling/order_validation.py`:
+
+(a) 순수 헬퍼 추가 — `_check_balance_and_warn`(라인 826) 정의 바로 앞 모듈 스코프:
+
+```python
+def _kis_mock_us_orderable_unsupported() -> bool:
+    """KIS 모의투자가 해외(USD) orderable-cash 서비스를 제공하지 않는지 여부.
+
+    OPSQ0002 "없는 서비스 코드" — 2026-05-27 live smoke로 확정. capability_matrix를
+    권위 소스로 사용하므로, 미래에 US mock cash 어댑터가 생겨 account_cash_read=True가
+    되면 이 가드는 자동으로 완화된다.
+    """
+    from app.services.us_dual_paper.capability_matrix import get_capability_matrix
+
+    return (
+        get_capability_matrix().get("kis_mock", {}).get("account_cash_read") is False
+    )
+```
+
+(b) `_check_balance_and_warn` 맨 앞(docstring 직후, 라인 840 `try:` 앞)에 조기 가드 삽입:
+
+```python
+    """Pre-check cash balance for buy orders.
+
+    Returns (warning_message_or_None, error_dict_or_None).
+    If error_dict is not None, the caller should return it immediately.
+    """
+    # ROB-417 — KIS 모의투자는 해외 orderable-cash 서비스가 없어(OPSQ0002) US mock
+    # 매수의 주문가능현금을 검증할 수 없다. capability_matrix 기반으로 KIS 호출 전
+    # 결정적으로 fail-closed 처리하고, 구조적 미지원을 mock_unsupported로 명시한다.
+    if (
+        is_mock
+        and market_type == "equity_us"
+        and side == "buy"
+        and _kis_mock_us_orderable_unsupported()
+    ):
+        message = (
+            "US mock buy unsupported: KIS 모의투자 provides no overseas "
+            "orderable-cash service (OPSQ0002), so orderable cash cannot be "
+            "verified. Use alpaca_paper for US paper buys; kis_mock supports KR."
+        )
+        if dry_run:
+            return f"Preview warning: {message}", None
+        err = order_error_fn(message)
+        err["mock_unsupported"] = True
+        err["capability"] = "kis_mock_us_orderable_cash_unsupported"
+        return None, err
+
+    try:
+        balance = await _get_balance_for_order(market_type, is_mock=is_mock)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run pytest tests/test_order_us_mock_buy_unsupported.py -v`
+Expected: PASS (5건).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-417
+git add app/mcp_server/tooling/order_validation.py tests/test_order_us_mock_buy_unsupported.py
+git commit -m "fix(ROB-417): US kis_mock 매수 미지원 capability 조기 가드(mock_unsupported)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: place_order 통합 경로 회귀 + lint
+
+**Files:**
+- (없음 — 검증만; Step 1에서 회귀 발견 시 갱신)
+
+배경: 조기 가드가 `_place_order_impl` buy 경로(`order_execution.py:1052-1067`)를 통해 흐를 때 dry_run=False는 즉시 error 반환, dry_run=True는 preview+warning 반환됨을 확인. 기존 mock US 관련 테스트가 generic OPSQ0002 메시지를 단언하면 갱신 필요.
+
+- [ ] **Step 1: 기존 OPSQ0002/balance precheck 단언 탐색**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && grep -rn "balance precheck unavailable\|OPSQ0002\|refusing to submit" tests/`
+조치: US mock **buy** 경로에서 generic 메시지를 단언하는 테스트가 있으면, 새 동작(`mock_unsupported=True` + "US mock buy unsupported")에 맞게 갱신하고 함께 커밋. KR/매도/예외 경로(진짜 일시실패) 단언은 무변경(그 경로는 가드 미적용이라 generic 유지). 매치 없으면 스킵.
+
+- [ ] **Step 2: 인접 회귀 스위트**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run pytest tests/test_order_us_mock_buy_unsupported.py tests/test_kis_mock_routing.py tests/test_mcp_place_order.py -q 2>&1 | tail -8`
+Expected: PASS — 신규 + routing + place_order 회귀 green. (로컬 공유-DB ledger 잔여물로 인한 pre-existing 실패가 있으면 단독 재현으로 내 변경 무관임을 확인하고 기록.)
+
+- [ ] **Step 3: Lint**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run ruff check app/mcp_server/tooling/order_validation.py tests/test_order_us_mock_buy_unsupported.py && uv run ruff format --check app/mcp_server/tooling/order_validation.py tests/test_order_us_mock_buy_unsupported.py`
+Expected: All checks passed / already formatted. (실패 시 `uv run ruff format <file>` 후 재확인.)
+
+- [ ] **Step 4: ty typecheck (CI lint 일부)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run ty check app/mcp_server/tooling/order_validation.py --error-on-warning 2>&1 | tail -5`
+Expected: All checks passed.
+
+- [ ] **Step 5: Mutation import guard (read-only invariant)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-417 && uv run pytest -k "import_guard or mutation_guard" -q 2>&1 | tail -5`
+Expected: green. guard 없으면 스킵.
+
+- [ ] **Step 6: Step 1에서 테스트 갱신했다면 커밋(없으면 스킵)**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-417
+git add -A && git commit -m "test(ROB-417): US mock buy 미지원 메시지 단언 갱신
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review 결과
+
+**Spec 커버리지:**
+- Unit 1 (capability 헬퍼 + 조기 가드, dry_run warning / 실주문 mock_unsupported 에러) → Task 1 ✅
+- KR/live/crypto 미적용 가드 → Task 1 테스트 4·5 ✅
+- 네트워크 선제차단(호출 안 됨) → Task 1 테스트 2 ✅
+- 회귀/lint/ty/import-guard → Task 2 ✅
+
+**Placeholder 스캔:** 없음 — 모든 코드 step에 실제 코드 포함.
+
+**Type 일관성:** `_kis_mock_us_orderable_unsupported() -> bool` 정의/호출 일치. 가드 조건 변수(`is_mock`/`market_type`/`side`/`dry_run`/`order_error_fn`)는 모두 `_check_balance_and_warn` 기존 파라미터. 에러 dict 키 `mock_unsupported`/`capability` 구현·테스트 일관.
+
+**안전 경계 재확인:** fail-closed 보존, broker/order/watch/order-intent mutation 없음, migration 0, read-only. `_is_kis_mock_unsupported` 공유 마커 미변경. US 활성화는 Non-goal. 매도 라우팅은 ROB-420 소관.

--- a/docs/superpowers/specs/2026-06-02-rob-417-us-mock-buy-unsupported-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob-417-us-mock-buy-unsupported-design.md
@@ -1,0 +1,93 @@
+# ROB-417 — kis_mock US 매수 미지원 명확화 (fail-closed UX)
+
+- **이슈**: ROB-417 (E라인 E2)
+- **유형**: Bug fix (UX / fail-closed 명확화)
+- **작성일**: 2026-06-02
+- **연관**: ROB-421(오케스트레이션), ROB-420(매도 라우팅 — 완료), ROB-341(mock shadow-exposure), ROB-409/407(live order ledger 경계), capability_matrix(us_dual_paper)
+
+## 증상 / 근본 원인
+
+`kis_mock_place_order`로 US 주식 **매수**(dry_run=False)를 제출하면 전건 거부:
+`KIS mock balance precheck unavailable for <SYM>: OPSQ0002 없는 서비스 코드 입니다; refusing to submit without verified orderable cash.`
+
+근본: `_get_balance_for_order(equity_us, is_mock=True)`가 `inquire_overseas_margin`에서 KIS 에러 OPSQ0002로 raise → `_check_balance_and_warn`의 예외 분기가 **generic** 메시지로 처리(`order_validation.py:852-868`). 이는 fail-closed(안전)지만:
+- "구조적 미지원(KIS 모의투자에 해외 orderable-cash 서비스 없음)"과 "일시적 precheck 실패"를 **구분하지 않음**.
+- `mock_unsupported` 태그가 없어 호출자/운영자가 미지원을 기계적으로 식별 못함.
+- `_is_kis_mock_unsupported` 마커(`미지원/unsupported/not available in mock/tttc8036r`)에 OPSQ0002("없는 서비스 코드") 미포함.
+
+`capability_matrix`(`app/services/us_dual_paper/capability_matrix.py`)는 이미 kis_mock `account_cash_read=False` + `known_unknown_fields=[cash_usd, buying_power_usd, ...]`로 OPSQ0002 미지원을 **권위 있게 문서화**(2026-05-27 live smoke 검증). `get_available_capital(kis_mock)`도 overseas margin을 `mock_unsupported`로 태그함. 즉 buy 주문 경로만 이 패턴을 안 따름.
+
+## 기대 동작 (스코프 = ROB-421 경계)
+
+US mock 매수가 **구조적 미지원**임을 명확한 fail-closed UX로 표면화. US 활성화(대체 orderable 경로/시드현금 가정)는 별도 product decision이라 범위 밖. 매도 라우팅 문서화는 ROB-420(완료) 커버.
+
+## 설계 (브레인스토밍 Approach A + dry_run 경고 유지)
+
+### 변경 표면 (read-only, migration 0, broker/order/watch mutation 없음)
+
+- `app/mcp_server/tooling/order_validation.py` — `_check_balance_and_warn`에 US mock buy 조기 가드 + 순수 헬퍼
+
+### Unit 1 — capability_matrix 조기 가드
+
+순수 헬퍼:
+```python
+def _kis_mock_us_orderable_unsupported() -> bool:
+    """KIS 모의투자가 해외(USD) orderable-cash 서비스를 제공하지 않는지
+    (OPSQ0002, 2026-05-27 smoke 검증). capability_matrix를 권위 소스로 사용 —
+    미래에 US mock cash 어댑터가 생겨 account_cash_read=True가 되면 가드 자동 완화."""
+    from app.services.us_dual_paper.capability_matrix import get_capability_matrix
+
+    return get_capability_matrix().get("kis_mock", {}).get("account_cash_read") is False
+```
+
+`_check_balance_and_warn` 맨 앞(네트워크 호출 전)에 가드 추가:
+```python
+if (
+    is_mock
+    and market_type == "equity_us"
+    and side == "buy"
+    and _kis_mock_us_orderable_unsupported()
+):
+    message = (
+        "US mock buy unsupported: KIS 모의투자 provides no overseas "
+        "orderable-cash service (OPSQ0002), so orderable cash cannot be "
+        "verified. Use alpaca_paper for US paper buys; kis_mock supports KR."
+    )
+    if dry_run:
+        return f"Preview warning: {message}", None
+    err = order_error_fn(message)
+    err["mock_unsupported"] = True
+    err["capability"] = "kis_mock_us_orderable_cash_unsupported"
+    return None, err
+```
+
+동작:
+- **dry_run=True**: `(warning, None)` 반환 → `_place_order_impl`은 balance_error=None이라 프리뷰를 그대로 반환하되 경고가 명확한 unsupported (현 동작과 일관, 정보성 보존).
+- **dry_run=False**: `(None, err)` 반환 → `_place_order_impl`이 즉시 err 반환(실주문 차단). `mock_unsupported=True` + `capability` 태그로 구조적 미지원이 기계적으로 식별 가능.
+- **KR mock**(`equity_kr`): `inquire_domestic_cash_balance` 정상 → 가드 미적용(equity_us only). crypto/live 무영향.
+- 조기 가드가 OPSQ0002 네트워크 round-trip을 **선제 차단**(결정적, KIS 호출 낭비 없음). 기존 예외 분기(`:852-868`)는 진짜 일시 실패용으로 유지(generic, `mock_unsupported` 미태깅 — 구조적 미지원과 구분).
+
+### 에러 dict 태깅
+
+`order_error_fn`(=`_order_error`→`_build_order_error`)은 고정 shape를 반환하므로, 반환 dict에 `mock_unsupported`/`capability` 키를 추가(dict mutable). `_build_order_error` 시그니처 무변경(다른 도구도 동일하게 ad-hoc 태깅).
+
+## 테스트 (TDD)
+
+`tests/`의 order_validation / place_order 테스트:
+
+1. `_kis_mock_us_orderable_unsupported()` — capability_matrix `account_cash_read=False` 반영(True 반환).
+2. US mock buy `dry_run=False` → `success=False`, `mock_unsupported=True`, `capability="kis_mock_us_orderable_cash_unsupported"`, 메시지에 "unsupported"/"OPSQ0002". **`_get_balance_for_order` 미호출**(monkeypatch spy로 네트워크 선제차단 검증).
+3. US mock buy `dry_run=True` → 에러 아님(`balance_error is None`), warning에 "US mock buy unsupported".
+4. KR mock buy → 가드 미적용(기존 `_get_balance_for_order` 경로 진입, monkeypatch로 호출 확인).
+5. US **live**(`is_mock=False`) buy → 가드 미적용.
+
+`_check_balance_and_warn`는 `order_error_fn`을 받으므로 테스트에서 간단한 dict-반환 스텁 주입으로 단위 검증 가능.
+
+## 안전 경계 / Non-goals
+
+- fail-closed 보존 — 미지원이면 실주문 차단(success 위장 금지).
+- dry_run preview가 orderable 검증 못함을 `mock_unsupported`로 명시.
+- broker/order/watch/order-intent mutation 없음, migration 0, read-only.
+- US mock 매수 **활성화**(대체 orderable 조회/시드현금 가정)는 별도 product decision — 범위 밖.
+- 매도 라우팅(toss/samsung)은 ROB-420(완료) 소관 — 본 PR 무관.
+- `_is_kis_mock_unsupported` 공유 마커 리스트는 **건드리지 않음**(modify/cancel soft-cancel 의미 변경 회피) — 조기 가드는 capability_matrix 기반이라 마커 불필요.

--- a/tests/test_order_us_mock_buy_unsupported.py
+++ b/tests/test_order_us_mock_buy_unsupported.py
@@ -1,0 +1,124 @@
+"""ROB-417 — US kis_mock buy is fail-closed unsupported (OPSQ0002), made explicit."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import (
+    _check_balance_and_warn,
+    _kis_mock_us_orderable_unsupported,
+)
+
+
+def _order_error(message: str) -> dict:
+    return {"success": False, "error": message}
+
+
+def test_kis_mock_us_orderable_unsupported_reflects_capability_matrix():
+    # capability_matrix documents kis_mock account_cash_read=False (OPSQ0002).
+    assert _kis_mock_us_orderable_unsupported() is True
+
+
+@pytest.mark.asyncio
+async def test_us_mock_buy_non_dry_run_blocked_with_mock_unsupported(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(*_a, **_k):
+        called["balance"] = True
+        return 0.0
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert warning is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["mock_unsupported"] is True
+    assert error["capability"] == "kis_mock_us_orderable_cash_unsupported"
+    assert "unsupported" in error["error"].lower()
+    # Early guard short-circuits BEFORE any KIS network call.
+    assert called["balance"] is False
+
+
+@pytest.mark.asyncio
+async def test_us_mock_buy_dry_run_returns_clear_warning_keeps_preview(monkeypatch):
+    async def spy_balance(*_a, **_k):
+        raise AssertionError("must not be called for US mock buy guard")
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert error is None  # preview not blocked
+    assert warning is not None
+    assert "US mock buy unsupported" in warning
+
+
+@pytest.mark.asyncio
+async def test_kr_mock_buy_not_guarded_enters_balance_path(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(market_type, is_mock=False):
+        called["balance"] = True
+        return 10_000_000.0  # ample KRW
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    # KR mock has a DB-shadow-exposure guard; stub it to the pass-through state.
+    async def fake_exposure(*_a, **_k):
+        return {"confidence": "db_shadow_pending", "buy_reserved_amount": 0.0}
+
+    monkeypatch.setattr(
+        order_validation, "_get_kis_mock_shadow_exposure", fake_exposure
+    )
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_kr",
+        normalized_symbol="005930",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=True,
+    )
+    assert error is None
+    assert called["balance"] is True  # guard did NOT short-circuit KR
+
+
+@pytest.mark.asyncio
+async def test_us_live_buy_not_guarded(monkeypatch):
+    called = {"balance": False}
+
+    async def spy_balance(*_a, **_k):
+        called["balance"] = True
+        return 10_000.0
+
+    monkeypatch.setattr(order_validation, "_get_balance_for_order", spy_balance)
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,  # live
+    )
+    assert error is None
+    assert called["balance"] is True  # live enters the real precheck


### PR DESCRIPTION
## 요약 (ROB-417, E라인 E2)

`kis_mock_place_order` US **매수**가 KIS 모의투자의 해외 orderable-cash 미지원(OPSQ0002)으로 원천 불가인데, 현재는 generic 메시지("KIS mock balance precheck unavailable ... OPSQ0002 ...")로 뭉개져 **구조적 미지원 vs 일시 실패**를 구분 못함. capability_matrix 기반 조기 가드로 fail-closed를 명확히 표면화합니다.

스코프(ROB-421 경계): US mock 매수 **미지원을 명확히 드러내는 fail-closed UX**. US 활성화(대체 orderable/시드현금)는 별도 product decision = Non-goal. 매도 라우팅은 ROB-420(완료) 소관.

## 변경 (read-only, migration 0, broker/order/watch mutation 없음)

`app/mcp_server/tooling/order_validation.py`:
- `_kis_mock_us_orderable_unsupported()` — `get_capability_matrix()["kis_mock"]["account_cash_read"] is False`를 권위 소스로 사용(2026-05-27 smoke로 OPSQ0002 확정; 미래 US mock cash 어댑터 생기면 자동 완화).
- `_check_balance_and_warn` 맨 앞(KIS 호출 전) 조기 가드: `is_mock and equity_us and side==buy and 미지원`이면:
  - **dry_run=True**: 프리뷰 유지 + 명확 `"US mock buy unsupported: ... OPSQ0002 ..."` warning.
  - **dry_run=False**: 즉시 차단, 에러에 `mock_unsupported=True` + `capability="kis_mock_us_orderable_cash_unsupported"` 태그.
  - KIS round-trip 선제 차단(결정적). 기존 예외 분기는 **진짜 일시 실패**용으로 유지(generic, 미태깅 — 구조적 미지원과 구분).

## 경계 보존

- **KR mock**(`equity_kr`): 가드 미적용 — `inquire_domestic_cash_balance` 정상. **US live**(`is_mock=False`)·crypto 무영향.
- fail-closed 보존(미지원이면 실주문 차단, success 위장 금지).
- `_is_kis_mock_unsupported` 공유 마커(modify/cancel soft-cancel) 미변경.

## 테스트

- 신규 5종: 헬퍼 capability 반영 / US mock buy dry_run=False→`mock_unsupported` 태그 + **KIS 호출 안 됨**(선제차단) / dry_run=True→프리뷰+명확 warning / KR mock→가드 미적용 balance 경로 진입 / US live→미적용. 단일-head 포함 6 passed. ruff/ty clean.
- 기존 `test_mcp_place_order.py`의 "balance precheck unavailable" 단언(`:1408/1460/1461`)은 **KR(005930)** 경로라 가드 미적용 → 무영향(회귀 없음).

## Pre-existing baseline (내 변경 무관)

- `test_mcp_place_order.py::TestOrderFillRecording` 등 `uq_live_ledger_order` 중복 위반(ROB-407 ledger, symbol=KRW-BTC crypto) — **깨끗한 main에서도 동일 실패**(로컬 dev DB 잔여물). CI fresh DB에서 통과, 내 회귀 아님.

## 충돌 경계 (ROB-421 E2)

- ROB-409/407 live order ledger/회계 경계 무접근(가드는 precheck 표면만). ROB-419(예약-인지 orderable)와 같은 `_check_balance_and_warn` 표면 공유하나 본 PR은 US-mock 분기만 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>