### PR TITLE
feat(ROB-463): kis_live_place_order NXT/TIF/예약 게이트된 타입 surface + spec

### DIFF
--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -129,6 +129,65 @@ def _limit_order_error(tool_name: str, symbol: str, order_type: str) -> dict[str
     }
 
 
+# ROB-463: NXT venue, TIF/order-validity, and 예약주문 are requested capabilities
+# but require operator confirmation of the exact KIS wire codes
+# (EXCG_ID_DVSN_CD='NXT', ORD_COND_DVSN_CD, RSV_ORD_TIME) before any live order
+# can carry them. Until then these knobs are surfaced (so callers get an explicit,
+# actionable response instead of silent non-support) but fail closed — no live
+# order is placed, even in dry_run. Day orders auto-route via SOR (NXT-eligible) /
+# KRX exactly as before. See docs/superpowers/specs for the gated questions.
+_SUPPORTED_VENUES = {None, "auto"}
+_SUPPORTED_ORDER_VALIDITIES = {None, "day"}
+
+
+def _venue_tif_gate(
+    tool_name: str,
+    symbol: str,
+    *,
+    venue: str | None,
+    order_validity: str | None,
+    reserved_time: str | None,
+) -> dict[str, Any] | None:
+    """Return a fail-closed error payload for not-yet-enabled venue/TIF knobs.
+
+    None means the request uses only the supported (auto-route, day) behaviour
+    and may proceed unchanged.
+    """
+    norm_venue = (venue or "").strip().lower() or None
+    norm_validity = (order_validity or "").strip().lower() or None
+    norm_reserved = (reserved_time or "").strip() or None
+
+    blocked: str | None = None
+    if norm_venue not in _SUPPORTED_VENUES:
+        blocked = f"venue={venue!r} (explicit KRX/NXT/unified routing)"
+    elif norm_validity not in _SUPPORTED_ORDER_VALIDITIES:
+        blocked = f"order_validity={order_validity!r} (TIF / 예약주문 / gtc)"
+    elif norm_reserved is not None:
+        blocked = f"reserved_time={reserved_time!r} (예약주문 / scheduled order)"
+
+    if blocked is None:
+        return None
+
+    return {
+        "success": False,
+        "error": "venue_tif_pending_operator_confirmation",
+        "source": "mcp",
+        "tool": tool_name,
+        "symbol": symbol,
+        "blocked": blocked,
+        "linear": "ROB-463",
+        "reason": (
+            f"{blocked} is not yet enabled for KIS live orders. NXT venue, "
+            "order validity/TIF, and 예약주문 require operator confirmation of "
+            "the exact KIS wire codes (EXCG_ID_DVSN_CD='NXT', ORD_COND_DVSN_CD, "
+            "RSV_ORD_TIME) before a live order can carry them — see ROB-463. "
+            "Until then orders auto-route via SOR (NXT-eligible) / KRX as day "
+            "orders; leave venue/order_validity/reserved_time unset (or "
+            "venue='auto', order_validity='day')."
+        ),
+    }
+
+
 async def _place_order_variant(
     *,
     tool_name: str,
@@ -327,6 +386,12 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "floor and requires side='sell', order_type='limit', and an "
             "approval_issue_id (e.g. 'ROB-164'); approval_issue_id is mandatory "
             "whenever defensive_trim=True, including dry_run (ROB-164 audit gate). "
+            "Orders auto-route via SOR (NXT-eligible) / KRX as day orders. "
+            "venue (krx|nxt|unified), order_validity (day|예약|gtc), and "
+            "reserved_time are accepted but NOT yet enabled — NXT/TIF/예약주문 "
+            "require operator confirmation of the exact KIS wire codes "
+            "(ROB-463) and currently fail closed with an explicit error (no live "
+            "order, even in dry_run); leave them unset for normal day orders. "
             "account_mode='kis_live' is accepted but redundant; "
             "any other account_mode value is rejected."
         ),
@@ -350,9 +415,21 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
         indicators_snapshot: dict[str, Any] | None = None,
         defensive_trim: bool = False,
         approval_issue_id: str | None = None,
+        venue: str | None = None,
+        order_validity: str | None = None,
+        reserved_time: str | None = None,
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
+        gate = _venue_tif_gate(
+            "kis_live_place_order",
+            symbol,
+            venue=venue,
+            order_validity=order_validity,
+            reserved_time=reserved_time,
+        )
+        if gate is not None:
+            return gate
         return await _place_order_variant(
             tool_name="kis_live_place_order",
             pinned_mode=_PINNED,

--- a/docs/superpowers/specs/2026-06-09-rob-463-nxt-venue-tif-spec.md
+++ b/docs/superpowers/specs/2026-06-09-rob-463-nxt-venue-tif-spec.md
@@ -1,0 +1,76 @@
+# ROB-463 — kis_live_place_order: NXT venue · TIF · 예약주문 (spec + gated surface)
+
+Status: **Phase 1 shipped (gated typed surface).** Enablement blocked on operator
+KIS-API wire-code confirmation. Live money — change with care.
+
+## Problem (2026-06-08~09 live operation, real losses)
+
+`kis_live_place_order` only supports **KRX 정규장 day orders**, so:
+- NAVER trims (286k/289k, KRX day) went unfilled → expired at close → the next-day
+  **08:02 NXT 신고가 300k gap-up was missed** (operator filled manually via HTS).
+- New buys / 물타기 unfilled and expired at close (reconcile: `would_mark_cancelled`).
+- Pre-market: a 113k buy limit was **rejected** because the order path used the KRX
+  previous close (112.4k) as "current price" instead of the NXT price (114.3k).
+
+## Current code (main @ dd3f1b83)
+
+- Venue is **auto-resolved**, not operator-selectable:
+  `app/services/brokers/kis/domestic_orders.py:291` —
+  `nxt = await is_nxt_eligible(stock_code); excg_id_dvsn_cd = "SOR" if nxt else "KRX"`.
+  Codes in live use today: **`SOR`** (smart routing, NXT-eligible), **`KRX`**, and
+  **`ALL`** (one branch). A pure **`NXT`** code is never sent.
+- `ORD_DVSN` only `00`(지정가)/`01`(시장가). No TIF / order-validity / reserved fields
+  (`ORD_COND_DVSN_CD`, `RSV_ORD_TIME`) are present in any request body.
+- `KISLiveOrderLedger` has no venue / order_validity / reserved columns.
+- Pre-market "current price" comes from `_get_current_price_for_order`
+  (`order_execution.py`), which for KR resolves the KRX daily/quote close → during
+  pre-market this is the prior close, not the NXT price.
+
+## Phase 1 (this PR) — gated typed surface, zero live risk
+
+`kis_live_place_order` gains `venue` / `order_validity` / `reserved_time` params,
+documented in the tool schema. `_venue_tif_gate` (orders_kis_variants.py) **fails
+closed** for any value beyond the verified `venue∈{None,"auto"}`,
+`order_validity∈{None,"day"}`, `reserved_time=None` — returning
+`error="venue_tif_pending_operator_confirmation"` (+ `linear: "ROB-463"`) and placing
+**no live order, even in dry_run**. Default behaviour (auto-route SOR/KRX, day) is
+byte-identical. No migration, no new wire codes sent.
+
+Rationale: the operator previously had **no way to express** "route to NXT" / "survive
+past close" and got silent non-support + real losses. An explicit, actionable, tracked
+error is strictly better, and it lays the typed contract so enablement is a gate-flip.
+
+## Blocked on operator KIS-API confirmation (enablement questions)
+
+1. **NXT venue:** is `EXCG_ID_DVSN_CD="NXT"` the correct code for a KRX-listed symbol,
+   and how does it differ from `SOR`/`ALL` during pre/after-market? Does `SOR` already
+   reach NXT when KRX is closed, or is explicit `NXT` required?
+2. **TIF / order validity:** exact field + values for day vs 예약주문 vs GTC-equivalent
+   (`ORD_COND_DVSN_CD`? values?). Does KR domestic support GTC at all, and with what
+   expiry semantics?
+3. **예약주문 (reserved):** field name + format for the reserved time (`RSV_ORD_TIME`,
+   `HHMMSS`?), and the TR_ID — is it the same place-order TR or a separate reserved TR?
+4. **Pre-market pricing:** during 08:00–09:00 KST, does `inquire_price` for an
+   NXT-eligible symbol return the NXT session price or the KRX previous close? This
+   determines whether the rejected-113k-buy fix is "route current-price to NXT" vs
+   "relax the pre-market price guard".
+5. **Cancel/modify:** do reserved / non-default-venue orders need different
+   cancel/modify handling (e.g., cancel a reserved order before its scheduled time)?
+
+## Phase 2 (after confirmation) — enablement plan
+
+1. Thread `venue` → `order_korea_stock` (map to confirmed `EXCG_ID_DVSN_CD`); add
+   `ORD_COND_DVSN_CD` / `RSV_ORD_TIME` to the request body per the confirmed spec.
+2. Additive `KISLiveOrderLedger` columns (`venue`, `order_validity`, `reserved_time`),
+   nullable, + alembic migration; record resolved venue on every live order (also fixes
+   the "couldn't tell the order missed NXT" visibility gap).
+3. Pre-market pricing: session-aware current-price (reuse
+   `app/mcp_server/tooling/market_session.kr_market_data_state` from ROB-464) — route to
+   NXT quote during pre-market or relax the guard per Q4.
+4. Flip `_venue_tif_gate` to accept confirmed values; keep unsupported ones fail-closed.
+
+## Safety
+
+- Phase 1: no broker mutation change, no migration, default path unchanged.
+- Shares the session-awareness root cause with **ROB-464** (quote-side pre-market) —
+  reuse `market_session` rather than duplicate.

--- a/tests/test_mcp_kis_order_variants.py
+++ b/tests/test_mcp_kis_order_variants.py
@@ -339,6 +339,70 @@ class TestKisLivePlaceOrder:
         assert "kis_live" in result["error"]
         assert "account_mode" in result["error"]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"venue": "nxt"},
+            {"venue": "krx"},
+            {"venue": "unified"},
+            {"order_validity": "gtc"},
+            {"order_validity": "예약"},
+            {"reserved_time": "093000"},
+        ],
+    )
+    async def test_nxt_venue_tif_reserved_are_gated_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, Any]
+    ) -> None:
+        # ROB-463: NXT venue / TIF / 예약주문 require operator confirmation of the
+        # exact KIS wire codes — until then they MUST fail closed (no live order),
+        # even in dry_run.
+        mcp = _build_live_mcp()
+
+        called = {"placed": False}
+
+        async def fake_place_order_impl(**_kwargs: Any) -> dict[str, Any]:
+            called["placed"] = True
+            return {"success": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+
+        result = await mcp.tools["kis_live_place_order"](
+            symbol="005930", side="buy", price=50000.0, dry_run=True, **kwargs
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "venue_tif_pending_operator_confirmation"
+        assert "ROB-463" in result.get("linear", "") + result.get("reason", "")
+        # The order path must NOT have been reached.
+        assert called["placed"] is False
+
+    @pytest.mark.asyncio
+    async def test_default_and_auto_day_venue_proceed_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # venue=None/"auto" + order_validity=None/"day" is the existing behaviour
+        # (auto-routing, day order) and must still reach the order path.
+        mcp = _build_live_mcp()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+
+        result = await mcp.tools["kis_live_place_order"](
+            symbol="005930",
+            side="buy",
+            price=50000.0,
+            venue="auto",
+            order_validity="day",
+        )
+        assert result["success"] is True
+        assert captured.get("is_mock") is False
+
 
 # ===========================================================================
 # kis_live_cancel_order


### PR DESCRIPTION
## 요약 (ROB-463) — Phase 1: 안전한 게이트된 타입 surface

라이브 NXT venue·TIF(주문유효기간)·예약주문은 **정확한 KIS wire code 확인이 필요**(operator/실계정)해 in-repo로 검증·구현이 불가합니다. 따라서 운영자 방침("build everything verifiable in-repo, gate the KIS codes")에 따라 **Phase 1은 게이트된 타입 surface + spec**만 제공합니다. 라이브 머니 경로는 무변경.

### 실손실 배경 (2026-06-08~09)
- NAVER 트림(KRX 데이) 미체결 → 마감 만료 → 다음날 **08:02 NXT 300k 갭업 미체결**(HTS 수동 처리).
- 프리마켓 113k 매수가 KRX 전일종가(112.4k)를 "현재가"로 적용해 거부.

### 변경 (Phase 1)
- `kis_live_place_order`에 `venue` / `order_validity` / `reserved_time` 파라미터 추가 + description 문서화.
- **`_venue_tif_gate`**: 검증된 값(`venue∈{None,auto}`, `order_validity∈{None,day}`, `reserved_time=None`) 외 **전부 fail-closed** → `error="venue_tif_pending_operator_confirmation"` (+ `linear: ROB-463`), **dry_run 포함 라이브 주문 미발생**.
- 기본 동작(자동 SOR/KRX 라우팅 = 코드 현행, day order) **byte-identical**. migration 없음, 신규 wire code 미전송, `_place_order_impl` 미변경.
- **spec 문서**(`docs/superpowers/specs/2026-06-09-rob-463-...md`): 코드 현황(`domestic_orders.py:291` SOR/KRX 자동) + 게이트된 KIS-code 질문(EXCG_ID_DVSN_CD='NXT' / ORD_COND_DVSN_CD / RSV_ORD_TIME / 프리마켓 inquire_price 세션) + Phase 2 enablement 계획.

### 왜 이게 진전인가
운영자가 이전엔 "NXT로 보내라 / 마감 후에도 살려라"를 **표현할 방법 자체가 없어** silent 비지원 + 실손실. 이제 명확·추적가능 에러를 받고, 타입 계약이 마련돼 enablement는 gate-flip + 확인된 코드 배선(Phase 2)으로 축소됨.

### 안전 경계
- 브로커 mutation 동작 무변경, migration 없음, 신규 wire code 미전송.
- ROB-464(시세측 프리마켓 세션 인식)와 동일 근본원인 → Phase 2에서 `market_session` 재사용.

### 테스트
- 게이트 6-파라미터(venue krx/nxt/unified, order_validity gtc/예약, reserved_time) 전부 fail-closed + `_place_order_impl` 미도달 검증.
- 기본/auto·day는 기존 경로 도달(무변경) 검증.
- order tooling 회귀 91 passed, ruff(app/+tests/) clean.

Linear: ROB-463 (Phase 1; Phase 2 operator-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional venue and order validity parameters for KIS live orders with built-in safety guards
  * Unsupported parameter values are rejected to prevent unintended order routing

* **Documentation**
  * Added specification document for phase-one venue and order timing control implementation

* **Tests**
  * Added test coverage for parameter validation and default behavior continuity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->