### PR TITLE
feat(ROB-440): US valuation ROE(percent) 공급 → high_yield_value US unblock (Phase 1 part 1)

### DIFF
--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -300,6 +300,19 @@ async def fetch_fast_info(ticker: str) -> dict[str, Any]:
     return await asyncio.to_thread(_fetch_fast_info_sync, ticker)
 
 
+def _roe_to_percent(raw_roe: Any) -> float | None:
+    """ROB-440: yfinance ``returnOnEquity`` is a fraction (0.35 = 35%); the screener
+    (high_yield_value ``roe >= 15``) and KR Naver ROE are both in percent. Convert
+    to percent; return None for missing/non-numeric so the row stays fail-closed
+    (a null ROE keeps high_yield_value preparing, never fabricated)."""
+    if raw_roe is None or isinstance(raw_roe, bool):
+        return None
+    try:
+        return float(raw_roe) * 100.0
+    except (TypeError, ValueError):
+        return None
+
+
 async def fetch_fundamental_info(ticker: str) -> dict:
     yahoo_ticker = to_yahoo_symbol(ticker)
 
@@ -315,6 +328,10 @@ async def fetch_fundamental_info(ticker: str) -> dict:
                     "EPS": info.get("trailingEps"),
                     "BPS": info.get("bookValue"),
                     "Dividend Yield": info.get("trailingAnnualDividendYield"),
+                    # ROB-440: ROE (percent) from the same .info call (no extra
+                    # request) unblocks US high_yield_value (already US-active,
+                    # ROB-427 PR3) which was empty because roe was never populated.
+                    "ROE": _roe_to_percent(info.get("returnOnEquity")),
                 }
             except Exception as exc:
                 last_exc = exc

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -219,5 +219,8 @@ class TestYahooService:
             "EPS": 5.6,
             "BPS": 20.1,
             "Dividend Yield": 0.012,
+            # ROB-440: ROE (percent) now extracted; None here (mock .info omits
+            # returnOnEquity) — fail-closed.
+            "ROE": None,
         }
         assert mock_ticker_class.call_args.kwargs["session"] is tracing_session

--- a/tests/test_yahoo_roe_rob440.py
+++ b/tests/test_yahoo_roe_rob440.py
@@ -1,0 +1,79 @@
+"""ROB-440 (Phase 1): yahoo client supplies ROE (percent) so US high_yield_value
+(already US-active, ROB-427 PR3) stops being empty due to roe=null.
+
+yfinance returnOnEquity is a fraction (0.35); the screener (roe >= 15) + KR Naver
+ROE are percent. Convert ×100; null stays fail-closed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.brokers.yahoo.client import _roe_to_percent
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0.35, 35.0),
+        (0.155, 15.5),
+        (0.0, 0.0),
+        (-0.1, -10.0),
+        (None, None),
+        (True, None),  # bool is not a real ROE
+        ("n/a", None),
+    ],
+)
+def test_roe_to_percent(raw, expected) -> None:
+    assert _roe_to_percent(raw) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("app.services.brokers.yahoo.client.yf.Ticker")
+async def test_fetch_fundamental_info_includes_roe_percent(
+    mock_ticker_class, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+        lambda: object(),
+    )
+    mock_ticker = MagicMock()
+    mock_ticker.info = {
+        "trailingPE": 8.0,
+        "priceToBook": 0.9,
+        "trailingEps": 1000.0,
+        "bookValue": 9000.0,
+        "trailingAnnualDividendYield": 0.04,
+        "returnOnEquity": 0.22,
+    }
+    mock_ticker_class.return_value = mock_ticker
+
+    from app.services.brokers.yahoo.client import fetch_fundamental_info
+
+    result = await fetch_fundamental_info("AAPL")
+    assert result["ROE"] == 22.0  # 0.22 fraction → 22.0 percent
+    assert result["PER"] == 8.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("app.services.brokers.yahoo.client.yf.Ticker")
+async def test_fetch_fundamental_info_roe_none_when_missing(
+    mock_ticker_class, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+        lambda: object(),
+    )
+    mock_ticker = MagicMock()
+    mock_ticker.info = {"trailingPE": 8.0}  # no returnOnEquity → fail-closed null
+    mock_ticker_class.return_value = mock_ticker
+
+    from app.services.brokers.yahoo.client import fetch_fundamental_info
+
+    result = await fetch_fundamental_info("AAPL")
+    assert result["ROE"] is None


### PR DESCRIPTION
## What & why (ROB-440 Phase 1, part 1 — ROE)
`high_yield_value`는 이미 **US-active**(ROB-427 PR3, `_US_ACTIVE_PRESET_IDS`)지만, US valuation 스냅샷의 `roe`가 **항상 null**이라 빈 결과였다 — yahoo client(`fetch_fundamental_info`)가 PER/PBR/EPS/BPS/DividendYield만 추출하고 `returnOnEquity`는 안 가져왔기 때문. `roe` 컬럼은 이미 존재 → **migration 0**.

## Change
- `brokers/yahoo/client.fetch_fundamental_info`: **같은 `.info` 호출**에서 `returnOnEquity`(fraction, 예 0.35) 추출 → `_roe_to_percent`로 **×100(percent)** → 반환 dict에 `"ROE"` 추가. **추가 API 호출 0**.
  - high_yield_value WHERE(`roe >= 15` percent) + KR Naver `ROE(%)`와 **단위 일치**.
  - 결측/비숫자/bool → `None`(**fail-closed**: roe 없으면 high_yield_value preparing 유지, 위조 0).
- `_payload_from_raw`는 이미 `raw.get("ROE")`를 읽음 → **builder 무변경**. operator가 US valuation 재빌드하면 high_yield_value US가 실데이터 표시.

## Verification
- 신규: `_roe_to_percent`(0.35→35.0 / 0.0 / 음수 / None / bool / 문자열) + `fetch_fundamental_info`에 ROE 포함 + 결측시 None.
- 기존 exact-shape 테스트(`test_fetch_fundamental_info`)에 `ROE: None` 추가(contract 변경 반영).
- **16 yahoo green** + **광역 715 green**(yahoo/fundamental/valuation/market_data/sell_signal/coverage consumer 회귀 0); `ruff check`+`format --check` clean; `alembic` single head(**migration 0**).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. migration 0. fail-closed(roe None 유지). 벤더 키/예산=operator. operator US valuation 재빌드 후 데이터 표시.
- **ROB-440 part 2**(별도): `high_52w_date` 컬럼(additive migration) + yfinance OHLC max(high) date + `undervalued_breakout` US 활성화.
- **ROB-441**: Phase 2(financial_fundamentals US source → 나머지 펀더멘털).

## Related
ROB-440(Phase 1) · ROB-434(umbrella) · ROB-427(high_yield_value US-active) · ROB-441(Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Return on Equity (ROE) financial metrics are now included when fetching fundamental company information.
  * ROE values are automatically formatted as percentages for improved readability.
  * Invalid or missing ROE data is handled gracefully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->