### PR TITLE
feat(ROB-452 P1): get_crypto_market_regime + get_crypto_catalysts MCP 도구 (정직 스캐폴드)

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_crypto_catalysts.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto_catalysts.py
@@ -1,0 +1,124 @@
+"""ROB-452 P1: get_crypto_catalysts — supply/event catalysts for crypto (read-only).
+
+Aggregates three sources, each independently fail-open (one source failing never kills
+the tool — partial results survive with per-block state):
+  * token_unlocks  — Tokenomist unlock/vesting (PoC stub today → state "disabled",
+                     honest: it emits no data without an enabled adapter).
+  * upbit_notices  — NEW keyless Upbit notices feed (listings / 유의 / 점검).
+  * market_warnings — existing Upbit market-warning read model (CAUTION designations).
+
+symbol (e.g. "XRP", "KRW-XRP") scopes warnings + notices; None = market-wide.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.mcp_server.tooling.fundamentals_sources_coingecko import (
+    _normalize_crypto_base_symbol,
+)
+from app.services.external.crypto_insights import (
+    fetch_tokenomist_unlocks_poc,
+    tokenomist_api_key_from_env,
+)
+from app.services.upbit_public_read_model.market_warnings import get_market_warnings
+from app.services.upbit_public_read_model.notices import fetch_upbit_notices
+
+
+async def _tokenomist_block() -> dict[str, Any]:
+    try:
+        result = await fetch_tokenomist_unlocks_poc(
+            api_key=tokenomist_api_key_from_env()
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-open per source
+        return {
+            "state": "unavailable",
+            "source": "tokenomist",
+            "items": [],
+            "warnings": [str(exc)],
+        }
+    items = [
+        {"metric": m.metric, "value": float(m.value) if m.value is not None else None}
+        for m in result.metrics
+    ]
+    return {
+        # PoC emits no metrics → honest "disabled" (do not claim live unlock data).
+        "state": "fresh" if items else "disabled",
+        "source": "tokenomist",
+        "items": items,
+        "warnings": list(result.warnings),
+    }
+
+
+async def _market_warnings_block(*, markets: list[str] | None) -> dict[str, Any]:
+    try:
+        block = await get_market_warnings(markets=markets, include_event_detail=False)
+    except Exception as exc:  # noqa: BLE001 — fail-open per source
+        return {
+            "state": "unavailable",
+            "source": "upbit_market_warnings",
+            "entries": {},
+            "errorReason": str(exc),
+        }
+    # Only CAUTION is a catalyst; NONE is noise.
+    entries = {
+        market: {"warning": entry.warning, "event": entry.event}
+        for market, entry in block.entries.items()
+        if entry.warning == "CAUTION"
+    }
+    return {
+        "state": block.meta.state,
+        "source": "upbit_market_warnings",
+        "fetched_at": (
+            block.meta.fetchedAt.isoformat() if block.meta.fetchedAt else None
+        ),
+        "entries": entries,
+    }
+
+
+def _filter_notices_by_base(block: dict[str, Any], base: str) -> dict[str, Any]:
+    if block.get("state") != "fresh":
+        return block
+    base_up = base.upper()
+    filtered = [
+        item
+        for item in block.get("items", [])
+        if item.get("title") and base_up in str(item["title"]).upper()
+    ]
+    return {**block, "items": filtered}
+
+
+async def handle_get_crypto_catalysts(
+    symbol: str | None = None,
+    days: int = 14,
+) -> dict[str, Any]:
+    """Aggregate crypto catalysts (token unlocks + Upbit notices + market warnings)."""
+    now = dt.datetime.now(dt.UTC)
+
+    base: str | None = None
+    market: str | None = None
+    if symbol:
+        try:
+            base = _normalize_crypto_base_symbol(symbol) or None
+        except Exception:  # noqa: BLE001 — normalization best-effort
+            base = None
+        if base:
+            market = f"KRW-{base}"
+
+    unlocks_block = await _tokenomist_block()
+    notices_block = await fetch_upbit_notices(days=days)
+    if base:
+        notices_block = _filter_notices_by_base(notices_block, base)
+    warnings_block = await _market_warnings_block(markets=[market] if market else None)
+
+    return {
+        "symbol": market or symbol or None,
+        "window_days": days,
+        "as_of": now.isoformat(),
+        "catalysts": {
+            "token_unlocks": unlocks_block,
+            "upbit_notices": notices_block,
+            "market_warnings": warnings_block,
+        },
+    }

--- a/app/mcp_server/tooling/fundamentals/_crypto_regime.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto_regime.py
@@ -1,0 +1,127 @@
+"""ROB-452 P1: get_crypto_market_regime — read-only view over crypto_insight_snapshots.
+
+The crypto_insight_snapshots table (DefiLlama / Coinglass / TradingView / Fear&Greed)
+was a dead-end — only the build job wrote it, no MCP tool read it. This exposes it.
+
+HONEST SCAFFOLD: each field is independently fresh/stale/missing/disabled. Only `fng`
+(Fear&Greed, alternative_me) is populated by the DEFAULT job. `tvl`/`stablecoin_supply`
+(defillama) and `breadth` (tradingview, reference-only) require operator-enabled
+providers; `aggregate_oi` (coinglass) is a disabled PoC that emits no rows. An empty
+table yields per-field "missing" — never an error.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.services.crypto_insight_snapshots.repository import (
+    get_latest_crypto_insight,
+    list_latest_crypto_insights,
+)
+
+# Regime metrics are slow-moving (daily-ish); treat older than this as stale unless the
+# row itself carries a tighter freshness_seconds.
+_REGIME_STALE_AFTER_SECONDS = 24 * 3600
+
+
+def _to_jsonable(value: Any) -> float | None:
+    return float(value) if value is not None else None
+
+
+def _state_for(snapshot: Any, *, now: dt.datetime) -> str:
+    if snapshot is None:
+        return "missing"
+    age = (now - snapshot.snapshot_at).total_seconds()
+    threshold = snapshot.freshness_seconds or _REGIME_STALE_AFTER_SECONDS
+    return "fresh" if age <= threshold else "stale"
+
+
+def _field_block(snapshot: Any, *, now: dt.datetime, provider: str) -> dict[str, Any]:
+    if snapshot is None:
+        return {"state": "missing", "provider": provider, "value": None}
+    return {
+        "state": _state_for(snapshot, now=now),
+        "provider": snapshot.provider,
+        "value": _to_jsonable(snapshot.value),
+        "unit": snapshot.unit,
+        "label": snapshot.label,
+        "as_of": snapshot.snapshot_at.astimezone(dt.UTC).isoformat(),
+    }
+
+
+def _tvl_block(rows: list[Any], *, now: dt.datetime) -> dict[str, Any]:
+    # DefiLlama writes one tvl row per protocol (e.g. bitcoin/ethereum) — there is no
+    # single global aggregate. Surface the per-protocol values honestly rather than
+    # fabricating a total.
+    if not rows:
+        return {"state": "missing", "provider": "defillama", "by_protocol": []}
+    freshest = max(rows, key=lambda r: r.snapshot_at)
+    return {
+        "state": _state_for(freshest, now=now),
+        "provider": "defillama",
+        "by_protocol": [
+            {
+                "symbol": r.symbol,
+                "value": _to_jsonable(r.value),
+                "unit": r.unit,
+                "as_of": r.snapshot_at.astimezone(dt.UTC).isoformat(),
+            }
+            for r in rows
+        ],
+    }
+
+
+async def handle_get_crypto_market_regime() -> dict[str, Any]:
+    """Latest crypto market-regime signals from crypto_insight_snapshots (read-only)."""
+    now = dt.datetime.now(dt.UTC)
+    try:
+        async with AsyncSessionLocal() as session:
+            fng = await get_latest_crypto_insight(
+                session, "fear_greed", provider="alternative_me", symbol=None
+            )
+            stablecoin = await get_latest_crypto_insight(
+                session, "stablecoin_supply", provider="defillama", symbol=None
+            )
+            breadth = await get_latest_crypto_insight(
+                session, "tv_crypto_breadth", provider="tradingview", symbol=None
+            )
+            tvl_rows = await list_latest_crypto_insights(
+                session, metrics=["tvl"], providers=["defillama"]
+            )
+    except Exception as exc:  # noqa: BLE001 — read-only; surface a structured error
+        return _error_payload(
+            source="crypto_insight_snapshots",
+            message=str(exc),
+            instrument_type="crypto",
+        )
+
+    return {
+        "as_of": now.isoformat(),
+        "source": "crypto_insight_snapshots",
+        "regime": {
+            "fng": _field_block(fng, now=now, provider="alternative_me"),
+            "tvl": _tvl_block(list(tvl_rows), now=now),
+            "stablecoin_supply": _field_block(
+                stablecoin, now=now, provider="defillama"
+            ),
+            "breadth": _field_block(breadth, now=now, provider="tradingview"),
+            "aggregate_oi": {
+                "state": "disabled",
+                "provider": "coinglass",
+                "value": None,
+                "note": (
+                    "coinglass PoC adapter is disabled (no API key / not in default "
+                    "providers) — emits no rows"
+                ),
+            },
+        },
+        # Honesty: tell the caller why fields may be empty.
+        "note": (
+            "fng is populated by the default snapshot job; tvl/stablecoin_supply "
+            "(defillama) + breadth (tradingview, reference-only) require operator-enabled "
+            "providers; aggregate_oi (coinglass) is a disabled PoC."
+        ),
+    }

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -10,6 +10,9 @@ from app.mcp_server.tooling.fundamentals._crypto import (
     handle_get_long_short_ratio,
     handle_get_open_interest,
 )
+from app.mcp_server.tooling.fundamentals._crypto_regime import (
+    handle_get_crypto_market_regime,
+)
 from app.mcp_server.tooling.fundamentals._financials import (
     handle_get_earnings_calendar,
     handle_get_financials,
@@ -61,6 +64,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_funding_rate",
     "get_open_interest",
     "get_long_short_ratio",
+    "get_crypto_market_regime",
     "get_market_index",
     "get_upbit_index",
     "get_upbit_altseason",
@@ -263,6 +267,20 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         limit: int = 30,
     ) -> dict[str, Any]:
         return await handle_get_long_short_ratio(symbol, period, limit)
+
+    @mcp.tool(
+        name="get_crypto_market_regime",
+        description=(
+            "Get crypto market-regime signals from the crypto_insight_snapshots store "
+            "(read-only): Fear&Greed (fng), DeFi TVL by protocol, stablecoin supply, "
+            "TradingView breadth, aggregate open interest. Each field is independently "
+            "fresh/stale/missing/disabled — only fng is populated by default; "
+            "tvl/stablecoin/breadth need operator-enabled providers and aggregate_oi "
+            "(coinglass) is a disabled PoC. No arguments."
+        ),
+    )
+    async def get_crypto_market_regime() -> dict[str, Any]:
+        return await handle_get_crypto_market_regime()
 
     @mcp.tool(
         name="get_market_index",

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -10,6 +10,9 @@ from app.mcp_server.tooling.fundamentals._crypto import (
     handle_get_long_short_ratio,
     handle_get_open_interest,
 )
+from app.mcp_server.tooling.fundamentals._crypto_catalysts import (
+    handle_get_crypto_catalysts,
+)
 from app.mcp_server.tooling.fundamentals._crypto_regime import (
     handle_get_crypto_market_regime,
 )
@@ -65,6 +68,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_open_interest",
     "get_long_short_ratio",
     "get_crypto_market_regime",
+    "get_crypto_catalysts",
     "get_market_index",
     "get_upbit_index",
     "get_upbit_altseason",
@@ -281,6 +285,22 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
     )
     async def get_crypto_market_regime() -> dict[str, Any]:
         return await handle_get_crypto_market_regime()
+
+    @mcp.tool(
+        name="get_crypto_catalysts",
+        description=(
+            "Get crypto supply/event catalysts (read-only): token unlocks (Tokenomist, "
+            "disabled PoC today), Upbit notices (listings / 유의 / 점검), and Upbit "
+            "market warnings (CAUTION). Each source is independently "
+            "fresh/disabled/unavailable. Pass symbol (e.g. 'XRP') to scope to one coin, "
+            "or omit for market-wide. days windows the notices feed."
+        ),
+    )
+    async def get_crypto_catalysts(
+        symbol: str | None = None,
+        days: int = 14,
+    ) -> dict[str, Any]:
+        return await handle_get_crypto_catalysts(symbol, days)
 
     @mcp.tool(
         name="get_market_index",

--- a/app/services/upbit_public_read_model/notices.py
+++ b/app/services/upbit_public_read_model/notices.py
@@ -1,0 +1,103 @@
+"""ROB-452 P1: Upbit notices (공지) read-only fetcher — listings / 유의(CAUTION) / 점검.
+
+Keyless public endpoint, used as a crypto catalyst feed alongside the market-warnings
+read model. The endpoint is UNOFFICIAL and its exact shape/host can change, so parsing
+is defensive (locate the item list across known shapes) and the caller treats any
+failure as a degraded ("unavailable") block — never a raise. Verify the live shape via
+the operator smoke before relying on the field set.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import httpx
+
+# Unofficial public notices API (verify in live smoke). Parsing tolerates shape drift.
+_UPBIT_NOTICES_URL = "https://api-manager.upbit.com/api/v1/notices"
+_DEFAULT_PARAMS = {"page": "1", "per_page": "30", "thread_name": "general"}
+_TIMEOUT = httpx.Timeout(10.0)
+
+
+def _extract_items(payload: Any) -> list[dict[str, Any]]:
+    """Find the notices list across known/likely response shapes (defensive)."""
+    if isinstance(payload, list):
+        return [x for x in payload if isinstance(x, dict)]
+    if not isinstance(payload, dict):
+        return []
+    data = payload.get("data", payload)
+    if isinstance(data, list):
+        return [x for x in data if isinstance(x, dict)]
+    if isinstance(data, dict):
+        for key in ("notice", "notices", "list", "items", "results"):
+            seq = data.get(key)
+            if isinstance(seq, list):
+                return [x for x in seq if isinstance(x, dict)]
+    return []
+
+
+def _item_date(item: dict[str, Any]) -> dt.datetime | None:
+    for key in ("listed_at", "first_listed_at", "created_at", "updated_at"):
+        raw = item.get(key)
+        if not raw:
+            continue
+        try:
+            return dt.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+async def fetch_upbit_notices(
+    *,
+    days: int = 14,
+    fetcher: Any = None,
+) -> dict[str, Any]:
+    """Return recent Upbit notices windowed to ``days``.
+
+    Shape: ``{"state": "fresh"|"unavailable", "source": "upbit_notices",
+    "fetched_at": iso, "items": [{title, category, listed_at}], "errorReason": str?}``.
+    Fail-open: any network/shape error → state="unavailable" with errorReason.
+    """
+    now = dt.datetime.now(dt.UTC)
+    try:
+        if fetcher is not None:
+            payload = await fetcher()
+        else:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                response = await client.get(_UPBIT_NOTICES_URL, params=_DEFAULT_PARAMS)
+                response.raise_for_status()
+                payload = response.json()
+    except Exception as exc:  # noqa: BLE001 — unofficial endpoint; degrade gracefully
+        return {
+            "state": "unavailable",
+            "source": "upbit_notices",
+            "fetched_at": now.isoformat(),
+            "items": [],
+            "errorReason": str(exc),
+        }
+
+    cutoff = now - dt.timedelta(days=max(days, 1))
+    items: list[dict[str, Any]] = []
+    for raw in _extract_items(payload):
+        listed = _item_date(raw)
+        if listed is not None and listed.tzinfo is None:
+            listed = listed.replace(tzinfo=dt.UTC)
+        # keep within window when a parseable date exists; undated items pass through
+        if listed is not None and listed < cutoff:
+            continue
+        items.append(
+            {
+                "title": raw.get("title"),
+                "category": raw.get("category") or raw.get("thread_name"),
+                "listed_at": listed.astimezone(dt.UTC).isoformat() if listed else None,
+            }
+        )
+
+    return {
+        "state": "fresh",
+        "source": "upbit_notices",
+        "fetched_at": now.isoformat(),
+        "items": items,
+    }

--- a/tests/test_crypto_catalysts_tool.py
+++ b/tests/test_crypto_catalysts_tool.py
@@ -1,0 +1,166 @@
+"""ROB-452 P1: Upbit notices fetcher + get_crypto_catalysts handler (hermetic)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _crypto_catalysts as mod
+from app.services.upbit_public_read_model import notices as notices_mod
+
+pytestmark = [pytest.mark.unit]  # async tests carry @pytest.mark.asyncio individually
+
+
+# ---------------- notices fetcher ----------------
+
+
+def test_extract_items_defensive_shapes():
+    today = "2026-06-08T00:00:00Z"
+    a = {"data": {"notice": [{"title": "x", "listed_at": today}]}}
+    b = {"data": {"list": [{"title": "y"}]}}
+    c = [{"title": "z"}]
+    assert notices_mod._extract_items(a)[0]["title"] == "x"
+    assert notices_mod._extract_items(b)[0]["title"] == "y"
+    assert notices_mod._extract_items(c)[0]["title"] == "z"
+    assert notices_mod._extract_items("garbage") == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_upbit_notices_success_windowed():
+    recent = dt.datetime.now(dt.UTC).isoformat()
+    old = (dt.datetime.now(dt.UTC) - dt.timedelta(days=60)).isoformat()
+
+    async def fake():
+        return {
+            "data": {
+                "notice": [
+                    {"title": "BTC 입출금", "category": "general", "listed_at": recent},
+                    {"title": "old notice", "category": "general", "listed_at": old},
+                ]
+            }
+        }
+
+    out = await notices_mod.fetch_upbit_notices(days=14, fetcher=fake)
+    assert out["state"] == "fresh"
+    titles = [i["title"] for i in out["items"]]
+    assert "BTC 입출금" in titles
+    assert "old notice" not in titles  # outside 14-day window
+
+
+@pytest.mark.asyncio
+async def test_fetch_upbit_notices_fail_open():
+    async def boom():
+        raise RuntimeError("endpoint down")
+
+    out = await notices_mod.fetch_upbit_notices(days=14, fetcher=boom)
+    assert out["state"] == "unavailable"
+    assert out["items"] == []
+    assert "endpoint down" in out["errorReason"]
+
+
+# ---------------- catalysts handler ----------------
+
+
+def _patch_sources(monkeypatch, *, tokenomist, notices, warnings):
+    monkeypatch.setattr(mod, "fetch_tokenomist_unlocks_poc", tokenomist)
+    monkeypatch.setattr(mod, "tokenomist_api_key_from_env", lambda: None)
+    monkeypatch.setattr(mod, "fetch_upbit_notices", notices)
+    monkeypatch.setattr(mod, "get_market_warnings", warnings)
+
+
+@pytest.mark.asyncio
+async def test_catalysts_aggregates_three_blocks(monkeypatch):
+    async def tokenomist(*, api_key=None):
+        return SimpleNamespace(
+            metrics=(), warnings=("tokenomist: disabled (missing API key)",)
+        )
+
+    async def notices(*, days=14, **kw):
+        return {
+            "state": "fresh",
+            "source": "upbit_notices",
+            "items": [
+                {"title": "XRP 유의 안내", "category": "general", "listed_at": None}
+            ],
+        }
+
+    async def warnings(*, markets=None, include_event_detail=False):
+        return SimpleNamespace(
+            meta=SimpleNamespace(state="fresh", fetchedAt=None),
+            entries={
+                "KRW-XRP": SimpleNamespace(warning="CAUTION", event={"k": 1}),
+                "KRW-BTC": SimpleNamespace(warning="NONE", event=None),
+            },
+        )
+
+    _patch_sources(
+        monkeypatch, tokenomist=tokenomist, notices=notices, warnings=warnings
+    )
+    out = await mod.handle_get_crypto_catalysts(symbol=None, days=14)
+
+    cat = out["catalysts"]
+    # tokenomist PoC → honest "disabled"
+    assert cat["token_unlocks"]["state"] == "disabled"
+    assert cat["upbit_notices"]["state"] == "fresh"
+    # only CAUTION surfaces (NONE filtered out)
+    assert set(cat["market_warnings"]["entries"]) == {"KRW-XRP"}
+
+
+@pytest.mark.asyncio
+async def test_catalysts_symbol_scopes_notices(monkeypatch):
+    async def tokenomist(*, api_key=None):
+        return SimpleNamespace(metrics=(), warnings=())
+
+    async def notices(*, days=14, **kw):
+        return {
+            "state": "fresh",
+            "source": "upbit_notices",
+            "items": [
+                {"title": "XRP 입출금 재개", "category": "general", "listed_at": None},
+                {"title": "ETH 점검 안내", "category": "general", "listed_at": None},
+            ],
+        }
+
+    async def warnings(*, markets=None, include_event_detail=False):
+        return SimpleNamespace(
+            meta=SimpleNamespace(state="fresh", fetchedAt=None), entries={}
+        )
+
+    _patch_sources(
+        monkeypatch, tokenomist=tokenomist, notices=notices, warnings=warnings
+    )
+    out = await mod.handle_get_crypto_catalysts(symbol="XRP", days=14)
+
+    titles = [i["title"] for i in out["catalysts"]["upbit_notices"]["items"]]
+    assert any("XRP" in t for t in titles)
+    assert not any("ETH" in t for t in titles)  # scoped to XRP
+    assert out["symbol"] == "KRW-XRP"
+
+
+@pytest.mark.asyncio
+async def test_catalysts_fail_open_per_source(monkeypatch):
+    async def tokenomist(*, api_key=None):
+        raise RuntimeError("tok boom")
+
+    async def notices(*, days=14, **kw):
+        return {
+            "state": "unavailable",
+            "source": "upbit_notices",
+            "items": [],
+            "errorReason": "n down",
+        }
+
+    async def warnings(*, markets=None, include_event_detail=False):
+        raise RuntimeError("warn boom")
+
+    _patch_sources(
+        monkeypatch, tokenomist=tokenomist, notices=notices, warnings=warnings
+    )
+    out = await mod.handle_get_crypto_catalysts()  # must not raise
+
+    cat = out["catalysts"]
+    assert cat["token_unlocks"]["state"] == "unavailable"
+    assert cat["upbit_notices"]["state"] == "unavailable"
+    assert cat["market_warnings"]["state"] == "unavailable"

--- a/tests/test_crypto_market_regime_tool.py
+++ b/tests/test_crypto_market_regime_tool.py
@@ -1,0 +1,123 @@
+"""ROB-452 P1: get_crypto_market_regime handler (hermetic — repo + session mocked)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _crypto_regime as mod
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _snap(
+    metric,
+    provider,
+    value,
+    *,
+    symbol=None,
+    age_seconds=60,
+    freshness=None,
+    unit=None,
+    label=None,
+):
+    return SimpleNamespace(
+        metric=metric,
+        provider=provider,
+        symbol=symbol,
+        value=Decimal(str(value)) if value is not None else None,
+        unit=unit,
+        label=label,
+        freshness_seconds=freshness,
+        snapshot_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=age_seconds),
+    )
+
+
+def _patch(monkeypatch, *, get_latest, list_latest):
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(mod, "get_latest_crypto_insight", get_latest)
+    monkeypatch.setattr(mod, "list_latest_crypto_insights", list_latest)
+
+
+async def test_fng_fresh_others_missing_oi_disabled(monkeypatch):
+    async def get_latest(session, metric, *, provider=None, symbol=None):
+        if metric == "fear_greed":
+            return _snap(
+                "fear_greed", "alternative_me", 72, label="Greed", unit="score"
+            )
+        return None  # stablecoin / breadth missing
+
+    async def list_latest(session, *, metrics=None, providers=None, **kw):
+        return []  # tvl missing
+
+    _patch(monkeypatch, get_latest=get_latest, list_latest=list_latest)
+    out = await mod.handle_get_crypto_market_regime()
+
+    regime = out["regime"]
+    assert regime["fng"]["state"] == "fresh"
+    assert regime["fng"]["value"] == pytest.approx(72.0)
+    assert regime["fng"]["label"] == "Greed"
+    assert regime["stablecoin_supply"]["state"] == "missing"
+    assert regime["breadth"]["state"] == "missing"
+    assert regime["tvl"]["state"] == "missing"
+    assert regime["tvl"]["by_protocol"] == []
+    # coinglass PoC is disabled — honest, not a fake value
+    assert regime["aggregate_oi"]["state"] == "disabled"
+    assert regime["aggregate_oi"]["value"] is None
+    assert out["source"] == "crypto_insight_snapshots"
+
+
+async def test_fng_stale_when_old(monkeypatch):
+    async def get_latest(session, metric, *, provider=None, symbol=None):
+        if metric == "fear_greed":
+            # 2 days old, no tighter freshness → past the 24h regime threshold
+            return _snap("fear_greed", "alternative_me", 30, age_seconds=2 * 24 * 3600)
+        return None
+
+    async def list_latest(session, *, metrics=None, providers=None, **kw):
+        return []
+
+    _patch(monkeypatch, get_latest=get_latest, list_latest=list_latest)
+    out = await mod.handle_get_crypto_market_regime()
+    assert out["regime"]["fng"]["state"] == "stale"
+
+
+async def test_tvl_per_protocol_when_present(monkeypatch):
+    async def get_latest(session, metric, *, provider=None, symbol=None):
+        return None
+
+    async def list_latest(session, *, metrics=None, providers=None, **kw):
+        return [
+            _snap("tvl", "defillama", 900_000_000_000, symbol="BTC", unit="usd"),
+            _snap("tvl", "defillama", 500_000_000_000, symbol="ETH", unit="usd"),
+        ]
+
+    _patch(monkeypatch, get_latest=get_latest, list_latest=list_latest)
+    out = await mod.handle_get_crypto_market_regime()
+    tvl = out["regime"]["tvl"]
+    assert tvl["state"] == "fresh"
+    syms = {p["symbol"] for p in tvl["by_protocol"]}
+    assert syms == {"BTC", "ETH"}  # honest per-protocol, no fabricated global total
+
+
+async def test_db_error_returns_structured_payload(monkeypatch):
+    async def get_latest(session, metric, *, provider=None, symbol=None):
+        raise RuntimeError("db down")
+
+    async def list_latest(session, *, metrics=None, providers=None, **kw):
+        return []
+
+    _patch(monkeypatch, get_latest=get_latest, list_latest=list_latest)
+    out = await mod.handle_get_crypto_market_regime()
+    assert "error" in out  # fail-open: structured error, not a raise


### PR DESCRIPTION
## What & why
코인 분석에 유용하나 MCP 미노출이던 데이터를 2개 read-only 도구로 노출. **⚠️ grounding이 이슈 전제 일부 정정**: "이미 구현"이라던 소스 상당수가 PoC 스텁/기본 비활성 provider → **정직 스캐폴드**(실데이터는 그대로, 미가용은 honest state).

## get_crypto_market_regime (P1a)
- `crypto_insight_snapshots` 읽기(기존 repo `get_latest`/`list_latest` 재사용). 필드별 독립 state.
- **fng(Fear&Greed)만 기본 실데이터**; tvl/stablecoin(defillama)·breadth(tradingview ref-only)는 operator provider 필요; aggregate_oi(coinglass)는 disabled PoC. tvl은 per-protocol(글로벌 집계 날조 안 함). payload note로 명시.

## get_crypto_catalysts (P1b)
- 3 소스 독립 fail-open: **upbit_notices(신규 keyless 클라이언트** — 상장/유의/점검; 비공식 endpoint→방어적 파싱+fail-open, operator live-smoke 검증 필요), **market_warnings(기존 재사용, CAUTION만)**, token_unlocks(Tokenomist PoC→honest disabled).
- symbol(예 XRP)이면 KRW-{base}로 warnings 스코프 + notices title 필터.

## Verification
- regime: fng fresh/stale + 나머지 missing/disabled + tvl per-protocol + DB에러 structured.
- catalysts: notices 방어파싱/윈도/fail-open + 3블록 집계/CAUTION필터/symbol스코프/소스별 fail-open.
- **양 도구 on_duplicate=error 부팅 스모크 통과**(이름 충돌 0). ROB-285 binance audit 무관. ruff clean, **migration 0**.

## Boundaries / operator
read-only. broker/order mutation 0. **데이터는 operator가 (1) defillama/coinglass/tradingview provider 활성화 (2) Upbit notices endpoint 검증 시 채워짐** → operator 요청 별도 정리. P2(order_flow/social)는 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)