### PR TITLE
feat(ROB-455 PR2): decide_item 주문 라이프사이클 verb cancel/reprice (migration)

### DIFF
--- a/alembic/versions/20260609_rob455_extend_decision_verbs.py
+++ b/alembic/versions/20260609_rob455_extend_decision_verbs.py
@@ -1,0 +1,57 @@
+"""ROB-455 — extend the decision-verb CHECK with order-lifecycle verbs.
+
+Adds ``cancel`` and ``reprice`` to
+``ck_investment_report_item_decisions_decision`` so an operator can record an
+adjustment outcome first-class instead of faking it with ``deny`` +
+``decision_note``. No new item.status value is introduced — cancel/reprice
+project onto the existing ``denied``/``approved`` statuses (see
+``decisions.py::_ITEM_STATUS_BY_DECISION``), so the item-status CHECK is
+untouched.
+
+The metadata naming convention ``ck_%(table_name)s_%(constraint_name)s`` expands
+the canonical name to a >63-char identifier that PostgreSQL truncates and
+hashes to ``ck_investment_report_item_decisions_ck_investment_repor_9aa6`` on
+databases built via ``create_all``. Drop the canonical and hashed forms
+defensively (matching the ROB-274 p1 precedent), then recreate via ``op.f``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260609_rob455"
+down_revision: str | None = "20260607_rob443b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "investment_report_item_decisions"
+_CHECK = "ck_investment_report_item_decisions_decision"
+# Truncated/hashed identifier present on convention-built (create_all) databases.
+_HASHED = "ck_investment_report_item_decisions_ck_investment_repor_9aa6"
+
+_NEW = (
+    "decision IN ('approve','deny','defer','skip','partial_approve','cancel','reprice')"
+)
+_OLD = "decision IN ('approve','deny','defer','skip','partial_approve')"
+
+
+def _drop_decision_check() -> None:
+    for name in (
+        _HASHED,
+        _CHECK,
+        # op.f-expanded form this migration emits on the create side.
+        f"ck_investment_report_item_decisions_{_CHECK}",
+    ):
+        op.execute(f'ALTER TABLE review.{_TABLE} DROP CONSTRAINT IF EXISTS "{name}"')
+
+
+def upgrade() -> None:
+    _drop_decision_check()
+    op.create_check_constraint(op.f(_CHECK), _TABLE, _NEW, schema="review")
+
+
+def downgrade() -> None:
+    _drop_decision_check()
+    op.create_check_constraint(op.f(_CHECK), _TABLE, _OLD, schema="review")

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -872,10 +872,15 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
     mcp.tool(
         name="investment_report_decide_item",
         description=(
-            "Record an operator decision on one investment_report_item. "
-            "Idempotent per (item_uuid, verb, actor) by default; pass "
-            "idempotency_key to override. partial_approve requires a "
-            "non-empty approved_payload_snapshot."
+            "Record an operator decision on one investment_report_item. Verbs: "
+            "approve | deny | defer | skip | partial_approve | cancel | reprice "
+            "(ROB-455 order-lifecycle verbs: cancel = withdraw a tranche, "
+            "reprice = adjust levels). Idempotent per (item_uuid, verb, actor) by "
+            "default; pass idempotency_key to override. partial_approve and "
+            "reprice both require a non-empty approved_payload_snapshot (the "
+            "scoped/adjusted params). item.status projection: approve/reprice -> "
+            "approved, deny/cancel -> denied, defer -> deferred, skip -> "
+            "unchanged (the exact verb is preserved in the decision audit row)."
         ),
     )(investment_report_decide_item_impl)
     mcp.tool(

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -406,7 +406,8 @@ class InvestmentReportItemDecision(Base):
             name="uq_investment_report_item_decisions_idempotency_key",
         ),
         CheckConstraint(
-            "decision IN ('approve','deny','defer','skip','partial_approve')",
+            "decision IN ('approve','deny','defer','skip','partial_approve',"
+            "'cancel','reprice')",
             name="ck_investment_report_item_decisions_decision",
         ),
         Index(

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -63,7 +63,13 @@ WatchActionModeLiteral = Literal[
     "notify_only", "preview_only", "approval_required", "auto_execute_mock"
 ]
 
-DecisionVerbLiteral = Literal["approve", "deny", "defer", "skip", "partial_approve"]
+# ROB-455 — order-lifecycle verbs. ``cancel`` / ``reprice`` express adjustment
+# outcomes the demo previously faked with deny + decision_note. The verb is the
+# first-class lifecycle record; item.status reuses an existing projection
+# (cancel→denied, reprice→approved) — see decisions.py ``_ITEM_STATUS_BY_DECISION``.
+DecisionVerbLiteral = Literal[
+    "approve", "deny", "defer", "skip", "partial_approve", "cancel", "reprice"
+]
 
 # ROB-274 — proposal lifecycle literals. ``operation=None`` is the legacy
 # shape and is treated as 'create' by the DB CHECK constraints (see
@@ -400,10 +406,15 @@ class RecordDecisionRequest(BaseModel):
     idempotency_key: str | None = None
 
     @model_validator(mode="after")
-    def _validate_partial_approve_has_payload(self) -> RecordDecisionRequest:
-        if self.decision == "partial_approve" and not self.approved_payload_snapshot:
+    def _validate_payload_required_verbs(self) -> RecordDecisionRequest:
+        # partial_approve and reprice both carry the scoped/adjusted params in
+        # approved_payload_snapshot — a verb without it is indistinguishable from
+        # a plain approve and must not transition the item.
+        if self.decision in ("partial_approve", "reprice") and (
+            not self.approved_payload_snapshot
+        ):
             raise ValueError(
-                "partial_approve requires non-empty approved_payload_snapshot"
+                f"{self.decision} requires non-empty approved_payload_snapshot"
             )
         return self
 

--- a/app/services/investment_reports/decisions.py
+++ b/app/services/investment_reports/decisions.py
@@ -22,13 +22,19 @@ from app.schemas.investment_reports import (
 from app.services.investment_reports.repository import InvestmentReportsRepository
 
 # Decision verb → resulting item.status. ``skip`` is audit-only and
-# leaves the item unchanged.
+# leaves the item unchanged. ROB-455 order-lifecycle verbs reuse existing
+# item.status values (no new status added): ``cancel`` projects to 'denied'
+# (the item won't proceed), ``reprice`` projects to 'approved' (an approval
+# with adjusted levels carried in approved_payload_snapshot). The precise verb
+# is preserved first-class in the decision audit row.
 _ITEM_STATUS_BY_DECISION: dict[DecisionVerbLiteral, str | None] = {
     "approve": "approved",
     "deny": "denied",
     "defer": "deferred",
     "skip": None,
     "partial_approve": "approved",
+    "cancel": "denied",
+    "reprice": "approved",
 }
 
 

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -279,6 +279,21 @@ async def session() -> AsyncSession:
                         "ADD CONSTRAINT ck_investment_watch_events_outcome "
                         "CHECK (outcome IN ('notified','review_required','preview_attached',"
                         "'executed','expired','ignored','failed'))",
+                        # ROB-455 — extend the decision-verb CHECK with the
+                        # order-lifecycle verbs cancel/reprice. create_all names
+                        # this via the convention hash; drop both forms then
+                        # recreate canonical with the new verb set. Mirrors
+                        # alembic 20260609_rob455.
+                        "ALTER TABLE review.investment_report_item_decisions "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_report_item_decisions_ck_investment_repor_9aa6",
+                        "ALTER TABLE review.investment_report_item_decisions "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_investment_report_item_decisions_decision",
+                        "ALTER TABLE review.investment_report_item_decisions "
+                        "ADD CONSTRAINT ck_investment_report_item_decisions_decision "
+                        "CHECK (decision IN ('approve','deny','defer','skip',"
+                        "'partial_approve','cancel','reprice'))",
                     ):
                         await conn.execute(sa.text(stmt))
                 factory = async_sessionmaker(engine, expire_on_commit=False)

--- a/tests/test_investment_reports_decisions.py
+++ b/tests/test_investment_reports_decisions.py
@@ -224,3 +224,54 @@ async def test_caller_supplied_idempotency_key_cross_item_collision_rejected(
                 idempotency_key=shared_key,
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# ROB-455 PR2 — order-lifecycle verbs: cancel + reprice
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cancel_records_verb_and_projects_item_to_denied(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    decision = await InvestmentReportDecisionService(session).record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="cancel", actor="operator-test"
+        )
+    )
+    # The verb is first-class in the decision audit row...
+    assert decision.decision == "cancel"
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    # ...while item.status reuses the 'denied' projection (no new status value).
+    assert refreshed is not None
+    assert refreshed.status == "denied"
+
+
+@pytest.mark.asyncio
+async def test_reprice_requires_payload_then_projects_to_approved(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    # reprice carries the new levels — rejected at the schema layer without them
+    # (mirrors partial_approve's approved_payload_snapshot requirement).
+    with pytest.raises(Exception) as exc:
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="reprice", actor="operator-test"
+        )
+    assert "approved_payload_snapshot" in str(exc.value)
+
+    decision = await InvestmentReportDecisionService(session).record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid,
+            decision="reprice",
+            actor="operator-test",
+            approved_payload_snapshot={"suggested_limit_price": 70000},
+        )
+    )
+    assert decision.decision == "reprice"
+    assert decision.approved_payload_snapshot == {"suggested_limit_price": 70000}
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed is not None
+    assert refreshed.status == "approved"


### PR DESCRIPTION
## 요약
ROB-455의 두 번째 PR(GAP3). `decide_item` verb가 `approve/deny/defer/skip/partial_approve`뿐이라 **조정 결과(취소·리프라이스)를 `deny`+`decision_note`로 우회**하던 문제를 해소. decision-verb DB CHECK를 확장하므로 **migration 포함**.

> PR1(#1181, GAP1+GAP2)과 독립적으로 머지 가능(다른 파일/관심사). 함께 ROB-455 완성.

## 변경
- **schema**: `DecisionVerbLiteral += cancel, reprice`. `reprice`는 `partial_approve`처럼 `approved_payload_snapshot`(조정 레벨)을 필수로 요구(스키마 검증 → 깔끔한 ValidationError).
- **decisions.py**: `_ITEM_STATUS_BY_DECISION`에 `cancel→denied`, `reprice→approved`.
  - **신규 `item.status` 값을 추가하지 않고 기존 projection을 재사용** — 정확한 verb는 `decision` 감사 row에 first-class로 보존되고, `item.status`는 coarse projection. 덕분에 item-status CHECK는 무변경, **decision-verb CHECK만** 확장(2차 migration·`ItemStatusLiteral` 변경·consumer ripple 회피).
- **model + alembic `20260609_rob455`**: `ck_investment_report_item_decisions_decision` CHECK에 `cancel/reprice` 추가. metadata naming-convention이 만든 해시 변형(`...ck_investment_repor_9aa6`)을 방어적으로 drop 후 `op.f`로 canonical 재생성(ROB-274 p1 선례). **upgrade/downgrade SQL 오프라인 렌더로 검증**.
- **test helper**: persistent test_db용 CHECK DDL 동기화(해시·canonical drop → 새 verb로 재생성).
- **decide_item 도구 description**: verb 집합 + status projection 명시.

## 설계 노트 (cancel→denied / reprice→approved)
verb 자체가 **lifecycle의 first-class 기록**(decision 테이블). `item.status`는 보조 projection이라 기존 값 재사용이 정직하고 안전(잠금된 설계 "execution은 journal/ledger에 산다"와 무충돌 — `filled/ack`는 의도적으로 제외). 전용 `canceled` item.status가 필요하면 후속으로 추가 가능.

## 안전 경계
- broker/order/watch mutation 0. operator가 `alembic upgrade head` 별도 실행(prod cutover gate).
- 단일 alembic head(`20260607_rob443b → 20260609_rob455`).

## 테스트 (TDD)
- `test_cancel_records_verb_and_projects_item_to_denied` — verb 기록 + denied projection
- `test_reprice_requires_payload_then_projects_to_approved` — payload 필수(no-payload는 schema reject) + approved projection
- decisions 11 + 광범위 회귀 93 green(decisions/mcp/model/repo/ingestion/query). ruff clean, ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)