### PR TITLE
feat(ROB-441): US fundamentals 데이터층 — financial_fundamentals US source + yfinance 파서 (Phase 2 PR1)

### DIFF
--- a/alembic/versions/2026_06_05_rob441_us_fundamentals_source.py
+++ b/alembic/versions/2026_06_05_rob441_us_fundamentals_source.py
@@ -1,0 +1,40 @@
+"""ROB-441: allow US non-DART sources in financial_fundamentals_snapshots.
+
+Additive: widens the ``source`` CHECK constraint from ('dart') to
+('dart', 'yfinance', 'finnhub') so US fundamentals periods (parsed from yfinance
+income statements, finnhub as fallback) can be stored alongside KR DART rows.
+The market CHECK already allows ('kr', 'us'); no other column changes. The derive
+layer is market-agnostic and reused as-is.
+
+Revision ID: 20260605_rob441
+Revises: 20260604_rob430
+Create Date: 2026-06-05
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260605_rob441"
+down_revision = "20260604_rob430"
+branch_labels = None
+depends_on = None
+
+_CONSTRAINT = "ck_financial_fundamentals_snapshots_source"
+_TABLE = "financial_fundamentals_snapshots"
+
+
+def upgrade() -> None:
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(
+        _CONSTRAINT,
+        _TABLE,
+        "source IN ('dart', 'yfinance', 'finnhub')",
+    )
+
+
+def downgrade() -> None:
+    # Reverting requires no non-DART rows remain (else the tighter CHECK fails).
+    op.execute(f"DELETE FROM {_TABLE} WHERE source <> 'dart'")
+    op.drop_constraint(_CONSTRAINT, _TABLE, type_="check")
+    op.create_check_constraint(_CONSTRAINT, _TABLE, "source IN ('dart')")

--- a/app/models/financial_fundamentals_snapshot.py
+++ b/app/models/financial_fundamentals_snapshot.py
@@ -46,7 +46,8 @@ class FinancialFundamentalsSnapshot(Base):
             name="ck_financial_fundamentals_snapshots_period_type",
         ),
         CheckConstraint(
-            "source IN ('dart')",
+            # ROB-441: KR=DART; US non-DART vendors (yfinance statements, finnhub).
+            "source IN ('dart', 'yfinance', 'finnhub')",
             name="ck_financial_fundamentals_snapshots_source",
         ),
         CheckConstraint(

--- a/app/services/financial_fundamentals_snapshots/builder_us.py
+++ b/app/services/financial_fundamentals_snapshots/builder_us.py
@@ -1,0 +1,154 @@
+"""ROB-441: US fundamentals from yfinance income statements → FinancialFundamentalsUpsert.
+
+KR uses DART (``builder.py``). US has no DART; this parses yfinance annual
+income-statement data (a ``{period_date: {row_label: value}}`` dict, the shape
+``_fetch_financials_yfinance`` returns) into the SAME period-row model so the
+market-agnostic derive layer (``derive.py``) is reused unchanged.
+
+yfinance exposes no filing date, so ``filing_date`` is approximated as
+``period_end + 90 days`` (US 10-K SEC deadline is ~60-90 days after fiscal
+year-end). derive's PIT visibility (``_visible_annual`` requires
+``filing_date <= report_date``) needs it set, and the lag avoids look-ahead — a
+period is not visible until it would plausibly have been filed. Fail-closed: a
+period with neither revenue nor net_income is skipped (no empty row written).
+
+This module is the data-parsing layer only (PR1). Writing to the DB (repository
+upsert), the CLI/operator orchestration, and the US display path are follow-ups.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.services.financial_fundamentals_snapshots.repository import (
+    FinancialFundamentalsUpsert,
+)
+
+logger = logging.getLogger(__name__)
+
+# US 10-K is due ~60-90 days after fiscal year-end; 90d is the conservative bound
+# that keeps recent periods PIT-invisible until they would plausibly be filed.
+_ANNUAL_FILING_LAG_DAYS = 90
+
+# yfinance income-statement row labels vary by ticker; try candidates in order.
+_REVENUE_LABELS = ("Total Revenue", "Operating Revenue", "Revenue")
+_NET_INCOME_LABELS = (
+    "Net Income",
+    "Net Income Common Stockholders",
+    "Net Income Continuous Operations",
+    "Net Income From Continuing Operation Net Minority Interest",
+    "Net Income Including Noncontrolling Interests",
+)
+_GROSS_PROFIT_LABELS = ("Gross Profit",)
+_COST_OF_SALES_LABELS = (
+    "Cost Of Revenue",
+    "Reconciled Cost Of Revenue",
+    "Cost Of Goods Sold",
+)
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        dec = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    if not dec.is_finite():
+        return None
+    return dec
+
+
+def _first_present(
+    period_data: dict[str, Any], candidates: tuple[str, ...]
+) -> Decimal | None:
+    for label in candidates:
+        if label in period_data:
+            dec = _to_decimal(period_data[label])
+            if dec is not None:
+                return dec
+    return None
+
+
+def _parse_period_end(key: str) -> dt.date | None:
+    try:
+        return dt.date.fromisoformat(str(key)[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def parse_us_annual_income_periods(
+    *, symbol: str, data: dict[str, Any], collected_at: dt.datetime
+) -> list[FinancialFundamentalsUpsert]:
+    """yfinance annual income-statement ``data`` → annual upsert rows (sorted by date).
+
+    ``data`` is the ``{period_date: {row_label: value}}`` mapping. Robust
+    label-matching per field; fail-closed (skip a period with no revenue AND no
+    net_income); filing_date = period_end + 90d (PIT, no look-ahead).
+    """
+    out: list[FinancialFundamentalsUpsert] = []
+    for key, period_data in (data or {}).items():
+        if not isinstance(period_data, dict):
+            continue
+        period_end = _parse_period_end(str(key))
+        if period_end is None:
+            continue
+        revenue = _first_present(period_data, _REVENUE_LABELS)
+        net_income = _first_present(period_data, _NET_INCOME_LABELS)
+        if revenue is None and net_income is None:
+            continue  # fail-closed: nothing usable for this period
+        gross_profit = _first_present(period_data, _GROSS_PROFIT_LABELS)
+        cost_of_sales = _first_present(period_data, _COST_OF_SALES_LABELS)
+        filing_date = period_end + dt.timedelta(days=_ANNUAL_FILING_LAG_DAYS)
+        out.append(
+            FinancialFundamentalsUpsert(
+                market="us",
+                symbol=symbol.upper(),
+                fiscal_period=f"{period_end.year}A",
+                period_type="annual",
+                period_end_date=period_end,
+                filing_date=filing_date,
+                effective_at=filing_date,
+                source="yfinance",
+                source_collected_at=collected_at,
+                currency="USD",
+                revenue=revenue,
+                net_income=net_income,
+                gross_profit=gross_profit,
+                cost_of_sales=cost_of_sales,
+                # annual: the discrete (single-period) facts equal the reported ones.
+                discrete_revenue=revenue,
+                discrete_net_income=net_income,
+                data_state="fresh",
+                raw_payload={
+                    "income_statement": {str(k): str(v) for k, v in period_data.items()}
+                },
+            )
+        )
+    out.sort(key=lambda p: p.period_end_date)
+    return out
+
+
+async def fetch_us_annual_fundamentals(
+    *, symbol: str, collected_at: dt.datetime
+) -> list[FinancialFundamentalsUpsert]:
+    """Fetch yfinance annual income statement for ``symbol`` and parse to upsert rows.
+
+    Returns [] (not an error) when yfinance has no data — fail-closed. The DB write
+    + operator/CLI orchestration is a follow-up; this returns the parsed rows.
+    """
+    from app.mcp_server.tooling.fundamentals_sources_yfinance import (
+        _fetch_financials_yfinance,
+    )
+
+    try:
+        payload = await _fetch_financials_yfinance(symbol, "income", "annual")
+    except Exception as exc:  # noqa: BLE001 — yfinance optional; fail-closed empty
+        logger.warning("US fundamentals fetch failed symbol=%s: %s", symbol, exc)
+        return []
+    return parse_us_annual_income_periods(
+        symbol=symbol, data=payload.get("data") or {}, collected_at=collected_at
+    )

--- a/tests/test_us_fundamentals_builder_rob441.py
+++ b/tests/test_us_fundamentals_builder_rob441.py
@@ -1,0 +1,168 @@
+"""ROB-441 PR1: US fundamentals parser (yfinance income → FinancialFundamentalsUpsert)
++ market-agnostic derive reuse. Pure unit tests (no DB)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.services.financial_fundamentals_snapshots.builder_us import (
+    fetch_us_annual_fundamentals,
+    parse_us_annual_income_periods,
+)
+
+_COLLECTED = dt.datetime(2026, 6, 5, tzinfo=dt.UTC)
+
+
+def _period(rev, ni, gp=None, cos=None) -> dict:
+    d: dict = {"Total Revenue": rev, "Net Income": ni}
+    if gp is not None:
+        d["Gross Profit"] = gp
+    if cos is not None:
+        d["Cost Of Revenue"] = cos
+    return d
+
+
+@pytest.mark.unit
+def test_parse_basic_annual() -> None:
+    rows = parse_us_annual_income_periods(
+        symbol="aapl",
+        data={"2024-12-31": _period(1000, 100, gp=400, cos=600)},
+        collected_at=_COLLECTED,
+    )
+    assert len(rows) == 1
+    r = rows[0]
+    assert (r.market, r.symbol, r.source) == ("us", "AAPL", "yfinance")
+    assert r.fiscal_period == "2024A"
+    assert r.period_type == "annual"
+    assert r.period_end_date == dt.date(2024, 12, 31)
+    # PIT: filing_date = period_end + 90d (no look-ahead)
+    assert r.filing_date == dt.date(2024, 12, 31) + dt.timedelta(days=90)
+    assert r.revenue == Decimal("1000")
+    assert r.net_income == Decimal("100")
+    assert r.gross_profit == Decimal("400")
+    assert r.cost_of_sales == Decimal("600")
+    assert r.discrete_revenue == Decimal("1000")  # annual: discrete == reported
+    assert r.currency == "USD"
+
+
+@pytest.mark.unit
+def test_label_matching_alternatives() -> None:
+    rows = parse_us_annual_income_periods(
+        symbol="X",
+        data={
+            "2023-09-30": {
+                "Operating Revenue": 500,
+                "Net Income Common Stockholders": 50,
+            }
+        },
+        collected_at=_COLLECTED,
+    )
+    assert len(rows) == 1
+    assert rows[0].revenue == Decimal("500")
+    assert rows[0].net_income == Decimal("50")
+    assert rows[0].fiscal_period == "2023A"
+
+
+@pytest.mark.unit
+def test_fail_closed_skips_period_without_revenue_or_income() -> None:
+    rows = parse_us_annual_income_periods(
+        symbol="X",
+        data={"2024-12-31": {"Gross Profit": 400}},  # no revenue/net_income
+        collected_at=_COLLECTED,
+    )
+    assert rows == []
+
+
+@pytest.mark.unit
+def test_skips_bad_date_and_non_finite() -> None:
+    rows = parse_us_annual_income_periods(
+        symbol="X",
+        data={
+            "not-a-date": {"Total Revenue": 100, "Net Income": 10},
+            "2024-12-31": {"Total Revenue": float("nan"), "Net Income": 10},
+        },
+        collected_at=_COLLECTED,
+    )
+    # bad-date skipped; 2024 kept (net_income present, NaN revenue → None)
+    assert len(rows) == 1
+    assert rows[0].revenue is None
+    assert rows[0].net_income == Decimal("10")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_parses_yfinance_payload() -> None:
+    async def _fake(symbol, statement, freq):  # noqa: ANN001
+        assert statement == "income"
+        assert freq == "annual"
+        return {"data": {"2024-12-31": _period(1000, 100)}}
+
+    with patch(
+        "app.mcp_server.tooling.fundamentals_sources_yfinance._fetch_financials_yfinance",
+        _fake,
+    ):
+        rows = await fetch_us_annual_fundamentals(
+            symbol="AAPL", collected_at=_COLLECTED
+        )
+    assert len(rows) == 1
+    assert rows[0].revenue == Decimal("1000")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_fail_closed_on_error() -> None:
+    async def _boom(symbol, statement, freq):  # noqa: ANN001
+        raise RuntimeError("yfinance down")
+
+    with patch(
+        "app.mcp_server.tooling.fundamentals_sources_yfinance._fetch_financials_yfinance",
+        _boom,
+    ):
+        rows = await fetch_us_annual_fundamentals(
+            symbol="AAPL", collected_at=_COLLECTED
+        )
+    assert rows == []
+
+
+@pytest.mark.unit
+def test_derive_reuses_us_periods() -> None:
+    from app.services.financial_fundamentals_snapshots.derive import (
+        FundamentalPeriod,
+        derive_fundamentals_metrics,
+    )
+
+    rows = parse_us_annual_income_periods(
+        symbol="X",
+        data={
+            "2021-12-31": _period(1000, 100),
+            "2022-12-31": _period(1100, 120),
+            "2023-12-31": _period(1210, 140),
+            "2024-12-31": _period(1331, 160),
+        },
+        collected_at=_COLLECTED,
+    )
+    periods = [
+        FundamentalPeriod(
+            fiscal_period=r.fiscal_period,
+            period_type=r.period_type,
+            period_end_date=r.period_end_date,
+            filing_date=r.filing_date,
+            revenue=r.revenue,
+            net_income=r.net_income,
+            gross_profit=r.gross_profit,
+            cost_of_sales=r.cost_of_sales,
+            discrete_revenue=r.discrete_revenue,
+            discrete_net_income=r.discrete_net_income,
+        )
+        for r in rows
+    ]
+    # report_date after all approximated filing dates (2024-12-31 + 90d = 2025-03-31)
+    deriv = derive_fundamentals_metrics(periods, report_date=dt.date(2025, 6, 1))
+    # 4 visible annuals → 3 YoY deltas → 3y-avg growth computed (not unavailable).
+    assert deriv.revenue_growth_3y_avg.value is not None
+    assert deriv.revenue_growth_3y_avg.state != "unavailable"
+    assert deriv.earnings_growth_3y_avg.value is not None


### PR DESCRIPTION
## What & why (ROB-441 Phase 2, PR1 — data layer)
US는 DART 불가 → `financial_fundamentals_snapshots`를 **US source(yfinance)**로 일반화하고, yfinance 연간 손익계산서를 **KR과 동일한 period-row 모델**로 파싱해 **market-agnostic derive 레이어를 그대로 재사용**. 이 PR은 데이터 파싱층(파서+migration); write 오케스트레이션·display·activation은 후속.

## Changes
- **migration(additive)**: `ck_financial_fundamentals_snapshots_source` `source IN ('dart')` → `('dart','yfinance','finnhub')`. `market` CHECK는 이미 `('kr','us')` 허용. 단일 head `20260605_rob441`(down_revision=20260604_rob430).
- **신규 `builder_us.py`**:
  - `parse_us_annual_income_periods`(**순수**): yfinance income `{period_date:{label:value}}` → `FinancialFundamentalsUpsert`(market=us, source=yfinance, 연간). 견고한 **label-matching**(Total/Operating Revenue, Net Income/Common Stockholders…, Gross Profit, Cost Of Revenue…).
  - **PIT**: yfinance에 filing date 없음 → `filing_date = period_end + 90d`(10-K 마감 ~60-90d; **look-ahead 방지** — derive `_visible_annual`이 `filing_date <= report_date` 요구).
  - **fail-closed**: revenue·net_income 둘 다 없으면 period skip(빈 row 0); NaN/inf/bad-date skip. discrete=reported(연간).
  - `fetch_us_annual_fundamentals`: yfinance fetch+parse, 에러 시 `[]`(fail-closed).
- **derive 재사용**: US periods → `derive_fundamentals_metrics`(revenue/earnings_growth_3y_avg 등) **무변경** 동작.

## Verification
- 신규 7 테스트: 기본 파싱 / label-matching 대안 / fail-closed(무 revenue·income) / bad-date·NaN skip / fetch mock / fetch 에러→[] / **derive 재사용**(US periods→3y-avg growth computed).
- **7 green + 172**(financial_fundamentals/derive sweep 회귀 0); `ruff check`+`format --check app/ tests/ alembic/` clean; **단일 alembic head**.

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. fail-closed(빈 row 0, NaN/missing skip). PIT 90d로 look-ahead 방지. KR DART 경로 무변경. **migration은 operator가 prod alembic upgrade**.
- **ROB-441 후속**: PR2=write 오케스트레이션(repository upsert)+CLI+operator backfill(4-8년) / PR3=US 펀더멘털 display 로더+나머지 프리셋 활성화. 분기(QoQ)+배당(payout/dps)=연간 후 확장.

## Related
ROB-441(Phase 2) · ROB-434(umbrella) · ROB-440(Phase 1 valuation) · ROB-433(KR DART, derive 공유).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for yfinance and finnhub as financial data sources for US fundamentals (in addition to DART)
  * Enabled automated parsing of US annual income statements

* **Tests**
  * Added comprehensive test coverage for US fundamentals data parsing and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->