### PR TITLE
feat(ROB-472): Claude lite 리포트 결정적 품질 grade (P1 evidence 기반)

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -42,8 +42,12 @@ from app.services.investment_reports.idempotency import kst_date_from_report_key
 from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
+from app.services.investment_reports.lite_grade import (
+    build_lite_report_quality_summary,
+)
 from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
+    _advisory_draft_profiles,
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
@@ -361,6 +365,29 @@ def _validate_report_items(
     return validated_items, None
 
 
+def _maybe_attach_lite_quality(
+    request: IngestReportRequest,
+) -> IngestReportRequest:
+    """ROB-472 — attach a deterministic lite quality grade to advisory reports.
+
+    Pure metadata (grade gates nothing). Only for advisory profiles; never
+    clobbers caller-supplied diagnostics; fail-open (a helper error never blocks
+    report creation). snapshot_freshness_summary/coverage_summary stay None so
+    the published-report DB CHECK is never triggered.
+    """
+    if request.snapshot_report_diagnostics is not None:
+        return request
+    if request.created_by_profile not in _advisory_draft_profiles():
+        return request
+    try:
+        summary = build_lite_report_quality_summary(request.items)
+    except Exception:
+        return request
+    return request.model_copy(
+        update={"snapshot_report_diagnostics": {"report_quality_summary": summary}}
+    )
+
+
 # ---------------------------------------------------------------------------
 # investment_report_create
 # ---------------------------------------------------------------------------
@@ -418,6 +445,10 @@ async def investment_report_create_impl(
         "kst_date": kst_date,
     }
     request = IngestReportRequest.model_validate(payload)
+    # ROB-472 — advisory lite reports get a deterministic, evidence-derived
+    # quality grade (display/audit metadata only). No-op for non-advisory
+    # profiles and when the caller already supplied diagnostics.
+    request = _maybe_attach_lite_quality(request)
 
     async with AsyncSessionLocal() as db:
         repo = InvestmentReportsRepository(db)

--- a/app/services/investment_reports/lite_grade.py
+++ b/app/services/investment_reports/lite_grade.py
@@ -1,0 +1,74 @@
+"""ROB-472 — deterministic lite quality grade for Claude advisory reports.
+
+The snapshot-backed generator grades reports from snapshot bundle coverage
+(build_report_quality_summary). The lite create path has no snapshot bundle, so
+this derives an HONEST grade from the per-item structured evidence shipped in
+ROB-459 P1. By construction it NEVER returns high_confidence — a lite report
+lacks the snapshot coverage that grade is defined around — so an evidence-thin
+report can never masquerade as snapshot-backed high confidence.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from app.schemas.investment_reports import IngestReportItem
+
+_LITE_BASIS = "item_evidence_lite"
+_ACTIONABLE_KINDS = frozenset({"action", "watch"})
+_FRESHNESS_VALUES = ("fresh", "soft_stale", "stale", "unknown")
+
+
+def build_lite_report_quality_summary(
+    items: list[IngestReportItem],
+) -> dict[str, Any]:
+    """Derive a lite report_quality_summary from per-item evidence/freshness.
+
+    Grade is capped at ``informational_only`` (never ``high_confidence``):
+    - ``no_action``: no actionable (action|watch) items, OR no item carries any
+      structured evidence — genuinely insufficient to advise.
+    - ``informational_only``: otherwise — an evidence-backed lite advisory.
+
+    ``freshness_breakdown`` counts both item-level ``freshness`` and each
+    evidence row's ``freshness`` (None values are not counted).
+    """
+    total_item_count = len(items)
+    actionable_item_count = sum(
+        1 for it in items if it.item_kind in _ACTIONABLE_KINDS
+    )
+    evidence_item_count = sum(1 for it in items if it.evidence)
+
+    sources: set[str] = set()
+    freshness_counter: Counter[str] = Counter()
+    for it in items:
+        if it.freshness is not None:
+            freshness_counter[it.freshness] += 1
+        for ev in it.evidence:
+            sources.add(ev.source)
+            if ev.freshness is not None:
+                freshness_counter[ev.freshness] += 1
+
+    if actionable_item_count == 0 or evidence_item_count == 0:
+        grade = "no_action"
+        reason = (
+            "no actionable (action|watch) items"
+            if actionable_item_count == 0
+            else "no structured evidence on any item"
+        )
+    else:
+        grade = "informational_only"
+        reason = "evidence-backed lite advisory (no snapshot coverage)"
+
+    return {
+        "grade": grade,
+        "basis": _LITE_BASIS,
+        "reason": reason,
+        "total_item_count": total_item_count,
+        "actionable_item_count": actionable_item_count,
+        "evidence_item_count": evidence_item_count,
+        "evidence_source_count": len(sources),
+        "freshness_breakdown": {
+            k: freshness_counter.get(k, 0) for k in _FRESHNESS_VALUES
+        },
+    }

--- a/app/services/investment_reports/lite_grade.py
+++ b/app/services/investment_reports/lite_grade.py
@@ -34,9 +34,7 @@ def build_lite_report_quality_summary(
     evidence row's ``freshness`` (None values are not counted).
     """
     total_item_count = len(items)
-    actionable_item_count = sum(
-        1 for it in items if it.item_kind in _ACTIONABLE_KINDS
-    )
+    actionable_item_count = sum(1 for it in items if it.item_kind in _ACTIONABLE_KINDS)
     evidence_item_count = sum(1 for it in items if it.evidence)
 
     sources: set[str] = set()

--- a/docs/superpowers/plans/2026-06-09-rob472-lite-report-grade.md
+++ b/docs/superpowers/plans/2026-06-09-rob472-lite-report-grade.md
@@ -1,0 +1,449 @@
+# ROB-472 — Claude lite 리포트 결정적 품질 grade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claude advisory lite 리포트(`investment_report_create`)가 P1 per-item evidence에서 파생한 결정적 품질 `report_quality_summary`를 갖게 한다 — `high_confidence`는 구조적으로 불가(정직), advisory 프로파일만, additive·migration 0.
+
+**Architecture:** 순수 헬퍼 `build_lite_report_quality_summary(items)`가 item evidence/freshness에서 2-레벨 grade(`no_action`|`informational_only`)를 산출. 핸들러 글루 `_maybe_attach_lite_quality(request)`가 advisory 프로파일일 때만(그리고 caller가 안 넘겼을 때만) `snapshot_report_diagnostics`에 주입. 기존 optional 필드라 schema/service/DB 변경 0.
+
+**Tech Stack:** Python 3.13, Pydantic v2, FastMCP, SQLAlchemy async, pytest. 스펙: `docs/superpowers/specs/2026-06-09-rob472-lite-report-grade-design.md`. 워크트리: `auto_trader.rob-472` (branch `rob-472`, off main `74dee6ee`).
+
+**전 슬라이스 제약:** broker/order/watch mutation 0 · migration 0 · schema 필드 추가 0(`snapshot_report_diagnostics` 이미 존재). 1 PR.
+
+---
+
+## 파일 맵
+- Create: `app/services/investment_reports/lite_grade.py` — 순수 grade 헬퍼.
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` — `_maybe_attach_lite_quality` 글루 + `create_impl`(:420 직후) 1줄 배선.
+- Test: `tests/test_investment_report_lite_grade.py` (신규, 헬퍼 + 글루 DB-free), `tests/test_investment_report_item_evidence.py` (DB round-trip 1개 추가) 또는 신규 round-trip 테스트.
+
+---
+
+### Task 1: 순수 헬퍼 `build_lite_report_quality_summary`
+
+**Files:**
+- Create: `app/services/investment_reports/lite_grade.py`
+- Test: `tests/test_investment_report_lite_grade.py`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+신규 `tests/test_investment_report_lite_grade.py`:
+
+```python
+"""ROB-472 — lite report quality grade 순수 헬퍼."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.investment_reports.lite_grade import (
+    build_lite_report_quality_summary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _item(**over):
+    base = dict(
+        client_item_key="k1",
+        item_kind="action",
+        intent="buy_review",
+        rationale="r",
+    )
+    base.update(over)
+    return IngestReportItem(**base)
+
+
+def test_no_actionable_items_grades_no_action():
+    items = [_item(item_kind="risk", intent="risk_review")]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "no_action"
+    assert out["basis"] == "item_evidence_lite"
+
+
+def test_actionable_but_no_evidence_grades_no_action():
+    items = [_item()]  # action item, evidence=[] (default)
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "no_action"
+    assert "evidence" in out["reason"]
+
+
+def test_evidence_backed_action_grades_informational_only():
+    items = [
+        _item(
+            evidence=[{"source": "consensus", "freshness": "fresh"}],
+            freshness="fresh",
+        )
+    ]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "informational_only"
+    assert out["evidence_item_count"] == 1
+    assert out["actionable_item_count"] == 1
+
+
+def test_never_returns_high_confidence_even_with_rich_evidence():
+    items = [
+        _item(
+            client_item_key=f"k{i}",
+            evidence=[
+                {"source": "consensus", "freshness": "fresh"},
+                {"source": "foreign_flow", "freshness": "fresh"},
+            ],
+            freshness="fresh",
+        )
+        for i in range(5)
+    ]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] != "high_confidence"
+    assert out["grade"] == "informational_only"
+
+
+def test_freshness_breakdown_counts_item_and_evidence():
+    items = [
+        _item(
+            evidence=[
+                {"source": "a", "freshness": "fresh"},
+                {"source": "b", "freshness": "stale"},
+            ],
+            freshness="soft_stale",
+        )
+    ]
+    out = build_lite_report_quality_summary(items)
+    # item.freshness(soft_stale) + evidence(fresh, stale)
+    assert out["freshness_breakdown"] == {
+        "fresh": 1,
+        "soft_stale": 1,
+        "stale": 1,
+        "unknown": 0,
+    }
+    assert out["evidence_source_count"] == 2
+
+
+def test_empty_items_grades_no_action():
+    out = build_lite_report_quality_summary([])
+    assert out["grade"] == "no_action"
+    assert out["total_item_count"] == 0
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py -p no:randomly -q`
+Expected: FAIL — `ModuleNotFoundError: app.services.investment_reports.lite_grade`
+
+- [ ] **Step 3: 헬퍼 구현**
+
+신규 `app/services/investment_reports/lite_grade.py`:
+
+```python
+"""ROB-472 — deterministic lite quality grade for Claude advisory reports.
+
+The snapshot-backed generator grades reports from snapshot bundle coverage
+(build_report_quality_summary). The lite create path has no snapshot bundle, so
+this derives an HONEST grade from the per-item structured evidence shipped in
+ROB-459 P1. By construction it NEVER returns high_confidence — a lite report
+lacks the snapshot coverage that grade is defined around — so an evidence-thin
+report can never masquerade as snapshot-backed high confidence.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from app.schemas.investment_reports import IngestReportItem
+
+_LITE_BASIS = "item_evidence_lite"
+_ACTIONABLE_KINDS = frozenset({"action", "watch"})
+_FRESHNESS_VALUES = ("fresh", "soft_stale", "stale", "unknown")
+
+
+def build_lite_report_quality_summary(
+    items: list[IngestReportItem],
+) -> dict[str, Any]:
+    """Derive a lite report_quality_summary from per-item evidence/freshness.
+
+    Grade is capped at ``informational_only`` (never ``high_confidence``):
+    - ``no_action``: no actionable (action|watch) items, OR no item carries any
+      structured evidence — genuinely insufficient to advise.
+    - ``informational_only``: otherwise — an evidence-backed lite advisory.
+
+    ``freshness_breakdown`` counts both item-level ``freshness`` and each
+    evidence row's ``freshness`` (None values are not counted).
+    """
+    total_item_count = len(items)
+    actionable_item_count = sum(
+        1 for it in items if it.item_kind in _ACTIONABLE_KINDS
+    )
+    evidence_item_count = sum(1 for it in items if it.evidence)
+
+    sources: set[str] = set()
+    freshness_counter: Counter[str] = Counter()
+    for it in items:
+        if it.freshness is not None:
+            freshness_counter[it.freshness] += 1
+        for ev in it.evidence:
+            sources.add(ev.source)
+            if ev.freshness is not None:
+                freshness_counter[ev.freshness] += 1
+
+    if actionable_item_count == 0 or evidence_item_count == 0:
+        grade = "no_action"
+        reason = (
+            "no actionable (action|watch) items"
+            if actionable_item_count == 0
+            else "no structured evidence on any item"
+        )
+    else:
+        grade = "informational_only"
+        reason = "evidence-backed lite advisory (no snapshot coverage)"
+
+    return {
+        "grade": grade,
+        "basis": _LITE_BASIS,
+        "reason": reason,
+        "total_item_count": total_item_count,
+        "actionable_item_count": actionable_item_count,
+        "evidence_item_count": evidence_item_count,
+        "evidence_source_count": len(sources),
+        "freshness_breakdown": {
+            k: freshness_counter.get(k, 0) for k in _FRESHNESS_VALUES
+        },
+    }
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py -p no:randomly -q`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/investment_reports/lite_grade.py tests/test_investment_report_lite_grade.py
+git commit -m "feat(ROB-472): lite report quality grade 순수 헬퍼 (high_confidence 불가)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: 핸들러 글루 `_maybe_attach_lite_quality` + create_impl 배선
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` (`:420` 직후 배선 + 글루 함수 추가)
+- Test: `tests/test_investment_report_lite_grade.py` (append, DB-free)
+
+- [ ] **Step 1: 글루 테스트 작성 (append)**
+
+`tests/test_investment_report_lite_grade.py`에 append:
+
+```python
+from app.mcp_server.tooling import investment_reports_handlers as h
+from app.schemas.investment_reports import IngestReportRequest
+
+
+def _request(profile="CLAUDE_ADVISOR", **over):
+    base = dict(
+        report_type="advisory_lite_v1",
+        market="kr",
+        created_by_profile=profile,
+        title="t",
+        summary="s",
+        kst_date="2026-06-09",
+        status="draft",
+        items=[
+            _item(
+                evidence=[{"source": "consensus", "freshness": "fresh"}],
+                freshness="fresh",
+            )
+        ],
+    )
+    base.update(over)
+    return IngestReportRequest(**base)
+
+
+def test_attach_lite_quality_advisory_profile_populates():
+    out = h._maybe_attach_lite_quality(_request(profile="CLAUDE_ADVISOR"))
+    rqs = out.snapshot_report_diagnostics["report_quality_summary"]
+    assert rqs["grade"] == "informational_only"
+    assert rqs["basis"] == "item_evidence_lite"
+
+
+def test_attach_lite_quality_non_advisory_profile_skips():
+    out = h._maybe_attach_lite_quality(_request(profile="t"))
+    assert out.snapshot_report_diagnostics is None
+
+
+def test_attach_lite_quality_does_not_clobber_caller_diagnostics():
+    caller = {"report_quality_summary": {"grade": "no_action", "basis": "caller"}}
+    out = h._maybe_attach_lite_quality(
+        _request(profile="CLAUDE_ADVISOR", snapshot_report_diagnostics=caller)
+    )
+    assert out.snapshot_report_diagnostics == caller
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py -k attach_lite -p no:randomly -q`
+Expected: FAIL — `AttributeError: ... has no attribute '_maybe_attach_lite_quality'`
+
+- [ ] **Step 3: 글루 함수 추가 + import**
+
+`app/mcp_server/tooling/investment_reports_handlers.py` 상단 import 영역에 추가:
+
+```python
+from app.services.investment_reports.lite_grade import (
+    build_lite_report_quality_summary,
+)
+from app.services.investment_reports.query_service import (
+    _advisory_draft_profiles,
+)
+```
+
+(주의: `query_service`는 이미 다른 심볼을 import 중일 수 있음 — 기존 `from app.services.investment_reports.query_service import InvestmentReportQueryService` 라인에 `_advisory_draft_profiles`를 합치거나 별도 import 추가. `git grep "from app.services.investment_reports.query_service import"`로 확인 후 병합.)
+
+그리고 `investment_report_create_impl` 정의 **위**(또는 인접 헬퍼 영역)에 글루 함수 추가:
+
+```python
+def _maybe_attach_lite_quality(
+    request: IngestReportRequest,
+) -> IngestReportRequest:
+    """ROB-472 — attach a deterministic lite quality grade to advisory reports.
+
+    Pure metadata (grade gates nothing). Only for advisory profiles; never
+    clobbers caller-supplied diagnostics; fail-open (a helper error never blocks
+    report creation). snapshot_freshness_summary/coverage_summary stay None so
+    the published-report DB CHECK is never triggered.
+    """
+    if request.snapshot_report_diagnostics is not None:
+        return request
+    if request.created_by_profile not in _advisory_draft_profiles():
+        return request
+    try:
+        summary = build_lite_report_quality_summary(request.items)
+    except Exception:
+        return request
+    return request.model_copy(
+        update={"snapshot_report_diagnostics": {"report_quality_summary": summary}}
+    )
+```
+
+- [ ] **Step 4: 통과 확인 (글루 단위)**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py -p no:randomly -q`
+Expected: PASS (9 tests)
+
+- [ ] **Step 5: create_impl 배선 (1줄)**
+
+`investment_report_create_impl`에서 `request = IngestReportRequest.model_validate(payload)`(현재 `:420`) **직후** 1줄 추가:
+
+```python
+    request = IngestReportRequest.model_validate(payload)
+    # ROB-472 — advisory lite reports get a deterministic, evidence-derived
+    # quality grade (display/audit metadata only). No-op for non-advisory
+    # profiles and when the caller already supplied diagnostics.
+    request = _maybe_attach_lite_quality(request)
+```
+
+- [ ] **Step 6: 핸들러 회귀 확인**
+
+Run: `uv run pytest tests/mcp_server/test_investment_report_create_handler.py tests/test_investment_report_lite_grade.py -p no:randomly -q`
+Expected: PASS (기존 create 핸들러 테스트 무회귀 + 신규 9)
+
+- [ ] **Step 7: ruff + 커밋**
+
+Run: `uv run ruff check app/mcp_server/tooling/investment_reports_handlers.py app/services/investment_reports/lite_grade.py tests/test_investment_report_lite_grade.py`
+Expected: All checks passed!
+
+```bash
+git add app/mcp_server/tooling/investment_reports_handlers.py tests/test_investment_report_lite_grade.py
+git commit -m "feat(ROB-472): advisory lite create에 lite quality grade 주입(글루)
+
+advisory 프로파일만, caller diagnostics 미clobber, fail-open. snapshot_*는
+freshness/coverage 미설정(DB CHECK 안전).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: DB round-trip 영속화 테스트
+
+**Files:**
+- Test: `tests/test_investment_report_lite_grade.py` (append, DB)
+
+- [ ] **Step 1: round-trip 테스트 작성 (append)**
+
+`tests/test_investment_report_lite_grade.py`에 append:
+
+```python
+@pytest.mark.asyncio
+async def test_lite_diagnostics_persists_and_round_trips(session) -> None:
+    """글루가 붙인 lite grade가 저장되고 ORM으로 round-trip된다."""
+    from app.services.investment_reports.ingestion import (
+        InvestmentReportIngestionService,
+    )
+    from app.services.investment_reports.repository import (
+        InvestmentReportsRepository,
+    )
+
+    request = h._maybe_attach_lite_quality(_request(profile="CLAUDE_ADVISOR"))
+    repo = InvestmentReportsRepository(session)
+    svc = InvestmentReportIngestionService(session, repository=repo)
+    report = await svc.ingest(request)
+    await session.flush()
+
+    diag = report.snapshot_report_diagnostics
+    assert diag is not None
+    assert diag["report_quality_summary"]["grade"] == "informational_only"
+    assert diag["report_quality_summary"]["basis"] == "item_evidence_lite"
+```
+
+(주의: 기존 `tests/test_investment_report_item_evidence.py`의 DB round-trip 테스트와 동일한 `session` 픽스처 사용 — 동작 확인됨. xdist 충돌 회피가 필요하면 그 파일의 관례를 따른다. `status="draft"`라 published freshness CHECK 미적용.)
+
+- [ ] **Step 2: 통과 확인**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py -p no:randomly -q`
+Expected: PASS (10 tests)
+
+- [ ] **Step 3: 슬라이스 전체 검증 + 커밋**
+
+Run: `uv run pytest tests/test_investment_report_lite_grade.py tests/mcp_server/test_investment_report_create_handler.py tests/test_investment_report_item_evidence.py -p no:randomly -q`
+Run: `uv run ruff check $(git diff --name-only origin/main...HEAD)`
+Expected: 전체 PASS, ruff clean.
+
+```bash
+git add tests/test_investment_report_lite_grade.py
+git commit -m "test(ROB-472): lite grade DB round-trip 영속화 검증
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+→ PR 생성 준비 완료.
+
+---
+
+## Self-Review (스펙 대비)
+
+**1. Spec coverage**
+- 스펙 §3-1(순수 헬퍼 + grade 규칙) → Task 1. ✅ no_action/informational_only 경계, high_confidence 부재, freshness_breakdown(item+evidence), source_count, basis 모두 테스트.
+- 스펙 §3-2(배선 + advisory-only + clobber 금지 + fail-open + freshness 미설정) → Task 2. ✅
+- 스펙 §3-3/3-4(데이터 흐름 + 에러 처리) → Task 2 글루(fail-open try/except). ✅
+- 스펙 §4(테스트: 헬퍼/핸들러/round-trip) → Task 1/2/3. ✅
+- 스펙 §5(additive/migration0/mutation0/no-flag) → 코드에 schema/DB/flag 변경 없음. ✅
+
+**2. Placeholder scan** — 모든 스텝 실제 코드/명령/기대출력 포함. TBD/TODO 없음. ✅
+
+**3. Type consistency**
+- `build_lite_report_quality_summary(items) -> dict` — Task 1 정의, Task 2 글루에서 동일 호출. ✅
+- `_maybe_attach_lite_quality(request) -> IngestReportRequest` — Task 2 정의·사용·테스트 일관. ✅
+- 반환 dict 키(`grade`/`basis`/`reason`/`*_count`/`freshness_breakdown`) — Task 1 정의, Task 2/3 단언에서 동일. ✅
+- `snapshot_report_diagnostics = {"report_quality_summary": summary}` — 글루·round-trip·핸들러 단언 일관. ✅
+
+**열린 실행-시 확인(차단 아님):** query_service import 라인 병합(기존 import 존재 시); DB 테스트 xdist 픽스처 관례.
+
+---
+
+## Execution Handoff
+(상위 세션에서 안내)

--- a/docs/superpowers/specs/2026-06-09-rob472-lite-report-grade-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob472-lite-report-grade-design.md
@@ -1,0 +1,140 @@
+# ROB-472 — Claude lite 리포트의 결정적 품질 grade (Design Spec)
+
+- **Issue:** [ROB-472](https://linear.app/mgh3326/issue/ROB-472) (Feature, ROB-459 P2에서 분리)
+- **Date:** 2026-06-09
+- **Status:** Approved design → writing-plans
+- **Scope:** 1 슬라이스 (1 PR). additive · migration 0 · schema 변경 0 · broker/order/watch mutation 0.
+
+---
+
+## 1. 배경 (코드-grounded, 현재 main `74dee6ee`)
+
+Claude가 `investment_report_create`(lite create)로 올린 advisory 리포트는 `snapshot_*`/품질 `grade`가 전부 null이다. HERMES generator 리포트(`snapshot_backed_advisory_v1`)는 `snapshot_report_diagnostics.report_quality_summary.grade`를 갖는 것과 대비 — Claude 리포트는 품질 신호가 없어 동급 신뢰도를 못 가진다.
+
+### 1-1. ⚠️ 전제 정정 (footgun은 실재하지 않음)
+ROB-472/ROB-459 P2 본문은 `build_report_quality_summary(freshness_summary=None, bundle_status=None)`이 **coverage 0인데도 `high_confidence`를 반환**한다고 했으나, 라인 단위 추적 결과 **거짓**이다. 빈 입력이면 `thin_coverage`(internal 0% < `HIGH_CONFIDENCE_MIN_COVERAGE_PCT`=70)가 발동해 **`informational_only`를 반환**한다 (`app/services/action_report/common/diagnostics.py:360,376-378`). 이 함수는 **이미 빈 입력에 fail-closed**다. 따라서 "근거 없는데 high_confidence로 위장" 시나리오는 없으며, 본 설계는 그 정직성을 *구조적으로* 더 강하게 보장한다(lite는 `high_confidence` 자체가 불가).
+
+### 1-2. grounded 사실
+- **grade는 display/audit 메타데이터 전용** — 어떤 백엔드도 grade로 생성/발행을 게이트하지 않음(`diagnostics.py:301`). lite-grade 추가는 순수 정보성·저위험.
+- **lite create seam이 깨끗**: `investment_report_create_impl`(`app/mcp_server/tooling/investment_reports_handlers.py:420`에서 `IngestReportRequest` 구성 → `:441` `service.ingest`). `snapshot_report_diagnostics`를 포함한 snapshot_* 필드는 **이미 optional**(`app/schemas/investment_reports.py:403` request / `:610` response)이고 ingestion→DB→response로 round-trip. **service/schema/DB 변경 불필요.**
+- **DB CHECK 주의**: published 리포트가 `snapshot_freshness_summary`를 세팅하면 `overall ∈ {fresh,soft_stale,partial}` 필수. → lite는 freshness_summary를 **비워두고** `snapshot_report_diagnostics.report_quality_summary`만 채운다(legacy NULL 허용 + 스냅샷 데이터 위조 방지).
+- **gate 개방은 과대**: `generate_from_bundle`/`SnapshotBackedReportGenerator.generate`는 심볼당 라이브 KIS/Upbit API 호출 + user_id 포트폴리오 수집 + bundle ensure. lite/캐시 경로 없음 → "Claude에 gate 개방"은 무겁고 안전 게이트 의미 변경 동반. **채택 안 함.**
+- **P1 evidence가 입력**: item `evidence: list[ItemEvidencePayload]`(`source` 필수, `freshness∈{fresh,soft_stale,stale,unknown}`) + item `freshness`(동일 literal)가 `evidence_snapshot.structured_evidence`/`item_freshness`에 저장됨(ROB-459 P1, 머지됨). 단 snapshot `FreshnessStatus`(`fresh|soft_stale|hard_stale|partial|unavailable`)와 literal이 다름 → **자체 집계 규칙** 필요(snapshot 로직 직접 재사용 불가).
+- **advisory 프로파일 셋 존재**: `query_service._advisory_draft_profiles()`(default `{HERMES_ADVISOR, CLAUDE_ADVISOR}` ∪ config) — 재사용.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Claude advisory lite 리포트가 **결정적·정직한 품질 grade**를 갖게 한다 (P1 evidence 기반).
+- 정직성: lite는 **`high_confidence` 절대 불가**(스냅샷 coverage 없음) — footgun을 설계로 제거.
+- `investment_report_get`으로 round-trip되어 운영자/Hermes가 품질 신호를 읽을 수 있게.
+
+**Non-goals**
+- generator gate(`SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`) 개방 / 라이브 스냅샷 수집. (Non-goal — 무거움/안전.)
+- snapshot_freshness_summary / coverage_summary 채우기(스냅샷 위조 금지).
+- broker/order/watch/order-intent mutation. DB 마이그레이션. 스키마 필드 추가(이미 존재).
+- report_item↔order linkage (= ROB-473, 별도).
+
+---
+
+## 3. 설계
+
+### 3-1. 컴포넌트 — 순수 헬퍼 (신규)
+**`app/services/investment_reports/lite_grade.py`** — 순수 함수, DB·IO 없음:
+
+```python
+def build_lite_report_quality_summary(items: list[IngestReportItem]) -> dict[str, Any]:
+    ...
+```
+
+**grade 규칙 (2-레벨, `high_confidence` 부재):**
+- `no_action` — actionable item(`item_kind∈{action,watch}`) 없음 **또는** 어떤 item도 structured evidence 없음(근거 부재).
+- `informational_only` — 그 외(근거 있는 advisory의 정직한 상한).
+- `high_confidence`는 **반환 경로 없음**(lite는 스냅샷 coverage가 없으므로).
+
+**반환 shape** (snapshot용 8-key와 별개, grade Literal 어휘는 공유):
+```json
+{
+  "grade": "informational_only",
+  "basis": "item_evidence_lite",
+  "reason": "evidence-backed lite advisory (no snapshot coverage)",
+  "total_item_count": 3,
+  "actionable_item_count": 2,
+  "evidence_item_count": 2,
+  "evidence_source_count": 4,
+  "freshness_breakdown": {"fresh": 3, "soft_stale": 1, "stale": 0, "unknown": 0}
+}
+```
+- `freshness_breakdown`은 **item.freshness + evidence[].freshness 둘 다** 집계(None은 미카운트).
+- `evidence_source_count`는 distinct `evidence[].source`.
+
+### 3-2. 배선 + 범위 (handlers.py)
+`investment_report_create_impl`에서 `request = IngestReportRequest.model_validate(payload)`(`:420`) **직후**, `async with`(`:422`) **전**에 1줄 주입:
+
+```python
+request = _maybe_attach_lite_quality(request)
+```
+
+헬퍼(같은 모듈 또는 lite_grade.py):
+```python
+def _maybe_attach_lite_quality(request: IngestReportRequest) -> IngestReportRequest:
+    # caller가 이미 diagnostics를 넘겼으면 존중(clobber 금지)
+    if request.snapshot_report_diagnostics is not None:
+        return request
+    # advisory 프로파일만(스모크/테스트/비-advisory 제외)
+    if request.created_by_profile not in _advisory_draft_profiles():
+        return request
+    try:
+        summary = build_lite_report_quality_summary(request.items)
+    except Exception:
+        return request  # fail-open: grade는 optional 메타데이터, 생성 차단 금지
+    return request.model_copy(
+        update={"snapshot_report_diagnostics": {"report_quality_summary": summary}}
+    )
+```
+- `_advisory_draft_profiles`는 `app/services/investment_reports/query_service`에서 import 재사용.
+- **snapshot_freshness_summary/coverage_summary 미설정**(None 유지) → DB CHECK 안전.
+
+### 3-3. 데이터 흐름
+`investment_report_create(items+evidence, created_by_profile="CLAUDE_ADVISOR")` → item 검증 → `_maybe_attach_lite_quality` → `snapshot_report_diagnostics={report_quality_summary:{grade, basis, ...}}` → `ingest` → DB → `investment_report_get`이 `snapshot_report_diagnostics` 반환.
+
+### 3-4. 에러 처리
+- **fail-open**: 헬퍼 예외 시 diagnostics 미주입, 리포트 생성 정상 진행.
+- **clobber 금지**: caller가 `snapshot_report_diagnostics`를 넘긴 경우 미변경.
+- **비-advisory 무영향**: 프로파일이 advisory 셋에 없으면 기존과 동일(diagnostics None).
+
+---
+
+## 4. 테스트
+- **헬퍼 단위** (`tests/test_investment_report_lite_grade.py`, 순수/no-DB):
+  - actionable item 없음(risk만) → `no_action`.
+  - evidence 전무(actionable 있으나 evidence 없음) → `no_action`(reason="no structured evidence...").
+  - evidence 있는 action item → `informational_only`.
+  - **`high_confidence` 절대 미반환**(어떤 입력에도) — 명시 단언.
+  - `freshness_breakdown`(item.freshness + evidence.freshness 합산) / `evidence_source_count`(distinct) 정확.
+  - `basis == "item_evidence_lite"`.
+- **핸들러 통합** (`tests/mcp_server/test_investment_report_create_handler.py` 확장 또는 DB 테스트):
+  - `created_by_profile="CLAUDE_ADVISOR"` + evidence item → 저장된 리포트의 `snapshot_report_diagnostics.report_quality_summary.grade == "informational_only"`.
+  - `created_by_profile="t"`(스모크) → `snapshot_report_diagnostics is None`.
+  - caller가 `snapshot_report_diagnostics`를 넘기면 미clobber.
+  - round-trip: `investment_report_get`이 lite grade 노출.
+
+---
+
+## 5. 제약 / 롤아웃
+- **additive · migration 0 · schema 변경 0**(`snapshot_report_diagnostics` 이미 존재) · **mutation 0**.
+- default-off 플래그 불필요(순수 메타데이터, 게이트 아님, advisory-only로 범위 제한). 즉시 동작.
+- 머지 후 operator 액션 없음.
+
+## 6. 핵심 코드 앵커
+| 무엇 | 위치 |
+|---|---|
+| 빈 입력→informational_only (footgun 부재) | `app/services/action_report/common/diagnostics.py:360,376-378` |
+| grade=display-only | `diagnostics.py:301` |
+| create seam (request→ingest) | `app/mcp_server/tooling/investment_reports_handlers.py:420,441` |
+| snapshot_report_diagnostics (req/resp, optional) | `app/schemas/investment_reports.py:403,610` |
+| advisory 프로파일 셋 | `app/services/investment_reports/query_service.py:61` `_advisory_draft_profiles()` |
+| P1 evidence/freshness | `app/schemas/investment_reports.py` `ItemEvidencePayload` / `IngestReportItem.evidence,freshness` (literals fresh\|soft_stale\|stale\|unknown) |
+| evidence 영속화 | `app/services/investment_reports/ingestion.py:381-391` |

--- a/tests/test_investment_report_lite_grade.py
+++ b/tests/test_investment_report_lite_grade.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from app.schemas.investment_reports import IngestReportItem
+from app.mcp_server.tooling import investment_reports_handlers as h
+from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
 from app.services.investment_reports.lite_grade import (
     build_lite_report_quality_summary,
 )
@@ -13,12 +14,12 @@ pytestmark = pytest.mark.unit
 
 
 def _item(**over):
-    base = dict(
-        client_item_key="k1",
-        item_kind="action",
-        intent="buy_review",
-        rationale="r",
-    )
+    base = {
+        "client_item_key": "k1",
+        "item_kind": "action",
+        "intent": "buy_review",
+        "rationale": "r",
+    }
     base.update(over)
     return IngestReportItem(**base)
 
@@ -92,3 +93,43 @@ def test_empty_items_grades_no_action():
     out = build_lite_report_quality_summary([])
     assert out["grade"] == "no_action"
     assert out["total_item_count"] == 0
+
+
+def _request(profile="CLAUDE_ADVISOR", **over):
+    base = {
+        "report_type": "advisory_lite_v1",
+        "market": "kr",
+        "created_by_profile": profile,
+        "title": "t",
+        "summary": "s",
+        "kst_date": "2026-06-09",
+        "status": "draft",
+        "items": [
+            _item(
+                evidence=[{"source": "consensus", "freshness": "fresh"}],
+                freshness="fresh",
+            )
+        ],
+    }
+    base.update(over)
+    return IngestReportRequest(**base)
+
+
+def test_attach_lite_quality_advisory_profile_populates():
+    out = h._maybe_attach_lite_quality(_request(profile="CLAUDE_ADVISOR"))
+    rqs = out.snapshot_report_diagnostics["report_quality_summary"]
+    assert rqs["grade"] == "informational_only"
+    assert rqs["basis"] == "item_evidence_lite"
+
+
+def test_attach_lite_quality_non_advisory_profile_skips():
+    out = h._maybe_attach_lite_quality(_request(profile="t"))
+    assert out.snapshot_report_diagnostics is None
+
+
+def test_attach_lite_quality_does_not_clobber_caller_diagnostics():
+    caller = {"report_quality_summary": {"grade": "no_action", "basis": "caller"}}
+    out = h._maybe_attach_lite_quality(
+        _request(profile="CLAUDE_ADVISOR", snapshot_report_diagnostics=caller)
+    )
+    assert out.snapshot_report_diagnostics == caller

--- a/tests/test_investment_report_lite_grade.py
+++ b/tests/test_investment_report_lite_grade.py
@@ -133,3 +133,25 @@ def test_attach_lite_quality_does_not_clobber_caller_diagnostics():
         _request(profile="CLAUDE_ADVISOR", snapshot_report_diagnostics=caller)
     )
     assert out.snapshot_report_diagnostics == caller
+
+
+@pytest.mark.asyncio
+async def test_lite_diagnostics_persists_and_round_trips(session) -> None:
+    """글루가 붙인 lite grade가 저장되고 ORM으로 round-trip된다."""
+    from app.services.investment_reports.ingestion import (
+        InvestmentReportIngestionService,
+    )
+    from app.services.investment_reports.repository import (
+        InvestmentReportsRepository,
+    )
+
+    request = h._maybe_attach_lite_quality(_request(profile="CLAUDE_ADVISOR"))
+    repo = InvestmentReportsRepository(session)
+    svc = InvestmentReportIngestionService(session, repository=repo)
+    report = await svc.ingest(request)
+    await session.flush()
+
+    diag = report.snapshot_report_diagnostics
+    assert diag is not None
+    assert diag["report_quality_summary"]["grade"] == "informational_only"
+    assert diag["report_quality_summary"]["basis"] == "item_evidence_lite"

--- a/tests/test_investment_report_lite_grade.py
+++ b/tests/test_investment_report_lite_grade.py
@@ -1,0 +1,94 @@
+"""ROB-472 — lite report quality grade 순수 헬퍼."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.investment_reports import IngestReportItem
+from app.services.investment_reports.lite_grade import (
+    build_lite_report_quality_summary,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _item(**over):
+    base = dict(
+        client_item_key="k1",
+        item_kind="action",
+        intent="buy_review",
+        rationale="r",
+    )
+    base.update(over)
+    return IngestReportItem(**base)
+
+
+def test_no_actionable_items_grades_no_action():
+    items = [_item(item_kind="risk", intent="risk_review")]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "no_action"
+    assert out["basis"] == "item_evidence_lite"
+
+
+def test_actionable_but_no_evidence_grades_no_action():
+    items = [_item()]  # action item, evidence=[] (default)
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "no_action"
+    assert "evidence" in out["reason"]
+
+
+def test_evidence_backed_action_grades_informational_only():
+    items = [
+        _item(
+            evidence=[{"source": "consensus", "freshness": "fresh"}],
+            freshness="fresh",
+        )
+    ]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] == "informational_only"
+    assert out["evidence_item_count"] == 1
+    assert out["actionable_item_count"] == 1
+
+
+def test_never_returns_high_confidence_even_with_rich_evidence():
+    items = [
+        _item(
+            client_item_key=f"k{i}",
+            evidence=[
+                {"source": "consensus", "freshness": "fresh"},
+                {"source": "foreign_flow", "freshness": "fresh"},
+            ],
+            freshness="fresh",
+        )
+        for i in range(5)
+    ]
+    out = build_lite_report_quality_summary(items)
+    assert out["grade"] != "high_confidence"
+    assert out["grade"] == "informational_only"
+
+
+def test_freshness_breakdown_counts_item_and_evidence():
+    items = [
+        _item(
+            evidence=[
+                {"source": "a", "freshness": "fresh"},
+                {"source": "b", "freshness": "stale"},
+            ],
+            freshness="soft_stale",
+        )
+    ]
+    out = build_lite_report_quality_summary(items)
+    # item.freshness(soft_stale) + evidence(fresh, stale)
+    assert out["freshness_breakdown"] == {
+        "fresh": 1,
+        "soft_stale": 1,
+        "stale": 1,
+        "unknown": 0,
+    }
+    assert out["evidence_source_count"] == 2
+
+
+def test_empty_items_grades_no_action():
+    out = build_lite_report_quality_summary([])
+    assert out["grade"] == "no_action"
+    assert out["total_item_count"] == 0


### PR DESCRIPTION
## 무엇 (ROB-459 P2에서 분리)

Claude가 `investment_report_create`로 올린 advisory 리포트는 품질 `grade`가 null이라 HERMES generator 리포트와 동급 신뢰도를 못 가졌다. 이 PR은 **머지된 ROB-459 P1 per-item evidence**에서 결정적 품질 `report_quality_summary`를 파생해 lite 리포트에 붙인다.

- **순수 헬퍼** `build_lite_report_quality_summary(items)` (`app/services/investment_reports/lite_grade.py`): item `evidence`/`freshness`에서 2-레벨 grade 산출.
  - `no_action` — actionable(action|watch) item 없음 또는 어떤 item도 evidence 없음.
  - `informational_only` — 그 외(근거 있는 advisory의 정직한 상한).
  - **`high_confidence`는 반환 경로 없음** — lite는 스냅샷 coverage가 없으므로 구조적으로 불가.
- **핸들러 글루** `_maybe_attach_lite_quality(request)` (handlers.py): `IngestReportRequest` 구성 직후 주입.
  - **advisory 프로파일만**(`_advisory_draft_profiles()` 재사용 — 스모크/테스트 제외).
  - caller가 `snapshot_report_diagnostics`를 넘기면 **미clobber**.
  - **fail-open**(예외 시 생성 차단 안 함). `snapshot_freshness_summary/coverage_summary`는 미설정 → **published DB CHECK 안전**.
- `snapshot_report_diagnostics`(이미 optional)에 저장 → `investment_report_get`으로 round-trip.

## ⚠️ 전제 정정
ROB-472/ROB-459 P2가 가정한 footgun — `build_report_quality_summary(None,None)`이 `high_confidence` 반환 — 은 **실재하지 않음**. 라인 추적 결과 빈 입력이면 `thin_coverage`(0%<70%)로 **`informational_only`** 반환(`diagnostics.py:360,376-378`). 본 설계는 그 정직성을 더 강하게(lite는 high_confidence 자체 불가) 보장.

## 테스트
- 신규 10 (헬퍼 6 + 글루 3 + DB round-trip 1) green. high_confidence 절대 미반환 명시 단언 포함.
- 광역 회귀 147 passed / 0 fail. ruff + format clean.

## 범위
- **additive · migration 0 · schema 변경 0**(snapshot_report_diagnostics 이미 존재) · **broker/order/watch mutation 0** · default-off 플래그 불필요(순수 메타데이터, advisory-only). 머지 후 operator 액션 없음.
- spec/plan: `docs/superpowers/{specs,plans}/2026-06-09-rob472-lite-report-grade*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advisory investment reports now automatically receive deterministic quality grade assessment. Grading is based on available evidence and the number of actionable items identified in reports.

* **Documentation**
  * Added design specification and implementation plan for the quality grading feature.
  * Added comprehensive test coverage for quality grading behavior and profile-based gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->