### PR TITLE
fix(ROB-410): register paused mock-loop TaskIQ tasks (404/405C/405E)

### DIFF
--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -7,8 +7,10 @@ from app.tasks import (
     invest_momentum_event_tasks,
     invest_screener_snapshot_tasks,
     investor_flow_snapshot_tasks,
+    journal_counterfactual_tasks,
     journal_verdict_tasks,
     kis_live_reconcile_tasks,  # noqa: F401
+    kis_mock_reconciliation_tasks,
     kr_candles_tasks,
     kr_symbol_universe_tasks,
     market_quote_snapshot_tasks,
@@ -20,6 +22,7 @@ from app.tasks import (
     upbit_symbol_universe_tasks,
     us_candles_tasks,
     us_symbol_universe_tasks,
+    watch_follow_up_tasks,
     watch_scan_tasks,
 )
 
@@ -36,6 +39,9 @@ TASKIQ_TASK_MODULES = (
     market_valuation_snapshot_tasks,
     mock_roundtrip_journal_tasks,
     journal_verdict_tasks,
+    journal_counterfactual_tasks,
+    kis_mock_reconciliation_tasks,
+    watch_follow_up_tasks,
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
     watch_scan_tasks,

--- a/tests/test_journal_counterfactual_task.py
+++ b/tests/test_journal_counterfactual_task.py
@@ -7,6 +7,14 @@ import pytest
 import app.tasks.journal_counterfactual_tasks as task_mod
 
 
+def test_task_registered_without_recurring_schedule():
+    import app.tasks as task_package
+
+    assert task_mod in task_package.TASKIQ_TASK_MODULES
+    labels = getattr(task_mod.journal_counterfactual_sync, "labels", {}) or {}
+    assert labels.get("schedule") is None
+
+
 @pytest.mark.asyncio
 async def test_disabled_when_flag_off(monkeypatch):
     monkeypatch.setattr(task_mod.settings, "JOURNAL_COUNTERFACTUAL_ENABLED", False)

--- a/tests/test_kis_mock_reconciliation_periodic_task.py
+++ b/tests/test_kis_mock_reconciliation_periodic_task.py
@@ -7,6 +7,14 @@ import pytest
 import app.tasks.kis_mock_reconciliation_tasks as task_mod
 
 
+def test_task_registered_without_recurring_schedule():
+    import app.tasks as task_package
+
+    assert task_mod in task_package.TASKIQ_TASK_MODULES
+    labels = getattr(task_mod.kis_mock_reconcile_periodic, "labels", {}) or {}
+    assert labels.get("schedule") is None
+
+
 @pytest.mark.asyncio
 async def test_periodic_paused_when_flag_off(monkeypatch):
     monkeypatch.setattr(

--- a/tests/test_watch_follow_up_task.py
+++ b/tests/test_watch_follow_up_task.py
@@ -7,6 +7,14 @@ import pytest
 import app.tasks.watch_follow_up_tasks as task_mod
 
 
+def test_task_registered_without_recurring_schedule():
+    import app.tasks as task_package
+
+    assert task_mod in task_package.TASKIQ_TASK_MODULES
+    labels = getattr(task_mod.watch_follow_up_sync, "labels", {}) or {}
+    assert labels.get("schedule") is None
+
+
 @pytest.mark.asyncio
 async def test_disabled_when_flag_off(monkeypatch):
     monkeypatch.setattr(task_mod.settings, "WATCH_FOLLOW_UP_LINK_ENABLED", False)


### PR DESCRIPTION
## 요약

mock 자율매매 루프의 paused TaskIQ task 3개가 `app/tasks/__init__.py`의 `TASKIQ_TASK_MODULES`에 등록되지 않아 broker가 발견하지 못했습니다(operator가 kick조차 불가). 누락분 등록 보정:
- `journal_counterfactual_tasks` (ROB-405 Slice C)
- `kis_mock_reconciliation_tasks` (ROB-404)
- `watch_follow_up_tasks` (ROB-405 Slice E)

(`mock_roundtrip_journal_tasks`/`journal_verdict_tasks`는 이미 등록돼 있었음.)

## 변경
- `app/tasks/__init__.py`: 위 3개 모듈을 import 블록 + `TASKIQ_TASK_MODULES` 튜플에 추가.
- 각 task 테스트에 `test_task_registered_without_recurring_schedule` 추가 — 모듈이 `TASKIQ_TASK_MODULES`에 있고 task의 `labels["schedule"]`가 None(= paused, recurring schedule 없음)임을 단언.

## 안전
- 등록만 추가 — task 자체는 여전히 **default-off flag 게이트 + recurring schedule 없음(paused)**. broker가 발견은 하되 자동 실행 안 함(operator가 flag flip + cron 추가해야 동작). broker/order mutation 없음.

## 검증
13 passed(3 신규 등록 + 기존 gating 테스트 across 5 task files), ruff clean.

## 관계
**#1102 supersede** — #1102는 167 commits behind main + `app/tasks/__init__.py` 충돌로 stale. 이 PR이 현재 main 기준 동일 수정을 깨끗이 적용. #1102는 닫음.

머지 시 ROB-410 코드 작업 완결 → ROB-401/410은 operator 활성화(alembic upgrade + flag flip + paused taskiq cron 등록 + live-mock smoke)만 남음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)