### PR TITLE
feat(ROB-438): valuation + investor_flow 스냅샷 default-off 리커링 스케줄러

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -331,6 +331,15 @@ class Settings(BaseSettings):
     # production rollout can move schedule → dry-run-on-cron → commit-on-cron in stages.
     invest_screener_schedule_enabled: bool = False
 
+    # ROB-438 — recurring schedulers for the valuation + investor-flow snapshots
+    # (the other inputs the screener depends on). Same double-gate as invest_screener:
+    # *_schedule_enabled registers cron (default off → manual kick only); *_commit_enabled
+    # allows DB writes (default off → dry-run-on-cron). Operator flips both to activate.
+    market_valuation_schedule_enabled: bool = False
+    market_valuation_snapshots_commit_enabled: bool = False
+    investor_flow_schedule_enabled: bool = False
+    investor_flow_snapshots_commit_enabled: bool = False
+
     # ROB-222 — Naver momentum/theme event snapshot writes stay dry-run unless explicitly enabled.
     invest_momentum_events_commit_enabled: bool = False
     invest_momentum_events_scheduler_enabled: bool = False

--- a/app/tasks/investor_flow_snapshot_tasks.py
+++ b/app/tasks/investor_flow_snapshot_tasks.py
@@ -1,19 +1,31 @@
 """TaskIQ wrappers for KR investor-flow snapshot freshness.
 
-No recurring schedule is attached intentionally. Operators can enqueue this task
-manually in dry-run mode to produce an approval packet. Persisting rows requires
-commit=True and separate production database-write approval.
+Manual entry (``build_investor_flow_snapshots``, dry-run by default) plus the
+ROB-438 default-off scheduled wrapper. Recurring activation is double-gated like
+invest_screener (ROB-281): ``investor_flow_schedule_enabled`` registers the cron
+(off → manual ``taskiq kick`` only), ``investor_flow_snapshots_commit_enabled``
+allows DB writes (off → dry-run-on-cron). Operator flips both to activate.
 """
 
 from __future__ import annotations
 
 from typing import Any, Literal
 
+from app.core.config import settings
 from app.core.taskiq_broker import broker
 from app.jobs.investor_flow_snapshots import (
     InvestorFlowSnapshotBuildRequest,
     run_investor_flow_snapshot_build,
 )
+
+_KST_LABEL = "Asia/Seoul"
+
+
+def _kr_flow_schedule(cron: str) -> list[dict[str, str]]:
+    """Cron labels gated by the schedule flag (default off → [] → not registered)."""
+    if not settings.investor_flow_schedule_enabled:
+        return []
+    return [{"cron": cron, "cron_offset": _KST_LABEL}]
 
 
 @broker.task(task_name="build_investor_flow_snapshots")
@@ -65,3 +77,24 @@ async def build_investor_flow_snapshots(
         ],
         "warnings": list(result.warnings),
     }
+
+
+@broker.task(
+    task_name="investor_flow_snapshots.kr_scheduled",
+    schedule=_kr_flow_schedule("40 16 * * 1-5"),
+)
+async def scheduled_kr_investor_flow() -> dict[str, Any]:
+    """ROB-438: KR investor-flow refresh at 16:40 KST (Naver 수급, post-close).
+
+    Holiday-gated via XKRX (skips non-trading days). Default-off; commit gated by
+    ``investor_flow_snapshots_commit_enabled`` (dry-run-on-cron until operator sets it).
+    """
+    from app.tasks.invest_screener_snapshot_tasks import is_market_session_today
+
+    if not is_market_session_today("kr"):
+        return {"status": "skipped_holiday", "market": "kr"}
+    return await build_investor_flow_snapshots(
+        market="kr",
+        all_symbols=True,
+        commit=settings.investor_flow_snapshots_commit_enabled,
+    )

--- a/app/tasks/market_valuation_snapshot_tasks.py
+++ b/app/tasks/market_valuation_snapshot_tasks.py
@@ -1,19 +1,31 @@
 """TaskIQ wrappers for valuation snapshot freshness.
 
-No recurring schedule is attached intentionally. Operators can enqueue this task
-manually in dry-run mode to produce an approval packet. Persisting rows requires
-commit=True and separate production database-write approval.
+Manual entry (``build_market_valuation_snapshots``, dry-run by default) plus the
+ROB-438 default-off scheduled wrapper. Recurring activation is double-gated like
+invest_screener (ROB-281): ``market_valuation_schedule_enabled`` registers the cron
+(off → manual ``taskiq kick`` only), ``market_valuation_snapshots_commit_enabled``
+allows DB writes (off → dry-run-on-cron). Operator flips both to activate.
 """
 
 from __future__ import annotations
 
 from typing import Any, Literal
 
+from app.core.config import settings
 from app.core.taskiq_broker import broker
 from app.jobs.market_valuation_snapshots import (
     MarketValuationSnapshotBuildRequest,
     run_market_valuation_snapshot_build,
 )
+
+_KST_LABEL = "Asia/Seoul"
+
+
+def _kr_valuation_schedule(cron: str) -> list[dict[str, str]]:
+    """Cron labels gated by the schedule flag (default off → [] → not registered)."""
+    if not settings.market_valuation_schedule_enabled:
+        return []
+    return [{"cron": cron, "cron_offset": _KST_LABEL}]
 
 
 @broker.task(task_name="build_market_valuation_snapshots")
@@ -65,3 +77,24 @@ async def build_market_valuation_snapshots(
         ],
         "warnings": list(result.warnings),
     }
+
+
+@broker.task(
+    task_name="market_valuation_snapshots.kr_scheduled",
+    schedule=_kr_valuation_schedule("30 16 * * 1-5"),
+)
+async def scheduled_kr_market_valuation() -> dict[str, Any]:
+    """ROB-438: KR valuation refresh at 16:30 KST (after KRX preliminary 16:20).
+
+    Holiday-gated via XKRX (skips non-trading days). Default-off; commit gated by
+    ``market_valuation_snapshots_commit_enabled`` (dry-run-on-cron until operator sets it).
+    """
+    from app.tasks.invest_screener_snapshot_tasks import is_market_session_today
+
+    if not is_market_session_today("kr"):
+        return {"status": "skipped_holiday", "market": "kr"}
+    return await build_market_valuation_snapshots(
+        market="kr",
+        all_symbols=True,
+        commit=settings.market_valuation_snapshots_commit_enabled,
+    )

--- a/tests/test_investor_flow_snapshot_tasks.py
+++ b/tests/test_investor_flow_snapshot_tasks.py
@@ -83,12 +83,21 @@ async def test_task_wrapper_defaults_to_dry_run_and_returns_camel_case(monkeypat
     assert payload["samples"][0]["doubleBuy"] is True
 
 
-def test_task_module_has_no_recurring_schedule_activation():
+def test_recurring_schedule_is_default_off():
+    # ROB-438: the module now has a recurring scheduled task, but it is DEFAULT-OFF
+    # — merging this PR alone registers no cron. The manual build task still carries
+    # no schedule; the scheduled task's cron labels are empty unless the schedule
+    # flag is set (operator-gated, mirroring invest_screener ROB-281).
+    from unittest.mock import patch
+
     from app.tasks import TASKIQ_TASK_MODULES
 
     assert tasks in TASKIQ_TASK_MODULES
     labels = getattr(tasks.build_investor_flow_snapshots, "labels", {}) or {}
-    assert labels.get("schedule") is None
-    source = tasks.__loader__.get_source(tasks.__name__)  # type: ignore[union-attr]
-    assert "schedule=[" not in source
-    assert "cron_offset" not in source
+    assert labels.get("schedule") is None  # manual task: no schedule
+    with patch.object(tasks.settings, "investor_flow_schedule_enabled", False):
+        assert tasks._kr_flow_schedule("40 16 * * 1-5") == []
+    with patch.object(tasks.settings, "investor_flow_schedule_enabled", True):
+        assert tasks._kr_flow_schedule("40 16 * * 1-5") == [
+            {"cron": "40 16 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]

--- a/tests/test_snapshot_schedulers_rob438.py
+++ b/tests/test_snapshot_schedulers_rob438.py
@@ -1,0 +1,106 @@
+"""ROB-438: default-off recurring schedulers for valuation + investor-flow snapshots.
+
+Mirrors the invest_screener double-gate (ROB-281): schedule flag registers the cron
+(default off → [] → not registered), commit flag gates DB writes (default off →
+dry-run-on-cron). Scheduled tasks also XKRX holiday-gate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.tasks import investor_flow_snapshot_tasks as fl
+from app.tasks import market_valuation_snapshot_tasks as mv
+
+# --- schedule-label gating (default off) --------------------------------------
+
+
+@pytest.mark.unit
+def test_valuation_schedule_labels_gated_by_flag() -> None:
+    with patch.object(mv.settings, "market_valuation_schedule_enabled", False):
+        assert mv._kr_valuation_schedule("30 16 * * 1-5") == []
+    with patch.object(mv.settings, "market_valuation_schedule_enabled", True):
+        assert mv._kr_valuation_schedule("30 16 * * 1-5") == [
+            {"cron": "30 16 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]
+
+
+@pytest.mark.unit
+def test_flow_schedule_labels_gated_by_flag() -> None:
+    with patch.object(fl.settings, "investor_flow_schedule_enabled", False):
+        assert fl._kr_flow_schedule("40 16 * * 1-5") == []
+    with patch.object(fl.settings, "investor_flow_schedule_enabled", True):
+        assert fl._kr_flow_schedule("40 16 * * 1-5") == [
+            {"cron": "40 16 * * 1-5", "cron_offset": "Asia/Seoul"}
+        ]
+
+
+# --- scheduled body: holiday-skip + commit gating -----------------------------
+
+
+def _patch_session(monkeypatch, is_session: bool) -> None:
+    import app.tasks.invest_screener_snapshot_tasks as iss
+
+    monkeypatch.setattr(iss, "is_market_session_today", lambda market, **_k: is_session)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scheduled_valuation_skips_holiday(monkeypatch) -> None:
+    _patch_session(monkeypatch, False)
+    out = await mv.scheduled_kr_market_valuation()
+    assert out["status"] == "skipped_holiday"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scheduled_flow_skips_holiday(monkeypatch) -> None:
+    _patch_session(monkeypatch, False)
+    out = await fl.scheduled_kr_investor_flow()
+    assert out["status"] == "skipped_holiday"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit_flag", [False, True])
+async def test_scheduled_valuation_commit_gated(monkeypatch, commit_flag) -> None:
+    _patch_session(monkeypatch, True)
+    captured: dict = {}
+
+    async def _fake_build(**kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        return {"committed": kwargs.get("commit")}
+
+    monkeypatch.setattr(mv, "build_market_valuation_snapshots", _fake_build)
+    with patch.object(
+        mv.settings, "market_valuation_snapshots_commit_enabled", commit_flag
+    ):
+        await mv.scheduled_kr_market_valuation()
+    assert captured["commit"] is commit_flag
+    assert captured["market"] == "kr"
+    assert captured["all_symbols"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("commit_flag", [False, True])
+async def test_scheduled_flow_commit_gated(monkeypatch, commit_flag) -> None:
+    _patch_session(monkeypatch, True)
+    captured: dict = {}
+
+    async def _fake_build(**kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        return {"committed": kwargs.get("commit")}
+
+    monkeypatch.setattr(fl, "build_investor_flow_snapshots", _fake_build)
+    with patch.object(
+        fl.settings, "investor_flow_snapshots_commit_enabled", commit_flag
+    ):
+        await fl.scheduled_kr_investor_flow()
+    assert captured["commit"] is commit_flag
+    assert captured["market"] == "kr"
+    assert captured["all_symbols"] is True


### PR DESCRIPTION
## What & why (operator 후속 — ROB-438 cadence)
operator가 invest_screener 스케줄(`INVEST_SCREENER_SCHEDULE_ENABLED` + commit flag)을 활성화했다. 스크리너가 의존하는 **나머지 2개 스냅샷**(valuation, investor_flow)에도 동일한 **default-off 리커링 스케줄러**를 배선해, operator가 플래그만 켜면 자동 갱신되게 한다(invest_screener ROB-281과 동일한 이중 게이트).

## Changes
- **settings**(전부 default False): `market_valuation_schedule_enabled` / `market_valuation_snapshots_commit_enabled`, `investor_flow_schedule_enabled` / `investor_flow_snapshots_commit_enabled`.
- **`scheduled_kr_market_valuation`** (`market_valuation_snapshot_tasks`): `@broker.task` cron **16:30 KST**(KRX preliminary 16:20 후), schedule flag off면 `[]`(cron 미등록), XKRX 휴장 skip, commit은 commit flag로 게이트(off=dry-run-on-cron), `all_symbols=True`.
- **`scheduled_kr_investor_flow`** (`investor_flow_snapshot_tasks`): cron **16:40 KST**, 동일 패턴.
- 둘 다 `is_market_session_today`(XKRX)로 휴장 skip; build는 기존 manual task 재사용(commit 게이트만 추가).

## Verification
- 신규 8 테스트: 라벨 게이팅(off→`[]` / on→`[{cron, KST}]`) + 휴장 skip + commit 게이트(parametrized False/True; market/all_symbols 검증).
- **26 green**(신규 8 + 기존 invest_screener 스케줄 18 회귀 0); `ruff check`+`format --check` clean; `alembic` single head(**migration 0**); 모듈 import/broker 등록 정상(테스트가 두 task 모듈 import).

## Activation (operator)
schedule flag on(dry-run-on-cron) → 검증 → commit flag on. default-off라 머지만으로는 아무 cron도 등록/commit 안 됨.

## Boundaries / 잔여
- broker/order/watch mutation 0. migration 0.
- **잔여(별도)**: DART fundamentals **budget-split 스케줄러**(신규 task 파일 + DART 예산 배치 설계) / **US non-DART fundamentals vendor**(ROB-434, /spec) / 펀더멘털 display 로더 freshness 모델 정합(별도 careful PR).

## Related
ROB-438 · ROB-281(invest_screener 스케줄 패턴) · ROB-205(investor_flow) · ROB-436(valuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)