### PR TITLE
fix(ROB-449): retail_sentiment parser 라이브 contents[] shape 미파싱 패치 (operator 검증)

### DIFF
--- a/app/services/naver_finance/discussion.py
+++ b/app/services/naver_finance/discussion.py
@@ -33,10 +33,16 @@ def _to_int(value: Any) -> int | None:
 
 
 def _extract_ranked_items(payload: Any) -> list[dict[str, Any]]:
-    """Find the ranked-items list across likely shapes (defensive, aggregate-only)."""
+    """Find the ranked-items list across likely shapes (defensive, aggregate-only).
+
+    ROB-449 live shape (operator-verified): items are under top-level ``contents[]``,
+    each ``{itemCode, ranking, sevenDayStats:{postCount,...}}``. The raw ``posts[]`` /
+    ``title`` / ``content`` are NEVER read (aggregate counts only).
+    """
     container: Any = payload
     if isinstance(payload, dict):
-        for key in ("rankings", "items", "list", "ranks", "result", "data"):
+        # "contents" is the verified live key; the rest are defensive fallbacks.
+        for key in ("contents", "rankings", "items", "list", "ranks", "result", "data"):
             seq = payload.get(key)
             if isinstance(seq, list):
                 container = seq
@@ -56,16 +62,27 @@ def _extract_ranked_items(payload: Any) -> list[dict[str, Any]]:
         )
         if not code:
             continue
-        rank = _to_int(row.get("rank")) or (idx + 1)
+        rank = _to_int(row.get("rank") or row.get("ranking")) or (idx + 1)
+        # Live shape nests aggregate counts under sevenDayStats; keep top-level fallbacks.
+        stats = row.get("sevenDayStats")
+        stats = stats if isinstance(stats, dict) else {}
         items.append(
             {
                 "code": str(code).strip().upper(),
                 "rank": rank,
-                # AGGREGATE counts only — never raw text fields.
-                "post_count": _to_int(row.get("postCount") or row.get("articleCount")),
-                "comment_count": _to_int(row.get("commentCount")),
+                # AGGREGATE counts only — never raw posts[]/title/content/author.
+                "post_count": _to_int(
+                    row.get("postCount")
+                    or row.get("articleCount")
+                    or stats.get("postCount")
+                ),
+                "comment_count": _to_int(
+                    row.get("commentCount") or stats.get("commentCount")
+                ),
                 "reaction_count": _to_int(
-                    row.get("reactionCount") or row.get("sympathyCount")
+                    row.get("reactionCount")
+                    or row.get("sympathyCount")
+                    or stats.get("reactionCount")
                 ),
             }
         )

--- a/tests/test_retail_sentiment_tool.py
+++ b/tests/test_retail_sentiment_tool.py
@@ -38,6 +38,36 @@ def test_extract_ranked_items_defensive():
     assert items[1]["rank"] == 2  # index-derived
 
 
+def test_extract_live_contents_shape():
+    # ROB-449: operator-verified live shape — items under contents[], code=itemCode,
+    # rank=ranking, post_count=sevenDayStats.postCount; raw posts[]/title/content ignored.
+    payload = {
+        "totalCount": 100,
+        "contents": [
+            {
+                "itemCode": "005930",
+                "ranking": 1,
+                "sevenDayStats": {"postCount": 530, "commentCount": 1200},
+                "posts": [{"title": "RAW IGNORE", "content": "RAW IGNORE"}],
+                "title": "RAW IGNORE",
+            },
+            {"itemCode": "035420", "ranking": 7, "sevenDayStats": {"postCount": 88}},
+        ],
+    }
+    items = disc._extract_ranked_items(payload)
+    assert len(items) == 2
+    assert items[0]["code"] == "005930"
+    assert items[0]["rank"] == 1
+    assert items[0]["post_count"] == 530  # from sevenDayStats
+    assert items[0]["comment_count"] == 1200
+    assert items[1]["code"] == "035420"
+    assert items[1]["rank"] == 7
+    assert items[1]["post_count"] == 88
+    # aggregate-only: raw post text/title never surfaced in the extracted dict
+    for it in items:
+        assert "posts" not in it and "title" not in it and "content" not in it
+
+
 @pytest.mark.asyncio
 async def test_fetch_rankings_fail_open():
     async def boom():


### PR DESCRIPTION
## What & why
operator 라이브 검증: Naver discussion rankings endpoint는 **200/totalCount=100** 정상이나 응답이 **top-level `contents[]`**(`{itemCode, ranking, sevenDayStats:{postCount,...}}`)인데, 내 ROB-449 초기 parser가 `rankings/items/list/...`만 봐서 `items_count=0` (gate를 켜도 aggregate 추출 0). shape 추정 오류(Upbit notices/DefiLlama 라이브-fix와 동류).

## Changes
- `_extract_ranked_items`: key 목록에 **`contents`**(검증된 라이브 키) 추가, `rank=ranking` 폴백, post/comment/reaction을 **`sevenDayStats.*` 중첩**에서도 추출(top-level 폴백 유지). **raw `posts[]`/`title`/`content`/author는 계속 무시**(aggregate-only 불변).
- live-shape 회귀 테스트(`contents[]`/`itemCode`/`ranking`/`sevenDayStats.postCount` → 추출 + raw 미노출 단언) + 기존 defensive-shape 테스트 유지.

## Verification
- **8 passed**(defensive + live-contents shape), ruff clean, **migration 0**. read-only.

## Boundaries
gate는 그대로 **OFF**(operator 유지). raw 텍스트 절대 미노출. ⚠️ operator가 gate ON 전 1회 더 live-smoke로 `contents[]` 추출 확인 권장(shape drift 대비 defensive 유지).

## Related
ROB-449(#1184) 후속 라이브-shape fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)