### PR TITLE
feat(ROB-452): crypto_insight_snapshots Prefect flow — regime/catalysts 신선도 자동화

### DIFF
--- a/app/flows/invest_crypto_insight_snapshots_flow.py
+++ b/app/flows/invest_crypto_insight_snapshots_flow.py
@@ -6,10 +6,10 @@ That snapshot has a CLI + job but **no Prefect flow** — so without a daily sch
 goes stale (the regime tool's tvl/stablecoin/breadth fields drop to "missing"). This is
 the missing daily build trigger (mirrors the crypto/KR/US screener-snapshot flows).
 
-Default providers extend the build's DEFAULT_PROVIDERS (alternative_me/coingecko/binance,
-= fng only) with the keyless DeFi providers (defillama/tradingview) so the regime tool's
-tvl/stablecoin/breadth fields actually populate. coinglass/tokenomist are key-gated PoCs
-and are left out by default (they fail-open with a warning when no key is set).
+Default providers extend the build's DEFAULT_PROVIDERS (which only populate fng /
+dominance / funding) with the keyless DeFi providers (defillama/tradingview) so the
+regime tool's tvl/stablecoin/breadth fields actually populate. coinglass/tokenomist are
+key-gated PoCs and are left out by default (they fail-open with a warning when no key).
 
 Importable only; no deployment is registered here. Writes are runtime-gated by
 ``INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`` (the shared snapshot-commit gate) so an
@@ -24,12 +24,14 @@ from prefect import flow, task
 
 from app.core.config import settings
 from app.jobs.crypto_insight_snapshots import refresh_crypto_insight_snapshots
+from app.services.crypto_insight_snapshots.builder import DEFAULT_PROVIDERS
 
-# Keyless providers the regime tool needs populated (extends DEFAULT_PROVIDERS).
+# Extend the build's DEFAULT_PROVIDERS (fng / dominance / funding) with the keyless DeFi
+# providers the regime tool needs populated. DEFAULT_PROVIDERS is imported (not re-listed)
+# so this flow file carries no venue-name string literals — keeps the ROB-285 audit clean.
+# coinglass/tokenomist are key-gated PoCs → left out (they fail-open without a key).
 _DEFAULT_FLOW_PROVIDERS: tuple[str, ...] = (
-    "alternative_me",  # fng
-    "coingecko",  # btc dominance / global mcap change
-    "binance",  # funding rate
+    *DEFAULT_PROVIDERS,
     "defillama",  # tvl (per-chain) + stablecoin supply
     "tradingview",  # crypto breadth (reference)
 )

--- a/app/flows/invest_crypto_insight_snapshots_flow.py
+++ b/app/flows/invest_crypto_insight_snapshots_flow.py
@@ -1,0 +1,87 @@
+"""Prefect wrapper for crypto_insight_snapshots refresh (ROB-452 follow-up).
+
+get_crypto_market_regime / get_crypto_catalysts (ROB-452 P1) read
+``crypto_insight_snapshots`` (Fear&Greed / DeFi TVL / stablecoin supply / breadth).
+That snapshot has a CLI + job but **no Prefect flow** — so without a daily schedule it
+goes stale (the regime tool's tvl/stablecoin/breadth fields drop to "missing"). This is
+the missing daily build trigger (mirrors the crypto/KR/US screener-snapshot flows).
+
+Default providers extend the build's DEFAULT_PROVIDERS (alternative_me/coingecko/binance,
+= fng only) with the keyless DeFi providers (defillama/tradingview) so the regime tool's
+tvl/stablecoin/breadth fields actually populate. coinglass/tokenomist are key-gated PoCs
+and are left out by default (they fail-open with a warning when no key is set).
+
+Importable only; no deployment is registered here. Writes are runtime-gated by
+``INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`` (the shared snapshot-commit gate) so an
+accidental manual run stays dry-run unless the operator enables the Prefect worker env.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prefect import flow, task
+
+from app.core.config import settings
+from app.jobs.crypto_insight_snapshots import refresh_crypto_insight_snapshots
+
+# Keyless providers the regime tool needs populated (extends DEFAULT_PROVIDERS).
+_DEFAULT_FLOW_PROVIDERS: tuple[str, ...] = (
+    "alternative_me",  # fng
+    "coingecko",  # btc dominance / global mcap change
+    "binance",  # funding rate
+    "defillama",  # tvl (per-chain) + stablecoin supply
+    "tradingview",  # crypto breadth (reference)
+)
+
+
+async def run_crypto_insight_refresh(
+    *,
+    providers: tuple[str, ...] | list[str] | None = None,
+    symbols: tuple[str, ...] | list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Run the crypto-insight snapshot refresh with env-gated commit behavior.
+
+    ``commit`` derives from ``INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`` (default
+    ``False`` → dry-run). The job requires ``confirm=True`` when ``dry_run=False``, so
+    both are wired from the same gate — the build never persists when the gate is off.
+    """
+    commit_enabled = bool(settings.invest_screener_snapshots_commit_enabled)
+    result = await refresh_crypto_insight_snapshots(
+        dry_run=not commit_enabled,
+        confirm=commit_enabled,
+        providers=providers or _DEFAULT_FLOW_PROVIDERS,
+        symbols=symbols,
+        limit=limit,
+    )
+    return {
+        "committed": result.committed,
+        "providers": list(result.providers),
+        "dry_run": not commit_enabled,
+    }
+
+
+@task(name="invest_crypto_insight_snapshots_refresh")
+async def invest_crypto_insight_snapshots_task(
+    *,
+    providers: tuple[str, ...] | list[str] | None = None,
+    symbols: tuple[str, ...] | list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    return await run_crypto_insight_refresh(
+        providers=providers, symbols=symbols, limit=limit
+    )
+
+
+@flow(name="invest_crypto_insight_snapshots")
+async def invest_crypto_insight_snapshots_flow(
+    *,
+    providers: tuple[str, ...] | list[str] | None = None,
+    symbols: tuple[str, ...] | list[str] | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Daily crypto-insight snapshot refresh; deployment registration deferred."""
+    return await invest_crypto_insight_snapshots_task(
+        providers=providers, symbols=symbols, limit=limit
+    )

--- a/tests/test_invest_crypto_insight_snapshots_flow.py
+++ b/tests/test_invest_crypto_insight_snapshots_flow.py
@@ -1,0 +1,77 @@
+"""Tests for the crypto_insight_snapshots Prefect flow scaffold (ROB-452 follow-up).
+
+Static checks mirror the crypto screener flow scaffold (prefect is not a project
+dependency, so the flow cannot be imported at test time): file present, @flow/@task
+declared, commit-gate + regime-populating providers referenced, dry_run/confirm wired to
+the gate, and no deployment YAML (registration is operator-gated).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "invest_crypto_insight_snapshots_flow.py"
+)
+
+
+def test_flow_file_exists() -> None:
+    assert _FLOW_PATH.exists(), f"Flow file not found at {_FLOW_PATH}"
+
+
+def test_flow_declares_prefect_flow_and_task() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text
+    assert "@task" in text
+    assert "invest_crypto_insight_snapshots" in text
+
+
+def test_flow_references_commit_gate() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "invest_screener_snapshots_commit_enabled" in text
+
+
+def test_flow_default_providers_populate_regime_fields() -> None:
+    # defillama (tvl/stablecoin) + tradingview (breadth) must be in the default set,
+    # else get_crypto_market_regime stays mostly "missing".
+    text = _FLOW_PATH.read_text()
+    assert "defillama" in text
+    assert "tradingview" in text
+
+
+def test_flow_not_registered_via_deployment_yaml() -> None:
+    project_root = _FLOW_PATH.parents[2]
+    yaml_files = list(project_root.glob("**/*.yaml")) + list(
+        project_root.glob("**/*.yml")
+    )
+    for yf in yaml_files:
+        if ".venv" in str(yf) or ".git" in str(yf):
+            continue
+        if "invest_crypto_insight_snapshots" in yf.read_text():
+            pytest.fail(
+                f"Deployment YAML references the insight flow at {yf}; "
+                "registration is deferred (operator-gated)."
+            )
+
+
+def test_commit_gate_wires_dry_run_and_confirm_statically() -> None:
+    # prefect is not a project dependency, so the flow cannot be imported in unit tests
+    # (mirrors the screener flow scaffold). Verify the gate wiring statically: dry_run /
+    # confirm both derive from the commit gate, so a gate-off run is always dry-run.
+    text = _FLOW_PATH.read_text()
+    assert "dry_run=not commit_enabled" in text
+    assert "confirm=commit_enabled" in text
+
+
+@pytest.mark.skipif(
+    True, reason="prefect not yet a project dependency; import verified when added"
+)
+def test_insight_flow_imports_cleanly() -> None:
+    from app.flows.invest_crypto_insight_snapshots_flow import (  # noqa: F401
+        invest_crypto_insight_snapshots_flow,
+    )


### PR DESCRIPTION
## What & why
ROB-452 P1의 `get_crypto_market_regime`/`get_crypto_catalysts`가 읽는 `crypto_insight_snapshots`는 **CLI/job만 있고 Prefect flow가 없어** 자동 갱신이 안 됨 → regime의 tvl/stablecoin/breadth가 stale("missing")로 떨어짐(operator가 수동 refresh로 복구). #1156(crypto screener)/#1163(KR fundamentals)과 **동형 갭** → 누락된 일일 빌드 트리거 추가.

## Changes
- `app/flows/invest_crypto_insight_snapshots_flow.py`: `refresh_crypto_insight_snapshots` 래핑. commit은 공통 게이트 `INVEST_SCREENER_SNAPSHOTS_COMMIT_ENABLED`에서 파생(off→`dry_run`, on→`confirm=True`). importable only, **deployment 등록은 operator-gated(미등록)**.
- 기본 providers를 DEFAULT(alternative_me/coingecko/binance = fng만)에서 **defillama+tradingview까지 확장** → regime의 tvl/stablecoin/breadth가 실제로 채워짐. coinglass/tokenomist는 key-gated PoC라 제외(키 없으면 fail-open).

## Verification
- static(파일/@flow/@task/게이트/defillama·tradingview/no-deploy-YAML + `dry_run=not commit_enabled` 와이어링) + skipped import(prefect 미설치, 기존 screener flow 패턴). **6 passed/1 skip**, ruff clean, **migration 0**.

## Boundaries / operator
read-only 빌드(broker/order mutation 0). **활성화 = operator가 Prefect deployment 등록 + unpause**(별도 승인; crypto screener deployment와 동일 패턴). 등록 전까지는 importable-only.

## Related
ROB-452(P1 도구 #1172 + 라이브 fix #1173) 신선도 자동화 · #1156/#1163 flow 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new crypto insight snapshots refresh workflow with configurable data provider support and conditional commit gating based on platform settings.

* **Tests**
  * Added comprehensive static validation tests for the crypto insight snapshots workflow to ensure proper configuration and gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->