### PR TITLE
test(ROB-423): serialize counterfactual watch-event fixture

### DIFF
--- a/tests/test_journal_counterfactual_service.py
+++ b/tests/test_journal_counterfactual_service.py
@@ -17,9 +17,20 @@ from app.models.review import TradeJournalCounterfactual
 from app.models.trade_journal import TradeJournal
 from app.services.trade_journal import journal_counterfactual_service as svc
 
+# These tests seed/read ``review.investment_watch_events`` on the shared test DB.
+# Hold the same advisory lock used by investment-report helper fixtures so a
+# concurrent xdist worker cannot TRUNCATE CASCADE the report/watch-event table
+# family while the counterfactual sync is selecting or inserting rows.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
 
 @pytest_asyncio.fixture(autouse=True)
-async def cleanup_journal_tables(db_session: AsyncSession):
+async def cleanup_journal_tables(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
     await db_session.execute(delete(TradeJournalCounterfactual))
     await db_session.execute(delete(TradeJournal))
     await db_session.execute(delete(InvestmentWatchEvent))


### PR DESCRIPTION
## Summary
- Post-merge main CI for ROB-423 repeatedly failed in `test (3.13)` with `asyncpg.exceptions.DeadlockDetectedError` around `review.investment_watch_events`.
- `tests/test_journal_counterfactual_service.py` seeds/reads committed `InvestmentWatchEvent` rows via the shared `db_session` while sibling xdist workers can run investment-report fixture `TRUNCATE ... CASCADE` on the same table family.
- Apply the existing `investment_reports_cleanup_lock` pattern to this file and make the autouse cleanup depend on the lock so setup/body table access is serialized against those truncates.

## Verification
- RED before fix: `uv run pytest tests/test_journal_counterfactual_service.py tests/test_investment_reports_mcp.py -m "not live" -n 2 --dist=loadfile -q --tb=short -ra -o faulthandler_timeout=120` → failed (`test_sync_records_counterfactual`, row wiped by concurrent cleanup; same shared-table race class as main CI deadlock)
- GREEN after fix: same command → `29 passed, 4 warnings`
- `uv run pytest tests/test_journal_counterfactual_service.py -q --tb=short -ra` → `6 passed, 2 warnings`
- `uv run ruff check tests/test_journal_counterfactual_service.py` → passed
- `uv run ruff format --check tests/test_journal_counterfactual_service.py` → passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture synchronization to improve test isolation and prevent concurrent data conflicts during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->