### PR TITLE
feat(ROB-470): Hermes ingest가 bundle에서 portfolio/market_snapshot project → delta_get holdings/index 활성화

### DIFF
--- a/app/services/investment_stages/hermes_ingest.py
+++ b/app/services/investment_stages/hermes_ingest.py
@@ -74,6 +74,49 @@ from app.services.investment_stages.symbol_report_repository import (
 _logger = logging.getLogger(__name__)
 
 
+def _project_market_snapshot(bundle_pairs: list[tuple[Any, Any]]) -> dict[str, Any]:
+    """ROB-470 — project a bundle ``market`` snapshot into the report's
+    ``market_snapshot`` column shape the delta loader expects.
+
+    The bundle market payload stores indices at top level (``payload["indices"]``,
+    ``{symbol: {current, ...}}``) but ``_baseline_indices`` reads
+    ``market_snapshot["baseline"]["indices"]`` — so wrap. Returns ``{}`` when no
+    market snapshot / no indices are present (missing != fabricated baseline).
+    """
+    for _item, snap in bundle_pairs:
+        if getattr(snap, "snapshot_kind", None) != "market":
+            continue
+        indices = (getattr(snap, "payload_json", None) or {}).get("indices")
+        if isinstance(indices, dict) and indices:
+            return {"baseline": {"indices": indices}}
+        return {}
+    return {}
+
+
+def _project_portfolio_snapshot(bundle_pairs: list[tuple[Any, Any]]) -> dict[str, Any]:
+    """ROB-470 — project a bundle ``portfolio`` snapshot into the lightweight
+    ``{holdings: [{ticker, pnl_rate}]}`` shape the delta loader's holdings
+    fallback reads.
+
+    Keeps only ``ticker``/``pnl_rate`` per holding (lightweight; the heavy
+    payload stays in the bundle). Returns ``{}`` when no portfolio snapshot or no
+    usable holdings are present so an absent baseline is never fabricated.
+    """
+    for _item, snap in bundle_pairs:
+        if getattr(snap, "snapshot_kind", None) != "portfolio":
+            continue
+        holdings = (getattr(snap, "payload_json", None) or {}).get("holdings")
+        if not isinstance(holdings, list):
+            return {}
+        projected = [
+            {"ticker": h.get("ticker"), "pnl_rate": h.get("pnl_rate")}
+            for h in holdings
+            if isinstance(h, dict) and h.get("ticker") is not None
+        ]
+        return {"holdings": projected} if projected else {}
+    return {}
+
+
 class HermesCompositionIngestError(RuntimeError):
     """Raised when the Hermes-produced envelope cannot be ingested."""
 
@@ -395,6 +438,15 @@ class HermesCompositionIngestService:
         if dimension_report_refs:
             metadata["dimension_report_uuids"] = dimension_report_refs
 
+        # ROB-470 — project the bundle's portfolio/market snapshots into the
+        # report's lightweight JSON columns so delta_get's holdings/index deltas
+        # work for Hermes-created reports (index in particular is read ONLY from
+        # report.market_snapshot, never the bundle). Fetched once and reused for
+        # the news projection below.
+        bundle_pairs = await self._snapshots.list_bundle_items_with_snapshots(bundle.id)
+        market_snapshot = _project_market_snapshot(bundle_pairs)
+        portfolio_snapshot = _project_portfolio_snapshot(bundle_pairs)
+
         ingest_request = IngestReportRequest(
             report_type=request.report_type,
             market=cast(MarketLiteral, request.market),
@@ -410,6 +462,8 @@ class HermesCompositionIngestService:
             status=request.status,
             kst_date=request.kst_date,
             items=list(composition.items),
+            market_snapshot=market_snapshot,
+            portfolio_snapshot=portfolio_snapshot,
             snapshot_bundle_uuid=composition.snapshot_bundle_uuid,
             snapshot_policy_version=request.policy_version,
             snapshot_coverage_summary=dict(bundle.coverage_summary or {}),
@@ -426,9 +480,7 @@ class HermesCompositionIngestService:
         # snapshot. Fail-open: matching gaps never block report creation.
         news_payloads = [
             (snap.payload_json or {})
-            for _item, snap in await self._snapshots.list_bundle_items_with_snapshots(
-                bundle.id
-            )
+            for _item, snap in bundle_pairs
             if snap.snapshot_kind == "news"
         ]
         await self._news_service.persist_from_composition(

--- a/tests/services/investment_stages/test_hermes_snapshot_projection.py
+++ b/tests/services/investment_stages/test_hermes_snapshot_projection.py
@@ -1,0 +1,204 @@
+# tests/services/investment_stages/test_hermes_snapshot_projection.py
+"""ROB-470 — Hermes ingest projects portfolio/market snapshot columns from the
+bundle so delta_get holdings/index deltas work for Hermes-created reports."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.investment_stages.hermes_ingest import (
+    HermesCompositionIngestService,
+    _project_market_snapshot,
+    _project_portfolio_snapshot,
+)
+
+
+def _pair(kind: str, payload: dict):
+    return (object(), SimpleNamespace(snapshot_kind=kind, payload_json=payload))
+
+
+# ---------------------------------------------------------------------------
+# Pure projector helpers
+# ---------------------------------------------------------------------------
+def test_project_market_snapshot_wraps_indices_into_baseline():
+    pairs = [
+        _pair("news", {"articles": []}),
+        _pair("market", {"indices": {"^GSPC": {"current": 5500.0, "name": "S&P"}}}),
+    ]
+    assert _project_market_snapshot(pairs) == {
+        "baseline": {"indices": {"^GSPC": {"current": 5500.0, "name": "S&P"}}}
+    }
+
+
+def test_project_market_snapshot_empty_when_absent_or_no_indices():
+    assert _project_market_snapshot([]) == {}
+    assert _project_market_snapshot([_pair("market", {})]) == {}  # no indices key
+    assert _project_market_snapshot([_pair("market", {"indices": {}})]) == {}  # empty
+
+
+def test_project_portfolio_snapshot_lightweight_holdings():
+    pairs = [
+        _pair(
+            "portfolio",
+            {
+                "holdings": [
+                    {"ticker": "AAPL", "pnl_rate": 3.1, "qty": "drop-me"},
+                    {"ticker": "MSFT", "pnl_rate": -2.0},
+                    {"pnl_rate": 9.0},  # no ticker -> skipped
+                ],
+                "reference_holdings": [],  # not projected
+            },
+        ),
+    ]
+    assert _project_portfolio_snapshot(pairs) == {
+        "holdings": [
+            {"ticker": "AAPL", "pnl_rate": 3.1},
+            {"ticker": "MSFT", "pnl_rate": -2.0},
+        ]
+    }
+
+
+def test_project_portfolio_snapshot_empty_when_absent_or_no_holdings():
+    assert _project_portfolio_snapshot([]) == {}
+    assert _project_portfolio_snapshot([_pair("portfolio", {})]) == {}
+    assert _project_portfolio_snapshot([_pair("portfolio", {"holdings": []})]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration — ingest_composition populates the report columns from the bundle
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_composition_projects_snapshot_columns(
+    session: AsyncSession,
+) -> None:
+    from datetime import UTC, datetime
+
+    from app.schemas.hermes_composition import (
+        HermesCompositionIngestRequest,
+        HermesCompositionResult,
+    )
+    from app.schemas.investment_snapshots import (
+        BundleCreate,
+        BundleItemCreate,
+        SnapshotCreate,
+        SnapshotRunCreate,
+    )
+    from app.services.investment_reports.repository import InvestmentReportsRepository
+    from app.services.investment_snapshots.repository import (
+        InvestmentSnapshotsRepository,
+    )
+
+    now = datetime.now(tz=UTC)
+    snapshots_repo = InvestmentSnapshotsRepository(session)
+    run = await snapshots_repo.insert_run(
+        SnapshotRunCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            requested_by="claude_code",
+            policy_version="intraday_action_report_v1",
+        )
+    )
+    bundle = await snapshots_repo.insert_bundle(
+        BundleCreate(
+            purpose="report_generation",
+            market="us",
+            account_scope="kis_live",
+            policy_version="intraday_action_report_v1",
+            as_of=now,
+            status="complete",
+        )
+    )
+    portfolio_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="portfolio",
+            market="us",
+            account_scope="kis_live",
+            source_kind="kis_mcp",
+            payload_json={
+                "holdings": [{"ticker": "AAPL", "pnl_rate": 3.1}],
+                "reference_holdings": [],
+            },
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    market_snap = await snapshots_repo.insert_snapshot(
+        SnapshotCreate(
+            run_uuid=run.run_uuid,
+            snapshot_kind="market",
+            market="us",
+            account_scope=None,
+            source_kind="auto_trader_mcp",
+            payload_json={"indices": {"^GSPC": {"current": 5500.0, "name": "S&P 500"}}},
+            as_of=now,
+            freshness_status="fresh",
+        )
+    )
+    for snap in (portfolio_snap, market_snap):
+        await snapshots_repo.link_bundle_item(
+            bundle_uuid=bundle.bundle_uuid,
+            item=BundleItemCreate(snapshot_uuid=snap.snapshot_uuid, role="optional"),
+        )
+    await session.commit()
+
+    composition = HermesCompositionResult(
+        snapshot_bundle_uuid=bundle.bundle_uuid,
+        hermes_run_id="run-proj",
+        title="Advisory",
+        summary="synth",
+        items=[],
+        news_citations=[],
+    )
+    request = HermesCompositionIngestRequest(
+        composition=composition,
+        kst_date="2026-05-23",
+        market="us",
+        account_scope="kis_live",
+        status="draft",
+    )
+
+    report = await HermesCompositionIngestService(session).ingest_composition(request)
+    await session.commit()
+
+    reports_repo = InvestmentReportsRepository(session)
+    refreshed = await reports_repo.get_report_by_id(report.id)
+    assert refreshed is not None
+    # portfolio: lightweight holdings projection
+    assert refreshed.portfolio_snapshot == {
+        "holdings": [{"ticker": "AAPL", "pnl_rate": 3.1}]
+    }
+    # market: bundle top-level indices wrapped into baseline.indices for the loader
+    assert refreshed.market_snapshot == {
+        "baseline": {"indices": {"^GSPC": {"current": 5500.0, "name": "S&P 500"}}}
+    }
+
+    # End-to-end: delta_get now computes BOTH signals for the Hermes report —
+    # index from the freshly-populated market_snapshot (the real gap), holdings
+    # from the bundle's portfolio snapshot. Neither is baseline_snapshot_absent.
+    from app.services.investment_reports.delta_service import DeltaService
+
+    async def journal_fn(*, account_type, market):
+        return {"entries": []}
+
+    async def holdings_fn(*, market):
+        return {"accounts": [{"positions": [{"symbol": "AAPL", "profit_rate": 5.0}]}]}
+
+    async def index_fn():
+        return {"indices": [{"symbol": "^GSPC", "current": 5533.0}]}
+
+    delta = await DeltaService(
+        session,
+        journal_fn=journal_fn,
+        holdings_fn=holdings_fn,
+        market_index_fn=index_fn,
+    ).compute_delta(report.report_uuid)
+    assert "holdings" not in delta.get("unavailable", {})
+    assert "index" not in delta.get("unavailable", {})
+    assert delta["holdings_pnl_delta"]["entries"][0]["symbol"] == "AAPL"
+    assert round(delta["index_delta"]["entries"][0]["change_pct"], 4) == 0.6


### PR DESCRIPTION
## 요약
ROB-456(#1178)이 `investment_report_create` 경로에 준 delta JSON fallback 가치를 **Hermes 합성 경로로 확장**합니다. `hermes_ingest.ingest_composition`이 `portfolio_snapshot`/`market_snapshot` 두 컬럼을 안 채워, **Hermes 생성 리포트는 `index_delta`가 구조적으로 항상 `baseline_snapshot_absent`**였습니다(holdings는 bundle에 portfolio 스냅샷이 있으면 bundle 경로로 동작). bundle에 데이터가 이미 있으므로 ingest 시점에 project합니다.

## 변경
- **`_project_market_snapshot`**: bundle market 스냅샷(`collectors/market.py` `snapshot_kind="market"`)의 **top-level** `payload["indices"]`(`{sym:{current,...}}`)를 로더가 기대하는 **`{baseline:{indices:...}}`로 wrap**(`_baseline_indices`/`_index_delta` 계약). 이게 load-bearing fix(index는 오직 `report.market_snapshot`에서만 읽힘).
- **`_project_portfolio_snapshot`**: bundle portfolio `holdings`를 경량 `{holdings:[{ticker,pnl_rate}]}`로 project(무거운 payload는 bundle에 유지). 일관성 + bundle pruning 후에도 report가 self-contained.
- **`ingest_composition`**: `list_bundle_items_with_snapshots(bundle.id)`를 **1회** 조회해 두 컬럼 project + `IngestReportRequest`에 설정, 동일 pairs를 뉴스 citation(ROB-423)에도 재사용(중복 DB 조회 제거).
- **missing != zero**: 데이터 없으면 `{}` → 로더가 `baseline_snapshot_absent` 처리(빈 baseline 날조 금지).

## 안전 경계
read-only/결정적, broker/order/watch mutation 0, **migration 0**(컬럼 기존). fail-open(스냅샷 부재/이상 shape는 `{}`).

## 테스트 (TDD)
- projector 단위: market wrap / portfolio 경량(ticker-less skip) / 부재·빈 → `{}`
- 통합: portfolio+market 스냅샷 bundle → `ingest_composition` → 두 컬럼이 기대 shape로 채워짐 + **end-to-end `delta_get`가 holdings/index 둘 다 산출**(index `change_pct=0.6`, 둘 다 absent 아님)
- 신규 5 + Hermes/stages 광범위 회귀 180 green. ruff clean, ty clean.

ROB-456 후속(Hermes 경로). Closes ROB-470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)