### PR TITLE
feat(ROB-439): consecutive_gainers 스냅샷 위 필터 조정 배선 (MVP PR2)

### DIFF
--- a/app/services/invest_view_model/screener_filters.py
+++ b/app/services/invest_view_model/screener_filters.py
@@ -285,3 +285,26 @@ def apply_filter_conditions(
     if not conditions:
         return list(rows)
     return [row for row in rows if all(_passes(row, c) for c in conditions)]
+
+
+def consecutive_gainers_loader_thresholds(
+    conditions: list[ScreenerFilterCondition],
+) -> dict[str, float | int]:
+    """Map a consecutive_gainers filter set → snapshot-loader WHERE kwargs.
+
+    Only this pilot loader's own SQL columns translate to WHERE thresholds:
+    ``consecutive_up_days`` (>=) and ``week_change_rate`` (>=). Other conditions
+    are ignored here — the loader has no column for them (those would post-filter).
+    Returns kwargs for ``_load_consecutive_gainers_from_snapshots`` so a loosened
+    threshold (e.g. days>=3) actually reaches the snapshot query, not just a
+    post-filter that can never widen the loader's own predicate.
+    """
+    out: dict[str, float | int] = {}
+    for c in conditions:
+        if c.operator != "gte":
+            continue
+        if c.field == "consecutive_up_days":
+            out["min_consecutive_up_days"] = int(c.value)
+        elif c.field == "week_change_rate":
+            out["min_week_change_rate"] = float(c.value)
+    return out

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -448,6 +448,8 @@ async def _load_consecutive_gainers_from_snapshots(
     *,
     market: str,
     limit: int = _SNAPSHOT_FIRST_LIMIT,
+    min_consecutive_up_days: int = 5,
+    min_week_change_rate: float = 0.0,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> _SnapshotLoadResult | None:
     """Return qualifying rows from the latest snapshot partition only.
@@ -508,8 +510,11 @@ async def _load_consecutive_gainers_from_snapshots(
         .where(
             InvestScreenerSnapshot.market == market,
             InvestScreenerSnapshot.snapshot_date == latest_snapshot_date,
-            InvestScreenerSnapshot.consecutive_up_days >= 5,
-            InvestScreenerSnapshot.week_change_rate >= 0,
+            # ROB-439: thresholds default to the preset's starting set (5 / 0.0) so
+            # existing callers are unchanged; build_screener_results passes adjusted
+            # values when filter_overrides loosen/tighten over the base snapshot.
+            InvestScreenerSnapshot.consecutive_up_days >= min_consecutive_up_days,
+            InvestScreenerSnapshot.week_change_rate >= min_week_change_rate,
         )
         .order_by(
             InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
@@ -1657,7 +1662,11 @@ async def build_screener_results(
     market: str = "kr",
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
     session: AsyncSession | None = None,
+    filter_overrides: list[Any] | None = None,
 ) -> ScreenerResultsResponse:
+    """ROB-439: ``filter_overrides`` (list[ScreenerFilterCondition]) lets a caller
+    adjust/add conditions over the preset's base snapshot (None = preset default).
+    Pilot: consecutive_gainers threads loosen/tighten thresholds into the loader."""
     requested_market = _normalize_market(market)
     preset = get_preset(preset_id, requested_market)
     if preset is None:
@@ -1715,11 +1724,32 @@ async def build_screener_results(
     )
     if session is not None and _should_use_snapshot_first(screening_service):
         if preset_id == "consecutive_gainers":
+            # ROB-439: derive loosen/tighten thresholds from filter_overrides over
+            # the base snapshot (default None → loader defaults → unchanged behavior).
+            _cg_loader_kwargs: dict[str, Any] = {}
+            if filter_overrides:
+                from app.services.invest_view_model.screener_filters import (
+                    consecutive_gainers_loader_thresholds,
+                    merge_filter_overrides,
+                    preset_starting_filters,
+                    validate_conditions,
+                )
+
+                _cg_conditions = merge_filter_overrides(
+                    preset_starting_filters("consecutive_gainers"), filter_overrides
+                )
+                _cg_conditions = validate_conditions(
+                    _cg_conditions, snapshot_kind="invest_screener_snapshots"
+                )
+                _cg_loader_kwargs = consecutive_gainers_loader_thresholds(
+                    _cg_conditions
+                )
             _snapshot_load_result = await _load_consecutive_gainers_from_snapshots(
                 session,
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
                 now=now,
+                **_cg_loader_kwargs,
             )
             if _snapshot_load_result is not None:
                 _snapshot_check_result = _snapshot_load_result.rows

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -253,6 +253,51 @@ async def test_build_screener_results_consecutive_gainers_happy_path() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_consecutive_gainers_threads_filter_overrides_to_loader(
+    monkeypatch,
+) -> None:
+    # ROB-439 PR2: filter_overrides must thread loosen/tighten thresholds into the
+    # snapshot loader's WHERE; no overrides → loader keeps the preset defaults.
+    from app.services.invest_view_model import screener_service as svc
+    from app.services.invest_view_model.screener_filters import ScreenerFilterCondition
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_loader(session, **kwargs):  # noqa: ANN001, ANN003
+        captured.clear()
+        captured.update(kwargs)
+        return svc._SnapshotLoadResult(rows=[], partition_date=date(2026, 5, 11))
+
+    monkeypatch.setattr(svc, "_should_use_snapshot_first", lambda _s: True)
+    monkeypatch.setattr(svc, "_load_consecutive_gainers_from_snapshots", _fake_loader)
+
+    fake_screening = MagicMock()
+    resolver = _FakeResolver(watched=set())
+
+    # no overrides → loader gets no threshold kwargs (defaults 5 / 0.0 apply).
+    await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+        session=object(),
+    )
+    assert "min_consecutive_up_days" not in captured
+    assert "min_week_change_rate" not in captured
+
+    # loosen days to 3 → threaded; unspecified week_change_rate keeps preset 0.0.
+    await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+        session=object(),
+        filter_overrides=[ScreenerFilterCondition("consecutive_up_days", "gte", 3)],
+    )
+    assert captured["min_consecutive_up_days"] == 3
+    assert captured["min_week_change_rate"] == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_forwards_us_market_and_formats_us_labels() -> (
     None
 ):

--- a/tests/test_screener_filters.py
+++ b/tests/test_screener_filters.py
@@ -14,6 +14,7 @@ from app.services.invest_view_model.screener_filters import (
     ScreenerFilterCondition,
     ScreenerFilterError,
     apply_filter_conditions,
+    consecutive_gainers_loader_thresholds,
     merge_filter_overrides,
     preset_starting_filters,
     snapshot_kind_for_preset,
@@ -181,3 +182,42 @@ def test_pilot_starting_filters_validate_against_their_snapshot() -> None:
             preset_starting_filters(preset), snapshot_kind=kind
         )
         assert len(validated) == len(preset_starting_filters(preset))
+
+
+# --- consecutive_gainers loader threshold derivation --------------------------
+
+
+@pytest.mark.unit
+def test_consecutive_gainers_loader_thresholds_default_and_adjust() -> None:
+    # default starting set → loader gets the preset defaults (5 / 0.0).
+    base = preset_starting_filters("consecutive_gainers")
+    assert consecutive_gainers_loader_thresholds(base) == {
+        "min_consecutive_up_days": 5,
+        "min_week_change_rate": 0.0,
+    }
+    # loosen days to 3 + tighten week rate to 5% (the "조정 over snapshot" path).
+    adjusted = merge_filter_overrides(
+        base,
+        [
+            ScreenerFilterCondition("consecutive_up_days", "gte", 3),
+            ScreenerFilterCondition("week_change_rate", "gte", 5.0),
+        ],
+    )
+    assert consecutive_gainers_loader_thresholds(adjusted) == {
+        "min_consecutive_up_days": 3,
+        "min_week_change_rate": 5.0,
+    }
+
+
+@pytest.mark.unit
+def test_consecutive_gainers_loader_thresholds_ignores_non_where_conditions() -> None:
+    # only gte on the loader's own SQL columns map to WHERE kwargs; a volume add
+    # (no LOOSEN semantics here) and an lte are not loader thresholds.
+    conds = [
+        ScreenerFilterCondition("consecutive_up_days", "gte", 7),
+        ScreenerFilterCondition("volume", "gte", 100000),  # not a CG WHERE column
+        ScreenerFilterCondition("week_change_rate", "lte", 50.0),  # not gte
+    ]
+    assert consecutive_gainers_loader_thresholds(conds) == {
+        "min_consecutive_up_days": 7,
+    }


### PR DESCRIPTION
## What & why (ROB-439 MVP — PR2 of N: first consumer)

PR1(#1133)의 필터 코어를 **첫 소비처**에 배선한다. `build_screener_results`가 base 스냅샷에서 임계값을 **loosen/tighten**하도록 — 사용자가 명시한 "프리셋의 기본 스냅샷에서 필터를 추가/조정" 모델의 실제 동작.

결정 **B**(사용자 확인): 로더 SQL WHERE 자체를 파라미터화. (post-filter는 로더가 이미 건 조건보다 **느슨하게** 못 함.)

## Changes
- **`_load_consecutive_gainers_from_snapshots`** — optional `min_consecutive_up_days=5` / `min_week_change_rate=0.0` 추가, WHERE에 사용. **default-보존**: 기존 호출자(미전달)는 5/0.0 → **동작 불변**.
- **`build_screener_results(..., filter_overrides=None)`** — consecutive_gainers면 `preset_starting_filters` + override를 `merge_filter_overrides`→`validate_conditions`(clamp/fail-closed)→`consecutive_gainers_loader_thresholds`로 loader kwargs 파생→로더에 스레딩. `None`이면 kwargs 비어 **기존 동작 그대로**.
- **`screener_filters.consecutive_gainers_loader_thresholds`** — 필터셋의 gte(consecutive_up_days/week_change_rate)→loader WHERE kwargs(로더 컬럼 없는 조건은 무시).

## Verification
- 신규 3 테스트 + 기존 회귀: 파생(default 5/0.0 · loosen 3/tighten · non-WHERE 무시) + `build_screener_results` 스레딩(override 없음→기본; days≥3 loosen→loader가 `min_consecutive_up_days=3` 수신, monkeypatch 캡처).
- **77 green**(test_screener_filters + test_invest_view_model_screener_service); screener 광역 sweep 716 green; `ruff check`+`format --check app/ tests/` clean; `alembic` single head(**migration 0**).
- ⚠️ sweep 1 fail = `test_candidate_universe_collector_evidence::test_kr_collector_sources_consecutive_gainers_preset` — **stash로 clean origin/main에서 동일 재현 확인**(내 변경과 무관한 pre-existing 격리 flake; full-suite green).

## Boundaries / 후속
- default-보존(기존 호출자 불변). broker/order/watch/order-intent mutation 0. 결과 fail-closed. migration 0. Toss benchmark only.
- **ROB-439 후속**: high_yield_value 동일 배선 / `screen_stocks` MCP 노출(filters-over-snapshot 입력) / 토스식 UI 칩 편집 / 사용자 저장 필터(DB) / 11프리셋 전체 / boolean(OR).

## Related
ROB-439(spec) · PR #1133(PR1 foundation) · ROB-432(11-preset audit) · ROB-435/436(표시 버그).

🤖 Generated with [Claude Code](https://claude.com/claude-code)