### PR TITLE
feat(ROB-440): US valuation 백필 정상화 — common-stock 필터 + high_52w_date opt-in (PR A)

### DIFF
--- a/app/jobs/market_valuation_snapshots.py
+++ b/app/jobs/market_valuation_snapshots.py
@@ -37,6 +37,14 @@ class MarketValuationSnapshotBuildRequest:
     concurrency: int = 4
     commit: bool = False
     today: dt.date | None = None
+    # ROB-440 PR4: US screener wants common stocks only (is_common_stock) — the full
+    # active universe (~12k incl ETFs/warrants) over-loads yfinance (FD/401). KR has
+    # no is_common_stock column, so this is US-effective only.
+    common_stocks_only: bool = False
+    # ROB-440 PR4: the 52w-high DATE needs a heavy OHLC fetch (3rd yahoo call/symbol);
+    # opt-in so the bulk valuation backfill stays light. Only undervalued_breakout
+    # date-recency consumes it.
+    include_high_date: bool = False
 
 
 @dataclass(frozen=True)
@@ -77,7 +85,13 @@ def _normalize_symbol(symbol: str) -> str:
     return symbol.strip().upper()
 
 
-async def resolve_symbols(market: str, override: list[str], limit: int) -> list[str]:
+async def resolve_symbols(
+    market: str,
+    override: list[str],
+    limit: int,
+    *,
+    common_stocks_only: bool = False,
+) -> list[str]:
     market_norm = _validate_market(market)
     if override:
         return [_normalize_symbol(symbol) for symbol in override if symbol.strip()]
@@ -94,17 +108,19 @@ async def resolve_symbols(market: str, override: list[str], limit: int) -> list[
         else:
             from app.models.us_symbol_universe import USSymbolUniverse
 
-            stmt = (
-                sa.select(USSymbolUniverse.symbol)
-                .where(USSymbolUniverse.is_active.is_(True))
-                .order_by(USSymbolUniverse.symbol)
-                .limit(limit)
+            stmt = sa.select(USSymbolUniverse.symbol).where(
+                USSymbolUniverse.is_active.is_(True)
             )
+            if common_stocks_only:  # ROB-440 PR4: US common-stock filter
+                stmt = stmt.where(USSymbolUniverse.is_common_stock.is_(True))
+            stmt = stmt.order_by(USSymbolUniverse.symbol).limit(limit)
         result = await session.execute(stmt)
         return [r[0] for r in result.all()]
 
 
-async def resolve_active_universe(market: str) -> list[str]:
+async def resolve_active_universe(
+    market: str, *, common_stocks_only: bool = False
+) -> list[str]:
     market_norm = _validate_market(market)
     async with AsyncSessionLocal() as session:
         if market_norm == "kr":
@@ -118,11 +134,12 @@ async def resolve_active_universe(market: str) -> list[str]:
         else:
             from app.models.us_symbol_universe import USSymbolUniverse
 
-            stmt = (
-                sa.select(USSymbolUniverse.symbol)
-                .where(USSymbolUniverse.is_active.is_(True))
-                .order_by(USSymbolUniverse.symbol)
+            stmt = sa.select(USSymbolUniverse.symbol).where(
+                USSymbolUniverse.is_active.is_(True)
             )
+            if common_stocks_only:  # ROB-440 PR4: US common-stock filter
+                stmt = stmt.where(USSymbolUniverse.is_common_stock.is_(True))
+            stmt = stmt.order_by(USSymbolUniverse.symbol)
         result = await session.execute(stmt)
         return [r[0] for r in result.all()]
 
@@ -204,9 +221,14 @@ async def run_market_valuation_snapshot_build(
     started_at = dt.datetime.now(dt.UTC)
     today = request.today or started_at.date()
     symbols = await (
-        resolve_active_universe(market)
+        resolve_active_universe(market, common_stocks_only=request.common_stocks_only)
         if request.all_symbols
-        else resolve_symbols(market, list(request.symbols), request.limit or 20)
+        else resolve_symbols(
+            market,
+            list(request.symbols),
+            request.limit or 20,
+            common_stocks_only=request.common_stocks_only,
+        )
     )
     if not symbols:
         finished_at = dt.datetime.now(dt.UTC)
@@ -239,6 +261,7 @@ async def run_market_valuation_snapshot_build(
             symbols=symbols[start : start + effective_batch_size],
             snapshot_date=today,
             concurrency=request.concurrency,
+            include_high_date=request.include_high_date,
         )
         payloads = list(result.payloads)
         warnings.extend(f"batch {batches}: {warning}" for warning in result.warnings)

--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import functools
 import logging
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
@@ -43,7 +44,9 @@ def _to_date(value: Any) -> dt.date | None:
     return None
 
 
-async def default_valuation_fetcher(symbol: str, market: str) -> dict[str, Any]:
+async def default_valuation_fetcher(
+    symbol: str, market: str, *, include_high_date: bool = False
+) -> dict[str, Any]:
     if market == "kr":
         from app.services.naver_finance.valuation import fetch_valuation
 
@@ -54,6 +57,16 @@ async def default_valuation_fetcher(symbol: str, market: str) -> dict[str, Any]:
             fetch_fast_info,
             fetch_fundamental_info,
         )
+
+        # ROB-440 PR4: the 52w-high DATE needs a heavy OHLC fetch (1y daily) — a 3rd
+        # yahoo call/symbol that over-loads yfinance at universe scale (FD/401). Opt-in
+        # so the bulk valuation backfill is 2 calls/symbol; only undervalued_breakout
+        # date-recency needs it (targeted run with include_high_date=True).
+        if not include_high_date:
+            fast_info, fundamentals = await asyncio.gather(
+                fetch_fast_info(symbol), fetch_fundamental_info(symbol)
+            )
+            return {**fast_info, **fundamentals}
 
         fast_info, fundamentals, high_52w_date = await asyncio.gather(
             fetch_fast_info(symbol),
@@ -105,11 +118,16 @@ async def build_valuation_snapshots_for_market(
     snapshot_date: dt.date,
     concurrency: int = 4,
     fetcher: ValuationFetcher | None = None,
+    include_high_date: bool = False,
 ) -> MarketValuationBuildResult:
     market_norm = market.strip().lower()
     if market_norm not in {"kr", "us"}:
         raise ValueError(f"unsupported market: {market}")
-    fetch = fetcher or default_valuation_fetcher
+    # ROB-440 PR4: thread include_high_date into the default fetcher (opt-in heavy
+    # OHLC). Custom fetchers manage their own behavior.
+    fetch = fetcher or functools.partial(
+        default_valuation_fetcher, include_high_date=include_high_date
+    )
     sem = asyncio.Semaphore(max(1, concurrency))
     symbols_list = [symbol.strip().upper() for symbol in symbols if symbol.strip()]
     payloads: list[MarketValuationSnapshotUpsert | None] = [None] * len(symbols_list)

--- a/scripts/build_market_valuation_snapshots.py
+++ b/scripts/build_market_valuation_snapshots.py
@@ -43,6 +43,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--concurrency", type=int, default=4, help="Per-symbol fetch concurrency."
     )
     parser.add_argument(
+        "--common-stocks-only",
+        dest="common_stocks_only",
+        action="store_true",
+        help=(
+            "US: restrict to is_common_stock (excludes ETFs/preferreds/warrants). "
+            "Strongly recommended for --all (full US universe ~12k over-loads yfinance)."
+        ),
+    )
+    parser.add_argument(
+        "--with-high-52w-date",
+        dest="include_high_date",
+        action="store_true",
+        help=(
+            "US: also fetch the 52-week-high DATE (extra OHLC call/symbol) for "
+            "undervalued_breakout date-recency. Heavy — omit for the bulk backfill."
+        ),
+    )
+    parser.add_argument(
         "--commit",
         action="store_true",
         help="Actually write to the database. Default is --dry-run/no writes.",
@@ -109,6 +127,8 @@ async def run(args: argparse.Namespace) -> int:
         batch_size=args.batch_size,
         concurrency=args.concurrency,
         commit=args.commit,
+        common_stocks_only=args.common_stocks_only,
+        include_high_date=args.include_high_date,
     )
     use_guarded = args.commit and not args.allow_partial
     try:

--- a/tests/test_invest_coverage_valuation.py
+++ b/tests/test_invest_coverage_valuation.py
@@ -293,3 +293,97 @@ async def test_valuation_builder_threads_high_52w_date_us(db_session):
         sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
     )
     await db_session.commit()
+
+
+# --- ROB-440 PR4: US valuation scale (common-stock filter + high_52w_date opt-in) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_valuation_fetcher_high_date_opt_in(monkeypatch):
+    from app.services.market_valuation_snapshots import builder
+
+    calls = {"high": 0}
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _fund(sym):  # noqa: ANN001
+        return {"PER": 8.0}
+
+    async def _high(sym):  # noqa: ANN001
+        calls["high"] += 1
+        return dt.date(2026, 5, 20)
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.fetch_fundamental_info", _fund
+    )
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_52w_high_date", _high)
+
+    # opt-out (default): no OHLC call, no high_52w_date → light bulk backfill
+    raw = await builder.default_valuation_fetcher("AAPL", "us")
+    assert calls["high"] == 0
+    assert "high_52w_date" not in raw
+
+    # opt-in: OHLC fetched, high_52w_date as JSON-safe iso string
+    raw2 = await builder.default_valuation_fetcher("AAPL", "us", include_high_date=True)
+    assert calls["high"] == 1
+    assert raw2["high_52w_date"] == "2026-05-20"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_resolve_us_common_stocks_only(db_session):
+    from app.jobs.market_valuation_snapshots import resolve_active_universe
+    from app.models.us_symbol_universe import USSymbolUniverse
+
+    syms = ["ZZCOM1", "ZZETF1", "ZZINA1"]
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol.in_(syms))
+    )
+    db_session.add_all(
+        [
+            USSymbolUniverse(
+                symbol="ZZCOM1", exchange="NASDAQ", is_active=True, is_common_stock=True
+            ),
+            USSymbolUniverse(
+                symbol="ZZETF1", exchange="NYSE", is_active=True, is_common_stock=False
+            ),
+            USSymbolUniverse(
+                symbol="ZZINA1",
+                exchange="NASDAQ",
+                is_active=False,
+                is_common_stock=True,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    common = set(await resolve_active_universe("us", common_stocks_only=True))
+    assert "ZZCOM1" in common  # common + active
+    assert "ZZETF1" not in common  # is_common_stock=False excluded
+    assert "ZZINA1" not in common  # inactive excluded
+
+    unfiltered = set(await resolve_active_universe("us"))
+    assert {"ZZCOM1", "ZZETF1"} <= unfiltered  # active non-common included w/o filter
+
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol.in_(syms))
+    )
+    await db_session.commit()
+
+
+@pytest.mark.unit
+def test_build_market_valuation_cli_flags():
+    from scripts.build_market_valuation_snapshots import parse_args
+
+    base = parse_args(["--market", "us", "--symbol", "AAPL"])
+    assert base.common_stocks_only is False
+    assert base.include_high_date is False
+
+    opted = parse_args(
+        ["--market", "us", "--all", "--common-stocks-only", "--with-high-52w-date"]
+    )
+    assert opted.common_stocks_only is True
+    assert opted.include_high_date is True


### PR DESCRIPTION
## What & why
operator US valuation 백필이 **FD 고갈 + yfinance 401/crumb**로 실패한 근본원인 수정.
- valuation 빌더는 **full active universe(US ~12,387, ETF/우선주/워런트 포함)**를 돌림 → 과부하.
- fundamentals 빌더는 `is_common_stock` 필터로 **5,118**만 처리 → 정상(에러 0). ← 동일 스케일로 맞춤.
- 추가로 my `high_52w_date` OHLC 호출이 symbol당 3번째(무거운) yahoo 호출로 부담 가중 → opt-in 분리.

## Changes
- **job**: `MarketValuationSnapshotBuildRequest`에 `common_stocks_only`(US `is_common_stock` 필터, KR 무효) + `include_high_date`(52w-high date opt-in). `resolve_symbols`/`resolve_active_universe`에 `common_stocks_only` kwarg.
- **builder**: `default_valuation_fetcher(*, include_high_date=False)` — opt-out 시 OHLC 미호출(**2 calls/symbol** 경량), opt-in 시에만 `fetch_52w_high_date`. `build_valuation_snapshots_for_market`가 `functools.partial`로 전파(커스텀 fetcher 무영향).
- **CLI**: `--common-stocks-only` + `--with-high-52w-date`.

## Verification
- 신규: fetcher opt-in 토글(OHLC 호출 0↔1, high_52w_date 부재↔iso) + resolve US common-stock 필터(common+active만; ETF/inactive 제외; 무필터 시 ETF 포함) + CLI 플래그.
- **10 + 94 green**(market_valuation/invest_coverage/valuation sweep 회귀 0); ruff clean; **migration 0**(high_52w_date 컬럼은 #1147 기존).

## Boundaries / operator
- read-mostly. broker/order/watch mutation 0. KR 경로 무변경(common_stocks_only는 US-effective).
- **operator**: `build_market_valuation_snapshots --market us --all --common-stocks-only` (12,387→5,118, fundamentals와 동일 스케일) → dry-run → `--commit`. undervalued_breakout date-recency는 별도 `--with-high-52w-date` 타겟 run.

## Related
ROB-440 PR3(#1147 high_52w_date) · ROB-441(resolve_us_symbols common-stock 패턴) · operator US valuation 실패 로그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to filter market data to common stocks only for US markets.
  * Added option to include 52-week high date data in valuation snapshots.
  * Added CLI flags `--common-stocks-only` and `--with-high-52w-date` to control filtering and data retrieval options.

* **Tests**
  * Added comprehensive test coverage for new filtering and data-fetch capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->