### PR TITLE
feat(ROB-471): get_quote(US) 가격 소스를 KIS 해외 현재가(HHDFS00000300)로 전환 (Yahoo fallback)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -180,6 +180,11 @@ class Settings(BaseSettings):
     kis_mock_access_token: str | None = None
     kis_mock_scalping_enabled: bool = False
 
+    # ROB-471: US get_quote 가격 소스 선택. True → KIS 해외 현재가(HHDFS00000300)
+    # primary + Yahoo fast_info fallback. False → Yahoo primary(레거시).
+    # 라이브 파싱 이상 시 operator가 US_QUOTE_KIS_PRIMARY=false 로 즉시 롤백.
+    us_quote_kis_primary: bool = True
+
     # Kiwoom Securities mock account. Disabled by default; mock-only foundation
     # added in ROB-97. Live URL is recorded so the runtime can defensively
     # reject it — no code path may target the live host in this PR.

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -8,6 +8,7 @@ ADX, Stochastic RSI, OBV, Fibonacci).
 from __future__ import annotations
 
 import datetime
+import logging
 from statistics import median
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
@@ -18,6 +19,7 @@ import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
 import app.services.market_data as market_data_service
 from app.core.config import settings
+from app.core.symbol import to_db_symbol
 from app.mcp_server.tooling.market_data_indicators import (
     IndicatorType,
     _compute_crypto_realtime_rsi_from_frame,
@@ -60,10 +62,37 @@ from app.services.market_data.constants import (
 )
 from app.services.upbit_symbol_universe_service import search_upbit_symbols
 from app.services.us_intraday_candles_read_service import read_us_intraday_candles
-from app.services.us_symbol_universe_service import search_us_symbols
+from app.services.us_symbol_universe_service import (
+    USSymbolInactiveError,
+    USSymbolNotRegisteredError,
+    USSymbolUniverseEmptyError,
+    get_us_exchange_by_symbol,
+    search_us_symbols,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+
+logger = logging.getLogger(__name__)
+
+
+def _to_float_or_none(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int_or_none(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
 
 
 _OHLCV_INDICATOR_ROW_KEYS = (
@@ -487,62 +516,96 @@ async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:
     }
 
 
+async def _fetch_us_quote_from_kis(normalized_symbol: str) -> dict[str, Any] | None:
+    """KIS 해외 현재가(HHDFS00000300) primary arm.
+
+    dict → 성공. None → Yahoo fallback 신호(KIS가 응답했으나 무가격, 또는
+    거래소 미해석). KIS HTTP/transport 에러는 호출자가 infra로 처리하도록 전파.
+    """
+    try:
+        exchange_code = await get_us_exchange_by_symbol(to_db_symbol(normalized_symbol))
+    except (
+        USSymbolNotRegisteredError,
+        USSymbolInactiveError,
+        USSymbolUniverseEmptyError,
+    ):
+        return None
+
+    df = await KISClient().inquire_overseas_price(normalized_symbol, exchange_code)
+    if df.empty:
+        return None
+    row = df.iloc[0].to_dict()
+    price = _to_float_or_none(row.get("close"))
+    if price is None or price <= 0:
+        return None
+    return {
+        "symbol": normalized_symbol,
+        "instrument_type": "equity_us",
+        "price": price,
+        "previous_close": _to_float_or_none(row.get("previous_close")),
+        "open": None,
+        "high": None,
+        "low": None,
+        "volume": _to_int_or_none(row.get("volume")),
+        "source": "kis_overseas",
+        "delayed": True,
+    }
+
+
 async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
-    """Fetch US equity quote from Yahoo Finance."""
+    """Fetch US equity quote.
+
+    ROB-471: KIS 해외 현재가 primary(settings.us_quote_kis_primary), Yahoo
+    fast_info fallback. 정직 에러 분리:
+      - 둘 다 정상응답·무가격 → symbol_not_found (ValueError)
+      - 한쪽이라도 infra 실패 + 무가격 → quote_unavailable (RuntimeError)
+    """
     normalized_symbol = str(symbol or "").strip().upper()
     not_found_message = f"Symbol '{normalized_symbol}' not found"
+    unavailable_message = f"US quote temporarily unavailable for '{normalized_symbol}'"
 
+    kis_infra_error = False
+    if settings.us_quote_kis_primary:
+        try:
+            kis_quote = await _fetch_us_quote_from_kis(normalized_symbol)
+        except Exception as exc:  # noqa: BLE001 — KIS infra 실패 시 Yahoo로 degrade
+            kis_infra_error = True
+            logger.warning(
+                "KIS overseas quote failed for '%s'; falling back to Yahoo: %s",
+                normalized_symbol,
+                exc,
+            )
+        else:
+            if kis_quote is not None:
+                return kis_quote
+
+    # FALLBACK: Yahoo fast_info
     try:
         fast_info = await yahoo_service.fetch_fast_info(normalized_symbol)
     except Exception as exc:
         raise RuntimeError(
-            f"Yahoo quote fetch failed for '{normalized_symbol}': {exc}"
+            f"{unavailable_message} (yahoo fallback failed): {exc}"
         ) from exc
 
-    close_raw = fast_info.get("close")
-    if close_raw is None:
-        raise ValueError(not_found_message) from None
-
-    try:
-        price = float(close_raw)
-    except (TypeError, ValueError):
-        raise ValueError(not_found_message) from None
-
-    if price <= 0:
+    price = _to_float_or_none(fast_info.get("close"))
+    if price is None or price <= 0:
+        if kis_infra_error:
+            raise RuntimeError(
+                f"{unavailable_message} (kis errored, yahoo returned no price)"
+            )
         raise ValueError(not_found_message)
-
-    previous_close_raw = fast_info.get("previous_close")
-    open_raw = fast_info.get("open")
-    high_raw = fast_info.get("high")
-    low_raw = fast_info.get("low")
-    volume_raw = fast_info.get("volume")
-
-    def _to_float_or_none(value: Any) -> float | None:
-        try:
-            if value is None:
-                return None
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-
-    def _to_int_or_none(value: Any) -> int | None:
-        try:
-            if value is None:
-                return None
-            return int(float(value))
-        except (TypeError, ValueError):
-            return None
 
     return {
         "symbol": normalized_symbol,
         "instrument_type": "equity_us",
         "price": price,
-        "previous_close": _to_float_or_none(previous_close_raw),
-        "open": _to_float_or_none(open_raw),
-        "high": _to_float_or_none(high_raw),
-        "low": _to_float_or_none(low_raw),
-        "volume": _to_int_or_none(volume_raw),
+        "previous_close": _to_float_or_none(fast_info.get("previous_close")),
+        "open": _to_float_or_none(fast_info.get("open")),
+        "high": _to_float_or_none(fast_info.get("high")),
+        "low": _to_float_or_none(fast_info.get("low")),
+        "volume": _to_int_or_none(fast_info.get("volume")),
         "source": "yahoo",
+        "delayed": True,
     }
 
 

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -252,6 +252,11 @@ class KISClient(BaseKISClient):
             symbol, exchange_code, n, period
         )
 
+    async def inquire_overseas_price(
+        self, symbol: str, exchange_code: str = "NASD"
+    ) -> DataFrame:
+        return await self._market_data.inquire_overseas_price(symbol, exchange_code)
+
     async def inquire_overseas_daily_price_unclamped(
         self,
         symbol: str,

--- a/app/services/brokers/kis/overseas_market_data.py
+++ b/app/services/brokers/kis/overseas_market_data.py
@@ -233,6 +233,60 @@ class OverseasMarketDataMixin(MarketDataBase):
         rows = await self._paginate_overseas_daily(symbol, excd, n, period)
         return self._build_overseas_daily_frame(rows, n)
 
+    async def inquire_overseas_price(
+        self, symbol: str, exchange_code: str = "NASD"
+    ) -> pd.DataFrame:
+        """해외주식 현재가 조회 (HHDFS00000300).
+
+        Returns a single-row DataFrame with columns [close, previous_close,
+        volume]. 'last'(현재가)이 없거나 <= 0이면 empty DataFrame(예외 아님).
+        transport/auth 에러는 _request_with_token_retry에서 예외로 전파된다.
+        """
+        excd_map = {"NASD": "NAS", "NYSE": "NYS", "AMEX": "AMS"}
+        excd = excd_map.get(exchange_code, exchange_code[:3])
+        js = await self._request_with_token_retry(
+            tr_id=constants.OVERSEAS_PRICE_TR,
+            url=self._kis_url(constants.OVERSEAS_PRICE_URL),
+            params={"AUTH": "", "EXCD": excd, "SYMB": to_kis_symbol(symbol)},
+            timeout=10,
+            api_name="inquire_overseas_price",
+        )
+        out = js.get("output") or {}
+        return self._build_overseas_price_frame(out)
+
+    @staticmethod
+    def _build_overseas_price_frame(out: dict[str, Any]) -> pd.DataFrame:
+        """HHDFS00000300 output dict → 단일행 현재가 DataFrame.
+
+        'last'(현재가) 없거나 <= 0 → empty frame. 위조 금지.
+        """
+        empty_cols = ["close", "previous_close", "volume"]
+
+        def _f(value: Any) -> float | None:
+            try:
+                return float(value) if value not in (None, "") else None
+            except (TypeError, ValueError):
+                return None
+
+        def _i(value: Any) -> int | None:
+            try:
+                return int(float(value)) if value not in (None, "") else None
+            except (TypeError, ValueError):
+                return None
+
+        close = _f(out.get("last"))
+        if close is None or close <= 0:
+            return pd.DataFrame(columns=empty_cols)
+        return pd.DataFrame(
+            [
+                {
+                    "close": close,
+                    "previous_close": _f(out.get("base")),
+                    "volume": _i(out.get("tvol")),
+                }
+            ]
+        )
+
     async def inquire_overseas_daily_price_unclamped(
         self,
         symbol: str,

--- a/docs/superpowers/plans/2026-06-09-rob471-get-quote-us-kis-overseas.md
+++ b/docs/superpowers/plans/2026-06-09-rob471-get-quote-us-kis-overseas.md
@@ -1,0 +1,711 @@
+# ROB-471 — get_quote(US) → KIS 해외 현재가 primary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** US `get_quote`의 가격 소스를 Yahoo fast_info에서 KIS 해외 현재가(HHDFS00000300) primary로 전환하고, 누락된 `inquire_overseas_price`를 구현한다(4개 깨진 호출지 부수 복구).
+
+**Architecture:** 새 `OverseasMarketDataMixin.inquire_overseas_price`(+ `KISClient` 위임)가 HHDFS00000300을 호출해 단일행 `close/previous_close/volume` DataFrame을 반환. `_fetch_quote_equity_us`가 `us_quote_kis_primary` 플래그(default True) 하에서 KIS-primary → Yahoo-fallback으로 동작하며, 거래소는 `get_us_exchange_by_symbol`(DB)로 해석. 정직 메타(`source`, `delayed`) + 에러 분리(symbol_not_found vs quote_unavailable).
+
+**Tech Stack:** Python 3.13, async, pandas, pydantic-settings, pytest/pytest-asyncio, KIS REST.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-rob471-get-quote-us-kis-overseas-design.md`
+
+---
+
+## File Structure
+
+| 파일 | 책임 | 변경 |
+|------|------|------|
+| `app/services/brokers/kis/overseas_market_data.py` | KIS 해외 마켓데이터 | `inquire_overseas_price` + `_build_overseas_price_frame` 추가 (Task 1) |
+| `app/services/brokers/kis/client.py` | KISClient 파사드 | `inquire_overseas_price` 위임 (Task 1) |
+| `tests/test_services_kis_market_data.py` | KIS 마켓데이터 단위 | 새 메서드 파싱/매핑/empty 테스트 (Task 1) |
+| `app/core/config.py` | 런타임 설정 | `us_quote_kis_primary` 플래그 (Task 2) |
+| `app/mcp_server/tooling/market_data_quotes.py` | get_quote 구현 | `_fetch_quote_equity_us` 전환 + `_fetch_us_quote_from_kis` + logger/imports/promoted helpers (Task 3) |
+| `tests/test_mcp_quotes_tools.py` | get_quote 단위 | US 테스트 재작성/추가 (Task 3) |
+| `tests/test_mcp_shared_utils.py` | get_quote 공유 단위 | INVALID 테스트 KIS-스킵 패치 (Task 4) |
+
+---
+
+## Task 1: KIS `inquire_overseas_price` (HHDFS00000300) + 위임
+
+**Files:**
+- Modify: `app/services/brokers/kis/overseas_market_data.py` (add method after `inquire_overseas_daily_price`, ~:234)
+- Modify: `app/services/brokers/kis/client.py` (add delegate after the `inquire_overseas_daily_price` delegate, ~:254)
+- Test: `tests/test_services_kis_market_data.py` (new class `TestKISOverseasPrice`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_services_kis_market_data.py` 끝에 추가 (기존 `TestKISOverseasDailyPrice`의 httpx/settings 패치 패턴을 미러):
+
+```python
+class TestKISOverseasPrice:
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_parses_output(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output": {"last": "150.25", "base": "148.00", "tvol": "1234567"},
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        result = await client.inquire_overseas_price(symbol="AAPL", exchange_code="NASD")
+
+        assert not result.empty
+        assert float(result.iloc[0]["close"]) == pytest.approx(150.25)
+        assert float(result.iloc[0]["previous_close"]) == pytest.approx(148.00)
+        assert int(result.iloc[0]["volume"]) == 1234567
+
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["EXCD"] == "NAS"
+        assert params["SYMB"] == "AAPL"
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_maps_exchange_and_symbol(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output": {"last": "402.10", "base": "400.00", "tvol": "9000"},
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        await client.inquire_overseas_price(symbol="BRK.B", exchange_code="NYSE")
+
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["EXCD"] == "NYS"
+        assert params["SYMB"] == "BRK/B"  # to_kis_symbol: . -> /
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_empty_when_no_last(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rt_cd": "0", "output": {"base": "100.0"}}
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        result = await client.inquire_overseas_price(symbol="AAPL")
+        assert result.empty
+        assert list(result.columns) == ["close", "previous_close", "volume"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_services_kis_market_data.py::TestKISOverseasPrice -v`
+Expected: FAIL — `AttributeError: 'KISClient' object has no attribute 'inquire_overseas_price'`
+
+- [ ] **Step 3: Implement the method + builder in the mixin**
+
+`app/services/brokers/kis/overseas_market_data.py`, `inquire_overseas_daily_price`(~:234) 바로 뒤에 추가. (파일 상단에 이미 `from app.core.symbol import to_kis_symbol`, `from . import constants`, `import pandas as pd`, `from typing import Any` 존재.)
+
+```python
+    async def inquire_overseas_price(
+        self, symbol: str, exchange_code: str = "NASD"
+    ) -> pd.DataFrame:
+        """해외주식 현재가 조회 (HHDFS00000300).
+
+        Returns a single-row DataFrame with columns [close, previous_close,
+        volume]. 'last'(현재가)이 없거나 <= 0이면 empty DataFrame(예외 아님).
+        transport/auth 에러는 _request_with_token_retry에서 예외로 전파된다.
+        """
+        excd_map = {"NASD": "NAS", "NYSE": "NYS", "AMEX": "AMS"}
+        excd = excd_map.get(exchange_code, exchange_code[:3])
+        js = await self._request_with_token_retry(
+            tr_id=constants.OVERSEAS_PRICE_TR,
+            url=self._kis_url(constants.OVERSEAS_PRICE_URL),
+            params={"AUTH": "", "EXCD": excd, "SYMB": to_kis_symbol(symbol)},
+            timeout=10,
+            api_name="inquire_overseas_price",
+        )
+        out = js.get("output") or {}
+        return self._build_overseas_price_frame(out)
+
+    @staticmethod
+    def _build_overseas_price_frame(out: dict[str, Any]) -> pd.DataFrame:
+        """HHDFS00000300 output dict → 단일행 현재가 DataFrame.
+
+        'last'(현재가) 없거나 <= 0 → empty frame. 위조 금지.
+        """
+        empty_cols = ["close", "previous_close", "volume"]
+
+        def _f(value: Any) -> float | None:
+            try:
+                return float(value) if value not in (None, "") else None
+            except (TypeError, ValueError):
+                return None
+
+        def _i(value: Any) -> int | None:
+            try:
+                return int(float(value)) if value not in (None, "") else None
+            except (TypeError, ValueError):
+                return None
+
+        close = _f(out.get("last"))
+        if close is None or close <= 0:
+            return pd.DataFrame(columns=empty_cols)
+        return pd.DataFrame(
+            [
+                {
+                    "close": close,
+                    "previous_close": _f(out.get("base")),
+                    "volume": _i(out.get("tvol")),
+                }
+            ]
+        )
+```
+
+- [ ] **Step 4: Add the `KISClient` delegate**
+
+`app/services/brokers/kis/client.py`, `inquire_overseas_daily_price` 위임(~:251-254) 바로 뒤에 추가 (`DataFrame`은 이미 import됨):
+
+```python
+    async def inquire_overseas_price(
+        self, symbol: str, exchange_code: str = "NASD"
+    ) -> DataFrame:
+        return await self._market_data.inquire_overseas_price(symbol, exchange_code)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_services_kis_market_data.py::TestKISOverseasPrice -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/brokers/kis/overseas_market_data.py app/services/brokers/kis/client.py tests/test_services_kis_market_data.py
+git commit -m "feat(ROB-471): KIS inquire_overseas_price (HHDFS00000300) 해외 현재가 구현
+
+last->close/base->previous_close/tvol->volume 단일행 frame, no-last면 empty.
+누락 계약(4개 호출지 의존) 구현. read-only 조회 TR.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `us_quote_kis_primary` config 플래그
+
+**Files:**
+- Modify: `app/core/config.py` (KIS 섹션, `kis_mock_scalping_enabled` ~:181 바로 뒤)
+
+- [ ] **Step 1: Add the field**
+
+`app/core/config.py`의 `kis_mock_scalping_enabled: bool = False` 줄(~:181) 다음에 추가:
+
+```python
+
+    # ROB-471: US get_quote 가격 소스 선택. True → KIS 해외 현재가(HHDFS00000300)
+    # primary + Yahoo fast_info fallback. False → Yahoo primary(레거시).
+    # 라이브 파싱 이상 시 operator가 US_QUOTE_KIS_PRIMARY=false 로 즉시 롤백.
+    us_quote_kis_primary: bool = True
+```
+
+- [ ] **Step 2: Verify the field loads with the correct default**
+
+Run: `uv run python -c "from app.core.config import settings; print(settings.us_quote_kis_primary)"`
+Expected: `True`
+
+(이 플래그의 동작은 Task 3의 `test_get_quote_us_flag_off_uses_yahoo`에서 기능적으로 검증된다.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/core/config.py
+git commit -m "feat(ROB-471): us_quote_kis_primary 플래그 (default True)
+
+US get_quote KIS-primary 컷오버의 operator 롤백 레버.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `_fetch_quote_equity_us` KIS-primary 전환
+
+**Files:**
+- Modify: `app/mcp_server/tooling/market_data_quotes.py` (imports 상단; `_fetch_quote_equity_us` :490-546 재작성; 새 헬퍼)
+- Test: `tests/test_mcp_quotes_tools.py` (US 섹션 :360-406 재작성/추가)
+
+- [ ] **Step 1: Write/replace the failing tests**
+
+`tests/test_mcp_quotes_tools.py` 상단 import에 다음이 없으면 추가:
+```python
+import pandas as pd
+from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
+```
+(`AsyncMock`, `_patch_runtime_attr`, `yahoo_service`, `build_tools`, `pytest`는 이미 import됨.)
+
+기존 `test_get_quote_us_equity`(:366-392)를 아래 KIS-primary 버전으로 **교체**하고, 기존 `test_get_quote_us_equity_propagates_upstream_exception`(:396-406)을 아래 버전으로 **교체**한 뒤, 나머지 4개 테스트를 **추가**:
+
+```python
+@pytest.mark.asyncio
+async def test_get_quote_us_equity(monkeypatch):
+    """KIS-primary happy path: source=kis_overseas, Yahoo 미호출."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+    price_df = pd.DataFrame(
+        [{"close": 205.0, "previous_close": 201.5, "volume": 123456789}]
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            return price_df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=AssertionError("Yahoo should not be called")),
+    )
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["instrument_type"] == "equity_us"
+    assert result["source"] == "kis_overseas"
+    assert result["price"] == pytest.approx(205.0)
+    assert result["previous_close"] == pytest.approx(201.5)
+    assert result["volume"] == 123456789
+    assert result["open"] is None
+    assert result["high"] is None
+    assert result["low"] is None
+    assert result["delayed"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_falls_back_to_yahoo(monkeypatch):
+    """KIS empty → Yahoo fallback, source=yahoo."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            return pd.DataFrame(columns=["close", "previous_close", "volume"])
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    mock_fast_info = AsyncMock(
+        return_value={
+            "symbol": "AAPL",
+            "close": 205.0,
+            "previous_close": 201.5,
+            "open": 202.0,
+            "high": 206.2,
+            "low": 200.8,
+            "volume": 123456789,
+        }
+    )
+    monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fast_info)
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["source"] == "yahoo"
+    assert result["price"] == pytest.approx(205.0)
+    assert result["open"] == pytest.approx(202.0)
+    assert result["delayed"] is True
+    mock_fast_info.assert_awaited_once_with("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_symbol_not_found(monkeypatch):
+    """KIS no-route(clean) + Yahoo close=None → ValueError symbol_not_found."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+    )
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    with pytest.raises(ValueError, match="Symbol 'AAPL' not found"):
+        await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_quote_unavailable(monkeypatch):
+    """KIS infra error + Yahoo close=None → RuntimeError quote_unavailable (not 'not found')."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            raise RuntimeError("kis http 500")
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    with pytest.raises(RuntimeError, match="temporarily unavailable"):
+        await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_equity_propagates_upstream_exception(monkeypatch):
+    """KIS no-route + Yahoo transport 실패 → RuntimeError (원인 메시지 보존)."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+    )
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+
+    with pytest.raises(RuntimeError, match="yahoo down"):
+        await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_flag_off_uses_yahoo(monkeypatch):
+    """us_quote_kis_primary=False → KIS 경로 스킵, Yahoo primary."""
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "us_quote_kis_primary", False)
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=AssertionError("KIS path should be skipped")),
+    )
+    mock_fast_info = AsyncMock(
+        return_value={
+            "symbol": "AAPL",
+            "close": 205.0,
+            "previous_close": 201.5,
+            "open": 202.0,
+            "high": 206.2,
+            "low": 200.8,
+            "volume": 123456789,
+        }
+    )
+    monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fast_info)
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["source"] == "yahoo"
+    assert result["price"] == pytest.approx(205.0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_quotes_tools.py -k "us_" -v`
+Expected: FAIL — `_patch_runtime_attr` raises `AttributeError: No runtime module exposes attribute 'get_us_exchange_by_symbol'` (아직 import 안 됨) / source 불일치.
+
+- [ ] **Step 3: Add imports + module logger + promote helpers**
+
+`app/mcp_server/tooling/market_data_quotes.py`:
+
+(a) `import datetime`(:10) 옆에 `import logging` 추가.
+
+(b) 기존 import 블록(`from app.services.brokers.kis.client import KISClient` :47 부근)에 추가:
+```python
+from app.core.symbol import to_db_symbol
+from app.services.us_symbol_universe_service import (
+    USSymbolInactiveError,
+    USSymbolNotRegisteredError,
+    USSymbolUniverseEmptyError,
+    get_us_exchange_by_symbol,
+)
+```
+
+(c) import 블록 종료 후(모듈 최상단 코드 시작 전) 모듈 로거 + promoted 헬퍼 추가:
+```python
+logger = logging.getLogger(__name__)
+
+
+def _to_float_or_none(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int_or_none(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+```
+
+- [ ] **Step 4: Replace `_fetch_quote_equity_us` and add the KIS helper**
+
+`_fetch_quote_equity_us`(:490-546) 전체를 아래로 **교체** (내부 중첩 `_to_float_or_none`/`_to_int_or_none`는 제거 — 모듈 헬퍼 사용):
+
+```python
+async def _fetch_us_quote_from_kis(normalized_symbol: str) -> dict[str, Any] | None:
+    """KIS 해외 현재가(HHDFS00000300) primary arm.
+
+    dict → 성공. None → Yahoo fallback 신호(KIS가 응답했으나 무가격, 또는
+    거래소 미해석). KIS HTTP/transport 에러는 호출자가 infra로 처리하도록 전파.
+    """
+    try:
+        exchange_code = await get_us_exchange_by_symbol(to_db_symbol(normalized_symbol))
+    except (
+        USSymbolNotRegisteredError,
+        USSymbolInactiveError,
+        USSymbolUniverseEmptyError,
+    ):
+        return None
+
+    df = await KISClient().inquire_overseas_price(normalized_symbol, exchange_code)
+    if df.empty:
+        return None
+    row = df.iloc[0].to_dict()
+    price = _to_float_or_none(row.get("close"))
+    if price is None or price <= 0:
+        return None
+    return {
+        "symbol": normalized_symbol,
+        "instrument_type": "equity_us",
+        "price": price,
+        "previous_close": _to_float_or_none(row.get("previous_close")),
+        "open": None,
+        "high": None,
+        "low": None,
+        "volume": _to_int_or_none(row.get("volume")),
+        "source": "kis_overseas",
+        "delayed": True,
+    }
+
+
+async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
+    """Fetch US equity quote.
+
+    ROB-471: KIS 해외 현재가 primary(settings.us_quote_kis_primary), Yahoo
+    fast_info fallback. 정직 에러 분리:
+      - 둘 다 정상응답·무가격 → symbol_not_found (ValueError)
+      - 한쪽이라도 infra 실패 + 무가격 → quote_unavailable (RuntimeError)
+    """
+    normalized_symbol = str(symbol or "").strip().upper()
+    not_found_message = f"Symbol '{normalized_symbol}' not found"
+    unavailable_message = (
+        f"US quote temporarily unavailable for '{normalized_symbol}'"
+    )
+
+    kis_infra_error = False
+    if settings.us_quote_kis_primary:
+        try:
+            kis_quote = await _fetch_us_quote_from_kis(normalized_symbol)
+        except Exception as exc:  # noqa: BLE001 — KIS infra 실패 시 Yahoo로 degrade
+            kis_infra_error = True
+            logger.warning(
+                "KIS overseas quote failed for '%s'; falling back to Yahoo: %s",
+                normalized_symbol,
+                exc,
+            )
+        else:
+            if kis_quote is not None:
+                return kis_quote
+
+    # FALLBACK: Yahoo fast_info
+    try:
+        fast_info = await yahoo_service.fetch_fast_info(normalized_symbol)
+    except Exception as exc:
+        raise RuntimeError(
+            f"{unavailable_message} (yahoo fallback failed): {exc}"
+        ) from exc
+
+    price = _to_float_or_none(fast_info.get("close"))
+    if price is None or price <= 0:
+        if kis_infra_error:
+            raise RuntimeError(
+                f"{unavailable_message} (kis errored, yahoo returned no price)"
+            )
+        raise ValueError(not_found_message)
+
+    return {
+        "symbol": normalized_symbol,
+        "instrument_type": "equity_us",
+        "price": price,
+        "previous_close": _to_float_or_none(fast_info.get("previous_close")),
+        "open": _to_float_or_none(fast_info.get("open")),
+        "high": _to_float_or_none(fast_info.get("high")),
+        "low": _to_float_or_none(fast_info.get("low")),
+        "volume": _to_int_or_none(fast_info.get("volume")),
+        "source": "yahoo",
+        "delayed": True,
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_quotes_tools.py -v`
+Expected: PASS (전체 파일 green — US 6개 포함)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/market_data_quotes.py tests/test_mcp_quotes_tools.py
+git commit -m "feat(ROB-471): _fetch_quote_equity_us KIS 해외 현재가 primary 전환
+
+KIS-primary + Yahoo fallback (us_quote_kis_primary 게이트), DB 거래소 해석,
+source=kis_overseas/delayed 정직 메타, quote_unavailable vs symbol_not_found 분리.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: 교차 테스트 정합 + 회귀 검증
+
+KIS-primary 디폴트 전환으로 US `get_quote`를 호출하는 기존 테스트가 실 DB(`get_us_exchange_by_symbol`)에 닿지 않도록 패치한다. 영향 테스트는 `tests/test_mcp_shared_utils.py`의 INVALID 테스트 1건뿐(나머지 US 호출지: `test_mcp_quotes_tools.py`는 Task 3에서 처리, `test_mcp_place_order.py`는 `_fetch_quote_equity_us` 자체를 패치하므로 무영향).
+
+**Files:**
+- Modify: `tests/test_mcp_shared_utils.py` (INVALID get_quote 테스트, :380-398 부근)
+
+- [ ] **Step 1: Run the broader suite to see the fallout**
+
+Run: `uv run pytest tests/test_mcp_shared_utils.py -k "get_quote or quote or INVALID" -v`
+Expected: INVALID 테스트가 FAIL 또는 실 DB 접근(`get_us_exchange_by_symbol` 미패치). 정확한 테스트 이름을 확인.
+
+- [ ] **Step 2: Patch the INVALID test to skip the KIS path cleanly**
+
+해당 테스트 함수에서, `yahoo_service.fetch_fast_info`를 close=None으로 패치하는 줄 **직전**에 KIS no-route 패치를 추가. 파일 상단 import에 없으면 추가:
+```python
+from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
+```
+(`_patch_runtime_attr`은 이 파일에서 이미 사용 중이면 그대로; 없으면 `from tests._mcp_tooling_support import _patch_runtime_attr` 확인 후 사용.)
+
+테스트 본문에 추가:
+```python
+        _patch_runtime_attr(
+            monkeypatch,
+            "get_us_exchange_by_symbol",
+            AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+        )
+```
+(이로써 KIS 경로는 clean no-route → None → Yahoo fallback → close=None → `kis_infra_error=False` → 기존 기대대로 `ValueError "Symbol 'INVALID' not found"`.)
+
+- [ ] **Step 3: Run the affected files + the 4-caller regression files**
+
+Run:
+```bash
+uv run pytest tests/test_mcp_shared_utils.py tests/test_mcp_quotes_tools.py tests/test_services_kis_market_data.py tests/test_merged_portfolio_service.py tests/test_kis_tasks.py tests/test_mcp_place_order.py -q
+```
+Expected: 전부 PASS. (merged_portfolio/kis_tasks는 `inquire_overseas_price`를 모킹하므로 계약 정합 유지 — D4 라이트 회귀.)
+
+- [ ] **Step 4: Sweep for any other US get_quote callers**
+
+Run: `grep -rn 'get_quote' tests/ | grep -iE '"[A-Z]{1,5}"' | grep -ivE 'KRW|btc|005930|999999|12450|0117V0|0123G0|market="kr"'`
+Expected: Task 3/4에서 다룬 호출지 외에 새로운 US 심볼 get_quote 호출이 없음. 있으면 동일 패턴(KIS 경로 패치)으로 처리.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_mcp_shared_utils.py
+git commit -m "test(ROB-471): KIS-primary 디폴트 하에서 INVALID get_quote 테스트 정합
+
+US get_quote 경로가 실 DB 거래소 해석에 닿지 않도록 KIS no-route 패치.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 최종 검증 (lint + 전체 영향 테스트)
+
+- [ ] **Step 1: Lint (ruff — app/ + tests/ 둘 다)**
+
+Run: `uv run ruff check app/services/brokers/kis/ app/mcp_server/tooling/market_data_quotes.py app/core/config.py tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py tests/test_services_kis_market_data.py`
+Expected: clean (또는 `uv run ruff check --fix` 후 재확인 — 미사용 import 제거 등). **CI lint는 app/와 tests/ 둘 다 본다.**
+
+- [ ] **Step 2: Format**
+
+Run: `uv run ruff format app/services/brokers/kis/overseas_market_data.py app/services/brokers/kis/client.py app/mcp_server/tooling/market_data_quotes.py app/core/config.py tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py tests/test_services_kis_market_data.py`
+Expected: 변경 없음 또는 포맷 적용.
+
+- [ ] **Step 3: Run the full quote/KIS/portfolio test surface**
+
+Run:
+```bash
+uv run pytest tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py tests/test_services_kis_market_data.py tests/test_merged_portfolio_service.py tests/test_kis_tasks.py tests/test_mcp_place_order.py tests/test_invest_quote_service.py tests/test_mcp_portfolio_tools.py -q
+```
+Expected: 전부 PASS.
+
+- [ ] **Step 4: Final commit (if format/lint changed anything)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-471): ruff lint/format 정리
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>" || echo "nothing to commit"
+```
+
+---
+
+## 비-goal / operator 게이트 (구현 범위 밖)
+- 4개 호출지의 per-caller 거래소 라우팅 정교화(현재 default NASD) → follow-up.
+- HHDFS76200200(현재가상세) 풀 OHLCV / `as_of` 타임스탬프 → follow-up.
+- 실 HHDFS00000300 필드명·15분 지연·프리/애프터마켓 동작 라이브 검증 → operator. 롤백 레버: `US_QUOTE_KIS_PRIMARY=false`.
+- 키움 US 현재가 → 별도 통합.
+
+## Self-Review 결과
+- **Spec coverage**: §4.1→T1, §4.2→T1, §4.3/§4.4/§4.5→T3, §4.6→T2, §6.1→T1, §6.2→T3, §6.3(라이트 회귀)→T4(모킹 호출지 green 확인), §교차정합→T4. 전 항목 커버.
+- **Placeholder scan**: 모든 step에 실 코드/명령/기대출력 포함. 없음.
+- **Type/name consistency**: `inquire_overseas_price(symbol, exchange_code="NASD")`, `_build_overseas_price_frame(out)`, `_fetch_us_quote_from_kis(normalized_symbol)`, `_to_float_or_none/_to_int_or_none`(모듈), `us_quote_kis_primary`, source 값 `"kis_overseas"`/`"yahoo"` — 태스크 간 일치.

--- a/docs/superpowers/specs/2026-06-09-rob471-get-quote-us-kis-overseas-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob471-get-quote-us-kis-overseas-design.md
@@ -1,0 +1,221 @@
+# ROB-471 — `get_quote(US)` 가격 소스를 KIS 해외 현재가로 전환 (Yahoo fast_info → KIS overseas primary)
+
+- **Linear**: ROB-471 (High, Improvement) · 관련 ROB-416 / ROB-365 / ROB-97
+- **Date**: 2026-06-09
+- **Status**: Design approved → plan → TDD implementation (subagent-driven)
+- **Scope**: read-only 시세 경로. broker/order/watch/order-intent mutation 없음. migration 없음.
+
+---
+
+## 1. 배경 / 문제
+
+`get_quote(market="us")`가 운영 중 **전건 실패**(`Symbol 'X' not found`)하는 사례가 반복된다(ROB-416). 근본원인은 "US 미지원"이 아니라 **Yahoo `fast_info`의 crumb/auth/rate-limit 취약성** — fast_info가 예외 없이 빈 `last_price`(close=None) dict를 반환하면 `_fetch_quote_equity_us`가 모든 US 티커를 `Symbol not found`로 표면화한다. 즉 시세 소스(Yahoo)가 systemically 흔들리면 US 시세 경로 전체가 죽는다.
+
+운영자 방향(2026-06-09): Yahoo fast_info가 불안정하면 **KIS 해외(해외주식) 현재가 broker API로 US 가격을 가져온다.** KIS를 **primary**, Yahoo를 **fallback**으로.
+
+## 2. 핵심 발견 (코드 grounding)
+
+`get_quote` 외에 **이미 존재하지만 구현되지 않은** 계약이 있다:
+
+- `KISClient.inquire_overseas_price(symbol)`는 **4개 프로덕션 호출지에서 호출**되지만 **어디에도 정의되지 않았다** → 런타임 `AttributeError` → 각 호출지가 `try/except`로 삼키고 `current_price = 0`으로 degrade:
+  - `app/jobs/kis_trading.py:79` (`_fetch_overseas_new_price`)
+  - `app/jobs/kis_market_adapters.py:760` (`fetch_manual_price`)
+  - `app/services/merged_portfolio_service.py:294`, `:458`
+- 테스트 모킹(`tests/test_merged_portfolio_service.py`, `tests/test_kis_tasks.py`)이 이미 계약을 고정한다: **`inquire_overseas_price(symbol) -> DataFrame`, `close` 컬럼, row 0 = 현재가, exchange 인자 불필요(positional 1개).**
+- KIS 상수는 이미 정의됨(미사용): `app/services/brokers/kis/constants.py:99-100`
+  - `OVERSEAS_PRICE_URL = "/uapi/overseas-price/v1/quotations/price"`
+  - `OVERSEAS_PRICE_TR = "HHDFS00000300"  # 해외주식 현재가 조회`
+
+→ 따라서 **이 누락된 메서드 하나를 구현**하고 `_fetch_quote_equity_us`를 그것으로 라우팅하면, get_quote가 고쳐지는 동시에 **위 4개 깨진 호출지가 부수적으로 복구**된다.
+
+## 3. 확정된 결정 (브레인스토밍, 2026-06-09)
+
+| # | 결정 | 선택 |
+|---|------|------|
+| D1 | 거래소(NASDAQ/NYSE/AMEX) 해석 | **DB 조회** `get_us_exchange_by_symbol()` (us_symbol_universe). 미등록/inactive/empty → Yahoo fallback. |
+| D2 | 컷오버 공격성 | **플래그, default KIS-primary.** `us_quote_kis_primary: bool = True`. operator가 `false`로 즉시 롤백. |
+| D3 | 응답 필드 / TR | **HHDFS00000300 minimal.** price(`last`) + previous_close(`base`) + volume(`tvol`). open/high/low = `None`(정직, 위조 금지). |
+| D4 | 4개 깨진 호출지 범위 | **메서드 구현(부수 복구) + 라이트 회귀 테스트.** 각 호출지 로직 확장은 follow-up. |
+
+추가 정직 메타(이슈 §4, 자명한 선택으로 채택): `source="kis_overseas"`, `delayed=True`. `as_of`는 HHDFS00000300에 타임스탬프 필드가 없어 생략(타임스탬프 TR 전환 시 follow-up).
+
+## 4. 설계
+
+### 4.1 컴포넌트 A — `OverseasMarketDataMixin.inquire_overseas_price`
+파일: `app/services/brokers/kis/overseas_market_data.py` (형제 메서드 `inquire_overseas_daily_price` 바로 뒤, ~:234)
+
+```python
+async def inquire_overseas_price(
+    self, symbol: str, exchange_code: str = "NASD"
+) -> pd.DataFrame:
+    """해외주식 현재가 조회 (HHDFS00000300).
+
+    Returns a single-row DataFrame with at least a 'close' column
+    (current price). previous_close/volume도 가능하면 포함.
+    빈/파싱불가 응답이면 empty DataFrame (예외 아님).
+    """
+    excd_map = {"NASD": "NAS", "NYSE": "NYS", "AMEX": "AMS"}
+    excd = excd_map.get(exchange_code, exchange_code[:3])
+    js = await self._request_with_token_retry(
+        tr_id=constants.OVERSEAS_PRICE_TR,
+        url=self._kis_url(constants.OVERSEAS_PRICE_URL),
+        params={"AUTH": "", "EXCD": excd, "SYMB": to_kis_symbol(symbol)},
+        timeout=10,
+        api_name="inquire_overseas_price",
+    )
+    out = js.get("output") or {}
+    return self._build_overseas_price_frame(out)
+```
+
+`_build_overseas_price_frame(out)` (정적 헬퍼):
+- `close = _to_float_or_none(out.get("last"))` — **현재가** (코드베이스의 minute 파서도 `last`를 close로 매핑: overseas_market_data.py:42). `last`만을 현재가 필드로 사용(grab-bag 금지 → 실제 KIS 필드가 다르면 잘못된 숫자가 아니라 None→fallback).
+- `previous_close = _to_float_or_none(out.get("base"))` — 전일종가
+- `volume = _to_int_or_none(out.get("tvol"))` — 당일거래량
+- `close`가 `None` 또는 `<= 0`이면 → **empty DataFrame** 반환(컬럼만 `["close","previous_close","volume"]`).
+- 아니면 1-row DataFrame: `[{close, previous_close, volume}]`.
+
+**에러 계약**: transport/auth 에러는 `_request_with_token_retry`에서 예외로 전파(기존 4개 호출지가 try/except로 처리). "응답했으나 가격 없음" → empty frame. → infra 실패 vs no-data 분리.
+
+> 참고: HHDFS00000300 정확한 `output` 필드명은 라이브/문서 검증 게이트(operator). `last/base/tvol`은 KIS 해외 현재가 표준 필드이며 코드베이스의 minute 파서(`last`→close)와 일치한다. 방어적 파싱 + D2 플래그가 안전망.
+
+### 4.2 컴포넌트 B — `KISClient.inquire_overseas_price` 위임
+파일: `app/services/brokers/kis/client.py` (`inquire_overseas_daily_price` 위임 ~:244-254 뒤)
+
+```python
+async def inquire_overseas_price(
+    self, symbol: str, exchange_code: str = "NASD"
+) -> DataFrame:
+    return await self._market_data.inquire_overseas_price(symbol, exchange_code)
+```
+
+### 4.3 컴포넌트 C — `_fetch_quote_equity_us` 전환
+파일: `app/mcp_server/tooling/market_data_quotes.py:490-546`
+
+구조 (KIS-primary, Yahoo-fallback, 플래그 게이트):
+
+```python
+async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
+    norm = str(symbol or "").strip().upper()
+    not_found_message = f"Symbol '{norm}' not found"
+    unavailable_message = f"Quote temporarily unavailable for '{norm}'"
+
+    kis_infra_error = False
+    if settings.us_quote_kis_primary:
+        try:
+            quote = await _fetch_us_quote_from_kis(norm)  # dict | None
+            if quote is not None:
+                return quote
+            # None = KIS가 응답했으나 가격 없음 / 심볼 미등록 → no-data, fall through
+        except Exception as exc:
+            kis_infra_error = True
+            logger.warning("KIS overseas quote failed for %s; falling back to Yahoo: %s", norm, exc)
+
+    # FALLBACK: Yahoo (기존 본문 보존)
+    try:
+        fast_info = await yahoo_service.fetch_fast_info(norm)
+    except Exception as exc:
+        raise RuntimeError(unavailable_message) from exc   # 양쪽 infra 실패 → quote_unavailable
+
+    close_raw = fast_info.get("close")
+    if close_raw is None or _to_float_or_none(close_raw) is None or float(close_raw) <= 0:
+        if kis_infra_error:
+            raise RuntimeError(unavailable_message)  # KIS infra + Yahoo no-price → 심볼 확정 불가
+        raise ValueError(not_found_message)          # 둘 다 정상응답·가격 없음 → symbol_not_found
+    # ... 기존 Yahoo 응답 dict (+ "delayed": True)
+```
+
+`_fetch_us_quote_from_kis(norm)` (헬퍼, KIS arm 격리):
+```python
+async def _fetch_us_quote_from_kis(norm: str) -> dict[str, Any] | None:
+    # 거래소 해석 (D1). 미등록/inactive/empty → None (Yahoo fallback)
+    try:
+        exchange = await get_us_exchange_by_symbol(to_db_symbol(norm))
+    except (USSymbolNotRegisteredError, USSymbolInactiveError, USSymbolUniverseEmptyError):
+        return None
+    df = await KISClient().inquire_overseas_price(norm, exchange)  # transport 에러는 전파
+    if df.empty:
+        return None
+    row = df.iloc[0].to_dict()
+    close = _to_float_or_none(row.get("close"))
+    if close is None or close <= 0:
+        return None
+    return {
+        "symbol": norm,
+        "instrument_type": "equity_us",
+        "price": close,
+        "previous_close": _to_float_or_none(row.get("previous_close")),
+        "open": None, "high": None, "low": None,
+        "volume": _to_int_or_none(row.get("volume")),
+        "source": "kis_overseas",
+        "delayed": True,
+    }
+```
+
+- KIS 거래소 해석 실패(미등록 등)는 **infra 아님** → `None` → Yahoo fallback(정상 분기).
+- KIS HTTP transport 에러만 예외 전파 → 상위에서 `kis_infra_error=True`.
+
+### 4.4 컴포넌트 D — 정직 에러 분리 (이슈 §3)
+- **symbol_not_found** (`ValueError`): KIS·Yahoo 둘 다 정상 응답했으나 가격 없음.
+- **quote_unavailable** (`RuntimeError`): 한쪽이라도 infra 실패 + 가격 미확보 → throttle/outage가 "Symbol not found"로 오분류되지 않음(ROB-416 핵심 불만 해소).
+
+`_get_quote_impl` 디스패치(:987-988)는 현재 equity_us를 try/except 없이 호출(예외 전파). 이 동작은 유지하되, `test_get_quote_us_equity_propagates_upstream_exception`과 정합. (US를 `_error_payload_from_exception`으로 감쌀지는 비-goal — 현 계약 보존.)
+
+### 4.5 컴포넌트 E — 응답 형태 / 정직 메타
+US KIS-primary 응답:
+```
+{symbol, instrument_type:"equity_us", price, previous_close, open:None, high:None, low:None,
+ volume, source:"kis_overseas", delayed:True}
+```
+Yahoo fallback 응답: 기존 형태 + `delayed:True`(무료 fast_info도 ~15분 지연 → 정직·일관). `source:"yahoo"` 유지. `open/high/low`는 KIS 경로에서 정직하게 `None`(HHDFS00000300 미제공, 위조 금지).
+
+### 4.6 컴포넌트 F — config 플래그
+파일: `app/core/config.py` (KIS 섹션, ~:181 부근)
+```python
+# ROB-471: US get_quote 가격 소스. True면 KIS 해외 현재가 primary + Yahoo fallback.
+# False면 Yahoo primary(레거시). 라이브 파싱 이상 시 operator 즉시 롤백 레버.
+us_quote_kis_primary: bool = True
+```
+env: `US_QUOTE_KIS_PRIMARY`.
+
+## 5. 새 import (market_data_quotes.py)
+- `from app.core.symbol import to_db_symbol`
+- `from app.services.us_symbol_universe_service import (get_us_exchange_by_symbol, USSymbolNotRegisteredError, USSymbolInactiveError, USSymbolUniverseEmptyError)` — 실제 export 명 확인 후 사용.
+- `import logging` / module logger (기존 패턴 확인).
+
+## 6. 테스트 (TDD)
+
+### 6.1 단위 — `inquire_overseas_price` 파싱
+파일: 기존 KIS 해외 테스트 위치(예: `tests/` KIS overseas) 또는 신규.
+- 정상 `output`(`{last,base,tvol}`) → 1-row frame, `close==last`, `previous_close==base`, `volume==tvol`.
+- `last` 누락/0/"" → empty frame.
+- `_request_with_token_retry` 예외 → 전파.
+- exchange_code 매핑(NASD→NAS, NYSE→NYS, AMEX→AMS) — params의 `EXCD` 검증.
+- `SYMB == to_kis_symbol(symbol)` 검증(BRK.B → BRK/B).
+
+### 6.2 `get_quote` US — `tests/test_mcp_quotes_tools.py`
+- **rewrite** `test_get_quote_us_equity`: KIS-primary happy path. `KISClient.inquire_overseas_price` + `get_us_exchange_by_symbol` 모킹 → `source=="kis_overseas"`, `price`, `previous_close`, `delayed is True`, KIS가 해석된 exchange로 호출됨.
+- **new** `test_get_quote_us_falls_back_to_yahoo`: KIS empty/raise → Yahoo 호출, `source=="yahoo"`, `delayed is True`.
+- **new** `test_get_quote_us_symbol_not_found`: KIS no-data + Yahoo close=None → `ValueError` "not found".
+- **new** `test_get_quote_us_quote_unavailable`: KIS infra raise + Yahoo raise → `RuntimeError` "temporarily unavailable".
+- **new** `test_get_quote_us_flag_off_uses_yahoo`: `settings.us_quote_kis_primary=False` → KIS 미호출, `source=="yahoo"`.
+- **reconcile** `test_get_quote_us_equity_propagates_upstream_exception`.
+
+### 6.3 라이트 회귀 (D4)
+- `KISClient().inquire_overseas_price(...)`가 실제로 존재하고 `close` 컬럼 frame을 반환함을 단언(4개 호출지가 의존하는 계약이 실재함). 기존 merged_portfolio/kis_tasks 모킹 테스트는 그대로 green이어야 함.
+
+## 7. 변경 파일 요약
+| 파일 | 변경 |
+|------|------|
+| `app/services/brokers/kis/overseas_market_data.py` | `inquire_overseas_price` + `_build_overseas_price_frame` 추가 |
+| `app/services/brokers/kis/client.py` | `inquire_overseas_price` 위임 추가 |
+| `app/core/config.py` | `us_quote_kis_primary` 플래그 추가 |
+| `app/mcp_server/tooling/market_data_quotes.py` | `_fetch_quote_equity_us` 전환 + `_fetch_us_quote_from_kis` 헬퍼 + import |
+| `tests/test_mcp_quotes_tools.py` | US quote 테스트 재작성/추가 |
+| (신규/기존) KIS overseas 단위 테스트 | `inquire_overseas_price` 파싱 테스트 |
+
+## 8. 안전 경계 / 비-goal / operator 게이트
+- **read-only.** broker mutation·order·watch·migration 없음. `inquire_overseas_price`는 GET TR.
+- get_quote US는 **live KIS client**(`KISClient()`, `kis_base_url`)만 사용 — mock 분기 없음. 따라서 실제 HHDFS00000300 필드명·15분 지연·프리/애프터마켓 동작은 **라이브 검증(operator)**이 게이트. 단위 테스트는 모킹 frame으로 로직 커버.
+- **비-goal**: 4개 깨진 호출지의 per-caller 거래소 라우팅 정교화(default NASD로만 동작) → follow-up. HHDFS76200200(현재가상세) 풀 OHLCV·`as_of` 타임스탬프 → follow-up. 키움 US 현재가 → 별도 통합(ROB-97 계열).
+- **ROB-416 처분**: 코드 내 stopgap 없음(grep 0 hits) — 본 이슈가 상위 해법. 별도 코드 액션 불필요.
+- **롤백 레버**: `US_QUOTE_KIS_PRIMARY=false`.

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -364,9 +364,55 @@ async def test_fetch_quote_equity_kr_passes_market_j(monkeypatch, symbol, label)
 
 @pytest.mark.asyncio
 async def test_get_quote_us_equity(monkeypatch):
+    """KIS-primary happy path: source=kis_overseas, Yahoo 미호출."""
     tools = build_tools()
 
-    mock_fetch_fast_info = AsyncMock(
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+    price_df = pd.DataFrame(
+        [{"close": 205.0, "previous_close": 201.5, "volume": 123456789}]
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            return price_df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=AssertionError("Yahoo should not be called")),
+    )
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["instrument_type"] == "equity_us"
+    assert result["source"] == "kis_overseas"
+    assert result["price"] == pytest.approx(205.0)
+    assert result["previous_close"] == pytest.approx(201.5)
+    assert result["volume"] == 123456789
+    assert result["open"] is None
+    assert result["high"] is None
+    assert result["low"] is None
+    assert result["delayed"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_falls_back_to_yahoo(monkeypatch):
+    """KIS empty → Yahoo fallback, source=yahoo."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            return pd.DataFrame(columns=["close", "previous_close", "volume"])
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    mock_fast_info = AsyncMock(
         return_value={
             "symbol": "AAPL",
             "close": 205.0,
@@ -377,25 +423,71 @@ async def test_get_quote_us_equity(monkeypatch):
             "volume": 123456789,
         }
     )
-    monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fetch_fast_info)
+    monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fast_info)
 
     result = await tools["get_quote"]("AAPL")
 
-    assert result["instrument_type"] == "equity_us"
     assert result["source"] == "yahoo"
     assert result["price"] == pytest.approx(205.0)
-    assert result["previous_close"] == pytest.approx(201.5)
     assert result["open"] == pytest.approx(202.0)
-    assert result["high"] == pytest.approx(206.2)
-    assert result["low"] == pytest.approx(200.8)
-    assert result["volume"] == 123456789
-    mock_fetch_fast_info.assert_awaited_once_with("AAPL")
+    assert result["delayed"] is True
+    mock_fast_info.assert_awaited_once_with("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_symbol_not_found(monkeypatch):
+    """KIS no-route(clean) + Yahoo close=None → ValueError symbol_not_found."""
+    from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
+
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+    )
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    with pytest.raises(ValueError, match="Symbol 'AAPL' not found"):
+        await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_quote_unavailable(monkeypatch):
+    """KIS infra error + Yahoo close=None → RuntimeError quote_unavailable (not 'not found')."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            raise RuntimeError("kis http 500")
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    with pytest.raises(RuntimeError, match="temporarily unavailable"):
+        await tools["get_quote"]("AAPL")
 
 
 @pytest.mark.asyncio
 async def test_get_quote_us_equity_propagates_upstream_exception(monkeypatch):
+    """KIS no-route + Yahoo transport 실패 → RuntimeError (원인 메시지 보존)."""
+    from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
+
     tools = build_tools()
 
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+    )
     monkeypatch.setattr(
         yahoo_service,
         "fetch_fast_info",
@@ -404,6 +496,38 @@ async def test_get_quote_us_equity_propagates_upstream_exception(monkeypatch):
 
     with pytest.raises(RuntimeError, match="yahoo down"):
         await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_flag_off_uses_yahoo(monkeypatch):
+    """us_quote_kis_primary=False → KIS 경로 스킵, Yahoo primary."""
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "us_quote_kis_primary", False)
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=AssertionError("KIS path should be skipped")),
+    )
+    mock_fast_info = AsyncMock(
+        return_value={
+            "symbol": "AAPL",
+            "close": 205.0,
+            "previous_close": 201.5,
+            "open": 202.0,
+            "high": 206.2,
+            "low": 200.8,
+            "volume": 123456789,
+        }
+    )
+    monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fast_info)
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["source"] == "yahoo"
+    assert result["price"] == pytest.approx(205.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -364,18 +364,21 @@ async def test_fetch_quote_equity_kr_passes_market_j(monkeypatch, symbol, label)
 
 @pytest.mark.asyncio
 async def test_get_quote_us_equity(monkeypatch):
-    """KIS-primary happy path: source=kis_overseas, Yahoo 미호출."""
+    """KIS-primary happy path: source=kis_overseas, Yahoo 미호출, resolved exchange 전달."""
     tools = build_tools()
 
     _patch_runtime_attr(
-        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NYSE")
     )
     price_df = pd.DataFrame(
         [{"close": 205.0, "previous_close": 201.5, "volume": 123456789}]
     )
+    captured: dict[str, object] = {}
 
     class DummyKISClient:
         async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            captured["symbol"] = symbol
+            captured["exchange_code"] = exchange_code
             return price_df
 
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
@@ -395,6 +398,71 @@ async def test_get_quote_us_equity(monkeypatch):
     assert result["open"] is None
     assert result["high"] is None
     assert result["low"] is None
+    assert result["delayed"] is True
+    # ROB-471: the DB-resolved exchange + symbol are threaded into the KIS call
+    # (regression guard — a dropped exchange_code arg would default to NASD).
+    assert captured["exchange_code"] == "NYSE"
+    assert captured["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_name", ["USSymbolInactiveError", "USSymbolUniverseEmptyError"]
+)
+async def test_get_quote_us_lookup_exc_falls_back_then_not_found(monkeypatch, exc_name):
+    """inactive/empty 거래소 해석 예외도 clean fallback → symbol_not_found(ValueError)."""
+    import app.services.us_symbol_universe_service as uss
+
+    exc = getattr(uss, exc_name)
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "get_us_exchange_by_symbol",
+        AsyncMock(side_effect=exc("no route")),
+    )
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    # clean no-route (not infra) → symbol_not_found, NOT quote_unavailable
+    with pytest.raises(ValueError, match="not found"):
+        await tools["get_quote"]("AAPL")
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_kis_raises_then_yahoo_succeeds(monkeypatch):
+    """KIS infra error + Yahoo 정상가격 → fallback 성공(source=yahoo, no raise)."""
+    tools = build_tools()
+
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            raise RuntimeError("kis http 500")
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(
+            return_value={
+                "close": 205.0,
+                "previous_close": 201.5,
+                "open": 202.0,
+                "high": 206.2,
+                "low": 200.8,
+                "volume": 123456789,
+            }
+        ),
+    )
+
+    result = await tools["get_quote"]("AAPL")
+
+    assert result["source"] == "yahoo"
+    assert result["price"] == pytest.approx(205.0)
     assert result["delayed"] is True
 
 

--- a/tests/test_mcp_shared_utils.py
+++ b/tests/test_mcp_shared_utils.py
@@ -17,6 +17,7 @@ import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
 from app.mcp_server.tooling import shared
 from app.services import naver_finance
+from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
 from tests._mcp_tooling_support import _patch_runtime_attr, build_tools
 
 # ---------------------------------------------------------------------------
@@ -379,6 +380,13 @@ class TestSymbolNotFound:
     @pytest.mark.asyncio
     async def test_get_quote_us_equity_not_found_raises(self, monkeypatch):
         tools = build_tools()
+        # ROB-471: KIS-primary 디폴트 하에서 KIS 경로를 clean no-route로 고정해
+        # 실 DB 거래소 해석에 의존하지 않도록 한다(Yahoo fallback → 무가격 → not found).
+        _patch_runtime_attr(
+            monkeypatch,
+            "get_us_exchange_by_symbol",
+            AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
+        )
         mock_fetch_fast_info = AsyncMock(
             return_value={
                 "symbol": "INVALID",

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -1734,3 +1734,34 @@ class TestKISOverseasPrice:
         result = await client.inquire_overseas_price(symbol="AAPL")
         assert result.empty
         assert list(result.columns) == ["close", "previous_close", "volume"]
+
+    @pytest.mark.parametrize("last_val", ["0", "0.0", "-1.5", ""])
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_empty_when_last_non_positive(
+        self, mock_settings, mock_client_class, last_val
+    ):
+        """ROB-471: last가 0/음수/빈문자열이면 위조 금지 → empty frame (zero-price guard)."""
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output": {"last": last_val, "base": "100.0", "tvol": "500"},
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        result = await client.inquire_overseas_price(symbol="AAPL")
+        assert result.empty
+        assert list(result.columns) == ["close", "previous_close", "volume"]

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -1636,3 +1636,101 @@ class TestBuildOhlcvDataframe:
         assert df.iloc[0]["datetime"] == pd.Timestamp("2026-02-19 09:30:00")
         assert df.iloc[0]["close"] == pytest.approx(180.5)
         assert df.iloc[1]["volume"] == 80
+
+
+class TestKISOverseasPrice:
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_parses_output(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output": {"last": "150.25", "base": "148.00", "tvol": "1234567"},
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        result = await client.inquire_overseas_price(
+            symbol="AAPL", exchange_code="NASD"
+        )
+
+        assert not result.empty
+        assert float(result.iloc[0]["close"]) == pytest.approx(150.25)
+        assert float(result.iloc[0]["previous_close"]) == pytest.approx(148.00)
+        assert int(result.iloc[0]["volume"]) == 1234567
+
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["EXCD"] == "NAS"
+        assert params["SYMB"] == "AAPL"
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_maps_exchange_and_symbol(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output": {"last": "402.10", "base": "400.00", "tvol": "9000"},
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        await client.inquire_overseas_price(symbol="BRK.B", exchange_code="NYSE")
+
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["EXCD"] == "NYS"
+        assert params["SYMB"] == "BRK/B"
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.kis.base.httpx.AsyncClient")
+    @patch("app.services.brokers.kis.client.settings")
+    async def test_inquire_overseas_price_empty_when_no_last(
+        self, mock_settings, mock_client_class
+    ):
+        from app.services.brokers.kis.client import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"rt_cd": "0", "output": {"base": "100.0"}}
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        result = await client.inquire_overseas_price(symbol="AAPL")
+        assert result.empty
+        assert list(result.columns) == ["close", "previous_close", "volume"]


### PR DESCRIPTION
## 배경

`get_quote(market="us")`가 운영 중 **전건 `Symbol not found`**로 실패하는 사례가 반복(ROB-416). 근본원인은 "US 미지원"이 아니라 **Yahoo `fast_info`의 crumb/auth/rate-limit 취약성** — fast_info가 예외 없이 빈 `last_price`(close=None)를 반환하면 모든 US 티커가 `Symbol not found`로 표면화됐다. 운영자 방향(2026-06-09): **KIS 해외 현재가를 primary 소스로 전환**, Yahoo는 fallback.

## 핵심 발견

`KISClient.inquire_overseas_price(symbol)`는 **이미 4개 프로덕션 호출지에서 호출**되지만 **어디에도 구현되지 않았다** → 런타임 `AttributeError` → 각 호출지가 try/except로 삼키고 `price=0`으로 degrade 중:
`app/jobs/kis_trading.py`, `app/jobs/kis_market_adapters.py`, `app/services/merged_portfolio_service.py`(2곳). 테스트 모킹이 이미 계약(`(symbol) -> DataFrame[close]`)을 고정하고 있었다. → 이 누락 메서드를 구현하면 get_quote가 고쳐지는 동시에 **4개 깨진 호출지가 부수 복구**된다.

## 변경 사항

- **새 KIS 메서드** `inquire_overseas_price(symbol, exchange_code="NASD")` (TR `HHDFS00000300`, `last→close`/`base→previous_close`/`tvol→volume`; `last` 없거나 ≤0이면 **empty frame**, transport 에러는 전파) + `KISClient` 위임. (constants는 기존부터 정의돼 있었음)
- **`_fetch_quote_equity_us` 전환**: `us_quote_kis_primary` 플래그(default True) 하에서 **KIS-primary → Yahoo-fallback**. 거래소는 `get_us_exchange_by_symbol`(us_symbol_universe DB)로 해석; 미등록/inactive/empty → Yahoo fallback.
- **정직 메타**: `source="kis_overseas"`(또는 `yahoo`), `delayed=True`. `open/high/low`는 KIS 경로에서 정직하게 `null`(HHDFS00000300 미제공, 위조 금지).
- **정직 에러 분리**(ROB-416 핵심): 둘 다 정상응답·무가격 → `symbol_not_found`(ValueError); 한쪽이라도 infra 실패 + 무가격 → `quote_unavailable`(RuntimeError). throttle/outage가 더 이상 "Symbol not found"로 오분류되지 않음.
- **롤백 레버**: `US_QUOTE_KIS_PRIMARY=false` → Yahoo-primary(레거시).

## 결정 (브레인스토밍, 2026-06-09)

| | 결정 |
|---|---|
| 거래소 해석 | DB 조회 `get_us_exchange_by_symbol` (US 경로 전반의 표준 리졸버) |
| 컷오버 | 플래그, default KIS-primary (operator 즉시 롤백 가능) |
| 응답 필드 | HHDFS00000300 minimal: price/previous_close/volume |
| 범위 | 메서드 구현(4개 호출지 부수 복구) + 라이트 회귀; per-caller 거래소 라우팅은 follow-up |

## 안전 경계

read-only 시세 경로. **broker/order/watch/order-intent mutation 없음, migration 없음.** `inquire_overseas_price`는 조회 TR.

## Follow-ups (이 PR 범위 밖)

- 4개 기존 호출지는 exchange 인자 없이 호출 → default `NASD`. NYSE/AMEX 종목은 빈 응답 → 기존처럼 `price=0` degrade(회귀 아님; 종전엔 AttributeError). 각 호출지에 resolved exchange를 배선하는 것은 별도 follow-up.
- 실 HHDFS00000300 필드명·15분 지연·프리/애프터마켓 동작 **라이브 검증 = operator** (플래그가 안전망). HHDFS76200200(현재가상세) 풀 OHLCV / `as_of` 타임스탬프 / 키움 US 현재가 = follow-up.

## Test Plan

- [x] `inquire_overseas_price` 단위: 파싱(last/base/tvol), EXCD/SYMB 매핑(NASD→NAS, NYSE→NYS, BRK.B→BRK/B), `last` 없음/0/음수/빈문자열 → empty frame
- [x] get_quote US: KIS-primary happy(+ resolved exchange 전달 단언), Yahoo fallback, symbol_not_found vs quote_unavailable 분리, inactive/empty 예외 fallback, KIS-raise+Yahoo-성공, 플래그 off, 예외 전파
- [x] 4개 mock-consumer 호출지 계약 회귀 green (merged_portfolio/kis_tasks)
- [x] ruff + ty clean (app + tests)
- [x] 196 passed (ROB-471 surface). `test_mcp_place_order`의 11 실패는 **사전 존재 test-DB ledger 오염**(단독 실행 시 green, 본 read-only 변경과 무관)
- [ ] operator: `US_QUOTE_KIS_PRIMARY` 라이브 스모크 — KIS 해외 현재가 실 필드/지연 확인

Linear: ROB-471

🤖 Generated with [Claude Code](https://claude.com/claude-code)