### PR TITLE
feat(ROB-428): PR-C — route high_yield_value + undervalued_breakout to tvscreener KR snapshot

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -53,6 +53,10 @@ class FundamentalsPresetSpec:
     min_dividend_paid_streak_years: int | None = None  # years (3)
     min_payout_ratio: Decimal | None = None  # percent (30) — DART 현금배당성향%
     min_earnings_growth_qoq: Decimal | None = None  # ratio (0.10)
+    # ROB-428 PR-C: 52-week-high proximity = price / week_high_52 (e.g. 0.95).
+    # Derive-style threshold for the tvscreener KR loader ONLY; the DART loader
+    # ignores it (no DART preset uses it).
+    min_high_52w_proximity: Decimal | None = None  # price / week_high_52 >= threshold
     sort_by: str = "roe"  # any metric key carried on the output row
 
 
@@ -112,6 +116,26 @@ GROWTH_EXPECTATION_TOSS_SPEC = FundamentalsPresetSpec(
     sort_by="earnings_growth_qoq",
 )
 
+# ROB-428 PR-C: the last 2 KR Toss valuation presets, rerouted onto the tvscreener
+# KR snapshot (replicates the OLD load_high_yield_value/undervalued_breakout rules
+# exactly so display fills category + uses tvscreener's 100% ROE coverage).
+# high_yield_value: ROE >= 15 + 0 < PER <= 10.
+HIGH_YIELD_VALUE_SPEC = FundamentalsPresetSpec(
+    preset_id="high_yield_value",
+    min_roe=Decimal("15"),
+    max_per=Decimal("10"),
+    sort_by="roe",
+)
+
+# undervalued_breakout: 0 < PER <= 10 + 0 < PBR <= 1 + 52w-high proximity >= 0.95.
+UNDERVALUED_BREAKOUT_SPEC = FundamentalsPresetSpec(
+    preset_id="undervalued_breakout",
+    max_per=Decimal("10"),
+    max_pbr=Decimal("1"),
+    min_high_52w_proximity=Decimal("0.95"),
+    sort_by="high_52w_proximity",
+)
+
 FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {
     s.preset_id: s
     for s in (
@@ -122,6 +146,8 @@ FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {
         CHEAP_VALUE_SPEC,
         STEADY_DIVIDEND_SPEC,
         GROWTH_EXPECTATION_TOSS_SPEC,
+        HIGH_YIELD_VALUE_SPEC,
+        UNDERVALUED_BREAKOUT_SPEC,
     )
 }
 

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -88,7 +88,23 @@ _SORT_KEY_TO_ROW_KEY: dict[str, str] = {
     "earnings_growth_3y_avg": "earnings_growth_3y_avg",
     "earnings_growth_qoq": "earnings_growth_qoq",
     "payout_ratio": "payout_ratio",
+    # ROB-428 PR-C: undervalued_breakout sorts by 52w-high proximity (price/high).
+    "high_52w_proximity": "high_52w_proximity",
 }
+
+
+def _high_52w_proximity(snap: InvestKrFundamentalsSnapshot) -> Decimal | None:
+    """price / week_high_52, or None when either is missing or week_high_52 <= 0.
+
+    ROB-428 PR-C: this is a *derived* threshold (not a single-column compare), so
+    it is checked explicitly in :func:`_passes_thresholds` and emitted in
+    :func:`_build_row` rather than via the ``_THRESHOLD_CHECKS`` column tuples.
+    """
+    price = snap.price
+    high = snap.week_high_52
+    if price is None or high is None or high <= 0:
+        return None
+    return Decimal(str(price)) / Decimal(str(high))
 
 
 def _to_float(value: Any) -> float | None:
@@ -220,6 +236,17 @@ def _passes_thresholds(
         else:
             if Decimal(str(value)) < Decimal(str(threshold)):
                 return False, f"{col_attr} below min"
+
+    # ROB-428 PR-C: 52-week-high proximity is a derived (price/week_high_52)
+    # threshold, not a single-column compare, so it is checked explicitly here
+    # (fail-closed: NULL price / NULL-or-zero week_high_52 excludes the row).
+    if spec.min_high_52w_proximity is not None:
+        proximity = _high_52w_proximity(snap)
+        if proximity is None:
+            return False, "high_52w_proximity unavailable"
+        if proximity < Decimal(str(spec.min_high_52w_proximity)):
+            return False, "high_52w_proximity below min"
+
     return True, None
 
 
@@ -256,6 +283,13 @@ def _build_row(
         "dividend_growth_streak_years": _to_float(snap.continuous_dividend_growth),
         "earnings_increase_streak_years": None,  # tvscreener does not provide it
         "rsi": _to_float(snap.rsi14),
+        # ROB-428 PR-C: 52w-high proximity metric (_METRIC_FIELD["undervalued_breakout"]
+        # = "high_52w_proximity") + the raw 52-week high for completeness. None when
+        # price / week_high_52 cannot be derived (missing or week_high_52 <= 0).
+        "week_high_52": _to_float(snap.week_high_52),
+        "high_52w_proximity": (
+            float(prox) if (prox := _high_52w_proximity(snap)) is not None else None
+        ),
         "_screener_snapshot_state": state,
         "snapshot_date": partition_date,
     }

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1705,34 +1705,13 @@ async def build_screener_results(
             _snapshot_empty_warning = (
                 "최신 수급/시세 스냅샷에서 쌍끌이 매수 조건에 맞는 종목이 없습니다."
             )
-        elif preset_id == "high_yield_value":
-            from app.services.invest_view_model.high_yield_value_screener import (
-                load_high_yield_value_from_snapshots,
-            )
-
-            _snapshot_check_result = await load_high_yield_value_from_snapshots(
-                session,
-                market=requested_market,
-                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
-            )
-            _snapshot_empty_warning = (
-                "최신 밸류에이션 스냅샷에서 고수익 저평가 조건(ROE 15%↑·PER 0~10)에 "
-                "맞는 종목이 없습니다."
-            )
-        elif preset_id == "undervalued_breakout":
-            from app.services.invest_view_model.undervalued_breakout_screener import (
-                load_undervalued_breakout_from_snapshots,
-            )
-
-            _snapshot_check_result = await load_undervalued_breakout_from_snapshots(
-                session,
-                market=requested_market,
-                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
-            )
-            _snapshot_empty_warning = (
-                "최신 밸류에이션/시세 스냅샷에서 저평가 탈출 조건"
-                "(PER 0~10·PBR 0~1·신고가 근접)에 맞는 종목이 없습니다."
-            )
+        # ROB-428 PR-C: high_yield_value + undervalued_breakout no longer have a
+        # dedicated dispatch branch. They are now registered in
+        # FUNDAMENTALS_PRESET_SPECS and fall into the tvscreener KR loader below
+        # (same path as the 7 fundamentals presets), so display fills category and
+        # uses tvscreener's full ROE coverage. The OLD valuation loaders
+        # (load_high_yield_value_from_snapshots / load_undervalued_breakout_from_snapshots)
+        # stay in place for reports/PIT (candidate_universe collector) and are untouched.
         elif preset_id in FUNDAMENTALS_PRESET_SPECS:
             # ROB-428 PR-B: KR display reads the tvscreener-backed snapshot
             # (invest_kr_fundamentals_snapshots) so result rows fill price/change/
@@ -1793,19 +1772,10 @@ async def build_screener_results(
         _snapshot_state_override = "missing"
         _snapshot_empty_warning = "수급 또는 시세 스냅샷이 아직 적재되지 않아 쌍끌이 매수 후보를 표시할 수 없습니다."
 
-    if preset_id == "high_yield_value" and _snapshot_check_result is None:
-        # snapshot-only preset; the generic provider has no ROE filter and could
-        # half-apply (PER only) the rule — never fall through to it.
-        _snapshot_check_result = []
-        _snapshot_state_override = "missing"
-        _snapshot_empty_warning = "밸류에이션 스냅샷이 아직 적재되지 않아 고수익 저평가 후보를 표시할 수 없습니다."
-
-    if preset_id == "undervalued_breakout" and _snapshot_check_result is None:
-        # snapshot-only; the generic provider has no 52-week-high proximity filter.
-        _snapshot_check_result = []
-        _snapshot_state_override = "missing"
-        _snapshot_empty_warning = "밸류에이션/시세 스냅샷이 아직 적재되지 않아 저평가 탈출 후보를 표시할 수 없습니다."
-
+    # ROB-428 PR-C: high_yield_value + undervalued_breakout are now in
+    # FUNDAMENTALS_PRESET_SPECS, so their None-handling (loader returned None →
+    # dataState=missing, never fall through to the generic provider) is covered by
+    # the shared block below. The dedicated valuation-only None blocks were removed.
     if preset_id in FUNDAMENTALS_PRESET_SPECS and _snapshot_check_result is None:
         # snapshot-only; the generic provider has neither a gross-margin nor a
         # fundamentals filter and could half-apply the rule — never fall through.
@@ -1924,12 +1894,11 @@ async def build_screener_results(
         primary_kind = "screener_snapshot"
         if preset_id == "investor_flow_momentum":
             primary_source = "investor_flow_snapshots"
-        elif preset_id == "high_yield_value":
-            primary_source = "market_valuation_snapshots"
-        elif preset_id == "undervalued_breakout":
-            primary_source = "market_valuation_snapshots"
         elif preset_id in FUNDAMENTALS_PRESET_SPECS:
             # ROB-428 PR-B: KR display now reads the tvscreener KR snapshot.
+            # ROB-428 PR-C: high_yield_value + undervalued_breakout joined this
+            # branch (dropped their market_valuation_snapshots primary_source) so
+            # all KR Toss fundamentals/valuation presets report the same source.
             primary_source = "invest_kr_fundamentals_snapshots"
         elif requested_market == "crypto":
             primary_source = "invest_crypto_screener_snapshots"

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -163,11 +163,14 @@ def test_ranking_by_roe_desc_nulls_last_and_limit_trim():
     assert [r["symbol"] for r in rows_all] == ["A", "F", "C", "E", "B", "D"]
 
 
-def test_registry_has_seven_specs_with_expected_thresholds():
+def test_registry_has_nine_specs_with_expected_thresholds():
     from app.services.invest_view_model.fundamentals_screener import (
         FUNDAMENTALS_PRESET_SPECS,
     )
 
+    # ROB-428 PR-C: high_yield_value + undervalued_breakout (the last 2 KR Toss
+    # valuation presets) were rerouted onto the tvscreener KR loader, so they now
+    # live in this registry alongside the 7 fundamentals presets.
     assert set(FUNDAMENTALS_PRESET_SPECS) == {
         "profitable_company",
         "undervalued_growth",
@@ -176,6 +179,8 @@ def test_registry_has_seven_specs_with_expected_thresholds():
         "cheap_value",
         "steady_dividend",
         "growth_expectation_toss",
+        "high_yield_value",
+        "undervalued_breakout",
     }
     ug = FUNDAMENTALS_PRESET_SPECS["undervalued_growth"]
     assert ug.max_per == Decimal("20") and ug.min_revenue_growth_3y_avg == Decimal(
@@ -195,6 +200,15 @@ def test_registry_has_seven_specs_with_expected_thresholds():
         dk.min_dividend_growth_streak_years == 3
         and dk.min_earnings_increase_streak_years == 3
     )
+    # ROB-428 PR-C: replicate the OLD valuation loaders' thresholds exactly.
+    hyv = FUNDAMENTALS_PRESET_SPECS["high_yield_value"]
+    assert hyv.min_roe == Decimal("15") and hyv.max_per == Decimal("10")
+    assert hyv.sort_by == "roe"
+    assert hyv.min_high_52w_proximity is None  # not a breakout preset
+    ub = FUNDAMENTALS_PRESET_SPECS["undervalued_breakout"]
+    assert ub.max_per == Decimal("10") and ub.max_pbr == Decimal("1")
+    assert ub.min_high_52w_proximity == Decimal("0.95")
+    assert ub.sort_by == "high_52w_proximity"
 
 
 def _growth_period(year, *, revenue, net_income, filing_date):

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -25,9 +25,11 @@ from app.services.invest_view_model.fundamentals_screener import (
     CHEAP_VALUE_SPEC,
     FUTURE_DIVIDEND_KING_SPEC,
     GROWTH_EXPECTATION_TOSS_SPEC,
+    HIGH_YIELD_VALUE_SPEC,
     PROFITABLE_COMPANY_SPEC,
     STABLE_GROWTH_SPEC,
     STEADY_DIVIDEND_SPEC,
+    UNDERVALUED_BREAKOUT_SPEC,
     UNDERVALUED_GROWTH_SPEC,
 )
 from app.services.invest_view_model.kr_fundamentals_tv_screener import (
@@ -506,3 +508,234 @@ async def test_stable_growth_includes_via_roe_and_yoy_skips_streak(db_session):
     assert result is not None
     assert [r["symbol"] for r in result.rows] == [sym]
     assert EARNINGS_STREAK_SKIP_WARNING in result.warnings
+
+
+# ---------------------------------------------------------------------------
+# ROB-428 PR-C: high_yield_value + undervalued_breakout (rerouted valuation presets)
+# ---------------------------------------------------------------------------
+
+
+async def test_high_yield_value_roe_and_per_bounds(db_session):
+    """high_yield_value: ROE >= 15 AND 0 < PER <= 10 (replicates the OLD loader)."""
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}A0"
+    sym_low_roe = f"{_PREFIX}A1"
+    sym_high_per = f"{_PREFIX}A2"
+    sym_neg_per = f"{_PREFIX}A3"
+    sym_null_roe = f"{_PREFIX}A4"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                price=Decimal("8000"),
+                change_rate=Decimal("0.5"),
+                volume=Decimal("500000"),
+                market_cap=Decimal("9000000000000"),
+                roe_ttm=Decimal("18"),  # >= 15
+                per=Decimal("8"),  # 0 < per <= 10
+                sector="Financials",
+                industry="Banks",
+            ),
+            _snap(
+                sym_low_roe,
+                market_cap=Decimal("8000000000000"),
+                roe_ttm=Decimal("9"),  # < 15 → excluded
+                per=Decimal("5"),
+            ),
+            _snap(
+                sym_high_per,
+                market_cap=Decimal("7000000000000"),
+                roe_ttm=Decimal("25"),
+                per=Decimal("12"),  # > 10 → excluded
+            ),
+            _snap(
+                sym_neg_per,
+                market_cap=Decimal("6000000000000"),
+                roe_ttm=Decimal("20"),
+                per=Decimal("-3"),  # per <= 0 → excluded (require_positive)
+            ),
+            _snap(
+                sym_null_roe,
+                market_cap=Decimal("5000000000000"),
+                roe_ttm=None,  # NULL roe → fail-closed exclude
+                per=Decimal("6"),
+            ),
+        ],
+        [
+            _universe(sym_pass, "고수익저평가"),
+            _universe(sym_low_roe, "낮은ROE"),
+            _universe(sym_high_per, "고PER"),
+            _universe(sym_neg_per, "적자기업"),
+            _universe(sym_null_roe, "ROE없음"),
+        ],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=HIGH_YIELD_VALUE_SPEC,
+        limit=20,
+        now=_now,
+        universe_count=5,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+    row = result.rows[0]
+    # high_yield_value metric is ROE (must be emitted) + category filled.
+    assert row["roe"] == 18.0
+    assert row["per"] == 8.0
+    assert row["category"] == "Banks"
+    assert row["name"] == "고수익저평가"
+    assert row["close"] == 8000.0
+    assert row["_screener_snapshot_state"] == "fresh"
+
+
+async def test_high_yield_value_sorts_by_roe_desc(db_session):
+    await _cleanup(db_session)
+    sym_hi = f"{_PREFIX}A5"
+    sym_lo = f"{_PREFIX}A6"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_lo,
+                market_cap=Decimal("9000000000000"),  # bigger cap, lower ROE
+                roe_ttm=Decimal("16"),
+                per=Decimal("9"),
+            ),
+            _snap(
+                sym_hi,
+                market_cap=Decimal("3000000000000"),
+                roe_ttm=Decimal("35"),
+                per=Decimal("7"),
+            ),
+        ],
+        [_universe(sym_hi, "고ROE"), _universe(sym_lo, "저ROE")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=HIGH_YIELD_VALUE_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_hi, sym_lo]
+
+
+async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
+    """undervalued_breakout: 0<PER<=10, 0<PBR<=1, price/week_high_52 >= 0.95."""
+    await _cleanup(db_session)
+    sym_pass = f"{_PREFIX}B0"
+    sym_far_from_high = f"{_PREFIX}B1"
+    sym_high_pbr = f"{_PREFIX}B2"
+    sym_null_high = f"{_PREFIX}B3"
+    sym_zero_high = f"{_PREFIX}B4"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_pass,
+                price=Decimal("9700"),
+                change_rate=Decimal("1.0"),
+                volume=Decimal("700000"),
+                market_cap=Decimal("9000000000000"),
+                per=Decimal("8"),  # 0 < per <= 10
+                pbr=Decimal("0.8"),  # 0 < pbr <= 1
+                week_high_52=Decimal("10000"),  # 9700/10000 = 0.97 >= 0.95
+                sector="Industrials",
+                industry="Machinery",
+            ),
+            _snap(
+                sym_far_from_high,
+                market_cap=Decimal("8000000000000"),
+                per=Decimal("6"),
+                pbr=Decimal("0.7"),
+                price=Decimal("9000"),
+                week_high_52=Decimal("10000"),  # 0.90 < 0.95 → excluded
+            ),
+            _snap(
+                sym_high_pbr,
+                market_cap=Decimal("7000000000000"),
+                per=Decimal("5"),
+                pbr=Decimal("1.5"),  # > 1 → excluded
+                price=Decimal("9900"),
+                week_high_52=Decimal("10000"),
+            ),
+            _snap(
+                sym_null_high,
+                market_cap=Decimal("6000000000000"),
+                per=Decimal("4"),
+                pbr=Decimal("0.5"),
+                price=Decimal("5000"),
+                week_high_52=None,  # NULL high → proximity unavailable → excluded
+            ),
+            _snap(
+                sym_zero_high,
+                market_cap=Decimal("5000000000000"),
+                per=Decimal("4"),
+                pbr=Decimal("0.5"),
+                price=Decimal("5000"),
+                week_high_52=Decimal("0"),  # high <= 0 → proximity unavailable → excl
+            ),
+        ],
+        [
+            _universe(sym_pass, "저평가탈출"),
+            _universe(sym_far_from_high, "고가멀음"),
+            _universe(sym_high_pbr, "고PBR"),
+            _universe(sym_null_high, "고가없음"),
+            _universe(sym_zero_high, "고가0"),
+        ],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=UNDERVALUED_BREAKOUT_SPEC,
+        limit=20,
+        now=_now,
+        universe_count=5,
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_pass]
+    row = result.rows[0]
+    # undervalued_breakout metric is high_52w_proximity (must be emitted) + category.
+    assert row["high_52w_proximity"] == pytest.approx(0.97)
+    assert row["week_high_52"] == 10000.0
+    assert row["per"] == 8.0
+    assert row["pbr"] == 0.8
+    assert row["category"] == "Machinery"
+    assert row["name"] == "저평가탈출"
+    # The excluded rows record a reason (fail-closed, never silent pass).
+    excluded_syms = {e["symbol"] for e in result.excluded}
+    assert {sym_far_from_high, sym_high_pbr, sym_null_high, sym_zero_high} <= (
+        excluded_syms
+    )
+
+
+async def test_undervalued_breakout_sorts_by_proximity_desc(db_session):
+    await _cleanup(db_session)
+    sym_closer = f"{_PREFIX}B5"
+    sym_further = f"{_PREFIX}B6"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_further,
+                market_cap=Decimal("9000000000000"),  # bigger cap, lower proximity
+                per=Decimal("6"),
+                pbr=Decimal("0.6"),
+                price=Decimal("9600"),  # 0.96
+                week_high_52=Decimal("10000"),
+            ),
+            _snap(
+                sym_closer,
+                market_cap=Decimal("3000000000000"),
+                per=Decimal("7"),
+                pbr=Decimal("0.7"),
+                price=Decimal("9990"),  # 0.999
+                week_high_52=Decimal("10000"),
+            ),
+        ],
+        [_universe(sym_closer, "근접"), _universe(sym_further, "덜근접")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=UNDERVALUED_BREAKOUT_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    assert [r["symbol"] for r in result.rows] == [sym_closer, sym_further]

--- a/tests/test_screener_presets_pr2c2.py
+++ b/tests/test_screener_presets_pr2c2.py
@@ -18,7 +18,10 @@ def test_undervalued_breakout_preset_full_toss_parity_kr_only():
     assert p.presetOrigin == "toss_parity"
     assert p.parityStatus == "full"
     assert "undervalued_breakout" in _KR_ONLY_PRESET_IDS
-    # valuation-only: NOT a fundamentals-registry preset
-    assert "undervalued_breakout" not in FUNDAMENTALS_PRESET_SPECS
+    # ROB-428 PR-C: undervalued_breakout's DISPLAY read-path was rerouted onto the
+    # tvscreener KR snapshot, so it is now a fundamentals-registry preset (the OLD
+    # market_valuation loader is kept only for reports/PIT). Its Toss-parity preset
+    # definition (KR-only, full parity, filter chips) is unchanged.
+    assert "undervalued_breakout" in FUNDAMENTALS_PRESET_SPECS
     chip_labels = {c.label for c in p.filterChips}
     assert {"PER", "PBR", "신고가"} <= chip_labels

--- a/tests/test_screener_service_profitable_company.py
+++ b/tests/test_screener_service_profitable_company.py
@@ -238,36 +238,41 @@ async def test_cheap_value_empty_fundamentals_surfaces_missing_dependency(monkey
 
 
 @pytest.mark.asyncio
-async def test_undervalued_breakout_routes_snapshot_only_no_fundamentals_dependency(
-    monkeypatch,
-):
-    # ROB-428 PR-B leaves undervalued_breakout on its CURRENT (market_valuation)
-    # loader — it is NOT one of the 7 rerouted presets.
+async def test_undervalued_breakout_routes_to_fundamentals_loader(monkeypatch):
+    # ROB-428 PR-C: undervalued_breakout's DISPLAY read-path was rerouted onto the
+    # tvscreener KR snapshot (it is now a FUNDAMENTALS_PRESET_SPECS preset), so it
+    # routes through the same TV loader as the 7 fundamentals presets and reports
+    # the invest_kr_fundamentals_snapshots source + a fundamentals dependency.
     monkeypatch.setattr(
         "app.services.invest_view_model.screener_service._should_use_snapshot_first",
         lambda service: True,
     )
+    captured = {}
 
-    async def _fake_loader(session, *, market, limit, today_market_date=None):
-        return [
-            {
-                "symbol": "907001",
-                "market": "kr",
-                "name": "종목907001",
-                "per": 8.0,
-                "pbr": 0.8,
-                "high_52w": 100.0,
-                "high_52w_proximity": 0.96,
-                "latest_close": 96.0,
-                "snapshot_date": dt.date(2026, 6, 4),
-                "_screener_snapshot_state": "fresh",
-            }
-        ]
+    async def _fake_loader(session, *, market, spec, limit, now):
+        captured["preset_id"] = spec.preset_id
+        return FundamentalsScreenResult(
+            rows=[
+                {
+                    "symbol": "907001",
+                    "market": "kr",
+                    "name": "종목907001",
+                    "close": 96.0,
+                    "per": 8.0,
+                    "pbr": 0.8,
+                    "week_high_52": 100.0,
+                    "high_52w_proximity": 0.96,
+                    "snapshot_date": dt.date(2026, 6, 4),
+                    "_screener_snapshot_state": "fresh",
+                }
+            ],
+            valuation_partition_date=dt.date(2026, 6, 4),
+            fundamentals_partition_date=dt.date(2026, 6, 4),
+            fundamentals_collected_at=dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
+            fundamentals_state="fresh",
+        )
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.undervalued_breakout_screener.load_undervalued_breakout_from_snapshots",
-        _fake_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
     result = await screener_service.build_screener_results(
         preset_id="undervalued_breakout",
         market="kr",
@@ -275,26 +280,77 @@ async def test_undervalued_breakout_routes_snapshot_only_no_fundamentals_depende
         screening_service=_StubScreening(),
         resolver=_MockResolver(),
     )
+    assert captured["preset_id"] == "undervalued_breakout"  # registry routed the spec
     assert [r.symbol for r in result.results] == ["907001"]
-    assert result.freshness.primary.source == "market_valuation_snapshots"
-    # valuation-only: NO fundamentals dependency attached
-    assert "fundamentals" not in {d.kind for d in result.freshness.dependencies}
+    assert result.freshness.primary.source == _FUNDAMENTALS_SOURCE
+    # now consistent with the 7 fundamentals presets: a fundamentals dependency IS
+    # attached.
+    assert "fundamentals" in {d.kind for d in result.freshness.dependencies}
+
+
+@pytest.mark.asyncio
+async def test_high_yield_value_routes_to_fundamentals_loader(monkeypatch):
+    # ROB-428 PR-C: high_yield_value likewise rerouted onto the TV loader; its
+    # metric (ROE) renders from the filled snapshot row.
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._should_use_snapshot_first",
+        lambda service: True,
+    )
+    captured = {}
+
+    async def _fake_loader(session, *, market, spec, limit, now):
+        captured["preset_id"] = spec.preset_id
+        return FundamentalsScreenResult(
+            rows=[
+                {
+                    "symbol": "905930",
+                    "market": "kr",
+                    "name": "고수익저평가",
+                    "close": 8000.0,
+                    "category": "Banks",
+                    "roe": 18.0,
+                    "per": 8.0,
+                    "snapshot_date": dt.date(2026, 6, 4),
+                    "_screener_snapshot_state": "fresh",
+                }
+            ],
+            valuation_partition_date=dt.date(2026, 6, 4),
+            fundamentals_partition_date=dt.date(2026, 6, 4),
+            fundamentals_collected_at=dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
+            fundamentals_state="fresh",
+        )
+
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
+    result = await screener_service.build_screener_results(
+        preset_id="high_yield_value",
+        market="kr",
+        session=_MockSession(),
+        screening_service=_StubScreening(),
+        resolver=_MockResolver(),
+    )
+    assert captured["preset_id"] == "high_yield_value"
+    assert [r.symbol for r in result.results] == ["905930"]
+    row = result.results[0]
+    assert row.category == "Banks"
+    assert row.metricValueLabel == "18.0%"  # high_yield_value metric=roe
+    assert result.freshness.primary.source == _FUNDAMENTALS_SOURCE
+    assert "fundamentals" in {d.kind for d in result.freshness.dependencies}
 
 
 @pytest.mark.asyncio
 async def test_undervalued_breakout_missing_when_loader_none(monkeypatch):
+    # ROB-428 PR-C: None from the TV loader → dataState=missing (handled by the
+    # shared FUNDAMENTALS_PRESET_SPECS None branch, never falls through to the
+    # generic provider).
     monkeypatch.setattr(
         "app.services.invest_view_model.screener_service._should_use_snapshot_first",
         lambda service: True,
     )
 
-    async def _none_loader(session, *, market, limit, today_market_date=None):
+    async def _none_loader(session, *, market, spec, limit, now):
         return None
 
-    monkeypatch.setattr(
-        "app.services.invest_view_model.undervalued_breakout_screener.load_undervalued_breakout_from_snapshots",
-        _none_loader,
-    )
+    monkeypatch.setattr(_TV_LOADER_PATH, _none_loader)
     result = await screener_service.build_screener_results(
         preset_id="undervalued_breakout",
         market="kr",


### PR DESCRIPTION
## What & why (ROB-428 follow-up, after #1115)

Completes KR Toss screener parity: the **last 2 valuation presets** — `high_yield_value` (ROE≥15 + 0<PER≤10) and `undervalued_breakout` (0<PER≤10 + 0<PBR≤1 + 52w-high proximity ≥95%) — now read the **tvscreener KR snapshot** (`invest_kr_fundamentals_snapshots`) via the PR-B loader, exactly like the 7 fundamentals presets. So they fill **category (industry)** + use tvscreener's 100% ROE coverage, and **all** KR Toss fundamentals/valuation presets are consistent.

## Changes
- `FundamentalsPresetSpec` gains `min_high_52w_proximity`; `HIGH_YIELD_VALUE_SPEC` + `UNDERVALUED_BREAKOUT_SPEC` added to `FUNDAMENTALS_PRESET_SPECS` (thresholds replicate the old loaders exactly).
- tv loader (`load_kr_fundamentals_preset_from_tv_snapshot`): 52w-high proximity = `price / week_high_52` (fail-closed on null / week_high_52≤0), emits `high_52w_proximity` + `week_high_52`, sorts by proximity for undervalued_breakout.
- `screener_service` dispatch: removed the 2 dedicated branches (loader dispatch + None-handling + primary_source) so both presets route through the `FUNDAMENTALS_PRESET_SPECS` tvscreener path (`primary_source=invest_kr_fundamentals_snapshots`). `_METRIC_FIELD` unchanged.

## Boundaries / preserved
- **DISPLAY read-path only.** Old loaders (`load_high_yield_value_from_snapshots`/`load_undervalued_breakout_from_snapshots`) **kept** — reports candidate_universe collector still calls the high_yield_value loader. No migration, no broker/order/watch, no scheduler.

## Verification (local)
- `pytest -k "kr_fundamentals or fundamentals_screener or screener_service or screener_preset or invest_screener or high_yield or undervalued or toss_parity"` → **426 passed, 1 skipped**.
- ruff check + format clean; `alembic heads` single (no new migration).
- 2 `test_candidate_universe_collector_evidence` failures are **pre-existing** (`KeyError: 'candidates'`, reproduced on clean main `27da5f49`; collector path untouched; CI passes them on a clean DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)