### PR TITLE
fix(ROB-464): 프리마켓/NXT 세션 KR 시세·지수·랭킹 data_state 태깅 + fake-0 억제

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -20,6 +20,10 @@ from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
 )
+from app.mcp_server.tooling.market_session import (
+    DATA_STATE_FRESH,
+    kr_market_data_state,
+)
 from app.mcp_server.tooling.shared import (
     is_crypto_market as _is_crypto_market,
 )
@@ -170,6 +174,34 @@ async def get_top_stocks_impl(
             message=str(exc),
         )
 
+    kst_tz = datetime.timezone(datetime.timedelta(hours=9))
+
+    # ROB-464: outside the KRX regular session the gainers/losers rankings come
+    # back with every change rate at 0, alphabetically ordered — not a real
+    # ranking. Suppress that fake-0 garbage and tag the session instead of
+    # presenting it as live data.
+    data_state: str | None = None
+    if market == "kr":
+        data_state = kr_market_data_state()
+        if ranking_type in ("gainers", "losers"):
+            has_real_move = any(r.get("change_rate") for r in rankings)
+            if data_state != DATA_STATE_FRESH and not has_real_move:
+                return {
+                    "rankings": [],
+                    "total_count": 0,
+                    "market": market,
+                    "ranking_type": ranking_type,
+                    "timestamp": datetime.datetime.now(kst_tz).isoformat(),
+                    "source": source,
+                    "data_state": data_state,
+                    "note": (
+                        "KRX is not in regular session; gainers/losers come back "
+                        "with all change rates at 0 (not a real ranking). Returning "
+                        "no rows instead of fake-0 entries — retry during market "
+                        "hours (09:00–15:30 KST)."
+                    ),
+                }
+
     if len(rankings) == 0 and market == "kr" and ranking_type == "losers":
         return analysis_screening._error_payload(
             source="kis",
@@ -184,8 +216,7 @@ async def get_top_stocks_impl(
             ),
         )
 
-    kst_tz = datetime.timezone(datetime.timedelta(hours=9))
-    return {
+    response: dict[str, Any] = {
         "rankings": rankings,
         "total_count": len(rankings),
         "market": market,
@@ -193,6 +224,9 @@ async def get_top_stocks_impl(
         "timestamp": datetime.datetime.now(kst_tz).isoformat(),
         "source": source,
     }
+    if data_state is not None:
+        response["data_state"] = data_state
+    return response
 
 
 async def get_disclosures_impl(

--- a/app/mcp_server/tooling/fundamentals/_market_index.py
+++ b/app/mcp_server/tooling/fundamentals/_market_index.py
@@ -14,7 +14,19 @@ from app.mcp_server.tooling.fundamentals_sources_indices import (
     _fetch_index_us_current,
     _fetch_index_us_history,
 )
+from app.mcp_server.tooling.market_session import kr_market_data_state
 from app.mcp_server.tooling.shared import error_payload as _error_payload
+
+
+def _tag_kr_index_data_state(index: Any) -> Any:
+    """ROB-464: tag KR (naver) index dicts with the KRX session data_state.
+
+    Pre-market / closed sessions otherwise return change_pct=0 (frozen at the
+    prior close), which reads as a real flat session.
+    """
+    if isinstance(index, dict) and "error" not in index:
+        index["data_state"] = kr_market_data_state()
+    return index
 
 
 async def handle_get_market_index(
@@ -42,7 +54,10 @@ async def handle_get_market_index(
                     _fetch_index_kr_current(meta["naver_code"], meta["name"]),
                     _fetch_index_kr_history(meta["naver_code"], capped_count, period),
                 )
-                return {"indices": [current_data], "history": history}
+                return {
+                    "indices": [_tag_kr_index_data_state(current_data)],
+                    "history": history,
+                }
             if meta["source"] == "coingecko":
                 current_data = await _fetch_index_crypto_current(
                     meta["cg_metric"], meta["name"], sym
@@ -77,6 +92,8 @@ async def handle_get_market_index(
         if isinstance(r, BaseException):
             indices.append({"symbol": _DEFAULT_INDICES[i], "error": str(r)})
         elif isinstance(r, dict):
+            if _INDEX_META[_DEFAULT_INDICES[i]]["source"] == "naver":
+                _tag_kr_index_data_state(r)
             indices.append(r)
         else:
             indices.append({"symbol": _DEFAULT_INDICES[i], "error": str(r)})

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.market_data_indicators import (
     _compute_indicators,
     _fetch_ohlcv_for_indicators,
 )
+from app.mcp_server.tooling.market_session import kr_market_data_state
 from app.mcp_server.tooling.shared import (
     error_payload as _error_payload,
 )
@@ -992,7 +993,12 @@ async def _get_quote_impl(
     try:
         if market_type == "crypto":
             return await _fetch_quote_crypto(symbol)
-        return await _fetch_quote_equity_kr(symbol)
+        # ROB-464: tag the KRX session so a pre-market / closed-session prior
+        # close is not mistaken for a live price. The shared fetcher (used by
+        # orders/portfolio) is left untouched; only the get_quote tool adds this.
+        quote = await _fetch_quote_equity_kr(symbol)
+        quote["data_state"] = kr_market_data_state()
+        return quote
     except Exception as exc:
         return _error_payload_from_exception(
             source=source,

--- a/app/mcp_server/tooling/market_session.py
+++ b/app/mcp_server/tooling/market_session.py
@@ -1,0 +1,64 @@
+"""ROB-464: KR market-session awareness for MCP read tools.
+
+When the KRX regular session is closed (pre-market, after-hours, weekend,
+holiday) the KIS-backed quote/index/ranking tools otherwise surface the prior
+close as if it were live: ``price == previous_close``, ``change_pct == 0``, and
+all-zero ``get_top_stocks`` rankings sorted alphabetically. These helpers let the
+read tools tag a ``data_state`` and suppress fake-zero values instead of
+presenting stale data as current.
+
+The classification is backed by ``exchange_calendars`` (``XKRX``), so KR holidays
+and the weekend are handled correctly — the same primitive the watch scanners use
+via :func:`app.jobs.watch_market_data.is_market_open`.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import pandas as pd
+
+# data_state values surfaced to MCP callers.
+DATA_STATE_FRESH = "fresh"
+DATA_STATE_PREMARKET_UNAVAILABLE = "premarket_unavailable"
+DATA_STATE_MARKET_CLOSED = "market_closed"
+
+# XKRX regular session opens at 09:00 KST.
+_KR_OPEN = pd.Timestamp("2000-01-01 09:00").time()
+
+
+@lru_cache(maxsize=1)
+def _get_kr_calendar() -> Any:
+    import exchange_calendars as xcals
+
+    return xcals.get_calendar("XKRX")
+
+
+def kr_market_data_state(now: Any = None) -> str:
+    """Classify the freshness of KRX regular-session market data right now.
+
+    Returns one of:
+
+    - ``DATA_STATE_FRESH`` — XKRX regular session is trading → data is live.
+    - ``DATA_STATE_PREMARKET_UNAVAILABLE`` — a KRX trading day, before the
+      session opens (09:00 KST). NXT may be trading, but the KRX-backed tools
+      only return the prior close, so the value is not yet live.
+    - ``DATA_STATE_MARKET_CLOSED`` — after close, weekend, or holiday.
+
+    ``now`` accepts any pandas-parseable timestamp (defaults to current UTC);
+    naive timestamps are assumed UTC.
+    """
+    cal = _get_kr_calendar()
+    ts = pd.Timestamp(now) if now is not None else pd.Timestamp.now("UTC")
+    if ts.tz is None:
+        ts = ts.tz_localize("UTC")
+    local = ts.tz_convert(cal.tz)
+
+    if cal.is_trading_minute(local.floor("min")):
+        return DATA_STATE_FRESH
+
+    session_day = pd.Timestamp(local.date())
+    if cal.is_session(session_day) and local.time() < _KR_OPEN:
+        return DATA_STATE_PREMARKET_UNAVAILABLE
+    return DATA_STATE_MARKET_CLOSED

--- a/tests/test_market_session.py
+++ b/tests/test_market_session.py
@@ -1,0 +1,66 @@
+"""ROB-464: KR market-session data_state classification."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import market_session
+
+
+class _StubCalendar:
+    """Deterministic XKRX stand-in so tests don't depend on the real calendar."""
+
+    tz = "Asia/Seoul"
+
+    def __init__(self, *, trading_minute: bool, session: bool) -> None:
+        self._trading_minute = trading_minute
+        self._session = session
+
+    def is_trading_minute(self, _ts) -> bool:
+        return self._trading_minute
+
+    def is_session(self, _ts) -> bool:
+        return self._session
+
+
+def _patch_calendar(monkeypatch, *, trading_minute: bool, session: bool) -> None:
+    monkeypatch.setattr(
+        market_session,
+        "_get_kr_calendar",
+        lambda: _StubCalendar(trading_minute=trading_minute, session=session),
+    )
+
+
+def test_returns_fresh_during_regular_session(monkeypatch):
+    _patch_calendar(monkeypatch, trading_minute=True, session=True)
+    now = pd.Timestamp("2026-06-08 10:00", tz="Asia/Seoul")
+    assert market_session.kr_market_data_state(now) == market_session.DATA_STATE_FRESH
+
+
+def test_returns_premarket_unavailable_before_open_on_trading_day(monkeypatch):
+    _patch_calendar(monkeypatch, trading_minute=False, session=True)
+    now = pd.Timestamp("2026-06-08 08:32", tz="Asia/Seoul")
+    assert (
+        market_session.kr_market_data_state(now)
+        == market_session.DATA_STATE_PREMARKET_UNAVAILABLE
+    )
+
+
+def test_returns_market_closed_after_session_on_trading_day(monkeypatch):
+    _patch_calendar(monkeypatch, trading_minute=False, session=True)
+    now = pd.Timestamp("2026-06-08 16:00", tz="Asia/Seoul")
+    assert (
+        market_session.kr_market_data_state(now)
+        == market_session.DATA_STATE_MARKET_CLOSED
+    )
+
+
+def test_returns_market_closed_on_non_session_day(monkeypatch):
+    # e.g. weekend / holiday — not a trading session at all.
+    _patch_calendar(monkeypatch, trading_minute=False, session=False)
+    now = pd.Timestamp("2026-06-07 08:32", tz="Asia/Seoul")
+    assert (
+        market_session.kr_market_data_state(now)
+        == market_session.DATA_STATE_MARKET_CLOSED
+    )

--- a/tests/test_market_session.py
+++ b/tests/test_market_session.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from app.mcp_server.tooling import market_session
 

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -1720,6 +1720,22 @@ class TestGetMarketIndex:
         assert len(result["history"]) == 3
         assert result["history"][0]["date"] == "2026-02-01"
 
+    async def test_single_kr_index_tags_premarket_data_state(self, monkeypatch):
+        """ROB-464: a pre-market KR index (change_pct frozen at prior close) is
+        tagged data_state so change_pct=0 is not read as a real flat session."""
+        tools = build_tools()
+        basic = _naver_basic_json()
+        history = _naver_price_history(3)
+        self._patch_naver(monkeypatch, basic, history)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.fundamentals._market_index.kr_market_data_state",
+            lambda *a, **k: "premarket_unavailable",
+        )
+
+        result = await tools["get_market_index"](symbol="KOSPI")
+
+        assert result["indices"][0]["data_state"] == "premarket_unavailable"
+
     async def test_single_us_index(self, monkeypatch):
         """Test fetching a single US index (NASDAQ)."""
         tools = build_tools()

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -202,6 +202,34 @@ async def test_get_quote_korean_equity(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_quote_korean_equity_tags_premarket_data_state(monkeypatch):
+    """ROB-464: KR get_quote tags data_state so a pre-market prior-close is not
+    mistaken for a live price."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    tools = build_tools()
+    df = _single_row_df()
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, code, market, n):
+            return df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        market_data_quotes,
+        "kr_market_data_state",
+        lambda *a, **k: "premarket_unavailable",
+    )
+
+    result = await tools["get_quote"]("005930")
+
+    assert result["instrument_type"] == "equity_kr"
+    assert result["data_state"] == "premarket_unavailable"
+    # The prior close is still surfaced as price (not dropped) — just flagged.
+    assert result["price"] == pytest.approx(105.0)
+
+
+@pytest.mark.asyncio
 async def test_get_quote_korean_equity_previous_close(monkeypatch):
     # ROB-448: with 2 candles, previous_close = the prior trading day's close.
     tools = build_tools()

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -882,6 +882,100 @@ class TestMCPLosers:
         assert len(result["rankings"]) == 1
         assert float(result["rankings"][0]["change_rate"]) > 0
 
+    async def test_kr_gainers_premarket_suppresses_zero_garbage(self, monkeypatch):
+        """ROB-464: pre-market KRX gainers come back all-zero/alphabetical garbage.
+        Suppress the fake-0 rows and tag data_state instead of presenting them."""
+        tools = build_tools()
+
+        class MockKISClient:
+            async def fluctuation_rank(self, market, direction, limit):
+                return [
+                    {
+                        "stck_shrn_iscd": "000020",
+                        "hts_kor_isnm": "동화약품",
+                        "stck_prpr": "10000",
+                        "prdy_ctrt": "0.00",
+                        "acml_vol": "0",
+                    },
+                    {
+                        "stck_shrn_iscd": "000040",
+                        "hts_kor_isnm": "KR모터스",
+                        "stck_prpr": "2000",
+                        "prdy_ctrt": "0.00",
+                        "acml_vol": "0",
+                    },
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers,
+            "kr_market_data_state",
+            lambda *a, **k: "premarket_unavailable",
+        )
+
+        result = await tools["get_top_stocks"](market="kr", ranking_type="gainers")
+
+        assert result["data_state"] == "premarket_unavailable"
+        assert result["rankings"] == []
+        assert result["total_count"] == 0
+        assert result.get("note")
+
+    async def test_kr_losers_premarket_empty_suppressed_with_data_state(
+        self, monkeypatch
+    ):
+        """ROB-464: pre-market losers filter to empty; return a premarket data_state
+        payload, not the legacy 'No losing stocks found' bullish-market error."""
+        tools = build_tools()
+
+        class MockKISClient:
+            async def fluctuation_rank(self, market, direction, limit):
+                return [
+                    {
+                        "stck_shrn_iscd": "000020",
+                        "hts_kor_isnm": "동화약품",
+                        "prdy_ctrt": "0.00",
+                    },
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers,
+            "kr_market_data_state",
+            lambda *a, **k: "premarket_unavailable",
+        )
+
+        result = await tools["get_top_stocks"](market="kr", ranking_type="losers")
+
+        assert result["data_state"] == "premarket_unavailable"
+        assert result["rankings"] == []
+        assert "error" not in result
+
+    async def test_kr_gainers_fresh_keeps_rankings_and_tags_fresh(self, monkeypatch):
+        """ROB-464: during the regular session, real movers are kept and tagged fresh."""
+        tools = build_tools()
+
+        class MockKISClient:
+            async def fluctuation_rank(self, market, direction, limit):
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "prdy_ctrt": "5.0",
+                        "acml_vol": "10000000",
+                    },
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
+
+        result = await tools["get_top_stocks"](market="kr", ranking_type="gainers")
+
+        assert result["data_state"] == "fresh"
+        assert len(result["rankings"]) == 1
+
 
 @pytest.mark.asyncio
 class TestMCPEmptyLosersErrors:
@@ -910,6 +1004,10 @@ class TestMCPEmptyLosersErrors:
                 ]
 
         monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        # Premise: a fresh, bullish trading session (no losers), not pre-market.
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
 
         result = await tools["get_top_stocks"](
             market="kr", ranking_type="losers", limit=5


### PR DESCRIPTION
## 요약 (ROB-464)

개장 전(프리마켓/장외) KR 시세 계열 도구가 KRX 전일종가/0값을 정상값처럼 반환해 의사결정 오류를 유발하던 버그. **세션 인식**을 추가해 stale을 명시(`data_state`)하고, 의미 없는 0% 랭킹 garbage를 억제 (epic ROB-468 범위).

## 변경

### 신규: `market_session.py` — KR 세션 인식 (재사용 가능)
- `kr_market_data_state(now=None)` → `fresh` / `premarket_unavailable` / `market_closed`
- `exchange_calendars`(XKRX) 기반 → **holiday/주말 정확 처리** (watch 스캐너의 `is_market_open`과 동일 primitive)
- `now` 주입 가능 → 결정적 단위 테스트 (벽시계 비의존)

### `get_quote(kr)`
- 응답에 `data_state` 태깅 → 프리마켓 전일종가를 라이브 가격으로 오인 방지
- 공유 `_fetch_quote_equity_kr`(orders/portfolio 사용)은 **무변경**; get_quote 경로에서만 태깅

### `get_market_index(kr/naver: KOSPI/KOSDAQ)`
- 각 KR 지수에 `data_state` 태깅 → `change_pct=0`을 실 보합으로 오인 방지

### `get_top_stocks(kr, gainers/losers)`
- 정규장 외 전 종목 `change_rate=0` 알파벳순 garbage(가장 해로운 증상)는 **빈 랭킹 + `data_state` + `note`로 억제** — "0을 정상 등락률로 주지 말 것" 충족
- 억제 조건은 **데이터 퇴화(all-zero) AND 세션 비-fresh** 결합 → 실 등락 데이터는 그대로 유지(벽시계 비의존, 기존 테스트 안전). 모든 KR 응답에 `data_state` 부가

## 안전 경계
- read-only. 브로커/주문 mutation 없음, migration 없음.
- US/crypto 응답 무변경(자체 거래시간 — 본 PR 범위 밖).
- ROB-463(주문측 프리마켓 NXT 게이트)와 **동일 근본원인(세션 인식)** 공유 — `market_session` 헬퍼를 재사용 예정.

## 테스트
- `market_session` 4-케이스(fresh/premarket/closed/non-session) — stub 캘린더로 결정적
- get_quote / get_market_index / get_top_stocks 각 premarket·fresh 케이스
- 레거시 empty-losers 테스트는 fresh 세션으로 핀(전제 보존)
- 영향 테스트군 199 passed, ruff clean.

Linear: ROB-464

🤖 Generated with [Claude Code](https://claude.com/claude-code)