### PR TITLE
feat(ROB-432): 저평가탈출 정렬 = PER 오름차순 (Toss 기본순), 로더 ascending 지원

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -59,6 +59,10 @@ class FundamentalsPresetSpec:
     # The DART loader ignores it (no DART preset uses it).
     max_new_high_age_days: int | None = None  # 52w-high set within this many days
     sort_by: str = "roe"  # any metric key carried on the output row
+    # ROB-432: display sort direction. Default desc (highest metric first, e.g. ROE).
+    # undervalued_breakout uses ascending PER (cheapest first) to mirror Toss's
+    # 저평가 탈출 default order (lowest PER on top).
+    sort_descending: bool = True
 
 
 PROFITABLE_COMPANY_SPEC = FundamentalsPresetSpec(
@@ -144,7 +148,11 @@ UNDERVALUED_BREAKOUT_SPEC = FundamentalsPresetSpec(
     max_per=Decimal("10"),
     max_pbr=Decimal("1"),
     max_new_high_age_days=_NEW_HIGH_RECENCY_TRADING_DAYS_AS_CALENDAR,
-    sort_by="market_cap",
+    # ROB-432: Toss 저평가 탈출 default order = PER ascending (cheapest PER first;
+    # observed PER 0.66 < 1.36 < 1.54 < 2.84). Was market_cap desc (ROB-430 PR-②
+    # wrong assumption) → visible top-N mismatched Toss.
+    sort_by="per",
+    sort_descending=False,
 )
 
 FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -428,13 +428,25 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
     total_matched = len(included)
 
     sort_row_key = _SORT_KEY_TO_ROW_KEY.get(spec.sort_by, spec.sort_by)
-    included.sort(
-        key=lambda r: (
-            r.get(sort_row_key) is None,
-            -(r.get(sort_row_key) or 0.0),
-            r["symbol"],
+    # ROB-432: nulls always last; direction from spec.sort_descending. Ascending
+    # (sort_descending=False) puts the smallest metric first — e.g. undervalued_breakout
+    # sorts by PER ascending (cheapest first) to mirror Toss's 저평가 탈출 order.
+    if spec.sort_descending:
+        included.sort(
+            key=lambda r: (
+                r.get(sort_row_key) is None,
+                -(r.get(sort_row_key) or 0.0),
+                r["symbol"],
+            )
         )
-    )
+    else:
+        included.sort(
+            key=lambda r: (
+                r.get(sort_row_key) is None,
+                (r.get(sort_row_key) or 0.0),
+                r["symbol"],
+            )
+        )
     included = included[:limit]
 
     warnings: list[str] = []

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -211,7 +211,9 @@ def test_registry_has_nine_specs_with_expected_thresholds():
     assert ub.max_per == Decimal("10") and ub.max_pbr == Decimal("1")
     # 30 calendar days ≈ Toss's "20 거래일" 신고가 window (see spec comment).
     assert ub.max_new_high_age_days == 30
-    assert ub.sort_by == "market_cap"
+    # ROB-432: Toss 저평가 탈출 default order = PER ascending (cheapest first).
+    assert ub.sort_by == "per"
+    assert ub.sort_descending is False
 
 
 def _growth_period(year, *, revenue, net_income, filing_date):

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -860,37 +860,42 @@ async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
     assert "pbr" in excluded[sym_high_pbr]
 
 
-async def test_undervalued_breakout_sorts_by_market_cap_desc(db_session):
-    """ROB-430 PR-②: both pass the recent-new-high filter; bigger market cap first."""
+async def test_undervalued_breakout_sorts_by_per_ascending(db_session):
+    """ROB-432: Toss 저평가 탈출 default order = PER ascending (cheapest first).
+
+    market_cap is reversed vs PER so the assertion can ONLY pass under PER-ascending
+    (not the old market_cap-desc): the low-PER name has the SMALLER market cap.
+    """
     await _cleanup(db_session)
-    sym_big = f"{_PREFIX}B5"
-    sym_small = f"{_PREFIX}B6"
+    sym_low_per = f"{_PREFIX}B5"
+    sym_high_per = f"{_PREFIX}B6"
     await _seed(
         db_session,
         [
             _snap(
-                sym_small,
-                market_cap=Decimal("3000000000000"),  # smaller cap → second
-                per=Decimal("7"),
+                sym_high_per,
+                market_cap=Decimal("9000000000000"),  # bigger cap, higher PER → second
+                per=Decimal("9"),
                 pbr=Decimal("0.7"),
                 price=Decimal("9990"),
                 week_high_52=Decimal("10000"),
                 week_high_52_date=dt.date(2026, 5, 28),  # recent
             ),
             _snap(
-                sym_big,
-                market_cap=Decimal("9000000000000"),  # bigger cap → first
-                per=Decimal("6"),
+                sym_low_per,
+                market_cap=Decimal("1000000000000"),  # smaller cap, lower PER → first
+                per=Decimal("4"),
                 pbr=Decimal("0.6"),
                 price=Decimal("9600"),
                 week_high_52=Decimal("10000"),
                 week_high_52_date=dt.date(2026, 5, 30),  # recent
             ),
         ],
-        [_universe(sym_big, "큰종목"), _universe(sym_small, "작은종목")],
+        [_universe(sym_low_per, "저PER주"), _universe(sym_high_per, "고PER주")],
     )
     result = await load_kr_fundamentals_preset_from_tv_snapshot(
         db_session, market="kr", spec=UNDERVALUED_BREAKOUT_SPEC, limit=20, now=_now
     )
     assert result is not None
-    assert [r["symbol"] for r in result.rows] == [sym_big, sym_small]
+    # PER ascending: 4 before 9 (even though sym_low_per has the smaller market cap).
+    assert [r["symbol"] for r in result.rows] == [sym_low_per, sym_high_per]


### PR DESCRIPTION
## What & why (ROB-432, 첫 슬라이스: 정렬)

저평가탈출(undervalued_breakout)이 Toss와 **count는 비슷(70≈77)하나 보이는 종목이 다른** 큰 원인은 **정렬 불일치**. browse로 Toss 기본 정렬을 규명:

| # | 종목(해외세트) | **PER** | PBR | 시총 |
|---|---|---|---|---|
| 1 | 뉴욕멜론은행 | **0.66** | 0.09 | 5.9조 |
| 2 | 오라메드 | **1.36** | 0.63 | 2,257억 |
| 3 | 트리마스 | **1.54** | 0.97 | 2.1조 |
| 4 | GMR | **2.84** | 0.9 | 8,856억 |

**PER strictly 오름차순**(0.66<1.36<1.54<2.84) = 정렬 키. PBR(4행 역전)·시총·거래량은 비단조 → PER이 키. 우리는 ROB-430 PR-②에서 "Toss 기본=시가총액"이라 **잘못 가정**해 `market_cap` desc였다.

## Change (migration 0)
- `FundamentalsPresetSpec.sort_descending`(default `True`) 추가. `UNDERVALUED_BREAKOUT_SPEC`: `sort_by` market_cap→**`per`**, `sort_descending=False`.
- `kr_fundamentals_tv_screener` 로더 정렬이 **desc-only**였음 → `spec.sort_descending`로 **ascending 지원**(nulls always last). 다른 프리셋은 default `True`라 동작 불변.

## Verification
- spec 단언(per asc / sort_descending False) + **PER 오름차순 정렬 테스트**(market_cap을 PER과 반대로 시드 → market_cap-desc로는 통과 불가, PER-asc만 통과).
- `pytest` 대상 파일 58 green; 광역 sweep(fundamentals/screener_service/kr_fundamentals) **525 green**; `ruff` clean; `alembic` single head(migration 0).

## Scope / boundaries
- **저평가탈출 정렬만**. 신고가 20거래일 window·다른 프리셋 정렬 타깃·멤버십 overlap 정량화는 ROB-432 잔여.
- exact 종목 일치는 벤더(tvscreener≠Toss) 차로 비목표. No broker/order/watch. migration 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)