### PR TITLE
fix(ROB-429): sanitize KR fundamentals raw payload JSON

### DIFF
--- a/app/services/invest_kr_fundamentals_snapshots/builder.py
+++ b/app/services/invest_kr_fundamentals_snapshots/builder.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import math
+import numbers
 from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
@@ -76,6 +78,49 @@ def _decimal_or_none(value: Any) -> Decimal | None:
     return result
 
 
+def _is_missing_scalar(value: Any) -> bool:
+    """Return true for values that must not be persisted to JSONB as scalars."""
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, Decimal):
+        return value.is_nan() or value.is_infinite()
+    if isinstance(value, numbers.Real):
+        try:
+            return not math.isfinite(float(value))
+        except (TypeError, ValueError, OverflowError):
+            return True
+    try:
+        return bool(value != value)
+    except (TypeError, ValueError):
+        return False
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert provider/raw values into strict JSON-compatible values.
+
+    PostgreSQL JSONB rejects bare ``NaN``/``Infinity`` tokens. tvscreener rows
+    can contain pandas/numpy NaN values for optional text columns such as sector
+    and industry, so sanitize the raw audit payload at the source.
+    """
+    if _is_missing_scalar(value):
+        return None
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, numbers.Integral) and not isinstance(value, bool):
+        return int(value)
+    if isinstance(value, numbers.Real) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (str, bool)):
+        return value
+    return str(value)
+
+
 def _extract_kr_symbol(raw: Any) -> str:
     """Strip a ``KRX:`` exchange prefix and uppercase the bare code."""
     text = str(raw or "").strip().upper()
@@ -87,7 +132,11 @@ def _extract_kr_symbol(raw: Any) -> str:
 
 
 def _str_or_none(value: Any) -> str | None:
+    if _is_missing_scalar(value):
+        return None
     text = str(value or "").strip()
+    if text.lower() in {"nan", "nat", "<na>"}:
+        return None
     return text or None
 
 
@@ -125,7 +174,7 @@ def build_kr_fundamentals_snapshot_payloads(
                 rsi14=row.rsi14,
                 sector=row.sector,
                 industry=row.industry,
-                raw_payload=row.raw_payload,
+                raw_payload=_json_safe(row.raw_payload),
                 source="tvscreener_kr",
             )
         )
@@ -258,5 +307,7 @@ def provider_row_from_mapping(row: dict[str, Any]) -> KrFundamentalsProviderRow 
         rsi14=_decimal_or_none(row.get("relative_strength_index_14")),
         sector=_str_or_none(row.get("sector")),
         industry=_str_or_none(row.get("industry")),
-        raw_payload={k: v for k, v in row.items() if k in _RAW_PAYLOAD_KEYS},
+        raw_payload={
+            k: _json_safe(v) for k, v in row.items() if k in _RAW_PAYLOAD_KEYS
+        },
     )

--- a/tests/test_invest_kr_fundamentals_snapshots_builder.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from decimal import Decimal
 
 import pytest
@@ -106,6 +107,24 @@ def test_build_payloads_drops_rows_without_symbol() -> None:
     assert payloads == []
 
 
+def test_build_payloads_sanitizes_non_finite_raw_payload_values() -> None:
+    payloads = build_kr_fundamentals_snapshot_payloads(
+        [
+            _sample_row(
+                raw_payload={
+                    "symbol": "KRX:005930",
+                    "sector": float("nan"),
+                    "nested": {"industry": float("inf")},
+                }
+            )
+        ],
+        snapshot_date=dt.date(2026, 6, 4),
+    )
+    assert payloads[0].raw_payload["sector"] is None
+    assert payloads[0].raw_payload["nested"]["industry"] is None
+    json.dumps(payloads[0].raw_payload, allow_nan=False)
+
+
 def test_provider_row_from_mapping_maps_normalized_keys() -> None:
     row = provider_row_from_mapping(
         {
@@ -176,6 +195,24 @@ def test_provider_row_from_mapping_missing_keys_become_none() -> None:
     assert row.continuous_dividend_payout is None
     assert row.week_high_52 is None
     assert row.industry is None
+
+
+def test_provider_row_from_mapping_sanitizes_nan_text_and_raw_payload() -> None:
+    row = provider_row_from_mapping(
+        {
+            "symbol": "KRX:610036",
+            "price": 26030,
+            "active_symbol": True,
+            "sector": float("nan"),
+            "industry": float("nan"),
+        }
+    )
+    assert row is not None
+    assert row.sector is None
+    assert row.industry is None
+    assert row.raw_payload["sector"] is None
+    assert row.raw_payload["industry"] is None
+    json.dumps(row.raw_payload, allow_nan=False)
 
 
 def test_provider_row_from_mapping_rejects_non_krx() -> None:


### PR DESCRIPTION
## Summary
- Sanitizes KR fundamentals provider/raw payload values before JSONB writes so tvscreener pandas/numpy `NaN` / `Infinity` values become JSON `null`.
- Treats `NaN`/`<NA>`/`NaT` text-like sector/industry values as missing instead of rendering/storing literal `nan`.
- Adds regression tests for strict JSON serialization and mapped provider rows.

## Why
Full-universe guarded commit reached 4,250 KR fundamentals rows after PR #1118 deploy, but production upsert failed because PostgreSQL JSONB rejects non-standard JSON tokens such as `NaN` in raw audit payloads.

## Validation
- `uv run --group test pytest tests/test_invest_kr_fundamentals_snapshots_builder.py -q` → 16 passed
- `uv run --group test pytest tests/test_invest_kr_fundamentals_snapshots_builder.py tests/test_invest_kr_fundamentals_snapshots_provider.py tests/test_invest_kr_fundamentals_snapshots_job.py -q` → 22 passed
- `uv run --group dev --group test ruff check app/services/invest_kr_fundamentals_snapshots/builder.py tests/test_invest_kr_fundamentals_snapshots_builder.py` → pass
- `uv run --group dev --group test ruff format --check app/services/invest_kr_fundamentals_snapshots/builder.py tests/test_invest_kr_fundamentals_snapshots_builder.py` → pass
- `uv run --group dev ty check app/services/invest_kr_fundamentals_snapshots/builder.py` → pass
- Live no-write provider check with prod env: `rows=4250 payloads=4250 strict_json_payloads=4250`

## Safety
- No broker/order/watchlist/trade-journal mutations.
- No production DB write in this PR itself; it only unblocks the separately guarded snapshot commit path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of invalid numeric values (NaN, Infinity) in financial fundamentals data to prevent database storage rejections and ensure data integrity.

* **Tests**
  * Added comprehensive test coverage for numeric value sanitization across data snapshot payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->