### PR TITLE
feat(ROB-439): screen_stocks_snapshot MCP 도구 — 스냅샷 위 필터 조정 (MVP PR3)

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -22,6 +22,7 @@ from app.mcp_server.tooling.research_pipeline_read import (
     research_summary_get_impl,
     stage_analysis_get_impl,
 )
+from app.mcp_server.tooling.screener_snapshot_tool import screen_stocks_snapshot_impl
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -31,6 +32,7 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "analyze_portfolio",
     "analyze_stock_batch",
     "screen_stocks",
+    "screen_stocks_snapshot",
     # ROB-359: "recommend_stocks" is intentionally registry-hidden (parked).
     # screen_stocks is the single candidate-discovery entrypoint; the
     # recommend_stocks_impl implementation is retained in
@@ -252,6 +254,30 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             market_cap_min_krw=market_cap_min_krw,
             market_cap_max_krw=market_cap_max_krw,
             limit=limit,
+        )
+
+    @mcp.tool(
+        name="screen_stocks_snapshot",
+        description=(
+            "Snapshot-backed screener: run an /invest/screener preset over its base "
+            "snapshot and adjust/add AND-filters on top (filters-over-snapshot, ROB-439). "
+            "Unlike screen_stocks (generic tvscreener/KIS path), this serves the persisted "
+            "screener snapshot data. filters=[{field, operator(gte|lte|eq), value}] tune the "
+            "preset's thresholds; the response includes availableFilters (the adjustable "
+            "catalog for that preset's snapshot) and appliedFilters. Currently threaded for "
+            "consecutive_gainers (e.g. loosen consecutive_up_days to 3 or tighten to 10); "
+            "other presets return default snapshot results and say so. Read-only."
+        ),
+    )
+    async def screen_stocks_snapshot(
+        preset: str,
+        market: Literal["kr", "us", "crypto"] = "kr",
+        filters: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        return await screen_stocks_snapshot_impl(
+            preset=preset,
+            market=market,
+            filters=filters,
         )
 
     # ROB-359: recommend_stocks is intentionally NOT registered on the MCP tool

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -1,0 +1,133 @@
+"""ROB-439 MVP (PR3): snapshot-backed screener MCP tool.
+
+`screen_stocks` is the generic tvscreener/KIS candidate-discovery path. This tool
+serves the /invest/screener *snapshot* data and lets a caller adjust/add AND-filters
+over a preset's base snapshot (the "필터를 추가/조정" model), reusing the same
+ScreenerFilterDefinition catalog + build_screener_results path the web screener uses.
+
+Read-only: build_screener_results never mutates broker/order/watch state. Filters
+currently thread through the consecutive_gainers loader (ROB-439 PR2); other presets
+return their default snapshot results (and say so), expanding as more presets get wired.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+
+
+class _NoopResolver:
+    """MCP candidate-discovery has no user context, so nothing is 'watched'.
+
+    build_screener_results only needs ``relation(market, symbol) -> str``; returning
+    "none" makes every row isWatched=False (no user personalization in MCP)."""
+
+    def relation(self, market: str, symbol: str) -> str:  # noqa: ARG002
+        return "none"
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _available_filters(preset: str) -> dict[str, dict[str, Any]]:
+    """The adjustable filter catalog for a preset's base snapshot (empty if none)."""
+    from app.services.invest_view_model.screener_filters import (
+        SNAPSHOT_FILTER_FIELDS,
+        snapshot_kind_for_preset,
+    )
+
+    kind = snapshot_kind_for_preset(preset)
+    if not kind or kind not in SNAPSHOT_FILTER_FIELDS:
+        return {}
+    return {
+        field: {
+            "label": d.label,
+            "operator": d.operator,
+            "valueType": d.value_type,
+            "default": d.default,
+            "min": d.min_bound,
+            "max": d.max_bound,
+            "step": d.step,
+            "unit": d.unit,
+        }
+        for field, d in SNAPSHOT_FILTER_FIELDS[kind].items()
+    }
+
+
+async def screen_stocks_snapshot_impl(
+    *,
+    preset: str,
+    market: str = "kr",
+    filters: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Run a screener preset over its base snapshot with adjustable AND-filters.
+
+    filters: list of {"field", "operator" (gte|lte|eq), "value"} conditions applied
+    on top of the preset's starting set (adjust same field, add new). Returns the
+    screener payload plus availableFilters (the adjustable catalog) and appliedFilters.
+    """
+    from app.services.invest_view_model.screener_filters import (
+        ScreenerFilterCondition,
+        ScreenerFilterError,
+        snapshot_kind_for_preset,
+    )
+    from app.services.invest_view_model.screener_service import build_screener_results
+    from app.services.screener_service import ScreenerService
+
+    available = _available_filters(preset)
+    snapshot_kind = snapshot_kind_for_preset(preset)
+
+    conditions: list[ScreenerFilterCondition] = []
+    for entry in filters or []:
+        try:
+            conditions.append(
+                ScreenerFilterCondition(
+                    field=str(entry["field"]),
+                    operator=str(entry["operator"]),
+                    value=entry["value"],
+                )
+            )
+        except (KeyError, TypeError) as exc:
+            return {
+                "error": f"invalid filter entry {entry!r}: {exc}",
+                "preset": preset,
+                "availableFilters": available,
+                "results": [],
+            }
+
+    try:
+        async with _session_factory()() as db:
+            resp = await build_screener_results(
+                preset_id=preset,
+                screening_service=ScreenerService(),
+                resolver=_NoopResolver(),
+                market=market,
+                session=db,
+                filter_overrides=conditions or None,
+            )
+    except ScreenerFilterError as exc:
+        return {
+            "error": str(exc),
+            "preset": preset,
+            "availableFilters": available,
+            "results": [],
+        }
+
+    payload: dict[str, Any] = resp.model_dump(mode="json")
+    payload["availableFilters"] = available
+    payload["appliedFilters"] = [
+        {"field": c.field, "operator": c.operator, "value": c.value} for c in conditions
+    ]
+    payload["snapshotKind"] = snapshot_kind
+    if conditions and snapshot_kind is None:
+        warnings = list(payload.get("warnings") or [])
+        warnings.append(
+            f"'{preset}' 프리셋은 아직 스냅샷 위 필터 조정이 배선되지 않아 "
+            "기본 결과를 반환했습니다 (필터 미적용)."
+        )
+        payload["warnings"] = warnings
+    return payload

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -1,0 +1,105 @@
+"""ROB-439 PR3: screen_stocks_snapshot MCP tool (filters-over-snapshot).
+
+Unit tests with build_screener_results + session factory monkeypatched (no DB):
+filter parsing → conditions, catalog exposure, threading, fail-soft on bad input.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling import screener_snapshot_tool as tool
+
+
+class _StubResp:
+    def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+        return {"presetId": "consecutive_gainers", "results": [], "warnings": ["base"]}
+
+
+class _FakeCM:
+    async def __aenter__(self) -> object:
+        return object()
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch the session factory, ScreenerService, and build_screener_results."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_build(**kwargs: Any) -> _StubResp:
+        captured.clear()
+        captured.update(kwargs)
+        return _StubResp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    return captured
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_threads_filters_and_exposes_catalog(patched) -> None:
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        filters=[{"field": "consecutive_up_days", "operator": "gte", "value": 3}],
+    )
+    # filter parsed into a condition and threaded to build_screener_results
+    overrides = patched["filter_overrides"]
+    assert overrides is not None and len(overrides) == 1
+    assert overrides[0].field == "consecutive_up_days"
+    assert overrides[0].operator == "gte"
+    assert overrides[0].value == 3
+    assert patched["preset_id"] == "consecutive_gainers"
+    # response echoes applied filters + exposes the adjustable catalog
+    assert out["appliedFilters"] == [
+        {"field": "consecutive_up_days", "operator": "gte", "value": 3}
+    ]
+    assert "consecutive_up_days" in out["availableFilters"]
+    assert out["availableFilters"]["consecutive_up_days"]["label"] == "연속상승일"
+    assert out["snapshotKind"] == "invest_screener_snapshots"
+    assert out["results"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_no_filters_passes_none_overrides(patched) -> None:
+    await tool.screen_stocks_snapshot_impl(preset="consecutive_gainers", market="kr")
+    assert patched["filter_overrides"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unwired_preset_with_filters_warns(patched) -> None:
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="cheap_value",  # catalogued but no snapshot_kind in the MVP pilot
+        market="kr",
+        filters=[{"field": "per", "operator": "lte", "value": 8}],
+    )
+    assert out["snapshotKind"] is None
+    assert out["availableFilters"] == {}
+    assert any("배선되지 않" in w for w in out["warnings"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_bad_filter_entry_fails_soft(patched) -> None:
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        filters=[{"field": "consecutive_up_days"}],  # missing operator/value
+    )
+    assert "error" in out
+    assert out["results"] == []
+    # build_screener_results must NOT have been called (no DB work on bad input)
+    assert patched == {}


### PR DESCRIPTION
## What & why (ROB-439 MVP — PR3: MCP exposure)

사용자가 강조한 **"screen_stocks 같은 MCP 도구에서 프리셋의 기본 스냅샷에 필터를 추가/조정"**을 end-to-end로 동작시킨다. 기존 `screen_stocks`(제네릭 tvscreener/KIS 경로)와 **별개의 신규 read-only 도구**로 /invest/screener 스냅샷 데이터를 서빙하고, PR1(필터 코어)+PR2(consecutive_gainers 배선)를 소비한다.

## Changes
- **신규 `app/mcp_server/tooling/screener_snapshot_tool.py`** — `screen_stocks_snapshot(preset, market, filters=[{field, operator(gte|lte|eq), value}])`:
  - `AsyncSessionLocal` 세션(기존 ledger 도구 패턴) + `ScreenerService()` + **no-op resolver**(MCP=무유저 → isWatched=False)로 `build_screener_results(filter_overrides=)` 호출.
  - 응답에 **`availableFilters`**(해당 프리셋 스냅샷의 조정 가능 카탈로그 = `SNAPSHOT_FILTER_FIELDS`) + **`appliedFilters`** + `snapshotKind` 첨부 → 호출자가 조정 가능 필드를 발견.
- **배선 상태**: `consecutive_gainers`는 PR2로 **실제 조정**(예: `consecutive_up_days` 5→3 loosen, 10 tighten). 미배선 프리셋은 기본 결과 + **정직 경고**(필터 미적용). 잘못된 filter 항목은 **fail-soft**(error 반환, DB 미접근).
- **등록**: `analysis_registration`에 `@mcp.tool` 블록 + `ANALYSIS_TOOL_NAMES`에 `screen_stocks_snapshot` 추가.

## Verification
- 신규 4 단위테스트: 필터 스레딩(→ build_screener_results `filter_overrides`) / 카탈로그 노출 / overrides 없으면 None / 미배선 프리셋 경고 / bad-entry fail-soft(DB 미접근).
- **MCP·registration·screen 광역 sweep 2312 passed / 0 fail**(도구명 일관성 테스트가 신규 도구 수용); `ruff check`+`format --check app/ tests/` clean; `alembic` single head(**migration 0**).
- 기존 `screen_stocks` 미변경(신규 도구 추가만) → 회귀 0.

## Boundaries / 후속
- read-only(`build_screener_results`는 broker/order/watch/order-intent mutation 0). migration 0. no-op resolver(무유저). Toss benchmark only.
- **ROB-439 후속**: high_yield_value(KR=fundamentals-family 로더 파라미터화 / US=operator 데이터 대기) + 추가 프리셋 배선 / 토스식 UI 칩 편집 / 사용자 저장 필터(DB) / boolean(OR).

## Related
ROB-439(spec) · #1133(PR1 foundation) · #1134(PR2 consecutive_gainers) · ROB-432(11-preset audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new stock screener snapshot tool that enables users to screen and filter stocks based on selected presets and markets with customizable filter options.

* **Tests**
  * Added comprehensive unit tests for stock screener functionality, including filter validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->