### PR TITLE
feat(ROB-440): undervalued_breakout US date-recency parity (high_52w_date, XNYS ≤20 sessions) — Phase 1 PR3

### DIFF
--- a/alembic/versions/2026_06_05_rob440_high_52w_date.py
+++ b/alembic/versions/2026_06_05_rob440_high_52w_date.py
@@ -1,0 +1,34 @@
+"""ROB-440 PR3: add high_52w_date to market_valuation_snapshots.
+
+Additive (nullable): the date the 52-week high occurred, sourced from yfinance
+daily OHLC (max High date) for US. Powers US undervalued_breakout date-recency
+parity (a NEW 52-week high within ~20 XNYS trading days — matching the KR/Toss
+"신고가 경신" definition, ROB-432) instead of the price-proximity proxy. KR rows
+leave it NULL (KR display uses the tvscreener week_high_52_date path).
+
+Revision ID: 20260605_rob440
+Revises: 20260605_rob441
+Create Date: 2026-06-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260605_rob440"
+down_revision = "20260605_rob441"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "market_valuation_snapshots",
+        sa.Column("high_52w_date", sa.Date(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("market_valuation_snapshots", "high_52w_date")

--- a/app/models/market_valuation_snapshot.py
+++ b/app/models/market_valuation_snapshot.py
@@ -57,6 +57,9 @@ class MarketValuationSnapshot(Base):
     market_cap: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
     high_52w: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
     low_52w: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    # ROB-440 PR3: date the 52-week high occurred (US, from yfinance OHLC) —
+    # powers undervalued_breakout date-recency parity. NULL for KR.
+    high_52w_date: Mapped[date | None] = mapped_column(Date, nullable=True)
     raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     computed_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -4,7 +4,7 @@ import logging
 import urllib.error
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 import pandas as pd
@@ -136,6 +136,24 @@ async def fetch_ohlcv(
     if normalized_period in {"day", "week", "month"}:
         return _filter_closed_buckets_nyse(raw, normalized_period)
     return raw
+
+
+async def fetch_52w_high_date(ticker: str) -> date | None:
+    """ROB-440: date of the 52-week high (max daily ``high`` over ~1y) for US
+    undervalued_breakout date-recency. None on any error / empty (fail-closed)."""
+    try:
+        df = await fetch_ohlcv(ticker, days=260, period="day")
+    except Exception as exc:  # noqa: BLE001 — fail-closed
+        logger.warning("52w-high-date fetch failed %s: %s", ticker, exc)
+        return None
+    if df is None or df.empty or "high" not in df.columns or "date" not in df.columns:
+        return None
+    try:
+        hi_idx = df["high"].idxmax()
+        value = df.loc[hi_idx, "date"]
+    except Exception:  # noqa: BLE001 — fail-closed
+        return None
+    return value if isinstance(value, date) else None
 
 
 async def _fetch_ohlcv_raw(

--- a/app/services/invest_view_model/undervalued_breakout_screener.py
+++ b/app/services/invest_view_model/undervalued_breakout_screener.py
@@ -27,6 +27,10 @@ logger = logging.getLogger(__name__)
 _MAX_PER = Decimal("10")
 _MAX_PBR = Decimal("1")
 _NEAR_HIGH_RATIO = Decimal("0.95")  # close within 5% of (or above) the 52-week high
+# ROB-440 PR3: US date-recency parity — a NEW 52-week high made within 20 *trading*
+# sessions (XNYS), matching the KR/Toss "신고가 경신" definition (ROB-432) instead of
+# the price-proximity proxy.
+_NEW_HIGH_RECENCY_TRADING_DAYS = 20
 
 
 def _near_high_proximity(
@@ -43,6 +47,23 @@ def _passes_near_high(
 ) -> bool:
     prox = _near_high_proximity(latest_close, high_52w)
     return prox is not None and prox >= ratio
+
+
+def _new_high_age_trading_days(
+    high_date: dt.date | None, partition_date: dt.date, market: str
+) -> int | None:
+    """Trading sessions from the 52-week-high date to the partition date (holiday-aware,
+    XNYS/XKRX via session_calendar). Smaller = a more recent new 52-week high. None
+    (fail-closed → excluded) when the date is missing, in the future, or out of the
+    calendar's range / any calendar error."""
+    if high_date is None or high_date > partition_date:
+        return None
+    from app.services.market_events.session_calendar import trading_sessions_in_range
+
+    sessions = trading_sessions_in_range(market, high_date, partition_date)
+    if not sessions:
+        return None
+    return sum(1 for s in sessions if s > high_date)
 
 
 async def load_undervalued_breakout_from_snapshots(
@@ -96,6 +117,7 @@ async def load_undervalued_breakout_from_snapshots(
             MarketValuationSnapshot.per,
             MarketValuationSnapshot.pbr,
             MarketValuationSnapshot.high_52w,
+            MarketValuationSnapshot.high_52w_date,
             MarketValuationSnapshot.market_cap,
             MarketValuationSnapshot.source,
             InvestScreenerSnapshot.latest_close,
@@ -176,11 +198,18 @@ async def load_undervalued_breakout_from_snapshots(
         name = name_map.get(sym)
         if market == "kr" and not _is_kr_toss_common_stock(sym, name):
             continue
-        # 신고가 근접 (fail-closed on NULL close / high_52w)
-        if not _passes_near_high(r["latest_close"], r["high_52w"], _NEAR_HIGH_RATIO):
+        prox = _near_high_proximity(r["latest_close"], r["high_52w"])
+        age: int | None = None
+        if market == "us":
+            # ROB-440 PR3: date-recency parity — a NEW 52w high made within 20 XNYS
+            # trading sessions (Toss "신고가 경신"), not the price-proximity proxy.
+            age = _new_high_age_trading_days(r["high_52w_date"], val_date, "us")
+            if age is None or age > _NEW_HIGH_RECENCY_TRADING_DAYS:
+                continue
+        # KR reports/PIT: price-proximity proxy (close >= 95% of the 52-week high).
+        elif not _passes_near_high(r["latest_close"], r["high_52w"], _NEAR_HIGH_RATIO):
             continue
         seen.add(sym)
-        prox = _near_high_proximity(r["latest_close"], r["high_52w"])
         rows.append(
             {
                 "symbol": sym,
@@ -197,6 +226,7 @@ async def load_undervalued_breakout_from_snapshots(
                 "pbr": float(r["pbr"]) if r["pbr"] is not None else None,
                 "high_52w": float(r["high_52w"]) if r["high_52w"] is not None else None,
                 "high_52w_proximity": float(prox) if prox is not None else None,
+                "new_high_age_trading_days": age,  # ROB-440 PR3 (US date-recency)
                 "market_cap": float(r["market_cap"])
                 if r["market_cap"] is not None
                 else None,
@@ -205,13 +235,26 @@ async def load_undervalued_breakout_from_snapshots(
             }
         )
 
-    # Rank by proximity to the 52-week high (desc), then cheapest PER (asc).
-    rows.sort(
-        key=lambda x: (
-            x["high_52w_proximity"] is None,
-            -(x["high_52w_proximity"] or 0.0),
-            x["per"] if x["per"] is not None else float("inf"),
-            x["symbol"],
+    if market == "us":
+        # ROB-440 PR3: Toss 저평가 탈출 default order = cheapest PER asc; tiebreak by
+        # the most recent new high (smaller age) then symbol.
+        rows.sort(
+            key=lambda x: (
+                x["per"] if x["per"] is not None else float("inf"),
+                x["new_high_age_trading_days"]
+                if x["new_high_age_trading_days"] is not None
+                else 10**9,
+                x["symbol"],
+            )
         )
-    )
+    else:
+        # KR reports/PIT: rank by proximity to the 52-week high (desc), then PER asc.
+        rows.sort(
+            key=lambda x: (
+                x["high_52w_proximity"] is None,
+                -(x["high_52w_proximity"] or 0.0),
+                x["per"] if x["per"] is not None else float("inf"),
+                x["symbol"],
+            )
+        )
     return rows[:limit]

--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -32,6 +32,17 @@ def _to_decimal(value: Any) -> Decimal | None:
         return None
 
 
+def _to_date(value: Any) -> dt.date | None:
+    if isinstance(value, dt.date):
+        return value
+    if isinstance(value, str) and value:
+        try:
+            return dt.date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
 async def default_valuation_fetcher(symbol: str, market: str) -> dict[str, Any]:
     if market == "kr":
         from app.services.naver_finance.valuation import fetch_valuation
@@ -39,14 +50,23 @@ async def default_valuation_fetcher(symbol: str, market: str) -> dict[str, Any]:
         return await fetch_valuation(symbol)
     if market == "us":
         from app.services.brokers.yahoo.client import (
+            fetch_52w_high_date,
             fetch_fast_info,
             fetch_fundamental_info,
         )
 
-        fast_info, fundamentals = await asyncio.gather(
-            fetch_fast_info(symbol), fetch_fundamental_info(symbol)
+        fast_info, fundamentals, high_52w_date = await asyncio.gather(
+            fetch_fast_info(symbol),
+            fetch_fundamental_info(symbol),
+            fetch_52w_high_date(symbol),  # ROB-440 PR3: 52w-high date (date-recency)
         )
-        return {**fast_info, **fundamentals}
+        # isoformat string keeps raw_payload (JSONB) serializable; parsed back in
+        # _payload_from_raw → the high_52w_date column.
+        return {
+            **fast_info,
+            **fundamentals,
+            "high_52w_date": high_52w_date.isoformat() if high_52w_date else None,
+        }
     raise ValueError(f"unsupported market: {market}")
 
 
@@ -73,6 +93,7 @@ def _payload_from_raw(
         market_cap=_to_decimal(raw.get("market_cap") or raw.get("marketCap")),
         high_52w=_to_decimal(raw.get("high_52w") or raw.get("yearHigh")),
         low_52w=_to_decimal(raw.get("low_52w") or raw.get("yearLow")),
+        high_52w_date=_to_date(raw.get("high_52w_date")),
         raw_payload=redact_sensitive_payload(dict(raw)),
     )
 

--- a/app/services/market_valuation_snapshots/repository.py
+++ b/app/services/market_valuation_snapshots/repository.py
@@ -28,6 +28,7 @@ class MarketValuationSnapshotUpsert(BaseModel):
     market_cap: Decimal | None = None
     high_52w: Decimal | None = None
     low_52w: Decimal | None = None
+    high_52w_date: dt.date | None = None  # ROB-440 PR3: US 52w-high date (date-recency)
     raw_payload: dict | None = None
 
 
@@ -67,6 +68,7 @@ class MarketValuationSnapshotsRepository:
                 "market_cap": stmt.excluded.market_cap,
                 "high_52w": stmt.excluded.high_52w,
                 "low_52w": stmt.excluded.low_52w,
+                "high_52w_date": stmt.excluded.high_52w_date,
                 "raw_payload": stmt.excluded.raw_payload,
                 "computed_at": func.now(),
                 "updated_at": func.now(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -459,14 +459,27 @@ async def db_session():
                     )
                 )
                 # ROB-440 PR3 — high_52w_date added to the (persistent) market
-                # valuation snapshot table for US undervalued_breakout date-recency;
-                # create_all is a no-op on the existing table (mirrors the migration).
-                await conn.execute(
-                    text(
-                        "ALTER TABLE market_valuation_snapshots "
-                        "ADD COLUMN IF NOT EXISTS high_52w_date DATE"
+                # valuation snapshot table for US undervalued_breakout date-recency.
+                # On a FRESH DB create_all already adds it (the ORM model declares
+                # it), so only ALTER when genuinely missing — an unconditional
+                # ALTER (even IF NOT EXISTS) takes an AccessExclusive lock on this
+                # HOT table and widens the xdist DDL-vs-test deadlock window.
+                mv_has_high_52w_date = (
+                    await conn.execute(
+                        text(
+                            "SELECT 1 FROM information_schema.columns "
+                            "WHERE table_name = 'market_valuation_snapshots' "
+                            "AND column_name = 'high_52w_date'"
+                        )
                     )
-                )
+                ).first()
+                if not mv_has_high_52w_date:
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE market_valuation_snapshots "
+                            "ADD COLUMN high_52w_date DATE"
+                        )
+                    )
                 # ROB-284 — crypto_candles_1d migrates in-place from the
                 # legacy (symbol, market) shape to the (instrument_id, time)
                 # shape. The test DB picks up its schema from

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -458,6 +458,15 @@ async def db_session():
                         "ADD COLUMN IF NOT EXISTS week_high_52_date DATE"
                     )
                 )
+                # ROB-440 PR3 — high_52w_date added to the (persistent) market
+                # valuation snapshot table for US undervalued_breakout date-recency;
+                # create_all is a no-op on the existing table (mirrors the migration).
+                await conn.execute(
+                    text(
+                        "ALTER TABLE market_valuation_snapshots "
+                        "ADD COLUMN IF NOT EXISTS high_52w_date DATE"
+                    )
+                )
                 # ROB-284 — crypto_candles_1d migrates in-place from the
                 # legacy (symbol, market) shape to the (instrument_id, time)
                 # shape. The test DB picks up its schema from

--- a/tests/test_invest_coverage_valuation.py
+++ b/tests/test_invest_coverage_valuation.py
@@ -234,3 +234,62 @@ async def test_valuation_builder_and_repository_upsert(db_session):
     await db_session.commit()
     counts = await repo.coverage_counts("kr", fresh_date=snapshot_date)
     assert counts.fresh_symbols >= 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_valuation_builder_threads_high_52w_date_us(db_session):
+    # ROB-440 PR3: the US fetcher's high_52w_date (iso string in raw, JSON-safe) →
+    # parsed to a date in the payload + persisted to the high_52w_date column
+    # (powers undervalued_breakout date-recency).
+    from app.services.market_valuation_snapshots.builder import (
+        build_valuation_snapshots_for_market,
+    )
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotsRepository,
+    )
+
+    snapshot_date = dt.date(2026, 5, 12)
+    sym = "ZZ9001"
+
+    async def fake_fetcher(symbol: str, market: str) -> dict[str, object]:
+        assert market == "us"
+        return {
+            "per": "8",
+            "pbr": "0.8",
+            "yearHigh": "100",
+            "high_52w_date": "2026-05-01",  # iso string (JSON-safe in raw_payload)
+        }
+
+    result = await build_valuation_snapshots_for_market(
+        market="us",
+        symbols=[sym],
+        snapshot_date=snapshot_date,
+        fetcher=fake_fetcher,
+    )
+    assert len(result.payloads) == 1
+    assert result.payloads[0].high_52w_date == dt.date(2026, 5, 1)
+    assert (
+        result.payloads[0].raw_payload["high_52w_date"] == "2026-05-01"
+    )  # not a date obj
+
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+    repo = MarketValuationSnapshotsRepository(db_session)
+    assert await repo.upsert(result.payloads) == 1
+    await db_session.commit()
+    row = (
+        await db_session.execute(
+            sa.select(MarketValuationSnapshot).where(
+                MarketValuationSnapshot.symbol == sym,
+                MarketValuationSnapshot.snapshot_date == snapshot_date,
+            )
+        )
+    ).scalar_one()
+    assert row.high_52w_date == dt.date(2026, 5, 1)  # persisted to the column
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()

--- a/tests/test_undervalued_breakout_screener.py
+++ b/tests/test_undervalued_breakout_screener.py
@@ -297,11 +297,13 @@ async def test_loader_ranks_by_proximity_desc_then_per_asc(db_session):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_loader_us_proximity_passes(db_session):
-    # ROB-440 Part 2: US runs on the same market-parameterized proximity loader
-    # (high_52w from Yahoo .info, latest_close from US invest_screener). No KR
-    # universe / common-stock filter for US.
-    vd = dt.date(2099, 12, 31)
+async def test_loader_us_date_recency_passes(db_session):
+    # ROB-440 PR3: US uses date-recency (a NEW 52-week high within 20 XNYS trading
+    # sessions of the partition), NOT the price-proximity proxy. latest_close=80 vs
+    # high_52w=100 (proximity 0.80) would FAIL the old >=0.95 rule — so passing here
+    # proves the switch to date-recency. In-range XNYS dates (2099 is out of range).
+    vd = dt.date(2026, 6, 2)
+    high_date = dt.date(2026, 5, 20)  # ~9 XNYS sessions before vd → recent new high
     sym = "907031"
     await db_session.execute(
         sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
@@ -319,6 +321,7 @@ async def test_loader_us_proximity_passes(db_session):
             per=Decimal("8"),
             pbr=Decimal("0.8"),
             high_52w=Decimal("100"),
+            high_52w_date=high_date,
             market_cap=Decimal("5e11"),
         )
     )
@@ -327,7 +330,7 @@ async def test_loader_us_proximity_passes(db_session):
             market="us",
             symbol=sym,
             snapshot_date=vd,
-            latest_close=Decimal("99"),  # 0.99 proximity >= 0.95 → passes
+            latest_close=Decimal("80"),  # proximity 0.80 < 0.95 (old rule would reject)
             closes_window=[],
             source="kis",
         )
@@ -340,7 +343,26 @@ async def test_loader_us_proximity_passes(db_session):
     assert rows is not None
     row = next(r for r in rows if r["symbol"] == sym)
     assert row["market"] == "us"  # market threaded through
-    assert row["high_52w"] == 100.0
+    assert row["new_high_age_trading_days"] is not None
+    assert row["new_high_age_trading_days"] <= 20  # recent new high
+
+
+@pytest.mark.unit
+def test_new_high_age_trading_days_xnys() -> None:
+    from app.services.invest_view_model.undervalued_breakout_screener import (
+        _new_high_age_trading_days,
+    )
+
+    part = dt.date(2026, 6, 2)
+    # ~9 trading sessions earlier → small, in-range age.
+    age = _new_high_age_trading_days(dt.date(2026, 5, 20), part, "us")
+    assert age is not None and 0 < age <= 20
+    # same day → age 0 (a new high made today is the most recent).
+    assert _new_high_age_trading_days(part, part, "us") == 0
+    # future high date → None (fail-closed, not "recent").
+    assert _new_high_age_trading_days(dt.date(2026, 6, 30), part, "us") is None
+    # missing date → None.
+    assert _new_high_age_trading_days(None, part, "us") is None
 
 
 @pytest.mark.integration

--- a/tests/test_yahoo_roe_rob440.py
+++ b/tests/test_yahoo_roe_rob440.py
@@ -77,3 +77,51 @@ async def test_fetch_fundamental_info_roe_none_when_missing(
 
     result = await fetch_fundamental_info("AAPL")
     assert result["ROE"] is None
+
+
+# --- ROB-440 PR3: 52-week-high date (for US undervalued_breakout date-recency) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_52w_high_date_picks_max_high() -> None:
+    import datetime as dt
+
+    import pandas as pd
+
+    from app.services.brokers.yahoo import client as yclient
+
+    df = pd.DataFrame(
+        {
+            "date": [dt.date(2026, 5, 1), dt.date(2026, 5, 20), dt.date(2026, 6, 1)],
+            "high": [90.0, 110.0, 100.0],  # max high on 2026-05-20
+            "low": [80.0, 100.0, 95.0],
+            "close": [88.0, 108.0, 99.0],
+        }
+    )
+
+    async def _fake_ohlcv(ticker, days=100, period="day", end_date=None):  # noqa: ANN001
+        return df
+
+    with patch.object(yclient, "fetch_ohlcv", _fake_ohlcv):
+        result = await yclient.fetch_52w_high_date("AAPL")
+    assert result == dt.date(2026, 5, 20)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_52w_high_date_fail_closed() -> None:
+    import pandas as pd
+
+    from app.services.brokers.yahoo import client as yclient
+
+    async def _empty(ticker, days=100, period="day", end_date=None):  # noqa: ANN001
+        return pd.DataFrame()
+
+    async def _boom(ticker, days=100, period="day", end_date=None):  # noqa: ANN001
+        raise RuntimeError("yfinance down")
+
+    with patch.object(yclient, "fetch_ohlcv", _empty):
+        assert await yclient.fetch_52w_high_date("AAPL") is None
+    with patch.object(yclient, "fetch_ohlcv", _boom):
+        assert await yclient.fetch_52w_high_date("AAPL") is None


### PR DESCRIPTION
## What & why (ROB-440 Part 2 후속 — date-recency parity)
ROB-440 Part 2에서 US undervalued_breakout를 **proximity**(close≥high_52w×0.95)로 활성화하며 date-recency는 후속으로 남겼음(사용자 승인). 이 PR은 US를 KR/Toss "신고가 경신"(ROB-432)과 동일한 **date-recency**(52주 신고가를 **≤20 XNYS 거래일** 이내 경신)로 전환. KR reports/PIT 경로는 proximity 유지(불변).

## Changes
- **migration(additive)**: `market_valuation_snapshots.high_52w_date`(Date, nullable). 단일 head `20260605_rob440`. conftest 동일 ALTER 패치(persistent 로컬 test DB, ROB-430 관례 미러).
- **model / Upsert / repository**: high_52w_date(`model_dump` → upsert excluded 자동).
- **yahoo `fetch_52w_high_date`**: `fetch_ohlcv`(1y daily)에서 `max(high)`의 date. fail-closed(empty/error→None).
- **market_valuation builder**: `default_valuation_fetcher` US가 `fetch_52w_high_date`도 gather → raw에 **iso 문자열**(JSONB `raw_payload` 직렬화 안전); `_payload_from_raw`가 `_to_date`로 파싱 → high_52w_date 컬럼.
- **loader** `load_undervalued_breakout_from_snapshots`: `_new_high_age_trading_days`(`session_calendar.trading_sessions_in_range`, **market 파라미터 XNYS/XKRX**) — US는 high_52w_date age≤20 거래일 필터(미존재/미래/범위밖 **fail-closed** 제외), 랭킹 PER asc(Toss 기본); KR은 proximity 유지.

## Verification
- 신규: `_new_high_age_trading_days`(XNYS, same-day=0, 미래→None) + **US date-recency 로더**(latest_close 80/high 100 = proximity 0.80인데 통과 → switch 증명) + yahoo `fetch_52w_high_date`(max-high / empty·error fail-closed) + builder high_52w_date 스레딩(iso→date, JSONB 안전, 컬럼 영속 검증).
- **229 sweep green**(undervalued_breakout/market_valuation/yahoo/screener/fundamentals 회귀 0); ruff clean; **단일 alembic head**(chains off ROB-441 #1146).

## Boundaries / 후속
- read-mostly. broker/order/watch mutation 0. fail-closed(미존재/미래/범위밖 제외). KR proximity 경로 불변. **operator: US valuation 재빌드**(fetch_52w_high_date의 추가 OHLC 호출 동반) 후 US undervalued_breakout가 신고가일 기준.
- 2099 등 XNYS 범위 밖 날짜는 fail-closed(테스트는 in-range 날짜 사용).

## Related
ROB-440(Phase 1) · #1141(Part 2 proximity) · ROB-432(KR date-recency) · session_calendar(XNYS/XKRX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 52-week high date tracking for US stocks, enabling date-based filtering within 20 trading days.
  * Updated ranking logic to include 52-week high recency alongside valuation metrics.

* **Chores**
  * Updated database schema to support new 52-week high date field.
  * Added comprehensive test coverage for new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->