### PR TITLE
fix(ROB-430): consecutive_gainers streak on COMPLETED sessions only (drop forming intraday bar)

### DIFF
--- a/app/services/invest_screener_snapshots/builder.py
+++ b/app/services/invest_screener_snapshots/builder.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import Any
 
 from app.mcp_server.tooling.market_data_indicators import _fetch_ohlcv_for_indicators
+from app.services.invest_screener_snapshots.freshness import expected_baseline_date
 from app.services.invest_screener_snapshots.repository import SnapshotUpsert
 
 logger = logging.getLogger(__name__)
@@ -120,7 +121,7 @@ def _coerce_snapshot_date(value: Any, fallback: dt.date) -> dt.date:
 
 
 async def build_snapshot_for_symbol(
-    *, market: str, symbol: str, today: dt.date
+    *, market: str, symbol: str, today: dt.date, now: dt.datetime | None = None
 ) -> SnapshotUpsert | None:
     market_type, source = _market_type_and_source(market)
     try:
@@ -133,6 +134,21 @@ async def build_snapshot_for_symbol(
     if df is None or df.empty or "close" not in df.columns:
         return None
     df = df.sort_values("date").reset_index(drop=True) if "date" in df.columns else df
+    if "date" in df.columns:
+        # ROB-430 트랙B follow-up: compute the streak on COMPLETED daily closes only
+        # (Toss "종가 기준"). The KIS daily endpoint returns a forming bar for the
+        # current session intraday; including it would let an intraday/down move
+        # prematurely break a streak. expected_baseline_date returns the prior
+        # session before KR close (or today once closed), so an incomplete today-bar
+        # is dropped only when present — a no-op for an end-of-day build.
+        completed_through = expected_baseline_date(market, now=now)
+        df = df[
+            df["date"].map(
+                lambda d: _coerce_snapshot_date(d, today) <= completed_through
+            )
+        ].reset_index(drop=True)
+        if df.empty:
+            return None
     closes_raw: list[Any] = list(df["close"].tolist())
     closes = [Decimal(str(c)) for c in closes_raw if c is not None]
     if not closes:

--- a/tests/test_invest_screener_snapshots_builder.py
+++ b/tests/test_invest_screener_snapshots_builder.py
@@ -89,6 +89,59 @@ async def test_build_snapshot_for_symbol_kr(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_snapshot_drops_forming_intraday_bar(monkeypatch):
+    """ROB-430 트랙B f/u: a forming (intraday) current-session bar is excluded so
+    consecutive_up_days is computed on COMPLETED closes only (Toss "종가 기준").
+
+    7 rising completed closes through 2026-06-03, then a DOWN forming 2026-06-04 bar.
+    Intraday (before 16:20 KST) → drop 06-04 → streak intact (6). Post-close → keep
+    the completed 06-04 down close → streak breaks (0).
+    """
+    df = pd.DataFrame(
+        {
+            "date": [
+                dt.date(2026, 5, 26),
+                dt.date(2026, 5, 27),
+                dt.date(2026, 5, 28),
+                dt.date(2026, 5, 29),
+                dt.date(2026, 6, 1),
+                dt.date(2026, 6, 2),
+                dt.date(2026, 6, 3),
+                dt.date(2026, 6, 4),
+            ],
+            "close": [100, 101, 102, 103, 104, 105, 106, 90],
+            "volume": [1_000_000] * 8,
+        }
+    )
+    monkeypatch.setattr(
+        "app.services.invest_screener_snapshots.builder._fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=df),
+    )
+
+    # 06-04 10:00 KST (01:00 UTC) — before 16:20 KST → forming 06-04 bar dropped.
+    intraday = await build_snapshot_for_symbol(
+        market="kr",
+        symbol="005930",
+        today=dt.date(2026, 6, 4),
+        now=dt.datetime(2026, 6, 4, 1, 0, tzinfo=dt.UTC),
+    )
+    assert intraday is not None
+    assert intraday.snapshot_date == dt.date(2026, 6, 3)
+    assert intraday.consecutive_up_days == 6  # streak intact through the last close
+
+    # 06-04 17:00 KST (08:00 UTC) — after 16:20 KST → completed 06-04 down close kept.
+    post_close = await build_snapshot_for_symbol(
+        market="kr",
+        symbol="005930",
+        today=dt.date(2026, 6, 4),
+        now=dt.datetime(2026, 6, 4, 8, 0, tzinfo=dt.UTC),
+    )
+    assert post_close is not None
+    assert post_close.snapshot_date == dt.date(2026, 6, 4)
+    assert post_close.consecutive_up_days == 0  # the down close ends the run
+
+
+@pytest.mark.asyncio
 async def test_build_snapshot_for_symbol_accepts_python_date_cells(monkeypatch):
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## What & why (ROB-430 follow-up — 연속 상승세 as-of correctness)

연속 상승세(consecutive_gainers)가 0건인 한 원인을 robust하게 차단합니다. Toss 연속상승 칩 팝업은 **"X월 X일 종가 기준"**(직전 완료 세션 종가 기준 배치)인데, 우리 스냅샷 빌드가 **장중**에 돌면 KIS 일별 엔드포인트가 반환하는 **현재 세션의 미완성(forming) 일봉**이 포함되어, 장중 하락이 직전까지 유효하던 연속상승을 **조기에 끊습니다**.

## Change (migration 0)
- `build_snapshot_for_symbol`: `derive_metrics` 전에 closes를 **`expected_baseline_date(market, now)`까지(= 완료된 직전 세션)** 로 필터. KR은 16:20 KST 이전이면 prior session, 이후면 today → **미완성 today-bar는 존재할 때만 제외**(EOD 빌드엔 no-op, Toss "종가 기준"과 동일). `now` 인자 추가(기본 None→now(UTC)); `build_snapshots_for_market`/job는 무변경(prod는 실시각 기준이라 자동 정합).

## Verification
- 신규 결정적 테스트(`test_build_snapshot_drops_forming_intraday_bar`): 7봉 연속상승 + 하락 forming 06-04 →
  - 장중(06-04 10:00 KST) → 06-04 제외 → **streak 유지(6)**, snapshot=06-03
  - 마감 후(06-04 17:00 KST) → 완료 06-04 하락 종가 반영 → **streak=0**, snapshot=06-04
- `pytest test_invest_screener_snapshots_builder.py` 8 passed; 빌드/연속 sweep 245 passed; `ruff check/format` clean; `alembic heads` single(migration 0).

## Note / boundaries
- No broker/order/watch. EOD 빌드엔 동작 변화 없음(no-op) — 장중 빌드의 정확성/Toss-as-of 정합만 개선.
- 연속상승세 0 vs Toss 2의 **주 원인은 freshness**(우리 06-04 fresh vs Toss 06-02 배치; 그 사이 5일 run들이 꺾임). 이 PR은 장중-forming-bar 노이즈를 제거해 "완료 종가 기준"을 보장.
- ⚠️ pre-existing: `test_candidate_universe_collector_evidence::test_kr_collector_sources_consecutive_gainers_preset` 는 origin/main에서도 실패(컬럼 직접 seed로 빌더 우회; 로컬 test-DB 아티팩트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Investment screener snapshots now correctly exclude incomplete intraday trading bars when market sessions are still forming.
- Snapshots are filtered to only include fully completed trading sessions, preventing calculations based on stale or partial market data.
- Snapshot generation is skipped if insufficient data remains after filtering, ensuring data quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->