### PR TITLE
feat(ROB-462): get_execution_strength — KR 주식 체결강도 (KIS REST, KIS-first)

### DIFF
--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -20,6 +20,7 @@ import app.services.brokers.yahoo.client as yahoo_service
 import app.services.market_data as market_data_service
 from app.core.config import settings
 from app.core.symbol import to_db_symbol
+from app.core.timezone import now_kst
 from app.mcp_server.tooling.market_data_indicators import (
     IndicatorType,
     _compute_crypto_realtime_rsi_from_frame,
@@ -47,6 +48,7 @@ from app.mcp_server.tooling.shared import (
 )
 from app.services import kis_ohlcv_cache
 from app.services.brokers.kis.client import KISClient
+from app.services.execution_strength.query_service import compute_execution_strength
 from app.services.kr_hourly_candles_read_service import (
     read_kr_hourly_candles_1h,
     read_kr_intraday_candles,
@@ -910,6 +912,7 @@ MARKET_DATA_TOOL_NAMES: set[str] = {
     "get_orderbook",
     "get_ohlcv",
     "get_indicators",
+    "get_execution_strength",
 }
 
 
@@ -1200,6 +1203,56 @@ async def _get_ohlcv_impl(
         )
 
 
+async def _get_execution_strength_impl(
+    symbol: str | int, market: str = "kr"
+) -> dict[str, Any]:
+    """ROB-462: KR 주식 체결강도 (execution strength) snapshot from KIS.
+
+    체결강도 = 매수체결량 / 매도체결량 × 100 (KIS FHKST01010100 ``cttr``).
+    KR equity only — crypto is served by get_crypto_order_flow.
+    """
+    requested = str(market or "kr").strip().lower() or "kr"
+    if requested not in ("kr", "kospi", "kosdaq"):
+        return _error_payload(
+            source="validation",
+            message=(
+                "get_execution_strength supports KR equity only "
+                "(crypto: use get_crypto_order_flow)."
+            ),
+            symbol=str(symbol),
+        )
+
+    normalized = _normalize_symbol_input(symbol, "kr")
+    if not normalized:
+        raise ValueError("symbol is required")
+    _, normalized = _resolve_market_type(normalized, "kr")
+
+    try:
+        raw = await KISClient().inquire_execution_strength(normalized)
+    except Exception as exc:
+        return _error_payload_from_exception(
+            source="kis",
+            exc=exc,
+            symbol=normalized,
+            instrument_type="equity_kr",
+        )
+
+    data = compute_execution_strength(
+        raw, symbol=normalized, as_of=now_kst().isoformat()
+    )
+    return {
+        "symbol": data.symbol,
+        "as_of": data.as_of,
+        "execution_strength_pct": data.execution_strength_pct,
+        "buy_volume": data.buy_volume,
+        "sell_volume": data.sell_volume,
+        "trend": data.trend,
+        "data_state": kr_market_data_state(),
+        "source": "kis",
+        "instrument_type": "equity_kr",
+    }
+
+
 def _register_market_data_tools_impl(mcp: FastMCP) -> None:
     @mcp.tool(
         name="search_symbol",
@@ -1235,6 +1288,22 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
         symbol: str | int, market: str = "kr", venue: str | None = None
     ) -> dict[str, Any]:
         return await _get_orderbook_impl(symbol, market, venue)
+
+    @mcp.tool(
+        name="get_execution_strength",
+        description=(
+            "Get KR equity 체결강도 (execution strength = 매수체결량/매도체결량 × 100) "
+            "from KIS. >100 buy-dominant, <100 sell-dominant. Returns "
+            "execution_strength_pct, buy_volume/sell_volume (null when KIS omits "
+            "them — never a fabricated 0), trend, and data_state (premarket/closed "
+            "sessions are tagged stale). KR equity only — for crypto taker order "
+            "flow use get_crypto_order_flow."
+        ),
+    )
+    async def get_execution_strength(
+        symbol: str | int, market: str = "kr"
+    ) -> dict[str, Any]:
+        return await _get_execution_strength_impl(symbol, market)
 
     @mcp.tool(
         name="get_ohlcv",

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -214,6 +214,36 @@ class DomesticMarketDataMixin(MarketDataBase):
         }
         return pd.DataFrame([row]).set_index("code")  # index = 종목코드
 
+    async def inquire_execution_strength(
+        self, code: str, market: str = "J"
+    ) -> dict[str, Any]:
+        """ROB-462: KIS FHKST01010100 (주식현재가 시세) 체결강도 raw 필드.
+
+        ``cttr`` 가 체결강도(매수/매도 × 100). 매수/매도 체결량(shnu/seln)·현재가·
+        누적거래량·체결시각을 raw 문자열 그대로 반환하고, 파싱/분류는
+        execution_strength.query_service 가 담당한다. 정확한 필드명은 라이브
+        스모크로 확정한다(없는 필드는 None 처리, 0 날조 금지).
+        """
+        js = await self._request_with_token_retry(
+            tr_id=constants.DOMESTIC_PRICE_TR,
+            url=self._kis_url(constants.DOMESTIC_PRICE_URL),
+            params={
+                "FID_COND_MRKT_DIV_CODE": market,
+                "FID_INPUT_ISCD": code.zfill(6),
+            },
+            api_name="inquire_execution_strength",
+        )
+        out = js.get("output") or {}
+        return {
+            "symbol": out.get("stck_shrn_iscd") or code,
+            "cttr": out.get("cttr"),
+            "shnu_cntg_qty": out.get("shnu_cntg_qty"),
+            "seln_cntg_qty": out.get("seln_cntg_qty"),
+            "last_price": out.get("stck_prpr"),
+            "acml_vol": out.get("acml_vol"),
+            "time": out.get("stck_cntg_hour") or out.get("stck_cntg_time"),
+        }
+
     async def _request_orderbook_snapshot(self, code: str, market: str = "J") -> dict:
         return await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_ORDERBOOK_TR,

--- a/app/services/execution_strength/query_service.py
+++ b/app/services/execution_strength/query_service.py
@@ -1,0 +1,61 @@
+"""ROB-462: KR 주식 체결강도 (execution strength) read model.
+
+체결강도 = 매수체결량 / 매도체결량 × 100. KIS FHKST01010100 (주식현재가 시세)
+returns the official value directly as ``cttr`` — we trust the broker's value
+rather than recomputing. Pure transform; the broker fetch + freshness tagging
+live in the MCP tool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExecutionStrengthData:
+    symbol: str
+    as_of: str | None
+    execution_strength_pct: float | None
+    buy_volume: float | None
+    sell_volume: float | None
+    trend: str | None
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _classify_trend(cttr: float | None) -> str | None:
+    """체결강도 100 = 매수/매도 균형. >100 매수우위, <100 매도우위."""
+    if cttr is None:
+        return None
+    if cttr > 100.0:
+        return "buy_dominant"
+    if cttr < 100.0:
+        return "sell_dominant"
+    return "neutral"
+
+
+def compute_execution_strength(
+    raw: dict[str, Any], *, symbol: str, as_of: str | None
+) -> ExecutionStrengthData:
+    """Build the read model from KIS FHKST01010100 raw output fields.
+
+    ``cttr`` is the authoritative 체결강도. Buy/sell contracted volumes are
+    surfaced when present, else None (missing != a fabricated 0).
+    """
+    cttr = _to_float(raw.get("cttr"))
+    return ExecutionStrengthData(
+        symbol=symbol,
+        as_of=as_of,
+        execution_strength_pct=cttr,
+        buy_volume=_to_float(raw.get("shnu_cntg_qty")),
+        sell_volume=_to_float(raw.get("seln_cntg_qty")),
+        trend=_classify_trend(cttr),
+    )

--- a/tests/test_execution_strength_query_service.py
+++ b/tests/test_execution_strength_query_service.py
@@ -1,0 +1,41 @@
+"""ROB-462: 체결강도 (execution strength) computation from KIS FHKST01010100 cttr."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.execution_strength.query_service import (
+    compute_execution_strength,
+)
+
+
+def test_buy_dominant_when_cttr_above_100():
+    raw = {"cttr": "135.5", "shnu_cntg_qty": "1200", "seln_cntg_qty": "800"}
+    data = compute_execution_strength(
+        raw, symbol="005930", as_of="2026-06-09T10:00:00+09:00"
+    )
+    assert data.symbol == "005930"
+    assert data.execution_strength_pct == pytest.approx(135.5)
+    assert data.buy_volume == pytest.approx(1200.0)
+    assert data.sell_volume == pytest.approx(800.0)
+    assert data.trend == "buy_dominant"
+
+
+def test_sell_dominant_when_cttr_below_100():
+    data = compute_execution_strength({"cttr": "72.0"}, symbol="005930", as_of=None)
+    assert data.execution_strength_pct == pytest.approx(72.0)
+    assert data.trend == "sell_dominant"
+    # missing buy/sell fields stay None — never fabricated 0.
+    assert data.buy_volume is None
+    assert data.sell_volume is None
+
+
+def test_neutral_at_exactly_100():
+    data = compute_execution_strength({"cttr": "100"}, symbol="x", as_of=None)
+    assert data.trend == "neutral"
+
+
+def test_missing_cttr_returns_none_not_fabricated():
+    data = compute_execution_strength({}, symbol="005930", as_of=None)
+    assert data.execution_strength_pct is None
+    assert data.trend is None

--- a/tests/test_mcp_execution_strength.py
+++ b/tests/test_mcp_execution_strength.py
@@ -1,0 +1,96 @@
+"""ROB-462: get_execution_strength MCP tool + KIS broker fetch (KR equity)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import market_data_quotes
+
+
+@pytest.mark.asyncio
+async def test_inquire_execution_strength_extracts_cttr():
+    from app.services.brokers.kis.domestic_market_data import DomesticMarketDataMixin
+
+    md = DomesticMarketDataMixin.__new__(DomesticMarketDataMixin)
+    md._kis_url = lambda path: path
+    md._request_with_token_retry = AsyncMock(
+        return_value={
+            "output": {
+                "stck_shrn_iscd": "005930",
+                "cttr": "120.3",
+                "shnu_cntg_qty": "10",
+                "seln_cntg_qty": "5",
+                "stck_prpr": "80000",
+                "acml_vol": "1000",
+                "stck_cntg_hour": "100000",
+            }
+        }
+    )
+
+    raw = await md.inquire_execution_strength("005930")
+
+    assert raw["symbol"] == "005930"
+    assert raw["cttr"] == "120.3"
+    assert raw["shnu_cntg_qty"] == "10"
+    assert raw["seln_cntg_qty"] == "5"
+    md._request_with_token_retry.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_execution_strength_kr_returns_strength(monkeypatch):
+    class _MockKIS:
+        async def inquire_execution_strength(self, code, market="J"):
+            return {
+                "symbol": code,
+                "cttr": "135.5",
+                "shnu_cntg_qty": "1200",
+                "seln_cntg_qty": "800",
+            }
+
+    monkeypatch.setattr(market_data_quotes, "KISClient", _MockKIS)
+    monkeypatch.setattr(
+        market_data_quotes, "kr_market_data_state", lambda *a, **k: "fresh"
+    )
+
+    result = await market_data_quotes._get_execution_strength_impl("005930", "kr")
+
+    assert result["symbol"] == "005930"
+    assert result["execution_strength_pct"] == pytest.approx(135.5)
+    assert result["trend"] == "buy_dominant"
+    assert result["buy_volume"] == pytest.approx(1200.0)
+    assert result["sell_volume"] == pytest.approx(800.0)
+    assert result["data_state"] == "fresh"
+    assert result["source"] == "kis"
+    assert result["instrument_type"] == "equity_kr"
+    assert result["as_of"]
+
+
+@pytest.mark.asyncio
+async def test_get_execution_strength_tags_premarket_data_state(monkeypatch):
+    class _MockKIS:
+        async def inquire_execution_strength(self, code, market="J"):
+            return {"cttr": "88.0"}
+
+    monkeypatch.setattr(market_data_quotes, "KISClient", _MockKIS)
+    monkeypatch.setattr(
+        market_data_quotes,
+        "kr_market_data_state",
+        lambda *a, **k: "premarket_unavailable",
+    )
+
+    result = await market_data_quotes._get_execution_strength_impl("005930", "kr")
+
+    assert result["data_state"] == "premarket_unavailable"
+    assert result["trend"] == "sell_dominant"
+
+
+@pytest.mark.asyncio
+async def test_get_execution_strength_rejects_non_kr():
+    result = await market_data_quotes._get_execution_strength_impl("AAPL", "us")
+    assert result.get("error") or result.get("success") is False
+
+
+def test_execution_strength_tool_registered():
+    assert "get_execution_strength" in market_data_quotes.MARKET_DATA_TOOL_NAMES


### PR DESCRIPTION
## 요약 (ROB-462)

KR 주식 **체결강도**(= 매수체결량/매도체결량 × 100) MCP 도구를 KIS-first로 구현. 

**핵심 발견:** KIS REST `inquire_price`(FHKST01010100)가 이미 응답에 `cttr`(체결강도)를 포함 — 지금은 버리고 있을 뿐. → **WebSocket 없이 REST 스냅샷**으로 제공(MCP 요청/응답에 적합, WS 인프라·장외 타임아웃 회피). WS(H0STCNT0/H0NXCNT0)는 실시간 스트리밍·NXT venue용 후속.

## 변경
- **브로커**: `domestic_market_data.inquire_execution_strength(code)` — FHKST01010100 raw에서 `cttr`/매수·매도 체결량/현재가/누적량/시각 추출(이미 호출하는 TR 재사용).
- **서비스(신규)**: `app/services/execution_strength/query_service.py` — `compute_execution_strength` 순수함수. `cttr → execution_strength_pct`, trend = >100 buy_dominant / <100 sell_dominant / 100 neutral. **결측은 None(0 날조 금지)**.
- **MCP**: `get_execution_strength(symbol, market="kr")` → `{symbol, as_of, execution_strength_pct, buy_volume, sell_volume, trend, data_state, source:"kis", instrument_type}`. **KR 전용**(crypto는 `get_crypto_order_flow`), `data_state` 태깅(ROB-464 `market_session` 재사용 — 프리마켓/장외 stale). DEFAULT 프로파일 등록.

## ⚠️ operator 라이브 스모크 필요 (Done 전 마지막)
정확한 KIS 필드명(`cttr`/`shnu_cntg_qty`/`seln_cntg_qty`)은 KIS 문서 기반으로 매핑했고 **라이브 미검증**입니다. 실 종목(예: 005930) 1회 호출로 값이 HTS 체결강도와 맞는지 확인 필요. 도구는 결측 시 graceful None(크래시 없음) — 필드명이 다르면 1줄 수정.

## 안전 경계
- read-only / migration 없음 / 브로커·주문 mutation 없음.

## 테스트
- query service 4 (buy/sell/neutral/결측), MCP+broker 5 (cttr 추출/shape/premarket data_state/non-KR 거부/등록), 회귀 45 green, ruff(app/+tests/) clean.

Linear: ROB-462 (KIS-first; 라이브 스모크 후 Done. WS·NXP·키움 0B는 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)