### PR TITLE
docs(ROB-459): create 도구 description에 structured evidence + CLAUDE_ADVISOR 체이닝 노출 (Task 3.3)

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -131,7 +131,14 @@ CREATE_DESCRIPTION = (
     "target_kind (asset|index|fx, default 'asset') is a SEPARATE optional field "
     "— it is NOT item_kind. "
     "decision_bucket (optional) must be one of: new_buy_candidate, open_action, "
-    "completed_or_existing, deferred_no_action, risk_watch."
+    "completed_or_existing, deferred_no_action, risk_watch. "
+    "Optional structured evidence per item: evidence=[{source, metric, value, "
+    "as_of, freshness}] (source required) plus item-level freshness "
+    "(fresh|soft_stale|stale|unknown) — source-links consensus/flow/forum "
+    "signals instead of burying them in rationale (ROB-459). "
+    "For prior-report chaining set created_by_profile='CLAUDE_ADVISOR' so the "
+    "draft is admitted by investment_report_context_get(draft_policy="
+    "'advisory_only')."
 )
 
 

--- a/tests/mcp_server/test_investment_report_create_handler.py
+++ b/tests/mcp_server/test_investment_report_create_handler.py
@@ -129,3 +129,12 @@ def test_create_tool_description_documents_item_contract():
     # item_kind vs target_kind 혼동 방지 문구가 반드시 노출되어야 한다(ROB-458 핵심).
     assert "target_kind" in desc
     assert "NOT item_kind" in desc
+
+
+def test_create_description_documents_structured_evidence_and_chaining():
+    # ROB-459 — 이제 main에 evidence 필드(P1)와 CLAUDE_ADVISOR 체이닝(P3)이 있으므로
+    # create 도구 description이 둘을 정직하게 광고해야 한다.
+    desc = h.CREATE_DESCRIPTION
+    assert "evidence" in desc
+    assert "source" in desc
+    assert "CLAUDE_ADVISOR" in desc


### PR DESCRIPTION
## 무엇
플랜 Task 3.3 — #1189(ROB-458, `CREATE_DESCRIPTION` 도입)과 #1194(ROB-459 P3+P1, advisory whitelist + evidence 필드)가 **둘 다 main에 머지된 뒤** 합류하는 1줄 후속.

`investment_report_create`의 `CREATE_DESCRIPTION`에 두 문장 추가:
- **P1 evidence 광고**: `evidence=[{source, metric, value, as_of, freshness}]`(source 필수) + item-level `freshness`(fresh|soft_stale|stale|unknown) — 컨센/수급/종토를 rationale에 묻지 않고 소스 연결.
- **P3 체이닝 안내**: 다음 리포트 baseline으로 체이닝하려면 `created_by_profile='CLAUDE_ADVISOR'`를 넘기라고 명시(→ `context_get(draft_policy='advisory_only')`가 admit).

**정직성**: 두 기능이 실제로 main에 존재한 뒤에만 광고 — 없는 필드를 description이 광고하는 silent-drop 안티패턴 회피(그래서 #1189/#1194 머지를 기다렸음).

## 테스트
- `test_create_description_documents_structured_evidence_and_chaining` 추가(evidence/source/CLAUDE_ADVISOR 노출 단언). create handler **9 passed**, ruff clean.

## 범위
- doc-only(도구 description 문자열 1곳 + 테스트). 코드/스키마/DB 무변경, migration 0, mutation 0.
- 스펙/플랜: `docs/superpowers/{specs,plans}/2026-06-09-rob458-459-*`.
- 이로써 ROB-458 + ROB-459(P3+P1) 플랜 슬라이스 전부 완료. 잔여 deferred: ROB-459 P2(graded lite)/P4(order linkage) 별도 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)