### PR TITLE
fix(ROB-438): diagnose/coverage stale 기준 session-aware baseline (UTC today → expected_baseline)

### DIFF
--- a/app/services/invest_coverage_service.py
+++ b/app/services/invest_coverage_service.py
@@ -33,7 +33,7 @@ from app.schemas.invest_coverage import (
     InvestCoverageSurface,
     InvestCoverageSymbol,
 )
-from app.services.invest_screener_snapshots.freshness import today_trading_date
+from app.services.invest_screener_snapshots.freshness import expected_baseline_date
 from app.services.market_data_coverage.ohlcv_freshness import (
     kr_candles_freshness,
     us_candles_freshness,
@@ -68,7 +68,10 @@ async def build_invest_coverage(
     if market_norm not in {"kr", "us", "crypto", "all"}:
         raise ValueError("market must be one of kr, us, crypto, all")
     symbol_list = _normalize_symbols(symbols or [])
-    trading_day = as_of or today_trading_date(
+    # ROB-438 follow-up: default to the session-aware baseline (prior trading day
+    # in the pre-market window) so coverage surfaces don't false-flag fresh
+    # prior-day snapshots as stale; explicit as_of still overrides.
+    trading_day = as_of or expected_baseline_date(
         "us" if market_norm == "all" else market_norm
     )
     now = dt.datetime.now(dt.UTC)

--- a/app/services/invest_screener_snapshots/coverage_service.py
+++ b/app/services/invest_screener_snapshots/coverage_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.invest_screener_snapshot import InvestScreenerSnapshot
 from app.services.invest_screener_snapshots.freshness import (
     DataState,
-    today_trading_date,
+    expected_baseline_date,
 )
 
 
@@ -26,7 +26,11 @@ class CoverageReport:
 
 
 async def build_coverage(session: AsyncSession, *, market: str) -> CoverageReport:
-    today = today_trading_date(market)
+    # ROB-438 follow-up: coverage must classify against the session-aware baseline
+    # (prior trading day during the pre-market window), matching the snapshot
+    # loaders (ROB-281). today_trading_date() returned today's calendar trading day,
+    # so a fresh prior-day partition was false-flagged stale/missing in pre-market.
+    today = expected_baseline_date(market)
     now = dt.datetime.now(dt.UTC)
 
     if market == "kr":

--- a/scripts/diagnose_invest_screener_toss_parity.py
+++ b/scripts/diagnose_invest_screener_toss_parity.py
@@ -246,10 +246,13 @@ async def load_auto_trader_rows(
     from app.models.invest_screener_snapshot import InvestScreenerSnapshot
     from app.services.invest_screener_snapshots.freshness import (
         classify_state,
-        today_trading_date,
+        expected_baseline_date,
     )
 
-    today = today_trading_date(market)
+    # ROB-438 follow-up: classify against the session-aware baseline (matches the
+    # loaders / classify_state usage), so prior-day partitions in the pre-market
+    # window aren't reported stale on the UTC calendar date.
+    today = expected_baseline_date(market)
     now = datetime.now(UTC)
 
     # Resolve the latest snapshot partition (mirrors production serving semantics).

--- a/tests/test_invest_screener_snapshots_router.py
+++ b/tests/test_invest_screener_snapshots_router.py
@@ -33,10 +33,15 @@ async def test_coverage_report_structure(db_session):
 @pytest.mark.asyncio
 async def test_coverage_counts_fresh_and_stale(db_session):
     from app.services.invest_screener_snapshots.coverage_service import build_coverage
-    from app.services.invest_screener_snapshots.freshness import today_trading_date
+    from app.services.invest_screener_snapshots.freshness import (
+        expected_baseline_date,
+    )
 
     repo = InvestScreenerSnapshotsRepository(db_session)
-    today = today_trading_date("kr")
+    # ROB-438 follow-up: build_coverage classifies against the session-aware
+    # baseline; seed the "fresh" row on the same baseline so the test holds in the
+    # KR pre-market window too (where baseline = prior trading day != calendar today).
+    today = expected_baseline_date("kr")
     await repo.upsert(
         SnapshotUpsert(
             market="kr",


### PR DESCRIPTION
## What & why (operator 후속)
operator가 지적한 "diagnose stale 기준을 UTC current date가 아니라 market baseline date로 정리". 스냅샷 staleness를 **UTC 달력 trading date**(`today_trading_date`)로 판정해, **KR pre-market 창(07:40-16:19 KST)에서 직전영업일의 신선한 파티션을 false-stale**로 표시했다(예: 06-04 데이터를 06-05 pre-market에 보면 stale로 오판). 사용자-facing 스냅샷 로더(consecutive_gainers)는 이미 `expected_baseline_date`(ROB-281)를 쓰는데, **diagnose/coverage 툴링이 어긋나** 있었다.

## Changes (3 sites → session-aware baseline)
- `invest_screener_snapshots/coverage_service.build_coverage`: `today_trading_date` → `expected_baseline_date` (snapshot_date==baseline 카운트가 pre-market에 직전일 파티션을 fresh로 인식).
- `invest_coverage_service.build_invest_coverage`: `trading_day` 기본값 동일 교체(explicit `as_of` override는 유지).
- `scripts/diagnose_invest_screener_toss_parity`: `classify_state`에 넘기는 `today` 동일 교체.

## Verification
- `test_coverage_counts_fresh_and_stale`를 build_coverage와 **같은 baseline**(`expected_baseline_date`)에 fresh row를 seed하도록 정렬 → pre-market 창에서도 안정(seed+check 동일 fn).
- **318 green**(coverage/freshness/diagnose sweep) + 19 green(router/coverage); `ruff check`+`format --check` clean; `alembic` single head(**migration 0**).
- `expected_baseline_date`는 비-KR/US는 today_trading_date로 fallback, 시그니처 동일(드롭인).

## ⚠️ 별도 후속 (이 PR 범위 밖)
펀더멘털 display 로더(`kr_fundamentals_tv_screener:451`, `fundamentals_screener`, `undervalued_breakout`, `high_yield_value`)는 state를 `partition == today_trading_date` **exact-equality**로 판정 — consecutive_gainers(`expected_baseline_date`)와 **freshness 모델이 다름**. 단순 fn 교체로는 깨짐(비교 로직 rework + 테스트 갱신 필요) → 별도 careful PR로 분리. (이 PR은 operator가 지적한 diagnose/coverage 툴링만.)

## Boundaries
broker/order/watch mutation 0. migration 0.

## Related
ROB-438(cadence/freshness) · ROB-281(session-aware baseline) · ROB-426(partition health).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized baseline date calculation in investment coverage reports and screener snapshots to ensure consistent data freshness classification in pre-market conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->