### PR TITLE
feat(ROB-455 PR1): 리포트 버저닝 first-class — previous_report_uuid 실효화 + status 전이 (migration 0)

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -33,6 +33,7 @@ from app.schemas.investment_reports import (
     InvestmentWatchEventResponse,
     PreviousReportContextResponse,
     RecordDecisionRequest,
+    SetReportStatusRequest,
 )
 from app.services import market_data as market_data_service
 from app.services.investment_reports.decisions import (
@@ -66,6 +67,7 @@ INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
     "investment_report_delta_get",
     "investment_report_generate_from_bundle",
     "investment_watch_recommend",
+    "investment_report_set_status",
 }
 
 # ROB-352 — mirror of the generator's canonical market/account_scope pairs.
@@ -571,6 +573,7 @@ async def investment_report_delta_get_impl(
     report_uuid: str,
     near_pct: float = 1.0,
     account_type: str = "live",
+    use_previous_as_baseline: bool = False,
 ) -> dict:
     from app.core.timezone import now_kst
     from app.services.investment_reports.delta_service import DeltaService
@@ -581,6 +584,15 @@ async def investment_report_delta_get_impl(
         return {"success": False, "error": "invalid_report_uuid"}
 
     async with AsyncSessionLocal() as db:
+        # ROB-455 — make previous_report_uuid load-bearing as the delta baseline:
+        # resolve to the report's predecessor when asked (falls back to the report
+        # itself when the chain link is unset).
+        if use_previous_as_baseline:
+            repo = InvestmentReportsRepository(db)
+            report = await repo.get_report_by_uuid(parsed)
+            if report is not None and report.previous_report_uuid is not None:
+                parsed = report.previous_report_uuid
+
         service = DeltaService(db)
         return await service.compute_delta(
             parsed,
@@ -588,6 +600,50 @@ async def investment_report_delta_get_impl(
             account_type=account_type,
             computed_at_kst=now_kst().isoformat(),
         )
+
+
+# ---------------------------------------------------------------------------
+# investment_report_set_status (ROB-455)
+# ---------------------------------------------------------------------------
+async def investment_report_set_status_impl(
+    report_uuid: str,
+    status: str,
+    reason: str | None = None,
+    actor: str | None = None,
+) -> dict:
+    try:
+        request = SetReportStatusRequest.model_validate(
+            {
+                "report_uuid": report_uuid,
+                "status": status,
+                "reason": reason,
+                "actor": actor,
+            }
+        )
+    except ValidationError as exc:
+        return {"success": False, "error": "invalid_request", "detail": str(exc)}
+
+    async with AsyncSessionLocal() as db:
+        service = InvestmentReportIngestionService(db)
+        report = await service.set_report_status(
+            report_uuid=request.report_uuid,
+            status=request.status,
+            reason=request.reason,
+            actor=request.actor,
+        )
+        if report is None:
+            return {
+                "success": False,
+                "error": "not_found",
+                "report_uuid": str(request.report_uuid),
+            }
+        await db.commit()
+        response = InvestmentReportResponse.model_validate(report)
+    return {
+        "success": True,
+        "status": request.status,
+        **response.model_dump(mode="json", by_alias=True),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -932,6 +988,20 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
             "no order is created or submitted."
         ),
     )(investment_watch_recommend_impl)
+    mcp.tool(
+        name="investment_report_set_status",
+        description=(
+            "ROB-455 — transition a report's lifecycle status to superseded | "
+            "decided | expired (draft/published are entry states set at create, "
+            "not transition targets here). Idempotent: setting the current status "
+            "is a no-op success. Records the transition (reason/actor) in "
+            "report_metadata.status_transitions for traceability. Use this to "
+            "mark a report explicitly superseded instead of relying on a "
+            "created_at heuristic — note that chaining a new report via "
+            "previous_report_uuid already auto-supersedes its predecessor. "
+            "No broker / order / watch mutation."
+        ),
+    )(investment_report_set_status_impl)
 
 
 __all__ = [
@@ -944,6 +1014,7 @@ __all__ = [
     "investment_report_generate_from_bundle_impl",
     "investment_report_get_impl",
     "investment_report_list_impl",
+    "investment_report_set_status_impl",
     "investment_watch_recommend_impl",
     "register_investment_report_tools",
 ]

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -40,6 +40,9 @@ MarketSessionLiteral = Literal["regular", "nxt", "pre", "post", "24x7"]
 AccountScopeLiteral = Literal["kis_live", "kis_mock", "alpaca_paper", "upbit_live"]
 ExecutionModeLiteral = Literal["advisory_only", "mock_preview"]
 ReportStatusLiteral = Literal["draft", "published", "decided", "expired", "superseded"]
+# ROB-455 — the lifecycle targets an operator may transition a report TO. draft /
+# published are entry states (set at create), not transition targets here.
+ReportStatusTransitionLiteral = Literal["superseded", "decided", "expired"]
 
 ItemKindLiteral = Literal["action", "watch", "risk"]
 ItemSideLiteral = Literal["buy", "sell"]
@@ -406,6 +409,15 @@ class RecordDecisionRequest(BaseModel):
                 "partial_approve requires non-empty approved_payload_snapshot"
             )
         return self
+
+
+class SetReportStatusRequest(BaseModel):
+    """ROB-455 — operator request to transition a report's lifecycle status."""
+
+    report_uuid: UUID
+    status: ReportStatusTransitionLiteral
+    reason: str | None = None
+    actor: str | None = None
 
 
 class WatchInvalidation(BaseModel):

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -15,6 +15,7 @@ but never commits).
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -241,6 +242,8 @@ class InvestmentReportIngestionService:
                 await self._insert_item(existing, item_req)
             await self._session.flush()
             await self._session.refresh(existing)
+            # ROB-455 — overwrite that (re)sets a predecessor chain supersedes it.
+            await self._maybe_supersede_previous(request.previous_report_uuid, existing)
             return existing, False, len(request.items)
 
         report = await self._repo.insert_report(
@@ -280,7 +283,72 @@ class InvestmentReportIngestionService:
             await self._insert_item(report, item_req)
 
         await self._session.flush()
+        # ROB-455 — a new report that chains from a predecessor supersedes it.
+        await self._maybe_supersede_previous(request.previous_report_uuid, report)
         return report, False, len(request.items)
+
+    async def set_report_status(
+        self,
+        *,
+        report_uuid: UUID,
+        status: str,
+        reason: str | None = None,
+        actor: str | None = None,
+        superseded_by: UUID | None = None,
+    ) -> InvestmentReport | None:
+        """ROB-455 — transition a report's lifecycle ``status`` first-class.
+
+        Returns the (refreshed) report, or ``None`` when no report matches
+        ``report_uuid`` so the caller can surface ``not_found``. Setting the
+        status it already has is an idempotent no-op. Each transition appends a
+        ``status_transitions`` entry to ``report_metadata`` for traceability;
+        the chosen 'superseded' target also records ``superseded_by``. The DB
+        CHECK is the authoritative gate on which status values are legal.
+        """
+        report = await self._repo.get_report_by_uuid(report_uuid)
+        if report is None:
+            return None
+        if report.status == status:
+            return report
+        metadata = dict(report.report_metadata or {})
+        entry: dict[str, Any] = {"to": status}
+        if reason is not None:
+            entry["reason"] = reason
+        if actor is not None:
+            entry["actor"] = actor
+        if superseded_by is not None:
+            metadata["superseded_by"] = str(superseded_by)
+            entry["superseded_by"] = str(superseded_by)
+        transitions = list(metadata.get("status_transitions") or [])
+        transitions.append(entry)
+        metadata["status_transitions"] = transitions
+        await self._repo.update_report(
+            report.id, status=status, report_metadata=metadata
+        )
+        await self._session.refresh(report)
+        return report
+
+    async def _maybe_supersede_previous(
+        self, previous_report_uuid: UUID | None, new_report: InvestmentReport
+    ) -> None:
+        """ROB-455 — make ``previous_report_uuid`` load-bearing: when a new report
+        chains from a predecessor, mark the predecessor 'superseded'.
+
+        No-op when the link is unset or dangles (a trace hint may not resolve),
+        and only draft/published predecessors are touched — already-terminal
+        (decided/expired/superseded) reports are left as-is.
+        """
+        if previous_report_uuid is None:
+            return
+        predecessor = await self._repo.get_report_by_uuid(previous_report_uuid)
+        if predecessor is None or predecessor.status not in ("draft", "published"):
+            return
+        await self.set_report_status(
+            report_uuid=previous_report_uuid,
+            status="superseded",
+            reason="auto_superseded_by_chain",
+            superseded_by=new_report.report_uuid,
+        )
 
     async def _insert_item(
         self, report: InvestmentReport, item_req: IngestReportItem

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -386,9 +386,7 @@ async def test_set_report_status_transitions_and_is_idempotent(
     assert transitions[-1]["actor"] == "operator"
 
     # Idempotent: setting the same status again is a no-op success.
-    again = await service.set_report_status(
-        report_uuid=a.report_uuid, status="decided"
-    )
+    again = await service.set_report_status(report_uuid=a.report_uuid, status="decided")
     assert again is not None and again.status == "decided"
 
     # Unknown report -> None (caller surfaces not_found).

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -322,3 +324,75 @@ async def test_cited_snapshot_uuids_round_trip(session: AsyncSession) -> None:
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)
     assert items[0].cited_snapshot_uuids == [u1, u2]
+
+
+# ---------------------------------------------------------------------------
+# ROB-455 PR1 — versioning first-class (auto-supersede on chain + set_status)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_chain_supersedes_previous_report(session: AsyncSession) -> None:
+    service = InvestmentReportIngestionService(session)
+    a = await service.ingest(_base_request(kst_date="2026-05-18"))
+    assert a.status == "draft"
+    b = await service.ingest(
+        _base_request(kst_date="2026-05-19", previous_report_uuid=a.report_uuid)
+    )
+    await session.refresh(a)
+    assert a.status == "superseded"
+    assert a.report_metadata.get("superseded_by") == str(b.report_uuid)
+
+
+@pytest.mark.asyncio
+async def test_chain_supersede_noop_when_previous_missing(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportIngestionService(session)
+    # A dangling previous_report_uuid is a trace hint that may not resolve — the
+    # new report must still be created without error.
+    b = await service.ingest(_base_request(previous_report_uuid=uuid.uuid4()))
+    assert b.report_uuid is not None
+
+
+@pytest.mark.asyncio
+async def test_chain_does_not_supersede_terminal_previous(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportIngestionService(session)
+    a = await service.ingest(_base_request(kst_date="2026-05-18"))
+    await service.set_report_status(report_uuid=a.report_uuid, status="expired")
+    await service.ingest(
+        _base_request(kst_date="2026-05-19", previous_report_uuid=a.report_uuid)
+    )
+    await session.refresh(a)
+    assert a.status == "expired"  # only draft/published are auto-superseded
+
+
+@pytest.mark.asyncio
+async def test_set_report_status_transitions_and_is_idempotent(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportIngestionService(session)
+    a = await service.ingest(_base_request())
+    updated = await service.set_report_status(
+        report_uuid=a.report_uuid,
+        status="decided",
+        actor="operator",
+        reason="all items resolved",
+    )
+    assert updated is not None
+    assert updated.status == "decided"
+    transitions = updated.report_metadata.get("status_transitions")
+    assert transitions and transitions[-1]["to"] == "decided"
+    assert transitions[-1]["actor"] == "operator"
+
+    # Idempotent: setting the same status again is a no-op success.
+    again = await service.set_report_status(
+        report_uuid=a.report_uuid, status="decided"
+    )
+    assert again is not None and again.status == "decided"
+
+    # Unknown report -> None (caller surfaces not_found).
+    assert (
+        await service.set_report_status(report_uuid=uuid.uuid4(), status="expired")
+        is None
+    )

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -824,9 +824,7 @@ async def test_delta_get_resolves_previous_report_as_baseline(
     # ROB-455 — when use_previous_as_baseline=True, the delta baseline resolves to
     # the report's previous_report_uuid (the report it chains from).
     a_uuid = await _create_report(kst_date="2026-05-18")
-    b_uuid = await _create_report(
-        kst_date="2026-05-19", previous_report_uuid=a_uuid
-    )
+    b_uuid = await _create_report(kst_date="2026-05-19", previous_report_uuid=a_uuid)
 
     captured: dict[str, str] = {}
 

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -20,9 +20,11 @@ from app.mcp_server.tooling.investment_reports_handlers import (
     investment_report_context_get_impl,
     investment_report_create_impl,
     investment_report_decide_item_impl,
+    investment_report_delta_get_impl,
     investment_report_generate_from_bundle_impl,
     investment_report_get_impl,
     investment_report_list_impl,
+    investment_report_set_status_impl,
     investment_watch_recommend_impl,
 )
 from tests._investment_reports_helpers import future_datetime
@@ -120,6 +122,8 @@ def test_tool_names_match_registered_set() -> None:
         "investment_report_generate_from_bundle",
         "investment_watch_recommend",
         "investment_report_delta_get",
+        # ROB-455 — report status lifecycle transition writer.
+        "investment_report_set_status",
     }
 
 
@@ -764,3 +768,84 @@ async def test_watch_recommend_commit_rejected_on_data_gap(
             symbol="005930", market="kr", item_uuid=item_uuid, commit=True, actor="op"
         )
     assert "data_gap" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# ROB-455 PR1 — set_status tool + previous_report_uuid as delta baseline
+# ---------------------------------------------------------------------------
+async def _create_report(**overrides) -> str:
+    out = await investment_report_create_impl(**_create_kwargs(**overrides))
+    return out["report"]["report_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_set_status_impl_transitions_report(session: AsyncSession) -> None:
+    report_uuid = await _create_report()
+    out = await investment_report_set_status_impl(
+        report_uuid=report_uuid, status="superseded", actor="operator", reason="v2"
+    )
+    assert out["success"] is True
+    assert out["status"] == "superseded"
+
+    fetched = await investment_report_get_impl(report_uuid)
+    assert fetched["report"]["status"] == "superseded"
+
+
+@pytest.mark.asyncio
+async def test_set_status_impl_rejects_invalid_status(session: AsyncSession) -> None:
+    report_uuid = await _create_report()
+    # 'published' is not a lifecycle transition target; 'garbage' is unknown.
+    for bad in ("published", "garbage"):
+        out = await investment_report_set_status_impl(
+            report_uuid=report_uuid, status=bad
+        )
+        assert out["success"] is False
+        assert out["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_set_status_impl_unknown_uuid_returns_not_found(
+    session: AsyncSession,
+) -> None:
+    out = await investment_report_set_status_impl(
+        report_uuid=str(uuid.uuid4()), status="expired"
+    )
+    assert out == {
+        "success": False,
+        "error": "not_found",
+        "report_uuid": out["report_uuid"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_delta_get_resolves_previous_report_as_baseline(
+    session: AsyncSession, monkeypatch
+) -> None:
+    # ROB-455 — when use_previous_as_baseline=True, the delta baseline resolves to
+    # the report's previous_report_uuid (the report it chains from).
+    a_uuid = await _create_report(kst_date="2026-05-18")
+    b_uuid = await _create_report(
+        kst_date="2026-05-19", previous_report_uuid=a_uuid
+    )
+
+    captured: dict[str, str] = {}
+
+    class _StubDelta:
+        def __init__(self, _db):
+            pass
+
+        async def compute_delta(self, report_uuid, **_kw):
+            captured["uuid"] = str(report_uuid)
+            return {"success": True, "baseline_report_uuid": str(report_uuid)}
+
+    monkeypatch.setattr(
+        "app.services.investment_reports.delta_service.DeltaService", _StubDelta
+    )
+
+    await investment_report_delta_get_impl(
+        report_uuid=b_uuid, use_previous_as_baseline=True
+    )
+    assert captured["uuid"] == a_uuid  # resolved to the predecessor
+
+    await investment_report_delta_get_impl(report_uuid=b_uuid)
+    assert captured["uuid"] == b_uuid  # default: the report itself is the baseline


### PR DESCRIPTION
## 요약
"주문 조정 → invest/report 기록" 사이클의 **버저닝 반쪽** 문제를 보강하는 ROB-455의 첫 PR(GAP1+GAP2). report status DB CHECK가 **이미** `superseded/decided/expired`를 허용하므로 **migration 0**. (GAP3 = decide_item `cancel/reprice` verb는 CHECK migration 필요 → 별도 PR2.)

## GAP1 — `previous_report_uuid`를 load-bearing으로 (기존: write-only, 효과 0)
- **자동 supersede**: `ingest` 시 새 리포트가 `previous_report_uuid`로 선행 리포트를 가리키면 선행을 자동 `superseded` 전이.
  - draft/published 선행만 대상(이미 terminal인 decided/expired/superseded는 보존), dangling(미존재) 링크는 no-op(trace hint가 안 풀릴 수 있음).
  - 선행 `report_metadata.superseded_by`에 후속 uuid 기록 → "최신/대체"가 `created_at` 휴리스틱이 아닌 **명시적 표현**.
- **delta baseline 해석**: `delta_get`에 `use_previous_as_baseline` 플래그. True면 baseline을 리포트의 `previous_report_uuid`(선행)로 해석(미설정 시 리포트 자신으로 폴백). **핸들러 레이어 해석**이라 `delta_service.py` 무변경(454/456 PR과 파일 충돌 회피).

## GAP2 — status 전이 writer/도구 (기존: writer 부재)
- `InvestmentReportIngestionService.set_report_status(report_uuid, status, reason, actor)` — `superseded/decided/expired` 전이. 멱등 no-op(동일 status), `not_found→None`, `report_metadata.status_transitions`에 감사 로그.
- 신규 MCP 도구 **`investment_report_set_status`** (`SetReportStatusRequest`, `ReportStatusTransitionLiteral=superseded|decided|expired`). draft/published는 전이 타깃 아님(생성 시 진입 상태) → invalid_request.

## 안전 경계
- migration 0 (CHECK가 이미 3개 status 허용). broker/order/watch mutation 0.
- 자동 supersede는 overwrite/insert 경로에만(멱등 reuse 경로 제외). overwrite-block 가드(ReportOverwriteBlockedError)와 무충돌(선행 리포트 status만 변경, 덮어쓰기 아님).

## 테스트 (TDD)
- 자동 supersede: 체인 전이 + superseded_by / dangling no-op / terminal 보존
- `set_report_status`: 전이 + 멱등 no-op + not_found + status_transitions 감사
- `set_status` 도구: 전이 / invalid_request(published·garbage) / not_found
- `delta_get` use_previous: 선행으로 해석 / 기본은 리포트 자신
- 신규 9 + 회귀 209 green(ingestion/mcp/model/repo/decisions/query/delta/idempotency/hermes/boot). ruff clean, ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)