### PR TITLE
feat(ROB-429): KR fundamentals 스냅샷 Prefect flow (freshness 활성화)

### DIFF
--- a/app/flows/invest_kr_fundamentals_snapshots_flow.py
+++ b/app/flows/invest_kr_fundamentals_snapshots_flow.py
@@ -1,0 +1,76 @@
+"""Prefect wrapper for KR fundamentals snapshot refresh (ROB-429 follow-up).
+
+The KR Toss-parity fundamentals presets (undervalued_growth / growth_expectation /
+stable_growth / cheap_value / steady_dividend / high_yield_value / undervalued_breakout)
+read ``invest_kr_fundamentals_snapshots`` (tvscreener KR), with DART-first 3y-avg
+growth when financial_fundamentals is backfilled. That snapshot had a build CLI +
+job but **no Prefect flow** — so without a daily schedule it goes stale (observed
+stuck at an old partition), and the "DART 미적재 근사치" path never refreshes. This
+flow is the missing daily build trigger (mirrors the crypto / US screener flows).
+
+Importable only; no deployment is registered in this PR. Writes are runtime-gated
+by ``INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`` (shared with the KR/US/crypto
+screener-snapshot flows) so accidental manual runs stay dry-run. ``allow_partial``
+defaults False so the ROB-429 coverage guard still blocks a thin shadow commit;
+operators opt in explicitly when a partial refresh is acceptable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prefect import flow, task
+
+from app.core.config import settings
+from app.jobs.invest_kr_fundamentals_snapshots import (
+    KrFundamentalsSnapshotBuildRequest,
+    run_kr_fundamentals_snapshot_build,
+)
+
+
+async def run_kr_fundamentals_refresh(
+    *,
+    all_symbols: bool = True,
+    limit: int | None = None,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    """Run the KR fundamentals snapshot builder with env-gated commit behavior.
+
+    ``commit`` comes from ``INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`` (default
+    ``False`` → dry-run/rollback). The builder's ROB-429 coverage guard still
+    applies; with ``allow_partial=False`` a thin partition is not committed.
+    """
+    commit_enabled = bool(settings.invest_screener_snapshots_commit_enabled)
+    return await run_kr_fundamentals_snapshot_build(
+        KrFundamentalsSnapshotBuildRequest(
+            limit=limit,
+            all_symbols=all_symbols,
+            commit=commit_enabled,
+            allow_partial=allow_partial,
+        )
+    )
+
+
+@task(name="invest_kr_fundamentals_snapshots_refresh")
+async def invest_kr_fundamentals_snapshots_task(
+    *,
+    all_symbols: bool = True,
+    limit: int | None = None,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    return await run_kr_fundamentals_refresh(
+        all_symbols=all_symbols, limit=limit, allow_partial=allow_partial
+    )
+
+
+@flow(name="invest_kr_fundamentals_snapshots")
+async def invest_kr_fundamentals_snapshots_flow(
+    *,
+    all_symbols: bool = True,
+    limit: int | None = None,
+    allow_partial: bool = False,
+) -> dict[str, Any]:
+    """Daily KR fundamentals snapshot refresh; deployment registration deferred."""
+    return await invest_kr_fundamentals_snapshots_task(
+        all_symbols=all_symbols, limit=limit, allow_partial=allow_partial
+    )

--- a/tests/test_invest_kr_fundamentals_snapshots_flow.py
+++ b/tests/test_invest_kr_fundamentals_snapshots_flow.py
@@ -1,0 +1,60 @@
+"""Tests for the KR fundamentals snapshot Prefect flow scaffold (ROB-429 follow-up).
+
+Prefect is not a project dependency, so the flow file is validated statically
+(decorators/name/gate wiring present + no deployment YAML), mirroring the crypto /
+US screener flow tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "invest_kr_fundamentals_snapshots_flow.py"
+)
+
+
+def test_flow_file_exists() -> None:
+    assert _FLOW_PATH.exists(), f"Flow file not found at {_FLOW_PATH}"
+
+
+def test_flow_file_declares_prefect_flow_and_task() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text, "Missing @flow decorator"
+    assert "@task" in text, "Missing @task decorator"
+    assert "invest_kr_fundamentals_snapshots" in text, "Missing flow name"
+
+
+def test_flow_file_has_commit_gate_and_builder() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "invest_screener_snapshots_commit_enabled" in text, (
+        "Flow must reference the commit env gate"
+    )
+    assert "commit=commit_enabled" in text, "commit must be env-gated, not literal"
+    assert "run_kr_fundamentals_snapshot_build" in text
+
+
+def test_flow_defaults_full_universe_and_guarded_partial() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "all_symbols: bool = True" in text  # daily refresh = full universe
+    assert "allow_partial: bool = False" in text  # ROB-429 coverage guard stays on
+
+
+def test_flow_is_not_registered_via_deployment_yaml() -> None:
+    project_root = _FLOW_PATH.parents[2]
+    yaml_files = list(project_root.glob("**/*.yaml")) + list(
+        project_root.glob("**/*.yml")
+    )
+    for yf in yaml_files:
+        if ".venv" in str(yf) or ".git" in str(yf):
+            continue
+        if "invest_kr_fundamentals_snapshots" in yf.read_text():
+            pytest.fail(
+                f"Found Prefect deployment YAML referencing the KR fundamentals flow at {yf}. "
+                "Deployment registration is deferred (operator-gated)."
+            )


### PR DESCRIPTION
## What & why
라이브 검증: KR 펀더멘털 프리셋(`undervalued_growth`/`growth_expectation`/...)의 `snapshotDate`가 **06-04에 며칠째 멈춤** + "DART 미적재 근사치" 경고 지속.

근본원인 = `invest_kr_fundamentals_snapshots`(tvscreener KR, KR 펀더 프리셋 소스)는 build CLI + job은 있으나 **Prefect flow가 없어** 일일 스케줄이 불가 → 마지막 수동 빌드(06-04)에 멈춤 (crypto #1156과 **동일 패턴**). 코드(ROB-433 DART-first 하이브리드)는 정상 — 스냅샷이 stale해 DART 정밀도/신선도가 반영 안 됨.

## Changes
- **신규** `app/flows/invest_kr_fundamentals_snapshots_flow.py` (crypto/US flow 미러): `run_kr_fundamentals_snapshot_build`를 env 게이트(`INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`, 공유, default dry-run)로 래핑.
  - `all_symbols=True` (전체 유니버스), `allow_partial=False` (**ROB-429 커버리지 가드 유지** = thin shadow commit 방지), 배포 등록 미포함.

## Verification
- flow 정적 검증(@flow/@task / 게이트 배선 `commit=commit_enabled` / full-universe·guarded-partial 기본 / 배포 YAML 부재).
- **5 passed**; ruff clean; **migration 0**.

## Boundaries / operator
- read-mostly(스냅샷 write는 repository.upsert + 커버리지 가드). broker/order/watch mutation 0.
- **operator**: 이 flow를 일일 스케줄(KRX 마감 후) 등록 + `INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED=true` → KR 펀더멘털 스냅샷 daily 갱신 → DART 백필분이 정밀도로 반영(근사치 경고 감소). default dry-run이라 등록만으로 write 안 됨.

## Related
ROB-429(KR fundamentals full-universe) · ROB-433(DART-first 하이브리드) · #1156(crypto flow 동일 패턴).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KR fundamentals snapshot refresh capability with configurable options for full or selective symbol updates.

* **Tests**
  * Added validation test suite for the KR fundamentals snapshot refresh workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->