### PR TITLE
fix(ROB-454): delta_get levels_delta를 리포트 포지션 범위로 한정 (stale 저널 오탐 제거)

### DIFF
--- a/app/services/investment_reports/delta_service.py
+++ b/app/services/investment_reports/delta_service.py
@@ -10,11 +10,59 @@ from __future__ import annotations
 
 import logging
 import math
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
 logger = logging.getLogger(__name__)
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+def _created_at_sort_key(raw: Any) -> tuple[bool, datetime]:
+    """Sortable key for a journal entry's ``created_at`` isoformat string.
+
+    Returns ``(True, aware_datetime)`` when parseable; ``(False, _EPOCH)`` when
+    missing/unparseable so dated journals always rank above undated ones and two
+    undated entries compare equal (stable, keeps the first seen).
+    """
+    if not raw or not isinstance(raw, str):
+        return (False, _EPOCH)
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return (False, _EPOCH)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return (True, parsed)
+
+
+def _scope_from_items(items: Iterable[Any]) -> dict[str, set[str] | None]:
+    """Build the report's levels scope: ``{symbol: {sides} | None}``.
+
+    ``None`` means "any side" — used when any item for that symbol has a NULL
+    side (watch/risk items, or legacy action rows). A symbol with only
+    side-bearing items maps to the union of those sides. Symbols without a
+    symbol value are skipped. (ROB-454)
+    """
+    scope: dict[str, set[str] | None] = {}
+    for item in items:
+        symbol = getattr(item, "symbol", None)
+        if not symbol:
+            continue
+        side = getattr(item, "side", None)
+        if symbol not in scope:
+            scope[symbol] = None if side is None else {side}
+            continue
+        current = scope[symbol]
+        if current is None:
+            continue  # already "any side"
+        if side is None:
+            scope[symbol] = None  # widen to "any side"
+        else:
+            current.add(side)
+    return scope
 
 
 def _is_finite_number(value: Any) -> bool:
@@ -34,22 +82,59 @@ def _near(current: Any, level: Any, near_pct: float) -> bool:
 
 def _levels_delta(
     journal_result: Mapping[str, Any],
-    symbols: set[str],
+    scope: Mapping[str, set[str] | None],
     *,
     near_pct: float,
+    baseline_created_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Project the journal's already-computed live enrichment into a delta block.
 
     Reuses ``target_reached`` / ``stop_reached`` / ``pnl_pct_live`` (computed by
     ``get_trade_journal(enrich_live=True)``); computes per-entry ``near_*`` flags
-    here. When ``symbols`` is empty, all entries are kept.
+    here.
+
+    ROB-454 scoping — there is no item↔journal link, so the report's position is
+    approximated:
+
+    * In-scope: a journal entry's ``symbol`` must be a ``scope`` key AND
+      (``scope[symbol]`` is ``None`` ⇒ any side, else the entry's ``side`` must be
+      in that set). An empty ``scope`` keeps every symbol (no filter).
+    * Stale cutoff: when ``baseline_created_at`` is given, journals created
+      strictly before it are dropped — they predate this baseline report and
+      belong to pre-existing positions, not to this report's delta. Entries with
+      a missing/unparseable ``created_at`` are kept (fail-open; never fabricate an
+      exclusion).
+    * Dedup: when multiple in-scope journals share a ``(symbol, side)``, only the
+      most-recent (by ``created_at``) is counted, so a stale duplicate does not
+      inflate ``stop_hit`` / ``target_hit``.
     """
-    entries: list[dict[str, Any]] = []
-    near_target = near_stop = target_hit = stop_hit = 0
+    selected: dict[tuple[Any, Any], dict[str, Any]] = {}
     for entry in journal_result.get("entries") or []:
         symbol = entry.get("symbol")
-        if symbols and symbol not in symbols:
-            continue
+        side = entry.get("side")
+        if scope:
+            if symbol not in scope:
+                continue
+            allowed = scope[symbol]
+            if allowed is not None and side not in allowed:
+                continue
+        created_key = _created_at_sort_key(entry.get("created_at"))
+        if baseline_created_at is not None and created_key[0]:
+            if created_key[1] < baseline_created_at:
+                continue  # predates the baseline report — stale (ROB-454)
+        key = (symbol, side)
+        incumbent = selected.get(key)
+        if incumbent is None or created_key > _created_at_sort_key(
+            incumbent.get("created_at")
+        ):
+            selected[key] = entry
+
+    entries: list[dict[str, Any]] = []
+    near_target = near_stop = target_hit = stop_hit = 0
+    for entry in sorted(
+        selected.values(),
+        key=lambda e: ((e.get("symbol") or ""), (e.get("side") or "")),
+    ):
         current = entry.get("current_price")
         target = entry.get("target_price")
         stop = entry.get("stop_loss")
@@ -63,8 +148,10 @@ def _levels_delta(
         stop_hit += int(is_stop_reached)
         entries.append(
             {
-                "symbol": symbol,
+                "symbol": entry.get("symbol"),
                 "side": entry.get("side"),
+                "journal_id": entry.get("id"),
+                "created_at": entry.get("created_at"),
                 "target_price": target,
                 "stop_loss": stop,
                 "current_price": current,
@@ -246,7 +333,11 @@ class DeltaService:
             return {"success": False, "error": "baseline_not_found"}
 
         market = baseline["market"]
-        symbols = baseline["symbols"]
+        scope = baseline.get("scope")
+        if scope is None:
+            # Back-compat: derive an any-side scope from a plain symbols set.
+            scope = dict.fromkeys(baseline.get("symbols") or set())
+        baseline_created_at = baseline.get("baseline_created_at")
         market_snapshot = baseline["market_snapshot"]
         baseline_pnl = baseline["baseline_pnl"]
         unavailable: dict[str, str] = {}
@@ -255,7 +346,12 @@ class DeltaService:
         try:
             journal_fn = self._journal_fn or _default_journal_fn
             journal_result = await journal_fn(account_type=account_type, market=market)
-            levels_delta = _levels_delta(journal_result, symbols, near_pct=near_pct)
+            levels_delta = _levels_delta(
+                journal_result,
+                scope,
+                near_pct=near_pct,
+                baseline_created_at=baseline_created_at,
+            )
         except Exception as exc:  # noqa: BLE001 — fail-open per signal
             logger.info("levels_delta failed: %r", exc)
             unavailable["levels"] = _reason(exc)
@@ -314,11 +410,7 @@ class DeltaService:
         if bundle is None:
             return None
         report = bundle["report"]
-        symbols = {
-            item.symbol
-            for item in (bundle.get("items") or [])
-            if getattr(item, "symbol", None)
-        }
+        scope = _scope_from_items(bundle.get("items") or [])
         baseline_pnl: dict[str, float] | None = None
         bundle_uuid = getattr(report, "snapshot_bundle_uuid", None)
         if bundle_uuid is not None:
@@ -331,7 +423,9 @@ class DeltaService:
                 baseline_pnl = _baseline_pnl_from_bundle_pairs(pairs)
         return {
             "market": report.market,
-            "symbols": symbols,
+            "symbols": set(scope),
+            "scope": scope,
+            "baseline_created_at": getattr(report, "created_at", None),
             "market_snapshot": report.market_snapshot or {},
             "baseline_pnl": baseline_pnl,
         }

--- a/tests/services/investment_reports/test_delta_service.py
+++ b/tests/services/investment_reports/test_delta_service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import types
+from datetime import UTC, datetime
 
 import pytest
 
@@ -50,7 +51,7 @@ def test_levels_delta_filters_to_symbols_and_projects_flags():
             },
         ]
     }
-    out = _levels_delta(journal, {"AAPL", "MSFT"}, near_pct=1.0)
+    out = _levels_delta(journal, {"AAPL": None, "MSFT": None}, near_pct=1.0)
     syms = [e["symbol"] for e in out["entries"]]
     assert syms == ["AAPL", "MSFT"]  # ZZZZ filtered out
     aapl = out["entries"][0]
@@ -83,9 +84,113 @@ def test_levels_delta_empty_symbols_keeps_all_entries():
             },
         ]
     }
-    out = _levels_delta(journal, set(), near_pct=1.0)
+    out = _levels_delta(journal, {}, near_pct=1.0)
     assert [e["symbol"] for e in out["entries"]] == ["AAPL"]
     assert out["entries"][0]["near_target"] is False  # no target -> not near
+
+
+def test_levels_delta_drops_journals_created_before_baseline():
+    # ROB-454 repro: the report's planned tranche has NO journal yet; the only
+    # journal for the symbol is a STALE pre-report position (breached). It must
+    # NOT contribute a stop_hit to this report's delta.
+    baseline = datetime(2026, 6, 8, 9, 0, tzinfo=UTC)
+    journal = {
+        "entries": [
+            {
+                "id": 35,
+                "symbol": "196170",
+                "side": "buy",
+                "target_price": 400000.0,
+                "stop_loss": 353500.0,
+                "current_price": 289500.0,
+                "pnl_pct_live": -18.0,
+                "target_reached": False,
+                "stop_reached": True,
+                "created_at": "2026-05-20T10:00:00+00:00",  # before baseline
+            },
+        ]
+    }
+    out = _levels_delta(
+        journal, {"196170": {"buy"}}, near_pct=1.0, baseline_created_at=baseline
+    )
+    assert out["entries"] == []
+    assert out["summary"]["stop_hit"] == 0
+
+
+def test_levels_delta_keeps_post_report_and_dedups_to_most_recent():
+    # Two post-baseline journals for the same (symbol, side): only the most
+    # recent one is counted, so an older breached duplicate does not inflate.
+    baseline = datetime(2026, 6, 8, 0, 0, tzinfo=UTC)
+    journal = {
+        "entries": [
+            {
+                "id": 50,  # newest, not breached
+                "symbol": "196170",
+                "side": "buy",
+                "target_price": 300000.0,
+                "stop_loss": 256500.0,
+                "current_price": 289500.0,
+                "pnl_pct_live": 2.0,
+                "target_reached": False,
+                "stop_reached": False,
+                "created_at": "2026-06-08T12:00:00+00:00",
+            },
+            {
+                "id": 48,  # older duplicate, breached -> must be dropped
+                "symbol": "196170",
+                "side": "buy",
+                "target_price": 300000.0,
+                "stop_loss": 300000.0,
+                "current_price": 289500.0,
+                "pnl_pct_live": -3.0,
+                "target_reached": False,
+                "stop_reached": True,
+                "created_at": "2026-06-08T09:00:00+00:00",
+            },
+        ]
+    }
+    out = _levels_delta(
+        journal, {"196170": {"buy"}}, near_pct=1.0, baseline_created_at=baseline
+    )
+    assert [e["journal_id"] for e in out["entries"]] == [50]
+    assert out["summary"]["stop_hit"] == 0
+
+
+def test_levels_delta_side_scope_excludes_opposite_and_null_allows_any():
+    journal = {
+        "entries": [
+            {
+                "id": 1,
+                "symbol": "AAPL",
+                "side": "buy",
+                "target_price": 230.0,
+                "stop_loss": 200.0,
+                "current_price": 231.0,
+                "pnl_pct_live": 4.0,
+                "target_reached": True,
+                "stop_reached": False,
+                "created_at": None,
+            },
+            {
+                "id": 2,
+                "symbol": "AAPL",
+                "side": "sell",
+                "target_price": 150.0,
+                "stop_loss": 260.0,
+                "current_price": 259.0,
+                "pnl_pct_live": 1.0,
+                "target_reached": False,
+                "stop_reached": False,
+                "created_at": None,
+            },
+        ]
+    }
+    # scope restricts AAPL to buy -> the sell journal is excluded
+    out = _levels_delta(journal, {"AAPL": {"buy"}}, near_pct=1.0)
+    assert {e["journal_id"] for e in out["entries"]} == {1}
+    # scope None (item had side=NULL) keeps any side, one entry per side
+    out_any = _levels_delta(journal, {"AAPL": None}, near_pct=1.0)
+    assert {e["journal_id"] for e in out_any["entries"]} == {1, 2}
 
 
 def _snap(kind, payload):
@@ -175,11 +280,20 @@ def test_index_delta_change_pct_and_null_guards():
 
 
 def _baseline(
-    *, market="us", symbols=None, market_snapshot=None, baseline_pnl="default"
+    *,
+    market="us",
+    symbols=None,
+    scope=None,
+    baseline_created_at=None,
+    market_snapshot=None,
+    baseline_pnl="default",
 ):
+    syms = symbols if symbols is not None else {"AAPL"}
     return {
         "market": market,
-        "symbols": symbols if symbols is not None else {"AAPL"},
+        "symbols": syms,
+        "scope": scope if scope is not None else dict.fromkeys(syms),
+        "baseline_created_at": baseline_created_at,
         "market_snapshot": market_snapshot
         if market_snapshot is not None
         else {"baseline": {"indices": {"^GSPC": {"current": 5500.0}}}},


### PR DESCRIPTION
## 요약
`investment_report_delta_get`의 `levels_delta`가 **리포트 item 범위가 아니라 심볼로 모든 active trade journal을 매칭**해, 그 리포트와 무관한 옛(stale) 저널의 target/stop touch까지 델타에 섞이던 버그(ROB-454)를 수정합니다. 주기 재분석 루프([ROB-453](https://linear.app/mgh3326/issue/ROB-453))의 무관한 stop-breach 오탐 제거.

## 재현 (live 2026-06-08)
`delta_get("16f3b03e…")`(KR 검은월요일 매수 리포트, 알테오젠 신규 stop=256,500)이 `summary.stop_hit: 2`를 보고하나, 그 2건은 리포트 item이 아니라 **5월에 만든 옛 알테오젠 live 저널**(id 35/32, stop 353,500)에서 옴. 리포트의 신규 알테오젠 tranche는 아직 저널이 없어, 같은 심볼(196170)의 stale 저널이 stop_hit를 부풀림.

## 근본 원인
`_levels_delta`가 `if symbols and symbol not in symbols: continue` 로 **심볼 membership만** 필터(`delta_service.py`). `get_trade_journal`은 마켓 전체의 active(draft+active) 저널을 반환하므로 한 심볼에 여러 저널이 있으면 전부 집계됨. item↔journal 구조적 링크는 존재하지 않음(확인됨).

## 수정 — 정직한 근사로 스코프 한정
구조적 링크가 없으므로 다음 3단계로 리포트 포지션을 근사:
1. **(symbol, side) 스코프** — 리포트 item의 symbol+side로 필터. `item.side`가 NULL(watch/risk·legacy action)이면 symbol-only fallback("any side")로 **under-count 회피**.
2. **stale cutoff** — baseline 리포트의 `created_at` **이전** 생성 저널 제외. 이전부터 보유한 포지션의 상태는 리포트 작성 시 이미 알려진 것이므로 "이 baseline 이후의 touch"라는 델타 의미와 일치. `created_at` 없으면 fail-open(제외하지 않음 — 배제를 날조하지 않음).
3. **most-recent dedup** — 같은 (symbol, side)에 저널이 여럿이면 최신 1건만 집계.

`created_at` 비교 불가/없음은 fail-open. projected entry에 `journal_id`/`created_at` 추가(어느 저널이 선택됐는지 투명).

### 설계 트레이드오프
기존 포지션을 **재평가**하는 리포트의 경우 그 포지션의 pre-report 저널도 cutoff에 의해 제외됩니다. 이는 의도된 동작 — 델타는 "이 baseline 리포트 **이후**의 레벨 touch"를 의미하고, 기존 포지션 상태는 리포트 작성 시 이미 반영됨. item↔journal 링크가 없어 "무관한 stale 포지션"과 "이 리포트가 다루는 기존 포지션"을 더 정밀히 구분할 수는 없음.

## 계약 변경 (내부)
`compute_delta`/`_default_baseline_loader`의 baseline 계약을 `symbols: set` → `scope: dict[symbol → {sides}|None]` + `baseline_created_at`으로 확장. back-compat: `symbols` set만 있으면 any-side scope로 수용.

## 테스트 (TDD)
- `test_levels_delta_drops_journals_created_before_baseline` — repro: stale pre-report 저널 제외 → stop_hit=0
- `test_levels_delta_keeps_post_report_and_dedups_to_most_recent` — 최신 1건만 집계
- `test_levels_delta_side_scope_excludes_opposite_and_null_allows_any` — side 스코프 + NULL fallback
- 기존 levels/compute_delta/DB 로더 테스트를 새 계약으로 갱신

`tests/services/investment_reports/test_delta_service*.py` + delta MCP/Hermes-intraday 소비자 = 47 green. ruff clean, ty clean. migration 0, broker/order/watch mutation 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)