### PR TITLE
fix(ROB-444 PR1): KR 배당 프리셋 min_dividend_yield 단위 정규화 (3% 미만 누출 차단)

### DIFF
--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -288,11 +288,22 @@ def _passes_thresholds(
             return False, f"{col_attr} unavailable", provenance
         if require_positive and value <= 0:
             return False, f"{col_attr} not positive", provenance
+        # ROB-444: tvscreener dividend_yield is a PERCENT (e.g. 6.32 = 6.32%), but the
+        # shared spec threshold is a RATIO (min_dividend_yield=0.03 = 3%; US
+        # market_valuation stores dividend_yield as a ratio). Compare in ratio so the
+        # 3% gate actually filters — without this, 0.48% passed `0.48 < 0.03` = False.
+        # The row's displayed dividend_yield stays percent (metric label `{v:.2f}%`).
+        cmp_value = (
+            Decimal(str(value)) / Decimal("100")
+            if col_attr == "dividend_yield"
+            else Decimal(str(value))
+        )
+        threshold_dec = Decimal(str(threshold))
         if spec_field in _MAX_FIELDS:
-            if Decimal(str(value)) > Decimal(str(threshold)):
+            if cmp_value > threshold_dec:
                 return False, f"{col_attr} above max", provenance
         else:
-            if Decimal(str(value)) < Decimal(str(threshold)):
+            if cmp_value < threshold_dec:
                 return False, f"{col_attr} below min", provenance
 
     # ROB-433: 3y-avg growth — DART (exact 3년평균) first, tvscreener YoY proxy fallback.

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -304,7 +304,8 @@ async def test_earnings_increase_streak_skipped_and_warned(db_session):
             _snap(
                 sym,
                 market_cap=Decimal("4000000000000"),
-                dividend_yield=Decimal("0.04"),  # >= 0.03
+                # ROB-444: tvscreener dividend_yield is PERCENT (4.0 = 4% >= 3%).
+                dividend_yield=Decimal("4.0"),
                 payout_ratio_ttm=Decimal("40"),  # >= 30
                 continuous_dividend_payout=Decimal("5"),  # >= 3
                 # NOTE: no earnings-increase-streak column exists; must be skipped.
@@ -330,7 +331,7 @@ async def test_steady_dividend_fail_closed_on_null_payout(db_session):
             _snap(
                 sym,
                 market_cap=Decimal("3000000000000"),
-                dividend_yield=Decimal("0.05"),
+                dividend_yield=Decimal("5.0"),  # ROB-444: percent (5% >= 3%)
                 payout_ratio_ttm=None,  # required → fail-closed
                 continuous_dividend_payout=Decimal("10"),
             )
@@ -354,14 +355,14 @@ async def test_future_dividend_king_growth_streak_and_payout(db_session):
             _snap(
                 sym_pass,
                 market_cap=Decimal("4000000000000"),
-                dividend_yield=Decimal("0.02"),  # >= 0.01
+                dividend_yield=Decimal("2.0"),  # ROB-444: percent (2% >= 1%)
                 payout_ratio_ttm=Decimal("35"),  # >= 30
                 continuous_dividend_growth=Decimal("5"),  # >= 3
             ),
             _snap(
                 sym_low_streak,
                 market_cap=Decimal("3500000000000"),
-                dividend_yield=Decimal("0.02"),
+                dividend_yield=Decimal("2.0"),  # ROB-444: percent
                 payout_ratio_ttm=Decimal("50"),
                 continuous_dividend_growth=Decimal("1"),  # < 3 → excluded
             ),
@@ -976,3 +977,40 @@ async def test_undervalued_breakout_sorts_by_per_ascending(db_session):
     assert result is not None
     # PER ascending: 4 before 9 (even though sym_low_per has the smaller market cap).
     assert [r["symbol"] for r in result.rows] == [sym_low_per, sym_high_per]
+
+
+async def test_steady_dividend_excludes_sub_threshold_percent_yield(db_session):
+    """ROB-444: tvscreener dividend_yield is PERCENT. min_dividend_yield=0.03 (ratio,
+    3%) must exclude a 0.48% symbol and include a 6.32% one. Pre-fix, the raw compare
+    (0.48 < 0.03 = False) wrongly let sub-3% yields through."""
+    await _cleanup(db_session)
+    sym_low = f"{_PREFIX}50"  # 0.48% → below 3% → excluded
+    sym_ok = f"{_PREFIX}51"  # 6.32% → above 3% → included
+    await _seed(
+        db_session,
+        [
+            _snap(
+                sym_low,
+                market_cap=Decimal("4000000000000"),
+                dividend_yield=Decimal("0.48"),  # percent → 0.48% < 3%
+                payout_ratio_ttm=Decimal("40"),
+                continuous_dividend_payout=Decimal("5"),
+            ),
+            _snap(
+                sym_ok,
+                market_cap=Decimal("4000000000000"),
+                dividend_yield=Decimal("6.32"),  # percent → 6.32% >= 3%
+                payout_ratio_ttm=Decimal("40"),
+                continuous_dividend_payout=Decimal("5"),
+            ),
+        ],
+        [_universe(sym_low, "저배당"), _universe(sym_ok, "고배당")],
+    )
+    result = await load_kr_fundamentals_preset_from_tv_snapshot(
+        db_session, market="kr", spec=STEADY_DIVIDEND_SPEC, limit=20, now=_now
+    )
+    assert result is not None
+    syms = [r["symbol"] for r in result.rows]
+    assert sym_ok in syms
+    assert sym_low not in syms  # ROB-444: sub-3% no longer leaks through
+    await _cleanup(db_session)


### PR DESCRIPTION
## What & why
라이브: `steady_dividend`(꾸준한 배당, ≥3%)가 **0.48%/0.68%(3% 미만)을 표시**. 원인 = `kr_fundamentals_tv_screener._THRESHOLD_CHECKS`가 `min_dividend_yield`(spec **0.03 ratio**)를 `snap.dividend_yield`(tvscreener **percent**, 예 6.32)와 raw 비교 → `0.48 < 0.03` = False → 통과(3% 게이트가 0.03% floor로 무력화). `min_payout_ratio`(30) vs `payout_ratio_ttm`(percent)은 percent↔percent라 정상 → dividend_yield 단독 불일치.

## Changes
- 비교 시 `dividend_yield` 컬럼만 **÷100(ratio 정규화)** 후 threshold(0.03 ratio)와 비교. row 표시값은 percent 유지(metric 라벨 `{v:.2f}%`). #1154 US dual-unit과 동형.
- ⚠️기존 테스트가 dividend_yield를 ratio(0.04/0.05/0.02)로 **잘못 seed**(버그를 가림) → percent(4.0/5.0/2.0)로 교정 + 신규 회귀(0.48% 제외, 6.32% 포함).

## Verification
- **23 + 135 sweep green**(kr_fundamentals_tv/screener_service); ruff clean; **migration 0**.

## Boundaries / 후속
- KR display만 영향. US/crypto 무변경. broker/order/watch mutation 0.
- ⚠️**단독 적용 시 steady_dividend count↓(3→1, 더 correct)**. 진짜 parity(Toss 27/14)는 **PR2**(배당 streak/payout DART-first 하이브리드 + operator 커버리지 진단).

## Related
ROB-444(PR1) · #1154(US dividend dual-unit) · ROB-433(DART-first growth, PR2가 dividend로 확장).

🤖 Generated with [Claude Code](https://claude.com/claude-code)