### PR TITLE
fix(ROB-442): chunk KR DART fundamentals bulk upsert + dedupe conflict keys

### DIFF
--- a/app/services/financial_fundamentals_snapshots/repository.py
+++ b/app/services/financial_fundamentals_snapshots/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from collections.abc import Iterable
 from decimal import Decimal
 
@@ -10,6 +11,19 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
+
+logger = logging.getLogger(__name__)
+
+# asyncpg caps bound arguments per statement at 32767 (signed int16 wire
+# field). A bounded-by-symbol DART backfill can build thousands of annual rows,
+# and with ~22 inserted columns the single-statement upsert overflows that
+# ceiling (ROB-442 evidence: $118404 placeholders). Stay well under the limit so
+# future column growth never silently breaches it mid-backfill; chunk size is
+# derived from the actual column count.
+_MAX_BIND_PARAMS = 30_000
+
+# Columns of the uq_financial_fundamentals_snapshots_msfs unique constraint.
+_CONFLICT_KEY_FIELDS = ("market", "symbol", "fiscal_period", "source")
 
 _UPSERTABLE_COLUMNS = (
     "period_type",
@@ -68,6 +82,40 @@ def _normalize_payload(row: FinancialFundamentalsUpsert) -> dict:
     return values
 
 
+def _chunk_rows_for_columns(column_count: int) -> int:
+    """Rows per upsert statement that keep bind params under the asyncpg ceiling."""
+    return max(1, _MAX_BIND_PARAMS // max(1, column_count))
+
+
+def _dedupe_payload(payload: list[dict]) -> tuple[list[dict], int]:
+    """Collapse duplicate conflict keys, keeping the latest-collected row.
+
+    A single multi-row ``VALUES`` upsert cannot reference the same ON CONFLICT
+    key twice (Postgres raises "command cannot affect row a second time"), so
+    duplicates must be removed before any statement is built. Dedup runs over
+    the whole payload up front, so chunk boundaries never split a key.
+
+    Winner per key: the row with the greatest ``source_collected_at``; on an
+    exact timestamp tie the last occurrence in ``payload`` wins (last-write-wins
+    — deterministic for a given payload, and a key's duplicates come from one
+    symbol's sequential parse so their relative order is stable). Surviving keys
+    keep their first-seen position (only the value is replaced), so output order
+    is stable. Returns ``(deduped_rows, dropped_count)``.
+    """
+    by_key: dict[tuple, dict] = {}
+    dropped = 0
+    for values in payload:
+        key = tuple(values[field] for field in _CONFLICT_KEY_FIELDS)
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = values
+            continue
+        dropped += 1
+        if values["source_collected_at"] >= existing["source_collected_at"]:
+            by_key[key] = values
+    return list(by_key.values()), dropped
+
+
 class FinancialFundamentalsSnapshotsRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -76,7 +124,22 @@ class FinancialFundamentalsSnapshotsRepository:
         payload = [_normalize_payload(row) for row in rows]
         if not payload:
             return 0
-        stmt = insert(FinancialFundamentalsSnapshot).values(payload)
+        deduped, dropped = _dedupe_payload(payload)
+        if dropped:
+            logger.info(
+                "financial_fundamentals upsert collapsed %d duplicate conflict "
+                "key(s) from %d payload rows (kept latest source_collected_at)",
+                dropped,
+                len(payload),
+            )
+        chunk_rows = _chunk_rows_for_columns(len(deduped[0]))
+        total = 0
+        for start in range(0, len(deduped), chunk_rows):
+            total += await self._upsert_chunk(deduped[start : start + chunk_rows])
+        return total
+
+    async def _upsert_chunk(self, chunk: list[dict]) -> int:
+        stmt = insert(FinancialFundamentalsSnapshot).values(chunk)
         set_ = {col: getattr(stmt.excluded, col) for col in _UPSERTABLE_COLUMNS}
         set_["computed_at"] = func.now()
         set_["updated_at"] = func.now()

--- a/docs/runbooks/financial_fundamentals.md
+++ b/docs/runbooks/financial_fundamentals.md
@@ -41,6 +41,25 @@ To safeguard OpenDART API keys from hitting the daily limit (20,000 requests/day
   - **Annual-only:** `~11 requests per symbol`
   - **With Quarterly:** `~41 requests per symbol`
 
+### Bulk Upsert Chunking (ROB-442)
+
+The DB write path chunks the bulk upsert so a large bounded-by-symbol backfill
+no longer overflows the asyncpg/Postgres bind-parameter ceiling (32767 args per
+statement):
+
+- `FinancialFundamentalsSnapshotsRepository.upsert()` splits the payload into row
+  batches sized from the column count (`_MAX_BIND_PARAMS // columns`, capped at
+  30,000 params), issuing one `INSERT ... ON CONFLICT` per chunk and summing the
+  affected-row counts.
+- Duplicate `(market, symbol, fiscal_period, source)` keys are collapsed before
+  any statement is built (latest `source_collected_at` wins, deterministically),
+  so a repeated key can never trigger `ON CONFLICT DO UPDATE command cannot
+  affect row a second time`.
+- **Operator impact:** the large one-shot backfill path is safe again — size
+  `--limit` purely against the **DART daily budget** (e.g. `--limit 1500` ≈
+  16,500 annual requests), not against any DB statement-size limit. (Before this
+  landed, the workaround was smaller chunks such as `--limit 250 --skip-existing`.)
+
 ---
 
 ## 4. Toss Parity: 성장 기대주 (growth_expectation_toss)

--- a/tests/test_financial_fundamentals_snapshots_chunking.py
+++ b/tests/test_financial_fundamentals_snapshots_chunking.py
@@ -1,0 +1,276 @@
+"""ROB-442: bulk-upsert chunking + payload-key dedupe for KR DART fundamentals.
+
+These are pure unit tests (no DB, no DART fetch) so chunking is provable in CI
+without a Postgres backend or any DART budget consumption.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from app.services.financial_fundamentals_snapshots.repository import (
+    _MAX_BIND_PARAMS,
+    FinancialFundamentalsSnapshotsRepository,
+    FinancialFundamentalsUpsert,
+    _chunk_rows_for_columns,
+    _dedupe_payload,
+    _normalize_payload,
+)
+
+_COLLECTED = dt.datetime(2026, 6, 6, 0, 0, tzinfo=dt.UTC)
+
+
+def _row(
+    symbol: str,
+    *,
+    fiscal_period: str = "2025A",
+    net_income: int = 100,
+    source: str = "dart",
+    source_collected_at: dt.datetime = _COLLECTED,
+) -> FinancialFundamentalsUpsert:
+    return FinancialFundamentalsUpsert(
+        market="kr",
+        symbol=symbol,
+        fiscal_period=fiscal_period,
+        period_type="annual",
+        period_end_date=dt.date(int(fiscal_period[:4]), 12, 31),
+        source=source,
+        source_collected_at=source_collected_at,
+        net_income=Decimal(net_income),
+    )
+
+
+class _SpySession:
+    """Minimal AsyncSession stand-in capturing executed statements.
+
+    Avoids AsyncMock so ``result.rowcount`` is a real int (not a child mock),
+    which the summed-rowcount assertion depends on.
+    """
+
+    def __init__(self, rowcounts: list[int] | None = None) -> None:
+        self.statements: list = []
+        self._rowcounts = list(rowcounts) if rowcounts is not None else None
+
+    async def execute(self, stmt):  # noqa: ANN001 - test double
+        idx = len(self.statements)
+        self.statements.append(stmt)
+        rowcount = self._rowcounts[idx] if self._rowcounts is not None else 0
+
+        class _Result:
+            pass
+
+        result = _Result()
+        result.rowcount = rowcount
+        return result
+
+
+def _bind_param_count(stmt) -> int:
+    return len(stmt.compile(dialect=postgresql.dialect()).params)
+
+
+# --------------------------------------------------------------------------- #
+# chunk sizing helper
+# --------------------------------------------------------------------------- #
+
+
+def test_max_bind_params_below_asyncpg_ceiling():
+    # asyncpg caps bound arguments per statement at 32767 (signed int16).
+    assert _MAX_BIND_PARAMS <= 32767
+
+
+@pytest.mark.parametrize("column_count", [1, 22, 25, 40, 120])
+def test_chunk_rows_keeps_statement_under_bind_limit(column_count):
+    chunk_rows = _chunk_rows_for_columns(column_count)
+    assert chunk_rows >= 1
+    assert chunk_rows * column_count <= _MAX_BIND_PARAMS
+
+
+# --------------------------------------------------------------------------- #
+# payload-key dedupe (key = market, symbol, fiscal_period, source)
+# --------------------------------------------------------------------------- #
+
+
+def test_dedupe_keeps_distinct_keys_untouched():
+    rows = [
+        _normalize_payload(_row("005930", fiscal_period="2024A")),
+        _normalize_payload(_row("005930", fiscal_period="2025A")),
+    ]
+    deduped, dropped = _dedupe_payload(rows)
+    assert dropped == 0
+    assert len(deduped) == 2
+
+
+def test_dedupe_distinguishes_by_source():
+    rows = [
+        _normalize_payload(_row("005930", source="dart")),
+        _normalize_payload(_row("005930", source="naver")),
+    ]
+    deduped, dropped = _dedupe_payload(rows)
+    assert dropped == 0
+    assert {r["source"] for r in deduped} == {"dart", "naver"}
+
+
+def test_dedupe_keeps_latest_by_source_collected_at():
+    early = _normalize_payload(
+        _row(
+            "005930",
+            net_income=100,
+            source_collected_at=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        )
+    )
+    late = _normalize_payload(
+        _row(
+            "005930",
+            net_income=999,
+            source_collected_at=dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+        )
+    )
+    deduped, dropped = _dedupe_payload([early, late])
+    assert dropped == 1
+    assert len(deduped) == 1
+    assert deduped[0]["net_income"] == Decimal(999)
+
+
+def test_dedupe_keeps_latest_regardless_of_input_order():
+    early = _normalize_payload(
+        _row(
+            "005930",
+            net_income=100,
+            source_collected_at=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        )
+    )
+    late = _normalize_payload(
+        _row(
+            "005930",
+            net_income=999,
+            source_collected_at=dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+        )
+    )
+    deduped, dropped = _dedupe_payload([late, early])
+    assert dropped == 1
+    assert deduped[0]["net_income"] == Decimal(999)
+
+
+def test_dedupe_tie_breaks_last_write_wins_in_both_orders():
+    # Equal source_collected_at is the common case (one job run shares a single
+    # collected_at). The contract is last-write-wins within the payload:
+    # deterministic for a given order, and the order is the builder's stable
+    # per-symbol parse order. Pin both directions so the behaviour is explicit.
+    a = _normalize_payload(
+        _row("005930", net_income=100, source_collected_at=_COLLECTED)
+    )
+    b = _normalize_payload(
+        _row("005930", net_income=222, source_collected_at=_COLLECTED)
+    )
+
+    deduped_ab, dropped_ab = _dedupe_payload([a, b])
+    assert dropped_ab == 1
+    assert deduped_ab[0]["net_income"] == Decimal(222)  # b is last → b wins
+
+    deduped_ba, dropped_ba = _dedupe_payload([b, a])
+    assert dropped_ba == 1
+    assert deduped_ba[0]["net_income"] == Decimal(100)  # a is last → a wins
+
+
+# --------------------------------------------------------------------------- #
+# upsert chunking behaviour (mock session)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_empty_payload_returns_zero_without_execute():
+    session = _SpySession()
+    repo = FinancialFundamentalsSnapshotsRepository(session)
+    assert await repo.upsert([]) == 0
+    assert session.statements == []
+
+
+@pytest.mark.asyncio
+async def test_small_payload_executes_single_statement():
+    session = _SpySession()
+    repo = FinancialFundamentalsSnapshotsRepository(session)
+    rows = [_row(f"S{i:04d}") for i in range(5)]
+    await repo.upsert(rows)
+    assert len(session.statements) == 1
+    assert _bind_param_count(session.statements[0]) <= _MAX_BIND_PARAMS
+
+
+@pytest.mark.asyncio
+async def test_large_payload_chunked_into_bounded_statements():
+    session = _SpySession()
+    repo = FinancialFundamentalsSnapshotsRepository(session)
+    n_rows = 3000
+    rows = [_row(f"S{i:05d}") for i in range(n_rows)]
+
+    await repo.upsert(rows)
+
+    column_count = len(_normalize_payload(rows[0]))
+    chunk_rows = _chunk_rows_for_columns(column_count)
+    expected_chunks = -(-n_rows // chunk_rows)  # ceil division
+
+    assert len(session.statements) == expected_chunks
+    assert len(session.statements) > 1  # genuinely chunked, not one oversized stmt
+
+    # Each statement carries exactly column_count * rows_in_chunk binds, and
+    # stays under the ceiling — proving the chunk math (not just an upper bound).
+    expected_sizes: list[int] = []
+    remaining = n_rows
+    while remaining > 0:
+        take = min(chunk_rows, remaining)
+        expected_sizes.append(take)
+        remaining -= take
+    for stmt, size in zip(session.statements, expected_sizes, strict=True):
+        assert _bind_param_count(stmt) == column_count * size
+        assert _bind_param_count(stmt) <= _MAX_BIND_PARAMS
+
+
+@pytest.mark.asyncio
+async def test_upsert_returns_summed_rowcount_across_chunks():
+    n_rows = 3000
+    rows = [_row(f"S{i:05d}") for i in range(n_rows)]
+    column_count = len(_normalize_payload(rows[0]))
+    chunk_rows = _chunk_rows_for_columns(column_count)
+
+    # each chunk reports its own row count as rowcount
+    rowcounts: list[int] = []
+    remaining = n_rows
+    while remaining > 0:
+        take = min(chunk_rows, remaining)
+        rowcounts.append(take)
+        remaining -= take
+
+    session = _SpySession(rowcounts=rowcounts)
+    repo = FinancialFundamentalsSnapshotsRepository(session)
+    total = await repo.upsert(rows)
+    assert total == n_rows
+
+
+@pytest.mark.asyncio
+async def test_duplicate_keys_collapsed_before_chunking():
+    # Same conflict key repeated would otherwise trigger Postgres
+    # "ON CONFLICT DO UPDATE command cannot affect row a second time". This
+    # unit test pins the collapse logic; the real-DB regression that would fail
+    # on the old single-statement code is
+    # test_upsert_dedupes_duplicate_keys_in_one_call_keeping_latest (repository).
+    session = _SpySession()
+    repo = FinancialFundamentalsSnapshotsRepository(session)
+    rows = [
+        _row(
+            "005930",
+            net_income=100,
+            source_collected_at=dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        ),
+        _row(
+            "005930",
+            net_income=999,
+            source_collected_at=dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+        ),
+    ]
+    await repo.upsert(rows)
+    assert len(session.statements) == 1
+    # one row in the statement (the latest), not two
+    assert _bind_param_count(session.statements[0]) == len(_normalize_payload(rows[0]))

--- a/tests/test_financial_fundamentals_snapshots_repository.py
+++ b/tests/test_financial_fundamentals_snapshots_repository.py
@@ -85,6 +85,90 @@ async def test_periods_for_symbol_returns_ascending_by_period_end(db_session):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_upsert_dedupes_duplicate_keys_in_one_call_keeping_latest(db_session):
+    # ROB-442: two rows with the same (market,symbol,fiscal_period,source) in a
+    # single upsert() call must NOT raise "ON CONFLICT DO UPDATE command cannot
+    # affect row a second time"; the latest-collected row wins deterministically.
+    await db_session.execute(
+        sa.delete(FinancialFundamentalsSnapshot).where(
+            FinancialFundamentalsSnapshot.symbol == "005930"
+        )
+    )
+    await db_session.commit()
+
+    repo = FinancialFundamentalsSnapshotsRepository(db_session)
+    base = _row("2025A", 100, filing_date=dt.date(2026, 3, 20))
+    early = base.model_copy(
+        update={
+            "net_income": Decimal("100"),
+            "source_collected_at": dt.datetime(2026, 6, 1, tzinfo=dt.UTC),
+        }
+    )
+    late = base.model_copy(
+        update={
+            "net_income": Decimal("999"),
+            "source_collected_at": dt.datetime(2026, 6, 5, tzinfo=dt.UTC),
+        }
+    )
+
+    await repo.upsert([early, late])
+    await db_session.commit()
+
+    rows = await repo.periods_for_symbol(market="kr", symbol="005930")
+    assert len(rows) == 1
+    assert rows[0].net_income == Decimal("999")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_chunks_across_statements_on_real_db(db_session, monkeypatch):
+    # ROB-442: force tiny chunks so >1 SQL statement is issued against a real
+    # asyncpg backend, then prove every distinct row persists and re-running is
+    # idempotent across chunk boundaries.
+    from app.services.financial_fundamentals_snapshots import repository as repo_mod
+
+    monkeypatch.setattr(repo_mod, "_MAX_BIND_PARAMS", 44)  # ~2 rows/chunk at 22 cols
+
+    await db_session.execute(
+        sa.delete(FinancialFundamentalsSnapshot).where(
+            FinancialFundamentalsSnapshot.symbol == "005930"
+        )
+    )
+    await db_session.commit()
+
+    repo = FinancialFundamentalsSnapshotsRepository(db_session)
+    rows = [
+        _row("2021A", 100, filing_date=dt.date(2022, 3, 20)),
+        _row("2022A", 200, filing_date=dt.date(2023, 3, 20)),
+        _row("2023A", 300, filing_date=dt.date(2024, 3, 20)),
+        _row("2024A", 400, filing_date=dt.date(2025, 3, 20)),
+        _row("2025A", 500, filing_date=dt.date(2026, 3, 20)),
+    ]
+
+    n = await repo.upsert(rows)
+    await db_session.commit()
+
+    # rowcount is summed across the (now 3) chunk statements on a real backend.
+    assert n == 5
+
+    persisted = await repo.periods_for_symbol(market="kr", symbol="005930")
+    assert [r.fiscal_period for r in persisted] == [
+        "2021A",
+        "2022A",
+        "2023A",
+        "2024A",
+        "2025A",
+    ]
+
+    # idempotent re-run across chunk boundaries → still 5 rows, no duplicates
+    await repo.upsert(rows)
+    await db_session.commit()
+    persisted_again = await repo.periods_for_symbol(market="kr", symbol="005930")
+    assert len(persisted_again) == 5
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_latest_periods_for_symbols_groups_by_symbol(db_session):
     # Clean up first to avoid cross-test pollution in persistent test DB
     await db_session.execute(


### PR DESCRIPTION
## What & why

`FinancialFundamentalsSnapshotsRepository.upsert()` built a single `insert().values(whole_payload)`. A bounded-by-symbol KR DART backfill (`--limit 1500`, ~10k annual rows × **22 insert columns**) generated **>100k bind params** (`$118404` in the captured failure) — past asyncpg's hard **32767** argument ceiling (`prepared_stmt.pyx:130`) — so the statement failed *before* the `ON CONFLICT` upsert could run. No KR rows were added.

Linear: **ROB-442** (Bug, High) · related ROB-433 operator backfill.

## Fix

1. **Chunk the upsert** (`repository.py`) into row batches sized from the *actual* column count: `_MAX_BIND_PARAMS=30000 // columns` → **1363 rows/chunk** at 22 cols = 29,986 binds, safely under 32767. One `INSERT … ON CONFLICT` per chunk; rowcounts summed. Computed (not a fixed 500) so adding a column never silently breaches the ceiling — it shrinks the chunk instead.
2. **Dedupe** `(market, symbol, fiscal_period, source)` over the **whole payload** before any statement is built. A repeated conflict key inside one multi-row `VALUES` would otherwise raise `ON CONFLICT DO UPDATE command cannot affect row a second time` (the secondary risk in the issue — upstream `_classify_idempotency` only *counts* dup keys, never removes them). Winner = greatest `source_collected_at`; ties are last-write-wins (deterministic per payload). Collapsed count is logged.
3. **Runbook** (`docs/runbooks/financial_fundamentals.md` §3): document the chunked write so `--limit 1500` is sized against the **DART daily budget**, not a DB statement-size limit.

## Acceptance criteria

- ✅ Large synthetic payload chunked & upserted without an oversized statement (unit proof: per-chunk bind count == `cols × rows` and ≤ 30000).
- ✅ Existing small bounded chunks stay idempotent (existing + new integration tests).
- ✅ KR DART **estimate-only** semantics unchanged, 0 budget (path untouched).
- ✅ Dry-run/**no-fetch** test covers chunking — the 16 unit tests use a spy session: **no DB, no DART** → CI-safe.
- ✅ Safety: **no schema/migration**, no broker/order/watch/order-intent/trade-journal mutation, no scheduler, no env/secret.

## Diagnostic consistency note

A reviewer flagged a possible mismatch with the job's `duplicatePayloadKeys` diagnostic. Verified it's **not** an issue: `_classify_idempotency` derives `wouldInsert`/`wouldUpdate` from `set(keys)` (already deduped), and `duplicatePayloadKeys` is a separate, accurate count of the redundant rows this change collapses. Before this fix, `--commit` with dup keys *crashed*; now the committed write **matches** the reported counts.

## Tests

- **Unit** (`tests/test_financial_fundamentals_snapshots_chunking.py`, new, 16): asyncpg ceiling guard, chunk math under limit for 1–120 cols, dedupe (distinct keys, by source, latest-collected, **both input orders** pinning last-write-wins), multiple bounded statements with exact per-chunk bind counts, summed rowcount, empty payload no-op, dup-collapse-before-chunk.
- **Integration** (`tests/…_repository.py`, +2 real-DB): two same-key rows in one `upsert()` call no longer raise and keep the latest value (would fail on old single-statement code); chunked writes persist all rows + idempotent re-run across chunk boundaries (via a monkeypatched low limit), asserting summed `rowcount == 5` on a real backend.

Full FF suite: **63 passed**. `ruff check`/`ruff format`/`ty check` clean (app + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large bulk upsert operations now automatically handle database parameter limits by splitting payloads into optimized chunks.
  * Duplicate rows within the same upsert call are now deduplicated, keeping the latest entry based on collection timestamp.

* **Documentation**
  * Updated runbook with guidance on bulk upsert chunking behavior and duplicate handling; clarified that `--limit` sizing should be based on data budget constraints rather than database limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->