### PR TITLE
feat(ROB-443): 코인 펀딩비 프리셋 squeeze/overheated (Phase 1 PR2 — 사용자 가시)

### DIFF
--- a/app/services/invest_crypto_screener_snapshots/repository.py
+++ b/app/services/invest_crypto_screener_snapshots/repository.py
@@ -100,6 +100,29 @@ class InvestCryptoScreenerSnapshotsRepository:
                 InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
                 InvestCryptoScreenerSnapshot.symbol.asc(),
             )
+        elif preset_id == "crypto_funding_squeeze":
+            # ROB-443: negative funding = shorts pay longs = crowded shorts →
+            # short-squeeze candidate. Most-negative first. funding_rate NULL
+            # (no perp) is excluded (fail-closed).
+            stmt = stmt.where(
+                InvestCryptoScreenerSnapshot.funding_rate.is_not(None),
+                InvestCryptoScreenerSnapshot.funding_rate < 0,
+            ).order_by(
+                InvestCryptoScreenerSnapshot.funding_rate.asc(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        elif preset_id == "crypto_funding_overheated":
+            # ROB-443: high positive funding = longs pay shorts = crowded longs →
+            # pullback risk. Highest first. funding_rate NULL excluded.
+            stmt = stmt.where(
+                InvestCryptoScreenerSnapshot.funding_rate.is_not(None),
+                InvestCryptoScreenerSnapshot.funding_rate > 0,
+            ).order_by(
+                InvestCryptoScreenerSnapshot.funding_rate.desc(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
         else:
             stmt = stmt.order_by(
                 InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -394,6 +394,34 @@ CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
         presetOrigin=_AT_OWN,
         parityNote="auto_trader 자체 가상자산 프리셋 (Toss 국내주식 골라보기 대상 아님).",
     ),
+    ScreenerPreset(
+        id="crypto_funding_squeeze",
+        name="펀딩비 음수 (숏 과열)",
+        description="펀딩비가 음수(숏이 롱에 지급) — 숏 쏠림으로 숏스퀴즈 가능성이 있는 가상자산",
+        badges=["가상자산"],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="펀딩비", detail="음수 (숏 과열)"),
+        ],
+        metricLabel="펀딩비",
+        market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (선물 펀딩비 기반, Toss 대상 아님).",
+    ),
+    ScreenerPreset(
+        id="crypto_funding_overheated",
+        name="펀딩비 과열 (롱 과열)",
+        description="펀딩비가 높은 양수(롱이 숏에 지급) — 롱 쏠림으로 되돌림 주의가 필요한 가상자산",
+        badges=["가상자산"],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="펀딩비", detail="높은 양수 (롱 과열)"),
+        ],
+        metricLabel="펀딩비",
+        market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (선물 펀딩비 기반, Toss 대상 아님).",
+    ),
 ]
 
 

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -964,7 +964,7 @@ async def _load_crypto_rows_from_snapshots(
                 "rsi": float(snap.rsi) if snap.rsi is not None else None,
                 "adx": float(snap.adx) if snap.adx is not None else None,
                 "funding_rate": float(snap.funding_rate)
-                if snap.funding_rate is not None
+                if getattr(snap, "funding_rate", None) is not None
                 else None,
                 "source": "tvscreener_upbit",
                 "computed_at": snap.computed_at.isoformat()

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -963,6 +963,9 @@ async def _load_crypto_rows_from_snapshots(
                 else None,
                 "rsi": float(snap.rsi) if snap.rsi is not None else None,
                 "adx": float(snap.adx) if snap.adx is not None else None,
+                "funding_rate": float(snap.funding_rate)
+                if snap.funding_rate is not None
+                else None,
                 "source": "tvscreener_upbit",
                 "computed_at": snap.computed_at.isoformat()
                 if getattr(snap, "computed_at", None) is not None
@@ -997,6 +1000,8 @@ _METRIC_FIELD: dict[str, str] = {
     "crypto_high_volume": "trade_amount_24h",
     "crypto_oversold": "rsi",
     "crypto_momentum": "change_rate",
+    "crypto_funding_squeeze": "funding_rate",
+    "crypto_funding_overheated": "funding_rate",
     "profitable_company": "roe",
     "undervalued_growth": "earnings_growth_3y_avg",
     "stable_growth": "roe",
@@ -1271,6 +1276,9 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
         return f"{float(value):.1f}%", []
     if field == "dividend_yield":
         return f"{float(value):.2f}%", []
+    if field == "funding_rate":
+        # ROB-443: ratio (e.g. 0.0001) → signed percent per funding interval.
+        return f"{float(value) * 100:+.4f}%", []
     if field in ("volume", "trade_amount_24h"):
         return f"{int(float(value)):,}", []
     if field == "foreign_net":
@@ -1956,6 +1964,17 @@ async def build_screener_results(
         _snapshot_check_result = []
         _snapshot_state_override = "missing"
         _snapshot_empty_warning = "밸류에이션/재무 스냅샷이 아직 적재되지 않아 해당 프리셋 후보를 표시할 수 없습니다."
+
+    if (
+        preset_id in {"crypto_funding_squeeze", "crypto_funding_overheated"}
+        and _snapshot_check_result is None
+    ):
+        # ROB-443: funding presets rank by funding_rate, which only the crypto
+        # snapshot carries (the live tvscreener fallback has no funding data).
+        # Snapshot-only — never fall through to the generic provider.
+        _snapshot_check_result = []
+        _snapshot_state_override = "missing"
+        _snapshot_empty_warning = "암호화폐 펀딩비 스냅샷이 아직 적재되지 않아 펀딩비 후보를 표시할 수 없습니다."
 
     _snapshot_was_checked = _snapshot_check_result is not None
     if _snapshot_was_checked:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,6 +480,25 @@ async def db_session():
                             "ADD COLUMN high_52w_date DATE"
                         )
                     )
+                # ROB-443 PR1 — funding_rate added to the (persistent) crypto
+                # screener snapshot table. Same fresh-DB/create_all logic: only
+                # ALTER when genuinely missing to avoid an AccessExclusive lock.
+                crypto_has_funding_rate = (
+                    await conn.execute(
+                        text(
+                            "SELECT 1 FROM information_schema.columns "
+                            "WHERE table_name = 'invest_crypto_screener_snapshots' "
+                            "AND column_name = 'funding_rate'"
+                        )
+                    )
+                ).first()
+                if not crypto_has_funding_rate:
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE invest_crypto_screener_snapshots "
+                            "ADD COLUMN funding_rate NUMERIC(12, 8)"
+                        )
+                    )
                 # ROB-284 — crypto_candles_1d migrates in-place from the
                 # legacy (symbol, market) shape to the (instrument_id, time)
                 # shape. The test DB picks up its schema from

--- a/tests/test_invest_crypto_funding_presets.py
+++ b/tests/test_invest_crypto_funding_presets.py
@@ -1,0 +1,80 @@
+"""ROB-443 Phase 1 PR2: crypto funding-rate presets (squeeze / overheated)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
+from app.services.invest_crypto_screener_snapshots.repository import (
+    InvestCryptoScreenerSnapshotsRepository,
+)
+
+
+def _row(
+    symbol: str, funding: Decimal | None, *, vd: dt.date
+) -> InvestCryptoScreenerSnapshot:
+    return InvestCryptoScreenerSnapshot(
+        symbol=symbol,
+        snapshot_date=vd,
+        latest_close=Decimal("100"),
+        funding_rate=funding,
+        market_warning=False,
+        source="tvscreener_upbit",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_funding_squeeze_returns_negatives_most_negative_first(db_session):
+    vd = dt.date(2099, 11, 1)
+    await db_session.execute(
+        InvestCryptoScreenerSnapshot.__table__.delete().where(
+            InvestCryptoScreenerSnapshot.snapshot_date == vd
+        )
+    )
+    db_session.add_all(
+        [
+            _row("KRW-AAA", Decimal("-0.0005"), vd=vd),
+            _row("KRW-BBB", Decimal("-0.0020"), vd=vd),  # most negative
+            _row("KRW-CCC", Decimal("0.0010"), vd=vd),  # positive → excluded
+            _row("KRW-DDD", None, vd=vd),  # no perp → excluded (fail-closed)
+        ]
+    )
+    await db_session.commit()
+    repo = InvestCryptoScreenerSnapshotsRepository(db_session)
+
+    rows = await repo.list_latest(preset_id="crypto_funding_squeeze", snapshot_date=vd)
+    symbols = [r.symbol for r in rows]
+    assert symbols == ["KRW-BBB", "KRW-AAA"]  # negatives only, most-negative first
+
+    rows_over = await repo.list_latest(
+        preset_id="crypto_funding_overheated", snapshot_date=vd
+    )
+    assert [r.symbol for r in rows_over] == ["KRW-CCC"]  # positives only
+
+    await db_session.execute(
+        InvestCryptoScreenerSnapshot.__table__.delete().where(
+            InvestCryptoScreenerSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.commit()
+
+
+def test_funding_metric_label_signed_percent() -> None:
+    from app.services.invest_view_model.screener_service import _metric_value_label
+
+    neg, _ = _metric_value_label("crypto_funding_squeeze", {"funding_rate": -0.00025})
+    pos, _ = _metric_value_label("crypto_funding_overheated", {"funding_rate": 0.0001})
+    assert neg == "-0.0250%"
+    assert pos == "+0.0100%"
+
+
+def test_funding_presets_registered_for_crypto() -> None:
+    from app.services.invest_view_model.screener_presets import preset_definitions
+
+    ids = {p.id for p in preset_definitions("crypto")}
+    assert "crypto_funding_squeeze" in ids
+    assert "crypto_funding_overheated" in ids

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -100,6 +100,8 @@ def test_crypto_preset_definitions_are_crypto_scoped() -> None:
         "crypto_high_volume",
         "crypto_oversold",
         "crypto_momentum",
+        "crypto_funding_squeeze",
+        "crypto_funding_overheated",
     ]
     assert all(p.market == "crypto" for p in presets)
     assert all(p.filterChips[0].label == "가상자산" for p in presets)

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -409,6 +409,8 @@ async def test_build_screener_presets_returns_crypto_presets() -> None:
         "crypto_high_volume",
         "crypto_oversold",
         "crypto_momentum",
+        "crypto_funding_squeeze",
+        "crypto_funding_overheated",
     ]
     assert all(p.market == "crypto" for p in resp.presets)
 


### PR DESCRIPTION
## What & why
PR1(#1157)의 `funding_rate` 컬럼을 소비하는 **2개 코인 네이티브 프리셋**. 펀딩비는 주식에 없는 선물 심리 신호 → 코인에서 진짜 차별화되는 발굴.

## Changes
- `repository.list_latest`:
  - `crypto_funding_squeeze` — funding<0(숏이 롱에 지급=숏 과열), 가장 음수 먼저 → **숏스퀴즈 후보**.
  - `crypto_funding_overheated` — funding>0, 가장 높은 순(롱 과열) → **되돌림 주의**.
  - funding NULL(no-perp) 제외(**fail-closed**).
- 읽기경로 row dict에 `funding_rate` 노출 + `_METRIC_FIELD` 매핑 + metric 라벨 포맷(ratio→부호 percent `+0.0100%`/`-0.0250%`).
- `screener_presets`: 2개 `ScreenerPreset`(가상자산, _AT_OWN).
- **snapshot-only 가드**: funding은 스냅샷에만 있으므로(라이브 tvscreener 폴백엔 펀딩 없음) 스냅샷 부재 시 빈 결과+`missing`+"펀딩비 스냅샷 미적재" 경고(investor_flow/double_buy 패턴 동일 — 잘못된 라이브 결과 방지).

## Verification
- 신규: repo 필터/정렬(음수만/양수만/null 제외/순서) · metric 라벨 부호 percent · preset 등록.
- conftest funding_rate 조건부 ALTER(persistent DB, #1147 deadlock 회피 패턴).
- **31 passed**(crypto screener 영역 회귀 0); ruff clean; **단일 head**.
- ⚠️`test_mcp_place_order` crypto 7실패 = **clean main에서도 stash로 동일**(로컬 persistent DB의 stale `uq_live_ledger_order` 행, ROB-407) → CI fresh DB 통과, 본 변경과 무관(order 경로 미접촉).

## Boundaries / 후속
- read-only 발굴. broker/order/watch mutation 0. **매수신호 아님**(심리 컨텍스트).
- filter 카탈로그 crypto kind(`screen_stocks_snapshot` 조정) + OI/long-short(per-symbol) = 후속.
- **operator**: 스냅샷 빌드(funding 적재) 후 펀딩 프리셋 라이브 가시.

## Related
ROB-443(PR0 #1156 flow / PR1 #1157 funding 컬럼) · ROB-377(Binance 펀딩).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new crypto screener presets for funding rate analysis: "Funding Squeeze" (negative funding rates) and "Funding Overheated" (positive funding rates), with results ordered by funding magnitude.
  * Crypto screeners now display funding rate metrics in percentage format.

* **Tests**
  * Added comprehensive test coverage for funding rate screener functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->