### PR TITLE
fix(ROB-429): guard KR fundamentals full-universe snapshots

### DIFF
--- a/app/jobs/invest_kr_fundamentals_snapshots.py
+++ b/app/jobs/invest_kr_fundamentals_snapshots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, replace
 from typing import Any
 
 from app.core.db import AsyncSessionLocal
@@ -8,11 +9,19 @@ from app.services.invest_kr_fundamentals_snapshots.builder import (
     build_kr_fundamentals_snapshots,
 )
 from app.services.invest_kr_fundamentals_snapshots.provider import (
+    KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT,
+    KR_FUNDAMENTALS_FULL_FETCH_UNIVERSE_BUFFER,
     TvScreenerKrFundamentalsProvider,
 )
 from app.services.invest_kr_fundamentals_snapshots.repository import (
     InvestKrFundamentalsSnapshotsRepository,
 )
+from app.services.invest_screener_snapshots.partition_health import (
+    active_universe_count,
+)
+from app.services.snapshot_commit_guard import assert_min_coverage
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -22,10 +31,32 @@ class KrFundamentalsSnapshotBuildRequest:
     commit: bool = False
 
 
+async def _fetch_limit_for_request(
+    request: KrFundamentalsSnapshotBuildRequest,
+    *,
+    universe_count: int | None = None,
+) -> int | None:
+    if not request.all_symbols:
+        return request.limit
+    if universe_count is None:
+        async with AsyncSessionLocal() as session:
+            universe_count = await active_universe_count(session, market="kr")
+    if universe_count and universe_count > 0:
+        return max(
+            KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT,
+            universe_count + KR_FUNDAMENTALS_FULL_FETCH_UNIVERSE_BUFFER,
+        )
+    logger.warning(
+        "KR fundamentals full-universe fetch falling back to provider floor: "
+        "active universe count is unavailable"
+    )
+    return None
+
+
 async def run_kr_fundamentals_snapshot_build(
     request: KrFundamentalsSnapshotBuildRequest,
 ) -> dict[str, Any]:
-    limit = None if request.all_symbols else request.limit
+    limit = await _fetch_limit_for_request(request)
     async with AsyncSessionLocal() as session:
         result = await build_kr_fundamentals_snapshots(
             provider=TvScreenerKrFundamentalsProvider(),
@@ -38,3 +69,33 @@ async def run_kr_fundamentals_snapshot_build(
         else:
             await session.rollback()
         return result
+
+
+async def run_kr_fundamentals_snapshot_build_guarded(
+    request: KrFundamentalsSnapshotBuildRequest,
+) -> dict[str, Any]:
+    """Two-pass coverage-guarded commit for KR fundamentals snapshots.
+
+    A no-commit pass first validates the provider can build enough rows relative
+    to the active KR universe.  If the build is thin (for example the historical
+    200-row default), ``assert_min_coverage`` raises ``PartialCommitBlocked`` and
+    the committing pass never runs.  ``--allow-partial`` callers should route to
+    ``run_kr_fundamentals_snapshot_build`` directly.
+    """
+    async with AsyncSessionLocal() as session:
+        universe_count = await active_universe_count(session, market="kr")
+    if universe_count <= 0:
+        logger.warning(
+            "KR fundamentals commit guard disabled: active universe count is 0 "
+            "(coverage could not be verified)"
+        )
+
+    dry_request = replace(request, commit=False)
+    dry = await run_kr_fundamentals_snapshot_build(dry_request)
+    assert_min_coverage(
+        int(dry.get("would_upsert") or 0),
+        universe_count,
+        market="kr",
+        metric="fundamentals rows",
+    )
+    return await run_kr_fundamentals_snapshot_build(request)

--- a/app/services/invest_kr_fundamentals_snapshots/provider.py
+++ b/app/services/invest_kr_fundamentals_snapshots/provider.py
@@ -15,6 +15,14 @@ from app.services.tvscreener_service import (
 
 logger = logging.getLogger(__name__)
 
+# TradingView/tvscreener defaults to a tiny range (150 rows) when no explicit
+# range is set. ROB-429 full-universe builds must therefore pass an explicit
+# large range instead of treating ``limit=None`` as the previous 200-row smoke
+# default. The job layer may choose an even larger value from the active KR
+# universe count + buffer; this floor keeps direct provider use broad as well.
+KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT = 6_000
+KR_FUNDAMENTALS_FULL_FETCH_UNIVERSE_BUFFER = 1_000
+
 # (model_key, [StockField name fallbacks]) — version-safe field resolution.
 # Probe-validated against tvscreener KOREA market (ROB-428, 2026-06-04).
 _KR_STOCK_FIELD_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -92,7 +100,11 @@ class TvScreenerKrFundamentalsProvider:
     async def fetch_rows(
         self, *, limit: int | None = None
     ) -> list[KrFundamentalsProviderRow]:
-        query_limit = limit or 200
+        query_limit = (
+            KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT if limit is None else int(limit)
+        )
+        if query_limit <= 0:
+            return []
         tvscreener = _import_tvscreener()
         stock_field = tvscreener.StockField
         market = tvscreener.Market

--- a/scripts/build_invest_kr_fundamentals_snapshots.py
+++ b/scripts/build_invest_kr_fundamentals_snapshots.py
@@ -16,7 +16,9 @@ from app.core.cli import setup_logging_and_sentry
 from app.jobs.invest_kr_fundamentals_snapshots import (
     KrFundamentalsSnapshotBuildRequest,
     run_kr_fundamentals_snapshot_build,
+    run_kr_fundamentals_snapshot_build_guarded,
 )
+from app.services.snapshot_commit_guard import PartialCommitBlocked
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -34,6 +36,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Actually write to the database. Default is dry-run/no writes.",
     )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help=(
+            "Acknowledge and commit a partial/thin KR fundamentals build, "
+            "bypassing the active-universe coverage guard. Use only for "
+            "small backfills with explicit operator approval."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.all and args.limit != 200:
         parser.error("--all is mutually exclusive with --limit")
@@ -41,13 +52,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace) -> int:
-    result = await run_kr_fundamentals_snapshot_build(
-        KrFundamentalsSnapshotBuildRequest(
-            limit=args.limit,
-            all_symbols=args.all,
-            commit=args.commit,
-        )
+    request = KrFundamentalsSnapshotBuildRequest(
+        limit=args.limit,
+        all_symbols=args.all,
+        commit=args.commit,
     )
+    try:
+        if args.commit and not args.allow_partial:
+            result = await run_kr_fundamentals_snapshot_build_guarded(request)
+        else:
+            result = await run_kr_fundamentals_snapshot_build(request)
+    except PartialCommitBlocked as exc:
+        print(f"\nCOMMIT BLOCKED: {exc}\n")
+        return 2
     print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
     if not args.commit:
         print(

--- a/tests/test_invest_kr_fundamentals_snapshots_job.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_job.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import pandas as pd
 import pytest
 from sqlalchemy import text
 
+from app.jobs import invest_kr_fundamentals_snapshots as job
 from app.jobs.invest_kr_fundamentals_snapshots import (
     KrFundamentalsSnapshotBuildRequest,
     run_kr_fundamentals_snapshot_build,
+    run_kr_fundamentals_snapshot_build_guarded,
 )
+from app.services.invest_kr_fundamentals_snapshots import provider as provider_mod
 from app.services.invest_kr_fundamentals_snapshots.builder import (
     KrFundamentalsProviderRow,
 )
+from app.services.invest_kr_fundamentals_snapshots.provider import (
+    KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT,
+    TvScreenerKrFundamentalsProvider,
+)
+from app.services.snapshot_commit_guard import PartialCommitBlocked
+from scripts import build_invest_kr_fundamentals_snapshots as cli
 
 _JOB_SYMBOL = "990010"
 
@@ -30,6 +40,56 @@ class _FakeProvider:
             )
         ]
         return rows[:limit] if limit is not None else rows
+
+
+class _RecordingProvider:
+    limits: list[int | None] = []
+
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[KrFundamentalsProviderRow]:
+        self.__class__.limits.append(limit)
+        return [
+            KrFundamentalsProviderRow(
+                symbol=_JOB_SYMBOL,
+                name="잡테스트",
+                price=Decimal("12345"),
+                roe_ttm=Decimal("10.0"),
+            )
+        ]
+
+
+class _FakeStockField:
+    ACTIVE_SYMBOL = "symbol"
+    PRICE = "price"
+
+
+class _FakeMarket:
+    KOREA = "korea"
+
+
+class _FakeTvScreenerModule:
+    StockField = _FakeStockField
+    Market = _FakeMarket
+
+
+class _RecordingTvScreenerService:
+    limits: list[int | None] = []
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def query_stock_screener(self, **kwargs):
+        self.__class__.limits.append(kwargs.get("limit"))
+        return pd.DataFrame(
+            [
+                {
+                    "symbol": _JOB_SYMBOL,
+                    "price": "12345",
+                    "description": "잡테스트",
+                }
+            ]
+        )
 
 
 @pytest.mark.asyncio
@@ -62,3 +122,117 @@ async def test_run_job_dry_run_persists_nothing(db_session):
         )
     ).scalar_one()
     assert persisted == 0
+
+
+@pytest.mark.asyncio
+async def test_run_job_all_symbols_uses_active_universe_buffer(monkeypatch):
+    _RecordingProvider.limits = []
+    monkeypatch.setattr(job, "TvScreenerKrFundamentalsProvider", _RecordingProvider)
+    monkeypatch.setattr(job, "active_universe_count", AsyncMock(return_value=7000))
+
+    result = await run_kr_fundamentals_snapshot_build(
+        KrFundamentalsSnapshotBuildRequest(all_symbols=True, commit=False)
+    )
+
+    assert _RecordingProvider.limits == [8000]
+    assert result["fetched"] == 1
+    assert result["would_upsert"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_job_all_symbols_falls_back_to_provider_floor_when_universe_missing():
+    limit = await job._fetch_limit_for_request(  # noqa: SLF001 - regression seam
+        KrFundamentalsSnapshotBuildRequest(all_symbols=True), universe_count=0
+    )
+
+    assert limit is None
+
+
+@pytest.mark.asyncio
+async def test_provider_none_limit_uses_full_fetch_floor(monkeypatch):
+    _RecordingTvScreenerService.limits = []
+    monkeypatch.setattr(
+        provider_mod, "_import_tvscreener", lambda: _FakeTvScreenerModule
+    )
+    monkeypatch.setattr(provider_mod, "TvScreenerService", _RecordingTvScreenerService)
+
+    rows = await TvScreenerKrFundamentalsProvider().fetch_rows(limit=None)
+
+    assert _RecordingTvScreenerService.limits == [KR_FUNDAMENTALS_FULL_FETCH_MIN_LIMIT]
+    assert [row.symbol for row in rows] == [_JOB_SYMBOL]
+
+
+@pytest.mark.asyncio
+async def test_provider_non_positive_limit_returns_no_rows():
+    assert await TvScreenerKrFundamentalsProvider().fetch_rows(limit=0) == []
+
+
+@pytest.mark.asyncio
+async def test_guarded_job_blocks_thin_commit(monkeypatch):
+    calls: list[bool] = []
+
+    async def _fake_run(request):
+        calls.append(request.commit)
+        return {"would_upsert": 200, "committed": request.commit}
+
+    monkeypatch.setattr(job, "run_kr_fundamentals_snapshot_build", _fake_run)
+    monkeypatch.setattr(job, "active_universe_count", AsyncMock(return_value=4000))
+
+    with pytest.raises(PartialCommitBlocked):
+        await run_kr_fundamentals_snapshot_build_guarded(
+            KrFundamentalsSnapshotBuildRequest(all_symbols=True, commit=True)
+        )
+
+    assert calls == [False]
+
+
+@pytest.mark.asyncio
+async def test_guarded_job_commits_when_coverage_is_healthy(monkeypatch):
+    calls: list[bool] = []
+
+    async def _fake_run(request):
+        calls.append(request.commit)
+        return {"would_upsert": 3000, "committed": request.commit}
+
+    monkeypatch.setattr(job, "run_kr_fundamentals_snapshot_build", _fake_run)
+    monkeypatch.setattr(job, "active_universe_count", AsyncMock(return_value=4000))
+
+    result = await run_kr_fundamentals_snapshot_build_guarded(
+        KrFundamentalsSnapshotBuildRequest(all_symbols=True, commit=True)
+    )
+
+    assert calls == [False, True]
+    assert result["committed"] is True
+
+
+def test_cli_allow_partial_arg() -> None:
+    assert cli.parse_args(["--commit", "--allow-partial"]).allow_partial is True
+    assert cli.parse_args([]).allow_partial is False
+
+
+@pytest.mark.asyncio
+async def test_cli_routes_guarded_by_default(monkeypatch):
+    guarded = AsyncMock(return_value={"committed": True})
+    plain = AsyncMock(return_value={"committed": True})
+    monkeypatch.setattr(cli, "run_kr_fundamentals_snapshot_build_guarded", guarded)
+    monkeypatch.setattr(cli, "run_kr_fundamentals_snapshot_build", plain)
+
+    assert await cli.run(cli.parse_args(["--commit", "--all"])) == 0
+    assert guarded.await_count == 1 and plain.await_count == 0
+
+    guarded.reset_mock()
+    plain.reset_mock()
+    assert await cli.run(cli.parse_args(["--commit", "--allow-partial"])) == 0
+    assert plain.await_count == 1 and guarded.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cli_returns_2_when_guard_blocks(monkeypatch):
+    guarded = AsyncMock(side_effect=PartialCommitBlocked("blocked"))
+    plain = AsyncMock(return_value={"committed": True})
+    monkeypatch.setattr(cli, "run_kr_fundamentals_snapshot_build_guarded", guarded)
+    monkeypatch.setattr(cli, "run_kr_fundamentals_snapshot_build", plain)
+
+    assert await cli.run(cli.parse_args(["--commit"])) == 2
+    assert guarded.await_count == 1
+    assert plain.await_count == 0


### PR DESCRIPTION
## Summary
- Removes the accidental KR fundamentals `--all` 200-row fallback by sizing full-universe tvscreener fetches from active KR universe + buffer, with a 6,000-row provider floor.
- Adds a default coverage commit guard for KR fundamentals snapshot `--commit`: dry-run first, block thin builds, then commit only if coverage is healthy.
- Adds explicit `--allow-partial` bypass for approved partial backfills and regression tests for fetch sizing, guard pass/block, CLI routing, and blocked exit code.

## Context
- Linear: ROB-429
- Follow-up to PR #1116 / ROB-428 after the 저평가 성장주 parity audit found the latest `invest_kr_fundamentals_snapshots` partition had only 200 rows (~5% KR universe coverage).

## Verification
- `uv run --group dev --group test ruff check app/jobs/invest_kr_fundamentals_snapshots.py app/services/invest_kr_fundamentals_snapshots/provider.py scripts/build_invest_kr_fundamentals_snapshots.py tests/test_invest_kr_fundamentals_snapshots_job.py`
- `uv run --group dev --group test ruff format --check app/jobs/invest_kr_fundamentals_snapshots.py app/services/invest_kr_fundamentals_snapshots/provider.py scripts/build_invest_kr_fundamentals_snapshots.py tests/test_invest_kr_fundamentals_snapshots_job.py`
- `uv run --group dev ty check app/jobs/invest_kr_fundamentals_snapshots.py app/services/invest_kr_fundamentals_snapshots/provider.py`
- `uv run --group test pytest tests/test_invest_kr_fundamentals_snapshots_job.py tests/test_snapshot_commit_guard_wiring.py -q` → 21 passed
- `ENV_FILE=/Users/mgh3326/work/auto_trader/.env uv run python -m scripts.build_invest_kr_fundamentals_snapshots --all` → dry-run only, fetched/would_upsert 4,250, committed=false
- Static added-line scans: secrets/shell-injection/eval/SQL-injection clean
- Independent reviewer subagent: no blockers; safe to commit/open PR

## Safety / non-actions
- No broker/order/watchlist/trade journal mutations.
- No production DB commit/backfill performed in this PR worktree.
- No scheduler activation or production config/secret changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guarded execution mode for fundamentals snapshot builds that validates coverage before committing data.
  * Introduced a new CLI flag to control whether partial commits are allowed.

* **Improvements**
  * Enhanced fetch limit calculations for better symbol data coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->