### PR TITLE
feat(ROB-441): US 분기(QoQ) 펀더멘털 → growth_expectation_toss US 활성화 (분기 확장)

### DIFF
--- a/app/services/financial_fundamentals_snapshots/builder_us.py
+++ b/app/services/financial_fundamentals_snapshots/builder_us.py
@@ -159,6 +159,92 @@ async def fetch_us_annual_fundamentals(
     )
 
 
+# --- ROB-441 PR4: quarterly periods (QoQ → growth_expectation_toss) -----------
+
+# 10-Q SEC deadline is ~40-45 days after quarter-end (large filers 40d).
+_QUARTERLY_FILING_LAG_DAYS = 45
+
+
+def _quarter_label(period_end: dt.date) -> str:
+    """Calendar-quarter label 'YYYYQN' (derive._quarter_idx-compatible). Calendar
+    quarters keep consecutive quarter-ends one index apart, so the QoQ adjacency
+    check holds regardless of a company's fiscal-year alignment."""
+    return f"{period_end.year}Q{(period_end.month - 1) // 3 + 1}"
+
+
+def parse_us_quarterly_income_periods(
+    *, symbol: str, data: dict[str, Any], collected_at: dt.datetime
+) -> list[FinancialFundamentalsUpsert]:
+    """yfinance quarterly income ``data`` → quarterly upsert rows (sorted by date).
+
+    yfinance quarterly columns are already single-quarter (discrete), unlike DART's
+    cumulative YTD filings — so discrete_* equal the reported values directly.
+    fail-closed (skip a period with no revenue AND no net_income); filing_date =
+    quarter_end + 45d (PIT, no look-ahead)."""
+    out: list[FinancialFundamentalsUpsert] = []
+    for key, period_data in (data or {}).items():
+        if not isinstance(period_data, dict):
+            continue
+        period_end = _parse_period_end(str(key))
+        if period_end is None:
+            continue
+        revenue = _first_present(period_data, _REVENUE_LABELS)
+        net_income = _first_present(period_data, _NET_INCOME_LABELS)
+        if revenue is None and net_income is None:
+            continue  # fail-closed: nothing usable (QoQ needs net_income)
+        gross_profit = _first_present(period_data, _GROSS_PROFIT_LABELS)
+        cost_of_sales = _first_present(period_data, _COST_OF_SALES_LABELS)
+        filing_date = period_end + dt.timedelta(days=_QUARTERLY_FILING_LAG_DAYS)
+        out.append(
+            FinancialFundamentalsUpsert(
+                market="us",
+                symbol=symbol.upper(),
+                fiscal_period=_quarter_label(period_end),
+                period_type="quarterly",
+                period_end_date=period_end,
+                filing_date=filing_date,
+                effective_at=filing_date,
+                source="yfinance",
+                source_collected_at=collected_at,
+                currency="USD",
+                revenue=revenue,
+                net_income=net_income,
+                gross_profit=gross_profit,
+                cost_of_sales=cost_of_sales,
+                discrete_revenue=revenue,  # yfinance quarterly is already discrete
+                discrete_net_income=net_income,
+                data_state="fresh",
+                raw_payload={
+                    "income_statement": {str(k): str(v) for k, v in period_data.items()}
+                },
+            )
+        )
+    out.sort(key=lambda p: p.period_end_date)
+    return out
+
+
+async def fetch_us_quarterly_fundamentals(
+    *, symbol: str, collected_at: dt.datetime
+) -> list[FinancialFundamentalsUpsert]:
+    """Fetch yfinance quarterly income statement for ``symbol`` → quarterly rows.
+
+    Returns [] (fail-closed) when yfinance has no quarterly data or errors."""
+    from app.mcp_server.tooling.fundamentals_sources_yfinance import (
+        _fetch_financials_yfinance,
+    )
+
+    try:
+        payload = await _fetch_financials_yfinance(symbol, "income", "quarterly")
+    except Exception as exc:  # noqa: BLE001 — yfinance optional; fail-closed empty
+        logger.warning(
+            "US quarterly fundamentals fetch failed symbol=%s: %s", symbol, exc
+        )
+        return []
+    return parse_us_quarterly_income_periods(
+        symbol=symbol, data=payload.get("data") or {}, collected_at=collected_at
+    )
+
+
 # --- ROB-441 PR2: build orchestration (resolve → fetch → optional commit) -----
 
 _UsFetcher = Callable[..., Awaitable[list[FinancialFundamentalsUpsert]]]
@@ -214,25 +300,36 @@ async def build_us_fundamentals_for_symbols(
     concurrency: int = 4,
     collected_at: dt.datetime | None = None,
     fetcher: _UsFetcher | None = None,
+    include_quarterly: bool = False,
+    quarterly_fetcher: _UsFetcher | None = None,
 ) -> UsFundamentalsBuildResult:
-    """Fetch + parse US annual fundamentals for ``symbols``; write only if commit.
+    """Fetch + parse US annual (and optionally quarterly) fundamentals; write if commit.
 
     dry-run by default (commit=False): fetches/parses + reports counts, no DB write.
-    commit=True upserts via the repository (operator-approved). Fail-closed: a symbol
-    whose fetch fails or yields no rows is warned and skipped (never fabricated).
+    commit=True upserts via the repository (operator-approved). include_quarterly also
+    builds quarterly periods (ROB-441 PR4, for QoQ → growth_expectation_toss).
+    Fail-closed: a symbol whose fetch fails or yields no rows is warned and skipped.
     """
     collected_at = collected_at or dt.datetime.now(dt.UTC)
-    fetch = fetcher or fetch_us_annual_fundamentals
+    annual_fetch = fetcher or fetch_us_annual_fundamentals
+    quarterly_fetch = quarterly_fetcher or fetch_us_quarterly_fundamentals
     sem = asyncio.Semaphore(max(1, concurrency))
     warnings: list[str] = []
 
     async def _one(sym: str) -> list[FinancialFundamentalsUpsert]:
         async with sem:
+            rows: list[FinancialFundamentalsUpsert] = []
             try:
-                rows = await fetch(symbol=sym, collected_at=collected_at)
+                rows.extend(await annual_fetch(symbol=sym, collected_at=collected_at))
             except Exception as exc:  # noqa: BLE001 — fail-closed per symbol
-                warnings.append(f"{sym}: fetch failed ({exc})")
-                return []
+                warnings.append(f"{sym}: annual fetch failed ({exc})")
+            if include_quarterly:
+                try:
+                    rows.extend(
+                        await quarterly_fetch(symbol=sym, collected_at=collected_at)
+                    )
+                except Exception as exc:  # noqa: BLE001 — fail-closed per symbol
+                    warnings.append(f"{sym}: quarterly fetch failed ({exc})")
             if not rows:
                 warnings.append(f"{sym}: no US fundamentals rows")
             return rows

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -51,8 +51,9 @@ _KR_ONLY_PRESET_IDS = {
 # ROB-441 PR3: profitable_company/undervalued_growth/cheap_value/stable_growth run on
 # the market-parameterized derive loader (market_valuation US per/pbr/roe +
 # financial_fundamentals US annual periods → derive) — load_fundamentals_preset_from_snapshots(market="us").
-# growth_expectation_toss (QoQ quarterly) + dividend presets stay data_pending until
-# US quarterly/dividend fundamentals are built (ROB-441 follow-up).
+# ROB-441 PR4: growth_expectation_toss (QoQ) runs once US quarterly periods are built
+# (yfinance quarterly income → derive earnings_growth_qoq). Dividend presets stay
+# data_pending until US dividend fundamentals are built (ROB-441 dividend follow-up).
 _US_ACTIVE_PRESET_IDS = {
     "high_yield_value",
     "undervalued_breakout",
@@ -60,11 +61,11 @@ _US_ACTIVE_PRESET_IDS = {
     "undervalued_growth",
     "cheap_value",
     "stable_growth",
+    "growth_expectation_toss",
 }
 _US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
 _US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
 _US_DATA_PENDING_REASON: dict[str, str] = {
-    "growth_expectation_toss": "미국 분기 순이익 증감률(QoQ) 데이터 준비중",
     "steady_dividend": "미국 배당·순이익 연속 데이터 준비중",
     "future_dividend_king": "미국 배당·순이익 연속 데이터 준비중",
 }

--- a/scripts/build_us_fundamentals_snapshots.py
+++ b/scripts/build_us_fundamentals_snapshots.py
@@ -39,6 +39,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--concurrency", type=int, default=4, help="Per-symbol fetch concurrency."
     )
     parser.add_argument(
+        "--with-quarterly",
+        dest="include_quarterly",
+        action="store_true",
+        help="Also build quarterly periods (annual-only by default; for QoQ presets).",
+    )
+    parser.add_argument(
         "--commit",
         action="store_true",
         help=(
@@ -94,7 +100,10 @@ async def run(args: argparse.Namespace) -> int:
         f"Resolved {len(symbols)} US symbols. NOTE: --dry-run still fetches yfinance."
     )
     result = await build_us_fundamentals_for_symbols(
-        symbols, commit=args.commit, concurrency=args.concurrency
+        symbols,
+        commit=args.commit,
+        concurrency=args.concurrency,
+        include_quarterly=args.include_quarterly,
     )
     _print_result(result)
     return 0

--- a/tests/test_build_us_fundamentals_cli.py
+++ b/tests/test_build_us_fundamentals_cli.py
@@ -36,3 +36,12 @@ def test_all_excludes_symbol_and_limit() -> None:
 def test_concurrency_must_be_positive() -> None:
     with pytest.raises(SystemExit):
         parse_args(["--symbol", "AAPL", "--concurrency", "0"])
+
+
+@pytest.mark.unit
+def test_with_quarterly_flag() -> None:
+    # ROB-441 PR4: --with-quarterly opts into quarterly periods (annual-only default).
+    assert parse_args(["--symbol", "AAPL"]).include_quarterly is False
+    assert (
+        parse_args(["--symbol", "AAPL", "--with-quarterly"]).include_quarterly is True
+    )

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -65,11 +65,9 @@ def test_us_flow_presets_unsupported_with_reason() -> None:
 @pytest.mark.unit
 def test_us_fundamentals_presets_data_pending_with_reason() -> None:
     us = {p.id: p for p in preset_definitions("us")}
-    # ROB-441 PR3: growth/valuation fundamentals presets are now active (yfinance
-    # annual derive); only QoQ (growth_expectation_toss) + dividend presets stay
-    # data_pending until US quarterly/dividend fundamentals are built.
+    # ROB-441 PR4: growth_expectation_toss (QoQ) is now active (yfinance quarterly);
+    # only the dividend presets stay data_pending until US dividend data is built.
     for pid in (
-        "growth_expectation_toss",
         "steady_dividend",
         "future_dividend_king",
     ):
@@ -82,11 +80,13 @@ def test_us_fundamentals_growth_presets_active() -> None:
     # ROB-441 PR3: market_valuation US (per/pbr/roe) + financial_fundamentals US
     # annual derive → these run for US.
     us = {p.id: p for p in preset_definitions("us")}
+    # ROB-441 PR4: growth_expectation_toss joins once US quarterly periods (QoQ) exist.
     for pid in (
         "profitable_company",
         "undervalued_growth",
         "cheap_value",
         "stable_growth",
+        "growth_expectation_toss",
     ):
         assert us[pid].availability == "active", pid
         assert us[pid].availabilityReason is None, pid

--- a/tests/test_us_fundamentals_builder_rob441.py
+++ b/tests/test_us_fundamentals_builder_rob441.py
@@ -13,6 +13,7 @@ from app.services.financial_fundamentals_snapshots.builder_us import (
     build_us_fundamentals_for_symbols,
     fetch_us_annual_fundamentals,
     parse_us_annual_income_periods,
+    parse_us_quarterly_income_periods,
 )
 
 _COLLECTED = dt.datetime(2026, 6, 5, tzinfo=dt.UTC)
@@ -239,3 +240,88 @@ async def test_build_fetch_error_is_fail_closed() -> None:
     assert result.snapshots_built == 0
     assert result.committed is False  # nothing to commit
     assert any("fetch failed" in w for w in result.warnings)
+
+
+# --- ROB-441 PR4: quarterly periods (QoQ → growth_expectation_toss) ----------
+
+
+@pytest.mark.unit
+def test_parse_quarterly_periods() -> None:
+    rows = parse_us_quarterly_income_periods(
+        symbol="aapl",
+        data={"2024-09-30": _period(500, 60), "2024-06-30": _period(480, 50)},
+        collected_at=_COLLECTED,
+    )
+    assert len(rows) == 2
+    by_fp = {r.fiscal_period: r for r in rows}
+    assert set(by_fp) == {"2024Q3", "2024Q2"}  # calendar-quarter labels
+    q3 = by_fp["2024Q3"]
+    assert q3.period_type == "quarterly"
+    assert q3.period_end_date == dt.date(2024, 9, 30)
+    assert q3.filing_date == dt.date(2024, 9, 30) + dt.timedelta(days=45)
+    assert q3.net_income == Decimal("60")
+    assert q3.discrete_net_income == Decimal("60")  # yfinance quarterly is discrete
+
+
+@pytest.mark.unit
+def test_derive_qoq_from_us_quarterly_periods() -> None:
+    from app.services.financial_fundamentals_snapshots.derive import (
+        FundamentalPeriod,
+        derive_fundamentals_metrics,
+    )
+
+    rows = parse_us_quarterly_income_periods(
+        symbol="X",
+        data={"2024-06-30": _period(480, 100), "2024-09-30": _period(500, 120)},
+        collected_at=_COLLECTED,
+    )
+    periods = [
+        FundamentalPeriod(
+            fiscal_period=r.fiscal_period,
+            period_type=r.period_type,
+            period_end_date=r.period_end_date,
+            filing_date=r.filing_date,
+            revenue=r.revenue,
+            net_income=r.net_income,
+            discrete_revenue=r.discrete_revenue,
+            discrete_net_income=r.discrete_net_income,
+        )
+        for r in rows
+    ]
+    # consecutive Q2→Q3 (idx diff 1), latest within staleness → QoQ = (120-100)/100
+    deriv = derive_fundamentals_metrics(periods, report_date=dt.date(2024, 12, 1))
+    assert deriv.earnings_growth_qoq.value is not None
+    assert deriv.earnings_growth_qoq.state == "ok"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_include_quarterly() -> None:
+    async def _annual(*, symbol, collected_at):  # noqa: ANN001
+        return parse_us_annual_income_periods(
+            symbol=symbol,
+            data={"2024-12-31": _period(1000, 100)},
+            collected_at=collected_at,
+        )
+
+    async def _quarterly(*, symbol, collected_at):  # noqa: ANN001
+        return parse_us_quarterly_income_periods(
+            symbol=symbol,
+            data={"2024-09-30": _period(500, 60)},
+            collected_at=collected_at,
+        )
+
+    result = await build_us_fundamentals_for_symbols(
+        ["AAPL"],
+        commit=False,
+        fetcher=_annual,
+        quarterly_fetcher=_quarterly,
+        include_quarterly=True,
+    )
+    assert result.snapshots_built == 2  # 1 annual + 1 quarterly
+
+    # default (no include_quarterly) → annual only
+    result2 = await build_us_fundamentals_for_symbols(
+        ["AAPL"], commit=False, fetcher=_annual, quarterly_fetcher=_quarterly
+    )
+    assert result2.snapshots_built == 1


### PR DESCRIPTION
## What & why (ROB-441 분기·배당 확장 — 분기/QoQ)
yfinance 분기 손익을 분기 period로 적재해 derive `earnings_growth_qoq`를 채우고 **성장 기대주(growth_expectation_toss) US 활성화**. PR3의 derive 로더가 이미 `latest_periods_for_symbols(period_type=None)`로 분기+연간 둘 다 로드 → **로더/dispatch 무변경**. migration 0.

## Changes
- **`parse_us_quarterly_income_periods`**(순수): yfinance 분기 income(이미 **단일분기 discrete**, DART 누적과 다름) → `FinancialFundamentalsUpsert`(period_type=quarterly, **fiscal_period=`YYYYQN`** 캘린더분기 — `_quarter_idx` 호환, 연속 분기-end가 인덱스차 1 → QoQ 인접성 유지, 회계연도 정렬 무관). discrete=reported. **filing_date=quarter_end+45d**(10-Q PIT, look-ahead 방지). fail-closed. + `fetch_us_quarterly_fundamentals`.
- **`build_us_fundamentals_for_symbols(..., include_quarterly=False)`**: True면 분기도 fetch+병합(연간/분기 각각 fail-closed warn). CLI **`--with-quarterly`**(annual-only default).
- **`screener_presets`**: `_US_ACTIVE`에 **growth_expectation_toss** 추가(QoQ + 연간 3y-avg 둘 다 충족). 배당 2개는 data_pending 유지(배당 데이터 미구축).

## Verification
- 신규: 분기파서(YYYYQN/discrete/+45d) + **QoQ derive**(연속 Q2→Q3 인접성, staleness) + orchestration include_quarterly(분기+연간 병합 vs annual-only) + CLI `--with-quarterly` + availability(growth_expectation_toss active, data_pending=배당 2개).
- **29 + 107 green**(financial_fundamentals/screener_presets/build_us sweep 회귀 0); ruff clean; **migration 0**(단일 head, 로더/dispatch 무변경).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. migration 0. fail-closed. KR 경로 무변경. **operator: `build_us_fundamentals_snapshots --all --with-quarterly --commit`** 후 화면 표시.
- **후속(배당)**: yfinance dividends → payout_ratio/dividend_per_share(연간 period) → derive 배당 streak → steady_dividend/future_dividend_king US.

## Related
ROB-441(Phase 2) · #1142/#1143/#1144(PR1-3) · derive `_earnings_growth_qoq`/`_quarter_idx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * US equities now support quarterly financial fundamentals data collection in addition to annual snapshots
  * Added `--with-quarterly` CLI option to enable quarterly snapshot gathering
  * Growth expectation preset now available for US market screening (previously data-pending)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->