### PR TITLE
feat(ROB-432): fundamentals 프리셋 표시 정렬을 Toss 기본순에 맞춤 (4 프리셋)

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -72,7 +72,9 @@ PROFITABLE_COMPANY_SPEC = FundamentalsPresetSpec(
     preset_id="profitable_company",
     min_roe=Decimal("15"),
     min_gross_margin_ttm=Decimal("0.20"),
-    sort_by="roe",
+    # ROB-432: Toss 돈 잘버는 회사 default order = 매출총이익률 desc (observed 100.00 >
+    # 99.09 > 99.02 ... strictly; ROE jumps around → not the key).
+    sort_by="gross_margin_ttm",
 )
 
 UNDERVALUED_GROWTH_SPEC = FundamentalsPresetSpec(
@@ -80,7 +82,9 @@ UNDERVALUED_GROWTH_SPEC = FundamentalsPresetSpec(
     max_per=Decimal("20"),
     min_revenue_growth_3y_avg=Decimal("0.10"),
     min_earnings_growth_3y_avg=Decimal("0.20"),
-    sort_by="earnings_growth_3y_avg",
+    # ROB-432: Toss 저평가 성장주 default order = 연평균 매출액 증감률 desc (observed
+    # 1806 > 333 > 290 ... strictly; the earnings-growth column is not monotonic).
+    sort_by="revenue_growth_3y_avg",
 )
 
 STABLE_GROWTH_SPEC = FundamentalsPresetSpec(
@@ -105,7 +109,10 @@ CHEAP_VALUE_SPEC = FundamentalsPresetSpec(
     max_per=Decimal("15"),
     max_pbr=Decimal("1.5"),
     min_earnings_growth_3y_avg=Decimal("0"),  # 3y-avg net income growth >= 0%
-    sort_by="earnings_growth_3y_avg",
+    # ROB-432: Toss 아직 저렴한 가치주 default order = PBR ascending (cheapest first;
+    # observed 0.02 < 0.05 ... ; PER and earnings-growth columns are not monotonic).
+    sort_by="pbr",
+    sort_descending=False,
 )
 
 STEADY_DIVIDEND_SPEC = FundamentalsPresetSpec(
@@ -121,7 +128,9 @@ GROWTH_EXPECTATION_TOSS_SPEC = FundamentalsPresetSpec(
     preset_id="growth_expectation_toss",
     min_earnings_growth_3y_avg=Decimal("0.03"),
     min_earnings_growth_qoq=Decimal("0.10"),
-    sort_by="earnings_growth_qoq",
+    # ROB-432: Toss 성장 기대주 default order = 연평균 순이익 증감률 desc (observed
+    # 700 > 687 > 550 ... strictly; the QoQ column is not monotonic).
+    sort_by="earnings_growth_3y_avg",
 )
 
 # ROB-428 PR-C: the last 2 KR Toss valuation presets, rerouted onto the tvscreener
@@ -298,13 +307,25 @@ def evaluate_fundamentals_candidates(
         for metric_attr in _CARRIED_DERIVE_METRICS:
             row[metric_attr] = _metric_float(getattr(derivation, metric_attr))
         included.append(row)
-    included.sort(
-        key=lambda r: (
-            r.get(spec.sort_by) is None,
-            -(r.get(spec.sort_by) or 0.0),
-            r["symbol"],
+    # ROB-432: honor spec.sort_descending (mirror the tvscreener KR loader) so an
+    # ascending preset (e.g. cheap_value sorts PBR ascending) is consistent on both
+    # the DART (report/PIT) path and the display path. Nulls always last.
+    if spec.sort_descending:
+        included.sort(
+            key=lambda r: (
+                r.get(spec.sort_by) is None,
+                -(r.get(spec.sort_by) or 0.0),
+                r["symbol"],
+            )
         )
-    )
+    else:
+        included.sort(
+            key=lambda r: (
+                r.get(spec.sort_by) is None,
+                (r.get(spec.sort_by) or 0.0),
+                r["symbol"],
+            )
+        )
     return included[:limit], excluded
 
 

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -9,6 +9,7 @@ import pytest
 from app.services.financial_fundamentals_snapshots.derive import FundamentalPeriod
 from app.services.invest_view_model.fundamentals_screener import (
     PROFITABLE_COMPANY_SPEC,
+    FundamentalsPresetSpec,
     evaluate_fundamentals_candidates,
 )
 
@@ -122,6 +123,14 @@ def test_pit_gate_excludes_unfiled_period():
 
 
 def test_ranking_by_roe_desc_nulls_last_and_limit_trim():
+    # Generic sort mechanism (roe desc, nulls last, limit trim) — uses a synthetic
+    # roe-sort spec so it stays valid regardless of any real preset's sort_by
+    # (ROB-432 changed profitable_company to gross_margin_ttm).
+    spec = FundamentalsPresetSpec(
+        preset_id="_test_roe_sort",
+        min_gross_margin_ttm=Decimal("0.20"),
+        sort_by="roe",
+    )
     # All candidates pass the gross-margin gate (margin 0.30); ranking + trim is the SUT.
     roes = {"A": 50.0, "B": 10.0, "C": 30.0, "D": None, "E": 20.0, "F": 40.0}
     valuation_rows = [
@@ -144,7 +153,7 @@ def test_ranking_by_roe_desc_nulls_last_and_limit_trim():
     rows, _ = evaluate_fundamentals_candidates(
         valuation_rows=valuation_rows,
         periods_by_symbol=periods,
-        spec=PROFITABLE_COMPANY_SPEC,
+        spec=spec,
         report_date=dt.date(2025, 6, 1),
         limit=4,
         name_map={},
@@ -155,7 +164,7 @@ def test_ranking_by_roe_desc_nulls_last_and_limit_trim():
     rows_all, _ = evaluate_fundamentals_candidates(
         valuation_rows=valuation_rows,
         periods_by_symbol=periods,
-        spec=PROFITABLE_COMPANY_SPEC,
+        spec=spec,
         report_date=dt.date(2025, 6, 1),
         limit=20,
         name_map={},
@@ -603,8 +612,15 @@ def test_undervalued_growth_full_include_all_three_conditions():
 
 
 def test_sort_by_non_roe_key_orders_desc():
-    from app.services.invest_view_model.fundamentals_screener import (
-        UNDERVALUED_GROWTH_SPEC,
+    # Generic non-roe-key desc sort mechanism — synthetic spec sorting by
+    # earnings_growth_3y_avg, so it stays valid regardless of any real preset's
+    # sort_by (ROB-432 changed undervalued_growth to revenue_growth_3y_avg).
+    spec = FundamentalsPresetSpec(
+        preset_id="_test_earnings_sort",
+        max_per=Decimal("20"),
+        min_revenue_growth_3y_avg=Decimal("0.10"),
+        min_earnings_growth_3y_avg=Decimal("0.20"),
+        sort_by="earnings_growth_3y_avg",
     )
 
     # Two qualifiers with different earnings growth; sort_by='earnings_growth_3y_avg' desc.
@@ -637,7 +653,7 @@ def test_sort_by_non_roe_key_orders_desc():
     rows, _ = evaluate_fundamentals_candidates(
         valuation_rows=valuation_rows,
         periods_by_symbol=periods,
-        spec=UNDERVALUED_GROWTH_SPEC,
+        spec=spec,
         report_date=dt.date(2025, 6, 1),
         limit=20,
         name_map={},

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -621,8 +621,10 @@ async def test_total_matched_counts_all_before_display_limit(db_session):
             _bulk_snap(
                 sym,
                 market_cap=Decimal(str((5 - i) * 1_000_000_000_000)),
-                roe_ttm=Decimal(str(20 + i)),  # all pass profitable_company
-                gross_margin_ttm=Decimal("0.30"),
+                roe_ttm=Decimal(str(20 + i)),  # all pass profitable_company (ROE >= 15)
+                # ROB-432: profitable_company sorts by gross_margin_ttm desc, so vary it
+                # (0.20..0.24, all >= 0.20) → the two highest are 004, 003.
+                gross_margin_ttm=Decimal(str(round(0.20 + i * 0.01, 2))),
             )
         )
         universe.append(_universe(sym, f"종목{i}"))
@@ -640,7 +642,7 @@ async def test_total_matched_counts_all_before_display_limit(db_session):
         assert result is not None
         assert result.total_matched == 5  # all 5 matched the predicate
         assert len(result.rows) == 2  # display limit applied after counting
-        # sort_by="roe" desc → the two highest-ROE symbols are shown.
+        # ROB-432: sort_by="gross_margin_ttm" desc → the two highest-margin shown.
         assert [r["symbol"] for r in result.rows] == [
             f"{_BULK_PREFIX}004",
             f"{_BULK_PREFIX}003",


### PR DESCRIPTION
## What & why (ROB-432, 슬라이스 3: 프리셋별 정렬 타깃)

저평가탈출(PER asc, #1126)에 이어 **나머지 fundamentals 프리셋의 Toss 기본 정렬을 browse로 일괄 캡처**해 적용. 각 프리셋 결과의 컬럼 단조성으로 정렬 키를 확정(어떤 컬럼이 strict monotone이면 그게 정렬 키, 나머지는 비단조).

| 프리셋 | Toss 기본 정렬 (관측) | 우리(이전) | 변경 |
|---|---|---|---|
| 돈잘버는회사 | **매출총이익률 desc** (100>99.09>99.02…) | roe | → `gross_margin_ttm` desc |
| 저평가성장주 | **연평균 매출액 증감률 desc** (1806>333>290…) | earnings_3y | → `revenue_growth_3y_avg` desc |
| 아직저렴한가치주 | **PBR asc** (0.02<0.05<…) | earnings_3y | → `pbr` **asc** |
| 성장기대주 | **연평균 순이익 증감률 desc** (700>687>550…) | earnings_qoq | → `earnings_growth_3y_avg` desc |
| 고수익저평가·안정성장 | roe desc | roe | 이미 일치 |
| 꾸준한배당주·미래배당왕 | dividend_yield desc | dividend_yield | 이미 일치 |

(각 케이스에서 비-타깃 컬럼은 비단조 — 예: 돈잘버는회사 ROE는 134.62 점프; 헤더 라벨로 col1=매출액/순이익 구분 확정.)

## Change (migration 0)
- 위 4개 프리셋 `sort_by`(+ cheap_value `sort_descending=False`) 변경.
- **DART 로더**(`evaluate_fundamentals_candidates`)도 `sort_descending` 반영(이전 desc-only) → cheap_value PBR asc가 report/PIT 경로에서도 일관(표시 경로는 tvscreener 로더).

## Verification
- row 키 emit 검증: `gross_margin_ttm`/`revenue_growth_3y_avg`/`pbr`/`earnings_growth_3y_avg` 모두 `_build_row`에 존재.
- 일반 정렬-메커니즘 테스트 2개(roe-desc, non-roe-desc)는 **합성 spec으로 분리**(실 프리셋 sort_by 변경에 종속되지 않게); `total_matched` 테스트는 gross_margin 가변 시드 → top-2 by margin.
- 대상 48 green; 광역 sweep **548 green**; `ruff check` + `ruff format --check app/ tests/` clean; `alembic` single head(migration 0).

## Assumption / boundaries
- **정렬은 preset-level**(시장은 행 필터)이라 해외 세트 관측이 국내에도 적용 — 저평가탈출에서 국내(아이티센씨티에스 PER 0.99 선두)와 일치 확인한 것과 동일 논리.
- exact 종목 일치는 벤더 차로 비목표. No broker/order/watch. migration 0.
- 멤버십 overlap 정량화(operator full-list)는 ROB-432 잔여.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sorting behavior in stock screening presets to properly respect ascending and descending order preferences instead of always sorting in descending order.
  * Updated sorting metrics across preset categories to enhance stock ranking accuracy.

* **Tests**
  * Updated test cases to validate sorting behavior across stock screening presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->