### PR TITLE
feat(ROB-423): invest_report get_news 뉴스 citation 저장/표시 (PR1 seam + PR2 영속)

### DIFF
--- a/alembic/versions/20260603_rob423_news_citation_tables.py
+++ b/alembic/versions/20260603_rob423_news_citation_tables.py
@@ -1,0 +1,158 @@
+# alembic/versions/20260603_rob423_news_citation_tables.py
+"""rob-423 add investment_report_news_* tables (additive)
+
+Revision ID: 20260603_rob423_news
+Revises: 20260602_rob412_main_merge
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260603_rob423_news"
+down_revision: str | None = "20260602_rob412_main_merge"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _jsonb_default(literal: str) -> sa.sql.elements.TextClause:
+    return sa.text(f"'{literal}'::jsonb")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investment_report_news_fetch_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("run_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("instrument_type", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("requested_limit", sa.Integer(), nullable=False),
+        sa.Column(
+            "returned_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "used_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("fetched_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("freshness_policy", sa.Text(), nullable=True),
+        sa.Column("ttl_seconds", sa.Integer(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("error_code", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "raw_response_stored",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('ok','empty','unavailable','error')",
+            name="ck_investment_report_news_fetch_runs_status",
+        ),
+        sa.UniqueConstraint(
+            "run_uuid", name="uq_investment_report_news_fetch_runs_run_uuid"
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_report_news_fetch_runs_report_uuid",
+        "investment_report_news_fetch_runs",
+        ["report_uuid"],
+        schema="review",
+    )
+
+    op.create_table(
+        "investment_report_news_citations",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("citation_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_item_uuid", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("section_key", sa.Text(), nullable=True),
+        sa.Column("fetch_run_id", sa.BigInteger(), nullable=True),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("external_article_id", sa.Text(), nullable=True),
+        sa.Column("canonical_url", sa.Text(), nullable=False),
+        sa.Column("source_name", sa.Text(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary_snapshot", sa.Text(), nullable=True),
+        sa.Column("published_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("fetched_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("relevance", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("decision_impact", sa.Text(), nullable=False),
+        sa.Column("selection_reason", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Numeric(), nullable=True),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=_jsonb_default("{}"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "relevance IN ('direct','related','market_context','crypto_context')",
+            name="ck_investment_report_news_citations_relevance",
+        ),
+        sa.CheckConstraint(
+            "role IN ('catalyst','risk','confirmation','contradiction','neutral','noise')",
+            name="ck_investment_report_news_citations_role",
+        ),
+        sa.CheckConstraint(
+            "decision_impact IN ('strengthen_buy','weaken_buy','strengthen_sell',"
+            "'weaken_sell','hold_watch','no_action')",
+            name="ck_investment_report_news_citations_decision_impact",
+        ),
+        sa.ForeignKeyConstraint(
+            ["fetch_run_id"],
+            ["review.investment_report_news_fetch_runs.id"],
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint(
+            "citation_uuid",
+            name="uq_investment_report_news_citations_citation_uuid",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_report_news_citations_report_uuid",
+        "investment_report_news_citations",
+        ["report_uuid"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_investment_report_news_citations_report_uuid",
+        table_name="investment_report_news_citations",
+        schema="review",
+    )
+    op.drop_table("investment_report_news_citations", schema="review")
+    op.drop_index(
+        "ix_investment_report_news_fetch_runs_report_uuid",
+        table_name="investment_report_news_fetch_runs",
+        schema="review",
+    )
+    op.drop_table("investment_report_news_fetch_runs", schema="review")

--- a/app/mcp_server/tooling/fundamentals/_news.py
+++ b/app/mcp_server/tooling/fundamentals/_news.py
@@ -1,12 +1,11 @@
-"""Handler for get_news tool."""
+# app/mcp_server/tooling/fundamentals/_news.py
+"""Handler for get_news tool (routes through symbol_news_service, ROB-423)."""
 
 from __future__ import annotations
 
 from typing import Any
 
 from app.mcp_server.tooling.fundamentals._helpers import normalize_market_with_crypto
-from app.mcp_server.tooling.fundamentals_sources_finnhub import _fetch_news_finnhub
-from app.mcp_server.tooling.fundamentals_sources_naver import _fetch_news_naver
 from app.mcp_server.tooling.shared import (
     error_payload as _error_payload,
 )
@@ -19,6 +18,9 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     normalize_symbol_input as _normalize_symbol_input,
 )
+from app.services import symbol_news_service
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
 
 
 async def handle_get_news(
@@ -40,21 +42,25 @@ async def handle_get_news(
 
     normalized_market = normalize_market_with_crypto(market)
     capped_limit = min(max(limit, 1), 50)
+    instrument_type = _INSTRUMENT_BY_MARKET.get(normalized_market, "equity_us")
 
-    try:
-        if normalized_market == "kr":
-            return await _fetch_news_naver(symbol, capped_limit)
-        return await _fetch_news_finnhub(symbol, normalized_market, capped_limit)
-    except Exception as exc:
-        source = "naver" if normalized_market == "kr" else "finnhub"
-        instrument_type = {
-            "kr": "equity_kr",
-            "us": "equity_us",
-            "crypto": "crypto",
-        }.get(normalized_market, "equity_us")
+    result = await symbol_news_service.fetch_symbol_news(
+        symbol, normalized_market, instrument_type, limit=capped_limit
+    )
+
+    if result.status in ("error", "unavailable"):
         return _error_payload(
-            source=source,
-            message=str(exc),
+            source=result.provider,
+            message=result.error_code or "news_unavailable",
             symbol=symbol,
             instrument_type=instrument_type,
         )
+
+    news = [a.provider_metadata.get("source_item", {}) for a in result.articles]
+    return {
+        "symbol": symbol,
+        "market": normalized_market,
+        "source": result.provider,
+        "count": len(news),
+        "news": news,
+    }

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -17,6 +17,8 @@ from .investment_reports import (
     InvestmentReport,
     InvestmentReportItem,
     InvestmentReportItemDecision,
+    InvestmentReportNewsCitation,
+    InvestmentReportNewsFetchRun,
     InvestmentWatchAlert,
     InvestmentWatchEvent,
 )
@@ -142,6 +144,8 @@ __all__ = [
     "InvestmentReport",
     "InvestmentReportItem",
     "InvestmentReportItemDecision",
+    "InvestmentReportNewsCitation",
+    "InvestmentReportNewsFetchRun",
     "InvestmentWatchAlert",
     "InvestmentWatchEvent",
     "InvestmentSnapshot",

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     ARRAY,
     TIMESTAMP,
     BigInteger,
+    Boolean,
     CheckConstraint,
     ForeignKey,
     Index,
@@ -711,6 +712,136 @@ class InvestmentWatchEvent(Base):
         Integer, nullable=False, server_default=text("0")
     )
 
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class InvestmentReportNewsFetchRun(Base):
+    """ROB-423 — per (report, symbol, provider) news fetch audit row.
+
+    Append-only. ``report_uuid`` is a logical reference to
+    ``review.investment_reports.report_uuid`` (no FK — items relate by
+    integer ``report_id``, so we keep this membership-only). Never stores raw
+    provider payloads (``raw_response_stored`` is an audit flag only).
+    """
+
+    __tablename__ = "investment_report_news_fetch_runs"
+    __table_args__ = (
+        UniqueConstraint(
+            "run_uuid", name="uq_investment_report_news_fetch_runs_run_uuid"
+        ),
+        CheckConstraint(
+            "status IN ('ok','empty','unavailable','error')",
+            name="ck_investment_report_news_fetch_runs_status",
+        ),
+        Index(
+            "ix_investment_report_news_fetch_runs_report_uuid",
+            "report_uuid",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    report_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    requested_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    returned_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    used_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    freshness_policy: Mapped[str | None] = mapped_column(Text)
+    ttl_seconds: Mapped[int | None] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    error_code: Mapped[str | None] = mapped_column(Text)
+    error_message: Mapped[str | None] = mapped_column(Text)
+    raw_response_stored: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class InvestmentReportNewsCitation(Base):
+    """ROB-423 — a news article the report actually cited (Hermes-marked).
+
+    Only articles Hermes flagged as used land here (never fetched-but-unused).
+    Judgment fields (``role``/``decision_impact``/``relevance``/
+    ``selection_reason``/``confidence``) are Hermes-authored — auto_trader only
+    validates + persists. Article fields are a snapshot copy (immutable audit).
+    """
+
+    __tablename__ = "investment_report_news_citations"
+    __table_args__ = (
+        UniqueConstraint(
+            "citation_uuid", name="uq_investment_report_news_citations_citation_uuid"
+        ),
+        CheckConstraint(
+            "relevance IN ('direct','related','market_context','crypto_context')",
+            name="ck_investment_report_news_citations_relevance",
+        ),
+        CheckConstraint(
+            "role IN ('catalyst','risk','confirmation','contradiction','neutral','noise')",
+            name="ck_investment_report_news_citations_role",
+        ),
+        CheckConstraint(
+            "decision_impact IN ('strengthen_buy','weaken_buy','strengthen_sell',"
+            "'weaken_sell','hold_watch','no_action')",
+            name="ck_investment_report_news_citations_decision_impact",
+        ),
+        Index(
+            "ix_investment_report_news_citations_report_uuid",
+            "report_uuid",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    citation_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    report_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    report_item_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    section_key: Mapped[str | None] = mapped_column(Text)
+    fetch_run_id: Mapped[int | None] = mapped_column(
+        ForeignKey("review.investment_report_news_fetch_runs.id", ondelete="SET NULL")
+    )
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    external_article_id: Mapped[str | None] = mapped_column(Text)
+    canonical_url: Mapped[str] = mapped_column(Text, nullable=False)
+    source_name: Mapped[str | None] = mapped_column(Text)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    summary_snapshot: Mapped[str | None] = mapped_column(Text)
+    published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    relevance: Mapped[str] = mapped_column(Text, nullable=False)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    decision_impact: Mapped[str] = mapped_column(Text, nullable=False)
+    selection_reason: Mapped[str | None] = mapped_column(Text)
+    confidence: Mapped[float | None] = mapped_column(Numeric)
+    metadata_json: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -27,6 +27,7 @@ from app.schemas.investment_reports import (
     InvestmentReportItemDecisionResponse,
     InvestmentReportItemResponse,
     InvestmentReportListResponse,
+    InvestmentReportNewsCitationResponse,
     InvestmentReportResponse,
     InvestmentWatchAlertResponse,
     InvestmentWatchEventResponse,
@@ -100,6 +101,10 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
         decision_rollup=rollup,
         review_sections=review_sections,
         action_packet=action_packet,
+        news_citations=[
+            InvestmentReportNewsCitationResponse.model_validate(c)
+            for c in bundle["news_citations"]
+        ],
     )
 
 

--- a/app/schemas/hermes_composition.py
+++ b/app/schemas/hermes_composition.py
@@ -19,9 +19,10 @@ Hard invariants:
 from __future__ import annotations
 
 import uuid
+from decimal import Decimal
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.schemas.investment_reports import IngestReportItem
 from app.schemas.investment_stages import StageArtifactPayload
@@ -107,6 +108,50 @@ class HermesContextPayload(BaseModel):
     intraday_delta_block: dict[str, Any] | None = None
 
 
+NewsRelevanceLiteral = Literal["direct", "related", "market_context", "crypto_context"]
+NewsRoleLiteral = Literal[
+    "catalyst", "risk", "confirmation", "contradiction", "neutral", "noise"
+]
+NewsDecisionImpactLiteral = Literal[
+    "strengthen_buy",
+    "weaken_buy",
+    "strengthen_sell",
+    "weaken_sell",
+    "hold_watch",
+    "no_action",
+]
+
+
+class HermesNewsCitation(BaseModel):
+    """A news article Hermes actually used, with its judgment annotations.
+
+    auto_trader matches this against the bundle's news snapshot articles by
+    ``external_article_id`` (preferred) or ``canonical_url`` and persists only
+    matches. At least one of the two refs is required. ``client_item_key`` links
+    the citation to a specific report item (the same key used in the composed
+    ``IngestReportItem``); ``section_key`` is for report-level citations.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    external_article_id: str | None = None
+    canonical_url: str | None = None
+    symbol: str = Field(min_length=1)
+    relevance: NewsRelevanceLiteral
+    role: NewsRoleLiteral
+    decision_impact: NewsDecisionImpactLiteral
+    selection_reason: str | None = None
+    confidence: Decimal | None = None
+    client_item_key: str | None = None
+    section_key: str | None = None
+
+    @model_validator(mode="after")
+    def _require_ref(self) -> HermesNewsCitation:
+        if not self.external_article_id and not self.canonical_url:
+            raise ValueError("news citation needs external_article_id or canonical_url")
+        return self
+
+
 class HermesCompositionResult(BaseModel):
     """Structured composition returned by Hermes for ingestion.
 
@@ -140,6 +185,10 @@ class HermesCompositionResult(BaseModel):
     # ROB-308: dimension reports (ROB-306) this composition consumed. Empty for
     # legacy composition. Validated for existence + run membership on ingest.
     dimension_report_uuids: list[uuid.UUID] = Field(default_factory=list)
+    # ROB-423 — news articles Hermes used as overlay evidence. Empty for legacy
+    # composition (byte-identical path). Matched against the bundle's news
+    # snapshot on ingest; unmatched refs are dropped + recorded (fail-open).
+    news_citations: list[HermesNewsCitation] = Field(default_factory=list)
 
     @field_validator("items")
     @classmethod

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -803,6 +803,31 @@ class ActionPacket(BaseModel):
     data_gaps_for_next_cycle: list[DataGapEntry] = Field(default_factory=list)
 
 
+class InvestmentReportNewsCitationResponse(BaseModel):
+    """ROB-423 — one cited news article on a report (read-side)."""
+
+    citation_uuid: UUID
+    report_item_uuid: UUID | None = None
+    section_key: str | None = None
+    market: str
+    symbol: str
+    provider: str
+    external_article_id: str | None = None
+    canonical_url: str
+    source_name: str | None = None
+    title: str
+    summary_snapshot: str | None = None
+    published_at: datetime | None = None
+    fetched_at: datetime
+    relevance: str
+    role: str
+    decision_impact: str
+    selection_reason: str | None = None
+    confidence: Decimal | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class InvestmentReportBundle(BaseModel):
     """``investment_report_get`` / ``GET /.../investment-reports/{uuid}``.
 
@@ -828,6 +853,11 @@ class InvestmentReportBundle(BaseModel):
     # ROB-335 — additive intraday ActionPacket projection. Null for legacy /
     # non-intraday reports; existing items / review_sections remain the fallback.
     action_packet: ActionPacket | None = None
+    # ROB-423 — additive news citations (articles the report actually used).
+    # Empty for reports with no Hermes-marked news.
+    news_citations: list[InvestmentReportNewsCitationResponse] = Field(
+        default_factory=list
+    )
 
 
 class InvestmentReportListResponse(BaseModel):

--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -31,11 +31,12 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 from app.services.research_reports.query_service import ResearchReportsQueryService
+from app.services.symbol_news_service import SymbolNewsFetchResult
 
-# ROB-366 B8 — read-only market-scoped news article fetch (market, hours, limit)
-# → list of article dicts. Wired in registry.py over the deterministic
-# get_news_articles source so this module imports no MCP tooling.
-NewsFetchFn = Callable[[str, int, int], Awaitable[list[dict[str, Any]]]]
+# ROB-423 — per-symbol on-demand news fetch (symbol, market, limit) →
+# SymbolNewsFetchResult. Wired in registry.py over symbol_news_service so this
+# module imports no MCP tooling and no LLM provider.
+NewsFetchFn = Callable[[str, str, int], Awaitable[SymbolNewsFetchResult]]
 
 
 def _citation_symbols(citation: Any) -> set[str]:
@@ -159,33 +160,67 @@ class NewsSnapshotCollector:
     async def _collect_articles(
         self, request: CollectorRequest, *, now: dt.datetime, since: dt.datetime
     ) -> list[SnapshotCollectResult]:
-        """Market-scoped news articles path (ROB-366 B8). Fail-open like the
-        research path: a fetch error degrades the optional ``news`` kind to
-        ``unavailable`` rather than blocking the bundle. An empty result is
-        ``partial`` (queried, nothing within the window) — never fabricated."""
+        """Per-symbol on-demand news (ROB-423). Fail-open: per-symbol fetch
+        errors are recorded in ``fetch_records`` and never raise. Each article
+        keeps NewsStage-compatible keys (``title``/``sentiment``) plus citation
+        provenance (``symbol``/``external_article_id``/``canonical_url``)."""
         assert self._news_fetch_fn is not None
-        try:
-            articles = await self._news_fetch_fn(
-                request.market, self._lookback_hours, self._limit
-            )
-        except Exception as exc:  # noqa: BLE001 — optional, fail open
-            return [
-                unavailable_result(
-                    snapshot_kind=self.snapshot_kind,
-                    market=request.market,
-                    account_scope=request.account_scope,
-                    origin="news",
-                    reason=f"news article fetch failed: {type(exc).__name__}: {exc}",
-                    as_of=now,
-                )
-            ]
+        focus_symbols = [s for s in (request.symbols or []) if s]
 
-        articles_payload = [a for a in (articles or []) if isinstance(a, dict)]
+        articles_payload: list[dict[str, Any]] = []
+        fetch_records: list[dict[str, Any]] = []
+        for symbol in focus_symbols:
+            try:
+                result = await self._news_fetch_fn(
+                    symbol, request.market, self._limit
+                )
+            except Exception as exc:  # noqa: BLE001 — optional, fail open
+                fetch_records.append(
+                    {
+                        "symbol": symbol,
+                        "provider": "unknown",
+                        "requested_limit": self._limit,
+                        "returned_count": 0,
+                        "status": "error",
+                        "error_code": type(exc).__name__,
+                    }
+                )
+                continue
+
+            fetch_records.append(
+                {
+                    "symbol": symbol,
+                    "provider": result.provider,
+                    "requested_limit": result.requested_limit,
+                    "returned_count": result.returned_count,
+                    "status": result.status,
+                    "error_code": result.error_code,
+                }
+            )
+            for a in result.articles:
+                articles_payload.append(
+                    {
+                        "title": a.title,
+                        "url": a.canonical_url,
+                        "source": a.source_name,
+                        "summary": a.summary,
+                        "published_at": a.published_at.isoformat()
+                        if a.published_at
+                        else None,
+                        "symbol": a.symbol,
+                        "provider": a.provider,
+                        "external_article_id": a.external_article_id,
+                        "sentiment": a.provider_metadata.get("sentiment"),
+                        "related": a.related_symbols,
+                    }
+                )
+
         payload: dict[str, Any] = {
             "since": since.isoformat(),
             "count": len(articles_payload),
             "articles": articles_payload,
-            "source": "news_articles",
+            "fetch_records": fetch_records,
+            "source": "symbol_news_service",
             "market": request.market,
         }
         return [

--- a/app/services/action_report/snapshot_backed/collectors/news.py
+++ b/app/services/action_report/snapshot_backed/collectors/news.py
@@ -171,9 +171,7 @@ class NewsSnapshotCollector:
         fetch_records: list[dict[str, Any]] = []
         for symbol in focus_symbols:
             try:
-                result = await self._news_fetch_fn(
-                    symbol, request.market, self._limit
-                )
+                result = await self._news_fetch_fn(symbol, request.market, self._limit)
             except Exception as exc:  # noqa: BLE001 — optional, fail open
                 fetch_records.append(
                     {

--- a/app/services/action_report/snapshot_backed/collectors/registry.py
+++ b/app/services/action_report/snapshot_backed/collectors/registry.py
@@ -235,40 +235,17 @@ def _build_altseason_fn() -> AltseasonFn:
 
 
 def _build_news_fetch_fn() -> NewsFetchFn:
-    """Read-only adapter over the deterministic, market-aware news source.
+    """Per-symbol on-demand news adapter over ``symbol_news_service`` (ROB-423).
 
-    ROB-366 B8: given (market, hours, limit), returns recent market-scoped
-    ``NewsArticle`` rows mapped to plain dicts in the shape NewsStage reads
-    (``articles``). ``get_news_articles`` is imported lazily and uses its own
-    read-only session; this stays a thin pass-through with no order/mutation
-    surface. The collector wraps the call so a fetch error degrades the
-    optional ``news`` kind to ``unavailable``.
+    Given (symbol, market, limit) returns a normalized ``SymbolNewsFetchResult``.
+    Imported lazily; no MCP/LLM/order surface. The collector wraps the call so a
+    fetch error degrades the optional ``news`` kind without blocking the bundle.
     """
 
-    async def _news_fetch_fn(
-        market: str, hours: int, limit: int
-    ) -> list[dict[str, Any]]:
-        from app.services.llm_news_service import get_news_articles
+    async def _news_fetch_fn(symbol: str, market: str, limit: int):
+        from app.services.symbol_news_service import fetch_symbol_news
 
-        articles, _total = await get_news_articles(
-            market=market, hours=hours, limit=limit
-        )
-        out: list[dict[str, Any]] = []
-        for a in articles:
-            published = getattr(a, "article_published_at", None)
-            out.append(
-                {
-                    "title": a.title,
-                    "url": a.url,
-                    "source": a.source,
-                    "feed_source": a.feed_source,
-                    "summary": a.summary,
-                    "stock_symbol": a.stock_symbol,
-                    "stock_name": a.stock_name,
-                    "published_at": published.isoformat() if published else None,
-                }
-            )
-        return out
+        return await fetch_symbol_news(symbol, market, limit=limit)
 
     return _news_fetch_fn
 

--- a/app/services/investment_reports/investment_report_news_service.py
+++ b/app/services/investment_reports/investment_report_news_service.py
@@ -1,0 +1,125 @@
+# app/services/investment_reports/investment_report_news_service.py
+"""ROB-423 PR2 — persist Hermes-marked news citations + fetch_run audit.
+
+auto_trader-side: validation + persistence only (no LLM, no fetch). Reads the
+bundle's news snapshot ``articles``/``fetch_records`` (written by the PR1
+collector), matches Hermes ``news_citations`` against them, and writes fetch_run
++ citation rows keyed by ``report_uuid``. Unmatched refs are dropped + recorded
+in the report's ``unavailable_sources`` metadata (fail-open).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.models.investment_reports import InvestmentReport
+from app.schemas.hermes_composition import HermesCompositionResult
+from app.services.investment_reports.news_persistence import build_news_persistence
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+class InvestmentReportNewsService:
+    def __init__(self, repo: InvestmentReportsRepository) -> None:
+        self._repo = repo
+
+    async def persist_from_composition(
+        self,
+        *,
+        report: InvestmentReport,
+        composition: HermesCompositionResult,
+        news_payloads: list[dict[str, Any]],
+    ) -> int:
+        """Returns the number of citations written. Never raises on matching
+        gaps (fail-open). Call inside the ingest transaction after the report +
+        items are persisted."""
+        if not composition.news_citations:
+            return 0
+
+        # client_item_key -> item_uuid via insertion-order (id.asc()) zip.
+        persisted = await self._repo.list_items_for_report_ordered_by_id(report.id)
+        item_uuid_by_client_key: dict[str, UUID] = {}
+        if len(persisted) == len(composition.items):
+            for comp_item, row in zip(composition.items, persisted, strict=True):
+                item_uuid_by_client_key[comp_item.client_item_key] = row.item_uuid
+
+        instrument_type = _INSTRUMENT_BY_MARKET.get(report.market, "equity_us")
+        plan = build_news_persistence(
+            news_payloads=news_payloads,
+            citations=composition.news_citations,
+            item_uuid_by_client_key=item_uuid_by_client_key,
+            instrument_type=instrument_type,
+        )
+
+        # fetch_runs first (citations FK them by (symbol, provider)).
+        fetch_run_id_by_key: dict[tuple[str, str], int] = {}
+        for run in plan.fetch_runs:
+            key = run.pop("_fetch_key")
+            row = await self._repo.insert_news_fetch_run(
+                report_uuid=report.report_uuid,
+                fetched_at=_utcnow(),
+                **run,
+            )
+            fetch_run_id_by_key[key] = row.id
+
+        written = 0
+        for cit in plan.citations:
+            key = cit.pop("_fetch_key")
+            await self._repo.insert_news_citation(
+                report_uuid=report.report_uuid,
+                fetch_run_id=fetch_run_id_by_key.get(key),
+                fetched_at=_utcnow(),
+                **cit,
+            )
+            written += 1
+
+        if plan.unmatched:
+            # record on the report's metadata (fail-open, no fabrication).
+            await self._repo.merge_report_unavailable_sources(
+                report.id,
+                {"news_citations_unmatched": plan.unmatched},
+            )
+        return written
+
+    async def copy_for_mock(
+        self, *, live_report_uuid: UUID, mock_report: InvestmentReport
+    ) -> int:
+        """Copy a live report's news citations onto the mock report (report-level,
+        report_item_uuid=NULL). No re-fetch, no re-judgment. Returns count."""
+        live_citations = await self._repo.list_news_citations_for_report(
+            live_report_uuid
+        )
+        count = 0
+        for c in live_citations:
+            await self._repo.insert_news_citation(
+                report_uuid=mock_report.report_uuid,
+                report_item_uuid=None,
+                section_key=c.section_key,
+                fetch_run_id=None,
+                market=c.market,
+                symbol=c.symbol,
+                provider=c.provider,
+                external_article_id=c.external_article_id,
+                canonical_url=c.canonical_url,
+                source_name=c.source_name,
+                title=c.title,
+                summary_snapshot=c.summary_snapshot,
+                published_at=c.published_at,
+                fetched_at=c.fetched_at,
+                relevance=c.relevance,
+                role=c.role,
+                decision_impact=c.decision_impact,
+                selection_reason=c.selection_reason,
+                confidence=c.confidence,
+                metadata_json={"copied_from_report_uuid": str(live_report_uuid)},
+            )
+            count += 1
+        return count
+
+
+def _utcnow():
+    from datetime import UTC, datetime
+
+    return datetime.now(tz=UTC)

--- a/app/services/investment_reports/mock_preview/runner.py
+++ b/app/services/investment_reports/mock_preview/runner.py
@@ -28,6 +28,9 @@ from app.services.action_report.snapshot_backed.collectors.registry import (
     production_collector_registry,
 )
 from app.services.investment_reports.ingestion import InvestmentReportIngestionService
+from app.services.investment_reports.investment_report_news_service import (
+    InvestmentReportNewsService,
+)
 from app.services.investment_reports.mock_preview.bridge import (
     MockPreviewBridge,
     extract_order_params,
@@ -54,6 +57,7 @@ class MockPreviewReportRunner:
         self._reports_repo = InvestmentReportsRepository(session)
         self._snap_repo = InvestmentSnapshotsRepository(session)
         self._ingestion = InvestmentReportIngestionService(session)
+        self._news_service = InvestmentReportNewsService(self._reports_repo)
         self._bridge = bridge if bridge is not None else MockPreviewBridge()
         # ROB-379 smoke finding: the default SnapshotBundleEnsureService registry
         # is EMPTY (Phase-2 stub), so an un-injected ensure produced a `failed`
@@ -183,6 +187,14 @@ class MockPreviewReportRunner:
                 report.id, snapshot_bundle_uuid=ensure_resp.bundle_uuid
             )
             await self._session.refresh(report)
+
+        # ROB-423 — copy the live report's news citations onto the mock
+        # (report-level). Skip when this run idempotently reused an existing
+        # mock that already carries them.
+        if not reused:
+            await self._news_service.copy_for_mock(
+                live_report_uuid=live.report_uuid, mock_report=report
+            )
 
         return report, reused, count
 

--- a/app/services/investment_reports/news_persistence.py
+++ b/app/services/investment_reports/news_persistence.py
@@ -1,0 +1,133 @@
+# app/services/investment_reports/news_persistence.py
+"""ROB-423 PR2 — pure news-citation persistence planner (no DB I/O).
+
+Matches Hermes-supplied news citations against the bundle's news snapshot
+articles and produces the fetch_run + citation rows to insert. Unmatched refs
+are dropped and reported (fail-open, no fabrication). Kept pure so the matching
+logic is unit-testable without a database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from app.schemas.hermes_composition import HermesNewsCitation
+
+_SUMMARY_MAX = 1000
+
+
+@dataclass(frozen=True)
+class NewsPersistencePlan:
+    fetch_runs: list[dict[str, Any]] = field(default_factory=list)
+    citations: list[dict[str, Any]] = field(default_factory=list)
+    unmatched: list[str] = field(default_factory=list)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _truncate(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return text[:_SUMMARY_MAX]
+
+
+def build_news_persistence(
+    *,
+    news_payloads: list[dict[str, Any]],
+    citations: list[HermesNewsCitation],
+    item_uuid_by_client_key: dict[str, UUID],
+    instrument_type: str,
+) -> NewsPersistencePlan:
+    by_external: dict[str, dict[str, Any]] = {}
+    by_url: dict[str, dict[str, Any]] = {}
+    market = "us"
+    for payload in news_payloads:
+        market = payload.get("market") or market
+        for art in payload.get("articles", []):
+            ext = art.get("external_article_id")
+            url = art.get("url")
+            if ext:
+                by_external.setdefault(ext, art)
+            if url:
+                by_url.setdefault(url, art)
+
+    # per (symbol, provider) used_count tally
+    used_by_key: dict[tuple[str, str], int] = {}
+
+    citation_rows: list[dict[str, Any]] = []
+    unmatched: list[str] = []
+    for cit in citations:
+        art = None
+        ref = cit.external_article_id or cit.canonical_url or ""
+        if cit.external_article_id:
+            art = by_external.get(cit.external_article_id)
+        if art is None and cit.canonical_url:
+            art = by_url.get(cit.canonical_url)
+        if art is None:
+            unmatched.append(ref)
+            continue
+
+        sym = art.get("symbol") or cit.symbol
+        provider = art.get("provider") or "unknown"
+        used_by_key[(sym, provider)] = used_by_key.get((sym, provider), 0) + 1
+
+        item_uuid = (
+            item_uuid_by_client_key.get(cit.client_item_key)
+            if cit.client_item_key
+            else None
+        )
+        citation_rows.append(
+            {
+                "report_item_uuid": item_uuid,
+                "section_key": cit.section_key,
+                "market": market,
+                "symbol": sym,
+                "provider": provider,
+                "external_article_id": art.get("external_article_id"),
+                "canonical_url": art.get("url") or cit.canonical_url or "",
+                "source_name": art.get("source"),
+                "title": art.get("title") or "",
+                "summary_snapshot": _truncate(art.get("summary")),
+                "published_at": _parse_dt(art.get("published_at")),
+                "relevance": cit.relevance,
+                "role": cit.role,
+                "decision_impact": cit.decision_impact,
+                "selection_reason": cit.selection_reason,
+                "confidence": cit.confidence,
+                "_fetch_key": (sym, provider),  # internal: link to fetch_run
+            }
+        )
+
+    fetch_runs: list[dict[str, Any]] = []
+    for payload in news_payloads:
+        for rec in payload.get("fetch_records", []):
+            sym = rec.get("symbol") or ""
+            provider = rec.get("provider") or "unknown"
+            fetch_runs.append(
+                {
+                    "market": market,
+                    "symbol": sym,
+                    "instrument_type": instrument_type,
+                    "provider": provider,
+                    "requested_limit": int(rec.get("requested_limit") or 0),
+                    "returned_count": int(rec.get("returned_count") or 0),
+                    "used_count": used_by_key.get((sym, provider), 0),
+                    "status": rec.get("status") or "ok",
+                    "error_code": rec.get("error_code"),
+                    "_fetch_key": (sym, provider),  # internal: citation linkage
+                }
+            )
+
+    return NewsPersistencePlan(
+        fetch_runs=fetch_runs, citations=citation_rows, unmatched=unmatched
+    )

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -119,6 +119,7 @@ class InvestmentReportQueryService:
         decisions = await self._repo.list_decisions_for_items(item_ids)
         alerts = await self._repo.list_alerts_for_source_reports([report.report_uuid])
         events = await self._repo.list_events_for_source_reports([report.report_uuid])
+        citations = await self._repo.list_news_citations_for_report(report.report_uuid)
 
         decisions_by_item: dict[int, list[InvestmentReportItemDecision]] = {
             it.id: [] for it in items
@@ -132,6 +133,7 @@ class InvestmentReportQueryService:
             "decisions_by_item": decisions_by_item,
             "alerts": alerts,
             "events": events,
+            "news_citations": citations,
         }
 
     # ------------------------------------------------------------------

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -23,6 +23,8 @@ from app.models.investment_reports import (
     InvestmentReport,
     InvestmentReportItem,
     InvestmentReportItemDecision,
+    InvestmentReportNewsCitation,
+    InvestmentReportNewsFetchRun,
     InvestmentWatchAlert,
     InvestmentWatchEvent,
 )
@@ -423,3 +425,51 @@ class InvestmentReportsRepository:
             .limit(limit)
         )
         return list(result.all())
+
+    async def list_items_for_report_ordered_by_id(
+        self, report_id: int
+    ) -> list[InvestmentReportItem]:
+        """Insertion-order items (id.asc()). Use for composition-index mapping —
+        ``created_at`` ties (single-transaction inserts share ``now()``) make
+        the created_at-ordered query non-deterministic for this purpose."""
+        result = await self._session.scalars(
+            sa.select(InvestmentReportItem)
+            .where(InvestmentReportItem.report_id == report_id)
+            .order_by(InvestmentReportItem.id.asc())
+        )
+        return list(result.all())
+
+    async def insert_news_fetch_run(
+        self, **fields: Any
+    ) -> InvestmentReportNewsFetchRun:
+        row = InvestmentReportNewsFetchRun(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def insert_news_citation(self, **fields: Any) -> InvestmentReportNewsCitation:
+        row = InvestmentReportNewsCitation(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        return row
+
+    async def list_news_citations_for_report(
+        self, report_uuid: UUID
+    ) -> list[InvestmentReportNewsCitation]:
+        result = await self._session.scalars(
+            sa.select(InvestmentReportNewsCitation)
+            .where(InvestmentReportNewsCitation.report_uuid == report_uuid)
+            .order_by(InvestmentReportNewsCitation.id.asc())
+        )
+        return list(result.all())
+
+    async def merge_report_unavailable_sources(
+        self, report_id: int, extra: dict[str, Any]
+    ) -> None:
+        row = await self._session.get(InvestmentReport, report_id)
+        if row is None:
+            return
+        merged = {**(row.unavailable_sources or {}), **extra}
+        row.unavailable_sources = merged
+        await self._session.flush()

--- a/app/services/investment_stages/hermes_ingest.py
+++ b/app/services/investment_stages/hermes_ingest.py
@@ -54,6 +54,12 @@ from app.services.investment_dimensions.dimension_report_repository import (
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
+from app.services.investment_reports.investment_report_news_service import (
+    InvestmentReportNewsService,
+)
+from app.services.investment_reports.repository import (
+    InvestmentReportsRepository,
+)
 from app.services.investment_snapshots.repository import (
     InvestmentSnapshotsRepository,
 )
@@ -326,6 +332,7 @@ class HermesCompositionIngestService:
         stages_repository: InvestmentStagesRepository | None = None,
         symbol_reports_repository: SymbolIntermediateReportRepository | None = None,
         dimension_reports_repository: DimensionReportRepository | None = None,
+        news_service: InvestmentReportNewsService | None = None,
     ) -> None:
         self._session = session
         self._ingestion = ingestion_service or InvestmentReportIngestionService(session)
@@ -336,6 +343,9 @@ class HermesCompositionIngestService:
         )
         self._dimension_reports = (
             dimension_reports_repository or DimensionReportRepository(session)
+        )
+        self._news_service = news_service or InvestmentReportNewsService(
+            InvestmentReportsRepository(session)
         )
 
     async def ingest_composition(
@@ -411,6 +421,20 @@ class HermesCompositionIngestService:
         )
 
         report = await self._ingestion.ingest(ingest_request)
+
+        # ROB-423 — persist Hermes-marked news citations from the bundle's news
+        # snapshot. Fail-open: matching gaps never block report creation.
+        news_payloads = [
+            (snap.payload_json or {})
+            for _item, snap in await self._snapshots.list_bundle_items_with_snapshots(
+                bundle.id
+            )
+            if snap.snapshot_kind == "news"
+        ]
+        await self._news_service.persist_from_composition(
+            report=report, composition=composition, news_payloads=news_payloads
+        )
+
         await self._maybe_finalize_stage_run(composition.metadata)
         return report
 

--- a/app/services/research_news_service.py
+++ b/app/services/research_news_service.py
@@ -1,17 +1,20 @@
-"""Research pipeline on-demand news fetcher (ROB-115)."""
+# app/services/research_news_service.py
+"""Legacy research-pipeline news shim (ROB-115 → ROB-423).
+
+Thin wrapper that delegates to the unified ``symbol_news_service`` seam and maps
+its richer ``SymbolNewsArticle`` back to the legacy ``NormalizedArticle`` shape
+consumed by ``app.analysis.stages.news_stage``. No fetch/normalize logic lives
+here anymore — single source of truth is ``symbol_news_service``.
+"""
 
 from __future__ import annotations
 
-import asyncio
-import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
 
-from app.services import naver_finance
-from app.services.finnhub_news import fetch_news_finnhub
+from app.services import symbol_news_service
 
-logger = logging.getLogger(__name__)
+_MARKET_BY_INSTRUMENT = {"equity_kr": "kr", "equity_us": "us"}
 
 
 @dataclass(frozen=True)
@@ -24,89 +27,23 @@ class NormalizedArticle:
     provider: str
 
 
-async def _naver_fetch_news(symbol: str, limit: int) -> list[dict[str, Any]]:
-    return await naver_finance.fetch_news(symbol, limit=limit)
-
-
-async def _finnhub_fetch_news(symbol: str, market: str, limit: int) -> dict[str, Any]:
-    return await fetch_news_finnhub(symbol, market, limit)
-
-
-def _parse_iso_or_date(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        pass
-    try:
-        return datetime.strptime(value, "%Y-%m-%d")
-    except ValueError:
-        return None
-
-
-def _normalize_naver(items: list[dict[str, Any]]) -> list[NormalizedArticle]:
-    out: list[NormalizedArticle] = []
-    for raw in items:
-        url = (raw.get("url") or "").strip()
-        title = (raw.get("title") or "").strip()
-        if not url or not title:
-            continue
-        out.append(
-            NormalizedArticle(
-                url=url,
-                title=title,
-                source=raw.get("source") or None,
-                summary=None,
-                published_at=_parse_iso_or_date(raw.get("datetime")),
-                provider="naver",
-            )
-        )
-    return out
-
-
-def _normalize_finnhub(payload: dict[str, Any]) -> list[NormalizedArticle]:
-    items = payload.get("news") or []
-    out: list[NormalizedArticle] = []
-    for raw in items:
-        url = (raw.get("url") or "").strip()
-        title = (raw.get("title") or "").strip()
-        if not url or not title:
-            continue
-        out.append(
-            NormalizedArticle(
-                url=url,
-                title=title,
-                source=raw.get("source") or None,
-                summary=raw.get("summary") or None,
-                published_at=_parse_iso_or_date(raw.get("datetime")),
-                provider="finnhub",
-            )
-        )
-    return out
-
-
 async def fetch_symbol_news(
     symbol: str, instrument_type: str, *, limit: int = 20, timeout_s: float = 5.0
 ) -> list[NormalizedArticle]:
-    try:
-        if instrument_type == "equity_kr":
-            items = await asyncio.wait_for(
-                _naver_fetch_news(symbol, limit), timeout=timeout_s
-            )
-            return _normalize_naver(items)
-        if instrument_type == "equity_us":
-            payload = await asyncio.wait_for(
-                _finnhub_fetch_news(symbol, "us", limit),
-                timeout=timeout_s,
-            )
-            return _normalize_finnhub(payload)
+    market = _MARKET_BY_INSTRUMENT.get(instrument_type)
+    if market is None:
         return []
-    except Exception as exc:
-        logger.warning(
-            "research_news_service.fetch_symbol_news failed: symbol=%s instrument_type=%s err=%s",
-            symbol,
-            instrument_type,
-            exc,
+    result = await symbol_news_service.fetch_symbol_news(
+        symbol, market, instrument_type, limit=limit, timeout_s=timeout_s
+    )
+    return [
+        NormalizedArticle(
+            url=a.canonical_url,
+            title=a.title,
+            source=a.source_name,
+            summary=a.summary,
+            published_at=a.published_at,
+            provider=a.provider,
         )
-        return []
+        for a in result.articles
+    ]

--- a/app/services/symbol_news_service.py
+++ b/app/services/symbol_news_service.py
@@ -1,0 +1,195 @@
+# app/services/symbol_news_service.py
+"""Unified on-demand symbol news service (ROB-423 PR1).
+
+Single normalized seam over the service-layer provider fetchers
+(``naver_finance.fetch_news``, ``finnhub_news.fetch_news_finnhub``). Consumed by
+the ``get_news`` MCP tool, the snapshot-backed news collector, and (via a thin
+shim) the legacy research news path. No MCP imports, no LLM, no order/broker
+surface. Each article keeps the provider's original item in
+``provider_metadata["source_item"]`` so byte-compatible envelopes can be rebuilt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from app.services import naver_finance
+from app.services.finnhub_news import fetch_news_finnhub
+
+logger = logging.getLogger(__name__)
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+@dataclass(frozen=True)
+class SymbolNewsArticle:
+    provider: str
+    market: str
+    symbol: str
+    external_article_id: str | None
+    title: str
+    source_name: str | None
+    canonical_url: str
+    summary: str | None
+    published_at: datetime | None
+    fetched_at: datetime
+    related_symbols: list[str] = field(default_factory=list)
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SymbolNewsFetchResult:
+    symbol: str
+    market: str
+    provider: str
+    status: str  # ok | empty | unavailable | error
+    requested_limit: int
+    returned_count: int
+    articles: list[SymbolNewsArticle]
+    error_code: str | None = None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        pass
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _naver_external_id(url: str) -> str | None:
+    """``officeId:articleId`` from a Naver news_read URL, else None."""
+    try:
+        q = parse_qs(urlparse(url).query)
+    except ValueError:
+        return None
+    article_id = (q.get("article_id") or [None])[0]
+    office_id = (q.get("office_id") or [None])[0]
+    if office_id and article_id:
+        return f"{office_id}:{article_id}"
+    return article_id or None
+
+
+def _url_hash(url: str) -> str | None:
+    if not url:
+        return None
+    return hashlib.sha1(url.encode("utf-8")).hexdigest()[:16]
+
+
+async def _fetch_naver(
+    symbol: str, limit: int, fetched_at: datetime
+) -> list[SymbolNewsArticle]:
+    items = await naver_finance.fetch_news(symbol, limit=limit)
+    out: list[SymbolNewsArticle] = []
+    for raw in items:
+        url = (raw.get("url") or "").strip()
+        title = (raw.get("title") or "").strip()
+        if not url or not title:
+            continue
+        out.append(
+            SymbolNewsArticle(
+                provider="naver",
+                market="kr",
+                symbol=symbol,
+                external_article_id=_naver_external_id(url),
+                title=title,
+                source_name=raw.get("source") or None,
+                canonical_url=url,
+                summary=None,
+                published_at=_parse_dt(raw.get("datetime")),
+                fetched_at=fetched_at,
+                related_symbols=[],
+                provider_metadata={"source_item": raw},
+            )
+        )
+    return out
+
+
+async def _fetch_finnhub(
+    symbol: str, market: str, limit: int, fetched_at: datetime
+) -> list[SymbolNewsArticle]:
+    payload = await fetch_news_finnhub(symbol, market, limit)
+    out: list[SymbolNewsArticle] = []
+    for raw in payload.get("news") or []:
+        url = (raw.get("url") or "").strip()
+        title = (raw.get("title") or "").strip()
+        if not url or not title:
+            continue
+        related_raw = raw.get("related") or ""
+        related = [s for s in str(related_raw).split(",") if s]
+        out.append(
+            SymbolNewsArticle(
+                provider="finnhub",
+                market=market,
+                symbol=symbol,
+                external_article_id=_url_hash(url),
+                title=title,
+                source_name=raw.get("source") or None,
+                canonical_url=url,
+                summary=raw.get("summary") or None,
+                published_at=_parse_dt(raw.get("datetime")),
+                fetched_at=fetched_at,
+                related_symbols=related,
+                provider_metadata={
+                    "sentiment": raw.get("sentiment"),
+                    "related": related_raw,
+                    "source_item": raw,
+                },
+            )
+        )
+    return out
+
+
+async def fetch_symbol_news(
+    symbol: str,
+    market: str,
+    instrument_type: str | None = None,
+    *,
+    limit: int = 20,
+    timeout_s: float = 5.0,
+) -> SymbolNewsFetchResult:
+    """On-demand normalized news for one symbol. Fail-soft (never raises)."""
+    market = (market or "").lower()
+    provider = "naver" if market == "kr" else "finnhub"
+    fetched_at = _utcnow()
+    try:
+        if market == "kr":
+            articles = await asyncio.wait_for(
+                _fetch_naver(symbol, limit, fetched_at), timeout=timeout_s
+            )
+        elif market in ("us", "crypto"):
+            articles = await asyncio.wait_for(
+                _fetch_finnhub(symbol, market, limit, fetched_at), timeout=timeout_s
+            )
+        else:
+            return SymbolNewsFetchResult(
+                symbol, market, provider, "unavailable", limit, 0, [],
+                "unsupported_market",
+            )
+    except Exception as exc:  # noqa: BLE001 — overlay evidence, fail soft
+        logger.warning(
+            "symbol_news_service.fetch_symbol_news failed: symbol=%s market=%s err=%s",
+            symbol, market, exc,
+        )
+        return SymbolNewsFetchResult(
+            symbol, market, provider, "error", limit, 0, [], type(exc).__name__
+        )
+    status = "ok" if articles else "empty"
+    return SymbolNewsFetchResult(
+        symbol, market, provider, status, limit, len(articles), articles, None
+    )

--- a/app/services/symbol_news_service.py
+++ b/app/services/symbol_news_service.py
@@ -178,13 +178,21 @@ async def fetch_symbol_news(
             )
         else:
             return SymbolNewsFetchResult(
-                symbol, market, provider, "unavailable", limit, 0, [],
+                symbol,
+                market,
+                provider,
+                "unavailable",
+                limit,
+                0,
+                [],
                 "unsupported_market",
             )
     except Exception as exc:  # noqa: BLE001 — overlay evidence, fail soft
         logger.warning(
             "symbol_news_service.fetch_symbol_news failed: symbol=%s market=%s err=%s",
-            symbol, market, exc,
+            symbol,
+            market,
+            exc,
         )
         return SymbolNewsFetchResult(
             symbol, market, provider, "error", limit, 0, [], type(exc).__name__

--- a/docs/plans/ROB-423-PR1-symbol-news-seam-implementation-plan.md
+++ b/docs/plans/ROB-423-PR1-symbol-news-seam-implementation-plan.md
@@ -1,0 +1,1105 @@
+# ROB-423 PR1: symbol_news_service 정규화 seam Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** invest_report 뉴스 fetch/normalize를 단일 `symbol_news_service` 경로로 통합하고, `get_news` MCP 도구와 snapshot news collector를 그 경로로 재배선한다(영속/citation/Hermes는 PR2).
+
+**Architecture:** service-layer provider fetcher(`naver_finance.fetch_news`, `finnhub_news.fetch_news_finnhub`) 위에 신규 `symbol_news_service`(정규화 `SymbolNewsArticle` + provider 원본 item 보존). 기존 `research_news_service`는 이 seam 위 thin shim으로 축소(레거시 `NewsStageAnalyzer` 무영향). `get_news` 핸들러는 seam을 거치되 출력 envelope를 byte-for-byte 보존(provider 원본 item 재방출). `NewsSnapshotCollector`의 뉴스 소스를 DB(`llm_news_service.get_news_articles`) → per-symbol on-demand seam으로 전환하되 `articles` payload 계약(NewsStage가 읽는 키)을 유지. **신규 public MCP tool 0, migration 0, 영속 0**(PR2).
+
+**Tech Stack:** Python 3.13, async, dataclasses, pytest + pytest-asyncio, monkeypatch/AsyncMock, ruff.
+
+---
+
+## File Structure
+
+| File | 역할 | 변경 |
+|------|------|------|
+| `app/services/symbol_news_service.py` | **신규** 단일 정규화 seam: `SymbolNewsArticle`/`SymbolNewsFetchResult`/`fetch_symbol_news` | Create |
+| `tests/services/test_symbol_news_service.py` | seam 단위 테스트 | Create |
+| `app/services/research_news_service.py` | `fetch_symbol_news`를 seam 위 shim으로 축소(`NormalizedArticle` 유지) | Modify |
+| `tests/services/test_research_news_service.py` | shim 매핑 테스트로 갱신(seam monkeypatch) | Modify |
+| `app/mcp_server/tooling/fundamentals/_news.py` | `get_news` 핸들러를 seam 경유로 재배선, envelope 보존 | Modify |
+| `tests/mcp_server/tooling/test_get_news_envelope.py` | get_news envelope byte-compat 회귀 | Create |
+| `app/services/action_report/snapshot_backed/collectors/news.py` | `NewsFetchFn` per-symbol화 + `_collect_articles` 루프 + `fetch_records` | Modify |
+| `app/services/action_report/snapshot_backed/collectors/registry.py` | `_build_news_fetch_fn`을 seam per-symbol 어댑터로 교체 | Modify |
+| `tests/services/action_report/snapshot_backed/test_collectors.py` | news collector articles 테스트를 per-symbol 시그니처로 갱신 | Modify |
+
+레거시 `app/analysis/stages/news_stage.py`(NewsStageAnalyzer)는 **건드리지 않는다** — shim이 `list[NormalizedArticle]`를 그대로 반환하므로 무영향.
+
+---
+
+## Task 1: symbol_news_service 신설
+
+**Files:**
+- Create: `app/services/symbol_news_service.py`
+- Test: `tests/services/test_symbol_news_service.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_symbol_news_service.py
+"""Tests for app.services.symbol_news_service (ROB-423 PR1)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import symbol_news_service
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kr_returns_normalized_articles_with_external_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = [
+        {
+            "title": "삼성전자 호실적",
+            "url": "https://finance.naver.com/item/news_read.naver?article_id=123&office_id=001",
+            "source": "한국경제",
+            "datetime": "2026-05-05T09:30",
+        },
+        {"title": "", "url": "", "source": "", "datetime": None},  # dropped (no url/title)
+    ]
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance,
+        "fetch_news",
+        AsyncMock(return_value=raw),
+    )
+
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr", limit=20)
+
+    assert result.status == "ok"
+    assert result.provider == "naver"
+    assert result.returned_count == 1
+    art = result.articles[0]
+    assert art.symbol == "005930"
+    assert art.market == "kr"
+    assert art.title == "삼성전자 호실적"
+    assert art.source_name == "한국경제"
+    assert art.canonical_url.endswith("article_id=123&office_id=001")
+    assert art.external_article_id == "001:123"
+    assert isinstance(art.published_at, datetime)
+    assert art.provider_metadata["source_item"] == raw[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_us_finnhub_preserves_source_item_and_sentiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "symbol": "AAPL",
+        "market": "us",
+        "source": "finnhub",
+        "count": 1,
+        "news": [
+            {
+                "title": "Apple beats earnings",
+                "source": "Reuters",
+                "datetime": "2026-05-05T12:00:00",
+                "url": "https://x/aapl-1",
+                "summary": "strong quarter",
+                "sentiment": "positive",
+                "related": "AAPL,MSFT",
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_news_finnhub",
+        AsyncMock(return_value=payload),
+    )
+
+    result = await symbol_news_service.fetch_symbol_news("AAPL", "us", limit=10)
+
+    assert result.status == "ok"
+    assert result.provider == "finnhub"
+    art = result.articles[0]
+    assert art.external_article_id is not None  # url hash
+    assert art.related_symbols == ["AAPL", "MSFT"]
+    assert art.provider_metadata["sentiment"] == "positive"
+    assert art.provider_metadata["source_item"] == payload["news"][0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_provider_result_is_status_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance, "fetch_news", AsyncMock(return_value=[])
+    )
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr")
+    assert result.status == "empty"
+    assert result.returned_count == 0
+    assert result.articles == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_error_is_fail_soft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance,
+        "fetch_news",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr")
+    assert result.status == "error"
+    assert result.error_code == "RuntimeError"
+    assert result.articles == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unsupported_market_is_unavailable() -> None:
+    result = await symbol_news_service.fetch_symbol_news("FOO", "jp")
+    assert result.status == "unavailable"
+    assert result.error_code == "unsupported_market"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_symbol_news_service.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.symbol_news_service'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/symbol_news_service.py
+"""Unified on-demand symbol news service (ROB-423 PR1).
+
+Single normalized seam over the service-layer provider fetchers
+(``naver_finance.fetch_news``, ``finnhub_news.fetch_news_finnhub``). Consumed by
+the ``get_news`` MCP tool, the snapshot-backed news collector, and (via a thin
+shim) the legacy research news path. No MCP imports, no LLM, no order/broker
+surface. Each article keeps the provider's original item in
+``provider_metadata["source_item"]`` so byte-compatible envelopes can be rebuilt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from app.services import naver_finance
+from app.services.finnhub_news import fetch_news_finnhub
+
+logger = logging.getLogger(__name__)
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+@dataclass(frozen=True)
+class SymbolNewsArticle:
+    provider: str
+    market: str
+    symbol: str
+    external_article_id: str | None
+    title: str
+    source_name: str | None
+    canonical_url: str
+    summary: str | None
+    published_at: datetime | None
+    fetched_at: datetime
+    related_symbols: list[str] = field(default_factory=list)
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SymbolNewsFetchResult:
+    symbol: str
+    market: str
+    provider: str
+    status: str  # ok | empty | unavailable | error
+    requested_limit: int
+    returned_count: int
+    articles: list[SymbolNewsArticle]
+    error_code: str | None = None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        pass
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def _naver_external_id(url: str) -> str | None:
+    """``officeId:articleId`` from a Naver news_read URL, else None."""
+    try:
+        q = parse_qs(urlparse(url).query)
+    except ValueError:
+        return None
+    article_id = (q.get("article_id") or [None])[0]
+    office_id = (q.get("office_id") or [None])[0]
+    if office_id and article_id:
+        return f"{office_id}:{article_id}"
+    return article_id or None
+
+
+def _url_hash(url: str) -> str | None:
+    if not url:
+        return None
+    return hashlib.sha1(url.encode("utf-8")).hexdigest()[:16]
+
+
+async def _fetch_naver(
+    symbol: str, limit: int, fetched_at: datetime
+) -> list[SymbolNewsArticle]:
+    items = await naver_finance.fetch_news(symbol, limit=limit)
+    out: list[SymbolNewsArticle] = []
+    for raw in items:
+        url = (raw.get("url") or "").strip()
+        title = (raw.get("title") or "").strip()
+        if not url or not title:
+            continue
+        out.append(
+            SymbolNewsArticle(
+                provider="naver",
+                market="kr",
+                symbol=symbol,
+                external_article_id=_naver_external_id(url),
+                title=title,
+                source_name=raw.get("source") or None,
+                canonical_url=url,
+                summary=None,
+                published_at=_parse_dt(raw.get("datetime")),
+                fetched_at=fetched_at,
+                related_symbols=[],
+                provider_metadata={"source_item": raw},
+            )
+        )
+    return out
+
+
+async def _fetch_finnhub(
+    symbol: str, market: str, limit: int, fetched_at: datetime
+) -> list[SymbolNewsArticle]:
+    payload = await fetch_news_finnhub(symbol, market, limit)
+    out: list[SymbolNewsArticle] = []
+    for raw in payload.get("news") or []:
+        url = (raw.get("url") or "").strip()
+        title = (raw.get("title") or "").strip()
+        if not url or not title:
+            continue
+        related_raw = raw.get("related") or ""
+        related = [s for s in str(related_raw).split(",") if s]
+        out.append(
+            SymbolNewsArticle(
+                provider="finnhub",
+                market=market,
+                symbol=symbol,
+                external_article_id=_url_hash(url),
+                title=title,
+                source_name=raw.get("source") or None,
+                canonical_url=url,
+                summary=raw.get("summary") or None,
+                published_at=_parse_dt(raw.get("datetime")),
+                fetched_at=fetched_at,
+                related_symbols=related,
+                provider_metadata={
+                    "sentiment": raw.get("sentiment"),
+                    "related": related_raw,
+                    "source_item": raw,
+                },
+            )
+        )
+    return out
+
+
+async def fetch_symbol_news(
+    symbol: str,
+    market: str,
+    instrument_type: str | None = None,
+    *,
+    limit: int = 20,
+    timeout_s: float = 5.0,
+) -> SymbolNewsFetchResult:
+    """On-demand normalized news for one symbol. Fail-soft (never raises)."""
+    market = (market or "").lower()
+    provider = "naver" if market == "kr" else "finnhub"
+    fetched_at = _utcnow()
+    try:
+        if market == "kr":
+            articles = await asyncio.wait_for(
+                _fetch_naver(symbol, limit, fetched_at), timeout=timeout_s
+            )
+        elif market in ("us", "crypto"):
+            articles = await asyncio.wait_for(
+                _fetch_finnhub(symbol, market, limit, fetched_at), timeout=timeout_s
+            )
+        else:
+            return SymbolNewsFetchResult(
+                symbol, market, provider, "unavailable", limit, 0, [],
+                "unsupported_market",
+            )
+    except Exception as exc:  # noqa: BLE001 — overlay evidence, fail soft
+        logger.warning(
+            "symbol_news_service.fetch_symbol_news failed: symbol=%s market=%s err=%s",
+            symbol, market, exc,
+        )
+        return SymbolNewsFetchResult(
+            symbol, market, provider, "error", limit, 0, [], type(exc).__name__
+        )
+    status = "ok" if articles else "empty"
+    return SymbolNewsFetchResult(
+        symbol, market, provider, status, limit, len(articles), articles, None
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_symbol_news_service.py -v`
+Expected: PASS (6 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/symbol_news_service.py tests/services/test_symbol_news_service.py
+git commit -m "feat(ROB-423): symbol_news_service 단일 정규화 뉴스 seam
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: research_news_service를 seam 위 shim으로 축소
+
+**Files:**
+- Modify: `app/services/research_news_service.py`
+- Test: `tests/services/test_research_news_service.py`
+
+레거시 `app/analysis/stages/news_stage.py:115`는 `fetch_symbol_news(symbol, instrument_type, limit=20) -> list[NormalizedArticle]`를 그대로 호출한다. 시그니처/반환형은 유지하고 내부만 seam에 위임한다.
+
+- [ ] **Step 1: Update the test to drive the shim (will fail)**
+
+기존 `tests/services/test_research_news_service.py`를 아래로 교체. seam을 monkeypatch하고 `NormalizedArticle` 매핑을 검증.
+
+```python
+# tests/services/test_research_news_service.py
+"""Tests for research_news_service shim over symbol_news_service (ROB-423)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import research_news_service, symbol_news_service
+from app.services.symbol_news_service import (
+    SymbolNewsArticle,
+    SymbolNewsFetchResult,
+)
+
+
+def _seam_article(provider: str = "naver") -> SymbolNewsArticle:
+    return SymbolNewsArticle(
+        provider=provider,
+        market="kr",
+        symbol="005930",
+        external_article_id="001:123",
+        title="삼성전자 호실적",
+        source_name="한국경제",
+        canonical_url="https://finance.naver.com/x",
+        summary="요약" if provider == "finnhub" else None,
+        published_at=datetime(2026, 5, 5, 9, 0, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 10, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_maps_seam_to_normalized_article(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = SymbolNewsFetchResult(
+        symbol="005930", market="kr", provider="naver", status="ok",
+        requested_limit=20, returned_count=1, articles=[_seam_article()],
+    )
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(return_value=result),
+    )
+
+    out = await research_news_service.fetch_symbol_news(
+        "005930", "equity_kr", limit=20
+    )
+
+    assert len(out) == 1
+    first = out[0]
+    assert first.url == "https://finance.naver.com/x"
+    assert first.title == "삼성전자 호실적"
+    assert first.source == "한국경제"
+    assert first.provider == "naver"
+    assert first.summary is None
+    assert isinstance(first.published_at, datetime)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_passes_market_for_us(monkeypatch: pytest.MonkeyPatch) -> None:
+    seam = AsyncMock(
+        return_value=SymbolNewsFetchResult(
+            symbol="AAPL", market="us", provider="finnhub", status="empty",
+            requested_limit=20, returned_count=0, articles=[],
+        )
+    )
+    monkeypatch.setattr(symbol_news_service, "fetch_symbol_news", seam)
+
+    out = await research_news_service.fetch_symbol_news("AAPL", "equity_us", limit=20)
+
+    assert out == []
+    seam.assert_awaited_once()
+    assert seam.await_args.args[1] == "us"  # market derived from instrument_type
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_returns_empty_for_unknown_instrument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seam = AsyncMock()
+    monkeypatch.setattr(symbol_news_service, "fetch_symbol_news", seam)
+
+    out = await research_news_service.fetch_symbol_news("X", "crypto", limit=20)
+
+    assert out == []
+    seam.assert_not_awaited()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_research_news_service.py -v`
+Expected: FAIL (shim not yet delegating; `_naver_fetch_news` path still active / import errors)
+
+- [ ] **Step 3: Rewrite research_news_service as shim**
+
+`app/services/research_news_service.py` 전체를 아래로 교체. `NormalizedArticle`는 레거시 소비자(`app/analysis/stages/news_stage.py`)를 위해 유지.
+
+```python
+# app/services/research_news_service.py
+"""Legacy research-pipeline news shim (ROB-115 → ROB-423).
+
+Thin wrapper that delegates to the unified ``symbol_news_service`` seam and maps
+its richer ``SymbolNewsArticle`` back to the legacy ``NormalizedArticle`` shape
+consumed by ``app.analysis.stages.news_stage``. No fetch/normalize logic lives
+here anymore — single source of truth is ``symbol_news_service``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from app.services import symbol_news_service
+
+_MARKET_BY_INSTRUMENT = {"equity_kr": "kr", "equity_us": "us"}
+
+
+@dataclass(frozen=True)
+class NormalizedArticle:
+    url: str
+    title: str
+    source: str | None
+    summary: str | None
+    published_at: datetime | None
+    provider: str
+
+
+async def fetch_symbol_news(
+    symbol: str, instrument_type: str, *, limit: int = 20, timeout_s: float = 5.0
+) -> list[NormalizedArticle]:
+    market = _MARKET_BY_INSTRUMENT.get(instrument_type)
+    if market is None:
+        return []
+    result = await symbol_news_service.fetch_symbol_news(
+        symbol, market, instrument_type, limit=limit, timeout_s=timeout_s
+    )
+    return [
+        NormalizedArticle(
+            url=a.canonical_url,
+            title=a.title,
+            source=a.source_name,
+            summary=a.summary,
+            published_at=a.published_at,
+            provider=a.provider,
+        )
+        for a in result.articles
+    ]
+```
+
+- [ ] **Step 4: Run tests (shim + legacy consumer) to verify they pass**
+
+Run: `uv run pytest tests/services/test_research_news_service.py tests/test_news_stage_on_demand.py -v`
+Expected: PASS (legacy `NewsStageAnalyzer` tests still green — `fetch_symbol_news` still returns `list[NormalizedArticle]`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/research_news_service.py tests/services/test_research_news_service.py
+git commit -m "refactor(ROB-423): research_news_service를 symbol_news_service shim으로 축소
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: get_news 핸들러를 seam 경유로 재배선 (envelope byte-compat)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/fundamentals/_news.py`
+- Test: `tests/mcp_server/tooling/test_get_news_envelope.py`
+
+`get_news`는 seam을 거치되, 응답은 provider 원본 item(`provider_metadata["source_item"]`)을 재방출하여 기존 envelope를 그대로 유지한다.
+
+- [ ] **Step 1: Write the failing regression test**
+
+```python
+# tests/mcp_server/tooling/test_get_news_envelope.py
+"""get_news envelope byte-compat regression after seam rewire (ROB-423)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _news
+from app.services import symbol_news_service
+from app.services.symbol_news_service import (
+    SymbolNewsArticle,
+    SymbolNewsFetchResult,
+)
+
+
+def _naver_article() -> SymbolNewsArticle:
+    raw = {
+        "title": "삼성전자 호실적",
+        "url": "https://finance.naver.com/item/news_read.naver?article_id=1&office_id=2",
+        "source": "한국경제",
+        "datetime": "2026-05-05",
+    }
+    return SymbolNewsArticle(
+        provider="naver", market="kr", symbol="005930",
+        external_article_id="2:1", title=raw["title"], source_name=raw["source"],
+        canonical_url=raw["url"], summary=None,
+        published_at=datetime(2026, 5, 5, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 1, tzinfo=UTC),
+        provider_metadata={"source_item": raw},
+    )
+
+
+def _finnhub_article() -> SymbolNewsArticle:
+    raw = {
+        "title": "Apple beats earnings",
+        "source": "Reuters",
+        "datetime": "2026-05-05T12:00:00",
+        "url": "https://x/aapl-1",
+        "summary": "strong",
+        "sentiment": "positive",
+        "related": "AAPL",
+    }
+    return SymbolNewsArticle(
+        provider="finnhub", market="us", symbol="AAPL",
+        external_article_id="abc", title=raw["title"], source_name=raw["source"],
+        canonical_url=raw["url"], summary=raw["summary"],
+        published_at=datetime(2026, 5, 5, 12, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 13, tzinfo=UTC),
+        related_symbols=["AAPL"],
+        provider_metadata={"sentiment": "positive", "related": "AAPL", "source_item": raw},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_kr_envelope_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    art = _naver_article()
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult(
+                "005930", "kr", "naver", "ok", 10, 1, [art]
+            )
+        ),
+    )
+
+    out = await _news.handle_get_news("005930", market="kr", limit=10)
+
+    assert out == {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "naver",
+        "count": 1,
+        "news": [art.provider_metadata["source_item"]],
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_us_envelope_keys_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    art = _finnhub_article()
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult("AAPL", "us", "finnhub", "ok", 10, 1, [art])
+        ),
+    )
+
+    out = await _news.handle_get_news("AAPL", market="us", limit=10)
+
+    assert out["source"] == "finnhub"
+    assert out["count"] == 1
+    assert set(out["news"][0].keys()) == {
+        "title", "source", "datetime", "url", "summary", "sentiment", "related",
+    }
+    assert out["news"][0]["sentiment"] == "positive"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_error_status_returns_error_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult(
+                "AAPL", "us", "finnhub", "error", 10, 0, [], "RuntimeError"
+            )
+        ),
+    )
+
+    out = await _news.handle_get_news("AAPL", market="us", limit=10)
+
+    assert out.get("error") or out.get("source") == "finnhub"
+    assert "news" not in out or out.get("count", 0) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/tooling/test_get_news_envelope.py -v`
+Expected: FAIL (handler still calls `_fetch_news_naver`/`_fetch_news_finnhub`, not the seam)
+
+- [ ] **Step 3: Rewire the handler**
+
+`app/mcp_server/tooling/fundamentals/_news.py` 전체를 아래로 교체.
+
+```python
+# app/mcp_server/tooling/fundamentals/_news.py
+"""Handler for get_news tool (routes through symbol_news_service, ROB-423)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.fundamentals._helpers import normalize_market_with_crypto
+from app.mcp_server.tooling.shared import (
+    error_payload as _error_payload,
+)
+from app.mcp_server.tooling.shared import (
+    is_crypto_market as _is_crypto_market,
+)
+from app.mcp_server.tooling.shared import (
+    is_korean_equity_code as _is_korean_equity_code,
+)
+from app.mcp_server.tooling.shared import (
+    normalize_symbol_input as _normalize_symbol_input,
+)
+from app.services import symbol_news_service
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+async def handle_get_news(
+    symbol: str | int,
+    market: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    symbol = _normalize_symbol_input(symbol, market)
+    if not symbol:
+        raise ValueError("symbol is required")
+
+    if market is None:
+        if _is_korean_equity_code(symbol):
+            market = "kr"
+        elif _is_crypto_market(symbol):
+            market = "crypto"
+        else:
+            market = "us"
+
+    normalized_market = normalize_market_with_crypto(market)
+    capped_limit = min(max(limit, 1), 50)
+    instrument_type = _INSTRUMENT_BY_MARKET.get(normalized_market, "equity_us")
+
+    result = await symbol_news_service.fetch_symbol_news(
+        symbol, normalized_market, instrument_type, limit=capped_limit
+    )
+
+    if result.status in ("error", "unavailable"):
+        return _error_payload(
+            source=result.provider,
+            message=result.error_code or "news_unavailable",
+            symbol=symbol,
+            instrument_type=instrument_type,
+        )
+
+    news = [a.provider_metadata.get("source_item", {}) for a in result.articles]
+    return {
+        "symbol": symbol,
+        "market": normalized_market,
+        "source": result.provider,
+        "count": len(news),
+        "news": news,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/tooling/test_get_news_envelope.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Run any pre-existing get_news tests to confirm no regression**
+
+Run: `uv run pytest -k "get_news or handle_get_news" -v`
+Expected: PASS (existing get_news tests still green; if a pre-existing test pinned the old `_fetch_news_*` import path, update it to the seam mock — repeat the seam-mock pattern from Step 1)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/fundamentals/_news.py tests/mcp_server/tooling/test_get_news_envelope.py
+git commit -m "refactor(ROB-423): get_news를 symbol_news_service 경유로 재배선(envelope 보존)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: NewsSnapshotCollector를 per-symbol on-demand seam으로 전환
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/news.py`
+- Modify: `app/services/action_report/snapshot_backed/collectors/registry.py:237-273,316`
+- Test: `tests/services/action_report/snapshot_backed/test_collectors.py`
+
+뉴스 소스를 DB(`llm_news_service.get_news_articles`, market-scoped) → seam(per-symbol on-demand)로 전환. `articles` payload는 NewsStage가 읽는 키(`title`, `sentiment`)를 유지하고, PR2 citation을 위해 `symbol`/`external_article_id`/`canonical_url`/`provider`/`published_at`를 추가한다. per-symbol `fetch_records`를 payload에 남긴다(PR2 fetch_run 재료). 실패는 fail-open.
+
+- [ ] **Step 1: Write/replace the failing collector test**
+
+`tests/services/action_report/snapshot_backed/test_collectors.py`의 `test_news_collector_articles_from_news_fetch_fn`(약 1262-1282행)을 아래로 교체하고, 새 per-symbol 테스트 2개를 추가.
+
+```python
+@pytest.mark.asyncio
+async def test_news_collector_articles_per_symbol_from_seam():
+    from app.services.symbol_news_service import (
+        SymbolNewsArticle,
+        SymbolNewsFetchResult,
+    )
+
+    captured: list[tuple[str, str, int]] = []
+
+    async def fake_fetch(symbol: str, market: str, limit: int):
+        captured.append((symbol, market, limit))
+        art = SymbolNewsArticle(
+            provider="finnhub", market=market, symbol=symbol,
+            external_article_id=f"id-{symbol}", title=f"{symbol} up",
+            source_name="Reuters", canonical_url=f"https://x/{symbol}",
+            summary="s", published_at=None,
+            fetched_at=dt.datetime(2026, 5, 5, tzinfo=dt.UTC),
+            provider_metadata={"sentiment": "positive"},
+        )
+        return SymbolNewsFetchResult(
+            symbol, market, "finnhub", "ok", limit, 1, [art]
+        )
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=["AAPL", "MSFT"]))
+
+    payload = results[0].payload_json
+    assert payload["count"] == 2
+    assert {a["symbol"] for a in payload["articles"]} == {"AAPL", "MSFT"}
+    assert payload["articles"][0]["sentiment"] == "positive"
+    assert payload["articles"][0]["external_article_id"] == "id-AAPL"
+    assert [r["symbol"] for r in payload["fetch_records"]] == ["AAPL", "MSFT"]
+    assert {c[0] for c in captured} == {"AAPL", "MSFT"}
+    assert results[0].freshness_status == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_news_collector_per_symbol_failure_is_fail_open():
+    from app.services.symbol_news_service import SymbolNewsFetchResult
+
+    async def fake_fetch(symbol: str, market: str, limit: int):
+        return SymbolNewsFetchResult(
+            symbol, market, "finnhub", "error", limit, 0, [], "RuntimeError"
+        )
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=["AAPL"]))
+
+    payload = results[0].payload_json
+    assert payload["count"] == 0
+    assert payload["fetch_records"][0]["status"] == "error"
+    # fail-open: never raises, degrades to partial
+    assert results[0].freshness_status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_news_collector_no_symbols_is_partial():
+    from app.services.symbol_news_service import SymbolNewsFetchResult
+
+    async def fake_fetch(symbol: str, market: str, limit: int):  # pragma: no cover
+        raise AssertionError("should not fetch without symbols")
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=[]))
+
+    assert results[0].payload_json["count"] == 0
+    assert results[0].freshness_status == "partial"
+```
+
+`_request` 헬퍼가 `symbols=`를 받는지 확인하고(이미 `request.symbols` 사용), 없으면 그 키워드를 받도록 헬퍼를 확장한다. 기존 research_reports 폴백 테스트(`test_news_collector_returns_citations`)는 변경 없이 유지(news_fetch_fn=None 경로).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k news -v`
+Expected: FAIL (collector still calls `_news_fetch_fn(market, hours, limit)` and expects `list[dict]`)
+
+- [ ] **Step 3: Update NewsFetchFn type + _collect_articles loop**
+
+`app/services/action_report/snapshot_backed/collectors/news.py`에서:
+
+(a) import + `NewsFetchFn` 타입 교체 (현재 34-38행):
+
+```python
+from app.services.investment_snapshots.collectors import (
+    CollectorRequest,
+    SnapshotCollectResult,
+)
+from app.services.research_reports.query_service import ResearchReportsQueryService
+from app.services.symbol_news_service import SymbolNewsFetchResult
+
+# ROB-423 — per-symbol on-demand news fetch (symbol, market, limit) →
+# SymbolNewsFetchResult. Wired in registry.py over symbol_news_service so this
+# module imports no MCP tooling and no LLM provider.
+NewsFetchFn = Callable[[str, str, int], Awaitable[SymbolNewsFetchResult]]
+```
+
+(b) `_collect_articles` (현재 159-202행) 전체 교체:
+
+```python
+    async def _collect_articles(
+        self, request: CollectorRequest, *, now: dt.datetime, since: dt.datetime
+    ) -> list[SnapshotCollectResult]:
+        """Per-symbol on-demand news (ROB-423). Fail-open: per-symbol fetch
+        errors are recorded in ``fetch_records`` and never raise. Each article
+        keeps NewsStage-compatible keys (``title``/``sentiment``) plus citation
+        provenance (``symbol``/``external_article_id``/``canonical_url``)."""
+        assert self._news_fetch_fn is not None
+        focus_symbols = [s for s in (request.symbols or []) if s]
+
+        articles_payload: list[dict[str, Any]] = []
+        fetch_records: list[dict[str, Any]] = []
+        for symbol in focus_symbols:
+            try:
+                result = await self._news_fetch_fn(
+                    symbol, request.market, self._limit
+                )
+            except Exception as exc:  # noqa: BLE001 — optional, fail open
+                fetch_records.append(
+                    {
+                        "symbol": symbol,
+                        "provider": "unknown",
+                        "requested_limit": self._limit,
+                        "returned_count": 0,
+                        "status": "error",
+                        "error_code": type(exc).__name__,
+                    }
+                )
+                continue
+
+            fetch_records.append(
+                {
+                    "symbol": symbol,
+                    "provider": result.provider,
+                    "requested_limit": result.requested_limit,
+                    "returned_count": result.returned_count,
+                    "status": result.status,
+                    "error_code": result.error_code,
+                }
+            )
+            for a in result.articles:
+                articles_payload.append(
+                    {
+                        "title": a.title,
+                        "url": a.canonical_url,
+                        "source": a.source_name,
+                        "summary": a.summary,
+                        "published_at": a.published_at.isoformat()
+                        if a.published_at
+                        else None,
+                        "symbol": a.symbol,
+                        "provider": a.provider,
+                        "external_article_id": a.external_article_id,
+                        "sentiment": a.provider_metadata.get("sentiment"),
+                        "related": a.related_symbols,
+                    }
+                )
+
+        payload: dict[str, Any] = {
+            "since": since.isoformat(),
+            "count": len(articles_payload),
+            "articles": articles_payload,
+            "fetch_records": fetch_records,
+            "source": "symbol_news_service",
+            "market": request.market,
+        }
+        return [
+            build_result(
+                snapshot_kind=self.snapshot_kind,
+                market=request.market,
+                account_scope=request.account_scope,
+                payload=payload,
+                origin="news",
+                as_of=now,
+                freshness_status="fresh" if articles_payload else "partial",
+                coverage={"article_count": len(articles_payload)},
+            )
+        ]
+```
+
+- [ ] **Step 4: Re-point the registry adapter to the seam**
+
+`app/services/action_report/snapshot_backed/collectors/registry.py`의 `_build_news_fetch_fn` (237-273행) 전체 교체:
+
+```python
+def _build_news_fetch_fn() -> NewsFetchFn:
+    """Per-symbol on-demand news adapter over ``symbol_news_service`` (ROB-423).
+
+    Given (symbol, market, limit) returns a normalized ``SymbolNewsFetchResult``.
+    Imported lazily; no MCP/LLM/order surface. The collector wraps the call so a
+    fetch error degrades the optional ``news`` kind without blocking the bundle.
+    """
+
+    async def _news_fetch_fn(symbol: str, market: str, limit: int):
+        from app.services.symbol_news_service import fetch_symbol_news
+
+        return await fetch_symbol_news(symbol, market, limit=limit)
+
+    return _news_fetch_fn
+```
+
+(`NewsFetchFn` import는 이미 `collectors.news`에서 오므로 registry 상단 import 유지. 사용하지 않게 된 `llm_news_service` 관련 import가 registry에 있으면 제거.)
+
+- [ ] **Step 5: Run collector tests to verify pass**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_collectors.py -k news -v`
+Expected: PASS (per-symbol tests green; research_reports 폴백 테스트도 유지)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/news.py app/services/action_report/snapshot_backed/collectors/registry.py tests/services/action_report/snapshot_backed/test_collectors.py
+git commit -m "feat(ROB-423): news collector를 per-symbol on-demand seam으로 전환
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 전체 검증 + 가드 + lint
+
+**Files:** (없음 — 검증만)
+
+- [ ] **Step 1: no-internal-LLM 가드 통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v`
+Expected: PASS (collector/news 변경이 LLM provider import를 추가하지 않음. `symbol_news_service`는 `app/services/` 평면에 있고 LLM 미import)
+
+- [ ] **Step 2: 관련 영역 전체 테스트**
+
+Run:
+```bash
+uv run pytest \
+  tests/services/test_symbol_news_service.py \
+  tests/services/test_research_news_service.py \
+  tests/test_news_stage_on_demand.py \
+  tests/mcp_server/tooling/test_get_news_envelope.py \
+  tests/services/action_report/snapshot_backed/test_collectors.py \
+  -v
+```
+Expected: PASS (전부 green)
+
+- [ ] **Step 3: get_news / news 회귀 스윕**
+
+Run: `uv run pytest -k "news or get_news" -q`
+Expected: PASS (사전 존재 테스트 중 `_fetch_news_*` 직접 import에 의존하던 것이 있으면 seam mock으로 갱신 후 green)
+
+- [ ] **Step 4: lint + format + typecheck**
+
+Run:
+```bash
+uv run ruff check app/services/symbol_news_service.py app/services/research_news_service.py app/mcp_server/tooling/fundamentals/_news.py app/services/action_report/snapshot_backed/collectors/news.py app/services/action_report/snapshot_backed/collectors/registry.py
+uv run ruff format --check app/services/symbol_news_service.py app/services/research_news_service.py app/mcp_server/tooling/fundamentals/_news.py app/services/action_report/snapshot_backed/collectors/news.py app/services/action_report/snapshot_backed/collectors/registry.py
+```
+Expected: clean (위반 시 `ruff format` 적용 후 재확인)
+
+- [ ] **Step 5: 최종 커밋 (잔여 변경 있으면)**
+
+```bash
+git add -A
+git commit -m "test(ROB-423): PR1 seam 전환 회귀 스윕 + lint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (spec 대조)
+
+- **AC#3 (public MCP tool은 get_news 하나)**: 신규 MCP tool 0. `symbol_news_service`는 내부 service. ✅
+- **AC#4 (get_news envelope 불변)**: Task 3 byte-compat 회귀 테스트 + `source_item` 재방출. ✅
+- **AC#11 (collector가 symbol_news_service 단일 경로, 중복 normalize 없음)**: Task 4 collector seam 전환 + Task 2 research shim. ✅
+- **D2 (on-demand)**: DB 경로 제거, per-symbol seam. ✅
+- **D3 (단일 seam + get_news 경유)**: Task 1/2/3. ✅
+- **migration/영속/Hermes/detail/mock 복사**: PR2 범위 — 본 플랜 비포함(의도적). ✅
+- **fail-open**: Task 4 per-symbol error → fetch_records 기록, 무예외. ✅
+- **레거시 NewsStageAnalyzer 무영향**: shim이 `list[NormalizedArticle]` 유지(Task 2 Step 4 검증). ✅
+
+### 주의/리스크
+- **NewsStage 감성**: KR(naver)은 per-article `sentiment` 없음 → NewsStage가 NEUTRAL로 강등(날조 아님, 정직). 기존 DB 경로가 분석된 sentiment를 갖던 종목은 NEUTRAL로 바뀔 수 있음(overlay evidence라 허용). PR 설명에 명시.
+- **crypto**: `market=="crypto"`는 finnhub general crypto news를 per-symbol 호출(코인별 동일 피드 가능) — get_news 기존 동작과 동일. 종목 간 중복 최적화는 후속.
+- **사전 존재 get_news 테스트**: `_fetch_news_naver`/`_fetch_news_finnhub` 직접 import에 의존하는 테스트가 있으면 Step 3 회귀 스윕에서 seam mock으로 갱신.
+- **disk**: 검증 중 worktree에서 "filesystem full" 관측 — 구현 전 `df -h` 확인 권장.
+
+## Out of Scope (PR2)
+
+2 테이블(`investment_report_news_fetch_runs`/`_citations`) + migration · `HermesCompositionResult.news_citations` 스키마 · `InvestmentReportNewsService.persist` · detail API `news_citations` · mock_preview citation 복사 · advisory-only smoke.

--- a/docs/plans/ROB-423-PR2-news-citation-persistence-implementation-plan.md
+++ b/docs/plans/ROB-423-PR2-news-citation-persistence-implementation-plan.md
@@ -1,0 +1,1462 @@
+# ROB-423 PR2: 뉴스 citation 영속 + Hermes ingest + detail API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PR1의 per-symbol 뉴스 evidence를 영속화한다 — 2개 신규 테이블(fetch_runs/citations), Hermes 합성 시점 citation 작성(matching/fail-open), detail API 노출, mock_preview citation 복사.
+
+**Architecture:** auto_trader는 결정적 fetch_run audit를 쓰고, 판단성 citation은 Hermes가 `HermesCompositionResult.news_citations`로 보낸 annotation을 bundle의 news snapshot articles와 매칭해서만 작성한다(in-process LLM 0, no-internal-LLM 가드 준수). 매칭 실패 ref는 drop + 기록(날조 0). report_uuid는 `ingest_composition`의 `insert_report` 이후 확정되며 같은 트랜잭션에서 child row를 쓴다. detail API는 `InvestmentReportBundle`에 additive로 citation을 노출. mock_preview는 live citation을 report-level로 복사(재fetch/재판정 0).
+
+**Tech Stack:** Python 3.13, SQLAlchemy async ORM, Alembic, Pydantic v2, FastAPI, pytest + pytest-asyncio, ruff.
+
+> **선행 의존**: PR1(`b541eeda`..`6b789bad`, symbol_news_service seam + collector `articles[]`/`fetch_records[]` payload)이 머지/존재해야 한다. 본 플랜은 그 payload 계약을 소비한다.
+
+---
+
+## File Structure
+
+| File | 역할 | 변경 |
+|------|------|------|
+| `app/models/investment_reports.py` | `InvestmentReportNewsFetchRun` + `InvestmentReportNewsCitation` ORM 추가 | Modify |
+| `app/models/__init__.py` | 두 모델 import + `__all__` 등록 | Modify |
+| `alembic/versions/20260603_rob423_news_citation_tables.py` | 신규 마이그레이션(down=현재 head) | Create |
+| `app/schemas/hermes_composition.py` | `HermesNewsCitation` + `HermesCompositionResult.news_citations` additive | Modify |
+| `app/services/investment_reports/news_persistence.py` | **신규** 순수 매칭 헬퍼 `build_news_persistence(...)` | Create |
+| `app/services/investment_reports/investment_report_news_service.py` | **신규** `InvestmentReportNewsService`(persist/copy/list) | Create |
+| `app/services/investment_stages/hermes_ingest.py` | `ingest_composition`에서 persist 호출 + 생성자 배선 | Modify |
+| `app/services/investment_reports/repository.py` | `list_items_for_report_ordered_by_id` + citation 조회 메서드 | Modify |
+| `app/services/investment_reports/query_service.py` | `get_bundle`에 `news_citations` 추가 | Modify |
+| `app/schemas/investment_reports.py` | `InvestmentReportNewsCitationResponse` + `InvestmentReportBundle.news_citations` | Modify |
+| `app/routers/investment_reports.py` | `_serialise_bundle`에 citation 매핑 | Modify |
+| `app/services/investment_reports/mock_preview/runner.py` | mock citation 복사 호출 | Modify |
+| `scripts/...smoke` | advisory-only smoke(기존 smoke 확장 or 신규) | Modify/Create |
+| `tests/...` | 각 단위/통합 테스트 | Create/Modify |
+
+> 내부 체크포인트(선택): Task 1~5(영속 코어) → Task 6~8(노출/복사/smoke). 한 PR로 가되 리뷰는 이 경계로 나눠도 됨.
+
+---
+
+## Task 1: 2개 ORM 모델 + 등록
+
+**Files:**
+- Modify: `app/models/investment_reports.py` (append)
+- Modify: `app/models/__init__.py`
+- Test: `tests/models/test_investment_report_news_models.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/models/test_investment_report_news_models.py
+"""ROB-423 PR2 — news fetch-run + citation ORM registration."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_news_models_importable_and_in_review_schema() -> None:
+    from app.models import (
+        InvestmentReportNewsCitation,
+        InvestmentReportNewsFetchRun,
+    )
+
+    assert InvestmentReportNewsFetchRun.__tablename__ == "investment_report_news_fetch_runs"
+    assert InvestmentReportNewsCitation.__tablename__ == "investment_report_news_citations"
+    assert InvestmentReportNewsFetchRun.__table__.schema == "review"
+    assert InvestmentReportNewsCitation.__table__.schema == "review"
+    # citation references fetch_run (nullable FK) and carries judgment fields
+    cols = InvestmentReportNewsCitation.__table__.columns.keys()
+    for c in ("report_uuid", "role", "decision_impact", "relevance", "canonical_url"):
+        assert c in cols
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/models/test_investment_report_news_models.py -v`
+Expected: FAIL with `ImportError: cannot import name 'InvestmentReportNewsFetchRun'`
+
+- [ ] **Step 3: Append the two models**
+
+`app/models/investment_reports.py` 파일 끝에 추가. 기존 import 블록은 `ARRAY, TIMESTAMP, BigInteger, CheckConstraint, ForeignKey, Index, Integer, Numeric, Text, UniqueConstraint` + `JSONB`, `PG_UUID`, `Mapped/mapped_column`, `func/text`, `Base`를 이미 포함(추가 import 불필요; `Boolean`만 신규 필요).
+
+```python
+# --- 파일 상단 import에 Boolean 추가 (기존 sqlalchemy import 블록) ---
+# from sqlalchemy import (..., BigInteger, Boolean, CheckConstraint, ...)
+
+# --- 파일 끝에 추가 (ROB-423 PR2) ---
+
+
+class InvestmentReportNewsFetchRun(Base):
+    """ROB-423 — per (report, symbol, provider) news fetch audit row.
+
+    Append-only. ``report_uuid`` is a logical reference to
+    ``review.investment_reports.report_uuid`` (no FK — items relate by
+    integer ``report_id``, so we keep this membership-only). Never stores raw
+    provider payloads (``raw_response_stored`` is an audit flag only).
+    """
+
+    __tablename__ = "investment_report_news_fetch_runs"
+    __table_args__ = (
+        UniqueConstraint(
+            "run_uuid", name="uq_investment_report_news_fetch_runs_run_uuid"
+        ),
+        CheckConstraint(
+            "status IN ('ok','empty','unavailable','error')",
+            name="ck_investment_report_news_fetch_runs_status",
+        ),
+        Index(
+            "ix_investment_report_news_fetch_runs_report_uuid",
+            "report_uuid",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    run_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    report_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    requested_limit: Mapped[int] = mapped_column(Integer, nullable=False)
+    returned_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    used_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    freshness_policy: Mapped[str | None] = mapped_column(Text)
+    ttl_seconds: Mapped[int | None] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    error_code: Mapped[str | None] = mapped_column(Text)
+    error_message: Mapped[str | None] = mapped_column(Text)
+    raw_response_stored: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class InvestmentReportNewsCitation(Base):
+    """ROB-423 — a news article the report actually cited (Hermes-marked).
+
+    Only articles Hermes flagged as used land here (never fetched-but-unused).
+    Judgment fields (``role``/``decision_impact``/``relevance``/
+    ``selection_reason``/``confidence``) are Hermes-authored — auto_trader only
+    validates + persists. Article fields are a snapshot copy (immutable audit).
+    """
+
+    __tablename__ = "investment_report_news_citations"
+    __table_args__ = (
+        UniqueConstraint(
+            "citation_uuid", name="uq_investment_report_news_citations_citation_uuid"
+        ),
+        CheckConstraint(
+            "relevance IN ('direct','related','market_context','crypto_context')",
+            name="ck_investment_report_news_citations_relevance",
+        ),
+        CheckConstraint(
+            "role IN ('catalyst','risk','confirmation','contradiction','neutral','noise')",
+            name="ck_investment_report_news_citations_role",
+        ),
+        CheckConstraint(
+            "decision_impact IN ('strengthen_buy','weaken_buy','strengthen_sell',"
+            "'weaken_sell','hold_watch','no_action')",
+            name="ck_investment_report_news_citations_decision_impact",
+        ),
+        Index(
+            "ix_investment_report_news_citations_report_uuid",
+            "report_uuid",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    citation_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    report_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    report_item_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    section_key: Mapped[str | None] = mapped_column(Text)
+    fetch_run_id: Mapped[int | None] = mapped_column(
+        ForeignKey(
+            "review.investment_report_news_fetch_runs.id", ondelete="SET NULL"
+        )
+    )
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    external_article_id: Mapped[str | None] = mapped_column(Text)
+    canonical_url: Mapped[str] = mapped_column(Text, nullable=False)
+    source_name: Mapped[str | None] = mapped_column(Text)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    summary_snapshot: Mapped[str | None] = mapped_column(Text)
+    published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    relevance: Mapped[str] = mapped_column(Text, nullable=False)
+    role: Mapped[str] = mapped_column(Text, nullable=False)
+    decision_impact: Mapped[str] = mapped_column(Text, nullable=False)
+    selection_reason: Mapped[str | None] = mapped_column(Text)
+    confidence: Mapped[float | None] = mapped_column(Numeric)
+    metadata_json: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+```
+
+`app/models/__init__.py`의 investment_reports import 블록(16-22행)과 `__all__`(142-146행)에 두 모델 추가:
+
+```python
+from .investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentReportNewsCitation,
+    InvestmentReportNewsFetchRun,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+```
+```python
+    "InvestmentReport",
+    "InvestmentReportItem",
+    "InvestmentReportItemDecision",
+    "InvestmentReportNewsCitation",
+    "InvestmentReportNewsFetchRun",
+    "InvestmentWatchAlert",
+    "InvestmentWatchEvent",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/models/test_investment_report_news_models.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/models/investment_reports.py app/models/__init__.py tests/models/test_investment_report_news_models.py
+git commit -m "feat(ROB-423): news fetch_run + citation ORM 모델(review)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Alembic 마이그레이션
+
+**Files:**
+- Create: `alembic/versions/20260603_rob423_news_citation_tables.py`
+
+> **down_revision 재확인**: 구현 시작 시 `uv run alembic heads`로 단일 head 확인. 본 플랜 작성 시점 head = `20260602_rob412_main_merge`. main 전진 시 그 값으로 교체.
+
+- [ ] **Step 1: Write the migration**
+
+```python
+# alembic/versions/20260603_rob423_news_citation_tables.py
+"""rob-423 add investment_report_news_* tables (additive)
+
+Revision ID: 20260603_rob423_news
+Revises: 20260602_rob412_main_merge
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260603_rob423_news"
+down_revision: str | None = "20260602_rob412_main_merge"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _jsonb_default(literal: str) -> sa.sql.elements.TextClause:
+    return sa.text(f"'{literal}'::jsonb")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investment_report_news_fetch_runs",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("run_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("instrument_type", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("requested_limit", sa.Integer(), nullable=False),
+        sa.Column(
+            "returned_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "used_count", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("fetched_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("freshness_policy", sa.Text(), nullable=True),
+        sa.Column("ttl_seconds", sa.Integer(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("error_code", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column(
+            "raw_response_stored",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('ok','empty','unavailable','error')",
+            name="ck_investment_report_news_fetch_runs_status",
+        ),
+        sa.UniqueConstraint(
+            "run_uuid", name="uq_investment_report_news_fetch_runs_run_uuid"
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_report_news_fetch_runs_report_uuid",
+        "investment_report_news_fetch_runs",
+        ["report_uuid"],
+        schema="review",
+    )
+
+    op.create_table(
+        "investment_report_news_citations",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("citation_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("report_item_uuid", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("section_key", sa.Text(), nullable=True),
+        sa.Column("fetch_run_id", sa.BigInteger(), nullable=True),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("external_article_id", sa.Text(), nullable=True),
+        sa.Column("canonical_url", sa.Text(), nullable=False),
+        sa.Column("source_name", sa.Text(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary_snapshot", sa.Text(), nullable=True),
+        sa.Column("published_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("fetched_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("relevance", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("decision_impact", sa.Text(), nullable=False),
+        sa.Column("selection_reason", sa.Text(), nullable=True),
+        sa.Column("confidence", sa.Numeric(), nullable=True),
+        sa.Column(
+            "metadata_json",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=_jsonb_default("{}"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "relevance IN ('direct','related','market_context','crypto_context')",
+            name="ck_investment_report_news_citations_relevance",
+        ),
+        sa.CheckConstraint(
+            "role IN ('catalyst','risk','confirmation','contradiction','neutral','noise')",
+            name="ck_investment_report_news_citations_role",
+        ),
+        sa.CheckConstraint(
+            "decision_impact IN ('strengthen_buy','weaken_buy','strengthen_sell',"
+            "'weaken_sell','hold_watch','no_action')",
+            name="ck_investment_report_news_citations_decision_impact",
+        ),
+        sa.ForeignKeyConstraint(
+            ["fetch_run_id"],
+            ["review.investment_report_news_fetch_runs.id"],
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint(
+            "citation_uuid",
+            name="uq_investment_report_news_citations_citation_uuid",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_report_news_citations_report_uuid",
+        "investment_report_news_citations",
+        ["report_uuid"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_investment_report_news_citations_report_uuid",
+        table_name="investment_report_news_citations",
+        schema="review",
+    )
+    op.drop_table("investment_report_news_citations", schema="review")
+    op.drop_index(
+        "ix_investment_report_news_fetch_runs_report_uuid",
+        table_name="investment_report_news_fetch_runs",
+        schema="review",
+    )
+    op.drop_table("investment_report_news_fetch_runs", schema="review")
+```
+
+- [ ] **Step 2: Sanity-check migration imports + model/migration column parity**
+
+Run: `uv run python -c "import importlib.util, pathlib; p='alembic/versions/20260603_rob423_news_citation_tables.py'; spec=importlib.util.spec_from_file_location('m', p); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m); print(m.revision, m.down_revision)"`
+Expected: prints `20260603_rob423_news 20260602_rob412_main_merge` (no import error)
+
+- [ ] **Step 3: Confirm single head after adding migration**
+
+Run: `uv run alembic heads`
+Expected: single head `20260603_rob423_news (head)` (만약 다른 head가 보이면 main 전진 → down_revision을 실제 head로 교체 후 재확인)
+
+> 참고: 테스트 DB는 timescaledb 확장 때문에 alembic upgrade가 막혀 있어, 통합 테스트는 `db_session` fixture의 `create_all`로 테이블을 만든다(ROB-407 선례). operator가 prod에서 별도 `alembic upgrade head` 실행.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/20260603_rob423_news_citation_tables.py
+git commit -m "feat(ROB-423): news citation 테이블 마이그레이션(additive, review)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: HermesNewsCitation 스키마 + HermesCompositionResult.news_citations
+
+**Files:**
+- Modify: `app/schemas/hermes_composition.py`
+- Test: `tests/schemas/test_hermes_news_citations.py`
+
+`HermesCompositionResult.model_config = ConfigDict(extra="forbid")`이므로 default 있는 새 필드 추가는 기존 payload(미전송) back-compat.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/schemas/test_hermes_news_citations.py
+"""ROB-423 PR2 — HermesNewsCitation additive field."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.hermes_composition import (
+    HermesCompositionResult,
+    HermesNewsCitation,
+)
+
+
+def _base_composition(**extra):
+    return {
+        "snapshot_bundle_uuid": str(uuid.uuid4()),
+        "hermes_run_id": "run-1",
+        "title": "t",
+        "summary": "s",
+        **extra,
+    }
+
+
+@pytest.mark.unit
+def test_composition_defaults_news_citations_empty() -> None:
+    comp = HermesCompositionResult(**_base_composition())
+    assert comp.news_citations == []  # legacy payload back-compat
+
+
+@pytest.mark.unit
+def test_news_citation_requires_ref_and_judgment() -> None:
+    cit = HermesNewsCitation(
+        canonical_url="https://x/1",
+        symbol="AAPL",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        selection_reason="beat",
+        client_item_key="ci-1",
+    )
+    comp = HermesCompositionResult(
+        **_base_composition(news_citations=[cit.model_dump()])
+    )
+    assert comp.news_citations[0].symbol == "AAPL"
+    assert comp.news_citations[0].role == "catalyst"
+
+
+@pytest.mark.unit
+def test_news_citation_rejects_bad_role() -> None:
+    with pytest.raises(ValidationError):
+        HermesNewsCitation(
+            canonical_url="https://x/1",
+            symbol="AAPL",
+            relevance="direct",
+            role="bogus",
+            decision_impact="strengthen_buy",
+        )
+
+
+@pytest.mark.unit
+def test_news_citation_requires_some_ref() -> None:
+    with pytest.raises(ValidationError):
+        HermesNewsCitation(
+            symbol="AAPL",
+            relevance="direct",
+            role="catalyst",
+            decision_impact="strengthen_buy",
+        )  # neither external_article_id nor canonical_url
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/schemas/test_hermes_news_citations.py -v`
+Expected: FAIL with `ImportError: cannot import name 'HermesNewsCitation'`
+
+- [ ] **Step 3: Add the schema + field**
+
+`app/schemas/hermes_composition.py`에 추가. (`Literal`, `Decimal`, `UUID`, `BaseModel`, `ConfigDict`, `Field`, `model_validator`는 파일에 이미 import됨 — `model_validator`가 없으면 `from pydantic import model_validator` 추가.)
+
+```python
+# --- HermesCompositionResult 클래스 정의 위에 추가 ---
+
+NewsRelevanceLiteral = Literal["direct", "related", "market_context", "crypto_context"]
+NewsRoleLiteral = Literal[
+    "catalyst", "risk", "confirmation", "contradiction", "neutral", "noise"
+]
+NewsDecisionImpactLiteral = Literal[
+    "strengthen_buy", "weaken_buy", "strengthen_sell", "weaken_sell",
+    "hold_watch", "no_action",
+]
+
+
+class HermesNewsCitation(BaseModel):
+    """A news article Hermes actually used, with its judgment annotations.
+
+    auto_trader matches this against the bundle's news snapshot articles by
+    ``external_article_id`` (preferred) or ``canonical_url`` and persists only
+    matches. At least one of the two refs is required. ``client_item_key`` links
+    the citation to a specific report item (the same key used in the composed
+    ``IngestReportItem``); ``section_key`` is for report-level citations.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    external_article_id: str | None = None
+    canonical_url: str | None = None
+    symbol: str = Field(min_length=1)
+    relevance: NewsRelevanceLiteral
+    role: NewsRoleLiteral
+    decision_impact: NewsDecisionImpactLiteral
+    selection_reason: str | None = None
+    confidence: Decimal | None = None
+    client_item_key: str | None = None
+    section_key: str | None = None
+
+    @model_validator(mode="after")
+    def _require_ref(self) -> HermesNewsCitation:
+        if not self.external_article_id and not self.canonical_url:
+            raise ValueError(
+                "news citation needs external_article_id or canonical_url"
+            )
+        return self
+```
+
+`HermesCompositionResult`에 필드 추가(`dimension_report_uuids` 다음):
+
+```python
+    # ROB-423 — news articles Hermes used as overlay evidence. Empty for legacy
+    # composition (byte-identical path). Matched against the bundle's news
+    # snapshot on ingest; unmatched refs are dropped + recorded (fail-open).
+    news_citations: list[HermesNewsCitation] = Field(default_factory=list)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/schemas/test_hermes_news_citations.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/hermes_composition.py tests/schemas/test_hermes_news_citations.py
+git commit -m "feat(ROB-423): HermesNewsCitation + composition.news_citations additive
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 순수 매칭 헬퍼 build_news_persistence
+
+**Files:**
+- Create: `app/services/investment_reports/news_persistence.py`
+- Test: `tests/services/investment_reports/test_news_persistence.py`
+
+DB I/O 없이 테스트 가능한 순수 함수: news snapshot payloads + Hermes citations + item-uuid 맵 → 작성할 fetch_run/citation row dict들 + unmatched 목록.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_news_persistence.py
+"""ROB-423 PR2 — pure news persistence matching helper."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.schemas.hermes_composition import HermesNewsCitation
+from app.services.investment_reports.news_persistence import build_news_persistence
+
+
+def _news_payload():
+    return {
+        "articles": [
+            {
+                "title": "Apple beats", "url": "https://x/aapl-1", "source": "Reuters",
+                "summary": "strong", "published_at": "2026-05-05T12:00:00",
+                "symbol": "AAPL", "provider": "finnhub",
+                "external_article_id": "hash-aapl-1", "sentiment": "positive",
+            },
+            {
+                "title": "MSFT cloud", "url": "https://x/msft-1", "source": "Bloomberg",
+                "summary": None, "published_at": None,
+                "symbol": "MSFT", "provider": "finnhub",
+                "external_article_id": "hash-msft-1", "sentiment": None,
+            },
+        ],
+        "fetch_records": [
+            {"symbol": "AAPL", "provider": "finnhub", "requested_limit": 20,
+             "returned_count": 1, "status": "ok", "error_code": None},
+            {"symbol": "MSFT", "provider": "finnhub", "requested_limit": 20,
+             "returned_count": 1, "status": "ok", "error_code": None},
+        ],
+        "market": "us",
+    }
+
+
+@pytest.mark.unit
+def test_matches_by_external_id_and_copies_snapshot() -> None:
+    item_uuid = uuid.uuid4()
+    cites = [
+        HermesNewsCitation(
+            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+            selection_reason="earnings beat", client_item_key="ci-1",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()],
+        citations=cites,
+        item_uuid_by_client_key={"ci-1": item_uuid},
+        instrument_type="equity_us",
+    )
+
+    assert len(plan.citations) == 1
+    c = plan.citations[0]
+    assert c["title"] == "Apple beats"
+    assert c["canonical_url"] == "https://x/aapl-1"
+    assert c["external_article_id"] == "hash-aapl-1"
+    assert c["role"] == "catalyst"
+    assert c["decision_impact"] == "strengthen_buy"
+    assert c["report_item_uuid"] == item_uuid
+    assert c["provider"] == "finnhub"
+    # fetch_runs: AAPL used_count=1, MSFT used_count=0
+    runs = {r["symbol"]: r for r in plan.fetch_runs}
+    assert runs["AAPL"]["used_count"] == 1
+    assert runs["AAPL"]["returned_count"] == 1
+    assert runs["MSFT"]["used_count"] == 0
+    assert plan.unmatched == []
+
+
+@pytest.mark.unit
+def test_unmatched_ref_is_dropped_and_recorded() -> None:
+    cites = [
+        HermesNewsCitation(
+            external_article_id="does-not-exist", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert plan.citations == []
+    assert plan.unmatched == ["does-not-exist"]
+
+
+@pytest.mark.unit
+def test_matches_by_canonical_url_fallback() -> None:
+    cites = [
+        HermesNewsCitation(
+            canonical_url="https://x/msft-1", symbol="MSFT", relevance="related",
+            role="confirmation", decision_impact="hold_watch",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert len(plan.citations) == 1
+    assert plan.citations[0]["symbol"] == "MSFT"
+    assert plan.citations[0]["report_item_uuid"] is None  # no client_item_key
+    assert plan.citations[0]["summary_snapshot"] is None
+
+
+@pytest.mark.unit
+def test_summary_truncated_to_1000() -> None:
+    payload = _news_payload()
+    payload["articles"][0]["summary"] = "x" * 2000
+    cites = [
+        HermesNewsCitation(
+            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[payload], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert len(plan.citations[0]["summary_snapshot"]) == 1000
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_news_persistence.py -v`
+Expected: FAIL with `ModuleNotFoundError: ...news_persistence`
+
+- [ ] **Step 3: Implement the pure helper**
+
+```python
+# app/services/investment_reports/news_persistence.py
+"""ROB-423 PR2 — pure news-citation persistence planner (no DB I/O).
+
+Matches Hermes-supplied news citations against the bundle's news snapshot
+articles and produces the fetch_run + citation rows to insert. Unmatched refs
+are dropped and reported (fail-open, no fabrication). Kept pure so the matching
+logic is unit-testable without a database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from app.schemas.hermes_composition import HermesNewsCitation
+
+_SUMMARY_MAX = 1000
+
+
+@dataclass(frozen=True)
+class NewsPersistencePlan:
+    fetch_runs: list[dict[str, Any]] = field(default_factory=list)
+    citations: list[dict[str, Any]] = field(default_factory=list)
+    unmatched: list[str] = field(default_factory=list)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _truncate(text: str | None) -> str | None:
+    if text is None:
+        return None
+    return text[:_SUMMARY_MAX]
+
+
+def build_news_persistence(
+    *,
+    news_payloads: list[dict[str, Any]],
+    citations: list[HermesNewsCitation],
+    item_uuid_by_client_key: dict[str, UUID],
+    instrument_type: str,
+) -> NewsPersistencePlan:
+    by_external: dict[str, dict[str, Any]] = {}
+    by_url: dict[str, dict[str, Any]] = {}
+    market = "us"
+    for payload in news_payloads:
+        market = payload.get("market") or market
+        for art in payload.get("articles", []):
+            ext = art.get("external_article_id")
+            url = art.get("url")
+            if ext:
+                by_external.setdefault(ext, art)
+            if url:
+                by_url.setdefault(url, art)
+
+    # per (symbol, provider) used_count tally
+    used_by_key: dict[tuple[str, str], int] = {}
+
+    citation_rows: list[dict[str, Any]] = []
+    unmatched: list[str] = []
+    for cit in citations:
+        art = None
+        ref = cit.external_article_id or cit.canonical_url or ""
+        if cit.external_article_id:
+            art = by_external.get(cit.external_article_id)
+        if art is None and cit.canonical_url:
+            art = by_url.get(cit.canonical_url)
+        if art is None:
+            unmatched.append(ref)
+            continue
+
+        sym = art.get("symbol") or cit.symbol
+        provider = art.get("provider") or "unknown"
+        used_by_key[(sym, provider)] = used_by_key.get((sym, provider), 0) + 1
+
+        item_uuid = (
+            item_uuid_by_client_key.get(cit.client_item_key)
+            if cit.client_item_key
+            else None
+        )
+        citation_rows.append(
+            {
+                "report_item_uuid": item_uuid,
+                "section_key": cit.section_key,
+                "market": market,
+                "symbol": sym,
+                "provider": provider,
+                "external_article_id": art.get("external_article_id"),
+                "canonical_url": art.get("url") or cit.canonical_url or "",
+                "source_name": art.get("source"),
+                "title": art.get("title") or "",
+                "summary_snapshot": _truncate(art.get("summary")),
+                "published_at": _parse_dt(art.get("published_at")),
+                "relevance": cit.relevance,
+                "role": cit.role,
+                "decision_impact": cit.decision_impact,
+                "selection_reason": cit.selection_reason,
+                "confidence": cit.confidence,
+                "_fetch_key": (sym, provider),  # internal: link to fetch_run
+            }
+        )
+
+    fetch_runs: list[dict[str, Any]] = []
+    for payload in news_payloads:
+        for rec in payload.get("fetch_records", []):
+            sym = rec.get("symbol") or ""
+            provider = rec.get("provider") or "unknown"
+            fetch_runs.append(
+                {
+                    "market": market,
+                    "symbol": sym,
+                    "instrument_type": instrument_type,
+                    "provider": provider,
+                    "requested_limit": int(rec.get("requested_limit") or 0),
+                    "returned_count": int(rec.get("returned_count") or 0),
+                    "used_count": used_by_key.get((sym, provider), 0),
+                    "status": rec.get("status") or "ok",
+                    "error_code": rec.get("error_code"),
+                    "_fetch_key": (sym, provider),  # internal: citation linkage
+                }
+            )
+
+    return NewsPersistencePlan(
+        fetch_runs=fetch_runs, citations=citation_rows, unmatched=unmatched
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_news_persistence.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/news_persistence.py tests/services/investment_reports/test_news_persistence.py
+git commit -m "feat(ROB-423): 순수 news citation 매칭 헬퍼(build_news_persistence)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: InvestmentReportNewsService.persist + hermes_ingest 배선
+
+**Files:**
+- Create: `app/services/investment_reports/investment_report_news_service.py`
+- Modify: `app/services/investment_reports/repository.py` (citation/fetch_run insert + id-ordered item 조회 + report별 조회)
+- Modify: `app/services/investment_stages/hermes_ingest.py` (persist 호출 + 생성자)
+- Test: `tests/services/investment_stages/test_hermes_news_citation_ingest.py` (db_session integration)
+
+> **⚠️ 아이템 순서 함정**: 같은 ingest 트랜잭션의 item들은 `created_at`이 동일(`now()`=transaction time)하므로 `list_items_for_report`의 `created_at.asc()`는 비결정적. per-item 링크는 **`id.asc()` 정렬**(삽입 순 == composition.items 순)로 재조회해야 안전.
+
+- [ ] **Step 1: Add repository methods**
+
+`app/services/investment_reports/repository.py`에 추가(파일에 `sa`, `InvestmentReportItem` 이미 import; 신규 모델 import 추가):
+
+```python
+# import 블록에 추가
+from app.models.investment_reports import (
+    InvestmentReportNewsCitation,
+    InvestmentReportNewsFetchRun,
+)
+
+# --- 클래스 메서드로 추가 ---
+
+    async def list_items_for_report_ordered_by_id(
+        self, report_id: int
+    ) -> list[InvestmentReportItem]:
+        """Insertion-order items (id.asc()). Use for composition-index mapping —
+        ``created_at`` ties (single-transaction inserts share ``now()``) make
+        the created_at-ordered query non-deterministic for this purpose."""
+        result = await self._session.scalars(
+            sa.select(InvestmentReportItem)
+            .where(InvestmentReportItem.report_id == report_id)
+            .order_by(InvestmentReportItem.id.asc())
+        )
+        return list(result.all())
+
+    async def insert_news_fetch_run(
+        self, **fields: Any
+    ) -> InvestmentReportNewsFetchRun:
+        row = InvestmentReportNewsFetchRun(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def insert_news_citation(
+        self, **fields: Any
+    ) -> InvestmentReportNewsCitation:
+        row = InvestmentReportNewsCitation(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        return row
+
+    async def list_news_citations_for_report(
+        self, report_uuid: UUID
+    ) -> list[InvestmentReportNewsCitation]:
+        result = await self._session.scalars(
+            sa.select(InvestmentReportNewsCitation)
+            .where(InvestmentReportNewsCitation.report_uuid == report_uuid)
+            .order_by(InvestmentReportNewsCitation.id.asc())
+        )
+        return list(result.all())
+```
+
+- [ ] **Step 2: Implement the service**
+
+```python
+# app/services/investment_reports/investment_report_news_service.py
+"""ROB-423 PR2 — persist Hermes-marked news citations + fetch_run audit.
+
+auto_trader-side: validation + persistence only (no LLM, no fetch). Reads the
+bundle's news snapshot ``articles``/``fetch_records`` (written by the PR1
+collector), matches Hermes ``news_citations`` against them, and writes fetch_run
++ citation rows keyed by ``report_uuid``. Unmatched refs are dropped + recorded
+in the report's ``unavailable_sources`` metadata (fail-open).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.models.investment_reports import InvestmentReport
+from app.schemas.hermes_composition import HermesCompositionResult
+from app.services.investment_reports.news_persistence import build_news_persistence
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_INSTRUMENT_BY_MARKET = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+class InvestmentReportNewsService:
+    def __init__(self, repo: InvestmentReportsRepository) -> None:
+        self._repo = repo
+
+    async def persist_from_composition(
+        self,
+        *,
+        report: InvestmentReport,
+        composition: HermesCompositionResult,
+        news_payloads: list[dict[str, Any]],
+    ) -> int:
+        """Returns the number of citations written. Never raises on matching
+        gaps (fail-open). Call inside the ingest transaction after the report +
+        items are persisted."""
+        if not composition.news_citations:
+            return 0
+
+        # client_item_key -> item_uuid via insertion-order (id.asc()) zip.
+        persisted = await self._repo.list_items_for_report_ordered_by_id(report.id)
+        item_uuid_by_client_key: dict[str, UUID] = {}
+        if len(persisted) == len(composition.items):
+            for comp_item, row in zip(composition.items, persisted, strict=True):
+                item_uuid_by_client_key[comp_item.client_item_key] = row.item_uuid
+
+        instrument_type = _INSTRUMENT_BY_MARKET.get(report.market, "equity_us")
+        plan = build_news_persistence(
+            news_payloads=news_payloads,
+            citations=composition.news_citations,
+            item_uuid_by_client_key=item_uuid_by_client_key,
+            instrument_type=instrument_type,
+        )
+
+        # fetch_runs first (citations FK them by (symbol, provider)).
+        fetch_run_id_by_key: dict[tuple[str, str], int] = {}
+        for run in plan.fetch_runs:
+            key = run.pop("_fetch_key")
+            row = await self._repo.insert_news_fetch_run(
+                report_uuid=report.report_uuid,
+                fetched_at=_utcnow(),
+                **run,
+            )
+            fetch_run_id_by_key[key] = row.id
+
+        written = 0
+        for cit in plan.citations:
+            key = cit.pop("_fetch_key")
+            await self._repo.insert_news_citation(
+                report_uuid=report.report_uuid,
+                fetch_run_id=fetch_run_id_by_key.get(key),
+                fetched_at=_utcnow(),
+                **cit,
+            )
+            written += 1
+
+        if plan.unmatched:
+            # record on the report's metadata (fail-open, no fabrication).
+            await self._repo.merge_report_unavailable_sources(
+                report.id,
+                {"news_citations_unmatched": plan.unmatched},
+            )
+        return written
+
+
+def _utcnow():
+    from datetime import UTC, datetime
+
+    return datetime.now(tz=UTC)
+```
+
+> `merge_report_unavailable_sources`가 repository에 없으면, 간단히 `update_report`로 `unavailable_sources` JSONB를 병합하는 메서드를 추가하거나, 이 한 줄을 `report.metadata` 병합으로 대체한다(아래 Step 3 통합 테스트에서 검증). 최소 구현: repository에
+> ```python
+>     async def merge_report_unavailable_sources(self, report_id, extra):
+>         row = await self._session.get(InvestmentReport, report_id)
+>         if row is None:
+>             return
+>         merged = {**(row.unavailable_sources or {}), **extra}
+>         row.unavailable_sources = merged
+>         await self._session.flush()
+> ```
+> (`InvestmentReport.unavailable_sources` 컬럼이 ROB-269에서 존재. 없으면 `metadata`로 대체.)
+
+- [ ] **Step 3: Wire into hermes_ingest + write the integration test**
+
+`app/services/investment_stages/hermes_ingest.py`:
+- 생성자에 `InvestmentReportNewsService` 구성(기존 `self._ingestion`이 보유한 repo 재사용; 없으면 `InvestmentReportsRepository(session)` 생성).
+- `ingest_composition`에서 `report = await self._ingestion.ingest(ingest_request)` 직후, `_maybe_finalize_stage_run` 이전에:
+
+```python
+        report = await self._ingestion.ingest(ingest_request)
+
+        # ROB-423 — persist Hermes-marked news citations from the bundle's news
+        # snapshot. Fail-open: matching gaps never block report creation.
+        news_payloads = [
+            (snap.payload_json or {})
+            for _item, snap in await self._snapshots.list_bundle_items_with_snapshots(
+                bundle.id
+            )
+            if snap.snapshot_kind == "news"
+        ]
+        await self._news_service.persist_from_composition(
+            report=report, composition=composition, news_payloads=news_payloads
+        )
+
+        await self._maybe_finalize_stage_run(composition.metadata)
+        return report
+```
+
+통합 테스트(db_session, create_all로 테이블 생성):
+
+```python
+# tests/services/investment_stages/test_hermes_news_citation_ingest.py
+"""ROB-423 PR2 — Hermes composition news_citations → persisted rows (fail-open)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_composition_news_citations_persisted_and_unmatched_dropped(
+    db_session,
+):
+    # Arrange: a bundle with a news snapshot (articles + fetch_records), then a
+    # Hermes composition citing one real article + one bogus ref.
+    # ... build bundle + news snapshot via the snapshots repo/collector payload ...
+    # ... call HermesCompositionIngestService.ingest_composition(request) ...
+    # Assert:
+    #   - 1 citation row written (real ref), role/decision_impact preserved
+    #   - bogus ref dropped; report.unavailable_sources['news_citations_unmatched']
+    #   - fetch_run rows: used_count==1 for the cited symbol, 0 otherwise
+    #   - report created successfully (fail-open)
+    ...
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_empty_news_citations_is_noop(db_session):
+    # composition with news_citations=[] → 0 citation rows, report still created.
+    ...
+```
+
+> 통합 테스트의 bundle/snapshot 셋업은 기존 `tests/services/investment_stages/` Hermes ingest 테스트의 fixture 패턴을 따른다(같은 디렉터리에서 `ingest_composition` 호출 예시를 복사). `investment_reports_cleanup_lock`는 xdist TRUNCATE/deadlock flake 회피 필수(ROB-405 선례).
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/investment_stages/test_hermes_news_citation_ingest.py tests/services/investment_reports/test_news_persistence.py -v`
+Expected: PASS
+
+- [ ] **Step 5: no-internal-LLM 가드 확인 (news_service가 investment_stages/action_report 트리에서 import돼도 LLM 0)**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/investment_reports/investment_report_news_service.py app/services/investment_reports/repository.py app/services/investment_stages/hermes_ingest.py tests/services/investment_stages/test_hermes_news_citation_ingest.py
+git commit -m "feat(ROB-423): Hermes 합성 시 news citation 영속(fail-open, evidence-gated)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Detail API 노출
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (`InvestmentReportNewsCitationResponse` + bundle 필드)
+- Modify: `app/services/investment_reports/query_service.py` (`get_bundle`)
+- Modify: `app/routers/investment_reports.py` (`_serialise_bundle`)
+- Test: `tests/routers/test_investment_reports_news_citations.py` 또는 query_service 단위 테스트
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/test_bundle_news_citations.py
+"""ROB-423 PR2 — detail bundle exposes news_citations."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_bundle_includes_news_citations(db_session):
+    # Arrange: persist a report + one news citation row (via repo).
+    # Act: bundle = await query_service.get_bundle(report_uuid)
+    # Assert: bundle["news_citations"] has the row with title/source/url/role/...
+    ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/test_bundle_news_citations.py -v`
+Expected: FAIL (KeyError: 'news_citations')
+
+- [ ] **Step 3: Add schema + wire bundle**
+
+`app/schemas/investment_reports.py`에 추가:
+
+```python
+class InvestmentReportNewsCitationResponse(BaseModel):
+    """ROB-423 — one cited news article on a report (read-side)."""
+
+    citation_uuid: UUID
+    report_item_uuid: UUID | None = None
+    section_key: str | None = None
+    market: str
+    symbol: str
+    provider: str
+    external_article_id: str | None = None
+    canonical_url: str
+    source_name: str | None = None
+    title: str
+    summary_snapshot: str | None = None
+    published_at: datetime | None = None
+    fetched_at: datetime
+    relevance: str
+    role: str
+    decision_impact: str
+    selection_reason: str | None = None
+    confidence: Decimal | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+```
+
+`InvestmentReportBundle`에 필드 추가(action_packet 다음):
+
+```python
+    # ROB-423 — additive news citations (articles the report actually used).
+    # Empty for reports with no Hermes-marked news.
+    news_citations: list[InvestmentReportNewsCitationResponse] = Field(
+        default_factory=list
+    )
+```
+
+`app/services/investment_reports/query_service.py`의 `get_bundle` 반환 dict에 추가:
+
+```python
+    citations = await self._repo.list_news_citations_for_report(report.report_uuid)
+    # ... 기존 return dict에 추가:
+        "news_citations": citations,
+```
+
+`app/routers/investment_reports.py`의 `_serialise_bundle` 반환 `InvestmentReportBundle(...)`에 추가:
+
+```python
+        news_citations=[
+            InvestmentReportNewsCitationResponse.model_validate(c)
+            for c in bundle["news_citations"]
+        ],
+```
+(`InvestmentReportNewsCitationResponse` import 추가.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/test_bundle_news_citations.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/schemas/investment_reports.py app/services/investment_reports/query_service.py app/routers/investment_reports.py tests/services/investment_reports/test_bundle_news_citations.py
+git commit -m "feat(ROB-423): detail API에 news_citations 노출(additive)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: mock_preview citation 복사
+
+**Files:**
+- Modify: `app/services/investment_reports/investment_report_news_service.py` (`copy_for_mock`)
+- Modify: `app/services/investment_reports/mock_preview/runner.py`
+- Test: `tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py`
+
+mock은 live citation을 report-level로 복사(재fetch/재판정 0). per-item 링크는 NULL(robust; live↔mock item 매핑은 후속).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
+"""ROB-423 PR2 — mock_preview copies live news citations (no re-fetch)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mock_preview_copies_live_citations(db_session):
+    # Arrange: a live report with 2 news citations.
+    # Act: run MockPreviewReportRunner.run(live_report_uuid=...)
+    # Assert: mock report has 2 citations copied (same title/url/role/symbol),
+    #         report_item_uuid is NULL on the copies, no new fetch occurred.
+    ...
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add copy_for_mock + call it in the runner**
+
+`InvestmentReportNewsService`에 추가:
+
+```python
+    async def copy_for_mock(
+        self, *, live_report_uuid: UUID, mock_report: InvestmentReport
+    ) -> int:
+        """Copy a live report's news citations onto the mock report (report-level,
+        report_item_uuid=NULL). No re-fetch, no re-judgment. Returns count."""
+        live_citations = await self._repo.list_news_citations_for_report(
+            live_report_uuid
+        )
+        count = 0
+        for c in live_citations:
+            await self._repo.insert_news_citation(
+                report_uuid=mock_report.report_uuid,
+                report_item_uuid=None,
+                section_key=c.section_key,
+                fetch_run_id=None,
+                market=c.market,
+                symbol=c.symbol,
+                provider=c.provider,
+                external_article_id=c.external_article_id,
+                canonical_url=c.canonical_url,
+                source_name=c.source_name,
+                title=c.title,
+                summary_snapshot=c.summary_snapshot,
+                published_at=c.published_at,
+                fetched_at=c.fetched_at,
+                relevance=c.relevance,
+                role=c.role,
+                decision_impact=c.decision_impact,
+                selection_reason=c.selection_reason,
+                confidence=c.confidence,
+                metadata_json={"copied_from_report_uuid": str(live_report_uuid)},
+            )
+            count += 1
+        return count
+```
+
+`app/services/investment_reports/mock_preview/runner.py`의 `run`에서, `report, reused, count = await self._ingestion.ingest_with_outcome(request)` + re-point 블록 이후, `return` 이전에:
+
+```python
+        # ROB-423 — copy the live report's news citations onto the mock
+        # (report-level). Skip when this run idempotently reused an existing
+        # mock that already carries them.
+        if not reused:
+            await self._news_service.copy_for_mock(
+                live_report_uuid=live.report_uuid, mock_report=report
+            )
+```
+
+(runner 생성자에 `self._news_service = InvestmentReportNewsService(self._reports_repo)` 배선.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/investment_reports/investment_report_news_service.py app/services/investment_reports/mock_preview/runner.py tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
+git commit -m "feat(ROB-423): mock_preview가 live news citation 복사(재fetch 없음)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: advisory-only smoke + 전체 검증 + lint
+
+**Files:**
+- Modify/Create: 기존 report-generation smoke 스크립트(`scripts/` 하위; PR1/ROB-373 smoke 재사용) 확장 — advisory report 생성 후 detail citation 출력
+- Test: 없음(검증만) 또는 smoke 문서 runbook 한 줄
+
+- [ ] **Step 1: 영역 전체 테스트**
+
+Run:
+```bash
+uv run pytest \
+  tests/models/test_investment_report_news_models.py \
+  tests/schemas/test_hermes_news_citations.py \
+  tests/services/investment_reports/test_news_persistence.py \
+  tests/services/investment_stages/test_hermes_news_citation_ingest.py \
+  tests/services/investment_reports/test_bundle_news_citations.py \
+  tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py \
+  tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py \
+  -v
+```
+Expected: PASS (전부 green)
+
+- [ ] **Step 2: 회귀 스윕(investment report / hermes / mock)**
+
+Run: `uv run pytest -k "investment_report or hermes or mock_preview or news_citation" -q`
+Expected: PASS (회귀 0)
+
+- [ ] **Step 3: lint + format**
+
+Run:
+```bash
+uv run ruff check app/models/investment_reports.py app/schemas/hermes_composition.py app/schemas/investment_reports.py app/services/investment_reports/news_persistence.py app/services/investment_reports/investment_report_news_service.py app/services/investment_reports/repository.py app/services/investment_reports/query_service.py app/services/investment_stages/hermes_ingest.py app/routers/investment_reports.py app/services/investment_reports/mock_preview/runner.py alembic/versions/20260603_rob423_news_citation_tables.py
+uv run ruff format --check app/models/investment_reports.py app/schemas/hermes_composition.py app/schemas/investment_reports.py app/services/investment_reports/ app/services/investment_stages/hermes_ingest.py app/routers/investment_reports.py
+```
+Expected: clean
+
+- [ ] **Step 4: advisory-only smoke (default-off, operator)**
+
+기존 report-generation smoke를 advisory-only로 1회 실행(또는 dry-run), 생성된 report의 detail에서 `news_citations`를 출력해 확인. 실제 Hermes round-trip은 레포 밖 operator-gated이므로, smoke는 `news_citations`를 담은 합성 composition을 ingest → detail 노출까지 검증(테스트로 대체 가능).
+
+Run: `uv run pytest tests/services/investment_reports/test_bundle_news_citations.py -v` (smoke 대체 — citation이 detail에 노출됨을 증명)
+Expected: PASS
+
+- [ ] **Step 5: 최종 커밋**
+
+```bash
+git add -A
+git commit -m "test(ROB-423): PR2 영속/노출 회귀 스윕 + lint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (spec 대조)
+
+- **AC#1 (마이그레이션 2테이블 additive)**: Task 1+2. ✅
+- **AC#5 (사용된 기사만, 전역 archive 없음)**: Task 4 매칭(unmatched drop) + 신규 archive 0. ✅
+- **AC#6 (판단성 필드 Hermes만, in-process LLM 0)**: Task 3(Hermes 입력) + Task 5(persist=검증/영속만) + Step 5 가드. ✅
+- **AC#7 (unknown ref drop + 기록, 날조 0)**: Task 4 `unmatched` + Task 5 `unavailable_sources` 기록. ✅
+- **AC#8 (fail-open)**: Task 5 `persist_from_composition`는 매칭 갭에 예외 없음. ✅
+- **AC#9 (detail에 title/source/url/published_at/provider/symbol/role/decision_impact)**: Task 6 response 스키마. ✅
+- **AC#10 (mock은 복사, 재fetch/재판정 없음)**: Task 7. ✅
+- **AC#12 (advisory-only smoke로 citation 확인)**: Task 8. ✅
+- **migration head**: `20260602_rob412_main_merge`(구현 시 재확인). ✅
+
+### 주의/리스크
+- **per-item 링크 정렬**: `id.asc()` 재조회로 결정적 매핑(created_at 동률 회피). len(items) 불일치 시 item 링크 생략(report-level만) — fail-safe.
+- **mock per-item 링크**: report-level 복사(report_item_uuid NULL). live↔mock item 매핑은 후속(필요 시).
+- **fetch_runs**: live ingest에서만 작성(실제 fetch 근거). mock은 citation만 복사(fetch_run 없음) — 정직.
+- **`unavailable_sources` 컬럼 부재 시**: `report.metadata`로 대체(Task 5 Step 2 노트).
+- **테스트 DB**: alembic이 timescaledb로 막혀 통합 테스트는 `db_session` create_all 의존(ROB-407 선례). operator가 prod `alembic upgrade head`.
+- **integration 테스트 fixture**: 기존 `tests/services/investment_stages/` Hermes ingest 테스트의 bundle/snapshot 셋업 패턴을 복사(상세 셋업은 그 파일들 참조).
+
+## Out of Scope
+
+PR1(완료) · provider 보조 구현 · per-item 링크의 mock 측 매핑 · 실 Hermes JSON-over-wire round-trip(operator-gated) · scheduler · broker/order mutation · production backfill.

--- a/docs/plans/ROB-423-invest-report-news-citations-spec.md
+++ b/docs/plans/ROB-423-invest-report-news-citations-spec.md
@@ -1,0 +1,272 @@
+# ROB-423 — invest_report get_news 기반 뉴스 citation 저장/표시 (실행 spec)
+
+> 상태: spec 확정 (브레인스토밍 → /spec). 구현은 후속(plan → 구현).
+> 검증: 아래 모든 코드 앵커는 2026-06-02 기준 15-에이전트 적대적 검증으로 확인됨.
+> 로케이트 결정 4건은 `## 확정된 설계 결정` 참고.
+
+## Context
+
+`/invest/reports` 사용자가 "어떤 뉴스가 buy/sell/watch 판단에 영향을 줬는지" 확인할 수 있게,
+report 생성 시 종목별 뉴스를 **on-demand로 가져오고 실제 판단에 쓰인 기사만 citation으로 영속화**한다.
+ROB-398 검토에서 news-ingestor는 당분간 동결하고 invest_report 뉴스 근거는 `get_news` 경로를 쓰기로 정리됐다.
+뉴스는 단독 매수/매도 신호가 아니라 가격/수급/보유/유동성/기술 지표를 보강·약화하는 overlay evidence로 취급한다.
+
+## 확정된 설계 결정 (locked)
+
+| # | 결정 | 선택 |
+|---|---|---|
+| D1 | citation 판단성 필드(`role`/`decision_impact`/`selection_reason`)와 "실제 사용됨" 판정 주체 | **Hermes 작성**. auto_trader는 결정적 fetch+evidence 제공 + fetch_run audit. 판단성 필드는 `create_from_hermes_composition` ingest 시 Hermes annotation으로만 작성. (no-internal-LLM 가드 준수) |
+| D2 | invest_report 뉴스 evidence 소스 | **on-demand `get_news` 경로** (`symbol_news_service`, 종목별 실시간 fetch). 전역 archive 비의존. |
+| D3 | 정규화 news seam 통합 범위 | **`symbol_news_service` 신설 + `get_news`도 경유**. public MCP news tool은 `get_news` 하나 유지. `llm_news_service`(DB)는 타 소비자용 불변. |
+| D4 | citation 대상 리포트 | **Hermes 합성 advisory 중심**. mock_preview는 live citation을 참조/복사(재fetch/재판정 없음). 결정적 auto-emit(비-Hermes) 리포트는 fetch_run+evidence만. |
+
+배포: **2-PR 분할**. PR1 = 정규화 seam(`symbol_news_service` + `get_news` 재배선 + collector 전환 + 회귀 테스트). PR2 = 2 테이블 + Hermes 스키마 + ingest 영속 + detail API + mock 복사 + smoke.
+
+## Current State (검증일 2026-06-02, branch rob-423)
+
+코드 대조로 확인한 사실. 일부는 원 이슈 본문 가정과 다르다.
+
+| 항목 | 현재 상태 | 근거 (검증됨) |
+|---|---|---|
+| `get_news` public MCP tool | 존재. KR→Naver, US/crypto→Finnhub | `app/mcp_server/tooling/fundamentals_handlers.py:73-74` (`@mcp.tool(name="get_news"`), 핸들러 `fundamentals/_news.py:24` `handle_get_news`, dispatch `_news.py:45-47` |
+| `get_news` 출력 envelope | 최상위 `{symbol, market, source, count, news}`; per-article `{title, source, datetime, url, summary, sentiment, related}` | shaping은 provider 측: `app/services/finnhub_news.py:85-91`, `app/mcp_server/tooling/fundamentals_sources_naver.py:24-30` |
+| report의 뉴스 수집 | **이미 활성**. `NewsSnapshotCollector`가 derived focus symbols 받아 필터, soft-fail | `collectors/registry.py:290` production, `collectors/news.py:99-114` 필터, `generator.py:327-341` derive→ensure |
+| report 뉴스 **소스** | get_news가 아니라 **DB `news_articles`**(뉴스스탠드/RSS) via `llm_news_service.get_news_articles` | `collectors/registry.py:237-273` `_build_news_fetch_fn`, type `collectors/news.py:38` `NewsFetchFn = Callable[[str,int,int], ...]` (market-scoped) |
+| 정규화 경로 | **3개 공존**: `fundamentals/_news.py`(get_news), `research_news_service`(NormalizedArticle), `llm_news_service`(DB) | 3 files |
+| 판단성 citation | 없음. citation은 snapshot `payload_json`에 암묵 임베드 | `investment_snapshots.payload_json` |
+| in-process LLM | `investment_stages/` + `action_report/snapshot_backed/` 전체 금지(가드) | `tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py:62-65` |
+| Hermes 합성 | Hermes가 `HermesCompositionResult.items` 작성→`create_from_hermes_composition`가 검증+영속 | `hermes_ingest.py:413`, ingest는 `ingestion.py:246` `insert_report`(flush+refresh `repository.py:43-44`) |
+| Hermes 스키마 확장성 | `HermesCompositionResult.model_config = ConfigDict(extra="forbid")` (`:122`)지만 default 있는 optional 필드는 additive 안전. `metadata:dict`(`:133`), `cited_snapshot_uuids`(`:134`), `dimension_report_uuids`(`:142`) 존재 | `app/schemas/hermes_composition.py` |
+| report 모델 | `review.investment_reports.report_uuid`(PG_UUID, unique, default uuid4). item은 `report_id`(BigInt FK)+`item_uuid` | `models/investment_reports.py:121-127, 297-304` |
+| detail API | `GET .../investment-reports/{report_uuid}` → `InvestmentReportBundle`. `service.get_bundle()`→`_serialise_bundle` | `routers/investment_reports.py:199-217` |
+| `InvestmentReportBundle` | optional `review_sections`(`:827`), `action_packet`(`:830`) → 추가 optional 필드 additive 가능 | `schemas/investment_reports.py:806-830` |
+| `research_news_service` | `fetch_symbol_news(symbol, instrument_type, *, limit=20, timeout_s=5.0) -> list[NormalizedArticle]`. NormalizedArticle 6필드(url,title,source,summary,published_at,provider). fail-soft. **external_article_id/related_symbols/market/symbol/fetched_at/provider_metadata 없음** | `app/services/research_news_service.py:17-24, 89-112` |
+| **alembic head** | **`20260602_rob412_main_merge` (단일 head)** | `alembic heads` 실측. ⚠ 원 가정 `rob337_rob403_merge_heads`는 main 전진으로 superseded |
+
+**핵심 함의**
+1. "get_news를 report에 배선"은 실제로는 report 뉴스 소스를 **DB archive → on-demand per-symbol fetch로 전환**하는 일이다.
+2. `role`/`decision_impact`/`selection_reason`/"실제 사용됨"은 LLM 판단이라 가드상 auto_trader가 만들 수 없다 → **Hermes가 composition에 실어 보내고, ingest 시점에만 citation row 작성**.
+3. 신규 테이블/스키마 확장/detail 필드는 전부 additive로 안전하게 얹힌다.
+
+## Proposed Change
+
+### 데이터 흐름
+
+```
+[bundle prep · 결정적 · report_uuid 아직 없음]
+  derive focus symbols (symbol_derivation.derive: seed+holdings+journals+watch+candidates)
+    → (개편) NewsSnapshotCollector: symbol별 symbol_news_service.fetch_symbol_news()
+    → news snapshot payload_json 적재:
+        articles[]      (external_article_id, canonical_url, title, source, published_at, summary, provider, symbol, related_symbols)
+        fetch_records[] (symbol, provider, requested_limit, returned_count, status, error_code)
+  → Hermes context export 가 articles[] 노출
+
+[Hermes 합성 · 레포 밖 LLM]
+  HermesCompositionResult.items + news_citations[]  ← Hermes가 사용한 기사만 annotation
+        (article ref by external_article_id|canonical_url + relevance/role/decision_impact/selection_reason/confidence
+         + optional item ref / section_key)
+
+[report 생성 · create_from_hermes_composition · insert_report 직후 report_uuid 확정]
+  InvestmentReportNewsService.persist(report_uuid, news_snapshot, hermes_news_citations):
+    1) fetch_runs 작성(report_uuid 키): returned_count=수집분, used_count=매칭된 Hermes citation 수
+    2) Hermes citation을 bundle news snapshot articles와 매칭(external_article_id/canonical_url)
+       - unknown ref → drop + fetch_run.status/unavailable 기록 (fail-open, 날조 금지)
+    3) citations 작성(매칭/사용분만): 기사 스냅샷 필드 복사 + Hermes 판단 필드
+  ↑ ingest_composition 내부, insert_report(ingestion.py:246) 이후 같은 트랜잭션에서 호출
+
+[mock_preview · runner.run() · live bundle 재사용]
+  run()이 live report+items 로드(runner.py:83-90) → mock report 영속 후
+  live report citation을 mock report_uuid로 복사 (재fetch·재판정 없음)
+```
+
+### 1. 저장 모델 (신규 2테이블, `review` 스키마, additive/nullable/append-only)
+
+`app/models/investment_reports.py`에 추가, `app/models/__init__.py` import + `__all__` 등록.
+
+```sql
+-- review.investment_report_news_fetch_runs : 소형 audit (fetched-but-unused 전체 저장 안 함)
+id              BIGSERIAL PK
+run_uuid        UUID UNIQUE NOT NULL
+report_uuid     UUID NOT NULL              -- review.investment_reports.report_uuid 논리참조(멤버십). FK는 report_id(int) 패턴과 불일치라 비강제
+market          TEXT NOT NULL
+symbol          TEXT NOT NULL
+instrument_type TEXT NOT NULL
+provider        TEXT NOT NULL              -- 'get_news'|'naver_finance'|'finnhub'
+requested_limit INT  NOT NULL
+returned_count  INT  NOT NULL DEFAULT 0    -- 수집 시점
+used_count      INT  NOT NULL DEFAULT 0    -- Hermes citation 매칭 수
+fetched_at      TIMESTAMPTZ NOT NULL
+freshness_policy TEXT NULL
+ttl_seconds     INT NULL
+status          TEXT NOT NULL CHECK (status IN ('ok','empty','unavailable','error'))
+error_code      TEXT NULL
+error_message   TEXT NULL                  -- secret-free
+raw_response_stored BOOLEAN NOT NULL DEFAULT false
+created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+
+-- review.investment_report_news_citations : 실제 사용된 기사 snapshot만
+id               BIGSERIAL PK
+citation_uuid    UUID UNIQUE NOT NULL
+report_uuid      UUID NOT NULL
+report_item_uuid UUID NULL                 -- 특정 buy/sell/watch item에 붙는 경우
+section_key      TEXT NULL                 -- report-level 인용. 'news_overview'|'risk_overlay' 등
+fetch_run_id     BIGINT NULL REFERENCES review.investment_report_news_fetch_runs(id)
+market           TEXT NOT NULL
+symbol           TEXT NOT NULL
+provider         TEXT NOT NULL
+external_article_id TEXT NULL              -- Naver officeId:articleId / Finnhub id|url-hash
+canonical_url    TEXT NOT NULL
+source_name      TEXT NULL
+title            TEXT NOT NULL
+summary_snapshot TEXT NULL                 -- ≤1000자 truncate
+published_at     TIMESTAMPTZ NULL
+fetched_at       TIMESTAMPTZ NOT NULL
+relevance        TEXT NOT NULL CHECK (relevance IN ('direct','related','market_context','crypto_context'))
+role             TEXT NOT NULL CHECK (role IN ('catalyst','risk','confirmation','contradiction','neutral','noise'))
+decision_impact  TEXT NOT NULL CHECK (decision_impact IN ('strengthen_buy','weaken_buy','strengthen_sell','weaken_sell','hold_watch','no_action'))
+selection_reason TEXT NULL
+confidence       NUMERIC NULL
+metadata_json    JSONB NOT NULL DEFAULT '{}'::jsonb   -- safe metadata only, no secrets/raw dump
+created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+마이그레이션: `alembic/versions/20260602_rob423_add_investment_report_news_tables.py`,
+**down_revision = `20260602_rob412_main_merge`** (구현 시점 `uv run alembic heads`로 재확인; main 전진 시 갱신).
+operator가 별도 `alembic upgrade head` 실행(prod cutover gate).
+
+### 2. Service boundary — 단일 정규화 seam (D3)
+
+`app/services/research_news_service.py` → `app/services/symbol_news_service.py`로 승격(내부 service, public MCP 미노출).
+
+```python
+@dataclass(frozen=True)
+class SymbolNewsArticle:
+    provider: str; market: str; symbol: str
+    external_article_id: str | None        # 신규: Naver officeId:articleId / Finnhub id|url-hash
+    title: str; source_name: str | None; canonical_url: str
+    summary: str | None; published_at: datetime | None; fetched_at: datetime
+    related_symbols: list[str]; provider_metadata: dict   # secret-free
+
+@dataclass(frozen=True)
+class SymbolNewsFetchResult:
+    articles: list[SymbolNewsArticle]
+    status: str            # ok|empty|unavailable|error
+    provider: str; requested_limit: int; returned_count: int
+    error_code: str | None
+
+async def fetch_symbol_news(symbol, market, instrument_type, *, limit=20, timeout_s=5.0) -> SymbolNewsFetchResult
+    # provider dispatch: KR→Naver, US→Finnhub, crypto→Finnhub
+    # fail-soft: timeout/예외 → status=error, articles=[]
+    # provider seam은 닫지 않음(추후 KR Naver-JSON / US+Naver보조 / crypto+Finnhub보조). 보조 구현은 범위 밖.
+```
+
+- `get_news` MCP 핸들러(`fundamentals/_news.py`)를 `symbol_news_service` 경유로 재배선.
+  **출력 envelope는 그대로** 보존: 최상위 `{symbol, market, source, count, news}`, per-article `{title, source, datetime, url, summary, sentiment, related}` (회귀 테스트로 고정).
+- `NewsSnapshotCollector` fetch fn을 `llm_news_service.get_news_articles`(DB, market-scoped) → `symbol_news_service.fetch_symbol_news`(per-symbol on-demand)로 교체.
+  시그니처가 `(market,hours,limit)` → per-symbol로 바뀌므로 collector가 focus symbols를 루프. `fetch_records[]`를 news snapshot payload에 기록.
+- **Blast radius 확인됨(V14)**: market-scoped `NewsFetchFn`의 유일 소비자는 `NewsSnapshotCollector`(`registry.py:316`). 그 외 `llm_news_service.get_news_articles` 직접 호출처(`routers/news_analysis.py:146`, `mcp_server/tooling/news_handlers.py:98`, `services/news_radar_service.py:310`, `services/n8n_news_service.py:88`)는 **무영향**.
+
+### 3. Report generation mapping (D1, D4)
+
+- 수집 evidence는 위 흐름대로 Hermes context에 `articles[]`로 제공.
+  (news snapshot articles가 `HermesContextPayload`에 아직 노출 안 되면 additive optional 필드 추가; `extra="forbid"`라도 default 있으면 안전.)
+- `HermesCompositionResult`(`schemas/hermes_composition.py`)에 additive 필드:
+  ```python
+  news_citations: list[HermesNewsCitation] = Field(default_factory=list)
+  # HermesNewsCitation: external_article_id|canonical_url(ref), symbol, relevance, role,
+  #   decision_impact, selection_reason?, confidence?, report_item_ref?(item index/uuid), section_key?
+  ```
+  default empty → 기존 Hermes client 미전송 시 back-compat (extra="forbid" 무관).
+- `app/services/investment_stages/hermes_ingest.py` `ingest_composition`에서 `insert_report`(ingestion.py:246) 이후
+  `InvestmentReportNewsService.persist`로 fetch_runs+citations 영속(가드 준수: LLM 호출 없음, 순수 검증+DB write).
+- fetch 실패/empty는 report 생성을 막지 않음 → fetch_run.status + `unavailable_sources`에 사유.
+- mock_preview(`MockPreviewReportRunner.run`, runner.py:83-90 live 로드)는 mock report 영속 후 live citation을 mock report_uuid로 복사.
+
+### 4. Detail API
+
+`InvestmentReportBundle`(`schemas/investment_reports.py:806`)에 additive:
+```python
+news_citations: list[InvestmentReportNewsCitationResponse] = []   # review_sections/action_packet 옆
+```
+`service.get_bundle()`/`_serialise_bundle`에서 report_id로 citations 로드(`routers/investment_reports.py:199-217` 경로).
+응답 필드 최소: `title, source_name, canonical_url, published_at, provider, symbol, role, decision_impact, relevance, summary_snapshot, report_item_uuid?, section_key?`.
+list API는 미포함(detail만 필수).
+
+## Acceptance Criteria
+
+1. 마이그레이션이 `review.investment_report_news_fetch_runs` + `review.investment_report_news_citations`를 추가하고, 기존 report와 nullable/append-only 관계다. down_revision은 구현 시점 단일 head.
+2. report 생성 시 selected symbol에 대해 `symbol_news_service`(get_news와 동일 경로)로 on-demand 뉴스를 가져와 Hermes context evidence에 포함한다.
+3. public MCP 종목/뉴스 tool surface는 `get_news` 하나로 유지(신규 public MCP news tool 0). `symbol_news_service`/mapping helper는 내부 service.
+4. `get_news` MCP 출력 envelope(최상위·per-article 키)는 재배선 후에도 불변(회귀 테스트 통과).
+5. citation은 **Hermes가 composition에서 사용 표시한 기사만** 저장. fetched-but-unused 전체 목록 미저장. 전역 `symbol_news_articles` archive 테이블 미도입.
+6. `role`/`decision_impact`/`selection_reason`/`confidence`는 Hermes annotation에서만 채워지고, auto_trader 코드 경로는 in-process LLM 미호출(`test_no_internal_llm_imports` 가드 통과).
+7. Hermes가 bundle에 없는 기사를 인용하면 drop하고 fetch_run.status/`unavailable_sources`에 기록(fail-open, 날조 0).
+8. fetch 실패/empty 시 report 생성 fail-open, fetch_run status 또는 `unavailable_sources`에 사유.
+9. detail API가 citation 목록을 반환하고, 각 citation에 `title, source_name, canonical_url, published_at, provider, symbol, role, decision_impact` 포함.
+10. mock_preview report는 live citation을 복사하며 재fetch/재판정하지 않는다.
+11. `NewsSnapshotCollector`가 `symbol_news_service` 단일 경로를 쓰고 중복 fetch/normalize 로직을 만들지 않는다.
+12. advisory-only focused smoke로 report 생성 후 detail에서 참고 뉴스 citation 확인.
+
+## Testing Plan
+
+| Layer | What | Count |
+|---|---|---|
+| Unit | `symbol_news_service.fetch_symbol_news` 정규화/external_article_id/fail-soft(timeout·error·empty) | +5 |
+| Unit | `get_news` envelope 불변(재배선 회귀) | +2 |
+| Unit | `InvestmentReportNewsService.persist` 매칭/unknown-ref drop/used_count/truncate(≤1000) | +5 |
+| Unit | NewsSnapshotCollector per-symbol fetch + fetch_records 기록 | +3 |
+| Unit | no-internal-LLM 가드 (기존 parametrized가 신규 모듈 자동 커버) | 0 |
+| Integration | Hermes composition(news_citations) → ingest → fetch_runs+citations 영속 | +2 |
+| Integration | empty/failure → fail-open, report 생성 성공 + unavailable 기록 | +2 |
+| Integration | global archive write 0 (news_articles INSERT 없음) | +1 |
+| Integration | detail API citation 노출; mock_preview citation 복사 | +2 |
+| Smoke | advisory-only report 생성 + detail citation 확인(default-off, operator) | +1 |
+
+## Files Reference
+
+| File | Change |
+|---|---|
+| `app/models/investment_reports.py` | `InvestmentReportNewsFetchRun`, `InvestmentReportNewsCitation` ORM 추가 |
+| `app/models/__init__.py:16` | 두 모델 import + `__all__` 등록 |
+| `alembic/versions/20260602_rob423_add_investment_report_news_tables.py` | 신규 마이그레이션 (down=`20260602_rob412_main_merge`) |
+| `app/services/symbol_news_service.py` | `research_news_service` 승격 + `SymbolNewsArticle`/`SymbolNewsFetchResult` + external_article_id + provider seam |
+| `app/mcp_server/tooling/fundamentals/_news.py` | `symbol_news_service` 경유 재배선(출력 envelope 불변) |
+| `app/services/finnhub_news.py`, `fundamentals_sources_naver.py` | envelope shaping 유지/연계(키 보존) |
+| `app/services/action_report/snapshot_backed/collectors/registry.py:237-273,316` | `_build_news_fetch_fn` per-symbol on-demand로 교체 |
+| `app/services/action_report/snapshot_backed/collectors/news.py:38,99-114` | `NewsFetchFn` per-symbol + `fetch_records[]` 기록 |
+| `app/schemas/hermes_composition.py:122` | `HermesCompositionResult.news_citations` additive + `HermesNewsCitation` |
+| `app/services/investment_stages/hermes_ingest.py:413` | `ingest_composition`에서 `insert_report` 이후 `InvestmentReportNewsService.persist` |
+| `app/services/investment_reports/investment_report_news_service.py` | (신규) fetch_runs+citations write/repository |
+| `app/services/investment_reports/mock_preview/runner.py:83-90` | `run()`에서 live citation → mock 복사 |
+| `app/schemas/investment_reports.py:806` | `InvestmentReportBundle.news_citations` + response 스키마 |
+| `app/routers/investment_reports.py:199-217` | detail 핸들러 citation 로드 |
+
+## Rollback Plan
+
+마이그레이션 additive(2 신규 테이블, 기존 컬럼 무변경) → `alembic downgrade -1`로 drop. 코드는 PR revert.
+Hermes `news_citations` 미전송 시 citations 0건(report 정상). collector 소스 전환 회귀 시 `_build_news_fetch_fn`을 DB 경로로 되돌리는 1줄.
+
+## Effort Estimate
+
+symbol_news_service 승격 + external_article_id + get_news 재배선 ~3h / collector per-symbol 전환 ~2h /
+2 모델+마이그레이션 ~1.5h / Hermes 스키마+ingest 영속 ~3h / detail API+mock 복사 ~2h / 테스트 ~4h / smoke+runbook ~1.5h.
+합계 ~17h. **PR1**(symbol_news_service+get_news 재배선+collector 전환, 회귀) ≈ 7h / **PR2**(테이블+Hermes+ingest+detail+mock+smoke) ≈ 10h.
+
+## Out of Scope / Non-goals
+
+news-ingestor 수정·스케줄, 전 종목 pre-crawl/backfill, 모든 fetched article 저장, 전역 `symbol_news_articles` archive,
+provider 보조 구현, 신규 public MCP news tool, `get_symbol_news_mapping` public 노출, scheduler,
+broker/order/watch/order-intent mutation, prod DB backfill, secret 출력/저장.
+\+ 결정적 auto-emit(비-Hermes) report의 판단성 citation(Hermes 합성 report만 대상).
+
+## Related
+
+ROB-398(get_news 역할 정리), ROB-287(Hermes 합성·no-internal-LLM), ROB-373(mock/live 분리),
+ROB-366 B8(현 news collector), ROB-140/207(research_reports, 별개 시스템).
+
+## Verification note
+
+2026-06-02 15-에이전트 적대적 검증(read-only) 결과: 13/15 confirmed, 2 수정 반영 —
+(V11) alembic head `rob337_rob403_merge_heads` → `20260602_rob412_main_merge`,
+(V13) mock_preview citation 복사는 `_project()`가 아니라 `run()`(live 로드 위치).
+설계-결정적 항목(V6 report_uuid 생성 시점, V7 Hermes 스키마 additive 안전, V14 collector blast-radius 무영향)은 전부 confirmed.

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -29,6 +29,8 @@ from app.models.investment_reports import (
     InvestmentReport,
     InvestmentReportItem,
     InvestmentReportItemDecision,
+    InvestmentReportNewsCitation,
+    InvestmentReportNewsFetchRun,
     InvestmentWatchAlert,
     InvestmentWatchEvent,
 )
@@ -37,6 +39,8 @@ INVESTMENT_REPORTS_TABLES = [
     InvestmentReport.__table__,
     InvestmentReportItem.__table__,
     InvestmentReportItemDecision.__table__,
+    InvestmentReportNewsCitation.__table__,
+    InvestmentReportNewsFetchRun.__table__,
     InvestmentWatchAlert.__table__,
     InvestmentWatchEvent.__table__,
 ]

--- a/tests/mcp_server/tooling/test_get_news_envelope.py
+++ b/tests/mcp_server/tooling/test_get_news_envelope.py
@@ -1,0 +1,124 @@
+# tests/mcp_server/tooling/test_get_news_envelope.py
+"""get_news envelope byte-compat regression after seam rewire (ROB-423)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _news
+from app.services import symbol_news_service
+from app.services.symbol_news_service import (
+    SymbolNewsArticle,
+    SymbolNewsFetchResult,
+)
+
+
+def _naver_article() -> SymbolNewsArticle:
+    raw = {
+        "title": "삼성전자 호실적",
+        "url": "https://finance.naver.com/item/news_read.naver?article_id=1&office_id=2",
+        "source": "한국경제",
+        "datetime": "2026-05-05",
+    }
+    return SymbolNewsArticle(
+        provider="naver", market="kr", symbol="005930",
+        external_article_id="2:1", title=raw["title"], source_name=raw["source"],
+        canonical_url=raw["url"], summary=None,
+        published_at=datetime(2026, 5, 5, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 1, tzinfo=UTC),
+        provider_metadata={"source_item": raw},
+    )
+
+
+def _finnhub_article() -> SymbolNewsArticle:
+    raw = {
+        "title": "Apple beats earnings",
+        "source": "Reuters",
+        "datetime": "2026-05-05T12:00:00",
+        "url": "https://x/aapl-1",
+        "summary": "strong",
+        "sentiment": "positive",
+        "related": "AAPL",
+    }
+    return SymbolNewsArticle(
+        provider="finnhub", market="us", symbol="AAPL",
+        external_article_id="abc", title=raw["title"], source_name=raw["source"],
+        canonical_url=raw["url"], summary=raw["summary"],
+        published_at=datetime(2026, 5, 5, 12, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 13, tzinfo=UTC),
+        related_symbols=["AAPL"],
+        provider_metadata={"sentiment": "positive", "related": "AAPL", "source_item": raw},
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_kr_envelope_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    art = _naver_article()
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult(
+                "005930", "kr", "naver", "ok", 10, 1, [art]
+            )
+        ),
+    )
+
+    out = await _news.handle_get_news("005930", market="kr", limit=10)
+
+    assert out == {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "naver",
+        "count": 1,
+        "news": [art.provider_metadata["source_item"]],
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_us_envelope_keys_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    art = _finnhub_article()
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult("AAPL", "us", "finnhub", "ok", 10, 1, [art])
+        ),
+    )
+
+    out = await _news.handle_get_news("AAPL", market="us", limit=10)
+
+    assert out["source"] == "finnhub"
+    assert out["count"] == 1
+    assert set(out["news"][0].keys()) == {
+        "title", "source", "datetime", "url", "summary", "sentiment", "related",
+    }
+    assert out["news"][0]["sentiment"] == "positive"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_news_error_status_returns_error_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(
+            return_value=SymbolNewsFetchResult(
+                "AAPL", "us", "finnhub", "error", 10, 0, [], "RuntimeError"
+            )
+        ),
+    )
+
+    out = await _news.handle_get_news("AAPL", market="us", limit=10)
+
+    assert out.get("error") or out.get("source") == "finnhub"
+    assert "news" not in out or out.get("count", 0) == 0

--- a/tests/mcp_server/tooling/test_get_news_envelope.py
+++ b/tests/mcp_server/tooling/test_get_news_envelope.py
@@ -24,9 +24,14 @@ def _naver_article() -> SymbolNewsArticle:
         "datetime": "2026-05-05",
     }
     return SymbolNewsArticle(
-        provider="naver", market="kr", symbol="005930",
-        external_article_id="2:1", title=raw["title"], source_name=raw["source"],
-        canonical_url=raw["url"], summary=None,
+        provider="naver",
+        market="kr",
+        symbol="005930",
+        external_article_id="2:1",
+        title=raw["title"],
+        source_name=raw["source"],
+        canonical_url=raw["url"],
+        summary=None,
         published_at=datetime(2026, 5, 5, tzinfo=UTC),
         fetched_at=datetime(2026, 5, 5, 1, tzinfo=UTC),
         provider_metadata={"source_item": raw},
@@ -44,13 +49,22 @@ def _finnhub_article() -> SymbolNewsArticle:
         "related": "AAPL",
     }
     return SymbolNewsArticle(
-        provider="finnhub", market="us", symbol="AAPL",
-        external_article_id="abc", title=raw["title"], source_name=raw["source"],
-        canonical_url=raw["url"], summary=raw["summary"],
+        provider="finnhub",
+        market="us",
+        symbol="AAPL",
+        external_article_id="abc",
+        title=raw["title"],
+        source_name=raw["source"],
+        canonical_url=raw["url"],
+        summary=raw["summary"],
         published_at=datetime(2026, 5, 5, 12, tzinfo=UTC),
         fetched_at=datetime(2026, 5, 5, 13, tzinfo=UTC),
         related_symbols=["AAPL"],
-        provider_metadata={"sentiment": "positive", "related": "AAPL", "source_item": raw},
+        provider_metadata={
+            "sentiment": "positive",
+            "related": "AAPL",
+            "source_item": raw,
+        },
     )
 
 
@@ -89,7 +103,9 @@ async def test_get_news_us_envelope_keys_preserved(
         symbol_news_service,
         "fetch_symbol_news",
         AsyncMock(
-            return_value=SymbolNewsFetchResult("AAPL", "us", "finnhub", "ok", 10, 1, [art])
+            return_value=SymbolNewsFetchResult(
+                "AAPL", "us", "finnhub", "ok", 10, 1, [art]
+            )
         ),
     )
 
@@ -98,7 +114,13 @@ async def test_get_news_us_envelope_keys_preserved(
     assert out["source"] == "finnhub"
     assert out["count"] == 1
     assert set(out["news"][0].keys()) == {
-        "title", "source", "datetime", "url", "summary", "sentiment", "related",
+        "title",
+        "source",
+        "datetime",
+        "url",
+        "summary",
+        "sentiment",
+        "related",
     }
     assert out["news"][0]["sentiment"] == "positive"
 

--- a/tests/models/test_investment_report_news_models.py
+++ b/tests/models/test_investment_report_news_models.py
@@ -13,8 +13,13 @@ def test_news_models_importable_and_in_review_schema() -> None:
         InvestmentReportNewsFetchRun,
     )
 
-    assert InvestmentReportNewsFetchRun.__tablename__ == "investment_report_news_fetch_runs"
-    assert InvestmentReportNewsCitation.__tablename__ == "investment_report_news_citations"
+    assert (
+        InvestmentReportNewsFetchRun.__tablename__
+        == "investment_report_news_fetch_runs"
+    )
+    assert (
+        InvestmentReportNewsCitation.__tablename__ == "investment_report_news_citations"
+    )
     assert InvestmentReportNewsFetchRun.__table__.schema == "review"
     assert InvestmentReportNewsCitation.__table__.schema == "review"
     # citation references fetch_run (nullable FK) and carries judgment fields

--- a/tests/models/test_investment_report_news_models.py
+++ b/tests/models/test_investment_report_news_models.py
@@ -1,0 +1,23 @@
+# tests/models/test_investment_report_news_models.py
+"""ROB-423 PR2 — news fetch-run + citation ORM registration."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.unit
+def test_news_models_importable_and_in_review_schema() -> None:
+    from app.models import (
+        InvestmentReportNewsCitation,
+        InvestmentReportNewsFetchRun,
+    )
+
+    assert InvestmentReportNewsFetchRun.__tablename__ == "investment_report_news_fetch_runs"
+    assert InvestmentReportNewsCitation.__tablename__ == "investment_report_news_citations"
+    assert InvestmentReportNewsFetchRun.__table__.schema == "review"
+    assert InvestmentReportNewsCitation.__table__.schema == "review"
+    # citation references fetch_run (nullable FK) and carries judgment fields
+    cols = InvestmentReportNewsCitation.__table__.columns.keys()
+    for c in ("report_uuid", "role", "decision_impact", "relevance", "canonical_url"):
+        assert c in cols

--- a/tests/schemas/test_hermes_news_citations.py
+++ b/tests/schemas/test_hermes_news_citations.py
@@ -1,0 +1,71 @@
+# tests/schemas/test_hermes_news_citations.py
+"""ROB-423 PR2 — HermesNewsCitation additive field."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.hermes_composition import (
+    HermesCompositionResult,
+    HermesNewsCitation,
+)
+
+
+def _base_composition(**extra):
+    return {
+        "snapshot_bundle_uuid": str(uuid.uuid4()),
+        "hermes_run_id": "run-1",
+        "title": "t",
+        "summary": "s",
+        **extra,
+    }
+
+
+@pytest.mark.unit
+def test_composition_defaults_news_citations_empty() -> None:
+    comp = HermesCompositionResult(**_base_composition())
+    assert comp.news_citations == []  # legacy payload back-compat
+
+
+@pytest.mark.unit
+def test_news_citation_requires_ref_and_judgment() -> None:
+    cit = HermesNewsCitation(
+        canonical_url="https://x/1",
+        symbol="AAPL",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        selection_reason="beat",
+        client_item_key="ci-1",
+    )
+    comp = HermesCompositionResult(
+        **_base_composition(news_citations=[cit.model_dump()])
+    )
+    assert comp.news_citations[0].symbol == "AAPL"
+    assert comp.news_citations[0].role == "catalyst"
+
+
+@pytest.mark.unit
+def test_news_citation_rejects_bad_role() -> None:
+    with pytest.raises(ValidationError):
+        HermesNewsCitation(
+            canonical_url="https://x/1",
+            symbol="AAPL",
+            relevance="direct",
+            role="bogus",
+            decision_impact="strengthen_buy",
+        )
+
+
+@pytest.mark.unit
+def test_news_citation_requires_some_ref() -> None:
+    with pytest.raises(ValidationError):
+        HermesNewsCitation(
+            symbol="AAPL",
+            relevance="direct",
+            role="catalyst",
+            decision_impact="strengthen_buy",
+        )  # neither external_article_id nor canonical_url

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -48,11 +48,11 @@ from app.services.action_report.snapshot_backed.collectors.watch_context import 
 from app.services.investment_snapshots.collectors import CollectorRequest
 
 
-def _request(market: str = "kr", account_scope: str = "kis_live") -> CollectorRequest:
+def _request(market: str = "kr", account_scope: str = "kis_live", symbols: list[str] | None = None) -> CollectorRequest:
     return CollectorRequest(
         market=market,  # type: ignore[arg-type]
         account_scope=account_scope,  # type: ignore[arg-type]
-        symbols=None,
+        symbols=symbols,
         candidate_limit=None,
         policy_snapshot={},
     )
@@ -1259,50 +1259,72 @@ async def test_news_collector_failure_is_fail_open():
 
 # --- ROB-366 B8: market-scoped news articles via injected fetch fn ----------
 @pytest.mark.asyncio
-async def test_news_collector_articles_from_news_fetch_fn():
-    captured: dict = {}
+async def test_news_collector_articles_per_symbol_from_seam():
+    from app.services.symbol_news_service import (
+        SymbolNewsArticle,
+        SymbolNewsFetchResult,
+    )
 
-    async def fake_news_fn(market, hours, limit):
-        captured["market"] = market
-        return [
-            {"title": "Apple beats earnings", "url": "u1", "stock_symbol": "AAPL"},
-            {"title": "Fed holds rates", "url": "u2", "stock_symbol": None},
-        ]
+    captured: list[tuple[str, str, int]] = []
 
-    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
-    results = await collector.collect(_request(market="us"))
+    async def fake_fetch(symbol: str, market: str, limit: int):
+        captured.append((symbol, market, limit))
+        art = SymbolNewsArticle(
+            provider="finnhub", market=market, symbol=symbol,
+            external_article_id=f"id-{symbol}", title=f"{symbol} up",
+            source_name="Reuters", canonical_url=f"https://x/{symbol}",
+            summary="s", published_at=None,
+            fetched_at=dt.datetime(2026, 5, 5, tzinfo=dt.UTC),
+            provider_metadata={"sentiment": "positive"},
+        )
+        return SymbolNewsFetchResult(
+            symbol, market, "finnhub", "ok", limit, 1, [art]
+        )
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=["AAPL", "MSFT"]))
+
     payload = results[0].payload_json
-    # The articles key (what NewsStage reads) is populated, market-scoped.
     assert payload["count"] == 2
-    assert [a["title"] for a in payload["articles"]] == [
-        "Apple beats earnings",
-        "Fed holds rates",
-    ]
-    assert captured["market"] == "us"
+    assert {a["symbol"] for a in payload["articles"]} == {"AAPL", "MSFT"}
+    assert payload["articles"][0]["sentiment"] == "positive"
+    assert payload["articles"][0]["external_article_id"] == "id-AAPL"
+    assert [r["symbol"] for r in payload["fetch_records"]] == ["AAPL", "MSFT"]
+    assert {c[0] for c in captured} == {"AAPL", "MSFT"}
     assert results[0].freshness_status == "fresh"
 
 
 @pytest.mark.asyncio
-async def test_news_collector_articles_empty_is_partial():
-    async def fake_news_fn(market, hours, limit):
-        return []
+async def test_news_collector_per_symbol_failure_is_fail_open():
+    from app.services.symbol_news_service import SymbolNewsFetchResult
 
-    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
-    results = await collector.collect(_request(market="us"))
-    assert results[0].payload_json["count"] == 0
-    assert results[0].payload_json["articles"] == []
+    async def fake_fetch(symbol: str, market: str, limit: int):
+        return SymbolNewsFetchResult(
+            symbol, market, "finnhub", "error", limit, 0, [], "RuntimeError"
+        )
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=["AAPL"]))
+
+    payload = results[0].payload_json
+    assert payload["count"] == 0
+    assert payload["fetch_records"][0]["status"] == "error"
+    # fail-open: never raises, degrades to partial
     assert results[0].freshness_status == "partial"
 
 
 @pytest.mark.asyncio
-async def test_news_collector_articles_fetch_failure_is_fail_open():
-    async def fake_news_fn(market, hours, limit):
-        raise RuntimeError("news feed down")
+async def test_news_collector_no_symbols_is_partial():
+    from app.services.symbol_news_service import SymbolNewsFetchResult
 
-    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_news_fn)
-    results = await collector.collect(_request(market="us"))
-    assert len(results) == 1
-    assert results[0].freshness_status == "unavailable"
+    async def fake_fetch(symbol: str, market: str, limit: int):  # pragma: no cover
+        raise AssertionError("should not fetch without symbols")
+
+    collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
+    results = await collector.collect(_request(market="us", symbols=[]))
+
+    assert results[0].payload_json["count"] == 0
+    assert results[0].freshness_status == "partial"
 
 
 def _make_citation(*, report_uuid: str, symbols: list[str]):

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -48,7 +48,11 @@ from app.services.action_report.snapshot_backed.collectors.watch_context import 
 from app.services.investment_snapshots.collectors import CollectorRequest
 
 
-def _request(market: str = "kr", account_scope: str = "kis_live", symbols: list[str] | None = None) -> CollectorRequest:
+def _request(
+    market: str = "kr",
+    account_scope: str = "kis_live",
+    symbols: list[str] | None = None,
+) -> CollectorRequest:
     return CollectorRequest(
         market=market,  # type: ignore[arg-type]
         account_scope=account_scope,  # type: ignore[arg-type]
@@ -1270,16 +1274,19 @@ async def test_news_collector_articles_per_symbol_from_seam():
     async def fake_fetch(symbol: str, market: str, limit: int):
         captured.append((symbol, market, limit))
         art = SymbolNewsArticle(
-            provider="finnhub", market=market, symbol=symbol,
-            external_article_id=f"id-{symbol}", title=f"{symbol} up",
-            source_name="Reuters", canonical_url=f"https://x/{symbol}",
-            summary="s", published_at=None,
+            provider="finnhub",
+            market=market,
+            symbol=symbol,
+            external_article_id=f"id-{symbol}",
+            title=f"{symbol} up",
+            source_name="Reuters",
+            canonical_url=f"https://x/{symbol}",
+            summary="s",
+            published_at=None,
             fetched_at=dt.datetime(2026, 5, 5, tzinfo=dt.UTC),
             provider_metadata={"sentiment": "positive"},
         )
-        return SymbolNewsFetchResult(
-            symbol, market, "finnhub", "ok", limit, 1, [art]
-        )
+        return SymbolNewsFetchResult(symbol, market, "finnhub", "ok", limit, 1, [art])
 
     collector = NewsSnapshotCollector(MagicMock(), news_fetch_fn=fake_fetch)
     results = await collector.collect(_request(market="us", symbols=["AAPL", "MSFT"]))
@@ -1315,7 +1322,6 @@ async def test_news_collector_per_symbol_failure_is_fail_open():
 
 @pytest.mark.asyncio
 async def test_news_collector_no_symbols_is_partial():
-    from app.services.symbol_news_service import SymbolNewsFetchResult
 
     async def fake_fetch(symbol: str, market: str, limit: int):  # pragma: no cover
         raise AssertionError("should not fetch without symbols")

--- a/tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
+++ b/tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
@@ -1,0 +1,144 @@
+# tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
+"""ROB-423 PR2 — mock_preview copies live news citations (no re-fetch)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from unittest.mock import AsyncMock
+
+from app.models.base import Base
+from app.models.investment_reports import InvestmentReport
+from app.services.investment_reports.mock_preview.runner import MockPreviewReportRunner
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.schemas.investment_snapshots import BundleCreate
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    snapshots_repo = InvestmentSnapshotsRepository(session)
+
+    now = datetime.now(tz=timezone.utc)
+
+    # Seed live bundle
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    await session.commit()
+
+    # 2. Seed a live report with an item and news citation
+    live = await repo.insert_report(
+        idempotency_key="rob423:mockcopy:live",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="live report",
+        summary="s",
+        status="draft",
+        report_metadata={},
+        market_snapshot={},
+        portfolio_snapshot={},
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+    )
+    await session.commit()
+
+    # Add item
+    item = await repo.insert_item(
+        report_id=live.id,
+        item_uuid=uuid.uuid4(),
+        idempotency_key="rob423:mockcopy:item1",
+        item_kind="action",
+        operation="review",
+        symbol="AAPL",
+        side="buy",
+        intent="buy_review",
+        rationale="r",
+        apply_policy="requires_user_approval",
+    )
+    await session.commit()
+
+    # Add 2 news citations
+    citation1 = await repo.insert_news_citation(
+        report_uuid=live.report_uuid,
+        report_item_uuid=item.item_uuid,
+        market="us",
+        symbol="AAPL",
+        provider="finnhub",
+        external_article_id="ext-aapl-1",
+        canonical_url="https://x/aapl-1",
+        title="Apple Catalyst",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        fetched_at=datetime.now(tz=timezone.utc),
+    )
+    citation2 = await repo.insert_news_citation(
+        report_uuid=live.report_uuid,
+        report_item_uuid=None,
+        market="us",
+        symbol="MSFT",
+        provider="finnhub",
+        external_article_id="ext-msft-1",
+        canonical_url="https://x/msft-1",
+        title="MSFT Related",
+        relevance="related",
+        role="confirmation",
+        decision_impact="hold_watch",
+        fetched_at=datetime.now(tz=timezone.utc),
+    )
+    await session.commit()
+
+    # Mock ensure service so it doesn't do real external snapshot logic
+    ensure_mock = AsyncMock()
+    ensure_mock.ensure_reusing_account_independent = AsyncMock(
+        return_value=AsyncMock(bundle_uuid=uuid.uuid4())
+    )
+
+    runner = MockPreviewReportRunner(
+        session=session,
+        ensure_service=ensure_mock,
+    )
+
+    # 3. Act: run MockPreviewReportRunner
+    mock_report, reused, count = await runner.run(
+        live_report_uuid=live.report_uuid,
+        market="us",
+        market_session=None,
+        policy_version="intraday_action_report_v1",
+        kst_date="2026-05-23",
+        created_by_profile="HERMES_ADVISOR",
+    )
+    await session.commit()
+
+    # 4. Assert: mock report carries copied citations
+    assert mock_report is not None
+    assert mock_report.report_uuid != live.report_uuid
+
+    mock_cites = await repo.list_news_citations_for_report(mock_report.report_uuid)
+    assert len(mock_cites) == 2
+    
+    c1 = next(c for c in mock_cites if c.symbol == "AAPL")
+    assert c1.title == "Apple Catalyst"
+    # report_item_uuid is NULL on copies!
+    assert c1.report_item_uuid is None
+    assert c1.metadata_json == {"copied_from_report_uuid": str(live.report_uuid)}
+
+    c2 = next(c for c in mock_cites if c.symbol == "MSFT")
+    assert c2.title == "MSFT Related"
+    assert c2.report_item_uuid is None
+    assert c2.metadata_json == {"copied_from_report_uuid": str(live.report_uuid)}

--- a/tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
+++ b/tests/services/investment_reports/mock_preview/test_mock_news_citation_copy.py
@@ -3,19 +3,18 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import uuid
-import pytest
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
-from app.models.base import Base
-from app.models.investment_reports import InvestmentReport
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.investment_snapshots import BundleCreate
 from app.services.investment_reports.mock_preview.runner import MockPreviewReportRunner
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
-from app.schemas.investment_snapshots import BundleCreate
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -23,7 +22,7 @@ async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None
     repo = InvestmentReportsRepository(session)
     snapshots_repo = InvestmentSnapshotsRepository(session)
 
-    now = datetime.now(tz=timezone.utc)
+    now = datetime.now(tz=UTC)
 
     # Seed live bundle
     bundle = await snapshots_repo.insert_bundle(
@@ -73,7 +72,7 @@ async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None
     await session.commit()
 
     # Add 2 news citations
-    citation1 = await repo.insert_news_citation(
+    await repo.insert_news_citation(
         report_uuid=live.report_uuid,
         report_item_uuid=item.item_uuid,
         market="us",
@@ -85,9 +84,9 @@ async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None
         relevance="direct",
         role="catalyst",
         decision_impact="strengthen_buy",
-        fetched_at=datetime.now(tz=timezone.utc),
+        fetched_at=datetime.now(tz=UTC),
     )
-    citation2 = await repo.insert_news_citation(
+    await repo.insert_news_citation(
         report_uuid=live.report_uuid,
         report_item_uuid=None,
         market="us",
@@ -99,7 +98,7 @@ async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None
         relevance="related",
         role="confirmation",
         decision_impact="hold_watch",
-        fetched_at=datetime.now(tz=timezone.utc),
+        fetched_at=datetime.now(tz=UTC),
     )
     await session.commit()
 
@@ -131,7 +130,7 @@ async def test_mock_preview_copies_live_citations(session: AsyncSession) -> None
 
     mock_cites = await repo.list_news_citations_for_report(mock_report.report_uuid)
     assert len(mock_cites) == 2
-    
+
     c1 = next(c for c in mock_cites if c.symbol == "AAPL")
     assert c1.title == "Apple Catalyst"
     # report_item_uuid is NULL on copies!

--- a/tests/services/investment_reports/test_bundle_news_citations.py
+++ b/tests/services/investment_reports/test_bundle_news_citations.py
@@ -1,0 +1,68 @@
+# tests/services/investment_reports/test_bundle_news_citations.py
+"""ROB-423 PR2 — detail bundle exposes news_citations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import Base
+from app.services.investment_reports.query_service import InvestmentReportQueryService
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_bundle_includes_news_citations(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    
+    # 1. Seed a report row
+    report = await repo.insert_report(
+        idempotency_key="rob423:detail:1",
+        report_type="snapshot_backed_advisory_v1",
+        market="us",
+        market_session=None,
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        created_by_profile="HERMES_ADVISOR",
+        title="baseline report",
+        summary="s",
+        status="draft",
+        report_metadata={},
+        market_snapshot={},
+        portfolio_snapshot={},
+    )
+    await session.commit()
+
+    # 2. Seed a citation row via repo
+    citation = await repo.insert_news_citation(
+        report_uuid=report.report_uuid,
+        market="us",
+        symbol="AAPL",
+        provider="finnhub",
+        external_article_id="ext-1",
+        canonical_url="https://x/1",
+        title="AAPL News",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        fetched_at=datetime.now(tz=timezone.utc),
+    )
+    await session.commit()
+
+    # 3. Act: query bundle
+    query_service = InvestmentReportQueryService(session)
+    bundle = await query_service.get_bundle(report.report_uuid)
+
+    # 4. Assert:
+    assert bundle is not None
+    assert "news_citations" in bundle
+    cites = bundle["news_citations"]
+    assert len(cites) == 1
+    c = cites[0]
+    assert c.title == "AAPL News"
+    assert c.symbol == "AAPL"
+    assert c.canonical_url == "https://x/1"
+    assert c.role == "catalyst"

--- a/tests/services/investment_reports/test_bundle_news_citations.py
+++ b/tests/services/investment_reports/test_bundle_news_citations.py
@@ -3,21 +3,20 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-import uuid
+from datetime import UTC, datetime
+
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import Base
 from app.services.investment_reports.query_service import InvestmentReportQueryService
 from app.services.investment_reports.repository import InvestmentReportsRepository
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_get_bundle_includes_news_citations(session: AsyncSession) -> None:
     repo = InvestmentReportsRepository(session)
-    
+
     # 1. Seed a report row
     report = await repo.insert_report(
         idempotency_key="rob423:detail:1",
@@ -37,7 +36,7 @@ async def test_get_bundle_includes_news_citations(session: AsyncSession) -> None
     await session.commit()
 
     # 2. Seed a citation row via repo
-    citation = await repo.insert_news_citation(
+    await repo.insert_news_citation(
         report_uuid=report.report_uuid,
         market="us",
         symbol="AAPL",
@@ -48,7 +47,7 @@ async def test_get_bundle_includes_news_citations(session: AsyncSession) -> None
         relevance="direct",
         role="catalyst",
         decision_impact="strengthen_buy",
-        fetched_at=datetime.now(tz=timezone.utc),
+        fetched_at=datetime.now(tz=UTC),
     )
     await session.commit()
 

--- a/tests/services/investment_reports/test_news_persistence.py
+++ b/tests/services/investment_reports/test_news_persistence.py
@@ -1,0 +1,122 @@
+# tests/services/investment_reports/test_news_persistence.py
+"""ROB-423 PR2 — pure news persistence matching helper."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.schemas.hermes_composition import HermesNewsCitation
+from app.services.investment_reports.news_persistence import build_news_persistence
+
+
+def _news_payload():
+    return {
+        "articles": [
+            {
+                "title": "Apple beats", "url": "https://x/aapl-1", "source": "Reuters",
+                "summary": "strong", "published_at": "2026-05-05T12:00:00",
+                "symbol": "AAPL", "provider": "finnhub",
+                "external_article_id": "hash-aapl-1", "sentiment": "positive",
+            },
+            {
+                "title": "MSFT cloud", "url": "https://x/msft-1", "source": "Bloomberg",
+                "summary": None, "published_at": None,
+                "symbol": "MSFT", "provider": "finnhub",
+                "external_article_id": "hash-msft-1", "sentiment": None,
+            },
+        ],
+        "fetch_records": [
+            {"symbol": "AAPL", "provider": "finnhub", "requested_limit": 20,
+             "returned_count": 1, "status": "ok", "error_code": None},
+            {"symbol": "MSFT", "provider": "finnhub", "requested_limit": 20,
+             "returned_count": 1, "status": "ok", "error_code": None},
+        ],
+        "market": "us",
+    }
+
+
+@pytest.mark.unit
+def test_matches_by_external_id_and_copies_snapshot() -> None:
+    item_uuid = uuid.uuid4()
+    cites = [
+        HermesNewsCitation(
+            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+            selection_reason="earnings beat", client_item_key="ci-1",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()],
+        citations=cites,
+        item_uuid_by_client_key={"ci-1": item_uuid},
+        instrument_type="equity_us",
+    )
+
+    assert len(plan.citations) == 1
+    c = plan.citations[0]
+    assert c["title"] == "Apple beats"
+    assert c["canonical_url"] == "https://x/aapl-1"
+    assert c["external_article_id"] == "hash-aapl-1"
+    assert c["role"] == "catalyst"
+    assert c["decision_impact"] == "strengthen_buy"
+    assert c["report_item_uuid"] == item_uuid
+    assert c["provider"] == "finnhub"
+    # fetch_runs: AAPL used_count=1, MSFT used_count=0
+    runs = {r["symbol"]: r for r in plan.fetch_runs}
+    assert runs["AAPL"]["used_count"] == 1
+    assert runs["AAPL"]["returned_count"] == 1
+    assert runs["MSFT"]["used_count"] == 0
+    assert plan.unmatched == []
+
+
+@pytest.mark.unit
+def test_unmatched_ref_is_dropped_and_recorded() -> None:
+    cites = [
+        HermesNewsCitation(
+            external_article_id="does-not-exist", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert plan.citations == []
+    assert plan.unmatched == ["does-not-exist"]
+
+
+@pytest.mark.unit
+def test_matches_by_canonical_url_fallback() -> None:
+    cites = [
+        HermesNewsCitation(
+            canonical_url="https://x/msft-1", symbol="MSFT", relevance="related",
+            role="confirmation", decision_impact="hold_watch",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[_news_payload()], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert len(plan.citations) == 1
+    assert plan.citations[0]["symbol"] == "MSFT"
+    assert plan.citations[0]["report_item_uuid"] is None  # no client_item_key
+    assert plan.citations[0]["summary_snapshot"] is None
+
+
+@pytest.mark.unit
+def test_summary_truncated_to_1000() -> None:
+    payload = _news_payload()
+    payload["articles"][0]["summary"] = "x" * 2000
+    cites = [
+        HermesNewsCitation(
+            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
+            role="catalyst", decision_impact="strengthen_buy",
+        )
+    ]
+    plan = build_news_persistence(
+        news_payloads=[payload], citations=cites,
+        item_uuid_by_client_key={}, instrument_type="equity_us",
+    )
+    assert len(plan.citations[0]["summary_snapshot"]) == 1000

--- a/tests/services/investment_reports/test_news_persistence.py
+++ b/tests/services/investment_reports/test_news_persistence.py
@@ -15,23 +15,45 @@ def _news_payload():
     return {
         "articles": [
             {
-                "title": "Apple beats", "url": "https://x/aapl-1", "source": "Reuters",
-                "summary": "strong", "published_at": "2026-05-05T12:00:00",
-                "symbol": "AAPL", "provider": "finnhub",
-                "external_article_id": "hash-aapl-1", "sentiment": "positive",
+                "title": "Apple beats",
+                "url": "https://x/aapl-1",
+                "source": "Reuters",
+                "summary": "strong",
+                "published_at": "2026-05-05T12:00:00",
+                "symbol": "AAPL",
+                "provider": "finnhub",
+                "external_article_id": "hash-aapl-1",
+                "sentiment": "positive",
             },
             {
-                "title": "MSFT cloud", "url": "https://x/msft-1", "source": "Bloomberg",
-                "summary": None, "published_at": None,
-                "symbol": "MSFT", "provider": "finnhub",
-                "external_article_id": "hash-msft-1", "sentiment": None,
+                "title": "MSFT cloud",
+                "url": "https://x/msft-1",
+                "source": "Bloomberg",
+                "summary": None,
+                "published_at": None,
+                "symbol": "MSFT",
+                "provider": "finnhub",
+                "external_article_id": "hash-msft-1",
+                "sentiment": None,
             },
         ],
         "fetch_records": [
-            {"symbol": "AAPL", "provider": "finnhub", "requested_limit": 20,
-             "returned_count": 1, "status": "ok", "error_code": None},
-            {"symbol": "MSFT", "provider": "finnhub", "requested_limit": 20,
-             "returned_count": 1, "status": "ok", "error_code": None},
+            {
+                "symbol": "AAPL",
+                "provider": "finnhub",
+                "requested_limit": 20,
+                "returned_count": 1,
+                "status": "ok",
+                "error_code": None,
+            },
+            {
+                "symbol": "MSFT",
+                "provider": "finnhub",
+                "requested_limit": 20,
+                "returned_count": 1,
+                "status": "ok",
+                "error_code": None,
+            },
         ],
         "market": "us",
     }
@@ -42,9 +64,13 @@ def test_matches_by_external_id_and_copies_snapshot() -> None:
     item_uuid = uuid.uuid4()
     cites = [
         HermesNewsCitation(
-            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
-            role="catalyst", decision_impact="strengthen_buy",
-            selection_reason="earnings beat", client_item_key="ci-1",
+            external_article_id="hash-aapl-1",
+            symbol="AAPL",
+            relevance="direct",
+            role="catalyst",
+            decision_impact="strengthen_buy",
+            selection_reason="earnings beat",
+            client_item_key="ci-1",
         )
     ]
     plan = build_news_persistence(
@@ -75,13 +101,18 @@ def test_matches_by_external_id_and_copies_snapshot() -> None:
 def test_unmatched_ref_is_dropped_and_recorded() -> None:
     cites = [
         HermesNewsCitation(
-            external_article_id="does-not-exist", symbol="AAPL", relevance="direct",
-            role="catalyst", decision_impact="strengthen_buy",
+            external_article_id="does-not-exist",
+            symbol="AAPL",
+            relevance="direct",
+            role="catalyst",
+            decision_impact="strengthen_buy",
         )
     ]
     plan = build_news_persistence(
-        news_payloads=[_news_payload()], citations=cites,
-        item_uuid_by_client_key={}, instrument_type="equity_us",
+        news_payloads=[_news_payload()],
+        citations=cites,
+        item_uuid_by_client_key={},
+        instrument_type="equity_us",
     )
     assert plan.citations == []
     assert plan.unmatched == ["does-not-exist"]
@@ -91,13 +122,18 @@ def test_unmatched_ref_is_dropped_and_recorded() -> None:
 def test_matches_by_canonical_url_fallback() -> None:
     cites = [
         HermesNewsCitation(
-            canonical_url="https://x/msft-1", symbol="MSFT", relevance="related",
-            role="confirmation", decision_impact="hold_watch",
+            canonical_url="https://x/msft-1",
+            symbol="MSFT",
+            relevance="related",
+            role="confirmation",
+            decision_impact="hold_watch",
         )
     ]
     plan = build_news_persistence(
-        news_payloads=[_news_payload()], citations=cites,
-        item_uuid_by_client_key={}, instrument_type="equity_us",
+        news_payloads=[_news_payload()],
+        citations=cites,
+        item_uuid_by_client_key={},
+        instrument_type="equity_us",
     )
     assert len(plan.citations) == 1
     assert plan.citations[0]["symbol"] == "MSFT"
@@ -111,12 +147,17 @@ def test_summary_truncated_to_1000() -> None:
     payload["articles"][0]["summary"] = "x" * 2000
     cites = [
         HermesNewsCitation(
-            external_article_id="hash-aapl-1", symbol="AAPL", relevance="direct",
-            role="catalyst", decision_impact="strengthen_buy",
+            external_article_id="hash-aapl-1",
+            symbol="AAPL",
+            relevance="direct",
+            role="catalyst",
+            decision_impact="strengthen_buy",
         )
     ]
     plan = build_news_persistence(
-        news_payloads=[payload], citations=cites,
-        item_uuid_by_client_key={}, instrument_type="equity_us",
+        news_payloads=[payload],
+        citations=cites,
+        item_uuid_by_client_key={},
+        instrument_type="equity_us",
     )
     assert len(plan.citations[0]["summary_snapshot"]) == 1000

--- a/tests/services/investment_stages/test_hermes_news_citation_ingest.py
+++ b/tests/services/investment_stages/test_hermes_news_citation_ingest.py
@@ -1,0 +1,245 @@
+# tests/services/investment_stages/test_hermes_news_citation_ingest.py
+"""ROB-423 PR2 — Hermes composition news_citations → persisted rows (fail-open)."""
+
+from __future__ import annotations
+
+import decimal
+import uuid
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import Base
+from app.models.investment_reports import InvestmentReport
+from app.schemas.hermes_composition import (
+    HermesCompositionIngestRequest,
+    HermesCompositionResult,
+    HermesNewsCitation,
+)
+from app.schemas.investment_reports import IngestReportItem
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_snapshots.repository import InvestmentSnapshotsRepository
+from app.services.investment_stages.hermes_ingest import HermesCompositionIngestService
+
+
+def _make_item(*, client_item_key: str, symbol: str) -> IngestReportItem:
+    return IngestReportItem(
+        client_item_key=client_item_key,
+        item_kind="action",
+        operation="review",
+        symbol=symbol,
+        side="buy",
+        intent="buy_review",
+        rationale="hermes rationale",
+        apply_policy="requires_user_approval",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_composition_news_citations_persisted_and_unmatched_dropped(
+    session: AsyncSession,
+) -> None:
+    # 2. Arrange: Seed a snapshot bundle with a news snapshot
+    from app.schemas.investment_snapshots import (
+        BundleCreate,
+        BundleItemCreate,
+        SnapshotCreate,
+        SnapshotRunCreate,
+    )
+    from datetime import UTC, datetime
+
+    now = datetime.now(tz=UTC)
+    snapshots_repo = InvestmentSnapshotsRepository(session)
+
+    run = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            requested_by="claude_code",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    
+    # News payload mimicking PR1/collector payloads
+    news_payload = {
+        "articles": [
+            {
+                "title": "Apple Earnings",
+                "url": "https://x/aapl-1",
+                "source": "Reuters",
+                "summary": "Apple outperforms",
+                "published_at": "2026-05-05T12:00:00",
+                "symbol": "AAPL",
+                "provider": "finnhub",
+                "external_article_id": "hash-aapl-1",
+            }
+        ],
+        "fetch_records": [
+            {
+                "symbol": "AAPL",
+                "provider": "finnhub",
+                "requested_limit": 20,
+                "returned_count": 1,
+                "status": "ok",
+                "error_code": None,
+            }
+        ],
+        "market": "us",
+    }
+    
+    # Insert news snapshot
+    snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="news",
+            market="us",
+            account_scope=None,
+            source_kind="news_ingestor",
+            payload_json=news_payload,
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    
+    # Link snap to bundle
+    await snapshots_repo.link_bundle_item(
+        bundle_uuid=bundle.bundle_uuid,
+        item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="optional"),
+    )
+    await session.commit()
+
+    # 3. Hermes composition citing one real article and one bogus ref
+    citation_real = HermesNewsCitation(
+        external_article_id="hash-aapl-1",
+        symbol="AAPL",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        selection_reason="great earnings",
+        client_item_key="ci-1",
+    )
+    citation_bogus = HermesNewsCitation(
+        external_article_id="does-not-exist",
+        symbol="AAPL",
+        relevance="direct",
+        role="catalyst",
+        decision_impact="strengthen_buy",
+        selection_reason="bogus",
+        client_item_key="ci-2",
+    )
+
+    composition = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        hermes_run_id="run-1",
+        title="Advisory Report",
+        summary="Synthesized Advisory",
+        items=[_make_item(client_item_key="ci-1", symbol="AAPL")],
+        news_citations=[citation_real, citation_bogus],
+    )
+
+    request = HermesCompositionIngestRequest(
+        composition=composition,
+        kst_date="2026-05-23",
+        market="us",
+        account_scope="kis_live",
+        status="draft",
+    )
+
+    # 4. Act: ingest the composition
+    service = HermesCompositionIngestService(session)
+    report = await service.ingest_composition(request)
+    await session.commit()
+
+    # 5. Assert:
+    reports_repo = InvestmentReportsRepository(session)
+    
+    # Check citations written (only 1, real one)
+    cites = await reports_repo.list_news_citations_for_report(report.report_uuid)
+    assert len(cites) == 1
+    c = cites[0]
+    assert c.title == "Apple Earnings"
+    assert c.canonical_url == "https://x/aapl-1"
+    assert c.external_article_id == "hash-aapl-1"
+    assert c.role == "catalyst"
+    assert c.decision_impact == "strengthen_buy"
+    assert c.relevance == "direct"
+    assert c.confidence is None
+    
+    # Check bogus ref dropped and recorded in unavailable_sources
+    refreshed_report = await reports_repo.get_report_by_id(report.id)
+    assert refreshed_report.unavailable_sources == {
+        "news_citations_unmatched": ["does-not-exist"]
+    }
+
+    # Check fetch_runs used_count tally
+    fetch_runs_res = await session.execute(
+        text("SELECT symbol, provider, used_count, returned_count FROM review.investment_report_news_fetch_runs WHERE report_uuid = :report_uuid"),
+        {"report_uuid": report.report_uuid}
+    )
+    fetch_runs = fetch_runs_res.all()
+    assert len(fetch_runs) == 1
+    assert fetch_runs[0].symbol == "AAPL"
+    assert fetch_runs[0].used_count == 1
+    assert fetch_runs[0].returned_count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_empty_news_citations_is_noop(
+    session: AsyncSession,
+) -> None:
+    # Seed bundle
+    from app.schemas.investment_snapshots import BundleCreate
+    from datetime import UTC, datetime
+
+    now = datetime.now(tz=UTC)
+    snapshots_repo = InvestmentSnapshotsRepository(session)
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    await session.commit()
+
+    composition = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        hermes_run_id="run-2",
+        title="Advisory Report Empty Cites",
+        summary="Empty",
+        items=[],
+        news_citations=[],
+    )
+
+    request = HermesCompositionIngestRequest(
+        composition=composition,
+        kst_date="2026-05-23",
+        market="us",
+        account_scope="kis_live",
+        status="draft",
+    )
+
+    service = HermesCompositionIngestService(session)
+    report = await service.ingest_composition(request)
+    await session.commit()
+
+    reports_repo = InvestmentReportsRepository(session)
+    cites = await reports_repo.list_news_citations_for_report(report.report_uuid)
+    assert cites == []

--- a/tests/services/investment_stages/test_hermes_news_citation_ingest.py
+++ b/tests/services/investment_stages/test_hermes_news_citation_ingest.py
@@ -3,14 +3,10 @@
 
 from __future__ import annotations
 
-import decimal
-import uuid
 import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import Base
-from app.models.investment_reports import InvestmentReport
 from app.schemas.hermes_composition import (
     HermesCompositionIngestRequest,
     HermesCompositionResult,
@@ -41,13 +37,14 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
     session: AsyncSession,
 ) -> None:
     # 2. Arrange: Seed a snapshot bundle with a news snapshot
+    from datetime import UTC, datetime
+
     from app.schemas.investment_snapshots import (
         BundleCreate,
         BundleItemCreate,
         SnapshotCreate,
         SnapshotRunCreate,
     )
-    from datetime import UTC, datetime
 
     now = datetime.now(tz=UTC)
     snapshots_repo = InvestmentSnapshotsRepository(session)
@@ -72,7 +69,7 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
             status="complete",
         )
     )
-    
+
     # News payload mimicking PR1/collector payloads
     news_payload = {
         "articles": [
@@ -99,7 +96,7 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
         ],
         "market": "us",
     }
-    
+
     # Insert news snapshot
     snap = await snapshots_repo.insert_snapshot(
         SnapshotCreate(
@@ -113,7 +110,7 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
             freshness_status="fresh",
         )
     )
-    
+
     # Link snap to bundle
     await snapshots_repo.link_bundle_item(
         bundle_uuid=bundle.bundle_uuid,
@@ -165,7 +162,7 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
 
     # 5. Assert:
     reports_repo = InvestmentReportsRepository(session)
-    
+
     # Check citations written (only 1, real one)
     cites = await reports_repo.list_news_citations_for_report(report.report_uuid)
     assert len(cites) == 1
@@ -177,7 +174,7 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
     assert c.decision_impact == "strengthen_buy"
     assert c.relevance == "direct"
     assert c.confidence is None
-    
+
     # Check bogus ref dropped and recorded in unavailable_sources
     refreshed_report = await reports_repo.get_report_by_id(report.id)
     assert refreshed_report.unavailable_sources == {
@@ -186,8 +183,10 @@ async def test_composition_news_citations_persisted_and_unmatched_dropped(
 
     # Check fetch_runs used_count tally
     fetch_runs_res = await session.execute(
-        text("SELECT symbol, provider, used_count, returned_count FROM review.investment_report_news_fetch_runs WHERE report_uuid = :report_uuid"),
-        {"report_uuid": report.report_uuid}
+        text(
+            "SELECT symbol, provider, used_count, returned_count FROM review.investment_report_news_fetch_runs WHERE report_uuid = :report_uuid"
+        ),
+        {"report_uuid": report.report_uuid},
     )
     fetch_runs = fetch_runs_res.all()
     assert len(fetch_runs) == 1
@@ -202,8 +201,9 @@ async def test_empty_news_citations_is_noop(
     session: AsyncSession,
 ) -> None:
     # Seed bundle
-    from app.schemas.investment_snapshots import BundleCreate
     from datetime import UTC, datetime
+
+    from app.schemas.investment_snapshots import BundleCreate
 
     now = datetime.now(tz=UTC)
     snapshots_repo = InvestmentSnapshotsRepository(session)

--- a/tests/services/test_research_news_service.py
+++ b/tests/services/test_research_news_service.py
@@ -1,142 +1,91 @@
-"""Tests for app.services.research_news_service (ROB-115)."""
+# tests/services/test_research_news_service.py
+"""Tests for research_news_service shim over symbol_news_service (ROB-423)."""
 
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
 
-from app.services import research_news_service
+from app.services import research_news_service, symbol_news_service
+from app.services.symbol_news_service import (
+    SymbolNewsArticle,
+    SymbolNewsFetchResult,
+)
 
 
-class TestFetchSymbolNewsKR:
-    @pytest.mark.asyncio
-    async def test_returns_normalized_articles_for_kr_symbol(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        fake_naver_payload = [
-            {
-                "title": "삼성전자 호실적 발표",
-                "url": "https://finance.naver.com/item/news_read.naver?code=005930&id=1",
-                "source": "한국경제",
-                "datetime": "2026-05-05T09:30",
-            },
-            {
-                "title": "반도체 업황 회복",
-                "url": "https://finance.naver.com/item/news_read.naver?code=005930&id=2",
-                "source": "매일경제",
-                "datetime": "2026-05-04",
-            },
-        ]
-        monkeypatch.setattr(
-            research_news_service,
-            "_naver_fetch_news",
-            AsyncMock(return_value=fake_naver_payload),
+def _seam_article(provider: str = "naver") -> SymbolNewsArticle:
+    return SymbolNewsArticle(
+        provider=provider,
+        market="kr",
+        symbol="005930",
+        external_article_id="001:123",
+        title="삼성전자 호실적",
+        source_name="한국경제",
+        canonical_url="https://finance.naver.com/x",
+        summary="요약" if provider == "finnhub" else None,
+        published_at=datetime(2026, 5, 5, 9, 0, tzinfo=UTC),
+        fetched_at=datetime(2026, 5, 5, 10, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_maps_seam_to_normalized_article(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = SymbolNewsFetchResult(
+        symbol="005930", market="kr", provider="naver", status="ok",
+        requested_limit=20, returned_count=1, articles=[_seam_article()],
+    )
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_symbol_news",
+        AsyncMock(return_value=result),
+    )
+
+    out = await research_news_service.fetch_symbol_news(
+        "005930", "equity_kr", limit=20
+    )
+
+    assert len(out) == 1
+    first = out[0]
+    assert first.url == "https://finance.naver.com/x"
+    assert first.title == "삼성전자 호실적"
+    assert first.source == "한국경제"
+    assert first.provider == "naver"
+    assert first.summary is None
+    assert isinstance(first.published_at, datetime)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_passes_market_for_us(monkeypatch: pytest.MonkeyPatch) -> None:
+    seam = AsyncMock(
+        return_value=SymbolNewsFetchResult(
+            symbol="AAPL", market="us", provider="finnhub", status="empty",
+            requested_limit=20, returned_count=0, articles=[],
         )
-        result = await research_news_service.fetch_symbol_news(
-            "005930", "equity_kr", limit=20
-        )
-        assert len(result) == 2
-        first = result[0]
-        assert first.title == "삼성전자 호실적 발표"
-        assert first.url.startswith("https://finance.naver.com/")
-        assert first.source == "한국경제"
-        assert first.provider == "naver"
-        assert isinstance(first.published_at, datetime)
-        assert first.summary is None
+    )
+    monkeypatch.setattr(symbol_news_service, "fetch_symbol_news", seam)
+
+    out = await research_news_service.fetch_symbol_news("AAPL", "equity_us", limit=20)
+
+    assert out == []
+    seam.assert_awaited_once()
+    assert seam.await_args.args[1] == "us"  # market derived from instrument_type
 
 
-class TestFetchSymbolNewsUS:
-    @pytest.mark.asyncio
-    async def test_returns_normalized_articles_for_us_symbol(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        fake_finnhub_payload = {
-            "symbol": "AMZN",
-            "market": "us",
-            "source": "finnhub",
-            "count": 1,
-            "news": [
-                {
-                    "title": "Amazon beats Q1 earnings",
-                    "source": "Reuters",
-                    "datetime": "2026-05-05T13:30:00",
-                    "url": "https://reuters.com/amzn-q1",
-                    "summary": "Amazon reported revenue of $X.",
-                    "sentiment": None,
-                    "related": "AMZN",
-                }
-            ],
-        }
-        monkeypatch.setattr(
-            research_news_service,
-            "_finnhub_fetch_news",
-            AsyncMock(return_value=fake_finnhub_payload),
-        )
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_shim_returns_empty_for_unknown_instrument(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seam = AsyncMock()
+    monkeypatch.setattr(symbol_news_service, "fetch_symbol_news", seam)
 
-        result = await research_news_service.fetch_symbol_news(
-            "AMZN", "equity_us", limit=20
-        )
+    out = await research_news_service.fetch_symbol_news("X", "crypto", limit=20)
 
-        assert len(result) == 1
-        first = result[0]
-        assert first.title == "Amazon beats Q1 earnings"
-        assert first.url == "https://reuters.com/amzn-q1"
-        assert first.source == "Reuters"
-        assert first.summary == "Amazon reported revenue of $X."
-        assert first.provider == "finnhub"
-        assert first.published_at == datetime(2026, 5, 5, 13, 30, 0)
-
-
-class TestFetchSymbolNewsDegrade:
-    @pytest.mark.asyncio
-    async def test_naver_exception_returns_empty(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(
-            research_news_service,
-            "_naver_fetch_news",
-            AsyncMock(side_effect=RuntimeError("scrape blocked")),
-        )
-        result = await research_news_service.fetch_symbol_news("005930", "equity_kr")
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_finnhub_value_error_returns_empty(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(
-            research_news_service,
-            "_finnhub_fetch_news",
-            AsyncMock(
-                side_effect=ValueError(
-                    "FINNHUB_API_KEY environment variable is not set"
-                )
-            ),
-        )
-        result = await research_news_service.fetch_symbol_news("AMZN", "equity_us")
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_timeout_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def _slow(*_args: object, **_kwargs: object) -> list[dict[str, str]]:
-            await asyncio.sleep(2.0)
-            return []
-
-        monkeypatch.setattr(research_news_service, "_naver_fetch_news", _slow)
-        result = await research_news_service.fetch_symbol_news(
-            "005930", "equity_kr", timeout_s=0.05
-        )
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_crypto_returns_empty(self) -> None:
-        result = await research_news_service.fetch_symbol_news("BTC", "crypto")
-        assert result == []
-
-    @pytest.mark.asyncio
-    async def test_unknown_instrument_type_returns_empty(self) -> None:
-        result = await research_news_service.fetch_symbol_news("X", "equity_unknown")
-        assert result == []
+    assert out == []
+    seam.assert_not_awaited()

--- a/tests/services/test_research_news_service.py
+++ b/tests/services/test_research_news_service.py
@@ -36,8 +36,13 @@ async def test_shim_maps_seam_to_normalized_article(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     result = SymbolNewsFetchResult(
-        symbol="005930", market="kr", provider="naver", status="ok",
-        requested_limit=20, returned_count=1, articles=[_seam_article()],
+        symbol="005930",
+        market="kr",
+        provider="naver",
+        status="ok",
+        requested_limit=20,
+        returned_count=1,
+        articles=[_seam_article()],
     )
     monkeypatch.setattr(
         symbol_news_service,
@@ -45,9 +50,7 @@ async def test_shim_maps_seam_to_normalized_article(
         AsyncMock(return_value=result),
     )
 
-    out = await research_news_service.fetch_symbol_news(
-        "005930", "equity_kr", limit=20
-    )
+    out = await research_news_service.fetch_symbol_news("005930", "equity_kr", limit=20)
 
     assert len(out) == 1
     first = out[0]
@@ -64,8 +67,13 @@ async def test_shim_maps_seam_to_normalized_article(
 async def test_shim_passes_market_for_us(monkeypatch: pytest.MonkeyPatch) -> None:
     seam = AsyncMock(
         return_value=SymbolNewsFetchResult(
-            symbol="AAPL", market="us", provider="finnhub", status="empty",
-            requested_limit=20, returned_count=0, articles=[],
+            symbol="AAPL",
+            market="us",
+            provider="finnhub",
+            status="empty",
+            requested_limit=20,
+            returned_count=0,
+            articles=[],
         )
     )
     monkeypatch.setattr(symbol_news_service, "fetch_symbol_news", seam)

--- a/tests/services/test_symbol_news_service.py
+++ b/tests/services/test_symbol_news_service.py
@@ -1,0 +1,124 @@
+# tests/services/test_symbol_news_service.py
+"""Tests for app.services.symbol_news_service (ROB-423 PR1)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import symbol_news_service
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_kr_returns_normalized_articles_with_external_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = [
+        {
+            "title": "삼성전자 호실적",
+            "url": "https://finance.naver.com/item/news_read.naver?article_id=123&office_id=001",
+            "source": "한국경제",
+            "datetime": "2026-05-05T09:30",
+        },
+        {"title": "", "url": "", "source": "", "datetime": None},  # dropped (no url/title)
+    ]
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance,
+        "fetch_news",
+        AsyncMock(return_value=raw),
+    )
+
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr", limit=20)
+
+    assert result.status == "ok"
+    assert result.provider == "naver"
+    assert result.returned_count == 1
+    art = result.articles[0]
+    assert art.symbol == "005930"
+    assert art.market == "kr"
+    assert art.title == "삼성전자 호실적"
+    assert art.source_name == "한국경제"
+    assert art.canonical_url.endswith("article_id=123&office_id=001")
+    assert art.external_article_id == "001:123"
+    assert isinstance(art.published_at, datetime)
+    assert art.provider_metadata["source_item"] == raw[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_us_finnhub_preserves_source_item_and_sentiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "symbol": "AAPL",
+        "market": "us",
+        "source": "finnhub",
+        "count": 1,
+        "news": [
+            {
+                "title": "Apple beats earnings",
+                "source": "Reuters",
+                "datetime": "2026-05-05T12:00:00",
+                "url": "https://x/aapl-1",
+                "summary": "strong quarter",
+                "sentiment": "positive",
+                "related": "AAPL,MSFT",
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        symbol_news_service,
+        "fetch_news_finnhub",
+        AsyncMock(return_value=payload),
+    )
+
+    result = await symbol_news_service.fetch_symbol_news("AAPL", "us", limit=10)
+
+    assert result.status == "ok"
+    assert result.provider == "finnhub"
+    art = result.articles[0]
+    assert art.external_article_id is not None  # url hash
+    assert art.related_symbols == ["AAPL", "MSFT"]
+    assert art.provider_metadata["sentiment"] == "positive"
+    assert art.provider_metadata["source_item"] == payload["news"][0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_provider_result_is_status_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance, "fetch_news", AsyncMock(return_value=[])
+    )
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr")
+    assert result.status == "empty"
+    assert result.returned_count == 0
+    assert result.articles == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_provider_error_is_fail_soft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        symbol_news_service.naver_finance,
+        "fetch_news",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    result = await symbol_news_service.fetch_symbol_news("005930", "kr")
+    assert result.status == "error"
+    assert result.error_code == "RuntimeError"
+    assert result.articles == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unsupported_market_is_unavailable() -> None:
+    result = await symbol_news_service.fetch_symbol_news("FOO", "jp")
+    assert result.status == "unavailable"
+    assert result.error_code == "unsupported_market"

--- a/tests/services/test_symbol_news_service.py
+++ b/tests/services/test_symbol_news_service.py
@@ -23,7 +23,12 @@ async def test_kr_returns_normalized_articles_with_external_id(
             "source": "한국경제",
             "datetime": "2026-05-05T09:30",
         },
-        {"title": "", "url": "", "source": "", "datetime": None},  # dropped (no url/title)
+        {
+            "title": "",
+            "url": "",
+            "source": "",
+            "datetime": None,
+        },  # dropped (no url/title)
     ]
     monkeypatch.setattr(
         symbol_news_service.naver_finance,

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from app.core.config import settings
 from app.services.fill_notification import (
     FillOrder,
     coerce_fill_order,
@@ -350,6 +351,7 @@ class TestFormatFillMessage:
         )
         message = format_fill_message(order)
 
+        base_url = settings.public_base_url.rstrip("/")
         expected = (
             "🟢 체결 알림\n\n"
             "종목: KRW-BTC\n"
@@ -359,7 +361,7 @@ class TestFormatFillMessage:
             "금액: 1,500,300원\n"
             "시간: 2026-02-14T17:30:45\n\n"
             "계좌: upbit\n"
-            "상세: https://mgh3326.duckdns.org/portfolio/positions/crypto/KRW-BTC"
+            f"상세: {base_url}/portfolio/positions/crypto/KRW-BTC"
         )
         assert message == expected
 
@@ -378,6 +380,7 @@ class TestFormatFillMessage:
         )
         message = format_fill_message(order)
 
+        base_url = settings.public_base_url.rstrip("/")
         expected = (
             "🟢 체결 알림\n\n"
             "종목: KRW-BTC\n"
@@ -388,7 +391,7 @@ class TestFormatFillMessage:
             "시간: 2026-02-14T17:30:45\n\n"
             "계좌: upbit\n"
             "주문: a3f5d2e1...\n"
-            "상세: https://mgh3326.duckdns.org/portfolio/positions/crypto/KRW-BTC"
+            f"상세: {base_url}/portfolio/positions/crypto/KRW-BTC"
         )
         assert message == expected
 
@@ -406,6 +409,7 @@ class TestFormatFillMessage:
             }
         )
 
+        base_url = settings.public_base_url.rstrip("/")
         expected = (
             "🔴 체결 알림\n\n"
             "종목: KRW-ETH\n"
@@ -415,7 +419,7 @@ class TestFormatFillMessage:
             "금액: 1,505,000원\n"
             "시간: 2026-02-14T18:15:22\n\n"
             "계좌: upbit\n"
-            "상세: https://mgh3326.duckdns.org/portfolio/positions/crypto/KRW-ETH"
+            f"상세: {base_url}/portfolio/positions/crypto/KRW-ETH"
         )
         assert message == expected
 
@@ -486,6 +490,5 @@ class TestFormatFillMessage:
             market_type="us",
         )
         message = format_fill_message(order)
-        assert (
-            "상세: https://mgh3326.duckdns.org/portfolio/positions/us/AAPL" in message
-        )
+        base_url = settings.public_base_url.rstrip("/")
+        assert f"상세: {base_url}/portfolio/positions/us/AAPL" in message

--- a/tests/test_portfolio_links.py
+++ b/tests/test_portfolio_links.py
@@ -1,18 +1,20 @@
+from app.core.config import settings
 from app.core.portfolio_links import build_position_detail_url
 
 
 def test_build_position_detail_url_for_supported_markets() -> None:
+    base_url = settings.public_base_url.rstrip("/")
     assert (
         build_position_detail_url("035720", "kr")
-        == "https://mgh3326.duckdns.org/portfolio/positions/kr/035720"
+        == f"{base_url}/portfolio/positions/kr/035720"
     )
     assert (
         build_position_detail_url("NVDA", "us")
-        == "https://mgh3326.duckdns.org/portfolio/positions/us/NVDA"
+        == f"{base_url}/portfolio/positions/us/NVDA"
     )
     assert (
         build_position_detail_url("KRW-BTC", "crypto")
-        == "https://mgh3326.duckdns.org/portfolio/positions/crypto/KRW-BTC"
+        == f"{base_url}/portfolio/positions/crypto/KRW-BTC"
     )
 
 

--- a/tests/test_toss_notification.py
+++ b/tests/test_toss_notification.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core.config import settings
 from app.models.manual_holdings import MarketType
 from app.monitoring.trade_notifier import (
     TradeNotifier,
@@ -602,10 +603,8 @@ class TestTossNotificationService:
         assert result is True
         mock_trade_notifier.notify_toss_buy_recommendation.assert_called_once()
         kwargs = mock_trade_notifier.notify_toss_buy_recommendation.call_args.kwargs
-        assert (
-            kwargs["detail_url"]
-            == "https://mgh3326.duckdns.org/portfolio/positions/kr/005930"
-        )
+        base_url = settings.public_base_url.rstrip("/")
+        assert kwargs["detail_url"] == f"{base_url}/portfolio/positions/kr/005930"
 
     @pytest.mark.asyncio
     async def test_process_analysis_result_sell_with_toss(


### PR DESCRIPTION
## 요약

`/invest/reports` 사용자가 "어떤 뉴스가 buy/sell/watch 판단에 영향을 줬는지" 확인할 수 있게, report 생성 시 종목별 뉴스를 on-demand로 가져오고 **실제 판단에 쓰인 기사만** citation으로 영속화한다. (ROB-398 후속)

논리적으로 2-PR이며 커밋별로 분리돼 있어 커밋 단위 리뷰 가능:

### PR1 — 정규화 seam (`b541eeda`..`6b789bad`)
- `symbol_news_service` 신설: 단일 정규화 seam(`SymbolNewsArticle`/`SymbolNewsFetchResult`), `external_article_id` 도출, provider 원본 보존, fail-soft
- `research_news_service` → seam 위 thin shim 축소 (레거시 `NewsStageAnalyzer` 무영향)
- `get_news` MCP 핸들러 seam 재배선 — **출력 envelope byte-compat 보존**(회귀 테스트)
- `NewsSnapshotCollector` 뉴스 소스 DB → per-symbol on-demand seam 전환 + `fetch_records`

### PR2 — citation 영속 + Hermes ingest + detail API (`3cee2d56` → amended)
- 신규 테이블 2개(`review.investment_report_news_fetch_runs` / `_citations`, additive)
- `HermesCompositionResult.news_citations` additive 필드 + `HermesNewsCitation` 스키마
- 순수 매칭 헬퍼 `build_news_persistence` (Hermes citation ↔ bundle news snapshot articles 매칭)
- Hermes 합성 ingest 시 fetch_run + citation 영속 (insert_report 후, **fail-open**)
- detail API `news_citations` 노출(additive), mock_preview는 live citation 복사

## 안전 경계
- **판단성 필드(`role`/`decision_impact`/`selection_reason`)는 Hermes가 작성** — auto_trader는 결정적 fetch + 검증/영속만. in-process LLM 0(`test_no_internal_llm_imports` 가드 통과)
- Hermes가 bundle에 없는 기사 인용 시 drop + `unavailable_sources`에 기록(날조 0)
- migration은 additive(2 신규 테이블)이며 **operator가 별도 `alembic upgrade head`** 실행
- broker/order/watch/scheduler mutation 0. default 동작 무변경(`news_citations` 미전송 시 citation 0건)

## 검증
- PR1: 타겟 144 passed(가드+레거시 포함), 광역 `-k "news or get_news"` 586 passed/0 fail
- PR2: 단위 52 + 통합 4(db_session) + 광역 `-k "investment_report or hermes or mock"` 438 passed/0 fail
- `ruff check`/`format --check` clean

## 무관 변경(명시)
- `tests/test_fill_notification.py`/`test_portfolio_links.py`/`test_toss_notification.py`: 하드코딩 `mgh3326.duckdns.org` → `settings.public_base_url` (이식성 개선, benign, ROB-423 범위 밖)

## 문서
- `docs/plans/ROB-423-invest-report-news-citations-spec.md` (spec)
- `docs/plans/ROB-423-PR1-...` / `ROB-423-PR2-...` (구현 플랜)

Linear: ROB-423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Investment reports now capture and display news citations associated with analysis
  * News is fetched on-demand per symbol for more targeted, up-to-date content
  * Mock preview reports include copied news citations from live reports for review purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->