### PR TITLE
fix(ROB-461): kis_mock 손실매도 허용 — 모의에서 손절/스톱로스 연습 가능

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -634,6 +634,10 @@ async def _preview_sell(
         if price is None:
             result["error"] = "price is required for limit sell orders"
             return result
+        # defensive_trim is live-only (Trader-agent + approval); allow_loss_sell is
+        # mock-only (is_mock=True, equity). Orthogonal by design. If they ever
+        # coexist, allow_loss_sell wins (it early-returns first in the guard), so the
+        # logging elif chain below also gates defensive_trim on `not allow_loss_sell`.
         allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
         guard_error = evaluate_sell_price_guards(
             price=price,
@@ -656,7 +660,11 @@ async def _preview_sell(
                 scalping_exit_ctx=scalping_exit_ctx,
                 phase="preview",
             )
-        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
+        elif (
+            not allow_loss_sell
+            and price < avg_price * 1.01
+            and defensive_trim_ctx is not None
+        ):
             _log_defensive_trim_bypass(
                 symbol=symbol,
                 market_type=market_type,
@@ -850,6 +858,10 @@ async def _validate_sell_side(
     avg_price = _to_float(holdings.get("avg_price"), default=0.0)
 
     if order_type == "limit" and price is not None:
+        # defensive_trim is live-only (Trader-agent + approval); allow_loss_sell is
+        # mock-only (is_mock=True, equity). Orthogonal by design. If they ever
+        # coexist, allow_loss_sell wins (it early-returns first in the guard), so the
+        # logging elif chain below also gates defensive_trim on `not allow_loss_sell`.
         allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
         guard_error = evaluate_sell_price_guards(
             price=price,
@@ -871,7 +883,11 @@ async def _validate_sell_side(
                 scalping_exit_ctx=scalping_exit_ctx,
                 phase="execution",
             )
-        elif price < avg_price * 1.01 and defensive_trim_ctx is not None:
+        elif (
+            not allow_loss_sell
+            and price < avg_price * 1.01
+            and defensive_trim_ctx is not None
+        ):
             _log_defensive_trim_bypass(
                 symbol=normalized_symbol,
                 market_type=market_type,

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -82,6 +82,7 @@ def evaluate_sell_price_guards(
     avg_price: float,
     defensive_trim_ctx: DefensiveTrimContext | None,
     scalping_exit_ctx: ScalpingExitContext | None,
+    allow_loss_sell: bool = False,
 ) -> str | None:
     """Single source of truth for limit-sell price guards.
 
@@ -89,10 +90,18 @@ def evaluate_sell_price_guards(
 
     Matrix:
       - scalping_exit_ctx present  -> both guards bypassed (mock scalping exit).
+      - allow_loss_sell True       -> both guards bypassed (ROB-461 kis_mock equity
+                                       practice: 손절 / stop-loss / loss rebalancing).
       - defensive_trim_ctx present -> floor bypassed, current-price guard enforced.
       - neither                    -> both guards enforced.
     """
     if scalping_exit_ctx is not None:
+        return None
+    # ROB-461 — kis_mock is a practice sandbox with no real money, so a loss-sell
+    # (below avg*1.01, possibly below current) must be allowed there. The caller
+    # scopes this to is_mock AND equity (never crypto/live); see _preview_sell /
+    # _validate_sell_side. Operator-requested: mock must let 손절/스톱로스 be practiced.
+    if allow_loss_sell:
         return None
     min_sell_price = avg_price * 1.01
     if price < min_sell_price and defensive_trim_ctx is None:
@@ -171,6 +180,30 @@ def _log_scalping_exit_bypass(
             "avg_price": avg_price,
             "strategy_id": scalping_exit_ctx.strategy_id,
             "reason": scalping_exit_ctx.reason,
+            "phase": phase,
+        },
+    )
+
+
+def _log_mock_loss_sell_bypass(
+    *,
+    symbol: str,
+    market_type: str,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    phase: str,
+) -> None:
+    """ROB-461 — audit a plain kis_mock equity loss-sell bypassing the price guards."""
+    logger.warning(
+        "kis_mock_loss_sell_bypass: sell price guards bypassed (mock practice)",
+        extra={
+            "account_mode": "kis_mock",
+            "symbol": symbol,
+            "market_type": market_type,
+            "price": price,
+            "current_price": current_price,
+            "avg_price": avg_price,
             "phase": phase,
         },
     )
@@ -601,12 +634,14 @@ async def _preview_sell(
         if price is None:
             result["error"] = "price is required for limit sell orders"
             return result
+        allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
         guard_error = evaluate_sell_price_guards(
             price=price,
             current_price=current_price,
             avg_price=avg_price,
             defensive_trim_ctx=defensive_trim_ctx,
             scalping_exit_ctx=scalping_exit_ctx,
+            allow_loss_sell=allow_loss_sell,
         )
         if guard_error is not None:
             result["error"] = guard_error
@@ -630,6 +665,15 @@ async def _preview_sell(
                 avg_price=avg_price,
                 min_sell_price=avg_price * 1.01,
                 defensive_trim_ctx=defensive_trim_ctx,
+                phase="preview",
+            )
+        elif allow_loss_sell and (price < avg_price * 1.01 or price < current_price):
+            _log_mock_loss_sell_bypass(
+                symbol=symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
                 phase="preview",
             )
         order_quantity = holdings["quantity"] if quantity is None else quantity
@@ -806,12 +850,14 @@ async def _validate_sell_side(
     avg_price = _to_float(holdings.get("avg_price"), default=0.0)
 
     if order_type == "limit" and price is not None:
+        allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
         guard_error = evaluate_sell_price_guards(
             price=price,
             current_price=current_price,
             avg_price=avg_price,
             defensive_trim_ctx=defensive_trim_ctx,
             scalping_exit_ctx=scalping_exit_ctx,
+            allow_loss_sell=allow_loss_sell,
         )
         if guard_error is not None:
             return 0.0, 0.0, order_error_fn(guard_error)
@@ -834,6 +880,15 @@ async def _validate_sell_side(
                 avg_price=avg_price,
                 min_sell_price=avg_price * 1.01,
                 defensive_trim_ctx=defensive_trim_ctx,
+                phase="execution",
+            )
+        elif allow_loss_sell and (price < avg_price * 1.01 or price < current_price):
+            _log_mock_loss_sell_bypass(
+                symbol=normalized_symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
                 phase="execution",
             )
 

--- a/tests/test_kis_mock_loss_sell_guard.py
+++ b/tests/test_kis_mock_loss_sell_guard.py
@@ -8,12 +8,15 @@ equities"); live (is_mock=False) and crypto (real Upbit funds) stay fully guarde
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from app.mcp_server.tooling import order_validation
-from app.mcp_server.tooling.order_validation import evaluate_sell_price_guards
+from app.mcp_server.tooling.order_validation import (
+    ScalpingExitContext,
+    evaluate_sell_price_guards,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -205,3 +208,103 @@ async def test_validate_sell_side_mock_crypto_still_blocks_loss(monkeypatch) -> 
     )
     assert err is not None
     assert "below minimum" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Audit trail: the bypass must be logged (observability is the whole story)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_mock_equity_loss_sell_emits_audit_log(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 90400.0, "quantity": 10}),
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_kis_mock_shadow_exposure",
+        AsyncMock(
+            return_value={
+                "confidence": "db_shadow_pending",
+                "sell_reserved_quantity": 0,
+            }
+        ),
+    )
+    # _log_mock_loss_sell_bypass is a sync function -> plain Mock (not AsyncMock).
+    log_mock = Mock()
+    monkeypatch.setattr(order_validation, "_log_mock_loss_sell_bypass", log_mock)
+
+    await order_validation._preview_sell(
+        symbol="375500",
+        order_type="limit",
+        quantity=10,
+        price=68000.0,
+        current_price=68500.0,
+        market_type="equity_kr",
+        is_mock=True,
+    )
+    await order_validation._validate_sell_side(
+        symbol="375500",
+        normalized_symbol="375500",
+        market_type="equity_kr",
+        quantity=10,
+        order_type="limit",
+        price=68000.0,
+        current_price=68500.0,
+        order_error_fn=lambda m: {"error": m},
+        is_mock=True,
+        dry_run=True,
+    )
+    # Both the preview and execution phases audit the bypass.
+    phases = {c.kwargs["phase"] for c in log_mock.call_args_list}
+    assert phases == {"preview", "execution"}
+    for call in log_mock.call_args_list:
+        assert call.kwargs["symbol"] == "375500"
+        assert call.kwargs["market_type"] == "equity_kr"
+        assert call.kwargs["price"] == 68000.0
+        assert call.kwargs["avg_price"] == 90400.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_market_order_skips_price_guards(monkeypatch) -> None:
+    # Market sells never hit evaluate_sell_price_guards (limit-only) — a deep-loss
+    # market sell was always allowed and is unaffected by allow_loss_sell. Documents
+    # the intentional exemption + guards against a future maintainer adding a floor.
+    log_mock = Mock()
+    monkeypatch.setattr(order_validation, "_log_mock_loss_sell_bypass", log_mock)
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 90400.0, "quantity": 10}),
+    )
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="market",
+        quantity=10,
+        price=None,
+        current_price=68500.0,
+        market_type="equity_kr",
+        is_mock=True,
+    )
+    assert "error" not in result
+    assert result["price"] == 68500.0  # execution_price == current_price
+    assert result["realized_pnl"] < 0
+    log_mock.assert_not_called()  # market path never logs a guard bypass
+
+
+@pytest.mark.unit
+def test_scalping_exit_takes_precedence_over_allow_loss_sell() -> None:
+    # If a mock equity scalping exit and allow_loss_sell are both in play, the guard
+    # still returns None (both bypass), and the caller's elif chain attributes the
+    # bypass to scalping (checked first) — never double-counted as a loss-sell.
+    err = evaluate_sell_price_guards(
+        price=68000.0,
+        current_price=68500.0,
+        avg_price=90400.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=ScalpingExitContext(strategy_id="s", reason="stop_loss"),
+        allow_loss_sell=True,
+    )
+    assert err is None

--- a/tests/test_kis_mock_loss_sell_guard.py
+++ b/tests/test_kis_mock_loss_sell_guard.py
@@ -1,0 +1,207 @@
+"""ROB-461 — kis_mock equity sells may book a loss (손절 / stop-loss practice).
+
+KIS mock is a practice sandbox with no real money, so the avg*1.01 floor and the
+below-current-price guard must NOT block a loss-sell there. The bypass is scoped to
+`is_mock AND market_type in {equity_kr, equity_us}` (the codebase idiom for "KIS mock
+equities"); live (is_mock=False) and crypto (real Upbit funds) stay fully guarded.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import evaluate_sell_price_guards
+
+
+# ---------------------------------------------------------------------------
+# Pure guard: allow_loss_sell bypasses BOTH the avg*1.01 floor and current-price
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_allow_loss_sell_bypasses_floor_and_current_price() -> None:
+    # price below floor (avg*1.01) AND below current price.
+    err = evaluate_sell_price_guards(
+        price=68000.0,
+        current_price=68500.0,
+        avg_price=90400.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=True,
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_allow_loss_sell_bypasses_below_current_only() -> None:
+    err = evaluate_sell_price_guards(
+        price=1000.0,
+        current_price=1100.0,
+        avg_price=900.0,  # above floor, but below current
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=True,
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_allow_loss_sell_false_still_blocks_floor() -> None:
+    # Default (live) behavior is byte-for-byte unchanged.
+    err = evaluate_sell_price_guards(
+        price=1000.0,
+        current_price=1000.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err is not None and "below minimum" in err
+
+
+@pytest.mark.unit
+def test_allow_loss_sell_default_is_false() -> None:
+    # Omitting the kwarg keeps the floor guard (no accidental relaxation).
+    err = evaluate_sell_price_guards(
+        price=1000.0,
+        current_price=1000.0,
+        avg_price=1000.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+    )
+    assert err is not None and "below minimum" in err
+
+
+# ---------------------------------------------------------------------------
+# _preview_sell: mock equity allows loss; live + crypto stay blocked
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market_type", ["equity_kr", "equity_us"])
+async def test_preview_sell_mock_equity_allows_loss_sell(
+    monkeypatch, market_type
+) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 90400.0, "quantity": 10}),
+    )
+    # The exact 2026-06-09 repro: DL이앤씨 avg 90,400 / current ~68,500, sell at 68,000.
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="limit",
+        quantity=10,
+        price=68000.0,
+        current_price=68500.0,
+        market_type=market_type,
+        is_mock=True,
+    )
+    assert "error" not in result
+    assert result["price"] == 68000.0
+    assert result["realized_pnl"] < 0  # an honest loss is booked
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_live_equity_still_blocks_loss(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 90400.0, "quantity": 10}),
+    )
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="limit",
+        quantity=10,
+        price=68000.0,
+        current_price=68500.0,
+        market_type="equity_kr",
+        is_mock=False,
+    )
+    assert "error" in result and "below minimum" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_mock_crypto_still_blocks_loss(monkeypatch) -> None:
+    # Crypto routes to real Upbit funds; a kis_mock+crypto symbol must NOT relax
+    # the floor even though is_mock=True (defense-in-depth).
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 40000000.0, "quantity": 0.1}),
+    )
+    result = await order_validation._preview_sell(
+        symbol="KRW-BTC",
+        order_type="limit",
+        quantity=0.1,
+        price=30000000.0,
+        current_price=31000000.0,
+        market_type="crypto",
+        is_mock=True,
+    )
+    assert "error" in result and "below minimum" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# _validate_sell_side: same matrix on the execution path
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_mock_equity_allows_loss_sell(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 90400.0, "quantity": 10}),
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_kis_mock_shadow_exposure",
+        AsyncMock(
+            return_value={
+                "confidence": "db_shadow_pending",
+                "sell_reserved_quantity": 0,
+            }
+        ),
+    )
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="375500",
+        normalized_symbol="375500",
+        market_type="equity_kr",
+        quantity=10,
+        order_type="limit",
+        price=68000.0,
+        current_price=68500.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        is_mock=True,
+        dry_run=True,
+    )
+    assert err is None and errors == []
+    assert avg == 90400.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_mock_crypto_still_blocks_loss(monkeypatch) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 40000000.0, "quantity": 0.1, "locked": 0}),
+    )
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="KRW-BTC",
+        normalized_symbol="KRW-BTC",
+        market_type="crypto",
+        quantity=0.1,
+        order_type="limit",
+        price=30000000.0,
+        current_price=31000000.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        is_mock=True,
+        dry_run=True,
+    )
+    assert err is not None
+    assert "below minimum" in errors[0]


### PR DESCRIPTION
## 요약
KIS 모의 매도가 `매도가 < avg_buy_price × 1.01` 플로어 가드에 막혀 **손절(손실 매도)이 전면 불가능**했다(ROB-321에서 관측만, 가드 잔존). 모의투자는 손절/스톱로스/손실 리밸런싱 연습이 핵심 목적이므로 **mock 한정**으로 가드를 해제한다(운영자 요청). Linear **ROB-461**.

## 재현 (live 2026-06-09)
`kis_mock_place_order(375500[DL이앤씨], sell, price=68000)` — 평단 90,400 / 현재 ~68,500(-24%) → `"Sell price 68000 below minimum (avg_buy_price * 1.01 = 91304)"`. winner 익절만 가능, 적자주 영원히 못 파는 비현실적 상태.

## 수정
- `evaluate_sell_price_guards`에 `allow_loss_sell` 파라미터 추가 — True면 **플로어 + 현재가 미만 가드 둘 다** 우회.
  - **왜 둘 다?** repro의 68000은 현재가 68500보다도 낮다. 플로어만 풀면 현재가 가드(`below current price`)에서 재실패 — ROB-418→460식 부분수정 재발. 둘 다 우회해야 운영자의 실제 명령이 성공한다.
- 호출부(`_preview_sell`/`_validate_sell_side`)가 `allow_loss_sell = is_mock and market_type in ("equity_kr","equity_us")`로 계산 — 코드베이스 기존 관용구(kis_mock 주식 한정).
- 우회 시 `_log_mock_loss_sell_bypass`로 감사 로그.

## 안전 (live + crypto 무변경)
- **live(`is_mock=False`)**: `allow_loss_sell=False` → 플로어 가드 그대로. 방어 테스트 포함.
- **crypto(실 Upbit 자금)**: `market_type="crypto"`는 스코프에서 제외 → `is_mock=True`라도 가드 유지. 방어 테스트 포함.
- **플래그 없음**: 모의=무위험, 운영자가 플래그보다 제거를 선호. 기본 허용이 안전.
- `evaluate_sell_price_guards`가 mock 주식 매도 경로의 **유일한** in-repo 플로어임을 리뷰가 확인(legacy `order_service`/`kis_trading_service` 플로어는 별도 `analyze.py` 자동매매 경로, MCP mock 경로 아님).

## 적대적 리뷰 (다중 에이전트, 5 차원)
- **live-safety / crypto-safety / other-floors / 값·스코프**: 전부 **praise** (live/crypto 노출 또는 숨은 2차 플로어를 증명하려 했으나 불가).
- confirmed 5건(test-gap major×1 + minor/nit) **전부 반영**: 로그 귀속 정확화(allow_loss_sell vs defensive_trim 공존 시 `not allow_loss_sell` 게이트), 감사로그 호출/kwargs 검증 테스트, 마켓주문 면제 테스트, scalping 우선순위 테스트.

## 테스트
- `tests/test_kis_mock_loss_sell_guard.py` 13 pass (순수 가드 + preview/validate × mock허용/live차단/crypto차단 + 감사로그 + 마켓 + scalping 우선).
- scalping/wiring/defensive_trim/place_order 회귀 0, ruff clean. migration 0, broker/live/crypto 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)