### PR TITLE
feat(ROB-345/346/347): US /invest/reports — journal 매핑 복구 + 후보 universe 품질·우선순위 + 예산 전제

### DIFF
--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -877,6 +877,8 @@ async def investment_report_generate_from_bundle_impl(
     user_id: int | None = None,
     overwrite_existing: bool = False,
     overwrite_reason: str | None = None,
+    budget_basis: str = "available_usd",
+    operator_budget_override_usd: float | None = None,
 ) -> dict:
     """Generate a snapshot-backed advisory report.
 
@@ -994,6 +996,8 @@ async def investment_report_generate_from_bundle_impl(
         "user_id": resolved_user_id,
         "overwrite_existing": overwrite_existing,
         "overwrite_reason": overwrite_reason,
+        "budget_basis": budget_basis,
+        "operator_budget_override_usd": operator_budget_override_usd,
     }
     request = ReportGenerationRequest.model_validate(payload)
 

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -122,3 +122,28 @@ def demote_for_quality(
         if flag in quality_flags:
             return "watch_only", flag
     return "buy_review", None
+
+
+def demote_for_budget(
+    verdict: str, budget_state: dict[str, Any]
+) -> tuple[str, list[str]]:
+    """ROB-347 — post-verdict budget demotion. Only buy_review is touched;
+    budget never upgrades. KRW is reference-only (no KRW→USD fabrication).
+    Returns (new_verdict, reasons)."""
+    if verdict != "buy_review":
+        return verdict, []
+    basis = budget_state.get("basis") or "available_usd"
+    override = budget_state.get("override_usd")
+    krw = budget_state.get("krw") or 0
+    # request override (operator/report budget) takes precedence when present.
+    usd = override if override is not None else budget_state.get("usd")
+    if basis == "krw_orderable_reference" and override is None:
+        return "watch_only", ["fx_required"]
+    if usd is not None and usd > 0:
+        return "buy_review", []
+    reasons = ["budget_gap"]
+    if krw and krw > 0:
+        reasons.append("fx_required")
+    if override is None:
+        reasons.append("operator_budget_required")
+    return "watch_only", reasons

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -96,3 +96,29 @@ def classify_candidate_symbol(
     if not universe_useful or not candidate_fresh:
         return "watch_only"
     return "buy_review"
+
+
+_QUALITY_WATCH_ORDER: tuple[str, ...] = (
+    "penny",
+    "illiquid",
+    "abnormal_spike",
+    "screener_stale",
+)
+
+
+def demote_for_quality(
+    verdict: str, quality_flags: frozenset[str]
+) -> tuple[str, str | None]:
+    """ROB-346 — post-verdict quality demotion. Quality only DEMOTES (never
+    upgrades). non_common_stock is always rejected; otherwise only buy_review
+    is touched. Returns (new_verdict, reason | None)."""
+    if "non_common_stock" in quality_flags:
+        return "rejected", "non_common_stock"
+    if verdict != "buy_review":
+        return verdict, None
+    if "common_stock_unknown" in quality_flags:
+        return "data_gap", "common_stock_unknown"
+    for flag in _QUALITY_WATCH_ORDER:
+        if flag in quality_flags:
+            return "watch_only", flag
+    return "buy_review", None

--- a/app/services/action_report/snapshot_backed/action_verdict.py
+++ b/app/services/action_report/snapshot_backed/action_verdict.py
@@ -98,6 +98,9 @@ def classify_candidate_symbol(
     return "buy_review"
 
 
+# Deterministic tiebreak when several watch-grade flags co-occur — the first
+# matching flag becomes the surfaced reason (penny > illiquid > abnormal_spike >
+# screener_stale). Order is policy, not derivable from code.
 _QUALITY_WATCH_ORDER: tuple[str, ...] = (
     "penny",
     "illiquid",

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -47,6 +47,7 @@ from app.services.action_report.snapshot_backed.action_verdict import (
     VERDICT_TO_BUCKET,
     classify_candidate_symbol,
     classify_held_symbol,
+    demote_for_quality,
 )
 from app.services.market_events.catalyst.contract import CatalystEvent
 from app.services.market_events.catalyst.guard import evaluate_catalyst_guard
@@ -56,6 +57,18 @@ from app.services.market_events.catalyst.polarity import (
 )
 
 _KST = ZoneInfo("Asia/Seoul")
+
+_REASON_KO: dict[str, str] = {
+    "low_liquidity": "저유동성",
+    "beyond_candidate_budget": "후보 예산 초과",
+    "screener_stale": "스크리너 stale",
+    "penny": "저가주",
+    "illiquid": "초저유동성",
+    "abnormal_spike": "비정상 급등",
+    "non_common_stock": "일반주 아님(ETF/우선주 등)",
+    "common_stock_unknown": "종목 분류 미확인",
+    "quote_missing": "호가 스냅샷 없음",
+}
 CATALYST_GUARD_WITHIN_DAYS = 7
 
 
@@ -268,6 +281,10 @@ def _candidate_item(
         "candidate_source_preset": cand.get("source_preset"),
         "candidate_data_state": cand.get("data_state"),
         "candidate_toss_parity_status": cand.get("toss_parity_status"),
+        # ROB-346 quality fields
+        "quality_flags": cand.get("quality_flags"),
+        "confidence_cap": cand.get("confidence_cap"),
+        "candidate_priority_score": cand.get("priority_score"),
         "news_matches": news_match_count,
         "quote_status": q.get("status") if quote is not None else "no_snapshot",
         "best_bid": q.get("best_bid"),
@@ -289,16 +306,13 @@ def _candidate_item(
             f"quote best_bid {q.get('best_bid')}, spread_bps {q.get('spread_bps')})"
         )
     elif is_gap:
-        rationale = f"신규 후보 판단 보류 — {sym} (호가 스냅샷 없음)"
-    elif reject_or_wait_reason == "low_liquidity":
-        rationale = (
-            f"신규 후보 관망 {priority}순위 — {sym} "
-            f"(저유동성: spread_bps {q.get('spread_bps')})"
-        )
-    elif reject_or_wait_reason == "beyond_candidate_budget":
-        rationale = f"신규 후보 관망 {priority}순위 — {sym} (후보 예산 초과)"
-    else:  # screener_stale
-        rationale = f"신규 후보 관망 {priority}순위 — {sym} (스크리너 stale)"
+        if reject_or_wait_reason == "common_stock_unknown":
+            rationale = f"신규 후보 판단 보류 — {sym} (종목 분류 미확인)"
+        else:
+            rationale = f"신규 후보 판단 보류 — {sym} (호가 스냅샷 없음)"
+    else:
+        reason_ko = _REASON_KO.get(reject_or_wait_reason or "", "관망")
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} ({reason_ko})"
 
     return IngestReportItem(
         client_item_key=(f"auto-buy-{sym}" if is_buy else f"auto-cand-{verdict}-{sym}"),
@@ -461,22 +475,28 @@ class EvidenceAutoEmitter:
         # candidate is silently dropped (ROB-350). Always-on whenever a
         # candidate_universe snapshot is present, independent of intraday_floor.
         buy_emitted = 0
+        demoted_emitted = 0
+        _MAX_DEMOTED_SHOWN = 10
         for cand in sorted(candidate_order, key=_candidate_sort_key):
             sym = cand.get("symbol")
             if not isinstance(sym, str) or sym in held:
                 continue  # held names handled by held_and_trending below
             symbol_pair = symbol_quotes.get(sym)
             quote = symbol_pair[1] if symbol_pair else None
-            verdict = classify_candidate_symbol(
+            base_verdict = classify_candidate_symbol(
                 quote,
                 universe_useful=candidate_actionable,
                 quote_snapshot_present=symbol_pair is not None,
                 candidate_fresh=(cand.get("data_state") or "fresh") == "fresh",
             )
-            reject_or_wait_reason: str | None = None
-            if verdict == "data_gap":
+            # ROB-346 — quality demotion (pure, no signature change).
+            quality_flags = frozenset(cand.get("quality_flags") or [])
+            verdict, reject_or_wait_reason = demote_for_quality(
+                base_verdict, quality_flags
+            )
+            if verdict == "data_gap" and reject_or_wait_reason is None:
                 reject_or_wait_reason = "quote_missing"
-            elif verdict == "watch_only":
+            elif verdict == "watch_only" and reject_or_wait_reason is None:
                 reject_or_wait_reason = (
                     "low_liquidity"
                     if symbol_pair is not None and not _quote_is_actionable(quote)
@@ -488,6 +508,11 @@ class EvidenceAutoEmitter:
                     reject_or_wait_reason = "beyond_candidate_budget"
                 else:
                     buy_emitted += 1
+
+            if verdict != "buy_review":
+                if demoted_emitted >= _MAX_DEMOTED_SHOWN:
+                    continue  # 노이즈 방지: 상위 N개 데모션만 카드화(집계는 candidate snapshot)
+                demoted_emitted += 1
 
             candidate_rank = _candidate_rank(cand)
             priority = candidate_rank if candidate_rank is not None else buy_emitted

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -513,9 +513,13 @@ class EvidenceAutoEmitter:
                 base_verdict, quality_flags
             )
             # ROB-347 — budget demotion (buy_review only; never fabricates USD).
-            verdict, budget_reasons = demote_for_budget(verdict, budget_state)
-            if budget_reasons and reject_or_wait_reason is None:
-                reject_or_wait_reason = budget_reasons[0]
+            # Applies only to US market under kis_live account scope.
+            if request_market == "us" and account_scope == "kis_live":
+                verdict, budget_reasons = demote_for_budget(verdict, budget_state)
+                if budget_reasons and reject_or_wait_reason is None:
+                    reject_or_wait_reason = budget_reasons[0]
+            else:
+                budget_reasons = []
 
             if verdict == "data_gap" and reject_or_wait_reason is None:
                 reject_or_wait_reason = "quote_missing"

--- a/app/services/action_report/snapshot_backed/auto_emit.py
+++ b/app/services/action_report/snapshot_backed/auto_emit.py
@@ -47,6 +47,7 @@ from app.services.action_report.snapshot_backed.action_verdict import (
     VERDICT_TO_BUCKET,
     classify_candidate_symbol,
     classify_held_symbol,
+    demote_for_budget,
     demote_for_quality,
 )
 from app.services.market_events.catalyst.contract import CatalystEvent
@@ -68,6 +69,9 @@ _REASON_KO: dict[str, str] = {
     "non_common_stock": "일반주 아님(ETF/우선주 등)",
     "common_stock_unknown": "종목 분류 미확인",
     "quote_missing": "호가 스냅샷 없음",
+    "budget_gap": "신규매수 예산 부족",
+    "fx_required": "달러(USD) 환전 필요",
+    "operator_budget_required": "운영자 예산 설정 필요",
 }
 CATALYST_GUARD_WITHIN_DAYS = 7
 
@@ -265,6 +269,7 @@ def _candidate_item(
     reject_or_wait_reason: str | None,
     candidate_usefulness: str | None,
     news_match_count: int,
+    budget_evidence: dict[str, Any] | None = None,
 ) -> IngestReportItem:
     is_buy = verdict == "buy_review"
     is_gap = verdict == "data_gap"
@@ -298,6 +303,9 @@ def _candidate_item(
     }
     if reject_or_wait_reason is not None:
         extra["reject_or_wait_reason"] = reject_or_wait_reason
+
+    if budget_evidence:
+        extra.update(budget_evidence)
 
     if is_buy:
         rationale = (
@@ -350,6 +358,8 @@ class EvidenceAutoEmitter:
         snapshots: list[Any],
         request_market: str,
         account_scope: str | None,
+        budget_basis: str = "available_usd",
+        operator_budget_override_usd: Any | None = None,
         now: dt.datetime | None = None,
     ) -> list[IngestReportItem]:
         """Emit review-only ``IngestReportItem`` drafts from the bundle's
@@ -415,6 +425,14 @@ class EvidenceAutoEmitter:
                     )
                     for sym in citation.symbols:
                         run_card_evidence_by_symbol.setdefault(sym, evidence)
+
+        buying_power = portfolio_payload.get("buying_power") or {}
+        budget_state = {
+            "basis": budget_basis,
+            "override_usd": _to_float(operator_budget_override_usd),
+            "usd": _to_float(buying_power.get("usd")),
+            "krw": _to_float(buying_power.get("krw")),
+        }
 
         held = _held_kis_symbols(portfolio_payload)
         candidate_actionable = candidate_usefulness == "useful"
@@ -494,6 +512,11 @@ class EvidenceAutoEmitter:
             verdict, reject_or_wait_reason = demote_for_quality(
                 base_verdict, quality_flags
             )
+            # ROB-347 — budget demotion (buy_review only; never fabricates USD).
+            verdict, budget_reasons = demote_for_budget(verdict, budget_state)
+            if budget_reasons and reject_or_wait_reason is None:
+                reject_or_wait_reason = budget_reasons[0]
+
             if verdict == "data_gap" and reject_or_wait_reason is None:
                 reject_or_wait_reason = "quote_missing"
             elif verdict == "watch_only" and reject_or_wait_reason is None:
@@ -514,6 +537,15 @@ class EvidenceAutoEmitter:
                     continue  # 노이즈 방지: 상위 N개 데모션만 카드화(집계는 candidate snapshot)
                 demoted_emitted += 1
 
+            budget_evidence = {
+                "budget_basis": budget_state["basis"],
+                "available_usd": budget_state["usd"],
+                "krw_orderable_reference": budget_state["krw"],
+                "operator_budget_override_usd": budget_state["override_usd"],
+                "budget_reasons": budget_reasons,
+                "budget_fit": verdict == "buy_review" and not budget_reasons,
+            }
+
             candidate_rank = _candidate_rank(cand)
             priority = candidate_rank if candidate_rank is not None else buy_emitted
             cand_item = _stamp(
@@ -530,6 +562,7 @@ class EvidenceAutoEmitter:
                     reject_or_wait_reason=reject_or_wait_reason,
                     candidate_usefulness=candidate_usefulness,
                     news_match_count=news_matches.get(sym, 0),
+                    budget_evidence=budget_evidence,
                 ),
                 verdict,
             )

--- a/app/services/action_report/snapshot_backed/candidate_quality.py
+++ b/app/services/action_report/snapshot_backed/candidate_quality.py
@@ -1,0 +1,91 @@
+"""Pure US new-buy candidate quality gates + priority (ROB-346). No I/O.
+
+Units: change_rate / week_change_rate are PERCENT (10.0 == +10%); latest_close
+is USD; daily_volume is shares. Conservative thresholds (spec §3.3).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+PENNY_PRICE_USD = 5.0
+ILLIQUID_DOLLAR_VOLUME_USD = 5_000_000.0
+ABNORMAL_DAY_CHANGE_PCT = 15.0
+ABNORMAL_WEEK_CHANGE_PCT = 50.0
+STALE_CONFIDENCE_CAP = 40
+
+
+def _f(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def dollar_volume_usd(latest_close: Any, daily_volume: Any) -> float | None:
+    close = _f(latest_close)
+    vol = _f(daily_volume)
+    if close is None or vol is None:
+        return None
+    return close * vol
+
+
+def compute_quality_flags(
+    *,
+    latest_close: Any,
+    daily_volume: Any,
+    change_rate: Any,
+    week_change_rate: Any,
+    is_common_stock: bool | None,
+    screener_stale: bool,
+) -> frozenset[str]:
+    flags: set[str] = set()
+    if is_common_stock is False:
+        flags.add("non_common_stock")
+    elif is_common_stock is None:
+        flags.add("common_stock_unknown")
+    close = _f(latest_close)
+    if close is not None and close < PENNY_PRICE_USD:
+        flags.add("penny")
+    dv = dollar_volume_usd(latest_close, daily_volume)
+    if dv is not None and dv < ILLIQUID_DOLLAR_VOLUME_USD:
+        flags.add("illiquid")
+    cr = _f(change_rate)
+    wcr = _f(week_change_rate)
+    if (cr is not None and cr > ABNORMAL_DAY_CHANGE_PCT) or (
+        wcr is not None and wcr > ABNORMAL_WEEK_CHANGE_PCT
+    ):
+        flags.add("abnormal_spike")
+    if screener_stale:
+        flags.add("screener_stale")
+    return frozenset(flags)
+
+
+def compute_priority_score(
+    *,
+    latest_close: Any,
+    daily_volume: Any,
+    change_rate: Any,
+    quality_flags: frozenset[str],
+) -> float:
+    dv = dollar_volume_usd(latest_close, daily_volume) or 0.0
+    liquidity_term = min(1.0, math.log10(max(dv, 1.0)) / 9.0)  # 9 ≈ log10($1B)
+    cr = _f(change_rate) or 0.0
+    momentum_term = max(-5.0, min(10.0, cr)) / 10.0
+    spike_penalty = 1.0 if "abnormal_spike" in quality_flags else 0.0
+    stale_penalty = 1.0 if "screener_stale" in quality_flags else 0.0
+    return (
+        1.0 * liquidity_term
+        + 0.5 * momentum_term
+        - 0.5 * spike_penalty
+        - 0.3 * stale_penalty
+    )
+
+
+def confidence_cap_for(quality_flags: frozenset[str]) -> int | None:
+    if "screener_stale" in quality_flags or "common_stock_unknown" in quality_flags:
+        return STALE_CONFIDENCE_CAP
+    return None

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -39,6 +39,12 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 from app.services.screener_evidence import CandidateEvidence, build_candidate_evidence
+from app.services.action_report.snapshot_backed.candidate_quality import (
+    compute_priority_score,
+    compute_quality_flags,
+    confidence_cap_for,
+    dollar_volume_usd,
+)
 
 TOP_N = 10
 logger = logging.getLogger(__name__)
@@ -319,9 +325,16 @@ class CandidateUniverseSnapshotCollector:
         usefulness = _classify_usefulness(
             actionable=coverage.fresh_count, stale=coverage.stale_count
         )
-        rows = await self._equity_repo.list_top_candidates(
-            market=request.market, limit=limit
-        )
+        is_us = request.market == "us"
+        if is_us:
+            pool_limit = max(limit * 5, 50)
+            rows = await self._equity_repo.list_candidate_pool(
+                market=request.market, limit=pool_limit
+            )
+        else:
+            rows = await self._equity_repo.list_top_candidates(
+                market=request.market, limit=limit
+            )
         rows = _dedupe_rows(rows, key=lambda r: to_db_symbol(r.symbol))
         latest_partition_date = (
             getattr(rows[0], "snapshot_date", None) if rows else None
@@ -336,6 +349,38 @@ class CandidateUniverseSnapshotCollector:
             preset="top_gainers",
             rows=[_equity_row_to_input(r) for r in rows],
         )
+
+        quality_by_symbol: dict[str, dict[str, Any]] | None = None
+        if is_us:
+            stale = days_stale > 0 or usefulness != "useful"
+            flags_by_symbol = await self._equity_repo.common_stock_flags(
+                [r.symbol for r in rows]
+            )
+            quality_by_symbol = {}
+            for r in rows:
+                qf = compute_quality_flags(
+                    latest_close=r.latest_close,
+                    daily_volume=r.daily_volume,
+                    change_rate=r.change_rate,
+                    week_change_rate=r.week_change_rate,
+                    is_common_stock=flags_by_symbol.get(r.symbol),
+                    screener_stale=stale,
+                )
+                quality_by_symbol[r.symbol] = {
+                    "quality_flags": sorted(qf),
+                    "dollar_volume_usd": dollar_volume_usd(r.latest_close, r.daily_volume),
+                    "priority_score": compute_priority_score(
+                        latest_close=r.latest_close,
+                        daily_volume=r.daily_volume,
+                        change_rate=r.change_rate,
+                        quality_flags=qf,
+                    ),
+                    "confidence_cap": confidence_cap_for(qf),
+                    "is_common_stock": flags_by_symbol.get(r.symbol),
+                    "week_change_rate": float(r.week_change_rate)
+                    if r.week_change_rate is not None else None,
+                }
+
         return [
             self._build_candidate_result(
                 request=request,
@@ -351,6 +396,7 @@ class CandidateUniverseSnapshotCollector:
                 expected_baseline_date=baseline,
                 latest_partition_date=latest_partition_date,
                 days_stale=days_stale,
+                quality_by_symbol=quality_by_symbol,
             )
         ]
 
@@ -482,12 +528,27 @@ class CandidateUniverseSnapshotCollector:
         expected_baseline_date: dt.date | None = None,
         latest_partition_date: dt.date | None = None,
         days_stale: int = 0,
+        quality_by_symbol: dict[str, dict[str, Any]] | None = None,
     ) -> SnapshotCollectResult:
         freshness_status = _FRESHNESS_BY_USEFULNESS.get(usefulness, "partial")
         # ROB-359 Scope E — stamp universe-level lineage onto each candidate dict
         # so a new-buy report item is self-describing (preset hit / freshness /
         # Toss parity status) without needing the universe payload for context.
         toss_parity_status = _toss_parity_status(preset, market)
+
+        ordered = list(evidence)
+        if quality_by_symbol:
+            ordered = sorted(
+                evidence,
+                key=lambda e: (
+                    -(quality_by_symbol.get(e.symbol, {}).get("priority_score") or 0.0),
+                    -(quality_by_symbol.get(e.symbol, {}).get("dollar_volume_usd") or 0.0),
+                    e.symbol,
+                ),
+            )
+            # slice to the requested candidate_limit
+            ordered = ordered[:candidate_limit]
+
         candidates = [
             {
                 **e.to_payload_dict(),
@@ -495,8 +556,9 @@ class CandidateUniverseSnapshotCollector:
                 "candidate_rank": rank,
                 "data_state": freshness_status,
                 "toss_parity_status": toss_parity_status,
+                **((quality_by_symbol or {}).get(e.symbol, {})),
             }
-            for rank, e in enumerate(evidence, start=1)
+            for rank, e in enumerate(ordered, start=1)
         ]
         universe_count = fresh_count + stale_count
         capped = universe_count > candidate_limit

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -22,6 +22,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.symbol import to_db_symbol
 from app.models.invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
 from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.services.action_report.snapshot_backed.candidate_quality import (
+    compute_priority_score,
+    compute_quality_flags,
+    confidence_cap_for,
+    dollar_volume_usd,
+)
 from app.services.action_report.snapshot_backed.collectors._base import (
     build_result,
     unavailable_result,
@@ -39,12 +45,6 @@ from app.services.investment_snapshots.collectors import (
     SnapshotCollectResult,
 )
 from app.services.screener_evidence import CandidateEvidence, build_candidate_evidence
-from app.services.action_report.snapshot_backed.candidate_quality import (
-    compute_priority_score,
-    compute_quality_flags,
-    confidence_cap_for,
-    dollar_volume_usd,
-)
 
 TOP_N = 10
 logger = logging.getLogger(__name__)
@@ -368,7 +368,9 @@ class CandidateUniverseSnapshotCollector:
                 )
                 quality_by_symbol[r.symbol] = {
                     "quality_flags": sorted(qf),
-                    "dollar_volume_usd": dollar_volume_usd(r.latest_close, r.daily_volume),
+                    "dollar_volume_usd": dollar_volume_usd(
+                        r.latest_close, r.daily_volume
+                    ),
                     "priority_score": compute_priority_score(
                         latest_close=r.latest_close,
                         daily_volume=r.daily_volume,
@@ -378,7 +380,8 @@ class CandidateUniverseSnapshotCollector:
                     "confidence_cap": confidence_cap_for(qf),
                     "is_common_stock": flags_by_symbol.get(r.symbol),
                     "week_change_rate": float(r.week_change_rate)
-                    if r.week_change_rate is not None else None,
+                    if r.week_change_rate is not None
+                    else None,
                 }
 
         return [
@@ -542,7 +545,10 @@ class CandidateUniverseSnapshotCollector:
                 evidence,
                 key=lambda e: (
                     -(quality_by_symbol.get(e.symbol, {}).get("priority_score") or 0.0),
-                    -(quality_by_symbol.get(e.symbol, {}).get("dollar_volume_usd") or 0.0),
+                    -(
+                        quality_by_symbol.get(e.symbol, {}).get("dollar_volume_usd")
+                        or 0.0
+                    ),
                     e.symbol,
                 ),
             )

--- a/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
+++ b/app/services/action_report/snapshot_backed/collectors/candidate_universe.py
@@ -577,6 +577,11 @@ class CandidateUniverseSnapshotCollector:
             "candidate_limit": candidate_limit,
             "universe_count": universe_count,
             "capped": capped,
+            # ROB-346 — pool_size = wide pool evaluated for ranking (US fetches
+            # max(limit*5,50)); displayed_count = candidates after the priority
+            # slice. Makes pool-vs-display transparent to the report UI.
+            "pool_size": len(evidence),
+            "displayed_count": len(candidates),
             "candidates": candidates,
             "fresh_count": fresh_count,
             "actionable_count": fresh_count,
@@ -653,6 +658,11 @@ class CandidateUniverseSnapshotCollector:
             "candidate_limit": candidate_limit,
             "universe_count": universe_count,
             "capped": capped,
+            # ROB-346 — pool_size = wide pool evaluated for ranking (US fetches
+            # max(limit*5,50)); displayed_count = candidates after the priority
+            # slice. Makes pool-vs-display transparent to the report UI.
+            "pool_size": len(evidence),
+            "displayed_count": len(candidates),
             "candidates": candidates,
             "fresh_count": fresh_count,
             "actionable_count": fresh_count,

--- a/app/services/action_report/snapshot_backed/collectors/journal.py
+++ b/app/services/action_report/snapshot_backed/collectors/journal.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import desc, select
+from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
 from app.services.action_report.snapshot_backed.collectors._base import (
     build_result,
     utcnow,
@@ -25,6 +26,14 @@ from app.services.investment_snapshots.collectors import (
 _ACTIVE_STATUSES: tuple[str, ...] = ("draft", "active")
 _RETROSPECTIVE_STATUSES: tuple[str, ...] = ("closed", "stopped", "expired")
 _DEFAULT_RECENT_LIMIT: int = 20
+
+# Mirror get_trade_journal market_map (app/mcp_server/tooling/trade_journal_tools.py)
+# — the only no-migration market discriminator on trade_journals.
+_MARKET_TO_INSTRUMENT: dict[str, InstrumentType] = {
+    "crypto": InstrumentType.crypto,
+    "kr": InstrumentType.equity_kr,
+    "us": InstrumentType.equity_us,
+}
 
 
 class JournalSnapshotCollector:
@@ -41,20 +50,25 @@ class JournalSnapshotCollector:
     async def collect(self, request: CollectorRequest) -> list[SnapshotCollectResult]:
         now = utcnow()
 
+        scope_filters = [TradeJournal.account_type == "live"]
+        itype = _MARKET_TO_INSTRUMENT.get(request.market)
+        if itype is not None:
+            scope_filters.append(TradeJournal.instrument_type == itype)
+        if request.account_scope == "kis_live":
+            # KIS broker scope; legacy rows may carry account=NULL (kis_live_ledger
+            # now writes account="kis"). instrument_type already excludes crypto.
+            scope_filters.append(
+                or_(TradeJournal.account == "kis", TradeJournal.account.is_(None))
+            )
+
         active_stmt = (
             select(TradeJournal)
-            .where(
-                TradeJournal.account_type == "live",
-                TradeJournal.status.in_(_ACTIVE_STATUSES),
-            )
+            .where(*scope_filters, TradeJournal.status.in_(_ACTIVE_STATUSES))
             .order_by(desc(TradeJournal.updated_at))
         )
         recent_stmt = (
             select(TradeJournal)
-            .where(
-                TradeJournal.account_type == "live",
-                TradeJournal.status.in_(_RETROSPECTIVE_STATUSES),
-            )
+            .where(*scope_filters, TradeJournal.status.in_(_RETROSPECTIVE_STATUSES))
             .order_by(desc(TradeJournal.updated_at))
             .limit(self._recent_limit)
         )
@@ -106,6 +120,7 @@ def _journal_to_dict(j: TradeJournal) -> dict[str, Any]:
         "exit_reason": j.exit_reason,
         "pnl_pct": j.pnl_pct,
         "account_type": j.account_type,
+        "account": j.account,
         "created_at": j.created_at,
         "updated_at": j.updated_at,
     }

--- a/app/services/action_report/snapshot_backed/collectors/journal.py
+++ b/app/services/action_report/snapshot_backed/collectors/journal.py
@@ -7,10 +7,13 @@ the only allowed write path, and is intentionally not imported here.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.models.trade_journal import TradeJournal
 from app.models.trading import InstrumentType
@@ -73,8 +76,29 @@ class JournalSnapshotCollector:
             .limit(self._recent_limit)
         )
 
-        active_rows = (await self._session.execute(active_stmt)).scalars().all()
-        recent_rows = (await self._session.execute(recent_stmt)).scalars().all()
+        try:
+            active_rows = (await self._session.execute(active_stmt)).scalars().all()
+            recent_rows = (await self._session.execute(recent_stmt)).scalars().all()
+        except Exception:  # defensive — surface as collector unavailable, never crash
+            logger.exception("journal collector query failed")
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={
+                        "active": [], "recent_retrospective": [],
+                        "active_count": 0, "retrospective_count": 0,
+                        "recent_limit": self._recent_limit,
+                        "collector_status": "unavailable",
+                        "error": "journal_query_failed",
+                    },
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="unavailable",
+                    errors={"reason": "journal_query_failed"},
+                )
+            ]
 
         payload: dict[str, Any] = {
             "active": [_journal_to_dict(j) for j in active_rows],
@@ -82,6 +106,7 @@ class JournalSnapshotCollector:
             "active_count": len(active_rows),
             "retrospective_count": len(recent_rows),
             "recent_limit": self._recent_limit,
+            "collector_status": "ok",
         }
 
         return [

--- a/app/services/action_report/snapshot_backed/collectors/journal.py
+++ b/app/services/action_report/snapshot_backed/collectors/journal.py
@@ -13,8 +13,6 @@ from typing import Any
 from sqlalchemy import desc, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
-
 from app.models.trade_journal import TradeJournal
 from app.models.trading import InstrumentType
 from app.services.action_report.snapshot_backed.collectors._base import (
@@ -25,6 +23,8 @@ from app.services.investment_snapshots.collectors import (
     CollectorRequest,
     SnapshotCollectResult,
 )
+
+logger = logging.getLogger(__name__)
 
 _ACTIVE_STATUSES: tuple[str, ...] = ("draft", "active")
 _RETROSPECTIVE_STATUSES: tuple[str, ...] = ("closed", "stopped", "expired")
@@ -87,8 +87,10 @@ class JournalSnapshotCollector:
                     market=request.market,
                     account_scope=request.account_scope,
                     payload={
-                        "active": [], "recent_retrospective": [],
-                        "active_count": 0, "retrospective_count": 0,
+                        "active": [],
+                        "recent_retrospective": [],
+                        "active_count": 0,
+                        "retrospective_count": 0,
                         "recent_limit": self._recent_limit,
                         "collector_status": "unavailable",
                         "error": "journal_query_failed",

--- a/app/services/action_report/snapshot_backed/generator.py
+++ b/app/services/action_report/snapshot_backed/generator.py
@@ -595,6 +595,8 @@ class SnapshotBackedReportGenerator:
             snapshots=[s for _i, s in item_snapshot_pairs],
             request_market=request.market,
             account_scope=request.account_scope,
+            budget_basis=request.budget_basis,
+            operator_budget_override_usd=request.operator_budget_override_usd,
         )
 
     async def _section_snapshot_descriptors(

--- a/app/services/action_report/snapshot_backed/request.py
+++ b/app/services/action_report/snapshot_backed/request.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from decimal import Decimal
 from typing import Any, Literal
 from uuid import UUID
 
@@ -62,6 +63,15 @@ class ReportGenerationRequest(BaseModel):
     # Snapshot-bundle inputs forwarded to SnapshotBundleEnsureService.
     symbols: list[str] | None = None
     candidate_limit: int | None = None
+
+    # ROB-347 — US new-buy budget basis policy. Default available_usd: USD
+    # buying power gates buy_review. USD<=0 demotes buy_review → watch_only with
+    # budget_gap/fx_required/operator_budget_required (never a silent buy). KRW
+    # is reference-only; no KRW→USD fabrication.
+    budget_basis: Literal[
+        "available_usd", "krw_orderable_reference", "operator_budget_override"
+    ] = "available_usd"
+    operator_budget_override_usd: Decimal | None = None
 
     # ROB-287 — fail-closed legacy field. The ROB-279 in-process LLM
     # composition path (Gemini-backed FinalComposer + LLM reducer stages)

--- a/app/services/invest_screener_snapshots/repository.py
+++ b/app/services/invest_screener_snapshots/repository.py
@@ -165,9 +165,7 @@ class InvestScreenerSnapshotsRepository:
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
-    async def common_stock_flags(
-        self, symbols: list[str]
-    ) -> dict[str, bool | None]:
+    async def common_stock_flags(self, symbols: list[str]) -> dict[str, bool | None]:
         """ROB-346 — us_symbol_universe.is_common_stock by symbol (US-only).
         Missing symbols are absent from the dict (caller treats as unknown)."""
         if not symbols:
@@ -179,7 +177,7 @@ class InvestScreenerSnapshotsRepository:
                 USSymbolUniverse.symbol.in_(symbols)
             )
         )
-        return {sym: flag for sym, flag in result.all()}
+        return dict(result.all())
 
     async def breadth(self, *, market: str) -> Breadth:
         latest = await self.latest_partition(market=market)

--- a/app/services/invest_screener_snapshots/repository.py
+++ b/app/services/invest_screener_snapshots/repository.py
@@ -140,6 +140,47 @@ class InvestScreenerSnapshotsRepository:
         )
         return list(result.scalars().all())
 
+    async def list_candidate_pool(
+        self, *, market: str, limit: int | None = None
+    ) -> list[InvestScreenerSnapshot]:
+        """ROB-346 — wide candidate pool from the latest partition. ``limit=None``
+        returns the whole partition (no early cap); quality/priority filtering
+        happens downstream in the collector."""
+        latest = await self.latest_partition(market=market)
+        if latest is None:
+            return []
+        stmt = (
+            select(InvestScreenerSnapshot)
+            .where(
+                InvestScreenerSnapshot.market == market,
+                InvestScreenerSnapshot.snapshot_date == latest,
+            )
+            .order_by(
+                InvestScreenerSnapshot.change_rate.desc().nullslast(),
+                InvestScreenerSnapshot.symbol.asc(),
+            )
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def common_stock_flags(
+        self, symbols: list[str]
+    ) -> dict[str, bool | None]:
+        """ROB-346 — us_symbol_universe.is_common_stock by symbol (US-only).
+        Missing symbols are absent from the dict (caller treats as unknown)."""
+        if not symbols:
+            return {}
+        from app.models.us_symbol_universe import USSymbolUniverse
+
+        result = await self._session.execute(
+            select(USSymbolUniverse.symbol, USSymbolUniverse.is_common_stock).where(
+                USSymbolUniverse.symbol.in_(symbols)
+            )
+        )
+        return {sym: flag for sym, flag in result.all()}
+
     async def breadth(self, *, market: str) -> Breadth:
         latest = await self.latest_partition(market=market)
         if latest is None:

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from app.schemas.investment_stages import (
     StageArtifactPayload,
     StageCitation,

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -137,7 +137,13 @@ class PortfolioJournalStage:
                 )
             )
 
-        missing_data = [] if journal_snaps else ["journal"]
+        def _journal_collector_status(snap: Any) -> str | None:
+            return (getattr(snap, "payload_json", None) or {}).get("collector_status")
+
+        journal_unavailable = (not journal_snaps) or any(
+            _journal_collector_status(s) == "unavailable" for s in journal_snaps
+        )
+        missing_data = ["journal"] if journal_unavailable else []
         key_points = [e.get("thesis", "") for e in entries[:5] if e.get("thesis")]
         # ROB-392 — surface the NAV scope label (byte-identical summary stays
         # unchanged; the label rides only in key_points).

--- a/app/services/investment_stages/stages/portfolio_journal.py
+++ b/app/services/investment_stages/stages/portfolio_journal.py
@@ -113,9 +113,12 @@ class PortfolioJournalStage:
         else:
             nav, buying_power, _cash = _krw_totals(payload)
 
+        # ROB-345 — collector emits "active" (draft/active journals), not
+        # "entries". Reading the wrong key made every market show
+        # "open journal: none". Mirror the real journal payload contract.
         entries = []
         for snap in journal_snaps:
-            entries.extend((snap.payload_json or {}).get("entries", []))
+            entries.extend((snap.payload_json or {}).get("active", []))
         symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
 
         citations = [
@@ -130,7 +133,7 @@ class PortfolioJournalStage:
                 StageCitation(
                     snapshot_uuid=snap.snapshot_uuid,
                     snapshot_kind="journal",
-                    payload_path="$.entries",
+                    payload_path="$.active",
                 )
             )
 

--- a/docs/superpowers/plans/2026-06-09-rob-345-us-journal-mapping-plan.md
+++ b/docs/superpowers/plans/2026-06-09-rob-345-us-journal-mapping-plan.md
@@ -1,0 +1,444 @@
+# ROB-345 — US kis_live journal 매핑 복구 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** US kis_live `/invest/reports` 의 journal stage가 active US KIS journal을 정확히 반영하고(payload 키 계약 정렬), KR/타 market journal과 섞이지 않으며(instrument_type scoping), "journal 없음" 과 "collector unavailable" 을 구분된 data_gap으로 남긴다.
+
+**Architecture:** 세 read-only/additive 레이어 — (1) stage가 collector 실제 키 `active` 를 읽도록 정렬 + 잘못된 테스트 fixture 정정, (2) collector가 `get_trade_journal` 의 검증된 `market_map` 필터(instrument_type) + account scope를 미러하고 `account` provenance를 emit, (3) collector_status로 empty vs unavailable 구분. migration-0, broker/order mutation 없음.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, pytest(-asyncio), FastAPI/MCP. 스펙: `docs/superpowers/specs/2026-06-09-rob-345-us-kis-live-journal-mapping-design.md`.
+
+---
+
+## File Structure
+
+- Modify: `app/services/investment_stages/stages/portfolio_journal.py` — stage가 `active` 키를 읽고, collector_status로 unavailable 판정.
+- Modify: `app/services/action_report/snapshot_backed/collectors/journal.py` — market(instrument_type) + kis account scoping, `account` emit, collector_status + unavailable 경로.
+- Test: `tests/services/investment_stages/stages/test_portfolio_journal.py` — 잘못된 `entries` fixture를 실제 `active` shape로 정정 + empty/unavailable 케이스.
+- Test (new): `tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py` — DB-seeded scoping + provenance + unavailable.
+
+> 작업 디렉토리: worktree `/Users/mgh3326/work/auto_trader.rob-345` (branch `rob-345`). 시작 전 `git fetch --prune origin && git switch -c rob-345-impl origin/main` 권장(스펙 커밋 cherry-pick 또는 main 머지 후 진행). 본 플랜은 현재 worktree 기준.
+
+---
+
+## Task 1: stage가 collector 실제 키(`active`)를 읽도록 정렬 + fixture 정정
+
+**Files:**
+- Modify: `app/services/investment_stages/stages/portfolio_journal.py:117-118`
+- Test: `tests/services/investment_stages/stages/test_portfolio_journal.py:40,287`
+
+- [ ] **Step 1: 실제 collector shape를 쓰는 실패 테스트 추가**
+
+`tests/services/investment_stages/stages/test_portfolio_journal.py` 에 추가:
+
+```python
+@pytest.mark.asyncio
+async def test_portfolio_journal_reads_active_from_real_collector_shape():
+    # ROB-345 회귀: collector는 active/recent_retrospective 를 emit한다.
+    # stage가 "entries"를 읽던 버그(=항상 open journal: none)를 방지한다.
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})
+            ],
+            "journal": [
+                _snap(
+                    "journal",
+                    {
+                        "active": [{"symbol": "AAPL", "thesis": "earnings"}],
+                        "recent_retrospective": [],
+                        "active_count": 1,
+                        "retrospective_count": 0,
+                        "collector_status": "ok",
+                    },
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "AAPL" in (payload.summary or "")
+    assert "journal" not in (payload.missing_data or [])
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py::test_portfolio_journal_reads_active_from_real_collector_shape -v`
+Expected: FAIL — `"AAPL"` not in summary (stage가 `entries` 를 읽어 `open journal: none`).
+
+- [ ] **Step 3: stage가 `active` 를 읽도록 수정**
+
+`portfolio_journal.py` 의 현재:
+```python
+        entries = []
+        for snap in journal_snaps:
+            entries.extend((snap.payload_json or {}).get("entries", []))
+        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
+```
+를 다음으로 교체:
+```python
+        # ROB-345 — collector emits "active" (draft/active journals), not
+        # "entries". Reading the wrong key made every market show
+        # "open journal: none". Mirror the real journal payload contract.
+        entries = []
+        for snap in journal_snaps:
+            entries.extend((snap.payload_json or {}).get("active", []))
+        symbols = ", ".join(e.get("symbol", "?") for e in entries[:5])
+```
+
+- [ ] **Step 4: 기존 잘못된 fixture 2곳 정정**
+
+`test_portfolio_journal.py:40` 및 `:287` 의
+`_snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})` /
+`_snap("journal", {"entries": [{"symbol": "005930", "thesis": "tech"}]})` 를 각각
+실제 shape로 교체:
+```python
+                _snap(
+                    "journal",
+                    {"active": [{"symbol": "035420", "thesis": "tech"}],
+                     "recent_retrospective": [], "active_count": 1,
+                     "retrospective_count": 0, "collector_status": "ok"},
+                )
+```
+(두 번째는 symbol `"005930"`.)
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+Expected: PASS (신규 + 정정된 기존 테스트 모두).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/investment_stages/stages/portfolio_journal.py \
+        tests/services/investment_stages/stages/test_portfolio_journal.py
+git commit -m "fix(ROB-345): journal stage reads collector 'active' key (not 'entries')"
+```
+
+---
+
+## Task 2: collector market(instrument_type) + kis account scoping + `account` provenance
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/journal.py`
+- Test (new): `tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py`
+
+- [ ] **Step 1: DB-seeded scoping 실패 테스트 추가**
+
+`tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py` 생성:
+
+```python
+import datetime as dt
+
+import pytest
+
+from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
+from app.services.action_report.snapshot_backed.collectors.journal import (
+    JournalSnapshotCollector,
+)
+from app.services.investment_snapshots.collectors import CollectorRequest
+
+
+def _journal(symbol, instrument_type, *, account="kis", account_type="live",
+             status="active"):
+    return TradeJournal(
+        symbol=symbol, instrument_type=instrument_type, side="buy",
+        status=status, account_type=account_type, account=account,
+        entry_price=1.0, quantity=1.0, thesis="t",
+    )
+
+
+def _req(market):
+    return CollectorRequest(market=market, account_scope="kis_live", symbols=None)
+
+
+@pytest.mark.asyncio
+async def test_us_scope_excludes_kr_live_journals(db_session):
+    db_session.add_all([
+        _journal("AAPL", InstrumentType.equity_us),
+        _journal("005930", InstrumentType.equity_kr),
+    ])
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    active_syms = {e["symbol"] for e in payload["active"]}
+    assert active_syms == {"AAPL"}
+    assert payload["active"][0]["account"] == "kis"  # provenance emitted
+    assert payload["collector_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_kr_scope_excludes_us_live_journals(db_session):
+    db_session.add_all([
+        _journal("AAPL", InstrumentType.equity_us),
+        _journal("005930", InstrumentType.equity_kr),
+    ])
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("kr"))
+    active_syms = {e["symbol"] for e in results[0].payload_json["active"]}
+    assert active_syms == {"005930"}
+
+
+@pytest.mark.asyncio
+async def test_us_scope_includes_legacy_null_account_kis_us(db_session):
+    db_session.add(_journal("MSFT", InstrumentType.equity_us, account=None))
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    active_syms = {e["symbol"] for e in results[0].payload_json["active"]}
+    assert "MSFT" in active_syms
+```
+
+> `db_session` fixture: 기존 collector/DB 테스트에서 쓰는 async session fixture를 재사용한다. 동일 패턴이 `tests/` 에 존재하는지 확인하고(예: `tests/conftest.py` 의 `db_session`), 테이블이 `create_all` 로 준비되는지 확인. (ROB-407 메모: timescaledb 확장으로 alembic 차단 시 `db_session` dep가 `create_all` 을 보장.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py -v`
+Expected: FAIL — 현재 collector는 market 필터가 없어 US scope에 005930 포함 + `account` 키 부재(KeyError).
+
+- [ ] **Step 3: collector에 scoping + provenance 구현**
+
+`journal.py` 상단 import에 추가:
+```python
+from sqlalchemy import desc, or_, select
+from app.models.trading import InstrumentType
+```
+모듈 상수 추가(`_DEFAULT_RECENT_LIMIT` 근처):
+```python
+# Mirror get_trade_journal market_map (app/mcp_server/tooling/trade_journal_tools.py)
+# — the only no-migration market discriminator on trade_journals.
+_MARKET_TO_INSTRUMENT: dict[str, InstrumentType] = {
+    "crypto": InstrumentType.crypto,
+    "kr": InstrumentType.equity_kr,
+    "us": InstrumentType.equity_us,
+}
+```
+`collect()` 의 쿼리 빌드 직전 scope 필터 구성:
+```python
+        scope_filters = [TradeJournal.account_type == "live"]
+        itype = _MARKET_TO_INSTRUMENT.get(request.market)
+        if itype is not None:
+            scope_filters.append(TradeJournal.instrument_type == itype)
+        if request.account_scope == "kis_live":
+            # KIS broker scope; legacy rows may carry account=NULL (kis_live_ledger
+            # now writes account="kis"). instrument_type already excludes crypto.
+            scope_filters.append(
+                or_(TradeJournal.account == "kis", TradeJournal.account.is_(None))
+            )
+```
+`active_stmt` / `recent_stmt` 의 `.where(...)` 를 scope_filters 사용으로 교체:
+```python
+        active_stmt = (
+            select(TradeJournal)
+            .where(*scope_filters, TradeJournal.status.in_(_ACTIVE_STATUSES))
+            .order_by(desc(TradeJournal.updated_at))
+        )
+        recent_stmt = (
+            select(TradeJournal)
+            .where(*scope_filters, TradeJournal.status.in_(_RETROSPECTIVE_STATUSES))
+            .order_by(desc(TradeJournal.updated_at))
+            .limit(self._recent_limit)
+        )
+```
+`_journal_to_dict` 에 `account` 추가(provenance):
+```python
+        "account_type": j.account_type,
+        "account": j.account,
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/journal.py \
+        tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
+git commit -m "fix(ROB-345): scope journal collector by market+kis account, emit account provenance"
+```
+
+---
+
+## Task 3: empty vs collector-unavailable 구분 (collector_status + stage data_gap)
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/journal.py` (collect)
+- Modify: `app/services/investment_stages/stages/portfolio_journal.py` (run)
+- Test: 위 두 테스트 파일
+
+- [ ] **Step 1: collector unavailable + empty 테스트 추가**
+
+`test_journal_collector.py` 에 추가:
+```python
+@pytest.mark.asyncio
+async def test_empty_active_reports_ok_status(db_session):
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    assert payload["active"] == []
+    assert payload["collector_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_query_failure_reports_unavailable(monkeypatch, db_session):
+    collector = JournalSnapshotCollector(db_session)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(db_session, "execute", _boom)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    assert payload["collector_status"] == "unavailable"
+    assert results[0].freshness_status == "unavailable"
+```
+
+`test_portfolio_journal.py` 에 추가:
+```python
+@pytest.mark.asyncio
+async def test_journal_unavailable_marks_data_gap():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
+            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
+                                          "collector_status": "unavailable"})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "journal" in (payload.missing_data or [])
+
+
+@pytest.mark.asyncio
+async def test_journal_empty_ok_is_not_data_gap():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
+            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
+                                          "collector_status": "ok"})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "journal" not in (payload.missing_data or [])
+    assert "open journal: none" in (payload.summary or "")
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+Expected: FAIL — collector_status 부재 + stage가 unavailable을 구분하지 않음.
+
+- [ ] **Step 3: collector — collector_status + unavailable 경로 구현**
+
+`collect()` 의 실행부를 try/except로 감싸고 status를 payload에 추가:
+```python
+        try:
+            active_rows = (await self._session.execute(active_stmt)).scalars().all()
+            recent_rows = (await self._session.execute(recent_stmt)).scalars().all()
+        except Exception:  # defensive — surface as collector unavailable, never crash
+            logger.exception("journal collector query failed")
+            return [
+                build_result(
+                    snapshot_kind=self.snapshot_kind,
+                    market=request.market,
+                    account_scope=request.account_scope,
+                    payload={
+                        "active": [], "recent_retrospective": [],
+                        "active_count": 0, "retrospective_count": 0,
+                        "recent_limit": self._recent_limit,
+                        "collector_status": "unavailable",
+                        "error": "journal_query_failed",
+                    },
+                    origin="auto_trader_db",
+                    as_of=now,
+                    freshness_status="unavailable",
+                    errors={"reason": "journal_query_failed"},
+                )
+            ]
+```
+정상 payload에 `"collector_status": "ok"` 추가:
+```python
+        payload: dict[str, Any] = {
+            "active": [_journal_to_dict(j) for j in active_rows],
+            "recent_retrospective": [_journal_to_dict(j) for j in recent_rows],
+            "active_count": len(active_rows),
+            "retrospective_count": len(recent_rows),
+            "recent_limit": self._recent_limit,
+            "collector_status": "ok",
+        }
+```
+파일 상단에 `import logging` + `logger = logging.getLogger(__name__)` 가 없으면 추가.
+
+- [ ] **Step 4: stage — unavailable 판정 구현**
+
+`portfolio_journal.py` 의 `journal_snaps = context.snapshots_for("journal")` 직후/관련부에 헬퍼 + 판정 추가. 현재
+`missing_data = [] if journal_snaps else ["journal"]` 를 교체:
+```python
+        def _journal_collector_status(snap: Any) -> str | None:
+            return (getattr(snap, "payload_json", None) or {}).get("collector_status")
+
+        journal_unavailable = (not journal_snaps) or any(
+            _journal_collector_status(s) == "unavailable" for s in journal_snaps
+        )
+        missing_data = ["journal"] if journal_unavailable else []
+```
+(나머지 `missing_data` 누적 로직은 그대로. summary는 Task 1에서 `active` 기반으로 이미
+"open journal: none" 정상 출력.)
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py tests/services/investment_stages/stages/test_portfolio_journal.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/collectors/journal.py \
+        app/services/investment_stages/stages/portfolio_journal.py \
+        tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py \
+        tests/services/investment_stages/stages/test_portfolio_journal.py
+git commit -m "feat(ROB-345): distinguish empty journals from collector-unavailable (data_gap)"
+```
+
+---
+
+## Task 4: lint / typecheck / 전체 게이트
+
+- [ ] **Step 1: lint + format**
+
+Run: `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/`
+Expected: clean. (CI는 app/ + tests/ 둘 다 검사 — 메모리 교훈.)
+
+- [ ] **Step 2: typecheck**
+
+Run: `uv run ty check app/`
+Expected: no new errors.
+
+- [ ] **Step 3: 관련 스위트 회귀**
+
+Run: `uv run pytest tests/services/investment_stages tests/services/action_report/snapshot_backed -v`
+Expected: PASS (KR 경로 포함 회귀 없음).
+
+- [ ] **Step 4: 필요 시 style 커밋**
+
+```bash
+git add -A && git commit -m "style(ROB-345): ruff check and formatting"
+```
+
+---
+
+## Self-review (작성자 체크)
+- 스펙 §4.1/4.2/4.3 → Task 1/2/3 매핑됨. AC 4건 전부 테스트 보유.
+- placeholder 없음(모든 코드/명령 구체).
+- 타입 일관: `collector_status`("ok"/"unavailable"), payload 키 `active`, `_MARKET_TO_INSTRUMENT` 값 = get_trade_journal market_map.
+- 안전: read-only collector, no broker/order mutation, KR 회귀 테스트 포함, migration 없음.
+- 미수정 경계: dead `us/` 모듈, `trade_journal_read_service`(범위 외).

--- a/docs/superpowers/plans/2026-06-09-rob-346-us-candidate-universe-plan.md
+++ b/docs/superpowers/plans/2026-06-09-rob-346-us-candidate-universe-plan.md
@@ -1,0 +1,765 @@
+# ROB-346 — US 신규매수 후보 universe 필터·우선순위 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** US 신규매수 후보를 예산보다 넓은 pool에서 수집하고, 결정적 품질 게이트(penny/illiquid/abnormal_spike/non_common_stock/screener_stale)로 저품질 후보를 `watch_only`/`rejected`/`data_gap` + 사유로 강등하며, priority 순으로 정렬한다.
+
+**Architecture:** classify_candidate_symbol signature는 **변경하지 않고** 순수 후처리 헬퍼 `demote_for_quality` 를 추가(PR-C와 무충돌). 품질 플래그/priority/confidence_cap은 **collector(US-only gate)** 에서 결정적으로 계산해 candidate evidence(JSONB)에 적재하고, auto_emit가 읽어 데모션·표시한다. migration-0, KR 경로 무회귀.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, pytest. 스펙: `docs/superpowers/specs/2026-06-09-rob-346-us-candidate-universe-design.md`. 단위: `change_rate`/`week_change_rate` 는 **percent**(10.0=+10%), `latest_close` USD, `daily_volume` 주.
+
+---
+
+## File Structure
+- Create: `app/services/action_report/snapshot_backed/candidate_quality.py` — 순수 품질/priority 계산.
+- Modify: `app/services/action_report/snapshot_backed/action_verdict.py` — `demote_for_quality` 순수 헬퍼.
+- Modify: `app/services/invest_screener_snapshots/repository.py` — `list_candidate_pool` + `common_stock_flags`.
+- Modify: `app/services/action_report/snapshot_backed/collectors/candidate_universe.py` — US `_collect_top_gainers` 가 wide pool + 품질 계산 + `_build_candidate_result(quality_by_symbol=...)`.
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py` — 후처리 데모션 + 사유/플래그 surface + 데모션 표시 cap.
+- Tests: 각 파일 대응 신규/확장.
+
+---
+
+## Task 1: 순수 품질·priority 모듈
+
+**Files:**
+- Create: `app/services/action_report/snapshot_backed/candidate_quality.py`
+- Test: `tests/services/action_report/snapshot_backed/test_candidate_quality.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_candidate_quality.py`:
+```python
+from app.services.action_report.snapshot_backed.candidate_quality import (
+    compute_quality_flags, compute_priority_score, confidence_cap_for, dollar_volume_usd,
+)
+
+
+def test_penny_and_illiquid_flags():
+    qf = compute_quality_flags(latest_close=3.5, daily_volume=1_000_000,
+        change_rate=2.0, week_change_rate=1.0, is_common_stock=True, screener_stale=False)
+    assert "penny" in qf            # 3.5 < 5.0
+    assert "illiquid" in qf         # 3.5 * 1e6 = 3.5e6 < 5e6
+
+
+def test_liquid_large_price_clean():
+    qf = compute_quality_flags(latest_close=150.0, daily_volume=10_000_000,
+        change_rate=2.0, week_change_rate=1.0, is_common_stock=True, screener_stale=False)
+    assert qf == frozenset()
+
+
+def test_abnormal_spike_percent_units():
+    assert "abnormal_spike" in compute_quality_flags(latest_close=50.0,
+        daily_volume=10_000_000, change_rate=16.0, week_change_rate=1.0,
+        is_common_stock=True, screener_stale=False)
+    assert "abnormal_spike" in compute_quality_flags(latest_close=50.0,
+        daily_volume=10_000_000, change_rate=1.0, week_change_rate=51.0,
+        is_common_stock=True, screener_stale=False)
+
+
+def test_common_stock_flag_tri_state():
+    assert "non_common_stock" in compute_quality_flags(latest_close=50.0,
+        daily_volume=10_000_000, change_rate=1.0, week_change_rate=1.0,
+        is_common_stock=False, screener_stale=False)
+    assert "common_stock_unknown" in compute_quality_flags(latest_close=50.0,
+        daily_volume=10_000_000, change_rate=1.0, week_change_rate=1.0,
+        is_common_stock=None, screener_stale=False)
+
+
+def test_priority_score_orders_liquid_over_illiquid():
+    big = compute_priority_score(latest_close=100.0, daily_volume=50_000_000,
+        change_rate=5.0, quality_flags=frozenset())
+    small = compute_priority_score(latest_close=4.0, daily_volume=100_000,
+        change_rate=5.0, quality_flags=frozenset({"illiquid", "penny"}))
+    assert big > small
+
+
+def test_confidence_cap_for_stale():
+    assert confidence_cap_for(frozenset({"screener_stale"})) == 40
+    assert confidence_cap_for(frozenset()) is None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_candidate_quality.py -v`
+Expected: FAIL — module 없음.
+
+- [ ] **Step 3: 모듈 구현**
+
+`app/services/action_report/snapshot_backed/candidate_quality.py`:
+```python
+"""Pure US new-buy candidate quality gates + priority (ROB-346). No I/O.
+
+Units: change_rate / week_change_rate are PERCENT (10.0 == +10%); latest_close
+is USD; daily_volume is shares. Conservative thresholds (spec §3.3).
+"""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+PENNY_PRICE_USD = 5.0
+ILLIQUID_DOLLAR_VOLUME_USD = 5_000_000.0
+ABNORMAL_DAY_CHANGE_PCT = 15.0
+ABNORMAL_WEEK_CHANGE_PCT = 50.0
+STALE_CONFIDENCE_CAP = 40
+
+
+def _f(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def dollar_volume_usd(latest_close: Any, daily_volume: Any) -> float | None:
+    close = _f(latest_close)
+    vol = _f(daily_volume)
+    if close is None or vol is None:
+        return None
+    return close * vol
+
+
+def compute_quality_flags(
+    *, latest_close: Any, daily_volume: Any, change_rate: Any,
+    week_change_rate: Any, is_common_stock: bool | None, screener_stale: bool,
+) -> frozenset[str]:
+    flags: set[str] = set()
+    if is_common_stock is False:
+        flags.add("non_common_stock")
+    elif is_common_stock is None:
+        flags.add("common_stock_unknown")
+    close = _f(latest_close)
+    if close is not None and close < PENNY_PRICE_USD:
+        flags.add("penny")
+    dv = dollar_volume_usd(latest_close, daily_volume)
+    if dv is not None and dv < ILLIQUID_DOLLAR_VOLUME_USD:
+        flags.add("illiquid")
+    cr = _f(change_rate)
+    wcr = _f(week_change_rate)
+    if (cr is not None and cr > ABNORMAL_DAY_CHANGE_PCT) or (
+        wcr is not None and wcr > ABNORMAL_WEEK_CHANGE_PCT
+    ):
+        flags.add("abnormal_spike")
+    if screener_stale:
+        flags.add("screener_stale")
+    return frozenset(flags)
+
+
+def compute_priority_score(
+    *, latest_close: Any, daily_volume: Any, change_rate: Any,
+    quality_flags: frozenset[str],
+) -> float:
+    dv = dollar_volume_usd(latest_close, daily_volume) or 0.0
+    liquidity_term = min(1.0, math.log10(max(dv, 1.0)) / 9.0)  # 9 ≈ log10($1B)
+    cr = _f(change_rate) or 0.0
+    momentum_term = max(-5.0, min(10.0, cr)) / 10.0
+    spike_penalty = 1.0 if "abnormal_spike" in quality_flags else 0.0
+    stale_penalty = 1.0 if "screener_stale" in quality_flags else 0.0
+    return 1.0 * liquidity_term + 0.5 * momentum_term - 0.5 * spike_penalty - 0.3 * stale_penalty
+
+
+def confidence_cap_for(quality_flags: frozenset[str]) -> int | None:
+    if "screener_stale" in quality_flags or "common_stock_unknown" in quality_flags:
+        return STALE_CONFIDENCE_CAP
+    return None
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_candidate_quality.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/candidate_quality.py \
+        tests/services/action_report/snapshot_backed/test_candidate_quality.py
+git commit -m "feat(ROB-346): pure US candidate quality flags + priority score"
+```
+
+---
+
+## Task 2: `demote_for_quality` 순수 헬퍼
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/action_verdict.py`
+- Test: `tests/services/action_report/snapshot_backed/test_action_verdict_demote.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_action_verdict_demote.py`:
+```python
+from app.services.action_report.snapshot_backed.action_verdict import demote_for_quality
+
+
+def test_non_common_always_rejected_even_if_buy():
+    assert demote_for_quality("buy_review", frozenset({"non_common_stock"})) == (
+        "rejected", "non_common_stock")
+
+
+def test_unknown_common_is_data_gap_for_buy():
+    assert demote_for_quality("buy_review", frozenset({"common_stock_unknown"})) == (
+        "data_gap", "common_stock_unknown")
+
+
+def test_quality_demotes_buy_to_watch_in_priority_order():
+    assert demote_for_quality("buy_review", frozenset({"penny", "illiquid"})) == (
+        "watch_only", "penny")
+    assert demote_for_quality("buy_review", frozenset({"abnormal_spike"})) == (
+        "watch_only", "abnormal_spike")
+
+
+def test_clean_buy_unchanged():
+    assert demote_for_quality("buy_review", frozenset()) == ("buy_review", None)
+
+
+def test_non_buy_not_upgraded():
+    # 이미 honest 하향된 verdict은 품질로 끌어올리지 않는다(non_common 제외).
+    assert demote_for_quality("watch_only", frozenset({"penny"})) == ("watch_only", None)
+    assert demote_for_quality("data_gap", frozenset()) == ("data_gap", None)
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict_demote.py -v`
+Expected: FAIL — `demote_for_quality` 없음.
+
+- [ ] **Step 3: 구현** — `action_verdict.py` 끝에 추가:
+```python
+_QUALITY_WATCH_ORDER: tuple[str, ...] = (
+    "penny", "illiquid", "abnormal_spike", "screener_stale",
+)
+
+
+def demote_for_quality(
+    verdict: str, quality_flags: frozenset[str]
+) -> tuple[str, str | None]:
+    """ROB-346 — post-verdict quality demotion. Quality only DEMOTES (never
+    upgrades). non_common_stock is always rejected; otherwise only buy_review
+    is touched. Returns (new_verdict, reason | None)."""
+    if "non_common_stock" in quality_flags:
+        return "rejected", "non_common_stock"
+    if verdict != "buy_review":
+        return verdict, None
+    if "common_stock_unknown" in quality_flags:
+        return "data_gap", "common_stock_unknown"
+    for flag in _QUALITY_WATCH_ORDER:
+        if flag in quality_flags:
+            return "watch_only", flag
+    return "buy_review", None
+```
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict_demote.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/action_verdict.py \
+        tests/services/action_report/snapshot_backed/test_action_verdict_demote.py
+git commit -m "feat(ROB-346): demote_for_quality pure helper (no signature change)"
+```
+
+---
+
+## Task 3: repository — wide pool + is_common_stock
+
+**Files:**
+- Modify: `app/services/invest_screener_snapshots/repository.py`
+- Test: `tests/services/invest_screener_snapshots/test_repository_candidate_pool.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/invest_screener_snapshots/test_repository_candidate_pool.py`:
+```python
+import datetime as dt
+
+import pytest
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.invest_screener_snapshots.repository import (
+    InvestScreenerSnapshotsRepository,
+)
+
+
+def _snap(symbol, change_rate, d):
+    return InvestScreenerSnapshot(market="us", symbol=symbol, snapshot_date=d,
+        latest_close=10, change_rate=change_rate, closes_window=[], source="yahoo",
+        daily_volume=1_000_000)
+
+
+@pytest.mark.asyncio
+async def test_list_candidate_pool_returns_wide_unlimited(db_session):
+    today = dt.date(2026, 6, 9)
+    db_session.add_all([_snap(f"S{i}", float(i), today) for i in range(30)])
+    await db_session.flush()
+    repo = InvestScreenerSnapshotsRepository(db_session)
+    rows = await repo.list_candidate_pool(market="us", limit=None)
+    assert len(rows) == 30  # no early cap
+
+
+@pytest.mark.asyncio
+async def test_common_stock_flags_lookup(db_session):
+    db_session.add_all([
+        USSymbolUniverse(symbol="AAA", exchange="NASDAQ", is_active=True,
+                         is_common_stock=True),
+        USSymbolUniverse(symbol="ETF1", exchange="NYSE", is_active=True,
+                         is_common_stock=False),
+    ])
+    await db_session.flush()
+    repo = InvestScreenerSnapshotsRepository(db_session)
+    flags = await repo.common_stock_flags(["AAA", "ETF1", "MISSING"])
+    assert flags["AAA"] is True
+    assert flags["ETF1"] is False
+    assert flags.get("MISSING") is None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/invest_screener_snapshots/test_repository_candidate_pool.py -v`
+Expected: FAIL — 메서드 없음.
+
+- [ ] **Step 3: 구현** — `repository.py` 의 `list_top_candidates` 아래에 추가:
+```python
+    async def list_candidate_pool(
+        self, *, market: str, limit: int | None = None
+    ) -> list[InvestScreenerSnapshot]:
+        """ROB-346 — wide candidate pool from the latest partition. ``limit=None``
+        returns the whole partition (no early cap); quality/priority filtering
+        happens downstream in the collector."""
+        latest = await self.latest_partition(market=market)
+        if latest is None:
+            return []
+        stmt = (
+            select(InvestScreenerSnapshot)
+            .where(
+                InvestScreenerSnapshot.market == market,
+                InvestScreenerSnapshot.snapshot_date == latest,
+            )
+            .order_by(
+                InvestScreenerSnapshot.change_rate.desc().nullslast(),
+                InvestScreenerSnapshot.symbol.asc(),
+            )
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def common_stock_flags(
+        self, symbols: list[str]
+    ) -> dict[str, bool | None]:
+        """ROB-346 — us_symbol_universe.is_common_stock by symbol (US-only).
+        Missing symbols are absent from the dict (caller treats as unknown)."""
+        if not symbols:
+            return {}
+        from app.models.us_symbol_universe import USSymbolUniverse
+
+        result = await self._session.execute(
+            select(USSymbolUniverse.symbol, USSymbolUniverse.is_common_stock).where(
+                USSymbolUniverse.symbol.in_(symbols)
+            )
+        )
+        return {sym: flag for sym, flag in result.all()}
+```
+(`select` 는 이미 import됨. 파일 상단 import 확인.)
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/invest_screener_snapshots/test_repository_candidate_pool.py -v` → PASS
+```bash
+git add app/services/invest_screener_snapshots/repository.py \
+        tests/services/invest_screener_snapshots/test_repository_candidate_pool.py
+git commit -m "feat(ROB-346): repository wide candidate pool + is_common_stock flags"
+```
+
+---
+
+## Task 4: collector — US wide pool + 품질 계산 + evidence 적재
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/collectors/candidate_universe.py`
+- Test: `tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py`
+
+- [ ] **Step 1: 실패 테스트 (US 품질/priority가 candidate dict에 실리는지)**
+
+`tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py`:
+```python
+import datetime as dt
+
+import pytest
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+    CandidateUniverseCollector,
+)
+from app.services.investment_snapshots.collectors import CollectorRequest
+
+
+def _snap(symbol, *, close, vol, change, d):
+    return InvestScreenerSnapshot(market="us", symbol=symbol, snapshot_date=d,
+        latest_close=close, change_rate=change, week_change_rate=0,
+        closes_window=[], source="yahoo", daily_volume=vol)
+
+
+@pytest.mark.asyncio
+async def test_us_candidates_carry_quality_flags_and_priority(db_session):
+    today = dt.date(2026, 6, 9)
+    db_session.add_all([
+        _snap("GOOD", close=150.0, vol=20_000_000, change=3.0, d=today),
+        _snap("PENNY", close=2.0, vol=100_000, change=3.0, d=today),
+        USSymbolUniverse(symbol="GOOD", exchange="NASDAQ", is_active=True,
+                         is_common_stock=True),
+        USSymbolUniverse(symbol="PENNY", exchange="NYSE", is_active=True,
+                         is_common_stock=True),
+    ])
+    await db_session.flush()
+    collector = CandidateUniverseCollector(db_session)
+    req = CollectorRequest(market="us", account_scope="kis_live", candidate_limit=5,
+                           symbols=None)
+    results = await collector.collect(req)
+    cands = {c["symbol"]: c for c in results[0].payload_json["candidates"]}
+    assert "priority_score" in cands["GOOD"]
+    assert "penny" in cands["PENNY"]["quality_flags"]
+    assert "illiquid" in cands["PENNY"]["quality_flags"]
+    # priority: GOOD (liquid) ranks above PENNY
+    assert cands["GOOD"]["candidate_rank"] < cands["PENNY"]["candidate_rank"]
+```
+
+> `CandidateUniverseCollector` 의 정확한 클래스명/생성자 인자는 `candidate_universe.py` 에서 확인(현재 `self._equity_repo` 를 들고 있음 — 생성자에서 repo를 주입하는지/세션을 받는지 확인 후 fixture 맞춤).
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py -v`
+Expected: FAIL — quality_flags/priority_score 부재.
+
+- [ ] **Step 3: `_collect_top_gainers` US 분기 구현**
+
+`candidate_universe.py` 상단 import 추가:
+```python
+from app.core.symbol import to_db_symbol  # 이미 있음
+from app.services.action_report.snapshot_backed.candidate_quality import (
+    compute_priority_score, compute_quality_flags, confidence_cap_for, dollar_volume_usd,
+)
+```
+`_collect_top_gainers` 에서 US일 때 wide pool + 품질 계산. 현재 `rows = await self._equity_repo.list_top_candidates(...)` 부분을 다음으로 교체(US 분기):
+```python
+        is_us = request.market == "us"
+        if is_us:
+            pool_limit = max(limit * 5, 50)
+            rows = await self._equity_repo.list_candidate_pool(
+                market=request.market, limit=pool_limit
+            )
+        else:
+            rows = await self._equity_repo.list_top_candidates(
+                market=request.market, limit=limit
+            )
+        rows = _dedupe_rows(rows, key=lambda r: to_db_symbol(r.symbol))
+```
+`days_stale`/`usefulness` 계산은 기존 그대로(이미 위에서 `coverage`/`usefulness` 산출). 그 뒤 품질 맵 구성(US-only):
+```python
+        quality_by_symbol: dict[str, dict[str, Any]] | None = None
+        if is_us:
+            stale = days_stale > 0 or usefulness != "useful"
+            flags_by_symbol = await self._equity_repo.common_stock_flags(
+                [r.symbol for r in rows]
+            )
+            quality_by_symbol = {}
+            for r in rows:
+                qf = compute_quality_flags(
+                    latest_close=r.latest_close, daily_volume=r.daily_volume,
+                    change_rate=r.change_rate, week_change_rate=r.week_change_rate,
+                    is_common_stock=flags_by_symbol.get(r.symbol),
+                    screener_stale=stale,
+                )
+                quality_by_symbol[r.symbol] = {
+                    "quality_flags": sorted(qf),
+                    "dollar_volume_usd": dollar_volume_usd(r.latest_close, r.daily_volume),
+                    "priority_score": compute_priority_score(
+                        latest_close=r.latest_close, daily_volume=r.daily_volume,
+                        change_rate=r.change_rate, quality_flags=qf,
+                    ),
+                    "confidence_cap": confidence_cap_for(qf),
+                    "is_common_stock": flags_by_symbol.get(r.symbol),
+                    "week_change_rate": float(r.week_change_rate)
+                    if r.week_change_rate is not None else None,
+                }
+```
+> `days_stale` 가 evidence 계산 *뒤*에 산출되면, 위 블록을 `latest_partition_date`/`days_stale` 계산 이후로 배치(파일의 기존 순서 확인 후 정렬).
+
+`evidence = build_candidate_evidence(...)` 는 그대로. 반환 호출에 `quality_by_symbol` 전달:
+```python
+        return [
+            self._build_candidate_result(
+                request=request, now=now, market=request.market,
+                preset="top_gainers", evidence=evidence, candidate_limit=limit,
+                fresh_count=coverage.fresh_count, stale_count=coverage.stale_count,
+                last_computed_at=coverage.last_computed_at, usefulness=usefulness,
+                expected_baseline_date=baseline,
+                latest_partition_date=latest_partition_date, days_stale=days_stale,
+                quality_by_symbol=quality_by_symbol,
+            )
+        ]
+```
+
+- [ ] **Step 4: `_build_candidate_result` 가 품질 merge + priority 정렬**
+
+시그니처에 추가: `quality_by_symbol: dict[str, dict[str, Any]] | None = None`.
+`candidates` 빌드 직전 priority 정렬(US만; quality 있을 때):
+```python
+        ordered = list(evidence)
+        if quality_by_symbol:
+            ordered = sorted(
+                evidence,
+                key=lambda e: (
+                    -(quality_by_symbol.get(e.symbol, {}).get("priority_score") or 0.0),
+                    -(quality_by_symbol.get(e.symbol, {}).get("dollar_volume_usd") or 0.0),
+                    e.symbol,
+                ),
+            )
+```
+`candidates` comprehension을 `ordered` 기반 + quality merge로 교체:
+```python
+        candidates = [
+            {
+                **e.to_payload_dict(),
+                "rank": rank, "candidate_rank": rank,
+                "data_state": freshness_status,
+                "toss_parity_status": toss_parity_status,
+                **((quality_by_symbol or {}).get(e.symbol, {})),
+            }
+            for rank, e in enumerate(ordered, start=1)
+        ]
+```
+
+- [ ] **Step 5: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/collectors/candidate_universe.py \
+        tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
+git commit -m "feat(ROB-346): US candidate collector computes quality flags + priority (wide pool)"
+```
+
+---
+
+## Task 5: auto_emit — 품질 데모션 + 사유/플래그 surface + 표시 cap
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py`
+- Test: `tests/services/action_report/snapshot_backed/test_auto_emit_quality.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_auto_emit_quality.py`:
+```python
+import datetime as dt
+from types import SimpleNamespace
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+def _snap(kind, payload, symbol=None):
+    return SimpleNamespace(snapshot_uuid=None, snapshot_kind=kind,
+                           payload_json=payload, symbol=symbol)
+
+
+def _actionable_quote(sym):
+    return {"status": "ok", "best_bid": 10, "best_ask": 10.1,
+            "bid_depth": 100, "ask_depth": 100}
+
+
+def test_penny_candidate_demoted_to_watch_with_reason():
+    cands = [{"symbol": "PENNY", "rank": 1, "candidate_rank": 1,
+              "data_state": "fresh", "quality_flags": ["penny", "illiquid"],
+              "priority_score": 0.1, "confidence_cap": None}]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap("symbol", {"symbol": "PENNY", "quote": _actionable_quote("PENNY")},
+              symbol="PENNY"),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="us", account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9))
+    item = next(i for i in items if i.symbol == "PENNY")
+    assert item.evidence_snapshot["action_verdict"] == "watch_only"
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "penny"
+    assert "penny" in item.evidence_snapshot["quality_flags"]
+
+
+def test_non_common_candidate_rejected():
+    cands = [{"symbol": "ETF1", "rank": 1, "candidate_rank": 1, "data_state": "fresh",
+              "quality_flags": ["non_common_stock"], "priority_score": 0.5}]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap("symbol", {"symbol": "ETF1", "quote": _actionable_quote("ETF1")},
+              symbol="ETF1"),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="us", account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9))
+    item = next(i for i in items if i.symbol == "ETF1")
+    assert item.evidence_snapshot["action_verdict"] == "rejected"
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "non_common_stock"
+
+
+def test_clean_candidate_stays_buy_review():
+    cands = [{"symbol": "GOOD", "rank": 1, "candidate_rank": 1, "data_state": "fresh",
+              "quality_flags": [], "priority_score": 0.9}]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap("symbol", {"symbol": "GOOD", "quote": _actionable_quote("GOOD")},
+              symbol="GOOD"),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="us", account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9))
+    item = next(i for i in items if i.symbol == "GOOD")
+    assert item.evidence_snapshot["action_verdict"] == "buy_review"
+```
+> `_stamp` 가 `evidence_snapshot["action_verdict"]` 를 채우는지 확인(verdict 인자로 stamp). 채움이 맞으므로 위 단언 사용. 아니라면 `_make_evidence` extra 경로로 단언 조정.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit_quality.py -v`
+Expected: FAIL — 품질 데모션 미적용.
+
+- [ ] **Step 3: candidate 루프에 데모션 삽입**
+
+`auto_emit.py` import에 추가:
+```python
+from app.services.action_report.snapshot_backed.action_verdict import (
+    classify_candidate_symbol, classify_held_symbol, demote_for_quality,
+)
+```
+(기존 import 라인 확장.)
+
+candidate 루프(`for cand in sorted(candidate_order, key=_candidate_sort_key):`) 내부의
+verdict/reason 블록을 교체. 현재:
+```python
+            verdict = classify_candidate_symbol(
+                quote,
+                universe_useful=candidate_actionable,
+                quote_snapshot_present=symbol_pair is not None,
+                candidate_fresh=(cand.get("data_state") or "fresh") == "fresh",
+            )
+            reject_or_wait_reason: str | None = None
+            if verdict == "data_gap":
+                reject_or_wait_reason = "quote_missing"
+            elif verdict == "watch_only":
+                reject_or_wait_reason = (
+                    "low_liquidity"
+                    if symbol_pair is not None and not _quote_is_actionable(quote)
+                    else "screener_stale"
+                )
+            elif verdict == "buy_review":
+                if buy_emitted >= self._max_buy_candidates:
+                    verdict = "watch_only"
+                    reject_or_wait_reason = "beyond_candidate_budget"
+                else:
+                    buy_emitted += 1
+```
+교체:
+```python
+            base_verdict = classify_candidate_symbol(
+                quote,
+                universe_useful=candidate_actionable,
+                quote_snapshot_present=symbol_pair is not None,
+                candidate_fresh=(cand.get("data_state") or "fresh") == "fresh",
+            )
+            # ROB-346 — quality demotion (pure, no signature change).
+            quality_flags = frozenset(cand.get("quality_flags") or [])
+            verdict, reject_or_wait_reason = demote_for_quality(
+                base_verdict, quality_flags
+            )
+            if verdict == "data_gap" and reject_or_wait_reason is None:
+                reject_or_wait_reason = "quote_missing"
+            elif verdict == "watch_only" and reject_or_wait_reason is None:
+                reject_or_wait_reason = (
+                    "low_liquidity"
+                    if symbol_pair is not None and not _quote_is_actionable(quote)
+                    else "screener_stale"
+                )
+            elif verdict == "buy_review":
+                if buy_emitted >= self._max_buy_candidates:
+                    verdict = "watch_only"
+                    reject_or_wait_reason = "beyond_candidate_budget"
+                else:
+                    buy_emitted += 1
+```
+
+- [ ] **Step 4: 표시 cap + quality 필드 surface**
+
+candidate 루프 시작 전 카운터 추가:
+```python
+        buy_emitted = 0
+        demoted_emitted = 0
+        _MAX_DEMOTED_SHOWN = 10
+```
+`items.append(cand_item)` 직전에 데모션 표시 cap 적용(buy_review는 항상, 데모션은 상위
+N개만 — candidate_order는 priority 순):
+```python
+            if verdict != "buy_review":
+                if demoted_emitted >= _MAX_DEMOTED_SHOWN:
+                    continue  # 노이즈 방지: 상위 N개 데모션만 카드화(집계는 candidate snapshot)
+                demoted_emitted += 1
+            items.append(cand_item)
+```
+`_candidate_item` 의 `extra` 에 quality 필드 추가(`extra` dict에 다음 키 삽입):
+```python
+        "quality_flags": cand.get("quality_flags"),
+        "confidence_cap": cand.get("confidence_cap"),
+        "candidate_priority_score": cand.get("priority_score"),
+```
+`_candidate_item` 의 rationale else-chain을 reason-맵으로 일반화. 현재 `elif reject_or_wait_reason == "low_liquidity": ... elif ... "beyond_candidate_budget": ... else: # screener_stale` 를
+다음 모듈 상수 + 분기로 교체:
+```python
+_REASON_KO: dict[str, str] = {
+    "low_liquidity": "저유동성",
+    "beyond_candidate_budget": "후보 예산 초과",
+    "screener_stale": "스크리너 stale",
+    "penny": "저가주",
+    "illiquid": "초저유동성",
+    "abnormal_spike": "비정상 급등",
+    "non_common_stock": "일반주 아님(ETF/우선주 등)",
+    "common_stock_unknown": "종목 분류 미확인",
+    "quote_missing": "호가 스냅샷 없음",
+}
+```
+rationale 분기(is_buy/is_gap 외):
+```python
+    else:
+        reason_ko = _REASON_KO.get(reject_or_wait_reason or "", "관망")
+        rationale = f"신규 후보 관망 {priority}순위 — {sym} ({reason_ko})"
+```
+
+- [ ] **Step 5: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit_quality.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/auto_emit.py \
+        tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
+git commit -m "feat(ROB-346): auto_emit applies quality demotion, surfaces flags, caps demoted display"
+```
+
+---
+
+## Task 6: lint / typecheck / KR 무회귀
+
+- [ ] **Step 1:** `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/` → clean
+- [ ] **Step 2:** `uv run ty check app/` → no new errors
+- [ ] **Step 3 (KR 무회귀):** `uv run pytest tests/services/action_report/snapshot_backed tests/services/invest_screener_snapshots -v` → PASS. 특히 KR candidate 경로 기존 테스트가 quality 게이트 미적용으로 그대로 통과하는지 확인.
+- [ ] **Step 4:** 필요 시 `git commit -m "style(ROB-346): ruff"`
+
+---
+
+## Self-review (작성자 체크)
+- 스펙 §3.2~3.6 → Task 3/4(pool+collector), Task 1(품질/priority), Task 2/5(demote+surface) 매핑.
+- 타입 일관: `quality_flags` = list(payload) / frozenset(헬퍼); `priority_score` float; `confidence_cap` int|None; reason 문자열 = `_REASON_KO` 키.
+- 단위: change_rate/week_change_rate percent(>15.0/>50.0), dollar_volume USD(<5e6), penny<5.0.
+- 무충돌: classify_candidate_symbol signature 불변 → PR-C는 같은 루프에 demote_for_budget만 추가.
+- 안전: US-only gate, decision_bucket enum 불변, migration 없음, no broker/order mutation, KR 회귀 테스트.
+- placeholder 없음.

--- a/docs/superpowers/plans/2026-06-09-rob-347-us-budget-fx-basis-plan.md
+++ b/docs/superpowers/plans/2026-06-09-rob-347-us-budget-fx-basis-plan.md
@@ -1,0 +1,448 @@
+# ROB-347 — US 리포트 신규매수 예산·환전 전제 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** US kis_live 후보에 예산 전제 정책을 적용한다. `available_usd` 기본 basis에서 USD buying power가 0이어도 후보는 발굴하되, `buy_review` 를 `watch_only` 로 강등하고 `budget_gap`/`fx_required`/`operator_budget_required` 를 명시한다. KRW는 reference로만(USD로 날조 금지).
+
+**Architecture:** PR-B와 동일하게 `classify_candidate_symbol` signature 불변. 순수 헬퍼 `demote_for_budget` 를 추가해 auto_emit candidate 루프에서 **품질 데모션 다음, count-cap 이전**에 적용. 예산 신호는 portfolio snapshot의 `buying_power`(이미 적재됨) + request의 basis/override. migration-0.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, pytest. 스펙: `docs/superpowers/specs/2026-06-09-rob-347-us-budget-fx-basis-design.md`. **선행: PR-B(ROB-346) 머지 후 origin/main 기준으로 시작** (같은 candidate 루프 수정).
+
+---
+
+## File Structure
+- Modify: `app/services/action_report/snapshot_backed/request.py` — `budget_basis` + `operator_budget_override_usd`.
+- Modify: `app/services/action_report/snapshot_backed/action_verdict.py` — `demote_for_budget` 순수 헬퍼.
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py` — propose budget 파라미터, budget_state, 데모션, evidence surface.
+- Modify: `app/services/action_report/snapshot_backed/generator.py:594-598` — request budget을 propose로 전달.
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` — 도구에 budget 파라미터 노출 → request.
+- Tests: 대응 신규/확장.
+
+---
+
+## Task 1: request 예산 필드
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/request.py`
+- Test: `tests/services/action_report/snapshot_backed/test_request_budget.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_request_budget.py`:
+```python
+from decimal import Decimal
+
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+
+
+def _base(**kw):
+    return ReportGenerationRequest(
+        market="us", account_scope="kis_live", created_by_profile="p",
+        title="t", summary="s", kst_date="2026-06-09", **kw,
+    )
+
+
+def test_budget_basis_defaults_available_usd():
+    assert _base().budget_basis == "available_usd"
+    assert _base().operator_budget_override_usd is None
+
+
+def test_budget_override_accepts_decimal():
+    r = _base(budget_basis="operator_budget_override",
+              operator_budget_override_usd=Decimal("1000"))
+    assert r.operator_budget_override_usd == Decimal("1000")
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_request_budget.py -v`
+Expected: FAIL — 필드/Decimal import 없음(extra="forbid"로 거부).
+
+- [ ] **Step 3: 구현** — `request.py` 상단 import에 `from decimal import Decimal` 추가.
+`candidate_limit: int | None = None` (line 64) 아래에 추가:
+```python
+    # ROB-347 — US new-buy budget basis policy. Default available_usd: USD
+    # buying power gates buy_review. USD<=0 demotes buy_review → watch_only with
+    # budget_gap/fx_required/operator_budget_required (never a silent buy). KRW
+    # is reference-only; no KRW→USD fabrication.
+    budget_basis: Literal[
+        "available_usd", "krw_orderable_reference", "operator_budget_override"
+    ] = "available_usd"
+    operator_budget_override_usd: Decimal | None = None
+```
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_request_budget.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/request.py \
+        tests/services/action_report/snapshot_backed/test_request_budget.py
+git commit -m "feat(ROB-347): budget_basis + operator_budget_override_usd request fields"
+```
+
+---
+
+## Task 2: `demote_for_budget` 순수 헬퍼
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/action_verdict.py`
+- Test: `tests/services/action_report/snapshot_backed/test_action_verdict_budget.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_action_verdict_budget.py`:
+```python
+from app.services.action_report.snapshot_backed.action_verdict import demote_for_budget
+
+
+def _state(basis="available_usd", usd=None, krw=0, override=None):
+    return {"basis": basis, "usd": usd, "krw": krw, "override_usd": override}
+
+
+def test_usd_zero_demotes_to_watch_budget_gap():
+    v, reasons = demote_for_budget("buy_review", _state(usd=0, krw=0))
+    assert v == "watch_only"
+    assert "budget_gap" in reasons
+    assert "operator_budget_required" in reasons  # override 없음
+
+
+def test_usd_zero_with_krw_adds_fx_required():
+    _, reasons = demote_for_budget("buy_review", _state(usd=0, krw=500000))
+    assert "fx_required" in reasons and "budget_gap" in reasons
+
+
+def test_usd_positive_keeps_buy():
+    assert demote_for_budget("buy_review", _state(usd=1000)) == ("buy_review", [])
+
+
+def test_override_takes_precedence_over_basis():
+    assert demote_for_budget("buy_review",
+        _state(basis="available_usd", usd=0, override=500)) == ("buy_review", [])
+
+
+def test_krw_reference_basis_flags_fx_required():
+    v, reasons = demote_for_budget("buy_review",
+        _state(basis="krw_orderable_reference", usd=0, krw=500000))
+    assert v == "watch_only" and reasons == ["fx_required"]
+
+
+def test_non_buy_unchanged():
+    assert demote_for_budget("watch_only", _state(usd=0)) == ("watch_only", [])
+    assert demote_for_budget("rejected", _state(usd=0)) == ("rejected", [])
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict_budget.py -v`
+Expected: FAIL — `demote_for_budget` 없음.
+
+- [ ] **Step 3: 구현** — `action_verdict.py` 끝에 추가:
+```python
+from typing import Any  # (이미 import되어 있으면 생략)
+
+
+def demote_for_budget(
+    verdict: str, budget_state: dict[str, Any]
+) -> tuple[str, list[str]]:
+    """ROB-347 — post-verdict budget demotion. Only buy_review is touched;
+    budget never upgrades. KRW is reference-only (no KRW→USD fabrication).
+    Returns (new_verdict, reasons)."""
+    if verdict != "buy_review":
+        return verdict, []
+    basis = budget_state.get("basis") or "available_usd"
+    override = budget_state.get("override_usd")
+    krw = budget_state.get("krw") or 0
+    # request override (operator/report budget) takes precedence when present.
+    usd = override if override is not None else budget_state.get("usd")
+    if basis == "krw_orderable_reference" and override is None:
+        return "watch_only", ["fx_required"]
+    if usd is not None and usd > 0:
+        return "buy_review", []
+    reasons = ["budget_gap"]
+    if krw and krw > 0:
+        reasons.append("fx_required")
+    if override is None:
+        reasons.append("operator_budget_required")
+    return "watch_only", reasons
+```
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_action_verdict_budget.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/action_verdict.py \
+        tests/services/action_report/snapshot_backed/test_action_verdict_budget.py
+git commit -m "feat(ROB-347): demote_for_budget pure helper (buy_review-only, no fabrication)"
+```
+
+---
+
+## Task 3: auto_emit — budget 파라미터 + budget_state + 데모션 + surface
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/auto_emit.py`
+- Test: `tests/services/action_report/snapshot_backed/test_auto_emit_budget.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+`tests/services/action_report/snapshot_backed/test_auto_emit_budget.py`:
+```python
+import datetime as dt
+from types import SimpleNamespace
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+def _snap(kind, payload, symbol=None):
+    return SimpleNamespace(snapshot_uuid=None, snapshot_kind=kind,
+                           payload_json=payload, symbol=symbol)
+
+
+def _q():
+    return {"status": "ok", "best_bid": 10, "best_ask": 10.1,
+            "bid_depth": 100, "ask_depth": 100}
+
+
+def _snaps(buying_power):
+    cands = [{"symbol": "GOOD", "rank": 1, "candidate_rank": 1, "data_state": "fresh",
+              "quality_flags": [], "priority_score": 0.9}]
+    return [
+        _snap("portfolio", {"buying_power": buying_power,
+                            "primary_source": "kis", "holdings": []}),
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap("symbol", {"symbol": "GOOD", "quote": _q()}, symbol="GOOD"),
+    ]
+
+
+def _item(snaps, **budget):
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="us", account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9), **budget)
+    return next(i for i in items if i.symbol == "GOOD")
+
+
+def test_usd_zero_demotes_with_budget_gap():
+    item = _item(_snaps({"usd": 0, "krw": 0}))
+    ev = item.evidence_snapshot
+    assert ev["action_verdict"] == "watch_only"
+    assert "budget_gap" in ev["budget_reasons"]
+    assert ev["budget_basis"] == "available_usd"
+
+
+def test_usd_zero_with_krw_reference_adds_fx_required_not_summed():
+    ev = _item(_snaps({"usd": 0, "krw": 500000})).evidence_snapshot
+    assert "fx_required" in ev["budget_reasons"]
+    assert ev["available_usd"] in (0, 0.0)
+    assert ev["krw_orderable_reference"] == 500000  # reference, not summed into USD
+
+
+def test_operator_override_keeps_buy():
+    ev = _item(_snaps({"usd": 0, "krw": 0}),
+               budget_basis="operator_budget_override",
+               operator_budget_override_usd=500).evidence_snapshot
+    assert ev["action_verdict"] == "buy_review"
+
+
+def test_usd_positive_keeps_buy():
+    ev = _item(_snaps({"usd": 2000, "krw": 0})).evidence_snapshot
+    assert ev["action_verdict"] == "buy_review"
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit_budget.py -v`
+Expected: FAIL — propose에 budget 파라미터/데모션/evidence 부재.
+
+- [ ] **Step 3: propose 시그니처 + budget_state**
+
+import 확장:
+```python
+from app.services.action_report.snapshot_backed.action_verdict import (
+    classify_candidate_symbol, classify_held_symbol, demote_for_budget,
+    demote_for_quality,
+)
+```
+`propose` 시그니처에 파라미터 추가:
+```python
+    def propose(
+        self,
+        *,
+        snapshots: list[Any],
+        request_market: str,
+        account_scope: str | None,
+        budget_basis: str = "available_usd",
+        operator_budget_override_usd: Any | None = None,
+        now: dt.datetime | None = None,
+    ) -> list[IngestReportItem]:
+```
+`held = _held_kis_symbols(portfolio_payload)` 근처(candidate 루프 전)에 budget_state 구성:
+```python
+        buying_power = portfolio_payload.get("buying_power") or {}
+        budget_state = {
+            "basis": budget_basis,
+            "override_usd": _to_float(operator_budget_override_usd),
+            "usd": _to_float(buying_power.get("usd")),
+            "krw": _to_float(buying_power.get("krw")),
+        }
+```
+(`_to_float` 는 모듈에 이미 존재 — `_candidate_sort_key` 가 사용.)
+
+- [ ] **Step 4: 루프에 budget 데모션 삽입 (품질 다음, count-cap 이전)**
+
+ROB-346에서 추가된 `verdict, reject_or_wait_reason = demote_for_quality(...)` **직후**,
+기존 `if verdict == "data_gap" ...` 블록 **이전**에 삽입:
+```python
+            # ROB-347 — budget demotion (buy_review only; never fabricates USD).
+            verdict, budget_reasons = demote_for_budget(verdict, budget_state)
+            if budget_reasons and reject_or_wait_reason is None:
+                reject_or_wait_reason = budget_reasons[0]
+```
+(이로써 예산-강등된 후보는 buy slot/count-cap을 소비하지 않는다.)
+
+- [ ] **Step 5: budget evidence surface**
+
+`_candidate_item` 호출에 `budget_evidence` 전달. 루프에서 호출부 직전:
+```python
+            budget_evidence = {
+                "budget_basis": budget_state["basis"],
+                "available_usd": budget_state["usd"],
+                "krw_orderable_reference": budget_state["krw"],
+                "operator_budget_override_usd": budget_state["override_usd"],
+                "budget_reasons": budget_reasons,
+                "budget_fit": verdict == "buy_review" and not budget_reasons,
+            }
+```
+`_candidate_item(...)` 호출에 `budget_evidence=budget_evidence` 추가. `_candidate_item`
+시그니처에 `budget_evidence: dict[str, Any] | None = None` 추가하고, `extra` 구성 후:
+```python
+    if budget_evidence:
+        extra.update(budget_evidence)
+```
+
+- [ ] **Step 6: 통과 확인 + 커밋**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_auto_emit_budget.py -v` → PASS
+```bash
+git add app/services/action_report/snapshot_backed/auto_emit.py \
+        tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
+git commit -m "feat(ROB-347): auto_emit budget demotion + budget evidence surface"
+```
+
+---
+
+## Task 4: generator가 request budget을 propose로 전달
+
+**Files:**
+- Modify: `app/services/action_report/snapshot_backed/generator.py:594-598`
+- Test: `tests/services/action_report/snapshot_backed/test_generator_budget_threads.py` (또는 기존 generator 테스트 확장)
+
+- [ ] **Step 1: 실패 테스트 (스레딩 단언)** — 가장 가벼운 방식은 propose를 monkeypatch해 kwargs 캡처:
+```python
+import pytest
+
+from app.services.action_report.snapshot_backed import generator as gen_mod
+
+
+@pytest.mark.asyncio
+async def test_auto_emit_threads_budget(monkeypatch):
+    captured = {}
+
+    class FakeEmitter:
+        def __init__(self, **_kw):
+            pass
+
+        def propose(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(
+        "app.services.action_report.snapshot_backed.auto_emit.EvidenceAutoEmitter",
+        FakeEmitter,
+    )
+    # _auto_emit_items_from_bundle 호출에 필요한 최소 stub는 기존 generator 테스트
+    # 픽스처를 재사용(bundle/snapshots repo). 핵심 단언:
+    # captured["budget_basis"] == request.budget_basis 등.
+```
+> 기존 generator 단위 테스트가 있으면 그 픽스처(bundle repo stub)를 재사용해
+> `_auto_emit_items_from_bundle` 를 호출하고 `captured` 의 budget kwargs를 단언한다.
+> 격리 stub 작성이 과하면 Task 4를 통합 테스트(end-to-end generate)로 대체 가능.
+
+- [ ] **Step 2: 실패 확인** — Run 후 FAIL(budget kwargs 미전달).
+
+- [ ] **Step 3: 구현** — `generator.py` 의 propose 호출(594-598)을 교체:
+```python
+        return emitter.propose(
+            snapshots=[s for _i, s in item_snapshot_pairs],
+            request_market=request.market,
+            account_scope=request.account_scope,
+            budget_basis=request.budget_basis,
+            operator_budget_override_usd=request.operator_budget_override_usd,
+        )
+```
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+```bash
+git add app/services/action_report/snapshot_backed/generator.py \
+        tests/services/action_report/snapshot_backed/test_generator_budget_threads.py
+git commit -m "feat(ROB-347): thread request budget basis/override into auto_emit"
+```
+
+---
+
+## Task 5: MCP 도구 파라미터 노출
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py` (investment_report_generate_from_bundle, ~854-936)
+- Test: 기존 핸들러 테스트 확장 또는 신규 `tests/.../test_generate_from_bundle_budget_param.py`
+
+- [ ] **Step 1: 핸들러에서 ReportGenerationRequest 생성부 확인**
+
+`investment_report_generate_from_bundle` 함수 시그니처와 `ReportGenerationRequest(...)`
+생성 위치를 연다(`grep -n "ReportGenerationRequest(" app/mcp_server/tooling/investment_reports_handlers.py`).
+
+- [ ] **Step 2: 실패 테스트** — 도구에 `budget_basis`/`operator_budget_override_usd` 인자가
+받아들여지고 request로 전달되는지(핸들러 단위 테스트). 핸들러 호출 패턴은 기존 테스트
+(`tests/.../test_investment_reports_handlers*` 또는 유사)를 모델로 작성.
+
+- [ ] **Step 3: 구현** — 도구 함수 시그니처에 추가(기존 선택 파라미터들과 같은 자리):
+```python
+    budget_basis: str = "available_usd",
+    operator_budget_override_usd: float | None = None,
+```
+`ReportGenerationRequest(...)` 생성에 전달:
+```python
+        budget_basis=budget_basis,
+        operator_budget_override_usd=operator_budget_override_usd,
+```
+도구 docstring에 한 줄 추가: "budget_basis(기본 available_usd)/operator_budget_override_usd로
+US 신규매수 예산 전제를 지정. USD=0이면 후보는 watch_only + budget_gap/fx_required."
+
+- [ ] **Step 4: 통과 확인 + 커밋**
+
+```bash
+git add app/mcp_server/tooling/investment_reports_handlers.py tests/...
+git commit -m "feat(ROB-347): expose budget_basis/operator_budget_override on generate_from_bundle"
+```
+
+---
+
+## Task 6: lint / typecheck / 회귀
+
+- [ ] **Step 1:** `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/` → clean
+- [ ] **Step 2:** `uv run ty check app/` → no new errors
+- [ ] **Step 3:** `uv run pytest tests/services/action_report/snapshot_backed -v` → PASS
+  (USD>0 정상 buy 유지, USD=0 데모션, override, KRW reference 비혼동 전부 green; PR-B 품질
+  데모션과의 순서 상호작용도 통과)
+- [ ] **Step 4:** 필요 시 `git commit -m "style(ROB-347): ruff"`
+
+---
+
+## Self-review (작성자 체크)
+- 스펙 §3.1~3.5 → Task 1(request)/2(헬퍼)/3(데모션+surface)/4(generator)/5(MCP) 매핑. AC 5건 테스트 보유.
+- 순서: base → demote_for_quality(B) → demote_for_budget(C) → count-cap. budget은 buy_review만 하향, 절대 상향 없음.
+- KRW 비혼동: `krw_orderable_reference` 별도 필드, USD로 합산/날조 안 함(`portfolio_journal.py:90` 정직 동작 보존).
+- override precedence: non-null이면 basis 무관 우선.
+- 무충돌: classify_candidate_symbol signature 불변; B와 같은 루프에 3줄 추가(인접).
+- 안전: 환전/주문/broker mutation 없음, migration 없음.
+- placeholder 없음(Task 4/5의 픽스처 재사용 지점만 구현자가 기존 테스트에서 확정 — 코드/명령은 구체).

--- a/docs/superpowers/specs/2026-06-09-rob-345-us-kis-live-journal-mapping-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-345-us-kis-live-journal-mapping-design.md
@@ -1,0 +1,146 @@
+# ROB-345 — US kis_live 리포트 trade journal 매핑 복구 (Design)
+
+- **Issue**: ROB-345 (Bug / High) — parent ROB-336 (`/invest/reports` Phase 2)
+- **Date**: 2026-06-09
+- **Scope**: PR-A (A→B→C 배치). Migration-0. 독립(346/347과 무충돌).
+- **Status**: design + adversarial spec-review 반영. pending user review → plan
+
+## 1. Context
+
+US snapshot-backed `/invest/reports` readiness 점검에서, 직접 조회한 live US trade
+journal에는 active 항목이 있었으나 생성된 snapshot/Hermes context의 journal stage는
+`open journal: none` 으로 표시되었다. 원 이슈는 원인을 `account_scope="kis_live"` →
+live KIS journal 변환 누락으로 추정.
+
+## 2. Root cause — 이슈 가설 정정 (코드 검증, DB 불요)
+
+검증 결과 제출 가설(account_scope 변환 누락)은 *부차적* latent 결함이고, "open journal:
+none" 의 *지배적 proximate 원인*은 journal snapshot **payload 키 계약 불일치**다.
+
+### 2.1 (지배 원인) journal payload 키 계약 불일치
+- Collector(`collectors/journal.py:66-67`)는 payload 키를 **`active` /
+  `recent_retrospective`** 로 emit.
+- Stage(`stages/portfolio_journal.py:118`)는 **`(snap.payload_json or {}).get("entries", [])`**
+  를 읽음. **`entries` 키는 어떤 collector도 쓰지 않는다.**
+- 따라서 stage가 `.get("entries")` 를 호출하는 한, payload에 active journal이 몇 개
+  있든 **entries는 항상 `[]`** → `symbols == ""` → `open journal: none` 이
+  **모든 market(KR/US)에서 항상** 출력. (journal 내용과 무관한 키 미스매치.)
+- 게다가 `missing_data = [] if journal_snaps else ["journal"]`
+  (`portfolio_journal.py:137`): journal snapshot은 *존재*하므로 missing으로도 표시되지
+  않아 **조용히 none** → 증상과 정확히 일치.
+- `portfolio_journal.py:108` 이 `snapshots_for("journal")` 의 **유일한 소비자**
+  (app/ 내 grep 확인).
+- 단위 테스트(`tests/services/investment_stages/stages/test_portfolio_journal.py:40,287`)가
+  `{"entries": [...]}` 를 **fabricate** 해 stage의 잘못된 기대와 맞춰 통과 → 버그를
+  가린 test-gap.
+
+### 2.2 (부차) market 미스코핑 + provenance 부재
+- Collector는 `account_type=="live"` + status 로만 필터(`journal.py:44-60`).
+  `market`/`instrument_type`/`account` 필터 없음 → US 리포트가 KR live journal까지 섞어
+  가져온다(2.1 키를 고치면 즉시 노출될 mixing; ROB-336 authority separation 위반).
+- `_journal_to_dict`(`journal.py:89-111`)는 `instrument_type`/`account_type`은 emit하나
+  **`account` 누락** → provenance 검증 불가.
+
+### 2.3 empty vs unavailable 미구분
+"active journal 없음(정상 empty)" 과 "collector가 못 돈 경우(unavailable)" 미구분.
+
+### 2.4 schema / 작동하는 참조 구현
+- `app/models/trade_journal.py`: `instrument_type` enum(`equity_kr`/`equity_us`/`crypto`/
+  `forex`/`index`), `account`(unconstrained Text), `account_type` CHECK(`live`/`paper`/`mock`).
+  **`market`/`broker` 컬럼 없음** → no-migration discriminator는 `instrument_type`뿐.
+- KIS-live ledger 체결 기록(`app/mcp_server/tooling/kis_live_ledger.py:504,511,535,536,549,550`)은
+  journal을 `account_type="live"`, `account="kis"`, `instrument_type=<equity_us|equity_kr>` 로 씀.
+- **작동하는 참조: `get_trade_journal`** (`app/mcp_server/tooling/trade_journal_tools.py:240-304`)
+  은 이미 `account_type` + `account` + `market`(→ `market_map` → `instrument_type`,
+  `:296-304`)로 필터한다. AC가 "get_trade_journal(market='us')에서 active US가 보인다"
+  라고 한 이유. **본 PR은 리포트 collector를 이 참조 동작에 맞추는 것.**
+
+## 3. Goal
+
+US kis_live 리포트 journal stage가 active US KIS journal을 정확히 반영하고, KR/타 market
+journal과 섞이지 않으며, "journal 없음" 과 "collector unavailable" 을 구분된 reason으로
+남긴다. **DB backfill/쓰기 없이, migration-0.** 리포트 collector를 `get_trade_journal`
+참조 필터와 일치시킨다.
+
+## 4. Design (read-only / additive, 3 레이어)
+
+### 4.1 Layer 1 — payload 계약 정렬 (지배 수정)
+- `portfolio_journal.py` stage가 collector 실제 키 **`active`** (open journals)를 읽도록
+  수정. summary semantic = active journal symbols 최대 5개(기존 포맷 유지).
+- `recent_retrospective` 은 본 PR summary 범위 밖. **현재 어떤 stage/service도 journal
+  snapshot의 `recent_retrospective` 를 소비하지 않음**(grep 확인; delta/retrospective는
+  별도 service 경로). 수집은 되나 stage 표면화는 follow-up.
+- **테스트 fixture 정정**: `test_portfolio_journal.py:40,287` 을 collector 실제 shape
+  (`{"active":[...], "recent_retrospective":[...], "active_count":n, "collector_status":"ok"}`)로
+  변경 → 계약을 테스트로 고정(회귀 방지). 이게 없으면 2.1 버그가 다시 통과한다.
+
+### 4.2 Layer 2 — market scoping + provenance (참조 미러)
+- `collectors/journal.py` collect()가 **`get_trade_journal` 의 검증된 필터 패턴**
+  (`trade_journal_tools.py:296-304` 의 `market_map`)을 미러:
+  - `TradeJournal.account_type == "live"` (유지)
+  - `TradeJournal.instrument_type == market_map[request.market]`
+    (us→`equity_us`, kr→`equity_kr`; 매핑은 `market_map` 과 동일 값으로 정의.
+    shared 헬퍼 없으면 collector 내부에 명시 정의 + 출처 주석. symbol collector
+    `collectors/symbol.py:229` 도 `equity_us` 하드코딩이라 helper 부재 확인됨.)
+  - `(TradeJournal.account == "kis") | (TradeJournal.account.is_(None))`
+- `_journal_to_dict` 에 **`account` 추가**(provenance).
+- **legacy NULL allowance**: 현재 write는 `account="kis"`(kis_live_ledger 확인). 과거 일부
+  live row가 `account=NULL` 일 수 있어 `account IS NULL` 을 허용(포착은 하되 강제 안 함)
+  — migration-0 하에 historical 데이터 보존. crypto 등 타 instrument_type은 자동 제외.
+- **읽기 서비스(`trade_journal_read_service.list_retrospective`)는 본 PR 범위 아님**:
+  리포트 collector는 자체 쿼리를 쓰고, `get_trade_journal` 은 이미 정확. retrospective
+  read service 수정은 불필요 scope creep → 제외.
+
+### 4.3 Layer 3 — empty vs unavailable 구분
+- Collector: 정상 시 `build_result` 로 `active`/`recent_retrospective`/counts +
+  **`collector_status: "ok"`** 를 payload에 emit. SELECT 예외 시
+  `unavailable_result(reason="journal_query_failed")` 반환.
+  - unavailable 트리거(현 PR): SELECT 쿼리 예외 → `journal_query_failed`. (timeout/
+    freshness 기반 unavailable은 follow-up.)
+- Stage 판정:
+  - journal snap 없음 **또는** snap이 unavailable(`freshness_status=="unavailable"`
+    또는 payload `collector_status != "ok"`) → `missing_data += ["journal"]`, data_gap
+    reason `journal_collector_unavailable`.
+  - snap 정상 + `active == []` → "open journal: none" 유지 + reason `no_open_journals`
+    (정상 상태, confidence 미감점).
+  - snap 정상 + `active` 존재 → symbols 렌더.
+  - (StageContext snapshot의 freshness 속성 접근은 plan에서 확정. 1순위는 payload
+    `collector_status` — 속성 의존 최소화.)
+
+## 5. Acceptance criteria (이슈 매핑)
+- `get_trade_journal(account_type="live", market="us")` 의 active US KIS journal이
+  snapshot-backed US report journal stage summary에 반영. → L1+L2
+- `account_scope="kis_live"`(→ market scoping) regression test 존재. → L2
+- journal 없음(`no_open_journals`) 과 collector unavailable(`journal_collector_unavailable`)
+  구분되어 data_gap에 남음. → L3
+- KIS live와 KR/Toss/reference/manual authority 미혼합(US 리포트에 KR journal 미포함). → L2
+
+## 6. Test plan
+1. **계약 회귀(지배)**: collector 실제 shape(`active`)로 stage가 symbol 렌더 —
+   `entries` fabrication 제거 후에도 그린.
+2. **market scoping (DB-seeded integration)**: `trade_journals` 에 live equity_us
+   (account="kis") + live equity_kr(account="kis") row를 seed. collect(market="us")는
+   equity_us만, collect(market="kr")는 equity_kr만 반환. account="kis"/NULL 포함, 타
+   account 제외 → ROB-336 per-market authority separation 증명.
+3. **provenance**: `_journal_to_dict` 가 `account` emit.
+4. **empty vs unavailable**: (a) active 0개 → `no_open_journals`, confidence 미감점;
+   (b) collector unavailable(쿼리 예외 mock) → `journal_collector_unavailable` data_gap.
+
+## 7. Safety boundaries / Non-goals
+- journal row 대량 수정/backfill **금지**(collector read-only; `TradeJournalWriteService`
+  유일 write, import 안 함). broker/order/watch/order-intent mutation·주문
+  preview/submit/cancel/modify 금지.
+- Toss/manual holdings를 KIS live journal로 승격 금지.
+- KR 경로 회귀 금지(scoping은 market별 additive; KRW summary byte-identical 계약 유지).
+- **read consistency**: collector는 기본 AsyncSession 격리(READ COMMITTED). collect 중
+  concurrent fill로 count가 payload list와 미세 불일치 가능 — 기존과 동일 fail-open 허용
+  (엄격 격리는 follow-up).
+- dead `app/services/action_report/us/` 모듈(zero non-test caller; action_classifier의
+  journal 읽기 포함)은 **본 PR에서 미수정/미제거** — 별도 cleanup 이슈.
+- migration 없음.
+
+## 8. Out of scope / follow-up
+- 실패 리포트 실제 DB row 대조(원인은 코드로 규명; 필요 시 operator).
+- `trade_journals` 명시 `market`/`broker` 컬럼(additive migration) — cross-broker live가
+  `account_type="live"` 공유 시 검토.
+- `recent_retrospective` stage 표면화; dead `us/` 제거.

--- a/docs/superpowers/specs/2026-06-09-rob-346-us-candidate-universe-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-346-us-candidate-universe-design.md
@@ -1,0 +1,158 @@
+# ROB-346 — US 신규매수 후보 universe 필터·우선순위 고도화 (Design)
+
+- **Issue**: ROB-346 (Improvement / High) — parent ROB-336
+- **Date**: 2026-06-09
+- **Scope**: PR-B (A→B→C 배치). Migration-0. **US-only**(KR 경로 무회귀).
+- **Status**: design + adversarial spec-review 반영. pending user review → plan
+- **Ordering**: PR-A(345)와 독립. PR-C(347)와 같은 candidate 루프를 건드리므로 **B 먼저
+  머지**. 단, 충돌을 구조적으로 없애기 위해 **classify_candidate_symbol signature는
+  바꾸지 않고**, 후처리 demotion 헬퍼를 추가한다(§3.3).
+
+## 1. Context / 현황 (코드 검증)
+
+US 신규매수 후보는 `invest_screener_snapshots` top-gainers에서 **순수 모멘텀**으로 수집:
+- `collectors/candidate_universe.py:302-355` `_collect_top_gainers`(US 분기;
+  `_collect_equity:291-300` 이 wrapper). 품질 필터 **전무**.
+- `invest_screener_snapshots/repository.py:123-141` `list_top_candidates`:
+  `ORDER BY change_rate DESC nullslast, symbol ASC LIMIT :limit`. 내부 pool == 표시 pool.
+- 후보 verdict `action_verdict.py:74-98` `classify_candidate_symbol(quote, *,
+  universe_useful, quote_snapshot_present, candidate_fresh)` → `data_gap`/`watch_only`/
+  `buy_review` (호가 actionability + freshness만; 가격/유동성/연령 입력 없음). **candidate
+  전용**(held는 `classify_held_symbol`).
+- auto_emit candidate 루프(`auto_emit.py:464-518`): verdict → reason if/elif(`:476-490`,
+  현 reasons `quote_missing`/`low_liquidity`/`beyond_candidate_budget`(=개수 cap)/
+  `screener_stale`) → `_candidate_item(..., verdict, priority, reject_or_wait_reason)`.
+  candidate dict은 `payload["candidates"]` 에서 옴(collector의 `build_candidate_evidence`).
+
+### 1.1 가용 데이터 (필터 feasibility)
+`invest_screener_snapshots`: `latest_close`(Decimal, 가격), `daily_volume`(BigInt, 주),
+`change_rate`(Decimal, 비율 e.g. 0.12=+12%), `week_change_rate`, `closes_window`(JSONB),
+`consecutive_up_days`. **`market_cap` 없음.**
+`us_symbol_universe`: `is_common_stock`(nullable Bool, ROB-204), `is_active`, `exchange`.
+**`market_cap`/`sector` 없음.**
+→ penny/illiquid/abnormal-spike/stale는 snapshot으로 직접 계산. **true 시총 마이크로캡은
+추가 fetch 없이는 불가 → 가격·달러볼륨 proxy + is_common_stock 으로 대체(정직하게
+"size/liquidity proxy" 명명).**
+
+## 2. Goal
+
+예산보다 넓은 pool에서 priority 순으로 신규매수 후보를 산출하되, 저품질 후보는 무조건
+제거가 아니라 `watch_only`/`rejected`/`data_gap` + 사유로 분류. stale-only 후보가 live buy로
+노출되지 않음.
+
+## 3. Design (migration-0, US-only gate)
+
+### 3.1 용어 (일관 사용)
+- **quality_flags**: 후보별로 *감지된* 품질 이슈 이름의 `frozenset[str]`. 가능한 멤버:
+  `{"penny","illiquid","abnormal_spike","non_common_stock","screener_stale",
+  "common_stock_unknown"}`. (true 플래그만 포함; 없으면 empty set.)
+- **verdict**: locked decision_bucket의 sub-verdict(`buy_review`/`watch_only`/`rejected`/
+  `data_gap`).
+- **reason**: auto_emit가 evidence에 기록하는 문자열(예: `penny`).
+
+### 3.2 pool 확장 + is_common_stock 조인 (collector, US-only)
+- `repository.py` 에 **신규** `list_candidate_pool(market, limit=None)`:
+  최신 partition 후보를 wide하게 반환(change_rate DESC nullslast, symbol ASC; limit None=
+  partition 전체 또는 cap). US는 `us_symbol_universe.is_common_stock` LEFT JOIN(없으면 None).
+  *기존 `list_top_candidates` 는 그대로 두고 신규 메서드 추가(타 호출자 무영향).*
+- `_collect_top_gainers` (US 분기, `request.market=="us"` 게이트): pool =
+  `max(candidate_limit × 5, 50)` 를 `list_candidate_pool` 로 수집.
+- 후보별 **quality_flags + 원지표**를 candidate evidence dict에 적재(`build_candidate_evidence`/
+  `_equity_row_to_input` 확장, additive):
+  `latest_close`, `daily_volume`, `dollar_volume_usd`, `change_rate`, `week_change_rate`,
+  `is_common_stock`, `quality_flags`(list), `priority_score`(float), `confidence_cap`(int|None).
+- **KR 경로 무변경**: `_collect_kr_presets` 및 KR top_gainers fallback은 신규 quality 로직
+  미적용(US-only gate). 기존 KR 테스트 green 유지.
+
+### 3.3 품질 게이트 (Conservative 기본; spec review에서 튜닝 가능)
+`dollar_volume_usd = float(latest_close) * daily_volume` (US는 `latest_close` USD 가정).
+후보별 quality_flags 산출:
+| flag | 기준(US) |
+|------|----------|
+| `penny` | `latest_close < 5.0` |
+| `illiquid` | `dollar_volume_usd < 5_000_000` |
+| `abnormal_spike` | `change_rate > 0.15` OR `week_change_rate > 0.50` |
+| `non_common_stock` | `is_common_stock is False` |
+| `common_stock_unknown` | `is_common_stock is None` (미분류) |
+| `screener_stale` | collector `days_stale > 0` 또는 usefulness != "useful" |
+
+**후처리 demotion(서명 충돌 회피 핵심):** `classify_candidate_symbol` 은 **그대로** 두고,
+`action_verdict.py` 에 **순수 헬퍼** 추가:
+```
+def demote_for_quality(verdict: str, quality_flags: frozenset[str]) -> tuple[str, str | None]:
+    # 우선순위: rejected > data_gap(미분류) > watch_only > 원 verdict
+    if "non_common_stock" in quality_flags:      return "rejected", "non_common_stock"
+    if verdict != "buy_review":                  return verdict, None  # 이미 honest 하향 — budget/품질로 끌어올리지 않음
+    if "common_stock_unknown" in quality_flags:  return "data_gap", "common_stock_unknown"
+    for f in ("penny","illiquid","abnormal_spike","screener_stale"):
+        if f in quality_flags:                   return "watch_only", f
+    return "buy_review", None
+```
+- 규칙: 품질 verdict가 **우선**; 품질은 **하향만**(절대 상향 없음). `non_common_stock` 은
+  buy 여부와 무관히 reject(거짓 확정이므로). `is_common_stock None` 은 reject 아닌 data_gap
+  (확정 거짓 아님).
+- auto_emit candidate 루프: `base = classify_candidate_symbol(...)` →
+  `verdict, q_reason = demote_for_quality(base, quality_flags)`. 기존 count-cap
+  (`beyond_candidate_budget`)은 **최종 buy_review 집합에 마지막으로** 적용.
+- reason 기록: 기존 단일 `reject_or_wait_reason` 은 primary로 유지(`q_reason` 우선),
+  추가로 evidence에 `quality_reasons: list[str]`(전체 flag) 적재 → UI rich 표시.
+- `auto_emit.py:476-490` if/elif에 신규 분기/헬퍼 호출 삽입(reason 매핑 확장).
+
+### 3.4 priority ranking (결정적 공식)
+buy_review 후보 정렬용 `priority_score`(높을수록 우선; collector가 계산해 evidence에 저장):
+```
+liquidity_term = min(1.0, log10(max(dollar_volume_usd, 1.0)) / 9.0)   # 9 ≈ log10($1B)
+momentum_term  = clamp(change_rate, -0.05, 0.10) / 0.10               # 적정 양(+) 선호, 상한
+spike_penalty  = 1.0 if "abnormal_spike" in quality_flags else 0.0
+stale_penalty  = 1.0 if "screener_stale" in quality_flags else 0.0
+priority_score = 1.0*liquidity_term + 0.5*momentum_term - 0.5*spike_penalty - 0.3*stale_penalty
+```
+정렬: `priority_score` DESC, tiebreak `dollar_volume_usd` DESC, `symbol` ASC(결정적).
+(가중치는 상수 모듈로 분리해 튜닝/테스트 용이.)
+
+### 3.5 confidence cap
+- `confidence_cap: int | None` 를 candidate evidence(JSONB)에 additive 저장(모델 변경 없음).
+  `screener_stale` 또는 `common_stock_unknown` 시 `40`, 아니면 `None`. ActionPacket/Hermes/
+  UI가 렌더 시 cap 적용. 결정적 경로가 값을 세팅(별도 모델/migration 불요).
+
+### 3.6 표시 정책
+- `buy_review`: `priority_score` 순, count-cap(`_max_buy_candidates`) 적용 후 상위.
+- 데모션(`watch_only`/`rejected`): 사유 포함, `candidate_rank`(pool 순위) 기준 **상위 10개만**
+  카드로, 나머지는 집계(`{watch_only_count, rejected_count, data_gap_count}`)만.
+- pool 크기 ≠ 표시 수 명시: evidence/summary에 `pool_size`, `buy_review_count`,
+  `demoted_shown`, `demoted_total`.
+
+### 3.7 sector/concentration "최소 정책"
+sector 데이터 부재 → 최소만: 이미 보유 종목 제외(auto_emit 기존 `sym in held` skip 유지) +
+per-report `buy_review` cap. **true 섹터 분산은 deferred**(sector 소스 추가 후속).
+
+## 4. Acceptance criteria (이슈 매핑)
+- 예산보다 넓은 pool에서 priority 순 산출. → 3.2/3.4
+- 저품질 후보는 제거 아닌 `rejected`/`watch_only` + 사유. → 3.3
+- stale-only 후보가 live buy로 노출 안 됨. → 3.3(screener_stale)/3.5/3.6
+- 카드에 priority, confidence cap, 주요 근거, 주요 제외/감점 사유 포함. → 3.4/3.5/3.6
+- focused tests가 stale exclusion, microcap/liquidity filter, priority ordering,
+  candidate_limit 표시 커버. → §5
+
+## 5. Test plan
+1. **demote_for_quality 단위(순수)**: 각 flag → 기대 verdict/reason; 비-buy_review는 미상향;
+   non_common_stock는 항상 rejected; None은 data_gap.
+2. **penny/illiquid 단위**: `latest_close<5` / `dollar_volume_usd<5e6` (예: 1M주×$3.50=$3.5M → illiquid).
+3. **abnormal_spike**: `change_rate>0.15` / `week>0.50` → watch_only.
+4. **non_common_stock / unknown**: False→rejected; None→data_gap; True→통과.
+5. **priority ordering(결정적)**: 공식 + tiebreak; 고정 입력 → 고정 순서.
+6. **pool > display**: 내부 pool(≥50) > 표시; 데모션 cap(10) + 집계 카운트.
+7. **screener_stale**: stale partition → watch_only + confidence_cap=40, buy_review 아님.
+8. **KR 무회귀**: KR 경로 quality 게이트 미적용(기존 KR 테스트 green).
+
+## 6. Safety boundaries / Non-goals
+- 자동 주문/주문 preview/submit/cancel/modify·broker/order/watch/order-intent mutation 금지.
+- 외부 scraping 필수 경로화 금지(best-effort market_cap fetch 비채택, proxy 사용).
+- 후보는 검토 대상이지 매수 지시 아님.
+- decision_bucket enum(locked 5) 미변경. **classify_candidate_symbol signature 미변경**
+  (후처리 헬퍼만 추가 → 모든 기존 caller·held 경로 무영향, PR-C와 무충돌).
+- build-time `common_stocks_only`(`jobs/invest_screener_snapshots.py`) 흐름과 혼동 금지.
+- migration 없음(품질은 동적 계산 + candidate evidence JSONB additive).
+
+## 7. Out of scope / follow-up
+- true 시총 마이크로캡(펀더멘털/valuation 소스); sector 분산; crypto/KR 후보 품질 — 별도.

--- a/docs/superpowers/specs/2026-06-09-rob-346-us-candidate-universe-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-346-us-candidate-universe-design.md
@@ -26,7 +26,7 @@ US 신규매수 후보는 `invest_screener_snapshots` top-gainers에서 **순수
 
 ### 1.1 가용 데이터 (필터 feasibility)
 `invest_screener_snapshots`: `latest_close`(Decimal, 가격), `daily_volume`(BigInt, 주),
-`change_rate`(Decimal, 비율 e.g. 0.12=+12%), `week_change_rate`, `closes_window`(JSONB),
+`change_rate`(Decimal, **percent** e.g. 12.0=+12%, ratio 아님), `week_change_rate`, `closes_window`(JSONB),
 `consecutive_up_days`. **`market_cap` 없음.**
 `us_symbol_universe`: `is_common_stock`(nullable Bool, ROB-204), `is_active`, `exchange`.
 **`market_cap`/`sector` 없음.**
@@ -71,7 +71,7 @@ US 신규매수 후보는 `invest_screener_snapshots` top-gainers에서 **순수
 |------|----------|
 | `penny` | `latest_close < 5.0` |
 | `illiquid` | `dollar_volume_usd < 5_000_000` |
-| `abnormal_spike` | `change_rate > 0.15` OR `week_change_rate > 0.50` |
+| `abnormal_spike` | `change_rate > 15.0` OR `week_change_rate > 50.0` (percent) |
 | `non_common_stock` | `is_common_stock is False` |
 | `common_stock_unknown` | `is_common_stock is None` (미분류) |
 | `screener_stale` | collector `days_stale > 0` 또는 usefulness != "useful" |
@@ -102,7 +102,7 @@ def demote_for_quality(verdict: str, quality_flags: frozenset[str]) -> tuple[str
 buy_review 후보 정렬용 `priority_score`(높을수록 우선; collector가 계산해 evidence에 저장):
 ```
 liquidity_term = min(1.0, log10(max(dollar_volume_usd, 1.0)) / 9.0)   # 9 ≈ log10($1B)
-momentum_term  = clamp(change_rate, -0.05, 0.10) / 0.10               # 적정 양(+) 선호, 상한
+momentum_term  = clamp(change_rate, -5.0, 10.0) / 10.0               # percent; 적정 양(+) 선호, 상한
 spike_penalty  = 1.0 if "abnormal_spike" in quality_flags else 0.0
 stale_penalty  = 1.0 if "screener_stale" in quality_flags else 0.0
 priority_score = 1.0*liquidity_term + 0.5*momentum_term - 0.5*spike_penalty - 0.3*stale_penalty

--- a/docs/superpowers/specs/2026-06-09-rob-347-us-budget-fx-basis-design.md
+++ b/docs/superpowers/specs/2026-06-09-rob-347-us-budget-fx-basis-design.md
@@ -1,0 +1,135 @@
+# ROB-347 — US 리포트 신규매수 예산·환전 전제 정책화 (Design)
+
+- **Issue**: ROB-347 (Improvement / Medium) — parent ROB-336
+- **Date**: 2026-06-09
+- **Scope**: PR-C (A→B→C 배치). Migration-0. **US kis_live**.
+- **Status**: design + adversarial spec-review 반영. pending user review → plan
+- **Depends**: PR-B(346) 머지 후. 같은 candidate 루프를 건드리지만, B와 동일하게
+  **classify_candidate_symbol signature는 미변경**하고 후처리 demotion 헬퍼만 추가 →
+  B의 `demote_for_quality` 다음에 `demote_for_budget` 를 체인(서명 충돌 없음).
+
+## 1. Context / 현황 (코드 검증) — dead-code 정정
+
+US KIS live readiness 점검: USD 주문가능금액 `$0`, KRW 주문가능금액 별도 존재. 후보가
+어떤 예산을 전제하는지 불명확.
+
+**정정(검증):**
+- `app/services/action_report/us/new_buy_candidates.py:72`, `us/account_snapshot.py:403`
+  (silent `quantity=0`, `_capital_basis`, `sizing_basis`)는 **dead code**(app/ 내 non-test
+  caller 0). **수정 위치 아님.**
+- 실제 US 후보 경로(`auto_emit.py:464-518` + `action_verdict.py:74-98`)는 **금액/예산을
+  전혀 읽지 않음**. `beyond_candidate_budget` 은 후보 *개수* cap. → "USD=0이 buy처럼
+  보임"은 verdict가 **구조적으로 budget-blind** 이기 때문.
+- USD buying power는 `collectors/portfolio.py:407-410` 에서 `buying_power={"krw":…,"usd":…}`
+  로 portfolio snapshot payload에 적재되나, `portfolio_journal.py:_usd_totals(:74-90)` 의
+  **display 전용**. USD/KRW 혼동 없음(`:90` USD 부재 시 None, KRW fallback 안 함 — 보존).
+- `request.py:14-149` ReportGenerationRequest 에 budget 필드 없음.
+
+### 1.1 feasibility 검증 (블로커 해소)
+- `auto_emit.propose(snapshots, request_market, account_scope, now)` 는 portfolio
+  snapshot을 순회해 `portfolio_payload`(`:361-363`)를 이미 보유. → `buying_power` 는
+  `portfolio_payload.get("buying_power")` 로 **즉시 접근 가능**(신규 collector 쓰기 불요).
+- request의 budget 파라미터는 `propose()` 인자로 전달(현재 `request_market`/`account_scope`
+  를 개별 인자로 받는 패턴 동일). generator는 `_auto_emit_items_from_bundle`
+  (`generator.py:560-600`)에서 propose 호출 시점에 `request` 보유 → budget 필드 전달 가능.
+- → 예산 신호 = **portfolio snapshot(자동 계산) + request override(사용자)**. 둘 다
+  propose 진입 시점에 가용함을 확인.
+
+## 2. Goal
+
+US 후보/ActionPacket이 예산 전제를 명시. USD buying power=0이어도 후보 발굴은 가능하되,
+`buy_review`/`watch_only`/`data_gap` 의미 혼동 없이 `budget_gap`/`fx_required`/
+`operator_budget_required` 를 남긴다.
+
+## 3. Design (migration-0)
+
+### 3.1 budget basis (request 필드)
+- `ReportGenerationRequest` 추가:
+  - `budget_basis: Literal["available_usd","krw_orderable_reference","operator_budget_override"]`
+    — **기본 `available_usd`**.
+  - `operator_budget_override_usd: Decimal | None`.
+- MCP `investment_report_generate_from_bundle`(`investment_reports_handlers.py:854-880`)에
+  두 파라미터 노출(선택, 기본 available_usd).
+- **override precedence(명확화)**: `operator_budget_override_usd` 가 non-null이면 basis와
+  무관하게 **effective_usd = override**(이슈의 "request budget이 있으면 그 값" 반영).
+  null이면 basis 선택을 따른다.
+
+### 3.2 budget 신호 소스 (propose 내부)
+propose가 portfolio snapshot payload에서 추출:
+- `usd_buying_power = (buying_power or {}).get("usd")` (0/None 가능)
+- `krw_orderable_reference = (buying_power or {}).get("krw")` (**reference only**)
+- `operator_override = operator_budget_override_usd` (request 인자)
+이를 `budget_state` dict로 정규화(아래 헬퍼 입력).
+
+### 3.3 budget-aware demotion (verdict, B의 다음 단계)
+`action_verdict.py` 에 **순수 헬퍼** 추가(서명 미변경 원칙 동일):
+```
+def demote_for_budget(verdict: str, budget_state: dict) -> tuple[str, list[str]]:
+    # buy_review 에만 적용. 절대 상향 없음. 사유는 리스트(복수 가능).
+    if verdict != "buy_review":
+        return verdict, []
+    basis = budget_state["basis"]; override = budget_state.get("override_usd")
+    usd = override if override is not None else budget_state.get("usd")
+    krw = budget_state.get("krw") or 0
+    if basis == "krw_orderable_reference" and override is None:
+        return "watch_only", ["fx_required"]          # USD 날조 금지; 환전 전제 표시
+    if usd is not None and usd > 0:
+        return "buy_review", []                        # 예산 충분 — 품질 verdict 유지
+    # usd <= 0 (0/None) and not krw_reference-permissive:
+    reasons = ["budget_gap"]
+    if krw > 0:        reasons.append("fx_required")
+    if override is None: reasons.append("operator_budget_required")
+    return "watch_only", reasons
+```
+- 적용 순서(candidate 루프): `base = classify_candidate_symbol(...)` →
+  `v, q = demote_for_quality(base, quality_flags)`(PR-B) →
+  `v, budget_reasons = demote_for_budget(v, budget_state)`(본 PR) → count-cap 마지막.
+- **품질 verdict 우선, budget은 buy_review만 하향**(rejected/data_gap/품질 watch는 불변).
+- **never fabricate USD from KRW.**
+
+### 3.4 reason / evidence 기록
+- primary `reject_or_wait_reason`: budget 하향 시 첫 budget reason(`budget_gap` 등)으로 세팅.
+- evidence_snapshot에 **enumerated additive 필드**(JSONB, 모델/migration 불요):
+  - `budget_basis: str`
+  - `budget_fit: bool` (effective_usd > 0 또는 충분)
+  - `available_usd: float | None`
+  - `krw_orderable_reference: float | None`
+  - `operator_budget_override_usd: float | None`
+  - `budget_reasons: list[str]` (∈ `budget_gap`/`fx_required`/`operator_budget_required`)
+- `auto_emit.py:476-490` verdict-assignment if/elif에 budget 분기/헬퍼 결과 병합.
+
+### 3.5 surfacing
+- ActionPacket/Hermes/UI가 evidence 필드 소비. UI에서 "현금 부족(budget_gap)"/"환전
+  필요(fx_required)"/"운영자 예산 입력 필요(operator_budget_required)" 구분. KRW는 USD와
+  섞지 않고 reference로만. (프론트 카드 컴포넌트 상세는 evidence 계약 확정 후 후속 가능.)
+
+## 4. Acceptance criteria (이슈 매핑)
+- USD buying power=0이면 후보를 숨기지 않고 `budget_gap`/`fx_required` 등 사유를 남김. → 3.3
+- KRW reference가 있어도 USD 주문가능금액과 혼동 안 함(합산/날조 금지). → 3.2/3.3
+- 카드에 budget basis + budget fit 표시. → 3.4
+- request에 operator budget/candidate cap이 오면 우선 적용. → 3.1(override precedence)
+- focused tests가 USD=0, KRW reference present, operator budget override 케이스 커버. → §5
+
+## 5. Test plan
+1. **demote_for_budget 단위(순수)**: basis×(usd 0/>0)×(krw 0/>0)×(override 유무) 매트릭스 →
+   기대 verdict/reasons. buy_review만 하향, 비-buy 불변.
+2. **USD=0 (available_usd 기본)**: 후보 present, watch_only, evidence `budget_reasons`에
+   `budget_gap`(+ KRW>0 시 `fx_required`, override 없으면 `operator_budget_required`).
+   buy_review 아님.
+3. **KRW reference present**: evidence `krw_orderable_reference` 세팅 + `available_usd` 에
+   합산 안 됨(별도 필드). basis별 표기 검증.
+4. **operator_budget_override**: override>0 제공 → basis 무관 effective_usd=override,
+   충분 시 buy_review 유지; override 없음 + USD=0 → `operator_budget_required`.
+5. **USD>0**: budget gate 미하향(buy_review 유지; budget은 절대 상향 안 함).
+6. **default basis**: budget_basis 미지정 → available_usd 적용.
+
+## 6. Safety boundaries / Non-goals
+- 환전 실행·주문 preview/submit/cancel/modify·broker/order/watch/order-intent mutation·
+  live trading automation 금지.
+- 자동 예산 추정으로 매수 권고 강화 금지(USD=0은 절대 silent buy 아님; budget은 하향 전용).
+- KRW→USD 숫자 fabrication 금지(`portfolio_journal.py:90` 정직 동작 보존).
+- **classify_candidate_symbol signature 미변경**(후처리 헬퍼만; PR-B와 무충돌).
+- migration 없음(request 필드 in-memory; evidence 필드 JSONB additive).
+
+## 7. Out of scope / follow-up
+- 실 FX rate 적용 후보 sizing(자동화 금지 경계); 프론트 카드 상세 디자인; dead `us/` 제거 — 별도.

--- a/tests/mcp_server/test_investment_report_generate_from_bundle_handler.py
+++ b/tests/mcp_server/test_investment_report_generate_from_bundle_handler.py
@@ -216,3 +216,45 @@ async def test_non_dict_item_does_not_crash(_enabled):
     assert res["error"] == "invalid_items"
     assert res["item_errors"][0]["index"] == 0
     assert "object" in str(res["item_errors"][0]["errors"])
+
+
+@pytest.mark.asyncio
+async def test_generate_from_bundle_budget_params_passed(_enabled, monkeypatch):
+    from app.services.action_report.snapshot_backed import generator as gen_mod
+    from app.services.action_report.snapshot_backed.request import (
+        ReportGenerationResponse,
+    )
+
+    captured = {}
+
+    async def _fake_generate(self, request):
+        captured["request"] = request
+        return ReportGenerationResponse(
+            report_uuid=uuid.uuid4(),
+            snapshot_bundle_uuid=uuid.uuid4(),
+            snapshot_policy_version="p",
+            snapshot_coverage_summary={},
+            snapshot_freshness_summary={},
+            source_conflicts={},
+            unavailable_sources={},
+            items_count=0,
+            warnings=[],
+            bundle_status="complete",
+            bundle_reused=False,
+            stale_gate={},
+        )
+
+    monkeypatch.setattr(
+        gen_mod.SnapshotBackedReportGenerator, "generate", _fake_generate
+    )
+
+    res = await h.investment_report_generate_from_bundle_impl(
+        **_kwargs(
+            budget_basis="operator_budget_override",
+            operator_budget_override_usd=750.0,
+        )
+    )
+    assert res["success"] is True
+    req = captured["request"]
+    assert req.budget_basis == "operator_budget_override"
+    assert req.operator_budget_override_usd == 750.0

--- a/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
@@ -79,32 +79,7 @@ async def test_us_unknown_common_stock_flagged(db_session):
     assert "common_stock_unknown" in cands["NOUNIV"]["quality_flags"]
 
 
-@pytest.mark.asyncio
-async def test_kr_candidates_have_no_quality_gate(db_session):
-    # ROB-346 is US-only: the KR path must not gain quality_flags (no regression).
-    today = dt.date(2026, 6, 9)
-    db_session.add(
-        InvestScreenerSnapshot(
-            market="kr",
-            symbol="005930",
-            snapshot_date=today,
-            latest_close=3.0,  # would be "penny" if US gate applied
-            change_rate=3.0,
-            week_change_rate=0,
-            closes_window=[],
-            source="kis",
-            daily_volume=100,
-        )
-    )
-    await db_session.flush()
-    collector = CandidateUniverseSnapshotCollector(db_session)
-    req = CollectorRequest(
-        market="kr",
-        account_scope="kis_live",
-        candidate_limit=5,
-        symbols=None,
-        policy_snapshot={},
-    )
-    results = await collector.collect(req)
-    for cand in results[0].payload_json["candidates"]:
-        assert "quality_flags" not in cand  # US-only gate: KR untouched
+# KR no-regression (US-only quality gate) is covered deterministically in
+# tests/services/action_report/test_candidate_universe_collector_evidence.py
+# (test_kr_equity_path_has_no_us_quality_gate) using the fake equity repo, which
+# avoids the real-DB KR preset path that was CI-flaky here.

--- a/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
@@ -1,0 +1,57 @@
+import datetime as dt
+
+import pytest
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.action_report.snapshot_backed.collectors.candidate_universe import (
+    CandidateUniverseSnapshotCollector,
+)
+from app.services.investment_snapshots.collectors import CollectorRequest
+
+
+def _snap(symbol, *, close, vol, change, d):
+    return InvestScreenerSnapshot(
+        market="us",
+        symbol=symbol,
+        snapshot_date=d,
+        latest_close=close,
+        change_rate=change,
+        week_change_rate=0,
+        closes_window=[],
+        source="yahoo",
+        daily_volume=vol,
+    )
+
+
+@pytest.mark.asyncio
+async def test_us_candidates_carry_quality_flags_and_priority(db_session):
+    today = dt.date(2026, 6, 9)
+    db_session.add_all(
+        [
+            _snap("GOOD", close=150.0, vol=20_000_000, change=3.0, d=today),
+            _snap("PENNY", close=2.0, vol=100_000, change=3.0, d=today),
+            USSymbolUniverse(
+                symbol="GOOD", exchange="NASDAQ", is_active=True, is_common_stock=True
+            ),
+            USSymbolUniverse(
+                symbol="PENNY", exchange="NYSE", is_active=True, is_common_stock=True
+            ),
+        ]
+    )
+    await db_session.flush()
+    collector = CandidateUniverseSnapshotCollector(db_session)
+    req = CollectorRequest(
+        market="us",
+        account_scope="kis_live",
+        candidate_limit=5,
+        symbols=None,
+        policy_snapshot={},
+    )
+    results = await collector.collect(req)
+    cands = {c["symbol"]: c for c in results[0].payload_json["candidates"]}
+    assert "priority_score" in cands["GOOD"]
+    assert "penny" in cands["PENNY"]["quality_flags"]
+    assert "illiquid" in cands["PENNY"]["quality_flags"]
+    # priority: GOOD (liquid) ranks above PENNY
+    assert cands["GOOD"]["candidate_rank"] < cands["PENNY"]["candidate_rank"]

--- a/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_candidate_universe_quality.py
@@ -55,3 +55,56 @@ async def test_us_candidates_carry_quality_flags_and_priority(db_session):
     assert "illiquid" in cands["PENNY"]["quality_flags"]
     # priority: GOOD (liquid) ranks above PENNY
     assert cands["GOOD"]["candidate_rank"] < cands["PENNY"]["candidate_rank"]
+    # pool/display transparency (ROB-346 §3.6)
+    assert results[0].payload_json["pool_size"] >= len(cands)
+
+
+@pytest.mark.asyncio
+async def test_us_unknown_common_stock_flagged(db_session):
+    # Liquid, non-penny US symbol with NO us_symbol_universe row → is_common_stock
+    # is None → "common_stock_unknown" (data_gap-grade), never silently rejected.
+    today = dt.date(2026, 6, 9)
+    db_session.add(_snap("NOUNIV", close=150.0, vol=20_000_000, change=3.0, d=today))
+    await db_session.flush()
+    collector = CandidateUniverseSnapshotCollector(db_session)
+    req = CollectorRequest(
+        market="us",
+        account_scope="kis_live",
+        candidate_limit=5,
+        symbols=None,
+        policy_snapshot={},
+    )
+    results = await collector.collect(req)
+    cands = {c["symbol"]: c for c in results[0].payload_json["candidates"]}
+    assert "common_stock_unknown" in cands["NOUNIV"]["quality_flags"]
+
+
+@pytest.mark.asyncio
+async def test_kr_candidates_have_no_quality_gate(db_session):
+    # ROB-346 is US-only: the KR path must not gain quality_flags (no regression).
+    today = dt.date(2026, 6, 9)
+    db_session.add(
+        InvestScreenerSnapshot(
+            market="kr",
+            symbol="005930",
+            snapshot_date=today,
+            latest_close=3.0,  # would be "penny" if US gate applied
+            change_rate=3.0,
+            week_change_rate=0,
+            closes_window=[],
+            source="kis",
+            daily_volume=100,
+        )
+    )
+    await db_session.flush()
+    collector = CandidateUniverseSnapshotCollector(db_session)
+    req = CollectorRequest(
+        market="kr",
+        account_scope="kis_live",
+        candidate_limit=5,
+        symbols=None,
+        policy_snapshot={},
+    )
+    results = await collector.collect(req)
+    for cand in results[0].payload_json["candidates"]:
+        assert "quality_flags" not in cand  # US-only gate: KR untouched

--- a/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
@@ -1,5 +1,3 @@
-import datetime as dt
-
 import pytest
 
 from app.models.trade_journal import TradeJournal
@@ -10,25 +8,36 @@ from app.services.action_report.snapshot_backed.collectors.journal import (
 from app.services.investment_snapshots.collectors import CollectorRequest
 
 
-def _journal(symbol, instrument_type, *, account="kis", account_type="live",
-             status="active"):
+def _journal(
+    symbol, instrument_type, *, account="kis", account_type="live", status="active"
+):
     return TradeJournal(
-        symbol=symbol, instrument_type=instrument_type, side="buy",
-        status=status, account_type=account_type, account=account,
-        entry_price=1.0, quantity=1.0, thesis="t",
+        symbol=symbol,
+        instrument_type=instrument_type,
+        side="buy",
+        status=status,
+        account_type=account_type,
+        account=account,
+        entry_price=1.0,
+        quantity=1.0,
+        thesis="t",
     )
 
 
 def _req(market):
-    return CollectorRequest(market=market, account_scope="kis_live", symbols=None, policy_snapshot={})
+    return CollectorRequest(
+        market=market, account_scope="kis_live", symbols=None, policy_snapshot={}
+    )
 
 
 @pytest.mark.asyncio
 async def test_us_scope_excludes_kr_live_journals(db_session):
-    db_session.add_all([
-        _journal("AAPL", InstrumentType.equity_us),
-        _journal("005930", InstrumentType.equity_kr),
-    ])
+    db_session.add_all(
+        [
+            _journal("AAPL", InstrumentType.equity_us),
+            _journal("005930", InstrumentType.equity_kr),
+        ]
+    )
     await db_session.flush()
     collector = JournalSnapshotCollector(db_session)
     results = await collector.collect(_req("us"))
@@ -41,10 +50,12 @@ async def test_us_scope_excludes_kr_live_journals(db_session):
 
 @pytest.mark.asyncio
 async def test_kr_scope_excludes_us_live_journals(db_session):
-    db_session.add_all([
-        _journal("AAPL", InstrumentType.equity_us),
-        _journal("005930", InstrumentType.equity_kr),
-    ])
+    db_session.add_all(
+        [
+            _journal("AAPL", InstrumentType.equity_us),
+            _journal("005930", InstrumentType.equity_kr),
+        ]
+    )
     await db_session.flush()
     collector = JournalSnapshotCollector(db_session)
     results = await collector.collect(_req("kr"))
@@ -83,4 +94,3 @@ async def test_query_failure_reports_unavailable(monkeypatch, db_session):
     payload = results[0].payload_json
     assert payload["collector_status"] == "unavailable"
     assert results[0].freshness_status == "unavailable"
-

--- a/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
@@ -1,0 +1,62 @@
+import datetime as dt
+
+import pytest
+
+from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
+from app.services.action_report.snapshot_backed.collectors.journal import (
+    JournalSnapshotCollector,
+)
+from app.services.investment_snapshots.collectors import CollectorRequest
+
+
+def _journal(symbol, instrument_type, *, account="kis", account_type="live",
+             status="active"):
+    return TradeJournal(
+        symbol=symbol, instrument_type=instrument_type, side="buy",
+        status=status, account_type=account_type, account=account,
+        entry_price=1.0, quantity=1.0, thesis="t",
+    )
+
+
+def _req(market):
+    return CollectorRequest(market=market, account_scope="kis_live", symbols=None, policy_snapshot={})
+
+
+@pytest.mark.asyncio
+async def test_us_scope_excludes_kr_live_journals(db_session):
+    db_session.add_all([
+        _journal("AAPL", InstrumentType.equity_us),
+        _journal("005930", InstrumentType.equity_kr),
+    ])
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    active_syms = {e["symbol"] for e in payload["active"]}
+    assert active_syms == {"AAPL"}
+    assert payload["active"][0]["account"] == "kis"  # provenance emitted
+    assert payload["collector_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_kr_scope_excludes_us_live_journals(db_session):
+    db_session.add_all([
+        _journal("AAPL", InstrumentType.equity_us),
+        _journal("005930", InstrumentType.equity_kr),
+    ])
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("kr"))
+    active_syms = {e["symbol"] for e in results[0].payload_json["active"]}
+    assert active_syms == {"005930"}
+
+
+@pytest.mark.asyncio
+async def test_us_scope_includes_legacy_null_account_kis_us(db_session):
+    db_session.add(_journal("MSFT", InstrumentType.equity_us, account=None))
+    await db_session.flush()
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    active_syms = {e["symbol"] for e in results[0].payload_json["active"]}
+    assert "MSFT" in active_syms

--- a/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
+++ b/tests/services/action_report/snapshot_backed/collectors/test_journal_collector.py
@@ -60,3 +60,27 @@ async def test_us_scope_includes_legacy_null_account_kis_us(db_session):
     results = await collector.collect(_req("us"))
     active_syms = {e["symbol"] for e in results[0].payload_json["active"]}
     assert "MSFT" in active_syms
+
+
+@pytest.mark.asyncio
+async def test_empty_active_reports_ok_status(db_session):
+    collector = JournalSnapshotCollector(db_session)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    assert payload["active"] == []
+    assert payload["collector_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_query_failure_reports_unavailable(monkeypatch, db_session):
+    collector = JournalSnapshotCollector(db_session)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(db_session, "execute", _boom)
+    results = await collector.collect(_req("us"))
+    payload = results[0].payload_json
+    assert payload["collector_status"] == "unavailable"
+    assert results[0].freshness_status == "unavailable"
+

--- a/tests/services/action_report/snapshot_backed/test_action_verdict_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict_budget.py
@@ -22,13 +22,15 @@ def test_usd_positive_keeps_buy():
 
 
 def test_override_takes_precedence_over_basis():
-    assert demote_for_budget("buy_review",
-        _state(basis="available_usd", usd=0, override=500)) == ("buy_review", [])
+    assert demote_for_budget(
+        "buy_review", _state(basis="available_usd", usd=0, override=500)
+    ) == ("buy_review", [])
 
 
 def test_krw_reference_basis_flags_fx_required():
-    v, reasons = demote_for_budget("buy_review",
-        _state(basis="krw_orderable_reference", usd=0, krw=500000))
+    v, reasons = demote_for_budget(
+        "buy_review", _state(basis="krw_orderable_reference", usd=0, krw=500000)
+    )
     assert v == "watch_only" and reasons == ["fx_required"]
 
 

--- a/tests/services/action_report/snapshot_backed/test_action_verdict_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict_budget.py
@@ -1,0 +1,37 @@
+from app.services.action_report.snapshot_backed.action_verdict import demote_for_budget
+
+
+def _state(basis="available_usd", usd=None, krw=0, override=None):
+    return {"basis": basis, "usd": usd, "krw": krw, "override_usd": override}
+
+
+def test_usd_zero_demotes_to_watch_budget_gap():
+    v, reasons = demote_for_budget("buy_review", _state(usd=0, krw=0))
+    assert v == "watch_only"
+    assert "budget_gap" in reasons
+    assert "operator_budget_required" in reasons  # override 없음
+
+
+def test_usd_zero_with_krw_adds_fx_required():
+    _, reasons = demote_for_budget("buy_review", _state(usd=0, krw=500000))
+    assert "fx_required" in reasons and "budget_gap" in reasons
+
+
+def test_usd_positive_keeps_buy():
+    assert demote_for_budget("buy_review", _state(usd=1000)) == ("buy_review", [])
+
+
+def test_override_takes_precedence_over_basis():
+    assert demote_for_budget("buy_review",
+        _state(basis="available_usd", usd=0, override=500)) == ("buy_review", [])
+
+
+def test_krw_reference_basis_flags_fx_required():
+    v, reasons = demote_for_budget("buy_review",
+        _state(basis="krw_orderable_reference", usd=0, krw=500000))
+    assert v == "watch_only" and reasons == ["fx_required"]
+
+
+def test_non_buy_unchanged():
+    assert demote_for_budget("watch_only", _state(usd=0)) == ("watch_only", [])
+    assert demote_for_budget("rejected", _state(usd=0)) == ("rejected", [])

--- a/tests/services/action_report/snapshot_backed/test_action_verdict_demote.py
+++ b/tests/services/action_report/snapshot_backed/test_action_verdict_demote.py
@@ -1,0 +1,41 @@
+from app.services.action_report.snapshot_backed.action_verdict import (
+    demote_for_quality,
+)
+
+
+def test_non_common_always_rejected_even_if_buy():
+    assert demote_for_quality("buy_review", frozenset({"non_common_stock"})) == (
+        "rejected",
+        "non_common_stock",
+    )
+
+
+def test_unknown_common_is_data_gap_for_buy():
+    assert demote_for_quality("buy_review", frozenset({"common_stock_unknown"})) == (
+        "data_gap",
+        "common_stock_unknown",
+    )
+
+
+def test_quality_demotes_buy_to_watch_in_priority_order():
+    assert demote_for_quality("buy_review", frozenset({"penny", "illiquid"})) == (
+        "watch_only",
+        "penny",
+    )
+    assert demote_for_quality("buy_review", frozenset({"abnormal_spike"})) == (
+        "watch_only",
+        "abnormal_spike",
+    )
+
+
+def test_clean_buy_unchanged():
+    assert demote_for_quality("buy_review", frozenset()) == ("buy_review", None)
+
+
+def test_non_buy_not_upgraded():
+    # 이미 honest 하향된 verdict은 품질로 끌어올리지 않는다(non_common 제외).
+    assert demote_for_quality("watch_only", frozenset({"penny"})) == (
+        "watch_only",
+        None,
+    )
+    assert demote_for_quality("data_gap", frozenset()) == ("data_gap", None)

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
@@ -5,21 +5,37 @@ from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmi
 
 
 def _snap(kind, payload, symbol=None):
-    return SimpleNamespace(snapshot_uuid=None, snapshot_kind=kind,
-                           payload_json=payload, symbol=symbol)
+    return SimpleNamespace(
+        snapshot_uuid=None, snapshot_kind=kind, payload_json=payload, symbol=symbol
+    )
 
 
 def _q():
-    return {"status": "ok", "best_bid": 10, "best_ask": 10.1,
-            "bid_depth": 100, "ask_depth": 100}
+    return {
+        "status": "ok",
+        "best_bid": 10,
+        "best_ask": 10.1,
+        "bid_depth": 100,
+        "ask_depth": 100,
+    }
 
 
 def _snaps(buying_power):
-    cands = [{"symbol": "GOOD", "rank": 1, "candidate_rank": 1, "data_state": "fresh",
-              "quality_flags": [], "priority_score": 0.9}]
+    cands = [
+        {
+            "symbol": "GOOD",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": [],
+            "priority_score": 0.9,
+        }
+    ]
     return [
-        _snap("portfolio", {"buying_power": buying_power,
-                            "primary_source": "kis", "holdings": []}),
+        _snap(
+            "portfolio",
+            {"buying_power": buying_power, "primary_source": "kis", "holdings": []},
+        ),
         _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
         _snap("symbol", {"symbol": "GOOD", "quote": _q()}, symbol="GOOD"),
     ]
@@ -27,8 +43,12 @@ def _snaps(buying_power):
 
 def _item(snaps, **budget):
     items = EvidenceAutoEmitter().propose(
-        snapshots=snaps, request_market="us", account_scope="kis_live",
-        now=dt.datetime(2026, 6, 9), **budget)
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+        **budget,
+    )
     return next(i for i in items if i.symbol == "GOOD")
 
 
@@ -48,9 +68,11 @@ def test_usd_zero_with_krw_reference_adds_fx_required_not_summed():
 
 
 def test_operator_override_keeps_buy():
-    ev = _item(_snaps({"usd": 0, "krw": 0}),
-               budget_basis="operator_budget_override",
-               operator_budget_override_usd=500).evidence_snapshot
+    ev = _item(
+        _snaps({"usd": 0, "krw": 0}),
+        budget_basis="operator_budget_override",
+        operator_budget_override_usd=500,
+    ).evidence_snapshot
     assert ev["action_verdict"] == "buy_review"
 
 

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
@@ -1,0 +1,59 @@
+import datetime as dt
+from types import SimpleNamespace
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+def _snap(kind, payload, symbol=None):
+    return SimpleNamespace(snapshot_uuid=None, snapshot_kind=kind,
+                           payload_json=payload, symbol=symbol)
+
+
+def _q():
+    return {"status": "ok", "best_bid": 10, "best_ask": 10.1,
+            "bid_depth": 100, "ask_depth": 100}
+
+
+def _snaps(buying_power):
+    cands = [{"symbol": "GOOD", "rank": 1, "candidate_rank": 1, "data_state": "fresh",
+              "quality_flags": [], "priority_score": 0.9}]
+    return [
+        _snap("portfolio", {"buying_power": buying_power,
+                            "primary_source": "kis", "holdings": []}),
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap("symbol", {"symbol": "GOOD", "quote": _q()}, symbol="GOOD"),
+    ]
+
+
+def _item(snaps, **budget):
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps, request_market="us", account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9), **budget)
+    return next(i for i in items if i.symbol == "GOOD")
+
+
+def test_usd_zero_demotes_with_budget_gap():
+    item = _item(_snaps({"usd": 0, "krw": 0}))
+    ev = item.evidence_snapshot
+    assert ev["action_verdict"] == "watch_only"
+    assert "budget_gap" in ev["budget_reasons"]
+    assert ev["budget_basis"] == "available_usd"
+
+
+def test_usd_zero_with_krw_reference_adds_fx_required_not_summed():
+    ev = _item(_snaps({"usd": 0, "krw": 500000})).evidence_snapshot
+    assert "fx_required" in ev["budget_reasons"]
+    assert ev["available_usd"] in (0, 0.0)
+    assert ev["krw_orderable_reference"] == 500000  # reference, not summed into USD
+
+
+def test_operator_override_keeps_buy():
+    ev = _item(_snaps({"usd": 0, "krw": 0}),
+               budget_basis="operator_budget_override",
+               operator_budget_override_usd=500).evidence_snapshot
+    assert ev["action_verdict"] == "buy_review"
+
+
+def test_usd_positive_keeps_buy():
+    ev = _item(_snaps({"usd": 2000, "krw": 0})).evidence_snapshot
+    assert ev["action_verdict"] == "buy_review"

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_budget.py
@@ -60,11 +60,23 @@ def test_usd_zero_demotes_with_budget_gap():
     assert ev["budget_basis"] == "available_usd"
 
 
-def test_usd_zero_with_krw_reference_adds_fx_required_not_summed():
+def test_usd_zero_with_krw_present_not_summed():
+    # default basis=available_usd; KRW present must NOT be summed into USD.
     ev = _item(_snaps({"usd": 0, "krw": 500000})).evidence_snapshot
     assert "fx_required" in ev["budget_reasons"]
     assert ev["available_usd"] in (0, 0.0)
     assert ev["krw_orderable_reference"] == 500000  # reference, not summed into USD
+
+
+def test_krw_orderable_reference_basis_flags_fx_required_only():
+    # basis=krw_orderable_reference (no override) → watch_only with fx_required
+    # ONLY (no budget_gap / operator_budget_required); KRW never fabricated to USD.
+    ev = _item(
+        _snaps({"usd": 0, "krw": 500000}),
+        budget_basis="krw_orderable_reference",
+    ).evidence_snapshot
+    assert ev["action_verdict"] == "watch_only"
+    assert ev["budget_reasons"] == ["fx_required"]
 
 
 def test_operator_override_keeps_buy():

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
@@ -94,7 +94,14 @@ def test_clean_candidate_stays_buy_review():
         }
     ]
     snaps = [
-        _snap("portfolio", {"buying_power": {"usd": 1000.0, "krw": 0.0}, "primary_source": "kis", "holdings": []}),
+        _snap(
+            "portfolio",
+            {
+                "buying_power": {"usd": 1000.0, "krw": 0.0},
+                "primary_source": "kis",
+                "holdings": [],
+            },
+        ),
         _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
         _snap(
             "symbol",
@@ -110,3 +117,75 @@ def test_clean_candidate_stays_buy_review():
     )
     item = next(i for i in items if i.symbol == "GOOD")
     assert item.evidence_snapshot["action_verdict"] == "buy_review"
+
+
+def test_quality_flag_priority_order_penny_over_illiquid():
+    # Input list order is ["illiquid", "penny"] but the surfaced reason must be
+    # "penny" — demote_for_quality iterates _QUALITY_WATCH_ORDER, not input order.
+    cands = [
+        {
+            "symbol": "PI",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": ["illiquid", "penny"],
+            "priority_score": 0.1,
+        }
+    ]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap(
+            "symbol",
+            {"symbol": "PI", "quote": _actionable_quote("PI")},
+            symbol="PI",
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+    )
+    item = next(i for i in items if i.symbol == "PI")
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "penny"
+
+
+def test_quality_reason_wins_over_budget_when_both_apply():
+    # Penny candidate (quality demotes buy→watch) AND USD=0 (budget would also
+    # demote). Quality runs first → verdict watch_only with the QUALITY reason;
+    # budget leaves an already-non-buy verdict untouched.
+    cands = [
+        {
+            "symbol": "PB",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": ["penny"],
+            "priority_score": 0.1,
+        }
+    ]
+    snaps = [
+        _snap(
+            "portfolio",
+            {
+                "buying_power": {"usd": 0, "krw": 0},
+                "primary_source": "kis",
+                "holdings": [],
+            },
+        ),
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap(
+            "symbol",
+            {"symbol": "PB", "quote": _actionable_quote("PB")},
+            symbol="PB",
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+    )
+    item = next(i for i in items if i.symbol == "PB")
+    assert item.evidence_snapshot["action_verdict"] == "watch_only"
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "penny"

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
@@ -94,6 +94,7 @@ def test_clean_candidate_stays_buy_review():
         }
     ]
     snaps = [
+        _snap("portfolio", {"buying_power": {"usd": 1000.0, "krw": 0.0}, "primary_source": "kis", "holdings": []}),
         _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
         _snap(
             "symbol",

--- a/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
+++ b/tests/services/action_report/snapshot_backed/test_auto_emit_quality.py
@@ -1,0 +1,111 @@
+import datetime as dt
+from types import SimpleNamespace
+
+from app.services.action_report.snapshot_backed.auto_emit import EvidenceAutoEmitter
+
+
+def _snap(kind, payload, symbol=None):
+    return SimpleNamespace(
+        snapshot_uuid=None, snapshot_kind=kind, payload_json=payload, symbol=symbol
+    )
+
+
+def _actionable_quote(sym):
+    return {
+        "status": "ok",
+        "best_bid": 10,
+        "best_ask": 10.1,
+        "bid_depth": 100,
+        "ask_depth": 100,
+    }
+
+
+def test_penny_candidate_demoted_to_watch_with_reason():
+    cands = [
+        {
+            "symbol": "PENNY",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": ["penny", "illiquid"],
+            "priority_score": 0.1,
+            "confidence_cap": None,
+        }
+    ]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap(
+            "symbol",
+            {"symbol": "PENNY", "quote": _actionable_quote("PENNY")},
+            symbol="PENNY",
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+    )
+    item = next(i for i in items if i.symbol == "PENNY")
+    assert item.evidence_snapshot["action_verdict"] == "watch_only"
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "penny"
+    assert "penny" in item.evidence_snapshot["quality_flags"]
+
+
+def test_non_common_candidate_rejected():
+    cands = [
+        {
+            "symbol": "ETF1",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": ["non_common_stock"],
+            "priority_score": 0.5,
+        }
+    ]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap(
+            "symbol",
+            {"symbol": "ETF1", "quote": _actionable_quote("ETF1")},
+            symbol="ETF1",
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+    )
+    item = next(i for i in items if i.symbol == "ETF1")
+    assert item.evidence_snapshot["action_verdict"] == "rejected"
+    assert item.evidence_snapshot["reject_or_wait_reason"] == "non_common_stock"
+
+
+def test_clean_candidate_stays_buy_review():
+    cands = [
+        {
+            "symbol": "GOOD",
+            "rank": 1,
+            "candidate_rank": 1,
+            "data_state": "fresh",
+            "quality_flags": [],
+            "priority_score": 0.9,
+        }
+    ]
+    snaps = [
+        _snap("candidate_universe", {"usefulness": "useful", "candidates": cands}),
+        _snap(
+            "symbol",
+            {"symbol": "GOOD", "quote": _actionable_quote("GOOD")},
+            symbol="GOOD",
+        ),
+    ]
+    items = EvidenceAutoEmitter().propose(
+        snapshots=snaps,
+        request_market="us",
+        account_scope="kis_live",
+        now=dt.datetime(2026, 6, 9),
+    )
+    item = next(i for i in items if i.symbol == "GOOD")
+    assert item.evidence_snapshot["action_verdict"] == "buy_review"

--- a/tests/services/action_report/snapshot_backed/test_candidate_quality.py
+++ b/tests/services/action_report/snapshot_backed/test_candidate_quality.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.services.action_report.snapshot_backed.candidate_quality import (
     compute_priority_score,
     compute_quality_flags,
@@ -87,3 +89,35 @@ def test_priority_score_orders_liquid_over_illiquid():
 def test_confidence_cap_for_stale():
     assert confidence_cap_for(frozenset({"screener_stale"})) == 40
     assert confidence_cap_for(frozenset()) is None
+
+
+def test_priority_score_formula_exact_values():
+    # dollar_volume = 100 * 10_000_000 = 1e9 → log10(1e9)/9 = 1.0 → liquidity_term=1.0
+    # change_rate=10.0 (percent) → clamp(10,-5,10)/10 = 1.0 → momentum_term=1.0
+    # no flags → 1.0*1.0 + 0.5*1.0 = 1.5
+    score = compute_priority_score(
+        latest_close=100.0,
+        daily_volume=10_000_000,
+        change_rate=10.0,
+        quality_flags=frozenset(),
+    )
+    assert score == pytest.approx(1.5)
+    # same inputs + spike(-0.5) + stale(-0.3) penalties → 1.5 - 0.8 = 0.7
+    penalized = compute_priority_score(
+        latest_close=100.0,
+        daily_volume=10_000_000,
+        change_rate=10.0,
+        quality_flags=frozenset({"abnormal_spike", "screener_stale"}),
+    )
+    assert penalized == pytest.approx(0.7)
+
+
+def test_priority_score_momentum_clamps_at_boundaries():
+    # change_rate=-10% clamps to -5 → momentum_term=-0.5; liquidity_term=1.0 → 0.75
+    low = compute_priority_score(
+        latest_close=100.0,
+        daily_volume=10_000_000,
+        change_rate=-10.0,
+        quality_flags=frozenset(),
+    )
+    assert low == pytest.approx(1.0 + 0.5 * -0.5)  # 0.75

--- a/tests/services/action_report/snapshot_backed/test_candidate_quality.py
+++ b/tests/services/action_report/snapshot_backed/test_candidate_quality.py
@@ -1,0 +1,89 @@
+from app.services.action_report.snapshot_backed.candidate_quality import (
+    compute_priority_score,
+    compute_quality_flags,
+    confidence_cap_for,
+)
+
+
+def test_penny_and_illiquid_flags():
+    qf = compute_quality_flags(
+        latest_close=3.5,
+        daily_volume=1_000_000,
+        change_rate=2.0,
+        week_change_rate=1.0,
+        is_common_stock=True,
+        screener_stale=False,
+    )
+    assert "penny" in qf  # 3.5 < 5.0
+    assert "illiquid" in qf  # 3.5 * 1e6 = 3.5e6 < 5e6
+
+
+def test_liquid_large_price_clean():
+    qf = compute_quality_flags(
+        latest_close=150.0,
+        daily_volume=10_000_000,
+        change_rate=2.0,
+        week_change_rate=1.0,
+        is_common_stock=True,
+        screener_stale=False,
+    )
+    assert qf == frozenset()
+
+
+def test_abnormal_spike_percent_units():
+    assert "abnormal_spike" in compute_quality_flags(
+        latest_close=50.0,
+        daily_volume=10_000_000,
+        change_rate=16.0,
+        week_change_rate=1.0,
+        is_common_stock=True,
+        screener_stale=False,
+    )
+    assert "abnormal_spike" in compute_quality_flags(
+        latest_close=50.0,
+        daily_volume=10_000_000,
+        change_rate=1.0,
+        week_change_rate=51.0,
+        is_common_stock=True,
+        screener_stale=False,
+    )
+
+
+def test_common_stock_flag_tri_state():
+    assert "non_common_stock" in compute_quality_flags(
+        latest_close=50.0,
+        daily_volume=10_000_000,
+        change_rate=1.0,
+        week_change_rate=1.0,
+        is_common_stock=False,
+        screener_stale=False,
+    )
+    assert "common_stock_unknown" in compute_quality_flags(
+        latest_close=50.0,
+        daily_volume=10_000_000,
+        change_rate=1.0,
+        week_change_rate=1.0,
+        is_common_stock=None,
+        screener_stale=False,
+    )
+
+
+def test_priority_score_orders_liquid_over_illiquid():
+    big = compute_priority_score(
+        latest_close=100.0,
+        daily_volume=50_000_000,
+        change_rate=5.0,
+        quality_flags=frozenset(),
+    )
+    small = compute_priority_score(
+        latest_close=4.0,
+        daily_volume=100_000,
+        change_rate=5.0,
+        quality_flags=frozenset({"illiquid", "penny"}),
+    )
+    assert big > small
+
+
+def test_confidence_cap_for_stale():
+    assert confidence_cap_for(frozenset({"screener_stale"})) == 40
+    assert confidence_cap_for(frozenset()) is None

--- a/tests/services/action_report/snapshot_backed/test_collectors.py
+++ b/tests/services/action_report/snapshot_backed/test_collectors.py
@@ -871,6 +871,7 @@ async def test_journal_collector_returns_active_and_recent():
         exit_reason = None
         pnl_pct = None
         account_type = "live"
+        account = "kis"
         created_at = dt.datetime(2026, 5, 18, tzinfo=dt.UTC)
         updated_at = dt.datetime(2026, 5, 19, tzinfo=dt.UTC)
 

--- a/tests/services/action_report/snapshot_backed/test_generator_budget_threads.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_budget_threads.py
@@ -1,8 +1,11 @@
-import pytest
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
-from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGenerator
+import pytest
+
+from app.services.action_report.snapshot_backed.generator import (
+    SnapshotBackedReportGenerator,
+)
 from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
 
 
@@ -31,8 +34,7 @@ async def test_auto_emit_threads_budget(monkeypatch):
     mock_repo.list_bundle_items_with_snapshots = AsyncMock(return_value=[])
 
     generator = SnapshotBackedReportGenerator(
-        session=mock_session,
-        snapshots_repository=mock_repo
+        session=mock_session, snapshots_repository=mock_repo
     )
 
     request = ReportGenerationRequest(

--- a/tests/services/action_report/snapshot_backed/test_generator_budget_threads.py
+++ b/tests/services/action_report/snapshot_backed/test_generator_budget_threads.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from app.services.action_report.snapshot_backed.generator import SnapshotBackedReportGenerator
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+
+
+@pytest.mark.asyncio
+async def test_auto_emit_threads_budget(monkeypatch):
+    captured = {}
+
+    class FakeEmitter:
+        def __init__(self, **_kw):
+            pass
+
+        def propose(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    monkeypatch.setattr(
+        "app.services.action_report.snapshot_backed.auto_emit.EvidenceAutoEmitter",
+        FakeEmitter,
+    )
+
+    mock_session = AsyncMock()
+    mock_repo = MagicMock()
+    mock_bundle = MagicMock()
+    mock_bundle.id = 123
+    mock_repo.get_bundle_by_uuid = AsyncMock(return_value=mock_bundle)
+    mock_repo.list_bundle_items_with_snapshots = AsyncMock(return_value=[])
+
+    generator = SnapshotBackedReportGenerator(
+        session=mock_session,
+        snapshots_repository=mock_repo
+    )
+
+    request = ReportGenerationRequest(
+        market="us",
+        account_scope="kis_live",
+        created_by_profile="operator",
+        title="Test Budget",
+        summary="Test",
+        kst_date="2026-06-09",
+        budget_basis="krw_orderable_reference",
+        operator_budget_override_usd=500.0,
+    )
+
+    bundle_uuid = uuid4()
+    await generator._auto_emit_items_from_bundle(
+        bundle_uuid=bundle_uuid,
+        request=request,
+    )
+
+    assert captured.get("budget_basis") == "krw_orderable_reference"
+    assert captured.get("operator_budget_override_usd") == 500.0

--- a/tests/services/action_report/snapshot_backed/test_request_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_request_budget.py
@@ -5,8 +5,13 @@ from app.services.action_report.snapshot_backed.request import ReportGenerationR
 
 def _base(**kw):
     return ReportGenerationRequest(
-        market="us", account_scope="kis_live", created_by_profile="p",
-        title="t", summary="s", kst_date="2026-06-09", **kw,
+        market="us",
+        account_scope="kis_live",
+        created_by_profile="p",
+        title="t",
+        summary="s",
+        kst_date="2026-06-09",
+        **kw,
     )
 
 
@@ -16,6 +21,8 @@ def test_budget_basis_defaults_available_usd():
 
 
 def test_budget_override_accepts_decimal():
-    r = _base(budget_basis="operator_budget_override",
-              operator_budget_override_usd=Decimal("1000"))
+    r = _base(
+        budget_basis="operator_budget_override",
+        operator_budget_override_usd=Decimal("1000"),
+    )
     assert r.operator_budget_override_usd == Decimal("1000")

--- a/tests/services/action_report/snapshot_backed/test_request_budget.py
+++ b/tests/services/action_report/snapshot_backed/test_request_budget.py
@@ -1,0 +1,21 @@
+from decimal import Decimal
+
+from app.services.action_report.snapshot_backed.request import ReportGenerationRequest
+
+
+def _base(**kw):
+    return ReportGenerationRequest(
+        market="us", account_scope="kis_live", created_by_profile="p",
+        title="t", summary="s", kst_date="2026-06-09", **kw,
+    )
+
+
+def test_budget_basis_defaults_available_usd():
+    assert _base().budget_basis == "available_usd"
+    assert _base().operator_budget_override_usd is None
+
+
+def test_budget_override_accepts_decimal():
+    r = _base(budget_basis="operator_budget_override",
+              operator_budget_override_usd=Decimal("1000"))
+    assert r.operator_budget_override_usd == Decimal("1000")

--- a/tests/services/action_report/test_candidate_universe_collector_evidence.py
+++ b/tests/services/action_report/test_candidate_universe_collector_evidence.py
@@ -21,6 +21,7 @@ class _EquityRow:
     source: str = "kis"
     daily_volume: int = 100_000
     consecutive_up_days: int | None = None
+    week_change_rate: Decimal | None = None  # ROB-346 US quality input
 
 
 class _FakeEquityRepository:
@@ -31,6 +32,7 @@ class _FakeEquityRepository:
             _EquityRow(symbol="035720", change_rate=Decimal("7.0")),
         ]
         self.requested_limits: list[int] = []
+        self.requested_pool_limits: list[int | None] = []
 
     async def coverage(
         self, *, market: str, today_trading_date: dt.date
@@ -43,11 +45,25 @@ class _FakeEquityRepository:
             last_computed_at=None,
         )
 
+    async def _candidate_rows(self, *, market: str, limit: int | None):
+        return self.rows if limit is None else self.rows[:limit]
+
     async def list_top_candidates(
         self, *, market: str, limit: int = 10
     ) -> list[_EquityRow]:
         self.requested_limits.append(limit)
-        return self.rows[:limit]
+        return await self._candidate_rows(market=market, limit=limit)
+
+    async def list_candidate_pool(
+        self, *, market: str, limit: int | None = None
+    ) -> list[_EquityRow]:
+        # ROB-346 — US path sources a wide pool here instead of list_top_candidates.
+        self.requested_pool_limits.append(limit)
+        return await self._candidate_rows(market=market, limit=limit)
+
+    async def common_stock_flags(self, symbols: list[str]) -> dict[str, bool | None]:
+        # Treat fixtures as common stock so no non_common/unknown flag is injected.
+        return dict.fromkeys(symbols, True)
 
 
 @pytest.mark.asyncio
@@ -65,7 +81,10 @@ async def test_equity_collector_respects_candidate_limit(db_session):
         )
     )
 
-    assert repo.requested_limits == [2]
+    # ROB-346 — US sources a wide pool (max(limit*5, 50)) then slices to the
+    # candidate_limit after priority ranking; list_top_candidates is not used.
+    assert repo.requested_pool_limits == [50]
+    assert repo.requested_limits == []
     payload = results[0].payload_json
     assert payload["candidate_limit"] == 2
     assert [candidate["symbol"] for candidate in payload["candidates"]] == [
@@ -73,6 +92,48 @@ async def test_equity_collector_respects_candidate_limit(db_session):
         "005930",
     ]
     assert results[0].coverage_json["candidate_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_kr_equity_path_has_no_us_quality_gate(db_session, monkeypatch):
+    """ROB-346 is US-only: KR (top_gainers fallback) must not gain quality_flags.
+
+    Presets are monkeypatched to no-op so KR deterministically falls to the
+    top_gainers path (list_top_candidates), where the US quality gate is skipped.
+    """
+    from app.services.invest_view_model import (
+        double_buy_screener,
+        high_yield_value_screener,
+        screener_service,
+    )
+
+    async def _no_rows(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(
+        screener_service, "load_consecutive_gainers_from_snapshots", _no_rows
+    )
+    monkeypatch.setattr(double_buy_screener, "load_double_buy_from_snapshots", _no_rows)
+    monkeypatch.setattr(
+        high_yield_value_screener, "load_high_yield_value_from_snapshots", _no_rows
+    )
+
+    repo = _FakeEquityRepository()
+    collector = CandidateUniverseSnapshotCollector(db_session, equity_repository=repo)
+    results = await collector.collect(
+        CollectorRequest(
+            market="kr",
+            account_scope=None,
+            symbols=[],
+            candidate_limit=5,
+            policy_snapshot={},
+        )
+    )
+    # KR uses list_top_candidates (not the US wide pool) and emits no quality gate.
+    assert repo.requested_limits  # list_top_candidates was used
+    assert repo.requested_pool_limits == []  # US wide pool NOT used for KR
+    for cand in results[0].payload_json["candidates"]:
+        assert "quality_flags" not in cand
 
 
 @pytest.mark.asyncio
@@ -563,8 +624,9 @@ async def test_stale_equity_payload_exposes_days_stale(db_session, monkeypatch):
                 last_computed_at=None,
             )
 
-        async def list_top_candidates(self, *, market, limit=10):
-            self.requested_limits.append(limit)
+        async def _candidate_rows(self, *, market, limit):
+            # Override at the row level so both list_top_candidates and the US
+            # list_candidate_pool path surface the stale partition row.
             return [
                 InvestScreenerSnapshot(
                     market=market,

--- a/tests/services/invest_screener_snapshots/test_repository_candidate_pool.py
+++ b/tests/services/invest_screener_snapshots/test_repository_candidate_pool.py
@@ -1,0 +1,52 @@
+import datetime as dt
+
+import pytest
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.invest_screener_snapshots.repository import (
+    InvestScreenerSnapshotsRepository,
+)
+
+
+def _snap(symbol, change_rate, d):
+    return InvestScreenerSnapshot(
+        market="us",
+        symbol=symbol,
+        snapshot_date=d,
+        latest_close=10,
+        change_rate=change_rate,
+        closes_window=[],
+        source="yahoo",
+        daily_volume=1_000_000,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_candidate_pool_returns_wide_unlimited(db_session):
+    today = dt.date(2026, 6, 9)
+    db_session.add_all([_snap(f"S{i}", float(i), today) for i in range(30)])
+    await db_session.flush()
+    repo = InvestScreenerSnapshotsRepository(db_session)
+    rows = await repo.list_candidate_pool(market="us", limit=None)
+    assert len(rows) == 30  # no early cap
+
+
+@pytest.mark.asyncio
+async def test_common_stock_flags_lookup(db_session):
+    db_session.add_all(
+        [
+            USSymbolUniverse(
+                symbol="AAA", exchange="NASDAQ", is_active=True, is_common_stock=True
+            ),
+            USSymbolUniverse(
+                symbol="ETF1", exchange="NYSE", is_active=True, is_common_stock=False
+            ),
+        ]
+    )
+    await db_session.flush()
+    repo = InvestScreenerSnapshotsRepository(db_session)
+    flags = await repo.common_stock_flags(["AAA", "ETF1", "MISSING"])
+    assert flags["AAA"] is True
+    assert flags["ETF1"] is False
+    assert flags.get("MISSING") is None

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -340,3 +340,35 @@ async def test_portfolio_journal_reads_active_from_real_collector_shape():
     assert "AAPL" in (payload.summary or "")
     assert "journal" not in (payload.missing_data or [])
 
+
+@pytest.mark.asyncio
+async def test_journal_unavailable_marks_data_gap():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
+            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
+                                          "collector_status": "unavailable"})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "journal" in (payload.missing_data or [])
+
+
+@pytest.mark.asyncio
+async def test_journal_empty_ok_is_not_data_gap():
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
+            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
+                                          "collector_status": "ok"})],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "journal" not in (payload.missing_data or [])
+    assert "open journal: none" in (payload.summary or "")
+
+

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -37,7 +37,16 @@ async def test_portfolio_journal_emits_neutral_with_buying_power():
                 _snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})
             ],
             "journal": [
-                _snap("journal", {"entries": [{"symbol": "035420", "thesis": "tech"}]})
+                _snap(
+                    "journal",
+                    {
+                        "active": [{"symbol": "035420", "thesis": "tech"}],
+                        "recent_retrospective": [],
+                        "active_count": 1,
+                        "retrospective_count": 0,
+                        "collector_status": "ok",
+                    },
+                )
             ],
         },
         bundle_metadata={},
@@ -284,10 +293,50 @@ async def test_portfolio_journal_surfaces_nav_scope_label_in_key_points():
                 )
             ],
             "journal": [
-                _snap("journal", {"entries": [{"symbol": "005930", "thesis": "tech"}]})
+                _snap(
+                    "journal",
+                    {
+                        "active": [{"symbol": "005930", "thesis": "tech"}],
+                        "recent_retrospective": [],
+                        "active_count": 1,
+                        "retrospective_count": 0,
+                        "collector_status": "ok",
+                    },
+                )
             ],
         },
         bundle_metadata={},
     )
     artifact = await PortfolioJournalStage().run(ctx)
     assert label in artifact.key_points
+
+
+@pytest.mark.asyncio
+async def test_portfolio_journal_reads_active_from_real_collector_shape():
+    # ROB-345 회귀: collector는 active/recent_retrospective 를 emit한다.
+    # stage가 "entries"를 읽던 버그(=항상 open journal: none)를 방지한다.
+    ctx = StageContext(
+        bundle_uuid=uuid.uuid4(),
+        snapshots_by_kind={
+            "portfolio": [
+                _snap("portfolio", {"buying_power_krw": 200000, "nav_krw": 1000000})
+            ],
+            "journal": [
+                _snap(
+                    "journal",
+                    {
+                        "active": [{"symbol": "AAPL", "thesis": "earnings"}],
+                        "recent_retrospective": [],
+                        "active_count": 1,
+                        "retrospective_count": 0,
+                        "collector_status": "ok",
+                    },
+                )
+            ],
+        },
+        bundle_metadata={},
+    )
+    payload = await PortfolioJournalStage().run(ctx)
+    assert "AAPL" in (payload.summary or "")
+    assert "journal" not in (payload.missing_data or [])
+

--- a/tests/services/investment_stages/stages/test_portfolio_journal.py
+++ b/tests/services/investment_stages/stages/test_portfolio_journal.py
@@ -347,8 +347,16 @@ async def test_journal_unavailable_marks_data_gap():
         bundle_uuid=uuid.uuid4(),
         snapshots_by_kind={
             "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
-            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
-                                          "collector_status": "unavailable"})],
+            "journal": [
+                _snap(
+                    "journal",
+                    {
+                        "active": [],
+                        "recent_retrospective": [],
+                        "collector_status": "unavailable",
+                    },
+                )
+            ],
         },
         bundle_metadata={},
     )
@@ -362,13 +370,19 @@ async def test_journal_empty_ok_is_not_data_gap():
         bundle_uuid=uuid.uuid4(),
         snapshots_by_kind={
             "portfolio": [_snap("portfolio", {"buying_power_krw": 1, "nav_krw": 10})],
-            "journal": [_snap("journal", {"active": [], "recent_retrospective": [],
-                                          "collector_status": "ok"})],
+            "journal": [
+                _snap(
+                    "journal",
+                    {
+                        "active": [],
+                        "recent_retrospective": [],
+                        "collector_status": "ok",
+                    },
+                )
+            ],
         },
         bundle_metadata={},
     )
     payload = await PortfolioJournalStage().run(ctx)
     assert "journal" not in (payload.missing_data or [])
     assert "open journal: none" in (payload.summary or "")
-
-


### PR DESCRIPTION
ROB-336 Phase 2 (US snapshot-backed `/invest/reports`)의 3개 이슈를 한 PR로 묶음. 모두 **migration-0**, read-only 분석 경로(브로커/주문/감시/order-intent mutation 없음), KR/crypto 경로 무회귀. brainstorm→spec→plan→구현→적대적 검증을 거침.

## ROB-345 (Bug/High) — US kis_live journal 매핑 복구
**근본원인 정정:** 이슈 가설(`account_scope` 변환 누락)은 부차. 지배 원인은 **journal snapshot payload 키 계약 불일치** — collector는 `active`/`recent_retrospective`를 emit하는데 stage(`portfolio_journal.py`)는 `entries`(아무도 안 쓰는 키)를 읽어 **모든 market에서 항상 `open journal: none`**, snapshot이 존재해 data_gap으로도 안 잡힘. 단위 테스트가 `entries`를 fabricate해 버그를 가렸음.
- stage가 collector 실제 키 `active`를 읽도록 정렬 + citation path `$.active` + 잘못된 fixture 정정.
- collector를 `get_trade_journal`의 검증된 `market_map`(instrument_type) + `account in (kis, NULL)` scope에 맞춰 US/KR 분리, `account` provenance emit.
- `collector_status`로 "journal 없음(`no_open_journals`)" vs "collector unavailable(`journal_collector_unavailable`)" 구분.

## ROB-346 (Improvement/High) — US 신규매수 후보 universe 품질·우선순위
widen-and-demote. `classify_candidate_symbol` signature **불변**, 순수 후처리 헬퍼로 구성.
- 신규 `candidate_quality.py`(penny<\$5 / illiquid<\$5M / abnormal_spike>15%·주간>50% / non_common / stale; `change_rate`는 percent 단위) + `priority_score` 결정적 공식.
- `action_verdict.demote_for_quality`(non_common→rejected, unknown→data_gap, 품질→watch_only).
- repository `list_candidate_pool`(wide, no early cap) + `common_stock_flags`(us_symbol_universe).
- collector(US-only gate): wide pool `max(limit*5,50)` 평가 → priority 정렬 → 표시 슬라이스. `pool_size`/`displayed_count` 투명성.
- auto_emit: 데모션 적용 + quality_flags/confidence_cap surface + 데모션 표시 cap(~10). market_cap 데이터 부재 → size/liquidity proxy(정직 명명).

## ROB-347 (Improvement/Med) — 예산·환전 전제 정책
**정정:** `app/services/action_report/us/`는 dead code(수정 위치 아님). 실제 후보 경로는 budget-blind였음.
- `budget_basis`(기본 `available_usd`) + `operator_budget_override_usd` request 필드 + MCP 노출.
- `action_verdict.demote_for_budget`(buy_review만 하향, override precedence, **KRW→USD 날조 금지**).
- auto_emit가 portfolio snapshot `buying_power`로 budget_state 구성, **US kis_live에서만** 적용. USD=0이어도 후보는 발굴하되 `budget_gap`/`fx_required`/`operator_budget_required`로 표시.
- 데모션 순서: base → quality → budget → count-cap.

## 안전 경계
- migration 0 (request 필드 in-memory, 모든 evidence는 JSONB additive).
- 브로커/주문/감시/order-intent mutation, 주문 preview/submit/cancel/modify 없음.
- KR/crypto 무회귀(품질/예산 게이트는 US kis_live 한정). decision_bucket enum 불변. KRW reference-only.

## 테스트
- 323 passed (관련 디렉토리), ruff check/format clean, ty clean.
- 신규: journal market scoping(DB-seeded equity_us vs equity_kr authority separation) + empty/unavailable, quality 플래그/priority 정확값·경계·우선순위, quality>budget 체이닝, basis별 budget(USD=0/KRW reference/override), common_stock_unknown, KR 무회귀.

## Linear
- ROB-345, ROB-346, ROB-347 (parent ROB-336).
- 설계/플랜 문서: `docs/superpowers/specs/2026-06-09-rob-34{5,6,7}-*.md`, `docs/superpowers/plans/2026-06-09-rob-34{5,6,7}-*-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added budget basis controls for investment reports with operator override capability
  * Enhanced candidate quality evaluation with quality flags for penny stocks, illiquidity, and abnormal price movements
  * Improved US trade journal data mapping in investment reports

* **Improvements**
  * Wider candidate pool evaluation for US markets with priority-based ranking
  * Better filtering of low-quality assets using confidence caps and quality gates

* **Documentation**
  * Added implementation plans and design specifications for US candidate universe filtering and budget-basis policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->