### PR TITLE
fix(ROB-437): 스크리너 메트릭 컬럼 수급칩 시각 분리 (CSS 배지)

### DIFF
--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -57,6 +57,30 @@
   background: var(--surface-2); color: var(--fg-3); opacity: 0.8;
 }
 
+/* ROB-437: the investor-flow chip rendered as unstyled inline text right after the
+   metric value, so it read as a single concatenated string ("1.9외국인 5일 순매수").
+   Give it a distinct pill badge (margin separates it from the metric value). */
+.investor-flow-chip {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--fg-3);
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.investor-flow-chip--double-buy,
+.investor-flow-chip--foreign-buy,
+.investor-flow-chip--institution-buy { color: var(--gain); }
+.investor-flow-chip--double-sell,
+.investor-flow-chip--foreign-sell,
+.investor-flow-chip--institution-sell { color: var(--loss); }
+.investor-flow-chip--stale { opacity: 0.6; }
+
 
 .screener-modal-backdrop { position: fixed; inset: 0; background: var(--overlay); display: flex; align-items: center; justify-content: center; z-index: 50; }
 .screener-modal { background: var(--surface); width: 720px; max-width: 90vw; max-height: 80vh; border-radius: 16px; display: flex; flex-direction: column; overflow: hidden; color: var(--fg); box-shadow: var(--shadow-3); }


### PR DESCRIPTION
## What & why
라이브에서 메트릭 컬럼이 **"1.9외국인 5일 순매수"**처럼 값 + 수급칩이 한 문자열로 붙어 보였다(아직저렴한가치주 순이익증가율, 꾸준한배당주 배당수익률, 연속상승세 주가등락률 등 전 프리셋 공통).

**근본원인**: 백엔드는 `metricValueLabel` / `investorFlowChip`을 **분리 저장(정상)**하고, 프론트 `ScreenerResultsTable.tsx:108-109`가 둘을 같은 셀에 인접 렌더한다. 그런데 **`.investor-flow-chip` CSS가 어디에도 정의돼 있지 않아** 칩이 스타일 없는 inline 텍스트로 값 바로 뒤에 붙어 한 덩어리로 보였다(워크플로 진단 E의 "프론트 concat" 추정이 정확).

## Fix
`screener.css`에 `.investor-flow-chip` 배지 스타일 추가(`.screener-cell__cap-badge` 패턴 미러): `margin-left`/`padding`/`border-radius` pill + 톤별 색(double/foreign/institution **buy=gain**, **sell=loss**, neutral=기본) + `--stale` dim. `InvestorFlowChip.tsx`가 emit하는 클래스명(tones 6 + base + dataState)과 **정확히 일치**.

## Verification
- 순수 **additive CSS** — TS/로직 영향 0, 기존 칩 렌더 테스트(`data-testid="investor-flow-chip"`) 불변.
- 클래스명 일치 확인: `InvestorFlowChip.tsx` TONE_CLASS(`--double-buy`…`--neutral`) + base `.investor-flow-chip` + `--${dataState}`(fresh|stale|missing).
- ⚠️ 프론트는 **별도 CI 게이트 없음**(auto_trader CI=Python 전용); vitest 로컬 미설치라 실행 불가하나 CSS-only라 로직 무영향. 배포/QA에서 시각 확인.

## Boundaries
broker/order/watch mutation 0, migration 0, Python 변경 0(프론트 CSS 1파일). Toss benchmark only.

## Related
ROB-437 · ROB-432(표시 parity) · ROB-277(investor flow chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)