### PR TITLE
fix(ROB-440): US freshness chip 정합 — source 라벨 + computed_at 백필

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1659,6 +1659,29 @@ def _build_freshness(
     )
 
 
+async def _us_valuation_partition_computed_at(
+    session: AsyncSession, *, snapshot_date: dt.date
+) -> datetime | None:
+    """Max computed_at of the US market_valuation partition (ROB-440). The US
+    fundamentals/valuation dispatch branches don't propagate the partition's
+    computed_at, so the freshness chip can't classify it; backfill it here.
+    Fail-open: any error returns None (chip unchanged)."""
+    import sqlalchemy as sa
+
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+
+    try:
+        result = await session.execute(
+            sa.select(sa.func.max(MarketValuationSnapshot.computed_at)).where(
+                MarketValuationSnapshot.market == "us",
+                MarketValuationSnapshot.snapshot_date == snapshot_date,
+            )
+        )
+        return result.scalar_one_or_none()
+    except Exception:  # noqa: BLE001 — fail-open
+        return None
+
+
 async def build_screener_results(
     preset_id: str,
     screening_service: _ScreeningServiceProto,
@@ -2046,11 +2069,15 @@ async def build_screener_results(
         if preset_id == "investor_flow_momentum":
             primary_source = "investor_flow_snapshots"
         elif preset_id in FUNDAMENTALS_PRESET_SPECS:
-            # ROB-428 PR-B: KR display now reads the tvscreener KR snapshot.
-            # ROB-428 PR-C: high_yield_value + undervalued_breakout joined this
-            # branch (dropped their market_valuation_snapshots primary_source) so
-            # all KR Toss fundamentals/valuation presets report the same source.
-            primary_source = "invest_kr_fundamentals_snapshots"
+            # ROB-428 PR-B/C: KR display reads the tvscreener KR snapshot, so all KR
+            # Toss fundamentals/valuation presets report invest_kr_fundamentals_snapshots.
+            # ROB-440: US reads the market-parameterized valuation/derive path, so its
+            # primary source is market_valuation_snapshots (not the KR-only table).
+            primary_source = (
+                "market_valuation_snapshots"
+                if requested_market == "us"
+                else "invest_kr_fundamentals_snapshots"
+            )
         elif requested_market == "crypto":
             primary_source = "invest_crypto_screener_snapshots"
         else:
@@ -2064,6 +2091,20 @@ async def build_screener_results(
             # Fallback for double_buy / crypto paths that don't use _SnapshotLoadResult
             primary_snapshot_date = rows[0].get("snapshot_date")
             primary_computed_at = rows[0].get("computed_at")
+        # ROB-440: the US fundamentals/valuation dispatch branches don't carry the
+        # market_valuation partition's computed_at (set None) → classify_state can't
+        # run → freshness chip falls to stale even when the partition is current.
+        # Backfill computed_at from market_valuation_snapshots so the chip matches.
+        if (
+            requested_market == "us"
+            and preset_id in FUNDAMENTALS_PRESET_SPECS
+            and primary_computed_at is None
+            and primary_snapshot_date is not None
+            and session is not None
+        ):
+            primary_computed_at = await _us_valuation_partition_computed_at(
+                session, snapshot_date=primary_snapshot_date
+            )
     else:
         primary_kind = "live"
         primary_source = "screening_service"

--- a/tests/test_invest_coverage_valuation.py
+++ b/tests/test_invest_coverage_valuation.py
@@ -387,3 +387,47 @@ def test_build_market_valuation_cli_flags():
     )
     assert opted.common_stocks_only is True
     assert opted.include_high_date is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_us_valuation_partition_computed_at_helper(db_session):
+    # ROB-440 freshness chip: backfill the US market_valuation partition computed_at
+    # (the US fundamentals/valuation dispatch branches don't propagate it).
+    from app.services.invest_view_model.screener_service import (
+        _us_valuation_partition_computed_at,
+    )
+
+    vd = dt.date(2099, 12, 31)
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    db_session.add(
+        MarketValuationSnapshot(
+            market="us",
+            symbol="ZZ9100",
+            snapshot_date=vd,
+            source="yahoo",
+            per=Decimal("8"),
+            computed_at=dt.datetime(2099, 12, 31, 21, 22, tzinfo=dt.UTC),
+        )
+    )
+    await db_session.commit()
+
+    got = await _us_valuation_partition_computed_at(db_session, snapshot_date=vd)
+    assert got is not None  # partition exists → computed_at surfaced
+    # no US partition on this date → None (fail-open)
+    assert (
+        await _us_valuation_partition_computed_at(
+            db_session, snapshot_date=dt.date(2098, 1, 1)
+        )
+        is None
+    )
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.commit()


### PR DESCRIPTION
## What & why
#1150은 **경고**(_aggregated_data_state)만 고쳤고, freshness **CHIP**은 별도 경로(`_build_freshness`→`classify_state`). US 펀더멘털/밸류에이션 chip이 여전히:
- (1) `source`를 `invest_kr_fundamentals_snapshots`(KR 전용 테이블)로 **오라벨**,
- (2) `computed_at=null`(US dispatch 분기가 `partition_computed_at=None`) → `classify_state`(non-null computed_at 요구) 불가 → **stale**로 떨어짐.

라이브 증거: high_yield_value US `snapshotDate=2026-06-05`(=baseline)인데 `computedAt:null` → chip stale, consecutive_gainers(computedAt 있음)는 fresh.

## Changes
- 프리셋 freshness `primary_source`: **US** fundamentals/valuation → `market_valuation_snapshots`(US 실 소스); KR은 기존 `invest_kr_fundamentals_snapshots` 유지.
- US fundamentals/valuation에서 `primary_computed_at`이 None이면 신규 `_us_valuation_partition_computed_at`(market_valuation_snapshots `max(computed_at)`, **fail-open**)로 백필 → `classify_state`가 snapshot_date==baseline + age로 정상 **fresh** 판정.

## Verification
- 신규: 헬퍼(파티션 존재→computed_at, 없으면 None).
- **11 + 1527 broad sweep green**(partition_health/coverage/screener/freshness 회귀 0); ruff clean; **migration 0**.
- ⚠️double_buy 3건은 **pre-existing** file-level isolation 실패(clean main에서도 stash로 동일 확인; broad/CI 컨텍스트에선 pass — #1150 1482 + 본 PR 1527에 포함).

## Boundaries / operator
- read-only 메타. broker/order/watch mutation 0. KR/crypto 무변경. **operator main 배포 후** US chip이 경고와 일관되게 fresh + source=market_valuation 표시.

## Related
ROB-440 · #1150(경고 fix, 본 PR은 그 chip 짝) · freshness `classify_state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of data freshness indicators for US fundamentals and valuation data to prevent false staleness detection.

* **Tests**
  * Added integration test to validate freshness timestamp handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->