### PR TITLE
feat(ROB-465): 대용량 MCP 응답 cap + limit/offset 페이지네이션

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -266,18 +266,25 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             "preset's thresholds; the response includes availableFilters (the adjustable "
             "catalog for that preset's snapshot) and appliedFilters. Currently threaded for "
             "consecutive_gainers (e.g. loosen consecutive_up_days to 3 or tighten to 10); "
-            "other presets return default snapshot results and say so. Read-only."
+            "other presets return default snapshot results and say so. Read-only. "
+            "Results are capped (limit default 40, max 200) and paginated via "
+            "limit/offset; pagination.total_available + pagination.next_offset let you "
+            "page through without exceeding the response token budget."
         ),
     )
     async def screen_stocks_snapshot(
         preset: str,
         market: Literal["kr", "us", "crypto"] = "kr",
         filters: list[dict[str, Any]] | None = None,
+        limit: int = 40,
+        offset: int = 0,
     ) -> dict[str, Any]:
         return await screen_stocks_snapshot_impl(
             preset=preset,
             market=market,
             filters=filters,
+            limit=limit,
+            offset=offset,
         )
 
     # ROB-359: recommend_stocks is intentionally NOT registered on the MCP tool

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -27,7 +27,6 @@ from app.schemas.investment_reports import (
     InvestmentReportDecideItemResponse,
     InvestmentReportItemDecisionResponse,
     InvestmentReportItemResponse,
-    InvestmentReportListResponse,
     InvestmentReportResponse,
     InvestmentWatchAlertResponse,
     InvestmentWatchEventResponse,
@@ -39,6 +38,7 @@ from app.services import market_data as market_data_service
 from app.services.investment_reports.decisions import (
     InvestmentReportDecisionService,
 )
+from app.services.investment_reports.idempotency import kst_date_from_report_key
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
@@ -327,22 +327,62 @@ async def investment_report_list_impl(
     status: str | None = None,
     report_type: str | None = None,
     limit: int = 20,
+    offset: int = 0,
 ) -> dict:
+    # ROB-465: the MCP list returns lightweight summaries (uuid/title/status/
+    # kst_date + filter context) instead of full report bodies — full reports
+    # (market_snapshot/portfolio_snapshot/report_metadata) blew the response
+    # token budget (~78k chars for ~20 reports). Detail lives in
+    # investment_report_get. The HTTP router keeps the full
+    # InvestmentReportListResponse contract (unchanged).
     capped = max(1, min(int(limit), 100))
+    eff_offset = max(0, int(offset))
     async with AsyncSessionLocal() as db:
         service = InvestmentReportQueryService(db)
+        # Fetch one extra row to derive has_more without a separate count query.
         rows = await service.list_reports(
             market=market,
             market_session=market_session,
             account_scope=account_scope,
             status=status,
             report_type=report_type,
-            limit=capped,
+            limit=capped + 1,
+            offset=eff_offset,
         )
-        response = InvestmentReportListResponse(
-            reports=[InvestmentReportResponse.model_validate(r) for r in rows]
-        )
-    return {"success": True, **response.model_dump(mode="json", by_alias=True)}
+        has_more = len(rows) > capped
+        page = rows[:capped]
+        summaries = [_report_summary(r) for r in page]
+    next_offset = eff_offset + len(page) if has_more else None
+    return {
+        "success": True,
+        "reports": summaries,
+        "pagination": {
+            "returned_count": len(summaries),
+            "offset": eff_offset,
+            "limit": capped,
+            "has_more": has_more,
+            "next_offset": next_offset,
+        },
+    }
+
+
+def _report_summary(row: Any) -> dict[str, Any]:
+    """ROB-465: lightweight list row — identifiers + filter context, no bodies.
+
+    Read straight off the ORM row (``InvestmentReport``); ``kst_date`` is not a
+    column, so recover it from the idempotency key.
+    """
+    return {
+        "report_uuid": str(row.report_uuid),
+        "report_type": row.report_type,
+        "market": row.market,
+        "market_session": row.market_session,
+        "account_scope": row.account_scope,
+        "title": row.title,
+        "status": row.status,
+        "kst_date": kst_date_from_report_key(row.idempotency_key),
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -922,7 +962,11 @@ def register_investment_report_tools(mcp: FastMCP) -> None:
         name="investment_report_list",
         description=(
             "List investment_reports filtered by market / market_session / "
-            "account_scope / status / report_type. limit clamped to 1..100."
+            "account_scope / status / report_type. Returns lightweight summaries "
+            "(report_uuid/title/status/kst_date + filter context) — NOT full "
+            "report bodies; fetch detail via investment_report_get. limit clamped "
+            "to 1..100 (default 20); paginate with offset using "
+            "pagination.next_offset (null when no more)."
         ),
     )(investment_report_list_impl)
     mcp.tool(

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -80,17 +80,27 @@ def _filters_are_threaded(preset: str, market: str) -> bool:
     return (market or "").strip().lower() == "crypto" and preset in _CRYPTO_PRESET_IDS
 
 
+_DEFAULT_RESULT_LIMIT = 40
+_MAX_RESULT_LIMIT = 200
+
+
 async def screen_stocks_snapshot_impl(
     *,
     preset: str,
     market: str = "kr",
     filters: list[dict[str, Any]] | None = None,
+    limit: int = _DEFAULT_RESULT_LIMIT,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Run a screener preset over its base snapshot with adjustable AND-filters.
 
     filters: list of {"field", "operator" (gte|lte|eq), "value"} conditions applied
     on top of the preset's starting set (adjust same field, add new). Returns the
     screener payload plus availableFilters (the adjustable catalog) and appliedFilters.
+
+    limit/offset: ROB-465 — results are capped (default 40, max 200) and paginated
+    at the tool boundary to keep responses inside the MCP token budget. The full
+    match count and a next_offset cursor are reported under ``pagination``.
     """
     from app.services.invest_view_model.screener_filters import (
         ScreenerFilterCondition,
@@ -157,4 +167,23 @@ async def screen_stocks_snapshot_impl(
             "기본 결과를 반환했습니다 (필터 미적용)."
         )
         payload["warnings"] = warnings
+
+    # ROB-465: cap + paginate at the tool boundary so large snapshots (e.g.
+    # high_yield_value ~161 rows / ~84k chars) don't blow the MCP token budget.
+    # The web screener path (build_screener_results) is left untouched.
+    all_results = payload.get("results") or []
+    total_available = len(all_results)
+    eff_limit = max(1, min(int(limit), _MAX_RESULT_LIMIT))
+    eff_offset = max(0, int(offset))
+    page = all_results[eff_offset : eff_offset + eff_limit]
+    next_offset = eff_offset + len(page)
+    payload["results"] = page
+    payload["pagination"] = {
+        "total_available": total_available,
+        "returned_count": len(page),
+        "offset": eff_offset,
+        "limit": eff_limit,
+        "has_more": next_offset < total_available,
+        "next_offset": next_offset if next_offset < total_available else None,
+    }
     return payload

--- a/app/services/investment_reports/idempotency.py
+++ b/app/services/investment_reports/idempotency.py
@@ -62,6 +62,22 @@ def report_key(
     )
 
 
+def kst_date_from_report_key(key: str | None) -> str | None:
+    """Recover the kst_date slot from a :func:`report_key` string.
+
+    Inverse of ``report_key`` — kept here so the two evolve together. Returns
+    ``None`` if the key is missing or doesn't match the expected 8-slot layout
+    (``report:type:market:session:scope:mode:kst_date:version``).
+    """
+    if not key:
+        return None
+    parts = key.split(":")
+    if len(parts) != 8 or parts[0] != "report":
+        return None
+    slot = parts[6]
+    return None if slot == _NONE_SLOT else slot
+
+
 def item_key(
     *,
     report_uuid: str,

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -78,6 +78,7 @@ class InvestmentReportQueryService:
         status: str | None = None,
         report_type: str | None = None,
         limit: int = 20,
+        offset: int = 0,
     ) -> list[InvestmentReport]:
         return await self._repo.list_reports(
             market=market,
@@ -86,6 +87,7 @@ class InvestmentReportQueryService:
             status=status,
             report_type=report_type,
             limit=limit,
+            offset=offset,
         )
 
     async def latest_report(

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -76,6 +76,7 @@ class InvestmentReportsRepository:
         status: str | None = None,
         report_type: str | None = None,
         limit: int = 20,
+        offset: int = 0,
     ) -> list[InvestmentReport]:
         stmt = sa.select(InvestmentReport).order_by(
             InvestmentReport.created_at.desc(), InvestmentReport.id.desc()
@@ -88,6 +89,8 @@ class InvestmentReportsRepository:
             status=status,
             report_type=report_type,
         )
+        if offset:
+            stmt = stmt.offset(offset)
         stmt = stmt.limit(limit)
         result = await self._session.scalars(stmt)
         return list(result.all())

--- a/tests/test_investment_reports_idempotency.py
+++ b/tests/test_investment_reports_idempotency.py
@@ -5,10 +5,30 @@ from __future__ import annotations
 from app.services.investment_reports.idempotency import (
     canonical_watch_condition_hash,
     item_key,
+    kst_date_from_report_key,
     report_key,
     watch_activation_key,
     watch_event_key,
 )
+
+
+def test_kst_date_from_report_key_round_trips() -> None:
+    key = report_key(
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        kst_date="2026-05-18",
+        generator_version="v1",
+    )
+    assert kst_date_from_report_key(key) == "2026-05-18"
+
+
+def test_kst_date_from_report_key_handles_bad_input() -> None:
+    assert kst_date_from_report_key(None) is None
+    assert kst_date_from_report_key("") is None
+    assert kst_date_from_report_key("not-a-report-key") is None
 
 
 def test_report_key_is_stable() -> None:

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -172,6 +172,40 @@ async def test_list_filters_propagate(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_returns_summary_only_and_paginates(session: AsyncSession) -> None:
+    # ROB-465: list returns lightweight summaries (no heavy report bodies) and
+    # paginates via limit/offset so the response stays inside the token budget.
+    for d in ("2026-05-18", "2026-05-19", "2026-05-20"):
+        await investment_report_create_impl(
+            items=[_action_item_dict()],
+            **_create_kwargs(market="kr", kst_date=d),
+        )
+
+    page1 = await investment_report_list_impl(market="kr", limit=2)
+    assert page1["success"] is True
+    assert len(page1["reports"]) == 2
+
+    summary = page1["reports"][0]
+    # summary-only: heavy bodies are dropped, key identifiers retained.
+    assert {"report_uuid", "title", "status", "kst_date"} <= set(summary.keys())
+    assert "market_snapshot" not in summary
+    assert "portfolio_snapshot" not in summary
+    assert "report_metadata" not in summary
+
+    pg = page1["pagination"]
+    assert pg["returned_count"] == 2
+    assert pg["offset"] == 0
+    assert pg["limit"] == 2
+    assert pg["has_more"] is True
+    assert pg["next_offset"] == 2
+
+    page2 = await investment_report_list_impl(market="kr", limit=2, offset=2)
+    assert len(page2["reports"]) == 1
+    assert page2["pagination"]["has_more"] is False
+    assert page2["pagination"]["next_offset"] is None
+
+
+@pytest.mark.asyncio
 async def test_get_returns_not_found_for_unknown(session: AsyncSession) -> None:
     response = await investment_report_get_impl(str(uuid.uuid4()))
     assert response == {"success": False, "error": "not_found"}

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -132,3 +132,62 @@ async def test_bad_filter_entry_fails_soft(patched) -> None:
     assert out["results"] == []
     # build_screener_results must NOT have been called (no DB work on bad input)
     assert patched == {}
+
+
+def _patch_build_with_n_results(monkeypatch, n: int) -> None:
+    class _BigResp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [{"symbol": f"S{i}"} for i in range(n)],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _BigResp:
+        return _BigResp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_caps_results_and_paginates(monkeypatch) -> None:
+    """ROB-465: a large snapshot is capped to a default page + pagination metadata."""
+    _patch_build_with_n_results(monkeypatch, 100)
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr"
+    )
+
+    assert len(out["results"]) == 40  # default cap
+    pg = out["pagination"]
+    assert pg["total_available"] == 100
+    assert pg["returned_count"] == 40
+    assert pg["offset"] == 0
+    assert pg["limit"] == 40
+    assert pg["has_more"] is True
+    assert pg["next_offset"] == 40
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_offset_paginates_last_partial_page(monkeypatch) -> None:
+    """ROB-465: offset + limit page through; the final partial page has no more."""
+    _patch_build_with_n_results(monkeypatch, 100)
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", limit=30, offset=90
+    )
+
+    assert [r["symbol"] for r in out["results"]] == [f"S{i}" for i in range(90, 100)]
+    pg = out["pagination"]
+    assert pg["returned_count"] == 10
+    assert pg["has_more"] is False
+    assert pg["next_offset"] is None


### PR DESCRIPTION
## 요약 (ROB-465)

일부 MCP 응답이 토큰 한도(25k+)를 초과해 파일 폴백 + jq 추출을 강제하던 DX 마찰 해소 (epic ROB-468 범위). 사례: `screen_stocks_snapshot` high_yield_value ~161행/~84k자, `investment_report_list` ~78k자.

## 변경

### `screen_stocks_snapshot` — cap + pagination
- 결과 **기본 cap 40**(max 200) + `limit`/`offset` 파라미터
- `pagination` 메타: `total_available` / `returned_count` / `offset` / `limit` / `has_more` / `next_offset`
- **MCP 경계에서 슬라이스** → 웹 스크리너(`build_screener_results`) 경로 **무변경** (frontend 안전)

### `investment_report_list` — 요약 응답 + pagination
- 본문(market_snapshot/portfolio_snapshot/report_metadata) 대신 **요약 필드만**: `report_uuid` / `title` / `status` / `kst_date` / `report_type` / `market` / `market_session` / `account_scope` / `created_at`
- 상세는 `investment_report_get`로 유도 (도구 description 명시)
- `limit`(1..100, 기본 20) + `offset`; `has_more`는 `limit+1` fetch로 count 쿼리 없이 도출
- **HTTP 라우터(`investment_reports.py`)의 풀 `InvestmentReportListResponse` 계약은 무변경** — MCP 도구만 슬림화 (frontend/API 비파괴)

### 보조
- `list_reports`에 `offset` 추가 (repository + query_service, 기본 0 → 기존 호출 무영향)
- `kst_date`는 컬럼이 아니라 `idempotency_key`에 인코딩 → 역헬퍼 `kst_date_from_report_key()` (`report_key`와 co-located, 형식 불일치 시 None fail-safe)

## 안전 경계
- read-only / migration 없음. 브로커/주문 mutation 없음.

## 테스트
- 스크리너 cap/offset 2건, report_list 요약+pagination 1건, kst_date 역헬퍼 round-trip/bad-input 2건
- 회귀: HTTP 라우터 풀-shape + registration boot + repo/query_service 전부 green, ruff clean.

Linear: ROB-465

🤖 Generated with [Claude Code](https://claude.com/claude-code)