### PR TITLE
feat(ROB-427 PR3): US high_yield_value 활성화 (Yahoo valuation 배선)

### DIFF
--- a/app/services/invest_view_model/high_yield_value_screener.py
+++ b/app/services/invest_view_model/high_yield_value_screener.py
@@ -1,14 +1,14 @@
 """Read-only loader for the 고수익 저평가 (Toss 고수익 저평가 parity) preset.
 
-Filters the latest ``market_valuation_snapshots`` partition (KR) by Toss's
+Filters the latest ``market_valuation_snapshots`` partition by Toss's
 high-yield-value rule:
 
-    market = kr
-    roe >= 15        (percent; sourced from Naver ROE(%) column)
+    market = kr | us   (ROB-427 PR3: US backed by Yahoo valuation snapshots)
+    roe >= 15          (percent; KR=Naver ROE(%), US=Yahoo ROE)
     0 < per <= 10
     sort by roe desc, per asc, symbol asc
 
-ROE/PER come from ``market_valuation_snapshots`` (source ``naver_finance``).
+ROE/PER come from ``market_valuation_snapshots`` (KR=``naver_finance``, US=``yahoo``).
 The latest ``invest_screener_snapshots`` price row is LEFT-joined for display
 only — a missing price row never drops a qualifying valuation row. NULL roe/per
 are excluded by the SQL predicate (fail-closed; never fabricate a qualifier).
@@ -46,7 +46,10 @@ async def load_high_yield_value_from_snapshots(
     []    -> latest partition exists but no qualifiers (caller renders empty + stale).
     Rows  -> ordered by roe desc, per asc, symbol asc.
     """
-    if session is None or market != "kr":
+    # ROB-427 PR3: KR + US. Both back this preset with market_valuation_snapshots
+    # (KR=naver_finance, US=yahoo) — ROE/PER are vendor-agnostic, so the same query
+    # serves both once the hardcoded "kr" literals below are parameterized.
+    if session is None or market not in {"kr", "us"}:
         return None
 
     from app.services.invest_screener_snapshots.partition_health import (
@@ -58,7 +61,7 @@ async def load_high_yield_value_from_snapshots(
         model=MarketValuationSnapshot,
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
-        market="kr",
+        market=market,
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:
@@ -67,7 +70,7 @@ async def load_high_yield_value_from_snapshots(
 
     latest_price_stmt = sa.select(
         sa.func.max(InvestScreenerSnapshot.snapshot_date)
-    ).where(InvestScreenerSnapshot.market == "kr")
+    ).where(InvestScreenerSnapshot.market == market)
     try:
         price_date = (await session.execute(latest_price_stmt)).scalar_one_or_none()
     except Exception as exc:  # noqa: BLE001
@@ -98,7 +101,7 @@ async def load_high_yield_value_from_snapshots(
             ),
         )
         .where(
-            MarketValuationSnapshot.market == "kr",
+            MarketValuationSnapshot.market == market,
             MarketValuationSnapshot.snapshot_date == val_date,
             MarketValuationSnapshot.roe >= _MIN_ROE,
             MarketValuationSnapshot.per > 0,
@@ -123,7 +126,10 @@ async def load_high_yield_value_from_snapshots(
 
     symbols = [r["symbol"] for r in candidate_rows]
     name_map: dict[str, str] = {}
-    if symbols:
+    # KR name hydration + the KR common-stock guard are KR-specific (KRX universe +
+    # Korean-name ETF/preferred heuristic). US mirrors the consecutive_gainers loader:
+    # no KR-universe lookup; the shared row builder fills the US name downstream.
+    if market == "kr" and symbols:
         try:
             names = await session.execute(
                 sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
@@ -152,7 +158,7 @@ async def load_high_yield_value_from_snapshots(
             today_trading_date,
         )
 
-        today_market_date = today_trading_date("kr", now=datetime.now(UTC))
+        today_market_date = today_trading_date(market, now=datetime.now(UTC))
     state = "fresh" if val_date == today_market_date else "stale"
     if partition_degraded:
         from app.services.invest_screener_snapshots.partition_health import (
@@ -168,13 +174,13 @@ async def load_high_yield_value_from_snapshots(
         if sym in seen:
             continue
         name = name_map.get(sym)
-        if not _is_kr_toss_common_stock(sym, name):
+        if market == "kr" and not _is_kr_toss_common_stock(sym, name):
             continue
         seen.add(sym)
         rows.append(
             {
                 "symbol": sym,
-                "market": "kr",
+                "market": market,
                 "name": name,
                 "latest_close": (
                     float(r["latest_close"]) if r["latest_close"] is not None else None

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -43,6 +43,10 @@ _KR_ONLY_PRESET_IDS = {
 # unsupported = no US equivalent (KR 외국인·기관 수급); data_pending = catalogued
 # but disabled until a US data source exists (Yahoo valuation / US fundamentals).
 # The remaining KR-only presets default to data_pending via _KR_ONLY_PRESET_IDS.
+# ROB-427 PR3: KR-only presets that ARE active for US (backed by US data now).
+# high_yield_value (ROE+PER) runs on Yahoo valuation snapshots — see
+# high_yield_value_screener.load_high_yield_value_from_snapshots(market="us").
+_US_ACTIVE_PRESET_IDS = {"high_yield_value"}
 _US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
 _US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
 _US_DATA_PENDING_REASON: dict[str, str] = {
@@ -66,6 +70,8 @@ def _preset_availability(preset_id: str, market: str) -> tuple[str, str | None]:
     (disabled with an honest reason, never fabricated), ``active`` otherwise.
     """
     if market != "us":
+        return "active", None
+    if preset_id in _US_ACTIVE_PRESET_IDS:  # ROB-427 PR3: Yahoo-backed US activation
         return "active", None
     if preset_id in _US_UNSUPPORTED_PRESET_IDS:
         return "unsupported", _US_UNSUPPORTED_REASON

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1740,6 +1740,33 @@ async def build_screener_results(
             _snapshot_empty_warning = (
                 "최신 수급/시세 스냅샷에서 쌍끌이 매수 조건에 맞는 종목이 없습니다."
             )
+        elif preset_id == "high_yield_value" and requested_market == "us":
+            # ROB-427 PR3: US high_yield_value is backed by Yahoo valuation snapshots
+            # (market_valuation_snapshots, market=us) — NOT the KR tvscreener snapshot
+            # below (invest_kr_fundamentals_snapshots is KR-only). Same ROE>=15 / PER
+            # 0~10 rule via the market-parameterized loader. Honest empty until the
+            # operator builds the US valuation partition (fail-closed, never fabricated).
+            from app.services.invest_view_model.high_yield_value_screener import (
+                load_high_yield_value_from_snapshots,
+            )
+
+            _hyv_rows = await load_high_yield_value_from_snapshots(
+                session,
+                market="us",
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+            )
+            if _hyv_rows is not None:
+                _snapshot_check_result = _hyv_rows
+                _snapshot_load_result = _SnapshotLoadResult(
+                    rows=_hyv_rows,
+                    partition_date=(
+                        _hyv_rows[0]["snapshot_date"] if _hyv_rows else None
+                    ),
+                    partition_computed_at=None,
+                )
+            _snapshot_empty_warning = (
+                "최신 미국 가치형(ROE·PER) 스냅샷에서 조건에 맞는 종목이 없습니다."
+            )
         # ROB-428 PR-C: high_yield_value + undervalued_breakout no longer have a
         # dedicated dispatch branch. They are now registered in
         # FUNDAMENTALS_PRESET_SPECS and fall into the tvscreener KR loader below

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -169,12 +169,11 @@ def test_high_yield_value_preset_is_full_toss_parity_kr_only() -> None:
     assert preset.presetOrigin == "toss_parity"
     assert preset.parityStatus == "full"
     assert preset.metricLabel == "ROE"
-    # ROB-427: no longer hidden in US — exposed with honest data_pending status
-    # (PR3 will flip it to active once the Yahoo-valuation US path is wired).
+    # ROB-427 PR3: exposed AND active for US (Yahoo valuation backs ROE+PER).
     us_by_id = {p.id: p for p in preset_definitions("us")}
     assert "high_yield_value" in us_by_id
-    assert us_by_id["high_yield_value"].availability == "data_pending"
-    assert us_by_id["high_yield_value"].availabilityReason
+    assert us_by_id["high_yield_value"].availability == "active"
+    assert us_by_id["high_yield_value"].availabilityReason is None
 
 
 @pytest.mark.unit

--- a/tests/test_invest_view_model_high_yield_value_screener.py
+++ b/tests/test_invest_view_model_high_yield_value_screener.py
@@ -15,7 +15,8 @@ from app.services.invest_view_model.high_yield_value_screener import (
 )
 
 # 9-prefix synthetic symbols, isolated from real KR symbols and sibling suites.
-_TEST_SYMBOLS = ["921000", "920001", "929999"]
+# ZZUS* are synthetic US tickers for the ROB-427 PR3 US-market path.
+_TEST_SYMBOLS = ["921000", "920001", "929999", "ZZUSHI", "ZZUSLO"]
 
 
 @pytest.fixture(autouse=True)
@@ -124,6 +125,49 @@ async def test_filters_by_roe_and_per(db_session):
 
 
 @pytest.mark.asyncio
+async def test_us_market_filters_by_roe_and_per(db_session):
+    """ROB-427 PR3: US runs on Yahoo valuation snapshots (market=us), same ROE>=15 /
+    PER 0~10 rule, no KR universe / common-stock filter. row.market == 'us'."""
+    val_date = dt.date(2099, 12, 31)
+    db_session.add_all(
+        [
+            # qualifies: ROE 22 >= 15, PER 7 in (0, 10]
+            MarketValuationSnapshot(
+                market="us",
+                symbol="ZZUSHI",
+                snapshot_date=val_date,
+                source="yahoo",
+                per=decimal.Decimal("7.0"),
+                roe=decimal.Decimal("22.0"),
+            ),
+            # excluded: ROE 8 < 15
+            MarketValuationSnapshot(
+                market="us",
+                symbol="ZZUSLO",
+                snapshot_date=val_date,
+                source="yahoo",
+                per=decimal.Decimal("4.0"),
+                roe=decimal.Decimal("8.0"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    rows = await load_high_yield_value_from_snapshots(
+        db_session, market="us", limit=20, today_market_date=val_date
+    )
+
+    assert rows is not None
+    symbols = [r["symbol"] for r in rows]
+    assert "ZZUSHI" in symbols
+    assert "ZZUSLO" not in symbols
+    target = next(r for r in rows if r["symbol"] == "ZZUSHI")
+    assert target["market"] == "us"
+    assert target["roe"] == pytest.approx(22.0)
+    assert target["per"] == pytest.approx(7.0)
+
+
+@pytest.mark.asyncio
 async def test_excludes_high_per_and_null_metrics(db_session):
     val_date = dt.date(2099, 12, 31)
     db_session.add(
@@ -224,7 +268,11 @@ async def test_stale_when_partition_is_not_todays_trading_date(db_session):
 
 @pytest.mark.asyncio
 async def test_returns_none_for_non_kr_market(db_session):
-    rows = await load_high_yield_value_from_snapshots(db_session, market="us", limit=20)
+    # ROB-427 PR3: US is now SUPPORTED (Yahoo valuation). crypto / unknown markets
+    # remain unsupported by this loader → None.
+    rows = await load_high_yield_value_from_snapshots(
+        db_session, market="crypto", limit=20
+    )
     assert rows is None
 
 

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -13,6 +13,7 @@ import pytest
 
 from app.services.invest_view_model.screener_presets import (
     _KR_ONLY_PRESET_IDS,
+    _US_ACTIVE_PRESET_IDS,
     _US_UNSUPPORTED_PRESET_IDS,
     preset_definitions,
 )
@@ -64,8 +65,8 @@ def test_us_flow_presets_unsupported_with_reason() -> None:
 @pytest.mark.unit
 def test_us_fundamentals_presets_data_pending_with_reason() -> None:
     us = {p.id: p for p in preset_definitions("us")}
+    # ROB-427 PR3: high_yield_value is now active (Yahoo-backed); the rest pending.
     for pid in (
-        "high_yield_value",
         "undervalued_breakout",
         "profitable_company",
         "undervalued_growth",
@@ -80,11 +81,21 @@ def test_us_fundamentals_presets_data_pending_with_reason() -> None:
 
 
 @pytest.mark.unit
+def test_us_high_yield_value_active() -> None:
+    # ROB-427 PR3: Yahoo valuation backs ROE+PER, so high_yield_value runs for US.
+    us = {p.id: p for p in preset_definitions("us")}
+    assert us["high_yield_value"].availability == "active"
+    assert us["high_yield_value"].availabilityReason is None
+    assert "high_yield_value" in _US_ACTIVE_PRESET_IDS
+
+
+@pytest.mark.unit
 def test_availability_partition_covers_all_kr_only() -> None:
     """Every KR-only preset is exactly one of unsupported / data_pending in US."""
     us = {p.id: p for p in preset_definitions("us")}
     for pid in _KR_ONLY_PRESET_IDS:
-        assert us[pid].availability in {"data_pending", "unsupported"}, pid
+        # PR3: a KR-only preset may now be active for US (e.g. high_yield_value).
+        assert us[pid].availability in {"active", "data_pending", "unsupported"}, pid
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why (ROB-427 PR3, builds on PR2 #1129)

PR2의 per-market availability 계약 위에서 **고수익저평가(high_yield_value)를 US에서 active**로 전환. US valuation은 이미 `market_valuation_snapshots`(market=us, source=yahoo)로 빌드되므로(`builder.py:40`) ROE≥15 / PER 0~10 규칙을 US에 그대로 적용 가능.

## Change (migration 0)
- **`high_yield_value_screener.load_high_yield_value_from_snapshots`**: `market!="kr"` 게이트 → `{kr,us}` 완화 + 하드코딩 `"kr"`(partition/price/valuation 쿼리)를 `market` 파라미터화. KR universe 이름조회 + KR common-stock 휴리스틱은 **KR 전용 가드**(US는 consecutive_gainers 로더와 동일 패턴). `row.market`·`today_trading_date(market)` 파라미터화.
- **`build_screener_results`**: US high_yield_value를 이 로더로 라우팅(KR tvscreener 스냅샷은 KR 전용이라 US 불가). 결과 없으면 **honest empty**(가짜 위조 0).
- **`screener_presets`**: high_yield_value를 `_US_ACTIVE_PRESET_IDS`로 → US availability `active`(PR2 data_pending에서 승격).

## Verification
- US 로더 테스트(ROE/PER 필터, `market=us`, `row.market=="us"`) + crypto→None + availability active + 기존 PR2/parity 테스트 갱신. 37 + 광역 sweep **203 green**.
- ⚠️ candidate_universe 격리실패 2건(test_kr_collector_sources / pool_capped)은 **origin/main에서 동일 재현**(PR3 stash 후 확인) = 무관한 pre-existing(교차파일 DB-state 의존, CI full-suite green). PR3의 KR 경로는 동작 불변.
- `ruff check`+`format --check app/ tests/` clean; `alembic` single head(migration 0).

## Boundaries / next
- broker/order/watch mutation 0. migration 0. Toss benchmark only.
- 실 데이터는 **operator가 US valuation 스냅샷**(`build_valuation_snapshots_for_market market=us`) 빌드해야 표시 — 그 전엔 fail-closed empty(정직).
- US 펀더멘털 벤더(3년평균/순이익 streak → disabled-pending 프리셋 활성화) + undervalued_breakout US 52w-high-date = 별도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * High-yield value screener now available for US market stocks (previously KR-only)
  * Both KR and US markets can use the high-yield value preset with ROE/PER filtering

* **Tests**
  * Added comprehensive test coverage for US market high-yield value screening functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->