### PR TITLE
feat(ROB-434): US valuation Finnhub fallback (field-fill)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -322,6 +322,12 @@ class Settings(BaseSettings):
     # Finnhub API (optional - for news and fundamentals)
     finnhub_api_key: str | None = None
 
+    # ROB-434 — US market_valuation Finnhub fallback (field-fill). When ON and
+    # FINNHUB_API_KEY is set, default_valuation_fetcher backfills valuation fields
+    # yahoo .info left null (operator "ROE rows 0") from company_basic_financials.
+    # Default False → inert until an operator enables it. No key → also inert.
+    market_valuation_finnhub_fallback_enabled: bool = False
+
     # WiseFn KR earnings calendar (ROB-171)
     # Default False until the upstream contract is confirmed; CI never calls live.
     wisefn_earnings_enabled: bool = False

--- a/app/jobs/market_valuation_snapshots.py
+++ b/app/jobs/market_valuation_snapshots.py
@@ -236,7 +236,7 @@ def _aggregate_report(
     derived from each payload's raw_payload['_field_provenance'] and column values.
     Operator smoke (acceptance #5): provider attribution + coverage, works in dry-run."""
     backfill: Counter[str] = Counter()
-    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
+    coverage: Counter[str] = Counter(dict.fromkeys(_COVERAGE_FIELDS, 0))
     for payload in payloads:
         provenance = (payload.raw_payload or {}).get("_field_provenance", {})
         for field_name, src in provenance.items():
@@ -289,7 +289,7 @@ async def run_market_valuation_snapshot_build(
     total_built = 0
     batches = 0
     finnhub_backfill: Counter[str] = Counter()
-    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
+    coverage: Counter[str] = Counter(dict.fromkeys(_COVERAGE_FIELDS, 0))
     for start in range(0, len(symbols), effective_batch_size):
         batches += 1
         result = await build_valuation_snapshots_for_market(

--- a/app/jobs/market_valuation_snapshots.py
+++ b/app/jobs/market_valuation_snapshots.py
@@ -72,6 +72,9 @@ class MarketValuationSnapshotBuildResult:
     idempotency: dict[str, int] = field(default_factory=dict)
     samples: tuple[MarketValuationSnapshotSample, ...] = ()
     warnings: tuple[str, ...] = ()
+    finnhub_backfill: dict[str, int] = field(default_factory=dict)
+    field_nonnull_coverage: dict[str, int] = field(default_factory=dict)
+
 
 
 def _validate_market(market: str) -> str:
@@ -214,6 +217,37 @@ def _sample(payload: MarketValuationSnapshotUpsert) -> MarketValuationSnapshotSa
     )
 
 
+_COVERAGE_FIELDS: tuple[str, ...] = (
+    "per",
+    "pbr",
+    "roe",
+    "dividend_yield",
+    "market_cap",
+    "high_52w",
+    "low_52w",
+    "high_52w_date",
+)
+
+
+def _aggregate_report(
+    payloads: list[MarketValuationSnapshotUpsert],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """ROB-434: per-field Finnhub-backfill counts + per-field non-null coverage,
+    derived from each payload's raw_payload['_field_provenance'] and column values.
+    Operator smoke (acceptance #5): provider attribution + coverage, works in dry-run."""
+    backfill: Counter[str] = Counter()
+    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
+    for payload in payloads:
+        provenance = (payload.raw_payload or {}).get("_field_provenance", {})
+        for field_name, src in provenance.items():
+            if src == "finnhub":
+                backfill[field_name] += 1
+        for field_name in _COVERAGE_FIELDS:
+            if getattr(payload, field_name) is not None:
+                coverage[field_name] += 1
+    return dict(backfill), dict(coverage)
+
+
 async def run_market_valuation_snapshot_build(
     request: MarketValuationSnapshotBuildRequest,
 ) -> MarketValuationSnapshotBuildResult:
@@ -254,6 +288,8 @@ async def run_market_valuation_snapshot_build(
     warnings: list[str] = []
     total_built = 0
     batches = 0
+    finnhub_backfill: Counter[str] = Counter()
+    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
     for start in range(0, len(symbols), effective_batch_size):
         batches += 1
         result = await build_valuation_snapshots_for_market(
@@ -269,6 +305,9 @@ async def run_market_valuation_snapshot_build(
         distribution.update(p.snapshot_date.isoformat() for p in payloads)
         idempotency.update(await _classify_idempotency(payloads))
         samples.extend(_sample(p) for p in payloads[: max(0, 10 - len(samples))])
+        batch_backfill, batch_coverage = _aggregate_report(payloads)
+        finnhub_backfill.update(batch_backfill)
+        coverage.update(batch_coverage)
         if request.commit and payloads:
             await _commit_payloads(payloads)
     finished_at = dt.datetime.now(dt.UTC)
@@ -284,6 +323,8 @@ async def run_market_valuation_snapshot_build(
         idempotency=dict(idempotency),
         samples=tuple(samples),
         warnings=tuple(warnings),
+        finnhub_backfill=dict(finnhub_backfill),
+        field_nonnull_coverage=dict(coverage),
     )
 
 

--- a/app/jobs/market_valuation_snapshots.py
+++ b/app/jobs/market_valuation_snapshots.py
@@ -76,7 +76,6 @@ class MarketValuationSnapshotBuildResult:
     field_nonnull_coverage: dict[str, int] = field(default_factory=dict)
 
 
-
 def _validate_market(market: str) -> str:
     market_norm = market.strip().lower()
     if market_norm not in {"kr", "us"}:

--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -57,29 +57,47 @@ async def default_valuation_fetcher(
             fetch_fast_info,
             fetch_fundamental_info,
         )
-
-        # ROB-440 PR4: the 52w-high DATE needs a heavy OHLC fetch (1y daily) — a 3rd
-        # yahoo call/symbol that over-loads yfinance at universe scale (FD/401). Opt-in
-        # so the bulk valuation backfill is 2 calls/symbol; only undervalued_breakout
-        # date-recency needs it (targeted run with include_high_date=True).
-        if not include_high_date:
-            fast_info, fundamentals = await asyncio.gather(
-                fetch_fast_info(symbol), fetch_fundamental_info(symbol)
-            )
-            return {**fast_info, **fundamentals}
-
-        fast_info, fundamentals, high_52w_date = await asyncio.gather(
-            fetch_fast_info(symbol),
-            fetch_fundamental_info(symbol),
-            fetch_52w_high_date(symbol),  # ROB-440 PR3: 52w-high date (date-recency)
+        from app.services.market_valuation_snapshots.finnhub_fallback import (
+            apply_valuation_fallback,
         )
-        # isoformat string keeps raw_payload (JSONB) serializable; parsed back in
-        # _payload_from_raw → the high_52w_date column.
-        return {
-            **fast_info,
-            **fundamentals,
-            "high_52w_date": high_52w_date.isoformat() if high_52w_date else None,
-        }
+
+        raw: dict[str, Any] = {}
+        yahoo_failed = False
+        yahoo_exc: Exception | None = None
+        try:
+            # ROB-440 PR4: the 52w-high DATE needs a heavy OHLC fetch (1y daily) — a 3rd
+            # yahoo call/symbol that over-loads yfinance at universe scale (FD/401). Opt-in
+            # so the bulk valuation backfill is 2 calls/symbol; only undervalued_breakout
+            # date-recency needs it (targeted run with include_high_date=True).
+            if not include_high_date:
+                fast_info, fundamentals = await asyncio.gather(
+                    fetch_fast_info(symbol), fetch_fundamental_info(symbol)
+                )
+                raw = {**fast_info, **fundamentals}
+            else:
+                fast_info, fundamentals, high_52w_date = await asyncio.gather(
+                    fetch_fast_info(symbol),
+                    fetch_fundamental_info(symbol),
+                    fetch_52w_high_date(symbol),  # ROB-440 PR3: 52w-high date (date-recency)
+                )
+                # isoformat string keeps raw_payload (JSONB) serializable; parsed back in
+                # _payload_from_raw → the high_52w_date column.
+                raw = {
+                    **fast_info,
+                    **fundamentals,
+                    "high_52w_date": high_52w_date.isoformat() if high_52w_date else None,
+                }
+        except Exception as exc:  # noqa: BLE001 — try Finnhub before giving up
+            raw, yahoo_failed, yahoo_exc = {}, True, exc
+
+        # ROB-434: backfill yahoo's null/missing valuation fields from Finnhub when
+        # gated on. No-op when disabled / no key / no gap. source stays 'yahoo'.
+        raw = await apply_valuation_fallback(symbol, raw, yahoo_failed=yahoo_failed)
+
+        # Nothing recovered from a total yahoo failure → preserve today's skip+warn.
+        if yahoo_failed and not raw and yahoo_exc is not None:
+            raise yahoo_exc
+        return raw
     raise ValueError(f"unsupported market: {market}")
 
 

--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -78,21 +78,30 @@ async def default_valuation_fetcher(
                 fast_info, fundamentals, high_52w_date = await asyncio.gather(
                     fetch_fast_info(symbol),
                     fetch_fundamental_info(symbol),
-                    fetch_52w_high_date(symbol),  # ROB-440 PR3: 52w-high date (date-recency)
+                    fetch_52w_high_date(
+                        symbol
+                    ),  # ROB-440 PR3: 52w-high date (date-recency)
                 )
                 # isoformat string keeps raw_payload (JSONB) serializable; parsed back in
                 # _payload_from_raw → the high_52w_date column.
                 raw = {
                     **fast_info,
                     **fundamentals,
-                    "high_52w_date": high_52w_date.isoformat() if high_52w_date else None,
+                    "high_52w_date": high_52w_date.isoformat()
+                    if high_52w_date
+                    else None,
                 }
         except Exception as exc:  # noqa: BLE001 — try Finnhub before giving up
             raw, yahoo_failed, yahoo_exc = {}, True, exc
 
         # ROB-434: backfill yahoo's null/missing valuation fields from Finnhub when
         # gated on. No-op when disabled / no key / no gap. source stays 'yahoo'.
-        raw = await apply_valuation_fallback(symbol, raw, yahoo_failed=yahoo_failed)
+        # include_high_date is threaded so high_52w_date counts as a gap/fill target
+        # ONLY on the opt-in run that fetched it — otherwise every bulk-path symbol
+        # (which never has the date) would falsely look "gapped" and call Finnhub.
+        raw = await apply_valuation_fallback(
+            symbol, raw, yahoo_failed=yahoo_failed, include_high_date=include_high_date
+        )
 
         # Nothing recovered from a total yahoo failure → preserve today's skip+warn.
         if yahoo_failed and not raw and yahoo_exc is not None:
@@ -152,7 +161,6 @@ def _payload_from_raw(
         high_52w_date=_to_date(_resolve_raw_value(raw, "high_52w_date")),
         raw_payload=redact_sensitive_payload(dict(raw)),
     )
-
 
 
 async def build_valuation_snapshots_for_market(

--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -87,6 +87,35 @@ def _source_for_market(market: str) -> str:
     return "naver_finance" if market == "kr" else "yahoo"
 
 
+# ROB-434: single source of truth for per-column raw-key priority. Used by
+# _payload_from_raw AND finnhub_fallback's gap detection so they never drift.
+# Mirrors _payload_from_raw's original or-chains exactly.
+_FIELD_SOURCE_KEYS: dict[str, tuple[str, ...]] = {
+    "per": ("per", "PER", "trailingPE"),
+    "pbr": ("pbr", "PBR", "priceToBook"),
+    "roe": ("roe", "ROE"),
+    "dividend_yield": (
+        "dividend_yield",
+        "Dividend Yield",
+        "trailingAnnualDividendYield",
+    ),
+    "market_cap": ("market_cap", "marketCap"),
+    "high_52w": ("high_52w", "yearHigh"),
+    "low_52w": ("low_52w", "yearLow"),
+    "high_52w_date": ("high_52w_date",),
+}
+
+
+def _resolve_raw_value(raw: dict[str, Any], field: str) -> Any:
+    """First truthy value among the field's priority keys (matches the original
+    or-chain: 0/None are treated as absent)."""
+    for key in _FIELD_SOURCE_KEYS[field]:
+        value = raw.get(key)
+        if value:
+            return value
+    return None
+
+
 def _payload_from_raw(
     *, market: str, symbol: str, snapshot_date: dt.date, raw: dict[str, Any]
 ) -> MarketValuationSnapshotUpsert:
@@ -95,20 +124,17 @@ def _payload_from_raw(
         symbol=symbol,
         snapshot_date=snapshot_date,
         source=_source_for_market(market),
-        per=_to_decimal(raw.get("per") or raw.get("PER") or raw.get("trailingPE")),
-        pbr=_to_decimal(raw.get("pbr") or raw.get("PBR") or raw.get("priceToBook")),
-        roe=_to_decimal(raw.get("roe") or raw.get("ROE")),
-        dividend_yield=_to_decimal(
-            raw.get("dividend_yield")
-            or raw.get("Dividend Yield")
-            or raw.get("trailingAnnualDividendYield")
-        ),
-        market_cap=_to_decimal(raw.get("market_cap") or raw.get("marketCap")),
-        high_52w=_to_decimal(raw.get("high_52w") or raw.get("yearHigh")),
-        low_52w=_to_decimal(raw.get("low_52w") or raw.get("yearLow")),
-        high_52w_date=_to_date(raw.get("high_52w_date")),
+        per=_to_decimal(_resolve_raw_value(raw, "per")),
+        pbr=_to_decimal(_resolve_raw_value(raw, "pbr")),
+        roe=_to_decimal(_resolve_raw_value(raw, "roe")),
+        dividend_yield=_to_decimal(_resolve_raw_value(raw, "dividend_yield")),
+        market_cap=_to_decimal(_resolve_raw_value(raw, "market_cap")),
+        high_52w=_to_decimal(_resolve_raw_value(raw, "high_52w")),
+        low_52w=_to_decimal(_resolve_raw_value(raw, "low_52w")),
+        high_52w_date=_to_date(_resolve_raw_value(raw, "high_52w_date")),
         raw_payload=redact_sensitive_payload(dict(raw)),
     )
+
 
 
 async def build_valuation_snapshots_for_market(

--- a/app/services/market_valuation_snapshots/finnhub_fallback.py
+++ b/app/services/market_valuation_snapshots/finnhub_fallback.py
@@ -82,8 +82,20 @@ def _finnhub_fallback_enabled() -> bool:
     return bool(getattr(settings, "market_valuation_finnhub_fallback_enabled", False))
 
 
-def _has_missing_fields(raw: dict[str, Any]) -> bool:
-    return any(_resolve_raw_value(raw, field) is None for field in _FIELD_SOURCE_KEYS)
+def _gap_field_names(include_high_date: bool) -> tuple[str, ...]:
+    """Fields that count toward gap-detection AND are eligible for backfill.
+
+    high_52w_date is EXCLUDED on the default bulk path (include_high_date=False):
+    that path never fetches the date from yahoo (it needs a separate heavy 1y-OHLC
+    call, deliberately opt-in), so treating its absence as a "gap" would make EVERY
+    symbol look gapped and fire Finnhub — defeating the per-symbol-only-on-gap
+    rate-limit boundary. The date is a gap/fill target only on the opt-in
+    (include_high_date=True) run that actually wants it (undervalued_breakout
+    date-recency).
+    """
+    if include_high_date:
+        return tuple(_FIELD_SOURCE_KEYS)
+    return tuple(field for field in _FIELD_SOURCE_KEYS if field != "high_52w_date")
 
 
 async def fetch_valuation_finnhub(symbol: str) -> dict[str, Any]:
@@ -105,17 +117,25 @@ async def fetch_valuation_finnhub(symbol: str) -> dict[str, Any]:
 
 
 async def apply_valuation_fallback(
-    symbol: str, raw: dict[str, Any], *, yahoo_failed: bool
+    symbol: str,
+    raw: dict[str, Any],
+    *,
+    yahoo_failed: bool,
+    include_high_date: bool = False,
 ) -> dict[str, Any]:
     """Backfill missing valuation fields in ``raw`` from Finnhub when gated on.
 
     No-op unless the settings flag is on AND there is a gap (or yahoo failed).
-    Fills only fields ``raw`` lacks; records provenance in raw['_field_provenance'].
+    Both gap-detection and the backfill are restricted to the gap field set for
+    this run mode (high_52w_date is in-scope only when include_high_date=True),
+    so a fully-populated bulk-path symbol never triggers Finnhub. Fills only
+    fields ``raw`` lacks; records provenance in raw['_field_provenance'].
     source stays 'yahoo' (caller never changes it). Fail-closed on any Finnhub error.
     """
     if not _finnhub_fallback_enabled():
         return raw
-    if not (yahoo_failed or _has_missing_fields(raw)):
+    targets = _gap_field_names(include_high_date)
+    if not (yahoo_failed or any(_resolve_raw_value(raw, f) is None for f in targets)):
         return raw
     try:
         metrics = await fetch_valuation_finnhub(symbol)
@@ -123,7 +143,8 @@ async def apply_valuation_fallback(
         logger.warning("finnhub valuation fallback failed symbol=%s: %s", symbol, exc)
         return raw
     filled: list[str] = []
-    for field, value in metrics.items():
+    for field in targets:
+        value = metrics.get(field)
         if value is None:
             continue
         if _resolve_raw_value(raw, field) is None:

--- a/app/services/market_valuation_snapshots/finnhub_fallback.py
+++ b/app/services/market_valuation_snapshots/finnhub_fallback.py
@@ -1,0 +1,73 @@
+"""ROB-434: US market_valuation Finnhub fallback (field-fill).
+
+When yahoo .info leaves valuation fields null (operator "ROE rows 0") or the
+yahoo call fails (crumb/session), backfill the missing valuation fields from
+Finnhub's company_basic_financials metric endpoint. Keeps source='yahoo';
+records per-field provenance in raw['_field_provenance']. Default-off settings
+gate; inert without FINNHUB_API_KEY. Fail-closed: any Finnhub error leaves raw
+unchanged (no fabrication).
+
+Service-layer only — does NOT import app.mcp_server (reuses the finnhub_news
+client factory). Single consumer is default_valuation_fetcher.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from app.services.market_valuation_snapshots.builder import (
+    _FIELD_SOURCE_KEYS,
+    _resolve_raw_value,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _map_finnhub_metrics(metric: dict[str, Any]) -> dict[str, Any]:
+    """Finnhub company_basic_financials['metric'] → canonical valuation fields.
+
+    Unit traps (the whole reason this is a dedicated, exhaustively-tested fn):
+    - roeTTM is ALREADY percent (yahoo returnOnEquity is a fraction ×100) → no ×100.
+    - dividendYieldIndicatedAnnual is percent → ÷100 to the stored ratio (guard ≤0.25).
+    - marketCapitalization is in MILLIONS → ×1e6 to absolute USD (guard ≥$100M).
+    Missing / non-finite / unparseable → field omitted (fail-closed, never fabricated).
+    """
+    out: dict[str, Any] = {}
+    roe = _to_float(metric.get("roeTTM"))
+    if roe is not None:
+        out["roe"] = roe  # already percent — do NOT ×100
+    per = _to_float(metric.get("peTTM"))
+    if per is not None:
+        out["per"] = per
+    pbr = _to_float(metric.get("pbAnnual"))
+    if pbr is not None:
+        out["pbr"] = pbr
+    dividend_yield = _to_float(metric.get("dividendYieldIndicatedAnnual"))
+    if dividend_yield is not None:
+        out["dividend_yield"] = dividend_yield / 100.0  # percent → ratio
+    market_cap_millions = _to_float(metric.get("marketCapitalization"))
+    if market_cap_millions is not None:
+        out["market_cap"] = market_cap_millions * 1_000_000.0  # millions → absolute
+    high_52w = _to_float(metric.get("52WeekHigh"))
+    if high_52w is not None:
+        out["high_52w"] = high_52w
+    low_52w = _to_float(metric.get("52WeekLow"))
+    if low_52w is not None:
+        out["low_52w"] = low_52w
+    high_date = metric.get("52WeekHighDate")
+    if isinstance(high_date, str) and high_date.strip():
+        # iso string keeps raw_payload JSON-safe; _payload_from_raw parses to date.
+        out["high_52w_date"] = high_date.strip()[:10]
+    return out

--- a/app/services/market_valuation_snapshots/finnhub_fallback.py
+++ b/app/services/market_valuation_snapshots/finnhub_fallback.py
@@ -13,6 +13,7 @@ client factory). Single consumer is default_valuation_fetcher.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 from typing import Any
@@ -71,3 +72,66 @@ def _map_finnhub_metrics(metric: dict[str, Any]) -> dict[str, Any]:
         # iso string keeps raw_payload JSON-safe; _payload_from_raw parses to date.
         out["high_52w_date"] = high_date.strip()[:10]
     return out
+
+
+def _finnhub_fallback_enabled() -> bool:
+    try:
+        from app.core.config import settings
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(getattr(settings, "market_valuation_finnhub_fallback_enabled", False))
+
+
+def _has_missing_fields(raw: dict[str, Any]) -> bool:
+    return any(_resolve_raw_value(raw, field) is None for field in _FIELD_SOURCE_KEYS)
+
+
+async def fetch_valuation_finnhub(symbol: str) -> dict[str, Any]:
+    """Finnhub company_basic_financials metric → canonical valuation dict.
+
+    Raises ImportError (finnhub lib missing) / ValueError (no key) / API errors —
+    the caller (apply_valuation_fallback) catches and fail-closes.
+    """
+    from app.services.finnhub_news import _get_finnhub_client
+
+    client = _get_finnhub_client()
+
+    def _fetch_sync() -> dict[str, Any]:
+        data = client.company_basic_financials(symbol.upper(), "all")
+        return (data or {}).get("metric", {}) or {}
+
+    metric = await asyncio.to_thread(_fetch_sync)
+    return _map_finnhub_metrics(metric)
+
+
+async def apply_valuation_fallback(
+    symbol: str, raw: dict[str, Any], *, yahoo_failed: bool
+) -> dict[str, Any]:
+    """Backfill missing valuation fields in ``raw`` from Finnhub when gated on.
+
+    No-op unless the settings flag is on AND there is a gap (or yahoo failed).
+    Fills only fields ``raw`` lacks; records provenance in raw['_field_provenance'].
+    source stays 'yahoo' (caller never changes it). Fail-closed on any Finnhub error.
+    """
+    if not _finnhub_fallback_enabled():
+        return raw
+    if not (yahoo_failed or _has_missing_fields(raw)):
+        return raw
+    try:
+        metrics = await fetch_valuation_finnhub(symbol)
+    except Exception as exc:  # noqa: BLE001 — no key / lib / API / rate-limit
+        logger.warning("finnhub valuation fallback failed symbol=%s: %s", symbol, exc)
+        return raw
+    filled: list[str] = []
+    for field, value in metrics.items():
+        if value is None:
+            continue
+        if _resolve_raw_value(raw, field) is None:
+            raw[field] = value
+            filled.append(field)
+    if filled:
+        provenance = raw.setdefault("_field_provenance", {})
+        for field in filled:
+            provenance[field] = "finnhub"
+    return raw
+

--- a/app/services/market_valuation_snapshots/finnhub_fallback.py
+++ b/app/services/market_valuation_snapshots/finnhub_fallback.py
@@ -134,4 +134,3 @@ async def apply_valuation_fallback(
         for field in filled:
             provenance[field] = "finnhub"
     return raw
-

--- a/docs/runbooks/invest-screener-snapshots.md
+++ b/docs/runbooks/invest-screener-snapshots.md
@@ -178,6 +178,21 @@ uv run python -m scripts.diagnose_invest_screener_snapshots --market us
 - UI: open `/invest/screener`, toggle 미국, confirm `consecutive_gainers` returns >0 rows.
 - API: confirm `freshness.dataState="fresh"` and non-empty `results[]`.
 
+### US valuation Finnhub fallback (ROB-434, default-off)
+
+`market_valuation_snapshots` US builds can backfill valuation fields that yahoo
+`.info` left null (operator "ROE rows 0" / Invalid Crumb) from Finnhub
+`company_basic_financials`. **Disabled by default.** To enable for a build:
+
+1. Set `FINNHUB_API_KEY` (operator secret manager — never commit).
+2. Set `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED=true`.
+3. Run `uv run python -m scripts.build_market_valuation_snapshots --market us --common-stocks-only --concurrency 4` (dry-run first). The summary prints `finnhub backfill` per-field counts and `non-null field coverage`.
+
+Without the key or flag the build is byte-identical to today (yahoo-only,
+fail-closed). `source` stays `yahoo`; per-field provenance is in
+`raw_payload._field_provenance`. Finnhub free tier ~60/min — keep `--concurrency`
+modest. Fallback fires only on a per-symbol gap, never per-symbol unconditionally.
+
 ---
 
 ## 8. Prefect Deployment (DEFERRED — ROB-204)

--- a/docs/superpowers/plans/2026-06-09-rob-434-us-market-valuation-finnhub-fallback.md
+++ b/docs/superpowers/plans/2026-06-09-rob-434-us-market-valuation-finnhub-fallback.md
@@ -1,0 +1,1086 @@
+# US market_valuation Finnhub fallback (field-fill) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When yahoo `.info` leaves US valuation fields null (operator's "ROE rows 0") or fails (crumb/session), backfill the missing valuation fields from Finnhub's `company_basic_financials` metric endpoint — keeping `source='yahoo'`, recording per-field provenance, with zero migration.
+
+**Architecture:** A new service-layer module `finnhub_fallback.py` owns the Finnhub metric fetch + unit conversions + the gap-fill merge. `default_valuation_fetcher`'s US branch wraps the yahoo gather in try/except and calls the fallback to fill gaps. The fallback is gated by a default-off settings flag and is inert without `FINNHUB_API_KEY`. Reporting (finnhub backfill counts + non-null coverage) is aggregated in the job layer from each payload's `raw_payload['_field_provenance']`.
+
+**Tech Stack:** Python 3.13, asyncio, pydantic-settings, `finnhub-python` (optional dep), pytest (`@pytest.mark.unit`/`asyncio`/`integration`), `uv run`.
+
+**Spec:** `docs/superpowers/specs/2026-06-09-rob-434-us-market-valuation-finnhub-fallback-design.md`
+
+**Key code facts (verified against current code):**
+- `app/services/market_valuation_snapshots/builder.py`: `default_valuation_fetcher(symbol, market, *, include_high_date=False)` (US branch at lines 54-82); `_payload_from_raw` (90-111) resolves each column from priority raw keys via an `or`-chain; `_source_for_market("us")` → `"yahoo"` (hardcoded); `build_valuation_snapshots_for_market` skips a symbol whose every metric is None and catches fetch exceptions (`_one`, 136-168).
+- `app/services/brokers/yahoo/client.py::fetch_fundamental_info` returns keys `PER/PBR/EPS/BPS/Dividend Yield/ROE/yearHigh/yearLow/marketCap` (ROE already percent via `_roe_to_percent`). Crumb errors re-raise after one retry.
+- `app/jobs/market_valuation_snapshots.py`: `run_market_valuation_snapshot_build` calls the builder **without** a `fetcher` (so the trigger flows through `default_valuation_fetcher`); aggregates `payloads` into `MarketValuationSnapshotBuildResult` (frozen dataclass, line 62) which the CLI's `_print_result` consumes.
+- `app/services/finnhub_news.py`: `_get_finnhub_client()` (env-first `FINNHUB_API_KEY` → `settings.finnhub_api_key`, lazy `finnhub` import) — the reuse target; **no `app.mcp_server` import**.
+- `app/core/config.py`: pydantic-settings `Settings` with snake_case fields; `finnhub_api_key: str | None = None` (line 323); feature flags like `invest_screener_snapshots_commit_enabled: bool = False`.
+
+**Boundaries:** migration 0; broker/order/watch mutation 0; KR/`naver_finance` + fundamentals table untouched; fail-closed preserved; secrets never printed.
+
+---
+
+## File Structure
+
+- **Create** `app/services/market_valuation_snapshots/finnhub_fallback.py` — Finnhub metric fetch + unit conversions + gap-fill merge + gate. Single responsibility: "given a partial yahoo raw dict, fill missing valuation fields from Finnhub when gated on."
+- **Modify** `app/core/config.py` — add one settings flag.
+- **Modify** `app/services/market_valuation_snapshots/builder.py` — extract a shared `_FIELD_SOURCE_KEYS` + `_resolve_raw_value` (DRY; reused by the fallback's gap detection), and wire the fallback into the US branch of `default_valuation_fetcher`.
+- **Modify** `app/jobs/market_valuation_snapshots.py` — additive `finnhub_backfill` + `field_nonnull_coverage` aggregates on the result dataclass.
+- **Modify** `scripts/build_market_valuation_snapshots.py` — print the two new aggregates in `_print_result`.
+- **Create** `tests/test_market_valuation_finnhub_fallback_rob434.py` — all unit tests + one integration test.
+- **Modify** `docs/runbooks/invest-screener-snapshots.md` — operator note on the flag.
+
+---
+
+## Task 1: Add the settings flag
+
+**Files:**
+- Modify: `app/core/config.py` (near line 323, beside `finnhub_api_key`)
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_market_valuation_finnhub_fallback_rob434.py`:
+
+```python
+"""ROB-434: US market_valuation Finnhub fallback (field-fill).
+
+When yahoo .info leaves valuation fields null (or fails), backfill the missing
+fields from Finnhub company_basic_financials. source stays 'yahoo'; per-field
+provenance in raw_payload['_field_provenance']; default-off, inert without key.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+
+@pytest.mark.unit
+def test_settings_flag_defaults_off() -> None:
+    from app.core.config import settings
+
+    assert settings.market_valuation_finnhub_fallback_enabled is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_settings_flag_defaults_off -v`
+Expected: FAIL with `AttributeError` (no `market_valuation_finnhub_fallback_enabled`).
+
+- [ ] **Step 3: Add the setting**
+
+In `app/core/config.py`, immediately after line 323 (`finnhub_api_key: str | None = None`):
+
+```python
+    # ROB-434 — US market_valuation Finnhub fallback (field-fill). When ON and
+    # FINNHUB_API_KEY is set, default_valuation_fetcher backfills valuation fields
+    # yahoo .info left null (operator "ROE rows 0") from company_basic_financials.
+    # Default False → inert until an operator enables it. No key → also inert.
+    market_valuation_finnhub_fallback_enabled: bool = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_settings_flag_defaults_off -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/core/config.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "feat(ROB-434): add market_valuation_finnhub_fallback_enabled flag (default off)
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Extract shared field-key resolver in builder (DRY, no behavior change)
+
+The fallback's gap detection must use the *same* per-field key priority that `_payload_from_raw` uses, or the two drift. Extract it once.
+
+**Files:**
+- Modify: `app/services/market_valuation_snapshots/builder.py` (lines 90-111)
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+@pytest.mark.unit
+def test_resolve_raw_value_priority_and_truthiness() -> None:
+    from app.services.market_valuation_snapshots.builder import _resolve_raw_value
+
+    # canonical lowercase key wins over the yahoo key
+    assert _resolve_raw_value({"roe": 22.0, "ROE": 9.9}, "roe") == 22.0
+    # falls back to the yahoo key when canonical absent
+    assert _resolve_raw_value({"marketCap": 1234}, "market_cap") == 1234
+    # 0/None/absent → None (truthiness, matches _payload_from_raw's or-chain)
+    assert _resolve_raw_value({"per": 0.0, "PER": 0}, "per") is None
+    assert _resolve_raw_value({}, "high_52w_date") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_resolve_raw_value_priority_and_truthiness -v`
+Expected: FAIL with `ImportError` (`_resolve_raw_value` not defined).
+
+- [ ] **Step 3: Refactor `_payload_from_raw` to use a shared resolver**
+
+In `app/services/market_valuation_snapshots/builder.py`, replace the `_payload_from_raw` function (lines 90-111) with:
+
+```python
+# ROB-434: single source of truth for per-column raw-key priority. Used by
+# _payload_from_raw AND finnhub_fallback's gap detection so they never drift.
+# Mirrors _payload_from_raw's original or-chains exactly.
+_FIELD_SOURCE_KEYS: dict[str, tuple[str, ...]] = {
+    "per": ("per", "PER", "trailingPE"),
+    "pbr": ("pbr", "PBR", "priceToBook"),
+    "roe": ("roe", "ROE"),
+    "dividend_yield": (
+        "dividend_yield",
+        "Dividend Yield",
+        "trailingAnnualDividendYield",
+    ),
+    "market_cap": ("market_cap", "marketCap"),
+    "high_52w": ("high_52w", "yearHigh"),
+    "low_52w": ("low_52w", "yearLow"),
+    "high_52w_date": ("high_52w_date",),
+}
+
+
+def _resolve_raw_value(raw: dict[str, Any], field: str) -> Any:
+    """First truthy value among the field's priority keys (matches the original
+    or-chain: 0/None are treated as absent)."""
+    for key in _FIELD_SOURCE_KEYS[field]:
+        value = raw.get(key)
+        if value:
+            return value
+    return None
+
+
+def _payload_from_raw(
+    *, market: str, symbol: str, snapshot_date: dt.date, raw: dict[str, Any]
+) -> MarketValuationSnapshotUpsert:
+    return MarketValuationSnapshotUpsert(
+        market=market,
+        symbol=symbol,
+        snapshot_date=snapshot_date,
+        source=_source_for_market(market),
+        per=_to_decimal(_resolve_raw_value(raw, "per")),
+        pbr=_to_decimal(_resolve_raw_value(raw, "pbr")),
+        roe=_to_decimal(_resolve_raw_value(raw, "roe")),
+        dividend_yield=_to_decimal(_resolve_raw_value(raw, "dividend_yield")),
+        market_cap=_to_decimal(_resolve_raw_value(raw, "market_cap")),
+        high_52w=_to_decimal(_resolve_raw_value(raw, "high_52w")),
+        low_52w=_to_decimal(_resolve_raw_value(raw, "low_52w")),
+        high_52w_date=_to_date(_resolve_raw_value(raw, "high_52w_date")),
+        raw_payload=redact_sensitive_payload(dict(raw)),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify pass + no regression**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_resolve_raw_value_priority_and_truthiness tests/test_invest_coverage_valuation.py tests/test_yahoo_roe_rob440.py -v`
+Expected: PASS (new test + all existing valuation/ROE tests — proves the refactor preserved behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_valuation_snapshots/builder.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "refactor(ROB-434): extract _FIELD_SOURCE_KEYS/_resolve_raw_value in valuation builder
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Finnhub metric mapping (unit conversions) — `finnhub_fallback.py`
+
+The riskiest code: the unit traps. Pure function, no IO — test exhaustively first.
+
+**Files:**
+- Create: `app/services/market_valuation_snapshots/finnhub_fallback.py`
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+@pytest.mark.unit
+def test_map_finnhub_metrics_unit_traps() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    out = _map_finnhub_metrics(
+        {
+            "roeTTM": 22.0,  # already percent → NOT ×100
+            "peTTM": 8.0,
+            "pbAnnual": 0.9,
+            "dividendYieldIndicatedAnnual": 3.0,  # percent → ÷100 ratio
+            "marketCapitalization": 1500.0,  # millions → ×1e6 absolute
+            "52WeekHigh": 110.0,
+            "52WeekLow": 80.0,
+            "52WeekHighDate": "2026-03-14",
+        }
+    )
+    assert out["roe"] == 22.0  # critical: not 2200
+    assert out["per"] == 8.0
+    assert out["pbr"] == 0.9
+    assert out["dividend_yield"] == 0.03
+    assert out["market_cap"] == 1_500_000_000.0
+    assert out["high_52w"] == 110.0
+    assert out["low_52w"] == 80.0
+    assert out["high_52w_date"] == "2026-03-14"  # iso str (JSON-safe, parsed later)
+
+
+@pytest.mark.unit
+def test_map_finnhub_metrics_fail_closed_on_missing_and_nonfinite() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    out = _map_finnhub_metrics(
+        {"roeTTM": None, "peTTM": "n/a", "marketCapitalization": float("inf")}
+    )
+    assert out == {}  # nothing fabricated; non-finite/None/unparseable dropped
+
+
+@pytest.mark.unit
+def test_map_finnhub_metrics_bad_date_dropped() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    assert "high_52w_date" not in _map_finnhub_metrics({"52WeekHighDate": ""})
+    assert "high_52w_date" not in _map_finnhub_metrics({"52WeekHighDate": None})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -k map_finnhub_metrics -v`
+Expected: FAIL with `ModuleNotFoundError` (module not created yet).
+
+- [ ] **Step 3: Create the module with the mapping**
+
+Create `app/services/market_valuation_snapshots/finnhub_fallback.py`:
+
+```python
+"""ROB-434: US market_valuation Finnhub fallback (field-fill).
+
+When yahoo .info leaves valuation fields null (operator "ROE rows 0") or the
+yahoo call fails (crumb/session), backfill the missing valuation fields from
+Finnhub's company_basic_financials metric endpoint. Keeps source='yahoo';
+records per-field provenance in raw['_field_provenance']. Default-off settings
+gate; inert without FINNHUB_API_KEY. Fail-closed: any Finnhub error leaves raw
+unchanged (no fabrication).
+
+Service-layer only — does NOT import app.mcp_server (reuses the finnhub_news
+client factory). Single consumer is default_valuation_fetcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Any
+
+from app.services.market_valuation_snapshots.builder import _resolve_raw_value
+
+logger = logging.getLogger(__name__)
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _map_finnhub_metrics(metric: dict[str, Any]) -> dict[str, Any]:
+    """Finnhub company_basic_financials['metric'] → canonical valuation fields.
+
+    Unit traps (the whole reason this is a dedicated, exhaustively-tested fn):
+    - roeTTM is ALREADY percent (yahoo returnOnEquity is a fraction ×100) → no ×100.
+    - dividendYieldIndicatedAnnual is percent → ÷100 to the stored ratio (guard ≤0.25).
+    - marketCapitalization is in MILLIONS → ×1e6 to absolute USD (guard ≥$100M).
+    Missing / non-finite / unparseable → field omitted (fail-closed, never fabricated).
+    """
+    out: dict[str, Any] = {}
+    roe = _to_float(metric.get("roeTTM"))
+    if roe is not None:
+        out["roe"] = roe  # already percent — do NOT ×100
+    per = _to_float(metric.get("peTTM"))
+    if per is not None:
+        out["per"] = per
+    pbr = _to_float(metric.get("pbAnnual"))
+    if pbr is not None:
+        out["pbr"] = pbr
+    dividend_yield = _to_float(metric.get("dividendYieldIndicatedAnnual"))
+    if dividend_yield is not None:
+        out["dividend_yield"] = dividend_yield / 100.0  # percent → ratio
+    market_cap_millions = _to_float(metric.get("marketCapitalization"))
+    if market_cap_millions is not None:
+        out["market_cap"] = market_cap_millions * 1_000_000.0  # millions → absolute
+    high_52w = _to_float(metric.get("52WeekHigh"))
+    if high_52w is not None:
+        out["high_52w"] = high_52w
+    low_52w = _to_float(metric.get("52WeekLow"))
+    if low_52w is not None:
+        out["low_52w"] = low_52w
+    high_date = metric.get("52WeekHighDate")
+    if isinstance(high_date, str) and high_date.strip():
+        # iso string keeps raw_payload JSON-safe; _payload_from_raw parses to date.
+        out["high_52w_date"] = high_date.strip()[:10]
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -k map_finnhub_metrics -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_valuation_snapshots/finnhub_fallback.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "feat(ROB-434): Finnhub metric → valuation field mapping with unit conversions
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Fetch + gap-fill merge + gate — `finnhub_fallback.py`
+
+**Files:**
+- Modify: `app/services/market_valuation_snapshots/finnhub_fallback.py`
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_disabled_is_noop(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: False)
+    calls = {"n": 0}
+
+    async def _never(symbol):  # noqa: ANN001
+        calls["n"] += 1
+        return {"roe": 22.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _never)
+    raw = {"PER": 8.0}  # roe missing
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out == {"PER": 8.0}  # untouched
+    assert calls["n"] == 0  # finnhub never called
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_fills_only_missing_fields(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 99.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    # yahoo gave PER (8.0) but no ROE/market_cap → fill ROE + market_cap, keep PER
+    raw = {"PER": 8.0}
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out["roe"] == 18.0
+    assert out["market_cap"] == 2_000_000_000.0
+    assert "per" not in out  # PER already present (yahoo) → NOT overwritten
+    assert out["_field_provenance"] == {"roe": "finnhub", "market_cap": "finnhub"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_total_yahoo_failure_fills_all(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 8.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    out = await fb.apply_valuation_fallback("AAPL", {}, yahoo_failed=True)
+    assert out["roe"] == 18.0 and out["per"] == 8.0
+    assert out["_field_provenance"]["per"] == "finnhub"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_finnhub_error_is_fail_closed(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _boom(symbol):  # noqa: ANN001
+        raise RuntimeError("finnhub rate limited")
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _boom)
+    raw = {"PER": 8.0}
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out == {"PER": 8.0}  # unchanged, no crash
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+    calls = {"n": 0}
+
+    async def _metrics(symbol):  # noqa: ANN001
+        calls["n"] += 1
+        return {"roe": 1.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    # every field present → no finnhub call
+    raw = {
+        "ROE": 15.0, "PER": 8.0, "PBR": 0.9, "Dividend Yield": 0.02,
+        "marketCap": 3e9, "yearHigh": 100.0, "yearLow": 80.0,
+        "high_52w_date": "2026-01-01",
+    }
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert calls["n"] == 0
+    assert "_field_provenance" not in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -k apply_fallback -v`
+Expected: FAIL with `AttributeError` (`apply_valuation_fallback` / `_finnhub_fallback_enabled` / `fetch_valuation_finnhub` not defined).
+
+- [ ] **Step 3: Implement fetch + merge + gate**
+
+Append to `app/services/market_valuation_snapshots/finnhub_fallback.py`:
+
+```python
+def _finnhub_fallback_enabled() -> bool:
+    try:
+        from app.core.config import settings
+    except Exception:  # noqa: BLE001
+        return False
+    return bool(getattr(settings, "market_valuation_finnhub_fallback_enabled", False))
+
+
+def _has_missing_fields(raw: dict[str, Any]) -> bool:
+    return any(_resolve_raw_value(raw, field) is None for field in _FIELD_SOURCE_KEYS)
+
+
+async def fetch_valuation_finnhub(symbol: str) -> dict[str, Any]:
+    """Finnhub company_basic_financials metric → canonical valuation dict.
+
+    Raises ImportError (finnhub lib missing) / ValueError (no key) / API errors —
+    the caller (apply_valuation_fallback) catches and fail-closes.
+    """
+    from app.services.finnhub_news import _get_finnhub_client
+
+    client = _get_finnhub_client()
+
+    def _fetch_sync() -> dict[str, Any]:
+        data = client.company_basic_financials(symbol.upper(), "all")
+        return (data or {}).get("metric", {}) or {}
+
+    metric = await asyncio.to_thread(_fetch_sync)
+    return _map_finnhub_metrics(metric)
+
+
+async def apply_valuation_fallback(
+    symbol: str, raw: dict[str, Any], *, yahoo_failed: bool
+) -> dict[str, Any]:
+    """Backfill missing valuation fields in ``raw`` from Finnhub when gated on.
+
+    No-op unless the settings flag is on AND there is a gap (or yahoo failed).
+    Fills only fields ``raw`` lacks; records provenance in raw['_field_provenance'].
+    source stays 'yahoo' (caller never changes it). Fail-closed on any Finnhub error.
+    """
+    if not _finnhub_fallback_enabled():
+        return raw
+    if not (yahoo_failed or _has_missing_fields(raw)):
+        return raw
+    try:
+        metrics = await fetch_valuation_finnhub(symbol)
+    except Exception as exc:  # noqa: BLE001 — no key / lib / API / rate-limit
+        logger.warning("finnhub valuation fallback failed symbol=%s: %s", symbol, exc)
+        return raw
+    filled: list[str] = []
+    for field, value in metrics.items():
+        if value is None:
+            continue
+        if _resolve_raw_value(raw, field) is None:
+            raw[field] = value
+            filled.append(field)
+    if filled:
+        provenance = raw.setdefault("_field_provenance", {})
+        for field in filled:
+            provenance[field] = "finnhub"
+    return raw
+```
+
+Also add the import needed by `_has_missing_fields` at the top of the file (it already imports `_resolve_raw_value`; add `_FIELD_SOURCE_KEYS`):
+
+```python
+from app.services.market_valuation_snapshots.builder import (
+    _FIELD_SOURCE_KEYS,
+    _resolve_raw_value,
+)
+```
+
+(Replace the single-name import added in Task 3 Step 3 with this two-name import.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -k "apply_fallback or map_finnhub" -v`
+Expected: PASS (all mapping + apply tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_valuation_snapshots/finnhub_fallback.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "feat(ROB-434): Finnhub valuation fetch + gap-fill merge + default-off gate
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire the fallback into `default_valuation_fetcher` (US branch)
+
+**Files:**
+- Modify: `app/services/market_valuation_snapshots/builder.py` (US branch, lines 54-82)
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_backfills_roe_when_yahoo_null(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _fund(sym):  # noqa: ANN001
+        return {"PER": 8.0, "ROE": None, "marketCap": 3_000_000_000}  # ROE missing
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _fund)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+
+    raw = await builder.default_valuation_fetcher("AAPL", "us")
+    assert raw["roe"] == 18.0  # backfilled
+    assert raw["PER"] == 8.0  # yahoo preserved
+    assert raw["_field_provenance"] == {"roe": "finnhub"}
+    # source unchanged downstream:
+    payload = builder._payload_from_raw(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 6, 9), raw=raw
+    )
+    assert payload.source == "yahoo"
+    assert payload.roe == __import__("decimal").Decimal("18.0")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_recovers_total_yahoo_failure(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _boom(sym):  # noqa: ANN001
+        raise RuntimeError("Invalid Crumb / Session is closed")
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 8.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+
+    raw = await builder.default_valuation_fetcher("AAPL", "us")  # no raise
+    assert raw["roe"] == 18.0 and raw["per"] == 8.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_total_failure_reraises_when_disabled(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _boom(sym):  # noqa: ANN001
+        raise RuntimeError("Invalid Crumb")
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: False)  # disabled
+
+    with pytest.raises(RuntimeError, match="Invalid Crumb"):
+        await builder.default_valuation_fetcher("AAPL", "us")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -k "fetcher_" -v`
+Expected: FAIL — `test_fetcher_backfills_roe_when_yahoo_null` fails (no `roe`/`_field_provenance` because the fallback isn't wired); `test_fetcher_recovers_total_yahoo_failure` fails (raises instead of recovering).
+
+- [ ] **Step 3: Wire the fallback into the US branch**
+
+In `app/services/market_valuation_snapshots/builder.py`, replace the US branch of `default_valuation_fetcher` (currently lines 54-82, from `if market == "us":` through `return {... "high_52w_date": ...}`) with:
+
+```python
+    if market == "us":
+        from app.services.brokers.yahoo.client import (
+            fetch_52w_high_date,
+            fetch_fast_info,
+            fetch_fundamental_info,
+        )
+        from app.services.market_valuation_snapshots.finnhub_fallback import (
+            apply_valuation_fallback,
+        )
+
+        raw: dict[str, Any] = {}
+        yahoo_failed = False
+        yahoo_exc: Exception | None = None
+        try:
+            # ROB-440 PR4: the 52w-high DATE needs a heavy OHLC fetch (1y daily) — a
+            # 3rd yahoo call/symbol that over-loads yfinance at universe scale. Opt-in.
+            if not include_high_date:
+                fast_info, fundamentals = await asyncio.gather(
+                    fetch_fast_info(symbol), fetch_fundamental_info(symbol)
+                )
+                raw = {**fast_info, **fundamentals}
+            else:
+                fast_info, fundamentals, high_52w_date = await asyncio.gather(
+                    fetch_fast_info(symbol),
+                    fetch_fundamental_info(symbol),
+                    fetch_52w_high_date(symbol),
+                )
+                raw = {
+                    **fast_info,
+                    **fundamentals,
+                    "high_52w_date": high_52w_date.isoformat()
+                    if high_52w_date
+                    else None,
+                }
+        except Exception as exc:  # noqa: BLE001 — try Finnhub before giving up
+            raw, yahoo_failed, yahoo_exc = {}, True, exc
+
+        # ROB-434: backfill yahoo's null/missing valuation fields from Finnhub when
+        # gated on. No-op when disabled / no key / no gap. source stays 'yahoo'.
+        raw = await apply_valuation_fallback(symbol, raw, yahoo_failed=yahoo_failed)
+
+        # Nothing recovered from a total yahoo failure → preserve today's skip+warn.
+        if yahoo_failed and not raw and yahoo_exc is not None:
+            raise yahoo_exc
+        return raw
+```
+
+- [ ] **Step 4: Run tests to verify pass + no regression**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py tests/test_invest_coverage_valuation.py::test_default_valuation_fetcher_high_date_opt_in -v`
+Expected: PASS (new fetcher tests + the existing opt-in test — proves the disabled/no-key default path is unchanged; note the existing test has no flag set, so the fallback is a no-op there).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/market_valuation_snapshots/builder.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "feat(ROB-434): wire Finnhub fallback into default_valuation_fetcher US branch
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Operator smoke reporting (finnhub backfill counts + non-null coverage)
+
+**Files:**
+- Modify: `app/jobs/market_valuation_snapshots.py` (result dataclass + `run_market_valuation_snapshot_build` loop)
+- Modify: `scripts/build_market_valuation_snapshots.py` (`_print_result`)
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+@pytest.mark.unit
+def test_aggregate_reporting_from_payloads() -> None:
+    from decimal import Decimal
+
+    from app.jobs.market_valuation_snapshots import _aggregate_report
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotUpsert,
+    )
+
+    p1 = MarketValuationSnapshotUpsert(
+        market="us", symbol="AAA", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
+        per=Decimal("8"), roe=Decimal("18"), market_cap=Decimal("3e9"),
+        raw_payload={"_field_provenance": {"roe": "finnhub"}},
+    )
+    p2 = MarketValuationSnapshotUpsert(
+        market="us", symbol="BBB", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
+        per=Decimal("9"), roe=None, market_cap=Decimal("5e9"),
+        raw_payload={},
+    )
+    backfill, coverage = _aggregate_report([p1, p2])
+    assert backfill == {"roe": 1}  # only p1's roe was finnhub
+    assert coverage["per"] == 2
+    assert coverage["roe"] == 1  # p2 roe is None
+    assert coverage["market_cap"] == 2
+    assert coverage["pbr"] == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_aggregate_reporting_from_payloads -v`
+Expected: FAIL with `ImportError` (`_aggregate_report` not defined).
+
+- [ ] **Step 3: Add aggregation + result fields**
+
+In `app/jobs/market_valuation_snapshots.py`:
+
+(a) Add two fields to `MarketValuationSnapshotBuildResult` (after line 74, `warnings`):
+
+```python
+    finnhub_backfill: dict[str, int] = field(default_factory=dict)
+    field_nonnull_coverage: dict[str, int] = field(default_factory=dict)
+```
+
+(b) Add a module-level helper + constant (after `_sample`, ~line 214):
+
+```python
+_COVERAGE_FIELDS: tuple[str, ...] = (
+    "per",
+    "pbr",
+    "roe",
+    "dividend_yield",
+    "market_cap",
+    "high_52w",
+    "low_52w",
+    "high_52w_date",
+)
+
+
+def _aggregate_report(
+    payloads: list[MarketValuationSnapshotUpsert],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """ROB-434: per-field Finnhub-backfill counts + per-field non-null coverage,
+    derived from each payload's raw_payload['_field_provenance'] and column values.
+    Operator smoke (acceptance #5): provider attribution + coverage, works in dry-run."""
+    backfill: Counter[str] = Counter()
+    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
+    for payload in payloads:
+        provenance = (payload.raw_payload or {}).get("_field_provenance", {})
+        for field_name, src in provenance.items():
+            if src == "finnhub":
+                backfill[field_name] += 1
+        for field_name in _COVERAGE_FIELDS:
+            if getattr(payload, field_name) is not None:
+                coverage[field_name] += 1
+    return dict(backfill), dict(coverage)
+```
+
+(c) In `run_market_valuation_snapshot_build`, accumulate across batches. After the line `total_built = 0` (line 255), add:
+
+```python
+    finnhub_backfill: Counter[str] = Counter()
+    coverage: Counter[str] = Counter({f: 0 for f in _COVERAGE_FIELDS})
+```
+
+Inside the batch loop, after `samples.extend(...)` (line 271), add:
+
+```python
+        batch_backfill, batch_coverage = _aggregate_report(payloads)
+        finnhub_backfill.update(batch_backfill)
+        coverage.update(batch_coverage)
+```
+
+In the final `return MarketValuationSnapshotBuildResult(...)` (line 275), add two kwargs:
+
+```python
+        finnhub_backfill=dict(finnhub_backfill),
+        field_nonnull_coverage=dict(coverage),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_aggregate_reporting_from_payloads -v`
+Expected: PASS.
+
+- [ ] **Step 5: Print the aggregates in the CLI**
+
+In `scripts/build_market_valuation_snapshots.py::_print_result`, after the `snapshot distribution` block (after line 103, before the `samples` block), add:
+
+```python
+    finnhub_backfill = getattr(result, "finnhub_backfill", {})
+    if finnhub_backfill:
+        print("finnhub backfill (fields filled where yahoo was null):")
+        for field_name, count in sorted(finnhub_backfill.items()):
+            print(f"  {field_name}: {count}")
+    coverage = getattr(result, "field_nonnull_coverage", {})
+    if coverage:
+        print("non-null field coverage:")
+        for field_name, count in sorted(coverage.items()):
+            print(f"  {field_name}: {count}/{result.snapshots_built}")
+```
+
+- [ ] **Step 6: Verify CLI smoke output (dry-run, no network needed for the print path)**
+
+Run: `uv run python -c "import ast,sys; ast.parse(open('scripts/build_market_valuation_snapshots.py').read()); print('syntax ok')"`
+Expected: `syntax ok`. (Full CLI dry-run hits the network; the print path is covered by the unit test on `_aggregate_report`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/jobs/market_valuation_snapshots.py scripts/build_market_valuation_snapshots.py tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "feat(ROB-434): operator smoke — finnhub backfill counts + non-null coverage
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Integration — backfilled row upserts, provenance survives, passes quality guard
+
+**Files:**
+- Test: `tests/test_market_valuation_finnhub_fallback_rob434.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```python
+import sqlalchemy as sa  # noqa: E402  (top-of-file import is fine too)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_backfilled_row_upserts_and_passes_quality_guard(db_session) -> None:
+    from decimal import Decimal
+
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_view_model.us_quality_guards import (
+        apply_us_valuation_quality_guards,
+    )
+    from app.services.market_valuation_snapshots.builder import (
+        build_valuation_snapshots_for_market,
+    )
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotsRepository,
+    )
+
+    snapshot_date = dt.date(2026, 6, 9)
+    sym = "ZZQ434"
+
+    # Simulate the merged raw a yahoo-partial + finnhub-backfill produced:
+    async def fake_fetcher(symbol: str, market: str) -> dict[str, object]:
+        assert market == "us"
+        return {
+            "PER": "8",  # yahoo
+            "roe": 18.0,  # finnhub-filled (≤300 guard)
+            "market_cap": 3_000_000_000.0,  # finnhub-filled (≥$100M guard)
+            "_field_provenance": {"roe": "finnhub", "market_cap": "finnhub"},
+        }
+
+    result = await build_valuation_snapshots_for_market(
+        market="us", symbols=[sym], snapshot_date=snapshot_date, fetcher=fake_fetcher
+    )
+    assert len(result.payloads) == 1
+    payload = result.payloads[0]
+    assert payload.source == "yahoo"
+    assert payload.roe == Decimal("18.0")
+    assert payload.raw_payload["_field_provenance"] == {
+        "roe": "finnhub",
+        "market_cap": "finnhub",
+    }
+
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+    assert await MarketValuationSnapshotsRepository(db_session).upsert(result.payloads) == 1
+    await db_session.commit()
+
+    # The backfilled row survives the read-time quality guard (mcap≥$100M, roe≤300%).
+    stmt = apply_us_valuation_quality_guards(
+        sa.select(MarketValuationSnapshot.symbol).where(
+            MarketValuationSnapshot.symbol == sym,
+            MarketValuationSnapshot.snapshot_date == snapshot_date,
+        ),
+        uses_roe=True,
+    )
+    rows = (await db_session.execute(stmt)).all()
+    assert len(rows) == 1  # passes the guard
+
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py::test_backfilled_row_upserts_and_passes_quality_guard -v`
+Expected: PASS if a test DB is available. If `apply_us_valuation_quality_guards`'s exact signature differs (verify with `grep -n "def apply_us_valuation_quality_guards" app/services/invest_view_model/us_quality_guards.py`), adjust the call (e.g. it may guard a `cand_stmt` against `MarketValuationSnapshot` columns) and re-run.
+
+> Note: if the local test DB is unavailable, this `@pytest.mark.integration` test is skipped/excluded by `-m "not integration"`; the unit coverage already proves the logic. Do not block the PR on DB availability, but DO run it once if the DB is up.
+
+- [ ] **Step 3: (only if Step 2 failed on signature/guard mismatch) fix the test call**
+
+Read `app/services/invest_view_model/us_quality_guards.py` and match the real `apply_us_valuation_quality_guards` signature (statement arg + `uses_roe`/`uses_dividend` kwargs) and the column it filters on. Update the test's `stmt = apply_us_valuation_quality_guards(...)` accordingly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_market_valuation_finnhub_fallback_rob434.py
+git commit -m "test(ROB-434): integration — backfilled row upserts + passes US quality guard
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Docs + full-suite gate
+
+**Files:**
+- Modify: `docs/runbooks/invest-screener-snapshots.md`
+- (verify) all touched files
+
+- [ ] **Step 1: Add an operator note to the runbook**
+
+In `docs/runbooks/invest-screener-snapshots.md`, add a subsection under the US valuation activation section (find it: `grep -n "valuation" docs/runbooks/invest-screener-snapshots.md`):
+
+```markdown
+### US valuation Finnhub fallback (ROB-434, default-off)
+
+`market_valuation_snapshots` US builds can backfill valuation fields that yahoo
+`.info` left null (operator "ROE rows 0" / Invalid Crumb) from Finnhub
+`company_basic_financials`. **Disabled by default.** To enable for a build:
+
+1. Set `FINNHUB_API_KEY` (operator secret manager — never commit).
+2. Set `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED=true`.
+3. Run `uv run python -m scripts.build_market_valuation_snapshots --market us --common-stocks-only --concurrency 4` (dry-run first). The summary prints `finnhub backfill` per-field counts and `non-null field coverage`.
+
+Without the key or flag the build is byte-identical to today (yahoo-only,
+fail-closed). `source` stays `yahoo`; per-field provenance is in
+`raw_payload._field_provenance`. Finnhub free tier ~60/min — keep `--concurrency`
+modest. Fallback fires only on a per-symbol gap, never per-symbol unconditionally.
+```
+
+- [ ] **Step 2: Run lint + typecheck on touched files**
+
+Run:
+```bash
+uv run ruff check app/services/market_valuation_snapshots/finnhub_fallback.py app/services/market_valuation_snapshots/builder.py app/jobs/market_valuation_snapshots.py app/core/config.py scripts/build_market_valuation_snapshots.py tests/test_market_valuation_finnhub_fallback_rob434.py
+uv run ruff format --check app/services/market_valuation_snapshots/finnhub_fallback.py tests/test_market_valuation_finnhub_fallback_rob434.py
+uv run ty check app/
+```
+Expected: clean (no errors). Fix any reported issues, re-run. (Reminder from project memory: CI lints **both** `app/` and `tests/` — run ruff on the test file too.)
+
+- [ ] **Step 3: Run the full relevant suite**
+
+Run:
+```bash
+uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py tests/test_invest_coverage_valuation.py tests/test_yahoo_roe_rob440.py -v -m "not integration"
+```
+Expected: all PASS. Then, if a DB is available, run once including integration:
+```bash
+uv run pytest tests/test_market_valuation_finnhub_fallback_rob434.py -v
+```
+
+- [ ] **Step 4: Commit docs + push + open PR**
+
+```bash
+git add docs/runbooks/invest-screener-snapshots.md
+git commit -m "docs(ROB-434): runbook note for US valuation Finnhub fallback (default-off)
+
+Co-authored-by: Hermes <hermes@example.invalid>
+Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git push -u origin rob-434-finnhub-valuation-fallback
+gh pr create --base main --title "feat(ROB-434): US valuation Finnhub fallback (field-fill)" --body "$(cat <<'EOF'
+## What
+When yahoo `.info` leaves US `market_valuation_snapshots` fields null (operator "ROE rows 0" / Invalid Crumb) or fails, backfill the missing valuation fields from Finnhub `company_basic_financials`. Keeps `source='yahoo'`, per-field provenance in `raw_payload._field_provenance`. **Migration 0.**
+
+## Design / Plan
+- Spec: `docs/superpowers/specs/2026-06-09-rob-434-us-market-valuation-finnhub-fallback-design.md`
+- Plan: `docs/superpowers/plans/2026-06-09-rob-434-us-market-valuation-finnhub-fallback.md`
+
+## Decisions
+- Scope: valuation table only. Provenance: field-fill, no migration. Backfill: all missing valuation fields. Toggle: `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED` default-off, inert without `FINNHUB_API_KEY`.
+- Unit traps nailed in tests: roeTTM already %, marketCapitalization millions→absolute, dividendYield %→ratio.
+
+## Safety
+- Default-off + no-key inert → byte-identical to today. Fail-closed preserved. broker/order/watch mutation 0. KR + fundamentals table untouched. Read-time quality guard unchanged (backfilled row must pass it — integration-tested).
+
+## Operator follow-up (out of PR)
+Set the key + flag, run dry-run build, review `finnhub backfill` / `non-null coverage` summary, then `--commit`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (each spec section → task):
+- 컴포넌트 1 (finnhub_fallback helper) → Tasks 3, 4. ✅
+- 컴포넌트 2 (trigger in default_valuation_fetcher) → Task 5. ✅
+- 컴포넌트 3 (field mapping + unit traps) → Task 3 (+ asserted in Task 5). ✅
+- 컴포넌트 4 (settings flag) → Task 1. ✅
+- 컴포넌트 5 (smoke reporting) → Task 6. ✅
+- Provenance / fail-closed → Tasks 3,4,5,7 (provenance survives + guard pass in Task 7). ✅
+- Boundaries (migration 0, KR untouched, no-key inert) → Tasks 1,2 (no-regression), 5 (disabled re-raise), 8 (lint/suite). ✅
+- Docs/runbook → Task 8. ✅
+- Out-of-scope (fundamentals table, separate finnhub source row, operator backfill) → not implemented, noted in PR body. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows full code. Task 7 Step 3 is a conditional fix-up (verify-then-adjust), not a placeholder — it carries the exact grep + what to match. ✅
+
+**3. Type consistency:** `_resolve_raw_value(raw, field)` defined in Task 2, imported/used in Tasks 3-4. `_FIELD_SOURCE_KEYS` defined Task 2, imported Task 4. `apply_valuation_fallback(symbol, raw, *, yahoo_failed)` defined Task 4, called Task 5 with the same signature. `_aggregate_report(payloads) -> (backfill, coverage)` defined + used Task 6. `_map_finnhub_metrics` / `fetch_valuation_finnhub` names consistent across Tasks 3-5. `MarketValuationSnapshotBuildResult` new fields `finnhub_backfill`/`field_nonnull_coverage` consistent across job + CLI (Task 6). ✅
+
+**Known coupling (documented):** `_FIELD_SOURCE_KEYS` is the single source of truth for raw-key priority; both `_payload_from_raw` and the fallback's gap detection use it via `_resolve_raw_value` (no drift). The fallback writes canonical lowercase keys, which `_resolve_raw_value` ranks first.

--- a/docs/superpowers/specs/2026-06-09-rob-434-us-market-valuation-finnhub-fallback-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-434-us-market-valuation-finnhub-fallback-design.md
@@ -1,0 +1,181 @@
+# ROB-434 — US market_valuation Finnhub fallback (field-fill) 설계
+
+- **Linear**: ROB-434 umbrella `[screener] US non-DART fundamentals vendor — ROE/growth/dividend + 52w-high-date unblock` 의 **남은 deferred 조각** (Finnhub fallback). 신규 이슈 미생성 (Linear 쿼터 비상 240/250) → ROB-434로 직접 진행.
+- **Priority**: Medium (umbrella), 이 조각 High 가치 (operator 라이브 블로커 직격)
+- **날짜**: 2026-06-09
+- **선행/완료**: ROB-440 (Phase 1, valuation ROE+52w via yfinance) · ROB-441 (Phase 2, fundamentals US) — 둘 다 Done·머지
+- **PR**: 단독 PR (`feat(ROB-434): US valuation Finnhub fallback (field-fill)`)
+- **벤더 결정 출처**: ROB-434 umbrella `/spec` D1 — "yfinance primary, Finnhub fallback (계약 문서화·구현 후속)". 이 설계가 그 "구현 후속"이다.
+
+## 문제
+
+operator 라이브 증거(2026-06-05): US valuation 스냅샷을 `scripts.build_market_valuation_snapshots --market us --commit` 로 빌드 시 **26행 커밋, ROE rows 0, PER 25, PBR 26, dividend 20**, 그리고 다수의 yahoo `Invalid Crumb / Session is closed` fetch 실패.
+
+근본 원인은 yahoo 단일 소스 의존이다. ROE는 `app/services/brokers/yahoo/client.py::fetch_fundamental_info` 가 `yf.Ticker(...).info['returnOnEquity']` 에서 가져오는데, `.info` 는 crumb/cookie 인증이 필요해 (a) 키가 통째로 누락된 dict 를 반환하거나(→ `roe=None`, **지배적 케이스** — PER/PBR 은 있는데 ROE 만 빠짐), (b) crumb 재시도 1회 소진 후 예외를 던져 builder 가 해당 심볼 전체를 skip 한다. 결과적으로 US `high_yield_value`(roe≥15 + 0<per≤10)·`undervalued_breakout`(per/pbr/52w-date) 가 정직하게 활성화되지 못한다.
+
+**설계 제약**: 현재의 fail-closed 동작(없으면 null/skip, 위조 금지)은 의도된 설계다. 이 설계는 그 게이트를 **유지**하되, yahoo gap 을 **Finnhub 보조 소스로 메우는** 회복 경로를 추가한다.
+
+## 접근 (결정됨)
+
+**valuation 테이블 한정 · field-fill · `source='yahoo'` 유지 · migration 0.**
+
+`market_valuation_snapshots` 의 US 빌드 경로(`default_valuation_fetcher`)에서, 게이트가 켜져 있고 yahoo 가 valuation 필드를 null 로 남기거나 통째로 실패하면, Finnhub `company_basic_financials` metric 엔드포인트를 **심볼당 1회**(gap 이 있을 때만) 호출해 누락 필드만 채운다. 기존 yahoo 행을 그대로 두고 필드별 출처를 `raw_payload` 에 기록한다.
+
+### 브레인스토밍에서 확정한 4개 결정
+
+1. **범위** — valuation 테이블(`market_valuation_snapshots`) 한정. fundamentals 테이블(income history) fallback 은 범위 외(별도 후속). operator 가 실제 본 증상이 valuation "ROE rows 0" 이고, 그 테이블이 `high_yield_value`/`undervalued_breakout` 를 직접 먹인다.
+2. **Provenance** — field-fill, `source='yahoo'` 유지, migration 없음. 필드별 출처는 `raw_payload['_field_provenance']` 에 기록. (대안 "별도 source='finnhub' 행"은 CheckConstraint widen migration + `_source_for_market` un-hardcode + 읽기/coverage 경로 source-preference 가 필요해 blast radius 가 큼 → 반려. "hybrid" 도 동일 이유로 반려.)
+3. **Backfill 필드 범위** — 누락된 valuation 필드 전부(roe/per/pbr/dividend_yield/market_cap/high_52w/high_52w_date). `company_basic_financials` 한 번 호출로 전부 얻으므로 추가 비용 0. `high_yield_value`(roe)뿐 아니라 `undervalued_breakout`(per/pbr/52w-date) + quality guard(market_cap non-null 필수)까지 resilience 확보.
+4. **Operator toggle** — `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED` settings/env 플래그, default `False`. `default_valuation_fetcher` 내부에서 게이트. `FINNHUB_API_KEY` 미설정 시 자동 inert. (레포 관례 `BINANCE_*_ENABLED` 등과 일치, CLI/job 스레딩 불필요.)
+
+### 왜 field-fill / no-migration 인가
+
+operator 의 지배적 케이스는 **yahoo `.info` 가 dict 는 주되 `returnOnEquity` 만 누락**(roe=None, per/pbr/dividend 존재)이다. 이건 기존 yahoo 행에 roe 하나만 메우면 되는 전형적 field-fill 케이스다. `source` 가 unique key 의 일부라 별도 'finnhub' 행은 중복행을 만들고 읽기경로(`latest_for_symbols` 는 source-agnostic recency 선택)에 source-preference 로직을 강제한다. field-fill 은 그 모든 것을 회피한다 — 단일 행, migration 0, 읽기/coverage/guard 무변경.
+
+## 컴포넌트
+
+### 1. 신규 서비스 헬퍼 — `app/services/market_valuation_snapshots/finnhub_fallback.py`
+
+```python
+async def fetch_valuation_finnhub(symbol: str) -> dict[str, Any]:
+    """Finnhub company_basic_financials metric → valuation 필드 dict.
+    실패(키없음/ImportError/API/rate-limit)는 호출자가 fail-closed 처리하도록 raise.
+    """
+```
+
+- **클라이언트 접근**: `app/services/finnhub_news.py` 의 env-first 패턴(`os.getenv("FINNHUB_API_KEY")` → `settings.finnhub_api_key`)을 미러. `finnhub` 패키지 lazy import(try/except ImportError). **`app.mcp_server` import 안 함** (valuation builder 는 이미 `app.services.brokers.yahoo.client` 만 import — 서비스 레이어 일관성 유지).
+- **엔드포인트**: `client.company_basic_financials(symbol, "all")["metric"]` (sync → `asyncio.to_thread`).
+- **반환 키**: `_payload_from_raw` 가 읽는 키 모양과 동일 — `roe / per / pbr / dividend_yield / market_cap / high_52w / low_52w / high_52w_date`. 각 metric 누락/비정상 → 해당 키 생략 또는 None(위조 금지).
+- **위치 근거(YAGNI)**: valuation 빌더 로컬 모듈. 재사용 가능한 `app/services/brokers/finnhub/` 승격은 범위 외(현재 소비자 1곳).
+
+### 2. 트리거 — `app/services/market_valuation_snapshots/builder.py::default_valuation_fetcher` (US 분기만)
+
+```python
+# 의사코드 (US 분기)
+gate = settings.market_valuation_finnhub_fallback_enabled and _finnhub_key_present()
+yahoo_exc = None
+try:
+    raw = <기존 yahoo gather: fast_info + fundamental_info [+ 52w_date]>
+except Exception as exc:
+    raw, yahoo_exc = {}, exc          # 종전: 그대로 전파 → 심볼 skip
+if gate and (yahoo_exc is not None or _has_missing_fields(raw)):
+    try:
+        metrics = await fetch_valuation_finnhub(symbol)   # 1회 호출
+        filled = _fill_missing(raw, metrics, _TARGET_FIELDS)  # null 필드만 채움
+        if filled:
+            raw.setdefault("_field_provenance", {}).update({f: "finnhub" for f in filled})
+    except Exception:
+        pass                          # fail-closed: raw 그대로
+if yahoo_exc is not None and not _row_usable(raw):
+    raise yahoo_exc                   # 회복 못하면 종전대로 skip+warn 보존
+return raw
+```
+
+- **플래그 OFF**: yahoo 예외가 종전대로 전파 → 동작 byte-identical. Finnhub 호출 0.
+- **키 없음**: `_finnhub_key_present()` False → 게이트 통과 못함 → inert.
+- **`_TARGET_FIELDS`**: roe/per/pbr/dividend_yield/market_cap/high_52w/low_52w/high_52w_date.
+- **`_has_missing_fields`**: 위 필드 중 하나라도 None/부재.
+- **`_row_usable`**: 종전 builder 의 "전 필드 null 이면 skip" 판정과 일치하는 최소 판정(어떤 metric 이든 non-null 이면 usable).
+- 커스텀 `fetcher=` 를 주입한 호출자(테스트 등)는 `default_valuation_fetcher` 를 우회하므로 영향 없음.
+
+### 3. 필드 매핑 + 단위 함정 (테스트로 못 박는 핵심 위험구간)
+
+| 컬럼 | Finnhub metric 키 | 변환 | 함정 |
+| -- | -- | -- | -- |
+| `roe` | `roeTTM` | **없음** | Finnhub 는 이미 percent(예 22.0). yahoo 경로는 fraction×100. Finnhub 에 ×100 하면 2200% 오류 |
+| `per` | `peTTM` | 없음 | (`peBasicExclExtraTTM` 폴백 고려) |
+| `pbr` | `pbAnnual` | 없음 | (`pbQuarterly` 폴백 고려) |
+| `dividend_yield` | `dividendYieldIndicatedAnnual` | **÷100** | Finnhub %(예 3.0) → 저장 ratio(0.03). PR #1154 가 컬럼이 ratio 임을 확정, guard `≤0.25` |
+| `market_cap` | `marketCapitalization` | **×1_000_000** | Finnhub 백만 단위 → 절대 USD. guard `≥$100M` non-null 필수 |
+| `high_52w` | `52WeekHigh` | 없음 | |
+| `low_52w` | `52WeekLow` | 없음 | |
+| `high_52w_date` | `52WeekHighDate` | `'YYYY-MM-DD'`→date | 파싱 실패 → None |
+
+비정상/누락 → 해당 필드 null 유지(위조 금지). 값은 `_to_decimal`/`_to_date` 의 non-finite 거부를 거쳐 저장된다.
+
+### 4. Operator toggle — `app/core/config.py`
+
+`market_valuation_finnhub_fallback_enabled: bool = False` (env `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED`) 추가. `finnhub_api_key` (line 323, 기존) 와 함께 게이트.
+
+### 5. Smoke 리포팅 (acceptance #5) — `builder.py` 결과 + `scripts/build_market_valuation_snapshots.py::_print_result`
+
+빌드 결과(`MarketValuationBuildResult`)에 additive 집계 추가:
+- **finnhub backfill 행 수** + **필드별 채움 수**(예: `roe: 14, high_52w_date: 9`).
+- **필드별 non-null 커버리지** (빌드된 payload 에서 파생 → dry-run 에서도 동작).
+
+`_print_result` 가 위를 출력. (latest snapshot date 는 기존 `snapshot_date_distribution` 에 이미 있음. freshness `coverage_counts()` 는 post-commit read 라 dry-run 에 안 맞아 핵심에서 제외, 후속 확장 여지만 언급.)
+
+## 데이터 흐름
+
+```
+operator: build_market_valuation_snapshots --market us [--commit]
+  └─> build_valuation_snapshots_for_market(fetcher=default)   # CLI/job 무변경
+        └─> default_valuation_fetcher(symbol, "us")
+              ├─ yahoo gather (fast_info + fundamental_info [+ 52w_date])
+              │     └─ roe=None  (operator 지배 케이스) 또는 예외
+              ├─ [gate ON & gap] fetch_valuation_finnhub(symbol)  # 1회
+              │     └─ 누락 필드만 fill + _field_provenance 기록
+              └─ raw (source='yahoo' 유지)
+        └─> _payload_from_raw → MarketValuationSnapshotUpsert
+        └─> (commit 시) repository.upsert  # source-agnostic, guard/read 무변경
+```
+
+읽기경로(`latest_for_symbols`)·quality guard(`apply_us_valuation_quality_guards`)·preset 로더 **전부 무변경**. Finnhub 가 채운 값은 source-agnostic guard(market_cap≥$100M, roe≤300%, dividend≤0.25)를 yahoo 값과 동일하게 통과해야 한다.
+
+## 안전 경계
+
+- **valuation US 한정**. KR(`naver_finance`) 경로 무변경. fundamentals 테이블 무변경.
+- **Default-off inert**: 플래그 미설정 또는 `FINNHUB_API_KEY` 부재 시 Finnhub 호출 0, 동작 byte-identical.
+- **Fail-closed 전부 보존**: finnhub 에러/키없음/rate-limit → 조용히 degrade(raw 그대로); yahoo 가 통째로 실패하고 회복 못하면 종전대로 심볼 skip+warn. 전 필드 null 행은 여전히 skip. 위조 0.
+- **Migration: 0** (source 그대로 'yahoo', 신규 컬럼 없음).
+- **broker/order/watch/order-intent mutation 0**. 라이브 트레이딩 동작 무변경.
+- **secret 미출력**: CLI 는 키 값 출력 없음, 키 부재는 inert 처리(이름조차 강제 출력 안 함).
+- **스케줄러 무변경**: TaskIQ/cron/Prefect 연결 없음. operator 가 CLI 로 호출.
+- **Rate limit**: Finnhub free tier ~60/min. fallback 은 yahoo gap 에서만 발화(전 심볼 아님)하고 operator 런은 bounded. 별도 token-bucket 미도입(YAGNI v1) — rate-limit 예외는 fail-closed(필드 null). 런북/설명에 modest `--concurrency` 권고.
+
+## 테스트 (TDD, 전부 오프라인 — 네트워크/DB 없음)
+
+기존 패턴: `tests/test_invest_coverage_valuation.py`(fetcher 주입 + yahoo client monkeypatch), `tests/test_yahoo_roe_rob440.py`(`.info` mock, fail-closed null). 신규 파일 `tests/test_market_valuation_finnhub_fallback_rob434.py`.
+
+### 단위 — 필드 매핑/단위 함정
+- `roeTTM=22.0` → `roe=22.0` (NOT 2200). **×100 회귀 방지.**
+- `marketCapitalization=1500`(백만) → `market_cap=1_500_000_000`.
+- `dividendYieldIndicatedAnnual=3.0` → `dividend_yield=0.03`.
+- `52WeekHighDate='2026-03-14'` → date(2026,3,14); 잘못된 문자열 → None.
+- metric 키 누락 → 해당 필드 None(위조 0).
+
+### 단위 — 합성 fetcher 트리거
+- yahoo 부분(roe=None) + 플래그 ON + finnhub roe 보유 → `raw['roe']` 채워짐, `source` 여전히 'yahoo', `_field_provenance['roe']=='finnhub'`.
+- yahoo 통째 실패(raise) + 플래그 ON + finnhub 전체 → 행 복구(필드 finnhub), 예외 re-raise 안 함.
+- yahoo 통째 실패 + 플래그 ON + finnhub 도 실패 → 원 yahoo 예외 re-raise(심볼 skip 보존).
+- 플래그 OFF → finnhub 호출 0, yahoo 예외 종전대로 전파.
+- 플래그 ON + `FINNHUB_API_KEY` 없음 → inert(finnhub 호출 0).
+- finnhub raise/rate-limit → fail-closed(raw 변경 없음).
+
+### 단위 — 리포팅
+- 빌드 결과의 finnhub backfill 카운터/필드별 non-null 커버리지 집계 정확성.
+
+### 통합 (선택, `db_session`)
+- 주입 fetcher 로 backfill 행 upsert → 행 존재 + `raw_payload['_field_provenance']` 보존.
+- backfill 행(market_cap≥$100M, roe≤300%)이 `apply_us_valuation_quality_guards` 를 **통과**.
+
+## 파일 참조
+
+| 파일 | 변경 |
+| -- | -- |
+| `app/services/market_valuation_snapshots/finnhub_fallback.py` | **신규** — `fetch_valuation_finnhub` + 필드매핑/단위변환 |
+| `app/services/market_valuation_snapshots/builder.py` | `default_valuation_fetcher` US 분기 트리거 + 결과 집계 |
+| `app/core/config.py` | `market_valuation_finnhub_fallback_enabled` (1개) |
+| `scripts/build_market_valuation_snapshots.py` | `_print_result` finnhub backfill/커버리지 출력 |
+| `tests/test_market_valuation_finnhub_fallback_rob434.py` | **신규** 테스트 |
+
+## Rollback
+
+PR revert(코드만). migration 0, 데이터 변환 없음. 플래그 default-off 라 머지 후에도 operator 가 켜기 전까지 inert.
+
+## 범위 외 / 후속
+
+- fundamentals 테이블(`financial_fundamentals_snapshots`) Finnhub fallback(income statements, growth/dividend presets) — 별도 후속. `_fetch_financials_finnhub` reports[]→date-keyed 어댑터 + XBRL 라벨 alias + 4-report cap 해제 필요.
+- 별도 `source='finnhub'` provenance 행(migration + 읽기경로 source-preference) — 반려, 후속 여지.
+- operator US valuation 재빌드/backfill 실행 + 플래그 flip — 이 PR 밖(operator-gated).
+- Finnhub rate-limit token-bucket / 재사용 가능 `brokers/finnhub/` 승격 — YAGNI, 후속.

--- a/scripts/build_market_valuation_snapshots.py
+++ b/scripts/build_market_valuation_snapshots.py
@@ -101,6 +101,16 @@ def _print_result(result) -> None:
         print("snapshot distribution:")
         for snapshot_key, count in distribution.items():
             print(f"  {snapshot_key}: {count}")
+    finnhub_backfill = getattr(result, "finnhub_backfill", {})
+    if finnhub_backfill:
+        print("finnhub backfill (fields filled where yahoo was null):")
+        for field_name, count in sorted(finnhub_backfill.items()):
+            print(f"  {field_name}: {count}")
+    coverage = getattr(result, "field_nonnull_coverage", {})
+    if coverage:
+        print("non-null field coverage:")
+        for field_name, count in sorted(coverage.items()):
+            print(f"  {field_name}: {count}/{result.snapshots_built}")
     if result.samples:
         print("samples:")
         for sample in result.samples[:10]:

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -1,0 +1,19 @@
+"""ROB-434: US market_valuation Finnhub fallback (field-fill).
+
+When yahoo .info leaves valuation fields null (or fails), backfill the missing
+fields from Finnhub company_basic_financials. source stays 'yahoo'; per-field
+provenance in raw_payload['_field_provenance']; default-off, inert without key.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+
+@pytest.mark.unit
+def test_settings_flag_defaults_off() -> None:
+    from app.core.config import settings
+
+    assert settings.market_valuation_finnhub_fallback_enabled is False

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -168,8 +168,13 @@ async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
     monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
     # every field present → no finnhub call
     raw = {
-        "ROE": 15.0, "PER": 8.0, "PBR": 0.9, "Dividend Yield": 0.02,
-        "marketCap": 3e9, "yearHigh": 100.0, "yearLow": 80.0,
+        "ROE": 15.0,
+        "PER": 8.0,
+        "PBR": 0.9,
+        "Dividend Yield": 0.02,
+        "marketCap": 3e9,
+        "yearHigh": 100.0,
+        "yearLow": 80.0,
         "high_52w_date": "2026-01-01",
     }
     out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
@@ -190,7 +195,9 @@ async def test_fetcher_backfills_roe_when_yahoo_null(monkeypatch) -> None:
         return {"PER": 8.0, "ROE": None, "marketCap": 3_000_000_000}  # ROE missing
 
     monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
-    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _fund)
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.fetch_fundamental_info", _fund
+    )
     monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
 
     async def _metrics(symbol):  # noqa: ANN001
@@ -223,7 +230,9 @@ async def test_fetcher_recovers_total_yahoo_failure(monkeypatch) -> None:
         raise RuntimeError("Invalid Crumb / Session is closed")
 
     monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
-    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.fetch_fundamental_info", _boom
+    )
     monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
 
     async def _metrics(symbol):  # noqa: ANN001
@@ -248,7 +257,9 @@ async def test_fetcher_total_failure_reraises_when_disabled(monkeypatch) -> None
         raise RuntimeError("Invalid Crumb")
 
     monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
-    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.fetch_fundamental_info", _boom
+    )
     monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: False)  # disabled
 
     with pytest.raises(RuntimeError, match="Invalid Crumb"):
@@ -265,13 +276,23 @@ def test_aggregate_reporting_from_payloads() -> None:
     )
 
     p1 = MarketValuationSnapshotUpsert(
-        market="us", symbol="AAA", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
-        per=Decimal("8"), roe=Decimal("18"), market_cap=Decimal("3e9"),
+        market="us",
+        symbol="AAA",
+        snapshot_date=dt.date(2026, 6, 9),
+        source="yahoo",
+        per=Decimal("8"),
+        roe=Decimal("18"),
+        market_cap=Decimal("3e9"),
         raw_payload={"_field_provenance": {"roe": "finnhub"}},
     )
     p2 = MarketValuationSnapshotUpsert(
-        market="us", symbol="BBB", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
-        per=Decimal("9"), roe=None, market_cap=Decimal("5e9"),
+        market="us",
+        symbol="BBB",
+        snapshot_date=dt.date(2026, 6, 9),
+        source="yahoo",
+        per=Decimal("9"),
+        roe=None,
+        market_cap=Decimal("5e9"),
         raw_payload={},
     )
     backfill, coverage = _aggregate_report([p1, p2])
@@ -330,7 +351,10 @@ async def test_backfilled_row_upserts_and_passes_quality_guard(db_session) -> No
         sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
     )
     await db_session.commit()
-    assert await MarketValuationSnapshotsRepository(db_session).upsert(result.payloads) == 1
+    assert (
+        await MarketValuationSnapshotsRepository(db_session).upsert(result.payloads)
+        == 1
+    )
     await db_session.commit()
 
     # The backfilled row survives the read-time quality guard (mcap≥$100M, roe≤300%).
@@ -348,9 +372,3 @@ async def test_backfilled_row_upserts_and_passes_quality_guard(db_session) -> No
         sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
     )
     await db_session.commit()
-
-
-
-
-
-

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -282,6 +282,75 @@ def test_aggregate_reporting_from_payloads() -> None:
     assert coverage["pbr"] == 0
 
 
+import sqlalchemy as sa  # noqa: E402
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_backfilled_row_upserts_and_passes_quality_guard(db_session) -> None:
+    from decimal import Decimal
+
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.invest_view_model.us_quality_guards import (
+        apply_us_valuation_quality_guards,
+    )
+    from app.services.market_valuation_snapshots.builder import (
+        build_valuation_snapshots_for_market,
+    )
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotsRepository,
+    )
+
+    snapshot_date = dt.date(2026, 6, 9)
+    sym = "ZZQ434"
+
+    # Simulate the merged raw a yahoo-partial + finnhub-backfill produced:
+    async def fake_fetcher(symbol: str, market: str) -> dict[str, object]:
+        assert market == "us"
+        return {
+            "PER": "8",  # yahoo
+            "roe": 18.0,  # finnhub-filled (≤300 guard)
+            "market_cap": 3_000_000_000.0,  # finnhub-filled (≥$100M guard)
+            "_field_provenance": {"roe": "finnhub", "market_cap": "finnhub"},
+        }
+
+    result = await build_valuation_snapshots_for_market(
+        market="us", symbols=[sym], snapshot_date=snapshot_date, fetcher=fake_fetcher
+    )
+    assert len(result.payloads) == 1
+    payload = result.payloads[0]
+    assert payload.source == "yahoo"
+    assert payload.roe == Decimal("18.0")
+    assert payload.raw_payload["_field_provenance"] == {
+        "roe": "finnhub",
+        "market_cap": "finnhub",
+    }
+
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+    assert await MarketValuationSnapshotsRepository(db_session).upsert(result.payloads) == 1
+    await db_session.commit()
+
+    # The backfilled row survives the read-time quality guard (mcap≥$100M, roe≤300%).
+    stmt = apply_us_valuation_quality_guards(
+        sa.select(MarketValuationSnapshot.symbol).where(
+            MarketValuationSnapshot.symbol == sym,
+            MarketValuationSnapshot.snapshot_date == snapshot_date,
+        ),
+        uses_roe=True,
+    )
+    rows = (await db_session.execute(stmt)).all()
+    assert len(rows) == 1  # passes the guard
+
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(MarketValuationSnapshot.symbol == sym)
+    )
+    await db_session.commit()
+
+
+
 
 
 

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -31,3 +31,54 @@ def test_resolve_raw_value_priority_and_truthiness() -> None:
     assert _resolve_raw_value({"per": 0.0, "PER": 0}, "per") is None
     assert _resolve_raw_value({}, "high_52w_date") is None
 
+
+@pytest.mark.unit
+def test_map_finnhub_metrics_unit_traps() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    out = _map_finnhub_metrics(
+        {
+            "roeTTM": 22.0,  # already percent → NOT ×100
+            "peTTM": 8.0,
+            "pbAnnual": 0.9,
+            "dividendYieldIndicatedAnnual": 3.0,  # percent → ÷100 ratio
+            "marketCapitalization": 1500.0,  # millions → ×1e6 absolute
+            "52WeekHigh": 110.0,
+            "52WeekLow": 80.0,
+            "52WeekHighDate": "2026-03-14",
+        }
+    )
+    assert out["roe"] == 22.0  # critical: not 2200
+    assert out["per"] == 8.0
+    assert out["pbr"] == 0.9
+    assert out["dividend_yield"] == 0.03
+    assert out["market_cap"] == 1_500_000_000.0
+    assert out["high_52w"] == 110.0
+    assert out["low_52w"] == 80.0
+    assert out["high_52w_date"] == "2026-03-14"  # iso str (JSON-safe, parsed later)
+
+
+@pytest.mark.unit
+def test_map_finnhub_metrics_fail_closed_on_missing_and_nonfinite() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    out = _map_finnhub_metrics(
+        {"roeTTM": None, "peTTM": "n/a", "marketCapitalization": float("inf")}
+    )
+    assert out == {}  # nothing fabricated; non-finite/None/unparseable dropped
+
+
+@pytest.mark.unit
+def test_map_finnhub_metrics_bad_date_dropped() -> None:
+    from app.services.market_valuation_snapshots.finnhub_fallback import (
+        _map_finnhub_metrics,
+    )
+
+    assert "high_52w_date" not in _map_finnhub_metrics({"52WeekHighDate": ""})
+    assert "high_52w_date" not in _map_finnhub_metrics({"52WeekHighDate": None})
+
+

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -166,7 +166,9 @@ async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
         return {"roe": 1.0}
 
     monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
-    # every field present → no finnhub call
+    # all 7 CORE fields present, NO high_52w_date — the real default bulk-path state
+    # (the date needs a separate opt-in yahoo OHLC call). Must NOT count as a gap,
+    # else Finnhub fires for every fully-populated symbol. (ROB-434 review: major.)
     raw = {
         "ROE": 15.0,
         "PER": 8.0,
@@ -175,11 +177,105 @@ async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
         "marketCap": 3e9,
         "yearHigh": 100.0,
         "yearLow": 80.0,
-        "high_52w_date": "2026-01-01",
     }
     out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
     assert calls["n"] == 0
+    assert "high_52w_date" not in out
     assert "_field_provenance" not in out
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_opt_in_treats_missing_date_as_gap(monkeypatch) -> None:
+    """ROB-434 review: on the opt-in run (include_high_date=True), a missing
+    high_52w_date IS a gap → Finnhub fills it (undervalued_breakout date-recency)."""
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"high_52w_date": "2026-03-14"}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    # all 7 core fields present, date missing — only a gap on the opt-in path
+    raw = {
+        "ROE": 15.0,
+        "PER": 8.0,
+        "PBR": 0.9,
+        "Dividend Yield": 0.02,
+        "marketCap": 3e9,
+        "yearHigh": 100.0,
+        "yearLow": 80.0,
+    }
+    out = await fb.apply_valuation_fallback(
+        "AAPL", raw, yahoo_failed=False, include_high_date=True
+    )
+    assert out["high_52w_date"] == "2026-03-14"
+    assert out["_field_provenance"] == {"high_52w_date": "finnhub"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_partial_yahoo_multi_field_merge(monkeypatch) -> None:
+    """ROB-434 review (test adequacy): exercise the REAL default_valuation_fetcher
+    merge for a multi-field partial-yahoo case (not the fake-fetcher shortcut).
+    Yahoo supplies PER+marketCap+yearHigh; Finnhub fills roe/pbr/dividend_yield/
+    low_52w. Assert preserve/fill/provenance/source + the ÷100 dividend ratio
+    survives into the payload."""
+    from decimal import Decimal
+
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _fund(sym):  # noqa: ANN001
+        return {
+            "PER": 8.0,
+            "marketCap": 3_000_000_000,
+            "yearHigh": 100.0,
+            "ROE": None,
+            "PBR": None,
+            "Dividend Yield": None,
+            "yearLow": None,
+        }
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr(
+        "app.services.brokers.yahoo.client.fetch_fundamental_info", _fund
+    )
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        # the canonical shape _map_finnhub_metrics emits (dividend already ÷100 ratio)
+        return {"roe": 18.0, "pbr": 0.7, "dividend_yield": 0.03, "low_52w": 60.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+
+    raw = await builder.default_valuation_fetcher("AAPL", "us")
+    # yahoo values preserved (never overwritten)
+    assert raw["PER"] == 8.0
+    assert raw["marketCap"] == 3_000_000_000
+    # finnhub-filled missing fields
+    assert raw["roe"] == 18.0
+    assert raw["pbr"] == 0.7
+    assert raw["dividend_yield"] == 0.03
+    assert raw["low_52w"] == 60.0
+    assert raw["_field_provenance"] == {
+        "roe": "finnhub",
+        "pbr": "finnhub",
+        "dividend_yield": "finnhub",
+        "low_52w": "finnhub",
+    }
+    # source stays yahoo; ratio + low_52w survive into the persisted payload
+    payload = builder._payload_from_raw(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 6, 9), raw=raw
+    )
+    assert payload.source == "yahoo"
+    assert payload.roe == Decimal("18.0")
+    assert payload.dividend_yield == Decimal("0.03")
+    assert payload.low_52w == Decimal("60.0")
 
 
 @pytest.mark.unit

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -17,3 +17,17 @@ def test_settings_flag_defaults_off() -> None:
     from app.core.config import settings
 
     assert settings.market_valuation_finnhub_fallback_enabled is False
+
+
+@pytest.mark.unit
+def test_resolve_raw_value_priority_and_truthiness() -> None:
+    from app.services.market_valuation_snapshots.builder import _resolve_raw_value
+
+    # canonical lowercase key wins over the yahoo key
+    assert _resolve_raw_value({"roe": 22.0, "ROE": 9.9}, "roe") == 22.0
+    # falls back to the yahoo key when canonical absent
+    assert _resolve_raw_value({"marketCap": 1234}, "market_cap") == 1234
+    # 0/None/absent → None (truthiness, matches _payload_from_raw's or-chain)
+    assert _resolve_raw_value({"per": 0.0, "PER": 0}, "per") is None
+    assert _resolve_raw_value({}, "high_52w_date") is None
+

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -177,4 +177,83 @@ async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
     assert "_field_provenance" not in out
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_backfills_roe_when_yahoo_null(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _fund(sym):  # noqa: ANN001
+        return {"PER": 8.0, "ROE": None, "marketCap": 3_000_000_000}  # ROE missing
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _fund)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+
+    raw = await builder.default_valuation_fetcher("AAPL", "us")
+    assert raw["roe"] == 18.0  # backfilled
+    assert raw["PER"] == 8.0  # yahoo preserved
+    assert raw["_field_provenance"] == {"roe": "finnhub"}
+    # source unchanged downstream:
+    payload = builder._payload_from_raw(
+        market="us", symbol="AAPL", snapshot_date=dt.date(2026, 6, 9), raw=raw
+    )
+    assert payload.source == "yahoo"
+    assert payload.roe == __import__("decimal").Decimal("18.0")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_recovers_total_yahoo_failure(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _boom(sym):  # noqa: ANN001
+        raise RuntimeError("Invalid Crumb / Session is closed")
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 8.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+
+    raw = await builder.default_valuation_fetcher("AAPL", "us")  # no raise
+    assert raw["roe"] == 18.0 and raw["per"] == 8.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetcher_total_failure_reraises_when_disabled(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import builder
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    async def _fast(sym):  # noqa: ANN001
+        return {"symbol": sym}
+
+    async def _boom(sym):  # noqa: ANN001
+        raise RuntimeError("Invalid Crumb")
+
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fast_info", _fast)
+    monkeypatch.setattr("app.services.brokers.yahoo.client.fetch_fundamental_info", _boom)
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: False)  # disabled
+
+    with pytest.raises(RuntimeError, match="Invalid Crumb"):
+        await builder.default_valuation_fetcher("AAPL", "us")
+
+
+
 

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -82,3 +82,99 @@ def test_map_finnhub_metrics_bad_date_dropped() -> None:
     assert "high_52w_date" not in _map_finnhub_metrics({"52WeekHighDate": None})
 
 
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_disabled_is_noop(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: False)
+    calls = {"n": 0}
+
+    async def _never(symbol):  # noqa: ANN001
+        calls["n"] += 1
+        return {"roe": 22.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _never)
+    raw = {"PER": 8.0}  # roe missing
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out == {"PER": 8.0}  # untouched
+    assert calls["n"] == 0  # finnhub never called
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_fills_only_missing_fields(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 99.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    # yahoo gave PER (8.0) but no ROE/market_cap → fill ROE + market_cap, keep PER
+    raw = {"PER": 8.0}
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out["roe"] == 18.0
+    assert out["market_cap"] == 2_000_000_000.0
+    assert "per" not in out  # PER already present (yahoo) → NOT overwritten
+    assert out["_field_provenance"] == {"roe": "finnhub", "market_cap": "finnhub"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_total_yahoo_failure_fills_all(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _metrics(symbol):  # noqa: ANN001
+        return {"roe": 18.0, "per": 8.0, "market_cap": 2_000_000_000.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    out = await fb.apply_valuation_fallback("AAPL", {}, yahoo_failed=True)
+    assert out["roe"] == 18.0 and out["per"] == 8.0
+    assert out["_field_provenance"]["per"] == "finnhub"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_finnhub_error_is_fail_closed(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+
+    async def _boom(symbol):  # noqa: ANN001
+        raise RuntimeError("finnhub rate limited")
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _boom)
+    raw = {"PER": 8.0}
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert out == {"PER": 8.0}  # unchanged, no crash
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_apply_fallback_no_gap_skips_finnhub(monkeypatch) -> None:
+    from app.services.market_valuation_snapshots import finnhub_fallback as fb
+
+    monkeypatch.setattr(fb, "_finnhub_fallback_enabled", lambda: True)
+    calls = {"n": 0}
+
+    async def _metrics(symbol):  # noqa: ANN001
+        calls["n"] += 1
+        return {"roe": 1.0}
+
+    monkeypatch.setattr(fb, "fetch_valuation_finnhub", _metrics)
+    # every field present → no finnhub call
+    raw = {
+        "ROE": 15.0, "PER": 8.0, "PBR": 0.9, "Dividend Yield": 0.02,
+        "marketCap": 3e9, "yearHigh": 100.0, "yearLow": 80.0,
+        "high_52w_date": "2026-01-01",
+    }
+    out = await fb.apply_valuation_fallback("AAPL", raw, yahoo_failed=False)
+    assert calls["n"] == 0
+    assert "_field_provenance" not in out
+
+
+

--- a/tests/test_market_valuation_finnhub_fallback_rob434.py
+++ b/tests/test_market_valuation_finnhub_fallback_rob434.py
@@ -255,5 +255,33 @@ async def test_fetcher_total_failure_reraises_when_disabled(monkeypatch) -> None
         await builder.default_valuation_fetcher("AAPL", "us")
 
 
+@pytest.mark.unit
+def test_aggregate_reporting_from_payloads() -> None:
+    from decimal import Decimal
+
+    from app.jobs.market_valuation_snapshots import _aggregate_report
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotUpsert,
+    )
+
+    p1 = MarketValuationSnapshotUpsert(
+        market="us", symbol="AAA", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
+        per=Decimal("8"), roe=Decimal("18"), market_cap=Decimal("3e9"),
+        raw_payload={"_field_provenance": {"roe": "finnhub"}},
+    )
+    p2 = MarketValuationSnapshotUpsert(
+        market="us", symbol="BBB", snapshot_date=dt.date(2026, 6, 9), source="yahoo",
+        per=Decimal("9"), roe=None, market_cap=Decimal("5e9"),
+        raw_payload={},
+    )
+    backfill, coverage = _aggregate_report([p1, p2])
+    assert backfill == {"roe": 1}  # only p1's roe was finnhub
+    assert coverage["per"] == 2
+    assert coverage["roe"] == 1  # p2 roe is None
+    assert coverage["market_cap"] == 2
+    assert coverage["pbr"] == 0
+
+
+
 
 


### PR DESCRIPTION
## What
When yahoo `.info` leaves US `market_valuation_snapshots` fields null (operator **"ROE rows 0"** / `Invalid Crumb / Session is closed`) or fails entirely, backfill the missing valuation fields from Finnhub `company_basic_financials` metric — **one call per symbol, only on a gap**. Keeps `source='yahoo'`; per-field provenance in `raw_payload._field_provenance`. **Migration 0.**

This is the deferred Finnhub-fallback piece of the **ROB-434 umbrella** (`/spec` D1: "yfinance primary, Finnhub fallback — 구현 후속"). Children ROB-440 (Phase 1) / ROB-441 (Phase 2) already merged; this completes the umbrella's remaining scope. (No new Linear issue — tracked under ROB-434 to respect the team's Linear quota.)

## Design / Plan (committed)
- Spec: `docs/superpowers/specs/2026-06-09-rob-434-us-market-valuation-finnhub-fallback-design.md`
- Plan: `docs/superpowers/plans/2026-06-09-rob-434-us-market-valuation-finnhub-fallback.md`

## Decisions (brainstormed)
- **Scope:** valuation table only (the table behind the operator symptom; feeds `high_yield_value` + `undervalued_breakout`).
- **Provenance:** field-fill keeping `source='yahoo'`, **no migration**; per-field source in `raw_payload._field_provenance`.
- **Backfill scope:** all missing valuation fields (one metric call).
- **Toggle:** `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED` (default **off**); inert without `FINNHUB_API_KEY`.

## Unit traps (nailed in tests)
`roeTTM` already percent (no ×100) · `marketCapitalization` millions→absolute (×1e6) · `dividendYieldIndicatedAnnual` percent→ratio (÷100) · `52WeekHighDate` → ISO date. Independently verified correct against the stored column scales (not just self-fulfilling asserts).

## Adversarial review + fix
A 3-lens adversarial review caught a **major** defect (since fixed, commit `3a1986fa`): `high_52w_date` was in the gap field-set, but the default bulk path (`include_high_date=False`) never fetches it → `_has_missing_fields` was always true → Finnhub would fire for **every** symbol, defeating the per-symbol-only-on-gap rate-limit boundary. Fix restricts gap-detection + fill to the 7 core fields on the bulk path; `high_52w_date` is a gap/fill target only on the opt-in run. Added regression test (the masking test now uses the real bulk-path raw) + a real-path multi-field merge test. Fail-closed/safety lens: **zero blockers**.

## Safety
- Default-off + no-key inert → **byte-identical** to today (verified). Fail-closed preserved (no fabrication, never crashes). broker/order/watch mutation 0. KR + fundamentals table untouched. Read-time quality guard unchanged — a backfilled row must pass it (integration-tested: `market_cap≥$100M`, `roe≤300%`).

## Verification
- `34 + 3` unit + `1` integration pass; `ty check app/` clean; `ruff check` + `ruff format --check` clean (incl. fixing 2 files the prior `style` commit left non-compliant).
- Regression sweep over all 22 valuation/screener/guard test files: green in isolation. (5 KR-preset/double_buy tests flake only under shared-DB run-ordering — confirmed pre-existing local DB-pollution, **passes on clean `origin/main` too**, no path to these changes.)

## Operator follow-up (out of PR)
Set `FINNHUB_API_KEY` + `MARKET_VALUATION_FINNHUB_FALLBACK_ENABLED=true`, run dry-run build, review the new `finnhub backfill` / `non-null coverage` summary, then `--commit`. Runbook: `docs/runbooks/invest-screener-snapshots.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)