### PR TITLE
fix(ROB-445): screen_stocks_snapshot 미배선 프리셋 필터 무경고 무시 → 정직한 '필터 미적용' 경고

### DIFF
--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -58,6 +58,28 @@ def _available_filters(preset: str) -> dict[str, dict[str, Any]]:
     }
 
 
+# ROB-445: presets whose filter_overrides build_screener_results actually CONSUMES.
+# Mirrors the two `if filter_overrides:` dispatch branches in screener_service:
+#   - consecutive_gainers (~1789): consecutive_gainers loader thresholds — ANY market
+#     (the branch has no market gate; it lives inside `if preset_id == "consecutive_gainers"`)
+#   - crypto presets (~1966): apply_filter_conditions — ONLY when market == "crypto"
+# Every other preset (incl. high_yield_value, which HAS a snapshot_kind but no dispatch
+# branch) silently drops filters → must warn. The old `snapshot_kind is None` guard missed
+# exactly high_yield_value (it has a kind), which is the ROB-445 silent no-op.
+_THREADED_ANY_MARKET: frozenset[str] = frozenset({"consecutive_gainers"})
+
+
+def _filters_are_threaded(preset: str, market: str) -> bool:
+    """True iff build_screener_results actually threads filter_overrides for this
+    (preset, market). Source of truth: the two filter_overrides dispatch branches in
+    screener_service. Used to emit an honest '필터 미적용' warning for every other preset."""
+    if preset in _THREADED_ANY_MARKET:
+        return True
+    from app.services.invest_view_model.screener_filters import _CRYPTO_PRESET_IDS
+
+    return (market or "").strip().lower() == "crypto" and preset in _CRYPTO_PRESET_IDS
+
+
 async def screen_stocks_snapshot_impl(
     *,
     preset: str,
@@ -123,7 +145,12 @@ async def screen_stocks_snapshot_impl(
         {"field": c.field, "operator": c.operator, "value": c.value} for c in conditions
     ]
     payload["snapshotKind"] = snapshot_kind
-    if conditions and snapshot_kind is None:
+    # ROB-445: warn whenever filters were passed but NOT actually threaded for the
+    # resolved (preset, market) — REGARDLESS of snapshotKind. The old `snapshot_kind
+    # is None` predicate let high_yield_value (kind=market_valuation_snapshots, but
+    # no dispatch branch) echo appliedFilters while silently returning the unfiltered
+    # snapshot (silent no-op). Now the unfiltered fact is reported honestly.
+    if conditions and not _filters_are_threaded(preset, market):
         warnings = list(payload.get("warnings") or [])
         warnings.append(
             f"'{preset}' 프리셋은 아직 스냅샷 위 필터 조정이 배선되지 않아 "

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -94,6 +94,35 @@ async def test_unwired_preset_with_filters_warns(patched) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_high_yield_value_with_filters_warns(patched) -> None:
+    # ROB-445: high_yield_value HAS a snapshot_kind (market_valuation_snapshots) but
+    # build_screener_results does NOT thread its filters → it must still warn (the old
+    # `snapshot_kind is None` guard let this slip through = silent no-op).
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="high_yield_value",
+        market="kr",
+        filters=[{"field": "per", "operator": "lte", "value": 8}],
+    )
+    assert out["snapshotKind"] is not None  # has a catalog, unlike cheap_value
+    assert any("배선되지 않" in w for w in out["warnings"])
+    # filters were still echoed (transparency) even though not applied
+    assert out["appliedFilters"] == [{"field": "per", "operator": "lte", "value": 8}]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_threaded_preset_does_not_double_warn(patched) -> None:
+    # ROB-445 guard: consecutive_gainers DOES thread filters → no '미적용' warning.
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        filters=[{"field": "consecutive_up_days", "operator": "gte", "value": 3}],
+    )
+    assert not any("배선되지 않" in w for w in out["warnings"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_bad_filter_entry_fails_soft(patched) -> None:
     out = await tool.screen_stocks_snapshot_impl(
         preset="consecutive_gainers",


### PR DESCRIPTION
## What & why
라이브: `screen_stocks_snapshot(market="kr", preset="high_yield_value", filters=[{per,lte,8}])` → 필터 무시 + **`warnings: []`** (silent no-op footgun — 운영자가 밸류 스크리닝했다고 믿지만 무필터 상위 랭킹을 봄).

원인: 경고 예측자가 `conditions and snapshot_kind is None` → high_yield_value는 snapshot_kind(`market_valuation_snapshots`)를 **가지고** 있어 경고를 빠져나감. `build_screener_results`는 `consecutive_gainers`(any market) + crypto 프리셋(market=="crypto")만 `filter_overrides`를 실제 스레딩.

## Changes (option 2 = 정직성, 단일 파일)
- `_filters_are_threaded(preset, market)` 헬퍼 — 두 dispatch 분기를 미러(`consecutive_gainers` ∪ `_CRYPTO_PRESET_IDS`@crypto).
- 예측자를 `conditions and not _filters_are_threaded(preset, market)`로 교체 → **has-kind이나 미배선인 high_yield_value도 경고**. 스레딩 프리셋 이중경고 X, 필터 없으면 경고 X. 필터는 그대로 echo(투명성).
- `build_screener_results` 무변경(필터 미배선은 의도, 정직성만 추가; 실제 스레딩=option 1은 ROB-427/443 영역).

## Verification
- 회귀: `high_yield_value`+filters→warns(snapshotKind≠None) / `consecutive_gainers`+filters→no-warn / cheap_value(kind=None)→warns / no-filters→no-warn. **6 passed**, ruff clean, **migration 0**.

## Boundaries
read-only(broker/order/watch mutation 0). MCP 경고 문자열만 추가(기존 경고 억제 없음, 스레딩 프리셋 제외 정상).

## Related
ROB-445 · ROB-439(filters-over-snapshot) 후속 갭 · MCP 매수/매도 분석 라이브 프로브에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filter application detection to provide accurate warnings when preset-market combinations don't support custom filters, ensuring users receive clear feedback instead of silently ignoring provided filter overrides.
  * Extended test coverage to prevent regressions in filter warning accuracy across all preset configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->