### PR TITLE
fix(ROB-440): US 시총 라벨 통화 — fundamentals row hardcoded market='kr' 교정

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -477,6 +477,12 @@ async def load_fundamentals_preset_from_snapshots(
     )
     for r in included:
         r["snapshot_date"] = val_date
+        # ROB-440: evaluate_fundamentals_candidates hardcodes row["market"]="kr"
+        # (it has no market param). For US that mislabels the row → the screener
+        # renders market_cap with the KR formatter ("2,884억원" for a USD value) and
+        # normalizes the symbol/relation as KR. Stamp the real market so US rows use
+        # the USD market_cap formatter ("$11.2B"). KR (reports/PIT) is unchanged.
+        r["market"] = market
         # ROB-440: market_valuation_snapshots stores dividend_yield as a RATIO
         # (yahoo trailingAnnualDividendYield; naver /100), but the screener metric
         # formatter expects PERCENT (matching the tvscreener KR snapshot, e.g. 5.20).

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -1335,6 +1335,13 @@ async def test_us_dividend_yield_displayed_as_percent(db_session):
     assert res is not None
     row = next(r for r in res.rows if r["symbol"] == sym)
     assert row["dividend_yield"] == 5.0  # 0.05 ratio ×100 → 5.0 percent (display)
+    # ROB-440: row market is the real market (was hardcoded "kr" by evaluate) so the
+    # screener renders market_cap as USD, not 억원.
+    assert row["market"] == "us"
+    from app.services.invest_view_model.screener_service import _format_market_cap
+
+    label, _ = _format_market_cap(row, row["market"])
+    assert label.startswith("$")  # USD formatter (was "...억원" with the "kr" bug)
     await _cleanup_db(db_session)
 
 


### PR DESCRIPTION
## What & why
라이브 발견: US 펀더멘털 프리셋(undervalued_growth/steady_dividend 등)이 시총을 **"2,884억원"** 으로 표시(USD를 KRW 단위로). high_yield_value의 VIRT만 `$11.2B` 정상이었음.

원인: `evaluate_fundamentals_candidates`가 `row["market"]`를 **"kr"로 하드코딩**(market 파라미터 없음). `build_screener_results`는 `row.get("market") or requested_market`로 통화/포맷 결정(screener_service:2227) → US 펀더멘털 row가 "kr"로 분류 → `_format_market_cap`이 KR 포맷터(억원) + 심볼/watch-relation도 KR 로직. high_yield_value/undervalued_breakout는 자체 로더가 market을 올바로 세팅(VIRT `$` 정상).

## Changes
- `load_fundamentals_preset_from_snapshots` 후처리 루프에서 `r["market"] = market` 스탬프 → US row가 **USD 시총 포맷터(`$11.2B`)** 사용 + 심볼/watch-relation도 US 로직. KR(reports/PIT)은 "kr" 동일.

## Verification
- 신규: US row `market=="us"` + `_format_market_cap` 라벨이 **"$"** 로 시작(was 억원).
- **30 + 205 sweep green**(fundamentals/screener_service/presets/coverage 회귀 0); ruff clean; **migration 0**.

## Boundaries / 후속
- read-only 디스플레이. broker/order/watch mutation 0. KR 동작 불변.
- **market_cap 값 자체**는 #1151 marketCap 재빌드 후 채워짐 — 미재빌드 종목은 USD 포맷터가 `null→"-"`로 정직 표시(더는 잘못된 억원 아님). operator US valuation 재빌드 시 `$` 값 채워짐.
- KR 성장률 YoY proxy = DART cron(06-08) 자동 해소.

## Related
ROB-440 · #1151(marketCap) · #1154(배당 라벨) · 라이브 후보 지표 검증에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)