### PR TITLE
feat(ROB-430 PR-①): consecutive_gainers fail-closed short OHLCV window + diagnostic

### DIFF
--- a/app/services/invest_screener_snapshots/builder.py
+++ b/app/services/invest_screener_snapshots/builder.py
@@ -15,6 +15,15 @@ logger = logging.getLogger(__name__)
 
 _LOOKBACK = 10
 
+#: ROB-430 PR-①: consecutive_gainers filters ``consecutive_up_days >= 5``, which
+#: requires at least 6 daily closes to even be possible (6 closes → 5 up-moves).
+#: When the OHLCV window is shorter than this, a trailing-streak count is a
+#: truncated lower bound (the start of the run is off-screen), so we record
+#: ``consecutive_up_days = None`` (insufficient data) rather than a misleadingly
+#: small number that would silently fail the >= 5 filter. The fix that actually
+#: surfaces streaks is an operator re-build over a full daily-candle history.
+_MIN_SESSIONS_FOR_RELIABLE_STREAK = 6
+
 
 @dataclass(frozen=True)
 class DerivedMetrics:
@@ -40,7 +49,10 @@ def derive_metrics(closes: Sequence[Decimal]) -> DerivedMetrics:
         change_rate = (change_amount / prev * Decimal("100")) if prev != 0 else None
 
     streak: int | None
-    if len(closes) < 2:
+    if len(closes) < _MIN_SESSIONS_FOR_RELIABLE_STREAK:
+        # ROB-430 PR-①: too few sessions to establish a streak the >= 5 filter
+        # needs; a trailing count here is a truncated lower bound, so report None
+        # (insufficient) instead of a misleadingly small, silently-excluded value.
         streak = None
     else:
         streak = 0
@@ -172,4 +184,25 @@ async def build_snapshots_for_market(
             )
 
     await asyncio.gather(*(_one(i, s) for i, s in enumerate(symbols_list)))
-    return [r for r in results if r is not None]
+    built = [r for r in results if r is not None]
+
+    # ROB-430 PR-①: operator diagnostic. If a large share of rows have an OHLCV
+    # window shorter than _MIN_SESSIONS_FOR_RELIABLE_STREAK, consecutive_up_days is
+    # None for them and consecutive_gainers (>= 5) will be empty regardless of the
+    # market — the partition needs a re-build over a fuller daily-candle history.
+    thin = sum(
+        1
+        for r in built
+        if len(r.closes_window or []) < _MIN_SESSIONS_FOR_RELIABLE_STREAK
+    )
+    if thin:
+        logger.warning(
+            "invest_screener_snapshots[%s]: %d/%d rows have < %d OHLCV sessions "
+            "(consecutive_up_days unreliable → consecutive_gainers may be empty; "
+            "re-build over a fuller daily-candle history)",
+            market,
+            thin,
+            len(built),
+            _MIN_SESSIONS_FOR_RELIABLE_STREAK,
+        )
+    return built

--- a/tests/test_invest_screener_snapshots_builder.py
+++ b/tests/test_invest_screener_snapshots_builder.py
@@ -34,11 +34,30 @@ def test_derive_metrics_streak_matches_view_model():
     )
 
 
-def test_derive_metrics_short_window_returns_partial():
+def test_derive_metrics_short_window_streak_is_none():
+    # ROB-430 PR-①: < 6 sessions → consecutive_up_days is None (insufficient), NOT a
+    # truncated lower bound that would silently fail the consecutive_gainers >= 5 filter.
     closes = [Decimal("100"), Decimal("101")]
     metrics = derive_metrics(closes)
-    assert metrics.consecutive_up_days == 1
+    assert metrics.consecutive_up_days is None
     assert metrics.week_change_rate is None  # < 6 elements
+    # change_rate is still computed from the latest pair (needs only 2 closes).
+    assert metrics.change_rate is not None
+
+
+def test_derive_metrics_streak_reliable_at_six_sessions():
+    # ROB-430 PR-①: 5 all-up closes can't confirm a >= 5 streak (max 4) → None;
+    # 6 all-up closes yield a reliable streak of 5 that passes the >= 5 filter.
+    assert (
+        derive_metrics([Decimal(c) for c in [10, 11, 12, 13, 14]]).consecutive_up_days
+        is None
+    )
+    assert (
+        derive_metrics(
+            [Decimal(c) for c in [10, 11, 12, 13, 14, 15]]
+        ).consecutive_up_days
+        == 5
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why (ROB-430 PR-①, track A — sibling of #1121)

연속 상승세 (consecutive_gainers) returns **0** (max `consecutive_up_days`=2) while Toss 국내 shows **~2**. Root cause (code-grounded): the streak calc is correct (10 closes → 9), but the stored OHLCV window is ~3 sessions, so `consecutive_up_days` is a **truncated lower bound** that silently fails the `>= 5` filter for every symbol. The fetch path already requests `count=10` and pulls from KIS when the cache is thin (`_cache_first_kr`), so the short window is a **build-time data state**, not a code truncation bug — the functional fix is an operator re-build over a fuller daily-candle history. This PR makes the failure honest + visible:

- `derive_metrics`: when `len(closes) < _MIN_SESSIONS_FOR_RELIABLE_STREAK` (6, the minimum to confirm a `>= 5` streak), `consecutive_up_days = None` (insufficient) instead of a small, silently-excluded number. No true `>= 5` match is lost (a `>= 5` streak needs `>= 6` closes anyway); the `>= 5` SQL filter excludes NULL just like a small int, but the stored value is now honest and the partition freshness already flags it `partial`.
- `build_snapshots_for_market`: warn with thin/total counts when a partition has many short-window rows → the operator knows consecutive_gainers will be empty and the partition needs a re-build.

## Verification
- `pytest tests/test_invest_screener_snapshots_builder.py` → 7 passed (short window → None + change_rate still computed; 5 closes → None / 6 closes → streak 5 boundary).
- Broad sweep (consecutive / screener_snapshot / derive / invest_screener) → 272 passed.
- `ruff check/format` clean; **no migration** (`alembic heads` single).

## Boundaries / note
No broker/order/watch. **consecutive_gainers parity (~2) is realised by the operator re-build** over a fuller daily-candle history (this PR is the honesty guard + diagnostic). Sibling PR #1121 (저평가 탈출 신고가) is merged.

## ⚠️ Pre-existing (NOT this PR)
`test_candidate_universe_collector_evidence::test_kr_collector_sources_consecutive_gainers_preset` fails on clean origin/main too (seeds the column directly, bypassing derive_metrics; local test-DB artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)