### PR TITLE
fix(ROB-429): KR fundamentals full-universe + read-path full-partition + commit guard (A+B)

### DIFF
--- a/app/jobs/invest_kr_fundamentals_snapshots.py
+++ b/app/jobs/invest_kr_fundamentals_snapshots.py
@@ -13,6 +13,9 @@ from app.services.invest_kr_fundamentals_snapshots.provider import (
 from app.services.invest_kr_fundamentals_snapshots.repository import (
     InvestKrFundamentalsSnapshotsRepository,
 )
+from app.services.invest_screener_snapshots.partition_health import (
+    active_universe_count,
+)
 
 
 @dataclass(frozen=True)
@@ -20,6 +23,7 @@ class KrFundamentalsSnapshotBuildRequest:
     limit: int | None = 200
     all_symbols: bool = False
     commit: bool = False
+    allow_partial: bool = False
 
 
 async def run_kr_fundamentals_snapshot_build(
@@ -27,13 +31,19 @@ async def run_kr_fundamentals_snapshot_build(
 ) -> dict[str, Any]:
     limit = None if request.all_symbols else request.limit
     async with AsyncSessionLocal() as session:
+        # ROB-429 A2: coverage denominator for the commit guard.
+        universe_count = await active_universe_count(session, market="kr")
         result = await build_kr_fundamentals_snapshots(
             provider=TvScreenerKrFundamentalsProvider(),
             repository=InvestKrFundamentalsSnapshotsRepository(session),
             commit=request.commit,
             limit=limit,
+            universe_count=universe_count,
+            allow_partial=request.allow_partial,
         )
-        if request.commit:
+        # Only persist when the build actually committed (the guard may have
+        # blocked a thin commit → result["committed"] is False → roll back).
+        if result.get("committed"):
             await session.commit()
         else:
             await session.rollback()

--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -199,3 +199,8 @@ class ScreenerResultsResponse(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     freshness: ScreenerFreshness
     sources: list[ScreenerSourceContext] = Field(default_factory=list)
+    # ROB-429 B2: full-partition predicate match total (totalCount) and the number
+    # actually returned after the display limit (returnedCount). Set on the KR
+    # fundamentals (FUNDAMENTALS_PRESET_SPECS) path only; None for other presets.
+    totalCount: int | None = None
+    returnedCount: int | None = None

--- a/app/services/invest_kr_fundamentals_snapshots/builder.py
+++ b/app/services/invest_kr_fundamentals_snapshots/builder.py
@@ -10,6 +10,14 @@ from app.services.invest_kr_fundamentals_snapshots.repository import (
     KrFundamentalsSnapshotUpsert,
 )
 from app.services.invest_screener_snapshots.freshness import today_trading_date
+from app.services.snapshot_commit_guard import (
+    PartialCommitBlocked,
+    assert_min_coverage,
+)
+
+#: ROB-429 A2 — production commit coverage floor for KR fundamentals snapshots.
+#: A commit below ceil(active_universe * floor) is blocked unless --allow-partial.
+_KR_FUNDAMENTALS_MIN_COMMIT_COVERAGE_RATIO = 0.80
 
 _RAW_PAYLOAD_KEYS = {
     "symbol",
@@ -131,23 +139,56 @@ async def build_kr_fundamentals_snapshots(
     snapshot_date: dt.date | None = None,
     commit: bool = False,
     limit: int | None = None,
+    universe_count: int = 0,
+    allow_partial: bool = False,
 ) -> dict[str, Any]:
     date_value = snapshot_date or today_trading_date("kr")
     provider_rows = await provider.fetch_rows(limit=limit)
     payloads = build_kr_fundamentals_snapshot_payloads(
         provider_rows, snapshot_date=date_value
     )
+    would_upsert = len(payloads)
+    coverage_ratio = (
+        round(would_upsert / universe_count, 4) if universe_count > 0 else 0.0
+    )
+
+    # ROB-429 A2: coverage guard (ROB-426 snapshot_commit_guard). A build below
+    # ceil(active_universe * 0.80) is NOT commit-allowed unless --allow-partial.
+    # We evaluate the gate for both dry-run and commit so the result always
+    # carries an honest commit_allowed/block_reason; the gate only blocks the
+    # actual upsert when committing. --allow-partial bypasses the gate entirely.
+    # universe_count <= 0 fail-opens (no denominator → cannot judge coverage).
+    commit_allowed = True
+    block_reason: str | None = None
+    if not allow_partial:
+        try:
+            assert_min_coverage(
+                count=would_upsert,
+                universe_count=universe_count,
+                market="kr",
+                metric="kr_fundamentals",
+                min_ratio=_KR_FUNDAMENTALS_MIN_COMMIT_COVERAGE_RATIO,
+            )
+        except PartialCommitBlocked as exc:
+            commit_allowed = False
+            block_reason = str(exc)
+
+    should_commit = commit and commit_allowed
     upserted = 0
-    if commit:
+    if should_commit:
         for payload in payloads:
             await repository.upsert(payload)
             upserted += 1
     return {
         "snapshot_date": date_value.isoformat(),
         "fetched": len(provider_rows),
-        "would_upsert": len(payloads),
+        "would_upsert": would_upsert,
         "upserted": upserted,
-        "committed": commit,
+        "committed": should_commit,
+        "active_universe_count": universe_count,
+        "coverage_ratio": coverage_ratio,
+        "commit_allowed": commit_allowed,
+        "block_reason": block_reason,
         "samples": [payload.model_dump(mode="json") for payload in payloads[:5]],
     }
 

--- a/app/services/invest_kr_fundamentals_snapshots/provider.py
+++ b/app/services/invest_kr_fundamentals_snapshots/provider.py
@@ -15,6 +15,12 @@ from app.services.tvscreener_service import (
 
 logger = logging.getLogger(__name__)
 
+#: ROB-429 A1 — full-universe (``limit=None``) fetch bound. tvscreener's
+#: ``query_stock_screener(limit=falsy)`` skips ``set_range`` and returns only its
+#: small default range (~150), so the full path MUST pass a large explicit bound.
+#: This cap sits well above the ~3,909 active KR universe / ~4,250 tvscreener rows.
+_FULL_UNIVERSE_FETCH_CAP = 10_000
+
 # (model_key, [StockField name fallbacks]) — version-safe field resolution.
 # Probe-validated against tvscreener KOREA market (ROB-428, 2026-06-04).
 _KR_STOCK_FIELD_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
@@ -92,7 +98,11 @@ class TvScreenerKrFundamentalsProvider:
     async def fetch_rows(
         self, *, limit: int | None = None
     ) -> list[KrFundamentalsProviderRow]:
-        query_limit = limit or 200
+        # ROB-429 A1: full mode (limit is None / non-positive) fetches the FULL KR
+        # universe via a large explicit bound; a positive limit is a bounded
+        # diagnostic. (`limit or 200` previously collapsed full mode to 200 rows.)
+        is_full = limit is None or limit <= 0
+        query_limit = _FULL_UNIVERSE_FETCH_CAP if is_full else limit
         tvscreener = _import_tvscreener()
         stock_field = tvscreener.StockField
         market = tvscreener.Market
@@ -123,4 +133,6 @@ class TvScreenerKrFundamentalsProvider:
             row = provider_row_from_mapping(mapping)
             if row is not None:
                 rows.append(row)
-        return rows[:query_limit]
+        # Full mode returns every provider row unsliced; a bounded diagnostic
+        # caps to the requested positive limit.
+        return rows if is_full else rows[:limit]

--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -164,6 +164,9 @@ class FundamentalsScreenResult:
     # (e.g. the earnings-streak condition skipped because tvscreener omits it).
     # The DART loader leaves this empty; the tvscreener KR loader populates it.
     warnings: list[str] = field(default_factory=list)
+    # ROB-429 B2: full-partition predicate match count BEFORE the display limit is
+    # applied (the tvscreener KR loader sets it; the DART loader leaves 0).
+    total_matched: int = 0
 
 
 def _to_period(row: FinancialFundamentalsSnapshot) -> FundamentalPeriod:
@@ -425,4 +428,7 @@ async def load_fundamentals_preset_from_snapshots(
         fundamentals_collected_at=fund_collected,
         fundamentals_state=fundamentals_state,
         excluded=excluded,
+        # The DART loader isn't the screener display path; total_matched mirrors
+        # the displayed rows here (B2 consistency, not full-partition).
+        total_matched=len(included),
     )

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -53,6 +53,11 @@ EARNINGS_STREAK_SKIP_WARNING = "순이익 연속증가 조건은 tvscreener 미�
 _MIN_HEALTHY_COVERAGE_RATIO = 0.50
 _MAX_PARTITION_SCAN_BACK = 10
 
+#: ROB-429 B1: the read-path now evaluates the FULL healthy partition (no market-cap
+#: cand_cap that excluded small caps). This is a pathological safety bound only —
+#: a KR partition is ~4,250 rows, so hitting it signals a corrupt partition.
+_MAX_PARTITION_ROWS = 20_000
+
 
 # (spec threshold field, snapshot column attr, require_positive) — each non-None
 # spec field is applied fail-closed against the tvscreener column. PROXY mappings
@@ -334,22 +339,21 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
     if hp and (hp.is_fallback or not hp.healthy):
         state = cap_degraded(state)
 
-    # Candidate universe: latest healthy partition, capped by market cap (prefer
-    # liquid names); preset ranking happens AFTER. Mirror fundamentals_screener
-    # cap = max(limit*8, 200).
-    cand_cap = max(limit * 8, 200)
+    # ROB-429 B1: evaluate the FULL healthy partition (no market-cap cand_cap that
+    # excluded small caps). ~4,250 rows in-memory is cheap. A generous safety bound
+    # only guards a pathological partition; hitting it is logged (not a normal cap).
     cand_stmt = (
         sa.select(InvestKrFundamentalsSnapshot)
         .where(InvestKrFundamentalsSnapshot.snapshot_date == partition_date)
-        .order_by(InvestKrFundamentalsSnapshot.market_cap.desc().nullslast())
-        .limit(cand_cap)
+        .order_by(InvestKrFundamentalsSnapshot.symbol)
+        .limit(_MAX_PARTITION_ROWS)
     )
     snaps = list((await session.execute(cand_stmt)).scalars().all())
-    if len(snaps) >= cand_cap:
+    if len(snaps) >= _MAX_PARTITION_ROWS:
         logger.warning(
-            "kr_fundamentals_tv_screener: candidate universe capped at %d for "
-            "preset=%s (lower-market-cap candidates not evaluated)",
-            cand_cap,
+            "kr_fundamentals_tv_screener: partition row load hit the safety bound "
+            "%d for preset=%s (partition may be corrupt; some rows not evaluated)",
+            _MAX_PARTITION_ROWS,
             spec.preset_id,
         )
 
@@ -389,6 +393,9 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
             _build_row(snap, name=name, state=state, partition_date=partition_date)
         )
 
+    # ROB-429 B2: full-partition match total BEFORE the display limit.
+    total_matched = len(included)
+
     sort_row_key = _SORT_KEY_TO_ROW_KEY.get(spec.sort_by, spec.sort_by)
     included.sort(
         key=lambda r: (
@@ -411,4 +418,5 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
         fundamentals_state="fresh" if snaps else "missing",
         excluded=excluded,
         warnings=warnings,
+        total_matched=total_matched,
     )

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -2107,6 +2107,18 @@ async def build_screener_results(
     ):
         upstream_warnings.append("비KRW 가상자산 행은 제외했습니다.")
 
+    # ROB-429 B2: surface the full-partition match total + returned count on the KR
+    # fundamentals path (FUNDAMENTALS_PRESET_SPECS). None for all other presets so
+    # their behavior is unchanged.
+    total_count: int | None = None
+    returned_count: int | None = None
+    if (
+        preset_id in FUNDAMENTALS_PRESET_SPECS
+        and _fundamentals_screen_result is not None
+    ):
+        total_count = _fundamentals_screen_result.total_matched
+        returned_count = len(results)
+
     return ScreenerResultsResponse(
         presetId=preset.id,
         title=preset.name,
@@ -2117,4 +2129,6 @@ async def build_screener_results(
         warnings=upstream_warnings,
         freshness=freshness,
         sources=response_sources,
+        totalCount=total_count,
+        returnedCount=returned_count,
     )

--- a/docs/plans/2026-06-04-ROB-429-kr-fundamentals-full-universe.md
+++ b/docs/plans/2026-06-04-ROB-429-kr-fundamentals-full-universe.md
@@ -1,0 +1,102 @@
+# ROB-429 — KR fundamentals tv snapshot full-universe loading + read-path full-partition + commit guard
+
+> **상태:** spec (구현 전). 근본원인 코드 grounding + 라이브 probe 정량화 완료.
+> **기준일:** 코드 2026-06-04 `origin/main` c2118bfc (#1115 PR-A+PR-B, #1116 PR-C 머지 후). 라이브 probe 2026-06-04.
+> **분류:** Bug (배포 후 parity 미달) + hardening. **스코프 A+B** (원 이슈 A만 → read-path B 확장).
+> **목표:** `/invest/screener` 국내 fundamentals 프리셋이 Toss와 **비교가능한 종목 집합**(comparable+honest)을 내도록 (A) 스냅샷 full-universe 적재 + (B) read-path full-partition 평가. exact 종목 일치는 비목표(C, follow-up).
+
+## Context
+
+ROB-428(#1115 PR-A+PR-B, #1116 PR-C) 머지·배포 후에도 KR fundamentals 프리셋 결과가 Toss와 크게 다름. operator가 backfill을 돌렸으나 스냅샷에 **200행만** 적재됐고, read-path도 시총 상위만 평가해 Toss의 중소형주 매칭이 표시 불가.
+
+## Current State (verified 2026-06-04, code-grounded + live probe)
+
+| 측정 | 값 | 근거 |
+|---|---|---|
+| active KR universe | ~3,909 | `active_universe_count(market="kr")` |
+| `invest_kr_fundamentals_snapshots` 최신 파티션 | 2026-06-04 | operator backfill |
+| **persisted rows** | **200 (5.1%)** | A 버그 |
+| tvscreener KR **full fetch** | **4,250** | 라이브 probe |
+| 저평가성장주(per≤20·rev_yoy≥10·eps_yoy≥20) full universe 매칭 | **181 ≈ Toss 187** | 라이브 probe |
+| 그 매칭 중 non-top-cap | **179/180** | A(200행)+B(market_cap cand_cap)에 배제 |
+
+### 근본 원인 (3)
+- **A (지배적, 스냅샷 데이터 cap)** — `app/services/invest_kr_fundamentals_snapshots/provider.py:95` `query_limit = limit or 200`. job(`all_symbols→limit=None`) + CLI(`--all`)을 써도 `None or 200 = 200` → tvscreener `set_range(0,200)` + `rows[:200]` → 200행만. operator full backfill이 이 버그를 침. (ROB-426 `limit or N` 가드우회와 동종)
+- **B (2차 병목, read-path cap)** — `app/services/invest_view_model/kr_fundamentals_tv_screener.py:340` `cand_cap = max(limit*8,200)` + `order_by(market_cap desc).limit(cand_cap)` → 스냅샷이 full이어도 시총 상위 N개만 후보 평가 → 중소형주 제외. **A만 고쳐도 B가 소형주를 다시 거름.**
+- **C (본질적, 작음, follow-up)** — YoY proxy(eps_yoy/revenue_yoy) vs Toss 3년평균 TTM, TradingView vs Toss 벤더 → 개수는 거의 같으나(181≈187) 종목 overlap 일부 상이. honest "comparable" 유지.
+
+## Decisions (locked)
+- **D1** B = **full-partition 평가**(cand_cap 제거): fundamentals 로더가 파티션 전체 row를 in-memory predicate 평가 후 spec.sort_by 정렬 + display limit.
+- **D2** **totalCount/returnedCount API 포함**: 응답에 full-partition 매칭 총개수 + 표시개수.
+- **D3** commit guard = **ROB-426 `snapshot_commit_guard.assert_min_coverage` 재사용 + coverage floor 0.80 + `--allow-partial` 오버라이드**.
+- **D4** 산출물 = worktree `auto_trader.rob-429` 문서 + Linear ROB-429 코멘트.
+
+## Proposed Change
+
+### A1 — full-universe provider semantics (migration 0)
+`provider.py`: `query_limit = limit or 200` 제거. **full 모드(limit=None)**는 전체 fetch — tvscreener StockScreener `set_range`를 충분히 큰 상한(예: 10_000)으로 설정하거나 range 미지정으로 전체 반환; `rows[:query_limit]` 슬라이스는 limit=None일 때 미적용. `--limit N` diagnostic 모드는 bounded 유지. job `KrFundamentalsSnapshotBuildRequest`: `all_symbols=True` → 전체, 기본 `limit=200`은 diagnostic 명시일 때만.
+
+### A2 — production commit guard (migration 0)
+job `run_kr_fundamentals_snapshot_build`: `--commit` 직전 `snapshot_commit_guard.assert_min_coverage(count=would_upsert, universe_count=await active_universe_count(session, market="kr"), market="kr", metric="kr_fundamentals", min_ratio=0.80)` 호출 → `PartialCommitBlocked` 시 commit 차단. `--allow-partial`(또는 `--diagnostic`) 플래그로만 우회. dry-run 결과 dict에 `active_universe_count`/`fetched`/`would_upsert`/`coverage_ratio`/`commit_allowed`/`block_reason` 포함. `BuildRequest`에 `allow_partial: bool=False` 추가.
+
+### A3 — read-path honesty (이미 PR-B에 일부 존재 — 보강)
+proxy metric(YoY=3y-avg proxy) 경고는 PR-B의 `EARNINGS_STREAK_SKIP_WARNING` 패턴과 함께 유지/문서화. exact Toss parity 함의 금지(comparable 명시).
+
+### B1 — read-path full-partition 평가 (migration 0)
+`kr_fundamentals_tv_screener.py`: `cand_cap = max(limit*8,200)` + market_cap-ordered `.limit(cand_cap)` **제거** → healthy 파티션 전체 row 로드(SELECT WHERE snapshot_date=partition), `_is_kr_toss_common_stock` 필터 + `_passes_thresholds` 전체 평가. `included` 전체에서 `spec.sort_by` desc 정렬 후 `display limit` 적용. (~4250행 in-memory 평가는 저렴; 안전 상한이 필요하면 cand_cap 대신 매우 큰 partition-size 상한.)
+
+### B2 — totalCount/returnedCount (migration 0)
+`FundamentalsScreenResult`에 `total_matched: int` 추가(predicate 통과 전체 수, display limit 적용 전). `app/schemas/invest_screener.py` `ScreenerResultsResponse`(extra=forbid)에 `totalCount: int | None = None` + `returnedCount: int | None = None` 추가. `screener_service.build_screener_results`가 fundamentals 경로에서 `totalCount=result.total_matched`, `returnedCount=len(results)` 설정. 프론트 `types/screener.ts` + (선택) UI 렌더는 후속 가능하나 API/스키마엔 포함.
+
+### operator track (runbook, 코드 아님)
+`docs/runbooks/` 갱신: dry-run(`--all`, coverage 출력) → 승인 → `--commit --all`(guard 통과) → 11-preset authenticated smoke. 200행/저커버리지 commit은 `--allow-partial` 명시 없이는 차단됨을 문서화.
+
+## Acceptance Criteria
+1. `uv run python -m scripts.build_invest_kr_fundamentals_snapshots --all` (dry-run) 가 **full-universe 규모 fetched count**(수천)와 `active_universe_count`/`coverage_ratio`/`commit_allowed` 메타를 출력(200 아님).
+2. `--commit`(또는 `--commit --all`)이 coverage < 0.80이면 `PartialCommitBlocked`로 차단; `--allow-partial`로만 우회.
+3. read-path가 파티션 전체를 평가 → 동일 partition·predicate에서 **시총 하위 종목도 결과에 포함**(테스트로 소형주 1건 이상 검증); cand_cap에 의한 누락 없음.
+4. `/invest/screener` fundamentals 응답에 `totalCount`(predicate 통과 총수) + `returnedCount`(표시 수)가 채워진다.
+5. PR #1116 프리셋(`high_yield_value`/`undervalued_breakout`) 포함 모든 fundamentals 프리셋이 tvscreener 스냅샷 경로 유지.
+6. exact Toss 종목 일치는 비목표; full coverage·full partition 시 매칭 개수가 Toss 수준(저평가성장주 ~187)에 근접함을 확인 가능(harness/probe).
+7. broker/order/watch mutation 0, migration 0, Toss 자동 scraping 0. production `--commit`/backfill은 operator 승인.
+
+## Testing Plan
+| Layer | What | Count |
+|---|---|---|
+| Unit | provider: `all_symbols=True`/`limit=None`가 200으로 안 떨어짐(set_range 상한/전체 fetch), `--limit N` diagnostic는 N | +2 |
+| Unit | commit guard: coverage<0.80 → PartialCommitBlocked, `--allow-partial` 우회, dry-run 메타(coverage/allowed/reason) | +3 |
+| Unit | read-path full-partition: 소형주(저시총)가 predicate 통과 시 결과 포함, cand_cap 누락 없음, sort+limit | +2 |
+| Unit | totalCount/returnedCount: total_matched=predicate 통과수, returnedCount=len(results) | +2 |
+| Integration | build_screener_results fundamentals 응답에 totalCount/returnedCount + 채워진 row | +1 |
+
+## Rollback Plan
+read-path/provider/job 코드 변경 + 스키마 additive 필드 → revert PR. 스냅샷 데이터는 operator가 이전 파티션 유지(파괴적 변경 없음). totalCount 필드는 optional(None default)이라 consumer 무해.
+
+## Effort
+A1 ~1-2h · A2 ~2h · B1 ~2h · B2 ~2h(스키마+service+TS) · runbook ~1h · tests 포함.
+
+## Files Reference
+| File | Change |
+|---|---|
+| `app/services/invest_kr_fundamentals_snapshots/provider.py:95` | `limit or 200` 제거, full=전체 fetch |
+| `app/jobs/invest_kr_fundamentals_snapshots.py` | `allow_partial` + commit 전 `assert_min_coverage`(0.80) + dry-run 메타 |
+| `scripts/build_invest_kr_fundamentals_snapshots.py` | `--allow-partial`(/`--diagnostic`) 플래그, coverage 출력 |
+| `app/services/invest_view_model/kr_fundamentals_tv_screener.py:339-352` | cand_cap 제거 → full-partition 평가; `total_matched` 계산 |
+| `app/services/invest_view_model/fundamentals_screener.py` | `FundamentalsScreenResult.total_matched: int` 추가 |
+| `app/services/invest_view_model/screener_service.py` | fundamentals 경로에서 totalCount/returnedCount 설정 |
+| `app/schemas/invest_screener.py` | `ScreenerResultsResponse.totalCount/returnedCount` (optional) |
+| `frontend/invest/src/.../types/screener.ts` | totalCount/returnedCount 인터페이스(렌더는 후속 가능) |
+| `app/services/snapshot_commit_guard.py` | 재사용(변경 없음) |
+| `docs/runbooks/...` | dry-run→승인→`--commit --all`→smoke |
+| `tests/...` | 위 testing plan |
+
+## Out of Scope (follow-up)
+- **C: exact 3년평균 TTM parity** — tvscreener 3Y/CAGR 필드로 proxy 개선 또는 DART 파생; 벤더 차이로 exact 불가. honest 유지.
+- totalCount의 **프론트 UI 렌더링**(Toss식 "검색된 N개" 표시) — API는 이 스펙에 포함, UI는 후속 가능.
+- crypto/US 동일 패턴, scheduler 활성화.
+
+## Related
+ROB-428(#1115/#1116, tvscreener KR 스냅샷 + read-path) · ROB-426(snapshot_commit_guard PR2b 재사용) · ROB-280(refresh cadence).
+
+## Appendix — probe 재현
+`TvScreenerKrFundamentalsProvider().fetch_rows(limit=6000)` → 4250행; 저평가성장주 predicate 적용 → 181 매칭(≈Toss 187), 179/180 non-top-cap. (full universe 데이터는 존재; 200-cap이 적재를 막았을 뿐.)

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -165,4 +165,9 @@ export interface ScreenerResultsResponse {
   warnings: string[];
   freshness: ScreenerFreshness;
   sources?: ScreenerSourceContext[];
+  // ROB-429 B2: full-partition predicate match total + returned (post-limit) count.
+  // Populated only on the KR fundamentals presets; null/undefined elsewhere.
+  // UI rendering is a follow-up — this is the type only.
+  totalCount?: number | null;
+  returnedCount?: number | null;
 }

--- a/scripts/build_invest_kr_fundamentals_snapshots.py
+++ b/scripts/build_invest_kr_fundamentals_snapshots.py
@@ -34,6 +34,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Actually write to the database. Default is dry-run/no writes.",
     )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help=(
+            "Override the ROB-429 coverage guard and commit a partial backfill "
+            "(below 80%% of the active KR universe). Operator-gated."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.all and args.limit != 200:
         parser.error("--all is mutually exclusive with --limit")
@@ -46,12 +54,30 @@ async def run(args: argparse.Namespace) -> int:
             limit=args.limit,
             all_symbols=args.all,
             commit=args.commit,
+            allow_partial=args.allow_partial,
         )
     )
     print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+    # ROB-429 A2: surface the coverage guard metadata for the operator packet.
+    print(
+        "\ncoverage: would_upsert={would_upsert} / active_universe={universe} "
+        "= {ratio:.1%} (commit_allowed={allowed})".format(
+            would_upsert=result.get("would_upsert"),
+            universe=result.get("active_universe_count"),
+            ratio=result.get("coverage_ratio") or 0.0,
+            allowed=result.get("commit_allowed"),
+        )
+    )
+    if result.get("block_reason"):
+        print(f"blocked: {result['block_reason']}")
     if not args.commit:
         print(
             "\n--dry-run: no rows written. Pass --commit only with operator approval."
+        )
+    elif not result.get("committed"):
+        print(
+            "\n--commit was requested but BLOCKED by the coverage guard; no rows "
+            "written. Pass --allow-partial to override (operator-gated)."
         )
     return 0
 

--- a/tests/test_invest_kr_fundamentals_snapshots_builder.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_builder.py
@@ -216,9 +216,92 @@ async def test_build_snapshots_commit_upserts() -> None:
         snapshot_date=dt.date(2026, 6, 4),
         commit=True,
         limit=10,
+        universe_count=2,  # 2/2 = 100% >= 80% floor → allowed
     )
     assert result["fetched"] == 2
     assert result["would_upsert"] == 2
     assert result["upserted"] == 2
     assert result["committed"] is True
+    assert result["commit_allowed"] is True
+    assert result["block_reason"] is None
     assert {p.symbol for p in repo.payloads} == {"005930", "000660"}
+
+
+# ---------------------------------------------------------------------------
+# ROB-429 A2 — production commit guard (assert_min_coverage, floor 0.80)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_dry_run_carries_coverage_metadata() -> None:
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider([_sample_row(symbol="005930")]),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=False,
+        limit=10,
+        universe_count=100,
+    )
+    # dry-run still reports the full coverage metadata.
+    assert result["active_universe_count"] == 100
+    assert result["coverage_ratio"] == 0.01  # 1 / 100
+    assert result["commit_allowed"] is False  # 1 < ceil(0.80 * 100) = 80
+    assert result["block_reason"] is not None
+    assert result["upserted"] == 0
+    assert repo.payloads == []
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_commit_blocked_below_floor() -> None:
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider([_sample_row(symbol="005930")]),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=True,
+        limit=10,
+        universe_count=100,  # floor = 80; would_upsert = 1 < 80 → blocked
+    )
+    assert result["commit_allowed"] is False
+    assert result["committed"] is False
+    assert result["upserted"] == 0
+    assert repo.payloads == []  # nothing upserted on a blocked commit
+    assert "80%" in result["block_reason"] or "floor" in result["block_reason"]
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_commit_allow_partial_overrides_floor() -> None:
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider([_sample_row(symbol="005930")]),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=True,
+        limit=10,
+        universe_count=100,
+        allow_partial=True,  # operator override → upsert despite thin coverage
+    )
+    assert result["committed"] is True
+    assert result["commit_allowed"] is True
+    assert result["upserted"] == 1
+    assert result["block_reason"] is None
+    assert {p.symbol for p in repo.payloads} == {"005930"}
+
+
+@pytest.mark.asyncio
+async def test_build_snapshots_guard_fail_open_when_universe_zero() -> None:
+    # universe_count <= 0 disables the gate (fail-open, consistent with PR2a/2b).
+    repo = _Repo()
+    result = await build_kr_fundamentals_snapshots(
+        provider=_Provider([_sample_row(symbol="005930")]),
+        repository=repo,
+        snapshot_date=dt.date(2026, 6, 4),
+        commit=True,
+        limit=10,
+        universe_count=0,
+    )
+    assert result["committed"] is True
+    assert result["commit_allowed"] is True
+    assert result["coverage_ratio"] == 0.0
+    assert result["upserted"] == 1

--- a/tests/test_invest_kr_fundamentals_snapshots_job.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_job.py
@@ -62,3 +62,104 @@ async def test_run_job_dry_run_persists_nothing(db_session):
         )
     ).scalar_one()
     assert persisted == 0
+    # ROB-429 A2: dry-run still carries the coverage guard metadata.
+    assert "active_universe_count" in result
+    assert "coverage_ratio" in result
+    assert "commit_allowed" in result
+    assert "block_reason" in result
+
+
+@pytest.mark.asyncio
+async def test_run_job_commit_blocked_below_floor_persists_nothing(db_session):
+    """ROB-429 A2: a thin --commit (below 80% of universe) is guard-blocked and
+    persists nothing, even though commit was requested."""
+    await db_session.execute(
+        text("DELETE FROM invest_kr_fundamentals_snapshots WHERE symbol = :s"),
+        {"s": _JOB_SYMBOL},
+    )
+    await db_session.commit()
+
+    async def _fake_universe(session, *, market):
+        return 100  # floor = ceil(0.80 * 100) = 80; the fake provider yields 1 row
+
+    with (
+        patch(
+            "app.jobs.invest_kr_fundamentals_snapshots.TvScreenerKrFundamentalsProvider",
+            _FakeProvider,
+        ),
+        patch(
+            "app.jobs.invest_kr_fundamentals_snapshots.active_universe_count",
+            _fake_universe,
+        ),
+    ):
+        result = await run_kr_fundamentals_snapshot_build(
+            KrFundamentalsSnapshotBuildRequest(limit=5, commit=True)
+        )
+
+    assert result["active_universe_count"] == 100
+    assert result["commit_allowed"] is False
+    assert result["committed"] is False
+    assert result["upserted"] == 0
+    assert result["block_reason"] is not None
+
+    persisted = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM invest_kr_fundamentals_snapshots "
+                "WHERE symbol = :s"
+            ),
+            {"s": _JOB_SYMBOL},
+        )
+    ).scalar_one()
+    assert persisted == 0
+
+
+@pytest.mark.asyncio
+async def test_run_job_commit_allow_partial_persists(db_session):
+    """ROB-429 A2: --allow-partial overrides the guard and commits the thin build."""
+    await db_session.execute(
+        text("DELETE FROM invest_kr_fundamentals_snapshots WHERE symbol = :s"),
+        {"s": _JOB_SYMBOL},
+    )
+    await db_session.commit()
+
+    async def _fake_universe(session, *, market):
+        return 100
+
+    try:
+        with (
+            patch(
+                "app.jobs.invest_kr_fundamentals_snapshots.TvScreenerKrFundamentalsProvider",
+                _FakeProvider,
+            ),
+            patch(
+                "app.jobs.invest_kr_fundamentals_snapshots.active_universe_count",
+                _fake_universe,
+            ),
+        ):
+            result = await run_kr_fundamentals_snapshot_build(
+                KrFundamentalsSnapshotBuildRequest(
+                    limit=5, commit=True, allow_partial=True
+                )
+            )
+
+        assert result["committed"] is True
+        assert result["commit_allowed"] is True
+        assert result["upserted"] == 1
+
+        persisted = (
+            await db_session.execute(
+                text(
+                    "SELECT count(*) FROM invest_kr_fundamentals_snapshots "
+                    "WHERE symbol = :s"
+                ),
+                {"s": _JOB_SYMBOL},
+            )
+        ).scalar_one()
+        assert persisted == 1
+    finally:
+        await db_session.execute(
+            text("DELETE FROM invest_kr_fundamentals_snapshots WHERE symbol = :s"),
+            {"s": _JOB_SYMBOL},
+        )
+        await db_session.commit()

--- a/tests/test_invest_kr_fundamentals_snapshots_provider.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_provider.py
@@ -1,0 +1,152 @@
+"""ROB-429 A1 — provider full-universe fetch semantics.
+
+The bug: ``fetch_rows(limit=None)`` (full mode) collapsed to 200 because
+``query_limit = limit or 200`` + ``return rows[:query_limit]``. tvscreener's
+``query_stock_screener(limit=None)`` also does NOT fetch everything — when
+``limit`` is falsy it skips ``set_range`` and TradingView returns its small
+default range (~150). So the full-universe path MUST pass a large explicit bound.
+
+These tests mock the tvscreener import + service so they never hit the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from app.services.invest_kr_fundamentals_snapshots import provider as provider_mod
+from app.services.invest_kr_fundamentals_snapshots.provider import (
+    _FULL_UNIVERSE_FETCH_CAP,
+    TvScreenerKrFundamentalsProvider,
+)
+
+
+class _FakeStockField:
+    # The provider resolves columns via _get_tvscreener_attr(stock_field, *names);
+    # any non-None attribute works because the fake service ignores the columns.
+    ACTIVE_SYMBOL = "active_symbol"
+    SYMBOL = "symbol"
+    NAME = "name"
+    DESCRIPTION = "description"
+    PRICE = "price"
+    CLOSE = "close"
+    CHANGE_PERCENT = "change_percent"
+    VOLUME = "volume"
+    MARKET_CAPITALIZATION = "market_capitalization"
+    MARKET_CAP_BASIC = "market_cap_basic"
+    PRICE_TO_EARNINGS_RATIO_TTM = "price_to_earnings_ratio_ttm"
+    PRICE_TO_EARNINGS_TTM = "price_to_earnings_ttm"
+    PRICE_TO_BOOK_FQ = "price_to_book_fq"
+    PRICE_TO_BOOK_MRQ = "price_to_book_mrq"
+    PRICE_BOOK_CURRENT = "price_book_current"
+    DIVIDEND_YIELD_FORWARD = "dividend_yield_forward"
+    DIVIDENDS_YIELD_CURRENT = "dividends_yield_current"
+    DIVIDEND_YIELD_RECENT = "dividend_yield_recent"
+    DIVIDEND_YIELD_CURRENT = "dividend_yield_current"
+    RETURN_ON_EQUITY_TTM = "return_on_equity_ttm"
+    RETURN_ON_EQUITY_FY = "return_on_equity_fy"
+    DIVIDEND_PAYOUT_RATIO_TTM = "dividend_payout_ratio_ttm"
+    DIVIDEND_PAYOUT_RATIO_PERCENT_TTM = "dividend_payout_ratio_percent_ttm"
+    DIVIDEND_PAYOUT_RATIO_FY = "dividend_payout_ratio_fy"
+    GROSS_MARGIN_TTM = "gross_margin_ttm"
+    GROSS_MARGIN_PERCENT_TTM = "gross_margin_percent_ttm"
+    REVENUE_ANNUAL_YOY_GROWTH = "revenue_annual_yoy_growth"
+    EPS_DILUTED_ANNUAL_YOY_GROWTH = "eps_diluted_annual_yoy_growth"
+    EPS_DILUTED_QUARTERLY_QOQ_GROWTH = "eps_diluted_quarterly_qoq_growth"
+    NET_INCOME_ANNUAL_YOY_GROWTH = "net_income_annual_yoy_growth"
+    NET_INCOME_CAGR_5Y = "net_income_cagr_5y"
+    CONTINUOUS_DIVIDEND_PAYOUT = "continuous_dividend_payout"
+    CONTINUOUS_DIVIDEND_GROWTH = "continuous_dividend_growth"
+    WEEK_HIGH_52 = "52_week_high"
+    RELATIVE_STRENGTH_INDEX_14 = "relative_strength_index_14"
+    SECTOR = "sector"
+    INDUSTRY = "industry"
+
+
+class _FakeMarket:
+    KOREA = "korea"
+
+
+class _FakeTvscreener:
+    StockField = _FakeStockField
+    Market = _FakeMarket
+
+
+def _fake_df(n: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "symbol": [f"KRX:{600000 + i:06d}" for i in range(n)],
+            "price": [1000.0 + i for i in range(n)],
+        }
+    )
+
+
+class _CapturingService:
+    """Captures the `limit` query_stock_screener was called with and returns a
+    DataFrame sized to that limit (mimicking a server that honors set_range)."""
+
+    last_limit: int | None = None
+
+    def __init__(self, *, full_rows: int) -> None:
+        self._full_rows = full_rows
+
+    async def query_stock_screener(
+        self, *, columns: Any, markets: Any, limit: int | None = None
+    ) -> pd.DataFrame:
+        type(self).last_limit = limit
+        # Server returns min(limit, full_rows) rows when a bound is given; when no
+        # bound is given it would return the small default — but the provider must
+        # always pass an explicit large bound in full mode, so we size to limit.
+        n = min(limit, self._full_rows) if limit else 150
+        return _fake_df(n)
+
+
+@pytest.fixture
+def _patch_tvscreener(monkeypatch):
+    monkeypatch.setattr(provider_mod, "_import_tvscreener", lambda: _FakeTvscreener)
+
+
+@pytest.mark.asyncio
+async def test_fetch_rows_full_universe_passes_large_cap_not_200(
+    monkeypatch, _patch_tvscreener
+):
+    # full universe ~4250 rows available; provider must request the large cap and
+    # return ALL of them (not collapse to 200).
+    full_rows = 4250
+    service = _CapturingService(full_rows=full_rows)
+    monkeypatch.setattr(provider_mod, "TvScreenerService", lambda **kw: service)
+
+    rows = await TvScreenerKrFundamentalsProvider().fetch_rows(limit=None)
+
+    assert _CapturingService.last_limit == _FULL_UNIVERSE_FETCH_CAP
+    assert _FULL_UNIVERSE_FETCH_CAP == 10_000
+    assert _CapturingService.last_limit != 200
+    # All full-universe rows returned (no 200-row slice).
+    assert len(rows) == full_rows
+
+
+@pytest.mark.asyncio
+async def test_fetch_rows_diagnostic_limit_is_bounded(monkeypatch, _patch_tvscreener):
+    service = _CapturingService(full_rows=4250)
+    monkeypatch.setattr(provider_mod, "TvScreenerService", lambda **kw: service)
+
+    rows = await TvScreenerKrFundamentalsProvider().fetch_rows(limit=50)
+
+    assert _CapturingService.last_limit == 50
+    assert len(rows) == 50
+
+
+@pytest.mark.asyncio
+async def test_fetch_rows_zero_or_negative_limit_treated_as_full(
+    monkeypatch, _patch_tvscreener
+):
+    # A non-positive limit must not silently shrink to a tiny range; treat as full.
+    service = _CapturingService(full_rows=300)
+    monkeypatch.setattr(provider_mod, "TvScreenerService", lambda **kw: service)
+
+    rows = await TvScreenerKrFundamentalsProvider().fetch_rows(limit=0)
+
+    assert _CapturingService.last_limit == _FULL_UNIVERSE_FETCH_CAP
+    assert len(rows) == 300

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -511,6 +511,145 @@ async def test_stable_growth_includes_via_roe_and_yoy_skips_streak(db_session):
 
 
 # ---------------------------------------------------------------------------
+# ROB-429 B1 — full-partition evaluation (cand_cap removed) + total_matched
+# ---------------------------------------------------------------------------
+
+
+_BULK_PREFIX = "991"  # 3 chars; + 3-digit index = 6-char KR-shaped synthetic codes
+# Isolated partition date (distinct from _SD = 2026-06-04) so full-partition
+# evaluation sees ONLY this suite's rows, not sibling-suite residue on _SD. The
+# resolver picks the newest date, so this future date is selected deterministically.
+_BULK_SD = dt.date(2026, 6, 5)
+
+
+async def _cleanup_bulk(db_session) -> None:
+    await db_session.execute(
+        sa.delete(InvestKrFundamentalsSnapshot).where(
+            InvestKrFundamentalsSnapshot.symbol.like(f"{_BULK_PREFIX}%")
+        )
+    )
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(
+            KRSymbolUniverse.symbol.like(f"{_BULK_PREFIX}%")
+        )
+    )
+    await db_session.commit()
+
+
+def _bulk_snap(symbol: str, **kw) -> InvestKrFundamentalsSnapshot:
+    base = {
+        "symbol": symbol,
+        "snapshot_date": _BULK_SD,
+        "name": symbol,
+        "source": "tvscreener_kr",
+        "raw_payload": {},
+    }
+    base.update(kw)
+    return InvestKrFundamentalsSnapshot(**base)
+
+
+async def test_full_partition_includes_low_market_cap_small_cap(db_session):
+    """ROB-429 B1: a small (low-market-cap) symbol that passes the preset predicate
+    must appear in results. Under the OLD cand_cap = max(limit*8, 200) market-cap-
+    ordered cap, a small cap ranked beyond the top 200 by market_cap was never
+    evaluated. We seed 200 large-cap passers + 1 tiny passer (rank 201) and assert
+    the tiny one IS included now."""
+    await _cleanup_bulk(db_session)
+    snaps = []
+    universe = []
+    # 200 large-cap passers (market_cap descends, all pass undervalued_growth).
+    # Symbols 991000..991199 keep the largest caps; the small cap is 991999.
+    for i in range(200):
+        sym = f"{_BULK_PREFIX}{i:03d}"
+        snaps.append(
+            _bulk_snap(
+                sym,
+                # huge caps so the small cap sorts to the very bottom by market_cap
+                market_cap=Decimal(str((10_000 - i) * 1_000_000_000_000)),
+                per=Decimal("15"),  # <= 20
+                revenue_yoy=Decimal("0.15"),  # >= 0.10
+                eps_yoy=Decimal("0.30"),  # >= 0.20 (proxy)
+            )
+        )
+        universe.append(_universe(sym, f"대형주{i}"))
+    # The tiny small cap (rank 201 by market_cap) — excluded by the OLD cap.
+    sym_small = f"{_BULK_PREFIX}999"
+    snaps.append(
+        _bulk_snap(
+            sym_small,
+            market_cap=Decimal("1000000000"),  # 1B — far below the top 200
+            per=Decimal("10"),
+            revenue_yoy=Decimal("0.20"),
+            eps_yoy=Decimal("0.40"),
+        )
+    )
+    universe.append(_universe(sym_small, "소형성장주"))
+    try:
+        await _seed(db_session, snaps, universe)
+
+        # Use a high universe_count so the 201-row partition is judged healthy.
+        result = await load_kr_fundamentals_preset_from_tv_snapshot(
+            db_session,
+            market="kr",
+            spec=UNDERVALUED_GROWTH_SPEC,
+            limit=300,  # large display limit so all matches show
+            now=_now,
+            universe_count=201,
+        )
+        assert result is not None
+        matched_syms = {r["symbol"] for r in result.rows}
+        # The small cap the OLD market-cap cand_cap would have excluded is present.
+        assert sym_small in matched_syms
+        # All 201 seeded passers matched the predicate (isolated partition date).
+        assert result.total_matched == 201
+        # The display limit (300) is high enough to show them all.
+        assert len(result.rows) == 201
+    finally:
+        await _cleanup_bulk(db_session)
+
+
+async def test_total_matched_counts_all_before_display_limit(db_session):
+    """total_matched = full-partition predicate matches BEFORE the display limit;
+    len(rows) is capped to the display limit. Uses the isolated bulk partition date
+    so total_matched is exact (no sibling-suite residue on _SD)."""
+    await _cleanup_bulk(db_session)
+    snaps = []
+    universe = []
+    for i in range(5):
+        sym = f"{_BULK_PREFIX}{i:03d}"
+        snaps.append(
+            _bulk_snap(
+                sym,
+                market_cap=Decimal(str((5 - i) * 1_000_000_000_000)),
+                roe_ttm=Decimal(str(20 + i)),  # all pass profitable_company
+                gross_margin_ttm=Decimal("0.30"),
+            )
+        )
+        universe.append(_universe(sym, f"종목{i}"))
+    try:
+        await _seed(db_session, snaps, universe)
+
+        result = await load_kr_fundamentals_preset_from_tv_snapshot(
+            db_session,
+            market="kr",
+            spec=PROFITABLE_COMPANY_SPEC,
+            limit=2,  # display only 2
+            now=_now,
+            universe_count=5,
+        )
+        assert result is not None
+        assert result.total_matched == 5  # all 5 matched the predicate
+        assert len(result.rows) == 2  # display limit applied after counting
+        # sort_by="roe" desc → the two highest-ROE symbols are shown.
+        assert [r["symbol"] for r in result.rows] == [
+            f"{_BULK_PREFIX}004",
+            f"{_BULK_PREFIX}003",
+        ]
+    finally:
+        await _cleanup_bulk(db_session)
+
+
+# ---------------------------------------------------------------------------
 # ROB-428 PR-C: high_yield_value + undervalued_breakout (rerouted valuation presets)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_screener_service_profitable_company.py
+++ b/tests/test_screener_service_profitable_company.py
@@ -338,6 +338,76 @@ async def test_high_yield_value_routes_to_fundamentals_loader(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fundamentals_response_carries_total_and_returned_counts(monkeypatch):
+    """ROB-429 B2: the fundamentals path sets totalCount = full-partition match
+    total and returnedCount = number actually returned (post display limit)."""
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._should_use_snapshot_first",
+        lambda service: True,
+    )
+
+    rows = [
+        {
+            "symbol": f"90{i:04d}",
+            "market": "kr",
+            "name": f"종목{i}",
+            "close": 1000.0 + i,
+            "roe": 20.0 + i,
+            "gross_margin_ttm": 0.30,
+            "snapshot_date": dt.date(2026, 6, 4),
+            "_screener_snapshot_state": "fresh",
+        }
+        for i in range(3)
+    ]
+
+    async def _fake_loader(session, *, market, spec, limit, now):
+        # total_matched (181) intentionally exceeds the 3 displayed rows so the
+        # distinction between totalCount and returnedCount is exercised.
+        return FundamentalsScreenResult(
+            rows=rows,
+            valuation_partition_date=dt.date(2026, 6, 4),
+            fundamentals_partition_date=dt.date(2026, 6, 4),
+            fundamentals_collected_at=dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
+            fundamentals_state="fresh",
+            total_matched=181,
+        )
+
+    monkeypatch.setattr(_TV_LOADER_PATH, _fake_loader)
+    result = await screener_service.build_screener_results(
+        preset_id="profitable_company",
+        market="kr",
+        session=_MockSession(),
+        screening_service=_StubScreening(),
+        resolver=_MockResolver(),
+    )
+    assert result.totalCount == 181
+    assert result.returnedCount == len(result.results) == 3
+
+
+@pytest.mark.asyncio
+async def test_non_fundamentals_preset_leaves_counts_none(monkeypatch):
+    """A non-fundamentals preset must NOT get totalCount/returnedCount set (they
+    stay None so the additive fields are inert for every other preset path)."""
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._should_use_snapshot_first",
+        lambda service: True,
+    )
+
+    # A fundamentals-shaped result returned for a NON-fundamentals preset must not
+    # leak counts onto the response, because the wiring is gated on the preset id
+    # being in FUNDAMENTALS_PRESET_SPECS (consecutive_gainers is not).
+    result = await screener_service.build_screener_results(
+        preset_id="__unknown_preset__",
+        market="kr",
+        session=_MockSession(),
+        screening_service=_StubScreening(),
+        resolver=_MockResolver(),
+    )
+    assert result.totalCount is None
+    assert result.returnedCount is None
+
+
+@pytest.mark.asyncio
 async def test_undervalued_breakout_missing_when_loader_none(monkeypatch):
     # ROB-428 PR-C: None from the TV loader → dataState=missing (handled by the
     # shared FUNDAMENTALS_PRESET_SPECS None branch, never falls through to the


### PR DESCRIPTION
## What & why (ROB-429, after ROB-428 #1115/#1116)

After ROB-428 shipped, KR `/invest/screener` fundamentals presets still differed sharply from Toss. Root cause was **data + read-path caps**, not the metric:
- Snapshot had only **200 rows / 5.1%** of the ~3,909 active KR universe (`provider.py` `query_limit = limit or 200` collapsed `--all`(None)→200; tvscreener `query_stock_screener(limit=falsy)` also skips `set_range` → TradingView default ~150).
- Read-path capped candidates at `max(limit*8,200)` ordered by market_cap → Toss's small/mid-cap matches excluded even with a full snapshot.

Live probe: full KR fetch = **4,250**; 저평가성장주 predicate over the full universe → **181 matches ≈ Toss 187**, 179/180 non-top-cap (excluded by both caps).

## Changes (scope A+B; no migration)
- **A1 full-universe provider**: full mode passes `_FULL_UNIVERSE_FETCH_CAP=10_000`, returns rows unsliced; `--limit N` stays a bounded diagnostic. Live-verified: `fetch_rows(None)`→4250, `fetch_rows(50)`→50.
- **A2 commit guard**: job computes `active_universe_count`; build reuses ROB-426 `assert_min_coverage` at **0.80** floor → blocks thin commits unless `--allow-partial`; result carries `active_universe_count/coverage_ratio/commit_allowed/block_reason`; job rolls back when blocked. (Prevents the next backfill from silently committing 200 rows as "full".)
- **B1 read-path full-partition**: drop the market_cap `cand_cap` → evaluate the whole healthy partition in-memory (20k safety bound) so small caps surface; `total_matched` computed before the display limit.
- **B2 totalCount/returnedCount**: `FundamentalsScreenResult.total_matched` + `ScreenerResultsResponse.totalCount/returnedCount` (optional) on the KR fundamentals path; TS type added (UI render = follow-up).

## Verification (local)
- `pytest -k "kr_fundamentals or fundamentals_screener or screener_service or screener_preset or invest_screener or high_yield or undervalued or snapshot_commit_guard"` → **456 passed, 1 skipped**.
- New `test_invest_kr_fundamentals_snapshots_provider.py` asserts full mode passes 10_000 (not 200) and returns all rows; bounded=50→50.
- `ruff check/format app/ tests/` clean; `alembic heads` single (no new migration).

## Boundaries / out of scope
- No broker/order/watch mutation. Production `--commit`/backfill operator-gated (now coverage-guarded). Toss = benchmark only (library scanner API, no kr.tradingview crawl).
- **C (exact 3yr-avg TTM parity / vendor exactness, totalCount UI rendering)** = follow-up. comparable+honest.

## ⚠️ Pre-existing (NOT this PR)
2 `test_candidate_universe_collector_evidence` failures reproduce on clean main (local test-DB artifact; pass in CI clean DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)