### PR TITLE
fix(ROB-467): stale manual_cash를 orderable 합산에서 제외

### DIFF
--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -370,6 +370,7 @@ async def get_available_capital_impl(
             exchange_rate = 1300.0
 
     total_orderable_krw = 0.0
+    manual_cash_excluded_krw = 0.0
     processed_accounts: list[dict[str, Any]] = []
 
     for acc in accounts:
@@ -402,12 +403,20 @@ async def get_available_capital_impl(
                 updated_at = manual_setting.get("updated_at")
                 stale_warning = _is_stale_manual_cash(updated_at)
 
+                # ROB-467: stale manual cash is no longer trustworthy as
+                # deployable capital. Keep it visible for transparency, but
+                # exclude it from the orderable total so it is not mistaken
+                # for real ammunition every session.
                 manual_cash_result = {
                     "amount": amount,
                     "updated_at": updated_at,
                     "stale_warning": stale_warning,
+                    "included_in_total": not stale_warning,
                 }
-                total_orderable_krw += amount
+                if stale_warning:
+                    manual_cash_excluded_krw += amount
+                else:
+                    total_orderable_krw += amount
         except Exception as exc:
             logger.warning("Failed to get manual cash setting: %s", exc)
             errors.append({"source": "manual_cash", "error": str(exc)})
@@ -417,6 +426,7 @@ async def get_available_capital_impl(
         "manual_cash": manual_cash_result,
         "summary": {
             "total_orderable_krw": total_orderable_krw,
+            "manual_cash_excluded_krw": manual_cash_excluded_krw,
             "exchange_rate_usd_krw": exchange_rate,
             "as_of": now_kst().isoformat(),
         },

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -1389,7 +1389,10 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "Converts USD orderable cash to KRW and can optionally exclude "
             "manual cash. Manual cash is stored via set_user_setting/"
             "get_user_setting with key='manual_cash'; it is not added for "
-            "paper account queries. "
+            "paper account queries. Stale manual cash (older than 3 days) is "
+            "flagged stale_warning=true, marked included_in_total=false, and "
+            "excluded from summary.total_orderable_krw (its amount is surfaced "
+            "as summary.manual_cash_excluded_krw); refresh it to count again. "
             "Use account_mode={'db_simulated','kis_mock','kis_live'} "
             "(preferred); account_type aliases are deprecated and emit warnings."
         ),

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -224,3 +224,96 @@ async def test_get_available_capital_toss_filter_uses_manual_cash_path(monkeypat
         call in (None, "toss") for call in cash_balance_calls
     )
     assert result["manual_cash"]["amount"] == 5000000
+
+
+@pytest.mark.asyncio
+async def test_get_available_capital_excludes_stale_manual_cash_from_total(monkeypatch):
+    """Stale manual cash is excluded from total_orderable_krw and reported separately (ROB-467)."""
+    from app.mcp_server.tooling import portfolio_cash
+
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "currency": "KRW",
+                    "orderable": 1000000.0,
+                },
+            ],
+            "summary": {"total_krw": 1000000.0, "total_usd": 0.0},
+            "errors": [],
+        }
+
+    stale_date = datetime.now(UTC) - timedelta(days=70)
+
+    async def mock_get_manual_cash_setting():
+        return {
+            "key": "manual_cash",
+            "value": {"amount": 10000000},
+            "updated_at": stale_date.isoformat(),
+        }
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl
+    )
+    monkeypatch.setattr(portfolio_cash, "get_usd_krw_rate", lambda: 1300.0)
+    monkeypatch.setattr(
+        portfolio_cash, "get_manual_cash_setting", mock_get_manual_cash_setting
+    )
+    monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
+
+    from app.mcp_server.tooling.portfolio_cash import get_available_capital_impl
+
+    result = await get_available_capital_impl()
+
+    # Stale manual cash stays visible for transparency...
+    assert result["manual_cash"]["amount"] == 10000000
+    assert result["manual_cash"]["stale_warning"] is True
+    # ...but is flagged as excluded and removed from the orderable total.
+    assert result["manual_cash"]["included_in_total"] is False
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(1000000.0)
+    assert result["summary"]["manual_cash_excluded_krw"] == pytest.approx(10000000.0)
+
+
+@pytest.mark.asyncio
+async def test_get_available_capital_includes_fresh_manual_cash_in_total(monkeypatch):
+    """Fresh manual cash is included in total with included_in_total=True and zero excluded (ROB-467)."""
+    from app.mcp_server.tooling import portfolio_cash
+
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "currency": "KRW",
+                    "orderable": 1000000.0,
+                },
+            ],
+            "summary": {"total_krw": 1000000.0, "total_usd": 0.0},
+            "errors": [],
+        }
+
+    async def mock_get_manual_cash_setting():
+        return {
+            "key": "manual_cash",
+            "value": {"amount": 5000000},
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl
+    )
+    monkeypatch.setattr(portfolio_cash, "get_usd_krw_rate", lambda: 1300.0)
+    monkeypatch.setattr(
+        portfolio_cash, "get_manual_cash_setting", mock_get_manual_cash_setting
+    )
+    monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
+
+    from app.mcp_server.tooling.portfolio_cash import get_available_capital_impl
+
+    result = await get_available_capital_impl()
+
+    assert result["manual_cash"]["stale_warning"] is False
+    assert result["manual_cash"]["included_in_total"] is True
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(6000000.0)
+    assert result["summary"]["manual_cash_excluded_krw"] == pytest.approx(0.0)


### PR DESCRIPTION
## 요약 (ROB-467)

`get_available_capital`이 `stale_warning=true`인 `manual_cash`(3일 경과)를 그대로 `summary.total_orderable_krw`에 합산해, 2개월+ 묵은 수동 현금(2026-04-01 입력 10,000,000원)이 매 세션 **실탄으로 오인될 위험**이 있었습니다.

## 변경

- **stale manual_cash는 orderable 합산에서 제외.** 기존 3일 staleness 계약을 그대로 사용(별도 임계치 신설 없음) — stale로 이미 판정된 값을 합산에서 빼는 것이 핵심.
- 투명성 유지: 값은 계속 노출하되
  - `manual_cash.included_in_total` (= `not stale_warning`) 추가
  - `summary.manual_cash_excluded_krw` 에 제외 금액 별도 표기
- **신선한 manual_cash는 기존대로 합산** (`included_in_total=true`, `manual_cash_excluded_krw=0`).
- `get_available_capital` 도구 description에 동작 명시 → 운영자가 매번 수동 제외하지 않아도 됨.

## 안전 경계

- read-only. 브로커/주문/감시 mutation 없음, migration 없음.
- `kis_domestic.orderable`(유일 신뢰 소스) 경로 무변경.
- paper 계좌(`manual_cash is None`) 무영향.

## 테스트

- 회귀 2건 추가: stale 제외(`total`에서 빠지고 `excluded`로 표기) / fresh 포함.
- `tests/test_mcp_available_capital.py` + `tests/test_mcp_portfolio_tools.py` 88 passed, ruff clean.

Linear: ROB-467 (epic ROB-468 정리 우선 범위)

🤖 Generated with [Claude Code](https://claude.com/claude-code)