### PR TITLE
fix(ROB-440): healthy fallback partition을 fresh로 — thin raw-latest의 '준비중' 제거

### DIFF
--- a/app/services/invest_screener_snapshots/partition_health.py
+++ b/app/services/invest_screener_snapshots/partition_health.py
@@ -49,6 +49,21 @@ class HealthyPartition:
     healthy: bool  # row_count met the coverage floor
 
 
+def served_partition_degraded(hp: HealthyPartition | None) -> bool:
+    """Whether a resolved partition should be treated as degraded for freshness.
+
+    ROB-440: a HEALTHY fallback (``is_fallback=True`` but ``healthy=True``) is NOT
+    degraded — resolve_healthy_partition correctly served the latest *healthy*
+    partition because a thinner raw-latest partition (e.g. a partial weekend build:
+    a 388-row 2026-06-06 partition shadowing the healthy 4,926-row 2026-06-05) was
+    skipped. Whether the served partition is stale vs the expected baseline is a
+    separate date check in the caller (``val_date == today_market_date``). Only a
+    served partition that failed the coverage floor (``healthy=False`` — no healthy
+    partition existed, thinnest served as last resort) is genuinely degraded.
+    """
+    return bool(hp is not None and not hp.healthy)
+
+
 def cap_degraded(state: DataState) -> DataState:
     """Never claim better than ``stale`` for a degraded partition.
 

--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -410,9 +410,14 @@ async def load_fundamentals_preset_from_snapshots(
         )
 
     val_state = "fresh" if val_date == today_market_date else "stale"
-    # ROB-426 PR2a: a thin/fallback valuation partition must not be labeled fresh
-    # even when its date matches today (consistency with the other screener loaders).
-    if val_hp and (val_hp.is_fallback or not val_hp.healthy):
+    # ROB-440: only an UNHEALTHY served partition degrades freshness. A healthy
+    # fallback (older than a thin raw-latest, e.g. a partial weekend build) is not
+    # degraded — its staleness vs the baseline is already the val_date date check.
+    from app.services.invest_screener_snapshots.partition_health import (
+        served_partition_degraded,
+    )
+
+    if served_partition_degraded(val_hp):
         from app.services.invest_screener_snapshots.partition_health import (
             cap_degraded,
         )

--- a/app/services/invest_view_model/high_yield_value_screener.py
+++ b/app/services/invest_view_model/high_yield_value_screener.py
@@ -54,6 +54,7 @@ async def load_high_yield_value_from_snapshots(
 
     from app.services.invest_screener_snapshots.partition_health import (
         resolve_healthy_partition,
+        served_partition_degraded,
     )
 
     val_hp = await resolve_healthy_partition(
@@ -66,7 +67,9 @@ async def load_high_yield_value_from_snapshots(
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:
         return None
-    partition_degraded = bool(val_hp and (val_hp.is_fallback or not val_hp.healthy))
+    # ROB-440: a healthy fallback partition is NOT degraded (date check handles
+    # staleness); only an unhealthy served partition is.
+    partition_degraded = served_partition_degraded(val_hp)
 
     latest_price_stmt = sa.select(
         sa.func.max(InvestScreenerSnapshot.snapshot_date)

--- a/app/services/invest_view_model/undervalued_breakout_screener.py
+++ b/app/services/invest_view_model/undervalued_breakout_screener.py
@@ -84,6 +84,7 @@ async def load_undervalued_breakout_from_snapshots(
 
     from app.services.invest_screener_snapshots.partition_health import (
         resolve_healthy_partition,
+        served_partition_degraded,
     )
 
     val_hp = await resolve_healthy_partition(
@@ -96,7 +97,9 @@ async def load_undervalued_breakout_from_snapshots(
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:
         return None
-    partition_degraded = bool(val_hp and (val_hp.is_fallback or not val_hp.healthy))
+    # ROB-440: a healthy fallback partition is NOT degraded (date check handles
+    # staleness); only an unhealthy served partition is.
+    partition_degraded = served_partition_degraded(val_hp)
 
     latest_price_stmt = sa.select(
         sa.func.max(InvestScreenerSnapshot.snapshot_date)

--- a/tests/test_partition_health.py
+++ b/tests/test_partition_health.py
@@ -213,3 +213,31 @@ async def test_active_universe_count_us_counts_common_stock_only(db_session):
         sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol.in_(syms))
     )
     await db_session.commit()
+
+
+def test_served_partition_degraded_healthy_fallback_not_degraded():
+    # ROB-440: a HEALTHY fallback (is_fallback=True, healthy=True) is NOT degraded —
+    # resolver correctly served the latest healthy partition over a thin raw-latest.
+    from app.services.invest_screener_snapshots.partition_health import (
+        HealthyPartition,
+        served_partition_degraded,
+    )
+
+    healthy_fallback = HealthyPartition(
+        partition_date=dt.date(2026, 6, 5),
+        row_count=4926,
+        coverage_ratio=0.96,
+        is_fallback=True,
+        healthy=True,
+    )
+    assert served_partition_degraded(healthy_fallback) is False
+
+    unhealthy = HealthyPartition(
+        partition_date=dt.date(2026, 6, 6),
+        row_count=388,
+        coverage_ratio=0.0758,
+        is_fallback=False,
+        healthy=False,
+    )
+    assert served_partition_degraded(unhealthy) is True
+    assert served_partition_degraded(None) is False


### PR DESCRIPTION
## What & why
operator 진단(prod read-only)으로 원인 확정:
- US common-stock universe = **5,118**.
- 최신 raw partition **2026-06-06 = 388 rows (7.58%)** — thin 부분빌드(주말).
- 직전 **2026-06-05 = 4,926 rows (96%)** — healthy. **데이터는 준비됨.**

`resolve_healthy_partition`은 이미 06-05(healthy)로 **fallback**함(freshness snapshotDate=06-05 확인). 그런데 로더가 `partition_degraded = is_fallback or not healthy` → **healthy fallback도 is_fallback=True → degraded → cap_degraded → stale → "데이터 준비중 — 일부 결과만"**. baseline 대비 진짜 staleness는 `val_date == today_market_date` 날짜 체크가 이미 처리하므로, is_fallback 조건은 중복이고 healthy baseline을 잘못 강등.

## Changes
- 신규 `partition_health.served_partition_degraded(hp)` = `not hp.healthy` — healthy fallback은 **비-degraded**(날짜 체크가 behind-baseline 처리), unhealthy(thin last-resort)만 degraded.
- `high_yield_value` / `undervalued_breakout` / `fundamentals` 3 로더의 `partition_degraded`를 이 헬퍼로 통일(is_fallback 조건 제거).
- 효과: 06-05(healthy, is_fallback=True, val_date==baseline) → 비-degraded → val_state **fresh** → 경고 제거. genuinely-behind(val_date<baseline)·unhealthy는 여전히 stale.

## Verification
- 신규: `served_partition_degraded`(healthy fallback→False / unhealthy→True / None→False).
- **53 + 1263 broad sweep green**(partition_health/screener/coverage/fundamentals/freshness 회귀 0; `dataState in {stale,fallback}` 기존 테스트 유지); ruff clean; **migration 0**.

## Boundaries / operator
- read-only 메타. broker/order/watch mutation 0. KR/crypto 동일 로직(healthy fallback at baseline = fresh, 일관). **operator: 코드만; main 배포 후 반영.** 06-06 thin partition(388)은 resolver가 06-05를 serve하므로 무해(정리 선택).

## Related
ROB-440 · ROB-426 PR2a(resolve_healthy_partition/cap_degraded) · #1150(coverage 분모) · operator prod 카운트(B/A=7.58%, 06-05 baseline 4,926).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined data freshness detection logic for investment screeners to more accurately identify degraded data sources.

* **Tests**
  * Added tests to verify correct classification of data partition health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->