### PR TITLE
feat(ROB-439): 스크리너 조정 가능 필터 스키마 foundation (MVP PR1)

### DIFF
--- a/app/services/invest_view_model/screener_filters.py
+++ b/app/services/invest_view_model/screener_filters.py
@@ -1,0 +1,287 @@
+"""ROB-439 MVP (foundation): a single adjustable-filter schema over the screener
+*base snapshots*.
+
+The /invest/screener filters were fragmented across three layers (display-only
+filterChips, the `_SCREENING_FILTERS` kwargs dict, and hardcoded loader WHERE
+constants), so neither a Toss-style chip editor nor the `screen_stocks` MCP tool
+could adjust thresholds. This module is the shared core: one filter definition,
+keyed to a base-snapshot column, that drives the UI chips, the loader predicates,
+and the MCP filter input.
+
+Model (locked decisions, see ROB-439):
+- **AND-only** stacking — a filter set is a conjunction of (field, operator, value)
+  conditions over snapshot columns. Boolean groups (OR) are a follow-up.
+- A preset is just a *starting* filter set over its base snapshot; users / the MCP
+  add or adjust conditions on top (this is the "필터를 추가/조정" model).
+- Fail-closed: a row whose field is NULL or non-numeric is excluded, never passed.
+
+This PR ships the schema + per-snapshot field catalog + the pure apply/validate/
+merge helpers + the two pilot presets (consecutive_gainers, high_yield_value).
+Wiring it into the loaders + the screen_stocks MCP tool is the follow-up PR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+FilterOperator = Literal["gte", "lte", "eq"]
+FilterValueType = Literal["int", "float", "percent"]
+# range is expressed as two conditions (a gte + an lte) rather than a dedicated op,
+# keeping apply/validate trivial for the MVP.
+
+_ALLOWED_OPERATORS: frozenset[str] = frozenset({"gte", "lte", "eq"})
+
+
+@dataclass(frozen=True)
+class ScreenerFilterDefinition:
+    """A single adjustable filter, keyed to a base-snapshot column.
+
+    Drives the UI chip (label/unit/step/bounds), the loader predicate (field +
+    operator), and validation of MCP overrides (bounds clamp). ``default`` is the
+    preset's starting value for this field (None = not part of the starting set).
+    """
+
+    field: (
+        str  # base-snapshot column / row-dict key (e.g. "per", "consecutive_up_days")
+    )
+    label: str  # Korean chip label (e.g. "PER", "연속상승일")
+    operator: FilterOperator  # the preset's default comparison for this field
+    value_type: FilterValueType
+    default: float | int | None = None
+    min_bound: float | int | None = None
+    max_bound: float | int | None = None
+    step: float | int | None = None
+    unit: str | None = None  # "일" / "%" / "배" / "원"
+
+
+@dataclass(frozen=True)
+class ScreenerFilterCondition:
+    """A concrete applied condition: row[field] <op> value (AND-combined)."""
+
+    field: str
+    operator: FilterOperator
+    value: float | int
+
+
+# --- per-base-snapshot filterable-field catalog -------------------------------
+# Keyed by base-snapshot kind. The field is the ROW-DICT key the loader emits, so
+# apply_filter_conditions can run over loaded rows. Each entry lists the columns a
+# user / the MCP may filter on, with the chip metadata + bounds. Extend per snapshot
+# as more presets migrate (ROB-439 follow-ups); MVP catalogs the 2 pilot snapshots.
+SNAPSHOT_FILTER_FIELDS: dict[str, dict[str, ScreenerFilterDefinition]] = {
+    # consecutive_gainers / oversold_recovery / volume presets (KIS OHLCV snapshot)
+    "invest_screener_snapshots": {
+        "consecutive_up_days": ScreenerFilterDefinition(
+            field="consecutive_up_days",
+            label="연속상승일",
+            operator="gte",
+            value_type="int",
+            default=5,
+            min_bound=2,
+            max_bound=20,
+            step=1,
+            unit="일",
+        ),
+        "week_change_rate": ScreenerFilterDefinition(
+            field="week_change_rate",
+            label="주가등락률(1주)",
+            operator="gte",
+            value_type="percent",
+            default=0.0,
+            min_bound=-50.0,
+            max_bound=100.0,
+            step=1.0,
+            unit="%",
+        ),
+        "change_rate": ScreenerFilterDefinition(
+            field="change_rate",
+            label="주가등락률(당일)",
+            operator="gte",
+            value_type="percent",
+            min_bound=-30.0,
+            max_bound=30.0,
+            step=1.0,
+            unit="%",
+        ),
+        "volume": ScreenerFilterDefinition(
+            field="volume",
+            label="거래량",
+            operator="gte",
+            value_type="int",
+            min_bound=0,
+            step=1000,
+            unit="주",
+        ),
+        "rsi": ScreenerFilterDefinition(
+            field="rsi",
+            label="RSI",
+            operator="lte",
+            value_type="float",
+            min_bound=0.0,
+            max_bound=100.0,
+            step=1.0,
+        ),
+    },
+    # high_yield_value (Naver/Yahoo valuation snapshot)
+    "market_valuation_snapshots": {
+        "roe": ScreenerFilterDefinition(
+            field="roe",
+            label="ROE",
+            operator="gte",
+            value_type="percent",
+            default=15.0,
+            min_bound=0.0,
+            max_bound=100.0,
+            step=1.0,
+            unit="%",
+        ),
+        "per": ScreenerFilterDefinition(
+            field="per",
+            label="PER",
+            operator="lte",
+            value_type="float",
+            default=10.0,
+            min_bound=0.0,
+            max_bound=100.0,
+            step=0.5,
+            unit="배",
+        ),
+        "pbr": ScreenerFilterDefinition(
+            field="pbr",
+            label="PBR",
+            operator="lte",
+            value_type="float",
+            min_bound=0.0,
+            max_bound=20.0,
+            step=0.1,
+            unit="배",
+        ),
+        "dividend_yield": ScreenerFilterDefinition(
+            field="dividend_yield",
+            label="배당수익률",
+            operator="gte",
+            value_type="percent",
+            min_bound=0.0,
+            max_bound=30.0,
+            step=0.5,
+            unit="%",
+        ),
+    },
+}
+
+# pilot preset → (base snapshot kind, starting filter set). A preset is just the
+# starting conditions; users adjust/add on top. Mirrors the current hardcoded
+# thresholds (consecutive_gainers min_consecutive_up_days=5/week_change_rate>=0;
+# high_yield_value roe>=15/per 0~10) so derived results match today's behavior.
+_PILOT_PRESET_SNAPSHOT: dict[str, str] = {
+    "consecutive_gainers": "invest_screener_snapshots",
+    "high_yield_value": "market_valuation_snapshots",
+}
+_PILOT_PRESET_STARTING: dict[str, tuple[ScreenerFilterCondition, ...]] = {
+    "consecutive_gainers": (
+        ScreenerFilterCondition("consecutive_up_days", "gte", 5),
+        ScreenerFilterCondition("week_change_rate", "gte", 0.0),
+    ),
+    "high_yield_value": (
+        ScreenerFilterCondition("roe", "gte", 15.0),
+        ScreenerFilterCondition("per", "lte", 10.0),
+    ),
+}
+
+
+def snapshot_kind_for_preset(preset_id: str) -> str | None:
+    """Base snapshot a (pilot) preset filters over, or None if not yet migrated."""
+    return _PILOT_PRESET_SNAPSHOT.get(preset_id)
+
+
+def preset_starting_filters(preset_id: str) -> list[ScreenerFilterCondition]:
+    """The preset's starting filter set (empty for '직접 만들기' / unmigrated)."""
+    return list(_PILOT_PRESET_STARTING.get(preset_id, ()))
+
+
+class ScreenerFilterError(ValueError):
+    """Raised when a requested filter field/operator is not allowed for a snapshot."""
+
+
+def validate_conditions(
+    conditions: list[ScreenerFilterCondition], *, snapshot_kind: str
+) -> list[ScreenerFilterCondition]:
+    """Validate against the snapshot's field catalog + clamp values to bounds.
+
+    Fail-closed: an unknown snapshot, field, or operator raises ScreenerFilterError
+    (never silently dropped or applied). Values outside a definition's min/max are
+    clamped (the UI step/bounds keep the user inside the valid range).
+    """
+    catalog = SNAPSHOT_FILTER_FIELDS.get(snapshot_kind)
+    if catalog is None:
+        raise ScreenerFilterError(f"unknown snapshot kind: {snapshot_kind!r}")
+    out: list[ScreenerFilterCondition] = []
+    for c in conditions:
+        if c.operator not in _ALLOWED_OPERATORS:
+            raise ScreenerFilterError(f"unsupported operator: {c.operator!r}")
+        definition = catalog.get(c.field)
+        if definition is None:
+            raise ScreenerFilterError(
+                f"field {c.field!r} not filterable on {snapshot_kind}"
+            )
+        value: float | int = c.value
+        if definition.min_bound is not None and value < definition.min_bound:
+            value = definition.min_bound
+        if definition.max_bound is not None and value > definition.max_bound:
+            value = definition.max_bound
+        out.append(ScreenerFilterCondition(c.field, c.operator, value))
+    return out
+
+
+def merge_filter_overrides(
+    base: list[ScreenerFilterCondition],
+    overrides: list[ScreenerFilterCondition],
+) -> list[ScreenerFilterCondition]:
+    """Merge user overrides onto a preset's starting set.
+
+    An override with the same (field, operator) replaces the base condition; a new
+    (field, operator) is appended (adds a filter). Order: base order preserved,
+    then any genuinely new conditions. This is the "필터를 추가/조정" merge.
+    """
+    by_key: dict[tuple[str, str], ScreenerFilterCondition] = {
+        (c.field, c.operator): c for c in base
+    }
+    appended: list[ScreenerFilterCondition] = []
+    for o in overrides:
+        key = (o.field, o.operator)
+        if key in by_key:
+            by_key[key] = o  # adjust existing
+        else:
+            appended.append(o)  # add new
+    return list(by_key.values()) + appended
+
+
+def _passes(row: dict[str, Any], cond: ScreenerFilterCondition) -> bool:
+    raw = row.get(cond.field)
+    if raw is None:
+        return False  # fail-closed: missing field never passes
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return False
+    if cond.operator == "gte":
+        return value >= cond.value
+    if cond.operator == "lte":
+        return value <= cond.value
+    if cond.operator == "eq":
+        return value == cond.value
+    return False
+
+
+def apply_filter_conditions(
+    rows: list[dict[str, Any]], conditions: list[ScreenerFilterCondition]
+) -> list[dict[str, Any]]:
+    """Return rows satisfying ALL conditions (AND). Fail-closed on NULL/non-numeric.
+
+    Pure over loaded snapshot rows (row-dict keys = catalog fields), so the same
+    conditions drive the loader display path and the screen_stocks MCP tool.
+    """
+    if not conditions:
+        return list(rows)
+    return [row for row in rows if all(_passes(row, c) for c in conditions)]

--- a/tests/test_screener_filters.py
+++ b/tests/test_screener_filters.py
@@ -1,0 +1,183 @@
+"""ROB-439 MVP foundation: adjustable-filter schema over screener base snapshots.
+
+Pure unit tests (no DB) for the shared filter core that will drive the UI chips,
+the loader predicates, and the screen_stocks MCP tool: catalog integrity, AND
+application (fail-closed), validation/clamping, override merge, pilot presets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.invest_view_model.screener_filters import (
+    SNAPSHOT_FILTER_FIELDS,
+    ScreenerFilterCondition,
+    ScreenerFilterError,
+    apply_filter_conditions,
+    merge_filter_overrides,
+    preset_starting_filters,
+    snapshot_kind_for_preset,
+    validate_conditions,
+)
+
+# --- catalog integrity --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_catalog_field_keys_match_definitions() -> None:
+    for snapshot_kind, fields in SNAPSHOT_FILTER_FIELDS.items():
+        assert fields, f"{snapshot_kind} has no filterable fields"
+        for key, definition in fields.items():
+            assert definition.field == key
+            assert definition.operator in {"gte", "lte", "eq"}
+            assert definition.value_type in {"int", "float", "percent"}
+
+
+# --- apply (AND, fail-closed) -------------------------------------------------
+
+
+@pytest.mark.unit
+def test_apply_and_combines_conditions() -> None:
+    rows = [
+        {"symbol": "A", "consecutive_up_days": 6, "week_change_rate": 3.0},
+        {"symbol": "B", "consecutive_up_days": 4, "week_change_rate": 9.0},
+        {"symbol": "C", "consecutive_up_days": 7, "week_change_rate": -1.0},
+    ]
+    conds = [
+        ScreenerFilterCondition("consecutive_up_days", "gte", 5),
+        ScreenerFilterCondition("week_change_rate", "gte", 0.0),
+    ]
+    out = apply_filter_conditions(rows, conds)
+    assert [r["symbol"] for r in out] == ["A"]  # B fails days, C fails rate
+
+
+@pytest.mark.unit
+def test_apply_lte_and_eq() -> None:
+    rows = [{"per": 8.0}, {"per": 12.0}, {"per": 10.0}]
+    assert (
+        len(
+            apply_filter_conditions(rows, [ScreenerFilterCondition("per", "lte", 10.0)])
+        )
+        == 2
+    )
+    assert (
+        len(apply_filter_conditions(rows, [ScreenerFilterCondition("per", "eq", 10.0)]))
+        == 1
+    )
+
+
+@pytest.mark.unit
+def test_apply_fail_closed_on_missing_or_non_numeric() -> None:
+    rows = [
+        {"symbol": "ok", "roe": 20.0},
+        {"symbol": "null", "roe": None},
+        {"symbol": "missing"},
+        {"symbol": "garbage", "roe": "n/a"},
+    ]
+    out = apply_filter_conditions(rows, [ScreenerFilterCondition("roe", "gte", 15.0)])
+    assert [r["symbol"] for r in out] == ["ok"]  # NULL/missing/non-numeric excluded
+
+
+@pytest.mark.unit
+def test_apply_empty_conditions_returns_all() -> None:
+    rows = [{"a": 1}, {"a": 2}]
+    assert apply_filter_conditions(rows, []) == rows
+
+
+# --- validate (fail-closed + clamp) -------------------------------------------
+
+
+@pytest.mark.unit
+def test_validate_rejects_unknown_snapshot_field_and_operator() -> None:
+    with pytest.raises(ScreenerFilterError):
+        validate_conditions([], snapshot_kind="does_not_exist")
+    with pytest.raises(ScreenerFilterError):
+        validate_conditions(
+            [ScreenerFilterCondition("not_a_field", "gte", 1)],
+            snapshot_kind="invest_screener_snapshots",
+        )
+    with pytest.raises(ScreenerFilterError):
+        validate_conditions(
+            [ScreenerFilterCondition("per", "between", 1)],  # type: ignore[arg-type]
+            snapshot_kind="market_valuation_snapshots",
+        )
+
+
+@pytest.mark.unit
+def test_validate_clamps_to_bounds() -> None:
+    # consecutive_up_days bounds 2..20; 99 clamps to 20, 0 clamps to 2.
+    high = validate_conditions(
+        [ScreenerFilterCondition("consecutive_up_days", "gte", 99)],
+        snapshot_kind="invest_screener_snapshots",
+    )
+    assert high[0].value == 20
+    low = validate_conditions(
+        [ScreenerFilterCondition("consecutive_up_days", "gte", 0)],
+        snapshot_kind="invest_screener_snapshots",
+    )
+    assert low[0].value == 2
+
+
+# --- merge overrides (adjust / add) -------------------------------------------
+
+
+@pytest.mark.unit
+def test_merge_adjusts_same_field_and_appends_new() -> None:
+    base = preset_starting_filters("consecutive_gainers")
+    # adjust the streak threshold + ADD a max_per condition (different snapshot
+    # field, but merge is field/op keyed — adding is the "필터 추가" path).
+    overrides = [
+        ScreenerFilterCondition("consecutive_up_days", "gte", 10),  # adjust
+        ScreenerFilterCondition("week_change_rate", "gte", 5.0),  # adjust
+    ]
+    merged = merge_filter_overrides(base, overrides)
+    by_field = {(c.field, c.operator): c.value for c in merged}
+    assert by_field[("consecutive_up_days", "gte")] == 10
+    assert by_field[("week_change_rate", "gte")] == 5.0
+    assert len(merged) == 2  # both adjusted, none appended
+
+    added = merge_filter_overrides(
+        base, [ScreenerFilterCondition("volume", "gte", 100000)]
+    )
+    assert len(added) == 3  # original 2 + 1 appended
+    assert ("volume", "gte") in {(c.field, c.operator) for c in added}
+
+
+# --- pilot presets ------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pilot_presets_starting_sets() -> None:
+    assert (
+        snapshot_kind_for_preset("consecutive_gainers") == "invest_screener_snapshots"
+    )
+    assert snapshot_kind_for_preset("high_yield_value") == "market_valuation_snapshots"
+    assert snapshot_kind_for_preset("not_a_preset") is None
+
+    cg = {
+        (c.field, c.operator, c.value)
+        for c in preset_starting_filters("consecutive_gainers")
+    }
+    assert ("consecutive_up_days", "gte", 5) in cg
+    assert ("week_change_rate", "gte", 0.0) in cg
+
+    hyv = {
+        (c.field, c.operator, c.value)
+        for c in preset_starting_filters("high_yield_value")
+    }
+    assert ("roe", "gte", 15.0) in hyv
+    assert ("per", "lte", 10.0) in hyv
+
+    assert preset_starting_filters("not_a_preset") == []
+
+
+@pytest.mark.unit
+def test_pilot_starting_filters_validate_against_their_snapshot() -> None:
+    # starting filters must be valid against the preset's own base snapshot.
+    for preset in ("consecutive_gainers", "high_yield_value"):
+        kind = snapshot_kind_for_preset(preset)
+        assert kind is not None
+        validated = validate_conditions(
+            preset_starting_filters(preset), snapshot_kind=kind
+        )
+        assert len(validated) == len(preset_starting_filters(preset))


### PR DESCRIPTION
## What & why (ROB-439 MVP — PR1 of 2: foundation)

토스식 필터 편집 + `screen_stocks` MCP 재사용을 위한 **공유 필터 코어**. 현재 /invest/screener 필터가 3겹 분산(`filterChips` 텍스트 / `_SCREENING_FILTERS` kwargs / 로더 WHERE 상수)이라 사용자·MCP가 임계값을 조정 못함. 이 PR은 그 단일 코어를 추가한다 — **자립 모듈, 기존 코드 미변경**(회귀 위험 0).

사용자 의도(명시): screen_stocks는 `preset_id`가 아니라 **프리셋의 기본 스냅샷에 필터를 추가/조정**. 이 코어가 그 모델의 기반.

## 추가된 것 (`app/services/invest_view_model/screener_filters.py`)
- **`ScreenerFilterDefinition`** — 스냅샷 컬럼 키 기반 정의(field/label 한글/operator gte·lte·eq/value_type/default/min·max_bound/step/unit). UI 칩·로더 predicate·MCP 입력을 한 정의로 구동.
- **`ScreenerFilterCondition`** — 적용 조건 (field, op, value). **AND-only 스택**(결정 D1).
- **`SNAPSHOT_FILTER_FIELDS`** — per-base-snapshot 필터가능 필드 카탈로그(MVP: 파일럿 2개 — `invest_screener_snapshots`, `market_valuation_snapshots`).
- **`apply_filter_conditions`** — 로드된 row에 AND 적용, NULL/비숫자 **fail-closed**(행 위조 0).
- **`validate_conditions`** — 미지 스냅샷/필드/op → `ScreenerFilterError`(fail-closed) + bound clamp.
- **`merge_filter_overrides`** — 같은 (field,op)=조정, 새 것=추가 (**"필터 추가/조정"**, 결정 D3).
- **`preset_starting_filters` / `snapshot_kind_for_preset`** — 파일럿 프리셋을 시작 필터셋으로(기존 임계값 미러: consecutive_gainers streak≥5·주등락≥0 / high_yield_value roe≥15·per≤10).

## Verification
- 10 단위테스트(no DB): 카탈로그 무결성 / AND·fail-closed(NULL·missing·non-numeric) / validate·clamp / merge(adjust+add) / 파일럿 시작셋 + 자체 스냅샷 검증.
- 10 green; `ruff check`+`format --check app/ tests/` clean; `alembic` single head(migration 0).
- **기존 코드 미변경** = 기존 테스트 회귀 0.

## Scope / 후속
- **MVP PR2**: 로더 + `screen_stocks` MCP가 이 코어 소비(base 스냅샷에 conditions 적용/조정, 파일럿 2프리셋 end-to-end).
- **ROB-439 후속**: 토스식 UI 칩 편집 / 사용자 저장 필터(DB) / 11프리셋 전체 마이그레이션 / boolean(OR).

## Boundaries
broker/order/watch/order-intent mutation 0. 결과 fail-closed. migration 0. Toss benchmark only.

## Related
ROB-439(spec) · ROB-432(11-preset audit) · ROB-435/436/437(표시 버그, 별도) · ROB-438(cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)