### PR TITLE
fix(ROB-419): live 매수 precheck를 예약-차감 orderable로 정합 (pending-order 예약 반영)

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -23,13 +23,15 @@ from app.mcp_server.tooling.portfolio_cash import (
     extract_usd_orderable_from_row as _extract_usd_orderable_from_row,
 )
 from app.mcp_server.tooling.portfolio_cash import (
+    get_cash_balance_impl,
+)
+from app.mcp_server.tooling.portfolio_cash import (
     select_usd_row_for_us_order as _select_usd_row_for_us_order,
 )
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.services.brokers.kis import (
     KISClient,
-    extract_domestic_cash_summary_from_integrated_margin,
 )
 from app.services.brokers.upbit.client import (
     parse_upbit_account_row as _parse_upbit_account_row,
@@ -373,6 +375,20 @@ async def _get_holdings_for_order(
     return None
 
 
+async def _live_kis_orderable(account_token: str) -> float:
+    """live KIS 예약-차감 orderable (단일 소스 = get_available_capital의 소스).
+
+    ``account_token``: "kis_domestic" (KRW) | "kis_overseas" (USD).
+    ``get_cash_balance_impl``이 raw orderable에서 대기주문 예약을 차감(실패 시 raw
+    fallback)하므로 precheck가 get_available_capital과 동일 orderable을 본다.
+    """
+    result = await get_cash_balance_impl(account=account_token, is_mock=False)
+    for acc in result.get("accounts", []):
+        if acc.get("account") == account_token:
+            return float(acc.get("orderable") or 0.0)
+    raise RuntimeError(f"{account_token} orderable not found in cash balance")
+
+
 async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> float:
     if market_type == "crypto":
         coins = await upbit_service.fetch_my_coins()
@@ -382,22 +398,23 @@ async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> flo
         return 0.0
 
     if market_type == "equity_kr":
-        kis = _create_kis_client(is_mock=is_mock)
         if is_mock:
+            kis = _create_kis_client(is_mock=is_mock)
             cash_summary = await _call_kis(
                 kis.inquire_domestic_cash_balance,
                 is_mock=is_mock,
             )
             return float(cash_summary.get("stck_cash_ord_psbl_amt") or 0)
-        margin_data = await _call_kis(
-            kis.inquire_integrated_margin,
-            is_mock=is_mock,
-        )
-        domestic_cash = extract_domestic_cash_summary_from_integrated_margin(
-            margin_data
-        )
-        return float(domestic_cash.get("orderable") or 0)
+        # ROB-419 — live: reservation-aware orderable (== get_available_capital),
+        # so pending-order cash reservations are not treated as spendable.
+        return await _live_kis_orderable("kis_domestic")
 
+    if not is_mock:
+        # ROB-419 — live US: reservation-aware orderable via the single source.
+        return await _live_kis_orderable("kis_overseas")
+
+    # mock US: KIS 모의투자엔 해외 orderable-cash 서비스가 없음(OPSQ0002). ROB-417
+    # 조기 가드가 _check_balance_and_warn에서 선제 차단하므로 여기 도달은 방어적.
     kis = _create_kis_client(is_mock=is_mock)
     margin_data = await _call_kis(kis.inquire_overseas_margin, is_mock=is_mock)
     usd_row = _select_usd_row_for_us_order(margin_data)

--- a/docs/superpowers/plans/2026-06-02-rob-419-live-precheck-reservation-aware.md
+++ b/docs/superpowers/plans/2026-06-02-rob-419-live-precheck-reservation-aware.md
@@ -1,0 +1,299 @@
+# ROB-419 live 매수 precheck 예약-인지 orderable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** live 매수 precheck `_get_balance_for_order`가 raw orderable 대신 `get_cash_balance_impl`의 예약-차감된 orderable(= `get_available_capital`과 동일)을 사용하도록 정합해, 대기주문이 현금을 예약한 경우 dry_run에서 insufficient를 잡게 한다.
+
+**Architecture:** `_get_balance_for_order`의 live(equity_kr/equity_us, is_mock=False) 분기를 `get_cash_balance_impl(account="kis_domestic"|"kis_overseas")` 위임으로 교체(단일 소스). mock/crypto 분기 무변경(mock 예약은 ROB-341 shadow-exposure가 담당). read-only(ledger 무접근), migration 0.
+
+**Tech Stack:** Python 3.13, pytest(asyncio + monkeypatch). 순수 위임 + async, 테스트는 get_cash_balance_impl 스텁.
+
+---
+
+## File Structure
+
+- Modify: `app/mcp_server/tooling/order_validation.py` — `_live_kis_orderable` 헬퍼 + `_get_balance_for_order` live 분기 + import
+- Create: `tests/test_order_live_precheck_reservation.py` — 위임/예약-차감/mock-미델리게이트 단위 테스트
+
+---
+
+## Task 1: live precheck를 get_cash_balance_impl 예약-차감 orderable로 위임
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py`
+- Test: `tests/test_order_live_precheck_reservation.py`
+
+배경: `_get_balance_for_order`(`order_validation.py:376-406`) live 분기는 raw orderable만 읽어 대기주문 예약을 미반영. `get_cash_balance_impl`(get_available_capital의 소스)은 `max(0, raw − pending_buy_amount)`로 차감하므로 그 값을 재사용해 precheck == get_available_capital을 보장.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/test_order_live_precheck_reservation.py` 신규 생성:
+
+```python
+"""ROB-419 — live buy precheck uses reservation-aware orderable (== get_available_capital)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import (
+    _check_balance_and_warn,
+    _get_balance_for_order,
+)
+
+
+def _order_error(message: str) -> dict:
+    return {"success": False, "error": message}
+
+
+@pytest.mark.asyncio
+async def test_live_kr_precheck_uses_reservation_adjusted_orderable(monkeypatch):
+    seen = {}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        seen["account"] = account
+        seen["is_mock"] = is_mock
+        # raw orderable was higher, but pending orders reserved it to 0.
+        return {"accounts": [{"account": "kis_domestic", "currency": "KRW", "orderable": 0.0}]}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    balance = await _get_balance_for_order("equity_kr", is_mock=False)
+    assert balance == 0.0
+    assert seen == {"account": "kis_domestic", "is_mock": False}
+
+
+@pytest.mark.asyncio
+async def test_live_us_precheck_uses_reservation_adjusted_orderable(monkeypatch):
+    seen = {}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        seen["account"] = account
+        return {"accounts": [{"account": "kis_overseas", "currency": "USD", "orderable": 0.0}]}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    balance = await _get_balance_for_order("equity_us", is_mock=False)
+    assert balance == 0.0
+    assert seen["account"] == "kis_overseas"
+
+
+@pytest.mark.asyncio
+async def test_live_us_buy_blocked_when_orderable_reserved_to_zero(monkeypatch):
+    # repro: pending orders reserved all cash → orderable=0 → buy must NOT pass.
+    async def fake_cash(account=None, *, is_mock=False):
+        return {"accounts": [{"account": "kis_overseas", "currency": "USD", "orderable": 0.0}]}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    # dry_run: insufficient warning (no error, preview still returned upstream).
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+    assert error is None
+    assert warning is not None and "Insufficient" in warning
+
+    # non-dry_run: hard error.
+    warning2, error2 = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+    assert error2 is not None
+    assert error2["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_mock_kr_precheck_does_not_delegate_to_cash_balance(monkeypatch):
+    called = {"cash": False}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        called["cash"] = True
+        return {"accounts": []}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    class FakeKIS:
+        def __init__(self, is_mock: bool = False):
+            self.is_mock = is_mock
+
+        async def inquire_domestic_cash_balance(self, *, is_mock: bool = False):
+            return {"stck_cash_ord_psbl_amt": 5_000_000}
+
+    monkeypatch.setattr(order_validation, "KISClient", FakeKIS)
+
+    balance = await _get_balance_for_order("equity_kr", is_mock=True)
+    assert balance == 5_000_000.0
+    assert called["cash"] is False  # mock path must NOT use get_cash_balance_impl
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && uv run pytest tests/test_order_live_precheck_reservation.py -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'get_cash_balance_impl'`(아직 import 안 함) 또는 live 분기가 위임 안 해 raw 경로로 빠짐.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`app/mcp_server/tooling/order_validation.py`:
+
+(a) import 추가 — 기존 portfolio_cash import 블록(`:22-27`) 뒤에:
+
+```python
+from app.mcp_server.tooling.portfolio_cash import (
+    get_cash_balance_impl,
+)
+```
+
+(b) 헬퍼 추가 — `_get_balance_for_order`(`:376`) 정의 바로 앞:
+
+```python
+async def _live_kis_orderable(account_token: str) -> float:
+    """live KIS 예약-차감 orderable (단일 소스 = get_available_capital의 소스).
+
+    ``account_token``: "kis_domestic" (KRW) | "kis_overseas" (USD).
+    ``get_cash_balance_impl``이 raw orderable에서 대기주문 예약을 차감(실패 시 raw
+    fallback)하므로 precheck가 get_available_capital과 동일 orderable을 본다.
+    """
+    result = await get_cash_balance_impl(account=account_token, is_mock=False)
+    for acc in result.get("accounts", []):
+        if acc.get("account") == account_token:
+            return float(acc.get("orderable") or 0.0)
+    raise RuntimeError(f"{account_token} orderable not found in cash balance")
+```
+
+(c) `_get_balance_for_order` live 분기 교체. 현재(`:384-406`):
+
+```python
+    if market_type == "equity_kr":
+        kis = _create_kis_client(is_mock=is_mock)
+        if is_mock:
+            cash_summary = await _call_kis(
+                kis.inquire_domestic_cash_balance,
+                is_mock=is_mock,
+            )
+            return float(cash_summary.get("stck_cash_ord_psbl_amt") or 0)
+        margin_data = await _call_kis(
+            kis.inquire_integrated_margin,
+            is_mock=is_mock,
+        )
+        domestic_cash = extract_domestic_cash_summary_from_integrated_margin(
+            margin_data
+        )
+        return float(domestic_cash.get("orderable") or 0)
+
+    kis = _create_kis_client(is_mock=is_mock)
+    margin_data = await _call_kis(kis.inquire_overseas_margin, is_mock=is_mock)
+    usd_row = _select_usd_row_for_us_order(margin_data)
+    if usd_row is None:
+        raise RuntimeError("USD margin data not found in KIS overseas margin")
+    return _extract_usd_orderable_from_row(usd_row)
+```
+
+교체:
+
+```python
+    if market_type == "equity_kr":
+        if is_mock:
+            kis = _create_kis_client(is_mock=is_mock)
+            cash_summary = await _call_kis(
+                kis.inquire_domestic_cash_balance,
+                is_mock=is_mock,
+            )
+            return float(cash_summary.get("stck_cash_ord_psbl_amt") or 0)
+        # ROB-419 — live: reservation-aware orderable (== get_available_capital),
+        # so pending-order cash reservations are not treated as spendable.
+        return await _live_kis_orderable("kis_domestic")
+
+    if not is_mock:
+        # ROB-419 — live US: reservation-aware orderable via the single source.
+        return await _live_kis_orderable("kis_overseas")
+
+    # mock US: KIS 모의투자엔 해외 orderable-cash 서비스가 없음(OPSQ0002). ROB-417
+    # 조기 가드가 _check_balance_and_warn에서 선제 차단하므로 여기 도달은 방어적.
+    kis = _create_kis_client(is_mock=is_mock)
+    margin_data = await _call_kis(kis.inquire_overseas_margin, is_mock=is_mock)
+    usd_row = _select_usd_row_for_us_order(margin_data)
+    if usd_row is None:
+        raise RuntimeError("USD margin data not found in KIS overseas margin")
+    return _extract_usd_orderable_from_row(usd_row)
+```
+
+> 참고: `extract_domestic_cash_summary_from_integrated_margin` import가 다른 곳에서 더 쓰이지 않으면 ruff가 unused로 잡을 수 있음 — Step 4 lint에서 확인 후 미사용 시 import 제거.
+
+- [ ] **Step 4: Run test + lint to verify it passes**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && uv run pytest tests/test_order_live_precheck_reservation.py -v && uv run ruff check app/mcp_server/tooling/order_validation.py`
+Expected: PASS (4건). ruff에서 unused import(`extract_domestic_cash_summary_from_integrated_margin` 등) 보고 시 해당 import 제거 후 재실행.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-419
+git add app/mcp_server/tooling/order_validation.py tests/test_order_live_precheck_reservation.py
+git commit -m "fix(ROB-419): live 매수 precheck를 예약-차감 orderable(get_available_capital 소스)로 정합
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: 회귀 + lint/ty 검증
+
+**Files:**
+- (없음 — 검증만; Step 1에서 회귀 발견 시 갱신)
+
+- [ ] **Step 1: 기존 precheck balance 단언 탐색**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && grep -rn "inquire_integrated_margin\|inquire_overseas_margin\|_get_balance_for_order\|stck_cash_ord_psbl_amt" tests/`
+조치: live KR/US 매수 precheck가 `inquire_integrated_margin`/`inquire_overseas_margin`을 직접 stub하고 raw orderable을 단언하는 테스트가 있으면, 이제 live는 `get_cash_balance_impl`로 위임하므로 해당 테스트를 `get_cash_balance_impl` 스텁 또는 그 내부 호출(inquire_korea_orders/inquire_overseas_orders 포함)에 맞게 갱신하고 함께 커밋. mock 경로 단언은 무변경. 매치 없으면 스킵.
+
+- [ ] **Step 2: 인접 회귀 스위트**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && uv run pytest tests/test_order_live_precheck_reservation.py tests/test_order_us_mock_buy_unsupported.py tests/test_kis_mock_routing.py tests/test_mcp_place_order.py -q 2>&1 | tail -10`
+Expected: PASS. (로컬 공유-DB `uq_live_ledger_order` 잔여물로 인한 pre-existing 실패는 단독 재현으로 내 변경 무관임을 확인하고 기록 — 깨끗한 main도 동일 실패.)
+
+- [ ] **Step 3: Lint + format + ty**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && uv run ruff check app/mcp_server/tooling/order_validation.py tests/test_order_live_precheck_reservation.py && uv run ruff format --check app/mcp_server/tooling/order_validation.py tests/test_order_live_precheck_reservation.py && uv run ty check app/mcp_server/tooling/order_validation.py --error-on-warning 2>&1 | tail -5`
+Expected: All checks passed / already formatted. (포맷 실패 시 `uv run ruff format <file>`.)
+
+- [ ] **Step 4: Mutation import guard (read-only invariant)**
+
+Run: `cd /Users/mgh3326/work/auto_trader.rob-419 && uv run pytest -k "import_guard or mutation_guard" -q 2>&1 | tail -5`
+Expected: green(order_validation에 broker order-mutation 미도입; KIS 조회만). guard 없으면 스킵.
+
+- [ ] **Step 5: Step 1/3에서 파일 갱신했다면 커밋(없으면 스킵)**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-419
+git add -A && git commit -m "test(ROB-419): live precheck 위임 회귀 갱신/포맷
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review 결과
+
+**Spec 커버리지:**
+- Unit 1 (`_live_kis_orderable` 위임 + live 분기 교체) → Task 1 ✅
+- live KR·US 예약-차감, mock 미델리게이트, crypto 무변경 → Task 1 테스트 1·2·4 ✅
+- repro 재현·해소(orderable=0 → dry_run warning / 실주문 error) → Task 1 테스트 3 ✅
+- 회귀/lint/ty/import-guard → Task 2 ✅
+
+**Placeholder 스캔:** 없음 — 모든 코드 step에 실제 코드 포함.
+
+**Type 일관성:** `_live_kis_orderable(account_token: str) -> float` 정의/호출 일치. `get_cash_balance_impl(account=..., is_mock=False)` 시그니처는 portfolio_cash 정의(`account: str | None, *, is_mock: bool`)와 일치. live equity_kr→"kis_domestic", equity_us→"kis_overseas" 토큰 일관.
+
+**안전 경계 재확인:** precheck read-only(KIS 조회만, ledger/주문 mutation 없음) → ROB-409/407 경계 무접근. 예약차감 실패 fallback(get_cash_balance_impl 상속). mock 무변경(ROB-341 이중차감 회피). migration 0. current_price echo는 Non-goal.

--- a/docs/superpowers/specs/2026-06-02-rob-419-live-precheck-reservation-aware-design.md
+++ b/docs/superpowers/specs/2026-06-02-rob-419-live-precheck-reservation-aware-design.md
@@ -1,0 +1,85 @@
+# ROB-419 — live 매수 precheck 예약-인지 orderable 정합
+
+- **이슈**: ROB-419 (E라인 E2)
+- **유형**: Bug fix
+- **작성일**: 2026-06-02
+- **연관**: ROB-421(오케스트레이션), ROB-409/407(live order ledger 경계 — 인접/무접근), ROB-341(mock shadow-exposure 예약차감), ROB-417(같은 precheck 표면)
+
+## 증상 / 근본 원인
+
+`get_available_capital(kis_live)`에서 kis_overseas `orderable=0`(대기 주문이 현금 예약)인 상태에서도 `kis_live_place_order(side=buy, dry_run=True)`가 거부 없이 success 반환 → 사용자가 실주문 단계에서야 insufficient를 발견.
+
+근본: live 매수 precheck `_get_balance_for_order`(`order_validation.py:376-406`)는 **raw** orderable만 읽는다:
+- equity_kr live: `inquire_integrated_margin` → `orderable`
+- equity_us live: `inquire_overseas_margin` → `frcr_gnrl_ord_psbl_amt`
+
+반면 `get_available_capital`의 소스 `get_cash_balance_impl`(`portfolio_cash.py`)은 동일 raw orderable에서 **대기주문 예약을 차감**한다:
+- KR: `orderable = max(0, raw − _get_kis_domestic_pending_buy_amount)` (`portfolio_cash.py:203-210`)
+- US: `orderable = max(0, raw − _get_kis_overseas_pending_buy_amount_usd)` (`portfolio_cash.py:274-282`)
+- 둘 다 예약 차감 실패 시 raw orderable로 fallback(경고 로그).
+
+즉 "live가 프리체크를 안 함"이 아니라(전제 정정 완료), **precheck의 잔고 소스가 pending-order 현금 예약을 미반영**하는 것이 진짜 갭. mock은 `_check_balance_and_warn`에서 ROB-341 shadow-exposure(`buy_reserved_amount`)로 예약을 별도 차감하므로 이미 예약-인지.
+
+## 기대 동작
+
+live 매수 precheck가 `get_available_capital`이 노출하는 것과 **동일한 예약-차감 후 orderable**을 사용해, orderable=0(예약됨)이면 dry_run에서 insufficient를 잡는다.
+
+## 설계 (브레인스토밍 Approach A + live KR·US)
+
+### 변경 표면 (read-only, migration 0, broker/order/watch/order-intent mutation 없음)
+
+- `app/mcp_server/tooling/order_validation.py` — `_get_balance_for_order` live 분기 + 헬퍼
+
+precheck는 KIS **조회만**(주문/ledger mutation 없음) → ROB-409/407 accepted-only ledger 경계에 무접근.
+
+### 순환 import 확인
+
+`order_validation.py`는 이미 `portfolio_cash`에서 import 중(`:22-27` extract_usd_orderable_from_row / select_usd_row_for_us_order). `portfolio_cash`는 `order_validation`을 import하지 않음 → 순환 없음, 모듈-레벨 import 안전.
+
+### Unit 1 — precheck를 단일 소스(get_cash_balance_impl)로 정합
+
+헬퍼:
+```python
+async def _live_kis_orderable(account_token: str) -> float:
+    """live KIS 예약-차감 orderable (단일 소스 = get_available_capital의 소스).
+
+    account_token: "kis_domestic" (KRW) | "kis_overseas" (USD).
+    get_cash_balance_impl이 raw orderable에서 대기주문 예약을 차감(실패 시 raw
+    fallback)하므로 precheck가 get_available_capital과 동일 값을 본다.
+    """
+    result = await get_cash_balance_impl(account=account_token, is_mock=False)
+    for acc in result.get("accounts", []):
+        if acc.get("account") == account_token:
+            return float(acc.get("orderable") or 0.0)
+    raise RuntimeError(f"{account_token} orderable not found in cash balance")
+```
+
+`_get_balance_for_order` 수정:
+- `equity_kr` + **live**(`is_mock=False`) → `return await _live_kis_orderable("kis_domestic")`
+- `equity_us` + **live** → `return await _live_kis_orderable("kis_overseas")`
+- **mock 분기 전부 무변경**: equity_kr mock은 `inquire_domestic_cash_balance` 그대로; equity_us mock은 ROB-417 조기 가드가 `_check_balance_and_warn`에서 선제 차단(여기 미도달). mock 예약은 ROB-341 shadow-exposure가 담당 → **이중차감 회피**.
+- **crypto 무변경**.
+
+`get_cash_balance_impl(account=...)`는 strict_mode라 KIS 실패 시 RuntimeError를 raise → live `_check_balance_and_warn`는 예외를 re-raise(기존 동작과 일관).
+
+import 추가: `from app.mcp_server.tooling.portfolio_cash import get_cash_balance_impl`.
+
+## 테스트 (TDD)
+
+`tests/`의 order_validation 단위 테스트(monkeypatch로 `order_validation.get_cash_balance_impl` 스텁):
+
+1. `_get_balance_for_order("equity_kr", is_mock=False)` → get_cash_balance_impl을 `account="kis_domestic"`로 호출하고 그 accounts의 예약-차감 `orderable`(예: 0.0)을 반환.
+2. `_get_balance_for_order("equity_us", is_mock=False)` → `account="kis_overseas"` 호출, USD orderable 반환.
+3. **repro 재현·해소**: `_check_balance_and_warn(equity_us, side=buy, is_mock=False, order_amount>0)`에서 get_cash_balance_impl가 orderable=0(예약됨) 반환 → `dry_run=True`면 warning(insufficient USD), `dry_run=False`면 error.
+4. **mock 미델리게이트**: `_get_balance_for_order("equity_kr", is_mock=True)`는 get_cash_balance_impl을 호출하지 않고 기존 `inquire_domestic_cash_balance` 경로(monkeypatch spy로 get_cash_balance_impl 미호출 검증).
+5. **crypto 무변경**: `_get_balance_for_order("crypto", is_mock=False)`는 upbit 경로(기존).
+
+## 안전 경계 / Non-goals
+
+- precheck read-only(KIS 조회만) → ledger/주문 mutation 없음, ROB-409/407 경계 무접근.
+- 예약차감 실패 시 raw orderable fallback(get_cash_balance_impl 로직 상속 — 과차단 회피).
+- mock 경로 무변경(ROB-341 shadow-exposure가 mock 예약 담당, 이중차감 회피).
+- dry_run이 orderable 검증 못하면 success 위장 금지(insufficient 경고/에러).
+- migration 0, broker/order/watch/order-intent mutation 없음.
+- `current_price`가 입력 limit price echo인지(이슈 #3 부차)는 별도 표면 — 범위 밖.
+- precheck가 KIS 호출 1건(margin) → 2건(margin + pending-orders)으로 늘어남(get_cash_balance_impl 내부). 정확성 trade-off로 수용.

--- a/tests/test_order_live_precheck_reservation.py
+++ b/tests/test_order_live_precheck_reservation.py
@@ -1,0 +1,118 @@
+"""ROB-419 — live buy precheck uses reservation-aware orderable (== get_available_capital)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import (
+    _check_balance_and_warn,
+    _get_balance_for_order,
+)
+
+
+def _order_error(message: str) -> dict:
+    return {"success": False, "error": message}
+
+
+@pytest.mark.asyncio
+async def test_live_kr_precheck_uses_reservation_adjusted_orderable(monkeypatch):
+    seen = {}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        seen["account"] = account
+        seen["is_mock"] = is_mock
+        # raw orderable was higher, but pending orders reserved it to 0.
+        return {
+            "accounts": [
+                {"account": "kis_domestic", "currency": "KRW", "orderable": 0.0}
+            ]
+        }
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    balance = await _get_balance_for_order("equity_kr", is_mock=False)
+    assert balance == 0.0
+    assert seen == {"account": "kis_domestic", "is_mock": False}
+
+
+@pytest.mark.asyncio
+async def test_live_us_precheck_uses_reservation_adjusted_orderable(monkeypatch):
+    seen = {}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        seen["account"] = account
+        return {
+            "accounts": [
+                {"account": "kis_overseas", "currency": "USD", "orderable": 0.0}
+            ]
+        }
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    balance = await _get_balance_for_order("equity_us", is_mock=False)
+    assert balance == 0.0
+    assert seen["account"] == "kis_overseas"
+
+
+@pytest.mark.asyncio
+async def test_live_us_buy_blocked_when_orderable_reserved_to_zero(monkeypatch):
+    # repro: pending orders reserved all cash → orderable=0 → buy must NOT pass.
+    async def fake_cash(account=None, *, is_mock=False):
+        return {
+            "accounts": [
+                {"account": "kis_overseas", "currency": "USD", "orderable": 0.0}
+            ]
+        }
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    # dry_run: insufficient warning (no error, preview still returned upstream).
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+    assert error is None
+    assert warning is not None and "Insufficient" in warning
+
+    # non-dry_run: hard error.
+    warning2, error2 = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="MSFT",
+        side="buy",
+        order_amount=1000.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+    assert error2 is not None
+    assert error2["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_mock_kr_precheck_does_not_delegate_to_cash_balance(monkeypatch):
+    called = {"cash": False}
+
+    async def fake_cash(account=None, *, is_mock=False):
+        called["cash"] = True
+        return {"accounts": []}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
+
+    class FakeKIS:
+        def __init__(self, is_mock: bool = False):
+            self.is_mock = is_mock
+
+        async def inquire_domestic_cash_balance(self, *, is_mock: bool = False):
+            return {"stck_cash_ord_psbl_amt": 5_000_000}
+
+    monkeypatch.setattr(order_validation, "KISClient", FakeKIS)
+
+    balance = await _get_balance_for_order("equity_kr", is_mock=True)
+    assert balance == 5_000_000.0
+    assert called["cash"] is False  # mock path must NOT use get_cash_balance_impl


### PR DESCRIPTION
## 요약 (ROB-419, E라인 E2)

`get_available_capital(kis_live)`에서 kis_overseas `orderable=0`(대기주문이 현금 예약)인데도 `kis_live_place_order(side=buy, dry_run=True)`가 거부 없이 success 반환 → 사용자가 실주문 단계에서야 insufficient 발견. live 매수 precheck가 **pending-order 현금 예약을 반영**하도록 정합합니다.

전제 정정 노트: "live가 프리체크를 안 함"은 FALSE(live·mock 둘 다 함). 실제 갭은 precheck의 잔고 소스가 raw orderable만 읽어 예약을 미반영하는 것.

## 변경 (read-only, migration 0, broker/order/watch/order-intent mutation 없음)

`app/mcp_server/tooling/order_validation.py`:
- `_live_kis_orderable(account_token)` 헬퍼: `get_cash_balance_impl(account="kis_domestic"|"kis_overseas", is_mock=False)`의 **예약-차감 orderable**(= get_available_capital의 소스) 추출. 단일 소스로 precheck == get_available_capital 보장.
- `_get_balance_for_order` live 분기 위임: equity_kr live→`kis_domestic`, equity_us live→`kis_overseas`. `get_cash_balance_impl`이 `max(0, raw − pending_buy_amount)`로 대기주문 예약 차감(실패 시 raw fallback).
- **mock 분기 무변경**: mock 예약은 `_check_balance_and_warn`의 ROB-341 shadow-exposure가 담당 → 이중차감 회피. **crypto 무변경**.
- unused import(`extract_domestic_cash_summary_from_integrated_margin`) 정리.

## 효과

repro(kis_overseas orderable=0, 대기주문 예약) → live US 매수 precheck가 0을 읽어 `balance < order_amount` → dry_run insufficient 경고 / 실주문 차단. live(pending 차감)/mock(ROB-341) 의미 정합.

## 안전 경계

- precheck는 **read-only**(KIS 조회만, ledger/주문 mutation 없음) → **ROB-409/407 accepted-only ledger 경계 무접근**.
- 예약차감 실패 시 raw orderable fallback(get_cash_balance_impl 로직 상속 — 과차단 회피).
- 순환 import 없음(order_validation는 이미 portfolio_cash 의존, 역방향 없음).

## 테스트

- 신규 4종: live KR/US 위임(`kis_domestic`/`kis_overseas` orderable 반환) / repro 재현·해소(orderable=0→dry_run warning, 실주문 error) / mock KR 미델리게이트(get_cash_balance_impl 미호출). 단일-head 포함 5 passed. ruff/ty clean.

## Pre-existing baseline (내 변경 무관)

- `test_mcp_place_order.py`의 11건(`uq_live_ledger_order` 중복, KRW-BTC crypto/US accepted-only ledger) — **깨끗한 main에서도 동일 11건 실패**(로컬 dev DB 잔여물). 내 변경이 추가한 실패 0건. CI fresh DB에서 통과.

## Non-goal

- `current_price`가 입력 limit price echo인지(이슈 #3 부차)는 별도 표면 — 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live order precheck to account for pending order reservations when calculating available cash for KR and US markets, ensuring precheck results align with actual order placement availability.
  * Live buy precheck now uses the same reservation-aware cash calculation as the available capital display, preventing false approvals when pending orders have reserved funds.
  * Mock trading behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->