### PR TITLE
feat(ROB-441): US fundamentals write 오케스트레이션 + CLI (Phase 2 PR2)

### DIFF
--- a/app/services/financial_fundamentals_snapshots/builder_us.py
+++ b/app/services/financial_fundamentals_snapshots/builder_us.py
@@ -18,10 +18,15 @@ upsert), the CLI/operator orchestration, and the US display path are follow-ups.
 
 from __future__ import annotations
 
+import asyncio
 import datetime as dt
 import logging
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
+
+import sqlalchemy as sa
 
 from app.services.financial_fundamentals_snapshots.repository import (
     FinancialFundamentalsUpsert,
@@ -151,4 +156,105 @@ async def fetch_us_annual_fundamentals(
         return []
     return parse_us_annual_income_periods(
         symbol=symbol, data=payload.get("data") or {}, collected_at=collected_at
+    )
+
+
+# --- ROB-441 PR2: build orchestration (resolve → fetch → optional commit) -----
+
+_UsFetcher = Callable[..., Awaitable[list[FinancialFundamentalsUpsert]]]
+
+
+@dataclass(frozen=True)
+class UsFundamentalsBuildResult:
+    symbols_resolved: int
+    snapshots_built: int
+    committed: bool
+    samples: tuple[dict[str, Any], ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+async def resolve_us_symbols(
+    *, override: Sequence[str], limit: int, all_symbols: bool
+) -> list[str]:
+    """US common-stock universe (is_common_stock + is_active), or the override list."""
+    if override:
+        return [s.strip().upper() for s in override if s.strip()]
+    from app.core.db import AsyncSessionLocal
+    from app.models.us_symbol_universe import USSymbolUniverse
+
+    async with AsyncSessionLocal() as session:
+        stmt = (
+            sa.select(USSymbolUniverse.symbol)
+            .where(
+                USSymbolUniverse.is_active.is_(True),
+                USSymbolUniverse.is_common_stock.is_(True),
+            )
+            .order_by(USSymbolUniverse.symbol)
+        )
+        if not all_symbols:
+            stmt = stmt.limit(limit)
+        return [r[0] for r in (await session.execute(stmt)).all()]
+
+
+def _sample(p: FinancialFundamentalsUpsert) -> dict[str, Any]:
+    return {
+        "symbol": p.symbol,
+        "fiscal_period": p.fiscal_period,
+        "period_end_date": p.period_end_date.isoformat(),
+        "filing_date": p.filing_date.isoformat() if p.filing_date else None,
+        "revenue": str(p.revenue) if p.revenue is not None else None,
+        "net_income": str(p.net_income) if p.net_income is not None else None,
+    }
+
+
+async def build_us_fundamentals_for_symbols(
+    symbols: Sequence[str],
+    *,
+    commit: bool = False,
+    concurrency: int = 4,
+    collected_at: dt.datetime | None = None,
+    fetcher: _UsFetcher | None = None,
+) -> UsFundamentalsBuildResult:
+    """Fetch + parse US annual fundamentals for ``symbols``; write only if commit.
+
+    dry-run by default (commit=False): fetches/parses + reports counts, no DB write.
+    commit=True upserts via the repository (operator-approved). Fail-closed: a symbol
+    whose fetch fails or yields no rows is warned and skipped (never fabricated).
+    """
+    collected_at = collected_at or dt.datetime.now(dt.UTC)
+    fetch = fetcher or fetch_us_annual_fundamentals
+    sem = asyncio.Semaphore(max(1, concurrency))
+    warnings: list[str] = []
+
+    async def _one(sym: str) -> list[FinancialFundamentalsUpsert]:
+        async with sem:
+            try:
+                rows = await fetch(symbol=sym, collected_at=collected_at)
+            except Exception as exc:  # noqa: BLE001 — fail-closed per symbol
+                warnings.append(f"{sym}: fetch failed ({exc})")
+                return []
+            if not rows:
+                warnings.append(f"{sym}: no US fundamentals rows")
+            return rows
+
+    gathered = await asyncio.gather(*[_one(s) for s in symbols])
+    payloads: list[FinancialFundamentalsUpsert] = [p for rows in gathered for p in rows]
+
+    committed = False
+    if commit and payloads:
+        from app.core.db import AsyncSessionLocal
+        from app.services.financial_fundamentals_snapshots.repository import (
+            FinancialFundamentalsSnapshotsRepository,
+        )
+
+        async with AsyncSessionLocal() as session:
+            await FinancialFundamentalsSnapshotsRepository(session).upsert(payloads)
+        committed = True
+
+    return UsFundamentalsBuildResult(
+        symbols_resolved=len(symbols),
+        snapshots_built=len(payloads),
+        committed=committed,
+        samples=tuple(_sample(p) for p in payloads[:5]),
+        warnings=tuple(warnings),
     )

--- a/scripts/build_us_fundamentals_snapshots.py
+++ b/scripts/build_us_fundamentals_snapshots.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Build US financial_fundamentals_snapshots from yfinance (ROB-441 PR2).
+
+DEFAULTS TO --dry-run: fetches + parses + prints a summary WITHOUT writing. Pass
+--commit only after operator approval. Annual income periods only (PR2);
+quarterly/dividend are follow-ups. Production migration apply (`alembic upgrade head`)
+remains operator-gated. yfinance has no per-request budget (unlike DART).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Dry-run-first US fundamentals (yfinance) snapshots builder (ROB-441 PR2)."
+    )
+    parser.add_argument("--market", choices=["us"], default="us")
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        default=[],
+        help="Restrict to specific US tickers. Repeatable.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Max active common-stock universe symbols. Defaults to 20 unless --all.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Iterate the full active US common-stock universe. Exclusive with --symbol/--limit.",
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=4, help="Per-symbol fetch concurrency."
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help=(
+            "Actually write to the database (fetches yfinance). Default is "
+            "--dry-run: fetch + parse, no writes."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.all and (args.symbol or args.limit is not None):
+        parser.error("--all is mutually exclusive with --symbol and --limit")
+    if args.limit is None:
+        args.limit = 20
+    if args.concurrency < 1:
+        parser.error("--concurrency must be >= 1")
+    args.dry_run = not args.commit
+    return args
+
+
+def _print_result(result) -> None:
+    print(
+        f"\nbuilt {result.snapshots_built} US fundamentals snapshots "
+        f"for {result.symbols_resolved} symbols (dry_run={not result.committed}):"
+    )
+    if result.samples:
+        print("samples:")
+        for sample in result.samples:
+            print(f"  {sample}")
+    if result.warnings:
+        print(f"warnings ({len(result.warnings)}):")
+        for warning in result.warnings[:20]:
+            print(f"  - {warning}")
+        if len(result.warnings) > 20:
+            print(f"  ... (+{len(result.warnings) - 20} more)")
+    if not result.committed:
+        print("\n--dry-run: no rows written.\n")
+    else:
+        print(f"\ncommitted {result.snapshots_built} rows.\n")
+
+
+async def run(args: argparse.Namespace) -> int:
+    from app.services.financial_fundamentals_snapshots.builder_us import (
+        build_us_fundamentals_for_symbols,
+        resolve_us_symbols,
+    )
+
+    symbols = await resolve_us_symbols(
+        override=list(args.symbol), limit=args.limit, all_symbols=args.all
+    )
+    if not symbols:
+        print("No US symbols resolved (build/refresh us_symbol_universe first).")
+        return 0
+    print(
+        f"Resolved {len(symbols)} US symbols. NOTE: --dry-run still fetches yfinance."
+    )
+    result = await build_us_fundamentals_for_symbols(
+        symbols, commit=args.commit, concurrency=args.concurrency
+    )
+    _print_result(result)
+    return 0
+
+
+async def main() -> int:
+    args = parse_args()
+    from app.core.cli import setup_logging_and_sentry
+
+    setup_logging_and_sentry(service_name="build-us-fundamentals-snapshots")
+    return await run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_build_us_fundamentals_cli.py
+++ b/tests/test_build_us_fundamentals_cli.py
@@ -1,0 +1,38 @@
+"""ROB-441 PR2: US fundamentals builder CLI arg parsing (dry-run default)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.build_us_fundamentals_snapshots import parse_args
+
+
+@pytest.mark.unit
+def test_defaults_to_dry_run() -> None:
+    args = parse_args(["--symbol", "AAPL"])
+    assert args.commit is False
+    assert args.dry_run is True
+    assert args.symbol == ["AAPL"]
+    assert args.limit == 20  # default when not --all
+
+
+@pytest.mark.unit
+def test_commit_flag() -> None:
+    args = parse_args(["--all", "--commit"])
+    assert args.commit is True
+    assert args.dry_run is False
+    assert args.all is True
+
+
+@pytest.mark.unit
+def test_all_excludes_symbol_and_limit() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--all", "--symbol", "AAPL"])
+    with pytest.raises(SystemExit):
+        parse_args(["--all", "--limit", "50"])
+
+
+@pytest.mark.unit
+def test_concurrency_must_be_positive() -> None:
+    with pytest.raises(SystemExit):
+        parse_args(["--symbol", "AAPL", "--concurrency", "0"])

--- a/tests/test_us_fundamentals_builder_rob441.py
+++ b/tests/test_us_fundamentals_builder_rob441.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from app.services.financial_fundamentals_snapshots.builder_us import (
+    build_us_fundamentals_for_symbols,
     fetch_us_annual_fundamentals,
     parse_us_annual_income_periods,
 )
@@ -166,3 +167,75 @@ def test_derive_reuses_us_periods() -> None:
     assert deriv.revenue_growth_3y_avg.value is not None
     assert deriv.revenue_growth_3y_avg.state != "unavailable"
     assert deriv.earnings_growth_3y_avg.value is not None
+
+
+# --- ROB-441 PR2: build orchestration --------------------------------------
+
+
+async def _fetch_one_period(*, symbol, collected_at):  # noqa: ANN001
+    if symbol == "EMPTY":
+        return []
+    return parse_us_annual_income_periods(
+        symbol=symbol,
+        data={"2024-12-31": _period(1000, 100)},
+        collected_at=collected_at,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_dry_run_no_commit() -> None:
+    result = await build_us_fundamentals_for_symbols(
+        ["AAPL", "EMPTY"], commit=False, fetcher=_fetch_one_period
+    )
+    assert result.symbols_resolved == 2
+    assert result.snapshots_built == 1  # AAPL 1 period; EMPTY 0
+    assert result.committed is False
+    assert any("EMPTY" in w for w in result.warnings)
+    assert len(result.samples) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_commit_writes(monkeypatch) -> None:
+    captured: dict = {}
+
+    class _StubRepo:
+        def __init__(self, session):  # noqa: ANN001
+            pass
+
+        async def upsert(self, payloads):  # noqa: ANN001
+            captured["rows"] = list(payloads)
+            return len(captured["rows"])
+
+    class _FakeCM:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *exc):  # noqa: ANN002
+            return False
+
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.financial_fundamentals_snapshots.repository."
+        "FinancialFundamentalsSnapshotsRepository",
+        _StubRepo,
+    )
+    result = await build_us_fundamentals_for_symbols(
+        ["AAPL"], commit=True, fetcher=_fetch_one_period
+    )
+    assert result.committed is True
+    assert result.snapshots_built == 1
+    assert len(captured["rows"]) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_fetch_error_is_fail_closed() -> None:
+    async def _boom(*, symbol, collected_at):  # noqa: ANN001
+        raise RuntimeError("yfinance down")
+
+    result = await build_us_fundamentals_for_symbols(["X"], commit=True, fetcher=_boom)
+    assert result.snapshots_built == 0
+    assert result.committed is False  # nothing to commit
+    assert any("fetch failed" in w for w in result.warnings)


### PR DESCRIPTION
## What & why (ROB-441 Phase 2, PR2 — write + CLI)
PR1(#1142)의 파서/derive를 **operator가 backfill**할 수 있게 빌드 오케스트레이션 + **dry-run-default CLI** 추가. migration 0(PR1이 source constraint 처리).

## Changes
- **`builder_us.build_us_fundamentals_for_symbols(symbols, *, commit=False, concurrency, fetcher)`**: 심볼별 `fetch_us_annual_fundamentals`(동시성 bounded) → Upsert 수집 → commit이면 `repository.upsert`. **dry-run default**(commit=False: fetch+parse만, 미기록). **fail-closed**(심볼 fetch 실패/무행 → warn+skip, 위조 0). `UsFundamentalsBuildResult`(symbols_resolved/snapshots_built/committed/samples/warnings).
- **`resolve_us_symbols(override, limit, all_symbols)`**: `us_symbol_universe`(is_common_stock + is_active) 또는 override.
- **신규 CLI `scripts/build_us_fundamentals_snapshots.py`**: KR CLI 미러(`--symbol`/`--limit`/`--all`/`--concurrency`/`--commit`), **dry-run default**, `--all`↔`--symbol`/`--limit` 상호배타. operator 승인 후 `--commit`.

## Verification
- 신규 7 테스트: orchestration(dry-run no-commit / commit[repository+session mock] writes / fetch-error fail-closed) + CLI parse_args(dry-run default / --commit / --all 배타 / concurrency≥1).
- **14 green + 58**(financial_fundamentals sweep 회귀 0); `ruff check`+`format --check app/ tests/` clean; **migration 0**(단일 head, PR1 머지됨); broker/order/watch mutation 0.

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. **dry-run default; --commit는 operator 승인**. operator backfill(4-8년 분기)는 별도 실행. yfinance 무 budget(DART와 달리).
- **ROB-441 PR3**: US 펀더멘털 **display 로더**(KR tvscreener 대응 / DART 로더 US 일반화) + 나머지 프리셋(profitable_company/undervalued_growth/dividend) US 활성화.
- 확장: 분기(QoQ) + 배당(payout_ratio/dps) = 연간 후.

## Related
ROB-441(Phase 2) · #1142(PR1 데이터층) · ROB-434(umbrella) · ROB-422(KR DART builder/CLI 미러).

🤖 Generated with [Claude Code](https://claude.com/claude-code)