### PR TITLE
feat(ROB-440): undervalued_breakout US 활성화 (proximity, yahoo high_52w) — Phase 1 part 2

### DIFF
--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -332,6 +332,11 @@ async def fetch_fundamental_info(ticker: str) -> dict:
                     # request) unblocks US high_yield_value (already US-active,
                     # ROB-427 PR3) which was empty because roe was never populated.
                     "ROE": _roe_to_percent(info.get("returnOnEquity")),
+                    # ROB-440 Part 2: 52-week high/low (price) from the same .info
+                    # call → market_valuation high_52w/low_52w populated → US
+                    # undervalued_breakout (proximity: close >= high_52w * 0.95).
+                    "yearHigh": info.get("fiftyTwoWeekHigh"),
+                    "yearLow": info.get("fiftyTwoWeekLow"),
                 }
             except Exception as exc:
                 last_exc = exc

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -46,12 +46,13 @@ _KR_ONLY_PRESET_IDS = {
 # ROB-427 PR3: KR-only presets that ARE active for US (backed by US data now).
 # high_yield_value (ROE+PER) runs on Yahoo valuation snapshots — see
 # high_yield_value_screener.load_high_yield_value_from_snapshots(market="us").
-_US_ACTIVE_PRESET_IDS = {"high_yield_value"}
+# ROB-440: undervalued_breakout (proximity) runs on the same Yahoo valuation
+# snapshots (high_52w price) — load_undervalued_breakout_from_snapshots(market="us").
+_US_ACTIVE_PRESET_IDS = {"high_yield_value", "undervalued_breakout"}
 _US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
 _US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
 _US_DATA_PENDING_REASON: dict[str, str] = {
     "high_yield_value": "미국 가치형(ROE·PER) 활성화 준비중",
-    "undervalued_breakout": "미국 신고가(52주) 데이터 소스 준비중",
     "profitable_company": "미국 펀더멘털(매출총이익률) 데이터 준비중",
     "undervalued_growth": "미국 펀더멘털(연평균 매출·순이익 증감률) 데이터 준비중",
     "cheap_value": "미국 펀더멘털(연평균 순이익 증감률) 데이터 준비중",

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1811,6 +1811,32 @@ async def build_screener_results(
             _snapshot_empty_warning = (
                 "최신 미국 가치형(ROE·PER) 스냅샷에서 조건에 맞는 종목이 없습니다."
             )
+        elif preset_id == "undervalued_breakout" and requested_market == "us":
+            # ROB-440 Part 2: US undervalued_breakout uses the market-parameterized
+            # market_valuation loader (proximity: close >= high_52w * 0.95) — NOT the
+            # KR tvscreener date-recency path below (invest_kr_fundamentals is KR-only).
+            # high_52w(price) comes from Yahoo .info; fail-closed empty until the
+            # operator builds the US valuation partition. (Date-recency US parity is a
+            # follow-up; KR display keeps date-recency via the tvscreener loader.)
+            from app.services.invest_view_model.undervalued_breakout_screener import (
+                load_undervalued_breakout_from_snapshots,
+            )
+
+            _ub_rows = await load_undervalued_breakout_from_snapshots(
+                session,
+                market="us",
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+            )
+            if _ub_rows is not None:
+                _snapshot_check_result = _ub_rows
+                _snapshot_load_result = _SnapshotLoadResult(
+                    rows=_ub_rows,
+                    partition_date=(_ub_rows[0]["snapshot_date"] if _ub_rows else None),
+                    partition_computed_at=None,
+                )
+            _snapshot_empty_warning = (
+                "최신 미국 신고가(52주) 스냅샷에서 조건에 맞는 종목이 없습니다."
+            )
         # ROB-428 PR-C: high_yield_value + undervalued_breakout no longer have a
         # dedicated dispatch branch. They are now registered in
         # FUNDAMENTALS_PRESET_SPECS and fall into the tvscreener KR loader below

--- a/app/services/invest_view_model/undervalued_breakout_screener.py
+++ b/app/services/invest_view_model/undervalued_breakout_screener.py
@@ -52,8 +52,13 @@ async def load_undervalued_breakout_from_snapshots(
     limit: int = 20,
     today_market_date: dt.date | None = None,
 ) -> list[dict[str, Any]] | None:
-    """Toss-parity 저평가 탈출 rows, or None when no KR valuation partition exists."""
-    if session is None or market != "kr":
+    """Toss-parity 저평가 탈출 rows, or None when no valuation partition exists.
+
+    ROB-440 Part 2: market-parameterized for US (proximity definition: close >=
+    high_52w * 0.95). KR display uses the tvscreener date-recency loader; this
+    market_valuation-backed loader serves US (+ KR reports/PIT). high_52w(price) +
+    latest_close required; NULL → fail-closed excluded."""
+    if session is None or market not in {"kr", "us"}:
         return None
 
     from app.services.invest_screener_snapshots.partition_health import (
@@ -65,7 +70,7 @@ async def load_undervalued_breakout_from_snapshots(
         model=MarketValuationSnapshot,
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
-        market="kr",
+        market=market,
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:
@@ -74,7 +79,7 @@ async def load_undervalued_breakout_from_snapshots(
 
     latest_price_stmt = sa.select(
         sa.func.max(InvestScreenerSnapshot.snapshot_date)
-    ).where(InvestScreenerSnapshot.market == "kr")
+    ).where(InvestScreenerSnapshot.market == market)
     try:
         price_date = (await session.execute(latest_price_stmt)).scalar_one_or_none()
     except Exception as exc:  # noqa: BLE001
@@ -106,7 +111,7 @@ async def load_undervalued_breakout_from_snapshots(
             ),
         )
         .where(
-            MarketValuationSnapshot.market == "kr",
+            MarketValuationSnapshot.market == market,
             MarketValuationSnapshot.snapshot_date == val_date,
             MarketValuationSnapshot.per > 0,
             MarketValuationSnapshot.per <= _MAX_PER,
@@ -130,7 +135,9 @@ async def load_undervalued_breakout_from_snapshots(
 
     symbols = [r["symbol"] for r in cand_rows]
     name_map: dict[str, str] = {}
-    if symbols:
+    if (
+        market == "kr" and symbols
+    ):  # ROB-440 Part 2: KR name/common-stock filter is KR-only
         try:
             names = await session.execute(
                 sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
@@ -151,7 +158,7 @@ async def load_undervalued_breakout_from_snapshots(
 
         from app.services.invest_screener_snapshots.freshness import today_trading_date
 
-        today_market_date = today_trading_date("kr", now=datetime.now(UTC))
+        today_market_date = today_trading_date(market, now=datetime.now(UTC))
     state = "fresh" if val_date == today_market_date else "stale"
     if partition_degraded:
         from app.services.invest_screener_snapshots.partition_health import (
@@ -167,7 +174,7 @@ async def load_undervalued_breakout_from_snapshots(
         if sym in seen:
             continue
         name = name_map.get(sym)
-        if not _is_kr_toss_common_stock(sym, name):
+        if market == "kr" and not _is_kr_toss_common_stock(sym, name):
             continue
         # 신고가 근접 (fail-closed on NULL close / high_52w)
         if not _passes_near_high(r["latest_close"], r["high_52w"], _NEAR_HIGH_RATIO):
@@ -177,7 +184,7 @@ async def load_undervalued_breakout_from_snapshots(
         rows.append(
             {
                 "symbol": sym,
-                "market": "kr",
+                "market": market,
                 "name": name,
                 "latest_close": float(r["latest_close"])
                 if r["latest_close"] is not None

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -65,9 +65,9 @@ def test_us_flow_presets_unsupported_with_reason() -> None:
 @pytest.mark.unit
 def test_us_fundamentals_presets_data_pending_with_reason() -> None:
     us = {p.id: p for p in preset_definitions("us")}
-    # ROB-427 PR3: high_yield_value is now active (Yahoo-backed); the rest pending.
+    # ROB-427 PR3 + ROB-440: high_yield_value + undervalued_breakout are now active
+    # (Yahoo-backed); the rest pending.
     for pid in (
-        "undervalued_breakout",
         "profitable_company",
         "undervalued_growth",
         "cheap_value",
@@ -87,6 +87,16 @@ def test_us_high_yield_value_active() -> None:
     assert us["high_yield_value"].availability == "active"
     assert us["high_yield_value"].availabilityReason is None
     assert "high_yield_value" in _US_ACTIVE_PRESET_IDS
+
+
+@pytest.mark.unit
+def test_us_undervalued_breakout_active() -> None:
+    # ROB-440 Part 2: Yahoo valuation backs high_52w(price) + PER/PBR, so
+    # undervalued_breakout (proximity) runs for US.
+    us = {p.id: p for p in preset_definitions("us")}
+    assert us["undervalued_breakout"].availability == "active"
+    assert us["undervalued_breakout"].availabilityReason is None
+    assert "undervalued_breakout" in _US_ACTIVE_PRESET_IDS
 
 
 @pytest.mark.unit

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -222,5 +222,8 @@ class TestYahooService:
             # ROB-440: ROE (percent) now extracted; None here (mock .info omits
             # returnOnEquity) — fail-closed.
             "ROE": None,
+            # ROB-440 Part 2: 52w high/low (price); None here (mock omits them).
+            "yearHigh": None,
+            "yearLow": None,
         }
         assert mock_ticker_class.call_args.kwargs["session"] is tracing_session

--- a/tests/test_undervalued_breakout_screener.py
+++ b/tests/test_undervalued_breakout_screener.py
@@ -217,10 +217,11 @@ async def test_loader_filters_per_pbr_and_near_high(db_session):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_loader_returns_none_without_valuation_partition(db_session):
+    # ROB-440 Part 2: kr+us are valid now; crypto (unsupported market) short-circuits.
     rows = await load_undervalued_breakout_from_snapshots(
-        db_session, market="us", limit=20, today_market_date=dt.date(2026, 6, 2)
+        db_session, market="crypto", limit=20, today_market_date=dt.date(2026, 6, 2)
     )
-    assert rows is None  # non-KR short-circuits
+    assert rows is None  # non-{kr,us} short-circuits
 
 
 @pytest.mark.integration
@@ -292,6 +293,54 @@ async def test_loader_ranks_by_proximity_desc_then_per_asc(db_session):
     )
     assert rows is not None
     assert [r["symbol"] for r in rows] == ["907021", "907024", "907023", "907022"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_loader_us_proximity_passes(db_session):
+    # ROB-440 Part 2: US runs on the same market-parameterized proximity loader
+    # (high_52w from Yahoo .info, latest_close from US invest_screener). No KR
+    # universe / common-stock filter for US.
+    vd = dt.date(2099, 12, 31)
+    sym = "907031"
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.execute(
+        sa.delete(InvestScreenerSnapshot).where(InvestScreenerSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+    db_session.add(
+        MarketValuationSnapshot(
+            market="us",
+            symbol=sym,
+            snapshot_date=vd,
+            source="yahoo",
+            per=Decimal("8"),
+            pbr=Decimal("0.8"),
+            high_52w=Decimal("100"),
+            market_cap=Decimal("5e11"),
+        )
+    )
+    db_session.add(
+        InvestScreenerSnapshot(
+            market="us",
+            symbol=sym,
+            snapshot_date=vd,
+            latest_close=Decimal("99"),  # 0.99 proximity >= 0.95 → passes
+            closes_window=[],
+            source="kis",
+        )
+    )
+    await db_session.commit()
+
+    rows = await load_undervalued_breakout_from_snapshots(
+        db_session, market="us", limit=20, today_market_date=vd
+    )
+    assert rows is not None
+    row = next(r for r in rows if r["symbol"] == sym)
+    assert row["market"] == "us"  # market threaded through
+    assert row["high_52w"] == 100.0
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What & why (ROB-440 Phase 1, part 2 — undervalued_breakout US)
저평가탈출(undervalued_breakout)을 US에 활성화. **구현 중 발견된 포크**(spec엔 date였으나): US-routable한 `load_undervalued_breakout_from_snapshots`는 **proximity**(close ≥ high_52w×0.95) 정의 — KR display의 date-recency(ROB-432)와 다름. **결정 A**(사용자 승인): proximity로 **migration 0** 즉시 활성화; date-recency US parity는 후속. 또한 US `high_52w`(가격)도 미적재였음 → yahoo `.info`에서 추가(추가 API 0).

## Changes
- **`brokers/yahoo/client.fetch_fundamental_info`**: 같은 `.info`에서 `fiftyTwoWeekHigh/Low` → dict `yearHigh`/`yearLow` 추가 → `_payload_from_raw`가 `high_52w`/`low_52w` 채움(**migration 0**, 컬럼 기존재).
- **`load_undervalued_breakout_from_snapshots`**: market 파라미터화(high_yield_value ROB-427 PR3 미러) — gate `market not in {kr,us}`, resolve/price/candidate WHERE에 market 전파, KR name lookup + `_is_kr_toss_common_stock`은 `if market=="kr"` 가드, row `market=market`, `today_trading_date(market)`.
- **`screener_service`**: undervalued_breakout US dispatch 분기(high_yield_value US 미러; KR FUNDAMENTALS_PRESET_SPECS[date-recency] 분기보다 먼저 → US는 proximity 로더).
- **`screener_presets`**: `_US_ACTIVE_PRESET_IDS`에 undervalued_breakout 추가 + data_pending reason 제거.

## Verification
- 신규: US availability active / US proximity 로더(market 전파·high_52w·fail-closed) / 비-{kr,us} gate(crypto→None) / yahoo yearHigh·yearLow.
- 계약변경 테스트 갱신: yahoo exact-shape(+yearHigh/Low None), us_availability(undervalued_breakout data_pending→active), 로더 None-gate(us→crypto).
- **32 + 1132 green**(screener/undervalued/yahoo/valuation/fundamentals sweep, 회귀 0); `ruff check`+`format --check` clean; `alembic` single head(**migration 0**).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. migration 0. fail-closed(NULL high_52w/close 제외). operator US valuation 재빌드 후 동작.
- KR undervalued_breakout 무변경(date-recency tvscreener 유지). **후속**: date-recency US parity(high_52w_date 컬럼+OHLC) / ROB-441 Phase 2(나머지 펀더멘털).

## Related
ROB-440(Phase 1) · ROB-434(umbrella) · ROB-427 PR3(high_yield_value US 미러) · ROB-432(KR date-recency) · ROB-441(Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)