### PR TITLE
feat(ROB-443): screen_stocks_snapshot crypto 필터 카탈로그 + 적용 (Phase 1 마무리)

### DIFF
--- a/app/services/invest_view_model/screener_filters.py
+++ b/app/services/invest_view_model/screener_filters.py
@@ -168,7 +168,80 @@ SNAPSHOT_FILTER_FIELDS: dict[str, dict[str, ScreenerFilterDefinition]] = {
             unit="%",
         ),
     },
+    # ROB-443: crypto screener snapshot (tvscreener_upbit + USD-M perp derivatives).
+    # Composing filters added ON TOP of a preset's base (the preset's defining
+    # filter runs in SQL; these tighten/add in-memory — see screener_service crypto
+    # dispatch). Liquidity floor (trade_amount_24h) is the most broadly useful.
+    "invest_crypto_screener_snapshots": {
+        "trade_amount_24h": ScreenerFilterDefinition(
+            field="trade_amount_24h",
+            label="거래대금(24h)",
+            operator="gte",
+            value_type="int",
+            min_bound=0,
+            step=1_000_000_000,
+            unit="원",
+        ),
+        "rsi": ScreenerFilterDefinition(
+            field="rsi",
+            label="RSI",
+            operator="lte",
+            value_type="float",
+            min_bound=0.0,
+            max_bound=100.0,
+            step=1.0,
+        ),
+        "change_rate": ScreenerFilterDefinition(
+            field="change_rate",
+            label="등락률(당일)",
+            operator="gte",
+            value_type="percent",
+            min_bound=-30.0,
+            max_bound=30.0,
+            step=1.0,
+            unit="%",
+        ),
+        "oi_change_24h": ScreenerFilterDefinition(
+            field="oi_change_24h",
+            label="미결제약정 변화(24h)",
+            operator="gte",
+            value_type="percent",
+            min_bound=-100.0,
+            max_bound=500.0,
+            step=1.0,
+            unit="%",
+        ),
+        "long_short_account_ratio": ScreenerFilterDefinition(
+            field="long_short_account_ratio",
+            label="롱숏비율(리테일)",
+            operator="gte",
+            value_type="float",
+            min_bound=0.0,
+            max_bound=10.0,
+            step=0.1,
+        ),
+        "funding_rate": ScreenerFilterDefinition(
+            field="funding_rate",
+            label="펀딩비(비율)",
+            operator="lte",
+            value_type="float",
+            min_bound=-1.0,
+            max_bound=1.0,
+            step=0.0001,
+        ),
+    },
 }
+
+_CRYPTO_SNAPSHOT_KIND = "invest_crypto_screener_snapshots"
+_CRYPTO_PRESET_IDS = (
+    "crypto_high_volume",
+    "crypto_oversold",
+    "crypto_momentum",
+    "crypto_funding_squeeze",
+    "crypto_funding_overheated",
+    "crypto_oi_surge",
+    "crypto_long_short_skew",
+)
 
 # pilot preset → (base snapshot kind, starting filter set). A preset is just the
 # starting conditions; users adjust/add on top. Mirrors the current hardcoded
@@ -177,6 +250,8 @@ SNAPSHOT_FILTER_FIELDS: dict[str, dict[str, ScreenerFilterDefinition]] = {
 _PILOT_PRESET_SNAPSHOT: dict[str, str] = {
     "consecutive_gainers": "invest_screener_snapshots",
     "high_yield_value": "market_valuation_snapshots",
+    # ROB-443: crypto presets share one snapshot catalog (composing filters on top).
+    **dict.fromkeys(_CRYPTO_PRESET_IDS, _CRYPTO_SNAPSHOT_KIND),
 }
 _PILOT_PRESET_STARTING: dict[str, tuple[ScreenerFilterCondition, ...]] = {
     "consecutive_gainers": (

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1951,6 +1951,26 @@ async def build_screener_results(
                 _snapshot_check_result, _snapshot_state_override = (
                     _crypto_snapshot_result
                 )
+                # ROB-443: apply screen_stocks_snapshot filter overrides on top of
+                # the preset's SQL base (add/tighten). The preset's defining filter
+                # already ran in repo.list_latest; these compose in-memory over the
+                # exposed row fields (e.g. liquidity floor, rsi cap). validate raises
+                # ScreenerFilterError on an unknown field (caught by the MCP tool).
+                if filter_overrides:
+                    from app.services.invest_view_model.screener_filters import (
+                        apply_filter_conditions,
+                        snapshot_kind_for_preset,
+                        validate_conditions,
+                    )
+
+                    _crypto_kind = snapshot_kind_for_preset(preset_id)
+                    if _crypto_kind is not None:
+                        _crypto_conditions = validate_conditions(
+                            filter_overrides, snapshot_kind=_crypto_kind
+                        )
+                        _snapshot_check_result = apply_filter_conditions(
+                            _snapshot_check_result, _crypto_conditions
+                        )
                 _snapshot_empty_warning = (
                     "최신 암호화폐 스크리너 스냅샷에서 조건에 맞는 결과가 없습니다."
                 )

--- a/tests/test_crypto_filter_catalog.py
+++ b/tests/test_crypto_filter_catalog.py
@@ -1,0 +1,83 @@
+"""ROB-443 follow-up: crypto screener filter catalog (screen_stocks_snapshot)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.invest_view_model.screener_filters import (
+    SNAPSHOT_FILTER_FIELDS,
+    ScreenerFilterCondition,
+    ScreenerFilterError,
+    apply_filter_conditions,
+    snapshot_kind_for_preset,
+    validate_conditions,
+)
+
+_KIND = "invest_crypto_screener_snapshots"
+
+
+def test_crypto_kind_catalog_fields() -> None:
+    catalog = SNAPSHOT_FILTER_FIELDS[_KIND]
+    assert {
+        "trade_amount_24h",
+        "rsi",
+        "change_rate",
+        "oi_change_24h",
+        "long_short_account_ratio",
+        "funding_rate",
+    } <= set(catalog)
+
+
+@pytest.mark.parametrize(
+    "preset",
+    [
+        "crypto_high_volume",
+        "crypto_oversold",
+        "crypto_momentum",
+        "crypto_funding_squeeze",
+        "crypto_funding_overheated",
+        "crypto_oi_surge",
+        "crypto_long_short_skew",
+    ],
+)
+def test_all_crypto_presets_map_to_crypto_kind(preset) -> None:
+    assert snapshot_kind_for_preset(preset) == _KIND
+
+
+def test_validate_conditions_crypto_ok_clamp_and_unknown() -> None:
+    ok = validate_conditions(
+        [ScreenerFilterCondition("trade_amount_24h", "gte", 5_000_000_000)],
+        snapshot_kind=_KIND,
+    )
+    assert ok[0].field == "trade_amount_24h"
+
+    # value clamped to the definition bound (rsi max 100)
+    clamped = validate_conditions(
+        [ScreenerFilterCondition("rsi", "lte", 999)], snapshot_kind=_KIND
+    )
+    assert clamped[0].value == 100.0
+
+    # unknown field is fail-closed (never silently dropped)
+    with pytest.raises(ScreenerFilterError):
+        validate_conditions(
+            [ScreenerFilterCondition("per", "lte", 10)], snapshot_kind=_KIND
+        )
+
+
+def test_apply_filter_conditions_on_crypto_rows() -> None:
+    rows = [
+        {"symbol": "KRW-AAA", "trade_amount_24h": 1.0e10, "rsi": 28.0},
+        {"symbol": "KRW-BBB", "trade_amount_24h": 1.0e8, "rsi": 25.0},  # below floor
+        {"symbol": "KRW-CCC", "trade_amount_24h": 5.0e10, "rsi": 60.0},  # rsi too high
+        {
+            "symbol": "KRW-DDD",
+            "trade_amount_24h": None,
+            "rsi": 20.0,
+        },  # null → fail-closed
+    ]
+    conds = [
+        ScreenerFilterCondition("trade_amount_24h", "gte", 1_000_000_000),
+        ScreenerFilterCondition("rsi", "lte", 35),
+    ]
+    out = apply_filter_conditions(rows, conds)
+    assert [r["symbol"] for r in out] == ["KRW-AAA"]


### PR DESCRIPTION
## What & why
크립토 7개 프리셋에 `screen_stocks_snapshot` 필터 조정 지원. 프리셋의 정의 필터는 repo SQL이 적용하고, user override는 그 위에 **in-memory로 add/tighten**(liquidity floor가 가장 범용). loosen은 프리셋 의미상 불필요(예: funding_squeeze에서 음수 펀딩 조건을 푸는 건 무의미).

## Changes
- `SNAPSHOT_FILTER_FIELDS`에 **`invest_crypto_screener_snapshots` kind** 추가 — `trade_amount_24h`(거래대금 floor)/`rsi`/`change_rate`/`oi_change_24h`/`long_short_account_ratio`/`funding_rate` + 7 크립토 프리셋 → `snapshot_kind_for_preset` 매핑.
- 크립토 dispatch: `filter_overrides` 있으면 `validate_conditions`(crypto kind, **unknown field fail-closed**) → `apply_filter_conditions`(노출된 row 필드 위 in-memory AND). 웹 스크리너(overrides None)는 **무변경**.
- 기존 generic helper(`validate_conditions`/`apply_filter_conditions`, ROB-439) 재사용 — 신규 적용 로직 없음.

## Verification
- 신규: 카탈로그 6필드 · 7프리셋 kind 매핑 · validate(ok/clamp/unknown raise) · apply(liquidity+rsi, null fail-closed).
- **10 + 1227 sweep green**(crypto/screener 회귀 0); ruff clean; **migration 0**.

## Boundaries
- read-only 발굴. broker/order/watch mutation 0.
- ⚠️semantics: 프리셋 base는 SQL(repo), override는 in-memory **tighten/add**(repo LIMIT 후 subset 위) — **loosen 미지원**(프리셋 정의 필터를 푸는 건 의도상 불필요). screen_stocks_snapshot으로 "프리셋 + 거래대금/RSI 등 추가 조정" 가능.

## Related
ROB-443(PR0 #1156 / PR1 #1157 / PR2 #1158 / OI·LS #1159) · ROB-439(필터 generic helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)