### PR TITLE
feat(ROB-262): KIS websocket approval-key 단일비행 발급 락 + OPSP0011 무-churn 하드닝

### DIFF
--- a/app/services/kis_websocket.py
+++ b/app/services/kis_websocket.py
@@ -5,12 +5,14 @@ KIS (한국투자증권) WebSocket Client for Execution Data
 """
 
 from app.services.kis_websocket_internal.approval_keys import (
+    ApprovalKeyIssuanceUnavailable,
     _cache_approval_key,
     _get_cached_approval_key,
     _is_valid_approval_key,
     _issue_approval_key,
     close_approval_key_redis,
     get_approval_key,
+    invalidate_and_reissue_approval_key,
 )
 from app.services.kis_websocket_internal.client import (
     KISAppKeyInUseError,
@@ -69,6 +71,7 @@ __all__ = [
     "OVERSEAS_FILL_FIELDS",
     "OVERSEAS_SIDE_MAP",
     "RECOVERABLE_APPROVAL_MSG_CODES",
+    "ApprovalKeyIssuanceUnavailable",
     "_SIDE_MAP",
     "_US_SYMBOL_RESERVED_TOKENS",
     "_cache_approval_key",
@@ -78,4 +81,5 @@ __all__ = [
     "build_lifecycle_event",
     "close_approval_key_redis",
     "get_approval_key",
+    "invalidate_and_reissue_approval_key",
 ]

--- a/app/services/kis_websocket_internal/approval_keys.py
+++ b/app/services/kis_websocket_internal/approval_keys.py
@@ -1,4 +1,8 @@
+import asyncio
 import logging
+import random
+import time
+import uuid
 from urllib.parse import urlparse
 
 import httpx
@@ -9,13 +13,27 @@ from app.core.config import settings, validate_kis_mock_config
 from .constants import (
     APPROVAL_ENDPOINT_HOSTS,
     APPROVAL_KEY_CACHE_KEYS,
+    APPROVAL_KEY_LOCK_CACHE_KEYS,
+    APPROVAL_KEY_LOCK_TTL_SECONDS,
     APPROVAL_KEY_TTL_SECONDS,
+    APPROVAL_KEY_WAIT_POLL_SECONDS,
+    APPROVAL_KEY_WAIT_TIMEOUT_SECONDS,
 )
 
 logger = logging.getLogger(__name__)
 
 # WebSocket approval keys are only issued for KIS environments.
 _SUPPORTED_ACCOUNT_MODES = ("kis_live", "kis_mock")
+
+
+class ApprovalKeyIssuanceUnavailable(RuntimeError):
+    """Raised when a cold-start contender cannot obtain an approval key.
+
+    Another process holds the single-flight issuance lock but did not publish a
+    cached key within the bounded wait. The contender deliberately fails/backs
+    off here rather than independently issuing a second approval key (which is
+    exactly the cold-start churn ROB-262 prevents).
+    """
 
 
 def _resolve_ws_account_mode(account_mode: str) -> str:
@@ -141,12 +159,175 @@ async def get_approval_key(account_mode: str = "kis_live") -> str:
     account_mode = _resolve_ws_account_mode(account_mode)
     approval_key = await _get_cached_approval_key(account_mode)
 
-    if not _is_valid_approval_key(approval_key):
-        approval_key = await _issue_approval_key(account_mode)
-        await _cache_approval_key(approval_key, account_mode)
+    if _is_valid_approval_key(approval_key):
+        logger.info("KIS approval key cache hit: account_mode=%s", account_mode)
+        assert approval_key is not None  # narrowed by _is_valid_approval_key
+        return approval_key
 
-    assert approval_key is not None  # _issue_approval_key() guarantees str return
-    return approval_key
+    logger.info("KIS approval key cache miss: account_mode=%s", account_mode)
+    return await _issue_approval_key_single_flight(account_mode)
+
+
+async def invalidate_and_reissue_approval_key(account_mode: str = "kis_live") -> str:
+    """Controlled, single-flight reissue of the approval key (OPSP0011 path).
+
+    This is the ONLY sanctioned path that discards a cached approval key. It runs
+    under the same single-flight lock as cold issuance: the lock holder clears the
+    known-bad key, issues exactly one fresh key, and re-caches it; concurrent
+    owners wait and reuse the holder's fresh key instead of each hammering the
+    approval endpoint. If the holder's reissue fails, the bad key is left cleared
+    so contenders fail/back off rather than reusing a key KIS already rejected.
+
+    Returns:
+        str: the freshly issued (or holder-published) approval key.
+
+    Raises:
+        ApprovalKeyIssuanceUnavailable: contender timed out waiting for the key.
+        Exception: the approval endpoint call failed (propagated to the caller).
+    """
+    account_mode = _resolve_ws_account_mode(account_mode)
+    logger.info(
+        "KIS approval key controlled reissue requested: account_mode=%s", account_mode
+    )
+    return await _issue_approval_key_single_flight(account_mode, force_reissue=True)
+
+
+async def _issue_approval_key_single_flight(
+    account_mode: str, *, force_reissue: bool = False
+) -> str:
+    """Issue the approval key under a Redis single-flight lock.
+
+    Lock holder: (optionally) invalidates the cached key, calls the approval
+    endpoint exactly once, caches the result, and always releases the lock.
+    Contender (lock held elsewhere): waits with bounded, jittered retries and
+    reuses the holder's cached key — never issues independently.
+    """
+    account_mode = _resolve_ws_account_mode(account_mode)
+    redis_client = await _get_redis_client()
+    lock_token = await _acquire_issuance_lock(redis_client, account_mode)
+
+    if lock_token is not None:
+        lock_key = APPROVAL_KEY_LOCK_CACHE_KEYS[account_mode]
+        try:
+            if force_reissue:
+                # Drop the KIS-rejected key first so a failed reissue cannot leave
+                # contenders reusing a bad key.
+                await _invalidate_cached_approval_key(account_mode)
+            else:
+                # Double-checked locking: another holder may have published a key
+                # between our cache miss and acquiring the lock.
+                cached = await _get_cached_approval_key(account_mode)
+                if _is_valid_approval_key(cached):
+                    logger.info(
+                        "KIS approval key reused after acquiring lock "
+                        "(published by prior holder): account_mode=%s",
+                        account_mode,
+                    )
+                    assert cached is not None
+                    return cached
+
+            logger.info(
+                "KIS approval key issuance lock acquired; calling approval "
+                "endpoint once: account_mode=%s force_reissue=%s",
+                account_mode,
+                force_reissue,
+            )
+            issued = await _issue_approval_key(account_mode)
+            await _cache_approval_key(issued, account_mode)
+            return issued
+        finally:
+            await _release_issuance_lock(redis_client, lock_key, lock_token)
+
+    logger.info(
+        "KIS approval key issuance lock held by another owner; waiting to reuse "
+        "cached key: account_mode=%s",
+        account_mode,
+    )
+    waited_key = await _wait_for_cached_approval_key(account_mode)
+    if _is_valid_approval_key(waited_key):
+        logger.info(
+            "KIS approval key reused after waiting on issuance lock: account_mode=%s",
+            account_mode,
+        )
+        assert waited_key is not None
+        return waited_key
+
+    logger.warning(
+        "KIS approval key issuance contended and no cached key appeared within "
+        "%.1fs; backing off without independent issuance: account_mode=%s",
+        APPROVAL_KEY_WAIT_TIMEOUT_SECONDS,
+        account_mode,
+    )
+    raise ApprovalKeyIssuanceUnavailable(
+        f"approval key issuance contended for {account_mode}; "
+        "no cached key after bounded wait"
+    )
+
+
+async def _acquire_issuance_lock(
+    redis_client: redis.Redis, account_mode: str
+) -> str | None:
+    """Acquire the single-flight issuance lock via ``SET NX EX``.
+
+    Returns a unique token on success (caller must release with that token), or
+    None if another owner holds the lock. Redis errors propagate (fail-closed),
+    matching the cache-read policy of this module.
+    """
+    lock_key = APPROVAL_KEY_LOCK_CACHE_KEYS[account_mode]
+    lock_token = f"{uuid.uuid4()}"
+    acquired = await redis_client.set(
+        lock_key,
+        lock_token,
+        nx=True,
+        ex=max(int(APPROVAL_KEY_LOCK_TTL_SECONDS), 1),
+    )
+    if acquired:
+        logger.info(
+            "KIS approval key issuance lock acquired: account_mode=%s", account_mode
+        )
+        return lock_token
+    logger.info(
+        "KIS approval key issuance lock contended: account_mode=%s", account_mode
+    )
+    return None
+
+
+async def _release_issuance_lock(
+    redis_client: redis.Redis, lock_key: str, lock_token: str
+) -> None:
+    """Release the issuance lock iff we still own it (compare-and-delete).
+
+    Fail-open: a release error is swallowed because the lock TTL guarantees
+    eventual recovery, and masking the holder's real error would be worse.
+    """
+    release_script = """
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        return redis.call('DEL', KEYS[1])
+    else
+        return 0
+    end
+    """
+    try:
+        await redis_client.eval(release_script, 1, lock_key, lock_token)
+    except Exception as exc:  # noqa: BLE001 - TTL self-heals; never mask holder error
+        logger.debug("KIS approval key lock release best-effort failure: %s", exc)
+
+
+async def _wait_for_cached_approval_key(account_mode: str) -> str | None:
+    """Bounded, jittered wait for another holder to publish the cached key.
+
+    Read-first: check the cache before each sleep so a key that is already
+    present (holder cached quickly) is returned without burning a poll interval.
+    """
+    deadline = time.monotonic() + APPROVAL_KEY_WAIT_TIMEOUT_SECONDS
+    while True:
+        cached = await _get_cached_approval_key(account_mode)
+        if _is_valid_approval_key(cached):
+            return cached
+        if time.monotonic() >= deadline:
+            return None
+        poll = max(float(APPROVAL_KEY_WAIT_POLL_SECONDS), 0.0)
+        await asyncio.sleep(poll + random.uniform(0.0, poll))
 
 
 async def _get_cached_approval_key(account_mode: str = "kis_live") -> str | None:
@@ -183,6 +364,24 @@ async def _cache_approval_key(
     await redis_client.set(cache_key, approval_key, ex=APPROVAL_KEY_TTL_SECONDS)
     logger.info(
         "KIS Approval Key cached in Redis: account_mode=%s (TTL: 23h)", account_mode
+    )
+
+
+async def _invalidate_cached_approval_key(account_mode: str = "kis_live") -> None:
+    """Delete the cached approval key (controlled invalidation only).
+
+    Called solely from the lock-guarded reissue path so the deletion can never
+    race a concurrent issuance. Never call this from a tight reconnect loop.
+
+    Raises:
+        redis.RedisError: Redis 접근 실패 시 (엄격 실패 정책)
+    """
+    cache_key = APPROVAL_KEY_CACHE_KEYS[_resolve_ws_account_mode(account_mode)]
+    redis_client = await _get_redis_client()
+    await redis_client.delete(cache_key)
+    logger.info(
+        "KIS approval key cache invalidated (controlled reissue): account_mode=%s",
+        account_mode,
     )
 
 

--- a/app/services/kis_websocket_internal/client.py
+++ b/app/services/kis_websocket_internal/client.py
@@ -171,29 +171,53 @@ class KISExecutionWebSocket:
                 await self._close_websocket_best_effort()
 
                 if recoverable_ack_failure:
-                    if (
-                        ack_error is not None
-                        and self._last_reissue_msg_code == ack_error.msg_cd
-                    ):
-                        # 동일한 ACK 오류가 연속으로 반복되면 최소 1초 대기 후 재발급합니다.
-                        await asyncio.sleep(1)
-                    self.approval_key = await approval_keys._issue_approval_key(
-                        self.account_mode
-                    )
-                    await approval_keys._cache_approval_key(
-                        self.approval_key, self.account_mode
-                    )
-                    self._last_reissue_msg_code = (
-                        ack_error.msg_cd if ack_error else None
-                    )
-                    logger.info(
-                        "Approval key reissued after recoverable ACK failure: "
-                        "msg_cd=%s attempt=%s messages_received=%s execution_events_received=%s",
-                        ack_error.msg_cd if ack_error else None,
-                        self.current_attempt,
-                        self.messages_received,
-                        self.execution_events_received,
-                    )
+                    ack_msg_cd = ack_error.msg_cd if ack_error else None
+                    if self._last_reissue_msg_code == ack_msg_cd:
+                        # A controlled reissue was already attempted for this streak
+                        # (it either succeeded and KIS still rejected the fresh key,
+                        # or it was contended) — so this is not a stale-key problem we
+                        # can fix by reissuing again. Do NOT churn the approval key;
+                        # just back off via reconnect_delay below. The single-flight
+                        # holder / next reconnect cycle resolves a genuine reissue.
+                        logger.warning(
+                            "KIS WebSocket recoverable ACK persists after controlled "
+                            "reissue; backing off without reissuing key: "
+                            "msg_cd=%s attempt=%s/%s",
+                            ack_msg_cd,
+                            self.current_attempt,
+                            self.max_reconnect_attempts,
+                        )
+                    else:
+                        # First occurrence in this streak: controlled, single-flight
+                        # reissue. It overwrites the rejected key under a Redis lock so
+                        # concurrent owners do not each hammer the approval endpoint.
+                        try:
+                            self.approval_key = (
+                                await approval_keys.invalidate_and_reissue_approval_key(
+                                    self.account_mode
+                                )
+                            )
+                            logger.info(
+                                "KIS approval key controlled reissue after recoverable "
+                                "ACK failure: msg_cd=%s attempt=%s messages_received=%s "
+                                "execution_events_received=%s",
+                                ack_msg_cd,
+                                self.current_attempt,
+                                self.messages_received,
+                                self.execution_events_received,
+                            )
+                        except approval_keys.ApprovalKeyIssuanceUnavailable:
+                            # Another owner holds the issuance lock and published no key
+                            # in time; back off instead of issuing a second key.
+                            logger.warning(
+                                "KIS approval key issuance contended during reconnect; "
+                                "backing off without independent reissue: "
+                                "msg_cd=%s attempt=%s/%s",
+                                ack_msg_cd,
+                                self.current_attempt,
+                                self.max_reconnect_attempts,
+                            )
+                        self._last_reissue_msg_code = ack_msg_cd
                 else:
                     self._last_reissue_msg_code = None
 

--- a/app/services/kis_websocket_internal/constants.py
+++ b/app/services/kis_websocket_internal/constants.py
@@ -1,6 +1,12 @@
 APPROVAL_KEY_CACHE_KEY = "kis:websocket:approval_key"
 APPROVAL_KEY_TTL_SECONDS = 82800
-RECOVERABLE_APPROVAL_MSG_CODES = {"OPSP0011", "OPSP8996"}
+# Codes that mean "the approval key we sent was rejected; reissue may recover".
+# OPSP8996 ("ALREADY IN USE appkey") is deliberately NOT here: it signals
+# websocket session occupancy by another owner and is handled by a dedicated
+# fail-fast/long-backoff branch (client.KISAppKeyInUseError) that must never
+# reissue/churn the approval key. Keeping it out of this set keeps the
+# reissue path honest. (ROB-262)
+RECOVERABLE_APPROVAL_MSG_CODES = {"OPSP0011"}
 
 # Per-account-mode Redis namespaces for the WebSocket approval key.
 # Live keeps the historical key (== APPROVAL_KEY_CACHE_KEY); mock is isolated so
@@ -9,6 +15,28 @@ APPROVAL_KEY_CACHE_KEYS = {
     "kis_live": "kis:websocket:approval_key",
     "kis_mock": "kis_mock:websocket:approval_key",
 }
+
+# Single-flight issuance lock (ROB-262). Only the lock holder may call the KIS
+# approval endpoint during a cold-issuance window; contenders wait briefly and
+# reuse the cached key. Namespaced per account mode so live/mock never contend.
+APPROVAL_KEY_LOCK_CACHE_KEYS = {
+    "kis_live": "kis:websocket:approval_key:lock",
+    "kis_mock": "kis_mock:websocket:approval_key:lock",
+}
+# Lock TTL must outlast the approval HTTP round-trip (10s client timeout) + the
+# cache write, yet be short enough to self-heal if the holder process dies.
+APPROVAL_KEY_LOCK_TTL_SECONDS = 15
+# Bounded wait a contender will spend re-reading Redis for the holder's key
+# before failing/backing off. Kept STRICTLY UNDER the lock TTL so a dead holder's
+# lock expires rather than deadlocking the next cold-issuance window. This is safe
+# because a live holder's work is hard-capped at ~10s (the approval HTTP call uses
+# httpx timeout=10 with no retries, then a sub-ms Redis cache write), leaving the
+# 12s contender a ~2s margin to observe the published key. Never raise this above
+# APPROVAL_KEY_LOCK_TTL_SECONDS — that would re-introduce prolonged blocking on a
+# dead holder.
+APPROVAL_KEY_WAIT_TIMEOUT_SECONDS = 12.0
+# Base poll interval between contender re-reads; jitter is added on top.
+APPROVAL_KEY_WAIT_POLL_SECONDS = 0.25
 
 # Transport-layer host allowlists (fail-closed). Two layers:
 #   1. approval endpoint (REST /oauth2/Approval) — issues the approval key

--- a/tests/services/kis_websocket/test_approval_key_single_flight.py
+++ b/tests/services/kis_websocket/test_approval_key_single_flight.py
@@ -1,0 +1,317 @@
+"""ROB-262: concurrent cold-start single-flight issuance + controlled reissue.
+
+These tests pin the Redis-backed single-flight lock that guards KIS websocket
+approval-key issuance so that N simultaneous cold-start callers result in *at
+most one* approval-endpoint call and every successful caller observes the same
+cached key. They also pin the controlled (lock-guarded) reissue path used by the
+OPSP0011 reconnect handler, which must not delete/reissue in a tight loop.
+
+No secret values are exercised — the issued "key" is an opaque test token.
+"""
+
+import asyncio
+
+import pytest
+
+from app.services.kis_websocket_internal import approval_keys
+
+pytestmark = pytest.mark.asyncio
+
+INTERNAL = "app.services.kis_websocket_internal.approval_keys"
+
+
+class _FakeRedis:
+    """Minimal async Redis double modelling the operations the lock needs.
+
+    Atomicity is faithful: every method runs to completion without an internal
+    ``await``, so ``set(nx=True)`` is genuinely single-winner across interleaved
+    coroutines (the only yield points are in the code under test). ``eval`` is
+    the compare-and-delete release script.
+    """
+
+    def __init__(self) -> None:
+        self.strings: dict[str, str] = {}
+        self.set_calls: list[tuple[str, str, bool]] = []
+
+    async def get(self, key: str) -> str | None:
+        return self.strings.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: str,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> bool | None:
+        del ex
+        self.set_calls.append((key, value, nx))
+        if nx and key in self.strings:
+            return None
+        self.strings[key] = value
+        return True
+
+    async def delete(self, *keys: str) -> int:
+        removed = 0
+        for key in keys:
+            if key in self.strings:
+                del self.strings[key]
+                removed += 1
+        return removed
+
+    async def eval(self, script: str, key_count: int, key: str, token: str) -> int:
+        del script, key_count
+        if self.strings.get(key) == token:
+            self.strings.pop(key, None)
+            return 1
+        return 0
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    redis = _FakeRedis()
+
+    async def _get_client() -> _FakeRedis:
+        return redis
+
+    monkeypatch.setattr(approval_keys, "_get_redis_client", _get_client)
+    # Keep waits short + deterministic for tests.
+    monkeypatch.setattr(approval_keys, "APPROVAL_KEY_WAIT_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(approval_keys, "APPROVAL_KEY_WAIT_POLL_SECONDS", 0.01)
+    return redis
+
+
+def _live_cache_key() -> str:
+    return approval_keys.APPROVAL_KEY_CACHE_KEYS["kis_live"]
+
+
+def _live_lock_key() -> str:
+    return approval_keys.APPROVAL_KEY_LOCK_CACHE_KEYS["kis_live"]
+
+
+async def test_cache_hit_returns_without_lock_or_issue(fake_redis, monkeypatch):
+    fake_redis.strings[_live_cache_key()] = "warm-key"
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        return "should-not-be-called"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    result = await approval_keys.get_approval_key("kis_live")
+
+    assert result == "warm-key"
+    assert issue_calls == 0
+    # No lock was ever taken on a pure cache hit.
+    assert _live_lock_key() not in fake_redis.strings
+
+
+async def test_concurrent_cold_start_issues_exactly_once(fake_redis, monkeypatch):
+    """N simultaneous cold-start callers -> at most one endpoint call, same key."""
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        # Simulate the ~10s approval HTTP round-trip yielding control so the
+        # other coroutines pile up as lock contenders rather than issuers.
+        await asyncio.sleep(0.05)
+        return "issued-key"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    results = await asyncio.gather(
+        *(approval_keys.get_approval_key("kis_live") for _ in range(10))
+    )
+
+    assert issue_calls == 1, f"expected single issuance, got {issue_calls}"
+    assert results == ["issued-key"] * 10
+    assert fake_redis.strings[_live_cache_key()] == "issued-key"
+    # Lock released after issuance.
+    assert _live_lock_key() not in fake_redis.strings
+
+
+async def test_contender_reuses_cached_key_after_wait(fake_redis, monkeypatch):
+    """A caller that loses the lock waits, re-reads Redis, and reuses the key."""
+    # Pre-acquire the lock with a foreign token so our caller is a contender.
+    fake_redis.strings[_live_lock_key()] = "another-owner-token"
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        return "must-not-issue"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    async def _holder_populates() -> None:
+        await asyncio.sleep(0.02)
+        fake_redis.strings[_live_cache_key()] = "holder-key"
+
+    contender = asyncio.create_task(approval_keys.get_approval_key("kis_live"))
+    populate = asyncio.create_task(_holder_populates())
+    result, _ = await asyncio.gather(contender, populate)
+
+    assert result == "holder-key"
+    assert issue_calls == 0  # contender never issues independently
+
+
+async def test_contender_times_out_and_fails_without_issuing(fake_redis, monkeypatch):
+    """If no cached key appears within the bounded wait, fail/backoff (no issue)."""
+    fake_redis.strings[_live_lock_key()] = "another-owner-token"
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        return "must-not-issue"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    with pytest.raises(approval_keys.ApprovalKeyIssuanceUnavailable):
+        await approval_keys.get_approval_key("kis_live")
+
+    assert issue_calls == 0
+
+
+async def test_lock_holder_failure_releases_lock_and_propagates(
+    fake_redis, monkeypatch
+):
+    """A failed lock holder must release the lock (no deadlock) and surface error."""
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        raise RuntimeError("approval endpoint down")
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    with pytest.raises(RuntimeError, match="approval endpoint down"):
+        await approval_keys.get_approval_key("kis_live")
+
+    # Lock released despite the failure -> a later caller is not deadlocked.
+    assert _live_lock_key() not in fake_redis.strings
+
+    async def _issue_ok(account_mode: str = "kis_live") -> str:
+        return "recovered-key"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue_ok)
+    assert await approval_keys.get_approval_key("kis_live") == "recovered-key"
+
+
+async def test_invalidate_and_reissue_forces_fresh_under_lock(fake_redis, monkeypatch):
+    """Controlled reissue overwrites a stale cached key with a fresh one (once)."""
+    fake_redis.strings[_live_cache_key()] = "stale-key"
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        return "fresh-key"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    result = await approval_keys.invalidate_and_reissue_approval_key("kis_live")
+
+    assert result == "fresh-key"
+    assert issue_calls == 1  # forced fresh issuance even though a value was cached
+    assert fake_redis.strings[_live_cache_key()] == "fresh-key"
+    assert _live_lock_key() not in fake_redis.strings
+
+
+async def test_invalidate_and_reissue_clears_bad_key_when_issue_fails(
+    fake_redis, monkeypatch
+):
+    """If forced reissue fails, the known-bad key is gone (contenders won't reuse)."""
+    fake_redis.strings[_live_cache_key()] = "bad-key"
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        raise RuntimeError("reissue failed")
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    with pytest.raises(RuntimeError, match="reissue failed"):
+        await approval_keys.invalidate_and_reissue_approval_key("kis_live")
+
+    assert _live_cache_key() not in fake_redis.strings
+    assert _live_lock_key() not in fake_redis.strings
+
+
+async def test_mock_and_live_namespaces_are_isolated(fake_redis, monkeypatch):
+    """Concurrent live + mock cold starts use disjoint lock + cache namespaces.
+
+    If the lock keys collided, one namespace's holder would block the other and
+    only one issuance would happen; asserting BOTH issue (count == 2) proves the
+    per-account-mode lock keys are genuinely disjoint, not just the cache keys.
+    """
+    issue_calls = 0
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        nonlocal issue_calls
+        issue_calls += 1
+        await asyncio.sleep(0.01)
+        return f"{account_mode}-key"
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+    live, mock = await asyncio.gather(
+        approval_keys.get_approval_key("kis_live"),
+        approval_keys.get_approval_key("kis_mock"),
+    )
+
+    assert live == "kis_live-key"
+    assert mock == "kis_mock-key"
+    assert issue_calls == 2  # both namespaces issued — locks did not collide
+    assert fake_redis.strings[approval_keys.APPROVAL_KEY_CACHE_KEYS["kis_live"]] == (
+        "kis_live-key"
+    )
+    assert fake_redis.strings[approval_keys.APPROVAL_KEY_CACHE_KEYS["kis_mock"]] == (
+        "kis_mock-key"
+    )
+
+
+async def test_wait_for_cached_key_reads_before_sleeping(fake_redis, monkeypatch):
+    """A contender that finds the key already cached returns with no wasted sleep."""
+    fake_redis.strings[_live_cache_key()] = "already-there"
+    sleeps = 0
+    real_sleep = asyncio.sleep
+
+    async def _counting_sleep(delay, *args, **kwargs):
+        nonlocal sleeps
+        sleeps += 1
+        await real_sleep(0)
+
+    monkeypatch.setattr(approval_keys.asyncio, "sleep", _counting_sleep)
+
+    result = await approval_keys._wait_for_cached_approval_key("kis_live")
+
+    assert result == "already-there"
+    assert sleeps == 0  # read-first: no poll sleep when the key is already present
+
+
+async def test_logs_never_leak_key_secret_or_lock_token(
+    fake_redis, monkeypatch, caplog
+):
+    """AC5 regression guard: cold-start issuance + controlled reissue redact secrets."""
+    secrets = {
+        "approval-key": "SECRET_APPROVAL_KEY_VALUE",
+        "appkey": "SECRET_APP_KEY",
+        "secret": "SECRET_APP_SECRET",
+        "account": "12345678-01",
+    }
+
+    async def _issue(account_mode: str = "kis_live") -> str:
+        return secrets["approval-key"]
+
+    monkeypatch.setattr(approval_keys, "_issue_approval_key", _issue)
+
+    with caplog.at_level("DEBUG", logger="app.services.kis_websocket_internal"):
+        first = await approval_keys.get_approval_key("kis_live")  # cold-start issue
+        await approval_keys.get_approval_key("kis_live")  # cache hit
+        await approval_keys.invalidate_and_reissue_approval_key("kis_live")  # reissue
+
+    assert first == secrets["approval-key"]
+    # The issued key + every configured secret must be absent from all log output,
+    # and so must any opaque lock token (uuid) — logs carry account_mode/booleans only.
+    for sensitive in secrets.values():
+        assert sensitive not in caplog.text
+    lock_token = fake_redis.strings.get(_live_lock_key())  # released -> None
+    assert lock_token is None or lock_token not in caplog.text

--- a/tests/services/kis_websocket/test_approval_keys.py
+++ b/tests/services/kis_websocket/test_approval_keys.py
@@ -58,6 +58,12 @@ async def test_get_approval_key_miss_flow(mocker):
         f"{INTERNAL}._issue_approval_key", new=AsyncMock(return_value="fresh")
     )
     mock_cache = mocker.patch(f"{INTERNAL}._cache_approval_key", new=AsyncMock())
+    # The cache-miss path now acquires a single-flight lock (ROB-262); give it a
+    # lock-capable Redis so the test stays hermetic (no real Redis dependency).
+    mocker.patch(
+        f"{INTERNAL}._get_redis_client",
+        new=AsyncMock(return_value=_lock_capable_redis()),
+    )
 
     result = await mod.get_approval_key()
 

--- a/tests/services/kis_websocket/test_approval_keys.py
+++ b/tests/services/kis_websocket/test_approval_keys.py
@@ -13,6 +13,20 @@ from app.services.kis_websocket_internal.constants import (
 INTERNAL = "app.services.kis_websocket_internal.approval_keys"
 
 
+def _lock_capable_redis() -> AsyncMock:
+    """AsyncMock Redis whose ``SET NX`` always wins and ``EVAL`` release is inert.
+
+    Lets the ROB-262 single-flight issuance lock run in single-caller cache-miss
+    tests without a live Redis. Concurrency semantics are covered separately in
+    test_approval_key_single_flight.py with a faithful in-memory fake.
+    """
+    redis = AsyncMock()
+    redis.set = AsyncMock(return_value=True)
+    redis.eval = AsyncMock(return_value=1)
+    redis.delete = AsyncMock(return_value=1)
+    return redis
+
+
 @pytest.mark.asyncio
 async def test_is_valid_approval_key_semantics():
     """Pin the semantics of _is_valid_approval_key"""
@@ -91,17 +105,17 @@ class TestKISWebSocketApprovalKey:
             )
             mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch(
-                f"{INTERNAL}._get_cached_approval_key",
-                return_value=None,
+            with (
+                patch(f"{INTERNAL}._get_cached_approval_key", return_value=None),
+                patch(f"{INTERNAL}._cache_approval_key", return_value=None),
+                patch(
+                    f"{INTERNAL}._get_redis_client",
+                    return_value=_lock_capable_redis(),
+                ),
             ):
-                with patch(
-                    f"{INTERNAL}._cache_approval_key",
-                    return_value=None,
-                ):
-                    approval_key = await mod.get_approval_key()
+                approval_key = await mod.get_approval_key()
 
-                    assert approval_key == "test_approval_key"
+                assert approval_key == "test_approval_key"
 
     @pytest.mark.asyncio
     async def test_issue_approval_key_missing_key(self):
@@ -119,16 +133,16 @@ class TestKISWebSocketApprovalKey:
             )
             mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch(
-                f"{INTERNAL}._get_cached_approval_key",
-                return_value=None,
+            with (
+                patch(f"{INTERNAL}._get_cached_approval_key", return_value=None),
+                patch(f"{INTERNAL}._cache_approval_key", return_value=None),
+                patch(
+                    f"{INTERNAL}._get_redis_client",
+                    return_value=_lock_capable_redis(),
+                ),
             ):
-                with patch(
-                    f"{INTERNAL}._cache_approval_key",
-                    return_value=None,
-                ):
-                    with pytest.raises(Exception, match="Approval Key not found"):
-                        await mod.get_approval_key()
+                with pytest.raises(Exception, match="Approval Key not found"):
+                    await mod.get_approval_key()
 
 
 @pytest.mark.unit
@@ -242,18 +256,18 @@ class TestApprovalKeyRedisCache:
             )
             mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch(
-                f"{INTERNAL}._get_cached_approval_key",
-                return_value=None,
+            with (
+                patch(f"{INTERNAL}._get_cached_approval_key", return_value=None),
+                patch(f"{INTERNAL}._cache_approval_key", cache_spy),
+                patch(
+                    f"{INTERNAL}._get_redis_client",
+                    return_value=_lock_capable_redis(),
+                ),
             ):
-                with patch(
-                    f"{INTERNAL}._cache_approval_key",
-                    cache_spy,
-                ):
-                    result = await mod.get_approval_key()
+                result = await mod.get_approval_key()
 
-                    assert result == "fresh_key_abc"
-                    cache_spy.assert_called_once_with("fresh_key_abc", "kis_live")
+                assert result == "fresh_key_abc"
+                cache_spy.assert_called_once_with("fresh_key_abc", "kis_live")
 
     @pytest.mark.asyncio
     async def test_cache_constants_are_correct(self):
@@ -310,18 +324,21 @@ class TestApprovalKeyEmptyCacheMiss:
             )
             mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch(
-                f"{INTERNAL}._get_cached_approval_key",
-                return_value="",  # Empty string from cache
+            with (
+                patch(
+                    f"{INTERNAL}._get_cached_approval_key",
+                    return_value="",  # Empty string from cache
+                ),
+                patch(f"{INTERNAL}._cache_approval_key", cache_spy),
+                patch(
+                    f"{INTERNAL}._get_redis_client",
+                    return_value=_lock_capable_redis(),
+                ),
             ):
-                with patch(
-                    f"{INTERNAL}._cache_approval_key",
-                    cache_spy,
-                ):
-                    result = await mod.get_approval_key()
+                result = await mod.get_approval_key()
 
-                    assert result == "fresh_key_empty"
-                    cache_spy.assert_called_once_with("fresh_key_empty", "kis_live")
+                assert result == "fresh_key_empty"
+                cache_spy.assert_called_once_with("fresh_key_empty", "kis_live")
 
     @pytest.mark.asyncio
     async def test_whitespace_cache_treated_as_miss(self):
@@ -341,18 +358,21 @@ class TestApprovalKeyEmptyCacheMiss:
             )
             mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
 
-            with patch(
-                f"{INTERNAL}._get_cached_approval_key",
-                return_value="   ",  # Whitespace from cache
+            with (
+                patch(
+                    f"{INTERNAL}._get_cached_approval_key",
+                    return_value="   ",  # Whitespace from cache
+                ),
+                patch(f"{INTERNAL}._cache_approval_key", cache_spy),
+                patch(
+                    f"{INTERNAL}._get_redis_client",
+                    return_value=_lock_capable_redis(),
+                ),
             ):
-                with patch(
-                    f"{INTERNAL}._cache_approval_key",
-                    cache_spy,
-                ):
-                    result = await mod.get_approval_key()
+                result = await mod.get_approval_key()
 
-                    assert result == "fresh_key_ws"
-                    cache_spy.assert_called_once_with("fresh_key_ws", "kis_live")
+                assert result == "fresh_key_ws"
+                cache_spy.assert_called_once_with("fresh_key_ws", "kis_live")
 
 
 @pytest.mark.unit

--- a/tests/services/kis_websocket/test_client.py
+++ b/tests/services/kis_websocket/test_client.py
@@ -8,6 +8,7 @@ from app.services.kis_websocket import (
     DOMESTIC_EXECUTION_TR_REAL,
     OVERSEAS_EXECUTION_TR_MOCK,
     OVERSEAS_EXECUTION_TR_REAL,
+    ApprovalKeyIssuanceUnavailable,
     KISAppKeyInUseError,
     KISExecutionWebSocket,
     KISSubscriptionAckError,
@@ -194,8 +195,9 @@ class TestKISWebSocketClient:
                 )
             client.is_connected = True
 
+        # ROB-262: OPSP0011 now routes through the controlled, single-flight
+        # reissue helper instead of hammering the approval endpoint directly.
         reissue_mock = AsyncMock(return_value="fresh-key")
-        cache_mock = AsyncMock()
         close_mock = AsyncMock()
 
         with (
@@ -218,21 +220,71 @@ class TestKISWebSocketClient:
             ),
             patch.object(client, "_close_websocket_best_effort", close_mock),
             patch(
-                "app.services.kis_websocket_internal.approval_keys._issue_approval_key",
+                "app.services.kis_websocket_internal.approval_keys."
+                "invalidate_and_reissue_approval_key",
                 reissue_mock,
-            ),
-            patch(
-                "app.services.kis_websocket_internal.approval_keys._cache_approval_key",
-                cache_mock,
             ),
         ):
             await client.connect_and_subscribe()
 
         assert client.is_connected is True
         assert client.approval_key == "fresh-key"
-        reissue_mock.assert_awaited_once()
-        cache_mock.assert_awaited_once_with("fresh-key", "kis_live")
+        reissue_mock.assert_awaited_once_with("kis_live")
         assert close_mock.await_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_repeated_opsp0011_reissues_once_without_churn(
+        self, execution_callback
+    ):
+        """Persistent OPSP0011 reissues once per streak, then backs off (no churn)."""
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=False)
+        client.is_running = True
+        client.reconnect_delay = 0
+        client.max_reconnect_attempts = 4
+        client.approval_key = "cached-key"
+
+        async def always_opsp0011() -> None:
+            raise KISSubscriptionAckError(
+                tr_id=DOMESTIC_EXECUTION_TR_REAL,
+                rt_cd="1",
+                msg_cd="OPSP0011",
+                msg1="invalid approval : NOT FOUND",
+            )
+
+        reissue_mock = AsyncMock(return_value="fresh-key")
+        close_mock = AsyncMock()
+
+        with (
+            patch.object(
+                client,
+                "_issue_approval_key_if_needed",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                client,
+                "_build_websocket_url",
+                new=AsyncMock(
+                    return_value="ws://ops.koreainvestment.com:21000/tryitout"
+                ),
+            ),
+            patch.object(
+                client,
+                "_connect_and_subscribe_internal",
+                new=AsyncMock(side_effect=always_opsp0011),
+            ),
+            patch.object(client, "_close_websocket_best_effort", close_mock),
+            patch(
+                "app.services.kis_websocket_internal.approval_keys."
+                "invalidate_and_reissue_approval_key",
+                reissue_mock,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="not established"):
+                await client.connect_and_subscribe()
+
+        # Exactly one controlled reissue across all attempts — not one per attempt.
+        reissue_mock.assert_awaited_once_with("kis_live")
+        assert client.approval_key == "fresh-key"
 
     @pytest.mark.asyncio
     async def test_already_in_use_msg_code_fails_fast_without_reissuing_key(
@@ -254,6 +306,7 @@ class TestKISWebSocketClient:
         )
         reissue_mock = AsyncMock(return_value="fresh-key-2")
         cache_mock = AsyncMock()
+        invalidate_mock = AsyncMock(return_value="fresh-key-2")
         close_mock = AsyncMock()
 
         with (
@@ -279,6 +332,11 @@ class TestKISWebSocketClient:
                 "app.services.kis_websocket_internal.approval_keys._cache_approval_key",
                 cache_mock,
             ),
+            patch(
+                "app.services.kis_websocket_internal.approval_keys."
+                "invalidate_and_reissue_approval_key",
+                invalidate_mock,
+            ),
         ):
             with pytest.raises(KISAppKeyInUseError, match="already in use"):
                 await client.connect_and_subscribe()
@@ -286,9 +344,134 @@ class TestKISWebSocketClient:
         assert client.is_connected is False
         assert client.approval_key == "cached-key"
         connect_mock.assert_awaited_once()
+        # OPSP8996 never reissues by any path (direct or controlled).
         reissue_mock.assert_not_awaited()
         cache_mock.assert_not_awaited()
+        invalidate_mock.assert_not_awaited()
         close_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_opsp0011_reissue_contended_backs_off_without_independent_issue(
+        self, execution_callback
+    ):
+        """A contended controlled reissue (ApprovalKeyIssuanceUnavailable) is caught
+        and backed off — the client never independently issues a second key, and the
+        cached key is left untouched (AC2: bounded, no deadlock, no churn)."""
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=False)
+        client.is_running = True
+        client.reconnect_delay = 0
+        client.max_reconnect_attempts = 4
+        client.approval_key = "cached-key"
+
+        async def always_opsp0011() -> None:
+            raise KISSubscriptionAckError(
+                tr_id=DOMESTIC_EXECUTION_TR_REAL,
+                rt_cd="1",
+                msg_cd="OPSP0011",
+                msg1="invalid approval : NOT FOUND",
+            )
+
+        reissue_mock = AsyncMock(
+            side_effect=ApprovalKeyIssuanceUnavailable("issuance contended")
+        )
+
+        with (
+            patch.object(
+                client,
+                "_issue_approval_key_if_needed",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                client,
+                "_build_websocket_url",
+                new=AsyncMock(
+                    return_value="ws://ops.koreainvestment.com:21000/tryitout"
+                ),
+            ),
+            patch.object(
+                client,
+                "_connect_and_subscribe_internal",
+                new=AsyncMock(side_effect=always_opsp0011),
+            ),
+            patch.object(client, "_close_websocket_best_effort", AsyncMock()),
+            patch(
+                "app.services.kis_websocket_internal.approval_keys."
+                "invalidate_and_reissue_approval_key",
+                reissue_mock,
+            ),
+        ):
+            # The contention exception is caught (not re-raised); the loop exhausts
+            # attempts and raises the generic not-established error instead.
+            with pytest.raises(RuntimeError, match="not established"):
+                await client.connect_and_subscribe()
+
+        # Reissue attempted once for the streak, then suppressed; key never changed.
+        reissue_mock.assert_awaited_once_with("kis_live")
+        assert client.approval_key == "cached-key"
+        assert client.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_flapping_opsp0011_reissue_stays_bounded_and_single_flight(
+        self, execution_callback
+    ):
+        """Characterize OPSP0011 <-> non-recoverable flapping (deliberate behavior).
+
+        A different intervening error ends the OPSP0011 streak, so a later OPSP0011
+        reissues again. This is NOT the churn AC4 forbids: each reissue routes through
+        the single-flight (Redis-locked) helper and the total count is hard-bounded by
+        max_reconnect_attempts — never a tight per-attempt unlocked loop.
+        """
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=False)
+        client.is_running = True
+        client.reconnect_delay = 0
+        client.max_reconnect_attempts = 5
+        client.approval_key = "cached-key"
+
+        # One code per attempt: 3 OPSP0011 occurrences across 5 attempts.
+        codes = iter(["OPSP0011", "OPSP0001", "OPSP0011", "OPSP0001", "OPSP0011"])
+
+        async def flap() -> None:
+            raise KISSubscriptionAckError(
+                tr_id=DOMESTIC_EXECUTION_TR_REAL,
+                rt_cd="1",
+                msg_cd=next(codes),
+                msg1="flapping ack",
+            )
+
+        reissue_mock = AsyncMock(return_value="fresh-key")
+
+        with (
+            patch.object(
+                client,
+                "_issue_approval_key_if_needed",
+                new=AsyncMock(return_value=None),
+            ),
+            patch.object(
+                client,
+                "_build_websocket_url",
+                new=AsyncMock(
+                    return_value="ws://ops.koreainvestment.com:21000/tryitout"
+                ),
+            ),
+            patch.object(
+                client,
+                "_connect_and_subscribe_internal",
+                new=AsyncMock(side_effect=flap),
+            ),
+            patch.object(client, "_close_websocket_best_effort", AsyncMock()),
+            patch(
+                "app.services.kis_websocket_internal.approval_keys."
+                "invalidate_and_reissue_approval_key",
+                reissue_mock,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="not established"):
+                await client.connect_and_subscribe()
+
+        # 3 OPSP0011 occurrences -> 3 controlled (single-flight) reissues, strictly
+        # bounded by max_reconnect_attempts; not an unbounded per-attempt loop.
+        assert reissue_mock.await_count == 3
+        assert reissue_mock.await_count <= client.max_reconnect_attempts
 
     @pytest.mark.asyncio
     async def test_connect_and_subscribe_raises_after_max_attempts(

--- a/tests/services/kis_websocket/test_protocol.py
+++ b/tests/services/kis_websocket/test_protocol.py
@@ -14,7 +14,11 @@ def test_protocol_constants():
     assert "H0STCNI0" in mod.DOMESTIC_EXECUTION_TR_CODES
     assert "H0GSCNI0" in mod.OVERSEAS_EXECUTION_TR_CODES
 
-    assert mod.RECOVERABLE_APPROVAL_MSG_CODES == {"OPSP0011", "OPSP8996"}
+    # ROB-262: OPSP8996 ("ALREADY IN USE appkey") is intentionally excluded — it
+    # is a fail-fast/long-backoff session-occupancy path (KISAppKeyInUseError),
+    # not an approval-key reissue path.
+    assert mod.RECOVERABLE_APPROVAL_MSG_CODES == {"OPSP0011"}
+    assert "OPSP8996" not in mod.RECOVERABLE_APPROVAL_MSG_CODES
 
 
 def test_kis_subscription_ack_error_properties():


### PR DESCRIPTION
## 무엇을 / 왜 (ROB-262)

KIS websocket approval-key 발급·세션 소유권 하드닝. 라즈베리파이(직접 OPSP8996 트리거)는 이미 폐기되었으므로 본 PR은 **방어적 하드닝**입니다.

근본 갭(코드로 검증): `get_approval_key()`는 **락 없는 cache-aside TOCTOU** — N개 콜드스타트 호출자가 동시에 캐시 미스를 보고 각자 KIS approval 엔드포인트를 호출. 또한 `OPSP0011` 재연결 경로가 매 시도마다 캐시·락을 우회해 새 키를 직접 재발급(churn).

## 변경

- **`approval_keys.py` — Redis 단일비행 발급 락**
  - `get_approval_key()`: 캐시 히트 fast-path, 미스 시 `_issue_approval_key_single_flight()`.
  - 홀더: `SET NX EX`(uuid 토큰) → **double-checked 캐시** → 1회 발급 → 캐시 → `finally`에서 Lua compare-and-delete 해제.
  - 경쟁자: bounded jittered **read-first** 대기 후 캐시 키 재사용, 타임아웃 시 `ApprovalKeyIssuanceUnavailable`로 fail/backoff(**독립 발급 금지**).
  - `invalidate_and_reissue_approval_key()` = 락-guarded force-reissue(락 안에서 bad key 삭제 → 1회 발급). **유일한 sanctioned 캐시 삭제 경로**.
- **`client.py` — OPSP0011 무-churn**: 재연결 시 `invalidate_and_reissue_approval_key`로 라우팅, `_last_reissue_msg_code`로 **streak당 1회만** 재발급. `OPSP8996`는 기존 fail-fast → supervisor 1800s backoff **그대로**.
- **`constants.py`**: 락 키(`…:approval_key:lock`) + TTL/wait 상수. `RECOVERABLE_APPROVAL_MSG_CODES` → `{"OPSP0011"}`(OPSP8996 데드코드 정리).
- redacted 구조적 로그(키/시크릿/토큰 값 미출력).

## Acceptance criteria 대응

1. N 동시 콜드스타트 → ≤1 엔드포인트 호출·동일 키 ✅ (`test_concurrent_cold_start_issues_exactly_once`, fakeredis 원자 NX)
2. 홀더 실패 bounded·무-deadlock ✅ (`test_lock_holder_failure_releases_lock_and_propagates`, `test_opsp0011_reissue_contended_backs_off_*`)
3. OPSP8996 fail-fast/장기 backoff·무-재발급 ✅ (`test_already_in_use_msg_code_fails_fast_*`)
4. OPSP0011 무-churn/controlled ✅ (`test_repeated_opsp0011_reissues_once_*`, `test_flapping_opsp0011_*`)
5. 로그 redaction ✅ (`test_logs_never_leak_key_secret_or_lock_token`)
6. broker/order/watch mutation 없음 ✅

## 스코프 외(검증만)

- **healthcheck**: 배포 stable probe는 이미 `AUTO_TRADER_HEALTHCHECK_SKIP_WS=1`(`native_deploy_lib.sh`) → `kis_connected=false`가 API/MCP 배포를 롤백하지 않음. 변경 없음.
- **Redis singleton-owner 키**: launchd `KeepAlive`가 단일 소유 강제 → 이슈 지시대로 추가 안 함.
- live broker/order/watch/order-intent mutation 없음.

## 검증 / 핸드오프

- **브랜치**: `rob-262` · **커밋**: `44c97f9f`
- **테스트**: `uv run pytest tests/services/kis_websocket/ tests/test_kis_websocket_monitor.py tests/test_kis_websocket_mock_smoke.py` → **108 passed**. kis_websocket 모듈 import 전체 회귀 **190 passed**. `ruff check` / `ruff format --check` / `ty check` 클린.
- **Redis 키**: 신규 `kis:websocket:approval_key:lock`, `kis_mock:websocket:approval_key:lock`(TTL 15s, 자가-치유). 기존 `…:approval_key` 변경 없음. **launchd label 변경 없음**. **migration 0**.
- **롤아웃**: 새 재연결/락 동작 반영을 위해 `com.robinco.auto-trader.kis-websocket` **controlled restart 권장**(필수는 아님 — 락은 콜드스타트부터 자연 적용).
- **서버 스모크(선택)**: MacBook 서버에서 controlled restart 후 로그에 `approval key cache hit/miss` + `H0STCNI0/H0GSCNI0 ... msg_cd=OPSP0000` ACK, Redis `kis:websocket:approval_key` TTL 확인(**시크릿 값 미출력**).
- 다중 리뷰어 adversarial review 통과(2 blocker + major findings는 verify 단계에서 false-positive/acceptable-by-design 확정; 확인된 실제 갭 1건=contended catch 경로 테스트는 본 PR에 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)