### PR TITLE
feat(ROB-448): get_valuation EPS/BPS/시총 + get_quote(KR) previous_close + get_investor_trends 외인보유율

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_valuation.py
+++ b/app/mcp_server/tooling/fundamentals/_valuation.py
@@ -161,6 +161,19 @@ async def handle_get_investor_trends(
     return result
 
 
+def _holding_rate_change(rows_sorted: list[dict[str, Any]]) -> float | None:
+    """ROB-448: bucket's foreign holding-rate delta in pp (newest − oldest).
+
+    ``rows_sorted`` is newest-first. Positive = foreigners accumulated over the bucket.
+    None when either endpoint's rate is missing (legacy 7-cell rows).
+    """
+    newest = rows_sorted[0].get("foreign_holding_rate")
+    oldest = rows_sorted[-1].get("foreign_holding_rate")
+    if newest is None or oldest is None:
+        return None
+    return round(newest - oldest, 2)
+
+
 def _aggregate_investor_data(
     daily_data: list[dict[str, Any]], period: str
 ) -> list[dict[str, Any]]:
@@ -207,6 +220,8 @@ def _aggregate_investor_data(
             # the bucket's most-recent value, like close (NOT a sum).
             "foreign_holding_shares": rows_sorted[0].get("foreign_holding_shares"),
             "foreign_holding_rate": rows_sorted[0].get("foreign_holding_rate"),
+            # ROB-448: 기간요약 — holding-rate change over the bucket (newest − oldest, pp).
+            "foreign_holding_rate_change": _holding_rate_change(rows_sorted),
         }
         aggregated.append(agg)
 

--- a/app/mcp_server/tooling/fundamentals/_valuation.py
+++ b/app/mcp_server/tooling/fundamentals/_valuation.py
@@ -203,6 +203,10 @@ def _aggregate_investor_data(
             "institutional_net": sum(r.get("institutional_net") or 0 for r in rows),
             "foreign_net": sum(r.get("foreign_net") or 0 for r in rows),
             "individual_net": sum(r.get("individual_net") or 0 for r in rows),
+            # ROB-448: holding shares/rate are point-in-time levels (not flows) → carry
+            # the bucket's most-recent value, like close (NOT a sum).
+            "foreign_holding_shares": rows_sorted[0].get("foreign_holding_shares"),
+            "foreign_holding_rate": rows_sorted[0].get("foreign_holding_rate"),
         }
         aggregated.append(agg)
 

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -420,15 +420,24 @@ async def _fetch_quote_equity_kr(symbol: str) -> dict[str, Any]:
     df = await kis.inquire_daily_itemchartprice(
         code=symbol,
         market="J",
-        n=1,
+        n=2,  # ROB-448: 2 candles so we can surface the prior trading day's close
     )
     if df.empty:
         raise ValueError(f"Symbol '{symbol}' not found")
     last = df.iloc[-1].to_dict()
+    # ROB-448: previous trading day's close (mirror the US path). None — never 0, never
+    # raise — when <2 candles (newly listed / sparse history). Consumers derive
+    # %change = (price - previous_close) / previous_close * 100.
+    previous_close: float | None = None
+    if len(df) >= 2:
+        prev_close_raw = df.iloc[-2].to_dict().get("close")
+        if prev_close_raw is not None and not pd.isna(prev_close_raw):
+            previous_close = float(prev_close_raw)
     return {
         "symbol": symbol,
         "instrument_type": "equity_kr",
         "price": last.get("close"),
+        "previous_close": previous_close,
         "open": last.get("open"),
         "high": last.get("high"),
         "low": last.get("low"),

--- a/app/services/naver_finance/investor.py
+++ b/app/services/naver_finance/investor.py
@@ -148,6 +148,23 @@ async def _build_investment_opinions_from_company_list_soup(
     return opinions
 
 
+def _parse_holding_rate(text: str | None) -> float | None:
+    """Foreign holding RATE as a percent in [0, 100] (e.g. '47.73%' → 47.73).
+
+    ROB-448: ``parse_korean_number`` divides by 100 on a trailing '%' (→0.4773), which
+    would mis-scale a holding rate. Strip the '%' and parse the bare number instead.
+    """
+    if not text:
+        return None
+    cleaned = text.replace("%", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except (ValueError, TypeError):
+        return None
+
+
 async def fetch_investor_trends(code: str, days: int = 20) -> dict[str, Any]:
     """Fetch foreign/institutional investor trading trends.
 
@@ -195,7 +212,10 @@ async def fetch_investor_trends(code: str, days: int = 20) -> dict[str, Any]:
     rows = target_table.select("tr")
     for row in rows:
         cells = row.select("td")
-        # Columns: 날짜(0), 종가(1), 전일비(2), 등락률(3), 거래량(4), 기관(5), 외국인(6)
+        # ROB-448: the 외국인 column is a 2-level header → the data row actually has 9
+        # cells (the old "7 cells" comment was stale). Columns:
+        #   날짜(0), 종가(1), 전일비(2), 등락률(3), 거래량(4), 기관 순매수(5),
+        #   외국인 순매수(6), 외국인 보유주수(7), 외국인 보유율(8)
         if len(cells) < 7:
             continue
 
@@ -217,6 +237,18 @@ async def fetch_investor_trends(code: str, days: int = 20) -> dict[str, Any]:
                     cells[5].get_text(strip=True)
                 ),
                 "foreign_net": _parse_korean_number(cells[6].get_text(strip=True)),
+                # ROB-448: foreign holding shares (count) + rate (%, 0..100). Guarded so
+                # a legacy 7-cell layout degrades to None instead of IndexError.
+                "foreign_holding_shares": (
+                    _parse_korean_number(cells[7].get_text(strip=True))
+                    if len(cells) >= 9
+                    else None
+                ),
+                "foreign_holding_rate": (
+                    _parse_holding_rate(cells[8].get_text(strip=True))
+                    if len(cells) >= 9
+                    else None
+                ),
             }
 
             trends["data"].append(data_point)

--- a/app/services/naver_finance/valuation.py
+++ b/app/services/naver_finance/valuation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from typing import Any
 
@@ -20,6 +21,8 @@ from app.services.naver_finance.parser import (
 )
 
 NAVER_MOBILE_API = "https://m.stock.naver.com/api/stock"
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_valuation_from_soups(
@@ -234,7 +237,28 @@ async def fetch_valuation(code: str) -> dict[str, Any]:
         _fetch_html(main_url, params={"code": code}),
         _fetch_html(sise_url, params={"code": code}),
     )
-    return _parse_valuation_from_soups(code, main_soup, sise_soup)
+    valuation = _parse_valuation_from_soups(code, main_soup, sise_soup)
+
+    # ROB-448: overlay EPS/BPS/market_cap from the Naver mobile integration endpoint
+    # (already parsed by _parse_total_infos, just not surfaced on the HTML path).
+    # Units are RAW KRW: market_cap = won, eps/bps = won/share (parse_korean_number
+    # expands 조/억/만). fail-open — a mobile-API hiccup leaves the 3 keys None and
+    # never breaks the existing HTML-scraped valuation.
+    valuation.setdefault("eps", None)
+    valuation.setdefault("bps", None)
+    valuation.setdefault("market_cap", None)
+    try:
+        async with httpx.AsyncClient(headers=DEFAULT_HEADERS, timeout=10) as client:
+            integ = await _fetch_integration(code, client)
+        for key in ("eps", "bps", "market_cap"):
+            if integ.get(key) is not None:
+                valuation[key] = integ[key]
+    except Exception as exc:  # noqa: BLE001 — additive overlay; degrade to None
+        logger.debug(
+            "fetch_valuation: integration overlay failed for %s: %s", code, exc
+        )
+
+    return valuation
 
 
 def _parse_total_infos(total_infos: list[dict[str, Any]]) -> dict[str, Any]:
@@ -304,6 +328,9 @@ async def _fetch_integration(
         "name": name,
         "per": metrics.get("per"),
         "pbr": metrics.get("pbr"),
+        # ROB-448: eps/bps are parsed by _parse_total_infos but were dropped here.
+        "eps": metrics.get("eps"),
+        "bps": metrics.get("bps"),
         "market_cap": metrics.get("market_cap"),
         "current_price": current_price,
         "change_pct": change_pct,

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4420,6 +4420,10 @@ def _make_daily_investor_data(days: int = 10) -> dict:
                 "volume": 10_000_000 + i * 500_000,
                 "institutional_net": 500_000 * (1 if i % 3 == 0 else -1),
                 "foreign_net": 300_000 * (1 if i % 2 == 0 else -1),
+                # ROB-448: holding levels — newest day (i=0) is HIGHEST so the
+                # aggregation's carry-newest (vs sum / carry-oldest) is unambiguous.
+                "foreign_holding_rate": round(48.00 - i * 0.01, 2),
+                "foreign_holding_shares": 2_800_000_000 - i * 1_000_000,
             }
         )
     return {
@@ -4476,6 +4480,9 @@ class TestGetInvestorTrends:
         result = await tools["get_investor_trends"]("005930", period="week")
 
         assert result["period"] == "week"
+        # ROB-448: holding rate/shares are point-in-time LEVELS — each bucket must carry
+        # the most-recent (date_end) day's value, NOT a sum and NOT the oldest.
+        date_to_rate = {r["date"]: r["foreign_holding_rate"] for r in mock["data"]}
         for row in result["data"]:
             assert "period_key" in row
             assert "date_start" in row
@@ -4484,6 +4491,20 @@ class TestGetInvestorTrends:
             assert "institutional_net" in row
             assert "foreign_net" in row
             assert "individual_net" in row
+            # carry-newest: bucket rate == the date_end day's rate (not a sum > 100)
+            assert row["foreign_holding_rate"] == date_to_rate[row["date_end"]]
+            assert 0 <= row["foreign_holding_rate"] <= 100
+            # 기간요약 delta present; newest(date_end) − oldest(date_start), so within a
+            # multi-day bucket where newer is higher → change >= 0
+            assert "foreign_holding_rate_change" in row
+            if row["trading_days"] > 1:
+                expected_change = round(
+                    date_to_rate[row["date_end"]] - date_to_rate[row["date_start"]], 2
+                )
+                assert row["foreign_holding_rate_change"] == expected_change
+            # holding shares carried (not summed): a single Samsung day is ~2.8e9, a
+            # summed week would exceed 1e10
+            assert row["foreign_holding_shares"] < 3_000_000_000
 
     async def test_monthly_aggregation(self, monkeypatch):
         """Test monthly aggregation sums investor flows."""

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -194,9 +194,50 @@ async def test_get_quote_korean_equity(monkeypatch):
     assert result["source"] == "kis"
     assert result["price"] == pytest.approx(105.0)  # price = close
     assert result["open"] == pytest.approx(100.0)
+    # ROB-448: single candle → previous_close is None (never 0, never raise)
+    assert result["previous_close"] is None
     assert called["code"] == "005930"
     assert called["market"] == "J"
-    assert called["n"] == 1
+    assert called["n"] == 2  # ROB-448: 2 candles to surface previous_close
+
+
+@pytest.mark.asyncio
+async def test_get_quote_korean_equity_previous_close(monkeypatch):
+    # ROB-448: with 2 candles, previous_close = the prior trading day's close.
+    tools = build_tools()
+    df = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-01",
+                "open": 98.0,
+                "high": 102.0,
+                "low": 97.0,
+                "close": 100.0,
+                "volume": 900,
+                "value": 90000.0,
+            },
+            {
+                "date": "2024-01-02",
+                "open": 100.0,
+                "high": 110.0,
+                "low": 99.0,
+                "close": 105.0,
+                "volume": 1000,
+                "value": 105000.0,
+            },
+        ]
+    )
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, code, market, n):
+            return df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+    result = await tools["get_quote"]("005930")
+
+    assert result["price"] == pytest.approx(105.0)  # latest close
+    assert result["previous_close"] == pytest.approx(100.0)  # prior day's close
 
 
 @pytest.mark.asyncio

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -278,7 +278,8 @@ SAMPLE_INVESTOR_TRENDS_HTML = """
 <table class="type2">
     <tbody><tr><td></td></tr></tbody>
 </table>
-<!-- Second table.type2 has the actual data -->
+<!-- Second table.type2 has the actual data (ROB-448: 9 cells — the 외국인 column is a
+     2-level header with 순매수 / 보유주수 / 보유율) -->
 <table class="type2">
     <tr>
         <td>2024.01.15</td>
@@ -288,6 +289,8 @@ SAMPLE_INVESTOR_TRENDS_HTML = """
         <td>10,000,000</td>
         <td>1,000,000</td>
         <td>-500,000</td>
+        <td>2,790,424,635</td>
+        <td>47.73%</td>
     </tr>
     <tr>
         <td>2024.01.14</td>
@@ -297,6 +300,8 @@ SAMPLE_INVESTOR_TRENDS_HTML = """
         <td>8,000,000</td>
         <td>-200,000</td>
         <td>300,000</td>
+        <td>2,789,924,635</td>
+        <td>47.72%</td>
     </tr>
 </table>
 </body>
@@ -618,11 +623,15 @@ class TestFetchInvestorTrends:
         assert day1["change"] == 500  # ▲500
         assert day1["institutional_net"] == 1000000
         assert day1["foreign_net"] == -500000
+        # ROB-448: foreign holding shares (count) + rate (percent, 0..100)
+        assert day1["foreign_holding_shares"] == 2790424635
+        assert day1["foreign_holding_rate"] == pytest.approx(47.73)
 
         # Second day
         day2 = result["data"][1]
         assert day2["date"] == "2024-01-14"
         assert day2["change"] == -300  # ▼300
+        assert day2["foreign_holding_rate"] == pytest.approx(47.72)
 
     async def test_days_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
         async def mock_fetch_html(
@@ -635,6 +644,44 @@ class TestFetchInvestorTrends:
         result = await naver_finance.fetch_investor_trends("005930", days=1)
 
         assert len(result["data"]) == 1
+
+    async def test_legacy_7cell_layout_degrades_to_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ROB-448: a 7-cell row (no holding columns) must degrade to None, not IndexError.
+        html = """
+        <html><body>
+        <table class="type2"><tbody><tr><td></td></tr></tbody></table>
+        <table class="type2">
+            <tr><td>2024.01.15</td><td>75,000</td><td>▲500</td><td>+0.67%</td>
+                <td>10,000,000</td><td>1,000,000</td><td>-500,000</td></tr>
+        </table>
+        </body></html>
+        """
+
+        async def mock_fetch_html(
+            url: str, params: dict[str, Any] | None = None
+        ) -> BeautifulSoup:
+            return BeautifulSoup(html, "lxml")
+
+        monkeypatch.setattr(naver_finance.investor, "_fetch_html", mock_fetch_html)
+
+        result = await naver_finance.fetch_investor_trends("005930", days=20)
+
+        assert len(result["data"]) == 1
+        assert result["data"][0]["foreign_net"] == -500000
+        assert result["data"][0]["foreign_holding_shares"] is None
+        assert result["data"][0]["foreign_holding_rate"] is None
+
+    def test_parse_holding_rate_unit(self) -> None:
+        # ROB-448: holding rate is a percent in [0,100] — '%' must NOT trigger the
+        # parse_korean_number /100 (which would yield 0.4773).
+        assert naver_finance.investor._parse_holding_rate("47.73%") == pytest.approx(
+            47.73
+        )
+        assert naver_finance.investor._parse_holding_rate("12.5") == pytest.approx(12.5)
+        assert naver_finance.investor._parse_holding_rate("") is None
+        assert naver_finance.investor._parse_holding_rate(None) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -673,15 +673,48 @@ class TestFetchInvestorTrends:
         assert result["data"][0]["foreign_holding_shares"] is None
         assert result["data"][0]["foreign_holding_rate"] is None
 
+
+@pytest.mark.unit
+class TestParseHoldingRate:
+    """ROB-448: foreign holding-rate parser (percent 0..100). Module-level/sync so it
+    does NOT inherit TestFetchInvestorTrends's class-level @pytest.mark.asyncio."""
+
     def test_parse_holding_rate_unit(self) -> None:
-        # ROB-448: holding rate is a percent in [0,100] — '%' must NOT trigger the
-        # parse_korean_number /100 (which would yield 0.4773).
+        # '%' must NOT trigger parse_korean_number's /100 (which would yield 0.4773).
         assert naver_finance.investor._parse_holding_rate("47.73%") == pytest.approx(
             47.73
         )
         assert naver_finance.investor._parse_holding_rate("12.5") == pytest.approx(12.5)
         assert naver_finance.investor._parse_holding_rate("") is None
         assert naver_finance.investor._parse_holding_rate(None) is None
+
+
+@pytest.mark.unit
+class TestParseTotalInfos:
+    """ROB-448: directly exercise _parse_total_infos (the eps/bps/market_cap source the
+    fetch_valuation overlay surfaces) — all overlay tests stub _fetch_integration, so
+    without this the raw-JSON → parsed-metric loop (and a typo like .get('esp')) is
+    untested."""
+
+    def test_parses_metrics_with_unit_suffixes(self) -> None:
+        result = naver_finance.valuation._parse_total_infos(
+            [
+                {"code": "eps", "value": "5,432원"},
+                {"code": "bps", "value": "50,000원"},
+                {"code": "marketValue", "value": "400조"},
+                {"code": "per", "value": "12.5배"},
+                {"code": "pbr", "value": "1.2배"},
+                {"code": "unmapped", "value": "ignore me"},
+            ]
+        )
+        assert result["eps"] == pytest.approx(5432)  # won/share, 원 stripped
+        assert result["bps"] == pytest.approx(50000)
+        assert result["market_cap"] == pytest.approx(
+            400_000_000_000_000
+        )  # 400조 raw KRW
+        assert result["per"] == pytest.approx(12.5)
+        assert result["pbr"] == pytest.approx(1.2)
+        assert "unmapped" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -995,6 +995,71 @@ class TestFetchHtml:
 class TestFetchValuation:
     """Tests for fetch_valuation function."""
 
+    @pytest.fixture(autouse=True)
+    def _stub_integration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ROB-448: fetch_valuation now overlays eps/bps/market_cap via the mobile
+        # _fetch_integration endpoint. Stub it to {} so these HTML-only tests stay
+        # hermetic (no network) — the overlay leaves the 3 keys None. The overlay
+        # behaviour itself is asserted in test_overlays_eps_bps_market_cap.
+        async def _empty(code: str, client: Any) -> dict[str, Any]:  # noqa: ARG001
+            return {}
+
+        monkeypatch.setattr(naver_finance.valuation, "_fetch_integration", _empty)
+
+    async def test_overlays_eps_bps_market_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ROB-448: eps/bps/market_cap (RAW KRW) from _fetch_integration overlay the
+        # HTML-scraped valuation. additive — existing keys untouched.
+        async def mock_fetch_html(
+            url: str, params: dict[str, Any] | None = None
+        ) -> BeautifulSoup:
+            if "main.naver" in url:
+                return BeautifulSoup(SAMPLE_VALUATION_MAIN_HTML, "lxml")
+            return BeautifulSoup(SAMPLE_VALUATION_SISE_HTML, "lxml")
+
+        async def fake_integration(code: str, client: Any) -> dict[str, Any]:  # noqa: ARG001
+            return {"eps": 5432.0, "bps": 50000.0, "market_cap": 400_000_000_000_000.0}
+
+        monkeypatch.setattr(naver_finance.valuation, "_fetch_html", mock_fetch_html)
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_integration
+        )
+
+        result = await naver_finance.fetch_valuation("005930")
+
+        assert result["eps"] == pytest.approx(5432.0)  # won/share
+        assert result["bps"] == pytest.approx(50000.0)
+        assert result["market_cap"] == pytest.approx(400_000_000_000_000.0)  # raw KRW
+        # HTML-scraped keys untouched by the overlay
+        assert result["per"] == pytest.approx(12.5)
+        assert result["pbr"] == pytest.approx(1.2)
+
+    async def test_overlay_fails_open_leaves_keys_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ROB-448: a mobile-API failure must not break valuation — eps/bps/market_cap
+        # degrade to None, HTML keys still returned.
+        async def mock_fetch_html(
+            url: str, params: dict[str, Any] | None = None
+        ) -> BeautifulSoup:
+            if "main.naver" in url:
+                return BeautifulSoup(SAMPLE_VALUATION_MAIN_HTML, "lxml")
+            return BeautifulSoup(SAMPLE_VALUATION_SISE_HTML, "lxml")
+
+        async def boom(code: str, client: Any) -> dict[str, Any]:  # noqa: ARG001
+            raise RuntimeError("mobile api down")
+
+        monkeypatch.setattr(naver_finance.valuation, "_fetch_html", mock_fetch_html)
+        monkeypatch.setattr(naver_finance.valuation, "_fetch_integration", boom)
+
+        result = await naver_finance.fetch_valuation("005930")
+
+        assert result["eps"] is None
+        assert result["bps"] is None
+        assert result["market_cap"] is None
+        assert result["per"] == pytest.approx(12.5)  # valuation still intact
+
     async def test_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
         async def mock_fetch_html(
             url: str, params: dict[str, Any] | None = None


### PR DESCRIPTION
## What & why
스키마/파서가 이미 대기 중이거나 작성됐으나 호출만 안 되던 KR 데이터를 MCP에 노출(거의 신규파서 없음, additive·고ROI). 매수/매도 분석에서 EPS/시총/전일종가/외인보유율이 없어 우회하던 갭.

## Changes (3 파트, 모두 ROB-448)

### get_valuation (KR) — `naver_finance/valuation.py`
- `_fetch_integration` 반환에 `eps`/`bps` 추가(이미 `_parse_total_infos`가 파싱하나 드롭).
- `fetch_valuation`이 mobile integration을 **fail-open overlay** → `eps`/`bps`/`market_cap` 노출. 단위=**RAW KRW**(market_cap=원, eps/bps=원/주). 실패 시 3키 None. MCP는 `**valuation` pass-through라 무변경.

### get_quote (KR) — `market_data_quotes.py`
- `inquire_daily_itemchartprice` n=1→2, `df.iloc[-2].close`로 `previous_close`(US 경로 미러). <2캔들 None.

### get_investor_trends (KR) — `naver_finance/investor.py`, `fundamentals/_valuation.py`
- frgn 테이블이 실제 **9-cell**(외국인=2단 헤더: 순매수/보유주수/보유율; 기존 "7 cells" 주석 stale). cells[7]=`foreign_holding_shares`, cells[8]=`foreign_holding_rate` 증분 파싱(JSON endpoint 교체 안 함=저위험). len>=9 가드 → 레거시 7-cell None degrade.
- ⚠️**단위 함정**: `parse_korean_number('47.73%')→0.4773`(÷100) → 전용 `_parse_holding_rate`로 0..100 percent. `individual_net`은 핸들러가 이미 -(기관+외인) 파생(중복 안 함).
- week/month aggregation에 보유주수/보유율 전파(level=최신값, 합산 아님).

## Verification
- valuation overlay(raw KRW) + fail-open None / quote previous_close(2캔들·단일None) / investor 9-cell 보유율 + 레거시 7-cell None + `_parse_holding_rate` 단위. **66 + 185 green**, ruff clean, **migration 0**.

## Boundaries
read-only·additive. broker/order/watch mutation 0. `stock_detail_service` "저장소 미적재" 경고는 별도(get_investor_trends 라이브 ≠ 스냅샷 스토어; 제거 시 거짓 — 후속). 단위 함정 사전점검: #1155(US 억원→$)는 display formatter였지 raw 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)