### PR TITLE
feat(ROB-443): 코인 OI/롱숏 지표 + oi_surge/long_short_skew 프리셋 (Phase 1 후속)

### DIFF
--- a/alembic/versions/2026_06_07_rob443b_crypto_oi_lsr.py
+++ b/alembic/versions/2026_06_07_rob443b_crypto_oi_lsr.py
@@ -1,0 +1,43 @@
+"""ROB-443 Phase 1 (follow-up): add open_interest / long_short to crypto snapshots.
+
+Additive (nullable), crypto-native derivative columns sourced per-symbol from the
+USD-M perp endpoints (open interest + global long/short account ratio). NULL for
+Upbit-only coins without a perp (fail-closed). Powers the crypto_oi_surge and
+crypto_long_short_skew presets.
+
+Revision ID: 20260607_rob443b
+Revises: 20260607_rob443
+Create Date: 2026-06-07
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260607_rob443b"
+down_revision = "20260607_rob443"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "invest_crypto_screener_snapshots",
+        sa.Column("open_interest_usd", sa.Numeric(28, 2), nullable=True),
+    )
+    op.add_column(
+        "invest_crypto_screener_snapshots",
+        sa.Column("oi_change_24h", sa.Numeric(10, 4), nullable=True),
+    )
+    op.add_column(
+        "invest_crypto_screener_snapshots",
+        sa.Column("long_short_account_ratio", sa.Numeric(10, 4), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("invest_crypto_screener_snapshots", "long_short_account_ratio")
+    op.drop_column("invest_crypto_screener_snapshots", "oi_change_24h")
+    op.drop_column("invest_crypto_screener_snapshots", "open_interest_usd")

--- a/app/models/invest_crypto_screener_snapshot.py
+++ b/app/models/invest_crypto_screener_snapshot.py
@@ -78,6 +78,16 @@ class InvestCryptoScreenerSnapshot(Base):
     # ratio e.g. 0.0001; vendor call localized to derivatives.py). NULL for
     # Upbit-only coins without a perp (fail-closed). Powers funding presets.
     funding_rate: Mapped[Decimal | None] = mapped_column(Numeric(12, 8), nullable=True)
+    # ROB-443 follow-up: per-symbol USD-M perp derivatives (open interest in USD,
+    # 24h OI change %, global retail long/short account ratio). NULL when no perp
+    # (fail-closed). Vendor calls localized to derivatives.py.
+    open_interest_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(28, 2), nullable=True
+    )
+    oi_change_24h: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    long_short_account_ratio: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4), nullable=True
+    )
     market_warning: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false"), default=False
     )

--- a/app/services/invest_crypto_screener_snapshots/builder.py
+++ b/app/services/invest_crypto_screener_snapshots/builder.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol
 
 from app.services.invest_crypto_screener_snapshots.derivatives import (
     fetch_funding_rates,
+    fetch_oi_and_long_short,
 )
 from app.services.invest_crypto_screener_snapshots.freshness import (
     today_crypto_snapshot_date,
@@ -54,13 +55,16 @@ def build_crypto_snapshot_payloads(
     *,
     snapshot_date: dt.date,
     funding_by_symbol: dict[str, Decimal] | None = None,
+    oi_ls_by_symbol: dict[str, dict[str, Decimal | None]] | None = None,
 ) -> list[CryptoSnapshotUpsert]:
     funding = funding_by_symbol or {}
+    oi_ls = oi_ls_by_symbol or {}
     payloads: list[CryptoSnapshotUpsert] = []
     for row in rows:
         symbol = str(row.symbol or "").strip().upper()
         if not symbol.startswith("KRW-"):
             continue
+        deriv = oi_ls.get(symbol) or {}
         payloads.append(
             CryptoSnapshotUpsert(
                 symbol=symbol,
@@ -77,6 +81,9 @@ def build_crypto_snapshot_payloads(
                 adx=row.adx,
                 # ROB-443: None when the coin has no USD-M perp (fail-closed).
                 funding_rate=funding.get(symbol),
+                open_interest_usd=deriv.get("open_interest_usd"),
+                oi_change_24h=deriv.get("oi_change_24h"),
+                long_short_account_ratio=deriv.get("long_short_account_ratio"),
                 market_warning=row.market_warning,
                 raw_payload=row.raw_payload,
                 source="tvscreener_upbit",
@@ -98,8 +105,14 @@ async def build_crypto_snapshots(
     # ROB-443: enrich with USD-M perp funding rate (one batch call; coins without
     # a perp stay None). Fail-open — funding errors never block the snapshot build.
     funding_by_symbol = await fetch_funding_rates([row.symbol for row in provider_rows])
+    # ROB-443 follow-up: OI + long/short are per-symbol, so enrich ONLY the perp
+    # coins (the ones funding matched) — not the whole universe. Fail-open per coin.
+    oi_ls_by_symbol = await fetch_oi_and_long_short(list(funding_by_symbol))
     payloads = build_crypto_snapshot_payloads(
-        provider_rows, snapshot_date=date_value, funding_by_symbol=funding_by_symbol
+        provider_rows,
+        snapshot_date=date_value,
+        funding_by_symbol=funding_by_symbol,
+        oi_ls_by_symbol=oi_ls_by_symbol,
     )
     upserted = 0
     if commit:
@@ -112,6 +125,10 @@ async def build_crypto_snapshots(
         "would_upsert": len(payloads),
         "upserted": upserted,
         "fundingEnriched": sum(1 for p in payloads if p.funding_rate is not None),
+        "oiEnriched": sum(1 for p in payloads if p.open_interest_usd is not None),
+        "longShortEnriched": sum(
+            1 for p in payloads if p.long_short_account_ratio is not None
+        ),
         "committed": commit,
         "samples": [payload.model_dump(mode="json") for payload in payloads[:5]],
     }

--- a/app/services/invest_crypto_screener_snapshots/derivatives.py
+++ b/app/services/invest_crypto_screener_snapshots/derivatives.py
@@ -13,15 +13,28 @@ sensitive, so they are deferred to a follow-up PR.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from app.mcp_server.tooling.fundamentals_sources_binance import (
     _fetch_funding_rate_batch,
+    _fetch_long_short_ratio,
+    _fetch_open_interest,
 )
 
 FundingBatchFetcher = Callable[[list[str]], Awaitable[list[dict[str, Any]]]]
+PerSymbolFetcher = Callable[[str, str, int], Awaitable[dict[str, Any]]]
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
 
 
 def base_symbol_from_upbit(upbit_symbol: str) -> str | None:
@@ -68,4 +81,61 @@ async def fetch_funding_rates(
             out[upbit] = Decimal(str(raw))
         except (InvalidOperation, ValueError):
             continue
+    return out
+
+
+async def fetch_oi_and_long_short(
+    perp_upbit_symbols: list[str],
+    *,
+    oi_fetcher: PerSymbolFetcher = _fetch_open_interest,
+    lsr_fetcher: PerSymbolFetcher = _fetch_long_short_ratio,
+    period: str = "1h",
+    limit: int = 24,
+    concurrency: int = 8,
+) -> dict[str, dict[str, Decimal | None]]:
+    """Per-symbol open-interest + global long/short ratio for coins that have a perp.
+
+    Unlike funding (one batch call), these endpoints are per-symbol, so the caller
+    should pass ONLY the perp coins (e.g. the symbols funding enrichment matched),
+    not the whole universe. Bounded concurrency; **fail-open per coin and per
+    metric** — one coin's (or one endpoint's) error leaves that field None and
+    never blocks the rest.
+
+    Returns ``{KRW-XXX: {"open_interest_usd", "oi_change_24h",
+    "long_short_account_ratio"}}`` for coins with at least one metric resolved.
+    """
+    base_to_upbit: dict[str, str] = {}
+    for sym in perp_upbit_symbols:
+        base = base_symbol_from_upbit(sym)
+        if base and base not in base_to_upbit:
+            base_to_upbit[base] = str(sym).strip().upper()
+    if not base_to_upbit:
+        return {}
+
+    sem = asyncio.Semaphore(max(1, concurrency))
+    out: dict[str, dict[str, Decimal | None]] = {}
+
+    async def _one(base: str, upbit: str) -> None:
+        async with sem:
+            row: dict[str, Decimal | None] = {}
+            try:
+                oi = await oi_fetcher(base, period, limit)
+                history = oi.get("open_interest_history") or []
+                latest_usd = (
+                    history[-1].get("sum_open_interest_value_usd") if history else None
+                )
+                row["open_interest_usd"] = _to_decimal(latest_usd)
+                row["oi_change_24h"] = _to_decimal(oi.get("oi_change_pct"))
+            except Exception:  # noqa: BLE001 — fail-open per metric
+                pass
+            try:
+                lsr = await lsr_fetcher(base, period, limit)
+                global_leg = lsr.get("global_account") or {}
+                row["long_short_account_ratio"] = _to_decimal(global_leg.get("ratio"))
+            except Exception:  # noqa: BLE001 — fail-open per metric
+                pass
+            if any(v is not None for v in row.values()):
+                out[upbit] = row
+
+    await asyncio.gather(*(_one(b, u) for b, u in base_to_upbit.items()))
     return out

--- a/app/services/invest_crypto_screener_snapshots/repository.py
+++ b/app/services/invest_crypto_screener_snapshots/repository.py
@@ -30,6 +30,9 @@ class CryptoSnapshotUpsert(BaseModel):
     rsi: Decimal | None = None
     adx: Decimal | None = None
     funding_rate: Decimal | None = None  # ROB-443: USD-M perp; None when no perp
+    open_interest_usd: Decimal | None = None  # ROB-443: USD-M perp OI (USD)
+    oi_change_24h: Decimal | None = None  # ROB-443: 24h OI change %
+    long_short_account_ratio: Decimal | None = None  # ROB-443: global retail L/S
     market_warning: bool = False
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     source: str = "tvscreener_upbit"
@@ -120,6 +123,29 @@ class InvestCryptoScreenerSnapshotsRepository:
                 InvestCryptoScreenerSnapshot.funding_rate > 0,
             ).order_by(
                 InvestCryptoScreenerSnapshot.funding_rate.desc(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        elif preset_id == "crypto_oi_surge":
+            # ROB-443: largest 24h open-interest increase = new capital / position
+            # buildup. oi_change_24h NULL (no perp / insufficient history) excluded.
+            stmt = stmt.where(
+                InvestCryptoScreenerSnapshot.oi_change_24h.is_not(None),
+                InvestCryptoScreenerSnapshot.oi_change_24h > 0,
+            ).order_by(
+                InvestCryptoScreenerSnapshot.oi_change_24h.desc(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        elif preset_id == "crypto_long_short_skew":
+            # ROB-443: retail long/short positioning most skewed from 1 (either
+            # direction) — a crowding/contrarian context signal. NULL excluded.
+            stmt = stmt.where(
+                InvestCryptoScreenerSnapshot.long_short_account_ratio.is_not(None),
+            ).order_by(
+                func.abs(
+                    InvestCryptoScreenerSnapshot.long_short_account_ratio - 1
+                ).desc(),
                 InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
                 InvestCryptoScreenerSnapshot.symbol.asc(),
             )

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -422,6 +422,34 @@ CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
         presetOrigin=_AT_OWN,
         parityNote="auto_trader 자체 가상자산 프리셋 (선물 펀딩비 기반, Toss 대상 아님).",
     ),
+    ScreenerPreset(
+        id="crypto_oi_surge",
+        name="미결제약정 급증",
+        description="24시간 미결제약정(OI)이 크게 늘어난 가상자산 — 신규 자금/포지션 유입 신호",
+        badges=["가상자산"],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="미결제약정", detail="24시간 증가 상위"),
+        ],
+        metricLabel="OI 변화",
+        market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (선물 미결제약정 기반, Toss 대상 아님).",
+    ),
+    ScreenerPreset(
+        id="crypto_long_short_skew",
+        name="롱숏 쏠림 (리테일)",
+        description="리테일 롱숏 계정 비율이 1에서 가장 벗어난 가상자산 — 포지션 쏠림/역추세 참고 신호",
+        badges=["가상자산"],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="롱숏비율", detail="1에서 가장 치우침"),
+        ],
+        metricLabel="롱숏비율",
+        market="crypto",
+        presetOrigin=_AT_OWN,
+        parityNote="auto_trader 자체 가상자산 프리셋 (선물 롱숏비율 기반, Toss 대상 아님).",
+    ),
 ]
 
 

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -966,6 +966,15 @@ async def _load_crypto_rows_from_snapshots(
                 "funding_rate": float(snap.funding_rate)
                 if getattr(snap, "funding_rate", None) is not None
                 else None,
+                "open_interest_usd": float(snap.open_interest_usd)
+                if getattr(snap, "open_interest_usd", None) is not None
+                else None,
+                "oi_change_24h": float(snap.oi_change_24h)
+                if getattr(snap, "oi_change_24h", None) is not None
+                else None,
+                "long_short_account_ratio": float(snap.long_short_account_ratio)
+                if getattr(snap, "long_short_account_ratio", None) is not None
+                else None,
                 "source": "tvscreener_upbit",
                 "computed_at": snap.computed_at.isoformat()
                 if getattr(snap, "computed_at", None) is not None
@@ -1002,6 +1011,8 @@ _METRIC_FIELD: dict[str, str] = {
     "crypto_momentum": "change_rate",
     "crypto_funding_squeeze": "funding_rate",
     "crypto_funding_overheated": "funding_rate",
+    "crypto_oi_surge": "oi_change_24h",
+    "crypto_long_short_skew": "long_short_account_ratio",
     "profitable_company": "roe",
     "undervalued_growth": "earnings_growth_3y_avg",
     "stable_growth": "roe",
@@ -1279,6 +1290,12 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
     if field == "funding_rate":
         # ROB-443: ratio (e.g. 0.0001) → signed percent per funding interval.
         return f"{float(value) * 100:+.4f}%", []
+    if field == "oi_change_24h":
+        # ROB-443: 24h open-interest change, already a percent.
+        return f"{float(value):+.2f}%", []
+    if field == "long_short_account_ratio":
+        # ROB-443: global retail long/short ratio (>1 long-skewed, <1 short-skewed).
+        return f"{float(value):.2f}", []
     if field in ("volume", "trade_amount_24h"):
         return f"{int(float(value)):,}", []
     if field == "foreign_net":
@@ -1966,15 +1983,21 @@ async def build_screener_results(
         _snapshot_empty_warning = "밸류에이션/재무 스냅샷이 아직 적재되지 않아 해당 프리셋 후보를 표시할 수 없습니다."
 
     if (
-        preset_id in {"crypto_funding_squeeze", "crypto_funding_overheated"}
+        preset_id
+        in {
+            "crypto_funding_squeeze",
+            "crypto_funding_overheated",
+            "crypto_oi_surge",
+            "crypto_long_short_skew",
+        }
         and _snapshot_check_result is None
     ):
-        # ROB-443: funding presets rank by funding_rate, which only the crypto
-        # snapshot carries (the live tvscreener fallback has no funding data).
-        # Snapshot-only — never fall through to the generic provider.
+        # ROB-443: these presets rank by derivative columns (funding / open
+        # interest / long-short), which only the crypto snapshot carries (the live
+        # tvscreener fallback has none). Snapshot-only — never fall through.
         _snapshot_check_result = []
         _snapshot_state_override = "missing"
-        _snapshot_empty_warning = "암호화폐 펀딩비 스냅샷이 아직 적재되지 않아 펀딩비 후보를 표시할 수 없습니다."
+        _snapshot_empty_warning = "암호화폐 선물 지표 스냅샷이 아직 적재되지 않아 해당 후보를 표시할 수 없습니다."
 
     _snapshot_was_checked = _snapshot_check_result is not None
     if _snapshot_was_checked:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -499,6 +499,33 @@ async def db_session():
                             "ADD COLUMN funding_rate NUMERIC(12, 8)"
                         )
                     )
+                # ROB-443 follow-up — OI / long-short columns on the (persistent)
+                # crypto screener snapshot table. Same conditional-ALTER pattern.
+                for _col, _ddl in (
+                    ("open_interest_usd", "open_interest_usd NUMERIC(28, 2)"),
+                    ("oi_change_24h", "oi_change_24h NUMERIC(10, 4)"),
+                    (
+                        "long_short_account_ratio",
+                        "long_short_account_ratio NUMERIC(10, 4)",
+                    ),
+                ):
+                    _has = (
+                        await conn.execute(
+                            text(
+                                "SELECT 1 FROM information_schema.columns "
+                                "WHERE table_name = 'invest_crypto_screener_snapshots' "
+                                "AND column_name = :c"
+                            ),
+                            {"c": _col},
+                        )
+                    ).first()
+                    if not _has:
+                        await conn.execute(
+                            text(
+                                "ALTER TABLE invest_crypto_screener_snapshots "
+                                f"ADD COLUMN {_ddl}"
+                            )
+                        )
                 # ROB-284 — crypto_candles_1d migrates in-place from the
                 # legacy (symbol, market) shape to the (instrument_id, time)
                 # shape. The test DB picks up its schema from

--- a/tests/test_invest_crypto_derivatives.py
+++ b/tests/test_invest_crypto_derivatives.py
@@ -9,6 +9,7 @@ import pytest
 from app.services.invest_crypto_screener_snapshots.derivatives import (
     base_symbol_from_upbit,
     fetch_funding_rates,
+    fetch_oi_and_long_short,
 )
 
 
@@ -68,3 +69,55 @@ async def test_fetch_funding_rates_empty_when_no_krw_symbols() -> None:
     out = await fetch_funding_rates(["BTC-ETH", "USDT-XRP"], fetcher=_fetcher)
     assert out == {}
     assert called is False  # no KRW coins → no fetch attempted
+
+
+@pytest.mark.asyncio
+async def test_fetch_oi_and_long_short_maps_perp_coins() -> None:
+    async def _oi(base, period, limit):
+        assert (period, limit) == ("1h", 24)
+        return {
+            "open_interest_history": [
+                {"sum_open_interest_value_usd": 1.0},
+                {"sum_open_interest_value_usd": 5_000_000.0},  # latest
+            ],
+            "oi_change_pct": 12.5,
+        }
+
+    async def _lsr(base, period, limit):
+        return {"global_account": {"ratio": 1.8}}
+
+    out = await fetch_oi_and_long_short(
+        ["KRW-BTC", "KRW-XYZ"], oi_fetcher=_oi, lsr_fetcher=_lsr
+    )
+    assert out["KRW-BTC"]["open_interest_usd"] == Decimal("5000000.0")
+    assert out["KRW-BTC"]["oi_change_24h"] == Decimal("12.5")
+    assert out["KRW-BTC"]["long_short_account_ratio"] == Decimal("1.8")
+
+
+@pytest.mark.asyncio
+async def test_fetch_oi_and_long_short_fail_open_per_metric() -> None:
+    async def _oi_boom(base, period, limit):
+        raise RuntimeError("oi down")
+
+    async def _lsr(base, period, limit):
+        return {"global_account": {"ratio": 0.7}}
+
+    out = await fetch_oi_and_long_short(
+        ["KRW-BTC"], oi_fetcher=_oi_boom, lsr_fetcher=_lsr
+    )
+    # OI failed but long/short still resolved → coin kept with partial data
+    assert out["KRW-BTC"].get("open_interest_usd") is None
+    assert out["KRW-BTC"]["long_short_account_ratio"] == Decimal("0.7")
+
+
+@pytest.mark.asyncio
+async def test_fetch_oi_and_long_short_empty_when_no_perp_symbols() -> None:
+    called = False
+
+    async def _oi(base, period, limit):
+        nonlocal called
+        called = True
+        return {}
+
+    out = await fetch_oi_and_long_short(["BTC-ETH"], oi_fetcher=_oi, lsr_fetcher=_oi)
+    assert out == {} and called is False

--- a/tests/test_invest_crypto_funding_presets.py
+++ b/tests/test_invest_crypto_funding_presets.py
@@ -78,3 +78,63 @@ def test_funding_presets_registered_for_crypto() -> None:
     ids = {p.id for p in preset_definitions("crypto")}
     assert "crypto_funding_squeeze" in ids
     assert "crypto_funding_overheated" in ids
+
+
+def _row_oi(symbol, *, oi_change, ls, vd):
+    return InvestCryptoScreenerSnapshot(
+        symbol=symbol,
+        snapshot_date=vd,
+        latest_close=Decimal("100"),
+        oi_change_24h=oi_change,
+        long_short_account_ratio=ls,
+        market_warning=False,
+        source="tvscreener_upbit",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_oi_surge_and_long_short_skew_presets(db_session):
+    vd = dt.date(2099, 11, 2)
+    await db_session.execute(
+        InvestCryptoScreenerSnapshot.__table__.delete().where(
+            InvestCryptoScreenerSnapshot.snapshot_date == vd
+        )
+    )
+    db_session.add_all(
+        [
+            _row_oi("KRW-AAA", oi_change=Decimal("5.0"), ls=Decimal("1.1"), vd=vd),
+            _row_oi("KRW-BBB", oi_change=Decimal("30.0"), ls=Decimal("0.4"), vd=vd),
+            _row_oi("KRW-CCC", oi_change=Decimal("-2.0"), ls=Decimal("2.5"), vd=vd),
+            _row_oi("KRW-DDD", oi_change=None, ls=None, vd=vd),  # no perp
+        ]
+    )
+    await db_session.commit()
+    repo = InvestCryptoScreenerSnapshotsRepository(db_session)
+
+    # oi_surge: positive oi_change only, biggest first (negative + null excluded)
+    surge = await repo.list_latest(preset_id="crypto_oi_surge", snapshot_date=vd)
+    assert [r.symbol for r in surge] == ["KRW-BBB", "KRW-AAA"]
+
+    # long_short_skew: most deviated from 1 (either direction), null excluded
+    # |2.5-1|=1.5 (CCC) > |0.4-1|=0.6 (BBB) > |1.1-1|=0.1 (AAA)
+    skew = await repo.list_latest(preset_id="crypto_long_short_skew", snapshot_date=vd)
+    assert [r.symbol for r in skew] == ["KRW-CCC", "KRW-BBB", "KRW-AAA"]
+
+    await db_session.execute(
+        InvestCryptoScreenerSnapshot.__table__.delete().where(
+            InvestCryptoScreenerSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.commit()
+
+
+def test_oi_and_long_short_metric_labels() -> None:
+    from app.services.invest_view_model.screener_service import _metric_value_label
+
+    oi, _ = _metric_value_label("crypto_oi_surge", {"oi_change_24h": 12.5})
+    ls, _ = _metric_value_label(
+        "crypto_long_short_skew", {"long_short_account_ratio": 1.83}
+    )
+    assert oi == "+12.50%"
+    assert ls == "1.83"

--- a/tests/test_invest_crypto_screener_snapshots_builder.py
+++ b/tests/test_invest_crypto_screener_snapshots_builder.py
@@ -30,6 +30,7 @@ def _stub_funding(monkeypatch):
         return {}
 
     monkeypatch.setattr(builder_mod, "fetch_funding_rates", _empty)
+    monkeypatch.setattr(builder_mod, "fetch_oi_and_long_short", _empty)
 
 
 class _Condition:

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -102,6 +102,8 @@ def test_crypto_preset_definitions_are_crypto_scoped() -> None:
         "crypto_momentum",
         "crypto_funding_squeeze",
         "crypto_funding_overheated",
+        "crypto_oi_surge",
+        "crypto_long_short_skew",
     ]
     assert all(p.market == "crypto" for p in presets)
     assert all(p.filterChips[0].label == "가상자산" for p in presets)

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -411,6 +411,8 @@ async def test_build_screener_presets_returns_crypto_presets() -> None:
         "crypto_momentum",
         "crypto_funding_squeeze",
         "crypto_funding_overheated",
+        "crypto_oi_surge",
+        "crypto_long_short_skew",
     ]
     assert all(p.market == "crypto" for p in resp.presets)
 


### PR DESCRIPTION
## What & why
펀딩비(#1157/#1158)에 이어 **per-symbol 선물 지표 2종**(미결제약정 OI, 리테일 롱숏비율) 추가. OI/롱숏은 배치 엔드포인트가 없어 per-symbol → **perp 코인(funding 매칭분)만** bounded concurrency(8)로 enrich, **코인·지표별 fail-open**.

## Changes
- **additive migration** `20260607_rob443b`: `open_interest_usd`(28,2) / `oi_change_24h`(10,4) / `long_short_account_ratio`(10,4) nullable + model + Upsert.
- `derivatives.fetch_oi_and_long_short(perp_upbit_symbols)`: `KRW-XXX`→base → `_fetch_open_interest`(history USD + oi_change_pct) / `_fetch_long_short_ratio`(`global_account.ratio`) (주입가능). no-perp/에러 → None.
- builder: funding 키(=perp 코인)만 enrich → payload 병합 + `oiEnriched`/`longShortEnriched` 카운트.
- `repository.list_latest`: `crypto_oi_surge`(oi_change>0 desc=신규자금) + `crypto_long_short_skew`(`abs(ratio-1)` desc=양방향 쏠림).
- 읽기경로 3필드 노출(getattr) + `_METRIC_FIELD` + 라벨(oi=부호%/ratio=2자리) + 2 `ScreenerPreset` + snapshot-only 가드 확장.
- conftest 3컬럼 조건부 ALTER, 기존 크립토 프리셋 정확-리스트 단언 5→7.

## Verification
- 신규: enricher 매핑/지표별 fail-open/perp-only · repo 정렬(oi 양수만·skew 양방향) · 라벨 · preset.
- **23 + 1217 sweep green**(crypto/screener 회귀 0); ruff clean; **단일 head**; ROB-285 audit **pass**(derivatives.py만 binance, 기존 allow-list).
- ⚠️`test_mcp_place_order` crypto 실패는 로컬 persistent DB ledger 오염(clean main 동일) → CI fresh DB 통과, 무관.

## Boundaries / operator
- read-only 발굴. broker/order/watch mutation 0. **매수신호 아님**. Binance public read만.
- ⚠️per-symbol = 빌드당 perp코인 × ~4 call(daily 빌드 + concurrency 제한 + fail-open). filter 카탈로그 crypto kind는 여전히 후속.
- **operator**: `alembic upgrade head` + crypto 스냅샷 재빌드 시 OI/LS 자동 적재(`oiEnriched`/`longShortEnriched` 확인).

## Related
ROB-443(PR0 #1156 / PR1 #1157 / PR2 #1158) · ROB-377(Binance OI/long-short).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new crypto metrics: open interest (USD), 24-hour open interest change, and long/short account ratio to screener snapshots.
  * Added two new crypto screener presets: "OI Surge" (filters by 24h open interest increases) and "Long/Short Skew" (filters by long/short account ratio deviation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->