### PR TITLE
feat(ROB-469 PR1): MCP /health + lifecycle observability + health-probe repoint

### DIFF
--- a/app/mcp_server/lifecycle.py
+++ b/app/mcp_server/lifecycle.py
@@ -1,0 +1,84 @@
+"""ROB-469: MCP server lifecycle observability.
+
+Unauthenticated, dependency-free /health route and startup/shutdown logging,
+factored out of app/mcp_server/main.py so they can be unit-tested against a
+minimal FastMCP instance without importing the full 128-tool production server.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+from fastmcp.server.lifespan import lifespan as fastmcp_lifespan
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# Module import is the closest in-process proxy to process start time.
+STARTED_MONOTONIC = time.monotonic()
+
+
+def register_health_route(
+    mcp: "FastMCP",
+    *,
+    service: str = "auto-trader-mcp",
+    version: str = "0.1.0",
+) -> None:
+    """Register an UNAUTHENTICATED, dependency-free GET /health route.
+
+    fastmcp 3.2.0 mounts custom routes outside RequireAuthMiddleware (which wraps
+    only the /mcp route), so /health returns 200 even when MCP_AUTH_TOKEN gates
+    /mcp. The handler touches NO DB/Redis/broker, so it is a true event-loop
+    liveness probe: a wedged loop stops answering it and supervision detects that.
+    """
+
+    @mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
+    async def health(request: Request) -> JSONResponse:  # noqa: ARG001
+        return JSONResponse(
+            {
+                "status": "ok",
+                "service": service,
+                "version": version,
+                "uptime_s": round(time.monotonic() - STARTED_MONOTONIC, 1),
+            }
+        )
+
+
+def build_server_lifespan(*, service: str = "auto-trader-mcp"):
+    """Build a FastMCP lifespan that logs startup-complete and shutdown.
+
+    Diagnosis property (ROB-469): a startup log with NO matching shutdown log
+    before the next startup ⇒ hard-kill/OOM/SIGKILL (teardown never ran); a
+    shutdown log ⇒ graceful stop. Signal type cannot be distinguished — uvicorn
+    owns signal handling, so we do NOT install signal handlers here.
+    """
+
+    @fastmcp_lifespan
+    async def _server_lifespan(server: "FastMCP") -> AsyncIterator[dict]:
+        try:
+            tool_count = len(await server.list_tools())
+        except Exception:  # never block startup on a best-effort count
+            tool_count = -1
+        logger.info(
+            "mcp.lifecycle.startup_complete service=%s tools=%d uptime_s=%.1f",
+            service,
+            tool_count,
+            time.monotonic() - STARTED_MONOTONIC,
+        )
+        try:
+            yield {}
+        finally:
+            logger.info(
+                "mcp.lifecycle.shutdown service=%s uptime_s=%.1f",
+                service,
+                time.monotonic() - STARTED_MONOTONIC,
+            )
+
+    return _server_lifespan

--- a/app/mcp_server/lifecycle.py
+++ b/app/mcp_server/lifecycle.py
@@ -26,7 +26,7 @@ STARTED_MONOTONIC = time.monotonic()
 
 
 def register_health_route(
-    mcp: "FastMCP",
+    mcp: FastMCP,
     *,
     service: str = "auto-trader-mcp",
     version: str = "0.1.0",
@@ -61,7 +61,7 @@ def build_server_lifespan(*, service: str = "auto-trader-mcp"):
     """
 
     @fastmcp_lifespan
-    async def _server_lifespan(server: "FastMCP") -> AsyncIterator[dict]:
+    async def _server_lifespan(server: FastMCP) -> AsyncIterator[dict]:
         try:
             tool_count = len(await server.list_tools())
         except Exception:  # never block startup on a best-effort count

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -32,6 +32,10 @@ from app.mcp_server.auth import build_auth_provider  # noqa: E402
 from app.mcp_server.caller_identity_middleware import (  # noqa: E402
     CallerIdentityMiddleware,
 )
+from app.mcp_server.lifecycle import (  # noqa: E402
+    build_server_lifespan,
+    register_health_route,
+)
 from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware  # noqa: E402
 from app.mcp_server.tooling import register_all_tools  # noqa: E402
 
@@ -49,12 +53,17 @@ mcp = FastMCP(
     # (last-registration-silently-wins), which had let the brief판 shadow the report판's
     # get_market_reports / get_latest_market_brief. Any future collision now raises.
     on_duplicate="error",
+    # ROB-469: startup/shutdown lifecycle logging (diagnose disconnect root cause).
+    lifespan=build_server_lifespan(),
 )
 
 mcp.add_middleware(McpToolCallSentryMiddleware())
 mcp.add_middleware(CallerIdentityMiddleware())
 _mcp_profile = resolve_mcp_profile(_env("MCP_PROFILE"))
 register_all_tools(mcp, profile=_mcp_profile)
+# ROB-469: unauthenticated, dependency-free liveness probe for HAProxy / native
+# healthcheck / docker healthcheck. Registered after tools so the count is final.
+register_health_route(mcp, version="0.1.0")
 
 
 def _validate_caller_agent_id_fallback(mcp_type: str) -> None:
@@ -83,9 +92,18 @@ def main() -> None:
     mcp_host = _env("MCP_HOST", "0.0.0.0")
     mcp_port = _env_int("MCP_PORT", 8765)
     mcp_path = _env("MCP_PATH", "/mcp")
+    graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
+    auth_enabled = bool(_auth_token and _auth_token.strip())
 
     logging.info(
-        f"Starting MCP server: type={mcp_type} host={mcp_host} port={mcp_port} path={mcp_path}"
+        "mcp.lifecycle.starting type=%s host=%s port=%s path=%s "
+        "graceful_shutdown_timeout=%s auth_enabled=%s",
+        mcp_type,
+        mcp_host,
+        mcp_port,
+        mcp_path,
+        graceful_shutdown_timeout,
+        auth_enabled,
     )
 
     try:
@@ -94,7 +112,6 @@ def main() -> None:
         if mcp_type == "stdio":
             mcp.run(transport="stdio")
         elif mcp_type == "sse":
-            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
             mcp.run(
                 transport="sse",
                 host=mcp_host,
@@ -103,7 +120,6 @@ def main() -> None:
                 uvicorn_config={"timeout_graceful_shutdown": graceful_shutdown_timeout},
             )
         elif mcp_type == "streamable-http":
-            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
             mcp.run(
                 transport="streamable-http",
                 host=mcp_host,
@@ -114,6 +130,14 @@ def main() -> None:
         else:
             raise ValueError(f"Unsupported MCP_TYPE: {mcp_type}")
     except Exception as exc:
+        # ROB-469: an unhandled mcp.run() exception is a CRASH, distinct from a
+        # graceful mcp.lifecycle.shutdown. Log it explicitly before Sentry capture.
+        logging.exception(
+            "mcp.lifecycle.crashed type=%s host=%s port=%s",
+            mcp_type,
+            mcp_host,
+            mcp_port,
+        )
         capture_exception(
             exc,
             mcp_type=mcp_type,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,6 +101,14 @@ services:
     restart: unless-stopped
     network_mode: host
     command: ["python", "-m", "app.mcp_server.main"]
+    healthcheck:
+      # ROB-469: L7 probe of the unauthenticated /health route. A TCP-connect
+      # check would pass even on a wedged loop; /health proves responsiveness.
+      test: [ "CMD", "python", "-c", "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8765/health', timeout=5).status == 200 else 1)" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
     deploy:
       resources:
         limits:

--- a/docs/runbooks/mcp-health-supervision.md
+++ b/docs/runbooks/mcp-health-supervision.md
@@ -1,0 +1,42 @@
+# Runbook: MCP server health & supervision (ROB-469)
+
+The auto_trader MCP server is a single FastMCP `streamable-http` uvicorn process.
+Production runs the native launchd blue/green path (8766 blue / 8767 green →
+HAProxy → stable 8765). `docker-compose.prod.yml` is the legacy/secondary path.
+
+## /health endpoint
+- `GET http://127.0.0.1:<port>/health` → `200 {"status":"ok","service":"auto-trader-mcp","version":"...","uptime_s":...}`.
+- **Unauthenticated** (bypasses `MCP_AUTH_TOKEN`) and **dependency-free** (no DB/Redis).
+  A 200 means the event loop is responsive; a wedged loop stops answering it.
+- Ports: stable 8765 (HAProxy), blue 8766, green 8767.
+
+## Probe interpretation
+- `/health` 200 → process up and loop responsive.
+- `/health` non-200 / timeout → process down OR event loop wedged. HAProxy
+  (`inter 5s`) marks the backend DOWN; launchd `KeepAlive` restarts only on
+  process EXIT (a wedged-but-alive process is NOT restarted until PR3's watchdog).
+
+## Lifecycle logs (diagnose a disconnect)
+Filter Sentry / logs for `service:auto-trader-mcp`. Log lines:
+- `mcp.lifecycle.starting ...` — env/config at boot.
+- `mcp.lifecycle.startup_complete tools=N ...` — server ready, N tools registered.
+- `mcp.lifecycle.shutdown ...` — graceful stop (teardown ran).
+- `mcp.lifecycle.crashed ...` — unhandled `mcp.run()` exception.
+- **Diagnosis:** `startup_complete` with NO matching `shutdown` before the next
+  `starting` ⇒ hard-kill/OOM/SIGKILL (teardown never ran). A `shutdown` ⇒ graceful.
+
+## Manual checks
+```bash
+# native, active color (find color from HAProxy or launchctl):
+curl -s http://127.0.0.1:8766/health   # blue
+curl -s http://127.0.0.1:8767/health   # green
+curl -s http://127.0.0.1:8765/health   # stable (via HAProxy)
+```
+
+## Restart
+- **Native (launchd):** `launchctl kickstart -k gui/$(id -u)/com.robinco.auto-trader.mcp-<color>`
+- **Docker (legacy):** `docker compose -f docker-compose.prod.yml restart mcp`
+
+## Notes
+- True in-session client reconnect is the Claude Code harness's job, not the server's.
+- Continuous hung-but-alive recovery (heartbeat watchdog) lands in ROB-469 PR3.

--- a/docs/superpowers/plans/2026-06-09-rob-469-pr1-mcp-observe-detect.md
+++ b/docs/superpowers/plans/2026-06-09-rob-469-pr1-mcp-observe-detect.md
@@ -1,0 +1,748 @@
+# ROB-469 PR1 — MCP Observe + Detect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the auto_trader MCP server detectable and the next disconnect diagnosable — add an unauthenticated, dependency-free `/health` route, startup/shutdown lifecycle logging, switch the native/HAProxy/docker health probes to `/health`→200, and add a supervision runbook.
+
+**Architecture:** Factor the health route + lifespan logging into a small, unit-testable `app/mcp_server/lifecycle.py` (so it can be tested against a minimal `FastMCP` without importing the 128-tool production server), wire it into `app/mcp_server/main.py`, and repoint the ops health probes from the auth-gated `/mcp` (401/400) to the new dependency-free `/health` (200). No application logic, no DB migration, no broker/order mutation.
+
+**Tech Stack:** Python 3.13, FastMCP 3.2.0 (`streamable-http` over uvicorn), Starlette (`custom_route`, `TestClient`), pytest, bash ops scripts, HAProxy, docker-compose.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-rob-469-mcp-server-resilience-design.md` (§4 PR1).
+
+**Branch / worktree:** work happens in the existing worktree `/Users/mgh3326/work/auto_trader.rob-469` on branch `rob-469`.
+
+---
+
+## Background facts (verified against installed source — do not re-derive)
+
+- `app/mcp_server/main.py` builds a module-level `mcp = FastMCP(name="auto_trader-mcp", ..., on_duplicate="error")`, adds two middlewares, calls `register_all_tools(mcp, profile=_mcp_profile)`, then `main()` selects transport and calls `mcp.run(...)`. The module-level `_auth_token = _env("MCP_AUTH_TOKEN", "")` (line 38) controls auth.
+- **`@mcp.custom_route("/health", methods=["GET"], include_in_schema=False)` is UNauthenticated.** In fastmcp 3.2.0, only the `/mcp` route is wrapped in `RequireAuthMiddleware` (`fastmcp/server/http.py:336`); custom routes are appended via `_additional_http_routes` (`transport.py:137`, mounted at `http.py:357-358`). App-level `AuthenticationMiddleware` only *populates* auth context, it does not reject. Verified: `GET /health` → 200 even with `MCP_AUTH_TOKEN` set.
+- **Lifespan:** `from fastmcp.server.lifespan import lifespan` is a decorator that turns an async-generator `(server) -> AsyncIterator[dict]` into a composable `Lifespan`; pass it to `FastMCP(..., lifespan=...)` (`server.py:273,337`). Teardown (the `finally` after `yield`) is the safe shutdown hook. **Do NOT call `signal.signal()`** — uvicorn's `capture_signals()` overrides custom handlers (`uvicorn/server.py:322-340`).
+- **Tool count:** `len(await server.list_tools())` works standalone (no request context needed). `get_tools()` does NOT exist; use `list_tools()`.
+- **Testing the route:** `app = mcp.http_app()` returns a `StarletteWithLifespan`; `from starlette.testclient import TestClient; with TestClient(app) as c: c.get("/health")` runs the lifespan and serves the route. Verified round-trip: `200 {'status':'ok'}`.
+- **Diagnosis property:** a *startup* log with no matching *shutdown* log before the next *startup* ⇒ hard-kill/OOM/SIGKILL (teardown never ran). A *shutdown* log ⇒ graceful. Signal-type cannot be distinguished (uvicorn owns it).
+
+---
+
+## File structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `app/mcp_server/lifecycle.py` | `/health` route registration + startup/shutdown lifespan logging (testable unit) | **Create** |
+| `tests/test_mcp_server_lifecycle.py` | Unit tests for `/health` (unauth, bypasses auth, dependency-free) + lifespan logs | **Create** |
+| `app/mcp_server/main.py` | Wire lifespan into `FastMCP(...)`, register `/health`, enrich startup log + crash log | **Modify** |
+| `ops/native/scripts/healthcheck-native.sh` | Probe `/health`→200 instead of `/mcp`→401/400 | **Modify** |
+| `ops/native/haproxy/haproxy.cfg.tmpl` | `bk_mcp` health-check → `GET /health` expect 200 | **Modify** |
+| `scripts/deploy-native.sh` | Built-in fallback probe → `/health`→200 | **Modify** |
+| `docker-compose.prod.yml` | Add the missing `mcp` service healthcheck (L7 `/health`) | **Modify** |
+| `docs/runbooks/mcp-health-supervision.md` | Operator runbook: health route, probe interpretation, restart per path | **Create** |
+
+---
+
+## Task 1: `/health` route in `app/mcp_server/lifecycle.py`
+
+**Files:**
+- Create: `app/mcp_server/lifecycle.py`
+- Test: `tests/test_mcp_server_lifecycle.py`
+
+- [ ] **Step 1: Write the failing tests for the health route**
+
+Create `tests/test_mcp_server_lifecycle.py`:
+
+```python
+"""ROB-469 PR1: MCP server lifecycle observability — /health route + lifespan logging.
+
+These tests run with NO database/redis available, which is itself the proof that
+/health is dependency-free (a true event-loop liveness probe).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from app.mcp_server.auth import build_auth_provider
+from app.mcp_server.lifecycle import build_server_lifespan, register_health_route
+
+
+@pytest.mark.unit
+def test_health_returns_ok_payload() -> None:
+    mcp = FastMCP(name="lifecycle-test")
+    register_health_route(mcp, service="test-mcp", version="9.9.9")
+    app = mcp.http_app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "test-mcp"
+    assert body["version"] == "9.9.9"
+    assert isinstance(body["uptime_s"], (int, float))
+
+
+@pytest.mark.unit
+def test_health_bypasses_auth_while_mcp_is_gated() -> None:
+    # Auth IS enabled, yet /health must still return 200 unauthenticated,
+    # while the /mcp protocol route stays gated.
+    mcp = FastMCP(name="lifecycle-test", auth=build_auth_provider("super-secret-token"))
+    register_health_route(mcp)
+    app = mcp.http_app()
+    with TestClient(app) as client:
+        health = client.get("/health")  # no Authorization header
+        mcp_route = client.get("/mcp")  # no Authorization header
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+    assert mcp_route.status_code in (400, 401, 406)  # NOT 200 — auth/headers reject
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.mcp_server.lifecycle'` (or ImportError on `register_health_route`).
+
+- [ ] **Step 3: Create `app/mcp_server/lifecycle.py` with the health route**
+
+```python
+"""ROB-469: MCP server lifecycle observability.
+
+Unauthenticated, dependency-free /health route and startup/shutdown logging,
+factored out of app/mcp_server/main.py so they can be unit-tested against a
+minimal FastMCP instance without importing the full 128-tool production server.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING
+
+from fastmcp.server.lifespan import lifespan as fastmcp_lifespan
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# Module import is the closest in-process proxy to process start time.
+STARTED_MONOTONIC = time.monotonic()
+
+
+def register_health_route(
+    mcp: "FastMCP",
+    *,
+    service: str = "auto-trader-mcp",
+    version: str = "0.1.0",
+) -> None:
+    """Register an UNAUTHENTICATED, dependency-free GET /health route.
+
+    fastmcp 3.2.0 mounts custom routes outside RequireAuthMiddleware (which wraps
+    only the /mcp route), so /health returns 200 even when MCP_AUTH_TOKEN gates
+    /mcp. The handler touches NO DB/Redis/broker, so it is a true event-loop
+    liveness probe: a wedged loop stops answering it and supervision detects that.
+    """
+
+    @mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
+    async def health(request: Request) -> JSONResponse:  # noqa: ARG001
+        return JSONResponse(
+            {
+                "status": "ok",
+                "service": service,
+                "version": version,
+                "uptime_s": round(time.monotonic() - STARTED_MONOTONIC, 1),
+            }
+        )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py -v`
+Expected: PASS for `test_health_returns_ok_payload` and `test_health_bypasses_auth_while_mcp_is_gated`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/lifecycle.py tests/test_mcp_server_lifecycle.py
+git commit -m "$(cat <<'EOF'
+feat(ROB-469 PR1): unauthenticated /health route for MCP server
+
+Dependency-free GET /health (status/service/version/uptime_s) registered via
+@mcp.custom_route, which fastmcp 3.2.0 mounts outside RequireAuthMiddleware → 200
+even when MCP_AUTH_TOKEN gates /mcp. A wedged event loop stops answering it.
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Startup/shutdown lifespan logging in `lifecycle.py`
+
+**Files:**
+- Modify: `app/mcp_server/lifecycle.py`
+- Test: `tests/test_mcp_server_lifecycle.py:append`
+
+- [ ] **Step 1: Write the failing test for lifespan logging**
+
+Append to `tests/test_mcp_server_lifecycle.py`:
+
+```python
+@pytest.mark.unit
+def test_lifespan_logs_startup_and_shutdown(caplog: pytest.LogCaptureFixture) -> None:
+    mcp = FastMCP(name="lifecycle-test", lifespan=build_server_lifespan(service="test-mcp"))
+
+    @mcp.tool
+    def echo(x: int) -> int:
+        return x
+
+    app = mcp.http_app()
+    with caplog.at_level(logging.INFO, logger="app.mcp_server.lifecycle"):
+        with TestClient(app):
+            pass  # entering runs startup, exiting runs shutdown teardown
+    assert "mcp.lifecycle.startup_complete" in caplog.text
+    assert "tools=1" in caplog.text  # the single registered tool was counted
+    assert "mcp.lifecycle.shutdown" in caplog.text
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py::test_lifespan_logs_startup_and_shutdown -v`
+Expected: FAIL with `ImportError: cannot import name 'build_server_lifespan'`.
+
+- [ ] **Step 3: Add `build_server_lifespan` to `app/mcp_server/lifecycle.py`**
+
+Append to `app/mcp_server/lifecycle.py`:
+
+```python
+def build_server_lifespan(*, service: str = "auto-trader-mcp"):
+    """Build a FastMCP lifespan that logs startup-complete and shutdown.
+
+    Diagnosis property (ROB-469): a startup log with NO matching shutdown log
+    before the next startup ⇒ hard-kill/OOM/SIGKILL (teardown never ran); a
+    shutdown log ⇒ graceful stop. Signal type cannot be distinguished — uvicorn
+    owns signal handling, so we do NOT install signal handlers here.
+    """
+
+    @fastmcp_lifespan
+    async def _server_lifespan(server: "FastMCP") -> AsyncIterator[dict]:
+        try:
+            tool_count = len(await server.list_tools())
+        except Exception:  # never block startup on a best-effort count
+            tool_count = -1
+        logger.info(
+            "mcp.lifecycle.startup_complete service=%s tools=%d uptime_s=%.1f",
+            service,
+            tool_count,
+            time.monotonic() - STARTED_MONOTONIC,
+        )
+        try:
+            yield {}
+        finally:
+            logger.info(
+                "mcp.lifecycle.shutdown service=%s uptime_s=%.1f",
+                service,
+                time.monotonic() - STARTED_MONOTONIC,
+            )
+
+    return _server_lifespan
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py -v`
+Expected: PASS for all three tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/lifecycle.py tests/test_mcp_server_lifecycle.py
+git commit -m "$(cat <<'EOF'
+feat(ROB-469 PR1): MCP startup/shutdown lifespan logging
+
+build_server_lifespan logs mcp.lifecycle.startup_complete (with tool count) and
+mcp.lifecycle.shutdown (graceful teardown). Presence/absence of the shutdown log
+distinguishes graceful stop from hard-kill/OOM. No signal handlers (uvicorn owns them).
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire lifecycle into `app/mcp_server/main.py`
+
+**Files:**
+- Modify: `app/mcp_server/main.py` (imports near top; `FastMCP(...)` ctor ~line 40-56; `register_all_tools` call ~line 56; startup log ~line 82-89; transport branches ~line 95-113; `except` ~line 116-124)
+- Test: `tests/test_mcp_server_lifecycle.py:append`
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Append to `tests/test_mcp_server_lifecycle.py`:
+
+```python
+@pytest.mark.unit
+def test_main_module_wires_health_route() -> None:
+    # Importing the production module must register /health on the real server
+    # instance. _additional_http_routes is where @custom_route appends (fastmcp 3.2.0).
+    # (Lifespan wiring is covered by test_lifespan_logs_startup_and_shutdown + the
+    # visible FastMCP(lifespan=...) ctor change; FastMCP's default _lifespan is a
+    # non-None default_lifespan, so an "is not None" check here would false-pass.)
+    import app.mcp_server.main as main_mod
+
+    paths = {getattr(r, "path", None) for r in main_mod.mcp._additional_http_routes}
+    assert "/health" in paths
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py::test_main_module_wires_health_route -v`
+Expected: FAIL — `/health` not in `_additional_http_routes` (route not yet wired).
+
+- [ ] **Step 3: Add the lifecycle import to `app/mcp_server/main.py`**
+
+Add after the existing `from app.mcp_server.tooling import register_all_tools  # noqa: E402` line (~line 36):
+
+```python
+from app.mcp_server.lifecycle import (  # noqa: E402
+    build_server_lifespan,
+    register_health_route,
+)
+```
+
+- [ ] **Step 4: Wire the lifespan into the `FastMCP(...)` constructor**
+
+Find the constructor (the `mcp = FastMCP(` block, ~line 40-56) and add a `lifespan=` kwarg. Change:
+
+```python
+mcp = FastMCP(
+    name="auto_trader-mcp",
+    instructions=(
+        "Market data, holdings lookup, and order execution tools for auto_trader "
+        "(symbol search, quote, holdings, OHLCV, indicators, trade, order management)."
+    ),
+    version="0.1.0",
+    auth=auth_provider,
+    # ROB-447: fail-fast on duplicate tool names at boot instead of the default "warn"
+    # (last-registration-silently-wins), which had let the brief판 shadow the report판's
+    # get_market_reports / get_latest_market_brief. Any future collision now raises.
+    on_duplicate="error",
+)
+```
+
+to (add the `lifespan=` line):
+
+```python
+mcp = FastMCP(
+    name="auto_trader-mcp",
+    instructions=(
+        "Market data, holdings lookup, and order execution tools for auto_trader "
+        "(symbol search, quote, holdings, OHLCV, indicators, trade, order management)."
+    ),
+    version="0.1.0",
+    auth=auth_provider,
+    # ROB-447: fail-fast on duplicate tool names at boot instead of the default "warn"
+    # (last-registration-silently-wins), which had let the brief판 shadow the report판's
+    # get_market_reports / get_latest_market_brief. Any future collision now raises.
+    on_duplicate="error",
+    # ROB-469: startup/shutdown lifecycle logging (diagnose disconnect root cause).
+    lifespan=build_server_lifespan(),
+)
+```
+
+- [ ] **Step 5: Register the `/health` route after tool registration**
+
+Find `register_all_tools(mcp, profile=_mcp_profile)` (~line 56) and add the health route registration immediately after it:
+
+```python
+register_all_tools(mcp, profile=_mcp_profile)
+# ROB-469: unauthenticated, dependency-free liveness probe for HAProxy / native
+# healthcheck / docker healthcheck. Registered after tools so the count is final.
+register_health_route(mcp, version="0.1.0")
+```
+
+- [ ] **Step 6: Enrich the startup log and crash log in `main()`**
+
+In `main()`, hoist the graceful-shutdown timeout and enrich the startup log. Change the existing log block (~line 82-89):
+
+```python
+    mcp_type = _env("MCP_TYPE", "streamable-http")
+    mcp_host = _env("MCP_HOST", "0.0.0.0")
+    mcp_port = _env_int("MCP_PORT", 8765)
+    mcp_path = _env("MCP_PATH", "/mcp")
+
+    logging.info(
+        f"Starting MCP server: type={mcp_type} host={mcp_host} port={mcp_port} path={mcp_path}"
+    )
+```
+
+to:
+
+```python
+    mcp_type = _env("MCP_TYPE", "streamable-http")
+    mcp_host = _env("MCP_HOST", "0.0.0.0")
+    mcp_port = _env_int("MCP_PORT", 8765)
+    mcp_path = _env("MCP_PATH", "/mcp")
+    graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
+    auth_enabled = bool(_auth_token and _auth_token.strip())
+
+    logging.info(
+        "mcp.lifecycle.starting type=%s host=%s port=%s path=%s "
+        "graceful_shutdown_timeout=%s auth_enabled=%s",
+        mcp_type,
+        mcp_host,
+        mcp_port,
+        mcp_path,
+        graceful_shutdown_timeout,
+        auth_enabled,
+    )
+```
+
+Then in the two transport branches that recompute the timeout, remove the now-duplicate local assignment. Change the `sse` branch:
+
+```python
+        elif mcp_type == "sse":
+            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
+            mcp.run(
+```
+
+to:
+
+```python
+        elif mcp_type == "sse":
+            mcp.run(
+```
+
+and the `streamable-http` branch:
+
+```python
+        elif mcp_type == "streamable-http":
+            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
+            mcp.run(
+```
+
+to:
+
+```python
+        elif mcp_type == "streamable-http":
+            mcp.run(
+```
+
+(The hoisted `graceful_shutdown_timeout` variable is already in scope for both branches.)
+
+Finally, enrich the `except` block (~line 116-124) with a distinct crash log. Change:
+
+```python
+    except Exception as exc:
+        capture_exception(
+            exc,
+            mcp_type=mcp_type,
+            mcp_host=mcp_host,
+            mcp_port=mcp_port,
+            mcp_path=mcp_path,
+        )
+        raise
+```
+
+to:
+
+```python
+    except Exception as exc:
+        # ROB-469: an unhandled mcp.run() exception is a CRASH, distinct from a
+        # graceful mcp.lifecycle.shutdown. Log it explicitly before Sentry capture.
+        logging.exception(
+            "mcp.lifecycle.crashed type=%s host=%s port=%s", mcp_type, mcp_host, mcp_port
+        )
+        capture_exception(
+            exc,
+            mcp_type=mcp_type,
+            mcp_host=mcp_host,
+            mcp_port=mcp_port,
+            mcp_path=mcp_path,
+        )
+        raise
+```
+
+- [ ] **Step 7: Run the wiring test + the full lifecycle test file**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py -v`
+Expected: PASS for all four tests (`test_main_module_wires_health_route` now green).
+
+- [ ] **Step 8: Run the existing boot test to confirm no regression**
+
+Run: `uv run pytest tests/test_mcp_tool_registration_boot.py -v`
+Expected: PASS (registration surface unchanged; lifespan/health are additive).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/mcp_server/main.py tests/test_mcp_server_lifecycle.py
+git commit -m "$(cat <<'EOF'
+feat(ROB-469 PR1): wire /health + lifecycle logging into MCP main
+
+FastMCP(lifespan=build_server_lifespan()), register_health_route after tools,
+enriched mcp.lifecycle.starting startup log (graceful_timeout + auth_enabled),
+and a distinct mcp.lifecycle.crashed log on unhandled mcp.run() exceptions.
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Repoint ops health probes to `/health`→200
+
+**Files:**
+- Modify: `ops/native/scripts/healthcheck-native.sh`
+- Modify: `ops/native/haproxy/haproxy.cfg.tmpl`
+- Modify: `scripts/deploy-native.sh`
+- Modify: `docker-compose.prod.yml`
+
+> No automated test harness exists for these shell/config files; each step is an exact edit plus a `grep` verification that the old `/mcp` probe is gone and the new `/health` probe is present.
+
+- [ ] **Step 1: `ops/native/scripts/healthcheck-native.sh` — probe `/health`→200**
+
+Replace the MCP probe block:
+
+```bash
+code=$(curl -sS -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' "http://127.0.0.1:${MCP_PORT}/mcp" || true)
+if [[ "$code" != "401" && "$code" != "400" ]]; then
+  echo "mcp unexpected status at :${MCP_PORT}: $code" >&2
+  rc=1
+fi
+```
+
+with:
+
+```bash
+# ROB-469: probe the unauthenticated, dependency-free /health route (200) instead
+# of the auth-gated /mcp (401/400). A 200 proves the event loop is responsive — a
+# wedged loop stops answering /health.
+code=$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:${MCP_PORT}/health" || true)
+if [[ "$code" != "200" ]]; then
+  echo "mcp health failed at :${MCP_PORT}: $code" >&2
+  rc=1
+fi
+```
+
+- [ ] **Step 2: `ops/native/haproxy/haproxy.cfg.tmpl` — `bk_mcp` → `GET /health` expect 200**
+
+Replace, inside `backend bk_mcp`, the probe lines:
+
+```
+    # ROB-259 review: send the same Accept: text/event-stream header that
+    # cloudflared/native healthcheck send, so FastMCP returns the expected
+    # 400/401 status. Without the header FastMCP can respond with a different
+    # status (e.g. 406) and HAProxy would mark the backend DOWN.
+    option httpchk
+    http-check send meth GET uri /mcp ver HTTP/1.1 hdr Host trader-mcp.robinco.dev hdr Accept text/event-stream
+    http-check expect status 400,401
+```
+
+with:
+
+```
+    # ROB-469: probe the unauthenticated /health route (200). Dependency-free, so
+    # a 200 means the event loop is live; a wedged loop stops answering and HAProxy
+    # marks the backend DOWN (inter 5s). Pre-ROB-469 /mcp probe kept commented for
+    # one release as a rollback reference.
+    option httpchk GET /health
+    http-check expect status 200
+    # OLD (pre-ROB-469):
+    # option httpchk
+    # http-check send meth GET uri /mcp ver HTTP/1.1 hdr Host trader-mcp.robinco.dev hdr Accept text/event-stream
+    # http-check expect status 400,401
+```
+
+- [ ] **Step 3: `scripts/deploy-native.sh` — built-in fallback probe → `/health`→200**
+
+Replace the MCP fallback probe block (inside `run_healthcheck_once`):
+
+```bash
+  code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' http://127.0.0.1:8765/mcp || true)"
+  if [[ "$code" != "401" && "$code" != "400" ]]; then
+    echo "MCP unexpected status: $code" >&2
+    rc=1
+  fi
+```
+
+with:
+
+```bash
+  # ROB-469: probe unauthenticated /health (200) instead of auth-gated /mcp.
+  code="$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/health || true)"
+  if [[ "$code" != "200" ]]; then
+    echo "MCP health failed: $code" >&2
+    rc=1
+  fi
+```
+
+- [ ] **Step 4: `docker-compose.prod.yml` — add the missing `mcp` healthcheck**
+
+In the `mcp:` service, immediately after the `command: ["python", "-m", "app.mcp_server.main"]` line, add a healthcheck block (L7 `/health` via stdlib `urllib`, so it needs no `curl` in the image):
+
+```yaml
+    command: ["python", "-m", "app.mcp_server.main"]
+    healthcheck:
+      # ROB-469: L7 probe of the unauthenticated /health route. A TCP-connect
+      # check would pass even on a wedged loop; /health proves responsiveness.
+      test: [ "CMD", "python", "-c", "import sys,urllib.request; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8765/health', timeout=5).status == 200 else 1)" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+```
+
+- [ ] **Step 5: Verify the probe switch with grep**
+
+Run:
+```bash
+grep -n "/health" ops/native/scripts/healthcheck-native.sh ops/native/haproxy/haproxy.cfg.tmpl scripts/deploy-native.sh docker-compose.prod.yml
+grep -n "http-check expect status 200" ops/native/haproxy/haproxy.cfg.tmpl
+! grep -nE "expect status 400,401" ops/native/haproxy/haproxy.cfg.tmpl | grep -v '^\s*#' | grep -v '# OLD'
+```
+Expected: each file shows a new `/health` probe; the active (non-commented) HAProxy expect is `200`; the only remaining `400,401` line is the commented `# OLD` reference.
+
+- [ ] **Step 6: Lint the shell scripts (if shellcheck is available; otherwise skip)**
+
+Run: `command -v shellcheck >/dev/null && shellcheck ops/native/scripts/healthcheck-native.sh scripts/deploy-native.sh || echo "shellcheck not installed — skip"`
+Expected: no new errors (or skip message).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ops/native/scripts/healthcheck-native.sh ops/native/haproxy/haproxy.cfg.tmpl scripts/deploy-native.sh docker-compose.prod.yml
+git commit -m "$(cat <<'EOF'
+feat(ROB-469 PR1): repoint MCP health probes to unauthenticated /health (200)
+
+native healthcheck-native.sh, HAProxy bk_mcp, deploy-native.sh fallback, and the
+docker-compose mcp service (previously had NO healthcheck) now probe /health→200
+instead of the auth-gated /mcp→401/400. Old /mcp probe kept commented one release.
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Supervision runbook
+
+**Files:**
+- Create: `docs/runbooks/mcp-health-supervision.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/runbooks/mcp-health-supervision.md`:
+
+```markdown
+# Runbook: MCP server health & supervision (ROB-469)
+
+The auto_trader MCP server is a single FastMCP `streamable-http` uvicorn process.
+Production runs the native launchd blue/green path (8766 blue / 8767 green →
+HAProxy → stable 8765). `docker-compose.prod.yml` is the legacy/secondary path.
+
+## /health endpoint
+- `GET http://127.0.0.1:<port>/health` → `200 {"status":"ok","service":"auto-trader-mcp","version":"...","uptime_s":...}`.
+- **Unauthenticated** (bypasses `MCP_AUTH_TOKEN`) and **dependency-free** (no DB/Redis).
+  A 200 means the event loop is responsive; a wedged loop stops answering it.
+- Ports: stable 8765 (HAProxy), blue 8766, green 8767.
+
+## Probe interpretation
+- `/health` 200 → process up and loop responsive.
+- `/health` non-200 / timeout → process down OR event loop wedged. HAProxy
+  (`inter 5s`) marks the backend DOWN; launchd `KeepAlive` restarts only on
+  process EXIT (a wedged-but-alive process is NOT restarted until PR3's watchdog).
+
+## Lifecycle logs (diagnose a disconnect)
+Filter Sentry / logs for `service:auto-trader-mcp`. Log lines:
+- `mcp.lifecycle.starting ...` — env/config at boot.
+- `mcp.lifecycle.startup_complete tools=N ...` — server ready, N tools registered.
+- `mcp.lifecycle.shutdown ...` — graceful stop (teardown ran).
+- `mcp.lifecycle.crashed ...` — unhandled `mcp.run()` exception.
+- **Diagnosis:** `startup_complete` with NO matching `shutdown` before the next
+  `starting` ⇒ hard-kill/OOM/SIGKILL (teardown never ran). A `shutdown` ⇒ graceful.
+
+## Manual checks
+```bash
+# native, active color (find color from HAProxy or launchctl):
+curl -s http://127.0.0.1:8766/health   # blue
+curl -s http://127.0.0.1:8767/health   # green
+curl -s http://127.0.0.1:8765/health   # stable (via HAProxy)
+```
+
+## Restart
+- **Native (launchd):** `launchctl kickstart -k gui/$(id -u)/com.robinco.auto-trader.mcp-<color>`
+- **Docker (legacy):** `docker compose -f docker-compose.prod.yml restart mcp`
+
+## Notes
+- True in-session client reconnect is the Claude Code harness's job, not the server's.
+- Continuous hung-but-alive recovery (heartbeat watchdog) lands in ROB-469 PR3.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/mcp-health-supervision.md
+git commit -m "$(cat <<'EOF'
+docs(ROB-469 PR1): MCP health & supervision runbook
+
+/health interpretation, lifecycle-log diagnosis (startup w/o shutdown = hard-kill),
+manual checks per port, restart per deploy path.
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Full verification gate
+
+- [ ] **Step 1: Run the full lifecycle + boot tests**
+
+Run: `uv run pytest tests/test_mcp_server_lifecycle.py tests/test_mcp_tool_registration_boot.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Lint + format the changed Python (CI checks `app/` AND `tests/`)**
+
+Run: `uv run ruff check app/mcp_server/lifecycle.py app/mcp_server/main.py tests/test_mcp_server_lifecycle.py && uv run ruff format --check app/mcp_server/lifecycle.py app/mcp_server/main.py tests/test_mcp_server_lifecycle.py`
+Expected: no lint errors; format clean. (If format fails, run `uv run ruff format <files>` and amend.)
+
+- [ ] **Step 3: Confirm zero migration / zero broker mutation**
+
+Run: `git diff --name-only main...HEAD`
+Expected: only `app/mcp_server/lifecycle.py`, `app/mcp_server/main.py`, `tests/test_mcp_server_lifecycle.py`, the four ops files, and the two docs files. No `alembic/`, no `app/services/brokers/`, no order/ledger paths.
+
+- [ ] **Step 4: Push and open the PR (only when the user asks to ship)**
+
+```bash
+git push -u origin rob-469
+```
+Then open a PR (base `main`) titled `feat(ROB-469 PR1): MCP /health + lifecycle observability + health-probe repoint`, body summarizing: unauthenticated dependency-free /health, lifecycle logging (startup/shutdown/crashed diagnosis), ops probes repointed to /health→200, runbook. Note: zero migration, no broker/order mutation; native launchd is the authoritative path.
+
+---
+
+## Operator deploy note (post-merge, gated)
+Deploy the **app change first** (so `/health` exists), verify `curl /health`→200 on 8766/8767/8765, *then* the config change is already bundled — the HAProxy/native probes will use `/health` on the next deploy cycle. The commented `/mcp` probe is the one-release rollback reference.
+
+---
+
+## Self-review notes (author)
+- **Spec coverage (§4):** /health route (T1), lifespan logging (T2), main wiring + enriched startup/crash log (T3), native+HAProxy+deploy+docker probe repoint (T4), runbook (T5). All §4 items mapped.
+- **Out of scope (correct):** no per-tool timeout/QueuePool/semaphore (PR2), no watchdog/heartbeat (PR3), no get_news (deferred).
+- **Type consistency:** `register_health_route(mcp, *, service, version)` and `build_server_lifespan(*, service)` used identically in tests and main wiring; `STARTED_MONOTONIC` single source; log keys `mcp.lifecycle.{starting,startup_complete,shutdown,crashed}` consistent across code, tests, and runbook.
+- **No placeholders:** every code/edit/command step contains the literal content.

--- a/docs/superpowers/specs/2026-06-09-rob-469-mcp-server-resilience-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-469-mcp-server-resilience-design.md
@@ -1,0 +1,241 @@
+# ROB-469 — auto_trader MCP server resilience (PR1 + PR2 + PR3)
+
+- **Issue:** ROB-469 `[Bug/Infra] auto_trader MCP 세션 중 연결 끊김 (128 tools 일괄 다운, get_news 포함) — 자동 재연결·뉴스 폴백 부재`
+- **Date:** 2026-06-09
+- **Status:** Design approved (pre-implementation)
+- **Author:** Hermes (with code-grounded multi-agent investigation)
+- **Scope decision:** PR1 (Observe + Detect) → PR2 (Harden the loop) → PR3 (Self-heal watchdog). `get_news` fallback (proposal #3) and the CDP read-only degrade guide (proposal #4) are **deferred**.
+
+---
+
+## 1. Problem
+
+During a live trading session (2026-06-09), the **entire auto_trader MCP server connection dropped** and all **128 tools became unavailable simultaneously** (`mcp__auto_trader_local__* (128) no longer available — MCP server disconnected`). The outage was **sustained**, not a transient blip. The CDP (9222 Naver) fallback could read quotes/flows/community but **not** news headlines.
+
+The server is a single **FastMCP `streamable-http`** uvicorn process (`app/mcp_server/main.py`), default port 8765 / path `/mcp`, that the Claude Code harness connects to over HTTP. In production it runs via the **native launchd blue/green** path (`scripts/deploy-native.sh`): ports 8766 (blue) / 8767 (green) → HAProxy → stable 8765. (`docker-compose.prod.yml` is the legacy path, retired by ROB-263.)
+
+### 1.1 The honest reframing (premise correction)
+
+ROB-469's headline ask is *"MCP 자동 재연결"* (auto-reconnect). **True in-session client auto-reconnect is NOT achievable in this repo** — it is the Claude Code harness/MCP-client's responsibility; the server cannot force a dropped client to re-establish a session or transparently retry the in-flight call. What this repo *can* own is the **server-side half** of resilience: don't wedge in the first place, be detectable when it does, be observable about *why*, and be supervised so the harness has something healthy to reconnect to. Proposal #1 is therefore re-scoped to **server-side resilience + supervision + a health endpoint**, not literal reconnect.
+
+### 1.2 Root-cause assessment (ranked, code-grounded)
+
+"All 128 down at once" means the **single uvicorn event loop stopped servicing everything** (a per-tool fault would not take everything down). Ranked likely causes:
+
+1. **MOST LIKELY — event-loop wedge.** There is **no per-tool timeout** today (`graceful_shutdown_timeout=10` is process-level only). One slow tool blocks the single worker → all tools stall. Confirmed hazards:
+   - `app/core/db.py:13-18` uses `poolclass=NullPool` → a fresh DB connection is opened per request; under load the connect itself awaits and piles up.
+   - `app/mcp_server/tooling/portfolio_holdings.py:995-1001` — unbounded `asyncio.gather` over crypto positions (task explosion on large portfolios); also `:668` equity-price gather.
+   - heavy pandas/indicator compute runs **on the event loop** without `run_in_executor` offload.
+   - `redis_max_connections=10` is a tight shared ceiling.
+2. **PLAUSIBLE — process died/OOM'd** and was restarted; the in-flight session was already severed. launchd `KeepAlive=true` restarts on **exit**, but the harness session is broken regardless.
+3. **PLAUSIBLE — hung-but-alive loop that supervision can't catch today.** launchd `KeepAlive` restarts only on process **exit**; `docker-compose.prod.yml` mcp service has **no** healthcheck; the only `/mcp`→401/400 probe runs at **deploy time**, not continuously.
+4. **LESS LIKELY / unverifiable in-repo — transport/SSE idle drop** (harness-side to recover).
+
+**We cannot retro-diagnose which one fired** — there is no shutdown-cause logging today (one startup `logging.info` + a top-level `except`). That gap is itself the strongest reason to **land observability first**.
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- Make a wedged/crashed MCP server **detectable** (continuous health signal) and the next incident **diagnosable** (lifecycle logging).
+- **Reduce the frequency** of event-loop wedges (per-tool timeout for I/O-bound tools; bounded fan-out; bounded DB/redis pools).
+- Provide a **recovery path** for a hung-but-alive process (self-heal watchdog).
+- Keep production safe: additive, env-gated where blast radius is wide, **zero DB migration**, no broker/order mutation.
+
+### Non-goals (explicit)
+- **Literal in-session client auto-reconnect** — harness's job.
+- **External alerting/paging** (Prometheus/PagerDuty heartbeat) — deployment/orchestration layer.
+- **`get_news` fallback** (proposal #3) — deferred; **DB-backed fallback** (read recent `NewsArticle` rows the ingestor already populates) is the recorded approach if/when revived.
+- **Proposal #4 CDP read-only degrade guide** — docs-only sub-issue, needs a concrete trigger + gated tool-set definition first.
+- **Retro-diagnosing the 2026-06-09 incident** — impossible without the logging PR1 adds.
+- **Multi-worker uvicorn** — risky with streamable-http session affinity + blue/green ports; a deployment decision, not an in-repo quick fix.
+
+### Honest limitation (stated, not hidden)
+`asyncio.wait_for` **cannot cancel a synchronous blocking call** (heavy pandas with no `await`, a blocking C call). The per-tool timeout fixes **I/O-bound** wedges (the majority — Naver scrape / Finnhub / KIS awaiting) but **not** a true sync-blocking wedge. That is precisely why PR3's watchdog (recover) and offloading heavy compute to threads (follow-up) are the backstop. The spec does not oversell the timeout as a total fix.
+
+---
+
+## 3. Architecture: prevent → detect → recover → diagnose
+
+| Layer | Mechanism | PR | Covers |
+|---|---|---|---|
+| Prevent (I/O wedge) | per-tool timeout middleware (cancels awaiting tools) | PR2 | common case |
+| Prevent (resource) | bound hot-path `gather`s; `NullPool→QueuePool`; redis tuning | PR2 | task explosion / conn exhaustion |
+| Detect | dependency-free `/health` on the loop (HAProxy `inter 5s`) + lifecycle logs | PR1 | any wedge/crash becomes visible |
+| Recover | launchd `KeepAlive` (clean exit/crash) + heartbeat watchdog → `launchctl kickstart -k` (hung-but-alive) | launchd today / PR3 | self-healing incl. hard sync-wedge |
+| Diagnose | lifespan startup/shutdown logs + Sentry — presence/absence of shutdown log = graceful vs hard-kill/OOM | PR1 | root-cause the next incident |
+
+---
+
+## 4. PR1 — Observe + Detect (ships first; low-risk; no new process)
+
+### 4.1 `/health` route — `app/mcp_server/main.py`
+Add after `register_all_tools(...)` and before `main()`/`mcp.run()`:
+
+```python
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+@mcp.custom_route("/health", methods=["GET"], include_in_schema=False)
+async def health_check(request: Request) -> JSONResponse:
+    return JSONResponse(
+        {"status": "ok", "service": "auto-trader-mcp",
+         "version": "0.1.0", "uptime_s": round(time.monotonic() - _STARTED_MONOTONIC, 1)}
+    )
+```
+
+- **Unauthenticated by construction** (verified against fastmcp 3.2.0 source): app-level `AuthenticationMiddleware` only *populates* auth context; only the `/mcp` route is wrapped in `RequireAuthMiddleware` (`fastmcp/server/http.py:336`); `custom_route` appends to `_additional_http_routes` mounted separately (`transport.py:100-148`, `http.py:357-358`). So `GET /health` → 200 even when `MCP_AUTH_TOKEN` is set.
+- **Dependency-free** — no DB / Redis / broker calls. A `/health` served on the same event loop is itself a liveness/wedge signal: if the loop is wedged, `/health` stops responding and HAProxy (`inter 5s`) marks the backend down. It must never hang on a backend blip.
+- `_STARTED_MONOTONIC = time.monotonic()` captured at module import.
+
+### 4.2 Lifecycle logging — `app/mcp_server/main.py`
+Use the FastMCP lifespan (teardown is the safe shutdown hook; **do not** call `signal.signal()` — uvicorn's `capture_signals()` overrides custom handlers, verified in `uvicorn/server.py:322-340`). FastMCP `_lifespan_manager` shields teardown from `CancelledError` (`fastmcp/server/mixins/lifespan.py:140-190`).
+
+```python
+from fastmcp.server.lifespan import lifespan as fastmcp_lifespan
+
+@fastmcp_lifespan
+async def server_lifespan(server):
+    logging.info("MCP server startup complete: tools=%d transport=%s ...", tool_count, mcp_type, ...)
+    # optional Sentry breadcrumb / message: "mcp.lifecycle.startup"
+    try:
+        yield {}
+    finally:
+        logging.info("MCP server shutdown initiated (graceful) uptime_s=%.1f", time.monotonic() - _STARTED_MONOTONIC)
+        # optional Sentry message: "mcp.lifecycle.shutdown"
+
+mcp = FastMCP(..., lifespan=server_lifespan)
+```
+
+- Add a **structured startup log** (tool count, transport, host/port, graceful-timeout, auth on/off) in `main()`.
+- **Enrich the existing top-level `except`** (`main.py:116-124`) so an unhandled `mcp.run()` exception is tagged distinctly from a graceful shutdown.
+- **Diagnosis property:** *startup logged → shutdown logged* ⇒ graceful. *startup logged → (no shutdown) → new startup* ⇒ hard-kill/OOM/SIGKILL (teardown never ran). This presence/absence pair is the crash-vs-graceful signal we lack today.
+
+### 4.3 Switch health probes to `/health` → 200
+Native is authoritative; keep the old `/mcp`→401/400 probe as a **commented fallback** for one release.
+- `ops/native/scripts/healthcheck-native.sh:54-58` — probe `http://127.0.0.1:${MCP_PORT}/health`, expect `200` (drop the `Accept: text/event-stream` header).
+- `ops/native/haproxy/haproxy.cfg.tmpl:43-55` (`backend bk_mcp`) — `option httpchk GET /health` + `http-check expect status 200`.
+- `scripts/deploy-native.sh:~181` — built-in fallback probe → `/health`/200.
+- `native_deploy_lib.sh` `probe_color_direct` / `probe_public_stable` — **no change** (data-driven by `healthcheck-native.sh`); just verify the 24×5s window covers MCP startup.
+- `docker-compose.prod.yml` mcp service (~lines 89-111) — **add** the missing healthcheck block mirroring `api` (`curl -sf http://127.0.0.1:8765/health`, interval 30s, timeout 10s, retries 3, start_period 40s).
+
+### 4.4 Runbook
+`docs/runbooks/mcp-health-supervision.md`: `/health` purpose, probe interpretation, manual check, restart per path (`launchctl kickstart -k gui/$uid/com.robinco.auto-trader.mcp-<color>` / `docker compose restart mcp`), Sentry filter `service:auto-trader-mcp`, blue/green + launchd specifics.
+
+### 4.5 PR1 tests
+- `GET /health` returns **200 unauthenticated** even with `MCP_AUTH_TOKEN` set, and `{status:"ok"}`; payload dependency-free (no DB/Redis touched).
+- startup + shutdown lifecycle logs emitted (capture via caplog around lifespan enter/exit).
+- `healthcheck-native.sh` parses a 200 as healthy (bash test or a small harness).
+
+---
+
+## 5. PR2 — Harden the loop (the real SPOF fix)
+
+### 5.1 `TimeoutMiddleware` (per-tool timeout)
+New `app/mcp_server/timeout_middleware.py` subclassing `fastmcp.server.middleware.Middleware`, implementing `on_call_tool`:
+
+```python
+from fastmcp.exceptions import ToolError
+
+class ToolTimeoutMiddleware(Middleware):
+    async def on_call_tool(self, context, call_next):
+        tool = context.message.name
+        budget = _budget_for(tool)              # default 45s + elevated/exempt map
+        if budget is None:                      # exempt → no timeout
+            return await call_next(context)
+        try:
+            return await asyncio.wait_for(call_next(context), timeout=budget)
+        except asyncio.TimeoutError:
+            raise ToolError(f"{tool} exceeded {budget:g}s budget") from None
+```
+
+- **Registration order (CRITICAL — verified against `fastmcp/server/server.py:448-451`):** the chain is built `chain = tool; for mw in reversed(self.middleware): chain = partial(mw, call_next=chain)`. With append-order `[Sentry, CallerIdentity]`, execution is `Sentry(outer) → CallerIdentity → tool`, i.e. **first-added = OUTERMOST**. To have the timeout (a) wrap the tool and (b) raise its `ToolError` *inside* the Sentry scope, **add `ToolTimeoutMiddleware` LAST** (innermost):
+  ```python
+  mcp.add_middleware(McpToolCallSentryMiddleware())   # outermost — captures the timeout error w/ context
+  mcp.add_middleware(CallerIdentityMiddleware())
+  mcp.add_middleware(ToolTimeoutMiddleware())          # innermost — wraps the tool
+  ```
+  > The integration-mapping agent recommended adding it *first*; that is **wrong** and would put the timeout outside the Sentry scope. Source-verified correction.
+- **Budgets** — default **45s**; generous **elevated/exempt** map (env-overridable), kept generous to avoid killing legitimate slow tools (per the "exempt heavy tools" choice):
+  - `analyze_stock_batch`, `analyze_portfolio`, `screen_stocks` → 120s
+  - `screen_stocks_snapshot` → 90s
+  - `get_holdings` → 120s (crypto-signal + price fan-out)
+  - `get_financials`, `get_company_profile` → 90s
+  - `get_indicators` → 75s
+  - `kis_live_reconcile_orders`, `live_reconcile_orders`, kis_mock reconcile → 60s
+  - `investment_report_generate_from_bundle`, `investment_report_prepare_bundle`, hermes composition → **exempt (None)** or 240s
+  - Map lives in a constant + env overrides (`MCP_TOOL_TIMEOUT_DEFAULT_S`, `MCP_TOOL_TIMEOUT_OVERRIDES`).
+- **Behavior:** a timeout raises `ToolError` → clean MCP error for that one call; the server and the other 127 tools stay up. (Caveat from §2: only cancellable for tools blocked on `await`.)
+
+### 5.2 Bound hot-path fan-outs
+- `app/mcp_server/tooling/portfolio_holdings.py:995-1001` — wrap the crypto-signals `gather` with `asyncio.Semaphore(4)` (each position does OHLCV I/O + voting-signal compute). Mirror the existing `analysis_tool_handlers.py` `Semaphore(5)` pattern.
+- `app/mcp_server/tooling/portfolio_holdings.py:~668` — bound the equity-price `gather` with `Semaphore(5)` (KIS/yfinance rate limits).
+- Colder fan-outs (`fundamentals_sources_yfinance.py:607`, `fundamentals/_market_index.py:73`, `screening/enrichment.py:116/331`, `market_data_indicators.py:449`) — noted as **opportunistic follow-up**, not in PR2, to keep the diff focused (those tools also get elevated timeouts).
+
+### 5.3 `NullPool → QueuePool` (env-gated; widest blast radius)
+`app/core/db.py` — the engine is **shared** by API + MCP + workers + scheduler across ~90 call sites; each is a **separate process with its own engine instance**. Investigation confirmed: **no pgbouncer/pooler** (direct `localhost:5432`), clean `async with AsyncSessionLocal()` lifecycle, no forking. QueuePool is "highly likely safe."
+
+```python
+from sqlalchemy.pool import NullPool, QueuePool
+
+_pool_class_name = os.getenv("DB_POOL_CLASS", "queue").lower()   # "queue" (default) | "null"
+if _pool_class_name == "null":
+    engine = create_async_engine(settings.DATABASE_URL, echo=_echo, pool_pre_ping=True, poolclass=NullPool)
+else:
+    engine = create_async_engine(
+        settings.DATABASE_URL, echo=_echo, pool_pre_ping=True, poolclass=QueuePool,
+        pool_size=int(os.getenv("DB_POOL_SIZE", "5")),
+        max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "10")),
+        pool_recycle=int(os.getenv("DB_POOL_RECYCLE_S", "1800")),
+        pool_timeout=int(os.getenv("DB_POOL_TIMEOUT_S", "10")),
+    )
+```
+
+- **Default = QueuePool** with conservative sizing + `pool_pre_ping` + `pool_recycle`. **`DB_POOL_CLASS=null` is an instant rollback.**
+- Document `DB_POOL_*` in `env.example` / `env.prod.example`.
+- This is the **lower-confidence, hardest-to-review** change — flag it clearly for reviewer + a prod load-check; it can be pulled out of PR2 without affecting the other items.
+
+### 5.4 Redis tuning
+- `app/core/config.py` Redis block — `redis_max_connections` 10 → 20; keep `redis_socket_timeout` (fail-fast); optionally add a pool-get timeout. Conservative, low-risk.
+
+### 5.5 PR2 tests
+- A deliberately-slow tool (sleeps past its budget) → `ToolError` raised; **other tools still respond** (server not wedged); error captured within Sentry scope (middleware order asserted).
+- An exempt/elevated tool gets its higher budget (does not time out under its budget).
+- `Semaphore` bounds observed concurrency on the crypto/equity gathers (monkeypatch a counting fetch).
+- QueuePool engine builds, round-trips a query; `DB_POOL_CLASS=null` falls back to NullPool.
+
+---
+
+## 6. PR3 — Self-heal watchdog (recover a hung-but-alive process)
+
+The only mechanism that recovers a **hard sync-wedge** (which §2's caveat and launchd `KeepAlive` cannot). Mirrors the existing `websocket_monitor.py` heartbeat precedent (`WS_MONITOR_HEARTBEAT_PATH` + atomic temp-file→rename).
+
+- **Heartbeat writer (app):** a small asyncio task started in the MCP lifespan that writes `{updated_at_unix, color, is_running}` to `MCP_HEARTBEAT_PATH` every N seconds (atomic write). If the loop wedges, the heartbeat goes stale — that staleness is the wedge signal.
+- **Watchdog (ops):** new `ops/native/scripts/mcp-watchdog.sh` — loops every ~10–15s, reads both blue/green heartbeat files, and if a file is stale (> 2–3× interval) calls `launchctl kickstart -k gui/$uid/com.robinco.auto-trader.mcp-<color>` to force-restart the wedged-but-alive process.
+- **Plist (ops):** new `ops/native/plists/com.robinco.auto-trader.mcp-watchdog.plist` — single non-color-specific instance monitoring both colors; `KeepAlive=true`.
+- **Deploy wiring:** add the watchdog label to `deploy-native.sh` `SINGLE_ACTIVE_LABELS` + `restart_single_active_services()`; export `MCP_HEARTBEAT_PATH` from `ops/native/scripts/run-mcp.sh`.
+- **Guards against flapping:** heartbeat must be written at startup before the main loop (avoid restart-loop on slow start); stale threshold ≥ 3× interval to absorb startup jitter; respect `ThrottleInterval`.
+- **Tests:** stale heartbeat → watchdog emits a kickstart for the correct color; fresh heartbeat → no action; atomic write under termination.
+
+---
+
+## 7. Rollout / operator steps
+- **No DB migration** anywhere in PR1/PR2/PR3.
+- **PR1:** deploy `/health` route **first**, verify `GET /health`→200 on 8766/8767/8765, then the HAProxy/healthcheck config switch (so the probe change never precedes the endpoint).
+- **PR2:** ships QueuePool default-on (rollback `DB_POOL_CLASS=null`); operator load-checks DB pool under prod concurrency; timeout budgets tunable via env without redeploy of code semantics.
+- **PR3:** install watchdog plist via the native deploy flow; confirm a synthetic stale heartbeat triggers a kickstart in staging.
+
+## 8. Risks & mitigations
+- **Probe change ordering** — endpoint must exist before HAProxy/healthcheck expect 200; mitigation: PR1 sequencing + commented `/mcp` fallback for one release.
+- **QueuePool sizing** — too small → queueing; too large → memory; mitigation: conservative env-tunable defaults + instant `DB_POOL_CLASS=null` rollback + load-check.
+- **Timeout too aggressive** — could kill legit slow tools; mitigation: generous default + elevated/exempt map + env overrides; report-gen exempt.
+- **Watchdog flapping** — restart loop on slow start; mitigation: startup-first heartbeat, ≥3× stale threshold, throttle.
+- **Sync-blocking wedge** — timeout can't cancel it; mitigation: PR3 watchdog recovers; offloading heavy pandas to `run_in_executor` is a noted follow-up.
+
+## 9. Out-of-scope follow-ups (tracked, not built here)
+- `get_news` DB-backed fallback (proposal #3).
+- CDP read-only degrade guide (proposal #4) — needs trigger + gated tool-set definition.
+- Offload heavy pandas/indicator compute to `run_in_executor`.
+- Bound the colder screener/fundamentals `gather`s.
+- External alerting/heartbeat (Prometheus/Sentry cron) at the orchestration layer.

--- a/ops/native/haproxy/haproxy.cfg.tmpl
+++ b/ops/native/haproxy/haproxy.cfg.tmpl
@@ -41,13 +41,16 @@ backend bk_api
     {{API_BACKUP_LINE}}
 
 backend bk_mcp
-    # ROB-259 review: send the same Accept: text/event-stream header that
-    # cloudflared/native healthcheck send, so FastMCP returns the expected
-    # 400/401 status. Without the header FastMCP can respond with a different
-    # status (e.g. 406) and HAProxy would mark the backend DOWN.
-    option httpchk
-    http-check send meth GET uri /mcp ver HTTP/1.1 hdr Host trader-mcp.robinco.dev hdr Accept text/event-stream
-    http-check expect status 400,401
+    # ROB-469: probe the unauthenticated /health route (200). Dependency-free, so
+    # a 200 means the event loop is live; a wedged loop stops answering and HAProxy
+    # marks the backend DOWN (inter 5s). Pre-ROB-469 /mcp probe kept commented for
+    # one release as a rollback reference.
+    option httpchk GET /health
+    http-check expect status 200
+    # OLD (pre-ROB-469):
+    # option httpchk
+    # http-check send meth GET uri /mcp ver HTTP/1.1 hdr Host trader-mcp.robinco.dev hdr Accept text/event-stream
+    # http-check expect status 400,401
     timeout server 1h
     timeout tunnel 1h
     default-server inter 5s fall 2 rise 1

--- a/ops/native/scripts/healthcheck-native.sh
+++ b/ops/native/scripts/healthcheck-native.sh
@@ -51,9 +51,12 @@ if ! curl -fsS "http://127.0.0.1:${API_PORT}/healthz" >/dev/null; then
   rc=1
 fi
 
-code=$(curl -sS -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' "http://127.0.0.1:${MCP_PORT}/mcp" || true)
-if [[ "$code" != "401" && "$code" != "400" ]]; then
-  echo "mcp unexpected status at :${MCP_PORT}: $code" >&2
+# ROB-469: probe the unauthenticated, dependency-free /health route (200) instead
+# of the auth-gated /mcp (401/400). A 200 proves the event loop is responsive — a
+# wedged loop stops answering /health.
+code=$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:${MCP_PORT}/health" || true)
+if [[ "$code" != "200" ]]; then
+  echo "mcp health failed at :${MCP_PORT}: $code" >&2
   rc=1
 fi
 

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -178,9 +178,10 @@ run_healthcheck_once() {
     rc=1
   }
 
-  code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' http://127.0.0.1:8765/mcp || true)"
-  if [[ "$code" != "401" && "$code" != "400" ]]; then
-    echo "MCP unexpected status: $code" >&2
+  # ROB-469: probe unauthenticated /health (200) instead of auth-gated /mcp.
+  code="$(curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:8765/health || true)"
+  if [[ "$code" != "200" ]]; then
+    echo "MCP health failed: $code" >&2
     rc=1
   fi
 

--- a/tests/scripts/test_deploy_native_bluegreen.py
+++ b/tests/scripts/test_deploy_native_bluegreen.py
@@ -37,7 +37,7 @@ def _stub_dir(tmp_path: Path) -> Path:
         "done\n"
         'case "$url" in\n'
         "  *127.0.0.1*)\n"
-        '    if [[ "$capture_status" == "1" ]]; then echo 401; fi\n'
+        '    if [[ "$capture_status" == "1" ]]; then echo 200; fi\n'
         "    exit 0 ;;\n"
         "  *) exit 6 ;;\n"
         "esac\n"
@@ -212,7 +212,7 @@ def test_full_deploy_rolls_back_on_probe_failure(tmp_path: Path) -> None:
         "done\n"
         'case "$url" in\n'
         "  *8002*|*8767*) exit 22 ;;\n"
-        '  *127.0.0.1*) if [[ "$capture_status" == "1" ]]; then echo 401; fi; exit 0 ;;\n'
+        '  *127.0.0.1*) if [[ "$capture_status" == "1" ]]; then echo 200; fi; exit 0 ;;\n'
         "  *) exit 6 ;;\n"
         "esac\n"
     )

--- a/tests/scripts/test_healthcheck_native.py
+++ b/tests/scripts/test_healthcheck_native.py
@@ -68,7 +68,7 @@ def _common_env(tmp_path: Path, bin_dir: Path) -> dict[str, str]:
 
 
 def test_default_mode_probes_stable_ports(tmp_path: Path) -> None:
-    bin_dir = _build_curl_stub(tmp_path, {8000: 200, 8765: 401})
+    bin_dir = _build_curl_stub(tmp_path, {8000: 200, 8765: 200})
     env = _common_env(tmp_path, bin_dir)
     proc = subprocess.run(
         ["bash", str(HC)], check=False, capture_output=True, text=True, env=env
@@ -77,7 +77,7 @@ def test_default_mode_probes_stable_ports(tmp_path: Path) -> None:
 
 
 def test_direct_blue_probes_8001_and_8766(tmp_path: Path) -> None:
-    bin_dir = _build_curl_stub(tmp_path, {8001: 200, 8766: 401})
+    bin_dir = _build_curl_stub(tmp_path, {8001: 200, 8766: 200})
     env = _common_env(tmp_path, bin_dir)
     proc = subprocess.run(
         ["bash", str(HC), "--direct", "blue"],
@@ -90,7 +90,7 @@ def test_direct_blue_probes_8001_and_8766(tmp_path: Path) -> None:
 
 
 def test_direct_green_probes_8002_and_8767(tmp_path: Path) -> None:
-    bin_dir = _build_curl_stub(tmp_path, {8002: 200, 8767: 400})
+    bin_dir = _build_curl_stub(tmp_path, {8002: 200, 8767: 200})
     env = _common_env(tmp_path, bin_dir)
     proc = subprocess.run(
         ["bash", str(HC), "--direct", "green"],
@@ -130,7 +130,7 @@ def test_unknown_arg_rejected(tmp_path: Path) -> None:
 
 
 def test_default_mode_fails_when_api_down(tmp_path: Path) -> None:
-    bin_dir = _build_curl_stub(tmp_path, {8000: 500, 8765: 401})
+    bin_dir = _build_curl_stub(tmp_path, {8000: 500, 8765: 200})
     env = _common_env(tmp_path, bin_dir)
     proc = subprocess.run(
         ["bash", str(HC)], check=False, capture_output=True, text=True, env=env

--- a/tests/test_mcp_server_lifecycle.py
+++ b/tests/test_mcp_server_lifecycle.py
@@ -48,7 +48,9 @@ def test_health_bypasses_auth_while_mcp_is_gated() -> None:
 
 @pytest.mark.unit
 def test_lifespan_logs_startup_and_shutdown(caplog: pytest.LogCaptureFixture) -> None:
-    mcp = FastMCP(name="lifecycle-test", lifespan=build_server_lifespan(service="test-mcp"))
+    mcp = FastMCP(
+        name="lifecycle-test", lifespan=build_server_lifespan(service="test-mcp")
+    )
 
     @mcp.tool
     def echo(x: int) -> int:
@@ -61,3 +63,16 @@ def test_lifespan_logs_startup_and_shutdown(caplog: pytest.LogCaptureFixture) ->
     assert "mcp.lifecycle.startup_complete" in caplog.text
     assert "tools=1" in caplog.text  # the single registered tool was counted
     assert "mcp.lifecycle.shutdown" in caplog.text
+
+
+@pytest.mark.unit
+def test_main_module_wires_health_route() -> None:
+    # Importing the production module must register /health on the real server
+    # instance. _additional_http_routes is where @custom_route appends (fastmcp 3.2.0).
+    # (Lifespan wiring is covered by test_lifespan_logs_startup_and_shutdown + the
+    # visible FastMCP(lifespan=...) ctor change; FastMCP's default _lifespan is a
+    # non-None default_lifespan, so an "is not None" check here would false-pass.)
+    import app.mcp_server.main as main_mod
+
+    paths = {getattr(r, "path", None) for r in main_mod.mcp._additional_http_routes}
+    assert "/health" in paths

--- a/tests/test_mcp_server_lifecycle.py
+++ b/tests/test_mcp_server_lifecycle.py
@@ -44,3 +44,20 @@ def test_health_bypasses_auth_while_mcp_is_gated() -> None:
     assert health.status_code == 200
     assert health.json()["status"] == "ok"
     assert mcp_route.status_code in (400, 401, 406)  # NOT 200 — auth/headers reject
+
+
+@pytest.mark.unit
+def test_lifespan_logs_startup_and_shutdown(caplog: pytest.LogCaptureFixture) -> None:
+    mcp = FastMCP(name="lifecycle-test", lifespan=build_server_lifespan(service="test-mcp"))
+
+    @mcp.tool
+    def echo(x: int) -> int:
+        return x
+
+    app = mcp.http_app()
+    with caplog.at_level(logging.INFO, logger="app.mcp_server.lifecycle"):
+        with TestClient(app):
+            pass  # entering runs startup, exiting runs shutdown teardown
+    assert "mcp.lifecycle.startup_complete" in caplog.text
+    assert "tools=1" in caplog.text  # the single registered tool was counted
+    assert "mcp.lifecycle.shutdown" in caplog.text

--- a/tests/test_mcp_server_lifecycle.py
+++ b/tests/test_mcp_server_lifecycle.py
@@ -43,7 +43,11 @@ def test_health_bypasses_auth_while_mcp_is_gated() -> None:
         mcp_route = client.get("/mcp")  # no Authorization header
     assert health.status_code == 200
     assert health.json()["status"] == "ok"
-    assert mcp_route.status_code in (400, 401, 406)  # NOT 200 — auth/headers reject
+    # Auth-enabled /mcp rejects an unauthenticated request with 401 (RequireAuthMiddleware).
+    # Asserting exactly 401 — not a {400,401,406} set — keeps the gating signal real: a
+    # 406 (missing MCP Accept headers) is what /mcp returns when auth is DISABLED, so
+    # allowing it would let this test false-pass if auth were accidentally broken.
+    assert mcp_route.status_code == 401
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_server_lifecycle.py
+++ b/tests/test_mcp_server_lifecycle.py
@@ -1,0 +1,46 @@
+"""ROB-469 PR1: MCP server lifecycle observability — /health route + lifespan logging.
+
+These tests run with NO database/redis available, which is itself the proof that
+/health is dependency-free (a true event-loop liveness probe).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from app.mcp_server.auth import build_auth_provider
+from app.mcp_server.lifecycle import build_server_lifespan, register_health_route
+
+
+@pytest.mark.unit
+def test_health_returns_ok_payload() -> None:
+    mcp = FastMCP(name="lifecycle-test")
+    register_health_route(mcp, service="test-mcp", version="9.9.9")
+    app = mcp.http_app()
+    with TestClient(app) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "test-mcp"
+    assert body["version"] == "9.9.9"
+    assert isinstance(body["uptime_s"], (int, float))
+
+
+@pytest.mark.unit
+def test_health_bypasses_auth_while_mcp_is_gated() -> None:
+    # Auth IS enabled, yet /health must still return 200 unauthenticated,
+    # while the /mcp protocol route stays gated.
+    mcp = FastMCP(name="lifecycle-test", auth=build_auth_provider("super-secret-token"))
+    register_health_route(mcp)
+    app = mcp.http_app()
+    with TestClient(app) as client:
+        health = client.get("/health")  # no Authorization header
+        mcp_route = client.get("/mcp")  # no Authorization header
+    assert health.status_code == 200
+    assert health.json()["status"] == "ok"
+    assert mcp_route.status_code in (400, 401, 406)  # NOT 200 — auth/headers reject

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -69,6 +69,21 @@ def _load_main_module(
     fake_monitoring.__dict__["capture_exception"] = MagicMock()
     fake_monitoring.__dict__["init_sentry"] = MagicMock()
 
+    # Pre-existing dependency of main.py (line 5). Previously relied on being
+    # already cached in sys.modules by an earlier test, so this harness failed
+    # in isolation; stub it explicitly so the isolation is real.
+    fake_profiles = ModuleType("app.mcp_server.profiles")
+    fake_profiles.__dict__["resolve_mcp_profile"] = MagicMock(return_value="profile")
+
+    # ROB-469: main.py now imports the lifecycle module (unauth /health route +
+    # startup/shutdown lifespan logging). Stub it like the other dependencies so
+    # main()'s transport/shutdown logic is tested in isolation.
+    fake_lifecycle = ModuleType("app.mcp_server.lifecycle")
+    fake_lifecycle.__dict__["build_server_lifespan"] = MagicMock(
+        return_value="server-lifespan"
+    )
+    fake_lifecycle.__dict__["register_health_route"] = MagicMock()
+
     env_utils_module = _load_env_utils_module()
 
     monkeypatch.setitem(sys.modules, "fastmcp", fake_fastmcp)
@@ -86,13 +101,18 @@ def _load_main_module(
     )
     monkeypatch.setitem(sys.modules, "app.mcp_server.tooling", fake_tooling)
     monkeypatch.setitem(sys.modules, "app.monitoring.sentry", fake_monitoring)
-    monkeypatch.delitem(sys.modules, "app.mcp_server.main", raising=False)
+    monkeypatch.setitem(sys.modules, "app.mcp_server.profiles", fake_profiles)
+    monkeypatch.setitem(sys.modules, "app.mcp_server.lifecycle", fake_lifecycle)
 
     spec = importlib.util.spec_from_file_location("app.mcp_server.main", main_path)
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules["app.mcp_server.main"] = module
+    # Use monkeypatch.setitem (NOT a raw `sys.modules[...] =`) so the fake module is
+    # restored/removed on teardown. A raw assignment paired with a no-op
+    # delitem(raising=False) leaked this fake `main` into sys.modules for the whole
+    # session, poisoning other tests that import the real app.mcp_server.main.
+    monkeypatch.setitem(sys.modules, "app.mcp_server.main", module)
     spec.loader.exec_module(module)
     return module, module.mcp, fake_monitoring.capture_exception
 


### PR DESCRIPTION
## ROB-469 PR1 — Observe + Detect (server-side resilience, layer 1 of 3)

Mid-session the auto_trader MCP server (FastMCP `streamable-http`) lost its connection and **all 128 tools went down at once** (SPOF). This PR is the *diagnose-before-cure* layer: make a wedged/crashed server **detectable** and the next incident **diagnosable**. (PR2 hardens the event loop; PR3 adds a self-heal watchdog.)

> Honest scope note: true in-session client auto-reconnect is the Claude Code **harness's** job, not the server's. This repo owns server-side robustness, observability, health, and supervision.

### What's in this PR
- **Unauthenticated, dependency-free `GET /health`** (`app/mcp_server/lifecycle.py`) via `@mcp.custom_route` — returns `200 {status,service,version,uptime_s}` even when `MCP_AUTH_TOKEN` gates `/mcp` (verified against fastmcp 3.2.0: only `/mcp` is wrapped in `RequireAuthMiddleware`). Touches no DB/Redis, so it's a true **event-loop liveness probe**.
- **Lifecycle logging** — `mcp.lifecycle.starting` / `startup_complete` (with tool count) / `shutdown` / `crashed`. Diagnosis property: a `startup_complete` with **no** matching `shutdown` before the next start ⇒ hard-kill/OOM (teardown never ran); a `shutdown` ⇒ graceful. (No signal handlers — uvicorn owns those.)
- **Health probes repointed to `/health`→200** on every path: native `healthcheck-native.sh`, HAProxy `bk_mcp`, `deploy-native.sh` fallback, and a **new** `docker-compose.prod.yml` mcp healthcheck (it had none). Old `/mcp`→401/400 probe kept commented as a one-release rollback reference.
- **Runbook** `docs/runbooks/mcp-health-supervision.md`.
- Design spec + implementation plan under `docs/superpowers/`.

### Reviews
spec ✅ · independent code-quality **APPROVED** (1 minor fixed: tightened a `/mcp` auth assertion to `== 401`) · final holistic **SHIP** (probe chain consistent end-to-end; streamable-http session manager provably untouched by the lifespan swap; docker one-liner correct on 3.13).

Also fixed two **pre-existing** test-harness bugs that PR1's regression sweep exposed (confirmed via merge-base they are not PR1 regressions): `test_mcp_server_main.py` isolation fragility (relied on `sys.modules` caching) and a `sys.modules` leak from a raw assignment paired with `delitem(raising=False)`.

### Test plan
- [x] `tests/test_mcp_server_lifecycle.py` (4) — `/health` 200 unauthenticated even with auth; `/mcp` → 401; lifespan logs emitted
- [x] `tests/test_mcp_server_main.py` (11) — now green in isolation and in both file orderings
- [x] `tests/test_mcp_tool_registration_boot.py`, `tests/scripts/test_native_run_wrappers.py` — no regression (28 passing total)
- [x] ruff clean; full-suite collection clean (9997)
- [x] **Zero DB migration; no broker/order mutation**

### Operator note (post-merge)
Deploy the app change first so `/health` exists; the HAProxy/native/docker probes use `/health`→200 on the next cycle. `DB_POOL_CLASS`/timeout knobs are PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unauthenticated GET /health endpoint returning ok, service, version, and uptime.
  * Server lifespan emits structured startup-complete and shutdown lifecycle logs.

* **Chores / Ops**
  * Deployment healthchecks and proxy probes switched to the new /health endpoint (Docker, HAProxy, native scripts).

* **Documentation**
  * New operator runbook and resilience design/plan docs for health & supervision.

* **Tests**
  * Added lifecycle tests validating /health, lifespan logs, and probe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->