### PR TITLE
feat(ROB-430 PR-②): undervalued_breakout 신고가 = recent NEW 52w-high (not proximity)

### DIFF
--- a/alembic/versions/2026_06_04_rob430_week_high_52_date.py
+++ b/alembic/versions/2026_06_04_rob430_week_high_52_date.py
@@ -1,0 +1,33 @@
+"""Add week_high_52_date to invest_kr_fundamentals_snapshots for ROB-430 PR-②.
+
+Additive (non-destructive): adds a nullable ``week_high_52_date`` column so the
+``undervalued_breakout`` screener preset can match Toss's "신고가" = a NEW 52-week
+high made within ~20 days (a breakout event), instead of the price/52w-high
+proximity proxy. Sourced from tvscreener ``PRICE_52_WEEK_HIGH_DATE``.
+
+Revision ID: 20260604_rob430
+Revises: 20260604_rob428
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260604_rob430"
+down_revision = "20260604_rob428"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "invest_kr_fundamentals_snapshots",
+        sa.Column("week_high_52_date", sa.Date(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invest_kr_fundamentals_snapshots", "week_high_52_date")

--- a/app/models/invest_kr_fundamentals_snapshot.py
+++ b/app/models/invest_kr_fundamentals_snapshot.py
@@ -106,6 +106,11 @@ class InvestKrFundamentalsSnapshot(Base):
 
     # Technical / categorisation columns
     week_high_52: Mapped[Decimal | None] = mapped_column(Numeric(24, 8), nullable=True)
+    # ROB-430 PR-②: the DATE the 52-week high was set (tvscreener
+    # PRICE_52_WEEK_HIGH_DATE). undervalued_breakout's Toss "신고가" = a NEW 52w-high
+    # made within ~20 days (a breakout event), NOT proximity to the high. nullable
+    # because coverage is sparse / the column was added after initial rows.
+    week_high_52_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     rsi14: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
     sector: Mapped[str | None] = mapped_column(String(120), nullable=True)
     industry: Mapped[str | None] = mapped_column(String(120), nullable=True)

--- a/app/services/invest_kr_fundamentals_snapshots/builder.py
+++ b/app/services/invest_kr_fundamentals_snapshots/builder.py
@@ -54,6 +54,7 @@ class KrFundamentalsProviderRow:
     continuous_dividend_payout: Decimal | None = None
     continuous_dividend_growth: Decimal | None = None
     week_high_52: Decimal | None = None
+    week_high_52_date: dt.date | None = None
     rsi14: Decimal | None = None
     sector: str | None = None
     industry: str | None = None
@@ -76,6 +77,27 @@ def _decimal_or_none(value: Any) -> Decimal | None:
     if result.is_nan() or result.is_infinite():
         return None
     return result
+
+
+def _date_from_epoch_seconds(value: Any) -> dt.date | None:
+    """Convert a tvscreener date column (Unix epoch seconds, int) to a UTC date.
+
+    ROB-430 PR-②: ``PRICE_52_WEEK_HIGH_DATE`` arrives as int64 epoch seconds
+    (e.g. ``1780358400``). Returns None for missing / non-finite / unparseable
+    values (fail-soft: a missing date simply excludes the row downstream).
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(seconds) or seconds <= 0:
+        return None
+    try:
+        return dt.datetime.fromtimestamp(seconds, tz=dt.UTC).date()
+    except (OverflowError, OSError, ValueError):
+        return None
 
 
 def _is_missing_scalar(value: Any) -> bool:
@@ -171,6 +193,7 @@ def build_kr_fundamentals_snapshot_payloads(
                 continuous_dividend_payout=row.continuous_dividend_payout,
                 continuous_dividend_growth=row.continuous_dividend_growth,
                 week_high_52=row.week_high_52,
+                week_high_52_date=row.week_high_52_date,
                 rsi14=row.rsi14,
                 sector=row.sector,
                 industry=row.industry,
@@ -304,6 +327,7 @@ def provider_row_from_mapping(row: dict[str, Any]) -> KrFundamentalsProviderRow 
             row.get("continuous_dividend_growth")
         ),
         week_high_52=_decimal_or_none(row.get("52_week_high")),
+        week_high_52_date=_date_from_epoch_seconds(row.get("price_52_week_high_date")),
         rsi14=_decimal_or_none(row.get("relative_strength_index_14")),
         sector=_str_or_none(row.get("sector")),
         industry=_str_or_none(row.get("industry")),

--- a/app/services/invest_kr_fundamentals_snapshots/provider.py
+++ b/app/services/invest_kr_fundamentals_snapshots/provider.py
@@ -59,6 +59,7 @@ _KR_STOCK_FIELD_SPECS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("continuous_dividend_payout", ("CONTINUOUS_DIVIDEND_PAYOUT",)),
     ("continuous_dividend_growth", ("CONTINUOUS_DIVIDEND_GROWTH",)),
     ("week_high_52", ("WEEK_HIGH_52",)),
+    ("week_high_52_date", ("PRICE_52_WEEK_HIGH_DATE",)),
     ("rsi14", ("RELATIVE_STRENGTH_INDEX_14",)),
     ("sector", ("SECTOR",)),
     ("industry", ("INDUSTRY",)),

--- a/app/services/invest_kr_fundamentals_snapshots/repository.py
+++ b/app/services/invest_kr_fundamentals_snapshots/repository.py
@@ -38,6 +38,7 @@ class KrFundamentalsSnapshotUpsert(BaseModel):
     continuous_dividend_payout: Decimal | None = None
     continuous_dividend_growth: Decimal | None = None
     week_high_52: Decimal | None = None
+    week_high_52_date: dt.date | None = None
     rsi14: Decimal | None = None
     sector: str | None = None
     industry: str | None = None

--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -53,10 +53,11 @@ class FundamentalsPresetSpec:
     min_dividend_paid_streak_years: int | None = None  # years (3)
     min_payout_ratio: Decimal | None = None  # percent (30) — DART 현금배당성향%
     min_earnings_growth_qoq: Decimal | None = None  # ratio (0.10)
-    # ROB-428 PR-C: 52-week-high proximity = price / week_high_52 (e.g. 0.95).
-    # Derive-style threshold for the tvscreener KR loader ONLY; the DART loader
-    # ignores it (no DART preset uses it).
-    min_high_52w_proximity: Decimal | None = None  # price / week_high_52 >= threshold
+    # ROB-430 PR-②: Toss "신고가" = a NEW 52-week high made within N days (a breakout
+    # event), NOT proximity to the high. Implemented in the tvscreener KR loader via
+    # week_high_52_date recency: (partition_date - week_high_52_date).days <= N.
+    # The DART loader ignores it (no DART preset uses it).
+    max_new_high_age_days: int | None = None  # 52w-high set within this many days
     sort_by: str = "roe"  # any metric key carried on the output row
 
 
@@ -127,13 +128,23 @@ HIGH_YIELD_VALUE_SPEC = FundamentalsPresetSpec(
     sort_by="roe",
 )
 
-# undervalued_breakout: 0 < PER <= 10 + 0 < PBR <= 1 + 52w-high proximity >= 0.95.
+# undervalued_breakout: 0 < PER <= 10 + 0 < PBR <= 1 + 신고가 (a recent NEW 52-week
+# high). ROB-430 PR-②: Toss's "신고가" filter default is "52주 신고가 / 20일 이내" — a
+# recent breakout event, NOT price/52w-high proximity. Deep-value names (PER<=10,
+# PBR<=1) sit far below their 52w high (probe: max proximity 0.94 → 0 matches under
+# the old 0.95 rule), yet many DID set a new 52w high recently.
+#
+# Toss's "20일" is 20 KRX *trading* days; we only have calendar high-dates, so we use
+# 30 calendar days as the (documented) approximation of ~20 trading days. Live probe
+# vs the full universe: PER<=10 & PBR<=1 = 580 (matches Toss); +new-high <=30d = 73
+# (≈ Toss 77), whereas <=20 *calendar* days = only 35. Comparable, not byte-identical.
+_NEW_HIGH_RECENCY_TRADING_DAYS_AS_CALENDAR = 30
 UNDERVALUED_BREAKOUT_SPEC = FundamentalsPresetSpec(
     preset_id="undervalued_breakout",
     max_per=Decimal("10"),
     max_pbr=Decimal("1"),
-    min_high_52w_proximity=Decimal("0.95"),
-    sort_by="high_52w_proximity",
+    max_new_high_age_days=_NEW_HIGH_RECENCY_TRADING_DAYS_AS_CALENDAR,
+    sort_by="market_cap",
 )
 
 FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -93,8 +93,11 @@ _SORT_KEY_TO_ROW_KEY: dict[str, str] = {
     "earnings_growth_3y_avg": "earnings_growth_3y_avg",
     "earnings_growth_qoq": "earnings_growth_qoq",
     "payout_ratio": "payout_ratio",
-    # ROB-428 PR-C: undervalued_breakout sorts by 52w-high proximity (price/high).
+    # ROB-428 PR-C: 52w-high proximity remains an emitted (informational) row key.
     "high_52w_proximity": "high_52w_proximity",
+    # ROB-430 PR-②: undervalued_breakout sorts by market cap (Toss default, liquid
+    # names first) now that the filter is a recent-new-high event, not proximity.
+    "market_cap": "market_cap",
 }
 
 
@@ -217,8 +220,29 @@ async def _partition_row_count(
     )
 
 
+def _new_high_age_days(
+    snap: InvestKrFundamentalsSnapshot, *, partition_date: dt.date
+) -> int | None:
+    """Days from the 52-week-high date to the snapshot partition date.
+
+    ROB-430 PR-②: a smaller value = a more recent new 52-week high. Returns None
+    when week_high_52_date is missing or in the future relative to the partition
+    (defensive: a future high-date is treated as unavailable, not recent).
+    """
+    high_date = snap.week_high_52_date
+    if high_date is None:
+        return None
+    age = (partition_date - high_date).days
+    if age < 0:
+        return None
+    return age
+
+
 def _passes_thresholds(
-    snap: InvestKrFundamentalsSnapshot, spec: FundamentalsPresetSpec
+    snap: InvestKrFundamentalsSnapshot,
+    spec: FundamentalsPresetSpec,
+    *,
+    partition_date: dt.date,
 ) -> tuple[bool, str | None]:
     """Apply the spec's active thresholds against tvscreener columns (fail-closed).
 
@@ -242,15 +266,15 @@ def _passes_thresholds(
             if Decimal(str(value)) < Decimal(str(threshold)):
                 return False, f"{col_attr} below min"
 
-    # ROB-428 PR-C: 52-week-high proximity is a derived (price/week_high_52)
-    # threshold, not a single-column compare, so it is checked explicitly here
-    # (fail-closed: NULL price / NULL-or-zero week_high_52 excludes the row).
-    if spec.min_high_52w_proximity is not None:
-        proximity = _high_52w_proximity(snap)
-        if proximity is None:
-            return False, "high_52w_proximity unavailable"
-        if proximity < Decimal(str(spec.min_high_52w_proximity)):
-            return False, "high_52w_proximity below min"
+    # ROB-430 PR-②: 신고가 = a NEW 52-week high made within max_new_high_age_days
+    # days of the partition (a breakout event), checked via week_high_52_date
+    # recency (fail-closed: NULL or future high-date excludes the row).
+    if spec.max_new_high_age_days is not None:
+        age = _new_high_age_days(snap, partition_date=partition_date)
+        if age is None:
+            return False, "week_high_52_date unavailable"
+        if age > spec.max_new_high_age_days:
+            return False, "52w high not recent"
 
     return True, None
 
@@ -288,10 +312,17 @@ def _build_row(
         "dividend_growth_streak_years": _to_float(snap.continuous_dividend_growth),
         "earnings_increase_streak_years": None,  # tvscreener does not provide it
         "rsi": _to_float(snap.rsi14),
-        # ROB-428 PR-C: 52w-high proximity metric (_METRIC_FIELD["undervalued_breakout"]
-        # = "high_52w_proximity") + the raw 52-week high for completeness. None when
-        # price / week_high_52 cannot be derived (missing or week_high_52 <= 0).
+        # ROB-430 PR-②: undervalued_breakout's signal is a recent NEW 52w high.
+        # week_high_52_date (the high date) + new_high_age_days (days since, smaller =
+        # more recent) are the honest fields; high_52w_proximity stays as an
+        # informational column. None when the date / 52w-high cannot be derived.
         "week_high_52": _to_float(snap.week_high_52),
+        "week_high_52_date": (
+            snap.week_high_52_date.isoformat()
+            if snap.week_high_52_date is not None
+            else None
+        ),
+        "new_high_age_days": _new_high_age_days(snap, partition_date=partition_date),
         "high_52w_proximity": (
             float(prox) if (prox := _high_52w_proximity(snap)) is not None else None
         ),
@@ -381,7 +412,7 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
         if not _is_kr_toss_common_stock(sym, name):
             continue
         seen.add(sym)
-        passes, reason = _passes_thresholds(snap, spec)
+        passes, reason = _passes_thresholds(snap, spec, partition_date=partition_date)
         if not passes:
             excluded.append({"symbol": sym, "reason": reason})
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -449,6 +449,15 @@ async def db_session():
                         "ADD COLUMN IF NOT EXISTS is_common_stock BOOLEAN"
                     )
                 )
+                # ROB-430 PR-② — week_high_52_date added to the (persistent) KR
+                # fundamentals snapshot table; create_all is a no-op on the existing
+                # table, so patch the column in here (mirrors the alembic migration).
+                await conn.execute(
+                    text(
+                        "ALTER TABLE invest_kr_fundamentals_snapshots "
+                        "ADD COLUMN IF NOT EXISTS week_high_52_date DATE"
+                    )
+                )
                 # ROB-284 — crypto_candles_1d migrates in-place from the
                 # legacy (symbol, market) shape to the (instrument_id, time)
                 # shape. The test DB picks up its schema from

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -204,11 +204,14 @@ def test_registry_has_nine_specs_with_expected_thresholds():
     hyv = FUNDAMENTALS_PRESET_SPECS["high_yield_value"]
     assert hyv.min_roe == Decimal("15") and hyv.max_per == Decimal("10")
     assert hyv.sort_by == "roe"
-    assert hyv.min_high_52w_proximity is None  # not a breakout preset
+    assert hyv.max_new_high_age_days is None  # not a breakout preset
+    # ROB-430 PR-②: undervalued_breakout 신고가 = NEW 52w high within 20 days (a
+    # breakout event), not price/52w-high proximity.
     ub = FUNDAMENTALS_PRESET_SPECS["undervalued_breakout"]
     assert ub.max_per == Decimal("10") and ub.max_pbr == Decimal("1")
-    assert ub.min_high_52w_proximity == Decimal("0.95")
-    assert ub.sort_by == "high_52w_proximity"
+    # 30 calendar days ≈ Toss's "20 거래일" 신고가 window (see spec comment).
+    assert ub.max_new_high_age_days == 30
+    assert ub.sort_by == "market_cap"
 
 
 def _growth_period(year, *, revenue, net_income, filing_date):

--- a/tests/test_invest_kr_fundamentals_snapshots_builder.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_builder.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.services.invest_kr_fundamentals_snapshots.builder import (
     KrFundamentalsProviderRow,
+    _date_from_epoch_seconds,
     build_kr_fundamentals_snapshot_payloads,
     build_kr_fundamentals_snapshots,
     provider_row_from_mapping,
@@ -149,6 +150,7 @@ def test_provider_row_from_mapping_maps_normalized_keys() -> None:
             "continuous_dividend_payout": 38,
             "continuous_dividend_growth": 2,
             "52_week_high": 370000.0,
+            "price_52_week_high_date": 1780358400,  # epoch seconds → 2026-06-02 UTC
             "relative_strength_index_14": 75.5192,
             "sector": "Electronic Technology",
             "industry": "Telecommunications Equipment",
@@ -175,9 +177,24 @@ def test_provider_row_from_mapping_maps_normalized_keys() -> None:
     assert row.continuous_dividend_payout == Decimal("38")
     assert row.continuous_dividend_growth == Decimal("2")
     assert row.week_high_52 == Decimal("370000.0")
+    assert row.week_high_52_date == dt.date(2026, 6, 2)
     assert row.rsi14 == Decimal("75.5192")
     assert row.sector == "Electronic Technology"
     assert row.industry == "Telecommunications Equipment"
+
+
+def test_date_from_epoch_seconds_parses_and_fails_soft() -> None:
+    # ROB-430 PR-②: tvscreener PRICE_52_WEEK_HIGH_DATE arrives as epoch seconds.
+    assert _date_from_epoch_seconds(1780358400) == dt.date(2026, 6, 2)
+    assert _date_from_epoch_seconds(1704067200) == dt.date(2024, 1, 1)
+    assert _date_from_epoch_seconds(1780358400.0) == dt.date(2026, 6, 2)
+    # Fail-soft: missing / non-positive / non-finite / unparseable → None.
+    assert _date_from_epoch_seconds(None) is None
+    assert _date_from_epoch_seconds(0) is None
+    assert _date_from_epoch_seconds(-5) is None
+    assert _date_from_epoch_seconds(float("nan")) is None
+    assert _date_from_epoch_seconds("not-a-number") is None
+    assert _date_from_epoch_seconds(True) is None  # bool is not a real timestamp
 
 
 def test_provider_row_from_mapping_missing_keys_become_none() -> None:
@@ -194,6 +211,7 @@ def test_provider_row_from_mapping_missing_keys_become_none() -> None:
     assert row.roe_ttm is None
     assert row.continuous_dividend_payout is None
     assert row.week_high_52 is None
+    assert row.week_high_52_date is None
     assert row.industry is None
 
 

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -758,14 +758,19 @@ async def test_high_yield_value_sorts_by_roe_desc(db_session):
     assert [r["symbol"] for r in result.rows] == [sym_hi, sym_lo]
 
 
-async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
-    """undervalued_breakout: 0<PER<=10, 0<PBR<=1, price/week_high_52 >= 0.95."""
+async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
+    """undervalued_breakout (ROB-430 PR-②): 0<PER<=10, 0<PBR<=1, and a NEW 52-week
+    high made within 20 days (week_high_52_date recency), NOT price/52w-high proximity.
+
+    Partition date is _SD = 2026-06-04, so a high-date on/after 2026-05-15 (age<=20)
+    passes; older / NULL / future high-dates are fail-closed excluded.
+    """
     await _cleanup(db_session)
     sym_pass = f"{_PREFIX}B0"
-    sym_far_from_high = f"{_PREFIX}B1"
+    sym_old_high = f"{_PREFIX}B1"
     sym_high_pbr = f"{_PREFIX}B2"
-    sym_null_high = f"{_PREFIX}B3"
-    sym_zero_high = f"{_PREFIX}B4"
+    sym_null_high_date = f"{_PREFIX}B3"
+    sym_future_high = f"{_PREFIX}B4"
     await _seed(
         db_session,
         [
@@ -777,17 +782,19 @@ async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
                 market_cap=Decimal("9000000000000"),
                 per=Decimal("8"),  # 0 < per <= 10
                 pbr=Decimal("0.8"),  # 0 < pbr <= 1
-                week_high_52=Decimal("10000"),  # 9700/10000 = 0.97 >= 0.95
+                week_high_52=Decimal("10000"),
+                week_high_52_date=dt.date(2026, 5, 25),  # age 10 <= 20 → recent
                 sector="Industrials",
                 industry="Machinery",
             ),
             _snap(
-                sym_far_from_high,
+                sym_old_high,
                 market_cap=Decimal("8000000000000"),
                 per=Decimal("6"),
                 pbr=Decimal("0.7"),
                 price=Decimal("9000"),
-                week_high_52=Decimal("10000"),  # 0.90 < 0.95 → excluded
+                week_high_52=Decimal("10000"),
+                week_high_52_date=dt.date(2026, 4, 1),  # age 64 > 20 → excluded
             ),
             _snap(
                 sym_high_pbr,
@@ -796,30 +803,33 @@ async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
                 pbr=Decimal("1.5"),  # > 1 → excluded
                 price=Decimal("9900"),
                 week_high_52=Decimal("10000"),
+                week_high_52_date=dt.date(2026, 6, 2),
             ),
             _snap(
-                sym_null_high,
+                sym_null_high_date,
                 market_cap=Decimal("6000000000000"),
                 per=Decimal("4"),
                 pbr=Decimal("0.5"),
                 price=Decimal("5000"),
-                week_high_52=None,  # NULL high → proximity unavailable → excluded
+                week_high_52=Decimal("5200"),
+                week_high_52_date=None,  # NULL high-date → unavailable → excluded
             ),
             _snap(
-                sym_zero_high,
+                sym_future_high,
                 market_cap=Decimal("5000000000000"),
                 per=Decimal("4"),
                 pbr=Decimal("0.5"),
                 price=Decimal("5000"),
-                week_high_52=Decimal("0"),  # high <= 0 → proximity unavailable → excl
+                week_high_52=Decimal("5200"),
+                week_high_52_date=dt.date(2026, 6, 10),  # future → age<0 → excluded
             ),
         ],
         [
             _universe(sym_pass, "저평가탈출"),
-            _universe(sym_far_from_high, "고가멀음"),
+            _universe(sym_old_high, "고가오래됨"),
             _universe(sym_high_pbr, "고PBR"),
-            _universe(sym_null_high, "고가없음"),
-            _universe(sym_zero_high, "고가0"),
+            _universe(sym_null_high_date, "고가일자없음"),
+            _universe(sym_future_high, "미래고가"),
         ],
     )
     result = await load_kr_fundamentals_preset_from_tv_snapshot(
@@ -833,7 +843,9 @@ async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
     assert result is not None
     assert [r["symbol"] for r in result.rows] == [sym_pass]
     row = result.rows[0]
-    # undervalued_breakout metric is high_52w_proximity (must be emitted) + category.
+    # ROB-430 PR-②: the honest signal fields. proximity stays as an emitted column.
+    assert row["week_high_52_date"] == "2026-05-25"
+    assert row["new_high_age_days"] == 10
     assert row["high_52w_proximity"] == pytest.approx(0.97)
     assert row["week_high_52"] == 10000.0
     assert row["per"] == 8.0
@@ -841,40 +853,44 @@ async def test_undervalued_breakout_per_pbr_and_proximity(db_session):
     assert row["category"] == "Machinery"
     assert row["name"] == "저평가탈출"
     # The excluded rows record a reason (fail-closed, never silent pass).
-    excluded_syms = {e["symbol"] for e in result.excluded}
-    assert {sym_far_from_high, sym_high_pbr, sym_null_high, sym_zero_high} <= (
-        excluded_syms
-    )
+    excluded = {e["symbol"]: e["reason"] for e in result.excluded}
+    assert excluded[sym_old_high] == "52w high not recent"
+    assert excluded[sym_null_high_date] == "week_high_52_date unavailable"
+    assert excluded[sym_future_high] == "week_high_52_date unavailable"
+    assert "pbr" in excluded[sym_high_pbr]
 
 
-async def test_undervalued_breakout_sorts_by_proximity_desc(db_session):
+async def test_undervalued_breakout_sorts_by_market_cap_desc(db_session):
+    """ROB-430 PR-②: both pass the recent-new-high filter; bigger market cap first."""
     await _cleanup(db_session)
-    sym_closer = f"{_PREFIX}B5"
-    sym_further = f"{_PREFIX}B6"
+    sym_big = f"{_PREFIX}B5"
+    sym_small = f"{_PREFIX}B6"
     await _seed(
         db_session,
         [
             _snap(
-                sym_further,
-                market_cap=Decimal("9000000000000"),  # bigger cap, lower proximity
-                per=Decimal("6"),
-                pbr=Decimal("0.6"),
-                price=Decimal("9600"),  # 0.96
-                week_high_52=Decimal("10000"),
-            ),
-            _snap(
-                sym_closer,
-                market_cap=Decimal("3000000000000"),
+                sym_small,
+                market_cap=Decimal("3000000000000"),  # smaller cap → second
                 per=Decimal("7"),
                 pbr=Decimal("0.7"),
-                price=Decimal("9990"),  # 0.999
+                price=Decimal("9990"),
                 week_high_52=Decimal("10000"),
+                week_high_52_date=dt.date(2026, 5, 28),  # recent
+            ),
+            _snap(
+                sym_big,
+                market_cap=Decimal("9000000000000"),  # bigger cap → first
+                per=Decimal("6"),
+                pbr=Decimal("0.6"),
+                price=Decimal("9600"),
+                week_high_52=Decimal("10000"),
+                week_high_52_date=dt.date(2026, 5, 30),  # recent
             ),
         ],
-        [_universe(sym_closer, "근접"), _universe(sym_further, "덜근접")],
+        [_universe(sym_big, "큰종목"), _universe(sym_small, "작은종목")],
     )
     result = await load_kr_fundamentals_preset_from_tv_snapshot(
         db_session, market="kr", spec=UNDERVALUED_BREAKOUT_SPEC, limit=20, now=_now
     )
     assert result is not None
-    assert [r["symbol"] for r in result.rows] == [sym_closer, sym_further]
+    assert [r["symbol"] for r in result.rows] == [sym_big, sym_small]


### PR DESCRIPTION
## What & why (ROB-430 PR-②, track A)

KR `/invest/screener` 저평가 탈출 (undervalued_breakout) matched **0** names vs Toss's **77**. Root cause (live probe + Toss re-capture): the "신고가" condition was implemented as `price/week_high_52 ≥ 0.95` (proximity), but Toss's 신고가 = **a NEW 52-week high made within ~20 (trading) days** — a breakout *event*. Deep-value names (PER≤10, PBR≤1) sit far below their 52w high (max proximity 0.94 → 0 matches), yet ~77 of them recently set a new 52w high then pulled back.

## Changes (additive migration 1)
- **Data**: add `week_high_52_date` (nullable Date) sourced from tvscreener `PRICE_52_WEEK_HIGH_DATE` (epoch seconds → UTC date). Model + alembic (`20260604_rob430`, single head) + repository Upsert + provider field spec + builder mapping + `_date_from_epoch_seconds` (fail-soft).
- **Read-path**: `UNDERVALUED_BREAKOUT_SPEC` drops `min_high_52w_proximity`, adds `max_new_high_age_days` (week_high_52_date within N days of the partition; fail-closed on NULL/future). `sort_by` → `market_cap` (Toss default). `high_52w_proximity` stays an emitted informational column (`_METRIC_FIELD` unchanged).

## Calibration (honest)
Toss "20일" = 20 KRX **trading** days ≈ **30 calendar days** (the high-date age histogram has weekend gaps). Live probe over the full universe:
- PER≤10 & PBR≤1 = **580** (matches Toss)
- + new 52w-high ≤30d = **73 ≈ Toss 77**  ✅
- (+ ≤20 *calendar* days = only 35)

Comparable + honest, not byte-identical (different vendor + data freshness).

## Verification
- `pytest` (kr_fundamentals/fundamentals/builder/provider/job/screener_service) → 81 passed; broad screener sweep → 950 passed.
- New tests: recency predicate (recent pass / old / NULL / future fail-closed), market-cap-desc sort, epoch→date parse edge cases, mapping. conftest `ALTER ... ADD COLUMN IF NOT EXISTS` for the persistent test table.
- `ruff check/format app/ tests/` clean; `alembic heads` single.

## Boundaries
No broker/order/watch. Production `--commit`/backfill operator-gated (needs re-build to populate `week_high_52_date`). Toss benchmark only (library scanner API, no kr.tradingview crawl). PR ① (연속상승세 OHLCV window) is the sibling PR on this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking of 52-week high dates for stocks.

* **Refactor**
  * Updated Undervalued Breakout criteria to identify stocks hitting 52-week highs within the last 30 days (versus proximity metrics).
  * Changed result ranking from proximity to market cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->