### PR TITLE
fix(ROB-429): build CLI exits non-zero when --commit blocked by coverage guard

### DIFF
--- a/scripts/build_invest_kr_fundamentals_snapshots.py
+++ b/scripts/build_invest_kr_fundamentals_snapshots.py
@@ -74,11 +74,16 @@ async def run(args: argparse.Namespace) -> int:
         print(
             "\n--dry-run: no rows written. Pass --commit only with operator approval."
         )
-    elif not result.get("committed"):
+        return 0
+    if not result.get("committed"):
+        # ROB-429 follow-up: a requested commit blocked by the coverage guard must
+        # exit non-zero so operator automation / CI detects the block — it is NOT a
+        # successful no-op. Pass --allow-partial to override (operator-gated).
         print(
             "\n--commit was requested but BLOCKED by the coverage guard; no rows "
             "written. Pass --allow-partial to override (operator-gated)."
         )
+        return 2
     return 0
 
 

--- a/tests/test_build_invest_kr_fundamentals_snapshots_cli.py
+++ b/tests/test_build_invest_kr_fundamentals_snapshots_cli.py
@@ -1,0 +1,96 @@
+"""ROB-429 follow-up: the build CLI must exit non-zero when a requested --commit
+is blocked by the coverage guard, so operator automation / CI detects the block
+(it is NOT a successful no-op). dry-run and successful/overridden commits exit 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from scripts import build_invest_kr_fundamentals_snapshots as cli
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    base = {"limit": 200, "all": False, "commit": False, "allow_partial": False}
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _result(**overrides: object) -> dict[str, object]:
+    base = {
+        "snapshot_date": "2026-06-04",
+        "fetched": 0,
+        "would_upsert": 0,
+        "upserted": 0,
+        "committed": False,
+        "active_universe_count": 3909,
+        "coverage_ratio": 0.0,
+        "commit_allowed": False,
+        "block_reason": None,
+        "samples": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, result: dict[str, object]) -> None:
+    async def _fake_run(_request: object) -> dict[str, object]:
+        return result
+
+    monkeypatch.setattr(cli, "run_kr_fundamentals_snapshot_build", _fake_run)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch(monkeypatch, _result(committed=False, would_upsert=10))
+    assert await cli.run(_args(commit=False)) == 0
+
+
+@pytest.mark.asyncio
+async def test_commit_blocked_exits_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch(
+        monkeypatch,
+        _result(
+            committed=False,
+            would_upsert=200,
+            coverage_ratio=0.0511,
+            commit_allowed=False,
+            block_reason="kr commit blocked: built 200 < floor 3128",
+        ),
+    )
+    assert await cli.run(_args(commit=True)) == 2
+
+
+@pytest.mark.asyncio
+async def test_commit_success_exits_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch(
+        monkeypatch,
+        _result(
+            committed=True,
+            would_upsert=3800,
+            upserted=3800,
+            coverage_ratio=0.9721,
+            commit_allowed=True,
+        ),
+    )
+    assert await cli.run(_args(commit=True)) == 0
+
+
+@pytest.mark.asyncio
+async def test_commit_allow_partial_exits_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # --allow-partial bypasses the guard → committed True → exit 0 even when thin.
+    _patch(
+        monkeypatch,
+        _result(
+            committed=True,
+            would_upsert=200,
+            upserted=200,
+            coverage_ratio=0.0511,
+            commit_allowed=True,
+        ),
+    )
+    assert await cli.run(_args(commit=True, allow_partial=True)) == 0


### PR DESCRIPTION
## What & why (ROB-429 follow-up after #1118)

#1118 added the coverage guard, but the build CLI still **returned 0** even when a requested `--commit` was blocked — so operator automation / CI couldn't tell that the run wrote nothing. The whole point of the guard (block thin/200-row commits) is undercut if a blocked commit looks like success.

## Change
`scripts/build_invest_kr_fundamentals_snapshots.py` `run()`:
- requested `--commit` blocked by the guard (`committed=False`) → **exit 2** (+ existing BLOCKED message).
- dry-run (no `--commit`) → exit 0; successful commit → exit 0; `--commit --allow-partial` (guard bypassed → committed) → exit 0.

Idea borrowed from the closed A-only PR #1117 (which used `return 2`); the rest of #1117 was superseded by #1118 (A+B).

## Tests
`tests/test_build_invest_kr_fundamentals_snapshots_cli.py` (new): asserts exit 0 (dry-run), **2 (commit blocked)**, 0 (commit success), 0 (commit + --allow-partial). 4 passed locally; ruff clean.

No migration, no broker/order/watch, scripts-only + a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)