### PR TITLE
fix(ROB-435/436): 연속상승세 ETF 제외(KIWOOM/1Q) + 펀더멘털 시가총액 이상값 숨김

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -54,7 +54,11 @@ from app.services.invest_view_model.screener_presets import (
 )
 
 _VALID_MARKETS = {"kr", "us", "crypto"}
-_KR_ABSURD_MARKET_CAP_KRW = 10_000_000_000_000_000
+# ROB-436 C-1: single-stock display-plausibility ceiling. The largest KR listing
+# (삼성전자) is ~500조 KRW, so anything above ~2,000조 is a bad/mis-unit row (e.g. the
+# tvscreener fundamentals snapshot rendered SG&G as 3,468.8조원). Was 10,000조 (1e16),
+# too lenient to catch it. Above this → hide the label (never render absurd values).
+_KR_ABSURD_MARKET_CAP_KRW = 2_000_000_000_000_000
 
 _KST = ZoneInfo("Asia/Seoul")
 _KR_OPEN = _time(9, 0)
@@ -82,6 +86,12 @@ _KR_TOSS_ETF_PREFIXES = (
     "WON ",
     "마이티 ",
     "히어로즈 ",
+    # ROB-435 A: KIWOOM (키움) + 1Q (한화) ETF issuer brands — these slipped into
+    # 연속상승세 (KIWOOM 미국S&P500모멘텀, 1Q 미국배당TOP30) because no KR common
+    # stock starts with these brand prefixes. (Long-term: kr_symbol_universe
+    # instrument_type from KRX master — see ROB-435.)
+    "KIWOOM ",
+    "1Q ",
 )
 _KR_TOSS_EXCLUDED_NAME_TOKENS = (
     " ETF",

--- a/tests/test_screener_display_quickfix.py
+++ b/tests/test_screener_display_quickfix.py
@@ -1,0 +1,82 @@
+"""ROB-435 A (ETF exclusion) + ROB-436 C-1 (absurd market_cap ceiling) quick fixes.
+
+These are pure-function display-fidelity fixes in screener_service:
+- _is_kr_toss_common_stock must exclude the KIWOOM / 1Q ETF brands that leaked
+  into 연속상승세 (live: KIWOOM 미국S&P500모멘텀, 1Q 미국배당TOP30).
+- the KR single-stock plausibility ceiling must hide absurd market caps
+  (live: SG&G rendered 3,468.8조원 from a bad tvscreener row).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.invest_view_model.screener_service import (
+    _KR_ABSURD_MARKET_CAP_KRW,
+    _format_market_cap,
+    _is_kr_toss_common_stock,
+)
+
+# --- ROB-435 A: ETF/ETN exclusion ---------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "symbol,name",
+    [
+        ("0137V0", "KIWOOM 미국S&P500모멘텀"),
+        ("0137W0", "KIWOOM 미국S&P500&GOLD"),
+        ("0004G0", "1Q 미국배당TOP30"),
+        ("069500", "KODEX 200"),  # existing prefix still excluded
+        ("005935", "삼성전자우"),  # preferred suffix still excluded
+    ],
+)
+def test_excludes_etf_and_preferred(symbol: str, name: str) -> None:
+    assert _is_kr_toss_common_stock(symbol, name) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "symbol,name",
+    [
+        ("040350", "크레오에스지"),
+        ("069960", "현대백화점"),
+        ("002350", "넥센타이어"),
+    ],
+)
+def test_keeps_ordinary_common_stocks(symbol: str, name: str) -> None:
+    assert _is_kr_toss_common_stock(symbol, name) is True
+
+
+# --- ROB-436 C-1: absurd market_cap ceiling -----------------------------------
+
+
+@pytest.mark.unit
+def test_absurd_ceiling_is_single_stock_plausible() -> None:
+    # ~2,000조 — generous over 삼성전자 (~500조), far below the bad 3,468조 row.
+    assert _KR_ABSURD_MARKET_CAP_KRW == 2_000_000_000_000_000
+
+
+@pytest.mark.unit
+def test_hides_absurd_high_market_cap() -> None:
+    # 3,468.8조 KRW (the live SG&G bug) → hidden, not rendered as "3,468.8조원".
+    label, warnings = _format_market_cap(
+        {"market_cap_krw": 3_468_800_000_000_000}, "kr"
+    )
+    assert label == "-"
+    assert warnings  # "시가총액 데이터 확인 필요"
+    # same when the value arrives via the generic market_cap field (KRW).
+    label2, warnings2 = _format_market_cap({"market_cap": 3_468_800_000_000_000}, "kr")
+    assert label2 == "-"
+    assert warnings2
+
+
+@pytest.mark.unit
+def test_keeps_plausible_market_cap() -> None:
+    # 삼성전자-scale ~500조 stays visible (under the ceiling).
+    label, warnings = _format_market_cap({"market_cap_krw": 500_000_000_000_000}, "kr")
+    assert label == "500.0조원"
+    assert warnings == []
+    # a normal mid-cap ~3,000억 renders cleanly (억 uses 0-decimal formatting).
+    label2, _ = _format_market_cap({"market_cap_krw": 300_000_000_000}, "kr")
+    assert label2 == "3,000억원"


### PR DESCRIPTION
## What & why (우선순위 #1 quick fix — ROB-435 A + ROB-436 C-1)

라이브(2026-06-05) 토스 비교에서 잡힌 표시 결함 2개의 작은·즉시 가시적 수정.

### ROB-435 A — 연속상승세 ETF 제외
연속상승세에 ETF가 섞임: `KIWOOM 미국S&P500모멘텀`, `KIWOOM 미국S&P500&GOLD`, `1Q 미국배당TOP30`. `_is_kr_toss_common_stock`의 이름 휴리스틱 `_KR_TOSS_ETF_PREFIXES`에 **ETF 발행사 브랜드 `"KIWOOM "`, `"1Q "`** 추가. KR 보통주는 이 접두사로 시작하지 않아 false-positive 0.

### ROB-436 C-1 — 펀더멘털 시가총액 이상값 숨김
펀더멘털 프리셋이 SG&G를 `3,468.8조원`(tvscreener 불량 row)으로 표시. `_KR_ABSURD_MARKET_CAP_KRW` 단일종목 표시 상한을 **10,000조(1e16) → 2,000조(2e15)**로 하향(삼성전자 ~500조 대비 넉넉). 이상값(3,468/8,020조)은 기존 `_format_market_cap` 정규화가 숨김 → `-`.

## Verification
- 신규 11 단위테스트: ETF/우선주 제외(KIWOOM/1Q/KODEX/우) + 보통주 유지(크레오에스지 등) / 상한 == 2,000조 / 이상값 숨김(market_cap_krw·market_cap 경로) / 정상값(500조·3,000억) 유지.
- 11 green; 광역 sweep 649 green; `ruff check`+`format --check app/ tests/` clean; `alembic` single head(migration 0).
- ⚠️ sweep 1 fail = `test_candidate_universe_collector_evidence::test_kr_collector_sources_consecutive_gainers_preset` — **origin/main에서 동일 재현(stash 확인)** = pre-existing 격리 flake(CI full-suite green), 무관.

## Boundaries / 잔여
- broker/order/watch mutation 0. migration 0. Toss benchmark only.
- **ROB-435 잔여**: 장기 = `kr_symbol_universe.instrument_type`(KRX master) 권위적 분류; (B) KRX/NXT 종가 basis 결정.
- **ROB-436 잔여**: 시총 **bogus-LOW**("1억원" 중형주) + 완전 신뢰성 = MarketValuationSnapshot 신뢰소스 join; (C-2) 결과수 limit; (D) 한글 카테고리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market-cap validation for Korean stocks in screeners to ensure accurate data display
  * Extended filtering logic to exclude additional branded investment products from common stock categories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->