### PR TITLE
feat(ROB-398): get_symbol_news_mapping MCP 도구 — 뉴스-종목 매핑 read-model 노출 (surface 슬라이스 1)

### DIFF
--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -22,6 +22,7 @@ AVAILABLE_TOOL_NAMES = [
     "get_ohlcv",
     "get_indicators",
     "get_news",
+    "get_symbol_news_mapping",
     "get_company_profile",
     "get_crypto_profile",
     "get_financials",

--- a/app/mcp_server/tooling/news_handlers.py
+++ b/app/mcp_server/tooling/news_handlers.py
@@ -16,7 +16,7 @@ from app.services.market_news_briefing_formatter import (
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
-NEWS_TOOL_NAMES = ["get_market_news", "get_market_issues"]
+NEWS_TOOL_NAMES = ["get_market_news", "get_market_issues", "get_symbol_news_mapping"]
 
 
 def _article_to_dict(
@@ -220,3 +220,27 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
             market=market, window_hours=window_hours, limit=limit
         )
         return response.model_dump(mode="json")
+
+    @mcp.tool(
+        name="get_symbol_news_mapping",
+        description=(
+            "Read-only: news mapped to a stock symbol from the news-symbol mapping "
+            "read-model (ROB-398). Returns per-article mapped_symbols "
+            "(symbol/mapping_source[naver_code|candidate|ner]/confidence/is_primary) "
+            "plus title/url/as_of and an honest data_state (fresh|stale|unavailable). "
+            "Use for symbol-level news evidence; empty mapping returns unavailable, not error."
+        ),
+    )
+    async def get_symbol_news_mapping(
+        symbol: str,
+        market: str = "kr",
+        hours: int = 24,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        from app.mcp_server.tooling.news_symbol_mapping import (
+            handle_get_symbol_news_mapping,
+        )
+
+        return await handle_get_symbol_news_mapping(
+            symbol=symbol, market=market, hours=hours, limit=limit
+        )

--- a/app/mcp_server/tooling/news_symbol_mapping.py
+++ b/app/mcp_server/tooling/news_symbol_mapping.py
@@ -1,0 +1,80 @@
+# app/mcp_server/tooling/news_symbol_mapping.py
+"""MCP handler for get_symbol_news_mapping (ROB-398 surface slice 1).
+
+Exposes the news-symbol mapping read-model: symbol -> mapped news (symbol /
+mapping_source / confidence / is_primary) + url + as_of, with honest data_state.
+Read-only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.services.kr_news_symbol_mapping.contract import SymbolNewsMapping
+from app.services.kr_news_symbol_mapping.db_provider import db_article_provider
+from app.services.kr_news_symbol_mapping.query_service import (
+    ArticleProvider,
+    get_symbol_news_mapping,
+)
+
+
+def _format_symbol_news_mapping(mapping: SymbolNewsMapping) -> dict[str, Any]:
+    data_state = mapping.freshness.overall
+    articles = [
+        {
+            "title": a.title,
+            "url": a.url,
+            "summary": a.summary,
+            "as_of": a.as_of.isoformat() if a.as_of else None,
+            "mapped_symbols": [
+                {
+                    "symbol": s.symbol,
+                    "market": s.market,
+                    "mapping_source": s.mapping_source,
+                    "confidence": s.confidence,
+                    "is_primary": s.is_primary,
+                    "matched_term": s.matched_term,
+                }
+                for s in a.mapped_symbols
+            ],
+        }
+        for a in mapping.articles
+    ]
+    warnings: list[str] = []
+    if data_state == "unavailable":
+        warnings.append("해당 종목에 매핑된 뉴스가 없습니다 (최근 윈도우 내).")
+    elif data_state == "stale":
+        warnings.append("매핑된 뉴스가 오래되었습니다 — 신선도에 주의하세요.")
+    return {
+        "symbol": mapping.symbol,
+        "market": mapping.market,
+        "data_state": data_state,
+        "latest_as_of": (
+            mapping.freshness.latest_as_of.isoformat()
+            if mapping.freshness.latest_as_of
+            else None
+        ),
+        "articles": articles,
+        "warnings": warnings,
+    }
+
+
+async def handle_get_symbol_news_mapping(
+    *,
+    symbol: str,
+    market: str = "kr",
+    hours: int = 24,
+    limit: int = 20,
+    now: datetime | None = None,
+    article_provider: ArticleProvider | None = None,
+) -> dict[str, Any]:
+    mapping = await get_symbol_news_mapping(
+        symbol,
+        market=market,
+        hours=hours,
+        limit=limit,
+        now=now,
+        article_provider=article_provider or db_article_provider,
+    )
+    return _format_symbol_news_mapping(mapping)

--- a/app/services/kr_news_symbol_mapping/contract.py
+++ b/app/services/kr_news_symbol_mapping/contract.py
@@ -53,6 +53,7 @@ class ArticleView:
     summary: str | None
     keywords: tuple[str, ...]
     as_of: datetime
+    url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -60,6 +61,8 @@ class MappedArticle:
     as_of: datetime
     title: str | None
     mapped_symbols: tuple[MappedSymbol, ...]
+    url: str | None = None
+    summary: str | None = None
 
 
 @dataclass(frozen=True)

--- a/app/services/kr_news_symbol_mapping/db_provider.py
+++ b/app/services/kr_news_symbol_mapping/db_provider.py
@@ -1,0 +1,44 @@
+# app/services/kr_news_symbol_mapping/db_provider.py
+"""DB-backed ArticleProvider for the kr_news_symbol_mapping read-model (ROB-398).
+
+Adapts get_news_articles_with_fallback (exact->related->alias) + a separate
+news_article_related_symbols lookup into ArticleView[] for get_symbol_news_mapping.
+Read-only; self-acquires sessions; no writes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.services.kr_news_symbol_mapping.contract import ArticleView, CandidateRow
+
+
+def _candidate_rows_from_orm(
+    rows: Sequence[NewsArticleRelatedSymbol],
+) -> tuple[CandidateRow, ...]:
+    return tuple(
+        CandidateRow(
+            symbol=r.symbol,
+            source=r.source,
+            score=r.score,
+            rank=r.rank,
+            matched_term=r.matched_term,
+        )
+        for r in rows
+    )
+
+
+def _article_to_view(
+    article: NewsArticle, related_rows: tuple[CandidateRow, ...]
+) -> ArticleView:
+    return ArticleView(
+        market=article.market,
+        stock_symbol=article.stock_symbol,
+        related_rows=related_rows,
+        title=article.title,
+        summary=article.summary,
+        keywords=tuple(article.keywords or ()),
+        as_of=article.article_published_at or article.scraped_at,
+        url=article.url,
+    )

--- a/app/services/kr_news_symbol_mapping/db_provider.py
+++ b/app/services/kr_news_symbol_mapping/db_provider.py
@@ -10,8 +10,12 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from sqlalchemy import select
+
+from app.core.db import AsyncSessionLocal
 from app.models.news import NewsArticle, NewsArticleRelatedSymbol
 from app.services.kr_news_symbol_mapping.contract import ArticleView, CandidateRow
+from app.services.llm_news_service import get_news_articles_with_fallback
 
 
 def _candidate_rows_from_orm(
@@ -42,3 +46,42 @@ def _article_to_view(
         as_of=article.article_published_at or article.scraped_at,
         url=article.url,
     )
+
+
+async def _load_related_rows(
+    article_ids: Sequence[int],
+) -> dict[int, tuple[CandidateRow, ...]]:
+    """Load news_article_related_symbols for the given article ids (own session,
+
+    avoids DetachedInstanceError from lazy article.related_symbols).
+    """
+    if not article_ids:
+        return {}
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(NewsArticleRelatedSymbol).where(
+                NewsArticleRelatedSymbol.article_id.in_(list(article_ids))
+            )
+        )
+        rows = result.scalars().all()
+    grouped: dict[int, list[NewsArticleRelatedSymbol]] = {}
+    for row in rows:
+        grouped.setdefault(row.article_id, []).append(row)
+    return {aid: _candidate_rows_from_orm(rs) for aid, rs in grouped.items()}
+
+
+async def db_article_provider(
+    symbol: str, market: str, hours: int, limit: int
+) -> list[ArticleView]:
+    """ArticleProvider: symbol-targeted articles (exact->related->alias) mapped to
+
+    ArticleView with per-article related_symbols. Positional signature matches the
+    ArticleProvider contract; fail-open is the caller's concern (returns [] if empty).
+    """
+    lookup = await get_news_articles_with_fallback(
+        symbol=symbol, market=market, hours=hours, limit=limit
+    )
+    if not lookup.articles:
+        return []
+    related = await _load_related_rows([a.id for a in lookup.articles])
+    return [_article_to_view(a, related.get(a.id, ())) for a in lookup.articles]

--- a/app/services/kr_news_symbol_mapping/query_service.py
+++ b/app/services/kr_news_symbol_mapping/query_service.py
@@ -62,7 +62,13 @@ async def get_symbol_news_mapping(
         # target 매핑을 앞으로 정렬(소비자 편의), 결정적 순서 유지.
         ordered = tuple(sorted(mapped, key=lambda m: (m.symbol != target, m.symbol)))
         mapped_articles.append(
-            MappedArticle(as_of=av.as_of, title=av.title, mapped_symbols=ordered)
+            MappedArticle(
+                as_of=av.as_of,
+                title=av.title,
+                mapped_symbols=ordered,
+                url=av.url,
+                summary=av.summary,
+            )
         )
         as_ofs.append(av.as_of)
 

--- a/docs/superpowers/plans/2026-06-09-rob398-symbol-news-mapping-tool.md
+++ b/docs/superpowers/plans/2026-06-09-rob398-symbol-news-mapping-tool.md
@@ -1,0 +1,694 @@
+# ROB-398 — `get_symbol_news_mapping` MCP 도구 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 기존 news-symbol mapping read-model을 신규 read-only MCP 도구 `get_symbol_news_mapping`으로 노출 — 심볼→매핑된 뉴스(symbol/mapping_source/confidence/is_primary + url + as_of)를 정직한 freshness와 함께 반환.
+
+**Architecture:** 신규 DB `ArticleProvider`가 `get_news_articles_with_fallback`(exact→related→alias+dedup)로 기사를 가져와 `ArticleView`로 매핑하고(related_symbols는 detached lazy-load 회피 위해 article_id로 별도 조회), 기존 `get_symbol_news_mapping` query_service가 매핑/freshness를 수행, 신규 MCP 핸들러가 응답 dict로 포맷·등록. 계약(`ArticleView`/`MappedArticle`)에 url/summary를 additive 추가.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async (`AsyncSessionLocal`), FastMCP `@mcp.tool`, pytest(asyncio), ruff. migration 0, read-only.
+
+---
+
+## File Structure
+
+- **Modify** `app/services/kr_news_symbol_mapping/contract.py` — `ArticleView.url`, `MappedArticle.url`/`.summary` 필드 추가(additive).
+- **Modify** `app/services/kr_news_symbol_mapping/query_service.py` — `MappedArticle` 생성 시 url/summary 전달.
+- **Create** `app/services/kr_news_symbol_mapping/db_provider.py` — `db_article_provider`(ArticleProvider 구현) + `_load_related_rows` + 순수 매퍼 `_candidate_rows_from_orm`/`_article_to_view`.
+- **Create** `app/mcp_server/tooling/news_symbol_mapping.py` — `handle_get_symbol_news_mapping` + 순수 `_format_symbol_news_mapping`.
+- **Modify** `app/mcp_server/tooling/news_handlers.py` — `@mcp.tool` 등록 + `NEWS_TOOL_NAMES` 추가.
+- **Modify** `app/mcp_server/__init__.py` — `AVAILABLE_TOOL_NAMES`에 추가.
+- **Tests**: extend `tests/test_kr_news_symbol_mapping_query.py`; create `tests/test_kr_news_symbol_mapping_db_provider.py`, `tests/test_news_symbol_mapping_handler.py`, `tests/test_mcp_news_symbol_mapping_tool.py`.
+
+참조(읽기 전용): `app/services/llm_news_service.py::get_news_articles_with_fallback(*, symbol, market, hours=24, limit=20) -> NewsLookupResult(articles: list[NewsArticle], match_reasons)` (self-acquires sessions → 반환 article은 detached); `app/models/news.py::NewsArticle`(id, url, title, summary, keywords, stock_symbol, market, article_published_at, scraped_at) / `NewsArticleRelatedSymbol`(article_id, market, symbol, source, matched_term, score, rank).
+
+---
+
+## Task 1: 계약 확장 (ArticleView.url, MappedArticle.url/summary) + query_service passthrough
+
+**Files:**
+- Modify: `app/services/kr_news_symbol_mapping/contract.py`
+- Modify: `app/services/kr_news_symbol_mapping/query_service.py`
+- Test: `tests/test_kr_news_symbol_mapping_query.py`
+
+- [ ] **Step 1: Write the failing test** (append to `tests/test_kr_news_symbol_mapping_query.py`)
+
+```python
+@pytest.mark.asyncio
+async def test_url_and_summary_passthrough_to_mapped_article():
+    async def provider(symbol, market, hours, limit):
+        return [
+            ArticleView(
+                market="kr",
+                stock_symbol="005930",
+                related_rows=(),
+                title="삼성전자 신규 투자",
+                summary="리드 문장",
+                keywords=(),
+                as_of=NOW,
+                url="https://n.news.naver.com/article/001/000",
+            )
+        ]
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", now=NOW, article_provider=provider
+    )
+    assert len(result.articles) == 1
+    art = result.articles[0]
+    assert art.url == "https://n.news.naver.com/article/001/000"
+    assert art.summary == "리드 문장"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_query.py::test_url_and_summary_passthrough_to_mapped_article -v`
+Expected: FAIL — `TypeError: ArticleView.__init__() got an unexpected keyword argument 'url'`.
+
+- [ ] **Step 3: Add the contract fields**
+
+In `app/services/kr_news_symbol_mapping/contract.py`, add `url` to `ArticleView` (after `as_of`):
+
+```python
+@dataclass(frozen=True)
+class ArticleView:
+    """resolver/query_service 입력용 기사 뷰 (DB ORM 비의존, 테스트 친화)."""
+
+    market: str
+    stock_symbol: str | None
+    related_rows: tuple[CandidateRow, ...]
+    title: str | None
+    summary: str | None
+    keywords: tuple[str, ...]
+    as_of: datetime
+    url: str | None = None
+```
+
+And add `url`/`summary` to `MappedArticle` (after `mapped_symbols`):
+
+```python
+@dataclass(frozen=True)
+class MappedArticle:
+    as_of: datetime
+    title: str | None
+    mapped_symbols: tuple[MappedSymbol, ...]
+    url: str | None = None
+    summary: str | None = None
+```
+
+- [ ] **Step 4: Thread url/summary in query_service**
+
+In `app/services/kr_news_symbol_mapping/query_service.py`, change the `MappedArticle(...)` construction (currently `MappedArticle(as_of=av.as_of, title=av.title, mapped_symbols=ordered)`):
+
+```python
+        mapped_articles.append(
+            MappedArticle(
+                as_of=av.as_of,
+                title=av.title,
+                mapped_symbols=ordered,
+                url=av.url,
+                summary=av.summary,
+            )
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_query.py -v`
+Expected: PASS (new test + all existing — defaults keep back-compat).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/kr_news_symbol_mapping/contract.py app/services/kr_news_symbol_mapping/query_service.py tests/test_kr_news_symbol_mapping_query.py
+git commit -m "feat(ROB-398): ArticleView.url + MappedArticle.url/summary passthrough"
+```
+
+---
+
+## Task 2: 순수 매퍼 — ORM rows → CandidateRow, NewsArticle → ArticleView
+
+**Files:**
+- Create: `app/services/kr_news_symbol_mapping/db_provider.py`
+- Test: `tests/test_kr_news_symbol_mapping_db_provider.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_kr_news_symbol_mapping_db_provider.py
+from datetime import UTC, datetime
+
+import pytest
+
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.services.kr_news_symbol_mapping import db_provider as dbp
+from app.services.kr_news_symbol_mapping.contract import CandidateRow
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_candidate_rows_from_orm_maps_fields():
+    rows = [
+        NewsArticleRelatedSymbol(
+            article_id=1, market="kr", symbol="035420", source="naver_code",
+            matched_term=None, score=None, rank=1,
+        ),
+        NewsArticleRelatedSymbol(
+            article_id=1, market="kr", symbol="000660", source="ner",
+            matched_term="닉스", score=0.5, rank=2,
+        ),
+    ]
+    out = dbp._candidate_rows_from_orm(rows)
+    assert out == (
+        CandidateRow(symbol="035420", source="naver_code", score=None, rank=1, matched_term=None),
+        CandidateRow(symbol="000660", source="ner", score=0.5, rank=2, matched_term="닉스"),
+    )
+
+
+@pytest.mark.unit
+def test_article_to_view_maps_fields_and_url():
+    article = NewsArticle(
+        id=7, market="kr", url="https://n.news.naver.com/a/1",
+        title="네이버 GTC 언급", summary="리드", keywords=["AI"],
+        stock_symbol="035420", article_published_at=NOW, scraped_at=NOW,
+    )
+    related = (CandidateRow(symbol="035420", source="naver_code"),)
+    view = dbp._article_to_view(article, related)
+    assert view.market == "kr"
+    assert view.stock_symbol == "035420"
+    assert view.related_rows == related
+    assert view.title == "네이버 GTC 언급"
+    assert view.summary == "리드"
+    assert view.keywords == ("AI",)
+    assert view.as_of == NOW
+    assert view.url == "https://n.news.naver.com/a/1"
+
+
+@pytest.mark.unit
+def test_article_to_view_as_of_falls_back_to_scraped_at():
+    article = NewsArticle(
+        id=8, market="kr", url="https://x/2", title="t", summary=None,
+        keywords=None, stock_symbol=None, article_published_at=None, scraped_at=NOW,
+    )
+    view = dbp._article_to_view(article, ())
+    assert view.as_of == NOW  # published_at None -> scraped_at
+    assert view.keywords == ()  # None -> ()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_db_provider.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.services.kr_news_symbol_mapping.db_provider`.
+
+- [ ] **Step 3: Write the pure mappers**
+
+```python
+# app/services/kr_news_symbol_mapping/db_provider.py
+"""DB-backed ArticleProvider for the kr_news_symbol_mapping read-model (ROB-398).
+
+Adapts get_news_articles_with_fallback (exact->related->alias) + a separate
+news_article_related_symbols lookup into ArticleView[] for get_symbol_news_mapping.
+Read-only; self-acquires sessions; no writes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+
+from app.core.db import AsyncSessionLocal
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.services.kr_news_symbol_mapping.contract import ArticleView, CandidateRow
+
+
+def _candidate_rows_from_orm(
+    rows: Sequence[NewsArticleRelatedSymbol],
+) -> tuple[CandidateRow, ...]:
+    return tuple(
+        CandidateRow(
+            symbol=r.symbol,
+            source=r.source,
+            score=r.score,
+            rank=r.rank,
+            matched_term=r.matched_term,
+        )
+        for r in rows
+    )
+
+
+def _article_to_view(
+    article: NewsArticle, related_rows: tuple[CandidateRow, ...]
+) -> ArticleView:
+    return ArticleView(
+        market=article.market,
+        stock_symbol=article.stock_symbol,
+        related_rows=related_rows,
+        title=article.title,
+        summary=article.summary,
+        keywords=tuple(article.keywords or ()),
+        as_of=article.article_published_at or article.scraped_at,
+        url=article.url,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_db_provider.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/kr_news_symbol_mapping/db_provider.py tests/test_kr_news_symbol_mapping_db_provider.py
+git commit -m "feat(ROB-398): db_provider pure mappers (ORM->CandidateRow, NewsArticle->ArticleView)"
+```
+
+---
+
+## Task 3: `_load_related_rows` + `db_article_provider` orchestration
+
+**Files:**
+- Modify: `app/services/kr_news_symbol_mapping/db_provider.py`
+- Test: `tests/test_kr_news_symbol_mapping_db_provider.py`
+
+Detached-instance 회피: fallback이 반환한 article들의 `related_symbols`는 lazy-load 불가 → `_load_related_rows`가 article_id로 `NewsArticleRelatedSymbol`을 별도 세션에서 조회. `db_article_provider`는 fallback + `_load_related_rows`를 patch 가능한 모듈 함수로 호출하므로 DB 없이 단위 테스트.
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_db_article_provider_builds_views(monkeypatch):
+    from app.services.llm_news_service import NewsLookupResult
+
+    a1 = NewsArticle(
+        id=1, market="kr", url="https://x/1", title="삼성", summary=None,
+        keywords=["반도체"], stock_symbol="005930",
+        article_published_at=NOW, scraped_at=NOW,
+    )
+    a2 = NewsArticle(
+        id=2, market="kr", url="https://x/2", title="네이버", summary="리드",
+        keywords=None, stock_symbol=None, article_published_at=None, scraped_at=NOW,
+    )
+
+    async def fake_fallback(*, symbol, market, hours, limit):
+        return NewsLookupResult(articles=[a1, a2], match_reasons={})
+
+    async def fake_load_related(article_ids):
+        assert set(article_ids) == {1, 2}
+        return {2: (CandidateRow(symbol="035420", source="naver_code"),)}
+
+    monkeypatch.setattr(dbp, "get_news_articles_with_fallback", fake_fallback)
+    monkeypatch.setattr(dbp, "_load_related_rows", fake_load_related)
+
+    views = await dbp.db_article_provider("005930", "kr", 24, 20)
+    assert [v.url for v in views] == ["https://x/1", "https://x/2"]
+    assert views[0].related_rows == ()          # a1 had no related rows
+    assert views[1].related_rows == (CandidateRow(symbol="035420", source="naver_code"),)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_db_article_provider_empty_when_no_articles(monkeypatch):
+    from app.services.llm_news_service import NewsLookupResult
+
+    async def fake_fallback(*, symbol, market, hours, limit):
+        return NewsLookupResult(articles=[], match_reasons={})
+
+    monkeypatch.setattr(dbp, "get_news_articles_with_fallback", fake_fallback)
+    views = await dbp.db_article_provider("999999", "kr", 24, 20)
+    assert views == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_db_provider.py -k db_article_provider -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'db_article_provider'`.
+
+- [ ] **Step 3: Implement orchestration** (append to `db_provider.py`)
+
+```python
+from app.services.llm_news_service import get_news_articles_with_fallback
+
+
+async def _load_related_rows(
+    article_ids: Sequence[int],
+) -> dict[int, tuple[CandidateRow, ...]]:
+    """Load news_article_related_symbols for the given article ids (own session,
+    avoids DetachedInstanceError from lazy article.related_symbols)."""
+    if not article_ids:
+        return {}
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(NewsArticleRelatedSymbol).where(
+                NewsArticleRelatedSymbol.article_id.in_(list(article_ids))
+            )
+        )
+        rows = result.scalars().all()
+    grouped: dict[int, list[NewsArticleRelatedSymbol]] = {}
+    for row in rows:
+        grouped.setdefault(row.article_id, []).append(row)
+    return {aid: _candidate_rows_from_orm(rs) for aid, rs in grouped.items()}
+
+
+async def db_article_provider(
+    symbol: str, market: str, hours: int, limit: int
+) -> list[ArticleView]:
+    """ArticleProvider: symbol-targeted articles (exact->related->alias) mapped to
+    ArticleView with per-article related_symbols. Positional signature matches the
+    ArticleProvider contract; fail-open is the caller's concern (returns [] if empty)."""
+    lookup = await get_news_articles_with_fallback(
+        symbol=symbol, market=market, hours=hours, limit=limit
+    )
+    if not lookup.articles:
+        return []
+    related = await _load_related_rows([a.id for a in lookup.articles])
+    return [_article_to_view(a, related.get(a.id, ())) for a in lookup.articles]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_db_provider.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/kr_news_symbol_mapping/db_provider.py tests/test_kr_news_symbol_mapping_db_provider.py
+git commit -m "feat(ROB-398): db_article_provider + _load_related_rows (detached-safe)"
+```
+
+---
+
+## Task 4: MCP 핸들러 — handle_get_symbol_news_mapping + _format_symbol_news_mapping
+
+**Files:**
+- Create: `app/mcp_server/tooling/news_symbol_mapping.py`
+- Test: `tests/test_news_symbol_mapping_handler.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_news_symbol_mapping_handler.py
+from datetime import UTC, datetime
+
+import pytest
+
+from app.mcp_server.tooling import news_symbol_mapping as nsm
+from app.services.kr_news_symbol_mapping.contract import ArticleView
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_handler_returns_mapped_symbols_and_url():
+    async def provider(symbol, market, hours, limit):
+        return [
+            ArticleView(
+                market="kr", stock_symbol="035420", related_rows=(),
+                title="네이버 GTC", summary="리드", keywords=(), as_of=NOW,
+                url="https://n.news.naver.com/a/1",
+            )
+        ]
+
+    resp = await nsm.handle_get_symbol_news_mapping(
+        symbol="035420", market="kr", now=NOW, article_provider=provider
+    )
+    assert resp["symbol"] == "035420"
+    assert resp["market"] == "kr"
+    assert resp["data_state"] == "fresh"
+    assert len(resp["articles"]) == 1
+    art = resp["articles"][0]
+    assert art["url"] == "https://n.news.naver.com/a/1"
+    assert art["summary"] == "리드"
+    assert art["mapped_symbols"][0]["symbol"] == "035420"
+    assert art["mapped_symbols"][0]["mapping_source"] == "naver_code"
+    assert art["mapped_symbols"][0]["is_primary"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_handler_unavailable_is_honest_not_error():
+    async def empty_provider(symbol, market, hours, limit):
+        return []
+
+    resp = await nsm.handle_get_symbol_news_mapping(
+        symbol="999999", market="kr", now=NOW, article_provider=empty_provider
+    )
+    assert resp["data_state"] == "unavailable"
+    assert resp["articles"] == []
+    assert any("매핑된 뉴스가 없" in w for w in resp["warnings"])
+    assert "error" not in resp
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_news_symbol_mapping_handler.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.mcp_server.tooling.news_symbol_mapping`.
+
+- [ ] **Step 3: Write the handler**
+
+```python
+# app/mcp_server/tooling/news_symbol_mapping.py
+"""MCP handler for get_symbol_news_mapping (ROB-398 surface slice 1).
+
+Exposes the news-symbol mapping read-model: symbol -> mapped news (symbol /
+mapping_source / confidence / is_primary) + url + as_of, with honest data_state.
+Read-only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from app.services.kr_news_symbol_mapping.contract import SymbolNewsMapping
+from app.services.kr_news_symbol_mapping.db_provider import db_article_provider
+from app.services.kr_news_symbol_mapping.query_service import (
+    ArticleProvider,
+    get_symbol_news_mapping,
+)
+
+
+def _format_symbol_news_mapping(mapping: SymbolNewsMapping) -> dict[str, Any]:
+    data_state = mapping.freshness.overall
+    articles = [
+        {
+            "title": a.title,
+            "url": a.url,
+            "summary": a.summary,
+            "as_of": a.as_of.isoformat() if a.as_of else None,
+            "mapped_symbols": [
+                {
+                    "symbol": s.symbol,
+                    "market": s.market,
+                    "mapping_source": s.mapping_source,
+                    "confidence": s.confidence,
+                    "is_primary": s.is_primary,
+                    "matched_term": s.matched_term,
+                }
+                for s in a.mapped_symbols
+            ],
+        }
+        for a in mapping.articles
+    ]
+    warnings: list[str] = []
+    if data_state == "unavailable":
+        warnings.append("해당 종목에 매핑된 뉴스가 없습니다 (최근 윈도우 내).")
+    elif data_state == "stale":
+        warnings.append("매핑된 뉴스가 오래되었습니다 — 신선도에 주의하세요.")
+    return {
+        "symbol": mapping.symbol,
+        "market": mapping.market,
+        "data_state": data_state,
+        "latest_as_of": (
+            mapping.freshness.latest_as_of.isoformat()
+            if mapping.freshness.latest_as_of
+            else None
+        ),
+        "articles": articles,
+        "warnings": warnings,
+    }
+
+
+async def handle_get_symbol_news_mapping(
+    *,
+    symbol: str,
+    market: str = "kr",
+    hours: int = 24,
+    limit: int = 20,
+    now: datetime | None = None,
+    article_provider: ArticleProvider | None = None,
+) -> dict[str, Any]:
+    mapping = await get_symbol_news_mapping(
+        symbol,
+        market=market,
+        hours=hours,
+        limit=limit,
+        now=now,
+        article_provider=article_provider or db_article_provider,
+    )
+    return _format_symbol_news_mapping(mapping)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_news_symbol_mapping_handler.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/news_symbol_mapping.py tests/test_news_symbol_mapping_handler.py
+git commit -m "feat(ROB-398): get_symbol_news_mapping MCP handler + honest formatter"
+```
+
+---
+
+## Task 5: 도구 등록 (news_handlers + NEWS_TOOL_NAMES + AVAILABLE_TOOL_NAMES)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/news_handlers.py`
+- Modify: `app/mcp_server/__init__.py`
+- Test: `tests/test_mcp_news_symbol_mapping_tool.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_mcp_news_symbol_mapping_tool.py
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.mcp_server import AVAILABLE_TOOL_NAMES
+from app.mcp_server.tooling.news_handlers import NEWS_TOOL_NAMES
+from tests._mcp_tooling_support import build_tools
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_tool_registered():
+    assert "get_symbol_news_mapping" in NEWS_TOOL_NAMES
+    assert "get_symbol_news_mapping" in AVAILABLE_TOOL_NAMES
+    tools = build_tools()
+    assert "get_symbol_news_mapping" in tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_tool_invokes_handler():
+    tools = build_tools()
+    fake_resp = {"symbol": "035420", "market": "kr", "data_state": "fresh",
+                 "latest_as_of": None, "articles": [], "warnings": []}
+    with patch(
+        "app.mcp_server.tooling.news_symbol_mapping.handle_get_symbol_news_mapping",
+        new=AsyncMock(return_value=fake_resp),
+    ) as mock_handle:
+        result = await tools["get_symbol_news_mapping"](symbol="035420", market="kr")
+    assert result["symbol"] == "035420"
+    mock_handle.assert_awaited_once()
+```
+
+> Before implementing, confirm how `build_tools()` (in `tests/_mcp_tooling_support.py`) discovers registered tools — it must register the news tools (`register_news_tools` / `_register_news_tools_impl`). If `build_tools` doesn't already include the news registration, add the new tool's registration path the same way the existing `get_market_news` is reachable there (mirror it). Adjust the patch target if the registered inner function imports the handler lazily vs at module top.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_news_symbol_mapping_tool.py -v`
+Expected: FAIL — `assert "get_symbol_news_mapping" in NEWS_TOOL_NAMES` fails (not registered).
+
+- [ ] **Step 3: Register the tool**
+
+In `app/mcp_server/tooling/news_handlers.py`, update line 19:
+
+```python
+NEWS_TOOL_NAMES = ["get_market_news", "get_market_issues", "get_symbol_news_mapping"]
+```
+
+Inside `_register_news_tools_impl(mcp)` (after the `get_market_issues` tool block, before the function ends), add:
+
+```python
+    @mcp.tool(
+        name="get_symbol_news_mapping",
+        description=(
+            "Read-only: news mapped to a stock symbol from the news-symbol mapping "
+            "read-model (ROB-398). Returns per-article mapped_symbols "
+            "(symbol/mapping_source[naver_code|candidate|ner]/confidence/is_primary) "
+            "plus title/url/as_of and an honest data_state (fresh|stale|unavailable). "
+            "Use for symbol-level news evidence; empty mapping returns unavailable, not error."
+        ),
+    )
+    async def get_symbol_news_mapping(
+        symbol: str,
+        market: str = "kr",
+        hours: int = 24,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        from app.mcp_server.tooling.news_symbol_mapping import (
+            handle_get_symbol_news_mapping,
+        )
+
+        return await handle_get_symbol_news_mapping(
+            symbol=symbol, market=market, hours=hours, limit=limit
+        )
+```
+
+In `app/mcp_server/__init__.py`, add `"get_symbol_news_mapping"` to the `AVAILABLE_TOOL_NAMES` list, immediately after the `"get_news"` entry (line 24):
+
+```python
+    "get_news",
+    "get_symbol_news_mapping",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mcp_news_symbol_mapping_tool.py -v`
+Expected: PASS (2 tests). If `test_tool_invokes_handler` patch target mismatches (lazy import), patch `app.mcp_server.tooling.news_handlers`-level reference per the Step 1 note.
+
+- [ ] **Step 5: Run the full slice + lint**
+
+Run: `uv run pytest tests/test_kr_news_symbol_mapping_query.py tests/test_kr_news_symbol_mapping_db_provider.py tests/test_news_symbol_mapping_handler.py tests/test_mcp_news_symbol_mapping_tool.py -v`
+Expected: all PASS.
+Run: `uv run ruff check app/services/kr_news_symbol_mapping/ app/mcp_server/tooling/news_symbol_mapping.py app/mcp_server/tooling/news_handlers.py app/mcp_server/__init__.py tests/test_kr_news_symbol_mapping_db_provider.py tests/test_news_symbol_mapping_handler.py tests/test_mcp_news_symbol_mapping_tool.py`
+Expected: `All checks passed!` (run `ruff format` on the same paths if needed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/news_handlers.py app/mcp_server/__init__.py tests/test_mcp_news_symbol_mapping_tool.py
+git commit -m "feat(ROB-398): register get_symbol_news_mapping MCP tool"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §3 D1 신규 도구 → Task 5 (등록). ✓
+- §3 D2 백킹=get_news_articles_with_fallback → Task 3 (`db_article_provider`). ✓
+- §3 D3 출력 매핑+url, summary best-effort → Task 1 (계약) + Task 4 (formatter). ✓
+- §3 D4 / §7 정직 리포팅 (data_state, unavailable=빈+warning) → Task 4 (`_format_symbol_news_mapping`). ✓
+- §5 related_symbols detached-safe 로딩 → Task 3 (`_load_related_rows` 별도 세션). ✓
+- §6 응답 shape → Task 4. ✓
+- §8 테스트(provider/passthrough/handler/integration/empty) → Tasks 1–5 tests. ✓
+- §9 비범위 (get_market_news/get_news/search_news/collection) → 미접근. ✓ migration 0. ✓
+
+**2. Placeholder scan:** No TBD/TODO. Two verification notes (build_tools discovery in Task 5; remove unused `Any` import in Task 3) are explicit instructions, not placeholders. ✓
+
+**3. Type consistency:** `ArticleView.url`/`MappedArticle.url`/`.summary` (Task 1) consumed by `_article_to_view` (Task 2) and `_format_symbol_news_mapping` (Task 4). `db_article_provider(symbol, market, hours, limit)` positional signature (Task 3) matches `ArticleProvider = Callable[[str,str,int,int], ...]` from query_service. `handle_get_symbol_news_mapping(article_provider=...)` defaults to `db_article_provider` (Task 4) and is invoked by the registered tool (Task 5). `_candidate_rows_from_orm`/`_load_related_rows`/`_article_to_view` names consistent across Tasks 2–3. ✓
+
+**Open verification flags for the implementer (resolve while implementing, do not guess):**
+- `build_tools()` news-tool discovery + the correct patch target for `test_tool_invokes_handler` (lazy import) — Task 5 Step 1 note.
+- Whether constructing `NewsArticle(...)`/`NewsArticleRelatedSymbol(...)` in-memory (no flush) is accepted by the test DB config — if a test plugin auto-flushes, build plain `SimpleNamespace` stand-ins exposing the same attributes instead (the pure mappers only read attributes).
+
+---
+
+## Execution Handoff
+
+Plan complete. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks.
+2. **Inline Execution** — execute tasks in this session with checkpoints.

--- a/docs/superpowers/specs/2026-06-09-rob398-symbol-news-mapping-tool-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob398-symbol-news-mapping-tool-design.md
@@ -1,0 +1,112 @@
+# ROB-398 surface PR1 — `get_symbol_news_mapping` MCP 도구 (설계)
+
+- **Linear**: ROB-398 ([수집] KR market-data collectors …) — surface 슬라이스 1
+- **작성일**: 2026-06-09
+- **상태**: 설계 확정 (구현 전)
+- **선행(완료)**: Slice 1 #1085(news-symbol mapping read-model + 별칭), Slice 2 #1090(kr_market_ranking), Slice 3 #1095(investor_flow) — 전부 머지+배포
+
+## 1. 배경
+
+ROB-398 **데이터 레이어**는 머지+배포됐으나, 사용자향 뉴스 MCP 도구(`get_news`/`get_market_news`/`search_news`)는 여전히 legacy 핸들러라 read-model/매핑이 노출되지 않음 → 이슈가 Done→In Progress로 되돌려짐.
+
+- 실증(2026-06-01 코멘트): 매수/매도 판단을 바꾼 결정적 뉴스 2건이 전부 DB 밖/매핑 안 됨.
+- 핵심 갭: `kr_news_symbol_mapping.query_service.get_symbol_news_mapping()`는 계약이 완비됐으나 ① 기본 `article_provider`가 `_empty_provider`(항상 빈 결과), ② **MCP 도구로 미등록**.
+
+## 2. 목표
+
+심볼 → **매핑된 뉴스**(symbol/mapping_source/confidence/is_primary + url + as_of)를 노출하는 신규 read-only MCP 도구 `get_symbol_news_mapping`. **신규 수집/NER 매핑 로직 0** — DB provider 배선 + 도구 등록 + 소폭 계약 확장(url/summary)만.
+
+## 3. 결정 (locked, 브레인스토밍 Q&A)
+
+- **D1** — 신규 도구 `get_symbol_news_mapping`. 기존 `get_news`/`get_market_news` 미변경(회귀 리스크 최소).
+- **D2** — 백킹 = `llm_news_service.get_news_articles_with_fallback(symbol, market, hours, limit)` (exact→related→alias + dedup, 이미 존재).
+- **D3** — 출력 = **매핑 + url**, summary는 best-effort. `ArticleView`/`MappedArticle`에 url(+summary) additive 추가.
+- **D4** — 정직 리포팅: `data_state ∈ {fresh, stale, unavailable}`. 매핑된 뉴스 없으면 **빈 articles + unavailable + warning**(에러/날조 아님).
+
+## 4. 그라운딩 (코드 앵커, 읽기 전용 참조)
+
+- **query service**: `app/services/kr_news_symbol_mapping/query_service.py::get_symbol_news_mapping(symbol, market="kr", hours=24, limit=20, now=None, ttl_hours=…, article_provider=None)` — `article_provider=None`이면 `_empty_provider`(빈 결과). `ArticleProvider = Callable[[symbol, market, hours, limit], Awaitable[Sequence[ArticleView]]]`.
+- **contract**: `app/services/kr_news_symbol_mapping/contract.py`
+  - `ArticleView(market, stock_symbol, related_rows: tuple[CandidateRow, ...], title, summary, keywords, as_of)`
+  - `SymbolNewsMapping(symbol, market, articles: tuple[MappedArticle, ...], freshness: Freshness)`
+  - `MappedArticle(as_of, title, mapped_symbols: tuple[MappedSymbol, ...])`
+  - `MappedSymbol(symbol, market, mapping_source, confidence, is_primary, matched_term)`
+  - `Freshness(overall: "fresh"|"stale"|"unavailable", latest_as_of, …)`
+- **backing**: `app/services/llm_news_service.py::get_news_articles_with_fallback(...) -> NewsLookupResult(articles: list[NewsArticle], match_reasons)`. `NewsArticle`은 `related_symbols`(→`NewsArticleRelatedSymbol{article_id, market, symbol, source, matched_term, score, rank, display_name, raw}`) 관계 + `url`/`title`/`summary`/`keywords`/`article_published_at`/`scraped_at` 보유.
+- **등록 패턴**: `app/mcp_server/tooling/news_handlers.py::_register_news_tools_impl` (+ `NEWS_TOOL_NAMES`). `get_market_news`/`get_market_issues`가 여기서 등록됨. 신규 도구는 뉴스 도구 옆에 등록 + `NEWS_TOOL_NAMES` + AVAILABLE 등록 set에 추가.
+
+## 5. 아키텍처 (3 컴포넌트, 각 단일 책임)
+
+**(1) DB ArticleProvider** (신규): `build_db_article_provider(session) -> ArticleProvider`. 반환 클로저 `(symbol, market, hours, limit)`:
+- `get_news_articles_with_fallback(symbol, market, hours, limit)` 호출 → `NewsLookupResult`.
+- 각 `NewsArticle` → `ArticleView`: `related_rows`=각 기사의 `NewsArticleRelatedSymbol`→`CandidateRow` 매핑, `url`=`article.url`, `as_of`=`article.article_published_at or article.scraped_at`, `title`/`summary`/`keywords` 전달.
+- ⚠️ **related_symbols 로딩**: `article.related_symbols` 관계를 세션 밖에서 접근하면 `DetachedInstanceError`. 따라서 provider는 세션 내에서 **확정 로드**해야 함 — `selectinload(NewsArticle.related_symbols)`로 eager-load 하거나, 반환된 article_id 묶음으로 `NewsArticleRelatedSymbol`을 핸들러 세션에서 명시 조회. (구체 방식은 플랜에서 확정.)
+
+**(2) MCP 핸들러** (신규 `app/mcp_server/tooling/fundamentals/_symbol_news_mapping.py`): `handle_get_symbol_news_mapping(symbol, market="kr", hours=24, limit=20)`:
+- 세션 획득(`AsyncSessionLocal`, screener_snapshot_tool 패턴) → `build_db_article_provider(session)` → `get_symbol_news_mapping(symbol, market, hours, limit, article_provider=provider)` → `SymbolNewsMapping` → 응답 dict 포맷(§6).
+
+**(3) 등록**: `news_handlers.py`(또는 fundamentals)에서 `get_symbol_news_mapping` 등록 + `NEWS_TOOL_NAMES`/AVAILABLE set 추가.
+
+**계약 확장 (additive, default None → 하위호환, migration 0)**:
+- `ArticleView.url: str | None = None`
+- `MappedArticle.url: str | None = None`, `MappedArticle.summary: str | None = None`
+- `query_service`가 `MappedArticle` 생성 시 `url=view.url, summary=view.summary` 전달.
+
+## 6. 응답 shape
+
+```json
+{
+  "symbol": "035420",
+  "market": "kr",
+  "data_state": "fresh",
+  "latest_as_of": "2026-06-09T01:23:00+09:00",
+  "articles": [
+    {
+      "title": "네이버클라우드, 젠슨황 GTC 언급",
+      "url": "https://n.news.naver.com/...",
+      "summary": null,
+      "as_of": "2026-06-09T01:23:00+09:00",
+      "mapped_symbols": [
+        {"symbol": "035420", "market": "kr", "mapping_source": "naver_code",
+         "confidence": 1.0, "is_primary": true, "matched_term": null}
+      ]
+    }
+  ],
+  "warnings": []
+}
+```
+
+## 7. 정직 리포팅
+
+- `data_state` = `freshness.overall`. `stale`/`unavailable`일 때 한글 warning 추가.
+- 매핑된 뉴스 0건 → `articles: []` + `data_state="unavailable"` + warning("해당 종목에 매핑된 뉴스가 없습니다 …"). **에러 아님, 빈 행 위조 아님.**
+- `confidence`/`is_primary`/`mapping_source`는 read-model에서 파생(naver_code=primary/고신뢰, candidate/ner=낮음). 추정/날조 금지. summary는 없으면 null(KR Naver upstream 한계 정직 노출).
+
+## 8. 테스트 (read-only, migration 0)
+
+- **provider 매핑(단위)**: `NewsArticle`(related_symbols + url + published_at) → `ArticleView`(related_rows/url/as_of). 페이크/픽스처로 `get_news_articles_with_fallback` 주입.
+- **계약 passthrough(단위)**: url/summary 있는 `ArticleView` → `get_symbol_news_mapping`이 `MappedArticle.url`/`.summary` 전파.
+- **핸들러 응답 shape(단위)**: 주입 provider로 mapped_symbols/data_state/url/summary 필드 검증.
+- **통합(db_session)**: `NewsArticle` + `NewsArticleRelatedSymbol` seed → 도구가 confidence/primary 포함 매핑 + url 반환.
+- **empty→unavailable(단위/통합)**: 빈 articles + data_state=unavailable + warning, 에러 없음.
+
+## 9. 비범위 (별도 슬라이스/이슈)
+
+- **get_market_news symbol enrich** — 다음 슬라이스.
+- **get_news KR dedup/timestamp/summary** — dedup만 싸고 timestamp·summary는 Naver 리스트 소스가 date-only+본문 없음(upstream 한계, 더 풍부한 소스 필요) → 별도.
+- **search_news 등록 위치 확인** — Explore가 NEWS_TOOL_NAMES에서 못 찾았으나 operator는 실행됨(등록이 다른 곳) → 별도 확인.
+- **paper_001 MCP 재시작/승격** — operator 작업.
+- 신규 데이터 수집/NER 변경 0. **migration 0**. broker/order/watch/order-intent mutation 0.
+
+## 10. Acceptance criteria
+
+- [ ] `get_symbol_news_mapping` MCP 도구 등록(AVAILABLE_TOOL_NAMES 포함, 스키마: symbol/market/hours/limit).
+- [ ] symbol에 매핑된 뉴스가 있으면 `mapped_symbols`(symbol/mapping_source/confidence/is_primary/matched_term) + title + url + as_of 반환, `data_state ∈ {fresh, stale}`.
+- [ ] 매핑 없으면 `articles: []` + `data_state="unavailable"` + warning (에러/날조 아님).
+- [ ] DB provider가 `get_news_articles_with_fallback` 기반(exact→related→alias+dedup).
+- [ ] `ArticleView.url` + `MappedArticle.url`/`.summary` additive(default None, 기존 테스트 무영향).
+- [ ] migration 0, broker/order/watch mutation 0. 단위 + 통합 테스트 green, ruff clean.
+
+## 11. 안전 경계
+
+read-only. DB write/backfill 없음(조회만). scheduler/cron 무접근. broker/order/watch/order-intent 무접근. 기존 매핑 로직(query_service) 재사용 — 신규 NER/매핑 휴리스틱 도입 없음.

--- a/tests/test_kr_news_symbol_mapping_db_provider.py
+++ b/tests/test_kr_news_symbol_mapping_db_provider.py
@@ -84,3 +84,62 @@ def test_article_to_view_as_of_falls_back_to_scraped_at():
     view = dbp._article_to_view(article, ())
     assert view.as_of == NOW  # published_at None -> scraped_at
     assert view.keywords == ()  # None -> ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_db_article_provider_builds_views(monkeypatch):
+    from app.services.llm_news_service import NewsLookupResult
+
+    a1 = NewsArticle(
+        id=1,
+        market="kr",
+        url="https://x/1",
+        title="삼성",
+        summary=None,
+        keywords=["반도체"],
+        stock_symbol="005930",
+        article_published_at=NOW,
+        scraped_at=NOW,
+    )
+    a2 = NewsArticle(
+        id=2,
+        market="kr",
+        url="https://x/2",
+        title="네이버",
+        summary="리드",
+        keywords=None,
+        stock_symbol=None,
+        article_published_at=None,
+        scraped_at=NOW,
+    )
+
+    async def fake_fallback(*, symbol, market, hours, limit):
+        return NewsLookupResult(articles=[a1, a2], match_reasons={})
+
+    async def fake_load_related(article_ids):
+        assert set(article_ids) == {1, 2}
+        return {2: (CandidateRow(symbol="035420", source="naver_code"),)}
+
+    monkeypatch.setattr(dbp, "get_news_articles_with_fallback", fake_fallback)
+    monkeypatch.setattr(dbp, "_load_related_rows", fake_load_related)
+
+    views = await dbp.db_article_provider("005930", "kr", 24, 20)
+    assert [v.url for v in views] == ["https://x/1", "https://x/2"]
+    assert views[0].related_rows == ()  # a1 had no related rows
+    assert views[1].related_rows == (
+        CandidateRow(symbol="035420", source="naver_code"),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_db_article_provider_empty_when_no_articles(monkeypatch):
+    from app.services.llm_news_service import NewsLookupResult
+
+    async def fake_fallback(*, symbol, market, hours, limit):
+        return NewsLookupResult(articles=[], match_reasons={})
+
+    monkeypatch.setattr(dbp, "get_news_articles_with_fallback", fake_fallback)
+    views = await dbp.db_article_provider("999999", "kr", 24, 20)
+    assert views == []

--- a/tests/test_kr_news_symbol_mapping_db_provider.py
+++ b/tests/test_kr_news_symbol_mapping_db_provider.py
@@ -1,0 +1,86 @@
+# tests/test_kr_news_symbol_mapping_db_provider.py
+from datetime import UTC, datetime
+
+import pytest
+
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.services.kr_news_symbol_mapping import db_provider as dbp
+from app.services.kr_news_symbol_mapping.contract import CandidateRow
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_candidate_rows_from_orm_maps_fields():
+    rows = [
+        NewsArticleRelatedSymbol(
+            article_id=1,
+            market="kr",
+            symbol="035420",
+            source="naver_code",
+            matched_term=None,
+            score=None,
+            rank=1,
+        ),
+        NewsArticleRelatedSymbol(
+            article_id=1,
+            market="kr",
+            symbol="000660",
+            source="ner",
+            matched_term="닉스",
+            score=0.5,
+            rank=2,
+        ),
+    ]
+    out = dbp._candidate_rows_from_orm(rows)
+    assert out == (
+        CandidateRow(
+            symbol="035420", source="naver_code", score=None, rank=1, matched_term=None
+        ),
+        CandidateRow(
+            symbol="000660", source="ner", score=0.5, rank=2, matched_term="닉스"
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_article_to_view_maps_fields_and_url():
+    article = NewsArticle(
+        id=7,
+        market="kr",
+        url="https://n.news.naver.com/a/1",
+        title="네이버 GTC 언급",
+        summary="리드",
+        keywords=["AI"],
+        stock_symbol="035420",
+        article_published_at=NOW,
+        scraped_at=NOW,
+    )
+    related = (CandidateRow(symbol="035420", source="naver_code"),)
+    view = dbp._article_to_view(article, related)
+    assert view.market == "kr"
+    assert view.stock_symbol == "035420"
+    assert view.related_rows == related
+    assert view.title == "네이버 GTC 언급"
+    assert view.summary == "리드"
+    assert view.keywords == ("AI",)
+    assert view.as_of == NOW
+    assert view.url == "https://n.news.naver.com/a/1"
+
+
+@pytest.mark.unit
+def test_article_to_view_as_of_falls_back_to_scraped_at():
+    article = NewsArticle(
+        id=8,
+        market="kr",
+        url="https://x/2",
+        title="t",
+        summary=None,
+        keywords=None,
+        stock_symbol=None,
+        article_published_at=None,
+        scraped_at=NOW,
+    )
+    view = dbp._article_to_view(article, ())
+    assert view.as_of == NOW  # published_at None -> scraped_at
+    assert view.keywords == ()  # None -> ()

--- a/tests/test_kr_news_symbol_mapping_query.py
+++ b/tests/test_kr_news_symbol_mapping_query.py
@@ -89,3 +89,28 @@ async def test_candidate_row_article_maps_target():
     m = result.articles[0].mapped_symbols[0]
     assert m.mapping_source == "candidate"
     assert m.confidence == 0.8
+
+
+@pytest.mark.asyncio
+async def test_url_and_summary_passthrough_to_mapped_article():
+    async def provider(symbol, market, hours, limit):
+        return [
+            ArticleView(
+                market="kr",
+                stock_symbol="005930",
+                related_rows=(),
+                title="삼성전자 신규 투자",
+                summary="리드 문장",
+                keywords=(),
+                as_of=NOW,
+                url="https://n.news.naver.com/article/001/000",
+            )
+        ]
+
+    result = await get_symbol_news_mapping(
+        "005930", market="kr", now=NOW, article_provider=provider
+    )
+    assert len(result.articles) == 1
+    art = result.articles[0]
+    assert art.url == "https://n.news.naver.com/article/001/000"
+    assert art.summary == "리드 문장"

--- a/tests/test_mcp_news_symbol_mapping_tool.py
+++ b/tests/test_mcp_news_symbol_mapping_tool.py
@@ -1,0 +1,40 @@
+# tests/test_mcp_news_symbol_mapping_tool.py
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.mcp_server import AVAILABLE_TOOL_NAMES
+from app.mcp_server.tooling.news_handlers import NEWS_TOOL_NAMES
+from tests._mcp_tooling_support import build_tools
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_tool_registered():
+    assert "get_symbol_news_mapping" in NEWS_TOOL_NAMES
+    assert "get_symbol_news_mapping" in AVAILABLE_TOOL_NAMES
+    tools = build_tools()
+    assert "get_symbol_news_mapping" in tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_tool_invokes_handler():
+    tools = build_tools()
+    fake_resp = {
+        "symbol": "035420",
+        "market": "kr",
+        "data_state": "fresh",
+        "latest_as_of": None,
+        "articles": [],
+        "warnings": [],
+    }
+    with patch(
+        "app.mcp_server.tooling.news_symbol_mapping.handle_get_symbol_news_mapping",
+        new=AsyncMock(return_value=fake_resp),
+    ) as mock_handle:
+        result = await tools["get_symbol_news_mapping"](symbol="035420", market="kr")
+    assert result["symbol"] == "035420"
+    mock_handle.assert_awaited_once()

--- a/tests/test_news_symbol_mapping_handler.py
+++ b/tests/test_news_symbol_mapping_handler.py
@@ -1,0 +1,56 @@
+# tests/test_news_symbol_mapping_handler.py
+from datetime import UTC, datetime
+
+import pytest
+
+from app.mcp_server.tooling import news_symbol_mapping as nsm
+from app.services.kr_news_symbol_mapping.contract import ArticleView
+
+NOW = datetime(2026, 6, 9, 3, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_handler_returns_mapped_symbols_and_url():
+    async def provider(symbol, market, hours, limit):
+        return [
+            ArticleView(
+                market="kr",
+                stock_symbol="035420",
+                related_rows=(),
+                title="네이버 GTC",
+                summary="리드",
+                keywords=(),
+                as_of=NOW,
+                url="https://n.news.naver.com/a/1",
+            )
+        ]
+
+    resp = await nsm.handle_get_symbol_news_mapping(
+        symbol="035420", market="kr", now=NOW, article_provider=provider
+    )
+    assert resp["symbol"] == "035420"
+    assert resp["market"] == "kr"
+    assert resp["data_state"] == "fresh"
+    assert len(resp["articles"]) == 1
+    art = resp["articles"][0]
+    assert art["url"] == "https://n.news.naver.com/a/1"
+    assert art["summary"] == "리드"
+    assert art["mapped_symbols"][0]["symbol"] == "035420"
+    assert art["mapped_symbols"][0]["mapping_source"] == "naver_code"
+    assert art["mapped_symbols"][0]["is_primary"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_handler_unavailable_is_honest_not_error():
+    async def empty_provider(symbol, market, hours, limit):
+        return []
+
+    resp = await nsm.handle_get_symbol_news_mapping(
+        symbol="999999", market="kr", now=NOW, article_provider=empty_provider
+    )
+    assert resp["data_state"] == "unavailable"
+    assert resp["articles"] == []
+    assert any("매핑된 뉴스가 없" in w for w in resp["warnings"])
+    assert "error" not in resp


### PR DESCRIPTION
## 요약

ROB-398 데이터 레이어(Slices 1-3: news-symbol mapping read-model 등)는 머지+배포됐으나 사용자향 MCP 뉴스 도구가 legacy 핸들러라 매핑이 미노출 → 이슈가 Done에서 In Progress로 되돌려짐. 본 PR은 그 read-model을 신규 read-only MCP 도구 **`get_symbol_news_mapping`** 으로 노출합니다 (surface 슬라이스 1).

## 배경

- 실증(이슈 코멘트, 2026-06-01): 매수/매도 판단을 바꾼 결정적 뉴스가 전부 DB 밖/매핑 안 됨.
- 갭: `kr_news_symbol_mapping.query_service.get_symbol_news_mapping()`는 계약이 완비됐으나 ① 기본 `article_provider`가 `_empty_provider`(빈 결과), ② MCP 미등록.

## 변경

- **신규 `get_symbol_news_mapping` MCP 도구**: 심볼 → 매핑된 뉴스 `mapped_symbols{symbol, mapping_source[naver_code|candidate|ner], confidence, is_primary, matched_term}` + `title`/`url`/`as_of` + 정직한 `data_state`(fresh/stale/unavailable).
- **DB `ArticleProvider`** (`db_article_provider`): `get_news_articles_with_fallback`(exact→related→alias + dedup) 재사용. ⚠️ fallback이 self-acquire 세션이라 반환 article이 **detached** → `article.related_symbols` lazy-load 불가 → **article_id로 `NewsArticleRelatedSymbol` 별도 세션 조회**(DetachedInstanceError 회피).
- **계약 additive 확장**: `ArticleView.url`, `MappedArticle.url`/`.summary` (default None → 하위호환).
- **등록**: `NEWS_TOOL_NAMES` + `AVAILABLE_TOOL_NAMES`.

## 정직성

- 매핑 0건 → 빈 `articles` + `data_state="unavailable"` + warning (에러/날조 아님). `confidence`/`is_primary`/`mapping_source`는 read-model에서 파생.

## 테스트

- 신규 13개(계약 passthrough / 순수 매퍼 / `db_article_provider` / 핸들러 / 등록). 신규 수집·NER 변경 0, **migration 0**, read-only, broker/order/watch/order-intent mutation 0.
- 회귀: news+mcp 스윕 677 + tool-surface 파일 175 전부 green (tool-surface 어서션은 전부 membership이라 신규 도구 무영향).

## 비범위 (후속 슬라이스/이슈)

- `get_market_news` symbol enrich(다음 슬라이스), `get_news` KR dedup/timestamp/summary(timestamp·summary는 Naver upstream 한계), `search_news` 등록 위치 확인, paper_001 operator restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
