### PR TITLE
fix(ROB-452): parse live DefiLlama regime payloads

### DIFF
--- a/app/services/external/crypto_insights.py
+++ b/app/services/external/crypto_insights.py
@@ -12,7 +12,7 @@ import httpx
 ALTERNATIVE_ME_FNG_URL = "https://api.alternative.me/fng/"
 COINGECKO_GLOBAL_URL = "https://api.coingecko.com/api/v3/global"
 BINANCE_FUNDING_URL = "https://fapi.binance.com/fapi/v1/premiumIndex"
-DEFILLAMA_PROTOCOL_URL = "https://api.llama.fi/protocol/{slug}"
+DEFILLAMA_CHAINS_URL = "https://api.llama.fi/v2/chains"
 DEFILLAMA_STABLECOINS_URL = "https://stablecoins.llama.fi/stablecoins"
 COINGLASS_OPEN_INTEREST_URL = (
     "https://open-api-v4.coinglass.com/api/futures/openInterest/ohlc-history"
@@ -227,6 +227,40 @@ async def fetch_binance_funding_rates(
     return CryptoInsightProviderResult(metrics=tuple(metrics), warnings=tuple(warnings))
 
 
+def _matches_defillama_slug(row: dict[str, Any], slug: str) -> bool:
+    candidates = (
+        row.get("gecko_id"),
+        row.get("name"),
+        row.get("tokenSymbol"),
+        row.get("symbol"),
+    )
+    return any(str(value).strip().lower() == slug for value in candidates if value)
+
+
+def _stablecoin_usd_total(payload: dict[str, Any]) -> Decimal | None:
+    direct = _decimal(payload.get("totalCirculatingUSD")) or _decimal(
+        payload.get("totalCirculating")
+    )
+    if direct is not None:
+        return direct
+    total = Decimal("0")
+    found = False
+    for chain in payload.get("chains") or []:
+        if not isinstance(chain, dict):
+            continue
+        circulating = chain.get("totalCirculatingUSD")
+        value = (
+            circulating.get("peggedUSD")
+            if isinstance(circulating, dict)
+            else circulating
+        )
+        amount = _decimal(value)
+        if amount is not None:
+            total += amount
+            found = True
+    return total if found else None
+
+
 async def fetch_defillama_reference(
     client: httpx.AsyncClient | None = None,
     *,
@@ -239,53 +273,67 @@ async def fetch_defillama_reference(
     metrics: list[CryptoInsightMetric] = []
     warnings: list[str] = []
     try:
-        for slug in [s.strip().lower() for s in protocol_slugs if s.strip()]:
-            try:
-                url = DEFILLAMA_PROTOCOL_URL.format(slug=slug)
-                response = await http.get(url)
-                response.raise_for_status()
-                payload = response.json()
+        wanted_slugs = [s.strip().lower() for s in protocol_slugs if s.strip()]
+        try:
+            response = await http.get(DEFILLAMA_CHAINS_URL)
+            response.raise_for_status()
+            payload = response.json()
+            chain_rows = (
+                [row for row in payload if isinstance(row, dict)]
+                if isinstance(payload, list)
+                else []
+            )
+            for slug in wanted_slugs:
+                row = next(
+                    (r for r in chain_rows if _matches_defillama_slug(r, slug)), None
+                )
+                if row is None:
+                    warnings.append(f"defillama:{slug}: chain not found")
+                    continue
                 metrics.append(
                     CryptoInsightMetric(
                         metric="tvl",
                         provider="defillama",
-                        symbol=(payload.get("symbol") or slug).upper(),
-                        value=_decimal(payload.get("tvl")),
+                        symbol=(
+                            row.get("tokenSymbol") or row.get("symbol") or slug
+                        ).upper(),
+                        value=_decimal(row.get("tvl")),
                         unit="usd",
-                        label=payload.get("name"),
-                        source_url=url,
+                        label=row.get("name"),
+                        source_url=DEFILLAMA_CHAINS_URL,
                         observed_at=observed_at,
                         freshness_seconds=0,
                         raw_payload={
-                            "name": payload.get("name"),
-                            "symbol": payload.get("symbol"),
-                            "tvl": payload.get("tvl"),
+                            "name": row.get("name"),
+                            "tokenSymbol": row.get("tokenSymbol"),
+                            "gecko_id": row.get("gecko_id"),
+                            "tvl": row.get("tvl"),
                         },
                     )
                 )
-            except Exception as exc:  # noqa: BLE001
-                warnings.append(f"defillama:{slug}: {exc}")
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"defillama:chains: {exc}")
         try:
             response = await http.get(
                 DEFILLAMA_STABLECOINS_URL, params={"includePrices": "false"}
             )
             response.raise_for_status()
             payload = response.json()
-            total = payload.get("totalCirculatingUSD") or payload.get(
-                "totalCirculating"
-            )
+            total = _stablecoin_usd_total(payload if isinstance(payload, dict) else {})
             metrics.append(
                 CryptoInsightMetric(
                     metric="stablecoin_supply",
                     provider="defillama",
                     symbol=None,
-                    value=_decimal(total),
+                    value=total,
                     unit="usd",
                     label="stablecoins circulating",
                     source_url=DEFILLAMA_STABLECOINS_URL,
                     observed_at=observed_at,
                     freshness_seconds=0,
-                    raw_payload={"totalCirculatingUSD": total},
+                    raw_payload={
+                        "totalCirculatingUSD": str(total) if total is not None else None
+                    },
                 )
             )
         except Exception as exc:  # noqa: BLE001

--- a/app/services/external/crypto_insights.py
+++ b/app/services/external/crypto_insights.py
@@ -56,13 +56,26 @@ def _decimal(value: Any) -> Decimal | None:
         return None
 
 
-def _freshness_from_unix(value: Any, now: dt.datetime) -> int | None:
+def _freshness_from_unix(
+    value: Any,
+    now: dt.datetime,
+    time_until_update: Any = None,
+) -> int | None:
     try:
         timestamp = int(value)
     except Exception:  # noqa: BLE001
         return None
     observed = dt.datetime.fromtimestamp(timestamp, tz=dt.UTC)
-    return max(0, int((now - observed).total_seconds()))
+    age_seconds = max(0, int((now - observed).total_seconds()))
+    if time_until_update is not None:
+        try:
+            return age_seconds + max(0, int(time_until_update))
+        except Exception:  # noqa: BLE001
+            pass
+    # Alternative.me is daily; when the live response lacks time_until_update,
+    # keep one day of freshness from the value timestamp rather than expiring at
+    # fetch time. The caller still compares this against snapshot_at age.
+    return 24 * 3600
 
 
 async def fetch_alternative_me_fear_greed(
@@ -85,7 +98,9 @@ async def fetch_alternative_me_fear_greed(
         current = rows[0]
         value = _decimal(current.get("value"))
         timestamp = current.get("timestamp")
-        freshness = _freshness_from_unix(timestamp, observed_at)
+        freshness = _freshness_from_unix(
+            timestamp, observed_at, current.get("time_until_update")
+        )
         if timestamp is not None:
             try:
                 observed_at = dt.datetime.fromtimestamp(int(timestamp), tz=dt.UTC)

--- a/app/services/upbit_public_read_model/notices.py
+++ b/app/services/upbit_public_read_model/notices.py
@@ -133,16 +133,16 @@ async def fetch_upbit_notices(
             {
                 "id": _first_present(raw, "id", "notice_id", "noticeId"),
                 "title": _first_present(raw, "title", "content"),
-                "category": _first_present(raw, "category", "thread_name", "threadName"),
+                "category": _first_present(
+                    raw, "category", "thread_name", "threadName"
+                ),
                 "listed_at": listed.astimezone(dt.UTC).isoformat() if listed else None,
                 "first_listed_at": (
                     first_listed.astimezone(dt.UTC).isoformat()
                     if first_listed
                     else None
                 ),
-                "need_new_badge": _first_present(
-                    raw, "need_new_badge", "needNewBadge"
-                ),
+                "need_new_badge": _first_present(raw, "need_new_badge", "needNewBadge"),
                 "need_update_badge": _first_present(
                     raw, "need_update_badge", "needUpdateBadge"
                 ),

--- a/app/services/upbit_public_read_model/notices.py
+++ b/app/services/upbit_public_read_model/notices.py
@@ -14,9 +14,11 @@ from typing import Any
 
 import httpx
 
-# Unofficial public notices API (verify in live smoke). Parsing tolerates shape drift.
-_UPBIT_NOTICES_URL = "https://api-manager.upbit.com/api/v1/notices"
-_DEFAULT_PARAMS = {"page": "1", "per_page": "30", "thread_name": "general"}
+# Unofficial public announcements API (verified by ROB-452 live smoke via
+# https://www.upbit.com/service_center/notice resource timing). Parsing tolerates
+# shape drift because this is not a documented Open API surface.
+_UPBIT_NOTICES_URL = "https://api-manager.upbit.com/api/v1/announcements"
+_DEFAULT_PARAMS = {"os": "web", "page": "1", "per_page": "30", "category": "all"}
 _TIMEOUT = httpx.Timeout(10.0)
 
 
@@ -30,15 +32,35 @@ def _extract_items(payload: Any) -> list[dict[str, Any]]:
     if isinstance(data, list):
         return [x for x in data if isinstance(x, dict)]
     if isinstance(data, dict):
-        for key in ("notice", "notices", "list", "items", "results"):
+        items: list[dict[str, Any]] = []
+        for key in (
+            # Upbit live shape returns fixed_notices + notices.
+            "fixed_notices",
+            "fixedNotices",
+            "notice",
+            "notices",
+            "list",
+            "items",
+            "results",
+        ):
             seq = data.get(key)
             if isinstance(seq, list):
-                return [x for x in seq if isinstance(x, dict)]
+                items.extend(x for x in seq if isinstance(x, dict))
+        return items
     return []
 
 
 def _item_date(item: dict[str, Any]) -> dt.datetime | None:
-    for key in ("listed_at", "first_listed_at", "created_at", "updated_at"):
+    for key in (
+        "listed_at",
+        "listedAt",
+        "first_listed_at",
+        "firstListedAt",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+    ):
         raw = item.get(key)
         if not raw:
             continue
@@ -47,6 +69,23 @@ def _item_date(item: dict[str, Any]) -> dt.datetime | None:
         except (ValueError, TypeError):
             continue
     return None
+
+
+def _first_present(item: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in item:
+            return item[key]
+    return None
+
+
+def _first_listed_date(item: dict[str, Any]) -> dt.datetime | None:
+    raw = _first_present(item, "first_listed_at", "firstListedAt")
+    if not raw:
+        return None
+    try:
+        return dt.datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
 
 
 async def fetch_upbit_notices(
@@ -87,11 +126,26 @@ async def fetch_upbit_notices(
         # keep within window when a parseable date exists; undated items pass through
         if listed is not None and listed < cutoff:
             continue
+        first_listed = _first_listed_date(raw)
+        if first_listed is not None and first_listed.tzinfo is None:
+            first_listed = first_listed.replace(tzinfo=dt.UTC)
         items.append(
             {
-                "title": raw.get("title"),
-                "category": raw.get("category") or raw.get("thread_name"),
+                "id": _first_present(raw, "id", "notice_id", "noticeId"),
+                "title": _first_present(raw, "title", "content"),
+                "category": _first_present(raw, "category", "thread_name", "threadName"),
                 "listed_at": listed.astimezone(dt.UTC).isoformat() if listed else None,
+                "first_listed_at": (
+                    first_listed.astimezone(dt.UTC).isoformat()
+                    if first_listed
+                    else None
+                ),
+                "need_new_badge": _first_present(
+                    raw, "need_new_badge", "needNewBadge"
+                ),
+                "need_update_badge": _first_present(
+                    raw, "need_update_badge", "needUpdateBadge"
+                ),
             }
         )
 

--- a/tests/test_crypto_catalysts_tool.py
+++ b/tests/test_crypto_catalysts_tool.py
@@ -21,9 +21,20 @@ def test_extract_items_defensive_shapes():
     a = {"data": {"notice": [{"title": "x", "listed_at": today}]}}
     b = {"data": {"list": [{"title": "y"}]}}
     c = [{"title": "z"}]
+    live = {
+        "success": True,
+        "data": {
+            "fixed_notices": [{"title": "fixed", "listed_at": today}],
+            "notices": [{"title": "normal", "listed_at": today}],
+        },
+    }
     assert notices_mod._extract_items(a)[0]["title"] == "x"
     assert notices_mod._extract_items(b)[0]["title"] == "y"
     assert notices_mod._extract_items(c)[0]["title"] == "z"
+    assert [i["title"] for i in notices_mod._extract_items(live)] == [
+        "fixed",
+        "normal",
+    ]
     assert notices_mod._extract_items("garbage") == []
 
 
@@ -34,12 +45,25 @@ async def test_fetch_upbit_notices_success_windowed():
 
     async def fake():
         return {
+            "success": True,
             "data": {
-                "notice": [
-                    {"title": "BTC 입출금", "category": "general", "listed_at": recent},
-                    {"title": "old notice", "category": "general", "listed_at": old},
+                "notices": [
+                    {
+                        "id": 1,
+                        "title": "BTC 입출금",
+                        "category": "입출금",
+                        "listed_at": recent,
+                        "first_listed_at": recent,
+                        "need_new_badge": False,
+                    },
+                    {
+                        "id": 2,
+                        "title": "old notice",
+                        "category": "general",
+                        "listed_at": old,
+                    },
                 ]
-            }
+            },
         }
 
     out = await notices_mod.fetch_upbit_notices(days=14, fetcher=fake)
@@ -47,6 +71,10 @@ async def test_fetch_upbit_notices_success_windowed():
     titles = [i["title"] for i in out["items"]]
     assert "BTC 입출금" in titles
     assert "old notice" not in titles  # outside 14-day window
+    recent_item = next(i for i in out["items"] if i["title"] == "BTC 입출금")
+    assert recent_item["id"] == 1
+    assert recent_item["category"] == "입출금"
+    assert recent_item["need_new_badge"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_crypto_insight_external_adapters.py
+++ b/tests/test_crypto_insight_external_adapters.py
@@ -102,15 +102,41 @@ async def test_binance_adapter_maps_public_funding_rate():
 async def test_defillama_adapter_maps_tvl_and_stablecoin_metrics():
     def handler(request):
         if request.url.host == "api.llama.fi":
+            assert request.url.path == "/v2/chains"
             return httpx.Response(
-                200, json={"name": "Ethereum", "symbol": "ETH", "tvl": 123}
+                200,
+                json=[
+                    {
+                        "name": "Ethereum",
+                        "tokenSymbol": "ETH",
+                        "gecko_id": "ethereum",
+                        "tvl": 123,
+                    },
+                    {
+                        "name": "Solana",
+                        "tokenSymbol": "SOL",
+                        "gecko_id": "solana",
+                        "tvl": 789,
+                    },
+                ],
             )
-        return httpx.Response(200, json={"totalCirculatingUSD": 456})
+        return httpx.Response(
+            200,
+            json={
+                "chains": [
+                    {"name": "Ethereum", "totalCirculatingUSD": {"peggedUSD": 456}},
+                    {"name": "Solana", "totalCirculatingUSD": {"peggedUSD": 44}},
+                ]
+            },
+        )
 
     async with _client(handler) as client:
         result = await fetch_defillama_reference(client, protocol_slugs=["ethereum"])
 
-    assert {metric.metric for metric in result.metrics} == {"tvl", "stablecoin_supply"}
+    metrics = {metric.metric: metric for metric in result.metrics}
+    assert set(metrics) == {"tvl", "stablecoin_supply"}
+    assert metrics["tvl"].symbol == "ETH"
+    assert metrics["stablecoin_supply"].value == Decimal("500")
 
 
 async def test_optional_poc_adapters_are_non_fatal_without_credentials():

--- a/tests/test_crypto_insight_external_adapters.py
+++ b/tests/test_crypto_insight_external_adapters.py
@@ -33,6 +33,7 @@ async def test_alternative_me_adapter_maps_fear_greed_metric():
                         "value": "72",
                         "value_classification": "Greed",
                         "timestamp": "1778620000",
+                        "time_until_update": "3600",
                     },
                     {
                         "value": "65",
@@ -55,6 +56,13 @@ async def test_alternative_me_adapter_maps_fear_greed_metric():
     assert metric.provider == "alternative_me"
     assert metric.value == Decimal("72")
     assert metric.label == "Greed"
+    expected_age = int(
+        (
+            dt.datetime(2026, 5, 13, tzinfo=dt.UTC)
+            - dt.datetime.fromtimestamp(1778620000, tz=dt.UTC)
+        ).total_seconds()
+    )
+    assert metric.freshness_seconds == expected_age + 3600
 
 
 async def test_coingecko_adapter_maps_global_metrics():


### PR DESCRIPTION
## Summary
- Fix DefiLlama regime adapter to parse the current live `/v2/chains` response instead of stale protocol TVL shape.
- Aggregate stablecoin supply from `chains[].totalCirculatingUSD.peggedUSD` when the top-level total is absent.
- Update adapter test to lock the current live response shape used by ROB-452.

## Test Plan
- `uv run ruff format --check app/services/external/crypto_insights.py tests/test_crypto_insight_external_adapters.py`
- `uv run ruff check app/services/external/crypto_insights.py tests/test_crypto_insight_external_adapters.py`
- `uv run --group test pytest tests/test_crypto_insight_external_adapters.py -q`
- Live dry-run: `uv run python /tmp/auto_trader_rob452_crypto_insight_run.py` → `snapshots_built=9`, `committed=false`, includes DefiLlama BTC/ETH TVL + stablecoin supply

## Safety
- Read-only provider/parser fix only.
- No broker/order/watch mutation.
- No migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upbit notices now include first-listed timestamps and badges for new/updated items.
  * Stablecoin supply metric added to DefiLlama-derived metrics.

* **Improvements**
  * More tolerant parsing of varied notice payloads and revised notice fetch endpoint.
  * DefiLlama data fetched more efficiently (single chains fetch) and TVL mapping improved.
  * Freshness calculation now respects API-provided update intervals when available.

* **Tests**
  * Expanded hermetic tests to cover new shapes, freshness logic, and stablecoin/TVL assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->