### PR TITLE
feat(ROB-440): US market_cap 보강 (yahoo marketCap → cand_cap 정렬)

### DIFF
--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -355,6 +355,10 @@ async def fetch_fundamental_info(ticker: str) -> dict:
                     # undervalued_breakout (proximity: close >= high_52w * 0.95).
                     "yearHigh": info.get("fiftyTwoWeekHigh"),
                     "yearLow": info.get("fiftyTwoWeekLow"),
+                    # ROB-440: marketCap from the same .info call (no extra request)
+                    # → market_valuation.market_cap populated so the screener cand_cap
+                    # ordering prefers liquid US names (was symbol-order with null cap).
+                    "marketCap": info.get("marketCap"),
                 }
             except Exception as exc:
                 last_exc = exc

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -225,5 +225,7 @@ class TestYahooService:
             # ROB-440 Part 2: 52w high/low (price); None here (mock omits them).
             "yearHigh": None,
             "yearLow": None,
+            # ROB-440: marketCap; None here (mock omits it).
+            "marketCap": None,
         }
         assert mock_ticker_class.call_args.kwargs["session"] is tracing_session

--- a/tests/test_yahoo_roe_rob440.py
+++ b/tests/test_yahoo_roe_rob440.py
@@ -7,6 +7,8 @@ ROE are percent. Convert ×100; null stays fail-closed.
 
 from __future__ import annotations
 
+import datetime as dt
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -125,3 +127,34 @@ async def test_fetch_52w_high_date_fail_closed() -> None:
         assert await yclient.fetch_52w_high_date("AAPL") is None
     with patch.object(yclient, "fetch_ohlcv", _boom):
         assert await yclient.fetch_52w_high_date("AAPL") is None
+
+
+# --- ROB-440: marketCap (US screener cand_cap ordering) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("app.services.brokers.yahoo.client.yf.Ticker")
+async def test_fetch_fundamental_info_includes_market_cap(
+    mock_ticker_class, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+        lambda: object(),
+    )
+    mock_ticker = MagicMock()
+    mock_ticker.info = {"trailingPE": 8.0, "marketCap": 1234567890}
+    mock_ticker_class.return_value = mock_ticker
+
+    from app.services.brokers.yahoo.client import fetch_fundamental_info
+
+    result = await fetch_fundamental_info("AAPL")
+    assert result["marketCap"] == 1234567890
+
+    # _payload_from_raw maps marketCap → market_cap
+    from app.services.market_valuation_snapshots.builder import _payload_from_raw
+
+    payload = _payload_from_raw(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 6, 6), raw=result
+    )
+    assert payload.market_cap == Decimal("1234567890")


### PR DESCRIPTION
## What & why
US `market_valuation.market_cap`이 null이라 스크리너 cand_cap 정렬(`market_cap desc nullslast`)이 symbol 순으로 떨어져 **유동성 우선순위가 없었음**(+표시 "-"). `_payload_from_raw`는 이미 `raw.get("marketCap")`를 읽어 `market_cap`에 매핑하므로, yahoo가 marketCap만 제공하면 됨.

## Changes
- `fetch_fundamental_info`: 같은 `.info` 호출에서 **`marketCap` 추가**(추가 API 0; ROE/yearHigh와 동일 패턴) → `_payload_from_raw`가 `market_cap`에 매핑 → US 후보를 시총 큰 순(유동성)으로 정렬.

## Verification
- 신규: marketCap 추출 + `_payload_from_raw` market_cap 매핑(1234567890→Decimal) + exact-shape에 `marketCap:None` 추가.
- **19 + 152 green**(yahoo/valuation/market_valuation sweep 회귀 0); ruff clean; **migration 0**.

## Boundaries / operator
- read-only. broker/order/watch mutation 0. **다음 US valuation 재빌드부터 market_cap 적재**(재빌드 전엔 기존 null 유지). 동작/표시 무해(null이면 기존대로).

## Related
ROB-440(US valuation) · PR A(#1148 common-stock build) — operator가 `--with-high-52w-date` 재빌드 시 marketCap도 함께 채워짐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)