### PR TITLE
fix(ROB-460): kiwoom_mock account-cash reads에 dmst_stex_tp 추가 (잔고/주문가능 조회 복구)

### DIFF
--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -58,3 +58,13 @@ TOKEN_REFRESH_LEEWAY_SECONDS = 30  # refresh slightly before expires_dt
 # 성립으로 회복하는 것이 1차 목표이며, 값의 scope 정확성은 smoke가 검증한다.
 ACCOUNT_BALANCE_QRY_TP_DEFAULT = "1"  # kt00018 조회구분
 ACCOUNT_ORDER_STK_BOND_TP_DEFAULT = "0"  # kt00009 주식채권구분(전체)
+
+# ROB-460 — Kiwoom REST account-cash reads also require dmst_stex_tp (국내거래소구분).
+# 2026-06-09 live: get_positions(kt00018)·get_orderable_cash returned return_code 2
+# (필수입력 파라미터=dmst_stex_tp). Unlike the qry_tp/stk_bond_tp convention-defaults,
+# this value is PROVEN: every order endpoint (kt10000-kt10003) submits
+# dmst_stex_tp=MOCK_EXCHANGE_KRX successfully. Mock is KRX-only (NXT/SOR rejected on
+# the order path), so KRX is the only valid selection. Applied to the account-cash
+# reads behind the two reported tools (kt00018 잔고, kt00010 주문가능금액); order-history
+# reads (kt00009/kt00007) are left untouched — not proven to need it (smoke-validated).
+ACCOUNT_DMST_STEX_TP_DEFAULT = MOCK_EXCHANGE_KRX  # "KRX" — 국내거래소구분

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -43,7 +43,13 @@ class KiwoomDomesticAccountClient:
         return await self._client.post_api(
             api_id=constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
             path=ACCOUNT_PATH,
-            body={"stk_cd": str(symbol).strip()},
+            # ROB-460 — kt00010 (get_orderable_cash symbol path) requires
+            # dmst_stex_tp (국내거래소구분), like its sibling kt00018; value "KRX" is
+            # proven by the order endpoints. Mock is KRX-only.
+            body={
+                "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
+                "stk_cd": str(symbol).strip(),
+            },
             cont_yn=cont_yn,
             next_key=next_key,
         )
@@ -59,7 +65,13 @@ class KiwoomDomesticAccountClient:
             path=ACCOUNT_PATH,
             # ROB-418 — kt00018 requires qry_tp; omitting it returns return_code 2
             # (필수입력 파라미터=qry_tp). Value is convention-default, smoke-confirmed.
-            body={"qry_tp": constants.ACCOUNT_BALANCE_QRY_TP_DEFAULT},
+            # ROB-460 — kt00018 ALSO requires dmst_stex_tp (국내거래소구분); 2026-06-09
+            # live returned return_code 2 (필수입력 파라미터=dmst_stex_tp) via
+            # get_positions/get_orderable_cash. Value "KRX" proven by order endpoints.
+            body={
+                "qry_tp": constants.ACCOUNT_BALANCE_QRY_TP_DEFAULT,
+                "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
+            },
             cont_yn=cont_yn,
             next_key=next_key,
         )

--- a/docs/runbooks/kiwoom-mock-smoke.md
+++ b/docs/runbooks/kiwoom-mock-smoke.md
@@ -24,8 +24,16 @@ these boundaries:
 - **ROB-418 — account-read 필수 파라미터:** kt00018(잔고)는 `qry_tp`, kt00009(미체결/
   이력)는 `stk_bond_tp`를 요구한다(누락 시 `return_code 2` 필수입력 파라미터 오류).
   기본값(`qry_tp="1"`, `stk_bond_tp="0"`)은 Kiwoom enum 관례이며 **이 mock smoke로
-  값의 scope 정확성을 확정**한다. kt00010(주문가능, with-symbol)의 필수 파라미터는
-  smoke 확인 후 follow-up(추측 미추가). ROB-399와 동일 버그(이 fix로 covered).
+  값의 scope 정확성을 확정**한다. ROB-399와 동일 버그(이 fix로 covered).
+- **ROB-460 — account-cash reads의 `dmst_stex_tp`:** 2026-06-09 live에서
+  `kiwoom_mock_get_positions`/`get_orderable_cash`가 `return_code 2`
+  (필수입력 파라미터=`dmst_stex_tp`, 국내거래소구분)로 재실패했다. account-cash
+  reads **kt00018(잔고) + kt00010(주문가능, with-symbol)** 의 요청 본문에
+  `dmst_stex_tp="KRX"`를 채운다. 이 값은 order 엔드포인트(kt10000-kt10003)에서 이미
+  검증된 값(추측 아님)이며 mock은 KRX 전용이다. **경계 결정:** order-history reads
+  **kt00009/kt00007**는 의도적으로 미변경 — 이미 ROB-418로 복구됐고 `dmst_stex_tp`
+  필요가 입증되지 않았다(작동 중인 엔드포인트에 추측 파라미터를 더해 회귀시키지 않음).
+  아래 smoke 체크리스트로 4개 read 도구를 한 번에 검증하여 잔여 누락을 선제 포착한다.
 - **`dry_run=False` requires `confirm=True`** on every order-mutating tool.
 - **No live anything.** No KIS live, Kiwoom live, Alpaca live, or real-money
   calls. No scheduler / recurring automation.
@@ -99,6 +107,23 @@ stays deferred). To pick a conservative buy limit well below market that will
 8. `kiwoom_mock_cancel_order(dry_run=False, confirm=True)` — in a finally-block.
 9. Final `kiwoom_mock_get_order_history` + `kiwoom_mock_get_positions`
    reconciliation.
+
+## Account-read 필수 파라미터 검증 (ROB-418 / ROB-460)
+
+각 fix 후, 4개 read 도구를 **한 번에** 호출해 `return_code 2`
+(필수입력 파라미터 누락)가 없는지 전수 확인한다 — 부분 수정으로 인한 재실패를 막는다.
+
+| 도구 | broker API | 필수 파라미터 (현재 채움) | 기대 |
+|---|---|---|---|
+| `kiwoom_mock_get_positions` | kt00018 | `qry_tp`, `dmst_stex_tp` | `return_code 0` |
+| `kiwoom_mock_get_orderable_cash` (no symbol) | kt00018 | `qry_tp`, `dmst_stex_tp` | `return_code 0` |
+| `kiwoom_mock_get_orderable_cash` (with symbol) | kt00010 | `dmst_stex_tp`, `stk_cd` | `return_code 0` |
+| `kiwoom_mock_get_order_history` | kt00009 | `stk_bond_tp` | `return_code 0` |
+
+- 어떤 도구든 `필수입력 파라미터=<name>`(`return_code 2`)가 나오면 그 `<name>`을
+  기록하고 해당 broker API 본문에 추가하는 follow-up을 연다(추측 금지, 증명된 누락만).
+- 특히 kt00009/kt00007은 ROB-460에서 의도적으로 `dmst_stex_tp` 미추가 — 이 smoke가
+  실제로 그 파라미터를 요구하는지 확정한다.
 
 ## Cleanup / verification after smoke
 

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -39,20 +39,23 @@ async def test_get_orderable_amount_uses_kt00010():
 
 
 @pytest.mark.asyncio
-async def test_get_orderable_amount_body_unchanged_no_qry_tp():
-    # ROB-418 — kt00010 (with-symbol) was NOT proven to fail by the operator;
-    # do not speculatively add params (avoid wrong/unexpected-param). Body stays
-    # {stk_cd: ...}; its required params are smoke-TBD follow-up.
+async def test_get_orderable_amount_includes_dmst_stex_tp():
+    # ROB-460 — get_orderable_cash(symbol=...) routes here (kt00010). Its sibling
+    # account-cash read kt00018 was PROVEN (2026-06-09 live) to require
+    # dmst_stex_tp (국내거래소구분); leaving kt00010 — the SAME tool's symbol path —
+    # without it would reproduce the partial-fix that produced ROB-460. The value
+    # "KRX" is proven correct by every order endpoint (kt10000-kt10003).
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)
     await acct.get_orderable_amount(symbol="005930")
     call = fake.calls[-1]
     assert call["api_id"] == constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
-    assert call["body"] == {"stk_cd": "005930"}
+    assert call["body"]["stk_cd"] == "005930"
+    assert call["body"]["dmst_stex_tp"] == constants.ACCOUNT_DMST_STEX_TP_DEFAULT
 
 
 @pytest.mark.asyncio
-async def test_get_balance_uses_kt00018_with_qry_tp():
+async def test_get_balance_uses_kt00018_with_qry_tp_and_dmst_stex_tp():
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)
     await acct.get_balance()
@@ -60,6 +63,10 @@ async def test_get_balance_uses_kt00018_with_qry_tp():
     assert call["api_id"] == constants.ACCOUNT_BALANCE_API_ID
     # ROB-418 — kt00018 requires qry_tp (operator return_code 2 without it).
     assert call["body"]["qry_tp"] == constants.ACCOUNT_BALANCE_QRY_TP_DEFAULT
+    # ROB-460 — kt00018 ALSO requires dmst_stex_tp; omitting it returned
+    # return_code 2 (필수입력 파라미터=dmst_stex_tp) on 2026-06-09 live via
+    # get_positions/get_orderable_cash.
+    assert call["body"]["dmst_stex_tp"] == constants.ACCOUNT_DMST_STEX_TP_DEFAULT
 
 
 @pytest.mark.asyncio
@@ -71,6 +78,11 @@ async def test_get_order_status_uses_kt00009_with_stk_bond_tp_and_continuation()
     assert call["api_id"] == constants.ACCOUNT_ORDER_STATUS_API_ID
     # ROB-418 — kt00009 requires stk_bond_tp (operator return_code 2 without it).
     assert call["body"]["stk_bond_tp"] == constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT
+    # ROB-460 boundary — kt00009 is an order-history read (different tool,
+    # get_order_history), already recovered by ROB-418, and NOT proven to need
+    # dmst_stex_tp. Do not speculatively add it to a working endpoint; scope is
+    # operator-smoke-validated (see kiwoom-mock-smoke runbook).
+    assert "dmst_stex_tp" not in call["body"]
     assert call["cont_yn"] == "Y"
     assert call["next_key"] == "page-2"
 
@@ -83,6 +95,9 @@ async def test_get_order_detail_uses_kt00007():
     call = fake.calls[-1]
     assert call["api_id"] == constants.ACCOUNT_ORDER_DETAIL_API_ID
     assert call["body"]["ord_no"] == "0000111222"
+    # ROB-460 boundary — kt00007 order-detail read left untouched (not proven to
+    # need dmst_stex_tp; not exercised by the bug). Smoke-validated follow-up.
+    assert "dmst_stex_tp" not in call["body"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 요약
`kiwoom_mock_get_positions` / `kiwoom_mock_get_orderable_cash`가 ROB-418(Done, `qry_tp`/`stk_bond_tp` 복구) 이후에도 2026-06-09 라이브에서 broker 필수 파라미터 누락으로 **재실패** — 이번엔 `dmst_stex_tp`(국내거래소구분). Linear **ROB-460**.

## 재현 (live 2026-06-09)
- `kiwoom_mock_get_positions()` → `필수입력 파라미터=dmst_stex_tp` (return_code 2)
- `kiwoom_mock_get_orderable_cash()` → 동일
- 대조군: `kiwoom_mock_preview_order`/`place_order`는 `exchange="KRX"`로 **정상** (order 엔드포인트는 `dmst_stex_tp`를 채움)

## 수정
- `ACCOUNT_DMST_STEX_TP_DEFAULT = MOCK_EXCHANGE_KRX`(`"KRX"`) 상수 추가.
- account-cash reads **kt00018(`get_balance`)** + **kt00010(`get_orderable_amount`)** 요청 본문에 `dmst_stex_tp`를 채움 → `get_positions`와 `get_orderable_cash`(symbol 유무 **양 경로**) 모두 복구.
- 값 `"KRX"`는 추측이 아님: 모든 order 엔드포인트(kt10000-kt10003)가 이미 `dmst_stex_tp=KRX`로 정상 동작. mock은 KRX 전용.

## 스코프 경계 (의도적)
order-history reads **kt00009(`get_order_status`)** / **kt00007(`get_order_detail`)** 은 **미변경**:
- 다른 도구(`get_order_history`)이고 ROB-418로 이미 복구됨, 이번 repro에 미포함.
- `dmst_stex_tp` 필요가 **입증되지 않음** → 작동 중인 엔드포인트에 추측 파라미터를 더해 회귀시키지 않는다(ROB-418의 "증명된 누락만 추가" 원칙 계승).
- 회귀 테스트가 cash reads의 `dmst_stex_tp` **존재**와 order-history reads의 **부재**를 전수 단언(proposal #3 "필수 파라미터 전수 가드").
- 런북에 4개 read 도구 전수 smoke 체크리스트 추가 → 잔여 누락을 다음 smoke 한 번에 선제 포착.

## 미채택 (proposal #2)
read 도구에 `exchange` 인자 노출은 미채택 — mock은 KRX 전용(NXT/SOR는 order 경로에서 거부)이라 KRX만 받는 인자는 dead surface. 기본 KRX로 충분.

## 테스트 / 안전
- `tests/test_kiwoom_domestic_account.py` 6 pass + 전체 kiwoom 141 pass, ruff clean.
- broker mutation 0, migration 0, KRX-only 유지. 값 scope 정확성은 operator live mock smoke가 확정(이 세션 creds 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)