### PR TITLE
fix(ROB-432): investor_flow를 수급 프리셋의 freshness dependency로만 한정 (overall 정합)

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -995,6 +995,13 @@ def build_screener_presets(market: str = "kr") -> ScreenerPresetsResponse:
     )
 
 
+# ROB-432: presets that screen ON investor_flow (수급) — only these treat a stale
+# investor_flow partition as a freshness dependency that can drag overallState.
+# Other KR presets still render the per-row investor_flow chip (display only).
+_INVESTOR_FLOW_DEPENDENCY_PRESETS: frozenset[str] = frozenset(
+    {"double_buy", "investor_flow_momentum"}
+)
+
 _METRIC_FIELD: dict[str, str] = {
     "consecutive_gainers": "week_change_rate",
     "cheap_value": "per",
@@ -2211,7 +2218,16 @@ async def build_screener_results(
     # _investor_flow_collected_at, and _investor_flow_data_state have been stashed
     # back on rows.
     dependency_specs: list[dict[str, Any]] = []
-    if requested_market == "kr" and investor_flow_chips:
+    # ROB-432: investor_flow is a freshness DEPENDENCY only for presets that screen
+    # on it (외인/기관 수급). For fundamentals/valuation/price presets it is a
+    # supplementary per-row CHIP (still hydrated + shown), not a screening input —
+    # so a stale investor_flow partition must NOT drag their overallState to stale
+    # ("펀더는 fresh인데 stale 표시" 오해 제거).
+    if (
+        requested_market == "kr"
+        and preset_id in _INVESTOR_FLOW_DEPENDENCY_PRESETS
+        and investor_flow_chips
+    ):
         from app.services.invest_screener_snapshots.freshness import (
             classify_investor_flow_partition,
             today_trading_date,

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -2583,10 +2583,12 @@ async def test_double_buy_flow_stale_warning_reports_actual_multiday_lag(
 async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_dependency() -> (
     None
 ):
-    """ROB-277 follow-up FU2/FU6: when primary partition is today's and an
-    investor_flow snapshot is 2 trading days older, freshness.dependencies must
-    surface that as a 'stale' investor_flow entry with the correct snapshotDate
-    and lagLabel, and overallState must be 'stale' per D1.c rule 2."""
+    """ROB-432: consecutive_gainers (price preset) must NOT be dragged stale by a
+    stale investor_flow partition. investor_flow is a supplementary per-row chip
+    here, not a screening input, so it is not a freshness dependency — overallState
+    stays fresh. (Supersedes the ROB-277 FU2/FU6 behavior where every KR preset
+    treated investor_flow as a dependency; now only double_buy /
+    investor_flow_momentum, which actually screen on 수급, do.)"""
     import datetime as dt
 
     today_kr = dt.date(2026, 5, 20)  # Wednesday
@@ -2693,17 +2695,14 @@ async def test_consecutive_gainers_fresh_primary_with_stale_investor_flow_depend
     assert f.primary is not None
     assert f.primary.snapshotDate == today_kr.isoformat()
     assert f.primary.dataState == "fresh"
-    # Dependency surfaces the investor-flow partition (NOT the primary date)
-    assert len(f.dependencies) == 1
-    dep = f.dependencies[0]
-    assert dep.kind == "investor_flow"
-    assert dep.snapshotDate == inv_partition.isoformat()
-    assert dep.dataState == "stale"
-    # lagLabel reflects the 2-day gap (calendar diff between today and inv_partition)
-    assert dep.lagLabel is not None and "일 지연" in dep.lagLabel
-    # D1.c rule 2: primary fresh + dep stale → overall stale
-    assert f.overallState == "stale"
-    assert f.dataState == "stale"
+    # ROB-432: consecutive_gainers screens on price momentum, NOT 수급. investor_flow
+    # is a supplementary per-row chip (still hydrated/shown), NOT a freshness
+    # dependency — so a stale investor_flow partition must NOT drag overallState.
+    # (Was: dep present + overall stale; only double_buy/investor_flow_momentum,
+    # which actually screen on 수급, treat it as a dependency now.)
+    assert f.dependencies == []
+    assert f.overallState == "fresh"
+    assert f.dataState == "fresh"
 
 
 @pytest.mark.unit
@@ -3346,3 +3345,17 @@ async def test_market_cap_source_fallback_when_valuation_partition_is_fallback(
 
     assert len(resp.results) == 1
     assert resp.results[0].marketCapSource == "fallback"
+
+
+def test_investor_flow_dependency_presets_are_supply_only() -> None:
+    # ROB-432: only 수급-screening presets treat investor_flow as a freshness
+    # dependency. Guards against re-broadening it to fundamentals/price presets.
+    from app.services.invest_view_model.screener_service import (
+        _INVESTOR_FLOW_DEPENDENCY_PRESETS,
+    )
+
+    assert _INVESTOR_FLOW_DEPENDENCY_PRESETS == frozenset(
+        {"double_buy", "investor_flow_momentum"}
+    )
+    for non_supply in ("undervalued_growth", "high_yield_value", "consecutive_gainers"):
+        assert non_supply not in _INVESTOR_FLOW_DEPENDENCY_PRESETS


### PR DESCRIPTION
## What & why
라이브: KR `undervalued_growth`가 **primary(fundamentals)=fresh@06-08인데 `overallState=stale`**. 원인 = KR 모든 프리셋에 investor_flow 칩이 hydrate되면 investor_flow를 freshness **dependency**로 추가 → `compute_overall_state`가 집계 → stale investor_flow(06-04)가 **펀더/가격 프리셋의 overall까지 끌어내림** ("fresh인데 stale" 오해).

## Changes
- `_INVESTOR_FLOW_DEPENDENCY_PRESETS = {double_buy, investor_flow_momentum}` (수급으로 **스크리닝하는** 프리셋).
- `dependency_specs`의 investor_flow 추가를 이 집합으로 **게이트**. 비-수급 프리셋(펀더/가격)은 per-row investor_flow **칩은 그대로 표시**(display)하되 freshness dependency에선 제외 → overall이 primary(자체 데이터) 기준.

## Verification
- `consecutive_gainers` fresh-primary + stale investor_flow → **overall fresh, dependencies=[]** (ROB-277 드래그 동작을 새 동작으로 갱신).
- 상수 멤버십 가드(undervalued_growth/high_yield_value/consecutive_gainers ∉ 집합).
- **324 sweep green**(screener_service/freshness/presets); ruff clean; **migration 0**.

## Boundaries
- read-only/표시 정합. broker/order/watch mutation 0.
- `double_buy`/`investor_flow_momentum`은 investor_flow가 criterion → dependency 유지(stale 시 드래그 정상).
- 별개: investor_flow 자체 신선도(06-04 stale)는 ROB-205(재적재) + KR Investor Flow Prefect 점검 — 본 PR은 "비-수급 프리셋이 잘못 끌려가는 표시" 만 수정.

## Related
ROB-432(표시 parity) · ROB-277(기존 dependency 모델) · ROB-205(investor_flow 신선도) · 라이브 검증에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Fixed screener data freshness indicators to be more accurate. Stale investor flow data no longer incorrectly marks fundamentals, valuation, and price presets as stale when displaying investor flow information for reference only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->