### PR TITLE
feat(ROB-441): KR DART budget-split — --skip-existing (PR B)

### DIFF
--- a/app/jobs/financial_fundamentals_snapshots.py
+++ b/app/jobs/financial_fundamentals_snapshots.py
@@ -35,6 +35,11 @@ class FinancialFundamentalsSnapshotBuildRequest:
     collected_at: dt.datetime | None = None
     estimate_only: bool = False
     allow_partial: bool = False
+    # ROB-441: DART budget-split. Skip symbols that already have a snapshot so daily
+    # re-runs advance through uncollected symbols (the full KR universe ~3,910 × 11 req
+    # exceeds the 18k daily budget → must be split across days). With --limit N this
+    # selects the NEXT N uncollected symbols (resolve full → drop collected → slice).
+    skip_existing: bool = False
 
 
 @dataclass(frozen=True)
@@ -99,6 +104,18 @@ async def resolve_active_universe(market: str) -> list[str]:
         )
         result = await session.execute(stmt)
         return [r[0] for r in result.all()]
+
+
+async def _already_collected_symbols(market: str) -> set[str]:
+    """Symbols with ≥1 existing financial_fundamentals snapshot (ROB-441 budget-split:
+    --skip-existing drops these so daily re-runs advance through uncollected symbols)."""
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            sa.select(FinancialFundamentalsSnapshot.symbol)
+            .where(FinancialFundamentalsSnapshot.market == market)
+            .distinct()
+        )
+        return {r[0] for r in result.all()}
 
 
 def _payload_key(p: FinancialFundamentalsUpsert) -> tuple[str, str, str, str]:
@@ -182,11 +199,28 @@ async def run_financial_fundamentals_snapshot_build(
     started_at = dt.datetime.now(dt.UTC)
     collected_at = request.collected_at or started_at
     use_fetcher = fetcher or default_dart_fetcher
-    symbols = await (
-        resolve_active_universe(market)
-        if request.all_symbols
-        else resolve_symbols(market, list(request.symbols), request.limit or 20)
-    )
+    skipped_existing = 0
+    if request.skip_existing:
+        # Budget-split: resolve the candidate pool, drop already-collected, then (for
+        # --limit) slice the NEXT N uncollected so each daily run stays under budget.
+        if request.symbols:
+            pool = [s.strip().upper() for s in request.symbols if s.strip()]
+        else:
+            pool = await resolve_active_universe(market)
+        done = await _already_collected_symbols(market)
+        remaining = [s for s in pool if s not in done]
+        skipped_existing = len(pool) - len(remaining)
+        symbols = (
+            remaining
+            if (request.all_symbols or request.symbols)
+            else remaining[: (request.limit or 20)]
+        )
+    else:
+        symbols = await (
+            resolve_active_universe(market)
+            if request.all_symbols
+            else resolve_symbols(market, list(request.symbols), request.limit or 20)
+        )
     if not symbols:
         finished_at = dt.datetime.now(dt.UTC)
         return FinancialFundamentalsSnapshotBuildResult(
@@ -220,6 +254,14 @@ async def run_financial_fundamentals_snapshot_build(
             finished_at=finished_at,
             idempotency={"wouldInsert": 0, "wouldUpdate": 0, "duplicatePayloadKeys": 0},
             warnings=(
+                (
+                    f"skip_existing: {skipped_existing} already-collected skipped; "
+                    f"{len(symbols)} uncollected remain",
+                )
+                if skipped_existing
+                else ()
+            )
+            + (
                 f"estimate-only: projected {projected} DART requests; "
                 "no fetch performed",
             ),
@@ -263,6 +305,13 @@ async def run_financial_fundamentals_snapshot_build(
     if should_commit and payloads:
         await _commit_payloads(payloads)
     finished_at = dt.datetime.now(dt.UTC)
+    final_warnings = list(warnings)
+    if skipped_existing:
+        final_warnings.insert(
+            0,
+            f"skip_existing: {skipped_existing} already-collected symbols skipped; "
+            f"{len(symbols)} uncollected processed (budget-split)",
+        )
     return FinancialFundamentalsSnapshotBuildResult(
         market=market,
         symbols_resolved=len(symbols),
@@ -272,5 +321,5 @@ async def run_financial_fundamentals_snapshot_build(
         finished_at=finished_at,
         idempotency=idempotency,
         samples=tuple(_sample(p) for p in payloads[:10]),
-        warnings=warnings,
+        warnings=tuple(final_warnings),
     )

--- a/scripts/build_financial_fundamentals_snapshots.py
+++ b/scripts/build_financial_fundamentals_snapshots.py
@@ -69,6 +69,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "for any --commit, since fundamentals is incremental by DART budget)."
         ),
     )
+    parser.add_argument(
+        "--skip-existing",
+        dest="skip_existing",
+        action="store_true",
+        help=(
+            "DART budget-split: skip symbols that already have a snapshot so daily "
+            "re-runs advance through uncollected symbols. With --limit N selects the "
+            "NEXT N uncollected (keep N*11 under the daily budget, e.g. --limit 1500)."
+        ),
+    )
     args = parser.parse_args(argv)
     if args.all and (args.symbol or args.limit is not None):
         parser.error("--all is mutually exclusive with --symbol and --limit")
@@ -153,6 +163,7 @@ async def run(args: argparse.Namespace) -> int:
                 commit=args.commit,
                 estimate_only=args.estimate_only,
                 allow_partial=args.allow_partial,
+                skip_existing=args.skip_existing,
             )
         )
     except PartialCommitBlocked as exc:

--- a/tests/test_build_financial_fundamentals_cli.py
+++ b/tests/test_build_financial_fundamentals_cli.py
@@ -38,3 +38,12 @@ def test_estimate_only_mutually_exclusive_with_commit():
 def test_estimate_only_defaults_false():
     args = parse_args(["--symbol", "005930"])
     assert args.estimate_only is False
+
+
+@pytest.mark.unit
+def test_skip_existing_flag() -> None:
+    # ROB-441 budget-split: --skip-existing (off by default).
+    assert parse_args(["--symbol", "005930"]).skip_existing is False
+    args = parse_args(["--limit", "1500", "--skip-existing"])
+    assert args.skip_existing is True
+    assert args.limit == 1500

--- a/tests/test_financial_fundamentals_job.py
+++ b/tests/test_financial_fundamentals_job.py
@@ -186,3 +186,59 @@ async def test_estimate_only_does_not_fetch_or_commit():
     assert result.committed is False
     assert result.snapshots_built == 0
     assert any("estimate-only" in w for w in result.warnings)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_skip_existing_budget_split(bind_job_session, db_session, monkeypatch):
+    # ROB-441 budget-split: --skip-existing drops already-collected symbols so daily
+    # re-runs advance through the uncollected universe within the DART daily budget.
+    import sqlalchemy as sa
+
+    from app.models.financial_fundamentals_snapshot import (
+        FinancialFundamentalsSnapshot,
+    )
+
+    syms = ["900001", "900002", "900003"]
+    await db_session.execute(
+        sa.delete(FinancialFundamentalsSnapshot).where(
+            FinancialFundamentalsSnapshot.symbol.in_(syms)
+        )
+    )
+    # 900001 already collected → must be skipped.
+    db_session.add(
+        FinancialFundamentalsSnapshot(
+            market="kr",
+            symbol="900001",
+            fiscal_period="2024A",
+            period_type="annual",
+            period_end_date=dt.date(2024, 12, 31),
+            source="dart",
+            source_collected_at=dt.datetime(2026, 1, 1, tzinfo=dt.UTC),
+            data_state="fresh",
+        )
+    )
+    await db_session.commit()
+
+    async def _fake_universe(market):  # noqa: ANN001
+        return list(syms)
+
+    monkeypatch.setattr(job, "resolve_active_universe", _fake_universe)
+
+    result = await job.run_financial_fundamentals_snapshot_build(
+        job.FinancialFundamentalsSnapshotBuildRequest(
+            market="kr", all_symbols=True, estimate_only=True, skip_existing=True
+        )
+    )
+    assert result.symbols_resolved == 2  # 900001 skipped (already collected)
+    assert result.projected_requests == 2 * 11  # only uncollected projected
+    assert any(
+        "skip_existing" in w and "1 already-collected" in w for w in result.warnings
+    )
+
+    await db_session.execute(
+        sa.delete(FinancialFundamentalsSnapshot).where(
+            FinancialFundamentalsSnapshot.symbol.in_(syms)
+        )
+    )
+    await db_session.commit()


### PR DESCRIPTION
## What & why
operator estimate 확인: **KR 3,910종목 × 11 = 43,010 DART req > 18,000/day** → 단일 `--all --commit` 불가, 일 ≤1,600 분할 필요. 그런데 빌드가 already-collected를 skip하지 않아 단순 재실행은 매번 같은 앞쪽 심볼만 처리 → day-2 진척 없음. `--skip-existing`으로 자연 진척 가능.

## Changes
- **`FinancialFundamentalsSnapshotBuildRequest.skip_existing`**: 이미 스냅샷 있는 심볼 제외. `run`에서 skip_existing이면 전체 유니버스 resolve → already-collected 차감 → (`--limit N`이면) **NEXT N uncollected** 슬라이스. 따라서 `--limit 1500 --skip-existing` = "다음 1,500 미수집"(1500×11=16,500 < 18,000 → budget 안전, 단일 run clean commit). 일 단위 재실행이 자연 진척.
- **`_already_collected_symbols(market)`**: financial_fundamentals_snapshots distinct symbol.
- 결과/estimate-only warnings에 skip 건수 표면화. CLI **`--skip-existing`**.

## Verification
- 신규: skip_existing budget-split(900001 수집됨→제외, 2종목만 projected 22, skip 경고) + CLI 플래그.
- **12 + 45 green**(financial_fundamentals sweep 회귀 0); ruff clean; **migration 0**.

## Boundaries / operator
- read-mostly(estimate/dry-run default). DART commit은 기존대로 `--allow-partial` 필요. budget-exceeded 경로 무변경(--limit로 budget 안전 유지하는 설계).
- **operator budget-split 레시피**: `build_financial_fundamentals_snapshots --limit 1500 --skip-existing --commit --allow-partial` 매일 → 미수집 1,500씩 ~3일에 3,910 완주(일 예산 내). `--estimate-only --skip-existing`로 잔여 미수집 확인 가능.

## Related
ROB-441(KR DART parity) · ROB-429(DART coverage) · operator estimate(43,010 req / 18k budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)