### PR TITLE
feat(ROB-444 PR2): KR 배당 payout/streak DART-first 하이브리드 (parity 커버리지)

### DIFF
--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -75,10 +75,28 @@ _THRESHOLD_CHECKS: tuple[tuple[str, str, bool], ...] = (
     ("max_pbr", "pbr", True),  # also requires pbr > 0
     ("min_dividend_yield", "dividend_yield", False),
     ("min_gross_margin_ttm", "gross_margin_ttm", False),
-    ("min_payout_ratio", "payout_ratio_ttm", False),
     ("min_earnings_growth_qoq", "eps_qoq", False),
-    ("min_dividend_paid_streak_years", "continuous_dividend_payout", False),
-    ("min_dividend_growth_streak_years", "continuous_dividend_growth", False),
+    # ROB-444: payout_ratio + dividend streaks moved to the DART-first block below
+    # (_DIVIDEND_DART_CHECKS) — tvscreener payout_ratio_ttm was 2.6% sparse.
+)
+
+# ROB-444: dividend payout/streak — DART-first (financial_fundamentals derive),
+# tvscreener column fallback. DART payout_ratio (현금배당성향, percent — same unit as
+# the tvscreener column + spec) covers far more KR symbols than tvscreener's
+# payout_ratio_ttm (~2.6%). Streaks fall back to tvscreener continuous_dividend_*
+# (~64%) when DART is absent. (spec_field, tvscreener_fallback_col, dart_metric_attr)
+_DIVIDEND_DART_CHECKS: tuple[tuple[str, str, str], ...] = (
+    ("min_payout_ratio", "payout_ratio_ttm", "payout_ratio"),
+    (
+        "min_dividend_paid_streak_years",
+        "continuous_dividend_payout",
+        "dividend_paid_streak_years",
+    ),
+    (
+        "min_dividend_growth_streak_years",
+        "continuous_dividend_growth",
+        "dividend_growth_streak_years",
+    ),
 )
 
 # ROB-433: 3-year-average growth thresholds are evaluated DART-first. Each entry is
@@ -277,7 +295,11 @@ def _passes_thresholds(
     absent. provenance = ``{"growth_source": "dart"|"proxy"|None,
     "streak_source": "dart"|"skipped"|None}`` and is only meaningful when passes.
     """
-    provenance: dict[str, str | None] = {"growth_source": None, "streak_source": None}
+    provenance: dict[str, str | None] = {
+        "growth_source": None,
+        "streak_source": None,
+        "dividend_source": None,  # ROB-444: "dart" | "tvscreener"
+    }
 
     for spec_field, col_attr, require_positive in _THRESHOLD_CHECKS:
         threshold = getattr(spec, spec_field)
@@ -340,6 +362,28 @@ def _passes_thresholds(
             provenance["streak_source"] = "dart"
         else:
             provenance["streak_source"] = "skipped"
+
+    # ROB-444: dividend payout/streak — DART-first, tvscreener column fallback.
+    # tvscreener payout_ratio_ttm is ~2.6% sparse (the binding constraint behind
+    # steady_dividend 3 / future_dividend_king 0); DART payout_ratio + dividend
+    # streaks (financial_fundamentals derive) recover coverage. NULL on BOTH sources
+    # is fail-closed (a real dividend condition, never fabricated).
+    for spec_field, fallback_col, dart_attr in _DIVIDEND_DART_CHECKS:
+        threshold = getattr(spec, spec_field)
+        if threshold is None:
+            continue
+        dm = getattr(dart, dart_attr, None) if dart is not None else None
+        if dm is not None and dm.state == "ok" and dm.value is not None:
+            value, source = dm.value, "dart"
+        else:
+            value, source = getattr(snap, fallback_col), "tvscreener"
+        if value is None:
+            return False, f"{dart_attr} unavailable", provenance
+        if Decimal(str(value)) < Decimal(str(threshold)):
+            return False, f"{dart_attr} below min", provenance
+        # DART wins; only downgrade to tvscreener if not already DART-sourced.
+        if provenance.get("dividend_source") != "tvscreener":
+            provenance["dividend_source"] = source
 
     # ROB-430 PR-② / ROB-432: 신고가 = a NEW 52-week high made within
     # max_new_high_age_trading_days KRX trading sessions of the partition (a breakout
@@ -537,6 +581,11 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
         spec.min_revenue_growth_3y_avg is not None
         or spec.min_earnings_growth_3y_avg is not None
         or spec.min_earnings_increase_streak_years is not None
+        # ROB-444: dividend payout/streak are DART-first too (tvscreener
+        # payout_ratio_ttm is ~2.6% sparse → it was the binding constraint).
+        or spec.min_payout_ratio is not None
+        or spec.min_dividend_paid_streak_years is not None
+        or spec.min_dividend_growth_streak_years is not None
     ):
         from app.services.financial_fundamentals_snapshots.derive import (
             derive_fundamentals_metrics,

--- a/tests/test_kr_fundamentals_tv_screener.py
+++ b/tests/test_kr_fundamentals_tv_screener.py
@@ -1014,3 +1014,42 @@ async def test_steady_dividend_excludes_sub_threshold_percent_yield(db_session):
     assert sym_ok in syms
     assert sym_low not in syms  # ROB-444: sub-3% no longer leaks through
     await _cleanup(db_session)
+
+
+def test_dividend_dart_first_recovers_when_tvscreener_payout_sparse():
+    """ROB-444 PR2: tvscreener payout_ratio_ttm is ~2.6% sparse (binding constraint).
+    DART-first payout/streak recovers a symbol whose tvscreener payout/streak are NULL
+    but whose DART derive has them. dart=None → fail-closed (no fabrication)."""
+    from types import SimpleNamespace
+
+    from app.services.financial_fundamentals_snapshots.derive import MetricResult
+    from app.services.invest_view_model.kr_fundamentals_tv_screener import (
+        _passes_thresholds,
+    )
+
+    snap = _snap(
+        f"{_PREFIX}60",
+        market_cap=Decimal("4000000000000"),
+        dividend_yield=Decimal("6.0"),  # percent → 0.06 >= 0.03 (PR1)
+        payout_ratio_ttm=None,  # tvscreener sparse
+        continuous_dividend_payout=None,  # tvscreener sparse
+    )
+    dart = SimpleNamespace(
+        payout_ratio=MetricResult(
+            value=Decimal("40"), state="ok"
+        ),  # 현금배당성향 % (>=30)
+        dividend_paid_streak_years=MetricResult(value=Decimal("5"), state="ok"),  # >=3
+        earnings_increase_streak_years=MetricResult(value=Decimal("4"), state="ok"),
+    )
+
+    ok, reason, prov = _passes_thresholds(
+        snap, STEADY_DIVIDEND_SPEC, partition_date=_SD, dart=dart
+    )
+    assert ok is True, reason  # DART recovered payout + streak
+    assert prov["dividend_source"] == "dart"
+
+    # dart=None → tvscreener payout/streak NULL → fail-closed (not fabricated)
+    ok2, reason2, _ = _passes_thresholds(
+        snap, STEADY_DIVIDEND_SPEC, partition_date=_SD, dart=None
+    )
+    assert ok2 is False and "payout_ratio" in (reason2 or "")


### PR DESCRIPTION
## What & why
operator 진단(prod 06-08): tvscreener `payout_ratio_ttm` **2.64%(112/4250)** = `steady_dividend`(3)/`future_dividend_king`(0)의 **바인딩 제약**(둘 다 `min_payout_ratio=30` 요구 → 112개만 보유 → fail-closed). `continuous_dividend_*` 63.6%, DART `dividend_per_share` **1456 심볼**.

## Changes
- `min_payout_ratio` / `min_dividend_paid_streak_years` / `min_dividend_growth_streak_years`를 `_THRESHOLD_CHECKS`(tvscreener)에서 빼고 **`_DIVIDEND_DART_CHECKS`(DART-first + tvscreener fallback)** 로 이동(ROB-433 growth 패턴).
  - DART derive `payout_ratio`(현금배당성향 percent — spec 30과 **동일 단위**)/`dividend_paid_streak_years`/`dividend_growth_streak_years`가 `state==ok`면 사용, 없으면 tvscreener `continuous_dividend_*`/`payout_ratio_ttm` fallback, **둘 다 NULL이면 fail-closed**(위조 금지).
- 로더 DART fetch 조건에 배당 spec 추가(valuation-only 프리셋은 여전히 skip). provenance에 `dividend_source`("dart"|"tvscreener").

## Verification
- `_passes_thresholds` 직접 단위(tvscreener payout/streak NULL이나 DART로 **복구→통과**, `dividend_source=dart`; `dart=None`→**fail-closed**) + 기존 tvscreener-fallback 테스트 유지.
- **24 + 168 sweep green**(kr_fundamentals_tv/fundamentals/screener_service); ruff clean; **migration 0**.

## Boundaries / operator
- KR display만. US/crypto 무변경. broker/order/watch mutation 0.
- payout 커버리지 2.64%→DART(1456)로 확대 → steady/future count가 Toss(27/14)에 **comparable**(벤더차로 exact 아닐 수 있음 — honest). operator: DART payout/배당 커버리지 추가 backfill 시 더 향상.

## Related
ROB-444(PR1 #1165 단위버그 → PR2 커버리지) · ROB-433(DART-first growth 패턴) · ROB-425(derive dividend 메트릭) · operator 진단 evidence(payout 2.64%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dividend threshold evaluation with multi-source data support, prioritizing primary data sources with automatic fallback to secondary sources when available.
  * Extended data source provenance tracking to indicate which source provided dividend metrics for screening decisions.

* **Improvements**
  * Improved robustness of dividend-based screening by excluding candidates when all data sources are unavailable, ensuring consistent filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->