### PR TITLE
fix(ROB-451): analyze_stock_batch quick 요약 RSI 항상 null — 포매터 더블-네스팅 (전 마켓)

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -451,7 +451,13 @@ def _summarize_analysis_result(
         return analysis
 
     quote = analysis.get("quote") or {}
-    indicators = (analysis.get("indicators") or {}).get("indicators", {})
+    # ROB-451: production stores a FLAT indicator map ({"rsi": {"14": ...}}) — the unwrap
+    # already happens in analysis_analyze.py. The old `.get("indicators", {})` assumed the
+    # pre-unwrap provider shape, so it found nothing → rsi_14 was ALWAYS null (all markets).
+    # Defensively accept both: nested provider payload OR the already-flat map.
+    raw_indicators = analysis.get("indicators") or {}
+    inner = raw_indicators.get("indicators")
+    indicators = inner if isinstance(inner, dict) else raw_indicators
     rsi = (indicators.get("rsi") or {}).get("14")
     sr = analysis.get("support_resistance") or {}
 

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -537,11 +537,11 @@ class TestAnalyzeStockBatch:
             "market_type": "equity_kr",
             "source": "kis",
             "quote": {"price": 75000},
+            # ROB-451: production stores the FLAT indicator map (already unwrapped in
+            # analysis_analyze.py). The old double-nested mock hid the batch-formatter bug.
             "indicators": {
-                "indicators": {
-                    "rsi": {"14": 45.0},
-                    "bollinger": {"lower": 74000},
-                }
+                "rsi": {"14": 45.0},
+                "bollinger": {"lower": 74000},
             },
             "support_resistance": {
                 "supports": [{"price": 73000}],
@@ -593,6 +593,32 @@ class TestAnalyzeStockBatch:
             "supports": [{"price": 73000}],
             "resistances": [{"price": 77000, "strength": "medium"}],
         }
+
+    async def test_analyze_stock_batch_quick_summary_crypto_rsi(self, monkeypatch):
+        # ROB-451: crypto batch quick summary must surface rsi_14 (flat indicator map),
+        # while consensus stays null (crypto has no analyst-consensus source — correct).
+        tools = build_tools()
+
+        mock_analysis = {
+            "symbol": "BTC",
+            "market_type": "crypto",
+            "source": "upbit",
+            "quote": {"price": 95000000},
+            "indicators": {"rsi": {"14": 61.2}},  # production FLAT shape
+            "support_resistance": {"supports": [], "resistances": []},
+            # no "opinions" → consensus is correctly null for crypto
+        }
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return mock_analysis
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        result = await tools["analyze_stock_batch"](["BTC"], market="crypto")
+
+        row = result["results"]["BTC"]
+        assert row["rsi_14"] == pytest.approx(61.2)  # ROB-451: no longer null
+        assert row.get("consensus") is None  # crypto: correct (not a regression)
 
     async def test_analyze_stock_batch_quick_false_returns_full_payload(
         self, monkeypatch


### PR DESCRIPTION
## What & why
라이브(크립토에서 가장 가시): `analyze_stock_batch(quick=True)`의 `rsi_14`가 **항상 null**. 크립토 한정이 아니라 **KR/US/crypto 전 마켓** 결함. 원인 = 배치 요약 포매터(`analysis_tool_handlers.py:454`)가 indicators를 **한 번 더 언랩**(`(analysis.get("indicators") or {}).get("indicators", {})`). 프로덕션은 이미 flat map(`{"rsi":{"14":...}}`, `analysis_analyze.py:369-376`에서 언랩) → `.get("indicators")` → None → `{}` → rsi None.

## Changes
- 포매터를 **양형 방어**로 수정: `inner = raw.get("indicators")`; flat이면 `raw` 그대로 사용 → nested/flat 둘 다 정상.
- ⚠️ 기존 테스트 mock이 **double-nested**(`{"indicators":{"indicators":...}}`)로 버그를 **가렸음** → 프로덕션 flat로 교정. `test_recommendation_generation_kr`(별도 함수 `build_recommendation_for_equity`)는 스코프 밖이라 무변경.
- crypto 회귀 추가: batch quick에서 `rsi_14` 비-null + `consensus` null 유지(크립토는 애널 컨센서스 소스 없음 — 정상, 회귀 아님).

## Verification
- KR/crypto batch quick에서 rsi_14 비-null + 양형 방어. **7 passed**, ruff clean, **migration 0**.

## Boundaries
read-only(요약 포매터). broker/order/watch mutation 0. `consensus`는 손대지 않음(크립토 null이 정답).

## Related
ROB-451 · ROB-386(같은 함수 current_price anchoring, rsi 미포함 → 부분 미커버).

🤖 Generated with [Claude Code](https://claude.com/claude-code)