### PR TITLE
feat(ROB-449): get_retail_sentiment — 네이버 종목토론 aggregate 신호 (KR, operator-gated)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -324,6 +324,11 @@ class Settings(BaseSettings):
     # ROB-204 — Prefect/manual US screener snapshot writes stay dry-run unless explicitly enabled.
     invest_screener_snapshots_commit_enabled: bool = False
 
+    # ROB-449 — get_retail_sentiment live Naver 종목토론 fetch is OFF by default. The source
+    # is a ToS-sensitive UGC surface; the tool returns status="disabled" until an operator
+    # explicitly enables it after a ToS/endpoint review. Aggregate counts only (never raw text).
+    retail_sentiment_live_enabled: bool = False
+
     # ROB-281 — Gates cron registration for KR/US screener snapshot scheduled refreshes.
     # When False, scheduled tasks remain defined as broker tasks (so operators can still
     # kick them manually via ``taskiq kick``) but no cron entries are registered. Pairs

--- a/app/mcp_server/tooling/fundamentals/_retail_sentiment.py
+++ b/app/mcp_server/tooling/fundamentals/_retail_sentiment.py
@@ -1,0 +1,111 @@
+"""ROB-449: get_retail_sentiment — Naver 종목토론 AGGREGATE retail-activity signal (KR).
+
+Promotes the ROB-199 PoC to a live (operator-gated) tool WITHOUT touching the ROB-199
+``StockDetailDiscussionSignal`` aggregate-only hardlock (kept intact as the /invest/stocks
+detail safety contract). This is a separate, generic tool returning aggregate counts only.
+
+Safety:
+  * Live fetch is OFF by default (``settings.retail_sentiment_live_enabled``) — a
+    ToS-sensitive UGC source. Off → status="disabled" (honest scaffold).
+  * AGGREGATE ONLY: rank + post/comment/reaction counts. NEVER raw post text / titles /
+    authors / nicknames.
+  * The rankings source is market-wide top-N; a symbol absent from it → status="not_ranked"
+    (missing != zero — itself a coarse "not in the hot-discussion list" signal).
+  * bull_bear_lean / top_themes are DEFERRED — they border on UGC interpretation and need
+    a careful classifier; v1 ships counts + overheat only.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.core.config import settings
+from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.mcp_server.tooling.shared import (
+    is_korean_equity_code as _is_korean_equity_code,
+)
+from app.services.naver_finance.discussion import fetch_discussion_rankings
+
+# Top-N rank at/under which a symbol's discussion activity is flagged "overheated".
+_OVERHEAT_RANK = 5
+
+
+async def handle_get_retail_sentiment(
+    symbol: str,
+    market: str = "kr",
+    window: str = "1d",
+) -> dict[str, Any]:
+    """Aggregate retail-discussion activity for a KR symbol (Naver 종목토론, gated)."""
+    symbol = (symbol or "").strip()
+    if not symbol:
+        raise ValueError("symbol is required")
+    if (market or "kr").strip().lower() != "kr" or not _is_korean_equity_code(symbol):
+        raise ValueError(
+            "retail sentiment is only available for Korean stocks "
+            "(6-digit codes like '005930')"
+        )
+
+    now = dt.datetime.now(dt.UTC)
+    base = {
+        "symbol": symbol,
+        "source": "naver_discussion",
+        "market": "kr",
+        "window": window,
+        "observed_at": now.isoformat(),
+    }
+
+    # Operator gate: ToS-sensitive UGC source stays off until explicitly enabled.
+    if not settings.retail_sentiment_live_enabled:
+        return {
+            **base,
+            "status": "disabled",
+            "note": (
+                "live Naver 종목토론 fetch is disabled "
+                "(set RETAIL_SENTIMENT_LIVE_ENABLED=true after a ToS/endpoint review)"
+            ),
+        }
+
+    try:
+        ranking = await fetch_discussion_rankings(size=20)
+    except Exception as exc:  # noqa: BLE001 — defensive; fetcher is already fail-open
+        return _error_payload(
+            source="naver_discussion",
+            message=str(exc),
+            symbol=symbol,
+            instrument_type="equity_kr",
+        )
+
+    if ranking.get("state") != "fresh":
+        return {**base, "status": "unavailable", "freshness": "missing"}
+
+    match = next(
+        (it for it in ranking.get("items", []) if it.get("code") == symbol.upper()),
+        None,
+    )
+    if match is None:
+        # Not in the hot-discussion top-N → no per-symbol counts (missing != zero).
+        return {
+            **base,
+            "status": "not_ranked",
+            "freshness": "fresh",
+            "fetched_at": ranking.get("fetched_at"),
+            "activity_rank": None,
+            "overheat_flag": False,
+        }
+
+    rank = match.get("rank")
+    return {
+        **base,
+        "status": "ok",
+        "freshness": "fresh",
+        "fetched_at": ranking.get("fetched_at"),
+        "activity_rank": rank,
+        "post_count": match.get("post_count"),
+        "comment_count": match.get("comment_count"),
+        "reaction_count": match.get("reaction_count"),
+        # momentum/bull_bear_lean/top_themes intentionally deferred (need history /
+        # UGC-safe classifier — ROB-449 follow-up).
+        "momentum": "unknown",
+        "overheat_flag": rank is not None and rank <= _OVERHEAT_RANK,
+    }

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -31,6 +31,9 @@ from app.mcp_server.tooling.fundamentals._profiles import (
     handle_get_company_profile,
     handle_get_crypto_profile,
 )
+from app.mcp_server.tooling.fundamentals._retail_sentiment import (
+    handle_get_retail_sentiment,
+)
 from app.mcp_server.tooling.fundamentals._sector_peers import (
     handle_get_sector_peers,
 )
@@ -73,6 +76,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_crypto_catalysts",
     "get_crypto_order_flow",
     "get_crypto_social",
+    "get_retail_sentiment",
     "get_market_index",
     "get_upbit_index",
     "get_upbit_altseason",
@@ -329,6 +333,23 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
     )
     async def get_crypto_social(symbol: str) -> dict[str, Any]:
         return await handle_get_crypto_social(symbol)
+
+    @mcp.tool(
+        name="get_retail_sentiment",
+        description=(
+            "Get aggregate retail-discussion activity for a KR stock from Naver 종목토론 "
+            "(rank + post/comment/reaction counts + overheat_flag). Aggregate-only — no "
+            "raw post text. Live fetch is operator-gated (status='disabled' until "
+            "enabled); a symbol outside the hot-discussion top-N returns status='not_ranked' "
+            "(not zero). KR 6-digit codes only."
+        ),
+    )
+    async def get_retail_sentiment(
+        symbol: str,
+        market: str = "kr",
+        window: str = "1d",
+    ) -> dict[str, Any]:
+        return await handle_get_retail_sentiment(symbol, market, window)
 
     @mcp.tool(
         name="get_market_index",

--- a/app/services/naver_finance/discussion.py
+++ b/app/services/naver_finance/discussion.py
@@ -1,0 +1,121 @@
+"""ROB-449: Naver 종목토론(discussion) AGGREGATE-ONLY signal fetcher.
+
+Reads the discussion *rankings* endpoint (the only Naver discussion surface probed in
+this repo, observed 200/signal-only in ROB-197/199) and extracts AGGREGATE counts only —
+rank + post/comment/reaction counts per item code. NEVER raw post text / titles / authors
+/ nicknames (ToS + ROB-199 aggregate-only contract).
+
+The endpoint is unofficial + market-wide top-N (not per-symbol), so a symbol absent from
+the ranking yields no counts (missing != zero). Parsing is defensive (shape may drift)
+and fail-open; the live call is gated off by default at the caller. Operator live-smoke
+verifies the shape before relying on it.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import time
+from typing import Any
+
+import httpx
+
+_DISCUSSION_RANKINGS_URL = "https://stock.naver.com/api/community/discussion/rankings"
+_TIMEOUT = httpx.Timeout(10.0)
+_CACHE_TTL_SECONDS = 600  # 10 min server-side cache (ROB-449: 5-15min)
+_CACHE: dict[str, dict[str, Any]] = {}
+
+
+def _to_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_ranked_items(payload: Any) -> list[dict[str, Any]]:
+    """Find the ranked-items list across likely shapes (defensive, aggregate-only)."""
+    container: Any = payload
+    if isinstance(payload, dict):
+        for key in ("rankings", "items", "list", "ranks", "result", "data"):
+            seq = payload.get(key)
+            if isinstance(seq, list):
+                container = seq
+                break
+    if not isinstance(container, list):
+        return []
+
+    items: list[dict[str, Any]] = []
+    for idx, row in enumerate(container):
+        if not isinstance(row, dict):
+            continue
+        code = (
+            row.get("itemCode")
+            or row.get("code")
+            or row.get("cd")
+            or row.get("reutersCode")
+        )
+        if not code:
+            continue
+        rank = _to_int(row.get("rank")) or (idx + 1)
+        items.append(
+            {
+                "code": str(code).strip().upper(),
+                "rank": rank,
+                # AGGREGATE counts only — never raw text fields.
+                "post_count": _to_int(row.get("postCount") or row.get("articleCount")),
+                "comment_count": _to_int(row.get("commentCount")),
+                "reaction_count": _to_int(
+                    row.get("reactionCount") or row.get("sympathyCount")
+                ),
+            }
+        )
+    return items
+
+
+async def fetch_discussion_rankings(
+    *,
+    size: int = 20,
+    fetcher: Any = None,
+) -> dict[str, Any]:
+    """Return the Naver 종목토론 ranking as aggregate counts per item code.
+
+    Shape: ``{"state": "fresh"|"unavailable", "source": "naver_discussion",
+    "fetched_at": iso, "total_count": int|None, "items": [{code, rank, post_count,
+    comment_count, reaction_count}]}``. Fail-open: any error → state="unavailable".
+    """
+    now = dt.datetime.now(dt.UTC)
+    cache_key = f"rankings:{size}"
+    cached = _CACHE.get(cache_key)
+    if cached and cached.get("expires_at", 0) > time.time():
+        return cached["value"]
+
+    try:
+        if fetcher is not None:
+            payload = await fetcher()
+        else:
+            async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+                response = await client.get(
+                    _DISCUSSION_RANKINGS_URL, params={"size": str(max(1, size))}
+                )
+                response.raise_for_status()
+                payload = response.json()
+    except Exception as exc:  # noqa: BLE001 — unofficial endpoint; degrade gracefully
+        return {
+            "state": "unavailable",
+            "source": "naver_discussion",
+            "fetched_at": now.isoformat(),
+            "total_count": None,
+            "items": [],
+            "errorReason": str(exc),
+        }
+
+    total = _to_int(payload.get("totalCount")) if isinstance(payload, dict) else None
+    value = {
+        "state": "fresh",
+        "source": "naver_discussion",
+        "fetched_at": now.isoformat(),
+        "total_count": total,
+        "items": _extract_ranked_items(payload),
+    }
+    _CACHE[cache_key] = {"expires_at": time.time() + _CACHE_TTL_SECONDS, "value": value}
+    return value

--- a/tests/test_retail_sentiment_tool.py
+++ b/tests/test_retail_sentiment_tool.py
@@ -1,0 +1,125 @@
+"""ROB-449: get_retail_sentiment handler + Naver discussion fetcher (hermetic)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _retail_sentiment as mod
+from app.services.naver_finance import discussion as disc
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------- fetcher ----------------
+
+
+def test_extract_ranked_items_defensive():
+    payload = {
+        "totalCount": 2,
+        "rankings": [
+            {
+                "itemCode": "005930",
+                "rank": 1,
+                "postCount": 128,
+                "commentCount": 342,
+                "reactionCount": 911,
+                "postTitle": "SHOULD BE IGNORED",
+            },
+            {"code": "000660", "postCount": 50},  # rank derived from index
+        ],
+    }
+    items = disc._extract_ranked_items(payload)
+    assert items[0]["code"] == "005930"
+    assert items[0]["rank"] == 1
+    assert items[0]["post_count"] == 128
+    # aggregate-only: no raw text keys leak into the extracted item
+    assert "postTitle" not in items[0] and "title" not in items[0]
+    assert items[1]["code"] == "000660"
+    assert items[1]["rank"] == 2  # index-derived
+
+
+@pytest.mark.asyncio
+async def test_fetch_rankings_fail_open():
+    async def boom():
+        raise RuntimeError("naver down")
+
+    out = await disc.fetch_discussion_rankings(size=20, fetcher=boom)
+    assert out["state"] == "unavailable"
+    assert out["items"] == []
+    assert "naver down" in out["errorReason"]
+
+
+# ---------------- handler ----------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default(monkeypatch):
+    monkeypatch.setattr(mod.settings, "retail_sentiment_live_enabled", False)
+    out = await mod.handle_get_retail_sentiment("005930")
+    assert out["status"] == "disabled"
+    assert out["source"] == "naver_discussion"
+
+
+@pytest.mark.asyncio
+async def test_ranked_symbol_returns_counts_and_overheat(monkeypatch):
+    monkeypatch.setattr(mod.settings, "retail_sentiment_live_enabled", True)
+
+    async def fake_rankings(size=20):
+        return {
+            "state": "fresh",
+            "source": "naver_discussion",
+            "fetched_at": "2026-06-09T00:00:00+00:00",
+            "items": [
+                {
+                    "code": "005930",
+                    "rank": 2,
+                    "post_count": 128,
+                    "comment_count": 342,
+                    "reaction_count": 911,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(mod, "fetch_discussion_rankings", fake_rankings)
+    out = await mod.handle_get_retail_sentiment("005930")
+    assert out["status"] == "ok"
+    assert out["activity_rank"] == 2
+    assert out["post_count"] == 128
+    assert out["overheat_flag"] is True  # rank 2 <= 5
+    # deferred fields not fabricated
+    assert "bull_bear_lean" not in out
+    assert "top_themes" not in out
+
+
+@pytest.mark.asyncio
+async def test_not_ranked_is_not_zero(monkeypatch):
+    monkeypatch.setattr(mod.settings, "retail_sentiment_live_enabled", True)
+
+    async def fake_rankings(size=20):
+        return {"state": "fresh", "items": [{"code": "005930", "rank": 1}]}
+
+    monkeypatch.setattr(mod, "fetch_discussion_rankings", fake_rankings)
+    out = await mod.handle_get_retail_sentiment("000660")  # not in ranking
+    assert out["status"] == "not_ranked"
+    assert out["activity_rank"] is None  # missing != zero
+    assert out["overheat_flag"] is False
+    assert "post_count" not in out
+
+
+@pytest.mark.asyncio
+async def test_unavailable_when_fetch_degrades(monkeypatch):
+    monkeypatch.setattr(mod.settings, "retail_sentiment_live_enabled", True)
+
+    async def fake_rankings(size=20):
+        return {"state": "unavailable", "items": []}
+
+    monkeypatch.setattr(mod, "fetch_discussion_rankings", fake_rankings)
+    out = await mod.handle_get_retail_sentiment("005930")
+    assert out["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_kr_only(monkeypatch):
+    monkeypatch.setattr(mod.settings, "retail_sentiment_live_enabled", True)
+    with pytest.raises(ValueError, match="Korean stocks"):
+        await mod.handle_get_retail_sentiment("AAPL")


### PR DESCRIPTION
## What & why
ROB-199 PoC(네이버 종목토론)를 라이브 MCP 도구로 승격. ⚠️ ROB-199 `StockDetailDiscussionSignal` **aggregate-only 하드락은 건드리지 않음**(/invest/stocks detail 안전계약 보존) — 별도 generic 도구로 구현.

## 안전 설계 (grounding 기반)
- **라이브 fetch OFF 기본**(`settings.retail_sentiment_live_enabled`) — ToS-sensitive UGC 소스. off → `status="disabled"` 정직 스캐폴드. operator가 ToS/endpoint 검토 후 활성화(insight/notices 패턴).
- **AGGREGATE ONLY**: rank + post/comment/reaction counts만. raw 글/제목/작성자/닉네임 **절대 미노출**(추출 단계에서 숫자만 뽑음).
- 소스 = 검증된 rankings endpoint(`stock.naver.com/api/community/discussion/rankings`, ROB-197/199 probe 200/signal-only). 시장전체 top-N → per-symbol = 랭킹 조회: 없으면 `status="not_ranked"`(**missing≠zero**, "핫 토론 목록 밖" 자체가 신호).
- **bull_bear_lean / top_themes DEFER**(UGC 해석 위험; 키워드/임베딩 분류는 후속). v1 = counts + overheat_flag만.
- KR 6-digit only. 방어적 파싱 + fail-open + 10분 캐시.

## Changes
신규 `naver_finance/discussion.py`(fetcher) + `fundamentals/_retail_sentiment.py`(handler) + config flag + `fundamentals_handlers` 등록(양 프로필).

## Verification
- 7 신규테스트(gated/ranked+overheat/not_ranked/unavailable/KR-only/fetcher 추출·fail-open) + **29(boot/audit/profiles) + 70(fundamentals/naver/ROB-199 schema) green**. on_duplicate=error 부팅 통과, ROB-285 무관, **ROB-199 하드락 스키마 테스트 무변경**, ruff clean, **migration 0**.

## Boundaries / operator
read-only. broker/order mutation 0. ⚠️ **operator 활성화 시 rankings endpoint live-smoke로 shape 검증 필요**(Upbit notices처럼; 불일치 시 honest degrade). bull_bear_lean/top_themes는 별도 후속(UGC-safe classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)