### PR TITLE
feat(ROB-428): KR Toss screener result parity — tvscreener-backed snapshot + read-path (PR-A+PR-B)

### DIFF
--- a/alembic/versions/2026_06_04_rob428_kr_fundamentals_snapshots.py
+++ b/alembic/versions/2026_06_04_rob428_kr_fundamentals_snapshots.py
@@ -1,0 +1,127 @@
+"""Add KR fundamentals screener snapshot table for ROB-428 PR-A.
+
+Additive (non-destructive): creates ``invest_kr_fundamentals_snapshots`` to
+back the KR ``/invest/screener`` with tvscreener-sourced valuation +
+fundamentals + sector/industry. Mirrors ``invest_crypto_screener_snapshots``.
+
+Revision ID: 20260604_rob428
+Revises: rob422_rob423_merge_heads
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260604_rob428"
+down_revision = "rob422_rob423_merge_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invest_kr_fundamentals_snapshots",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=True),
+        sa.Column("price", sa.Numeric(24, 8), nullable=True),
+        sa.Column("change_rate", sa.Numeric(18, 6), nullable=True),
+        sa.Column("volume", sa.Numeric(28, 4), nullable=True),
+        sa.Column("market_cap", sa.Numeric(28, 4), nullable=True),
+        sa.Column("per", sa.Numeric(18, 6), nullable=True),
+        sa.Column("pbr", sa.Numeric(18, 6), nullable=True),
+        sa.Column("dividend_yield", sa.Numeric(18, 6), nullable=True),
+        sa.Column("roe_ttm", sa.Numeric(18, 6), nullable=True),
+        sa.Column("payout_ratio_ttm", sa.Numeric(18, 6), nullable=True),
+        sa.Column("gross_margin_ttm", sa.Numeric(18, 6), nullable=True),
+        sa.Column("revenue_yoy", sa.Numeric(18, 6), nullable=True),
+        sa.Column("eps_yoy", sa.Numeric(18, 6), nullable=True),
+        sa.Column("eps_qoq", sa.Numeric(18, 6), nullable=True),
+        sa.Column("net_income_yoy", sa.Numeric(18, 6), nullable=True),
+        sa.Column("net_income_cagr_5y", sa.Numeric(18, 6), nullable=True),
+        sa.Column("continuous_dividend_payout", sa.Numeric(10, 2), nullable=True),
+        sa.Column("continuous_dividend_growth", sa.Numeric(10, 2), nullable=True),
+        sa.Column("week_high_52", sa.Numeric(24, 8), nullable=True),
+        sa.Column("rsi14", sa.Numeric(18, 6), nullable=True),
+        sa.Column("sector", sa.String(length=120), nullable=True),
+        sa.Column("industry", sa.String(length=120), nullable=True),
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column(
+            "computed_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "symbol",
+            "snapshot_date",
+            name="uq_invest_kr_fundamentals_snapshots_symbol_date",
+        ),
+        sa.CheckConstraint(
+            "source IN ('tvscreener_kr')",
+            name="ck_invest_kr_fundamentals_snapshots_source",
+        ),
+    )
+    op.create_index(
+        "ix_invest_kr_fundamentals_snapshots_date",
+        "invest_kr_fundamentals_snapshots",
+        ["snapshot_date"],
+    )
+    op.create_index(
+        "ix_invest_kr_fundamentals_snapshots_date_roe",
+        "invest_kr_fundamentals_snapshots",
+        ["snapshot_date", "roe_ttm"],
+    )
+    op.create_index(
+        "ix_invest_kr_fundamentals_snapshots_date_per",
+        "invest_kr_fundamentals_snapshots",
+        ["snapshot_date", "per"],
+    )
+    op.create_index(
+        "ix_invest_kr_fundamentals_snapshots_date_dividend_yield",
+        "invest_kr_fundamentals_snapshots",
+        ["snapshot_date", "dividend_yield"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_invest_kr_fundamentals_snapshots_date_dividend_yield",
+        table_name="invest_kr_fundamentals_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_kr_fundamentals_snapshots_date_per",
+        table_name="invest_kr_fundamentals_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_kr_fundamentals_snapshots_date_roe",
+        table_name="invest_kr_fundamentals_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_kr_fundamentals_snapshots_date",
+        table_name="invest_kr_fundamentals_snapshots",
+    )
+    op.drop_table("invest_kr_fundamentals_snapshots")

--- a/app/jobs/invest_kr_fundamentals_snapshots.py
+++ b/app/jobs/invest_kr_fundamentals_snapshots.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.services.invest_kr_fundamentals_snapshots.builder import (
+    build_kr_fundamentals_snapshots,
+)
+from app.services.invest_kr_fundamentals_snapshots.provider import (
+    TvScreenerKrFundamentalsProvider,
+)
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+)
+
+
+@dataclass(frozen=True)
+class KrFundamentalsSnapshotBuildRequest:
+    limit: int | None = 200
+    all_symbols: bool = False
+    commit: bool = False
+
+
+async def run_kr_fundamentals_snapshot_build(
+    request: KrFundamentalsSnapshotBuildRequest,
+) -> dict[str, Any]:
+    limit = None if request.all_symbols else request.limit
+    async with AsyncSessionLocal() as session:
+        result = await build_kr_fundamentals_snapshots(
+            provider=TvScreenerKrFundamentalsProvider(),
+            repository=InvestKrFundamentalsSnapshotsRepository(session),
+            commit=request.commit,
+            limit=limit,
+        )
+        if request.commit:
+            await session.commit()
+        else:
+            await session.rollback()
+        return result

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ from .crypto_instruments import CryptoInstrument
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
 from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
+from .invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
 from .invest_momentum_event_snapshot import (
     InvestMomentumEventSnapshot,
     InvestThemeEventSnapshot,
@@ -155,6 +156,7 @@ __all__ = [
     "InvestmentSnapshotBundleItem",
     "InvestorFlowSnapshot",
     "InvestCryptoScreenerSnapshot",
+    "InvestKrFundamentalsSnapshot",
     "InvestMomentumEventSnapshot",
     "InvestThemeEventSnapshot",
     "InvestThemeEventSnapshotStock",

--- a/app/models/invest_kr_fundamentals_snapshot.py
+++ b/app/models/invest_kr_fundamentals_snapshot.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Date,
+    Index,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class InvestKrFundamentalsSnapshot(Base):
+    """Daily tvscreener-backed KR valuation + fundamentals snapshot (ROB-428).
+
+    Mirrors ``InvestCryptoScreenerSnapshot``: a daily snapshot keyed by
+    ``(symbol, snapshot_date)`` so the KR ``/invest/screener`` can read
+    meaningful filled fundamentals/valuation rows (PR-B, out of scope here).
+    All numeric columns are nullable because tvscreener coverage is sparse.
+    """
+
+    __tablename__ = "invest_kr_fundamentals_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "symbol",
+            "snapshot_date",
+            name="uq_invest_kr_fundamentals_snapshots_symbol_date",
+        ),
+        CheckConstraint(
+            "source IN ('tvscreener_kr')",
+            name="source",
+        ),
+        Index("ix_invest_kr_fundamentals_snapshots_date", "snapshot_date"),
+        Index(
+            "ix_invest_kr_fundamentals_snapshots_date_roe",
+            "snapshot_date",
+            "roe_ttm",
+        ),
+        Index(
+            "ix_invest_kr_fundamentals_snapshots_date_per",
+            "snapshot_date",
+            "per",
+        ),
+        Index(
+            "ix_invest_kr_fundamentals_snapshots_date_dividend_yield",
+            "snapshot_date",
+            "dividend_yield",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+
+    # Quote / market columns
+    price: Mapped[Decimal | None] = mapped_column(Numeric(24, 8), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    volume: Mapped[Decimal | None] = mapped_column(Numeric(28, 4), nullable=True)
+    market_cap: Mapped[Decimal | None] = mapped_column(Numeric(28, 4), nullable=True)
+
+    # Valuation columns
+    per: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    pbr: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    dividend_yield: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True
+    )
+
+    # Fundamentals columns
+    roe_ttm: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    payout_ratio_ttm: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True
+    )
+    gross_margin_ttm: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True
+    )
+    revenue_yoy: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    eps_yoy: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    eps_qoq: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    net_income_yoy: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True
+    )
+    net_income_cagr_5y: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True
+    )
+
+    # Dividend streak columns (integer-valued counts persisted as Numeric)
+    continuous_dividend_payout: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 2), nullable=True
+    )
+    continuous_dividend_growth: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 2), nullable=True
+    )
+
+    # Technical / categorisation columns
+    week_high_52: Mapped[Decimal | None] = mapped_column(Numeric(24, 8), nullable=True)
+    rsi14: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    sector: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    industry: Mapped[str | None] = mapped_column(String(120), nullable=True)
+
+    raw_payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/services/invest_kr_fundamentals_snapshots/__init__.py
+++ b/app/services/invest_kr_fundamentals_snapshots/__init__.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from .builder import (
+    KrFundamentalsProviderRow,
+    KrFundamentalsSnapshotProvider,
+    build_kr_fundamentals_snapshot_payloads,
+    build_kr_fundamentals_snapshots,
+    provider_row_from_mapping,
+)
+from .provider import TvScreenerKrFundamentalsProvider
+from .repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+    KrFundamentalsCoverageCounts,
+    KrFundamentalsSnapshotUpsert,
+)
+
+__all__ = [
+    "InvestKrFundamentalsSnapshotsRepository",
+    "KrFundamentalsCoverageCounts",
+    "KrFundamentalsProviderRow",
+    "KrFundamentalsSnapshotProvider",
+    "KrFundamentalsSnapshotUpsert",
+    "TvScreenerKrFundamentalsProvider",
+    "build_kr_fundamentals_snapshot_payloads",
+    "build_kr_fundamentals_snapshots",
+    "provider_row_from_mapping",
+]

--- a/app/services/invest_kr_fundamentals_snapshots/builder.py
+++ b/app/services/invest_kr_fundamentals_snapshots/builder.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+    KrFundamentalsSnapshotUpsert,
+)
+from app.services.invest_screener_snapshots.freshness import today_trading_date
+
+_RAW_PAYLOAD_KEYS = {
+    "symbol",
+    "name",
+    "description",
+    "active_symbol",
+    "sector",
+    "industry",
+    "source",
+}
+
+
+@dataclass(frozen=True)
+class KrFundamentalsProviderRow:
+    symbol: str
+    name: str | None = None
+    price: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: Decimal | None = None
+    market_cap: Decimal | None = None
+    per: Decimal | None = None
+    pbr: Decimal | None = None
+    dividend_yield: Decimal | None = None
+    roe_ttm: Decimal | None = None
+    payout_ratio_ttm: Decimal | None = None
+    gross_margin_ttm: Decimal | None = None
+    revenue_yoy: Decimal | None = None
+    eps_yoy: Decimal | None = None
+    eps_qoq: Decimal | None = None
+    net_income_yoy: Decimal | None = None
+    net_income_cagr_5y: Decimal | None = None
+    continuous_dividend_payout: Decimal | None = None
+    continuous_dividend_growth: Decimal | None = None
+    week_high_52: Decimal | None = None
+    rsi14: Decimal | None = None
+    sector: str | None = None
+    industry: str | None = None
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+
+
+class KrFundamentalsSnapshotProvider(Protocol):
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[KrFundamentalsProviderRow]: ...
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    if result.is_nan() or result.is_infinite():
+        return None
+    return result
+
+
+def _extract_kr_symbol(raw: Any) -> str:
+    """Strip a ``KRX:`` exchange prefix and uppercase the bare code."""
+    text = str(raw or "").strip().upper()
+    if not text:
+        return ""
+    if ":" in text:
+        text = text.split(":", maxsplit=1)[-1].strip()
+    return text
+
+
+def _str_or_none(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def build_kr_fundamentals_snapshot_payloads(
+    rows: list[KrFundamentalsProviderRow], *, snapshot_date: dt.date
+) -> list[KrFundamentalsSnapshotUpsert]:
+    payloads: list[KrFundamentalsSnapshotUpsert] = []
+    for row in rows:
+        symbol = _extract_kr_symbol(row.symbol)
+        if not symbol or row.price is None:
+            continue
+        payloads.append(
+            KrFundamentalsSnapshotUpsert(
+                symbol=symbol,
+                snapshot_date=snapshot_date,
+                name=row.name,
+                price=row.price,
+                change_rate=row.change_rate,
+                volume=row.volume,
+                market_cap=row.market_cap,
+                per=row.per,
+                pbr=row.pbr,
+                dividend_yield=row.dividend_yield,
+                roe_ttm=row.roe_ttm,
+                payout_ratio_ttm=row.payout_ratio_ttm,
+                gross_margin_ttm=row.gross_margin_ttm,
+                revenue_yoy=row.revenue_yoy,
+                eps_yoy=row.eps_yoy,
+                eps_qoq=row.eps_qoq,
+                net_income_yoy=row.net_income_yoy,
+                net_income_cagr_5y=row.net_income_cagr_5y,
+                continuous_dividend_payout=row.continuous_dividend_payout,
+                continuous_dividend_growth=row.continuous_dividend_growth,
+                week_high_52=row.week_high_52,
+                rsi14=row.rsi14,
+                sector=row.sector,
+                industry=row.industry,
+                raw_payload=row.raw_payload,
+                source="tvscreener_kr",
+            )
+        )
+    return payloads
+
+
+async def build_kr_fundamentals_snapshots(
+    *,
+    provider: KrFundamentalsSnapshotProvider,
+    repository: InvestKrFundamentalsSnapshotsRepository,
+    snapshot_date: dt.date | None = None,
+    commit: bool = False,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    date_value = snapshot_date or today_trading_date("kr")
+    provider_rows = await provider.fetch_rows(limit=limit)
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        provider_rows, snapshot_date=date_value
+    )
+    upserted = 0
+    if commit:
+        for payload in payloads:
+            await repository.upsert(payload)
+            upserted += 1
+    return {
+        "snapshot_date": date_value.isoformat(),
+        "fetched": len(provider_rows),
+        "would_upsert": len(payloads),
+        "upserted": upserted,
+        "committed": commit,
+        "samples": [payload.model_dump(mode="json") for payload in payloads[:5]],
+    }
+
+
+def provider_row_from_mapping(row: dict[str, Any]) -> KrFundamentalsProviderRow | None:
+    """Map a normalised snake_case tvscreener row into a provider row.
+
+    Returns ``None`` when the symbol cannot be resolved to a KR code or no
+    price is present (defensive: ETF-ish / non-``KRX:`` rows are dropped).
+    """
+    symbol = _extract_kr_symbol(row.get("symbol") or row.get("active_symbol"))
+    # tvscreener emits ``KRX:NNNNNN``-shaped symbols for KOREA equities; the
+    # ``name`` column is frequently the ticker itself, so prefer ``description``
+    # when present for a human-readable display name.
+    raw_symbol = str(row.get("symbol") or row.get("active_symbol") or "").strip()
+    if raw_symbol and ":" in raw_symbol and not raw_symbol.upper().startswith("KRX:"):
+        return None
+    price = _decimal_or_none(row.get("price") or row.get("close"))
+    if not symbol or price is None:
+        return None
+    name = _str_or_none(row.get("description")) or _str_or_none(row.get("name"))
+    return KrFundamentalsProviderRow(
+        symbol=symbol,
+        name=name,
+        price=price,
+        change_rate=_decimal_or_none(row.get("change_percent") or row.get("change")),
+        volume=_decimal_or_none(row.get("volume")),
+        market_cap=_decimal_or_none(
+            row.get("market_capitalization") or row.get("market_cap_basic")
+        ),
+        per=_decimal_or_none(
+            row.get("price_to_earnings_ratio_ttm") or row.get("price_to_earnings_ttm")
+        ),
+        pbr=_decimal_or_none(
+            row.get("price_to_book_fq")
+            or row.get("price_to_book_mrq")
+            or row.get("price_book_current")
+        ),
+        dividend_yield=_decimal_or_none(
+            row.get("dividend_yield_forward")
+            or row.get("dividends_yield_current")
+            or row.get("dividend_yield_current")
+        ),
+        roe_ttm=_decimal_or_none(
+            row.get("return_on_equity_ttm") or row.get("return_on_equity_fy")
+        ),
+        payout_ratio_ttm=_decimal_or_none(
+            row.get("dividend_payout_ratio_ttm")
+            or row.get("dividend_payout_ratio_percent_ttm")
+            or row.get("dividend_payout_ratio_fy")
+        ),
+        gross_margin_ttm=_decimal_or_none(
+            row.get("gross_margin_ttm") or row.get("gross_margin_percent_ttm")
+        ),
+        revenue_yoy=_decimal_or_none(row.get("revenue_annual_yoy_growth")),
+        eps_yoy=_decimal_or_none(row.get("eps_diluted_annual_yoy_growth")),
+        eps_qoq=_decimal_or_none(row.get("eps_diluted_quarterly_qoq_growth")),
+        net_income_yoy=_decimal_or_none(row.get("net_income_annual_yoy_growth")),
+        net_income_cagr_5y=_decimal_or_none(row.get("net_income_cagr_5y")),
+        continuous_dividend_payout=_decimal_or_none(
+            row.get("continuous_dividend_payout")
+        ),
+        continuous_dividend_growth=_decimal_or_none(
+            row.get("continuous_dividend_growth")
+        ),
+        week_high_52=_decimal_or_none(row.get("52_week_high")),
+        rsi14=_decimal_or_none(row.get("relative_strength_index_14")),
+        sector=_str_or_none(row.get("sector")),
+        industry=_str_or_none(row.get("industry")),
+        raw_payload={k: v for k, v in row.items() if k in _RAW_PAYLOAD_KEYS},
+    )

--- a/app/services/invest_kr_fundamentals_snapshots/provider.py
+++ b/app/services/invest_kr_fundamentals_snapshots/provider.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.mcp_server.tooling.screening.common import _get_tvscreener_attr
+from app.services.invest_kr_fundamentals_snapshots.builder import (
+    KrFundamentalsProviderRow,
+    provider_row_from_mapping,
+)
+from app.services.tvscreener_service import (
+    TvScreenerService,
+    _import_tvscreener,
+)
+
+logger = logging.getLogger(__name__)
+
+# (model_key, [StockField name fallbacks]) — version-safe field resolution.
+# Probe-validated against tvscreener KOREA market (ROB-428, 2026-06-04).
+_KR_STOCK_FIELD_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("symbol", ("ACTIVE_SYMBOL", "SYMBOL")),
+    ("name", ("NAME", "DESCRIPTION")),
+    ("price", ("PRICE", "CLOSE")),
+    ("change_rate", ("CHANGE_PERCENT",)),
+    ("volume", ("VOLUME",)),
+    ("market_cap", ("MARKET_CAPITALIZATION", "MARKET_CAP_BASIC")),
+    ("per", ("PRICE_TO_EARNINGS_RATIO_TTM", "PRICE_TO_EARNINGS_TTM")),
+    ("pbr", ("PRICE_TO_BOOK_FQ", "PRICE_TO_BOOK_MRQ", "PRICE_BOOK_CURRENT")),
+    (
+        "dividend_yield",
+        (
+            "DIVIDEND_YIELD_FORWARD",
+            "DIVIDENDS_YIELD_CURRENT",
+            "DIVIDEND_YIELD_RECENT",
+            "DIVIDEND_YIELD_CURRENT",
+        ),
+    ),
+    ("roe_ttm", ("RETURN_ON_EQUITY_TTM", "RETURN_ON_EQUITY_FY")),
+    (
+        "payout_ratio_ttm",
+        (
+            "DIVIDEND_PAYOUT_RATIO_TTM",
+            "DIVIDEND_PAYOUT_RATIO_PERCENT_TTM",
+            "DIVIDEND_PAYOUT_RATIO_FY",
+        ),
+    ),
+    ("gross_margin_ttm", ("GROSS_MARGIN_TTM", "GROSS_MARGIN_PERCENT_TTM")),
+    ("revenue_yoy", ("REVENUE_ANNUAL_YOY_GROWTH",)),
+    ("eps_yoy", ("EPS_DILUTED_ANNUAL_YOY_GROWTH",)),
+    ("eps_qoq", ("EPS_DILUTED_QUARTERLY_QOQ_GROWTH",)),
+    ("net_income_yoy", ("NET_INCOME_ANNUAL_YOY_GROWTH",)),
+    ("net_income_cagr_5y", ("NET_INCOME_CAGR_5Y",)),
+    ("continuous_dividend_payout", ("CONTINUOUS_DIVIDEND_PAYOUT",)),
+    ("continuous_dividend_growth", ("CONTINUOUS_DIVIDEND_GROWTH",)),
+    ("week_high_52", ("WEEK_HIGH_52",)),
+    ("rsi14", ("RELATIVE_STRENGTH_INDEX_14",)),
+    ("sector", ("SECTOR",)),
+    ("industry", ("INDUSTRY",)),
+)
+
+
+def _resolve_kr_fields(stock_field: Any) -> list[Any]:
+    """Resolve probe-validated KR StockFields; skip any unresolved field."""
+    resolved: list[Any] = []
+    for model_key, candidates in _KR_STOCK_FIELD_SPECS:
+        field = _get_tvscreener_attr(stock_field, *candidates)
+        if field is None:
+            logger.warning(
+                "[KR-Fundamentals] StockField for %s unresolved (tried %s); "
+                "column omitted from select",
+                model_key,
+                candidates,
+            )
+            continue
+        resolved.append(field)
+    return resolved
+
+
+class TvScreenerKrFundamentalsProvider:
+    """Pure market-data provider for KR fundamentals screener snapshots.
+
+    Delegates to the tvscreener library's StockScreener (scanner API) for the
+    KOREA market, normalises the DataFrame to snake_case keys, and converts
+    each row into a snapshot DTO. It does not persist rows or mutate any
+    broker/order/watch state. ``kr.tradingview.com`` is never crawled — only
+    the library scanner API is used.
+    """
+
+    def __init__(self, *, timeout: float | None = None) -> None:
+        self._timeout = timeout
+
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[KrFundamentalsProviderRow]:
+        query_limit = limit or 200
+        tvscreener = _import_tvscreener()
+        stock_field = tvscreener.StockField
+        market = tvscreener.Market
+
+        columns = _resolve_kr_fields(stock_field)
+        if not columns:
+            logger.warning(
+                "[KR-Fundamentals] No KR StockFields resolved; returning no rows"
+            )
+            return []
+
+        service = (
+            TvScreenerService(timeout=self._timeout)
+            if self._timeout is not None
+            else TvScreenerService()
+        )
+        df = await service.query_stock_screener(
+            columns=columns,
+            markets=[market.KOREA],
+            limit=query_limit,
+        )
+
+        rows: list[KrFundamentalsProviderRow] = []
+        if df is None or df.empty:
+            return rows
+        for _, raw in df.iterrows():
+            mapping = {key: raw[key] for key in df.columns}
+            row = provider_row_from_mapping(mapping)
+            if row is not None:
+                rows.append(row)
+        return rows[:query_limit]

--- a/app/services/invest_kr_fundamentals_snapshots/repository.py
+++ b/app/services/invest_kr_fundamentals_snapshots/repository.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
+
+
+class KrFundamentalsSnapshotUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    snapshot_date: dt.date
+    name: str | None = None
+    price: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: Decimal | None = None
+    market_cap: Decimal | None = None
+    per: Decimal | None = None
+    pbr: Decimal | None = None
+    dividend_yield: Decimal | None = None
+    roe_ttm: Decimal | None = None
+    payout_ratio_ttm: Decimal | None = None
+    gross_margin_ttm: Decimal | None = None
+    revenue_yoy: Decimal | None = None
+    eps_yoy: Decimal | None = None
+    eps_qoq: Decimal | None = None
+    net_income_yoy: Decimal | None = None
+    net_income_cagr_5y: Decimal | None = None
+    continuous_dividend_payout: Decimal | None = None
+    continuous_dividend_growth: Decimal | None = None
+    week_high_52: Decimal | None = None
+    rsi14: Decimal | None = None
+    sector: str | None = None
+    industry: str | None = None
+    raw_payload: dict[str, Any] = Field(default_factory=dict)
+    source: str = "tvscreener_kr"
+
+
+@dataclass(frozen=True)
+class KrFundamentalsCoverageCounts:
+    latest_partition_date: dt.date | None
+    latest_partition_count: int
+    stale_count: int
+    last_computed_at: dt.datetime | None
+
+
+class InvestKrFundamentalsSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, payload: KrFundamentalsSnapshotUpsert) -> None:
+        values = payload.model_dump()
+        stmt = insert(InvestKrFundamentalsSnapshot).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_invest_kr_fundamentals_snapshots_symbol_date",
+            set_={
+                **{
+                    k: stmt.excluded[k]
+                    for k in values
+                    if k not in {"symbol", "snapshot_date"}
+                },
+                "updated_at": func.now(),
+                "computed_at": func.now(),
+            },
+        )
+        await self._session.execute(stmt)
+
+    async def latest_partition(self) -> dt.date | None:
+        result = await self._session.execute(
+            select(func.max(InvestKrFundamentalsSnapshot.snapshot_date))
+        )
+        return result.scalar_one_or_none()
+
+    async def coverage(self, *, today: dt.date) -> KrFundamentalsCoverageCounts:
+        latest = await self.latest_partition()
+        if latest is None:
+            return KrFundamentalsCoverageCounts(
+                latest_partition_date=None,
+                latest_partition_count=0,
+                stale_count=0,
+                last_computed_at=None,
+            )
+        result = await self._session.execute(
+            sa.select(
+                sa.func.count()
+                .filter(InvestKrFundamentalsSnapshot.snapshot_date == latest)
+                .label("latest_count"),
+                sa.func.count()
+                .filter(InvestKrFundamentalsSnapshot.snapshot_date < today)
+                .label("stale"),
+                sa.func.max(InvestKrFundamentalsSnapshot.computed_at).label("last"),
+            )
+        )
+        row = result.one()
+        return KrFundamentalsCoverageCounts(
+            latest_partition_date=latest,
+            latest_partition_count=int(row.latest_count or 0),
+            stale_count=int(row.stale or 0),
+            last_computed_at=row.last,
+        )

--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -134,6 +134,10 @@ class FundamentalsScreenResult:
     fundamentals_collected_at: dt.datetime | None
     fundamentals_state: str  # 'fresh' | 'stale' | 'missing'
     excluded: list[dict[str, Any]] = field(default_factory=list)
+    # ROB-428 PR-B: honest-divergence warnings the caller surfaces to the user
+    # (e.g. the earnings-streak condition skipped because tvscreener omits it).
+    # The DART loader leaves this empty; the tvscreener KR loader populates it.
+    warnings: list[str] = field(default_factory=list)
 
 
 def _to_period(row: FinancialFundamentalsSnapshot) -> FundamentalPeriod:

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -1,0 +1,380 @@
+"""Read-only loader for the KR /invest/screener fundamentals presets, backed by
+the tvscreener KR snapshot (``invest_kr_fundamentals_snapshots``, ROB-428 PR-A).
+
+This is the DISPLAY read-path for the 7 ``FUNDAMENTALS_PRESET_SPECS`` presets
+(cheap_value, steady_dividend, profitable_company, undervalued_growth,
+stable_growth, future_dividend_king, growth_expectation_toss). It replaces the
+DART-backed ``load_fundamentals_preset_from_snapshots`` ONLY for KR display;
+the DART loader stays in place for reports/PIT (ROB-330) and is untouched.
+
+Honest-divergence notes (ROB-428 spec §"미충족"):
+
+* ``min_earnings_increase_streak_years`` — tvscreener exposes only *dividend*
+  streaks, no *net-income* streak. That sub-condition is SKIPPED (never
+  fail-closed, never fabricated) and the result surfaces
+  :data:`EARNINGS_STREAK_SKIP_WARNING` so the caller can tell the user.
+* ``min_revenue_growth_3y_avg`` / ``min_earnings_growth_3y_avg`` — tvscreener
+  serves 1-year YoY, not Toss's 3-year average. We apply the YoY column as a
+  documented PROXY (comparable, not identical).
+
+Every other active spec threshold is applied fail-closed: a candidate whose
+required tvscreener column is NULL is EXCLUDED (never a silent pass).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import math
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.invest_screener_snapshots.partition_health import (
+    HealthyPartition,
+    active_universe_count,
+    cap_degraded,
+)
+from app.services.invest_view_model.fundamentals_screener import (
+    FundamentalsPresetSpec,
+    FundamentalsScreenResult,
+)
+
+logger = logging.getLogger(__name__)
+
+EARNINGS_STREAK_SKIP_WARNING = "순이익 연속증가 조건은 tvscreener 미제공으로 미적용"
+
+#: Mirror partition_health._MIN_HEALTHY_COVERAGE_RATIO so a thin tvscreener smoke
+#: partition cannot shadow a healthy one. Locked here; change = telemetry-backed PR.
+_MIN_HEALTHY_COVERAGE_RATIO = 0.50
+_MAX_PARTITION_SCAN_BACK = 10
+
+
+# (spec threshold field, snapshot column attr, require_positive) — each non-None
+# spec field is applied fail-closed against the tvscreener column. PROXY mappings
+# (3y-avg → 1yr YoY) are noted in the module docstring.
+_THRESHOLD_CHECKS: tuple[tuple[str, str, bool], ...] = (
+    ("min_roe", "roe_ttm", False),
+    ("max_per", "per", True),  # also requires per > 0
+    ("max_pbr", "pbr", True),  # also requires pbr > 0
+    ("min_dividend_yield", "dividend_yield", False),
+    ("min_gross_margin_ttm", "gross_margin_ttm", False),
+    ("min_payout_ratio", "payout_ratio_ttm", False),
+    ("min_revenue_growth_3y_avg", "revenue_yoy", False),  # PROXY: YoY not 3y-avg
+    ("min_earnings_growth_3y_avg", "eps_yoy", False),  # PROXY: YoY not 3y-avg
+    ("min_earnings_growth_qoq", "eps_qoq", False),
+    ("min_dividend_paid_streak_years", "continuous_dividend_payout", False),
+    ("min_dividend_growth_streak_years", "continuous_dividend_growth", False),
+)
+
+#: ``min_*`` thresholds are lower bounds (column >= threshold); ``max_*`` are
+#: upper bounds (column <= threshold).
+_MAX_FIELDS = frozenset({"max_per", "max_pbr"})
+
+#: spec.sort_by metric key -> the row dict key carrying that metric. The DART
+#: loader carries derive metrics under these same keys, so _METRIC_FIELD,
+#: _CARRIED_DERIVE_METRICS, and the ScreenerResultRow renderer all work unchanged.
+_SORT_KEY_TO_ROW_KEY: dict[str, str] = {
+    "roe": "roe",
+    "per": "per",
+    "pbr": "pbr",
+    "dividend_yield": "dividend_yield",
+    "gross_margin_ttm": "gross_margin_ttm",
+    "revenue_growth_3y_avg": "revenue_growth_3y_avg",
+    "earnings_growth_3y_avg": "earnings_growth_3y_avg",
+    "earnings_growth_qoq": "earnings_growth_qoq",
+    "payout_ratio": "payout_ratio",
+}
+
+
+def _to_float(value: Any) -> float | None:
+    return float(value) if value is not None else None
+
+
+async def _resolve_kr_partition(
+    session: AsyncSession,
+    *,
+    universe_count: int | None,
+) -> HealthyPartition | None:
+    """Latest-healthy-partition selection for the market-less KR snapshot table.
+
+    Mirrors ``resolve_healthy_partition`` (coverage ratio, bounded scan-back,
+    fail-open, degraded last-resort) but the ``invest_kr_fundamentals_snapshots``
+    table is KR-only and has NO market column, so we cannot pass a ``market_col``.
+    Returns None only when the table has no partitions.
+    """
+    date_col = InvestKrFundamentalsSnapshot.snapshot_date
+    try:
+        dates = [
+            d
+            for (d,) in (
+                await session.execute(
+                    sa.select(date_col)
+                    .distinct()
+                    .order_by(date_col.desc())
+                    .limit(_MAX_PARTITION_SCAN_BACK)
+                )
+            ).all()
+        ]
+        if not dates:
+            return None
+        newest = dates[0]
+
+        if universe_count is None:
+            universe_count = await active_universe_count(session, market="kr")
+        if universe_count <= 0:
+            # No coverage denominator → cannot judge health; treat newest as healthy
+            # (fail-open, never reduce availability).
+            return HealthyPartition(
+                partition_date=newest,
+                row_count=0,
+                coverage_ratio=0.0,
+                is_fallback=False,
+                healthy=True,
+            )
+
+        floor = math.ceil(universe_count * _MIN_HEALTHY_COVERAGE_RATIO)
+        for d in dates:
+            count = await _partition_row_count(session, partition_date=d)
+            if count >= floor:
+                return HealthyPartition(
+                    partition_date=d,
+                    row_count=count,
+                    coverage_ratio=count / universe_count,
+                    is_fallback=(d != newest),
+                    healthy=True,
+                )
+
+        newest_count = await _partition_row_count(session, partition_date=newest)
+        return HealthyPartition(
+            partition_date=newest,
+            row_count=newest_count,
+            coverage_ratio=newest_count / universe_count,
+            is_fallback=False,
+            healthy=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-open, never reduce availability
+        logger.warning(
+            "kr_fundamentals_tv_screener: partition resolve failed; "
+            "falling back to max(): %s",
+            exc,
+            exc_info=True,
+        )
+        try:
+            newest = (
+                await session.execute(sa.select(sa.func.max(date_col)))
+            ).scalar_one_or_none()
+        except Exception:  # noqa: BLE001
+            return None
+        if newest is None:
+            return None
+        return HealthyPartition(
+            partition_date=newest,
+            row_count=0,
+            coverage_ratio=0.0,
+            is_fallback=False,
+            healthy=True,
+        )
+
+
+async def _partition_row_count(
+    session: AsyncSession, *, partition_date: dt.date
+) -> int:
+    return int(
+        (
+            await session.execute(
+                sa.select(sa.func.count())
+                .select_from(InvestKrFundamentalsSnapshot)
+                .where(InvestKrFundamentalsSnapshot.snapshot_date == partition_date)
+            )
+        ).scalar()
+        or 0
+    )
+
+
+def _passes_thresholds(
+    snap: InvestKrFundamentalsSnapshot, spec: FundamentalsPresetSpec
+) -> tuple[bool, str | None]:
+    """Apply the spec's active thresholds against tvscreener columns (fail-closed).
+
+    Returns (passes, reject_reason). ``min_earnings_increase_streak_years`` is
+    intentionally NOT in _THRESHOLD_CHECKS — it has no tvscreener column and is
+    skipped (the caller surfaces EARNINGS_STREAK_SKIP_WARNING instead).
+    """
+    for spec_field, col_attr, require_positive in _THRESHOLD_CHECKS:
+        threshold = getattr(spec, spec_field)
+        if threshold is None:
+            continue
+        value = getattr(snap, col_attr)
+        if value is None:
+            return False, f"{col_attr} unavailable"
+        if require_positive and value <= 0:
+            return False, f"{col_attr} not positive"
+        if spec_field in _MAX_FIELDS:
+            if Decimal(str(value)) > Decimal(str(threshold)):
+                return False, f"{col_attr} above max"
+        else:
+            if Decimal(str(value)) < Decimal(str(threshold)):
+                return False, f"{col_attr} below min"
+    return True, None
+
+
+def _build_row(
+    snap: InvestKrFundamentalsSnapshot,
+    *,
+    name: str | None,
+    state: str,
+    partition_date: dt.date,
+) -> dict[str, Any]:
+    """Row dict using the metric keys the screener renderer + _METRIC_FIELD expect."""
+    return {
+        "symbol": snap.symbol,
+        "market": "kr",
+        "name": name,  # from KRSymbolUniverse — NOT snap.name (ticker for KR)
+        "close": _to_float(snap.price),
+        "change_rate": _to_float(snap.change_rate),
+        "volume": _to_float(snap.volume),
+        "market_cap": _to_float(snap.market_cap),
+        # ScreenerResultRow reads `row.get("sector") or row.get("category")`; the
+        # granular industry best matches Toss labels, sector is the fallback.
+        "category": snap.industry or snap.sector,
+        "per": _to_float(snap.per),
+        "pbr": _to_float(snap.pbr),
+        "roe": _to_float(snap.roe_ttm),
+        "dividend_yield": _to_float(snap.dividend_yield),
+        "gross_margin_ttm": _to_float(snap.gross_margin_ttm),
+        "payout_ratio": _to_float(snap.payout_ratio_ttm),
+        # PROXY: tvscreener YoY mapped onto the 3y-avg metric keys (see docstring).
+        "revenue_growth_3y_avg": _to_float(snap.revenue_yoy),
+        "earnings_growth_3y_avg": _to_float(snap.eps_yoy),
+        "earnings_growth_qoq": _to_float(snap.eps_qoq),
+        "dividend_paid_streak_years": _to_float(snap.continuous_dividend_payout),
+        "dividend_growth_streak_years": _to_float(snap.continuous_dividend_growth),
+        "earnings_increase_streak_years": None,  # tvscreener does not provide it
+        "rsi": _to_float(snap.rsi14),
+        "_screener_snapshot_state": state,
+        "snapshot_date": partition_date,
+    }
+
+
+async def load_kr_fundamentals_preset_from_tv_snapshot(
+    session: AsyncSession | None,
+    *,
+    market: str,
+    spec: FundamentalsPresetSpec,
+    limit: int = 20,
+    now: Any = None,
+    universe_count: int | None = None,
+) -> FundamentalsScreenResult | None:
+    """KR display read-path: serve a fundamentals preset from the tvscreener snapshot.
+
+    Returns None when session is None, market != "kr", or no snapshot partition
+    exists (caller → dataState=missing). Otherwise returns a
+    :class:`FundamentalsScreenResult` with filled rows (price/change/volume/
+    category/market_cap + metrics), the (capped) freshness state, and any honest
+    skip warnings (e.g. the earnings-streak gap).
+    """
+    if session is None or market != "kr":
+        return None
+
+    from datetime import UTC, datetime
+
+    from app.services.invest_screener_snapshots.freshness import today_trading_date
+    from app.services.invest_view_model.screener_service import (
+        _is_kr_toss_common_stock,
+    )
+
+    now_dt = now() if callable(now) else datetime.now(UTC)
+    today_market_date = today_trading_date("kr", now=now_dt)
+
+    hp = await _resolve_kr_partition(session, universe_count=universe_count)
+    partition_date = hp.partition_date if hp else None
+    if partition_date is None:
+        return None
+
+    state = "fresh" if partition_date == today_market_date else "stale"
+    if hp and (hp.is_fallback or not hp.healthy):
+        state = cap_degraded(state)
+
+    # Candidate universe: latest healthy partition, capped by market cap (prefer
+    # liquid names); preset ranking happens AFTER. Mirror fundamentals_screener
+    # cap = max(limit*8, 200).
+    cand_cap = max(limit * 8, 200)
+    cand_stmt = (
+        sa.select(InvestKrFundamentalsSnapshot)
+        .where(InvestKrFundamentalsSnapshot.snapshot_date == partition_date)
+        .order_by(InvestKrFundamentalsSnapshot.market_cap.desc().nullslast())
+        .limit(cand_cap)
+    )
+    snaps = list((await session.execute(cand_stmt)).scalars().all())
+    if len(snaps) >= cand_cap:
+        logger.warning(
+            "kr_fundamentals_tv_screener: candidate universe capped at %d for "
+            "preset=%s (lower-market-cap candidates not evaluated)",
+            cand_cap,
+            spec.preset_id,
+        )
+
+    symbols = [s.symbol for s in snaps]
+    name_map: dict[str, str] = {}
+    if symbols:
+        names = await session.execute(
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                KRSymbolUniverse.symbol.in_(symbols),
+                KRSymbolUniverse.is_active.is_(True),
+            )
+        )
+        name_map = {r.symbol: r.name for r in names.all()}
+
+    included: list[dict[str, Any]] = []
+    excluded: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    last_computed_at: dt.datetime | None = None
+    for snap in snaps:
+        sym = snap.symbol
+        if sym in seen:
+            continue
+        name = name_map.get(sym)
+        # common-stock filter (drop ETF/preferred/SPAC) + symbol dedup
+        if not _is_kr_toss_common_stock(sym, name):
+            continue
+        seen.add(sym)
+        passes, reason = _passes_thresholds(snap, spec)
+        if not passes:
+            excluded.append({"symbol": sym, "reason": reason})
+            continue
+        if snap.computed_at is not None and (
+            last_computed_at is None or snap.computed_at > last_computed_at
+        ):
+            last_computed_at = snap.computed_at
+        included.append(
+            _build_row(snap, name=name, state=state, partition_date=partition_date)
+        )
+
+    sort_row_key = _SORT_KEY_TO_ROW_KEY.get(spec.sort_by, spec.sort_by)
+    included.sort(
+        key=lambda r: (
+            r.get(sort_row_key) is None,
+            -(r.get(sort_row_key) or 0.0),
+            r["symbol"],
+        )
+    )
+    included = included[:limit]
+
+    warnings: list[str] = []
+    if spec.min_earnings_increase_streak_years is not None:
+        warnings.append(EARNINGS_STREAK_SKIP_WARNING)
+
+    return FundamentalsScreenResult(
+        rows=included,
+        valuation_partition_date=partition_date,
+        fundamentals_partition_date=partition_date,
+        fundamentals_collected_at=last_computed_at,
+        fundamentals_state="fresh" if snaps else "missing",
+        excluded=excluded,
+        warnings=warnings,
+    )

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1734,25 +1734,34 @@ async def build_screener_results(
                 "(PER 0~10·PBR 0~1·신고가 근접)에 맞는 종목이 없습니다."
             )
         elif preset_id in FUNDAMENTALS_PRESET_SPECS:
-            from app.services.invest_view_model.fundamentals_screener import (
-                load_fundamentals_preset_from_snapshots,
+            # ROB-428 PR-B: KR display reads the tvscreener-backed snapshot
+            # (invest_kr_fundamentals_snapshots) so result rows fill price/change/
+            # volume/category/market_cap + metrics and the count gap closes. The
+            # DART loader (load_fundamentals_preset_from_snapshots) stays in place
+            # for reports/PIT and is untouched.
+            from app.services.invest_view_model.kr_fundamentals_tv_screener import (
+                load_kr_fundamentals_preset_from_tv_snapshot,
             )
 
-            _fundamentals_screen_result = await load_fundamentals_preset_from_snapshots(
-                session,
-                market=requested_market,
-                spec=FUNDAMENTALS_PRESET_SPECS[preset_id],
-                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
-                now=now,
+            _fundamentals_screen_result = (
+                await load_kr_fundamentals_preset_from_tv_snapshot(
+                    session,
+                    market=requested_market,
+                    spec=FUNDAMENTALS_PRESET_SPECS[preset_id],
+                    limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                    now=now,
+                )
             )
             if _fundamentals_screen_result is not None:
                 _snapshot_check_result = _fundamentals_screen_result.rows
                 _snapshot_load_result = _SnapshotLoadResult(
                     rows=_fundamentals_screen_result.rows,
                     partition_date=_fundamentals_screen_result.valuation_partition_date,
-                    partition_computed_at=None,
+                    partition_computed_at=_fundamentals_screen_result.fundamentals_collected_at,
                 )
-            _snapshot_empty_warning = "최신 밸류에이션/재무 스냅샷에서 해당 프리셋 조건에 맞는 종목이 없습니다."
+            _snapshot_empty_warning = (
+                "최신 KR 펀더멘털 스냅샷에서 해당 프리셋 조건에 맞는 종목이 없습니다."
+            )
         elif requested_market == "crypto":
             _crypto_snapshot_result = await _load_crypto_rows_from_snapshots(
                 session,
@@ -1920,7 +1929,8 @@ async def build_screener_results(
         elif preset_id == "undervalued_breakout":
             primary_source = "market_valuation_snapshots"
         elif preset_id in FUNDAMENTALS_PRESET_SPECS:
-            primary_source = "market_valuation_snapshots"
+            # ROB-428 PR-B: KR display now reads the tvscreener KR snapshot.
+            primary_source = "invest_kr_fundamentals_snapshots"
         elif requested_market == "crypto":
             primary_source = "invest_crypto_screener_snapshots"
         else:
@@ -2019,9 +2029,17 @@ async def build_screener_results(
                 "snapshot_date": _fundamentals_screen_result.fundamentals_partition_date,
                 "collected_at": _fundamentals_screen_result.fundamentals_collected_at,
                 "data_state": _fundamentals_screen_result.fundamentals_state,
-                "source": "financial_fundamentals_snapshots",
+                # ROB-428 PR-B: KR display fundamentals now come from the
+                # tvscreener KR snapshot, not the DART table.
+                "source": "invest_kr_fundamentals_snapshots",
             }
         )
+        # ROB-428 PR-B: surface honest-divergence warnings (e.g. the earnings
+        # streak condition skipped because tvscreener does not expose it).
+        for _w in _fundamentals_screen_result.warnings:
+            _safe = _safe_warning(_w)
+            if _safe not in upstream_warnings:
+                upstream_warnings.append(_safe)
 
     freshness = _build_freshness(
         raw_timestamp=raw.get("timestamp"),

--- a/app/services/tvscreener_capabilities.py
+++ b/app/services/tvscreener_capabilities.py
@@ -49,6 +49,23 @@ _STOCK_CAPABILITY_ALIASES: dict[str, tuple[str, ...]] = {
         "DIVIDEND_YIELD_CURRENT",
     ),
     "sector": ("SECTOR",),
+    # ROB-428: KR fundamentals snapshot capabilities (tvscreener-backed).
+    "roe_ttm": ("RETURN_ON_EQUITY_TTM", "RETURN_ON_EQUITY_FY"),
+    "payout_ratio_ttm": (
+        "DIVIDEND_PAYOUT_RATIO_TTM",
+        "DIVIDEND_PAYOUT_RATIO_PERCENT_TTM",
+        "DIVIDEND_PAYOUT_RATIO_FY",
+    ),
+    "gross_margin_ttm": ("GROSS_MARGIN_TTM", "GROSS_MARGIN_PERCENT_TTM"),
+    "revenue_yoy": ("REVENUE_ANNUAL_YOY_GROWTH",),
+    "eps_yoy": ("EPS_DILUTED_ANNUAL_YOY_GROWTH",),
+    "eps_qoq": ("EPS_DILUTED_QUARTERLY_QOQ_GROWTH",),
+    "net_income_yoy": ("NET_INCOME_ANNUAL_YOY_GROWTH",),
+    "net_income_cagr_5y": ("NET_INCOME_CAGR_5Y",),
+    "continuous_dividend_payout": ("CONTINUOUS_DIVIDEND_PAYOUT",),
+    "continuous_dividend_growth": ("CONTINUOUS_DIVIDEND_GROWTH",),
+    "week_high_52": ("WEEK_HIGH_52",),
+    "industry": ("INDUSTRY",),
 }
 
 _CRYPTO_CAPABILITY_ALIASES: dict[str, tuple[str, ...]] = {

--- a/docs/plans/2026-06-04-ROB-428-kr-toss-result-parity.md
+++ b/docs/plans/2026-06-04-ROB-428-kr-toss-result-parity.md
@@ -1,0 +1,114 @@
+# ROB-428 — KR Toss 11-preset 스크리너 result parity (tvscreener-backed snapshot)
+
+> **상태:** spec (구현 전). 검토·probe·결정 grounding 완료(Linear ROB-428 코멘트 + 메모리).
+> **기준일:** 코드 2026-06-04 `origin/main` d4ad9c3f. Toss 캡처 2026-06-04(operator 브라우저, benchmark only). tvscreener probe 2026-06-04.
+> **목표 기준:** exact 종목 일치(불가) 아님 → **comparable coverage + 정직한 불일치 노출**.
+
+## Context
+
+`/invest/screener` 국내 탭 fundamentals 프리셋이 Toss 대비 거의 빈 결과 + 값 `-`. 코드 parity는 11/11 full(ROB-359/422/425)이나 **결과(종목 집합·표시값)가 Toss와 크게 다름**: 아직 저렴한 가치주 549 vs 10, 저평가 성장주 187 vs 3.
+
+당초 원인 진단은 "fundamentals coverage(DART backfill 미실행)"였으나, **probe로 더 빠른 경로를 확인**: tvscreener 라이브러리(공개 scanner API)가 KR 펀더멘털을 직접·고커버리지로 제공한다. 따라서 screener **디스플레이**(PIT 불요)는 tvscreener-backed 스냅샷으로 즉시 parity에 접근하고, DART는 리포트/PIT 전용으로 둔다.
+
+> **거버넌스 메모(중요):** "Toss/Naver/tvscreener 격상 금지"는 `kr.tradingview.com/screener/` **페이지를 Chrome remote-debug로 크롤링**하지 말라는 것. **tvscreener 라이브러리(scanner API) 사용은 허용**(crypto 스냅샷이 이미 `source="tvscreener_upbit"`로 사용 중). 리포트-of-record 권위 소스는 DART 유지.
+
+## tvscreener KR probe 결과 (2026-06-04, 상위 300 KR, scanner API)
+
+| Toss 필요 지표 | tvscreener StockField | KR 채움률 |
+|---|---|---|
+| ROE | `RETURN_ON_EQUITY_TTM` | 100% |
+| 배당성향 | `DIVIDEND_PAYOUT_RATIO_TTM` | 100% |
+| 매출총이익률 | `GROSS_MARGIN_TTM` | 93% |
+| 매출 증감률 | `REVENUE_ANNUAL_YOY_GROWTH` | 100% |
+| 순이익/EPS 증감률 | `NET_INCOME_ANNUAL_YOY_GROWTH` / `EPS_DILUTED_ANNUAL_YOY_GROWTH` | 92% |
+| QoQ(성장기대주) | `EPS_DILUTED_QUARTERLY_QOQ_GROWTH` | 81% |
+| 배당 연속지급(꾸준한배당주) | `CONTINUOUS_DIVIDEND_PAYOUT` | 100% (삼성=38) |
+| 배당 연속성장(미래배당왕) | `CONTINUOUS_DIVIDEND_GROWTH` | 100% |
+| 신고가(저평가탈출) | `WEEK_HIGH_52` | 100% |
+| 카테고리 | `SECTOR` / `INDUSTRY`(세분류) | 100% |
+| PER/PBR/배당수익률/시총/RSI | (있음) | 78–100% |
+
+**미충족(정직):** ① `순이익 연속증가 연수` — tvscreener엔 연속 *배당*만 있고 연속 *순이익* 필드 없음 → derive 필요(DART) 또는 honest 생략/근사. ② `3년 평균` 정확 정의 — TV는 YoY(1년)+CAGR_5Y → "comparable"로 수용. ③ **PIT(filing_date/as-of)** — TV 현재값만 → 리포트/백테스트(ROB-330)는 DART 유지.
+
+## Decisions (locked)
+- **D1** comparable + honest (exact 종목 일치 비목표).
+- **D2** PR-A(tvscreener KR 스냅샷) + PR-B(read-path) + PR-C(parity harness). operator DART backfill은 **count 레버에서 강등**(리포트 트랙).
+- **D3** `oversold_recovery`(RSI) = tvscreener RSI로 스냅샷 백킹 가능(probe 100%) → 정직 노출.
+- **D4** worktree `auto_trader.rob-428` 문서 + Linear ROB-428 코멘트.
+- **D5/D6 갱신** 카테고리 = tvscreener `INDUSTRY`(+`SECTOR`)를 **PR-A 스냅샷 컬럼**으로 보유(별도 `kr_symbol_universe.sector` 컬럼/별도 sync 불요 → D6 superseded).
+- **D7** tvscreener-backed로 아키텍처 개정. DART는 리포트/PIT/순이익연속 보강.
+
+## Proposed Change
+
+### PR-A — tvscreener-backed KR 스크리너 스냅샷 (crypto 패턴 미러, additive migration)
+
+1. **모델/마이그레이션**: 신규 `invest_kr_fundamentals_snapshot`(또는 동등) — `invest_crypto_screener_snapshot` 패턴. 컬럼: `snapshot_date, symbol, name, price, change_rate, change_amount, volume, market_cap, per, pbr, dividend_yield, roe_ttm, payout_ratio_ttm, gross_margin_ttm, revenue_yoy, eps_yoy, eps_qoq, net_income_yoy, net_income_cagr_5y, continuous_dividend_payout, continuous_dividend_growth, week_high_52, rsi14, sector, industry, source('tvscreener_kr'), computed_at`. additive(non-destructive), operator `alembic upgrade`.
+2. **빌더/잡**: `app/services/invest_kr_fundamentals_snapshots/builder.py` + `app/jobs/...` — `TvScreenerService.query_stock_screener(markets=[Market.KOREA], columns=[...probe-validated fields...])` → 정규화 → upsert(`computed_at=func.now()`, crypto `repository.py:61` 패턴). dry-run 기본, `--commit` write, 분포/행수 가드(`snapshot_commit_guard`) 재사용. tvscreener 필드명은 `_get_tvscreener_attr` 버전-안전 조회(`screening/kr.py` 패턴) + `tvscreener_capabilities.py`에 신규 capability 추가.
+3. **freshness**: crypto와 동일 `computed_at` 나이 기반(라이브 소스 → 저장 스냅샷). healthy-partition/`resolve_healthy_partition` 재사용.
+
+### PR-B — read-path: fundamentals/valuation 프리셋이 tvscreener 스냅샷 소비 (migration 0)
+
+- `fundamentals_screener.py` / `high_yield_value_screener.py` / `undervalued_breakout_screener.py` 및 catalog 로더가 **DISPLAY 경로에서 신규 tvscreener KR 스냅샷**을 primary로 읽도록 배선. row에 price/change/volume/category(sector·industry)/market_cap/per/pbr/roe/payout/margin/growth/dividend-streak 채움 → `-` 및 count gap 동시 해소.
+- 프리셋 매핑: 고수익저평가(ROE+PER)·돈잘버는회사(ROE+gross_margin)·저평가탈출(PER/PBR/52wH)·아직저렴한가치주(PER/PBR+eps_yoy)·저평가성장주(rev/eps growth)·성장기대주(eps 3y+QoQ)·고수익저평가/안정성장주(ROE+growth)·꾸준한배당주(yield+payout+`continuous_dividend_payout`)·미래배당왕(yield+`continuous_dividend_growth`+payout). 연속상승세는 OHLCV(invest_screener_snapshots) 유지.
+- **순이익 연속증가 3년**(steady_dividend/stable_growth/future_dividend_king): tvscreener 미제공 → 해당 sub-condition은 honest 생략 또는 `net_income_yoy>0` 근사 + warning, 또는 DART 보강(후속). fail-closed/위조 금지.
+- `oversold_recovery`: tvscreener RSI로 스냅샷 백킹(더는 live-only 아님).
+- 미적재 심볼/필드는 `-`+warning, fail-closed 유지.
+
+### PR-C — parity validation harness (dry-run, migration 0)
+
+`scripts/validate_screener_toss_parity.py` — operator 캡처 Toss JSON(자동 scraping 금지) vs auto_trader, preset별 count/top-N overlap/rank diff artifact. acceptance smoke 11 preset.
+
+### reports/PIT track (별도, DART 유지)
+
+DART `financial_fundamentals_snapshots`(ROB-422/425)는 **리포트/백테스트 PIT(ROB-330)** + 순이익 연속증가 보강용으로 유지. operator DART backfill은 리포트 정확도용이며 **screener 디스플레이의 블로커 아님**.
+
+## Acceptance Criteria
+
+1. tvscreener KR 스냅샷이 probe-validated 필드를 dry-run/commit으로 적재(`computed_at` freshness).
+2. 국내 탭 fundamentals/valuation 프리셋 결과 row의 현재가/등락률/거래량/카테고리/시총 + 프리셋 지표가 `-` 없이 채워짐(스냅샷 존재 시); 누락은 `-`+warning, fail-closed(위조 0).
+3. count가 Toss 수준에 **비교 가능**(harness로 측정); operator DART backfill 불요.
+4. `순이익 연속증가` 미충족 프리셋은 honest 처리(생략/근사+warning, 위조 금지).
+5. `oversold_recovery` RSI 스냅샷 백킹.
+6. parity harness가 preset별 count/overlap/rank diff 출력.
+7. broker/order/watch mutation 0. **kr.tradingview.com 브라우저 크롤링 0**(라이브러리 scanner API만). migration = additive 1건(operator upgrade).
+
+## Testing Plan
+| Layer | What | Count |
+|---|---|---|
+| Unit | tvscreener 빌더 정규화/필드 매핑/dry-run·commit | +3 |
+| Unit | read-path 프리셋 매핑(채움/누락 degrade) + 순이익연속 honest | +3 |
+| Unit | parity harness count/overlap/rank | +2 |
+| Integration | fundamentals preset e2e: 채워진 row + category + freshness | +2 |
+
+## Out of Scope
+- DART를 screener 디스플레이에서 제거하지 않음(리포트/PIT/순이익연속 유지). market_valuation_snapshots(Naver) 폐기 안 함(별도 결정).
+- exact 종목 일치, US(ROB-427), scheduler 활성화.
+
+## Files Reference
+| File | Change |
+|---|---|
+| `app/models/invest_kr_fundamentals_snapshot.py` | 신규 모델(crypto 스냅샷 미러) |
+| `alembic/versions/*` | additive 신규 테이블 |
+| `app/services/invest_kr_fundamentals_snapshots/{builder,repository}.py` | tvscreener KR 빌더+upsert |
+| `app/jobs/invest_kr_fundamentals_snapshots.py` | dry-run-default 잡 |
+| `app/services/tvscreener_capabilities.py` | roe/payout/gross_margin/growth/continuous_dividend/industry/52wH capability 추가 |
+| `app/services/invest_view_model/fundamentals_screener.py` 외 로더 | read-path → tvscreener 스냅샷 primary(display) |
+| `scripts/validate_screener_toss_parity.py` | parity harness |
+| `tests/...` | builder/read-path/harness |
+
+## Effort
+PR-A ~5-6h(모델+migration 1h / 빌더+잡 3h / capability+test 2h) · PR-B ~4-5h · PR-C ~2-3h.
+
+## Sequencing
+PR-A → PR-B(스냅샷 소비) → PR-C(검증). DART/reports 트랙 병렬·독립. US(ROB-427)는 동일 패턴(tvscreener US StockScreener) 재사용 가능.
+
+## Safety / Boundaries
+- tvscreener는 **라이브러리 scanner API**로 주기적 sync→스냅샷 적재(요청당 라이브 아님). kr.tradingview.com 브라우저 크롤링 금지.
+- additive 테이블 + dry-run 잡 + read-path. broker/order/watch mutation 없음.
+- DART = 리포트 권위 소스 유지. production commit/scheduler 활성화 operator 승인.
+
+## Related
+ROB-359(parent) · ROB-422/425(DART fundamentals=리포트/PIT) · ROB-426(degraded-state·healthy-partition 재사용) · ROB-427(US, 동일 tvscreener 패턴) · ROB-280/281(refresh cadence) · ROB-330(PIT).
+
+## Appendix — probe 재현
+`StockScreener().set_markets(Market.KOREA).select(*fields).set_range(0,N).get()` (`tvscreener_service.query_stock_screener`). 검증 필드/커버리지는 위 표. 전체 universe 커버리지(소형주 포함)·DART 교차 정확도는 PR-A 빌더 구현 시 재확인.

--- a/scripts/build_invest_kr_fundamentals_snapshots.py
+++ b/scripts/build_invest_kr_fundamentals_snapshots.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Build invest_kr_fundamentals_snapshots rows from the tvscreener KR screener.
+
+Defaults to dry-run/no DB writes. Pass --commit only after operator approval
+and reviewing dry-run evidence (ROB-428 PR-A). Uses the tvscreener library
+scanner API only — kr.tradingview.com is never crawled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from app.core.cli import setup_logging_and_sentry
+from app.jobs.invest_kr_fundamentals_snapshots import (
+    KrFundamentalsSnapshotBuildRequest,
+    run_kr_fundamentals_snapshot_build,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only KR fundamentals screener snapshot builder (ROB-428)."
+    )
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Fetch the full provider result set instead of --limit rows.",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write to the database. Default is dry-run/no writes.",
+    )
+    args = parser.parse_args(argv)
+    if args.all and args.limit != 200:
+        parser.error("--all is mutually exclusive with --limit")
+    return args
+
+
+async def run(args: argparse.Namespace) -> int:
+    result = await run_kr_fundamentals_snapshot_build(
+        KrFundamentalsSnapshotBuildRequest(
+            limit=args.limit,
+            all_symbols=args.all,
+            commit=args.commit,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+    if not args.commit:
+        print(
+            "\n--dry-run: no rows written. Pass --commit only with operator approval."
+        )
+    return 0
+
+
+async def main() -> int:
+    setup_logging_and_sentry(service_name="build-invest-kr-fundamentals-snapshots")
+    return await run(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_invest_kr_fundamentals_snapshots_builder.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_builder.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.invest_kr_fundamentals_snapshots.builder import (
+    KrFundamentalsProviderRow,
+    build_kr_fundamentals_snapshot_payloads,
+    build_kr_fundamentals_snapshots,
+    provider_row_from_mapping,
+)
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    KrFundamentalsSnapshotUpsert,
+)
+
+
+def _sample_row(**overrides: object) -> KrFundamentalsProviderRow:
+    base: dict[str, object] = {
+        "symbol": "005930",
+        "name": "삼성전자",
+        "price": Decimal("356250"),
+        "change_rate": Decimal("-1.1789"),
+        "volume": Decimal("15118684"),
+        "market_cap": Decimal("1482709604635.74"),
+        "per": Decimal("28.5551"),
+        "pbr": Decimal("4.957"),
+        "dividend_yield": Decimal("0.4646"),
+        "roe_ttm": Decimal("19.1610"),
+        "payout_ratio_ttm": Decimal("13.2668"),
+        "gross_margin_ttm": Decimal("47.0017"),
+        "revenue_yoy": Decimal("10.8801"),
+        "eps_yoy": Decimal("32.7484"),
+        "eps_qoq": Decimal("144.9448"),
+        "net_income_yoy": Decimal("31.6453"),
+        "net_income_cagr_5y": Decimal("11.1492"),
+        "continuous_dividend_payout": Decimal("38"),
+        "continuous_dividend_growth": Decimal("2"),
+        "week_high_52": Decimal("370000"),
+        "rsi14": Decimal("75.5192"),
+        "sector": "Electronic Technology",
+        "industry": "Telecommunications Equipment",
+        "raw_payload": {"symbol_raw": "KRX:005930"},
+    }
+    base.update(overrides)
+    return KrFundamentalsProviderRow(**base)  # type: ignore[arg-type]
+
+
+class _Provider:
+    def __init__(self, rows: list[KrFundamentalsProviderRow]) -> None:
+        self._rows = rows
+
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[KrFundamentalsProviderRow]:
+        return self._rows[:limit] if limit is not None else self._rows
+
+
+class _Repo:
+    def __init__(self) -> None:
+        self.payloads: list[KrFundamentalsSnapshotUpsert] = []
+
+    async def upsert(self, payload: KrFundamentalsSnapshotUpsert) -> None:
+        self.payloads.append(payload)
+
+
+def test_build_payloads_extracts_symbol_and_sets_source() -> None:
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        [_sample_row(symbol="KRX:005930")],
+        snapshot_date=dt.date(2026, 6, 4),
+    )
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload.symbol == "005930"
+    assert payload.snapshot_date == dt.date(2026, 6, 4)
+    assert payload.source == "tvscreener_kr"
+    assert payload.name == "삼성전자"
+    assert payload.roe_ttm == Decimal("19.1610")
+    assert payload.continuous_dividend_payout == Decimal("38")
+    assert payload.week_high_52 == Decimal("370000")
+    assert payload.industry == "Telecommunications Equipment"
+
+
+def test_build_payloads_uppercases_and_strips_krx_prefix() -> None:
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        [_sample_row(symbol="krx:000660")],
+        snapshot_date=dt.date(2026, 6, 4),
+    )
+    assert payloads[0].symbol == "000660"
+
+
+def test_build_payloads_drops_rows_without_price() -> None:
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        [_sample_row(symbol="005930", price=None)],
+        snapshot_date=dt.date(2026, 6, 4),
+    )
+    assert payloads == []
+
+
+def test_build_payloads_drops_rows_without_symbol() -> None:
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        [_sample_row(symbol="")],
+        snapshot_date=dt.date(2026, 6, 4),
+    )
+    assert payloads == []
+
+
+def test_provider_row_from_mapping_maps_normalized_keys() -> None:
+    row = provider_row_from_mapping(
+        {
+            "symbol": "KRX:005930",
+            "name": "005930",
+            "description": "삼성전자",
+            "price": 356250.0,
+            "change_percent": -1.1789,
+            "volume": 15118684.0,
+            "market_capitalization": 1482709604635.74,
+            "price_to_earnings_ratio_ttm": 28.5551,
+            "price_to_book_mrq": 4.957,
+            "dividend_yield_forward": 0.4646,
+            "return_on_equity_ttm": 19.1610,
+            "dividend_payout_ratio_ttm": 13.2668,
+            "gross_margin_ttm": 47.0017,
+            "revenue_annual_yoy_growth": 10.8801,
+            "eps_diluted_annual_yoy_growth": 32.7484,
+            "eps_diluted_quarterly_qoq_growth": 144.9448,
+            "net_income_annual_yoy_growth": 31.6453,
+            "net_income_cagr_5y": 11.1492,
+            "continuous_dividend_payout": 38,
+            "continuous_dividend_growth": 2,
+            "52_week_high": 370000.0,
+            "relative_strength_index_14": 75.5192,
+            "sector": "Electronic Technology",
+            "industry": "Telecommunications Equipment",
+        }
+    )
+    assert row is not None
+    assert row.symbol == "005930"
+    # description preferred over the ticker-shaped name column
+    assert row.name == "삼성전자"
+    assert row.price == Decimal("356250.0")
+    assert row.change_rate == Decimal("-1.1789")
+    assert row.market_cap == Decimal("1482709604635.74")
+    assert row.per == Decimal("28.5551")
+    assert row.pbr == Decimal("4.957")
+    assert row.dividend_yield == Decimal("0.4646")
+    assert row.roe_ttm == Decimal("19.161")
+    assert row.payout_ratio_ttm == Decimal("13.2668")
+    assert row.gross_margin_ttm == Decimal("47.0017")
+    assert row.revenue_yoy == Decimal("10.8801")
+    assert row.eps_yoy == Decimal("32.7484")
+    assert row.eps_qoq == Decimal("144.9448")
+    assert row.net_income_yoy == Decimal("31.6453")
+    assert row.net_income_cagr_5y == Decimal("11.1492")
+    assert row.continuous_dividend_payout == Decimal("38")
+    assert row.continuous_dividend_growth == Decimal("2")
+    assert row.week_high_52 == Decimal("370000.0")
+    assert row.rsi14 == Decimal("75.5192")
+    assert row.sector == "Electronic Technology"
+    assert row.industry == "Telecommunications Equipment"
+
+
+def test_provider_row_from_mapping_missing_keys_become_none() -> None:
+    row = provider_row_from_mapping(
+        {
+            "symbol": "KRX:005930",
+            "price": 1000.0,
+        }
+    )
+    assert row is not None
+    assert row.symbol == "005930"
+    assert row.price == Decimal("1000.0")
+    assert row.name is None
+    assert row.roe_ttm is None
+    assert row.continuous_dividend_payout is None
+    assert row.week_high_52 is None
+    assert row.industry is None
+
+
+def test_provider_row_from_mapping_rejects_non_krx() -> None:
+    assert provider_row_from_mapping({"symbol": "NASDAQ:AAPL", "price": 100.0}) is None
+
+
+def test_provider_row_from_mapping_rejects_missing_price() -> None:
+    assert provider_row_from_mapping({"symbol": "KRX:005930"}) is None
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_dry_run_does_not_upsert() -> None:
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider([_sample_row()]),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=False,
+        limit=10,
+    )
+    assert result["snapshot_date"] == "2026-06-04"
+    assert result["fetched"] == 1
+    assert result["would_upsert"] == 1
+    assert result["upserted"] == 0
+    assert result["committed"] is False
+    assert repo.payloads == []
+    assert len(result["samples"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_commit_upserts() -> None:
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider(
+            [_sample_row(symbol="005930"), _sample_row(symbol="000660")]
+        ),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=True,
+        limit=10,
+    )
+    assert result["fetched"] == 2
+    assert result["would_upsert"] == 2
+    assert result["upserted"] == 2
+    assert result["committed"] is True
+    assert {p.symbol for p in repo.payloads} == {"005930", "000660"}

--- a/tests/test_invest_kr_fundamentals_snapshots_job.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_job.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import text
+
+from app.jobs.invest_kr_fundamentals_snapshots import (
+    KrFundamentalsSnapshotBuildRequest,
+    run_kr_fundamentals_snapshot_build,
+)
+from app.services.invest_kr_fundamentals_snapshots.builder import (
+    KrFundamentalsProviderRow,
+)
+
+_JOB_SYMBOL = "990010"
+
+
+class _FakeProvider:
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[KrFundamentalsProviderRow]:
+        rows = [
+            KrFundamentalsProviderRow(
+                symbol=_JOB_SYMBOL,
+                name="잡테스트",
+                price=Decimal("12345"),
+                roe_ttm=Decimal("10.0"),
+            )
+        ]
+        return rows[:limit] if limit is not None else rows
+
+
+@pytest.mark.asyncio
+async def test_run_job_dry_run_persists_nothing(db_session):
+    await db_session.execute(
+        text("DELETE FROM invest_kr_fundamentals_snapshots WHERE symbol = :s"),
+        {"s": _JOB_SYMBOL},
+    )
+    await db_session.commit()
+
+    with patch(
+        "app.jobs.invest_kr_fundamentals_snapshots.TvScreenerKrFundamentalsProvider",
+        _FakeProvider,
+    ):
+        result = await run_kr_fundamentals_snapshot_build(
+            KrFundamentalsSnapshotBuildRequest(limit=5, commit=False)
+        )
+
+    assert result["committed"] is False
+    assert result["would_upsert"] == 1
+    assert result["upserted"] == 0
+
+    persisted = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM invest_kr_fundamentals_snapshots "
+                "WHERE symbol = :s"
+            ),
+            {"s": _JOB_SYMBOL},
+        )
+    ).scalar_one()
+    assert persisted == 0

--- a/tests/test_invest_kr_fundamentals_snapshots_model.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_model.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
+
+
+def _constraint_sql(name: str) -> str:
+    table = InvestKrFundamentalsSnapshot.__table__
+    constraint = next(c for c in table.constraints if c.name == name)
+    assert isinstance(constraint, sa.CheckConstraint)
+    return str(constraint.sqltext)
+
+
+def test_kr_fundamentals_table_name_and_unique_constraint() -> None:
+    table = InvestKrFundamentalsSnapshot.__table__
+    assert table.name == "invest_kr_fundamentals_snapshots"
+    assert "uq_invest_kr_fundamentals_snapshots_symbol_date" in {
+        c.name for c in table.constraints
+    }
+
+
+def test_kr_fundamentals_source_check_constraint() -> None:
+    assert "tvscreener_kr" in _constraint_sql(
+        "ck_invest_kr_fundamentals_snapshots_source"
+    )
+
+
+def test_kr_fundamentals_has_fundamentals_columns() -> None:
+    columns = InvestKrFundamentalsSnapshot.__table__.columns
+    for name in (
+        "symbol",
+        "snapshot_date",
+        "name",
+        "price",
+        "change_rate",
+        "volume",
+        "market_cap",
+        "per",
+        "pbr",
+        "dividend_yield",
+        "roe_ttm",
+        "payout_ratio_ttm",
+        "gross_margin_ttm",
+        "revenue_yoy",
+        "eps_yoy",
+        "eps_qoq",
+        "net_income_yoy",
+        "net_income_cagr_5y",
+        "continuous_dividend_payout",
+        "continuous_dividend_growth",
+        "week_high_52",
+        "rsi14",
+        "sector",
+        "industry",
+        "raw_payload",
+        "source",
+        "computed_at",
+    ):
+        assert name in columns
+
+
+def test_kr_fundamentals_required_columns_not_nullable() -> None:
+    columns = InvestKrFundamentalsSnapshot.__table__.columns
+    assert columns["symbol"].nullable is False
+    assert columns["snapshot_date"].nullable is False
+    assert columns["source"].nullable is False
+    # Numeric fundamentals columns are sparse — all nullable.
+    assert columns["price"].nullable is True
+    assert columns["roe_ttm"].nullable is True
+    assert columns["name"].nullable is True

--- a/tests/test_invest_kr_fundamentals_snapshots_repository.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_repository.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+    KrFundamentalsSnapshotUpsert,
+)
+
+# Synthetic KR-shaped codes distinct from any production-shaped symbols so the
+# full-suite cleanup fixtures don't collide with these rows.
+_SYM_A = "990001"
+_SYM_B = "990002"
+_SYM_OLD = "990003"
+
+
+async def _cleanup(db_session) -> None:
+    await db_session.execute(
+        text(
+            "DELETE FROM invest_kr_fundamentals_snapshots WHERE symbol IN (:a, :b, :c)"
+        ),
+        {"a": _SYM_A, "b": _SYM_B, "c": _SYM_OLD},
+    )
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_upsert_inserts_then_updates_idempotently(db_session):
+    await _cleanup(db_session)
+    repo = InvestKrFundamentalsSnapshotsRepository(db_session)
+    snapshot_date = dt.date(2026, 6, 4)
+
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_A,
+            snapshot_date=snapshot_date,
+            name="테스트종목",
+            price=Decimal("10000"),
+            roe_ttm=Decimal("12.5"),
+            per=Decimal("8.1"),
+            dividend_yield=Decimal("3.2"),
+            sector="Finance",
+            industry="Banks",
+        )
+    )
+    await db_session.commit()
+
+    first = (
+        await db_session.execute(
+            text(
+                "SELECT computed_at FROM invest_kr_fundamentals_snapshots "
+                "WHERE symbol = :s AND snapshot_date = :d"
+            ),
+            {"s": _SYM_A, "d": snapshot_date},
+        )
+    ).scalar_one()
+
+    # Re-upsert with a changed metric on the same (symbol, snapshot_date).
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_A,
+            snapshot_date=snapshot_date,
+            name="테스트종목",
+            price=Decimal("11000"),
+            roe_ttm=Decimal("13.5"),
+        )
+    )
+    await db_session.commit()
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT price, roe_ttm, computed_at "
+                "FROM invest_kr_fundamentals_snapshots "
+                "WHERE symbol = :s AND snapshot_date = :d"
+            ),
+            {"s": _SYM_A, "d": snapshot_date},
+        )
+    ).all()
+    assert len(rows) == 1, "upsert must be idempotent on (symbol, snapshot_date)"
+    assert rows[0].price == Decimal("11000")
+    assert rows[0].roe_ttm == Decimal("13.5")
+    assert rows[0].computed_at >= first
+
+
+@pytest.mark.asyncio
+async def test_latest_partition_returns_max_date(db_session):
+    await _cleanup(db_session)
+    repo = InvestKrFundamentalsSnapshotsRepository(db_session)
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_OLD,
+            snapshot_date=dt.date(2026, 6, 1),
+            price=Decimal("100"),
+        )
+    )
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_A,
+            snapshot_date=dt.date(2026, 6, 4),
+            price=Decimal("100"),
+        )
+    )
+    await db_session.commit()
+
+    latest = await repo.latest_partition()
+    assert latest is not None
+    assert latest >= dt.date(2026, 6, 4)
+
+
+@pytest.mark.asyncio
+async def test_coverage_counts_latest_and_stale(db_session):
+    await _cleanup(db_session)
+    repo = InvestKrFundamentalsSnapshotsRepository(db_session)
+    today = dt.date(2026, 6, 4)
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_A,
+            snapshot_date=today,
+            price=Decimal("100"),
+        )
+    )
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_B,
+            snapshot_date=today,
+            price=Decimal("100"),
+        )
+    )
+    await repo.upsert(
+        KrFundamentalsSnapshotUpsert(
+            symbol=_SYM_OLD,
+            snapshot_date=dt.date(2026, 6, 1),
+            price=Decimal("100"),
+        )
+    )
+    await db_session.commit()
+
+    coverage = await repo.coverage(today=today)
+    assert coverage.latest_partition_date is not None
+    assert coverage.latest_partition_date >= today
+    # The two today rows are in the latest partition.
+    assert coverage.latest_partition_count >= 2
+    # The 2026-06-01 row is strictly before today → stale.
+    assert coverage.stale_count >= 1
+    assert coverage.last_computed_at is not None

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -1,0 +1,508 @@
+"""ROB-428 PR-B — read-path loader for tvscreener-backed KR fundamentals presets.
+
+These tests drive ``load_kr_fundamentals_preset_from_tv_snapshot`` against the new
+``invest_kr_fundamentals_snapshots`` table (PR-A). The loader replaces the DART
+``load_fundamentals_preset_from_snapshots`` on the KR display read-path for the 7
+``FUNDAMENTALS_PRESET_SPECS`` presets, filling price/change/volume/category/
+market_cap + all metrics so result rows stop being empty ``-`` and the count gap
+closes (cheap_value, undervalued_growth, ...).
+
+Synthetic KR-shaped codes (``99xxxx``) keep us clear of any production-shaped rows
+the full-suite cleanup fixtures may touch.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.invest_view_model.fundamentals_screener import (
+    CHEAP_VALUE_SPEC,
+    FUTURE_DIVIDEND_KING_SPEC,
+    GROWTH_EXPECTATION_TOSS_SPEC,
+    PROFITABLE_COMPANY_SPEC,
+    STABLE_GROWTH_SPEC,
+    STEADY_DIVIDEND_SPEC,
+    UNDERVALUED_GROWTH_SPEC,
+)
+from app.services.invest_view_model.kr_fundamentals_tv_screener import (
+    EARNINGS_STREAK_SKIP_WARNING,
+    load_kr_fundamentals_preset_from_tv_snapshot,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+_SD = dt.date(2026, 6, 4)
+_PREFIX = "9913"
+
+
+def _now():
+    # 2026-06-04 is a Thursday → a KR trading day; today_trading_date("kr") == _SD.
+    return dt.datetime(2026, 6, 4, 6, 0, tzinfo=dt.UTC)
+
+
+async def _cleanup(db_session) -> None:
+    await db_session.execute(
+        sa.delete(InvestKrFundamentalsSnapshot).where(
+            InvestKrFundamentalsSnapshot.symbol.like(f"{_PREFIX}%")
+        )
+    )
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like(f"{_PREFIX}%"))
+    )
+    await db_session.commit()
+
+
+def _snap(symbol: str, **kw) -> InvestKrFundamentalsSnapshot:
+    base = {
+        "symbol": symbol,
+        "snapshot_date": _SD,
+        "name": symbol,  # snapshot name is the ticker for KR (must NOT be used)
+        "source": "tvscreener_kr",
+        "raw_payload": {},
+    }
+    base.update(kw)
+    return InvestKrFundamentalsSnapshot(**base)
+
+
+def _universe(symbol: str, name: str) -> KRSymbolUniverse:
+    return KRSymbolUniverse(symbol=symbol, name=name, exchange="KOSPI", is_active=True)
+
+
+async def _seed(db_session, snaps, universe) -> None:
+    db_session.add_all(snaps)
+    db_session.add_all(universe)
+    await db_session.commit()
+
+
+async def test_returns_none_when_session_none_or_non_kr():
+    assert (
+        await load_kr_fundamentals_preset_from_tv_snapshot(
+            None, market="kr", spec=CHEAP_VALUE_SPEC
+        )
+        is None
+    )
+
+
+async def test_returns_none_when_market_not_kr(db_session):
+    assert (
+        await load_kr_fundamentals_preset_from_tv_snapshot(
+            db_session, market="us", spec=CHEAP_VALUE_SPEC
+        )
+        is None
+    )
+
+
+async def test_profitable_company_includes_and_excludes_on_thresholds(db_session):
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}01"
+    sym_low_roe = f"{_PREFIX}02"
+    sym_low_margin = f"{_PREFIX}03"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                price=Decimal("10000"),
+                change_rate=Decimal("1.5"),
+                volume=Decimal("1234567"),
+                market_cap=Decimal("9000000000000"),
+                roe_ttm=Decimal("20"),
+                gross_margin_ttm=Decimal("0.31"),
+                sector="Technology",
+                industry="Semiconductors",
+            ),
+            _snap(
+                sym_low_roe,
+                market_cap=Decimal("8000000000000"),
+                roe_ttm=Decimal("10"),  # < 15 → excluded
+                gross_margin_ttm=Decimal("0.40"),
+            ),
+            _snap(
+                sym_low_margin,
+                market_cap=Decimal("7000000000000"),
+                roe_ttm=Decimal("25"),
+                gross_margin_ttm=Decimal("0.10"),  # < 0.20 → excluded
+            ),
+        ],
+        [
+            _universe(sym_pass, "통과종목"),
+            _universe(sym_low_roe, "낮은ROE"),
+            _universe(sym_low_margin, "낮은마진"),
+        ],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=PROFITABLE_COMPANY_SPEC,
+        limit=20,
+        now=_now,
+        # The shared test DB carries residual kr_symbol_universe rows; pin the
+        # coverage denominator so this partition's health is deterministic and
+        # the date-based freshness ("fresh" on the current trading date) is
+        # exercised faithfully (mirrors high_yield_value's cap_degraded path).
+        universe_count=3,
+    )
+    assert result is not None
+    symbols = [r["symbol"] for r in result.rows]
+    assert symbols == [sym_pass]
+    row = result.rows[0]
+    # filled row: name from universe (NOT snapshot ticker), category, price, volume, metrics
+    assert row["name"] == "통과종목"
+    assert row["name"] != sym_pass
+    assert row["category"] == "Semiconductors"  # industry preferred over sector
+    assert row["close"] == 10000.0
+    assert row["change_rate"] == 1.5
+    assert row["volume"] == 1234567.0
+    assert row["market_cap"] == 9000000000000.0
+    assert row["roe"] == 20.0
+    assert row["gross_margin_ttm"] == 0.31
+    assert row["_screener_snapshot_state"] == "fresh"
+    assert row["snapshot_date"] == _SD
+
+
+async def test_fail_closed_on_null_required_column(db_session):
+    await _cleanup(db_session)
+    sym_null = f"{_PREFIX}10"
+    # roe_ttm is required by profitable_company; NULL must be EXCLUDED, never a pass.
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_null,
+                market_cap=Decimal("5000000000000"),
+                roe_ttm=None,
+                gross_margin_ttm=Decimal("0.50"),
+            )
+        ],
+        [_universe(sym_null, "널종목")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=PROFITABLE_COMPANY_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == []
+    assert any(e["symbol"] == sym_null for e in result.excluded)
+
+
+async def test_cheap_value_per_pbr_must_be_positive(db_session):
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}20"
+    sym_neg_per = f"{_PREFIX}21"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                market_cap=Decimal("6000000000000"),
+                per=Decimal("12"),
+                pbr=Decimal("1.0"),
+                eps_yoy=Decimal("0.05"),  # cheap_value: min_earnings_growth_3y_avg=0
+            ),
+            _snap(
+                sym_neg_per,
+                market_cap=Decimal("5000000000000"),
+                per=Decimal("-3"),  # per<=0 → excluded
+                pbr=Decimal("0.9"),
+                eps_yoy=Decimal("0.10"),
+            ),
+        ],
+        [_universe(sym_pass, "싼가치주"), _universe(sym_neg_per, "적자기업")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=CHEAP_VALUE_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+
+
+async def test_earnings_increase_streak_skipped_and_warned(db_session):
+    """steady_dividend includes a symbol that lacks any earnings-streak signal —
+    it must NOT be fail-closed on min_earnings_increase_streak_years (no tv column),
+    and the result must surface the honest skip warning."""
+    await _cleanup(db_session)
+    sym = f"{_PREFIX}30"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym,
+                market_cap=Decimal("4000000000000"),
+                dividend_yield=Decimal("0.04"),  # >= 0.03
+                payout_ratio_ttm=Decimal("40"),  # >= 30
+                continuous_dividend_payout=Decimal("5"),  # >= 3
+                # NOTE: no earnings-increase-streak column exists; must be skipped.
+            )
+        ],
+        [_universe(sym, "꾸준배당")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=STEADY_DIVIDEND_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    # Passes despite the un-applied streak condition.
+    assert [r["symbol"] for r in result.rows] == [sym]
+    assert EARNINGS_STREAK_SKIP_WARNING in result.warnings
+
+
+async def test_steady_dividend_fail_closed_on_null_payout(db_session):
+    await _cleanup(db_session)
+    sym = f"{_PREFIX}31"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym,
+                market_cap=Decimal("3000000000000"),
+                dividend_yield=Decimal("0.05"),
+                payout_ratio_ttm=None,  # required → fail-closed
+                continuous_dividend_payout=Decimal("10"),
+            )
+        ],
+        [_universe(sym, "배당미달")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=STEADY_DIVIDEND_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == []
+
+
+async def test_future_dividend_king_growth_streak_and_payout(db_session):
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}40"
+    sym_low_streak = f"{_PREFIX}41"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                market_cap=Decimal("4000000000000"),
+                dividend_yield=Decimal("0.02"),  # >= 0.01
+                payout_ratio_ttm=Decimal("35"),  # >= 30
+                continuous_dividend_growth=Decimal("5"),  # >= 3
+            ),
+            _snap(
+                sym_low_streak,
+                market_cap=Decimal("3500000000000"),
+                dividend_yield=Decimal("0.02"),
+                payout_ratio_ttm=Decimal("50"),
+                continuous_dividend_growth=Decimal("1"),  # < 3 → excluded
+            ),
+        ],
+        [_universe(sym_pass, "배당왕"), _universe(sym_low_streak, "짧은성장")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=FUTURE_DIVIDEND_KING_SPEC,
+        limit=20,
+        now=_now,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+    # Still surfaces the streak-skip warning (it also has min_earnings_increase_streak).
+    assert EARNINGS_STREAK_SKIP_WARNING in result.warnings
+
+
+async def test_undervalued_growth_uses_yoy_proxy(db_session):
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}50"
+    sym_low_eps = f"{_PREFIX}51"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                market_cap=Decimal("5000000000000"),
+                per=Decimal("15"),  # <= 20
+                revenue_yoy=Decimal("0.15"),  # >= 0.10
+                eps_yoy=Decimal("0.30"),  # >= 0.20 (proxy for 3y-avg)
+            ),
+            _snap(
+                sym_low_eps,
+                market_cap=Decimal("4500000000000"),
+                per=Decimal("12"),
+                revenue_yoy=Decimal("0.20"),
+                eps_yoy=Decimal("0.05"),  # < 0.20 → excluded
+            ),
+        ],
+        [_universe(sym_pass, "저평가성장"), _universe(sym_low_eps, "저성장")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=UNDERVALUED_GROWTH_SPEC,
+        limit=20,
+        now=_now,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+    row = result.rows[0]
+    assert row["earnings_growth_3y_avg"] == 0.30  # eps_yoy mapped onto the metric key
+    assert row["revenue_growth_3y_avg"] == 0.15
+
+
+async def test_growth_expectation_toss_uses_qoq(db_session):
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}60"
+    sym_low_qoq = f"{_PREFIX}61"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                market_cap=Decimal("5000000000000"),
+                eps_yoy=Decimal("0.05"),  # >= 0.03
+                eps_qoq=Decimal("0.15"),  # >= 0.10
+            ),
+            _snap(
+                sym_low_qoq,
+                market_cap=Decimal("4000000000000"),
+                eps_yoy=Decimal("0.10"),
+                eps_qoq=Decimal("0.05"),  # < 0.10 → excluded
+            ),
+        ],
+        [_universe(sym_pass, "성장기대"), _universe(sym_low_qoq, "QoQ미달")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=GROWTH_EXPECTATION_TOSS_SPEC,
+        limit=20,
+        now=_now,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+    assert result.rows[0]["earnings_growth_qoq"] == 0.15
+
+
+async def test_sort_by_spec_sort_key_desc(db_session):
+    await _cleanup(db_session)
+    # profitable_company sort_by="roe"; higher ROE first.
+    sym_hi = f"{_PREFIX}70"
+    sym_lo = f"{_PREFIX}71"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_lo,
+                market_cap=Decimal("9000000000000"),  # bigger cap, but lower ROE
+                roe_ttm=Decimal("16"),
+                gross_margin_ttm=Decimal("0.30"),
+            ),
+            _snap(
+                sym_hi,
+                market_cap=Decimal("3000000000000"),
+                roe_ttm=Decimal("40"),
+                gross_margin_ttm=Decimal("0.30"),
+            ),
+        ],
+        [_universe(sym_hi, "고ROE"), _universe(sym_lo, "저ROE")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=PROFITABLE_COMPANY_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_hi, sym_lo]
+
+
+async def test_limit_caps_output(db_session):
+    await _cleanup(db_session)
+    snaps = []
+    universe = []
+    for i in range(5):
+        sym = f"{_PREFIX}8{i}"
+        snaps.append(
+            _snap(
+                sym,
+                market_cap=Decimal(str((5 - i) * 1_000_000_000_000)),
+                roe_ttm=Decimal(str(20 + i)),
+                gross_margin_ttm=Decimal("0.30"),
+            )
+        )
+        universe.append(_universe(sym, f"종목{i}"))
+    await _seed(db_session, snaps, universe)
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=PROFITABLE_COMPANY_SPEC, limit=2, now=_now
+    )
+    assert result is not None
+    assert len(result.rows) == 2
+
+
+async def test_returns_none_when_no_partition(monkeypatch, db_session):
+    # No partition for the table -> resolve returns None -> loader returns None
+    # (caller renders dataState=missing). The shared test DB always carries rows
+    # from sibling suites on _SD, so exercise the empty-table branch directly via
+    # the real resolver against a patched no-rows path.
+    from app.services.invest_view_model import kr_fundamentals_tv_screener as mod
+
+    async def _no_partition(session, *, universe_count=None):
+        return None
+
+    monkeypatch.setattr(mod, "_resolve_kr_partition", _no_partition)
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=CHEAP_VALUE_SPEC, limit=20, now=_now
+    )
+    assert result is None
+
+
+async def test_thin_partition_capped_to_stale(db_session):
+    """A partition below the coverage floor must not be labeled fresh, even when
+    its date matches today (mirrors high_yield_value cap_degraded)."""
+    await _cleanup(db_session)
+    sym = f"{_PREFIX}95"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym,
+                market_cap=Decimal("5000000000000"),
+                roe_ttm=Decimal("20"),
+                gross_margin_ttm=Decimal("0.30"),
+            )
+        ],
+        [_universe(sym, "얇은파티션")],
+    )
+    # universe_count=100 → floor=50 >> 1 seeded row → unhealthy → capped to stale.
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=PROFITABLE_COMPANY_SPEC,
+        limit=20,
+        now=_now,
+        universe_count=100,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym]
+    assert result.rows[0]["_screener_snapshot_state"] == "stale"
+    assert result.fundamentals_state == "fresh"  # rows exist → not missing
+
+
+async def test_stable_growth_includes_via_roe_and_yoy_skips_streak(db_session):
+    await _cleanup(db_session)
+    sym = f"{_PREFIX}90"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym,
+                market_cap=Decimal("5000000000000"),
+                roe_ttm=Decimal("18"),  # >= 15
+                eps_yoy=Decimal("0.15"),  # proxy for min_earnings_growth_3y_avg=0.10
+                # no earnings-streak column → skipped + warned
+            )
+        ],
+        [_universe(sym, "안정성장")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=STABLE_GROWTH_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym]
+    assert EARNINGS_STREAK_SKIP_WARNING in result.warnings

--- a/tests/test_screener_service_profitable_company.py
+++ b/tests/test_screener_service_profitable_company.py
@@ -10,6 +10,16 @@ from app.services.invest_view_model.fundamentals_screener import (
     FundamentalsScreenResult,
 )
 
+# ROB-428 PR-B: the 7 FUNDAMENTALS_PRESET_SPECS presets now read the
+# tvscreener-backed KR snapshot (invest_kr_fundamentals_snapshots) on the KR
+# display read-path, not the DART market_valuation/financial_fundamentals tables.
+# These tests therefore monkeypatch the new loader and assert the new source.
+_TV_LOADER_PATH = (
+    "app.services.invest_view_model.kr_fundamentals_tv_screener."
+    "load_kr_fundamentals_preset_from_tv_snapshot"
+)
+_FUNDAMENTALS_SOURCE = "invest_kr_fundamentals_snapshots"
+
 
 class _StubScreening:
     async def list_screening(self, **kwargs):  # must never be called for this preset
@@ -58,22 +68,24 @@ async def test_profitable_company_uses_fundamentals_loader_and_is_snapshot_only(
                     "symbol": "005930",
                     "market": "kr",
                     "name": "삼성전자",
+                    "close": 78000.0,
+                    "change_rate": 1.2,
+                    "volume": 12_345_678.0,
+                    "market_cap": 470_000_000_000_000.0,
+                    "category": "Semiconductors",
                     "roe": 20.0,
                     "gross_margin_ttm": 0.31,
-                    "snapshot_date": dt.date(2026, 6, 2),
+                    "snapshot_date": dt.date(2026, 6, 4),
                     "_screener_snapshot_state": "fresh",
                 }
             ],
-            valuation_partition_date=dt.date(2026, 6, 2),
-            fundamentals_partition_date=dt.date(2025, 12, 31),
-            fundamentals_collected_at=dt.datetime(2026, 6, 2, tzinfo=dt.UTC),
+            valuation_partition_date=dt.date(2026, 6, 4),
+            fundamentals_partition_date=dt.date(2026, 6, 4),
+            fundamentals_collected_at=dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
             fundamentals_state="fresh",
         )
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.fundamentals_screener.load_fundamentals_preset_from_snapshots",
-        _fake_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
     result = await screener_service.build_screener_results(
         preset_id="profitable_company",
         market="kr",
@@ -82,9 +94,16 @@ async def test_profitable_company_uses_fundamentals_loader_and_is_snapshot_only(
         resolver=_MockResolver(),
     )
     assert [row.symbol for row in result.results] == ["005930"]
-    assert result.freshness.primary.source == "market_valuation_snapshots"
-    dep_kinds = {d.kind for d in result.freshness.dependencies}
-    assert "fundamentals" in dep_kinds
+    # filled row fields come straight from the tvscreener snapshot
+    row = result.results[0]
+    assert row.name == "삼성전자"
+    assert row.category == "Semiconductors"
+    assert row.priceLabel != "-"
+    assert row.metricValueLabel == "20.0%"  # profitable_company metric=roe
+    assert result.freshness.primary.source == _FUNDAMENTALS_SOURCE
+    deps = {d.kind: d for d in result.freshness.dependencies}
+    assert "fundamentals" in deps
+    assert deps["fundamentals"].source == _FUNDAMENTALS_SOURCE
 
 
 @pytest.mark.asyncio
@@ -97,10 +116,7 @@ async def test_profitable_company_missing_when_loader_returns_none(monkeypatch):
     async def _none_loader(session, *, market, spec, limit, now):
         return None
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.fundamentals_screener.load_fundamentals_preset_from_snapshots",
-        _none_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _none_loader)
     result = await screener_service.build_screener_results(
         preset_id="profitable_company",
         market="kr",
@@ -122,22 +138,15 @@ async def test_stable_growth_routes_to_fundamentals_loader(monkeypatch):
 
     async def _fake_loader(session, *, market, spec, limit, now):
         captured["preset_id"] = spec.preset_id
-        from app.services.invest_view_model.fundamentals_screener import (
-            FundamentalsScreenResult,
-        )
-
         return FundamentalsScreenResult(
             rows=[],
-            valuation_partition_date=dt.date(2026, 6, 2),
+            valuation_partition_date=dt.date(2026, 6, 4),
             fundamentals_partition_date=None,
             fundamentals_collected_at=None,
             fundamentals_state="missing",
         )
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.fundamentals_screener.load_fundamentals_preset_from_snapshots",
-        _fake_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
     result = await screener_service.build_screener_results(
         preset_id="stable_growth",
         market="kr",
@@ -146,14 +155,16 @@ async def test_stable_growth_routes_to_fundamentals_loader(monkeypatch):
         resolver=_MockResolver(),
     )
     assert captured["preset_id"] == "stable_growth"  # registry routed the right spec
-    assert result.freshness.primary.source == "market_valuation_snapshots"
+    assert result.freshness.primary.source == _FUNDAMENTALS_SOURCE
     assert "fundamentals" in {d.kind for d in result.freshness.dependencies}
 
 
 @pytest.mark.asyncio
-async def test_cheap_value_empty_fundamentals_surfaces_missing_dependency(monkeypatch):
-    from app.services.invest_view_model.fundamentals_screener import (
-        FundamentalsScreenResult,
+async def test_steady_dividend_surfaces_streak_skip_warning(monkeypatch):
+    """ROB-428 PR-B: the honest earnings-streak skip warning must reach the
+    response warnings when the loader returns it."""
+    from app.services.invest_view_model.kr_fundamentals_tv_screener import (
+        EARNINGS_STREAK_SKIP_WARNING,
     )
 
     monkeypatch.setattr(
@@ -161,20 +172,56 @@ async def test_cheap_value_empty_fundamentals_surfaces_missing_dependency(monkey
         lambda service: True,
     )
 
+    async def _fake_loader(session, *, market, spec, limit, now):
+        return FundamentalsScreenResult(
+            rows=[
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "name": "삼성전자",
+                    "close": 78000.0,
+                    "dividend_yield": 3.5,
+                    "snapshot_date": dt.date(2026, 6, 4),
+                    "_screener_snapshot_state": "fresh",
+                }
+            ],
+            valuation_partition_date=dt.date(2026, 6, 4),
+            fundamentals_partition_date=dt.date(2026, 6, 4),
+            fundamentals_collected_at=dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
+            fundamentals_state="fresh",
+            warnings=[EARNINGS_STREAK_SKIP_WARNING],
+        )
+
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
+    result = await screener_service.build_screener_results(
+        preset_id="steady_dividend",
+        market="kr",
+        session=_MockSession(),
+        screening_service=_StubScreening(),
+        resolver=_MockResolver(),
+    )
+    assert [row.symbol for row in result.results] == ["005930"]
+    assert EARNINGS_STREAK_SKIP_WARNING in result.warnings
+
+
+@pytest.mark.asyncio
+async def test_cheap_value_empty_fundamentals_surfaces_missing_dependency(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._should_use_snapshot_first",
+        lambda service: True,
+    )
+
     async def _empty_fundamentals_loader(session, *, market, spec, limit, now):
-        # valuation partition exists, but no fundamentals rows backfilled (Path B).
+        # partition exists, but no qualifying rows (Path B → missing dependency).
         return FundamentalsScreenResult(
             rows=[],
-            valuation_partition_date=dt.date(2026, 6, 2),
+            valuation_partition_date=dt.date(2026, 6, 4),
             fundamentals_partition_date=None,
             fundamentals_collected_at=None,
             fundamentals_state="missing",
         )
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.fundamentals_screener.load_fundamentals_preset_from_snapshots",
-        _empty_fundamentals_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _empty_fundamentals_loader)
     result = await screener_service.build_screener_results(
         preset_id="cheap_value",
         market="kr",
@@ -187,12 +234,15 @@ async def test_cheap_value_empty_fundamentals_surfaces_missing_dependency(monkey
         d for d in result.freshness.dependencies if d.kind == "fundamentals"
     ]
     assert fundamentals_deps and fundamentals_deps[0].dataState == "missing"
+    assert fundamentals_deps[0].source == _FUNDAMENTALS_SOURCE
 
 
 @pytest.mark.asyncio
 async def test_undervalued_breakout_routes_snapshot_only_no_fundamentals_dependency(
     monkeypatch,
 ):
+    # ROB-428 PR-B leaves undervalued_breakout on its CURRENT (market_valuation)
+    # loader — it is NOT one of the 7 rerouted presets.
     monkeypatch.setattr(
         "app.services.invest_view_model.screener_service._should_use_snapshot_first",
         lambda service: True,
@@ -209,7 +259,7 @@ async def test_undervalued_breakout_routes_snapshot_only_no_fundamentals_depende
                 "high_52w": 100.0,
                 "high_52w_proximity": 0.96,
                 "latest_close": 96.0,
-                "snapshot_date": dt.date(2026, 6, 2),
+                "snapshot_date": dt.date(2026, 6, 4),
                 "_screener_snapshot_state": "fresh",
             }
         ]


### PR DESCRIPTION
## What & why (ROB-428)

KR `/invest/screener` fundamentals presets showed near-empty results with `-` cells (아직 저렴한 가치주 Toss **549** vs auto_trader **10**; 저평가 성장주 **187** vs **3**). Root cause: fundamentals **coverage** (DART backfill not run) + fundamentals-preset **row enrichment** gap. A probe showed the `tvscreener` **library** (scanner API, not browser-crawl) populates KR fundamentals at **80–100%** (ROE/payout/gross_margin/growth/QoQ/continuous_dividend_payout+growth/52wH/sector/industry). So the screener **display** is now backed by a tvscreener KR snapshot (PIT not needed for display); DART stays for reports/PIT.

Goal is **comparable + honest** parity (exact Toss stock-set is structurally impossible: different vendor/universe/as-of), not byte-identical.

## Contents (spec + 2 slices on one branch — PR-B depends on PR-A)

**PR-A — tvscreener-backed KR snapshot** (mirrors the crypto snapshot pattern)
- New `invest_kr_fundamentals_snapshots` table (additive migration, single head `20260604_rob428`) + model/repository/builder/provider/job/CLI.
- `TvScreenerKrFundamentalsProvider` → `query_stock_screener(Market.KOREA, …)` (library scanner API; **no kr.tradingview.com crawl**). dry-run default; `--commit` to persist.

**PR-B — read-path reroute** (display only)
- The 7 fundamentals presets (cheap_value, steady_dividend, profitable_company, undervalued_growth, stable_growth, future_dividend_king, growth_expectation_toss) now read the tvscreener snapshot via `load_kr_fundamentals_preset_from_tv_snapshot` (same `FundamentalsScreenResult` contract) → rows fill price/change/volume/**category(industry)**/market_cap + metrics; count gap closes.
- **DART loader untouched** (reports/PIT, ROB-330). Reports candidate_universe collector untouched.

## Honest divergences (no fabrication)
- `min_earnings_increase_streak_years` — no tvscreener column → **skipped + warning** surfaced ("순이익 연속증가 조건은 tvscreener 미제공으로 미적용"). Affects steady_dividend/stable_growth/future_dividend_king.
- 3yr-avg growth → tvscreener **YoY proxy** (documented; comparable, not identical).
- Fail-closed on NULL required columns. Names from `KRSymbolUniverse` (snapshot `name` is the ticker for KR).

## Verification (run locally)
- `pytest -k "kr_fundamentals or fundamentals_screener or screener_service or screener_preset or invest_screener"` → **407 passed, 1 skipped** (skip = prefect-not-a-dep).
- PR-A live integration: real KR `fetch_rows(8)` returns populated rows (ROE 8/8, continuous_dividend_payout 8/8, industry 8/8).
- `ruff check` + `ruff format --check` clean; `alembic heads` single (no new migration in PR-B).

## ⚠️ Pre-existing (NOT this PR)
`tests/services/action_report/test_candidate_universe_collector_evidence.py::{test_kr_collector_sources_consecutive_gainers_preset, test_kr_preset_pool_wider_than_limit_is_capped}` fail on **baseline `d4ad9c3f`** too (verified) — pre-existing `KeyError: 'candidates'` in the reports collector, unrelated to ROB-428.

## Boundaries / operator follow-ups
- No broker/order/watch/order-intent/trade-journal mutation. Additive migration only (operator runs `alembic upgrade`). tvscreener snapshot `--commit` backfill is operator-gated. No scheduler activation.
- Out of scope (follow-up): high_yield_value / undervalued_breakout migration to the tv snapshot (still on valuation loaders; category `-` remains for those 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean stock fundamentals snapshot system with daily data from TV Screener integration.
  * Introduced honest-divergence warnings to highlight missing or unavailable metrics in fundamentals results.
  * Fundamentals preset filters now source from the new snapshot system for improved data consistency.

* **Documentation**
  * Added design specification document for Korean fundamentals parity initiative.

* **Tests**
  * Added comprehensive test coverage for snapshot building, repository operations, and preset filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->