### PR TITLE
fix(ROB-440): US 배당수익률 라벨 100배 오차 — ratio→percent 디스플레이 정규화

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -477,6 +477,15 @@ async def load_fundamentals_preset_from_snapshots(
     )
     for r in included:
         r["snapshot_date"] = val_date
+        # ROB-440: market_valuation_snapshots stores dividend_yield as a RATIO
+        # (yahoo trailingAnnualDividendYield; naver /100), but the screener metric
+        # formatter expects PERCENT (matching the tvscreener KR snapshot, e.g. 5.20).
+        # Convert for US display so steady_dividend/future_dividend_king show "5.00%"
+        # not "0.05%". The SQL candidate filter ran on the raw ratio column above, so
+        # the min_dividend_yield gate is unaffected. KR via this loader (reports/PIT,
+        # not the screener display path) keeps the raw ratio.
+        if market == "us" and r.get("dividend_yield") is not None:
+            r["dividend_yield"] = r["dividend_yield"] * 100
     return FundamentalsScreenResult(
         rows=included,
         valuation_partition_date=val_date,

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -1276,3 +1276,111 @@ def test_toss_growth_expectation_fail_closed_on_missing_quarterly_data():
     assert rows == []
     assert excluded[0]["symbol"] == "005930"
     assert "earnings_growth_qoq unavailable" in excluded[0]["reason"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_us_dividend_yield_displayed_as_percent(db_session):
+    # ROB-440: market_valuation stores dividend_yield as a RATIO (0.05); the screener
+    # formatter expects PERCENT. US display rows must be ×100 (0.05 → 5.0) so the
+    # dividend label shows "5.00%" not "0.05%". The SQL filter ran on the raw ratio.
+    await _cleanup_db(db_session)
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_screener_snapshots.partition_health import (
+        resolve_healthy_partition,
+    )
+    from app.services.invest_view_model.fundamentals_screener import (
+        FundamentalsPresetSpec,
+        load_fundamentals_preset_from_snapshots,
+    )
+
+    sym = "906470"
+    val_hp = await resolve_healthy_partition(
+        db_session,
+        model=MarketValuationSnapshot,
+        date_col=MarketValuationSnapshot.snapshot_date,
+        market_col=MarketValuationSnapshot.market,
+        market="us",
+    )
+    vd = (
+        val_hp.partition_date
+        if (val_hp and val_hp.partition_date)
+        else dt.date(2026, 6, 5)
+    )
+    db_session.add(
+        MarketValuationSnapshot(
+            market="us",
+            symbol=sym,
+            snapshot_date=vd,
+            source="yahoo",
+            dividend_yield=Decimal("0.05"),  # ratio (= 5%)
+            market_cap=Decimal("500000000000"),
+        )
+    )
+    await db_session.commit()
+
+    # dividend-only spec (no derive checks → no financial_fundamentals needed)
+    spec = FundamentalsPresetSpec(
+        preset_id="_test_div",
+        min_dividend_yield=Decimal("0.01"),
+        sort_by="dividend_yield",
+    )
+    res = await load_fundamentals_preset_from_snapshots(
+        db_session,
+        market="us",
+        spec=spec,
+        limit=20,
+        now=lambda: dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+    )
+    assert res is not None
+    row = next(r for r in res.rows if r["symbol"] == sym)
+    assert row["dividend_yield"] == 5.0  # 0.05 ratio ×100 → 5.0 percent (display)
+    await _cleanup_db(db_session)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kr_dividend_yield_not_double_scaled(db_session):
+    # KR via this loader (reports/PIT) keeps the raw ratio — only US display is ×100.
+    await _cleanup_db(db_session)
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_view_model.fundamentals_screener import (
+        FundamentalsPresetSpec,
+        load_fundamentals_preset_from_snapshots,
+    )
+
+    sym = "906471"
+    vd = dt.date(2026, 6, 4)
+    db_session.add(
+        MarketValuationSnapshot(
+            market="kr",
+            symbol=sym,
+            snapshot_date=vd,
+            source="naver_finance",
+            dividend_yield=Decimal("0.05"),
+            market_cap=Decimal("500000000000"),
+        )
+    )
+    db_session.add(
+        KRSymbolUniverse(
+            symbol=sym, name="배당테스트", exchange="KOSPI", is_active=True
+        )
+    )
+    await db_session.commit()
+    spec = FundamentalsPresetSpec(
+        preset_id="_test_div_kr",
+        min_dividend_yield=Decimal("0.01"),
+        sort_by="dividend_yield",
+    )
+    res = await load_fundamentals_preset_from_snapshots(
+        db_session,
+        market="kr",
+        spec=spec,
+        limit=20,
+        now=lambda: dt.datetime(2026, 6, 4, tzinfo=dt.UTC),
+    )
+    assert res is not None
+    row = next(r for r in res.rows if r["symbol"] == sym)
+    assert row["dividend_yield"] == 0.05  # KR unchanged (no ×100)
+    await _cleanup_db(db_session)


### PR DESCRIPTION
## What & why
라이브 발견: US `steady_dividend`/`future_dividend_king`이 배당수익률을 **"0.05%"** 로 표시 (OKE 실제 ~5%). 
- `market_valuation_snapshots.dividend_yield`는 **RATIO**로 저장(yahoo `trailingAnnualDividendYield` 0.05 / naver `/100`).
- 스크리너 metric 포맷터는 `{v:.2f}%` (×100 없음) → **PERCENT 기대**. tvscreener KR은 percent(5.20) 저장이라 정상이지만, US는 market_valuation(ratio)이라 **100배 작게** 표시됨.

## Changes
- `load_fundamentals_preset_from_snapshots`: `market=="us"`일 때 included row의 `dividend_yield`를 **×100(ratio→percent)** — 디스플레이 전용. SQL 후보 필터(`dividend_yield >= min_dividend_yield`, ratio 0.03)는 raw 컬럼에서 이미 적용돼 **영향 없음**. KR(이 로더 = reports/PIT; 스크리너 표시는 tvscreener) 은 raw ratio 유지.

## Verification
- 신규: US dividend_yield 0.05→**5.0**(percent) / KR 0.05 **유지**(no ×100, 회귀 가드).
- **30 + 183 sweep green**(fundamentals_screener/screener_service/presets 회귀 0); ruff clean; **migration 0**.

## Boundaries / 후속(미포함)
- read-only 디스플레이. broker/order/watch mutation 0. 필터/KR 동작 불변.
- **US 시총 라벨 통화**(USD를 `억원` 표기) + operator US valuation 재빌드(#1151 marketCap 채움) = 별도 후속.
- **KR 성장률 YoY proxy 극단값** = DART cron(06-08)으로 해소 예정.

## Related
ROB-440 · #1151(marketCap) · 라이브 후보 지표 검증에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dividend yield values for the US market now display as percentages (e.g., "5.00%") instead of decimal ratios for consistency.

* **Tests**
  * Added test coverage for dividend yield display formatting across different markets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->