### PR TITLE
fix(ROB-436): 펀더멘털 시가총액 신뢰소스 join + 결과수 limit 상향 (C-1 LOW + C-2)

### DIFF
--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -481,6 +481,41 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
         )
         name_map = {r.symbol: r.name for r in names.all()}
 
+    # ROB-436 C-1: the tvscreener snapshot market_cap is unreliable for KR display
+    # (renders absurd-high like 3,468조원 AND bogus-low like 1억원 for real mid-caps).
+    # Override with the trusted Naver KRW market cap from the latest healthy
+    # market_valuation_snapshots partition when present. Symbols without a valuation
+    # row keep the tvscreener value (the ROB-436 C-1 absurd-high ceiling still hides
+    # implausible ones). Coverage scales with the operator's valuation-snapshot builds.
+    market_cap_map: dict[str, float] = {}
+    if symbols:
+        from app.models.market_valuation_snapshot import MarketValuationSnapshot
+        from app.services.invest_screener_snapshots.partition_health import (
+            resolve_healthy_partition,
+        )
+
+        val_hp = await resolve_healthy_partition(
+            session,
+            model=MarketValuationSnapshot,
+            date_col=MarketValuationSnapshot.snapshot_date,
+            market_col=MarketValuationSnapshot.market,
+            market="kr",
+        )
+        if val_hp and val_hp.partition_date is not None:
+            val_rows = await session.execute(
+                sa.select(
+                    MarketValuationSnapshot.symbol,
+                    MarketValuationSnapshot.market_cap,
+                ).where(
+                    MarketValuationSnapshot.market == "kr",
+                    MarketValuationSnapshot.snapshot_date == val_hp.partition_date,
+                    MarketValuationSnapshot.symbol.in_(symbols),
+                )
+            )
+            for r in val_rows.all():
+                if r.market_cap is not None:
+                    market_cap_map[r.symbol] = float(r.market_cap)
+
     # ROB-433: DART-first growth/streak. Only fetch the financial_fundamentals
     # derivation when this preset uses a 3년평균 growth or 순이익 연속증가 threshold
     # (valuation-only presets skip the extra query). DART coverage is sparse
@@ -551,6 +586,16 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
                 provenance=prov,
             )
         )
+
+    # ROB-436 C-1: apply the trusted KRW market cap to display + sort. market_cap_krw
+    # is what _normalize_market_cap_krw prefers for the label; overwrite market_cap too
+    # so a market_cap-sorted preset orders on the trusted value, not the tvscreener one.
+    if market_cap_map:
+        for row in included:
+            trusted = market_cap_map.get(row["symbol"])
+            if trusted is not None:
+                row["market_cap"] = trusted
+                row["market_cap_krw"] = trusted
 
     # ROB-429 B2: full-partition match total BEFORE the display limit.
     total_matched = len(included)

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -65,6 +65,10 @@ _KR_OPEN = _time(9, 0)
 _KR_CLOSE = _time(15, 30)
 _CACHE_HIT_FRESH_SECONDS = 300
 _SNAPSHOT_FIRST_LIMIT = 80
+# ROB-436 C-2: KR fundamentals presets (tvscreener display path) were capped at 20
+# rows while Toss shows the full match set (e.g. 아직저렴한가치주 553). Raise the
+# display cap so the count gap closes; total_matched still reports the true count.
+_FUNDAMENTALS_DISPLAY_LIMIT = 200
 _MAX_WARNING_CHARS = 240
 _US_SCREENER_DATA_NOT_READY_WARNING = (
     "미국 스크리너 데이터 준비중 — 일부 결과만 표시됩니다."
@@ -1824,14 +1828,14 @@ async def build_screener_results(
                 load_kr_fundamentals_preset_from_tv_snapshot,
             )
 
-            _fundamentals_screen_result = (
-                await load_kr_fundamentals_preset_from_tv_snapshot(
-                    session,
-                    market=requested_market,
-                    spec=FUNDAMENTALS_PRESET_SPECS[preset_id],
-                    limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
-                    now=now,
-                )
+            _fundamentals_screen_result = await load_kr_fundamentals_preset_from_tv_snapshot(
+                session,
+                market=requested_market,
+                spec=FUNDAMENTALS_PRESET_SPECS[preset_id],
+                # ROB-436 C-2: fundamentals presets show closer to the full Toss
+                # match set (was 20 via _SCREENING_FILTERS); total_matched unchanged.
+                limit=_FUNDAMENTALS_DISPLAY_LIMIT,
+                now=now,
             )
             if _fundamentals_screen_result is not None:
                 _snapshot_check_result = _fundamentals_screen_result.rows

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -298,6 +298,46 @@ async def test_consecutive_gainers_threads_filter_overrides_to_loader(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_fundamentals_presets_use_raised_display_limit(monkeypatch) -> None:
+    # ROB-436 C-2: fundamentals presets (tvscreener path) display closer to the full
+    # Toss match set (was 20). build_screener_results must pass the raised limit.
+    from app.services.invest_view_model import kr_fundamentals_tv_screener as tv
+    from app.services.invest_view_model import screener_service as svc
+    from app.services.invest_view_model.fundamentals_screener import (
+        FundamentalsScreenResult,
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_loader(session, **kwargs):  # noqa: ANN001, ANN003
+        captured.clear()
+        captured.update(kwargs)
+        return FundamentalsScreenResult(
+            rows=[],
+            valuation_partition_date=date(2026, 6, 4),
+            fundamentals_partition_date=date(2026, 6, 4),
+            fundamentals_collected_at=None,
+            fundamentals_state="fresh",
+        )
+
+    monkeypatch.setattr(svc, "_should_use_snapshot_first", lambda _s: True)
+    monkeypatch.setattr(
+        tv, "load_kr_fundamentals_preset_from_tv_snapshot", _fake_loader
+    )
+
+    fake_screening = MagicMock()
+    resolver = _FakeResolver(watched=set())
+    await build_screener_results(
+        preset_id="cheap_value",
+        screening_service=fake_screening,
+        resolver=resolver,
+        session=object(),
+    )
+    assert captured["limit"] == svc._FUNDAMENTALS_DISPLAY_LIMIT == 200
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_forwards_us_market_and_formats_us_labels() -> (
     None
 ):

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -21,6 +21,7 @@ import sqlalchemy as sa
 
 from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
 from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
 from app.services.invest_view_model.fundamentals_screener import (
     CHEAP_VALUE_SPEC,
     FUTURE_DIVIDEND_KING_SPEC,
@@ -56,6 +57,11 @@ async def _cleanup(db_session) -> None:
     )
     await db_session.execute(
         sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like(f"{_PREFIX}%"))
+    )
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.symbol.like(f"{_PREFIX}%")
+        )
     )
     await db_session.commit()
 
@@ -166,6 +172,69 @@ async def test_profitable_company_includes_and_excludes_on_thresholds(db_session
     assert row["gross_margin_ttm"] == 0.31
     assert row["_screener_snapshot_state"] == "fresh"
     assert row["snapshot_date"] == _SD
+
+
+async def test_market_cap_overridden_by_valuation_snapshot(db_session):
+    """ROB-436 C-1: trusted Naver KRW market cap overrides the bogus tvscreener one."""
+    await _cleanup(db_session)
+    sym = f"{_PREFIX}10"
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym,
+                price=Decimal("5000"),
+                roe_ttm=Decimal("20"),
+                gross_margin_ttm=Decimal("0.31"),
+                # bogus tvscreener market cap (1억 for a real mid-cap = the live bug)
+                market_cap=Decimal("100000000"),
+                sector="Technology",
+                industry="Semiconductors",
+            )
+        ],
+        [_universe(sym, "정상중형주")],
+    )
+    # Seed the trusted Naver valuation (1,251.9억 KRW) on the partition the loader
+    # WILL resolve. The shared test DB / xdist may carry kr valuation rows on a date
+    # newer than _SD, so resolve first then seed there — otherwise the loader's
+    # newest-partition pick wouldn't contain this symbol (deterministic in CI too).
+    from app.services.invest_screener_snapshots.partition_health import (
+        resolve_healthy_partition,
+    )
+
+    val_hp = await resolve_healthy_partition(
+        db_session,
+        model=MarketValuationSnapshot,
+        date_col=MarketValuationSnapshot.snapshot_date,
+        market_col=MarketValuationSnapshot.market,
+        market="kr",
+    )
+    val_date = val_hp.partition_date if (val_hp and val_hp.partition_date) else _SD
+    db_session.add(
+        MarketValuationSnapshot(
+            market="kr",
+            symbol=sym,
+            snapshot_date=val_date,
+            source="naver_finance",
+            market_cap=Decimal("125190000000"),
+        )
+    )
+    await db_session.commit()
+
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session,
+        market="kr",
+        spec=PROFITABLE_COMPANY_SPEC,
+        limit=20,
+        now=_now,
+        universe_count=1,
+    )
+    assert result is not None
+    row = next(r for r in result.rows if r["symbol"] == sym)
+    # display + sort use the trusted KRW value, NOT the tvscreener 1e8 bogus one.
+    assert row["market_cap"] == 125190000000.0
+    assert row["market_cap_krw"] == 125190000000.0
+    await _cleanup(db_session)
 
 
 async def test_fail_closed_on_null_required_column(db_session):


### PR DESCRIPTION
## What & why (ROB-436 완성 — C-1 LOW + C-2)

KR 펀더멘털(tvscreener 표시 경로)의 남은 표시 결함 2개. #1132이 시총 이상값-HIGH(SG&G `3,468조원`)를 숨겼고, 이 PR이 **bogus-LOW** + **개수 갭**을 해소한다.

### C-1 — bogus-LOW market_cap (신뢰소스 join)
tvscreener 스냅샷 market_cap이 실 중형주를 `1억원`으로 표시(KG에코솔루션·동국홀딩스 등 = 라이브 버그). `kr_fundamentals_tv_screener` 로더가 최신 healthy `market_valuation_snapshots`(Naver 신뢰 KRW) 파티션을 symbol join → 있으면 row `market_cap` + `market_cap_krw`를 신뢰값으로 override(표시는 `_normalize_market_cap_krw`가 선호, **정렬도 신뢰값**). 없으면 tvscreener값 유지(#1132 이상값-HIGH 가드 적용). 커버리지는 operator의 valuation-snapshot 빌드에 비례.

### C-2 — 결과수 limit
펀더멘털 9프리셋 표시 limit **20 → `_FUNDAMENTALS_DISPLAY_LIMIT=200`**(토스 553에 근접; `total_matched`는 실 매치수 그대로 보고). `build_screener_results` 펀더멘털 분기에서 적용.

## Verification
- 신규 2 테스트: C-1 join override(실 db_session — InvestKrFundamentalsSnapshot bogus 1억 + MarketValuationSnapshot 1,251.9억 seed → row가 신뢰값으로 덮어쓰는지) + C-2 limit 스레딩(build_screener_results → loader `limit==200`).
- **88 green**(test_kr_fundamentals_tv_screener + test_invest_view_model_screener_service); `ruff check`+`format --check app/ tests/` clean; `alembic` single head(**migration 0**).
- ⚠️ broad sweep 2 fail = `test_candidate_universe_collector_evidence`(2건) — **stash로 clean origin/main에서 동일 재현 확인**(pre-existing 격리 flake; full xdist suite green → CI full=green).

## Boundaries / 잔여
- broker/order/watch mutation 0. migration 0. Toss benchmark only. 신뢰 join은 operator valuation 커버리지에 비례(없는 symbol은 tvscreener값+이상값 가드).
- **ROB-436 잔여 = D 한글 카테고리**: MarketValuationSnapshot에 sector 컬럼 없음(raw_payload만, fragile). 신뢰 한글 sector 소스(sector 컬럼+backfill=operator, 또는 영문→한글 매핑)가 필요 → **operator/후속**(아래 operator 정리에 포함).

## Related
ROB-436 · #1132(C-1 HIGH) · ROB-428(fundamentals 표시 경로) · ROB-426(market_cap join 선례).

🤖 Generated with [Claude Code](https://claude.com/claude-code)