### PR TITLE
fix(ROB-430 트랙B): double_buy 수급-stale 경고가 실제 지연일수 보고 (하드코딩 '1일' 제거)

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -106,7 +106,11 @@ _KR_TOSS_EXCLUDED_NAME_TOKENS = (
 )
 _KR_PREFERRED_SUFFIXES = ("우", "우B", "우C")
 _INVESTOR_FLOW_MIN_STREAK = 3
-_INVESTOR_FLOW_STALE_SUFFIX = " · 1일 지연"
+# ROB-430 트랙 B: the compact chip cannot count the lag (it lacks the market
+# reference date), so it states staleness without a hardcoded "1일" that
+# understated multi-day-old investor-flow partitions. The page-level warning
+# carries the precise snapshot date + lag.
+_INVESTOR_FLOW_STALE_SUFFIX = " · 지연"
 logger = logging.getLogger(__name__)
 
 
@@ -412,11 +416,18 @@ def _double_buy_dependency_warnings(
             "시세 스냅샷이 직전 영업일 기준이라 일부 데이터가 1일 지연되었습니다."
         )
     flow_dates = {row.get("flow_snapshot_date") for row in snapshot_rows}
-    if flow_dates and all(
-        isinstance(d, dt.date) and d < now_market_date for d in flow_dates
-    ):
+    valid_flow = {d for d in flow_dates if isinstance(d, dt.date)}
+    if valid_flow and all(d < now_market_date for d in valid_flow):
+        # ROB-430 트랙 B: report the actual flow snapshot date + lag instead of a
+        # hardcoded "1일" that understated multi-day-old partitions (investor_flow
+        # has no recurring refresh, so it can lag by several days). The lag is a
+        # calendar-day diff (matches ScreenerFreshnessDependency.lagLabel); weekend/
+        # holiday gaps inflate it, so the exact snapshot date is stated alongside.
+        latest_flow = max(valid_flow)
+        flow_lag_days = (now_market_date - latest_flow).days
         warnings.append(
-            "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+            f"수급 스냅샷이 {latest_flow.isoformat()} 기준이라 외인/기관 정보가 "
+            f"{flow_lag_days}일 지연되었습니다."
         )
     state_override = "stale" if warnings else None
     return warnings, state_override

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1884,7 +1884,14 @@ def test_build_freshness_no_change_to_existing_callsite_with_defaults() -> None:
 # ---------------------------------------------------------------------------
 
 
-_DOUBLE_BUY_TEST_SYMBOLS = ["921100", "921200", "921300", "922100", "923000"]
+_DOUBLE_BUY_TEST_SYMBOLS = [
+    "921100",
+    "921200",
+    "921300",
+    "922100",
+    "923000",
+    "923100",
+]
 
 
 @pytest.mark.unit
@@ -2300,8 +2307,10 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
         )
 
         fake_screening.list_screening.assert_not_called()
+        # ROB-430 트랙 B: flow stale by exactly 1 calendar day (12-30 vs 12-31) →
+        # the warning states the actual snapshot date + lag (not a hardcoded "1일").
         flow_warning = (
-            "수급 스냅샷이 직전 영업일 기준이라 외인/기관 정보가 1일 지연되었습니다."
+            "수급 스냅샷이 2099-12-30 기준이라 외인/기관 정보가 1일 지연되었습니다."
         )
         assert flow_warning in resp.warnings, (
             f"expected flow-side stale warning in {resp.warnings}"
@@ -2312,6 +2321,103 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
             f"price-stale warning must not appear when price==flow date: {resp.warnings}"
         )
         # state_override from helper bumps fresh → stale.
+        assert resp.freshness.dataState in {"stale", "fallback"}
+    finally:
+        await _purge()
+
+
+@pytest.mark.asyncio
+async def test_double_buy_flow_stale_warning_reports_actual_multiday_lag(
+    db_session,
+) -> None:
+    """ROB-430 트랙 B: a multi-day-old investor-flow partition must report the real
+    lag (e.g. 3일), not a hardcoded "1일" that understated the staleness.
+    """
+    import datetime as _dt
+    import decimal as _dec
+
+    import sqlalchemy as _sa
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    snap_dt = _dt.date(2099, 12, 28)  # both partitions; market date will be 12-31
+    symbol = "923100"
+
+    async def _purge() -> None:
+        await db_session.execute(
+            _sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.execute(
+            _sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(_DOUBLE_BUY_TEST_SYMBOLS)
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    try:
+        db_session.add(
+            KRSymbolUniverse(
+                symbol=symbol, name="다일지연주", exchange="KOSPI", is_active=True
+            )
+        )
+        db_session.add(
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=snap_dt,
+                foreign_net=1,
+                institution_net=1,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            )
+        )
+        db_session.add(
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=snap_dt,
+                latest_close=_dec.Decimal("10000"),
+                prev_close=_dec.Decimal("9000"),
+                change_rate=_dec.Decimal("11.0"),
+                daily_volume=1,
+                closes_window=[9000, 9500, 9800, 9900, 10000],
+                source="kis",
+            )
+        )
+        await db_session.commit()
+
+        fake_screening = type(
+            "ScreenerService",
+            (_FakeProductionScreening,),
+            {"__module__": "app.services.screener_service"},
+        )()
+
+        # market date = 12-31; flow date = 12-28 → 3 calendar days behind.
+        resp = await build_screener_results(
+            preset_id="double_buy",
+            screening_service=fake_screening,
+            resolver=_FakeResolver(watched=set()),
+            session=db_session,
+            now=lambda: datetime(2099, 12, 31, 6, 0, tzinfo=UTC),
+        )
+
+        assert any(r.symbol == symbol for r in resp.results)
+        # The actual lag (3일) + snapshot date must appear — never a flat "1일".
+        assert (
+            "수급 스냅샷이 2099-12-28 기준이라 외인/기관 정보가 3일 지연되었습니다."
+            in resp.warnings
+        ), f"expected actual 3-day flow lag in {resp.warnings}"
         assert resp.freshness.dataState in {"stale", "fallback"}
     finally:
         await _purge()

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -78,7 +78,10 @@ def test_stale_state_annotates_label():
     )
     assert chip is not None
     assert chip.dataState == "stale"
-    assert "1일 지연" in chip.label
+    # ROB-430 트랙 B: the compact chip flags staleness without a hardcoded "1일"
+    # (the page-level warning carries the precise lag); it must not understate.
+    assert "지연" in chip.label
+    assert "1일 지연" not in chip.label
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why (ROB-430 track B)

쌍끌이 매수(double_buy)의 investor-flow staleness 경고가 항상 **"1일 지연"** 으로 하드코딩돼 있어, `investor_flow_snapshots`가 여러 날 오래됐을 때(이 테이블은 recurring 스케줄러가 없어 operator 수동 적재 → 며칠씩 stale 가능; 보고된 사례 06-02 vs 06-04 = 2일+) 실제보다 **덜 오래된 것처럼 understate** 했습니다.

> 참고: 원래 트랙 B 전제였던 "경고가 조용히 누락된다"는 **검증 결과 false** 였습니다 — 경고는 `_double_buy_dependency_warnings`에서 무조건 append되고 (`screener_service.py:1878-1880`), 기존 회귀테스트 2개(`test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past`, `..._stale_when_price_snapshot_older_than_flow`)가 이미 보장합니다. 진짜 갭은 이 understatement였습니다.

## Changes (migration 0)
- `_double_buy_dependency_warnings`: 수급 경고가 **실제 flow 스냅샷 날짜 + 지연일수**(`now_market_date - max(flow_date)`, 달력일 — `ScreenerFreshnessDependency.lagLabel`과 동일 관례 + weekend-inflation 캐비엇 명시)를 보고. 시세(price) 경고는 **불변**(price 파티션은 최신이라 통상 직전 1세션 → "1일"이 맞음).
- `_INVESTOR_FLOW_STALE_SUFFIX` (`" · 1일 지연"` → `" · 지연"`): 컴팩트 칩은 시장 기준일이 없어 지연일수를 셀 수 없으니 거짓 "1일" 없이 staleness만 표기; 정확한 날짜/지연은 페이지 경고가 전달.

## Verification
- 칩이 "1일"을 단정하지 않음 + 1일-지연 경고가 날짜 포함 + **신규 multi-day(3일) 지연 경고가 실제 "3일 지연"을 보고** (`test_double_buy_flow_stale_warning_reports_actual_multiday_lag`).
- 169 passed (screener_service / investor_flow / double_buy sweep); `ruff check/format` clean; migration 0.

## Boundaries / note
No broker/order/watch. **investor_flow_snapshots 재적재 자체는 ROB-205 operator-gated**(scheduleless by design). 이 PR은 staleness를 정직하게 표기만. 트랙 A(#1121/#1122)와 disjoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)