### PR TITLE
fix(ROB-440): US 커버리지 분모를 common-stock로 — 정상 데이터의 '준비중' 경고 제거 (#3)

### DIFF
--- a/app/services/invest_screener_snapshots/partition_health.py
+++ b/app/services/invest_screener_snapshots/partition_health.py
@@ -71,10 +71,19 @@ async def active_universe_count(session: AsyncSession, *, market: str) -> int:
         else:
             from app.models.us_symbol_universe import USSymbolUniverse
 
+            # ROB-440: US screener snapshots (valuation/fundamentals/OHLCV) are built
+            # over the COMMON-STOCK universe (is_common_stock), not the full active set
+            # (~12.4k incl ETFs/preferreds/warrants we intentionally skip). Use the
+            # common-stock count as the coverage denominator so a complete common-stock
+            # build (~5.1k) isn't mislabeled "below floor" (~41% of the full universe →
+            # partition flagged degraded → cap_degraded → spurious stale/"준비중").
             stmt = (
                 sa.select(sa.func.count())
                 .select_from(USSymbolUniverse)
-                .where(USSymbolUniverse.is_active.is_(True))
+                .where(
+                    USSymbolUniverse.is_active.is_(True),
+                    USSymbolUniverse.is_common_stock.is_(True),
+                )
             )
         return int((await session.execute(stmt)).scalar() or 0)
     except Exception as exc:  # noqa: BLE001

--- a/tests/test_partition_health.py
+++ b/tests/test_partition_health.py
@@ -170,3 +170,46 @@ async def test_active_universe_count_counts_active_kr(db_session):
         )
     )
     await db_session.flush()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_active_universe_count_us_counts_common_stock_only(db_session):
+    # ROB-440: US coverage denominator must count common stocks (the build scope),
+    # not the full active universe (incl ETFs). Otherwise a complete common-stock
+    # build is mislabeled below-floor → partition degraded → spurious stale/"준비중".
+    from app.models.us_symbol_universe import USSymbolUniverse
+
+    syms = ["ZZC1", "ZZC2", "ZZETF", "ZZINA"]
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol.in_(syms))
+    )
+    await db_session.commit()
+
+    before = await active_universe_count(db_session, market="us")
+    db_session.add_all(
+        [
+            USSymbolUniverse(
+                symbol="ZZC1", exchange="NASDAQ", is_active=True, is_common_stock=True
+            ),
+            USSymbolUniverse(
+                symbol="ZZC2", exchange="NYSE", is_active=True, is_common_stock=True
+            ),
+            USSymbolUniverse(
+                symbol="ZZETF", exchange="NYSE", is_active=True, is_common_stock=False
+            ),
+            USSymbolUniverse(
+                symbol="ZZINA", exchange="NASDAQ", is_active=False, is_common_stock=True
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    after = await active_universe_count(db_session, market="us")
+    # only the 2 active common stocks add to the count (ETF + inactive excluded)
+    assert after == before + 2
+
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol.in_(syms))
+    )
+    await db_session.commit()


### PR DESCRIPTION
## What & why
라이브 확인 결과: operator US 백필 후 **9/11 프리셋이 결과(20~80개)를 보여주는데도** 전부 `미국 스크리너 데이터 준비중 — 일부 결과만 표시됩니다` 경고가 붙음.

**근본원인**: `partition_health.active_universe_count("us")`가 **full active universe(~12,387, ETF/우선주/워런트 포함)**를 coverage 분모로 사용. 하지만 US 스냅샷은 **common-stock(~5,118)**만 빌드 → 5,118/12,387 = **41.3% < 0.50** health floor → 파티션이 degraded로 분류 → `cap_degraded` → `val_state` stale → 경고. (날짜는 06-05 == baseline로 일치; `cap_degraded`가 유일 원인.)

라이브 증거: high_yield_value US `snapshotDate:2026-06-05`(=baseline)인데 `dataState:stale`. consecutive_gainers US도 `coverage_below_floor 5,118/12,387 (41.3%)` false 라벨.

## Changes
- `active_universe_count(market="us")`에 **`is_common_stock` 필터** 추가 → 분모 = common-stock(~5,118), US 빌드 스코프와 일치. 완전한 common-stock 빌드는 ~100% → healthy → fresh → **경고 제거** + consecutive_gainers의 false coverage_below_floor 해소. KR 무변경.

## Verification
- 신규: `active_universe_count` US가 active common-stock만 카운트(ETF/inactive 제외, delta 검증).
- **9 + 1482 sweep green**(partition_health/coverage/screener/invest_coverage/snapshot 회귀 0); ruff clean; **migration 0**.

## Boundaries / 후속
- read-only 메타 계산. broker/order/watch mutation 0. **operator 데이터 재빌드 불요** — 기존 5,118 파티션이 분모 변경만으로 healthy.
- 후속(별도, 비차단): US freshness **chip**의 `computedAt:null` + source 라벨 `invest_kr_fundamentals_snapshots`(US 오라벨, FUNDAMENTALS_PRESET_SPECS 공용 분기) = 칩 cosmetic. 경고와 무관.

## Related
ROB-440(US valuation) · ROB-426(partition_health resolve/cap_degraded) · PR A(#1148, common-stock build) — 본 PR은 그 health 분모 짝.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected US screener partition coverage calculation to count only common stocks, preventing partitions from being incorrectly marked as degraded or stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->