### PR TITLE
feat(ROB-427 PR2): US screener per-market availability 계약 (하드제외 → 정직한 status)

### DIFF
--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -47,6 +47,13 @@ ScreenerRiskSeverity = Literal["info", "warning", "danger"]
 # preset matches Toss semantics (auto_trader_original presets leave it None).
 ScreenerPresetOrigin = Literal["toss_parity", "auto_trader_original"]
 ScreenerParityStatus = Literal["full", "partial", "mismatch"]
+# ROB-427: per-preset × market availability. Orthogonal to parityStatus (Toss
+# semantic closeness): availability says whether this preset can RUN in the
+# requested market right now. "active" runs; "data_pending" is catalogued but
+# disabled until a US data source/backfill exists; "unsupported" has no market
+# equivalent (e.g. KR-only investor flow). data_pending/unsupported never
+# fabricate rows — build_screener_results fail-closes with availabilityReason.
+ScreenerPresetAvailability = Literal["active", "data_pending", "unsupported"]
 
 
 class ScreenerInvestorFlowChip(BaseModel):
@@ -79,6 +86,11 @@ class ScreenerPreset(BaseModel):
     presetOrigin: ScreenerPresetOrigin | None = None
     parityStatus: ScreenerParityStatus | None = None
     parityNote: str | None = None
+    # ROB-427: per-market availability. Default "active" keeps every existing
+    # construction (KR/crypto) valid; preset_definitions(market="us") sets
+    # data_pending/unsupported with availabilityReason instead of hiding presets.
+    availability: ScreenerPresetAvailability = "active"
+    availabilityReason: str | None = None
 
 
 class ScreenerSourceContext(BaseModel):

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -38,6 +38,43 @@ _KR_ONLY_PRESET_IDS = {
     "growth_expectation_toss",
 }
 
+# ROB-427: per-market availability. Instead of HIDING the KR-only presets for US
+# (the old hard-filter), the US catalog now exposes them with an honest status.
+# unsupported = no US equivalent (KR 외국인·기관 수급); data_pending = catalogued
+# but disabled until a US data source exists (Yahoo valuation / US fundamentals).
+# The remaining KR-only presets default to data_pending via _KR_ONLY_PRESET_IDS.
+_US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
+_US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
+_US_DATA_PENDING_REASON: dict[str, str] = {
+    "high_yield_value": "미국 가치형(ROE·PER) 활성화 준비중",
+    "undervalued_breakout": "미국 신고가(52주) 데이터 소스 준비중",
+    "profitable_company": "미국 펀더멘털(매출총이익률) 데이터 준비중",
+    "undervalued_growth": "미국 펀더멘털(연평균 매출·순이익 증감률) 데이터 준비중",
+    "cheap_value": "미국 펀더멘털(연평균 순이익 증감률) 데이터 준비중",
+    "growth_expectation_toss": "미국 펀더멘털(연평균 순이익 증감률) 데이터 준비중",
+    "stable_growth": "미국 펀더멘털(증감률·순이익 연속증가) 데이터 준비중",
+    "steady_dividend": "미국 배당·순이익 연속 데이터 준비중",
+    "future_dividend_king": "미국 배당·순이익 연속 데이터 준비중",
+}
+
+
+def _preset_availability(preset_id: str, market: str) -> tuple[str, str | None]:
+    """(availability, reason) for a preset in a market (ROB-427).
+
+    KR/crypto: every catalogued preset is ``active``. US: ``unsupported`` for
+    KR-only flow presets, ``data_pending`` for the rest of the KR-only set
+    (disabled with an honest reason, never fabricated), ``active`` otherwise.
+    """
+    if market != "us":
+        return "active", None
+    if preset_id in _US_UNSUPPORTED_PRESET_IDS:
+        return "unsupported", _US_UNSUPPORTED_REASON
+    if preset_id in _KR_ONLY_PRESET_IDS:
+        return "data_pending", _US_DATA_PENDING_REASON.get(
+            preset_id, "미국 데이터 준비중"
+        )
+    return "active", None
+
 
 SCREENER_PRESETS: list[ScreenerPreset] = [
     ScreenerPreset(
@@ -477,7 +514,15 @@ def _with_market(preset: ScreenerPreset, market: str) -> ScreenerPreset:
         chips[0] = _market_chip(market)
     else:
         chips = [_market_chip(market)]
-    return preset.model_copy(update={"market": market, "filterChips": chips})
+    availability, reason = _preset_availability(preset.id, market)
+    return preset.model_copy(
+        update={
+            "market": market,
+            "filterChips": chips,
+            "availability": availability,
+            "availabilityReason": reason,
+        }
+    )
 
 
 def _normalize_requested_market(market: str) -> str:
@@ -489,10 +534,10 @@ def preset_definitions(market: str = "kr") -> list[ScreenerPreset]:
     normalized_market = _normalize_requested_market(market)
     if normalized_market == "crypto":
         return [_with_market(p, "crypto") for p in CRYPTO_SCREENER_PRESETS]
-    presets = SCREENER_PRESETS
-    if normalized_market != "kr":
-        presets = [p for p in SCREENER_PRESETS if p.id not in _KR_ONLY_PRESET_IDS]
-    return [_with_market(p, normalized_market) for p in presets]
+    # ROB-427: no longer hide KR-only presets for US — expose the full catalog and
+    # let _with_market stamp per-market availability (active/data_pending/unsupported)
+    # so the US tab is honest instead of artificially sparse.
+    return [_with_market(p, normalized_market) for p in SCREENER_PRESETS]
 
 
 def get_preset(preset_id: str, market: str = "kr") -> ScreenerPreset | None:

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1668,6 +1668,30 @@ async def build_screener_results(
             freshness=freshness,
         )
 
+    # ROB-427: a preset that is catalogued for this market but not `active`
+    # (data_pending / unsupported) must fail-closed — never run a loader or
+    # fabricate rows. Surface the honest availabilityReason as a warning.
+    if preset.availability != "active":
+        freshness = _build_freshness(
+            raw_timestamp=None,
+            cache_hit=False,
+            market=requested_market,
+            now=now,
+        )
+        return ScreenerResultsResponse(
+            presetId=preset_id,
+            title=preset.name,
+            description=preset.description,
+            filterChips=preset.filterChips,
+            metricLabel=preset.metricLabel,
+            results=[],
+            warnings=[
+                preset.availabilityReason
+                or "이 시장에서는 아직 제공되지 않는 프리셋입니다."
+            ],
+            freshness=freshness,
+        )
+
     filters = screening_filters_for(preset_id, requested_market)
     # ROB-277 follow-up: loaders for consecutive_gainers and investor_flow_momentum
     # now return _SnapshotLoadResult so partition metadata threads through even when

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -169,8 +169,12 @@ def test_high_yield_value_preset_is_full_toss_parity_kr_only() -> None:
     assert preset.presetOrigin == "toss_parity"
     assert preset.parityStatus == "full"
     assert preset.metricLabel == "ROE"
-    # KR-only: must not surface in the US catalog.
-    assert "high_yield_value" not in {p.id for p in preset_definitions("us")}
+    # ROB-427: no longer hidden in US — exposed with honest data_pending status
+    # (PR3 will flip it to active once the Yahoo-valuation US path is wired).
+    us_by_id = {p.id: p for p in preset_definitions("us")}
+    assert "high_yield_value" in us_by_id
+    assert us_by_id["high_yield_value"].availability == "data_pending"
+    assert us_by_id["high_yield_value"].availabilityReason
 
 
 @pytest.mark.unit

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -1,0 +1,128 @@
+"""ROB-427 PR2: US per-market availability contract.
+
+The US catalog must expose the FULL preset set (no longer hide KR-only presets),
+each stamped with an honest availability (active / data_pending / unsupported),
+and `build_screener_results` must fail-closed for non-active presets.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.invest_view_model.screener_presets import (
+    _KR_ONLY_PRESET_IDS,
+    _US_UNSUPPORTED_PRESET_IDS,
+    preset_definitions,
+)
+from app.services.invest_view_model.screener_service import build_screener_results
+
+
+class _Resolver:
+    def relation(self, market: str, symbol: str) -> str:  # pragma: no cover - unused
+        return "none"
+
+
+@pytest.mark.unit
+def test_us_catalog_exposes_full_set_not_filtered() -> None:
+    """US no longer drops KR-only presets — same membership as KR, statuses differ."""
+    kr_ids = {p.id for p in preset_definitions("kr")}
+    us_ids = {p.id for p in preset_definitions("us")}
+    assert us_ids == kr_ids  # nothing hidden
+    # every KR-only preset is present in US (with a non-active status, asserted below)
+    assert _KR_ONLY_PRESET_IDS <= us_ids
+
+
+@pytest.mark.unit
+def test_kr_catalog_all_active() -> None:
+    for p in preset_definitions("kr"):
+        assert p.availability == "active", p.id
+        assert p.availabilityReason is None, p.id
+
+
+@pytest.mark.unit
+def test_us_price_technical_presets_active() -> None:
+    us = {p.id: p for p in preset_definitions("us")}
+    for pid in (
+        "consecutive_gainers",
+        "oversold_recovery",
+        "kr_high_volume_surge",
+        "growth_expectation",
+    ):
+        assert us[pid].availability == "active", pid
+
+
+@pytest.mark.unit
+def test_us_flow_presets_unsupported_with_reason() -> None:
+    us = {p.id: p for p in preset_definitions("us")}
+    for pid in _US_UNSUPPORTED_PRESET_IDS:
+        assert us[pid].availability == "unsupported", pid
+        assert us[pid].availabilityReason, pid
+
+
+@pytest.mark.unit
+def test_us_fundamentals_presets_data_pending_with_reason() -> None:
+    us = {p.id: p for p in preset_definitions("us")}
+    for pid in (
+        "high_yield_value",
+        "undervalued_breakout",
+        "profitable_company",
+        "undervalued_growth",
+        "cheap_value",
+        "growth_expectation_toss",
+        "stable_growth",
+        "steady_dividend",
+        "future_dividend_king",
+    ):
+        assert us[pid].availability == "data_pending", pid
+        assert us[pid].availabilityReason, pid
+
+
+@pytest.mark.unit
+def test_availability_partition_covers_all_kr_only() -> None:
+    """Every KR-only preset is exactly one of unsupported / data_pending in US."""
+    us = {p.id: p for p in preset_definitions("us")}
+    for pid in _KR_ONLY_PRESET_IDS:
+        assert us[pid].availability in {"data_pending", "unsupported"}, pid
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_results_fail_closed_for_data_pending_us() -> None:
+    """A data_pending US preset returns 0 rows + the honest reason — no loader,
+    no fabrication (screening_service must not even be called)."""
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={"results": [], "warnings": []}
+    )
+    resp = await build_screener_results(
+        preset_id="high_yield_value",
+        screening_service=fake_screening,
+        resolver=_Resolver(),
+        market="us",
+        session=None,
+    )
+    assert resp.presetId == "high_yield_value"
+    assert resp.results == []
+    assert resp.warnings and any("준비중" in w for w in resp.warnings)
+    fake_screening.list_screening.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_results_fail_closed_for_unsupported_us() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={"results": [], "warnings": []}
+    )
+    resp = await build_screener_results(
+        preset_id="double_buy",
+        screening_service=fake_screening,
+        resolver=_Resolver(),
+        market="us",
+        session=None,
+    )
+    assert resp.results == []
+    assert resp.warnings
+    fake_screening.list_screening.assert_not_called()


### PR DESCRIPTION
## What & why (ROB-427 PR2)

US `/invest/screener`가 **연속상승세뿐**인 근본원인 = `screener_presets.py` `_KR_ONLY_PRESET_IDS`(11개)를 `market != "kr"`에서 **하드 제거** → US 카탈로그 4개뿐. Toss US는 11개 전부 노출(가치/배당/성장 포함). 숨기지 말고 **정직한 per-market 상태**로 구분한다.

## Change (migration 0)
- **schema** (`invest_screener.py`): `ScreenerPreset`에 `availability`(`active`|`data_pending`|`unsupported`) + `availabilityReason` 추가. default `active` → KR/crypto 무영향. `parityStatus`(Toss 의미 근접도)와 **직교** — availability는 "이 시장에서 지금 실행 가능한가".
- **screener_presets**: `preset_definitions(us)`가 `_KR_ONLY` 하드필터 제거 → 전체 카탈로그 노출 + `_preset_availability`로 per-market status 스탬프.
  - US: 가격·기술 4개(consecutive_gainers/oversold_recovery/kr_high_volume_surge/growth_expectation) = **active**; KR수급(double_buy/investor_flow_momentum) = **unsupported**; 나머지 펀더멘털 9개 = **data_pending**(정직한 사유). KR/crypto = 전부 active.
- **build_screener_results**: 비-active 프리셋은 **fail-closed** — 로더 미실행·행 위조 금지, `availabilityReason`을 warning으로(빈 결과). `screening_service` 호출조차 안 함.

## Verification
- US 카탈로그 KR과 동일 멤버십(숨김 0) / 4 active / 2 unsupported / 9 data_pending + 사유 / KR 전부 active / `build_screener_results` fail-closed(data_pending·unsupported, screening_service.assert_not_called).
- 신규 8 + 기존 갱신(high_yield_value US 노출=data_pending) → 28 green; 광역 sweep **159 green**; `ruff check`+`format --check app/ tests/` clean; `alembic` single head(migration 0).

## Boundaries / next
- broker/order/watch mutation 0. migration 0. Toss benchmark only.
- **PR3**: high_yield_value를 data_pending→active(Yahoo valuation US 배선). undervalued_breakout는 US 52w-high-date 소스 확보 시.
- US 펀더멘털 벤더(3년평균/streak 활성화)·operator US 스냅샷 재빌드 = 별도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)