### PR TITLE
feat(ROB-431): 쌍끌이 매수 = 전일대비 순매수 증가(DoD delta), not level (net>0)

### DIFF
--- a/app/services/invest_view_model/double_buy_screener.py
+++ b/app/services/invest_view_model/double_buy_screener.py
@@ -1,14 +1,19 @@
 """Read-only loader for the 쌍끌이 매수 (Toss screenId=18 parity) preset.
 
 Joins the latest investor_flow_snapshots row with the latest
-invest_screener_snapshots row per symbol and applies the Toss-parity filter
-(Interpretation A, locked 2026-05-20 under Task 0 safer-fallback rule — see
-plan Decision 1):
+invest_screener_snapshots row per symbol AND the prior flow partition (self-join)
+and applies the Toss-parity filter (ROB-431: redefined from the level rule to the
+day-over-day net-buy increase Toss actually uses):
 
     market = kr
-    foreign_net  > 0   AND institution_net  > 0
+    foreign_net(today)     > foreign_net(prior session)      (외국인 순매수 전일比 증가)
+    institution_net(today) > institution_net(prior session)  (기관 순매수 전일比 증가)
     change_rate >= 0
     sort by change_rate desc, symbol asc
+
+When no prior flow partition exists (investor_flow has no recurring refresh,
+ROB-205) the delta cannot be computed → no qualifiers (fail-closed, never a
+level-only fallback).
 """
 
 from __future__ import annotations
@@ -21,6 +26,7 @@ if TYPE_CHECKING:
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.models.invest_screener_snapshot import InvestScreenerSnapshot
 from app.models.investor_flow_snapshot import InvestorFlowSnapshot
@@ -72,6 +78,22 @@ async def load_double_buy_from_snapshots(
         flow_hp and (flow_hp.is_fallback or not flow_hp.healthy)
     ) or bool(price_hp and (price_hp.is_fallback or not price_hp.healthy))
 
+    # ROB-431: 쌍끌이 = 외국인·기관 순매수가 전일보다 늘어난(day-over-day 증가) 종목
+    # (Toss screenId=18). The latest flow partition supplies today's net-buy; the
+    # most-recent flow partition strictly before it supplies the prior session for
+    # a self-join delta. investor_flow_snapshots has no recurring refresh
+    # (ROB-205), so a prior partition may be absent → fail-closed (no comparison →
+    # no qualifiers, never a fabricated level-only result).
+    prior_flow_date = (
+        await session.execute(
+            sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+                InvestorFlowSnapshot.market == "kr",
+                InvestorFlowSnapshot.snapshot_date < flow_date,
+            )
+        )
+    ).scalar_one_or_none()
+
+    prior_flow = aliased(InvestorFlowSnapshot)
     candidate_stmt = (
         sa.select(
             InvestorFlowSnapshot.symbol,
@@ -96,11 +118,26 @@ async def load_double_buy_from_snapshots(
                 InvestScreenerSnapshot.snapshot_date == price_date,
             ),
         )
+        # ROB-431: self-join the prior flow partition on the same (market, symbol,
+        # source) to compare today's net-buy against the previous session's.
+        .join(
+            prior_flow,
+            sa.and_(
+                prior_flow.market == InvestorFlowSnapshot.market,
+                prior_flow.symbol == InvestorFlowSnapshot.symbol,
+                prior_flow.source == InvestorFlowSnapshot.source,
+                prior_flow.snapshot_date == prior_flow_date,
+            ),
+        )
         .where(
             InvestorFlowSnapshot.market == "kr",
             InvestorFlowSnapshot.snapshot_date == flow_date,
-            InvestorFlowSnapshot.foreign_net > 0,
-            InvestorFlowSnapshot.institution_net > 0,
+            # ROB-431: day-over-day INCREASE in net-buy for BOTH foreign and
+            # institution (Toss "전일보다 순매수량이 늘어난"). Literal increase,
+            # sign-agnostic; a NULL on either side makes the comparison NULL →
+            # excluded (fail-closed). Replaces the prior level rule (net > 0).
+            InvestorFlowSnapshot.foreign_net > prior_flow.foreign_net,
+            InvestorFlowSnapshot.institution_net > prior_flow.institution_net,
             sa.func.coalesce(InvestScreenerSnapshot.change_rate, 0) >= 0,
         )
         .order_by(
@@ -110,12 +147,24 @@ async def load_double_buy_from_snapshots(
         )
         .limit(max(limit * 4, limit + 40))
     )
-    try:
-        result = await session.execute(candidate_stmt)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("double_buy: candidate query failed: %s", exc, exc_info=True)
-        return None
-    candidate_rows = list(result.mappings().all())
+    if prior_flow_date is None:
+        # No prior flow partition → cannot compute the DoD delta → no qualifiers
+        # (honest empty, never a level-only fallback). The empty result is flagged
+        # via the normal partition-degradation reason below.
+        logger.warning(
+            "double_buy: no prior flow partition before %s; day-over-day delta "
+            "unavailable → no qualifiers (investor_flow has no recurring refresh, "
+            "see ROB-205)",
+            flow_date,
+        )
+        candidate_rows: list[Any] = []
+    else:
+        try:
+            result = await session.execute(candidate_stmt)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("double_buy: candidate query failed: %s", exc, exc_info=True)
+            return None
+        candidate_rows = list(result.mappings().all())
 
     symbols = [r["symbol"] for r in candidate_rows]
     name_map: dict[str, str] = {}

--- a/tests/test_invest_view_model_double_buy_screener.py
+++ b/tests/test_invest_view_model_double_buy_screener.py
@@ -16,7 +16,17 @@ from app.services.invest_view_model.double_buy_screener import (
 
 # Test symbols use a 9-prefix range to stay isolated from real KR symbols and
 # from sibling tests that already claim "900xxx" ranges.
-_TEST_SYMBOLS = ["911000", "910001", "919999", "912000"]
+_TEST_SYMBOLS = [
+    "911000",
+    "910001",
+    "919999",
+    "912000",
+    "913000",
+    "913001",
+    "913002",
+    "913003",
+    "914000",
+]
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -73,14 +83,27 @@ async def test_returns_rows_filtered_by_double_buy_and_positive_change_rate(
             ),
         ]
     )
+    prior = dt.date(2099, 12, 30)  # ROB-431: prior flow partition for the DoD delta
     db_session.add_all(
         [
+            # today: both flows higher than the prior session → qualifies (DoD ↑).
             InvestorFlowSnapshot(
                 market="kr",
                 symbol="911000",
                 snapshot_date=today,
                 foreign_net=1_000_000,
                 institution_net=2_000_000,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            ),
+            # prior session: lower net-buy so today's > prior.
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol="911000",
+                snapshot_date=prior,
+                foreign_net=500_000,
+                institution_net=1_000_000,
                 double_buy=True,
                 double_sell=False,
                 source="naver_finance",
@@ -230,17 +253,30 @@ async def test_state_is_stale_when_price_snapshot_date_differs_from_flow_snapsho
             symbol=symbol, name="테스트종목", is_active=True, exchange="KOSPI"
         )
     )
-    db_session.add(
-        InvestorFlowSnapshot(
-            market="kr",
-            symbol=symbol,
-            snapshot_date=flow_date,
-            foreign_net=1,
-            institution_net=1,
-            double_buy=True,
-            double_sell=False,
-            source="naver_finance",
-        )
+    db_session.add_all(
+        [
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=flow_date,
+                foreign_net=1,
+                institution_net=1,
+                double_buy=True,
+                double_sell=False,
+                source="naver_finance",
+            ),
+            # ROB-431: prior flow partition with lower net so the DoD delta passes.
+            InvestorFlowSnapshot(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=dt.date(2099, 12, 29),
+                foreign_net=0,
+                institution_net=0,
+                double_buy=False,
+                double_sell=False,
+                source="naver_finance",
+            ),
+        ]
     )
     db_session.add(
         InvestScreenerSnapshot(
@@ -324,3 +360,112 @@ async def test_double_buy_returns_snapshot_load_result_with_reason(monkeypatch):
     assert result.partition_date == dt.date(2026, 6, 3)
     assert result.degradation_reason == "healthy_no_matches"
     assert result.coverage_label is None
+
+
+@pytest.mark.asyncio
+async def test_dod_delta_includes_only_both_sides_increasing(db_session):
+    """ROB-431: only symbols whose foreign AND institution net-buy BOTH rose vs the
+    prior session qualify; flat/decrease/one-side-only are excluded (fail-closed)."""
+    today = dt.date(2099, 12, 31)
+    prior = dt.date(2099, 12, 30)
+    cases = {
+        "913000": ((100, 100), (200, 200)),  # both ↑ → include
+        "913001": ((100, 100), (100, 200)),  # foreign flat → exclude
+        "913002": ((100, 100), (200, 50)),  # institution ↓ → exclude
+        "913003": ((100, 100), (200, 100)),  # institution flat → exclude
+    }
+    for sym, ((pf, pi), (tf, ti)) in cases.items():
+        db_session.add(
+            KRSymbolUniverse(
+                symbol=sym, name=f"종목{sym}", exchange="KOSPI", is_active=True
+            )
+        )
+        db_session.add_all(
+            [
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=sym,
+                    snapshot_date=prior,
+                    foreign_net=pf,
+                    institution_net=pi,
+                    double_buy=False,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=sym,
+                    snapshot_date=today,
+                    foreign_net=tf,
+                    institution_net=ti,
+                    double_buy=False,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+            ]
+        )
+        db_session.add(
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=sym,
+                snapshot_date=today,
+                latest_close=decimal.Decimal("11000"),
+                prev_close=decimal.Decimal("10000"),
+                change_rate=decimal.Decimal("10.0"),
+                daily_volume=1,
+                closes_window=[10000, 11000],
+                source="kis",
+            )
+        )
+    await db_session.commit()
+
+    result = await load_double_buy_from_snapshots(db_session, market="kr", limit=50)
+    assert result is not None
+    got = {r["symbol"] for r in result.rows}
+    assert "913000" in got  # both increased
+    assert {"913001", "913002", "913003"}.isdisjoint(got)  # flat/decrease/one-side
+
+
+@pytest.mark.asyncio
+async def test_dod_delta_excluded_when_no_prior_flow_partition(db_session):
+    """ROB-431: with no prior flow partition the DoD delta can't be computed →
+    fail-closed (no qualifiers), never a level-only fallback."""
+    today = dt.date(2099, 12, 31)
+    sym = "914000"
+    db_session.add(
+        KRSymbolUniverse(
+            symbol=sym, name="단일파티션주", exchange="KOSPI", is_active=True
+        )
+    )
+    db_session.add(
+        InvestorFlowSnapshot(
+            market="kr",
+            symbol=sym,
+            snapshot_date=today,
+            foreign_net=1_000_000,
+            institution_net=1_000_000,
+            double_buy=True,
+            double_sell=False,
+            source="naver_finance",
+        )
+    )
+    db_session.add(
+        InvestScreenerSnapshot(
+            market="kr",
+            symbol=sym,
+            snapshot_date=today,
+            latest_close=decimal.Decimal("11000"),
+            prev_close=decimal.Decimal("10000"),
+            change_rate=decimal.Decimal("10.0"),
+            daily_volume=1,
+            closes_window=[10000, 11000],
+            source="kis",
+        )
+    )
+    await db_session.commit()
+
+    result = await load_double_buy_from_snapshots(db_session, market="kr", limit=20)
+    assert result is not None
+    # No prior flow partition for this symbol's date → level-only would have
+    # included it (net>0); DoD must NOT.
+    assert all(r["symbol"] != sym for r in result.rows)

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -2034,6 +2034,27 @@ async def test_double_buy_preset_returns_snapshot_filtered_rows(db_session) -> N
                     double_sell=True,
                     source="naver_finance",
                 ),
+                # ROB-431: prior flow partition (DoD delta) — lower net so today's > prior.
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol="921100",
+                    snapshot_date=today - _dt.timedelta(days=1),
+                    foreign_net=500_000,
+                    institution_net=1_000_000,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol="921200",
+                    snapshot_date=today - _dt.timedelta(days=1),
+                    foreign_net=100_000,
+                    institution_net=100_000,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
             ]
         )
         db_session.add_all(
@@ -2155,17 +2176,30 @@ async def test_double_buy_preset_stale_when_price_snapshot_older_than_flow(
                 is_active=True,
             )
         )
-        db_session.add(
-            InvestorFlowSnapshot(
-                market="kr",
-                symbol=symbol,
-                snapshot_date=flow_date,
-                foreign_net=1,
-                institution_net=1,
-                double_buy=True,
-                double_sell=False,
-                source="naver_finance",
-            )
+        db_session.add_all(
+            [
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=flow_date,
+                    foreign_net=1,
+                    institution_net=1,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                # ROB-431: prior flow partition (DoD delta) — lower net so today > prior.
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=flow_date - _dt.timedelta(days=1),
+                    foreign_net=0,
+                    institution_net=0,
+                    double_buy=False,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+            ]
         )
         db_session.add(
             InvestScreenerSnapshot(
@@ -2263,17 +2297,30 @@ async def test_double_buy_preset_flow_stale_warning_when_all_flow_dates_in_past(
                 is_active=True,
             )
         )
-        db_session.add(
-            InvestorFlowSnapshot(
-                market="kr",
-                symbol=symbol,
-                snapshot_date=past_dt,
-                foreign_net=1,
-                institution_net=1,
-                double_buy=True,
-                double_sell=False,
-                source="naver_finance",
-            )
+        db_session.add_all(
+            [
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=past_dt,
+                    foreign_net=1,
+                    institution_net=1,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                # ROB-431: prior flow partition (DoD delta) — lower net so today > prior.
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=past_dt - _dt.timedelta(days=1),
+                    foreign_net=0,
+                    institution_net=0,
+                    double_buy=False,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+            ]
         )
         db_session.add(
             InvestScreenerSnapshot(
@@ -2370,17 +2417,30 @@ async def test_double_buy_flow_stale_warning_reports_actual_multiday_lag(
                 symbol=symbol, name="다일지연주", exchange="KOSPI", is_active=True
             )
         )
-        db_session.add(
-            InvestorFlowSnapshot(
-                market="kr",
-                symbol=symbol,
-                snapshot_date=snap_dt,
-                foreign_net=1,
-                institution_net=1,
-                double_buy=True,
-                double_sell=False,
-                source="naver_finance",
-            )
+        db_session.add_all(
+            [
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=snap_dt,
+                    foreign_net=1,
+                    institution_net=1,
+                    double_buy=True,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+                # ROB-431: prior flow partition (DoD delta) — lower net so today > prior.
+                InvestorFlowSnapshot(
+                    market="kr",
+                    symbol=symbol,
+                    snapshot_date=snap_dt - _dt.timedelta(days=1),
+                    foreign_net=0,
+                    institution_net=0,
+                    double_buy=False,
+                    double_sell=False,
+                    source="naver_finance",
+                ),
+            ]
         )
         db_session.add(
             InvestScreenerSnapshot(


### PR DESCRIPTION
## What & why (ROB-431, 11-preset parity audit T5)

/invest/screener **쌍끌이 매수**가 Toss(/screener/18, 국내 189개)와 종목이 크게 달랐다. 근본원인은 데이터 freshness가 아니라 **조건 mismatch**:
- 우리(이전): `foreign_net > 0 AND institution_net > 0 AND change_rate >= 0` = **레벨**(외국인·기관 둘 다 순매수 + 주가↑).
- Toss: "외국인 순매수 비교 · 하루 전 보다 · **늘어난**" + "기관 순매수 · 하루 전 보다 · **늘어난**" + 주가 전일↑ = **전일대비 순매수 증가(day-over-day delta)**.

## Change (migration 0)
`load_double_buy_from_snapshots`:
- 직전 flow 파티션 `prior_flow_date = max(snapshot_date) WHERE market='kr' AND snapshot_date < flow_date` resolve → `(market, symbol, source)` **self-join**.
- WHERE를 **DoD 증가**로 교체: `today.foreign_net > prior.foreign_net AND today.institution_net > prior.institution_net` + `change_rate >= 0`. literal 증가(부호 무관); 한쪽 NULL이면 비교 NULL → 제외(fail-closed). 기존 레벨 규칙(net>0) 제거.
- 전일 flow 파티션 부재 시(investor_flow는 recurring 스케줄러 없음, ROB-205) → DoD 계산 불가 → **fail-closed(결과 없음 + 경고)**, 레벨 폴백 금지.

## Verification
- 신규: DoD 양측 증가만 포함 / flat·decrease·one-side 제외 / 전일 파티션 결측 시 제외(레벨이면 포함됐을 종목). 기존 double_buy 테스트 6개를 전일 파티션 시드로 갱신.
- `pytest -k double_buy` 14 green; 광역 sweep(double_buy/investor_flow/screener_service) 171 green; `ruff check/format` clean; `alembic heads` single(migration 0).

## Boundaries / note
- No broker/order/watch. migration 0(전일 net-buy row 기존).
- **investor_flow_snapshots 재적재(2연속일 확보) = ROB-205**(operator-gated, 스케줄러 없음). 2연속일 부재 시 fail-closed.
- 라이브 ~189 근접 검증은 operator post-deploy(2-파티션 prod 데이터 필요). exact 종목=벤더/freshness 차로 비목표.
- 표시 정렬 parity는 별도 ROB-432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated double buy screener to identify qualified symbols based on day-over-day increases in both foreign and institutional net-buy amounts, replacing absolute level checks.

* **Bug Fixes**
  * Improved handling for symbols without prior flow data; they are now properly excluded instead of using fallback criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->