### PR TITLE
feat(ROB-388): screen_stocks(kr) snapshot-primary 발굴 경로 복구 (kr_market_ranking)

### DIFF
--- a/app/mcp_server/tooling/screening/kr.py
+++ b/app/mcp_server/tooling/screening/kr.py
@@ -27,6 +27,7 @@ from app.mcp_server.tooling.screening.enrichment import _pick_display_name
 from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
 from app.mcp_server.tooling.screening.kr_ranking_snapshot import (
     load_kr_ranking_snapshot,
+    snapshot_path_applicable,
 )
 from app.mcp_server.tooling.screening.tvscreener_support import (
     _adapt_tvscreener_stock_response,
@@ -673,25 +674,45 @@ async def _screen_kr_with_fallback(
     """Screen Korean market with tvscreener fallback to legacy."""
     # ROB-388: snapshot-primary. Serve the durable kr_market_ranking read-model first
     # (fresh OR stale, honestly labeled) so screen_stocks never hard-0s when the live
-    # KRX session is down. None => ineligible sort_by / zero rows / error => live path.
-    snapshot = await load_kr_ranking_snapshot(
-        sort_by=sort_by, sort_order=sort_order, limit=limit
-    )
-    if snapshot is not None and snapshot.rows:
-        return _build_screen_response(
-            snapshot.rows,
-            snapshot.total_count,
-            {
-                "market": market,
-                "sort_by": sort_by,
-                "sort_order": sort_order,
-                "asset_type": asset_type,
-                "category": category,
-            },
-            market,
-            warnings=snapshot.warnings or None,
-            meta_fields=snapshot.meta_fields,
+    # KRX session is down. Gated to plain KR-wide ranking queries: a market sub-filter
+    # (kospi/kosdaq/konex), ETF/category/sector, or any quality filter would be
+    # mislabeled/silently dropped by the read-model, so those use the live path (which
+    # honors them). None => ineligible sort_by / zero rows / error => live path.
+    if snapshot_path_applicable(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        sector=sector,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        max_pbr=max_pbr,
+        min_dividend_yield=min_dividend_yield,
+        min_analyst_buy=min_analyst_buy,
+        max_rsi=max_rsi,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
+        instrument_types=instrument_types,
+        exclude_sectors=exclude_sectors,
+    ):
+        snapshot = await load_kr_ranking_snapshot(
+            sort_by=sort_by, sort_order=sort_order, limit=limit
         )
+        if snapshot is not None and snapshot.rows:
+            return _build_screen_response(
+                snapshot.rows,
+                snapshot.total_count,
+                {
+                    "market": market,
+                    "sort_by": sort_by,
+                    "sort_order": sort_order,
+                    "asset_type": asset_type,
+                    "category": category,
+                },
+                market,
+                warnings=snapshot.warnings or None,
+                meta_fields=snapshot.meta_fields,
+            )
 
     try:
         capability_snapshot = await _get_tvscreener_stock_capability_snapshot(

--- a/app/mcp_server/tooling/screening/kr.py
+++ b/app/mcp_server/tooling/screening/kr.py
@@ -25,6 +25,9 @@ from app.mcp_server.tooling.screening.common import (
 )
 from app.mcp_server.tooling.screening.enrichment import _pick_display_name
 from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
+from app.mcp_server.tooling.screening.kr_ranking_snapshot import (
+    load_kr_ranking_snapshot,
+)
 from app.mcp_server.tooling.screening.tvscreener_support import (
     _adapt_tvscreener_stock_response,
     _can_use_tvscreener_stock_path,
@@ -668,6 +671,28 @@ async def _screen_kr_with_fallback(
     exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen Korean market with tvscreener fallback to legacy."""
+    # ROB-388: snapshot-primary. Serve the durable kr_market_ranking read-model first
+    # (fresh OR stale, honestly labeled) so screen_stocks never hard-0s when the live
+    # KRX session is down. None => ineligible sort_by / zero rows / error => live path.
+    snapshot = await load_kr_ranking_snapshot(
+        sort_by=sort_by, sort_order=sort_order, limit=limit
+    )
+    if snapshot is not None and snapshot.rows:
+        return _build_screen_response(
+            snapshot.rows,
+            snapshot.total_count,
+            {
+                "market": market,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "asset_type": asset_type,
+                "category": category,
+            },
+            market,
+            warnings=snapshot.warnings or None,
+            meta_fields=snapshot.meta_fields,
+        )
+
     try:
         capability_snapshot = await _get_tvscreener_stock_capability_snapshot(
             market=market,

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -43,6 +43,59 @@ def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
     return _ORDER_TYPE_BY_SORT.get(sort_by, ())
 
 
+def snapshot_path_applicable(
+    *,
+    market: str,
+    asset_type: str | None,
+    category: str | None,
+    sector: str | None,
+    min_market_cap: float | None,
+    max_per: float | None,
+    max_pbr: float | None,
+    min_dividend_yield: float | None,
+    min_analyst_buy: float | None,
+    max_rsi: float | None,
+    adv_krw_min: int | None,
+    market_cap_min_krw: int | None,
+    market_cap_max_krw: int | None,
+    instrument_types: list[str] | None,
+    exclude_sectors: list[str] | None,
+) -> bool:
+    """True iff this is a plain KR-wide ranking query the kr_market_ranking read-model
+    can faithfully serve.
+
+    The read-model is KR-wide (KOSPI+KOSDAQ) common stocks with no quality fields, so:
+    - a market sub-filter (kospi/kosdaq/konex) would mislabel KR-wide rows,
+    - an ETF/category/sector constraint or any quality filter cannot be honored.
+    In those cases this returns False so the caller uses the live path (which honors
+    them) instead of silently returning unfiltered / mislabeled snapshot rows.
+    """
+    if market not in {"kr", "all"}:
+        return False
+    if asset_type not in (None, "stock"):
+        return False
+    if category is not None or sector is not None:
+        return False
+    if any(
+        v is not None
+        for v in (
+            min_market_cap,
+            max_per,
+            max_pbr,
+            min_dividend_yield,
+            min_analyst_buy,
+            max_rsi,
+            adv_krw_min,
+            market_cap_min_krw,
+            market_cap_max_krw,
+        )
+    ):
+        return False
+    if instrument_types or exclude_sectors:
+        return False
+    return True
+
+
 def _opt_float(value: float | int | None) -> float | None:
     return float(value) if value is not None else None
 

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -152,8 +152,62 @@ def _build_query_service(session: Any) -> Any:
     return MomentumRankingQueryService(InvestMomentumEventSnapshotsRepository(session))
 
 
-async def _enrich_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return rows  # replaced in Task 5
+async def _load_universe_by_code() -> dict[str, dict[str, Any]]:
+    from app.services.krx import fetch_stock_all_cached
+
+    out: dict[str, dict[str, Any]] = {}
+    for mkt in ("STK", "KSQ"):
+        for item in await fetch_stock_all_cached(market=mkt):
+            code = str(item.get("short_code") or item.get("code") or "").strip()
+            if code:
+                out[code] = item
+    return out
+
+
+async def _load_valuation_by_code() -> dict[str, dict[str, Any]]:
+    from app.services.krx import fetch_valuation_all_cached
+
+    return await fetch_valuation_all_cached(market="ALL")
+
+
+async def _enrich_rows(
+    rows: list[dict[str, Any]],
+    *,
+    universe_by_code: dict[str, dict[str, Any]] | None = None,
+    valuation_by_code: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Best-effort enrich snapshot rows with code/sector/instrument_type + per/pbr/
+    dividend_yield from KRX universe/valuation caches. Fail-open and no fabrication:
+    on any cache error or missing key, leave fields as-is (null)."""
+    from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
+
+    try:
+        if universe_by_code is None:
+            universe_by_code = await _load_universe_by_code()
+        if valuation_by_code is None:
+            valuation_by_code = await _load_valuation_by_code()
+    except Exception:  # noqa: BLE001 — enrichment is best-effort
+        return rows
+
+    for r in rows:
+        code = r.get("symbol") or ""
+        base = universe_by_code.get(code) or {}
+        val = valuation_by_code.get(code) or {}
+        if base.get("code"):
+            r["code"] = base["code"]
+        if base.get("sector") and not r.get("sector"):
+            r["sector"] = base["sector"]
+        r["instrument_type"] = classify_kr_instrument(
+            code, r.get("name"), base.get("subtype")
+        )
+        if r.get("per") is None:
+            r["per"] = val.get("per")
+        if r.get("pbr") is None:
+            r["pbr"] = val.get("pbr")
+        if r.get("dividend_yield") is None:
+            r["dividend_yield"] = val.get("dividend_yield")
+    return rows
+
 
 
 async def load_kr_ranking_snapshot(

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -123,3 +123,116 @@ def freshness_to_meta(
     return data_state, meta, warnings
 
 
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KrRankingSnapshotResult:
+    rows: list[dict[str, Any]]
+    total_count: int
+    data_state: str  # "fresh" | "stale"
+    source: str
+    latest_snapshot_at: str | None
+    warnings: list[str] = field(default_factory=list)
+    meta_fields: dict[str, Any] = field(default_factory=dict)
+
+
+def _build_query_service(session: Any) -> Any:
+    from app.services.invest_momentum_events.query_service import (
+        MomentumRankingQueryService,
+    )
+    from app.services.invest_momentum_events.repository import (
+        InvestMomentumEventSnapshotsRepository,
+    )
+
+    return MomentumRankingQueryService(InvestMomentumEventSnapshotsRepository(session))
+
+
+async def _enrich_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return rows  # replaced in Task 5
+
+
+async def load_kr_ranking_snapshot(
+    *,
+    sort_by: str,
+    sort_order: str,
+    limit: int,
+    now: dt.datetime | None = None,
+    query_service: Any | None = None,
+    enrich: bool = True,
+) -> KrRankingSnapshotResult | None:
+    """Primary KR discovery source for screen_stocks. Returns a result with rows
+    (fresh OR stale, honestly labeled) or None (ineligible sort_by / zero rows /
+    any error) so the caller falls through to the live path. Fail-open by design."""
+    if not is_snapshot_eligible_sort(sort_by):
+        return None
+    if now is None:
+        now = dt.datetime.now(dt.UTC)
+
+    order_types = order_types_for_sort(sort_by)
+    try:
+        if query_service is not None:
+            return await _run(
+                query_service, sort_by, sort_order, limit, now, order_types, enrich, None
+            )
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as session:
+            qs = _build_query_service(session)
+            return await _run(
+                qs, sort_by, sort_order, limit, now, order_types, enrich, session
+            )
+    except Exception as exc:  # fail-open: never break screen_stocks
+        logger.debug("kr_market_ranking snapshot unavailable, falling back: %s", exc)
+        return None
+
+
+async def _run(
+    qs: Any,
+    sort_by: str,
+    sort_order: str,
+    limit: int,
+    now: dt.datetime,
+    order_types: tuple[str, ...],
+    enrich: bool,
+    session: Any | None,
+) -> KrRankingSnapshotResult | None:
+    collected: list[dict[str, Any]] = []
+    freshnesses: list[Freshness] = []
+    for ot in order_types:
+        ranking = await qs.get_ranking(
+            order_type=ot, market="kr", limit=max(limit, 50), now=now
+        )
+        freshnesses.append(ranking.freshness)
+        collected.extend(ranking_row_to_screen_row(r) for r in ranking.rows)
+
+    if not collected:
+        return None  # unavailable -> live fallthrough
+
+    rows = dedupe_and_sort_rows(collected, sort_by=sort_by, sort_order=sort_order)
+    rows = rows[:limit]
+
+    # Worst freshness wins (stale beats fresh when buckets disagree).
+    overall = "stale" if any(f.overall == "stale" for f in freshnesses) else "fresh"
+    base = next((f for f in freshnesses if f.overall == overall), freshnesses[0])
+
+    if enrich and session is not None:
+        rows = await _enrich_rows(rows)  # defined in Task 5
+
+    data_state, meta, warnings = freshness_to_meta(base, row_count=len(rows))
+    return KrRankingSnapshotResult(
+        rows=rows,
+        total_count=len(rows),
+        data_state=data_state,
+        source="kr_market_ranking",
+        latest_snapshot_at=meta.get("latest_snapshot_at"),
+        warnings=warnings,
+        meta_fields=meta,
+    )
+
+
+

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -32,3 +32,36 @@ def is_snapshot_eligible_sort(sort_by: str) -> bool:
 
 def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
     return _ORDER_TYPE_BY_SORT.get(sort_by, ())
+
+
+from typing import Any
+
+from app.services.invest_momentum_events.query_service import RankingRow
+
+
+def _opt_float(value: float | int | None) -> float | None:
+    return float(value) if value is not None else None
+
+
+def ranking_row_to_screen_row(row: RankingRow) -> dict[str, Any]:
+    """Map one RankingRow to the screen_stocks result-row shape. Pure; null-safe;
+    never fabricates valuation fields (per/pbr/dividend_yield default to None and
+    are filled best-effort later by enrichment)."""
+    code = row.symbol
+    return {
+        "symbol": code,
+        "short_code": code,
+        "code": code,
+        "name": row.name or code,
+        "price": _opt_float(row.price),
+        "change_rate": _opt_float(row.change_rate),
+        "volume": _opt_float(row.volume),
+        "trade_amount": _opt_float(row.trade_value),
+        "market_cap": _opt_float(row.market_cap),
+        "market": "kr",
+        "per": None,
+        "pbr": None,
+        "dividend_yield": None,
+        "instrument_type": "stock",
+    }
+

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -9,6 +9,15 @@ falls through to the live (tvscreener -> legacy KRX) path.
 
 from __future__ import annotations
 
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.services.invest_momentum_events.query_service import Freshness, RankingRow
+
+logger = logging.getLogger(__name__)
+
 # sort_by values the kr_market_ranking read-model can serve. Everything else
 # (dividend_yield, week_change_rate, rsi, score, ...) must go to the live path.
 SNAPSHOT_ELIGIBLE_SORTS: frozenset[str] = frozenset(
@@ -32,11 +41,6 @@ def is_snapshot_eligible_sort(sort_by: str) -> bool:
 
 def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
     return _ORDER_TYPE_BY_SORT.get(sort_by, ())
-
-
-from typing import Any
-
-from app.services.invest_momentum_events.query_service import Freshness, RankingRow
 
 
 def _opt_float(value: float | int | None) -> float | None:
@@ -123,13 +127,6 @@ def freshness_to_meta(
     return data_state, meta, warnings
 
 
-import datetime as dt
-import logging
-from dataclasses import dataclass, field
-
-logger = logging.getLogger(__name__)
-
-
 @dataclass(frozen=True)
 class KrRankingSnapshotResult:
     rows: list[dict[str, Any]]
@@ -209,7 +206,6 @@ async def _enrich_rows(
     return rows
 
 
-
 async def load_kr_ranking_snapshot(
     *,
     sort_by: str,
@@ -231,7 +227,14 @@ async def load_kr_ranking_snapshot(
     try:
         if query_service is not None:
             return await _run(
-                query_service, sort_by, sort_order, limit, now, order_types, enrich, None
+                query_service,
+                sort_by,
+                sort_order,
+                limit,
+                now,
+                order_types,
+                enrich,
+                None,
             )
         from app.core.db import AsyncSessionLocal
 
@@ -287,6 +290,3 @@ async def _run(
         warnings=warnings,
         meta_fields=meta,
     )
-
-
-

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -36,7 +36,7 @@ def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
 
 from typing import Any
 
-from app.services.invest_momentum_events.query_service import RankingRow
+from app.services.invest_momentum_events.query_service import Freshness, RankingRow
 
 
 def _opt_float(value: float | int | None) -> float | None:
@@ -64,4 +64,62 @@ def ranking_row_to_screen_row(row: RankingRow) -> dict[str, Any]:
         "dividend_yield": None,
         "instrument_type": "stock",
     }
+
+
+def dedupe_and_sort_rows(
+    rows: list[dict[str, Any]], *, sort_by: str, sort_order: str
+) -> list[dict[str, Any]]:
+    """Dedupe by symbol (first wins) and sort by the requested field. None sorts last
+    regardless of order. Used for trade_amount / market_cap which have no native
+    momentum bucket (we union 'up'+'quantTop' then re-rank)."""
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for r in rows:
+        sym = r.get("symbol")
+        if sym in seen:
+            continue
+        seen.add(sym)
+        deduped.append(r)
+
+    reverse = sort_order != "asc"
+
+    def key(r: dict[str, Any]) -> tuple[int, float]:
+        v = r.get(sort_by)
+        if v is None:
+            # None always last: sort to the extreme opposite of the active direction
+            return (1, float("-inf") if reverse else float("inf"))
+        return (0, float(v))
+
+    return sorted(deduped, key=key, reverse=reverse)
+
+
+def freshness_to_meta(
+    freshness: Freshness, *, row_count: int
+) -> tuple[str, dict[str, Any], list[str]]:
+    """Map momentum Freshness to (data_state, meta_fields, warnings) for screen_stocks.
+    'unavailable' is handled by the caller (returns None -> live), so only fresh/stale
+    produce a response here."""
+    data_state = freshness.overall
+    meta: dict[str, Any] = {
+        "data_state": data_state,
+        "source": "kr_market_ranking",
+        "latest_snapshot_at": (
+            freshness.latest_snapshot_at.isoformat()
+            if freshness.latest_snapshot_at is not None
+            else None
+        ),
+    }
+    warnings: list[str] = [
+        f"모멘텀 랭킹 상위 {row_count}종목 기반 — 전체 KRX 스캔이 아닙니다."
+    ]
+    if data_state == "stale":
+        meta["stale_reason"] = freshness.stale_reason
+        meta["retryable"] = False
+        meta["reason"] = "kr_market_ranking_stale"
+        warnings.append(
+            "모멘텀 랭킹 스냅샷이 오래되었습니다"
+            f"({freshness.stale_reason}) — 신규 후보 발굴에 주의하세요."
+        )
+    return data_state, meta, warnings
+
 

--- a/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+++ b/app/mcp_server/tooling/screening/kr_ranking_snapshot.py
@@ -1,0 +1,34 @@
+"""ROB-388: screen_stocks(kr) snapshot-primary adapter.
+
+Reads the kr_market_ranking durable read-model (InvestMomentumEvent snapshots via
+MomentumRankingQueryService) and adapts it to the screen_stocks row/response shape,
+with honest freshness. Self-acquires its DB session (mirrors screener_snapshot_tool)
+and is fail-open: any error / ineligible sort_by / zero rows -> None, so the caller
+falls through to the live (tvscreener -> legacy KRX) path.
+"""
+
+from __future__ import annotations
+
+# sort_by values the kr_market_ranking read-model can serve. Everything else
+# (dividend_yield, week_change_rate, rsi, score, ...) must go to the live path.
+SNAPSHOT_ELIGIBLE_SORTS: frozenset[str] = frozenset(
+    {"change_rate", "volume", "trade_amount", "market_cap"}
+)
+
+# Momentum read-model is bucketed by order_type. "up" = 상승(change_rate),
+# "quantTop" = 거래량(volume). trade_amount / market_cap have no native bucket, so we
+# union the two default-collected buckets and re-sort by the requested field.
+_ORDER_TYPE_BY_SORT: dict[str, tuple[str, ...]] = {
+    "change_rate": ("up",),
+    "volume": ("quantTop",),
+    "trade_amount": ("up", "quantTop"),
+    "market_cap": ("up", "quantTop"),
+}
+
+
+def is_snapshot_eligible_sort(sort_by: str) -> bool:
+    return sort_by in SNAPSHOT_ELIGIBLE_SORTS
+
+
+def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
+    return _ORDER_TYPE_BY_SORT.get(sort_by, ())

--- a/docs/superpowers/plans/2026-06-08-rob-388-screen-stocks-snapshot-primary.md
+++ b/docs/superpowers/plans/2026-06-08-rob-388-screen-stocks-snapshot-primary.md
@@ -1,0 +1,929 @@
+# ROB-388 — screen_stocks(kr) snapshot-primary 발굴 경로 복구 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `screen_stocks(market="kr")`가 KRX live가 죽어도 0건으로 끝나지 않도록, `kr_market_ranking` durable read-model을 primary로 소비하고 stale도 정직하게 반환한다.
+
+**Architecture:** 신규 모듈 `screening/kr_ranking_snapshot.py`가 `MomentumRankingQueryService`(기존 read-model)에서 랭킹을 읽어 screen_stocks 행 모양으로 매핑·enrich하고 freshness를 정직 메타로 변환한다. 이 헬퍼는 `screener_snapshot_tool.py`처럼 `AsyncSessionLocal`로 **자체 세션을 획득**(dispatch 시그니처 변경 없음)하고 **fail-open**(오류·미커버 sort_by·행 0 → `None`)이다. `_screen_kr_with_fallback` 맨 앞에 사다리로 끼워, 스냅샷에 행이 있으면(fresh/stale) 반환하고, 그렇지 않으면 기존 tvscreener→legacy 경로로 흐른다.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async (`AsyncSessionLocal`), pytest, ruff. 기존 `app/services/invest_momentum_events/{query_service,repository}.py` 재사용. migration 없음, read-only.
+
+---
+
+## File Structure
+
+- **Create** `app/mcp_server/tooling/screening/kr_ranking_snapshot.py` — 매핑/정렬/freshness 순수 함수 + `load_kr_ranking_snapshot` 오케스트레이터 + `KrRankingSnapshotResult` dataclass. (단일 책임: kr_market_ranking → screen_stocks 어댑터.)
+- **Modify** `app/mcp_server/tooling/screening/kr.py` — `_screen_kr_with_fallback` 맨 앞에 snapshot-primary 사다리 삽입.
+- **Create** `tests/test_kr_ranking_snapshot.py` — 순수 함수 + 오케스트레이터(주입 query_service) 단위 테스트.
+- **Modify** `tests/test_mcp_screen_stocks_kr.py` — 사다리 회귀(스냅샷 행 있음→반환 / stale 정직 / None→live fallthrough / 미커버 sort_by→live).
+
+기존 참조(읽기 전용, 변경 없음):
+- `app/services/invest_momentum_events/query_service.py` — `MomentumRankingQueryService.get_ranking(order_type, market, limit, now)`, `RankingRow(rank, symbol, name, price, change_rate, volume, trade_value, market_cap)`, `Freshness(overall, latest_snapshot_at, stale_reason)`, `MomentumRanking(market, order_type, trading_date, rows, freshness)`.
+- `app/services/invest_momentum_events/repository.py` — `InvestMomentumEventSnapshotsRepository(session)`.
+- `app/core/db.py` — `AsyncSessionLocal`.
+- `app/services/krx.py` — `fetch_stock_all_cached(market="STK"|"KSQ")`, `fetch_valuation_all_cached(market="ALL")`.
+- `app/mcp_server/tooling/screening/instrument_type.py` — `classify_kr_instrument(code, name, subtype)`.
+- `app/mcp_server/tooling/screening/common.py` — `_build_screen_response(results, total_count, filters_applied, market, warnings=None, meta_fields=None)`.
+
+---
+
+## Task 1: sort_by → order_type 매핑 + 모듈 스캐폴드
+
+**Files:**
+- Create: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`
+- Test: `tests/test_kr_ranking_snapshot.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_ranking_snapshot.py
+import pytest
+
+from app.mcp_server.tooling.screening import kr_ranking_snapshot as krs
+
+
+@pytest.mark.unit
+def test_snapshot_eligible_sorts_membership():
+    assert krs.is_snapshot_eligible_sort("change_rate") is True
+    assert krs.is_snapshot_eligible_sort("volume") is True
+    assert krs.is_snapshot_eligible_sort("trade_amount") is True
+    assert krs.is_snapshot_eligible_sort("market_cap") is True
+    # not covered by the momentum ranking read-model -> must go live
+    assert krs.is_snapshot_eligible_sort("dividend_yield") is False
+    assert krs.is_snapshot_eligible_sort("week_change_rate") is False
+    assert krs.is_snapshot_eligible_sort("rsi") is False
+    assert krs.is_snapshot_eligible_sort("score") is False
+
+
+@pytest.mark.unit
+def test_order_types_for_sort():
+    # direct single-bucket dimensions
+    assert krs.order_types_for_sort("change_rate") == ("up",)
+    assert krs.order_types_for_sort("volume") == ("quantTop",)
+    # re-sort dimensions union both default buckets
+    assert krs.order_types_for_sort("trade_amount") == ("up", "quantTop")
+    assert krs.order_types_for_sort("market_cap") == ("up", "quantTop")
+    # ineligible -> empty
+    assert krs.order_types_for_sort("rsi") == ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -v`
+Expected: FAIL — `ModuleNotFoundError`/`AttributeError` (module/functions not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/mcp_server/tooling/screening/kr_ranking_snapshot.py
+"""ROB-388: screen_stocks(kr) snapshot-primary adapter.
+
+Reads the kr_market_ranking durable read-model (InvestMomentumEvent snapshots via
+MomentumRankingQueryService) and adapts it to the screen_stocks row/response shape,
+with honest freshness. Self-acquires its DB session (mirrors screener_snapshot_tool)
+and is fail-open: any error / ineligible sort_by / zero rows -> None, so the caller
+falls through to the live (tvscreener -> legacy KRX) path.
+"""
+
+from __future__ import annotations
+
+# sort_by values the kr_market_ranking read-model can serve. Everything else
+# (dividend_yield, week_change_rate, rsi, score, ...) must go to the live path.
+SNAPSHOT_ELIGIBLE_SORTS: frozenset[str] = frozenset(
+    {"change_rate", "volume", "trade_amount", "market_cap"}
+)
+
+# Momentum read-model is bucketed by order_type. "up" = 상승(change_rate),
+# "quantTop" = 거래량(volume). trade_amount / market_cap have no native bucket, so we
+# union the two default-collected buckets and re-sort by the requested field.
+_ORDER_TYPE_BY_SORT: dict[str, tuple[str, ...]] = {
+    "change_rate": ("up",),
+    "volume": ("quantTop",),
+    "trade_amount": ("up", "quantTop"),
+    "market_cap": ("up", "quantTop"),
+}
+
+
+def is_snapshot_eligible_sort(sort_by: str) -> bool:
+    return sort_by in SNAPSHOT_ELIGIBLE_SORTS
+
+
+def order_types_for_sort(sort_by: str) -> tuple[str, ...]:
+    return _ORDER_TYPE_BY_SORT.get(sort_by, ())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr_ranking_snapshot.py tests/test_kr_ranking_snapshot.py
+git commit -m "feat(ROB-388): kr_ranking_snapshot sort_by->order_type mapping + eligibility"
+```
+
+---
+
+## Task 2: RankingRow → screen_stocks 행 매핑 (순수)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`
+- Test: `tests/test_kr_ranking_snapshot.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_kr_ranking_snapshot.py
+from app.services.invest_momentum_events.query_service import RankingRow
+
+
+@pytest.mark.unit
+def test_ranking_row_to_screen_row_maps_fields():
+    row = RankingRow(
+        rank=1, symbol="005930", name="삼성전자", price=71000.0,
+        change_rate=3.5, volume=12_000_000, trade_value=8.5e11, market_cap=4.2e14,
+    )
+    out = krs.ranking_row_to_screen_row(row)
+    assert out["symbol"] == "005930"
+    assert out["short_code"] == "005930"
+    assert out["code"] == "005930"
+    assert out["name"] == "삼성전자"
+    assert out["price"] == 71000.0
+    assert out["change_rate"] == 3.5
+    assert out["volume"] == 12_000_000.0  # int -> float
+    assert out["trade_amount"] == 8.5e11   # trade_value -> trade_amount
+    assert out["market_cap"] == 4.2e14
+    assert out["market"] == "kr"
+    # not provided by the ranking read-model -> explicit null (no fabrication)
+    assert out["per"] is None
+    assert out["pbr"] is None
+    assert out["dividend_yield"] is None
+
+
+@pytest.mark.unit
+def test_ranking_row_to_screen_row_null_safe():
+    row = RankingRow(
+        rank=2, symbol="000660", name=None, price=None,
+        change_rate=None, volume=None, trade_value=None, market_cap=None,
+    )
+    out = krs.ranking_row_to_screen_row(row)
+    assert out["symbol"] == "000660"
+    assert out["name"] == "000660"  # falls back to symbol when name missing
+    assert out["price"] is None
+    assert out["volume"] is None
+    assert out["trade_amount"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k ranking_row_to_screen_row -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'ranking_row_to_screen_row'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add imports at top of kr_ranking_snapshot.py
+from typing import Any
+
+from app.services.invest_momentum_events.query_service import RankingRow
+
+
+def _opt_float(value: float | int | None) -> float | None:
+    return float(value) if value is not None else None
+
+
+def ranking_row_to_screen_row(row: RankingRow) -> dict[str, Any]:
+    """Map one RankingRow to the screen_stocks result-row shape. Pure; null-safe;
+    never fabricates valuation fields (per/pbr/dividend_yield default to None and
+    are filled best-effort later by enrichment)."""
+    code = row.symbol
+    return {
+        "symbol": code,
+        "short_code": code,
+        "code": code,
+        "name": row.name or code,
+        "price": _opt_float(row.price),
+        "change_rate": _opt_float(row.change_rate),
+        "volume": _opt_float(row.volume),
+        "trade_amount": _opt_float(row.trade_value),
+        "market_cap": _opt_float(row.market_cap),
+        "market": "kr",
+        "per": None,
+        "pbr": None,
+        "dividend_yield": None,
+        "instrument_type": "stock",
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k ranking_row_to_screen_row -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr_ranking_snapshot.py tests/test_kr_ranking_snapshot.py
+git commit -m "feat(ROB-388): RankingRow -> screen_stocks row mapping (null-safe, no fabrication)"
+```
+
+---
+
+## Task 3: 행 정렬(trade_amount/market_cap) + freshness → 정직 메타 (순수)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`
+- Test: `tests/test_kr_ranking_snapshot.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_kr_ranking_snapshot.py
+from app.services.invest_momentum_events.query_service import Freshness
+
+
+@pytest.mark.unit
+def test_dedupe_and_sort_rows_by_trade_amount_desc():
+    rows = [
+        {"symbol": "A", "trade_amount": 100.0, "market_cap": 5.0},
+        {"symbol": "B", "trade_amount": 300.0, "market_cap": 1.0},
+        {"symbol": "A", "trade_amount": 100.0, "market_cap": 5.0},  # dup symbol
+    ]
+    out = krs.dedupe_and_sort_rows(rows, sort_by="trade_amount", sort_order="desc")
+    assert [r["symbol"] for r in out] == ["B", "A"]  # deduped + sorted desc
+
+
+@pytest.mark.unit
+def test_dedupe_and_sort_rows_market_cap_asc_nulls_last():
+    rows = [
+        {"symbol": "A", "market_cap": None},
+        {"symbol": "B", "market_cap": 2.0},
+        {"symbol": "C", "market_cap": 1.0},
+    ]
+    out = krs.dedupe_and_sort_rows(rows, sort_by="market_cap", sort_order="asc")
+    assert [r["symbol"] for r in out] == ["C", "B", "A"]  # None sorts last
+
+
+@pytest.mark.unit
+def test_freshness_to_meta_fresh():
+    fr = Freshness(overall="fresh", latest_snapshot_at=None, stale_reason=None)
+    data_state, meta, warnings = krs.freshness_to_meta(fr, row_count=20)
+    assert data_state == "fresh"
+    assert meta["source"] == "kr_market_ranking"
+    assert meta["data_state"] == "fresh"
+    # coverage caveat is always present (top-movers, not full universe)
+    assert any("전체 KRX 스캔" in w for w in warnings)
+
+
+@pytest.mark.unit
+def test_freshness_to_meta_stale_adds_warning_and_not_retryable():
+    fr = Freshness(overall="stale", latest_snapshot_at=None, stale_reason="older_than_ttl")
+    data_state, meta, warnings = krs.freshness_to_meta(fr, row_count=10)
+    assert data_state == "stale"
+    assert meta["data_state"] == "stale"
+    assert meta["stale_reason"] == "older_than_ttl"
+    assert meta["retryable"] is False  # stale snapshot won't recover by immediate retry
+    assert any("오래" in w for w in warnings)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k "dedupe_and_sort or freshness_to_meta" -v`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to kr_ranking_snapshot.py
+from app.services.invest_momentum_events.query_service import Freshness
+
+
+def dedupe_and_sort_rows(
+    rows: list[dict[str, Any]], *, sort_by: str, sort_order: str
+) -> list[dict[str, Any]]:
+    """Dedupe by symbol (first wins) and sort by the requested field. None sorts last
+    regardless of order. Used for trade_amount / market_cap which have no native
+    momentum bucket (we union 'up'+'quantTop' then re-rank)."""
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for r in rows:
+        sym = r.get("symbol")
+        if sym in seen:
+            continue
+        seen.add(sym)
+        deduped.append(r)
+
+    reverse = sort_order != "asc"
+
+    def key(r: dict[str, Any]) -> tuple[int, float]:
+        v = r.get(sort_by)
+        if v is None:
+            # None always last: sort to the extreme opposite of the active direction
+            return (1, float("-inf") if reverse else float("inf"))
+        return (0, float(v))
+
+    return sorted(deduped, key=key, reverse=reverse)
+
+
+def freshness_to_meta(
+    freshness: Freshness, *, row_count: int
+) -> tuple[str, dict[str, Any], list[str]]:
+    """Map momentum Freshness to (data_state, meta_fields, warnings) for screen_stocks.
+    'unavailable' is handled by the caller (returns None -> live), so only fresh/stale
+    produce a response here."""
+    data_state = freshness.overall
+    meta: dict[str, Any] = {
+        "data_state": data_state,
+        "source": "kr_market_ranking",
+        "latest_snapshot_at": (
+            freshness.latest_snapshot_at.isoformat()
+            if freshness.latest_snapshot_at is not None
+            else None
+        ),
+    }
+    warnings: list[str] = [
+        f"모멘텀 랭킹 상위 {row_count}종목 기반 — 전체 KRX 스캔이 아닙니다."
+    ]
+    if data_state == "stale":
+        meta["stale_reason"] = freshness.stale_reason
+        meta["retryable"] = False
+        meta["reason"] = "kr_market_ranking_stale"
+        warnings.append(
+            "모멘텀 랭킹 스냅샷이 오래되었습니다"
+            f"({freshness.stale_reason}) — 신규 후보 발굴에 주의하세요."
+        )
+    return data_state, meta, warnings
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k "dedupe_and_sort or freshness_to_meta" -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr_ranking_snapshot.py tests/test_kr_ranking_snapshot.py
+git commit -m "feat(ROB-388): snapshot row dedupe/sort + freshness->honest meta"
+```
+
+---
+
+## Task 4: `load_kr_ranking_snapshot` 오케스트레이터 (async, fail-open)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`
+- Test: `tests/test_kr_ranking_snapshot.py`
+
+`KrRankingSnapshotResult`를 정의하고, 주입 가능한 `query_service`로 단위 테스트한다 (DB 불필요). 미커버 sort_by → `None`; `unavailable`(행 0) → `None`; fresh/stale → 결과. enrichment는 다음 Task에서 추가(여기서는 `enrich=False` 기본 경로로 매핑만).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_kr_ranking_snapshot.py
+import datetime as dt
+
+from app.services.invest_momentum_events.query_service import MomentumRanking
+
+
+class _FakeQS:
+    """Fake MomentumRankingQueryService: returns canned MomentumRanking per order_type."""
+    def __init__(self, by_order_type: dict[str, MomentumRanking]):
+        self._by = by_order_type
+        self.calls: list[str] = []
+
+    async def get_ranking(self, *, order_type, market, limit, now, **_):
+        self.calls.append(order_type)
+        return self._by[order_type]
+
+
+def _ranking(order_type, overall, rows):
+    return MomentumRanking(
+        market="kr", order_type=order_type, trading_date=None,
+        rows=tuple(rows), freshness=Freshness(overall, None, None if overall == "fresh" else "older_than_ttl"),
+    )
+
+
+@pytest.mark.unit
+async def test_load_returns_none_for_ineligible_sort():
+    qs = _FakeQS({})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="rsi", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is None
+    assert qs.calls == []  # never queried
+
+
+@pytest.mark.unit
+async def test_load_returns_none_when_unavailable():
+    qs = _FakeQS({"up": _ranking("up", "unavailable", [])})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is None  # zero rows -> live fallthrough
+
+
+@pytest.mark.unit
+async def test_load_fresh_change_rate_returns_rows():
+    rows = [RankingRow(1, "005930", "삼성전자", 71000.0, 3.5, 100, 5e11, 4e14)]
+    qs = _FakeQS({"up": _ranking("up", "fresh", rows)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None
+    assert out.data_state == "fresh"
+    assert out.total_count == 1
+    assert out.rows[0]["symbol"] == "005930"
+    assert out.source == "kr_market_ranking"
+    assert qs.calls == ["up"]
+
+
+@pytest.mark.unit
+async def test_load_stale_returned_honestly_not_dropped():
+    rows = [RankingRow(1, "005930", "삼성", 71000.0, 1.0, 100, 5e11, 4e14)]
+    qs = _FakeQS({"quantTop": _ranking("quantTop", "stale", rows)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="volume", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None and out.rows  # stale still returns rows (no hard-0)
+    assert out.data_state == "stale"
+    assert any("오래" in w for w in out.warnings)
+
+
+@pytest.mark.unit
+async def test_load_trade_amount_unions_buckets_and_resorts():
+    up = [RankingRow(1, "A", "A", 1.0, 9.0, 10, 100.0, 5.0)]
+    qt = [RankingRow(1, "B", "B", 1.0, 1.0, 99, 300.0, 1.0)]
+    qs = _FakeQS({"up": _ranking("up", "fresh", up), "quantTop": _ranking("quantTop", "fresh", qt)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="trade_amount", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None
+    assert [r["symbol"] for r in out.rows] == ["B", "A"]  # 300 > 100
+    assert set(qs.calls) == {"up", "quantTop"}
+
+
+@pytest.mark.unit
+async def test_load_fail_open_on_query_error():
+    class _Boom:
+        async def get_ranking(self, **_):
+            raise RuntimeError("db down")
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="volume", sort_order="desc", limit=20, query_service=_Boom(), enrich=False
+    )
+    assert out is None  # fail-open -> live fallthrough
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k load_ -v`
+Expected: FAIL — `KrRankingSnapshotResult` / `load_kr_ranking_snapshot` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to kr_ranking_snapshot.py
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KrRankingSnapshotResult:
+    rows: list[dict[str, Any]]
+    total_count: int
+    data_state: str  # "fresh" | "stale"
+    source: str
+    latest_snapshot_at: str | None
+    warnings: list[str] = field(default_factory=list)
+    meta_fields: dict[str, Any] = field(default_factory=dict)
+
+
+def _build_query_service(session: Any) -> Any:
+    from app.services.invest_momentum_events.query_service import (
+        MomentumRankingQueryService,
+    )
+    from app.services.invest_momentum_events.repository import (
+        InvestMomentumEventSnapshotsRepository,
+    )
+
+    return MomentumRankingQueryService(InvestMomentumEventSnapshotsRepository(session))
+
+
+async def load_kr_ranking_snapshot(
+    *,
+    sort_by: str,
+    sort_order: str,
+    limit: int,
+    now: dt.datetime | None = None,
+    query_service: Any | None = None,
+    enrich: bool = True,
+) -> KrRankingSnapshotResult | None:
+    """Primary KR discovery source for screen_stocks. Returns a result with rows
+    (fresh OR stale, honestly labeled) or None (ineligible sort_by / zero rows /
+    any error) so the caller falls through to the live path. Fail-open by design."""
+    if not is_snapshot_eligible_sort(sort_by):
+        return None
+    if now is None:
+        now = dt.datetime.now(dt.UTC)
+
+    order_types = order_types_for_sort(sort_by)
+    try:
+        if query_service is not None:
+            return await _run(
+                query_service, sort_by, sort_order, limit, now, order_types, enrich, None
+            )
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as session:
+            qs = _build_query_service(session)
+            return await _run(
+                qs, sort_by, sort_order, limit, now, order_types, enrich, session
+            )
+    except Exception as exc:  # fail-open: never break screen_stocks
+        logger.debug("kr_market_ranking snapshot unavailable, falling back: %s", exc)
+        return None
+
+
+async def _run(
+    qs: Any,
+    sort_by: str,
+    sort_order: str,
+    limit: int,
+    now: dt.datetime,
+    order_types: tuple[str, ...],
+    enrich: bool,
+    session: Any | None,
+) -> KrRankingSnapshotResult | None:
+    collected: list[dict[str, Any]] = []
+    freshnesses: list[Freshness] = []
+    for ot in order_types:
+        ranking = await qs.get_ranking(
+            order_type=ot, market="kr", limit=max(limit, 50), now=now
+        )
+        freshnesses.append(ranking.freshness)
+        collected.extend(ranking_row_to_screen_row(r) for r in ranking.rows)
+
+    if not collected:
+        return None  # unavailable -> live fallthrough
+
+    if sort_by in {"trade_amount", "market_cap"}:
+        rows = dedupe_and_sort_rows(collected, sort_by=sort_by, sort_order=sort_order)
+    else:
+        rows = dedupe_and_sort_rows(collected, sort_by=sort_by, sort_order=sort_order)
+    rows = rows[:limit]
+
+    # Worst freshness wins (stale beats fresh when buckets disagree).
+    overall = "stale" if any(f.overall == "stale" for f in freshnesses) else "fresh"
+    base = next((f for f in freshnesses if f.overall == overall), freshnesses[0])
+
+    if enrich and session is not None:
+        rows = await _enrich_rows(rows)  # defined in Task 5
+
+    data_state, meta, warnings = freshness_to_meta(base, row_count=len(rows))
+    return KrRankingSnapshotResult(
+        rows=rows,
+        total_count=len(rows),
+        data_state=data_state,
+        source="kr_market_ranking",
+        latest_snapshot_at=meta.get("latest_snapshot_at"),
+        warnings=warnings,
+        meta_fields=meta,
+    )
+```
+
+> Note: Task 5 adds `_enrich_rows`. Until then, `_run` references it only when `enrich and session is not None`; all Task 4 tests pass `enrich=False`, so it is never called yet. Define a temporary stub now to keep the module importable:
+
+```python
+async def _enrich_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return rows  # replaced in Task 5
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k load_ -v`
+Expected: PASS (6 tests). Note: async tests rely on the repo's existing `asyncio_mode=auto` (pytest-asyncio); if a test needs an explicit marker, add `@pytest.mark.asyncio` — check a neighboring async unit test in `tests/` for the project convention.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr_ranking_snapshot.py tests/test_kr_ranking_snapshot.py
+git commit -m "feat(ROB-388): load_kr_ranking_snapshot orchestrator (fail-open, stale-honest)"
+```
+
+---
+
+## Task 5: 행 enrichment (universe + valuation, fail-open)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`
+- Test: `tests/test_kr_ranking_snapshot.py`
+
+RankingRow에 없는 식별/밸류에이션 필드(`code`/`sector`/`instrument_type`, best-effort `per`/`pbr`/`dividend_yield`)를 KRX universe + valuation 캐시에서 보강한다. 위조 금지(없으면 null). 캐시 조회는 주입 가능하게 하여 DB/IO 없이 테스트한다.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_kr_ranking_snapshot.py
+@pytest.mark.unit
+async def test_enrich_rows_fills_code_sector_valuation_best_effort():
+    rows = [
+        {"symbol": "005930", "code": "005930", "per": None, "pbr": None,
+         "dividend_yield": None, "instrument_type": "stock", "name": "삼성전자"},
+    ]
+    universe = {"005930": {"code": "KR7005930003", "sector": "반도체", "name": "삼성전자"}}
+    valuation = {"005930": {"per": 12.3, "pbr": 1.1, "dividend_yield": 2.5}}
+
+    out = await krs._enrich_rows(
+        rows,
+        universe_by_code=universe,
+        valuation_by_code=valuation,
+    )
+    assert out[0]["code"] == "KR7005930003"
+    assert out[0]["sector"] == "반도체"
+    assert out[0]["per"] == 12.3
+    assert out[0]["pbr"] == 1.1
+    assert out[0]["dividend_yield"] == 2.5
+
+
+@pytest.mark.unit
+async def test_enrich_rows_no_fabrication_when_missing():
+    rows = [{"symbol": "999999", "code": "999999", "per": None, "pbr": None,
+             "dividend_yield": None, "instrument_type": "stock", "name": "x"}]
+    out = await krs._enrich_rows(rows, universe_by_code={}, valuation_by_code={})
+    assert out[0]["per"] is None
+    assert out[0]["pbr"] is None
+    assert out[0]["dividend_yield"] is None
+    assert out[0]["code"] == "999999"  # unchanged when no universe match
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k enrich_rows -v`
+Expected: FAIL — `_enrich_rows` does not accept `universe_by_code` / current stub returns rows unchanged.
+
+- [ ] **Step 3: Replace the stub with the real implementation**
+
+```python
+# replace the temporary _enrich_rows stub in kr_ranking_snapshot.py
+async def _load_universe_by_code() -> dict[str, dict[str, Any]]:
+    from app.services.krx import fetch_stock_all_cached
+
+    out: dict[str, dict[str, Any]] = {}
+    for mkt in ("STK", "KSQ"):
+        for item in await fetch_stock_all_cached(market=mkt):
+            code = str(item.get("short_code") or item.get("code") or "").strip()
+            if code:
+                out[code] = item
+    return out
+
+
+async def _load_valuation_by_code() -> dict[str, dict[str, Any]]:
+    from app.services.krx import fetch_valuation_all_cached
+
+    return await fetch_valuation_all_cached(market="ALL")
+
+
+async def _enrich_rows(
+    rows: list[dict[str, Any]],
+    *,
+    universe_by_code: dict[str, dict[str, Any]] | None = None,
+    valuation_by_code: dict[str, dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Best-effort enrich snapshot rows with code/sector/instrument_type + per/pbr/
+    dividend_yield from KRX universe/valuation caches. Fail-open and no fabrication:
+    on any cache error or missing key, leave fields as-is (null)."""
+    from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
+
+    try:
+        if universe_by_code is None:
+            universe_by_code = await _load_universe_by_code()
+        if valuation_by_code is None:
+            valuation_by_code = await _load_valuation_by_code()
+    except Exception:  # noqa: BLE001 — enrichment is best-effort
+        return rows
+
+    for r in rows:
+        code = r.get("symbol") or ""
+        base = universe_by_code.get(code) or {}
+        val = valuation_by_code.get(code) or {}
+        if base.get("code"):
+            r["code"] = base["code"]
+        if base.get("sector") and not r.get("sector"):
+            r["sector"] = base["sector"]
+        r["instrument_type"] = classify_kr_instrument(
+            code, r.get("name"), base.get("subtype")
+        )
+        if r.get("per") is None:
+            r["per"] = val.get("per")
+        if r.get("pbr") is None:
+            r["pbr"] = val.get("pbr")
+        if r.get("dividend_yield") is None:
+            r["dividend_yield"] = val.get("dividend_yield")
+    return rows
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_ranking_snapshot.py -k enrich_rows -v`
+Expected: PASS (2 tests). Then run the whole file: `uv run pytest tests/test_kr_ranking_snapshot.py -v` — all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr_ranking_snapshot.py tests/test_kr_ranking_snapshot.py
+git commit -m "feat(ROB-388): best-effort universe/valuation enrichment (fail-open, no fabrication)"
+```
+
+---
+
+## Task 6: 사다리 배선 — `_screen_kr_with_fallback` + 회귀 테스트
+
+**Files:**
+- Modify: `app/mcp_server/tooling/screening/kr.py:649` (`_screen_kr_with_fallback`)
+- Test: `tests/test_mcp_screen_stocks_kr.py`
+
+스냅샷-primary 사다리를 dispatcher 맨 앞에 끼운다. 스냅샷에 행이 있으면(fresh/stale) `_build_screen_response`로 반환하고, `None`이면 기존 tvscreener→legacy 경로로 흐른다.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_mcp_screen_stocks_kr.py
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.mcp_server.tooling.screening import kr as kr_mod
+from app.mcp_server.tooling.screening.kr_ranking_snapshot import KrRankingSnapshotResult
+
+
+@pytest.mark.unit
+async def test_fallback_uses_snapshot_when_available():
+    snap = KrRankingSnapshotResult(
+        rows=[{"symbol": "005930", "name": "삼성전자", "change_rate": 3.5, "market": "kr"}],
+        total_count=1, data_state="fresh", source="kr_market_ranking",
+        latest_snapshot_at="2026-06-08T00:00:00+00:00",
+        warnings=["모멘텀 랭킹 상위 1종목 기반 — 전체 KRX 스캔이 아닙니다."],
+        meta_fields={"data_state": "fresh", "source": "kr_market_ranking"},
+    )
+    with patch.object(
+        kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=snap)
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr", asset_type=None, category=None, sector=None,
+            min_market_cap=None, max_per=None, max_pbr=None, min_dividend_yield=None,
+            min_analyst_buy=None, max_rsi=None, sort_by="change_rate",
+            sort_order="desc", limit=20,
+        )
+    assert resp["meta"]["data_state"] == "fresh"
+    assert resp["meta"]["source"] == "kr_market_ranking"
+    assert resp["stocks"][0]["symbol"] == "005930"
+
+
+@pytest.mark.unit
+async def test_fallback_stale_snapshot_returned_not_hard_zero():
+    snap = KrRankingSnapshotResult(
+        rows=[{"symbol": "005930", "name": "삼성", "market": "kr"}],
+        total_count=1, data_state="stale", source="kr_market_ranking",
+        latest_snapshot_at=None,
+        warnings=["모멘텀 랭킹 스냅샷이 오래되었습니다(older_than_ttl) — 신규 후보 발굴에 주의하세요."],
+        meta_fields={"data_state": "stale", "source": "kr_market_ranking",
+                     "retryable": False, "reason": "kr_market_ranking_stale"},
+    )
+    with patch.object(
+        kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=snap)
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr", asset_type=None, category=None, sector=None,
+            min_market_cap=None, max_per=None, max_pbr=None, min_dividend_yield=None,
+            min_analyst_buy=None, max_rsi=None, sort_by="volume",
+            sort_order="desc", limit=20,
+        )
+    assert resp["meta"]["data_state"] == "stale"
+    assert len(resp["stocks"]) == 1  # NOT hard-0
+
+
+@pytest.mark.unit
+async def test_fallback_none_snapshot_goes_live():
+    """When the snapshot helper returns None (ineligible sort / zero rows / error),
+    the legacy live path must still run (here it returns an empty legacy response)."""
+    with (
+        patch.object(kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=None)),
+        patch.object(
+            kr_mod, "_get_tvscreener_stock_capability_snapshot",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(kr_mod, "_can_use_tvscreener_stock_path", return_value=False),
+        patch.object(
+            kr_mod, "_screen_kr",
+            new=AsyncMock(return_value={"meta": {"source": "legacy"}, "stocks": []}),
+        ),
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr", asset_type=None, category=None, sector=None,
+            min_market_cap=None, max_per=None, max_pbr=None, min_dividend_yield=None,
+            min_analyst_buy=None, max_rsi=None, sort_by="rsi",
+            sort_order="desc", limit=20,
+        )
+    assert resp["meta"]["source"] == "legacy"  # fell through to live
+```
+
+> Before writing the impl, open `tests/test_mcp_screen_stocks_kr.py` and confirm the response shape these assertions use (`resp["meta"]["data_state"]`, `resp["stocks"]`). `_build_screen_response` puts `meta_fields` under the `meta` key and rows under `stocks` — verify against an existing assertion in that file and adjust key names if the project uses different ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_screen_stocks_kr.py -k "fallback_uses_snapshot or fallback_stale or fallback_none" -v`
+Expected: FAIL — `kr_mod` has no `load_kr_ranking_snapshot` (not imported/wired yet).
+
+- [ ] **Step 3: Wire the snapshot-primary ladder**
+
+In `app/mcp_server/tooling/screening/kr.py`, add the import near the other screening imports (after line ~32):
+
+```python
+from app.mcp_server.tooling.screening.kr_ranking_snapshot import (
+    load_kr_ranking_snapshot,
+)
+```
+
+Then insert the ladder at the very top of `_screen_kr_with_fallback`'s body, before the `try:`/capability snapshot block (after the docstring, ~line 670):
+
+```python
+    # ROB-388: snapshot-primary. Serve the durable kr_market_ranking read-model first
+    # (fresh OR stale, honestly labeled) so screen_stocks never hard-0s when the live
+    # KRX session is down. None => ineligible sort_by / zero rows / error => live path.
+    snapshot = await load_kr_ranking_snapshot(
+        sort_by=sort_by, sort_order=sort_order, limit=limit
+    )
+    if snapshot is not None and snapshot.rows:
+        return _build_screen_response(
+            snapshot.rows,
+            snapshot.total_count,
+            {
+                "market": market,
+                "sort_by": sort_by,
+                "sort_order": sort_order,
+                "asset_type": asset_type,
+                "category": category,
+            },
+            market,
+            warnings=snapshot.warnings or None,
+            meta_fields=snapshot.meta_fields,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mcp_screen_stocks_kr.py -k "fallback_uses_snapshot or fallback_stale or fallback_none" -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run the full KR screening regression + lint**
+
+Run: `uv run pytest tests/test_mcp_screen_stocks_kr.py tests/test_kr_ranking_snapshot.py -v`
+Expected: all PASS (existing live-path tests still green because snapshot defaults to the real DB and is fail-open → None in unit context; the 3 new tests cover the wired ladder).
+Run: `uv run ruff check app/mcp_server/tooling/screening/kr_ranking_snapshot.py app/mcp_server/tooling/screening/kr.py tests/test_kr_ranking_snapshot.py tests/test_mcp_screen_stocks_kr.py`
+Expected: `All checks passed!`
+
+> If any pre-existing test in `test_mcp_screen_stocks_kr.py` calls `_screen_kr_with_fallback` for an eligible sort_by (change_rate/volume/trade_amount/market_cap) and asserts the *legacy/tvscreener* path, it may now hit the snapshot branch. Such tests must patch `load_kr_ranking_snapshot` to return `None` (snapshot absent) to assert the live path — update them as part of this step. List each one you change in the commit body.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/screening/kr.py tests/test_mcp_screen_stocks_kr.py
+git commit -m "feat(ROB-388): wire snapshot-primary ladder into _screen_kr_with_fallback"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §3 D1 snapshot-primary → Task 6 (ladder). ✓
+- §3 D3 stale 정직 반환 / live는 완전 부재 시 → Task 4 (`unavailable`→None) + Task 6 (`None`→live, rows→return). ✓
+- §6 sort_by↔order_type (미커버→live) → Task 1 + Task 4 (`is_snapshot_eligible_sort` → None). ✓
+- §6 trade_amount/market_cap union+resort + top-movers warning → Task 3 (`dedupe_and_sort_rows`) + Task 4 (union) + Task 3 (`freshness_to_meta` coverage warning). ✓
+- §7 enrichment best-effort null-safe → Task 5. ✓
+- §8 정직 리포팅 (data_state/source/latest_snapshot_at/stale_reason/warnings) → Task 3 (`freshness_to_meta`) + Task 6 (meta_fields wired). ✓
+- §9 테스트 (단위 + 회귀) → Tasks 1–6 tests. ✓
+- §10 비범위 (ROB-446 cron / #2 classifier / investor_flow / live re-auth / migration) → not touched by any task. ✓
+
+**2. Placeholder scan:** No TBD/TODO. The only forward reference is `_enrich_rows` in Task 4 — explicitly stubbed in Task 4 and replaced in Task 5 (called out inline). ✓
+
+**3. Type consistency:** `load_kr_ranking_snapshot` returns `KrRankingSnapshotResult | None` (Task 4) — consumed in Task 6 via `.rows`/`.total_count`/`.warnings`/`.meta_fields`. `freshness_to_meta` returns `(data_state, meta, warnings)` (Task 3), used by `_run` (Task 4). `ranking_row_to_screen_row` field names (`trade_amount`, `per`, `pbr`, `dividend_yield`, `code`, `sector`, `instrument_type`) match what `_enrich_rows` (Task 5) mutates and what `_build_screen_response` consumes (per `_screen_kr`). ✓
+
+**Open verification flags for the implementer (resolve while implementing, do not guess):**
+- Response key names: `_build_screen_response` output uses `meta`/`stocks` keys per `_screen_kr`; Task 6 assertions assume this. Confirm against an existing assertion in `test_mcp_screen_stocks_kr.py` (noted inline at Task 6 Step 1).
+- pytest async marker convention (`asyncio_mode=auto` vs explicit `@pytest.mark.asyncio`) — match a neighboring async test (noted at Task 4 Step 4).
+- Pre-existing eligible-sort tests that assert the live path must patch the snapshot to `None` (noted at Task 6 Step 5).
+
+---
+
+## Execution Handoff
+
+Plan complete. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks.
+2. **Inline Execution** — execute tasks in this session with checkpoints.

--- a/docs/superpowers/specs/2026-06-08-rob-388-screen-stocks-snapshot-primary-design.md
+++ b/docs/superpowers/specs/2026-06-08-rob-388-screen-stocks-snapshot-primary-design.md
@@ -1,0 +1,141 @@
+# ROB-388 — screen_stocks(kr) snapshot-primary 발굴 경로 복구 (설계)
+
+- **Linear**: ROB-388 ([데이터] screen_stocks KR 발굴 경로가 장 개장 시점에 다운)
+- **작성일**: 2026-06-08
+- **상태**: 설계 확정 (구현 전)
+- **짝꿍 이슈**: ROB-446 (write-side 신선도 — Naver 모멘텀 빌더 cron 미커밋)
+
+## 1. 배경 / 문제
+
+`screen_stocks(market="kr")`는 KR 신규매수 후보 발굴의 핵심 경로인데, 장 개장 시점에 두 가지로 다운한다.
+
+1. **KRX 세션 만료**: `krx_session_expired` → `{data_state:"unavailable", retryable:true, ...}`, `results:[]`/`total_count:0`. `retryable:true`인데 즉시 재시도 3회 모두 동일 실패(실제로는 회복 안 됨).
+2. **classifier 일시 불가**: 정규장에서 호출 안전 분류기 일시 불가로 `screen_stocks` 실행 자체가 거부됨.
+
+근본 구조 문제: KR 발굴이 **live-only**(tvscreener → legacy KRX API)라 durable fallback이 없다. KRX 세션이 죽으면 무조건 0건으로 끝난다. 폴백 후보였던 `get_momentum_candidates`도 stale(ROB-389/446)이라 우회 불가.
+
+## 2. 목표
+
+`screen_stocks(market="kr")`가 KRX live가 죽어도 **0건으로 끝나지 않도록**, durable read-model `kr_market_ranking`을 **primary**로 소비한다. stale/missing/partial이면 신규매수 후보로 과장하지 말고 `data_state`/`freshness`/`warnings`로 정직하게 표기한다.
+
+## 3. 결정 (locked, 브레인스토밍 Q&A 결과)
+
+- **D1 — snapshot-primary**: `screen_stocks(kr)`는 `kr_market_ranking` read-model을 primary로 읽는다.
+- **D2 — read-adapter only**: 스냅샷 신선도(cron 미커밋)는 **ROB-446**(짝꿍)이 담당한다. ROB-388은 read-side 어댑터 + 정직 리포팅 + live fallback만 구현한다. 이 PR만으로는 "정직하게 stale 표기"까지만 보장되고, 실제 fresh 발굴은 ROB-446이 cron을 고쳐야 발현된다.
+- **D3 — 사다리**: snapshot-primary. **stale도 정직히 반환**(하드-0 금지). live(tvscreener → legacy KRX)는 스냅샷이 **완전 부재(행 0 = unavailable)** 일 때만 fallback.
+- **D4 — 세부 (이 spec에서 확정)**:
+  - enrichment는 best-effort + null-safe (위조 금지).
+  - 미커버 `sort_by`는 스냅샷을 스킵하고 곧장 live.
+  - failure mode #2(classifier 일시 거부)는 **비범위**(일시 인프라, 코드 버그 아님).
+  - 수급/`investor_flow`(ROB-398 Slice 3)는 **비범위**(`sort_by` 차원 아님).
+  - live KRX 세션 re-auth 수리(option C)는 **미채택**(fallback으로 남김).
+
+## 4. 데이터 소스 (그라운딩)
+
+- **read-model**: `app/models/invest_momentum_event_snapshot.py::InvestMomentumEventSnapshot`. `kr_market_ranking`은 snapshot_kind으로 등록(`app/models/investment_snapshots.py` CHECK).
+- **query service**: `app/services/invest_momentum_events/query_service.py::MomentumRankingQueryService.get_ranking(order_type, market="kr", limit, now, ttl_minutes=RANKING_TTL_MINUTES=15)`
+  - 반환 `MomentumRanking(market, order_type, trading_date, rows: tuple[RankingRow], freshness: Freshness)`.
+  - `RankingRow(rank, symbol, name, price, change_rate, volume, trade_value, market_cap)`.
+  - `Freshness(overall: "fresh"|"stale"|"unavailable", latest_snapshot_at, stale_reason)`.
+  - **세션만으로 호출 가능**(유저 컨텍스트 불요). MCP 세션 획득은 `app/mcp_server/tooling/screener_snapshot_tool.py` 패턴을 미러.
+- **order_type 버킷**: `up`(상승), `quantTop`(거래량), `priceTop`, `searchTop`. 빌더 기본 수집은 `("up","quantTop")` (`app/services/action_report/snapshot_backed/collectors/kr_market_ranking.py`).
+- **freshness 규칙(자체 스킴, screener partition_health 아님)**: `trading_date != today(KST)` → `stale(older_trading_date)`; `now - latest_snapshot_at > 15min` → `stale(older_than_ttl)`; 행 0 → `unavailable(no_ranking_rows)`.
+
+> ⚠️ 이 소스는 ROB-446이 "23거래일 stale, cron 미커밋"으로 보고한 바로 그 파이프라인이다. ROB-388은 read-side만 책임지고, 신선도는 ROB-446에 위임한다(D2).
+
+## 5. 아키텍처 / 시임(seam)
+
+신규 헬퍼를 screening 레이어에 추가한다 (예: `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`):
+
+```python
+async def load_kr_ranking_snapshot(
+    session, *, sort_by, sort_order, filters, limit, now
+) -> KrRankingSnapshotResult | None
+```
+
+- `sort_by`가 snapshot-eligible이 아니면 **None** 반환(→ 호출자가 live로).
+- `get_ranking(order_type=<매핑>, market="kr", limit, now)` 호출 → 행 매핑 + enrichment + freshness.
+- 반환 `KrRankingSnapshotResult`: `rows`(screen_stocks 행 모양), `data_state`, `source`, `latest_snapshot_at`, `stale_reason`, `warnings`, `total_count`, `coverage_note`.
+
+**배선 지점**: `app/mcp_server/tooling/screening/kr.py::_screen_kr_with_fallback`의 **맨 앞**(tvscreener/legacy 시도 *전*)에 사다리를 끼운다. `AsyncSession`을 스레딩해야 한다: `screen_stocks_impl`(handler) → `screen_stocks_unified` → `_dispatch_kr_screen` → `_screen_kr_with_fallback` 경로에 `session` 인자 추가, handler에서 세션 생성/주입.
+
+**사다리 의사코드**:
+
+```text
+if session and sort_by in SNAPSHOT_ELIGIBLE_SORTS:
+    snap = await load_kr_ranking_snapshot(session, sort_by=..., ...)
+    if snap is not None and snap.rows:        # fresh OR stale → 둘 다 행 반환
+        return build_screen_response(snap.rows, snap.total_count, ...,
+                                     meta_fields={data_state, source, latest_snapshot_at,
+                                                  stale_reason, warnings})   # 하드-0 아님
+    # snap is None(미커버 sort_by) 또는 snap.rows 비어있음(unavailable) → live로 진행
+# 기존 경로: tvscreener → legacy KRX(_screen_kr) → KRXSessionExpired → _krx_session_unavailable_response
+```
+
+## 6. sort_by ↔ ranking 매핑
+
+| `sort_by` | 매핑 | 비고 |
+|---|---|---|
+| `change_rate` | order_type `up` | 직접 |
+| `volume` | order_type `quantTop` | 직접 |
+| `trade_amount` | 수집 행(up∪quantTop)을 `trade_value` desc 재정렬 | **top-movers 한정(버킷당 ~30) — 전체 유니버스 아님** → `coverage_note` + warning |
+| `market_cap` | 수집 행을 `market_cap` desc 재정렬 | 동일 한계 → warning |
+| `dividend_yield`, `week_change_rate`, `rsi`, `score` | **미커버** | 헬퍼 None 반환 → live(tvscreener가 rsi 등 지원) |
+
+- `sort_order`(asc/desc)를 존중한다.
+- 정확한 `sort_by` enum은 `app/mcp_server/tooling/screening/common.py`의 KR 정렬 정의를 기준으로 한다.
+
+## 7. 행 enrichment (best-effort, null-safe)
+
+- **직접 매핑**: `symbol`, `name`, `price`(Decimal→float), `change_rate`, `volume`(int→float), `trade_value`→**`trade_amount`**(필드명 다름), `market_cap`.
+- **KRX universe(cached)** 에서: `short_code`/`code`/`sector`/`instrument_type`. 매칭 실패 시 symbol 기반 최선 + null.
+- **valuation cached** 에서 best-effort: `per`/`pbr`/`dividend_yield`. 없으면 **null**(기존 screen_stocks 동작과 동일).
+- **위조 금지**: 값을 못 구하면 null. 추정/날조 금지.
+
+## 8. 정직 리포팅
+
+- `data_state`: `freshness.overall` 매핑 — `fresh`→`"fresh"`, `stale`→`"stale"`. (`unavailable`은 스냅샷 경로를 끝내고 live로 넘어가므로 스냅샷 응답으로는 나오지 않음.)
+- `meta_fields`: `source="kr_market_ranking"`, `latest_snapshot_at`, `stale_reason`, `warnings`(한글).
+  - stale 시: `"모멘텀 랭킹 스냅샷이 오래됨(<stale_reason>) — 신규 후보 발굴에 주의"`.
+  - 항상: `"모멘텀 랭킹 상위 N종목 기반 — 전체 KRX 스캔이 아님"` (커버리지 경고).
+- `total_count`는 실제 반환 행 수. data_state를 동봉하여 신규매수 후보로 과장되지 않게 한다.
+
+## 9. 테스트 (migration 0, read-only)
+
+**단위(신규)**:
+- `sort_by` → order_type 매핑 (change_rate→up, volume→quantTop).
+- 미커버 `sort_by`(dividend_yield 등) → 헬퍼 None.
+- 행 매핑: `trade_value`→`trade_amount`, Decimal→float, int→float.
+- `freshness.overall` → `data_state` 매핑.
+- **stale 스냅샷도 행 반환**(하드-0 아님) + warnings.
+- `unavailable`(행 0) → None → live fallthrough.
+- enrichment null-safe (universe/valuation 미스 시 null, 위조 없음).
+- `trade_amount`/`market_cap` 재정렬 + top-movers 한계 warning.
+
+**회귀**: `tests/test_mcp_screen_stocks_kr.py`
+- 스냅샷 비활성/empty 시 기존 live 경로(tvscreener→legacy) 보존.
+- 미커버 sort_by 시 live.
+- 세션 주입 경로.
+
+## 10. 비범위 (Out of scope)
+
+- **ROB-446** 모멘텀 cron 신선도(write-side) — 짝꿍 후속. 없으면 ROB-388은 "정직하게 stale"까지만.
+- **failure mode #2** (classifier 일시 거부) — 일시 인프라, screen_stocks 코드 버그 아님. snapshot durable이 간접 완화하나 분류기는 추적하지 않음.
+- **수급/`investor_flow`** (ROB-398 Slice 3) — `sort_by` 차원이 아님.
+- **live KRX 세션 re-auth 수리**(option C) — 미채택. fallback으로 남김.
+- **migration 없음**. broker/order/watch/order-intent/scheduler mutation 없음.
+
+## 11. Acceptance criteria
+
+- [ ] `screen_stocks(market="kr", sort_by ∈ {change_rate, volume, trade_amount, market_cap})`가 **fresh** `kr_market_ranking` 스냅샷이 있으면 그것을 반환 (`data_state="fresh"`, `source="kr_market_ranking"`).
+- [ ] 스냅샷이 **stale**이면 행을 반환하되 `data_state="stale"` + warnings (**하드-0 아님**).
+- [ ] 스냅샷 **완전 부재**(행 0)면 live(tvscreener→legacy KRX)로 fallthrough, 그것도 실패면 기존 `unavailable` 응답.
+- [ ] **미커버** sort_by(dividend_yield/week_change_rate/rsi/score)는 스냅샷 스킵하고 live.
+- [ ] `trade_amount`/`market_cap`은 top-movers 한계를 warning으로 정직 표기.
+- [ ] enrichment는 null-safe, 위조 없음.
+- [ ] migration 0, broker/order/watch mutation 0.
+- [ ] 단위 + 회귀 테스트 green, ruff clean.
+
+## 12. 안전 경계
+
+read-only 데이터 경로. 신규 쿼리/테이블 없음(기존 `MomentumRankingQueryService` 재사용). broker/order/watch/order-intent/scheduler 무접근. 시세/발굴 데이터만 다룬다.

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.mcp_server.tooling.screening import kr_ranking_snapshot as krs
+
+
+@pytest.mark.unit
+def test_snapshot_eligible_sorts_membership():
+    assert krs.is_snapshot_eligible_sort("change_rate") is True
+    assert krs.is_snapshot_eligible_sort("volume") is True
+    assert krs.is_snapshot_eligible_sort("trade_amount") is True
+    assert krs.is_snapshot_eligible_sort("market_cap") is True
+    # not covered by the momentum ranking read-model -> must go live
+    assert krs.is_snapshot_eligible_sort("dividend_yield") is False
+    assert krs.is_snapshot_eligible_sort("week_change_rate") is False
+    assert krs.is_snapshot_eligible_sort("rsi") is False
+    assert krs.is_snapshot_eligible_sort("score") is False
+
+
+@pytest.mark.unit
+def test_order_types_for_sort():
+    # direct single-bucket dimensions
+    assert krs.order_types_for_sort("change_rate") == ("up",)
+    assert krs.order_types_for_sort("volume") == ("quantTop",)
+    # re-sort dimensions union both default buckets
+    assert krs.order_types_for_sort("trade_amount") == ("up", "quantTop")
+    assert krs.order_types_for_sort("market_cap") == ("up", "quantTop")
+    # ineligible -> empty
+    assert krs.order_types_for_sort("rsi") == ()

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -214,4 +214,39 @@ async def test_load_fail_open_on_query_error():
     assert out is None  # fail-open -> live fallthrough
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_enrich_rows_fills_code_sector_valuation_best_effort():
+    rows = [
+        {"symbol": "005930", "code": "005930", "per": None, "pbr": None,
+         "dividend_yield": None, "instrument_type": "stock", "name": "삼성전자"},
+    ]
+    universe = {"005930": {"code": "KR7005930003", "sector": "반도체", "name": "삼성전자"}}
+    valuation = {"005930": {"per": 12.3, "pbr": 1.1, "dividend_yield": 2.5}}
+
+    out = await krs._enrich_rows(
+        rows,
+        universe_by_code=universe,
+        valuation_by_code=valuation,
+    )
+    assert out[0]["code"] == "KR7005930003"
+    assert out[0]["sector"] == "반도체"
+    assert out[0]["per"] == 12.3
+    assert out[0]["pbr"] == 1.1
+    assert out[0]["dividend_yield"] == 2.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_enrich_rows_no_fabrication_when_missing():
+    rows = [{"symbol": "999999", "code": "999999", "per": None, "pbr": None,
+             "dividend_yield": None, "instrument_type": "stock", "name": "x"}]
+    out = await krs._enrich_rows(rows, universe_by_code={}, valuation_by_code={})
+    assert out[0]["per"] is None
+    assert out[0]["pbr"] is None
+    assert out[0]["dividend_yield"] is None
+    assert out[0]["code"] == "999999"  # unchanged when no universe match
+
+
+
 

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -115,3 +115,103 @@ def test_freshness_to_meta_stale_adds_warning_and_not_retryable():
     assert any("오래" in w for w in warnings)
 
 
+import datetime as dt
+
+from app.services.invest_momentum_events.query_service import MomentumRanking
+
+
+class _FakeQS:
+    """Fake MomentumRankingQueryService: returns canned MomentumRanking per order_type."""
+    def __init__(self, by_order_type: dict[str, MomentumRanking]):
+        self._by = by_order_type
+        self.calls: list[str] = []
+
+    async def get_ranking(self, *, order_type, market, limit, now, **_):
+        self.calls.append(order_type)
+        return self._by[order_type]
+
+
+def _ranking(order_type, overall, rows):
+    return MomentumRanking(
+        market="kr", order_type=order_type, trading_date=None,
+        rows=tuple(rows), freshness=Freshness(overall, None, None if overall == "fresh" else "older_than_ttl"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_returns_none_for_ineligible_sort():
+    qs = _FakeQS({})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="rsi", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is None
+    assert qs.calls == []  # never queried
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_returns_none_when_unavailable():
+    qs = _FakeQS({"up": _ranking("up", "unavailable", [])})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is None  # zero rows -> live fallthrough
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_fresh_change_rate_returns_rows():
+    rows = [RankingRow(1, "005930", "삼성전자", 71000.0, 3.5, 100, 5e11, 4e14)]
+    qs = _FakeQS({"up": _ranking("up", "fresh", rows)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None
+    assert out.data_state == "fresh"
+    assert out.total_count == 1
+    assert out.rows[0]["symbol"] == "005930"
+    assert out.source == "kr_market_ranking"
+    assert qs.calls == ["up"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_stale_returned_honestly_not_dropped():
+    rows = [RankingRow(1, "005930", "삼성", 71000.0, 1.0, 100, 5e11, 4e14)]
+    qs = _FakeQS({"quantTop": _ranking("quantTop", "stale", rows)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="volume", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None and out.rows  # stale still returns rows (no hard-0)
+    assert out.data_state == "stale"
+    assert any("오래" in w for w in out.warnings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_trade_amount_unions_buckets_and_resorts():
+    up = [RankingRow(1, "A", "A", 1.0, 9.0, 10, 100.0, 5.0)]
+    qt = [RankingRow(1, "B", "B", 1.0, 1.0, 99, 300.0, 1.0)]
+    qs = _FakeQS({"up": _ranking("up", "fresh", up), "quantTop": _ranking("quantTop", "fresh", qt)})
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="trade_amount", sort_order="desc", limit=20, query_service=qs, enrich=False
+    )
+    assert out is not None
+    assert [r["symbol"] for r in out.rows] == ["B", "A"]  # 300 > 100
+    assert set(qs.calls) == {"up", "quantTop"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_load_fail_open_on_query_error():
+    class _Boom:
+        async def get_ranking(self, **_):
+            raise RuntimeError("db down")
+    out = await krs.load_kr_ranking_snapshot(
+        sort_by="volume", sort_order="desc", limit=20, query_service=_Boom(), enrich=False
+    )
+    assert out is None  # fail-open -> live fallthrough
+
+
+

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -300,3 +300,93 @@ async def test_enrich_rows_no_fabrication_when_missing():
     assert out[0]["pbr"] is None
     assert out[0]["dividend_yield"] is None
     assert out[0]["code"] == "999999"  # unchanged when no universe match
+
+
+# --- ROB-388 follow-up: snapshot_path_applicable guard (sub-market + filter safety) ---
+
+_GUARD_BASE: dict[str, object] = {
+    "asset_type": None,
+    "category": None,
+    "sector": None,
+    "min_market_cap": None,
+    "max_per": None,
+    "max_pbr": None,
+    "min_dividend_yield": None,
+    "min_analyst_buy": None,
+    "max_rsi": None,
+    "adv_krw_min": None,
+    "market_cap_min_krw": None,
+    "market_cap_max_krw": None,
+    "instrument_types": None,
+    "exclude_sectors": None,
+}
+
+
+@pytest.mark.unit
+def test_snapshot_path_applicable_only_kr_wide():
+    # KR-wide ranking is faithfully serveable
+    assert krs.snapshot_path_applicable(market="kr", **_GUARD_BASE) is True
+    assert krs.snapshot_path_applicable(market="all", **_GUARD_BASE) is True
+    # sub-markets would mislabel KR-wide data -> not applicable
+    assert krs.snapshot_path_applicable(market="kospi", **_GUARD_BASE) is False
+    assert krs.snapshot_path_applicable(market="kosdaq", **_GUARD_BASE) is False
+    assert krs.snapshot_path_applicable(market="konex", **_GUARD_BASE) is False
+
+
+@pytest.mark.unit
+def test_snapshot_path_applicable_disqualified_by_asset_or_scope():
+    assert (
+        krs.snapshot_path_applicable(
+            market="kr", **{**_GUARD_BASE, "asset_type": "etf"}
+        )
+        is False
+    )
+    assert (
+        krs.snapshot_path_applicable(
+            market="kr", **{**_GUARD_BASE, "category": "반도체"}
+        )
+        is False
+    )
+    assert (
+        krs.snapshot_path_applicable(market="kr", **{**_GUARD_BASE, "sector": "Tech"})
+        is False
+    )
+    # asset_type="stock" is explicitly allowed
+    assert (
+        krs.snapshot_path_applicable(
+            market="kr", **{**_GUARD_BASE, "asset_type": "stock"}
+        )
+        is True
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_path_applicable_disqualified_by_any_quality_filter():
+    # the snapshot has no way to honor these -> must go live (which does)
+    for key in (
+        "min_market_cap",
+        "max_per",
+        "max_pbr",
+        "min_dividend_yield",
+        "min_analyst_buy",
+        "max_rsi",
+        "adv_krw_min",
+        "market_cap_min_krw",
+        "market_cap_max_krw",
+    ):
+        assert (
+            krs.snapshot_path_applicable(market="kr", **{**_GUARD_BASE, key: 1})
+            is False
+        ), key
+    assert (
+        krs.snapshot_path_applicable(
+            market="kr", **{**_GUARD_BASE, "instrument_types": ["etf"]}
+        )
+        is False
+    )
+    assert (
+        krs.snapshot_path_applicable(
+            market="kr", **{**_GUARD_BASE, "exclude_sectors": ["금융"]}
+        )
+        is False
+    )

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -67,3 +67,51 @@ def test_ranking_row_to_screen_row_null_safe():
     assert out["volume"] is None
     assert out["trade_amount"] is None
 
+
+from app.services.invest_momentum_events.query_service import Freshness
+
+
+@pytest.mark.unit
+def test_dedupe_and_sort_rows_by_trade_amount_desc():
+    rows = [
+        {"symbol": "A", "trade_amount": 100.0, "market_cap": 5.0},
+        {"symbol": "B", "trade_amount": 300.0, "market_cap": 1.0},
+        {"symbol": "A", "trade_amount": 100.0, "market_cap": 5.0},  # dup symbol
+    ]
+    out = krs.dedupe_and_sort_rows(rows, sort_by="trade_amount", sort_order="desc")
+    assert [r["symbol"] for r in out] == ["B", "A"]  # deduped + sorted desc
+
+
+@pytest.mark.unit
+def test_dedupe_and_sort_rows_market_cap_asc_nulls_last():
+    rows = [
+        {"symbol": "A", "market_cap": None},
+        {"symbol": "B", "market_cap": 2.0},
+        {"symbol": "C", "market_cap": 1.0},
+    ]
+    out = krs.dedupe_and_sort_rows(rows, sort_by="market_cap", sort_order="asc")
+    assert [r["symbol"] for r in out] == ["C", "B", "A"]  # None sorts last
+
+
+@pytest.mark.unit
+def test_freshness_to_meta_fresh():
+    fr = Freshness(overall="fresh", latest_snapshot_at=None, stale_reason=None)
+    data_state, meta, warnings = krs.freshness_to_meta(fr, row_count=20)
+    assert data_state == "fresh"
+    assert meta["source"] == "kr_market_ranking"
+    assert meta["data_state"] == "fresh"
+    # coverage caveat is always present (top-movers, not full universe)
+    assert any("전체 KRX 스캔" in w for w in warnings)
+
+
+@pytest.mark.unit
+def test_freshness_to_meta_stale_adds_warning_and_not_retryable():
+    fr = Freshness(overall="stale", latest_snapshot_at=None, stale_reason="older_than_ttl")
+    data_state, meta, warnings = krs.freshness_to_meta(fr, row_count=10)
+    assert data_state == "stale"
+    assert meta["data_state"] == "stale"
+    assert meta["stale_reason"] == "older_than_ttl"
+    assert meta["retryable"] is False  # stale snapshot won't recover by immediate retry
+    assert any("오래" in w for w in warnings)
+
+

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -26,3 +26,44 @@ def test_order_types_for_sort():
     assert krs.order_types_for_sort("market_cap") == ("up", "quantTop")
     # ineligible -> empty
     assert krs.order_types_for_sort("rsi") == ()
+
+
+from app.services.invest_momentum_events.query_service import RankingRow
+
+
+@pytest.mark.unit
+def test_ranking_row_to_screen_row_maps_fields():
+    row = RankingRow(
+        rank=1, symbol="005930", name="삼성전자", price=71000.0,
+        change_rate=3.5, volume=12_000_000, trade_value=8.5e11, market_cap=4.2e14,
+    )
+    out = krs.ranking_row_to_screen_row(row)
+    assert out["symbol"] == "005930"
+    assert out["short_code"] == "005930"
+    assert out["code"] == "005930"
+    assert out["name"] == "삼성전자"
+    assert out["price"] == 71000.0
+    assert out["change_rate"] == 3.5
+    assert out["volume"] == 12_000_000.0  # int -> float
+    assert out["trade_amount"] == 8.5e11   # trade_value -> trade_amount
+    assert out["market_cap"] == 4.2e14
+    assert out["market"] == "kr"
+    # not provided by the ranking read-model -> explicit null (no fabrication)
+    assert out["per"] is None
+    assert out["pbr"] is None
+    assert out["dividend_yield"] is None
+
+
+@pytest.mark.unit
+def test_ranking_row_to_screen_row_null_safe():
+    row = RankingRow(
+        rank=2, symbol="000660", name=None, price=None,
+        change_rate=None, volume=None, trade_value=None, market_cap=None,
+    )
+    out = krs.ranking_row_to_screen_row(row)
+    assert out["symbol"] == "000660"
+    assert out["name"] == "000660"  # falls back to symbol when name missing
+    assert out["price"] is None
+    assert out["volume"] is None
+    assert out["trade_amount"] is None
+

--- a/tests/test_kr_ranking_snapshot.py
+++ b/tests/test_kr_ranking_snapshot.py
@@ -1,6 +1,11 @@
 import pytest
 
 from app.mcp_server.tooling.screening import kr_ranking_snapshot as krs
+from app.services.invest_momentum_events.query_service import (
+    Freshness,
+    MomentumRanking,
+    RankingRow,
+)
 
 
 @pytest.mark.unit
@@ -28,14 +33,17 @@ def test_order_types_for_sort():
     assert krs.order_types_for_sort("rsi") == ()
 
 
-from app.services.invest_momentum_events.query_service import RankingRow
-
-
 @pytest.mark.unit
 def test_ranking_row_to_screen_row_maps_fields():
     row = RankingRow(
-        rank=1, symbol="005930", name="삼성전자", price=71000.0,
-        change_rate=3.5, volume=12_000_000, trade_value=8.5e11, market_cap=4.2e14,
+        rank=1,
+        symbol="005930",
+        name="삼성전자",
+        price=71000.0,
+        change_rate=3.5,
+        volume=12_000_000,
+        trade_value=8.5e11,
+        market_cap=4.2e14,
     )
     out = krs.ranking_row_to_screen_row(row)
     assert out["symbol"] == "005930"
@@ -45,7 +53,7 @@ def test_ranking_row_to_screen_row_maps_fields():
     assert out["price"] == 71000.0
     assert out["change_rate"] == 3.5
     assert out["volume"] == 12_000_000.0  # int -> float
-    assert out["trade_amount"] == 8.5e11   # trade_value -> trade_amount
+    assert out["trade_amount"] == 8.5e11  # trade_value -> trade_amount
     assert out["market_cap"] == 4.2e14
     assert out["market"] == "kr"
     # not provided by the ranking read-model -> explicit null (no fabrication)
@@ -57,8 +65,14 @@ def test_ranking_row_to_screen_row_maps_fields():
 @pytest.mark.unit
 def test_ranking_row_to_screen_row_null_safe():
     row = RankingRow(
-        rank=2, symbol="000660", name=None, price=None,
-        change_rate=None, volume=None, trade_value=None, market_cap=None,
+        rank=2,
+        symbol="000660",
+        name=None,
+        price=None,
+        change_rate=None,
+        volume=None,
+        trade_value=None,
+        market_cap=None,
     )
     out = krs.ranking_row_to_screen_row(row)
     assert out["symbol"] == "000660"
@@ -66,9 +80,6 @@ def test_ranking_row_to_screen_row_null_safe():
     assert out["price"] is None
     assert out["volume"] is None
     assert out["trade_amount"] is None
-
-
-from app.services.invest_momentum_events.query_service import Freshness
 
 
 @pytest.mark.unit
@@ -106,7 +117,9 @@ def test_freshness_to_meta_fresh():
 
 @pytest.mark.unit
 def test_freshness_to_meta_stale_adds_warning_and_not_retryable():
-    fr = Freshness(overall="stale", latest_snapshot_at=None, stale_reason="older_than_ttl")
+    fr = Freshness(
+        overall="stale", latest_snapshot_at=None, stale_reason="older_than_ttl"
+    )
     data_state, meta, warnings = krs.freshness_to_meta(fr, row_count=10)
     assert data_state == "stale"
     assert meta["data_state"] == "stale"
@@ -115,13 +128,9 @@ def test_freshness_to_meta_stale_adds_warning_and_not_retryable():
     assert any("오래" in w for w in warnings)
 
 
-import datetime as dt
-
-from app.services.invest_momentum_events.query_service import MomentumRanking
-
-
 class _FakeQS:
     """Fake MomentumRankingQueryService: returns canned MomentumRanking per order_type."""
+
     def __init__(self, by_order_type: dict[str, MomentumRanking]):
         self._by = by_order_type
         self.calls: list[str] = []
@@ -133,8 +142,13 @@ class _FakeQS:
 
 def _ranking(order_type, overall, rows):
     return MomentumRanking(
-        market="kr", order_type=order_type, trading_date=None,
-        rows=tuple(rows), freshness=Freshness(overall, None, None if overall == "fresh" else "older_than_ttl"),
+        market="kr",
+        order_type=order_type,
+        trading_date=None,
+        rows=tuple(rows),
+        freshness=Freshness(
+            overall, None, None if overall == "fresh" else "older_than_ttl"
+        ),
     )
 
 
@@ -154,7 +168,11 @@ async def test_load_returns_none_for_ineligible_sort():
 async def test_load_returns_none_when_unavailable():
     qs = _FakeQS({"up": _ranking("up", "unavailable", [])})
     out = await krs.load_kr_ranking_snapshot(
-        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+        sort_by="change_rate",
+        sort_order="desc",
+        limit=20,
+        query_service=qs,
+        enrich=False,
     )
     assert out is None  # zero rows -> live fallthrough
 
@@ -165,7 +183,11 @@ async def test_load_fresh_change_rate_returns_rows():
     rows = [RankingRow(1, "005930", "삼성전자", 71000.0, 3.5, 100, 5e11, 4e14)]
     qs = _FakeQS({"up": _ranking("up", "fresh", rows)})
     out = await krs.load_kr_ranking_snapshot(
-        sort_by="change_rate", sort_order="desc", limit=20, query_service=qs, enrich=False
+        sort_by="change_rate",
+        sort_order="desc",
+        limit=20,
+        query_service=qs,
+        enrich=False,
     )
     assert out is not None
     assert out.data_state == "fresh"
@@ -193,9 +215,18 @@ async def test_load_stale_returned_honestly_not_dropped():
 async def test_load_trade_amount_unions_buckets_and_resorts():
     up = [RankingRow(1, "A", "A", 1.0, 9.0, 10, 100.0, 5.0)]
     qt = [RankingRow(1, "B", "B", 1.0, 1.0, 99, 300.0, 1.0)]
-    qs = _FakeQS({"up": _ranking("up", "fresh", up), "quantTop": _ranking("quantTop", "fresh", qt)})
+    qs = _FakeQS(
+        {
+            "up": _ranking("up", "fresh", up),
+            "quantTop": _ranking("quantTop", "fresh", qt),
+        }
+    )
     out = await krs.load_kr_ranking_snapshot(
-        sort_by="trade_amount", sort_order="desc", limit=20, query_service=qs, enrich=False
+        sort_by="trade_amount",
+        sort_order="desc",
+        limit=20,
+        query_service=qs,
+        enrich=False,
     )
     assert out is not None
     assert [r["symbol"] for r in out.rows] == ["B", "A"]  # 300 > 100
@@ -208,8 +239,13 @@ async def test_load_fail_open_on_query_error():
     class _Boom:
         async def get_ranking(self, **_):
             raise RuntimeError("db down")
+
     out = await krs.load_kr_ranking_snapshot(
-        sort_by="volume", sort_order="desc", limit=20, query_service=_Boom(), enrich=False
+        sort_by="volume",
+        sort_order="desc",
+        limit=20,
+        query_service=_Boom(),
+        enrich=False,
     )
     assert out is None  # fail-open -> live fallthrough
 
@@ -218,10 +254,19 @@ async def test_load_fail_open_on_query_error():
 @pytest.mark.unit
 async def test_enrich_rows_fills_code_sector_valuation_best_effort():
     rows = [
-        {"symbol": "005930", "code": "005930", "per": None, "pbr": None,
-         "dividend_yield": None, "instrument_type": "stock", "name": "삼성전자"},
+        {
+            "symbol": "005930",
+            "code": "005930",
+            "per": None,
+            "pbr": None,
+            "dividend_yield": None,
+            "instrument_type": "stock",
+            "name": "삼성전자",
+        },
     ]
-    universe = {"005930": {"code": "KR7005930003", "sector": "반도체", "name": "삼성전자"}}
+    universe = {
+        "005930": {"code": "KR7005930003", "sector": "반도체", "name": "삼성전자"}
+    }
     valuation = {"005930": {"per": 12.3, "pbr": 1.1, "dividend_yield": 2.5}}
 
     out = await krs._enrich_rows(
@@ -239,14 +284,19 @@ async def test_enrich_rows_fills_code_sector_valuation_best_effort():
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_enrich_rows_no_fabrication_when_missing():
-    rows = [{"symbol": "999999", "code": "999999", "per": None, "pbr": None,
-             "dividend_yield": None, "instrument_type": "stock", "name": "x"}]
+    rows = [
+        {
+            "symbol": "999999",
+            "code": "999999",
+            "per": None,
+            "pbr": None,
+            "dividend_yield": None,
+            "instrument_type": "stock",
+            "name": "x",
+        }
+    ]
     out = await krs._enrich_rows(rows, universe_by_code={}, valuation_by_code={})
     assert out[0]["per"] is None
     assert out[0]["pbr"] is None
     assert out[0]["dividend_yield"] is None
     assert out[0]["code"] == "999999"  # unchanged when no universe match
-
-
-
-

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pandas as pd
 import pytest
 
 from app.mcp_server.tooling import analysis_screening
+from app.mcp_server.tooling.screening import kr as kr_mod
 from app.mcp_server.tooling.screening import kr as kr_screening
+from app.mcp_server.tooling.screening.kr_ranking_snapshot import KrRankingSnapshotResult
 from tests._mcp_screen_stocks_support import (
     TestScreenStocksFundamentalsExpansion,
     TestScreenStocksKR,
@@ -24,6 +27,15 @@ __all__ = [
     "TestScreenStocksFundamentalsExpansion",
     "test_screen_stocks_smoke",
 ]
+
+
+@pytest.fixture(autouse=True)
+def mock_disable_kr_ranking_snapshot_by_default():
+    with patch(
+        "app.mcp_server.tooling.screening.kr.load_kr_ranking_snapshot",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
 
 
 def test_analysis_screening_reexports_screen_contract_helpers() -> None:
@@ -262,3 +274,120 @@ async def test_normalize_kr_results_prefers_krx_canonical_name(
 
     assert rows[0]["name"] == "삼성전자"
     assert rows[0]["instrument_type"] == "common"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_uses_snapshot_when_available():
+    snap = KrRankingSnapshotResult(
+        rows=[
+            {"symbol": "005930", "name": "삼성전자", "change_rate": 3.5, "market": "kr"}
+        ],
+        total_count=1,
+        data_state="fresh",
+        source="kr_market_ranking",
+        latest_snapshot_at="2026-06-08T00:00:00+00:00",
+        warnings=["모멘텀 랭킹 상위 1종목 기반 — 전체 KRX 스캔이 아닙니다."],
+        meta_fields={"data_state": "fresh", "source": "kr_market_ranking"},
+    )
+    with patch.object(
+        kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=snap)
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr",
+            asset_type=None,
+            category=None,
+            sector=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            sort_by="change_rate",
+            sort_order="desc",
+            limit=20,
+        )
+    assert resp["meta"]["data_state"] == "fresh"
+    assert resp["meta"]["source"] == "kr_market_ranking"
+    assert resp["results"][0]["symbol"] == "005930"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_stale_snapshot_returned_not_hard_zero():
+    snap = KrRankingSnapshotResult(
+        rows=[{"symbol": "005930", "name": "삼성", "market": "kr"}],
+        total_count=1,
+        data_state="stale",
+        source="kr_market_ranking",
+        latest_snapshot_at=None,
+        warnings=[
+            "모멘텀 랭킹 스냅샷이 오래되었습니다(older_than_ttl) — 신규 후보 발굴에 주의하세요."
+        ],
+        meta_fields={
+            "data_state": "stale",
+            "source": "kr_market_ranking",
+            "retryable": False,
+            "reason": "kr_market_ranking_stale",
+        },
+    )
+    with patch.object(
+        kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=snap)
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr",
+            asset_type=None,
+            category=None,
+            sector=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=20,
+        )
+    assert resp["meta"]["data_state"] == "stale"
+    assert len(resp["results"]) == 1  # NOT hard-0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_none_snapshot_goes_live():
+    """When the snapshot helper returns None (ineligible sort / zero rows / error),
+    the legacy live path must still run (here it returns an empty legacy response)."""
+    with (
+        patch.object(
+            kr_mod, "load_kr_ranking_snapshot", new=AsyncMock(return_value=None)
+        ),
+        patch.object(
+            kr_mod,
+            "_get_tvscreener_stock_capability_snapshot",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(kr_mod, "_can_use_tvscreener_stock_path", return_value=False),
+        patch.object(
+            kr_mod,
+            "_screen_kr",
+            new=AsyncMock(return_value={"meta": {"source": "legacy"}, "results": []}),
+        ),
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr",
+            asset_type=None,
+            category=None,
+            sector=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            sort_by="rsi",
+            sort_order="desc",
+            limit=20,
+        )
+    assert resp["meta"]["source"] == "legacy"  # fell through to live

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -391,3 +391,88 @@ async def test_fallback_none_snapshot_goes_live():
             limit=20,
         )
     assert resp["meta"]["source"] == "legacy"  # fell through to live
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_skips_snapshot_when_filtered():
+    """A quality filter (max_per) cannot be honored by the KR-wide ranking snapshot,
+    so the guard must skip the snapshot path entirely and go live (which honors it)."""
+    snap_mock = AsyncMock(
+        return_value=KrRankingSnapshotResult(
+            rows=[{"symbol": "X"}],
+            total_count=1,
+            data_state="fresh",
+            source="kr_market_ranking",
+            latest_snapshot_at=None,
+        )
+    )
+    with (
+        patch.object(kr_mod, "load_kr_ranking_snapshot", new=snap_mock),
+        patch.object(
+            kr_mod,
+            "_get_tvscreener_stock_capability_snapshot",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(kr_mod, "_can_use_tvscreener_stock_path", return_value=False),
+        patch.object(
+            kr_mod,
+            "_screen_kr",
+            new=AsyncMock(return_value={"meta": {"source": "legacy"}, "results": []}),
+        ),
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kr",
+            asset_type=None,
+            category=None,
+            sector=None,
+            min_market_cap=None,
+            max_per=10.0,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=20,
+        )
+    snap_mock.assert_not_awaited()  # guard prevented the snapshot path
+    assert resp["meta"]["source"] == "legacy"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fallback_skips_snapshot_for_submarket():
+    """market=kospi would be mislabeled by the KR-wide snapshot -> guard goes live."""
+    snap_mock = AsyncMock(return_value=None)
+    with (
+        patch.object(kr_mod, "load_kr_ranking_snapshot", new=snap_mock),
+        patch.object(
+            kr_mod,
+            "_get_tvscreener_stock_capability_snapshot",
+            new=AsyncMock(return_value={}),
+        ),
+        patch.object(kr_mod, "_can_use_tvscreener_stock_path", return_value=False),
+        patch.object(
+            kr_mod,
+            "_screen_kr",
+            new=AsyncMock(return_value={"meta": {"source": "legacy"}, "results": []}),
+        ),
+    ):
+        resp = await kr_mod._screen_kr_with_fallback(
+            market="kospi",
+            asset_type=None,
+            category=None,
+            sector=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=20,
+        )
+    snap_mock.assert_not_awaited()  # sub-market -> live path
+    assert resp["meta"]["source"] == "legacy"

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -13,6 +13,19 @@ from app.services.tvscreener_service import (
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+
+
+@pytest.fixture(autouse=True)
+def _disable_kr_ranking_snapshot():
+    """ROB-388: these contract tests assert the *tvscreener* KR path specifically. The
+    snapshot-primary path (kr_market_ranking) now precedes tvscreener for plain eligible
+    KR requests and is covered in test_mcp_screen_stocks_kr.py, so disable it here to keep
+    exercising the tvscreener contract in isolation."""
+    with patch(
+        "app.mcp_server.tooling.screening.kr.load_kr_ranking_snapshot",
+        new=AsyncMock(return_value=None),
+    ):
+        yield
 
 
 def _stock_capability_snapshot(


### PR DESCRIPTION
## 요약

`screen_stocks(market="kr")`가 KRX live 세션이 죽어도 **0건으로 끝나지 않도록**, durable read-model `kr_market_ranking`을 **primary**로 소비하도록 복구합니다. stale도 정직하게 반환하고, live(tvscreener→legacy KRX)는 스냅샷이 완전 부재일 때만 fallback합니다.

## 배경

- `screen_stocks(market="kr")`가 장 개장 시점에 두 가지로 다운: ① KRX 세션 만료(재시도 미회복) ② call-safety classifier 일시 거부. 근본 구조가 **live-only**라 durable fallback이 없어 KRX가 죽으면 무조건 0건.
- 딱 맞는 durable 소스 = ROB-398 Slice 2가 만든 `kr_market_ranking`(Naver 랭킹 read-model). 이미 머지됐으나 사용자향 미노출 상태 → 본 PR이 screen_stocks 관점에서 연결.

## 변경

- **신규** `app/mcp_server/tooling/screening/kr_ranking_snapshot.py`: `MomentumRankingQueryService`에서 랭킹을 읽어 screen_stocks 행 모양으로 매핑 + best-effort enrichment(KRX universe/valuation, **위조 없음** — 없으면 null) + freshness→정직 메타. `screener_snapshot_tool.py`처럼 자체 세션 획득, **fail-open**(미커버 sort_by / 행 0 / 오류 → `None` → live).
- **수정** `_screen_kr_with_fallback` 맨 앞에 snapshot-primary 사다리 + `snapshot_path_applicable` 가드 → **순수 KR-wide 랭킹 질의에서만** 작동(`market∈{kr,all}`, stock, category/sector 없음, 품질 필터 없음). 하위시장(kospi/kosdaq/konex)·필터 질의는 live 경로(필터 honor)로.

## sort_by ↔ ranking 매핑

- `change_rate`→`up`, `volume`→`quantTop` (직접). `trade_amount`/`market_cap`→`up∪quantTop` union 후 재정렬(**top-movers ~30 한정**, 전체 유니버스 아님 → warning 명시). `dividend_yield`/`week_change_rate`/`rsi`/`score`는 미커버 → live.

## 정직성

- `data_state`(fresh/stale) + `source="kr_market_ranking"` + `latest_snapshot_at` + stale 시 `retryable=false` + "모멘텀 랭킹 상위 N종목 기반 — 전체 KRX 스캔이 아닙니다" 커버리지 경고.

## 비범위

- **ROB-446**(모멘텀 cron 신선도, write-side) = 짝꿍 후속. 이 PR 없이는 "정직하게 stale"까지만 보장되고, 실제 fresh 발굴은 ROB-446이 cron을 고쳐야 발현됩니다.
- failure mode #2(classifier 일시 거부), investor_flow 수급(ROB-398 S3), live KRX re-auth 수리 = 비범위.

## 테스트

- `kr_ranking_snapshot` 단위 24개 + `_screen_kr_with_fallback` 사다리/가드 회귀. 전체 스크리닝 스윕 **1064 pass, 본 변경으로 인한 실패 0**. migration 0, broker/order/watch/order-intent mutation 0.
- 참고: main에 **사전존재**하는 `double_buy` date-flaky 4건은 무관(base 커밋에서도 동일 실패, 2026-06-09 날짜 롤오버 민감).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
