### PR TITLE
feat(ROB-441): US 배당 펀더멘털 → steady_dividend/future_dividend_king US 활성화 (배당 확장)

### DIFF
--- a/app/mcp_server/tooling/fundamentals_sources_yfinance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_yfinance.py
@@ -249,6 +249,32 @@ async def _fetch_financials_yfinance(
     }
 
 
+async def _fetch_dividends_yfinance(symbol: str) -> dict[str, Any]:
+    """ROB-441: yfinance ``Ticker.dividends`` (per-share payments, split-adjusted) →
+    ``{"data": {year: total_dps}}`` aggregated per calendar year."""
+
+    def fetch_sync(ticker: yf.Ticker) -> dict[str, float]:
+        series = ticker.dividends
+        out: dict[str, float] = {}
+        if series is None or len(series) == 0:
+            return out
+        for ts, amount in series.items():
+            year = getattr(ts, "year", None)
+            if year is None or not pd.notna(amount):
+                continue
+            val = _normalize_value(amount)
+            if val is None:
+                continue
+            out[str(year)] = out.get(str(year), 0.0) + float(val)
+        return out
+
+    with yfinance_tracing_session() as session:
+        ticker = yf.Ticker(symbol, session=session)
+        data = await asyncio.to_thread(fetch_sync, ticker)
+
+    return {"symbol": symbol.upper(), "source": "yfinance", "data": data}
+
+
 async def _fetch_investment_opinions_yfinance(
     symbol: str,
     limit: int,

--- a/app/services/financial_fundamentals_snapshots/builder_us.py
+++ b/app/services/financial_fundamentals_snapshots/builder_us.py
@@ -245,6 +245,102 @@ async def fetch_us_quarterly_fundamentals(
     )
 
 
+# --- ROB-441 PR5: dividends (→ steady_dividend / future_dividend_king) ---------
+
+# yfinance cashflow "dividends paid" labels (a cash OUTFLOW → stored negative).
+_CASHFLOW_DIVIDEND_LABELS = (
+    "Cash Dividends Paid",
+    "Common Stock Dividends Paid",
+    "Common Stock Dividend Paid",
+    "Cash Dividend Paid",
+    "Dividends Paid",
+)
+
+
+def _dps_by_year_from_payload(data: dict[str, Any]) -> dict[int, Decimal]:
+    """Dividends payload ``{year: total_dps}`` → ``{int year: Decimal dps}``."""
+    out: dict[int, Decimal] = {}
+    for year_str, dps in (data or {}).items():
+        dec = _to_decimal(dps)
+        if dec is None:
+            continue
+        try:
+            out[int(str(year_str)[:4])] = dec
+        except (ValueError, TypeError):
+            continue
+    return out
+
+
+def parse_us_cashflow_dividends_paid(data: dict[str, Any]) -> dict[int, Decimal]:
+    """yfinance cashflow ``data`` → ``{year: abs(dividends paid)}`` (total cash out)."""
+    out: dict[int, Decimal] = {}
+    for key, period_data in (data or {}).items():
+        if not isinstance(period_data, dict):
+            continue
+        period_end = _parse_period_end(str(key))
+        if period_end is None:
+            continue
+        raw = _first_present(period_data, _CASHFLOW_DIVIDEND_LABELS)
+        if raw is None:
+            continue
+        out[period_end.year] = abs(raw)  # cashflow stores the outflow as negative
+    return out
+
+
+def enrich_annual_with_dividends(
+    periods: list[FinancialFundamentalsUpsert],
+    *,
+    dps_by_year: dict[int, Decimal],
+    dividends_paid_by_year: dict[int, Decimal],
+) -> list[FinancialFundamentalsUpsert]:
+    """Set dividend_per_share (per-share, for streak direction) + payout_ratio
+    (percent = total dividends paid / net_income × 100, total-based to avoid split
+    skew) on each ANNUAL period. Quarterly rows pass through. Fail-closed: a missing
+    figure leaves that field None (the derive streak/payout metric → excluded)."""
+    out: list[FinancialFundamentalsUpsert] = []
+    for p in periods:
+        if p.period_type != "annual":
+            out.append(p)
+            continue
+        year = p.period_end_date.year
+        dps = dps_by_year.get(year)
+        payout: Decimal | None = None
+        div_paid = dividends_paid_by_year.get(year)
+        if div_paid is not None and p.net_income is not None and p.net_income > 0:
+            payout = (div_paid / p.net_income) * Decimal(100)
+        if dps is None and payout is None:
+            out.append(p)  # nothing to enrich
+            continue
+        out.append(
+            p.model_copy(update={"dividend_per_share": dps, "payout_ratio": payout})
+        )
+    return out
+
+
+async def fetch_us_dividend_data(
+    *, symbol: str
+) -> tuple[dict[int, Decimal], dict[int, Decimal]]:
+    """(dps_by_year, dividends_paid_by_year) for ``symbol`` — both fail-closed empty."""
+    from app.mcp_server.tooling.fundamentals_sources_yfinance import (
+        _fetch_dividends_yfinance,
+        _fetch_financials_yfinance,
+    )
+
+    dps_by_year: dict[int, Decimal] = {}
+    dividends_paid_by_year: dict[int, Decimal] = {}
+    try:
+        dv = await _fetch_dividends_yfinance(symbol)
+        dps_by_year = _dps_by_year_from_payload(dv.get("data") or {})
+    except Exception as exc:  # noqa: BLE001 — fail-closed
+        logger.warning("US dividends fetch failed symbol=%s: %s", symbol, exc)
+    try:
+        cf = await _fetch_financials_yfinance(symbol, "cashflow", "annual")
+        dividends_paid_by_year = parse_us_cashflow_dividends_paid(cf.get("data") or {})
+    except Exception as exc:  # noqa: BLE001 — fail-closed
+        logger.warning("US cashflow fetch failed symbol=%s: %s", symbol, exc)
+    return dps_by_year, dividends_paid_by_year
+
+
 # --- ROB-441 PR2: build orchestration (resolve → fetch → optional commit) -----
 
 _UsFetcher = Callable[..., Awaitable[list[FinancialFundamentalsUpsert]]]
@@ -302,27 +398,46 @@ async def build_us_fundamentals_for_symbols(
     fetcher: _UsFetcher | None = None,
     include_quarterly: bool = False,
     quarterly_fetcher: _UsFetcher | None = None,
+    include_dividends: bool = False,
+    dividend_fetcher: Callable[..., Awaitable[tuple[dict, dict]]] | None = None,
 ) -> UsFundamentalsBuildResult:
     """Fetch + parse US annual (and optionally quarterly) fundamentals; write if commit.
 
     dry-run by default (commit=False): fetches/parses + reports counts, no DB write.
     commit=True upserts via the repository (operator-approved). include_quarterly also
-    builds quarterly periods (ROB-441 PR4, for QoQ → growth_expectation_toss).
+    builds quarterly periods (ROB-441 PR4, QoQ → growth_expectation_toss);
+    include_dividends enriches annual periods with dividend_per_share + payout_ratio
+    (ROB-441 PR5, → steady_dividend / future_dividend_king).
     Fail-closed: a symbol whose fetch fails or yields no rows is warned and skipped.
     """
     collected_at = collected_at or dt.datetime.now(dt.UTC)
     annual_fetch = fetcher or fetch_us_annual_fundamentals
     quarterly_fetch = quarterly_fetcher or fetch_us_quarterly_fundamentals
+    dividend_fetch = dividend_fetcher or fetch_us_dividend_data
     sem = asyncio.Semaphore(max(1, concurrency))
     warnings: list[str] = []
 
     async def _one(sym: str) -> list[FinancialFundamentalsUpsert]:
         async with sem:
             rows: list[FinancialFundamentalsUpsert] = []
+            annual_rows: list[FinancialFundamentalsUpsert] = []
             try:
-                rows.extend(await annual_fetch(symbol=sym, collected_at=collected_at))
+                annual_rows = list(
+                    await annual_fetch(symbol=sym, collected_at=collected_at)
+                )
             except Exception as exc:  # noqa: BLE001 — fail-closed per symbol
                 warnings.append(f"{sym}: annual fetch failed ({exc})")
+            if include_dividends and annual_rows:
+                try:
+                    dps_by_year, div_paid_by_year = await dividend_fetch(symbol=sym)
+                    annual_rows = enrich_annual_with_dividends(
+                        annual_rows,
+                        dps_by_year=dps_by_year,
+                        dividends_paid_by_year=div_paid_by_year,
+                    )
+                except Exception as exc:  # noqa: BLE001 — fail-closed per symbol
+                    warnings.append(f"{sym}: dividend fetch failed ({exc})")
+            rows.extend(annual_rows)
             if include_quarterly:
                 try:
                     rows.extend(

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -51,9 +51,11 @@ _KR_ONLY_PRESET_IDS = {
 # ROB-441 PR3: profitable_company/undervalued_growth/cheap_value/stable_growth run on
 # the market-parameterized derive loader (market_valuation US per/pbr/roe +
 # financial_fundamentals US annual periods → derive) — load_fundamentals_preset_from_snapshots(market="us").
-# ROB-441 PR4: growth_expectation_toss (QoQ) runs once US quarterly periods are built
-# (yfinance quarterly income → derive earnings_growth_qoq). Dividend presets stay
-# data_pending until US dividend fundamentals are built (ROB-441 dividend follow-up).
+# ROB-441 PR4: growth_expectation_toss (QoQ) runs on yfinance quarterly income.
+# ROB-441 PR5: steady_dividend / future_dividend_king run on yfinance dividends
+# (per-share) + cashflow dividends-paid → payout_ratio + dividend streaks (derive).
+# Every Toss fundamentals preset is now US-active; only the supply-flow presets
+# (double_buy / investor_flow_momentum) remain KR-only (no US equivalent feed).
 _US_ACTIVE_PRESET_IDS = {
     "high_yield_value",
     "undervalued_breakout",
@@ -62,13 +64,12 @@ _US_ACTIVE_PRESET_IDS = {
     "cheap_value",
     "stable_growth",
     "growth_expectation_toss",
+    "steady_dividend",
+    "future_dividend_king",
 }
 _US_UNSUPPORTED_PRESET_IDS = {"double_buy", "investor_flow_momentum"}
 _US_UNSUPPORTED_REASON = "외국인·기관 수급은 국내 전용 지표입니다"
-_US_DATA_PENDING_REASON: dict[str, str] = {
-    "steady_dividend": "미국 배당·순이익 연속 데이터 준비중",
-    "future_dividend_king": "미국 배당·순이익 연속 데이터 준비중",
-}
+_US_DATA_PENDING_REASON: dict[str, str] = {}
 
 
 def _preset_availability(preset_id: str, market: str) -> tuple[str, str | None]:

--- a/scripts/build_us_fundamentals_snapshots.py
+++ b/scripts/build_us_fundamentals_snapshots.py
@@ -45,6 +45,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Also build quarterly periods (annual-only by default; for QoQ presets).",
     )
     parser.add_argument(
+        "--with-dividends",
+        dest="include_dividends",
+        action="store_true",
+        help="Enrich annual periods with dividend_per_share + payout_ratio (for dividend presets).",
+    )
+    parser.add_argument(
         "--commit",
         action="store_true",
         help=(
@@ -104,6 +110,7 @@ async def run(args: argparse.Namespace) -> int:
         commit=args.commit,
         concurrency=args.concurrency,
         include_quarterly=args.include_quarterly,
+        include_dividends=args.include_dividends,
     )
     _print_result(result)
     return 0

--- a/tests/test_build_us_fundamentals_cli.py
+++ b/tests/test_build_us_fundamentals_cli.py
@@ -45,3 +45,12 @@ def test_with_quarterly_flag() -> None:
     assert (
         parse_args(["--symbol", "AAPL", "--with-quarterly"]).include_quarterly is True
     )
+
+
+@pytest.mark.unit
+def test_with_dividends_flag() -> None:
+    # ROB-441 PR5: --with-dividends enriches annual periods (off by default).
+    assert parse_args(["--symbol", "AAPL"]).include_dividends is False
+    assert (
+        parse_args(["--symbol", "AAPL", "--with-dividends"]).include_dividends is True
+    )

--- a/tests/test_screener_presets_us_availability.py
+++ b/tests/test_screener_presets_us_availability.py
@@ -14,6 +14,7 @@ import pytest
 from app.services.invest_view_model.screener_presets import (
     _KR_ONLY_PRESET_IDS,
     _US_ACTIVE_PRESET_IDS,
+    _US_DATA_PENDING_REASON,
     _US_UNSUPPORTED_PRESET_IDS,
     preset_definitions,
 )
@@ -63,16 +64,15 @@ def test_us_flow_presets_unsupported_with_reason() -> None:
 
 
 @pytest.mark.unit
-def test_us_fundamentals_presets_data_pending_with_reason() -> None:
+def test_us_no_fundamentals_presets_data_pending() -> None:
+    # ROB-441 PR5: every Toss fundamentals preset is now US-active (yfinance
+    # annual/quarterly/dividends); no fundamentals preset stays data_pending.
     us = {p.id: p for p in preset_definitions("us")}
-    # ROB-441 PR4: growth_expectation_toss (QoQ) is now active (yfinance quarterly);
-    # only the dividend presets stay data_pending until US dividend data is built.
-    for pid in (
-        "steady_dividend",
-        "future_dividend_king",
-    ):
-        assert us[pid].availability == "data_pending", pid
-        assert us[pid].availabilityReason, pid
+    assert _US_DATA_PENDING_REASON == {}
+    assert all(p.availability != "data_pending" for p in us.values())
+    for pid in ("steady_dividend", "future_dividend_king"):
+        assert us[pid].availability == "active", pid
+        assert us[pid].availabilityReason is None, pid
 
 
 @pytest.mark.unit

--- a/tests/test_us_fundamentals_builder_rob441.py
+++ b/tests/test_us_fundamentals_builder_rob441.py
@@ -11,8 +11,10 @@ import pytest
 
 from app.services.financial_fundamentals_snapshots.builder_us import (
     build_us_fundamentals_for_symbols,
+    enrich_annual_with_dividends,
     fetch_us_annual_fundamentals,
     parse_us_annual_income_periods,
+    parse_us_cashflow_dividends_paid,
     parse_us_quarterly_income_periods,
 )
 
@@ -325,3 +327,122 @@ async def test_build_include_quarterly() -> None:
         ["AAPL"], commit=False, fetcher=_annual, quarterly_fetcher=_quarterly
     )
     assert result2.snapshots_built == 1
+
+
+# --- ROB-441 PR5: dividends (→ steady_dividend / future_dividend_king) --------
+
+
+@pytest.mark.unit
+def test_parse_cashflow_dividends_paid() -> None:
+    # cashflow stores dividends paid as a negative outflow → abs() per year.
+    out = parse_us_cashflow_dividends_paid(
+        {
+            "2024-12-31": {"Cash Dividends Paid": -500, "Net Income": 1000},
+            "2023-12-31": {"Common Stock Dividend Paid": -450},
+            "bad": {"Cash Dividends Paid": -1},  # bad date skipped
+        }
+    )
+    assert out == {2024: Decimal("500"), 2023: Decimal("450")}
+
+
+@pytest.mark.unit
+def test_enrich_annual_with_dividends() -> None:
+    annual = parse_us_annual_income_periods(
+        symbol="X",
+        data={"2023-12-31": _period(900, 100), "2024-12-31": _period(1000, 120)},
+        collected_at=_COLLECTED,
+    )
+    enriched = enrich_annual_with_dividends(
+        annual,
+        dps_by_year={2023: Decimal("2"), 2024: Decimal("3")},
+        dividends_paid_by_year={2023: Decimal("30"), 2024: Decimal("36")},
+    )
+    by_year = {r.period_end_date.year: r for r in enriched}
+    assert by_year[2023].dividend_per_share == Decimal("2")
+    assert by_year[2023].payout_ratio == Decimal("30")  # 30/100 * 100
+    assert by_year[2024].dividend_per_share == Decimal("3")
+    assert by_year[2024].payout_ratio == Decimal("30")  # 36/120 * 100
+
+
+@pytest.mark.unit
+def test_enrich_skips_payout_when_net_income_nonpositive() -> None:
+    annual = parse_us_annual_income_periods(
+        symbol="X",
+        data={"2024-12-31": {"Net Income": 0, "Total Revenue": 1000}},
+        collected_at=_COLLECTED,
+    )
+    enriched = enrich_annual_with_dividends(
+        annual,
+        dps_by_year={2024: Decimal("1")},
+        dividends_paid_by_year={2024: Decimal("50")},
+    )
+    # net_income 0 → payout fail-closed None; dps still set.
+    assert enriched[0].dividend_per_share == Decimal("1")
+    assert enriched[0].payout_ratio is None
+
+
+@pytest.mark.unit
+def test_derive_dividend_streaks_from_enriched_us_periods() -> None:
+    from app.services.financial_fundamentals_snapshots.derive import (
+        FundamentalPeriod,
+        derive_fundamentals_metrics,
+    )
+
+    annual = parse_us_annual_income_periods(
+        symbol="X",
+        data={
+            "2021-12-31": _period(1000, 100),
+            "2022-12-31": _period(1100, 120),
+            "2023-12-31": _period(1200, 140),
+            "2024-12-31": _period(1300, 160),
+        },
+        collected_at=_COLLECTED,
+    )
+    enriched = enrich_annual_with_dividends(
+        annual,
+        dps_by_year={
+            2021: Decimal("1"),
+            2022: Decimal("2"),
+            2023: Decimal("3"),
+            2024: Decimal("4"),
+        },
+        dividends_paid_by_year={},
+    )
+    periods = [
+        FundamentalPeriod(
+            fiscal_period=r.fiscal_period,
+            period_type=r.period_type,
+            period_end_date=r.period_end_date,
+            filing_date=r.filing_date,
+            net_income=r.net_income,
+            dividend_per_share=r.dividend_per_share,
+            payout_ratio=r.payout_ratio,
+        )
+        for r in enriched
+    ]
+    deriv = derive_fundamentals_metrics(periods, report_date=dt.date(2025, 6, 1))
+    assert deriv.dividend_paid_streak_years.value  # 4 years paid
+    assert deriv.dividend_growth_streak_years.value  # rising 1→2→3→4
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_include_dividends_enriches_annual() -> None:
+    async def _annual(*, symbol, collected_at):  # noqa: ANN001
+        return parse_us_annual_income_periods(
+            symbol=symbol,
+            data={"2024-12-31": _period(1000, 100)},
+            collected_at=collected_at,
+        )
+
+    async def _dividends(*, symbol):  # noqa: ANN001
+        return ({2024: Decimal("3")}, {2024: Decimal("30")})
+
+    result = await build_us_fundamentals_for_symbols(
+        ["AAPL"],
+        commit=False,
+        fetcher=_annual,
+        include_dividends=True,
+        dividend_fetcher=_dividends,
+    )
+    assert result.snapshots_built == 1


### PR DESCRIPTION
## What & why (ROB-441 분기·배당 확장 — 배당)
yfinance 배당(per-share) + cashflow(배당지급액)으로 연간 period에 `dividend_per_share` + `payout_ratio`를 채워 derive 배당 streak/payout을 활성화하고 **마지막 펀더멘털 프리셋 2개(steady_dividend / future_dividend_king) US 활성화**. migration 0.

## Changes
- **`_fetch_dividends_yfinance`**(fundamentals_sources_yfinance): `Ticker.dividends`(split-adjusted per-share) → `{year: total_dps}` 캘린더연 집계.
- **`builder_us`**:
  - `parse_us_cashflow_dividends_paid`(순수): cashflow(음수 outflow)→`abs` per year, 라벨 후보군(Cash Dividends Paid 등).
  - `enrich_annual_with_dividends`(순수): 연간 period에 **dividend_per_share**(per-share → streak 방향 정확) + **payout_ratio**(=배당지급액/순이익×100 percent, **total 기반 → split 왜곡 회피**) `model_copy`. fail-closed(net_income≤0 → payout None).
  - `fetch_us_dividend_data`(dividends + cashflow, 각각 fail-closed) + `build_us_fundamentals_for_symbols(include_dividends=)`(annual enrich).
- **CLI `--with-dividends`**. **`screener_presets`**: `_US_ACTIVE`에 steady_dividend/future_dividend_king 추가, **`_US_DATA_PENDING_REASON` 비움**(모든 Toss 펀더멘털 US 활성).

## Verification
- 신규: cashflow 파서 / 배당 enrich(dps+payout) / net_income≤0 payout fail-closed / **derive 배당 streak 재사용**(paid+growth) / orchestration include_dividends / CLI `--with-dividends` / availability(배당 2개 active, **data_pending 0**).
- **35 + 143 green**(financial_fundamentals/screener_presets/build_us/yfinance sweep 회귀 0); ruff clean; **migration 0**(단일 head, 로더/dispatch 무변경).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. migration 0. fail-closed. KR 경로 무변경. **operator: `build_us_fundamentals_snapshots --all --with-quarterly --with-dividends --commit`** 후 표시.
- payout_ratio는 total 기반(cashflow/net_income)으로 split 왜곡 회피; dps는 per-share(streak 방향).

## 결과: US 9/11 Toss 프리셋 active
가격/기술 4 + 밸류에이션 2(ROB-440) + 펀더멘털 4(PR3) + QoQ 1(분기) + 배당 2(이 PR) = **9 active**. 나머지 2 = double_buy/investor_flow_momentum(국내전용 수급, unsupported).

## Related
ROB-441(Phase 2) · #1142/#1143/#1144/#1145(PR1-4) · derive `_dividend_paid_streak`/`_dividend_growth_streak`/`_payout_ratio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)