### PR TITLE
feat(ROB-441): US 펀더멘털 display 로더 + 성장/가치 프리셋 활성화 (Phase 2 PR3)

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -337,8 +337,12 @@ async def load_fundamentals_preset_from_snapshots(
     limit: int = 20,
     now: Any = None,
 ) -> FundamentalsScreenResult | None:
-    """None when no valuation partition exists (caller → dataState=missing)."""
-    if session is None or market != "kr":
+    """None when no valuation partition exists (caller → dataState=missing).
+
+    ROB-441 PR3: market-parameterized for US — market_valuation (per/pbr/roe, US=Yahoo)
+    + financial_fundamentals (US=yfinance) periods → the market-agnostic derive layer.
+    KR name/common-stock filtering is KR-only (guarded)."""
+    if session is None or market not in {"kr", "us"}:
         return None
     from datetime import UTC, datetime
 
@@ -346,7 +350,7 @@ async def load_fundamentals_preset_from_snapshots(
     from app.services.invest_view_model.screener_service import _is_kr_toss_common_stock
 
     now_dt = now() if callable(now) else datetime.now(UTC)
-    today_market_date = today_trading_date("kr", now=now_dt)
+    today_market_date = today_trading_date(market, now=now_dt)
 
     from app.services.invest_screener_snapshots.partition_health import (
         resolve_healthy_partition,
@@ -357,7 +361,7 @@ async def load_fundamentals_preset_from_snapshots(
         model=MarketValuationSnapshot,
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
-        market="kr",
+        market=market,
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:
@@ -371,7 +375,7 @@ async def load_fundamentals_preset_from_snapshots(
         MarketValuationSnapshot.market_cap,
         MarketValuationSnapshot.dividend_yield,
     ).where(
-        MarketValuationSnapshot.market == "kr",
+        MarketValuationSnapshot.market == market,
         MarketValuationSnapshot.snapshot_date == val_date,
     )
     if spec.min_roe is not None:
@@ -417,7 +421,9 @@ async def load_fundamentals_preset_from_snapshots(
     symbols = [m["symbol"] for m in cand_mappings]
 
     name_map: dict[str, str] = {}
-    if symbols:
+    if (
+        market == "kr" and symbols
+    ):  # ROB-441 PR3: KR name/common-stock filter is KR-only
         names = await session.execute(
             sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
                 KRSymbolUniverse.symbol.in_(symbols),
@@ -434,14 +440,14 @@ async def load_fundamentals_preset_from_snapshots(
         sym = m["symbol"]
         if sym in seen:
             continue
-        if not _is_kr_toss_common_stock(sym, name_map.get(sym)):
+        if market == "kr" and not _is_kr_toss_common_stock(sym, name_map.get(sym)):
             continue
         seen.add(sym)
         valuation_rows.append({**dict(m), "_screener_snapshot_state": val_state})
 
     repo = FinancialFundamentalsSnapshotsRepository(session)
     period_rows = await repo.latest_periods_for_symbols(
-        market="kr", symbols=[v["symbol"] for v in valuation_rows]
+        market=market, symbols=[v["symbol"] for v in valuation_rows]
     )
     periods_by_symbol = {
         sym: [_to_period(r) for r in rows] for sym, rows in period_rows.items()

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -48,16 +48,23 @@ _KR_ONLY_PRESET_IDS = {
 # high_yield_value_screener.load_high_yield_value_from_snapshots(market="us").
 # ROB-440: undervalued_breakout (proximity) runs on the same Yahoo valuation
 # snapshots (high_52w price) — load_undervalued_breakout_from_snapshots(market="us").
-_US_ACTIVE_PRESET_IDS = {"high_yield_value", "undervalued_breakout"}
+# ROB-441 PR3: profitable_company/undervalued_growth/cheap_value/stable_growth run on
+# the market-parameterized derive loader (market_valuation US per/pbr/roe +
+# financial_fundamentals US annual periods → derive) — load_fundamentals_preset_from_snapshots(market="us").
+# growth_expectation_toss (QoQ quarterly) + dividend presets stay data_pending until
+# US quarterly/dividend fundamentals are built (ROB-441 follow-up).
+_US_ACTIVE_PRESET_IDS = {
+    "high_yield_value",
+    "undervalued_breakout",
+    "profitable_company",
+    "undervalued_growth",
+    "cheap_value",
+    "stable_growth",
+}
 _US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
 _US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
 _US_DATA_PENDING_REASON: dict[str, str] = {
-    "high_yield_value": "미국 가치형(ROE·PER) 활성화 준비중",
-    "profitable_company": "미국 펀더멘털(매출총이익률) 데이터 준비중",
-    "undervalued_growth": "미국 펀더멘털(연평균 매출·순이익 증감률) 데이터 준비중",
-    "cheap_value": "미국 펀더멘털(연평균 순이익 증감률) 데이터 준비중",
-    "growth_expectation_toss": "미국 펀더멘털(연평균 순이익 증감률) 데이터 준비중",
-    "stable_growth": "미국 펀더멘털(증감률·순이익 연속증가) 데이터 준비중",
+    "growth_expectation_toss": "미국 분기 순이익 증감률(QoQ) 데이터 준비중",
     "steady_dividend": "미국 배당·순이익 연속 데이터 준비중",
     "future_dividend_king": "미국 배당·순이익 연속 데이터 준비중",
 }

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1837,6 +1837,25 @@ async def build_screener_results(
             _snapshot_empty_warning = (
                 "최신 미국 신고가(52주) 스냅샷에서 조건에 맞는 종목이 없습니다."
             )
+        elif preset_id in FUNDAMENTALS_PRESET_SPECS and requested_market == "us":
+            # ROB-441 PR3: US fundamentals presets (profitable_company/undervalued_growth/
+            # cheap_value/stable_growth) run on the market-parameterized derive loader
+            # (market_valuation US per/pbr/roe + financial_fundamentals US periods → derive)
+            # — NOT the KR tvscreener loader below (invest_kr_fundamentals is KR-only).
+            # Honest empty until the operator backfills US financial_fundamentals.
+            from app.services.invest_view_model.fundamentals_screener import (
+                load_fundamentals_preset_from_snapshots,
+            )
+
+            _fundamentals_screen_result = await load_fundamentals_preset_from_snapshots(
+                session,
+                market="us",
+                spec=FUNDAMENTALS_PRESET_SPECS[preset_id],
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                now=now,
+            )
+            if _fundamentals_screen_result is not None:
+                _snapshot_check_result = _fundamentals_screen_result.rows
         # ROB-428 PR-C: high_yield_value + undervalued_breakout no longer have a
         # dedicated dispatch branch. They are now registered in
         # FUNDAMENTALS_PRESET_SPECS and fall into the tvscreener KR loader below

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -432,6 +432,78 @@ async def test_loader_valuation_filter_max_per_excludes_high_per(db_session):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_loader_us_candidate_filtering_and_fail_closed(db_session):
+    # ROB-441 PR3: US runs the market-parameterized derive loader. Verify the US
+    # candidate query (market=us) filters by the spec's valuation thresholds, and
+    # that without US financial_fundamentals backfilled the candidates fail-closed
+    # (reach derive then get excluded; never silently passed). The derive-inclusion
+    # path is market-agnostic and covered by the KR + PR1 derive-reuse tests.
+    await _cleanup_db(db_session)
+
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_screener_snapshots.partition_health import (
+        resolve_healthy_partition,
+    )
+    from app.services.invest_view_model.fundamentals_screener import (
+        UNDERVALUED_GROWTH_SPEC,
+        load_fundamentals_preset_from_snapshots,
+    )
+
+    # seed on the US valuation partition the loader will resolve (shared DB safety).
+    val_hp = await resolve_healthy_partition(
+        db_session,
+        model=MarketValuationSnapshot,
+        date_col=MarketValuationSnapshot.snapshot_date,
+        market_col=MarketValuationSnapshot.market,
+        market="us",
+    )
+    vd = (
+        val_hp.partition_date
+        if (val_hp and val_hp.partition_date)
+        else dt.date(2026, 6, 2)
+    )
+    db_session.add_all(
+        [
+            MarketValuationSnapshot(
+                market="us",
+                symbol="906451",
+                snapshot_date=vd,
+                source="yahoo",
+                per=Decimal("15"),  # <= 20 → candidate
+                roe=Decimal("20"),
+                market_cap=Decimal("500000000000"),
+            ),
+            MarketValuationSnapshot(
+                market="us",
+                symbol="906452",
+                snapshot_date=vd,
+                source="yahoo",
+                per=Decimal("40"),  # > 20 → filtered at SQL candidate stage
+                roe=Decimal("20"),
+                market_cap=Decimal("400000000000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    result = await load_fundamentals_preset_from_snapshots(
+        db_session,
+        market="us",
+        spec=UNDERVALUED_GROWTH_SPEC,
+        limit=20,
+        now=lambda: dt.datetime(2026, 6, 2, tzinfo=dt.UTC),
+    )
+    assert result is not None
+    excluded_symbols = {e["symbol"] for e in result.excluded}
+    assert (
+        "906451" in excluded_symbols
+    )  # candidate (per<=20) but no US ff → fail-closed
+    assert "906452" not in excluded_symbols  # filtered at SQL candidate stage (per>20)
+    await _cleanup_db(db_session)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_loader_valuation_filter_dividend_yield_excludes_null(db_session):
     await _cleanup_db(db_session)
     # spec §7 item 2: min_dividend_yield candidate filter must drop NULL dividend_yield

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -65,19 +65,32 @@ def test_us_flow_presets_unsupported_with_reason() -> None:
 @pytest.mark.unit
 def test_us_fundamentals_presets_data_pending_with_reason() -> None:
     us = {p.id: p for p in preset_definitions("us")}
-    # ROB-427 PR3 + ROB-440: high_yield_value + undervalued_breakout are now active
-    # (Yahoo-backed); the rest pending.
+    # ROB-441 PR3: growth/valuation fundamentals presets are now active (yfinance
+    # annual derive); only QoQ (growth_expectation_toss) + dividend presets stay
+    # data_pending until US quarterly/dividend fundamentals are built.
     for pid in (
-        "profitable_company",
-        "undervalued_growth",
-        "cheap_value",
         "growth_expectation_toss",
-        "stable_growth",
         "steady_dividend",
         "future_dividend_king",
     ):
         assert us[pid].availability == "data_pending", pid
         assert us[pid].availabilityReason, pid
+
+
+@pytest.mark.unit
+def test_us_fundamentals_growth_presets_active() -> None:
+    # ROB-441 PR3: market_valuation US (per/pbr/roe) + financial_fundamentals US
+    # annual derive → these run for US.
+    us = {p.id: p for p in preset_definitions("us")}
+    for pid in (
+        "profitable_company",
+        "undervalued_growth",
+        "cheap_value",
+        "stable_growth",
+    ):
+        assert us[pid].availability == "active", pid
+        assert us[pid].availabilityReason is None, pid
+        assert pid in _US_ACTIVE_PRESET_IDS
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why (ROB-441 Phase 2, PR3 — display + activation)
PR1/PR2가 채운 US financial_fundamentals(yfinance)를 **화면에 노출**. market_valuation US(per/pbr/roe) + financial_fundamentals US(derive 3y-avg/streak/gross_margin)를 결합하는 derive 로더를 US로 일반화하고, **데이터가 준비된 성장/가치 4개 프리셋을 US 활성화**. migration 0.

## Changes
- **`load_fundamentals_preset_from_snapshots`**(derive 로더) market 파라미터화(high_yield_value ROB-427 PR3 미러): gate `market not in {kr,us}`, resolve/candidate WHERE/`latest_periods_for_symbols`에 market 전파, KR name lookup + `_is_kr_toss_common_stock`은 `if market=="kr"` 가드, `today_trading_date(market)`. `evaluate_fundamentals_candidates`는 이미 market-agnostic(무변경).
- **`screener_service`**: US 펀더멘털 dispatch 분기(high_yield_value/undervalued_breakout US 다음, KR tvscreener 분기보다 **먼저** → US는 derive 로더로). `_fundamentals_screen_result` 다운스트림 소비는 KR과 공유.
- **`screener_presets`**: `_US_ACTIVE`에 **profitable_company / undervalued_growth / cheap_value / stable_growth** 추가(연간 derive+mv 필드 충족). **growth_expectation_toss**(QoQ 분기) · **steady_dividend** · **future_dividend_king**은 data_pending 유지(분기/배당 데이터 미구축).

## Verification
- 신규: US 후보필터+fail-closed 통합(market=us candidate query 필터, ff 미적재→derive 도달 후 excluded, per>20 SQL 단계 제외) + US 성장/가치 4개 active + data_pending 3개(QoQ/배당) availability.
- **39 + 1084 green**(screener/fundamentals/invest_view/valuation sweep 회귀 0); `ruff check`+`format --check app/ tests/` clean; **migration 0**(단일 head); broker/order/watch mutation 0.
- 참고: derive **inclusion** 경로는 market-agnostic(`evaluate_fundamentals_candidates`) → PR1 derive-reuse(pure) + 기존 KR 통합 테스트가 커버. US 통합 테스트는 fail-closed 후보필터 검증(로컬 검증가능; ff insert는 #1142 migration 적용된 CI fresh DB 필요).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. migration 0. fail-closed(미적재→excluded, 위조 0). KR DART/tvscreener 경로 무변경. **operator US fundamentals backfill(PR2 CLI) 후 화면 표시**.
- US market_cap은 yahoo 미제공(null)→cand_cap(200) 정렬이 symbol 순(유동성 우선순위 없음); 후속 보강 가능.
- **확장**: 분기(QoQ growth_expectation_toss) + 배당(payout/dps → steady_dividend/future_dividend_king) = 연간 후.

## Related
ROB-441(Phase 2) · #1142(PR1 데이터층) · #1143(PR2 write/CLI) · ROB-440(Phase 1 valuation) · ROB-427 PR3(미러).

🤖 Generated with [Claude Code](https://claude.com/claude-code)