### PR TITLE
feat(ROB-440): US 펀더멘털 품질 가드 — 마이크로캡/이상치 제외 (라이브 후속)

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -184,6 +184,18 @@ FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {
     )
 }
 
+# ROB-440: US fundamentals quality guards. Once the labels were corrected (#1154
+# dividend ×100, #1155 market_cap currency), yahoo .info ratios for micro-caps and
+# bad data points surfaced at the TOP of the rankings: DCX ROE 1177% on a $48M cap,
+# NVO dividend 26.74% from a bad trailingAnnualDividendYield. KR uses tvscreener
+# (cleaner) so these apply to US only. Guards: a size/liquidity floor (global) plus
+# metric sanity caps applied only when that metric is the preset's filter/sort.
+_US_MIN_MARKET_CAP_USD = Decimal("100000000")  # $100M — drop nano-caps (DCX $48M)
+_US_MAX_ROE_PERCENT = Decimal(
+    "300"
+)  # drop egregious ROE artifacts (keep real high ROE)
+_US_MAX_DIVIDEND_RATIO = Decimal("0.25")  # 25% — drop bad dividend data (real ≤ ~20%)
+
 
 @dataclass(frozen=True)
 class FundamentalsScreenResult:
@@ -394,6 +406,28 @@ async def load_fundamentals_preset_from_snapshots(
         cand_stmt = cand_stmt.where(
             MarketValuationSnapshot.dividend_yield >= spec.min_dividend_yield
         )
+    if market == "us":
+        # ROB-440 quality guards (US only; KR uses cleaner tvscreener). Drop the
+        # micro-cap / bad-data outliers the now-correct labels expose. NULL passes
+        # the ratio caps (missing ≠ anomalous); the size floor requires a value.
+        cand_stmt = cand_stmt.where(
+            MarketValuationSnapshot.market_cap.is_not(None),
+            MarketValuationSnapshot.market_cap >= _US_MIN_MARKET_CAP_USD,
+        )
+        if spec.min_roe is not None or spec.sort_by == "roe":
+            cand_stmt = cand_stmt.where(
+                sa.or_(
+                    MarketValuationSnapshot.roe.is_(None),
+                    MarketValuationSnapshot.roe <= _US_MAX_ROE_PERCENT,
+                )
+            )
+        if spec.min_dividend_yield is not None or spec.sort_by == "dividend_yield":
+            cand_stmt = cand_stmt.where(
+                sa.or_(
+                    MarketValuationSnapshot.dividend_yield.is_(None),
+                    MarketValuationSnapshot.dividend_yield <= _US_MAX_DIVIDEND_RATIO,
+                )
+            )
     # Cap the candidate universe by market_cap (prefer liquid names); ranking by the
     # preset's sort_by happens AFTER derive. Surface truncation honestly (no silent cap).
     _cand_cap = max(limit * 8, 200)

--- a/tests/test_fundamentals_screener.py
+++ b/tests/test_fundamentals_screener.py
@@ -1391,3 +1391,164 @@ async def test_kr_dividend_yield_not_double_scaled(db_session):
     row = next(r for r in res.rows if r["symbol"] == sym)
     assert row["dividend_yield"] == 0.05  # KR unchanged (no ×100)
     await _cleanup_db(db_session)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_us_quality_guards_drop_microcap_and_bad_data(db_session):
+    # ROB-440: US fundamentals quality guards — micro-cap (size floor) + ROE/dividend
+    # sanity caps drop the yahoo outliers the corrected labels exposed. KR unaffected.
+    await _cleanup_db(db_session)
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_view_model.fundamentals_screener import (
+        FundamentalsPresetSpec,
+        load_fundamentals_preset_from_snapshots,
+    )
+
+    vd = dt.date(2099, 12, 1)
+
+    def _mv(symbol, *, market, roe=None, per=None, div=None, mcap):
+        return MarketValuationSnapshot(
+            market=market,
+            symbol=symbol,
+            snapshot_date=vd,
+            source="yahoo",
+            roe=roe,
+            per=per,
+            dividend_yield=div,
+            market_cap=Decimal(str(mcap)),
+        )
+
+    db_session.add_all(
+        [
+            _mv(
+                "DCX",
+                market="us",
+                roe=Decimal("1177"),
+                per=Decimal("5"),
+                mcap=48_000_000,
+            ),  # micro + ROE artifact
+            _mv(
+                "BLKB",
+                market="us",
+                roe=Decimal("418"),
+                per=Decimal("5"),
+                mcap=1_300_000_000,
+            ),  # large-cap ROE artifact
+            _mv(
+                "GOODR",
+                market="us",
+                roe=Decimal("25"),
+                per=Decimal("8"),
+                mcap=190_000_000_000,
+            ),  # legit
+        ]
+    )
+    await db_session.commit()
+    now = lambda: dt.datetime(2099, 12, 1, tzinfo=dt.UTC)  # noqa: E731
+
+    roe_spec = FundamentalsPresetSpec(
+        preset_id="_t_roe", min_roe=Decimal("15"), sort_by="roe"
+    )
+    res = await load_fundamentals_preset_from_snapshots(
+        db_session, market="us", spec=roe_spec, limit=20, now=now
+    )
+    syms = {r["symbol"] for r in res.rows}
+    assert syms == {"GOODR"}  # DCX(size floor) + BLKB(ROE cap) dropped
+
+    # dividend cap: bad-data NVO-like dropped, legit high-yield kept
+    await db_session.execute(
+        MarketValuationSnapshot.__table__.delete().where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    db_session.add_all(
+        [
+            _mv(
+                "BADDIV", market="us", div=Decimal("0.2674"), mcap=190_000_000_000
+            ),  # yahoo artifact
+            _mv(
+                "AGNCX", market="us", div=Decimal("0.14"), mcap=12_000_000_000
+            ),  # legit ~14%
+        ]
+    )
+    await db_session.commit()
+    div_spec = FundamentalsPresetSpec(
+        preset_id="_t_div", min_dividend_yield=Decimal("0.03"), sort_by="dividend_yield"
+    )
+    res2 = await load_fundamentals_preset_from_snapshots(
+        db_session, market="us", spec=div_spec, limit=20, now=now
+    )
+    assert {r["symbol"] for r in res2.rows} == {"AGNCX"}  # BADDIV(>25%) dropped
+
+    await db_session.execute(
+        MarketValuationSnapshot.__table__.delete().where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.commit()
+    await _cleanup_db(db_session)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_kr_unaffected_by_us_quality_guards(db_session):
+    # KR path (reports/PIT) must NOT apply the US-only guards.
+    await _cleanup_db(db_session)
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_view_model.fundamentals_screener import (
+        FundamentalsPresetSpec,
+        load_fundamentals_preset_from_snapshots,
+    )
+
+    vd = dt.date(2099, 12, 2)
+    # idempotent on the persistent local DB (prior runs may have left these)
+    await db_session.execute(
+        MarketValuationSnapshot.__table__.delete().where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.execute(
+        KRSymbolUniverse.__table__.delete().where(KRSymbolUniverse.symbol == "900001")
+    )
+    db_session.add(
+        MarketValuationSnapshot(
+            market="kr",
+            symbol="900001",
+            snapshot_date=vd,
+            source="naver_finance",
+            roe=Decimal("1177"),
+            per=Decimal("5"),
+            market_cap=Decimal("48000000"),
+        )
+    )
+    db_session.add(
+        KRSymbolUniverse(
+            symbol="900001", name="마이크로", exchange="KOSDAQ", is_active=True
+        )
+    )
+    await db_session.commit()
+    res = await load_fundamentals_preset_from_snapshots(
+        db_session,
+        market="kr",
+        spec=FundamentalsPresetSpec(
+            preset_id="_t_kr", min_roe=Decimal("15"), sort_by="roe"
+        ),
+        limit=20,
+        now=lambda: dt.datetime(2099, 12, 2, tzinfo=dt.UTC),
+    )
+    assert "900001" in {
+        r["symbol"] for r in res.rows
+    }  # KR micro-cap kept (no US guard)
+
+    await db_session.execute(
+        MarketValuationSnapshot.__table__.delete().where(
+            MarketValuationSnapshot.snapshot_date == vd
+        )
+    )
+    await db_session.execute(
+        KRSymbolUniverse.__table__.delete().where(KRSymbolUniverse.symbol == "900001")
+    )
+    await db_session.commit()
+    await _cleanup_db(db_session)


### PR DESCRIPTION
## What & why
라이브 검증에서 라벨 fix(#1154 배당 ×100 / #1155 시총 통화) 후 **yahoo `.info` 이상치가 정렬 상단에 노출**:
- `high_yield_value` **DCX ROE 1177%** ($48M 마이크로캡, 자본 왜곡)
- `steady_dividend` **NVO 배당 26.74%** (실제 ~2% → trailingAnnualDividendYield 이상치)

KR은 tvscreener라 덜함 → **US만** 품질 가드 추가.

## Changes
US 후보 쿼리(`load_fundamentals_preset_from_snapshots`, `market=="us"`)에:
- **시총 floor `$100M`**(전역): 나노캡 ROE/PER 왜곡 제거 (DCX $48M).
- **ROE 상한 `300%`**(ROE 프리셋=min_roe 또는 sort_by roe): 극단 아티팩트 제거(DCX 1177%/BLKB 418%), 정상 고ROE 보존.
- **배당 상한 `25%`**(배당 프리셋): yahoo 배당 이상치 제거(NVO 0.2674), 정상 고배당 보존(AGNC 0.14).
- NULL은 ratio 상한 **통과**(결측≠이상); 시총 floor만 값 요구. **KR 무영향**(동일 로더지만 us 게이트).

## Verification
- 신규: US micro/ROE-artifact 제외+정상 보존 · US 배당이상치 제외+정상 보존 · KR 미적용(마이크로캡 유지).
- **32 + 165 sweep green**(fundamentals/screener/coverage 회귀 0); ruff clean; **migration 0**.

## Boundaries / notes
- read-only. broker/order/watch mutation 0. KR/crypto 무변경.
- `totalCount`는 가드 후 집계(아티팩트 제외 = 더 정직). 임계값 상수(`_US_MIN_MARKET_CAP_USD`/`_US_MAX_ROE_PERCENT`/`_US_MAX_DIVIDEND_RATIO`)는 보수적(false-positive 최소) + 튜닝 가능.
- ⚠️일부 중간 이상치(예: QTTB ROE 157%)는 보수적 임계값을 통과할 수 있음 — 필요 시 임계값 하향.

## Related
ROB-440(#1154 배당 라벨 / #1155 시총 라벨) · 라이브 검증에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented US market-specific quality filters in the fundamentals screener, introducing minimum market cap thresholds and profitability/dividend ratio sanity checks to enhance candidate selection quality.

* **Tests**
  * Added comprehensive integration tests validating quality guard behavior across US and non-US markets to ensure proper filtering implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->