### PR TITLE
fix: filter KR DART fundamentals universe

### DIFF
--- a/app/jobs/financial_fundamentals_snapshots.py
+++ b/app/jobs/financial_fundamentals_snapshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -75,6 +76,89 @@ def _validate_market(market: str) -> str:
     return market_norm
 
 
+_KR_COMMON_SYMBOL_RE = re.compile(r"^\d{6}$")
+_KR_PREFERRED_NAME_RE = re.compile(r"(?:\d+)?우B?$|우선주")
+_KR_ETF_OR_STRUCTURED_PREFIXES = (
+    "ACE",
+    "ARIRANG",
+    "BNK",
+    "HANARO",
+    "HK",
+    "IBK",
+    "ITF",
+    "KBSTAR",
+    "KODEX",
+    "KOSEF",
+    "KTOP",
+    "마이티",
+    "PLUS",
+    "RISE",
+    "SOL",
+    "TIMEFOLIO",
+    "TIGER",
+    "TREX",
+    "UNICORN",
+    "WOORI",
+    "1Q",
+)
+_KR_NON_COMMON_NAME_TOKENS = (
+    "ETF",
+    "ETN",
+    "스팩",
+    "기업인수목적",
+    "커버드콜",
+    "액티브",
+    "합성",
+    "회사채",
+    "국고채",
+    "채권",
+    "인프라",
+    "리츠",
+    "REIT",
+    "선박투자",
+    "부동산투자",
+)
+
+
+def _compact_name(name: str) -> str:
+    return "".join(str(name or "").split())
+
+
+def is_dart_common_kr_equity(symbol: str, name: str) -> bool:
+    """Return True for KR ordinary/common stocks suitable for DART fundamentals.
+
+    ``kr_symbol_universe`` is venue-sourced and includes ETFs/ETNs/SPACs,
+    alphanumeric issue codes, preferred shares, REITs, and infrastructure funds.
+    DART fundamentals backfill should spend request budget only on ordinary equity
+    stock codes; otherwise --skip-existing eventually burns the daily quota on the
+    non-common tail that OpenDART cannot resolve.
+    """
+
+    symbol_norm = str(symbol or "").strip().upper()
+    if _KR_COMMON_SYMBOL_RE.fullmatch(symbol_norm) is None:
+        return False
+
+    name_norm = _compact_name(name)
+    if not name_norm:
+        return False
+
+    name_upper = name_norm.upper()
+    if _KR_PREFERRED_NAME_RE.search(name_norm):
+        return False
+    if any(
+        name_upper.startswith(prefix.upper())
+        for prefix in _KR_ETF_OR_STRUCTURED_PREFIXES
+    ):
+        return False
+    if any(token.upper() in name_upper for token in _KR_NON_COMMON_NAME_TOKENS):
+        return False
+    return True
+
+
+def _common_symbols_from_rows(rows: list[tuple[str, str]]) -> list[str]:
+    return [symbol for symbol, name in rows if is_dart_common_kr_equity(symbol, name)]
+
+
 async def resolve_symbols(market: str, override: list[str], limit: int) -> list[str]:
     _validate_market(market)
     if override:
@@ -83,13 +167,12 @@ async def resolve_symbols(market: str, override: list[str], limit: int) -> list[
         from app.models.kr_symbol_universe import KRSymbolUniverse
 
         stmt = (
-            sa.select(KRSymbolUniverse.symbol)
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name)
             .where(KRSymbolUniverse.is_active.is_(True))
             .order_by(KRSymbolUniverse.symbol)
-            .limit(limit)
         )
         result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
+        return _common_symbols_from_rows(list(result.all()))[:limit]
 
 
 async def resolve_active_universe(market: str) -> list[str]:
@@ -98,12 +181,12 @@ async def resolve_active_universe(market: str) -> list[str]:
         from app.models.kr_symbol_universe import KRSymbolUniverse
 
         stmt = (
-            sa.select(KRSymbolUniverse.symbol)
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name)
             .where(KRSymbolUniverse.is_active.is_(True))
             .order_by(KRSymbolUniverse.symbol)
         )
         result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
+        return _common_symbols_from_rows(list(result.all()))
 
 
 async def _already_collected_symbols(market: str) -> set[str]:

--- a/tests/test_financial_fundamentals_job.py
+++ b/tests/test_financial_fundamentals_job.py
@@ -5,8 +5,10 @@ from contextlib import AbstractAsyncContextManager
 
 import pandas as pd
 import pytest
+import sqlalchemy as sa
 
 from app.jobs import financial_fundamentals_snapshots as job
+from app.models.kr_symbol_universe import KRSymbolUniverse
 from app.services.financial_fundamentals_snapshots.builder import (
     RawAnnualFiling,
     RawFundamentalsBundle,
@@ -54,6 +56,82 @@ async def _fake_fetcher(
         annual=(RawAnnualFiling(bsns_year=2024, rcept_no="r1", income_statement=df),),
         filing_dates={"r1": dt.date(2025, 3, 20)},
     )
+
+
+@pytest.mark.parametrize(
+    ("symbol", "name", "expected"),
+    [
+        ("005930", "삼성전자", True),
+        ("035420", "NAVER", True),
+        ("000087", "하이트진로2우B", False),
+        ("005935", "삼성전자우", False),
+        ("069500", "KODEX 200", False),
+        ("0000H0", "KODEX 인도Nifty미드캡100", False),
+        ("0004Y0", "디비금융제14호스팩", False),
+        ("123456", "맥쿼리인프라", False),
+    ],
+)
+def test_dart_common_kr_equity_filter_excludes_non_common(symbol, name, expected):
+    assert job.is_dart_common_kr_equity(symbol, name) is expected
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_resolve_symbols_filters_common_kr_equities_before_limit(
+    bind_job_session, db_session
+):
+    symbols = ["0000H0", "000001", "000002", "000003", "000004", "000005"]
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_(symbols))
+    )
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol="0000H0",
+                name="KODEX 인도Nifty미드캡100",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="000001",
+                name="테스트보통주A",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="000002",
+                name="테스트보통주A우",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="000003",
+                name="TIGER 테스트ETF",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="000004",
+                name="테스트제1호스팩",
+                exchange="KOSDAQ",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol="000005",
+                name="테스트보통주B",
+                exchange="KOSDAQ",
+                is_active=True,
+            ),
+        ]
+    )
+    await db_session.commit()
+    try:
+        assert await job.resolve_symbols("kr", [], 2) == ["000001", "000005"]
+    finally:
+        await db_session.execute(
+            sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_(symbols))
+        )
+        await db_session.commit()
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Add a DART-oriented KR common-stock filter for `build_financial_fundamentals_snapshots` candidate resolution.
- Exclude alphanumeric issue codes, preferred shares, ETFs/ETNs, SPACs, REIT/infrastructure/bond-like instruments before applying `--limit`/`--skip-existing`.
- Add regression coverage for the filter and for resolving common-stock candidates before limit truncation.

## Operator evidence
- Previous prod operator run returned `snapshots_built=0` because the remaining `--skip-existing` universe was dominated by non-common instruments (e.g. ETF/SPAC/preferred/alphanumeric codes).
- Read-only prod preflight with this branch:
  - `/tmp/rob433-filtered-universe-preflight-20260610.log`
  - active_total=3913, common_total=2574, rejected_total=1339
  - first common candidates now start with ordinary stocks: `000020:동화약품`, `000040:KR모터스`, ...
- Estimate-only prod preflight with this branch:
  - `/tmp/rob433-estimate-after-filter-20260610.log`
  - `--skip-existing`: 2493 already-collected skipped; 81 uncollected remain
  - projected DART requests: 3321 (budget 18000)
  - no fetch, no DB writes

## Tests
- `uv run ruff check app/jobs/financial_fundamentals_snapshots.py tests/test_financial_fundamentals_job.py`
- `uv run ruff format --check app/jobs/financial_fundamentals_snapshots.py tests/test_financial_fundamentals_job.py`
- `uv run pytest tests/test_financial_fundamentals_job.py -q` (14 passed)

Refs ROB-433
