### PR TITLE
feat(ROB-452 P2): get_crypto_order_flow(Upbit 체결강도) + get_crypto_social(CoinGecko) MCP 도구

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_crypto.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto.py
@@ -11,11 +11,14 @@ from app.mcp_server.tooling.fundamentals_sources_binance import (
     _fetch_open_interest,
 )
 from app.mcp_server.tooling.fundamentals_sources_coingecko import (
+    _fetch_coingecko_coin_social,
     _normalize_crypto_base_symbol,
     _resolve_batch_crypto_symbols,
+    _resolve_coingecko_coin_id,
 )
 from app.mcp_server.tooling.fundamentals_sources_naver import _fetch_kimchi_premium
 from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.services.brokers.upbit.public_trades import fetch_recent_trades
 
 _ALLOWED_PERIODS = {"5m", "15m", "30m", "1h", "2h", "4h", "6h", "12h", "1d"}
 
@@ -132,5 +135,100 @@ async def handle_get_long_short_ratio(
             source="binance",
             message=str(exc),
             symbol=f"{normalized_symbol}USDT",
+            instrument_type="crypto",
+        )
+
+
+async def handle_get_crypto_order_flow(
+    symbol: str,
+    count: int = 200,
+) -> dict[str, Any]:
+    """ROB-452 P2: Upbit recent-trade taker order-flow (retail buy/sell pressure proxy).
+
+    Volume-weighted taker_buy_ratio / taker_sell_ratio / net from /v1/trades/ticks.
+    Repo convention (upbit_websocket.py): ask_bid "BID" = taker buy, "ASK" = taker sell.
+    Read-only public Upbit data — source is "upbit" (NOT binance).
+    """
+    if not symbol or not symbol.strip():
+        raise ValueError("symbol is required")
+    try:
+        base = _normalize_crypto_base_symbol(symbol)
+        if not base:
+            raise ValueError("symbol is required")
+        market = f"KRW-{base}"
+        capped = min(max(count, 1), 500)
+        trades = await fetch_recent_trades(market=market, count=capped)
+
+        buy_vol = 0.0
+        sell_vol = 0.0
+        used = 0
+        for tick in trades:
+            raw = tick.get("trade_volume")
+            try:
+                vol = float(raw) if raw is not None else None
+            except (TypeError, ValueError):
+                vol = None
+            if vol is None:
+                continue
+            side = tick.get("ask_bid")
+            if side == "BID":
+                buy_vol += vol
+                used += 1
+            elif side == "ASK":
+                sell_vol += vol
+                used += 1
+
+        total = buy_vol + sell_vol
+        if total > 0:
+            taker_buy_ratio: float | None = round(buy_vol / total, 4)
+            taker_sell_ratio: float | None = round(sell_vol / total, 4)
+            net: float | None = round((buy_vol - sell_vol) / total, 4)
+        else:
+            # missing != zero: no usable ticks → None, never a fabricated 0.0
+            taker_buy_ratio = taker_sell_ratio = net = None
+
+        return {
+            "symbol": market,
+            "taker_buy_ratio": taker_buy_ratio,
+            "taker_sell_ratio": taker_sell_ratio,
+            "net": net,
+            "trade_count": used,
+            "source": "upbit",
+            "instrument_type": "crypto",
+        }
+    except Exception as exc:
+        return _error_payload(
+            source="upbit",
+            message=str(exc),
+            symbol=symbol,
+            instrument_type="crypto",
+        )
+
+
+async def handle_get_crypto_social(symbol: str) -> dict[str, Any]:
+    """ROB-452 P2: CoinGecko community/developer social signals for a crypto symbol."""
+    if not symbol or not symbol.strip():
+        raise ValueError("symbol is required")
+    try:
+        coin_id = await _resolve_coingecko_coin_id(symbol)
+        data = await _fetch_coingecko_coin_social(coin_id)
+        community = data.get("community_data") or {}
+        developer = data.get("developer_data") or {}
+        return {
+            "symbol": _normalize_crypto_base_symbol(symbol) or symbol,
+            "coin_id": coin_id,
+            # sentiment_votes_up_percentage sits at the top level of the coin object.
+            "sentiment_votes_up_pct": data.get("sentiment_votes_up_percentage"),
+            "twitter_followers": community.get("twitter_followers"),
+            "reddit_subscribers": community.get("reddit_subscribers"),
+            "dev_commits_4w": developer.get("commit_count_4_weeks"),
+            "source": "coingecko",
+            "instrument_type": "crypto",
+        }
+    except Exception as exc:
+        return _error_payload(
+            source="coingecko",
+            message=str(exc),
+            symbol=symbol,
             instrument_type="crypto",
         )

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from app.mcp_server.tooling.fundamentals._crypto import (
+    handle_get_crypto_order_flow,
+    handle_get_crypto_social,
     handle_get_funding_rate,
     handle_get_kimchi_premium,
     handle_get_long_short_ratio,
@@ -69,6 +71,8 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_long_short_ratio",
     "get_crypto_market_regime",
     "get_crypto_catalysts",
+    "get_crypto_order_flow",
+    "get_crypto_social",
     "get_market_index",
     "get_upbit_index",
     "get_upbit_altseason",
@@ -301,6 +305,30 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         days: int = 14,
     ) -> dict[str, Any]:
         return await handle_get_crypto_catalysts(symbol, days)
+
+    @mcp.tool(
+        name="get_crypto_order_flow",
+        description=(
+            "Get Upbit recent-trade taker order-flow for a KRW crypto market (retail "
+            "buy/sell pressure proxy): volume-weighted taker_buy_ratio, taker_sell_ratio, "
+            "and net (buy-sell, in [-1,1]; >0 = net buying). Read-only public Upbit "
+            "/v1/trades/ticks. count in [1,500]. None when no usable ticks."
+        ),
+    )
+    async def get_crypto_order_flow(symbol: str, count: int = 200) -> dict[str, Any]:
+        return await handle_get_crypto_order_flow(symbol, count)
+
+    @mcp.tool(
+        name="get_crypto_social",
+        description=(
+            "Get CoinGecko community/developer social signals for a crypto symbol: "
+            "sentiment_votes_up_pct, twitter_followers, reddit_subscribers, "
+            "dev_commits_4w. Read-only; degrades (null fields) when CoinGecko lacks "
+            "social data for the coin."
+        ),
+    )
+    async def get_crypto_social(symbol: str) -> dict[str, Any]:
+        return await handle_get_crypto_social(symbol)
 
     @mcp.tool(
         name="get_market_index",

--- a/app/mcp_server/tooling/fundamentals_sources_coingecko.py
+++ b/app/mcp_server/tooling/fundamentals_sources_coingecko.py
@@ -62,6 +62,11 @@ _COINGECKO_PROFILE_CACHE: dict[str, dict[str, Any]] = {}
 _COINGECKO_REDIS_CLIENT: redis.Redis | None = None
 _COINGECKO_LIST_LOCK = asyncio.Lock()
 _COINGECKO_PROFILE_LOCK = asyncio.Lock()
+# ROB-452 P2: social fetch needs community_data/developer_data=true. The profile cache
+# above is keyed by coin_id with those toggles OFF, so reusing it would return a payload
+# missing the social blocks — keep a separate cache for the social-toggled response.
+_COINGECKO_SOCIAL_CACHE: dict[str, dict[str, Any]] = {}
+_COINGECKO_SOCIAL_LOCK = asyncio.Lock()
 
 logger = logging.getLogger(__name__)
 
@@ -387,6 +392,55 @@ async def _fetch_coingecko_coin_profile(coin_id: str) -> dict[str, Any]:
             data = response.json()
 
         _COINGECKO_PROFILE_CACHE[cache_key] = {
+            "expires_at": now + COINGECKO_CACHE_TTL_SECONDS,
+            "data": data,
+        }
+        return data
+
+
+async def _fetch_coingecko_coin_social(coin_id: str) -> dict[str, Any]:
+    """ROB-452 P2: CoinGecko coin detail with community + developer blocks enabled.
+
+    Mirrors ``_fetch_coingecko_coin_profile`` but flips community_data/developer_data on
+    (and market_data off — social tool doesn't need price), with its own cache so the
+    profile cache (toggles off) is never mistaken for a social payload.
+    """
+    cache_key = coin_id.strip().lower()
+    if not cache_key:
+        raise ValueError("coin_id is required")
+
+    now = time.time()
+    cached = _COINGECKO_SOCIAL_CACHE.get(cache_key)
+    if cached and _coingecko_cache_valid(cached.get("expires_at"), now):
+        data = cached.get("data")
+        if isinstance(data, dict):
+            return data
+
+    async with _COINGECKO_SOCIAL_LOCK:
+        now = time.time()
+        cached = _COINGECKO_SOCIAL_CACHE.get(cache_key)
+        if cached and _coingecko_cache_valid(cached.get("expires_at"), now):
+            data = cached.get("data")
+            if isinstance(data, dict):
+                return data
+
+        async with httpx.AsyncClient(timeout=15) as cli:
+            response = await cli.get(
+                COINGECKO_COIN_DETAIL_URL.format(coin_id=cache_key),
+                params={
+                    "localization": "false",
+                    "tickers": "false",
+                    "market_data": "false",
+                    "community_data": "true",
+                    "developer_data": "true",
+                    "sparkline": "false",
+                    "include_categories_details": "false",
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        _COINGECKO_SOCIAL_CACHE[cache_key] = {
             "expires_at": now + COINGECKO_CACHE_TTL_SECONDS,
             "data": data,
         }

--- a/tests/test_crypto_order_flow_social.py
+++ b/tests/test_crypto_order_flow_social.py
@@ -1,0 +1,117 @@
+"""ROB-452 P2: get_crypto_order_flow + get_crypto_social handlers (hermetic)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _crypto as mod
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+# ---------------- order_flow ----------------
+
+
+def _tick(ask_bid, volume):
+    return {"ask_bid": ask_bid, "trade_volume": volume, "trade_price": 100.0}
+
+
+async def test_order_flow_volume_weighted(monkeypatch):
+    captured = {}
+
+    async def fake_trades(market="KRW-BTC", count=50):
+        captured["market"] = market
+        captured["count"] = count
+        # buy vol 30, sell vol 10 → buy 0.75 / sell 0.25 / net 0.5 (volume-weighted,
+        # NOT count-weighted: 2 buy ticks vs 1 sell tick would give 0.667 if by count)
+        return [_tick("BID", 20), _tick("BID", 10), _tick("ASK", 10)]
+
+    monkeypatch.setattr(mod, "fetch_recent_trades", fake_trades)
+    out = await mod.handle_get_crypto_order_flow("btc", count=200)
+
+    assert out["source"] == "upbit"  # ROB-285: not binance
+    assert captured["market"] == "KRW-BTC"  # symbol normalized
+    assert captured["count"] == 200
+    assert out["taker_buy_ratio"] == pytest.approx(0.75)
+    assert out["taker_sell_ratio"] == pytest.approx(0.25)
+    assert out["net"] == pytest.approx(0.5)
+    assert out["trade_count"] == 3
+
+
+async def test_order_flow_empty_is_none(monkeypatch):
+    async def fake_trades(market="KRW-BTC", count=50):
+        return []
+
+    monkeypatch.setattr(mod, "fetch_recent_trades", fake_trades)
+    out = await mod.handle_get_crypto_order_flow("KRW-XRP")
+    assert out["taker_buy_ratio"] is None  # missing != zero
+    assert out["net"] is None
+    assert out["trade_count"] == 0
+
+
+async def test_order_flow_fail_open(monkeypatch):
+    async def boom(market="KRW-BTC", count=50):
+        raise RuntimeError("upbit down")
+
+    monkeypatch.setattr(mod, "fetch_recent_trades", boom)
+    out = await mod.handle_get_crypto_order_flow("BTC")
+    assert "error" in out
+    assert out["source"] == "upbit"
+    assert "binance" not in str(out.get("source"))
+
+
+async def test_order_flow_requires_symbol():
+    with pytest.raises(ValueError, match="symbol is required"):
+        await mod.handle_get_crypto_order_flow("")
+
+
+# ---------------- social ----------------
+
+
+async def test_social_maps_fields(monkeypatch):
+    async def fake_resolve(symbol):
+        return "bitcoin"
+
+    async def fake_social(coin_id):
+        assert coin_id == "bitcoin"
+        return {
+            "sentiment_votes_up_percentage": 68.5,
+            "community_data": {"twitter_followers": 1000, "reddit_subscribers": 500},
+            "developer_data": {"commit_count_4_weeks": 42},
+        }
+
+    monkeypatch.setattr(mod, "_resolve_coingecko_coin_id", fake_resolve)
+    monkeypatch.setattr(mod, "_fetch_coingecko_coin_social", fake_social)
+    out = await mod.handle_get_crypto_social("BTC")
+
+    assert out["source"] == "coingecko"
+    assert out["coin_id"] == "bitcoin"
+    assert out["sentiment_votes_up_pct"] == pytest.approx(68.5)
+    assert out["twitter_followers"] == 1000
+    assert out["reddit_subscribers"] == 500
+    assert out["dev_commits_4w"] == 42
+
+
+async def test_social_degrades_on_missing_blocks(monkeypatch):
+    async def fake_resolve(symbol):
+        return "smallcoin"
+
+    async def fake_social(coin_id):
+        return {}  # no community/developer blocks (small coin)
+
+    monkeypatch.setattr(mod, "_resolve_coingecko_coin_id", fake_resolve)
+    monkeypatch.setattr(mod, "_fetch_coingecko_coin_social", fake_social)
+    out = await mod.handle_get_crypto_social("SMALL")
+    assert out["twitter_followers"] is None
+    assert out["dev_commits_4w"] is None
+    assert out["sentiment_votes_up_pct"] is None
+
+
+async def test_social_fail_open(monkeypatch):
+    async def boom(symbol):
+        raise RuntimeError("coingecko 429")
+
+    monkeypatch.setattr(mod, "_resolve_coingecko_coin_id", boom)
+    out = await mod.handle_get_crypto_social("BTC")
+    assert "error" in out
+    assert out["source"] == "coingecko"


### PR DESCRIPTION
## What & why
ROB-452 P2 — 코인 분석 데이터 노출 마무리(P1 catalysts/regime에 이어). 둘 다 **기존 코드 노출**, read-only.

## get_crypto_order_flow(symbol, count=200)
- Upbit `/v1/trades/ticks`(`public_trades.fetch_recent_trades`, 기존엔 view-model만 소비) → retail 매수/매도 압력 프록시(체결강도).
- **volume-weighted** taker_buy_ratio / taker_sell_ratio / net(buy-sell, [-1,1]). 레포 관례(`upbit_websocket.py:327`): BID=taker buy, ASK=taker sell.
- symbol→KRW-{base}, count [1,500]. 사용가능 tick 0이면 **None**(0.0 날조 금지, missing≠zero).
- ⚠️ `source="upbit"`(NOT binance) — 같은 `_crypto.py`의 funding/oi는 binance지만 order_flow는 Upbit.

## get_crypto_social(symbol)
- CoinGecko community_data/developer_data 토글 ON. **신규 `_fetch_coingecko_coin_social`**(별도 캐시 — profile 캐시는 토글 OFF라 재사용 불가; grounding이 짚은 함정). `_resolve_coingecko_coin_id` 재사용.
- sentiment_votes_up_pct / twitter_followers / reddit_subscribers / dev_commits_4w. 소형코인 블록 없으면 null degrade.

## Verification
- 7 신규테스트(volume-weighted/empty None/fail-open/symbol-norm/social mapping/degrade/fail-open) + **29 boot/audit/profiles green**, ruff clean, **migration 0**. on_duplicate=error 부팅 스모크 통과(4 신규 crypto 도구 충돌 0). ROB-285 audit 무관.
- ⚠️ 로컬 sweep의 place_order cooldown 실패는 persistent test-DB의 leftover `live_order_ledger`(cd-* order_no) 오염 = 본 변경 무관(crypto read 도구, ledger 미접근); 정리 후 통과 확인, CI는 fresh DB.

## Boundaries
read-only. broker/order/watch mutation 0. **ROB-452 P1+P2 = 4개 코인 도구 완결**(catalysts/regime/order_flow/social).

🤖 Generated with [Claude Code](https://claude.com/claude-code)