### PR TITLE
chore(ROB-444): KR 배당 프리셋 바인딩 조건 진단 스크립트 (read-only)

### DIFF
--- a/scripts/diagnose_kr_dividend_conditions.py
+++ b/scripts/diagnose_kr_dividend_conditions.py
@@ -1,0 +1,191 @@
+"""ROB-444 follow-up: binding-condition diagnostic for the KR dividend presets.
+
+Why: after the DART-first hybrid (#1166) + backfill, steady_dividend stayed at 15
+and future_dividend_king at 5 (vs Toss 27/14). Coverage is no longer the binding
+constraint (operator: payout/dps ~95%, 2396 symbols with 3y depth). This read-only
+script reports, for each dividend preset, how many candidates pass EACH condition
+individually and the cumulative funnel — so we can see WHICH condition limits the
+count and compare it to Toss's filter definition.
+
+Mirrors ``kr_fundamentals_tv_screener._passes_thresholds`` exactly (DART-first
+payout/streak, dividend_yield ÷100 per #1165, earnings-streak skip-if-absent). It
+does NOT write anything. Run on prod (read-only):
+
+    uv run python -m scripts.diagnose_kr_dividend_conditions
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.models.invest_kr_fundamentals_snapshot import InvestKrFundamentalsSnapshot
+from app.services.financial_fundamentals_snapshots.derive import (
+    derive_fundamentals_metrics,
+)
+from app.services.financial_fundamentals_snapshots.repository import (
+    FinancialFundamentalsSnapshotsRepository,
+)
+from app.services.invest_screener_snapshots.freshness import today_trading_date
+from app.services.invest_view_model.fundamentals_screener import (
+    FUTURE_DIVIDEND_KING_SPEC,
+    STEADY_DIVIDEND_SPEC,
+    _to_period,
+)
+
+
+def _dart_metric(dart: Any, attr: str):
+    """Return the DART metric value if state=='ok', else None (mirrors loader)."""
+    if dart is None:
+        return None
+    dm = getattr(dart, attr, None)
+    if dm is not None and dm.state == "ok" and dm.value is not None:
+        return dm.value
+    return None
+
+
+def _dart_first(dart: Any, attr: str, snap: Any, col: str):
+    """DART-first value with tvscreener column fallback (mirrors _DIVIDEND_DART_CHECKS)."""
+    v = _dart_metric(dart, attr)
+    if v is not None:
+        return v, "dart"
+    fv = getattr(snap, col, None)
+    return fv, ("tvscreener" if fv is not None else None)
+
+
+def _ge(value: Any, threshold: Decimal) -> bool:
+    return value is not None and Decimal(str(value)) >= threshold
+
+
+def _conditions(spec, snap, dart) -> list[tuple[str, bool]]:
+    """Per-condition (name, passed) for a dividend preset — same logic as the loader."""
+    out: list[tuple[str, bool]] = []
+    if spec.min_dividend_yield is not None:
+        # PR1 (#1165): tvscreener dividend_yield is PERCENT → ÷100 to compare ratio.
+        dy = snap.dividend_yield
+        ok = (
+            dy is not None
+            and (Decimal(str(dy)) / Decimal("100")) >= spec.min_dividend_yield
+        )
+        out.append((f"dividend_yield>={spec.min_dividend_yield * 100:g}%", ok))
+    if spec.min_payout_ratio is not None:
+        v, _ = _dart_first(dart, "payout_ratio", snap, "payout_ratio_ttm")
+        out.append(
+            (f"payout_ratio>={spec.min_payout_ratio:g}", _ge(v, spec.min_payout_ratio))
+        )
+    if spec.min_dividend_paid_streak_years is not None:
+        v, _ = _dart_first(
+            dart, "dividend_paid_streak_years", snap, "continuous_dividend_payout"
+        )
+        out.append(
+            (
+                f"div_paid_streak>={spec.min_dividend_paid_streak_years}",
+                _ge(v, Decimal(str(spec.min_dividend_paid_streak_years))),
+            )
+        )
+    if spec.min_dividend_growth_streak_years is not None:
+        v, _ = _dart_first(
+            dart, "dividend_growth_streak_years", snap, "continuous_dividend_growth"
+        )
+        out.append(
+            (
+                f"div_growth_streak>={spec.min_dividend_growth_streak_years}",
+                _ge(v, Decimal(str(spec.min_dividend_growth_streak_years))),
+            )
+        )
+    if spec.min_earnings_increase_streak_years is not None:
+        # DART-first SKIP: absent DART → skipped → passes (loader 316-342).
+        dm_v = _dart_metric(dart, "earnings_increase_streak_years")
+        ok = dm_v is None or Decimal(str(dm_v)) >= Decimal(
+            str(spec.min_earnings_increase_streak_years)
+        )
+        out.append(
+            (f"earnings_streak>={spec.min_earnings_increase_streak_years}(skip-ok)", ok)
+        )
+    return out
+
+
+async def _diagnose(session, spec) -> None:
+    now = dt.datetime.now(dt.UTC)
+    report_date = today_trading_date("kr", now=now)
+
+    latest = (
+        await session.execute(
+            sa.select(sa.func.max(InvestKrFundamentalsSnapshot.snapshot_date))
+        )
+    ).scalar_one_or_none()
+    if latest is None:
+        print(f"[{spec.preset_id}] no KR fundamentals snapshot partition")
+        return
+    snaps = list(
+        (
+            await session.execute(
+                sa.select(InvestKrFundamentalsSnapshot).where(
+                    InvestKrFundamentalsSnapshot.snapshot_date == latest
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    symbols = [s.symbol for s in snaps]
+    period_rows = await FinancialFundamentalsSnapshotsRepository(
+        session
+    ).latest_periods_for_symbols(market="kr", symbols=symbols)
+    dart_by_symbol = {
+        sym: derive_fundamentals_metrics(
+            [_to_period(r) for r in rows], report_date=report_date
+        )
+        for sym, rows in period_rows.items()
+    }
+
+    cond_names: list[str] = []
+    individual: dict[str, int] = {}
+    survivors = list(snaps)
+    funnel: list[tuple[str, int]] = []
+
+    # individual pass counts (each condition over the full candidate set)
+    for snap in snaps:
+        for name, ok in _conditions(spec, snap, dart_by_symbol.get(snap.symbol)):
+            if name not in individual:
+                individual[name] = 0
+                cond_names.append(name)
+            if ok:
+                individual[name] += 1
+
+    # cumulative funnel (apply conditions in declared order)
+    for idx, name in enumerate(cond_names):
+        survivors = [
+            s
+            for s in survivors
+            if _conditions(spec, s, dart_by_symbol.get(s.symbol))[idx][1]
+        ]
+        funnel.append((name, len(survivors)))
+
+    print(f"\n=== {spec.preset_id} | partition={latest} | candidates={len(snaps)} ===")
+    print("  individual pass (each condition over all candidates):")
+    for name in cond_names:
+        print(f"    {name:32} {individual[name]:5}")
+    print("  cumulative funnel (declared order):")
+    for name, n in funnel:
+        print(f"    + {name:30} {n:5}")
+    if cond_names:
+        binding = min(cond_names, key=lambda n: individual[n])
+        print(f"  most-restrictive (individual): {binding} ({individual[binding]})")
+    print(f"  FINAL (all conditions): {funnel[-1][1] if funnel else len(snaps)}")
+
+
+async def main() -> int:
+    async with AsyncSessionLocal() as session:
+        for spec in (STEADY_DIVIDEND_SPEC, FUTURE_DIVIDEND_KING_SPEC):
+            await _diagnose(session, spec)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_diagnose_kr_dividend_conditions.py
+++ b/tests/test_diagnose_kr_dividend_conditions.py
@@ -1,0 +1,45 @@
+"""ROB-444: guard the dividend binding-condition diagnostic mirrors the loader."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.services.financial_fundamentals_snapshots.derive import MetricResult
+from app.services.invest_view_model.fundamentals_screener import STEADY_DIVIDEND_SPEC
+from scripts.diagnose_kr_dividend_conditions import _conditions
+
+
+def _snap(dividend_yield):
+    return SimpleNamespace(
+        dividend_yield=dividend_yield,
+        payout_ratio_ttm=None,
+        continuous_dividend_payout=None,
+        continuous_dividend_growth=None,
+    )
+
+
+def _dart():
+    return SimpleNamespace(
+        payout_ratio=MetricResult(value=Decimal("40"), state="ok"),
+        dividend_paid_streak_years=MetricResult(value=Decimal("5"), state="ok"),
+        earnings_increase_streak_years=MetricResult(value=Decimal("4"), state="ok"),
+    )
+
+
+def test_conditions_all_pass_with_dart_and_high_yield():
+    conds = dict(_conditions(STEADY_DIVIDEND_SPEC, _snap(Decimal("6.0")), _dart()))
+    assert all(conds.values()), conds  # 6% yield + DART payout/streak → all pass
+
+
+def test_conditions_dividend_yield_fails_sub_threshold_percent():
+    # PR1: 0.48% (percent) → ÷100 = 0.0048 < 0.03 → dividend_yield condition fails
+    conds = _conditions(STEADY_DIVIDEND_SPEC, _snap(Decimal("0.48")), _dart())
+    dy = [ok for name, ok in conds if name.startswith("dividend_yield")][0]
+    assert dy is False
+
+
+def test_conditions_payout_fails_when_no_dart_and_null_tvscreener():
+    conds = _conditions(STEADY_DIVIDEND_SPEC, _snap(Decimal("6.0")), None)
+    payout = [ok for name, ok in conds if name.startswith("payout_ratio")][0]
+    assert payout is False  # DART absent + tvscreener null → fail-closed


### PR DESCRIPTION
## What & why
backfill 후에도 `steady_dividend` 15 / `future_dividend_king` 5 정체(operator 진단: payout/dps 커버리지 95%, 3년 depth 2396 → **커버리지는 더 이상 병목 아님**). 갭(vs Toss 27/14)이 **조건/벤더 parity**임을 확정하려면 어느 조건이 count를 묶는지 봐야 함.

## Changes
- **신규** `scripts/diagnose_kr_dividend_conditions.py` (read-only): 각 배당 프리셋의 조건(dividend_yield≥3% / payout≥30% / 배당 streak≥3 / 순이익 streak≥3)별 **개별 통과 수 + 누적 funnel** 출력 → 바인딩 조건 식별. 로더 `_passes_thresholds`와 **동일 로직 미러**(DART-first payout/streak, dividend_yield ÷100 #1165, earnings_streak skip-if-absent). **write 0**.
- 테스트: `_conditions`가 로더 동작 미러(고yield+DART→전통과 / 0.48%→yield 실패 / DART無+tvscreener null→payout fail-closed).

## Verification
- **3 passed**; ruff clean; **migration 0**.

## Operator (prod read-only)
```bash
uv run python -m scripts.diagnose_kr_dividend_conditions
```
→ 출력의 "most-restrictive (individual)" + funnel에서 어느 조건이 15/5로 묶는지 확인. 특히 `earnings_streak`(배당과 무관한 순이익 연속증가)가 바인딩이면 Toss 정의 대조 후 스펙에서 제외 검토.

## Related
ROB-444(배당 parity; PR1 #1165 / PR2 #1166 후속 진단) · 다음=결과로 Toss 조건 대조 → 스펙 정정 여부 결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added diagnostic script for analyzing preset condition evaluation and reporting.
  * Added test coverage for diagnostic script functionality across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->