### PR TITLE
fix(ROB-440): US 품질 가드를 high_yield_value/undervalued_breakout 로더에도 적용

### DIFF
--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -184,18 +184,6 @@ FUNDAMENTALS_PRESET_SPECS: dict[str, FundamentalsPresetSpec] = {
     )
 }
 
-# ROB-440: US fundamentals quality guards. Once the labels were corrected (#1154
-# dividend ×100, #1155 market_cap currency), yahoo .info ratios for micro-caps and
-# bad data points surfaced at the TOP of the rankings: DCX ROE 1177% on a $48M cap,
-# NVO dividend 26.74% from a bad trailingAnnualDividendYield. KR uses tvscreener
-# (cleaner) so these apply to US only. Guards: a size/liquidity floor (global) plus
-# metric sanity caps applied only when that metric is the preset's filter/sort.
-_US_MIN_MARKET_CAP_USD = Decimal("100000000")  # $100M — drop nano-caps (DCX $48M)
-_US_MAX_ROE_PERCENT = Decimal(
-    "300"
-)  # drop egregious ROE artifacts (keep real high ROE)
-_US_MAX_DIVIDEND_RATIO = Decimal("0.25")  # 25% — drop bad dividend data (real ≤ ~20%)
-
 
 @dataclass(frozen=True)
 class FundamentalsScreenResult:
@@ -407,27 +395,19 @@ async def load_fundamentals_preset_from_snapshots(
             MarketValuationSnapshot.dividend_yield >= spec.min_dividend_yield
         )
     if market == "us":
-        # ROB-440 quality guards (US only; KR uses cleaner tvscreener). Drop the
-        # micro-cap / bad-data outliers the now-correct labels expose. NULL passes
-        # the ratio caps (missing ≠ anomalous); the size floor requires a value.
-        cand_stmt = cand_stmt.where(
-            MarketValuationSnapshot.market_cap.is_not(None),
-            MarketValuationSnapshot.market_cap >= _US_MIN_MARKET_CAP_USD,
+        # ROB-440 quality guards (US only; KR uses cleaner tvscreener). Shared with
+        # the high_yield_value / undervalued_breakout US loaders.
+        from app.services.invest_view_model.us_quality_guards import (
+            apply_us_valuation_quality_guards,
         )
-        if spec.min_roe is not None or spec.sort_by == "roe":
-            cand_stmt = cand_stmt.where(
-                sa.or_(
-                    MarketValuationSnapshot.roe.is_(None),
-                    MarketValuationSnapshot.roe <= _US_MAX_ROE_PERCENT,
-                )
-            )
-        if spec.min_dividend_yield is not None or spec.sort_by == "dividend_yield":
-            cand_stmt = cand_stmt.where(
-                sa.or_(
-                    MarketValuationSnapshot.dividend_yield.is_(None),
-                    MarketValuationSnapshot.dividend_yield <= _US_MAX_DIVIDEND_RATIO,
-                )
-            )
+
+        cand_stmt = apply_us_valuation_quality_guards(
+            cand_stmt,
+            uses_roe=spec.min_roe is not None or spec.sort_by == "roe",
+            uses_dividend=(
+                spec.min_dividend_yield is not None or spec.sort_by == "dividend_yield"
+            ),
+        )
     # Cap the candidate universe by market_cap (prefer liquid names); ranking by the
     # preset's sort_by happens AFTER derive. Surface truncation honestly (no silent cap).
     _cand_cap = max(limit * 8, 200)

--- a/app/services/invest_view_model/high_yield_value_screener.py
+++ b/app/services/invest_view_model/high_yield_value_screener.py
@@ -110,14 +110,22 @@ async def load_high_yield_value_from_snapshots(
             MarketValuationSnapshot.per > 0,
             MarketValuationSnapshot.per <= _MAX_PER,
         )
-        .order_by(
-            MarketValuationSnapshot.roe.desc().nullslast(),
-            MarketValuationSnapshot.per.asc().nullslast(),
-            MarketValuationSnapshot.symbol.asc(),
-            MarketValuationSnapshot.source.asc(),
-        )
-        .limit(max(limit * 4, limit + 40))
     )
+    if market == "us":
+        # ROB-440: drop yahoo micro-cap / ROE-artifact outliers (DCX 1177% @ $48M).
+        from app.services.invest_view_model.us_quality_guards import (
+            apply_us_valuation_quality_guards,
+        )
+
+        candidate_stmt = apply_us_valuation_quality_guards(
+            candidate_stmt, uses_roe=True
+        )
+    candidate_stmt = candidate_stmt.order_by(
+        MarketValuationSnapshot.roe.desc().nullslast(),
+        MarketValuationSnapshot.per.asc().nullslast(),
+        MarketValuationSnapshot.symbol.asc(),
+        MarketValuationSnapshot.source.asc(),
+    ).limit(max(limit * 4, limit + 40))
     try:
         result = await session.execute(candidate_stmt)
     except Exception as exc:  # noqa: BLE001

--- a/app/services/invest_view_model/undervalued_breakout_screener.py
+++ b/app/services/invest_view_model/undervalued_breakout_screener.py
@@ -143,13 +143,19 @@ async def load_undervalued_breakout_from_snapshots(
             MarketValuationSnapshot.pbr > 0,
             MarketValuationSnapshot.pbr <= _MAX_PBR,
         )
-        .order_by(
-            MarketValuationSnapshot.per.asc().nullslast(),
-            MarketValuationSnapshot.symbol.asc(),
-            MarketValuationSnapshot.source.asc(),
-        )
-        .limit(max(limit * 6, limit + 60))
     )
+    if market == "us":
+        # ROB-440: drop yahoo micro-cap outliers (PER/PBR distort at nano-cap).
+        from app.services.invest_view_model.us_quality_guards import (
+            apply_us_valuation_quality_guards,
+        )
+
+        cand_stmt = apply_us_valuation_quality_guards(cand_stmt)
+    cand_stmt = cand_stmt.order_by(
+        MarketValuationSnapshot.per.asc().nullslast(),
+        MarketValuationSnapshot.symbol.asc(),
+        MarketValuationSnapshot.source.asc(),
+    ).limit(max(limit * 6, limit + 60))
     try:
         cand_rows = list((await session.execute(cand_stmt)).mappings().all())
     except Exception as exc:  # noqa: BLE001

--- a/app/services/invest_view_model/us_quality_guards.py
+++ b/app/services/invest_view_model/us_quality_guards.py
@@ -1,0 +1,59 @@
+"""ROB-440: US fundamentals/valuation quality guards (shared across loaders).
+
+Once the labels were corrected (#1154 dividend ×100, #1155 market_cap currency),
+yahoo .info ratios for micro-caps and bad data points surfaced at the TOP of the
+US rankings: DCX ROE 1177% on a $48M cap, NVO dividend 26.74% from a bad
+trailingAnnualDividendYield. KR uses tvscreener (cleaner) so these apply to US only.
+
+The three US loaders that build a market_valuation_snapshots candidate query
+(load_fundamentals_preset_from_snapshots, load_high_yield_value_from_snapshots,
+load_undervalued_breakout_from_snapshots) share this helper so the thresholds stay
+in one place. Callers gate on ``market == "us"``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+
+# Conservative thresholds (minimise false-positives); tunable.
+US_MIN_MARKET_CAP_USD = Decimal("100000000")  # $100M — drop nano-caps (DCX $48M)
+US_MAX_ROE_PERCENT = Decimal("300")  # drop egregious ROE artifacts (keep real high ROE)
+US_MAX_DIVIDEND_RATIO = Decimal("0.25")  # 25% — drop bad dividend data (real ≤ ~20%)
+
+
+def apply_us_valuation_quality_guards(
+    stmt: Any, *, uses_roe: bool = False, uses_dividend: bool = False
+) -> Any:
+    """Add US quality guards to a market_valuation candidate SELECT.
+
+    - market_cap size floor (always): requires a value ≥ floor (drop nano-caps).
+    - ROE sanity cap (when the preset filters/sorts on ROE): NULL passes
+      (missing ≠ anomalous).
+    - dividend sanity cap (when the preset filters/sorts on dividend): NULL passes.
+
+    Returns the augmented statement. Caller must gate on ``market == "us"``.
+    """
+    stmt = stmt.where(
+        MarketValuationSnapshot.market_cap.is_not(None),
+        MarketValuationSnapshot.market_cap >= US_MIN_MARKET_CAP_USD,
+    )
+    if uses_roe:
+        stmt = stmt.where(
+            sa.or_(
+                MarketValuationSnapshot.roe.is_(None),
+                MarketValuationSnapshot.roe <= US_MAX_ROE_PERCENT,
+            )
+        )
+    if uses_dividend:
+        stmt = stmt.where(
+            sa.or_(
+                MarketValuationSnapshot.dividend_yield.is_(None),
+                MarketValuationSnapshot.dividend_yield <= US_MAX_DIVIDEND_RATIO,
+            )
+        )
+    return stmt

--- a/tests/test_invest_view_model_high_yield_value_screener.py
+++ b/tests/test_invest_view_model_high_yield_value_screener.py
@@ -139,6 +139,7 @@ async def test_us_market_filters_by_roe_and_per(db_session):
                 source="yahoo",
                 per=decimal.Decimal("7.0"),
                 roe=decimal.Decimal("22.0"),
+                market_cap=decimal.Decimal("5000000000"),  # ROB-440: above US floor
             ),
             # excluded: ROE 8 < 15
             MarketValuationSnapshot(
@@ -148,6 +149,7 @@ async def test_us_market_filters_by_roe_and_per(db_session):
                 source="yahoo",
                 per=decimal.Decimal("4.0"),
                 roe=decimal.Decimal("8.0"),
+                market_cap=decimal.Decimal("5000000000"),
             ),
         ]
     )
@@ -296,3 +298,64 @@ def test_metric_value_label_formats_roe_as_percent():
     label, warnings = _metric_value_label("high_yield_value", {"roe": 18.3})
     assert label == "18.3%"
     assert warnings == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_us_quality_guards_drop_microcap_and_roe_artifacts(db_session):
+    # ROB-440: high_yield_value US must apply the shared quality guards (the live DCX
+    # ROE 1177% @ $48M / BLKB 418% outliers that #1161 missed for this loader).
+    val_date = dt.date(2099, 12, 30)
+    for s in ("ZZUDCX", "ZZUBLK", "ZZUGUD"):
+        await db_session.execute(
+            MarketValuationSnapshot.__table__.delete().where(
+                MarketValuationSnapshot.symbol == s
+            )
+        )
+    db_session.add_all(
+        [
+            MarketValuationSnapshot(  # micro-cap + ROE artifact → dropped (size floor + ROE cap)
+                market="us",
+                symbol="ZZUDCX",
+                snapshot_date=val_date,
+                source="yahoo",
+                per=decimal.Decimal("5.0"),
+                roe=decimal.Decimal("1177.0"),
+                market_cap=decimal.Decimal("48000000"),
+            ),
+            MarketValuationSnapshot(  # large-cap ROE artifact → dropped (ROE cap)
+                market="us",
+                symbol="ZZUBLK",
+                snapshot_date=val_date,
+                source="yahoo",
+                per=decimal.Decimal("5.0"),
+                roe=decimal.Decimal("418.0"),
+                market_cap=decimal.Decimal("1300000000"),
+            ),
+            MarketValuationSnapshot(  # legit → kept
+                market="us",
+                symbol="ZZUGUD",
+                snapshot_date=val_date,
+                source="yahoo",
+                per=decimal.Decimal("8.0"),
+                roe=decimal.Decimal("25.0"),
+                market_cap=decimal.Decimal("190000000000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    rows = await load_high_yield_value_from_snapshots(
+        db_session, market="us", limit=20, today_market_date=val_date
+    )
+    syms = {r["symbol"] for r in (rows or [])}
+    assert "ZZUGUD" in syms
+    assert "ZZUDCX" not in syms and "ZZUBLK" not in syms  # outliers dropped
+
+    for s in ("ZZUDCX", "ZZUBLK", "ZZUGUD"):
+        await db_session.execute(
+            MarketValuationSnapshot.__table__.delete().where(
+                MarketValuationSnapshot.symbol == s
+            )
+        )
+    await db_session.commit()


### PR DESCRIPTION
## What & why
라이브 재검증: **#1161 후에도 `high_yield_value` US가 DCX ROE 1177%($48M) / BLKB 418% 여전**. 원인 = US `high_yield_value`/`undervalued_breakout`은 `screener_service:1835`의 **별도 분기**(`load_high_yield_value_from_snapshots` / `load_undervalued_breakout_from_snapshots`)를 쓰는데 #1161은 `load_fundamentals_preset_from_snapshots`에만 적용됨. (`steady_dividend` NVO는 펀더 로더라 #1161로 정상 제거됨.)

## Changes
- **공유 모듈 `us_quality_guards.py`**: 상수(`US_MIN_MARKET_CAP_USD` $100M / `US_MAX_ROE_PERCENT` 300 / `US_MAX_DIVIDEND_RATIO` 0.25) + `apply_us_valuation_quality_guards(stmt, uses_roe, uses_dividend)`.
- **3개 US 로더 모두 헬퍼 사용**(`market=="us"` 게이트):
  - `fundamentals_screener` — 인라인 가드를 헬퍼로 리팩터(동작 동일).
  - `high_yield_value_screener` — `uses_roe=True` (후보쿼리 체인 분리로 가드 삽입).
  - `undervalued_breakout_screener` — 시총 floor만.

## Verification
- 신규: high_yield_value US 가드 wiring(DCX/BLKB 제외, 정상 보존) + 기존 US 테스트 market_cap 보강.
- 영향 로더 **42 passed 회귀 0**; ruff clean; **migration 0**. KR/crypto 무영향.
- ⚠️로컬 `test_loader_us_date_recency_passes` 실패는 **pre-existing**(clean main도 동일 — 로컬 test_db의 오늘 날짜 US 행이 2026-06-02 파티션을 shadow; 삭제 후 42 passed; CI fresh DB 무관).

## Related
ROB-440(#1161 펀더 로더 가드 — 본 PR이 나머지 2 로더로 확장) · 라이브 재검증에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated US stock quality filters across multiple screeners for consistent filtering by market cap, ROE, and dividend yield thresholds.

* **Tests**
  * Added integration tests to verify US market quality filtering works correctly across screeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->