### PR TITLE
feat(ROB-432): 저평가탈출 신고가 window = 20 KRX 거래일 (정밀), 30 calendar 근사 제거

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -55,9 +55,12 @@ class FundamentalsPresetSpec:
     min_earnings_growth_qoq: Decimal | None = None  # ratio (0.10)
     # ROB-430 PR-②: Toss "신고가" = a NEW 52-week high made within N days (a breakout
     # event), NOT proximity to the high. Implemented in the tvscreener KR loader via
-    # week_high_52_date recency: (partition_date - week_high_52_date).days <= N.
+    # week_high_52_date recency. ROB-432: N counts KRX *trading* sessions (XKRX,
+    # holiday-aware via session_calendar), not calendar days — Toss's "20일" = 20 거래일.
     # The DART loader ignores it (no DART preset uses it).
-    max_new_high_age_days: int | None = None  # 52w-high set within this many days
+    max_new_high_age_trading_days: int | None = (
+        None  # 52w-high set within N KRX sessions
+    )
     sort_by: str = "roe"  # any metric key carried on the output row
     # ROB-432: display sort direction. Default desc (highest metric first, e.g. ROE).
     # undervalued_breakout uses ascending PER (cheapest first) to mirror Toss's
@@ -138,16 +141,18 @@ HIGH_YIELD_VALUE_SPEC = FundamentalsPresetSpec(
 # PBR<=1) sit far below their 52w high (probe: max proximity 0.94 → 0 matches under
 # the old 0.95 rule), yet many DID set a new 52w high recently.
 #
-# Toss's "20일" is 20 KRX *trading* days; we only have calendar high-dates, so we use
-# 30 calendar days as the (documented) approximation of ~20 trading days. Live probe
-# vs the full universe: PER<=10 & PBR<=1 = 580 (matches Toss); +new-high <=30d = 73
-# (≈ Toss 77), whereas <=20 *calendar* days = only 35. Comparable, not byte-identical.
-_NEW_HIGH_RECENCY_TRADING_DAYS_AS_CALENDAR = 30
+# Toss's "20일" is 20 KRX *trading* days. ROB-432: we now count exact trading
+# sessions between week_high_52_date and the partition via XKRX (session_calendar,
+# holiday-aware), replacing the earlier 30-calendar-day approximation. Earlier probe:
+# PER<=10 & PBR<=1 = 580 (matches Toss); the new-high recency narrows it toward Toss's
+# 77 (the trading-day window is tighter than 30 calendar days; comparable, not
+# byte-identical). Out-of-XKRX-range dates fail closed (excluded), never mis-included.
+_NEW_HIGH_RECENCY_TRADING_DAYS = 20
 UNDERVALUED_BREAKOUT_SPEC = FundamentalsPresetSpec(
     preset_id="undervalued_breakout",
     max_per=Decimal("10"),
     max_pbr=Decimal("1"),
-    max_new_high_age_days=_NEW_HIGH_RECENCY_TRADING_DAYS_AS_CALENDAR,
+    max_new_high_age_trading_days=_NEW_HIGH_RECENCY_TRADING_DAYS,
     # ROB-432: Toss 저평가 탈출 default order = PER ascending (cheapest PER first;
     # observed PER 0.66 < 1.36 < 1.54 < 2.84). Was market_cap desc (ROB-430 PR-②
     # wrong assumption) → visible top-N mismatched Toss.

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -43,6 +43,7 @@ from app.services.invest_view_model.fundamentals_screener import (
     FundamentalsPresetSpec,
     FundamentalsScreenResult,
 )
+from app.services.market_events.session_calendar import trading_sessions_in_range
 
 logger = logging.getLogger(__name__)
 
@@ -95,8 +96,8 @@ _SORT_KEY_TO_ROW_KEY: dict[str, str] = {
     "payout_ratio": "payout_ratio",
     # ROB-428 PR-C: 52w-high proximity remains an emitted (informational) row key.
     "high_52w_proximity": "high_52w_proximity",
-    # ROB-430 PR-②: undervalued_breakout sorts by market cap (Toss default, liquid
-    # names first) now that the filter is a recent-new-high event, not proximity.
+    # market_cap is a valid sort key (generic). NOTE (ROB-432): undervalued_breakout
+    # now sorts by PER ascending (Toss 저평가 탈출 default), not market_cap.
     "market_cap": "market_cap",
 }
 
@@ -220,22 +221,30 @@ async def _partition_row_count(
     )
 
 
-def _new_high_age_days(
+def _new_high_age_trading_days(
     snap: InvestKrFundamentalsSnapshot, *, partition_date: dt.date
 ) -> int | None:
-    """Days from the 52-week-high date to the snapshot partition date.
+    """KRX *trading* sessions from the 52-week-high date to the partition date.
 
-    ROB-430 PR-②: a smaller value = a more recent new 52-week high. Returns None
-    when week_high_52_date is missing or in the future relative to the partition
-    (defensive: a future high-date is treated as unavailable, not recent).
+    ROB-432: counts holiday-aware KRX sessions (XKRX via session_calendar) in the
+    half-open range ``(week_high_52_date, partition_date]`` — a smaller value = a
+    more recent new 52-week high. Toss's "20일" is 20 거래일, so trading days (not
+    calendar days) are the correct unit.
+
+    Returns None (fail-closed → excluded) when:
+    * week_high_52_date is missing, or in the future relative to the partition
+      (a future high-date is treated as unavailable, not recent); or
+    * the range is outside the XKRX calendar's precomputed bounds / any calendar
+      error (``trading_sessions_in_range`` returns [] → never mis-included).
     """
     high_date = snap.week_high_52_date
-    if high_date is None:
+    if high_date is None or high_date > partition_date:
         return None
-    age = (partition_date - high_date).days
-    if age < 0:
+    sessions = trading_sessions_in_range("kr", high_date, partition_date)
+    if not sessions:
+        # Out of XKRX range or calendar error → cannot confirm recency → fail-closed.
         return None
-    return age
+    return sum(1 for s in sessions if s > high_date)
 
 
 def _passes_thresholds(
@@ -266,14 +275,23 @@ def _passes_thresholds(
             if Decimal(str(value)) < Decimal(str(threshold)):
                 return False, f"{col_attr} below min"
 
-    # ROB-430 PR-②: 신고가 = a NEW 52-week high made within max_new_high_age_days
-    # days of the partition (a breakout event), checked via week_high_52_date
-    # recency (fail-closed: NULL or future high-date excludes the row).
-    if spec.max_new_high_age_days is not None:
-        age = _new_high_age_days(snap, partition_date=partition_date)
+    # ROB-430 PR-② / ROB-432: 신고가 = a NEW 52-week high made within
+    # max_new_high_age_trading_days KRX trading sessions of the partition (a breakout
+    # event), checked via week_high_52_date recency. Fail-closed with DISTINCT reasons
+    # so an operator can tell a missing-data exclude from a calendar-range one:
+    #   NULL date / future date / out-of-XKRX-range each get their own reason.
+    if spec.max_new_high_age_trading_days is not None:
+        high_date = snap.week_high_52_date
+        if high_date is None:
+            return False, "52w-high date unavailable"
+        if high_date > partition_date:
+            return False, "52w-high date in future"
+        age = _new_high_age_trading_days(snap, partition_date=partition_date)
         if age is None:
-            return False, "week_high_52_date unavailable"
-        if age > spec.max_new_high_age_days:
+            # date present & not future, yet no sessions in (high, partition] →
+            # the date is outside the XKRX calendar's range (or a calendar error).
+            return False, "52w-high recency unavailable (calendar range)"
+        if age > spec.max_new_high_age_trading_days:
             return False, "52w high not recent"
 
     return True, None
@@ -312,17 +330,20 @@ def _build_row(
         "dividend_growth_streak_years": _to_float(snap.continuous_dividend_growth),
         "earnings_increase_streak_years": None,  # tvscreener does not provide it
         "rsi": _to_float(snap.rsi14),
-        # ROB-430 PR-②: undervalued_breakout's signal is a recent NEW 52w high.
-        # week_high_52_date (the high date) + new_high_age_days (days since, smaller =
-        # more recent) are the honest fields; high_52w_proximity stays as an
-        # informational column. None when the date / 52w-high cannot be derived.
+        # ROB-430 PR-② / ROB-432: undervalued_breakout's signal is a recent NEW 52w
+        # high. week_high_52_date (the high date) + new_high_age_trading_days (KRX
+        # trading sessions since, smaller = more recent) are the honest fields;
+        # high_52w_proximity stays as an informational column. None when the date /
+        # 52w-high cannot be derived or the date is out of the XKRX calendar range.
         "week_high_52": _to_float(snap.week_high_52),
         "week_high_52_date": (
             snap.week_high_52_date.isoformat()
             if snap.week_high_52_date is not None
             else None
         ),
-        "new_high_age_days": _new_high_age_days(snap, partition_date=partition_date),
+        "new_high_age_trading_days": _new_high_age_trading_days(
+            snap, partition_date=partition_date
+        ),
         "high_52w_proximity": (
             float(prox) if (prox := _high_52w_proximity(snap)) is not None else None
         ),

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -204,13 +204,14 @@ def test_registry_has_nine_specs_with_expected_thresholds():
     hyv = FUNDAMENTALS_PRESET_SPECS["high_yield_value"]
     assert hyv.min_roe == Decimal("15") and hyv.max_per == Decimal("10")
     assert hyv.sort_by == "roe"
-    assert hyv.max_new_high_age_days is None  # not a breakout preset
-    # ROB-430 PR-②: undervalued_breakout 신고가 = NEW 52w high within 20 days (a
-    # breakout event), not price/52w-high proximity.
+    assert hyv.max_new_high_age_trading_days is None  # not a breakout preset
+    # ROB-430 PR-②: undervalued_breakout 신고가 = NEW 52w high within 20 trading days
+    # (a breakout event), not price/52w-high proximity.
     ub = FUNDAMENTALS_PRESET_SPECS["undervalued_breakout"]
     assert ub.max_per == Decimal("10") and ub.max_pbr == Decimal("1")
-    # 30 calendar days ≈ Toss's "20 거래일" 신고가 window (see spec comment).
-    assert ub.max_new_high_age_days == 30
+    # ROB-432: Toss's "20 거래일" 신고가 window = 20 KRX trading sessions (XKRX),
+    # replacing the earlier 30-calendar-day approximation.
+    assert ub.max_new_high_age_trading_days == 20
     # ROB-432: Toss 저평가 탈출 default order = PER ascending (cheapest first).
     assert ub.sort_by == "per"
     assert ub.sort_descending is False

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -759,11 +759,13 @@ async def test_high_yield_value_sorts_by_roe_desc(db_session):
 
 
 async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
-    """undervalued_breakout (ROB-430 PR-②): 0<PER<=10, 0<PBR<=1, and a NEW 52-week
-    high made within 20 days (week_high_52_date recency), NOT price/52w-high proximity.
+    """undervalued_breakout (ROB-430 PR-② / ROB-432): 0<PER<=10, 0<PBR<=1, and a NEW
+    52-week high made within 20 KRX *trading* sessions (week_high_52_date recency via
+    XKRX, holiday-aware), NOT price/52w-high proximity.
 
-    Partition date is _SD = 2026-06-04, so a high-date on/after 2026-05-15 (age<=20)
-    passes; older / NULL / future high-dates are fail-closed excluded.
+    Partition date is _SD = 2026-06-04. high-date 2026-05-25 → 8 trading sessions
+    (passes); 2026-04-01 → 43 sessions (excluded); NULL / future high-dates are
+    fail-closed excluded.
     """
     await _cleanup(db_session)
     sym_pass = f"{_PREFIX}B0"
@@ -783,7 +785,7 @@ async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
                 per=Decimal("8"),  # 0 < per <= 10
                 pbr=Decimal("0.8"),  # 0 < pbr <= 1
                 week_high_52=Decimal("10000"),
-                week_high_52_date=dt.date(2026, 5, 25),  # age 10 <= 20 → recent
+                week_high_52_date=dt.date(2026, 5, 25),  # 8 trading days <= 20 → recent
                 sector="Industrials",
                 industry="Machinery",
             ),
@@ -794,7 +796,9 @@ async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
                 pbr=Decimal("0.7"),
                 price=Decimal("9000"),
                 week_high_52=Decimal("10000"),
-                week_high_52_date=dt.date(2026, 4, 1),  # age 64 > 20 → excluded
+                week_high_52_date=dt.date(
+                    2026, 4, 1
+                ),  # 43 trading days > 20 → excluded
             ),
             _snap(
                 sym_high_pbr,
@@ -845,7 +849,8 @@ async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
     row = result.rows[0]
     # ROB-430 PR-②: the honest signal fields. proximity stays as an emitted column.
     assert row["week_high_52_date"] == "2026-05-25"
-    assert row["new_high_age_days"] == 10
+    # ROB-432: 8 KRX trading sessions between 2026-05-25 (a holiday) and 2026-06-04.
+    assert row["new_high_age_trading_days"] == 8
     assert row["high_52w_proximity"] == pytest.approx(0.97)
     assert row["week_high_52"] == 10000.0
     assert row["per"] == 8.0
@@ -855,8 +860,9 @@ async def test_undervalued_breakout_per_pbr_and_new_high_recency(db_session):
     # The excluded rows record a reason (fail-closed, never silent pass).
     excluded = {e["symbol"]: e["reason"] for e in result.excluded}
     assert excluded[sym_old_high] == "52w high not recent"
-    assert excluded[sym_null_high_date] == "week_high_52_date unavailable"
-    assert excluded[sym_future_high] == "week_high_52_date unavailable"
+    # ROB-432: distinct reasons so missing-data vs future vs calendar-range differ.
+    assert excluded[sym_null_high_date] == "52w-high date unavailable"
+    assert excluded[sym_future_high] == "52w-high date in future"
     assert "pbr" in excluded[sym_high_pbr]
 
 


### PR DESCRIPTION
## What & why (ROB-432, 슬라이스 2: 신고가 window 정밀화)

Toss 저평가 탈출의 "신고가 20일 이내"는 **20 KRX 거래일**. ROB-430 PR-②에서는 거래일 캘린더가 없다고 보고 **30 calendar days로 근사**했는데, 레포에 이미 `exchange_calendars`(XKRX)를 감싼 **`session_calendar.trading_sessions_in_range`**(휴일 인식, fail-closed)가 있어 정밀화한다.

## Change (migration 0)
- `kr_fundamentals_tv_screener`: `_new_high_age_days`(calendar `(partition-high).days`) → **`_new_high_age_trading_days`** = `trading_sessions_in_range("kr", high_date, partition_date)`의 `(high, partition]` 거래일 수.
  - **fail-closed → 제외(None)**: `week_high_52_date` NULL / 미래 / **XKRX 범위 밖**(또는 캘린더 오류).
- `fundamentals_screener`: spec 필드 `max_new_high_age_days`(30) → **`max_new_high_age_trading_days`(20)**.
- 행 키 `new_high_age_days` → `new_high_age_trading_days`(거래일 단위). **DART 로더는 이 필드 미사용 → 불변**.
- **검증 워크플로(3 lens) 반영**: reject 사유를 **distinct하게 분리**(NULL 데이터 / 미래 / 캘린더 범위 밖)해 운영자가 "누락 데이터"와 "캘린더 범위"를 구분 가능(honesty contract).

## Verification
- XKRX 독립 probe: high **2026-05-25(KR 휴일) → 8 거래일**(≤20 통과), **2026-04-01 → 43**(>20 제외). 멤버십 동일, age 값만 변경.
- `pytest` 대상 48 green; 광역 sweep 544 green; `ruff` clean; `alembic` single head(migration 0).

## Boundaries / follow-up
- No broker/order/watch. migration 0(`week_high_52_date` 기보유).
- XKRX bounds = 2006-06-05 .. ~2027-06-04(자동 연장). production 날짜가 last_session 초과 시 fail-closed로 preset이 비워질 수 있음 → **operator 모니터링은 별도 follow-up**(`exchange_calendars` 업그레이드로 자동 연장됨; reject 사유 "calendar range"로 excluded 목록에 표면화).
- 다른 프리셋 정렬 타깃·멤버십 overlap 정량화는 ROB-432 잔여.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Stock screener now measures 52-week high recency using trading days instead of calendar days, providing more accurate results aligned with actual trading sessions.
  * Enhanced diagnostic messages when stock data is unavailable, future-dated, or outside expected date ranges, improving user feedback clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->