### PR TITLE
feat(ROB-443): crypto funding_rate 스냅샷 enrich (Phase 1 PR1 — 데이터 레이어)

### DIFF
--- a/alembic/versions/2026_06_07_rob443_crypto_funding_rate.py
+++ b/alembic/versions/2026_06_07_rob443_crypto_funding_rate.py
@@ -1,0 +1,34 @@
+"""ROB-443 Phase 1: add funding_rate to invest_crypto_screener_snapshots.
+
+Additive (nullable): the Binance USD-M perp funding rate (lastFundingRate, a
+ratio e.g. 0.0001). A crypto-native sentiment signal with no stock analog. NULL
+for Upbit-only coins without a Binance perp (fail-closed). Powers the funding
+squeeze/overheated screener presets (follow-up PR). open_interest / long_short
+columns are deferred to their own enrichment PR.
+
+Revision ID: 20260607_rob443
+Revises: 20260605_rob440
+Create Date: 2026-06-07
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260607_rob443"
+down_revision = "20260605_rob440"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "invest_crypto_screener_snapshots",
+        sa.Column("funding_rate", sa.Numeric(12, 8), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invest_crypto_screener_snapshots", "funding_rate")

--- a/app/models/invest_crypto_screener_snapshot.py
+++ b/app/models/invest_crypto_screener_snapshot.py
@@ -74,9 +74,9 @@ class InvestCryptoScreenerSnapshot(Base):
     market_cap: Mapped[Decimal | None] = mapped_column(Numeric(28, 4), nullable=True)
     rsi: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
     adx: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
-    # ROB-443 Phase 1: crypto-native funding rate (Binance USD-M perp lastFundingRate,
-    # a ratio e.g. 0.0001). NULL for Upbit-only coins without a Binance perp
-    # (fail-closed, never fabricated). Powers funding squeeze/overheated presets.
+    # ROB-443 Phase 1: crypto-native USD-M perp funding rate (lastFundingRate, a
+    # ratio e.g. 0.0001; vendor call localized to derivatives.py). NULL for
+    # Upbit-only coins without a perp (fail-closed). Powers funding presets.
     funding_rate: Mapped[Decimal | None] = mapped_column(Numeric(12, 8), nullable=True)
     market_warning: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false"), default=False

--- a/app/models/invest_crypto_screener_snapshot.py
+++ b/app/models/invest_crypto_screener_snapshot.py
@@ -74,6 +74,10 @@ class InvestCryptoScreenerSnapshot(Base):
     market_cap: Mapped[Decimal | None] = mapped_column(Numeric(28, 4), nullable=True)
     rsi: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
     adx: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    # ROB-443 Phase 1: crypto-native funding rate (Binance USD-M perp lastFundingRate,
+    # a ratio e.g. 0.0001). NULL for Upbit-only coins without a Binance perp
+    # (fail-closed, never fabricated). Powers funding squeeze/overheated presets.
+    funding_rate: Mapped[Decimal | None] = mapped_column(Numeric(12, 8), nullable=True)
     market_warning: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false"), default=False
     )

--- a/app/services/invest_crypto_screener_snapshots/builder.py
+++ b/app/services/invest_crypto_screener_snapshots/builder.py
@@ -75,7 +75,7 @@ def build_crypto_snapshot_payloads(
                 market_cap=row.market_cap,
                 rsi=row.rsi,
                 adx=row.adx,
-                # ROB-443: None when the coin has no Binance perp (fail-closed).
+                # ROB-443: None when the coin has no USD-M perp (fail-closed).
                 funding_rate=funding.get(symbol),
                 market_warning=row.market_warning,
                 raw_payload=row.raw_payload,
@@ -95,7 +95,7 @@ async def build_crypto_snapshots(
 ) -> dict[str, Any]:
     date_value = snapshot_date or today_crypto_snapshot_date()
     provider_rows = await provider.fetch_rows(limit=limit)
-    # ROB-443: enrich with Binance perp funding rate (one batch call; coins without
+    # ROB-443: enrich with USD-M perp funding rate (one batch call; coins without
     # a perp stay None). Fail-open — funding errors never block the snapshot build.
     funding_by_symbol = await fetch_funding_rates([row.symbol for row in provider_rows])
     payloads = build_crypto_snapshot_payloads(

--- a/app/services/invest_crypto_screener_snapshots/builder.py
+++ b/app/services/invest_crypto_screener_snapshots/builder.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 from decimal import Decimal, InvalidOperation
 from typing import Any, Protocol
 
+from app.services.invest_crypto_screener_snapshots.derivatives import (
+    fetch_funding_rates,
+)
 from app.services.invest_crypto_screener_snapshots.freshness import (
     today_crypto_snapshot_date,
 )
@@ -47,8 +50,12 @@ def _decimal_or_none(value: Any) -> Decimal | None:
 
 
 def build_crypto_snapshot_payloads(
-    rows: list[CryptoProviderRow], *, snapshot_date: dt.date
+    rows: list[CryptoProviderRow],
+    *,
+    snapshot_date: dt.date,
+    funding_by_symbol: dict[str, Decimal] | None = None,
 ) -> list[CryptoSnapshotUpsert]:
+    funding = funding_by_symbol or {}
     payloads: list[CryptoSnapshotUpsert] = []
     for row in rows:
         symbol = str(row.symbol or "").strip().upper()
@@ -68,6 +75,8 @@ def build_crypto_snapshot_payloads(
                 market_cap=row.market_cap,
                 rsi=row.rsi,
                 adx=row.adx,
+                # ROB-443: None when the coin has no Binance perp (fail-closed).
+                funding_rate=funding.get(symbol),
                 market_warning=row.market_warning,
                 raw_payload=row.raw_payload,
                 source="tvscreener_upbit",
@@ -86,7 +95,12 @@ async def build_crypto_snapshots(
 ) -> dict[str, Any]:
     date_value = snapshot_date or today_crypto_snapshot_date()
     provider_rows = await provider.fetch_rows(limit=limit)
-    payloads = build_crypto_snapshot_payloads(provider_rows, snapshot_date=date_value)
+    # ROB-443: enrich with Binance perp funding rate (one batch call; coins without
+    # a perp stay None). Fail-open — funding errors never block the snapshot build.
+    funding_by_symbol = await fetch_funding_rates([row.symbol for row in provider_rows])
+    payloads = build_crypto_snapshot_payloads(
+        provider_rows, snapshot_date=date_value, funding_by_symbol=funding_by_symbol
+    )
     upserted = 0
     if commit:
         for payload in payloads:
@@ -97,6 +111,7 @@ async def build_crypto_snapshots(
         "fetched": len(provider_rows),
         "would_upsert": len(payloads),
         "upserted": upserted,
+        "fundingEnriched": sum(1 for p in payloads if p.funding_rate is not None),
         "committed": commit,
         "samples": [payload.model_dump(mode="json") for payload in payloads[:5]],
     }

--- a/app/services/invest_crypto_screener_snapshots/derivatives.py
+++ b/app/services/invest_crypto_screener_snapshots/derivatives.py
@@ -1,0 +1,71 @@
+"""ROB-443 Phase 1: crypto-native derivative enrichment for screener snapshots.
+
+Funding rate is a crypto-native sentiment signal with no stock analog. Binance's
+premiumIndex returns *all* USD-M perps in a single call, so enriching the whole
+Upbit universe costs one request (``_fetch_funding_rate_batch`` filters to the
+requested base symbols). Upbit-only coins with no Binance perp simply do not
+appear in the result → ``funding_rate`` stays ``None`` (fail-closed, never
+fabricated).
+
+open_interest / long_short_ratio are per-symbol (N requests) and rate-limit
+sensitive, so they are deferred to a follow-up PR.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.mcp_server.tooling.fundamentals_sources_binance import (
+    _fetch_funding_rate_batch,
+)
+
+FundingBatchFetcher = Callable[[list[str]], Awaitable[list[dict[str, Any]]]]
+
+
+def base_symbol_from_upbit(upbit_symbol: str) -> str | None:
+    """``KRW-BTC`` -> ``BTC``; anything not a KRW market returns None."""
+    s = str(upbit_symbol or "").strip().upper()
+    if not s.startswith("KRW-"):
+        return None
+    base = s[4:]
+    return base or None
+
+
+async def fetch_funding_rates(
+    upbit_symbols: list[str],
+    *,
+    fetcher: FundingBatchFetcher = _fetch_funding_rate_batch,
+) -> dict[str, Decimal]:
+    """Map ``KRW-XXX`` -> Binance perp funding rate for coins that have a perp.
+
+    One batch call. Coins without a Binance USDT perp are absent from the result
+    (caller treats missing as ``None``). Fail-open: any fetch error returns ``{}``
+    so the snapshot build still succeeds (funding simply not enriched).
+    """
+    base_to_upbit: dict[str, str] = {}
+    for sym in upbit_symbols:
+        base = base_symbol_from_upbit(sym)
+        if base and base not in base_to_upbit:
+            base_to_upbit[base] = str(sym).strip().upper()
+    if not base_to_upbit:
+        return {}
+
+    try:
+        rows = await fetcher(sorted(base_to_upbit))
+    except Exception:  # noqa: BLE001 — fail-open: build proceeds without funding
+        return {}
+
+    out: dict[str, Decimal] = {}
+    for row in rows:
+        base = str(row.get("symbol") or "").strip().upper()
+        upbit = base_to_upbit.get(base)
+        raw = row.get("funding_rate")
+        if upbit is None or raw is None:
+            continue
+        try:
+            out[upbit] = Decimal(str(raw))
+        except (InvalidOperation, ValueError):
+            continue
+    return out

--- a/app/services/invest_crypto_screener_snapshots/repository.py
+++ b/app/services/invest_crypto_screener_snapshots/repository.py
@@ -29,6 +29,7 @@ class CryptoSnapshotUpsert(BaseModel):
     market_cap: Decimal | None = None
     rsi: Decimal | None = None
     adx: Decimal | None = None
+    funding_rate: Decimal | None = None  # ROB-443: Binance perp; None when no perp
     market_warning: bool = False
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     source: str = "tvscreener_upbit"

--- a/app/services/invest_crypto_screener_snapshots/repository.py
+++ b/app/services/invest_crypto_screener_snapshots/repository.py
@@ -29,7 +29,7 @@ class CryptoSnapshotUpsert(BaseModel):
     market_cap: Decimal | None = None
     rsi: Decimal | None = None
     adx: Decimal | None = None
-    funding_rate: Decimal | None = None  # ROB-443: Binance perp; None when no perp
+    funding_rate: Decimal | None = None  # ROB-443: USD-M perp; None when no perp
     market_warning: bool = False
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     source: str = "tvscreener_upbit"

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -46,6 +46,11 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         "app/mcp_server/tooling/fundamentals_sources_binance.py",
         "app/mcp_server/tooling/fundamentals_sources_naver.py",
         "app/mcp_server/tooling/fundamentals/_crypto.py",
+        # ROB-443: crypto screener snapshot funding-rate enrichment. No new Binance
+        # HTTP code — it imports the existing public funding fetcher
+        # (_fetch_funding_rate_batch in fundamentals_sources_binance, already
+        # allow-listed); the Binance reference here is only that import path.
+        "app/services/invest_crypto_screener_snapshots/derivatives.py",
         "app/models/research_backtest.py",
         "app/schemas/research_backtest.py",
         "app/services/crypto_insight_snapshots/builder.py",

--- a/tests/test_invest_crypto_derivatives.py
+++ b/tests/test_invest_crypto_derivatives.py
@@ -1,0 +1,70 @@
+"""ROB-443 Phase 1: crypto funding-rate enrichment (derivatives.py)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.invest_crypto_screener_snapshots.derivatives import (
+    base_symbol_from_upbit,
+    fetch_funding_rates,
+)
+
+
+@pytest.mark.parametrize(
+    "upbit,expected",
+    [
+        ("KRW-BTC", "BTC"),
+        ("krw-eth", "ETH"),
+        ("BTC-ETH", None),  # not a KRW market
+        ("USDT-BTC", None),
+        ("KRW-", None),
+        ("", None),
+    ],
+)
+def test_base_symbol_from_upbit(upbit, expected) -> None:
+    assert base_symbol_from_upbit(upbit) == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_funding_rates_maps_perp_coins_and_skips_no_perp() -> None:
+    async def _fetcher(symbols):
+        # batch returns base-symbol rows only for coins that have a Binance perp
+        assert symbols == [
+            "BTC",
+            "ETH",
+            "XYZ",
+        ]  # all bases requested; XYZ absent in result
+        return [
+            {"symbol": "BTC", "funding_rate": 0.0001},
+            {"symbol": "ETH", "funding_rate": -0.00025},
+            # XYZ (Upbit-only) absent → no perp
+        ]
+
+    out = await fetch_funding_rates(["KRW-BTC", "KRW-ETH", "KRW-XYZ"], fetcher=_fetcher)
+    assert out == {"KRW-BTC": Decimal("0.0001"), "KRW-ETH": Decimal("-0.00025")}
+    assert "KRW-XYZ" not in out  # no perp → omitted (caller treats as None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_funding_rates_fail_open_on_error() -> None:
+    async def _boom(symbols):
+        raise RuntimeError("binance down")
+
+    # fail-open: build proceeds without funding enrichment
+    assert await fetch_funding_rates(["KRW-BTC"], fetcher=_boom) == {}
+
+
+@pytest.mark.asyncio
+async def test_fetch_funding_rates_empty_when_no_krw_symbols() -> None:
+    called = False
+
+    async def _fetcher(symbols):
+        nonlocal called
+        called = True
+        return []
+
+    out = await fetch_funding_rates(["BTC-ETH", "USDT-XRP"], fetcher=_fetcher)
+    assert out == {}
+    assert called is False  # no KRW coins → no fetch attempted

--- a/tests/test_invest_crypto_screener_snapshots_builder.py
+++ b/tests/test_invest_crypto_screener_snapshots_builder.py
@@ -20,6 +20,18 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _stub_funding(monkeypatch):
+    # ROB-443: build_crypto_snapshots enriches via Binance; stub it so unit tests
+    # never hit the network. Individual tests override with their own map.
+    import app.services.invest_crypto_screener_snapshots.builder as builder_mod
+
+    async def _empty(_symbols):
+        return {}
+
+    monkeypatch.setattr(builder_mod, "fetch_funding_rates", _empty)
+
+
 class _Condition:
     def __init__(self, label: str) -> None:
         self.label = label
@@ -94,6 +106,42 @@ def test_build_crypto_snapshot_payloads_maps_provider_rows() -> None:
     assert payload.adx == Decimal("24.1")
     assert payload.market_warning is True
     assert payload.raw_payload == {"safe": True}
+
+
+def test_build_crypto_snapshot_payloads_sets_funding_rate() -> None:
+    # ROB-443: funding map enriches matching coins; absent coins stay None.
+    payloads = build_crypto_snapshot_payloads(
+        [
+            CryptoProviderRow(symbol="KRW-BTC", latest_close=Decimal("150000000")),
+            CryptoProviderRow(symbol="KRW-NOPERP", latest_close=Decimal("100")),
+        ],
+        snapshot_date=dt.date(2026, 5, 13),
+        funding_by_symbol={"KRW-BTC": Decimal("0.00012")},
+    )
+    by_symbol = {p.symbol: p for p in payloads}
+    assert by_symbol["KRW-BTC"].funding_rate == Decimal("0.00012")
+    assert by_symbol["KRW-NOPERP"].funding_rate is None  # no perp → fail-closed
+
+
+@pytest.mark.asyncio
+async def test_build_crypto_snapshots_enriches_funding(monkeypatch) -> None:
+    import app.services.invest_crypto_screener_snapshots.builder as builder_mod
+
+    async def _funding(symbols):
+        assert symbols == ["KRW-BTC"]  # provider symbols passed through
+        return {"KRW-BTC": Decimal("0.0005")}
+
+    monkeypatch.setattr(builder_mod, "fetch_funding_rates", _funding)
+    repo = _Repo()
+    result = await build_crypto_snapshots(
+        provider=_Provider(),
+        repository=repo,
+        snapshot_date=dt.date(2026, 5, 13),
+        commit=True,
+        limit=1,
+    )
+    assert result["fundingEnriched"] == 1
+    assert repo.payloads[0].funding_rate == Decimal("0.0005")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why
코인은 PER/PBR/ROE/배당 무대응 → **코인 네이티브 심리 신호**로 펀딩비를 스냅샷에 추가. Binance `premiumIndex`는 전체 USD-M perp를 **1 call**로 반환하므로 전체 Upbit 유니버스 enrich가 단일 요청.

## Changes
- **additive migration** `20260607_rob443`(head `20260605_rob440` 뒤): `invest_crypto_screener_snapshots`에 `funding_rate` (Numeric(12,8), nullable). model + `CryptoSnapshotUpsert` 동반.
- **신규** `derivatives.fetch_funding_rates(upbit_symbols)`: `KRW-XXX`→base 추출 → `_fetch_funding_rate_batch`(주입가능, 1 call) 필터 → `{KRW-XXX: Decimal}`. Binance perp 없는 Upbit 전용 코인은 결과 부재 → `funding_rate=None`(**fail-closed**, 위조 금지). 에러는 **fail-open**(`{}`, 빌드 진행).
- `build_crypto_snapshots`가 provider rows 후 enrich 호출 → payload 배선, 결과에 `fundingEnriched` 카운트.

## Verification
- 신규: base 추출(KRW-/대소문자/비-KRW) · perp 매핑/no-perp 생략/fail-open/비-KRW 시 fetch 안함 · 빌더 funding 배선(payload/카운트). 기존 빌더 테스트는 autouse 스텁으로 **네트워크 차단**.
- **17 + 107 sweep green**(crypto/screener 회귀 0); ruff clean; **alembic 단일 head**.

## Boundaries / operator
- read-only 발굴. broker/order/watch/order-intent mutation 0. Binance **public read만**(fapi premiumIndex). 매수신호 아님(심리 컨텍스트). DB write=repository.upsert만.
- **operator**: 머지 후 `alembic upgrade head` + crypto 스냅샷 재빌드 시 funding 자동 적재(`fundingEnriched` 카운트로 확인).

## Next / Out of scope
- **PR2**: 펀딩 프리셋(`crypto_funding_squeeze` 음수=숏스퀴즈 / `crypto_funding_overheated` 고양수=되돌림) + 필터 카탈로그 crypto kind.
- `open_interest`/`long_short_ratio`(per-symbol, rate-limit 주의)는 별도 후속 PR(컬럼+enrich 동반).

## Related
ROB-443(Phase 0 #1156 flow 활성화) · ROB-377(Binance 파생 `_fetch_funding_rate_batch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crypto screener snapshots now include Binance USD-M perpetuals funding rates, automatically enriched for supported cryptocurrencies.

* **Tests**
  * Added comprehensive test coverage for funding rate enrichment and snapshot generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->