### PR TITLE
fix: route KIS mock fill evidence smoke via client facade

### DIFF
--- a/scripts/kis_mock_fill_evidence_smoke.py
+++ b/scripts/kis_mock_fill_evidence_smoke.py
@@ -74,7 +74,7 @@ async def run_smoke(args: argparse.Namespace) -> int:
 
     client = _create_kis_client(is_mock=True)
     try:
-        rows = await client.domestic_orders.inquire_daily_order_domestic(
+        rows = await client.inquire_daily_order_domestic(
             start_date=args.from_date,
             end_date=args.to_date,
             stock_code=args.symbol or "",

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -70,6 +70,7 @@ async def session() -> AsyncSession:
             )
             try:
                 async with engine.begin() as conn:
+                    await conn.execute(sa.text("CREATE SCHEMA IF NOT EXISTS review"))
                     await conn.run_sync(
                         Base.metadata.create_all,
                         tables=INVESTMENT_REPORTS_TABLES,

--- a/tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -32,7 +32,7 @@ async def test_classifies_when_order_no_given(mocker) -> None:
     mocker.patch.object(smoke.settings, "kis_mock_app_secret", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_account_no", "fake")
     fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         return_value=[
             {"odno": "123456", "ord_qty": "1", "tot_ccld_qty": "1", "avg_prvs": "70000"}
         ]
@@ -40,6 +40,13 @@ async def test_classifies_when_order_no_given(mocker) -> None:
     mocker.patch.object(smoke, "_create_kis_client", return_value=fake_client)
     rc = await smoke.run_smoke(smoke._parse_args(["--order-no", "123456"]))
     assert rc == 0
+    fake_client.inquire_daily_order_domestic.assert_awaited_once_with(
+        start_date=ANY,
+        end_date=ANY,
+        stock_code="",
+        order_number="123456",
+        is_mock=True,
+    )
 
 
 @pytest.mark.unit
@@ -50,7 +57,7 @@ async def test_inquiry_error_returns_2(mocker) -> None:
     mocker.patch.object(smoke.settings, "kis_mock_app_secret", "fake")
     mocker.patch.object(smoke.settings, "kis_mock_account_no", "fake")
     fake_client = mocker.MagicMock()
-    fake_client.domestic_orders.inquire_daily_order_domestic = AsyncMock(
+    fake_client.inquire_daily_order_domestic = AsyncMock(
         side_effect=RuntimeError("boom")
     )
     mocker.patch.object(smoke, "_create_kis_client", return_value=fake_client)


### PR DESCRIPTION
## Summary
- Route `scripts.kis_mock_fill_evidence_smoke` through the public `KISClient.inquire_daily_order_domestic` facade instead of the non-existent `client.domestic_orders` attribute.
- Update ROB-334/338 fill-evidence CLI tests so they assert the facade call shape and preserve the read-only error path.

## Operator evidence
- Before fix, ROB-338 preflight failed with: `'KISClient' object has no attribute 'domestic_orders'`.
- After fix, read-only KIS mock daily execution inquiry returned HTTP 200 and `rows=0` without broker mutation.
- Sanitized smoke log: `/tmp/rob338-fill-evidence-readonly-after-fix-20260609-230703.log`.

## Validation
- `uv run ruff check scripts/kis_mock_fill_evidence_smoke.py tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py`
- `uv run ruff format --check scripts/kis_mock_fill_evidence_smoke.py tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py`
- `uv run pytest tests/brokers/kis/mock_scalping_exec/test_fill_evidence_smoke_cli.py -q`
- `python -m scripts.kis_mock_fill_evidence_smoke --help` with dummy env

No KIS mock order was submitted by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated fill-evidence smoke test mock configurations and assertions.

* **Refactor**
  * Adjusted internal API call patterns in mock utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->