### PR TITLE
fix(ROB-463): 프리마켓 KR 주문 가격을 live NXT 호가로 산출 (전일종가 거부 제거)

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -12,12 +12,17 @@ from typing import Any
 import httpx
 
 import app.services.brokers.upbit.client as upbit_service
+import app.services.market_data as market_data_service
 from app.core.config import settings
 from app.mcp_server.caller_identity import get_caller_agent_id, get_caller_source
 from app.mcp_server.tooling.kis_mock_ledger import _get_kis_mock_shadow_exposure
 from app.mcp_server.tooling.market_data_quotes import (
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
+)
+from app.mcp_server.tooling.market_session import (
+    DATA_STATE_PREMARKET_UNAVAILABLE,
+    kr_market_data_state,
 )
 from app.mcp_server.tooling.portfolio_cash import (
     extract_usd_orderable_from_row as _extract_usd_orderable_from_row,
@@ -334,6 +339,34 @@ def _resolve_scalping_exit_context(
     return ScalpingExitContext(strategy_id=strategy_id, reason=resolved_reason)
 
 
+async def _premarket_nxt_price_for_kr(symbol: str) -> float | None:
+    """ROB-463: live NXT price for a KR equity during pre-market, else None.
+
+    Returns None (so the caller falls back to the KRX quote) when it is not the
+    KR pre-market session, when the symbol has no NXT book, or on any fetch error
+    — the order path must never be blocked by this best-effort price source.
+    Priced as the NXT 예상체결가 (expected_price) when present, else the best
+    bid/ask mid (or whichever single side exists).
+    """
+    if kr_market_data_state() != DATA_STATE_PREMARKET_UNAVAILABLE:
+        return None
+    try:
+        book = await market_data_service.get_orderbook(symbol, "kr", venue="nxt")
+    except Exception as exc:  # best-effort; never block the order on pricing
+        logger.warning("NXT pre-market price fetch failed for %s: %s", symbol, exc)
+        return None
+    if book is None or book.is_empty_book:
+        return None
+    if book.expected_price:
+        return float(book.expected_price)
+    best_ask = book.asks[0].price if book.asks else None
+    best_bid = book.bids[0].price if book.bids else None
+    if best_ask and best_bid:
+        return (best_ask + best_bid) / 2.0
+    single = best_ask or best_bid
+    return float(single) if single else None
+
+
 async def _get_current_price_for_order(symbol: str, market_type: str) -> float | None:
     if market_type == "crypto":
         prices = await upbit_service.fetch_multiple_current_prices(
@@ -341,6 +374,12 @@ async def _get_current_price_for_order(symbol: str, market_type: str) -> float |
         )
         return prices.get(symbol)
     if market_type == "equity_kr":
+        # ROB-463: during KR pre-market, the KRX quote is the prior close — using
+        # it as "current price" falsely rejected valid pre-market buys. Prefer the
+        # live NXT orderbook price when available; otherwise fall back to KRX.
+        nxt_price = await _premarket_nxt_price_for_kr(symbol)
+        if nxt_price is not None:
+            return nxt_price
         quote = await _fetch_quote_equity_kr(symbol)
         return float(quote.get("price")) if quote.get("price") else None
 

--- a/docs/superpowers/specs/2026-06-09-rob-463-nxt-venue-tif-spec.md
+++ b/docs/superpowers/specs/2026-06-09-rob-463-nxt-venue-tif-spec.md
@@ -57,6 +57,18 @@ error is strictly better, and it lays the typed contract so enablement is a gate
 5. **Cancel/modify:** do reserved / non-default-venue orders need different
    cancel/modify handling (e.g., cancel a reserved order before its scheduled time)?
 
+## Phase 2 Part A — pre-market pricing (SHIPPED, no broker codes needed)
+
+The rejected-113k-buy root cause (Q4) is fixed in-repo without any KIS order wire
+codes: `order_validation._get_current_price_for_order` now prices a KR equity order
+off the **live NXT orderbook** during pre-market
+(`market_data.get_orderbook(symbol, "kr", venue="nxt")` — NXT 예상체결가, else best
+bid/ask mid) instead of the stale KRX previous close. Gated by ROB-464's
+`kr_market_data_state()`; best-effort with a KRX fallback on any error/empty book (the
+regular session and non-NXT-eligible symbols are unchanged). This stops the false
+*validation rejection*; whether the order then *fills* on NXT still depends on Q1
+(SOR↔NXT execution), which remains gated below.
+
 ## Phase 2 (after confirmation) — enablement plan
 
 1. Thread `venue` → `order_korea_stock` (map to confirmed `EXCG_ID_DVSN_CD`); add
@@ -64,9 +76,7 @@ error is strictly better, and it lays the typed contract so enablement is a gate
 2. Additive `KISLiveOrderLedger` columns (`venue`, `order_validity`, `reserved_time`),
    nullable, + alembic migration; record resolved venue on every live order (also fixes
    the "couldn't tell the order missed NXT" visibility gap).
-3. Pre-market pricing: session-aware current-price (reuse
-   `app/mcp_server/tooling/market_session.kr_market_data_state` from ROB-464) — route to
-   NXT quote during pre-market or relax the guard per Q4.
+3. ~~Pre-market pricing~~ — DONE (Part A above).
 4. Flip `_venue_tif_gate` to accept confirmed values; keep unsupported ones fail-closed.
 
 ## Safety

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -666,6 +666,143 @@ async def test_kis_overseas_order_payload_fields_buy(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+class TestPremarketNxtPricing:
+    """ROB-463: KR pre-market orders price off the live NXT orderbook, not the
+    stale KRX previous close."""
+
+    @staticmethod
+    def _nxt_book(expected_price=None, asks=None, bids=None, empty=False):
+        import app.services.market_data as market_data_service
+
+        return market_data_service.OrderbookSnapshot(
+            symbol="005930",
+            instrument_type="equity_kr",
+            source="kis",
+            asks=[
+                market_data_service.OrderbookLevel(price=p, quantity=q)
+                for p, q in (asks or [])
+            ],
+            bids=[
+                market_data_service.OrderbookLevel(price=p, quantity=q)
+                for p, q in (bids or [])
+            ],
+            total_ask_qty=0.0,
+            total_bid_qty=0.0,
+            bid_ask_ratio=None,
+            expected_price=expected_price,
+            venue="nxt",
+            is_empty_book=empty,
+        )
+
+    @pytest.mark.asyncio
+    async def test_premarket_uses_nxt_expected_price(self, monkeypatch):
+        from app.mcp_server.tooling import order_validation
+        from app.mcp_server.tooling.market_session import (
+            DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+
+        monkeypatch.setattr(
+            order_validation,
+            "kr_market_data_state",
+            lambda *a, **k: DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+        monkeypatch.setattr(
+            order_validation.market_data_service,
+            "get_orderbook",
+            AsyncMock(return_value=self._nxt_book(expected_price=114300)),
+        )
+        monkeypatch.setattr(
+            order_validation,
+            "_fetch_quote_equity_kr",
+            AsyncMock(return_value={"price": 112400}),
+        )
+
+        price = await order_validation._get_current_price_for_order(
+            "005930", "equity_kr"
+        )
+        assert price == pytest.approx(114300.0)
+
+    @pytest.mark.asyncio
+    async def test_premarket_uses_nxt_mid_when_no_expected(self, monkeypatch):
+        from app.mcp_server.tooling import order_validation
+        from app.mcp_server.tooling.market_session import (
+            DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+
+        monkeypatch.setattr(
+            order_validation,
+            "kr_market_data_state",
+            lambda *a, **k: DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+        monkeypatch.setattr(
+            order_validation.market_data_service,
+            "get_orderbook",
+            AsyncMock(
+                return_value=self._nxt_book(asks=[(114500, 10)], bids=[(114100, 10)])
+            ),
+        )
+        monkeypatch.setattr(
+            order_validation,
+            "_fetch_quote_equity_kr",
+            AsyncMock(return_value={"price": 112400}),
+        )
+
+        price = await order_validation._get_current_price_for_order(
+            "005930", "equity_kr"
+        )
+        assert price == pytest.approx(114300.0)  # mid of 114500 / 114100
+
+    @pytest.mark.asyncio
+    async def test_premarket_empty_book_falls_back_to_krx(self, monkeypatch):
+        from app.mcp_server.tooling import order_validation
+        from app.mcp_server.tooling.market_session import (
+            DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+
+        monkeypatch.setattr(
+            order_validation,
+            "kr_market_data_state",
+            lambda *a, **k: DATA_STATE_PREMARKET_UNAVAILABLE,
+        )
+        monkeypatch.setattr(
+            order_validation.market_data_service,
+            "get_orderbook",
+            AsyncMock(return_value=self._nxt_book(empty=True)),
+        )
+        monkeypatch.setattr(
+            order_validation,
+            "_fetch_quote_equity_kr",
+            AsyncMock(return_value={"price": 112400}),
+        )
+
+        price = await order_validation._get_current_price_for_order(
+            "005930", "equity_kr"
+        )
+        assert price == pytest.approx(112400.0)
+
+    @pytest.mark.asyncio
+    async def test_regular_session_uses_krx_and_skips_nxt(self, monkeypatch):
+        from app.mcp_server.tooling import order_validation
+        from app.mcp_server.tooling.market_session import DATA_STATE_FRESH
+
+        ob = AsyncMock()
+        monkeypatch.setattr(
+            order_validation, "kr_market_data_state", lambda *a, **k: DATA_STATE_FRESH
+        )
+        monkeypatch.setattr(order_validation.market_data_service, "get_orderbook", ob)
+        monkeypatch.setattr(
+            order_validation,
+            "_fetch_quote_equity_kr",
+            AsyncMock(return_value={"price": 112400}),
+        )
+
+        price = await order_validation._get_current_price_for_order(
+            "005930", "equity_kr"
+        )
+        assert price == pytest.approx(112400.0)
+        ob.assert_not_awaited()  # NXT orderbook not consulted in regular session
+
+
 class TestPlaceOrderHighAmount:
     """Tests for place_order with high-amount orders."""
 


### PR DESCRIPTION
## 요약 (ROB-463 Phase 2 Part A) — KIS order wire-code 불필요

프리마켓 매수 거부(실손실)의 근본원인을 in-repo로 해결. **읽기 전용**(NXT 호가 조회)이라 operator의 KIS order 코드 확정 없이 즉시 적용 가능.

### 근본원인
주문 검증 경로 `order_validation._get_current_price_for_order`가 KR 주식의 "현재가"로 KIS 일봉 종가(`_fetch_quote_equity_kr`)를 사용 → **프리마켓엔 전일종가**. 그 결과 프리마켓 정상 매수(예: 113k)가 전일종가(112.4k) 기준으로 거부됨(2026-06-08~09).

### 변경
- `_premarket_nxt_price_for_kr(symbol)`: `kr_market_data_state()`(ROB-464, 머지됨)가 **프리마켓일 때만** `market_data.get_orderbook(symbol, "kr", venue="nxt")` 조회 → **NXT 예상체결가(expected_price)** 우선, 없으면 best bid/ask **mid**, 한쪽만 있으면 그 값.
- `equity_kr` 경로가 이 값을 우선 사용, **None이면 기존 KRX 종가로 폴백**.
- **best-effort**: 비-프리마켓 / NXT 빈 호가 / 조회 예외 → None → KRX 폴백. 정규장·비-NXT 종목·CI(KIS creds 없음)에서 동작 **불변**.

### 범위/한계 (정직)
- 검증 단계의 **false rejection만 제거**. 주문은 여전히 자동 SOR/KRX 라우팅 — 실제 **NXT 체결 보장은 Q1(SOR↔NXT, gated)** 확정 후(Phase 2 본편).
- NXT 호가는 **읽기**라 신규 KIS order wire code 미사용. migration 없음.

### 테스트
- 프리마켓: 예상체결가 사용 / bid·ask mid 사용 / 빈 호가→KRX 폴백 / 정규장→KRX(NXT 미조회) 4건.
- order 회귀 sweep 143 passed(place_order + order_tools + kis_variants + market_session), ruff(app/+tests/) clean.

Linear: ROB-463 (Phase 2 Part A; 본편 enablement은 operator KIS 5질문 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)