### PR TITLE
fix(ROB-466): order_history status='all' 무심볼 허용 + defensive_trim 의존성 문서화

### DIFF
--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -32,6 +32,15 @@ from app.mcp_server.tooling.shared import (
 from app.services.brokers.kis.client import KISClient
 from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
 
+# ROB-466: status='all' without a symbol returns the symbol-free subset (open
+# orders across all markets). Broker fill/cancel history is keyed by symbol, so
+# it is omitted in that case; surface a warning rather than silently dropping it.
+ALL_SYMBOLS_CLOSED_HISTORY_WARNING = (
+    "status='all' without a symbol returns open/pending orders across markets "
+    "only; filled/cancelled history is broker-symbol-keyed — pass a symbol to "
+    "include it."
+)
+
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:
     if is_mock:
@@ -85,10 +94,12 @@ def _validate_history_inputs(
         (symbol, order_id, market_hint, side, effective_days,
          limit_val, market_types, normalized_symbol)
     """
-    if status != "pending" and not symbol:
+    if status in ("filled", "cancelled") and not symbol:
         raise ValueError(
-            f"symbol is required when status='{status}'. "
-            "Use status='pending' for symbol-free queries, "
+            f"symbol is required when status='{status}' "
+            "(broker fill/cancel history is keyed by symbol). "
+            "Use status='pending' or status='all' for symbol-free queries "
+            "(open orders across markets), "
             "or provide a symbol (e.g. symbol='KRW-BTC')."
         )
 
@@ -119,7 +130,7 @@ def _validate_history_inputs(
         if norm:
             market_types = [norm]
 
-    if not market_types and status == "pending":
+    if not market_types and status in ("pending", "all"):
         market_types = ["crypto", "equity_kr", "equity_us"]
 
     if not market_types and order_id:
@@ -391,6 +402,12 @@ def _build_history_response(
     """Build the final order history response dict."""
     summary = _calculate_order_summary(response_orders)
 
+    warnings: list[str] = []
+    if any(o.get("source") == "kis_mock_ledger_shadow" for o in response_orders):
+        warnings.append(KIS_MOCK_SHADOW_PENDING_WARNING)
+    if status == "all" and normalized_symbol is None:
+        warnings.append(ALL_SYMBOLS_CLOSED_HISTORY_WARNING)
+
     ret_market = "mixed"
     if len(market_types) == 1:
         ret_market = _normalize_market_type_to_external(market_types[0])
@@ -417,9 +434,7 @@ def _build_history_response(
         "truncated": truncated,
         "total_available": total_available,
         "errors": errors,
-        "warnings": [KIS_MOCK_SHADOW_PENDING_WARNING]
-        if any(o.get("source") == "kis_mock_ledger_shadow" for o in response_orders)
-        else [],
+        "warnings": warnings,
     }
 
 

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -322,6 +322,11 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "dry_run=True by default for safety. "
             "For buy orders (dry_run=False), thesis and strategy are required. "
             "Safety limit: max 20 orders/day. "
+            "Normal weight-management trims do NOT need defensive_trim — leave "
+            "it False. defensive_trim=True only bypasses the sell-side price "
+            "floor and requires side='sell', order_type='limit', and an "
+            "approval_issue_id (e.g. 'ROB-164'); approval_issue_id is mandatory "
+            "whenever defensive_trim=True, including dry_run (ROB-164 audit gate). "
             "account_mode='kis_live' is accepted but redundant; "
             "any other account_mode value is rejected."
         ),

--- a/tests/test_mcp_order_tools.py
+++ b/tests/test_mcp_order_tools.py
@@ -17,12 +17,86 @@ def _patch_kis_client(monkeypatch: pytest.MonkeyPatch, client_factory) -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", ["all", "filled", "cancelled"])
-async def test_get_order_history_requires_symbol_for_non_pending_status(status):
+@pytest.mark.parametrize("status", ["filled", "cancelled"])
+async def test_get_order_history_requires_symbol_for_closed_status(status):
+    # filled/cancelled history is broker-symbol-keyed, so it still requires a symbol.
     tools = build_tools()
 
     with pytest.raises(ValueError, match="symbol is required when status="):
         await tools["get_order_history"](status=status, order_id="some-id")
+
+
+@pytest.mark.asyncio
+async def test_get_order_history_all_without_symbol_returns_open_orders_with_warning(
+    monkeypatch,
+):
+    """status='all' without a symbol no longer hard-errors (ROB-466): it returns
+    open orders across markets and warns that closed history needs a symbol."""
+    tools = build_tools()
+
+    async def fetch_open_orders(market):
+        return [
+            {
+                "uuid": "uuid-open",
+                "side": "bid",
+                "ord_type": "limit",
+                "price": "50000000",
+                "volume": "0.1",
+                "remaining_volume": "0.1",
+                "market": "KRW-BTC",
+                "created_at": "2025-01-01T00:00:00",
+                "state": "wait",
+            }
+        ]
+
+    monkeypatch.setattr(upbit_service, "fetch_open_orders", fetch_open_orders)
+
+    class MockKIS:
+        async def inquire_korea_orders(self):
+            return []
+
+        async def inquire_overseas_orders(self, exchange_code):
+            return []
+
+    _patch_kis_client(monkeypatch, lambda: MockKIS())
+
+    result = await tools["get_order_history"](status="all")
+
+    # Open orders are returned (no hard error)...
+    assert [o["order_id"] for o in result["orders"]] == ["uuid-open"]
+    # ...and the response warns that filled/cancelled history was omitted.
+    assert any("filled/cancelled" in w for w in result["warnings"])
+
+
+def test_validate_history_inputs_allows_all_status_without_symbol():
+    # status='all' without a symbol resolves to all markets and does not raise (ROB-466).
+    (_symbol, _oid, _mh, _side, _days, _lim, market_types, normalized_symbol) = (
+        orders_history._validate_history_inputs(
+            symbol=None,
+            status="all",
+            order_id=None,
+            market=None,
+            side=None,
+            days=None,
+            limit=50,
+        )
+    )
+    assert normalized_symbol is None
+    assert set(market_types) == {"crypto", "equity_kr", "equity_us"}
+
+
+@pytest.mark.parametrize("status", ["filled", "cancelled"])
+def test_validate_history_inputs_still_requires_symbol_for_closed(status):
+    with pytest.raises(ValueError, match="symbol is required when status="):
+        orders_history._validate_history_inputs(
+            symbol=None,
+            status=status,
+            order_id=None,
+            market=None,
+            side=None,
+            days=None,
+            limit=50,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_place_order_defensive_trim.py
+++ b/tests/test_mcp_place_order_defensive_trim.py
@@ -565,3 +565,29 @@ async def test_flag_on_buy_side_rejected() -> None:
         result["error"]
         == "defensive_trim requires side='sell' (buy orders always use existing path)"
     )
+
+
+def test_kis_live_place_order_documents_defensive_trim_approval_dependency():
+    """ROB-466: the kis_live_place_order schema description must surface that
+    defensive_trim=True requires approval_issue_id, so callers discover the
+    dependency before a runtime rejection (even in dry_run)."""
+    from app.mcp_server.tooling.orders_kis_variants import (
+        register_kis_live_order_tools,
+    )
+
+    captured: dict[str, str] = {}
+
+    class _CaptureMCP:
+        def tool(self, *, name: str, description: str = ""):
+            captured[name] = description
+
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+    register_kis_live_order_tools(_CaptureMCP())
+
+    desc = captured["kis_live_place_order"]
+    assert "defensive_trim" in desc
+    assert "approval_issue_id" in desc


### PR DESCRIPTION
## 요약 (ROB-466)

주문 도구의 비직관적 제약 2건을 정리 (epic ROB-468 범위).

### 1) `kis_live_get_order_history` — `status='all'` 무심볼 허용
- 기존: `status != 'pending'`이면 symbol 필수 → 전 종목 조회 불가, `status='pending'`으로 우회해야 함(비직관적).
- 변경: `status='all'`(및 `pending`)은 **symbol 없이도 전 마켓 미체결 주문**을 반환.
- 체결/취소 이력은 브로커 일별주문 조회가 **종목 키 기반**이라 무심볼로는 불가 → 무심볼 `status='all'`에서는 closed 이력을 생략하고 `warnings`로 명시(**silent drop 금지**).
- `status='filled'`/`'cancelled'` 무심볼은 여전히 actionable 에러(대안 안내 포함).

### 2) `kis_live_place_order` — `defensive_trim` 의존성 문서화
- 기존: `defensive_trim=True`가 `approval_issue_id`를 요구하나 스키마/설명에 미기재 → dry_run조차 `"defensive_trim=True requires approval_issue_id"`로 실패.
- 변경: 도구 description에 의존성 명시 — defensive_trim은 **매도 가격 플로어 우회 전용**, `side='sell'`+`order_type='limit'`+`approval_issue_id`(예: 'ROB-164') 필요, **dry_run 포함**(ROB-164 감사 게이트 보존). 일반 비중관리 트림은 플래그 불필요함을 명확화.
- 게이트 동작 자체는 무변경(감사 추적 유지) — 문서화로 발견성만 개선.

## 안전 경계
- read-path/문서 변경. 브로커/주문 mutation 동작 무변경, migration 없음.
- ROB-164 defensive-trim 감사 게이트 보존(loosen 안 함).

## 테스트
- `_validate_history_inputs` 단위 (all 무심볼 허용 / filled·cancelled 무심볼 raise)
- `status='all'` 무심볼 통합 (open 주문 반환 + warning)
- description lock 테스트 (defensive_trim/approval_issue_id 명시)
- `test_mcp_order_tools.py` + `test_orders_history_kis_mock.py` + `test_mcp_place_order_defensive_trim.py` 전체 green, ruff clean.

Linear: ROB-466

🤖 Generated with [Claude Code](https://claude.com/claude-code)