### PR TITLE
chore(ROB-457): investment_report 도구 description 정정 — account_scope 집합 + 멱등키 7요소

### DIFF
--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -456,6 +456,9 @@ def register_investment_hermes_tools(mcp: FastMCP) -> None:
             "Auto-finalises any matching Hermes stage run "
             "(metadata.investment_stage_run_uuid) from 'running' to "
             "'completed' (§D4). "
+            "Accepts any account_scope (kis_live | kis_mock | alpaca_paper | "
+            "upbit_live) — this is the path for alpaca_paper / paper:<name> "
+            "reports that investment_report_generate_from_bundle rejects. "
             "Gated by SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
         ),
     )(investment_report_create_from_hermes_composition_impl)

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -850,8 +850,15 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         name="investment_report_create",
         description=(
             "Persist one ROB-265 investment_report bundle (report + items). "
-            "Idempotent on (report_type, market, market_session, account_scope, "
-            "execution_mode, kst_date, generator_version). "
+            "Idempotent on the 7-tuple (report_type, market, market_session, "
+            "account_scope, execution_mode, kst_date, generator_version) — "
+            "created_by_profile is NOT part of the key, so to mint a new row bump "
+            "generator_version (recommended) or another keyed field, not "
+            "created_by_profile. "
+            "account_scope accepts kis_live | kis_mock | alpaca_paper | upbit_live "
+            "(alpaca_paper IS accepted here; only "
+            "investment_report_generate_from_bundle restricts to the live "
+            "KIS/Upbit pairs and steers paper to the Hermes composition path). "
             "No broker / order submission is performed."
         ),
     )(investment_report_create_impl)

--- a/tests/mcp_server/test_investment_report_tool_descriptions.py
+++ b/tests/mcp_server/test_investment_report_tool_descriptions.py
@@ -1,0 +1,43 @@
+# tests/mcp_server/test_investment_report_tool_descriptions.py
+"""ROB-457 — tool descriptions state the valid account_scope set accurately.
+
+Guards against the stale operational note that claimed alpaca_paper is rejected
+by the create tools (it is not — only generate_from_bundle restricts to the
+live KIS/Upbit pairs).
+"""
+
+from __future__ import annotations
+
+import app.mcp_server.tooling.investment_hermes_handlers as hermes_handlers
+import app.mcp_server.tooling.investment_reports_handlers as handlers
+
+_VALID_ACCOUNT_SCOPES = ("kis_live", "kis_mock", "alpaca_paper", "upbit_live")
+
+
+def _capture(register) -> dict[str, str]:
+    captured: dict[str, str] = {}
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            captured[name] = description
+            return lambda fn: fn
+
+    register(_FakeMCP())
+    return captured
+
+
+def test_create_description_lists_valid_account_scopes():
+    desc = _capture(handlers.register_investment_report_tools)[
+        "investment_report_create"
+    ]
+    for scope in _VALID_ACCOUNT_SCOPES:
+        assert scope in desc, f"create description must name account_scope {scope!r}"
+
+
+def test_create_from_hermes_description_advertises_alpaca_paper():
+    # generate_from_bundle steers alpaca_paper here; this description should
+    # confirm the path accepts it (and all four scopes).
+    desc = _capture(hermes_handlers.register_investment_hermes_tools)[
+        "investment_report_create_from_hermes_composition"
+    ]
+    assert "alpaca_paper" in desc


### PR DESCRIPTION
## 요약
라이브 감사로 확인된 운영 메모 부정확성 2건을 **코드 사실**에 맞게 도구 description에 명시(ROB-457). 코드 로직 변경 없음, migration 0.

## 정정 1 — alpaca_paper account_scope는 허용됨
- 유효 `account_scope` = `{kis_live, kis_mock, alpaca_paper, upbit_live}` (`schemas/investment_reports.py:40` Literal + DB CHECK `models/investment_reports.py:70-74`).
- `investment_report_create`·`create_from_hermes_composition`은 **alpaca_paper를 받음**(실증: report `86f37cde` = account_scope="alpaca_paper" 정상 생성).
- alpaca_paper를 **거부하는 건** `investment_report_generate_from_bundle` **한 도구뿐**(라이브 KIS/Upbit 3쌍 전용, 페이퍼는 Hermes 경로 안내).
- → `create` description에 유효 scope 집합 + alpaca_paper 수용 명시. `create_from_hermes_composition` description에 "alpaca_paper/paper의 경로"임을 명시(generate_from_bundle가 가리키는 목적지 확인).

## 정정 2 — 멱등키에 created_by_profile 미포함
- 멱등키 7요소 = `report_type:market:market_session:account_scope:execution_mode:kst_date:generator_version` (`idempotency.py:40-62`). **created_by_profile은 키 요소가 아님** → 그것만 바꿔도 새 행이 안 생김.
- → `create` description에 7요소 명시 + "새 행은 generator_version(권장) 등을 바꿔라" 명시(created_by_profile 변경은 새 행 못 만듦).

## 범위 메모
- 이 레포의 `create` description은 이미 멱등 7-tuple을 정확히 명시(created_by_profile 없음)했고, 잘못된 주장을 반복하는 in-repo 텍스트는 없음(감사로 확인). 이 PR은 유효 scope 집합 명시 + created_by_profile 비포함을 명문화하는 **additive 정정**.
- 운영 **CLAUDE.md §2** 문구 정정은 **client repo** 측 작업이라 이 트리 범위 밖.

## 테스트 (TDD)
- `test_create_description_lists_valid_account_scopes` — 4개 scope 전부 명시
- `test_create_from_hermes_description_advertises_alpaca_paper` — Hermes 경로 alpaca_paper 명시
- 기존 hermes "no internal LLM/mutation" description 가드 유지(25 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported account scope values for investment report creation tools, including paper trading accounts and Hermes composition support.
  * Documented idempotency key semantics for report creation operations.

* **Tests**
  * Added validation tests to ensure tool documentation accurately reflects supported account scopes and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->