### PR TITLE
feat(ROB-450): get_cost_basis_distribution — self-OHLCV VPVR 평단분포 추정 (execution_strength defer)

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_cost_basis_distribution.py
+++ b/app/mcp_server/tooling/fundamentals/_cost_basis_distribution.py
@@ -1,0 +1,140 @@
+"""ROB-450: get_cost_basis_distribution — holder cost-basis ESTIMATE via self-OHLCV VPVR.
+
+A volume-by-price (VPVR) APPROXIMATION of where holders are positioned, built from the
+symbol's own trailing OHLCV — NOT a Naver/vendor holder-cost widget (license-clean).
+Reuses the existing VPVR engine (_fetch_ohlcv_for_volume_profile + _calculate_volume_profile);
+this handler only adds the holder-cost derivations (vwap estimate, underwater/in_profit,
+heaviest bucket). Clearly labelled ``estimate=True`` — it is a proxy, not exact avg cost.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from app.mcp_server.tooling.market_data_indicators import (
+    _calculate_volume_profile,
+    _fetch_ohlcv_for_volume_profile,
+)
+from app.mcp_server.tooling.market_data_quotes import fetch_us_live_last_price
+from app.mcp_server.tooling.shared import (
+    error_payload as _error_payload,
+)
+from app.mcp_server.tooling.shared import (
+    resolve_market_type as _resolve_market_type,
+)
+
+# Holder cost-basis horizon (trailing daily candles). Internal — not a public arg.
+_PERIOD_DAYS = 120
+
+
+async def get_cost_basis_distribution_impl(
+    symbol: str,
+    market: str | None = None,
+    buckets: int = 10,
+    preloaded_df: pd.DataFrame | None = None,
+) -> dict[str, Any]:
+    """VPVR-based holder cost-basis ESTIMATE for a kr/us/crypto symbol."""
+    symbol = (symbol or "").strip()
+    if not symbol:
+        raise ValueError("symbol is required")
+
+    market_type, normalized_symbol = _resolve_market_type(symbol, market)
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source = source_map[market_type]
+    bucket_count = max(2, min(int(buckets), 100))
+
+    try:
+        if preloaded_df is not None and not preloaded_df.empty:
+            df = preloaded_df
+        else:
+            df = await _fetch_ohlcv_for_volume_profile(
+                normalized_symbol, market_type, _PERIOD_DAYS
+            )
+        if df.empty:
+            raise ValueError(f"No data available for symbol '{normalized_symbol}'")
+        for col in ("high", "low", "close", "volume"):
+            if col not in df.columns:
+                raise ValueError(f"Missing required column: {col}")
+
+        current_price = round(float(df["close"].iloc[-1]), 6)
+        current_price_source = "ohlcv_close"
+        current_price_stale = market_type == "equity_us"
+        if market_type == "equity_us":
+            live = await fetch_us_live_last_price(normalized_symbol)
+            if live is not None:
+                current_price = round(live, 6)
+                current_price_source = "yahoo_live"
+                current_price_stale = False
+
+        vp = _calculate_volume_profile(df, bins=bucket_count)
+        profile = vp.get("profile", [])
+
+        buckets_out: list[dict[str, Any]] = []
+        underwater = 0.0
+        in_profit = 0.0
+        for entry in profile:
+            low = entry.get("price_low")
+            high = entry.get("price_high")
+            share = entry.get("volume_pct") or 0.0
+            buckets_out.append(
+                {
+                    "price_low": low,
+                    "price_high": high,
+                    "holder_share_pct": share,
+                    "est_volume": entry.get("volume"),
+                }
+            )
+            if low is not None and high is not None:
+                mid = (float(low) + float(high)) / 2
+                # mid above current price → those holders bought higher = underwater
+                if mid > current_price:
+                    underwater += float(share)
+                else:
+                    in_profit += float(share)
+
+        heaviest = (
+            max(buckets_out, key=lambda b: b["holder_share_pct"] or 0.0)
+            if buckets_out
+            else None
+        )
+
+        # typical-price VWAP over the window = estimate of the average holder cost
+        typical = (df["high"] + df["low"] + df["close"]) / 3.0
+        vol = df["volume"]
+        vol_sum = float(vol.sum())
+        vwap_estimate = (
+            round(float((typical * vol).sum() / vol_sum), 6) if vol_sum > 0 else None
+        )
+
+        as_of = str(df["date"].iloc[-1]) if "date" in df.columns else None
+
+        return {
+            "symbol": normalized_symbol,
+            "instrument_type": market_type,
+            "source": source,
+            "estimate": True,  # honesty: VPVR proxy, not an exact holder-cost file
+            "method": "vpvr_self_ohlcv",
+            "as_of": as_of,
+            "period_days": _PERIOD_DAYS,
+            "candles_used": int(len(df)),
+            "current_price": current_price,
+            "current_price_source": current_price_source,
+            "current_price_stale": current_price_stale,
+            "vwap_estimate": vwap_estimate,
+            "buckets": buckets_out,
+            "pct_holders_underwater": round(underwater, 2),
+            "pct_holders_in_profit": round(in_profit, 2),
+            "heaviest_bucket": heaviest,
+        }
+    except Exception as exc:  # noqa: BLE001 — read-only; fail-open structured error
+        return _error_payload(
+            source=source,
+            message=str(exc),
+            symbol=normalized_symbol,
+            instrument_type=market_type,
+        )
+
+
+_DEFAULT_GET_COST_BASIS_DISTRIBUTION_IMPL = get_cost_basis_distribution_impl

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from app.mcp_server.tooling.fundamentals._cost_basis_distribution import (
+    _DEFAULT_GET_COST_BASIS_DISTRIBUTION_IMPL,
+)
+from app.mcp_server.tooling.fundamentals._cost_basis_distribution import (
+    get_cost_basis_distribution_impl as _get_cost_basis_distribution_impl,
+)
 from app.mcp_server.tooling.fundamentals._crypto import (
     handle_get_crypto_order_flow,
     handle_get_crypto_social,
@@ -81,6 +87,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_upbit_index",
     "get_upbit_altseason",
     "get_support_resistance",
+    "get_cost_basis_distribution",
     "get_sector_peers",
 }
 
@@ -414,6 +421,26 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
         return await impl(symbol, market)
 
     @mcp.tool(
+        name="get_cost_basis_distribution",
+        description=(
+            "ESTIMATE holder cost-basis distribution (volume-by-price/VPVR) from the "
+            "symbol's own trailing OHLCV — buckets with holder_share_pct, "
+            "pct_holders_underwater/in_profit vs current price, vwap_estimate, "
+            "heaviest_bucket. A proxy (estimate=true), NOT an exact holder file. "
+            "kr/us/crypto. buckets in [2,100]."
+        ),
+    )
+    async def get_cost_basis_distribution(
+        symbol: str,
+        market: str | None = None,
+        buckets: int = 10,
+    ) -> dict[str, Any]:
+        impl = _get_cost_basis_distribution_impl
+        if not callable(impl):
+            impl = _DEFAULT_GET_COST_BASIS_DISTRIBUTION_IMPL
+        return await impl(symbol, market, buckets)
+
+    @mcp.tool(
         name="get_sector_peers",
         description=(
             "Get sector peer stocks for comparison. Supports Korean and US stocks. "
@@ -433,4 +460,5 @@ __all__ = [
     "FUNDAMENTALS_TOOL_NAMES",
     "_register_fundamentals_tools_impl",
     "_get_support_resistance_impl",
+    "_get_cost_basis_distribution_impl",
 ]

--- a/tests/test_mcp_cost_basis_distribution.py
+++ b/tests/test_mcp_cost_basis_distribution.py
@@ -1,0 +1,72 @@
+"""ROB-450: get_cost_basis_distribution handler (VPVR holder cost-basis estimate)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _cost_basis_distribution as mod
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _ohlcv(n=20, start=100.0):
+    rows = []
+    for i in range(n):
+        close = start + i  # 100..119
+        rows.append(
+            {
+                "date": f"2026-05-{(i % 28) + 1:02d}",
+                "open": close - 0.5,
+                "high": close + 1.0,
+                "low": close - 1.0,
+                "close": close,
+                "volume": 1000.0,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+async def test_cost_basis_estimate_shape_and_sums():
+    df = _ohlcv()  # closes 100..119, current = 119
+    out = await mod.get_cost_basis_distribution_impl(
+        "005930", market="kr", buckets=10, preloaded_df=df
+    )
+    assert out["estimate"] is True
+    assert out["method"] == "vpvr_self_ohlcv"
+    assert out["instrument_type"] == "equity_kr"
+    assert out["current_price"] == pytest.approx(119.0)
+    # buckets present + holder shares sum ~100%
+    assert len(out["buckets"]) == 10
+    share_sum = sum(b["holder_share_pct"] or 0.0 for b in out["buckets"])
+    assert share_sum == pytest.approx(100.0, abs=0.5)
+    # underwater + in_profit ~100% (mutually exclusive partition by bucket midpoint)
+    assert out["pct_holders_underwater"] + out[
+        "pct_holders_in_profit"
+    ] == pytest.approx(100.0, abs=0.5)
+    # most holders bought below 119 → mostly in profit
+    assert out["pct_holders_in_profit"] > out["pct_holders_underwater"]
+    assert out["heaviest_bucket"] is not None
+    assert out["vwap_estimate"] is not None
+
+
+async def test_buckets_clamped():
+    df = _ohlcv()
+    out = await mod.get_cost_basis_distribution_impl(
+        "005930", market="kr", buckets=1, preloaded_df=df
+    )
+    assert len(out["buckets"]) == 2  # clamped to >=2
+
+
+async def test_empty_data_fail_open(monkeypatch):
+    async def empty_fetch(symbol, market_type, period_days):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(mod, "_fetch_ohlcv_for_volume_profile", empty_fetch)
+    out = await mod.get_cost_basis_distribution_impl("005930", market="kr")
+    assert "error" in out  # fail-open structured error, not a raise
+
+
+async def test_requires_symbol():
+    with pytest.raises(ValueError, match="symbol is required"):
+        await mod.get_cost_basis_distribution_impl("")


### PR DESCRIPTION
## What & why
평단/오버행 분포를 네이버 위젯 scrape 대신 **자체 OHLCV VPVR 근사**로 제공(license-clean, "estimate" 명시). **기존 VPVR 엔진 재사용**(thin handler) — `_fetch_ohlcv_for_volume_profile`(kr/us/crypto) + `_calculate_volume_profile`(버킷팅/POC).

## Changes
- `_cost_basis_distribution.py` handler가 더하는 것: `vwap_estimate`(typical-price VWAP), `pct_holders_underwater`/`pct_holders_in_profit`(버킷 midpoint vs 현재가), `heaviest_bucket`. **`estimate=True` + `method="vpvr_self_ohlcv"`** 정직 라벨(정확한 평단 아님).
- kr/us/crypto, `buckets` [2,100] clamp, US는 `fetch_us_live_last_price` 오버레이. fail-open.
- 등록 `fundamentals_handlers`(SR callable-rebind 패턴 미러, 양 프로필).

## ⚠️ get_execution_strength → DEFER (grounding 근거)
KIS에 per-tick 체결(체결강도) endpoint **부재** → 신규 TR `FHPST01060000` client 메서드 필요(thin-handler 범위 밖; 이슈도 OPTIONAL로 표기). crypto 체결강도는 **ROB-452 P2 `get_crypto_order_flow`가 이미 커버**. KR 주식 체결강도는 별도 후속(KIS client 확장 이슈).

## Verification
- VPVR 버킷 합~100% + underwater+in_profit~100% + estimate/vwap/heaviest + clamp + empty fail-open + symbol 필수. **4 신규 + 38(boot/indicator/audit) green**, on_duplicate=error 부팅 통과, ruff clean, **migration 0**(read-only).

## Boundaries
read-only. broker/order mutation 0. cost_basis는 estimate proxy(버킷 coarse — 라벨 명시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)