### PR TITLE
fix(ROB-462): expose KIS execution strength facade

### DIFF
--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -147,6 +147,11 @@ class KISClient(BaseKISClient):
     async def inquire_price(self, code: str, market: str = "J") -> DataFrame:
         return await self._market_data.inquire_price(code, market)
 
+    async def inquire_execution_strength(
+        self, code: str, market: str = "J"
+    ) -> dict[str, Any]:
+        return await self._market_data.inquire_execution_strength(code, market)
+
     async def inquire_orderbook(self, code: str, market: str = "J") -> dict[str, Any]:
         return await self._market_data.inquire_orderbook(code, market)
 

--- a/tests/test_mcp_execution_strength.py
+++ b/tests/test_mcp_execution_strength.py
@@ -39,6 +39,24 @@ async def test_inquire_execution_strength_extracts_cttr():
 
 
 @pytest.mark.asyncio
+async def test_kis_facade_delegates_execution_strength():
+    from app.services.brokers.kis.client import KISClient
+
+    client = KISClient.__new__(KISClient)
+    client._market_data = AsyncMock()
+    client._market_data.inquire_execution_strength = AsyncMock(
+        return_value={"cttr": "120.3"}
+    )
+
+    raw = await client.inquire_execution_strength("005930", market="J")
+
+    assert raw == {"cttr": "120.3"}
+    client._market_data.inquire_execution_strength.assert_awaited_once_with(
+        "005930", "J"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_execution_strength_kr_returns_strength(monkeypatch):
     class _MockKIS:
         async def inquire_execution_strength(self, code, market="J"):


### PR DESCRIPTION
## Summary
- Add the missing `KISClient.inquire_execution_strength()` facade method that delegates to the domestic market-data client.
- Add a regression test that catches the exact production smoke failure: MCP calls the facade, not the raw mixin.

## Test Plan
- `uv run --group test pytest tests/test_mcp_execution_strength.py -q`
- `uv run --group test pytest tests/brokers/kis/mock_scalping_ws/test_quote_parsers.py -q`
- `uv run --group dev ruff check app/services/brokers/kis/client.py tests/test_mcp_execution_strength.py`
- `uv run --group dev ruff format --check app/services/brokers/kis/client.py tests/test_mcp_execution_strength.py`

## Safety
- Read-only KIS market-data path only.
- No broker order placement/cancel/modify surface touched.
- No DB migration, scheduler activation, watch/order-intent mutation, or secret changes.

ROB-462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution strength inquiry capability now available for market code analysis

* **Tests**
  * Added unit tests validating execution strength inquiry functionality and service integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->