### PR TITLE
fix(ROB-416): split US quote unavailable errors

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -42,9 +42,10 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `search_symbol(query, limit=20)`
 - `get_quote(symbol, market=None)`
 - `get_orderbook(symbol, market="kr")`
-- US equity quote price resolution uses Yahoo directly via `app.services.brokers.yahoo.client`
-  - US quote response keeps `source: "yahoo"` and includes `previous_close/open/high/low/volume` from Yahoo `fast_info`
-  - US equity Yahoo lookup failures are propagated as tool-level errors (exceptions), not returned as in-band error payload dicts
+- US equity quote price resolution uses KIS overseas current price first when `settings.us_quote_kis_primary` is enabled, then falls back to Yahoo `fast_info`
+  - US quote response keeps `source: "kis_overseas"` or `source: "yahoo"` and includes `previous_close/open/high/low/volume` when the provider supplies them
+  - US quote failures are propagated as tool-level errors (exceptions), not returned as in-band error payload dicts
+  - Explicit provider not-found errors remain `Symbol '<ticker>' not found`; successful Yahoo `fast_info` responses with no usable price are reported as temporarily unavailable instead of symbol-not-found
 - `get_holdings(account=None, market=None, include_current_price=True, minimum_value=None, account_mode=None)`
   - Crypto positions may include optional `strategy_signal` field when Phase 2 exit logic triggers (4.5% stop-loss or RSI > 46 mean-reversion on profitable positions)
 - `get_position(symbol, market=None, account_mode=None)`

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -554,13 +554,25 @@ async def _fetch_us_quote_from_kis(normalized_symbol: str) -> dict[str, Any] | N
     }
 
 
+def _is_yahoo_symbol_not_found_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "quote not found",
+            "symbol not found",
+            "not found for symbol",
+        )
+    )
+
+
 async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
     """Fetch US equity quote.
 
     ROB-471: KIS 해외 현재가 primary(settings.us_quote_kis_primary), Yahoo
     fast_info fallback. 정직 에러 분리:
-      - 둘 다 정상응답·무가격 → symbol_not_found (ValueError)
-      - 한쪽이라도 infra 실패 + 무가격 → quote_unavailable (RuntimeError)
+      - provider 명시적 not-found → symbol_not_found (ValueError)
+      - fast_info 정상응답·무가격 → quote_unavailable (RuntimeError)
     """
     normalized_symbol = str(symbol or "").strip().upper()
     not_found_message = f"Symbol '{normalized_symbol}' not found"
@@ -585,6 +597,8 @@ async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
     try:
         fast_info = await yahoo_service.fetch_fast_info(normalized_symbol)
     except Exception as exc:
+        if _is_yahoo_symbol_not_found_error(exc):
+            raise ValueError(not_found_message) from exc
         raise RuntimeError(
             f"{unavailable_message} (yahoo fallback failed): {exc}"
         ) from exc
@@ -595,7 +609,7 @@ async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
             raise RuntimeError(
                 f"{unavailable_message} (kis errored, yahoo returned no price)"
             )
-        raise ValueError(not_found_message)
+        raise RuntimeError(f"{unavailable_message} (yahoo returned no price)")
 
     return {
         "symbol": normalized_symbol,

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -409,8 +409,10 @@ async def test_get_quote_us_equity(monkeypatch):
 @pytest.mark.parametrize(
     "exc_name", ["USSymbolInactiveError", "USSymbolUniverseEmptyError"]
 )
-async def test_get_quote_us_lookup_exc_falls_back_then_not_found(monkeypatch, exc_name):
-    """inactive/empty 거래소 해석 예외도 clean fallback → symbol_not_found(ValueError)."""
+async def test_get_quote_us_lookup_exc_then_yahoo_no_price_is_unavailable(
+    monkeypatch, exc_name
+):
+    """fast_info succeeds but has no price -> quote_unavailable, not symbol_not_found."""
     import app.services.us_symbol_universe_service as uss
 
     exc = getattr(uss, exc_name)
@@ -425,8 +427,7 @@ async def test_get_quote_us_lookup_exc_falls_back_then_not_found(monkeypatch, ex
         yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
     )
 
-    # clean no-route (not infra) → symbol_not_found, NOT quote_unavailable
-    with pytest.raises(ValueError, match="not found"):
+    with pytest.raises(RuntimeError, match="temporarily unavailable"):
         await tools["get_quote"]("AAPL")
 
 
@@ -504,7 +505,7 @@ async def test_get_quote_us_falls_back_to_yahoo(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_quote_us_symbol_not_found(monkeypatch):
-    """KIS no-route(clean) + Yahoo close=None → ValueError symbol_not_found."""
+    """Yahoo explicit not-found errors stay symbol_not_found."""
     from app.services.us_symbol_universe_service import USSymbolNotRegisteredError
 
     tools = build_tools()
@@ -515,11 +516,13 @@ async def test_get_quote_us_symbol_not_found(monkeypatch):
         AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
     )
     monkeypatch.setattr(
-        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+        yahoo_service,
+        "fetch_fast_info",
+        AsyncMock(side_effect=ValueError("Quote not found for symbol: INVALID")),
     )
 
-    with pytest.raises(ValueError, match="Symbol 'AAPL' not found"):
-        await tools["get_quote"]("AAPL")
+    with pytest.raises(ValueError, match="Symbol 'INVALID' not found"):
+        await tools["get_quote"]("INVALID")
 
 
 @pytest.mark.asyncio
@@ -596,6 +599,21 @@ async def test_get_quote_us_flag_off_uses_yahoo(monkeypatch):
 
     assert result["source"] == "yahoo"
     assert result["price"] == pytest.approx(205.0)
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_flag_off_yahoo_no_price_is_unavailable(monkeypatch):
+    """Yahoo primary fast_info with no price is a runtime data gap, not not-found."""
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "us_quote_kis_primary", False)
+    tools = build_tools()
+    monkeypatch.setattr(
+        yahoo_service, "fetch_fast_info", AsyncMock(return_value={"close": None})
+    )
+
+    with pytest.raises(RuntimeError, match="temporarily unavailable"):
+        await tools["get_quote"]("AAPL")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_shared_utils.py
+++ b/tests/test_mcp_shared_utils.py
@@ -380,23 +380,15 @@ class TestSymbolNotFound:
     @pytest.mark.asyncio
     async def test_get_quote_us_equity_not_found_raises(self, monkeypatch):
         tools = build_tools()
-        # ROB-471: KIS-primary 디폴트 하에서 KIS 경로를 clean no-route로 고정해
-        # 실 DB 거래소 해석에 의존하지 않도록 한다(Yahoo fallback → 무가격 → not found).
+        # ROB-416: true symbol_not_found requires an explicit provider not-found
+        # signal; a successful fast_info payload with no price is quote_unavailable.
         _patch_runtime_attr(
             monkeypatch,
             "get_us_exchange_by_symbol",
             AsyncMock(side_effect=USSymbolNotRegisteredError("not registered")),
         )
         mock_fetch_fast_info = AsyncMock(
-            return_value={
-                "symbol": "INVALID",
-                "close": None,
-                "previous_close": None,
-                "open": None,
-                "high": None,
-                "low": None,
-                "volume": None,
-            }
+            side_effect=ValueError("Quote not found for symbol: INVALID")
         )
         monkeypatch.setattr(yahoo_service, "fetch_fast_info", mock_fetch_fast_info)
 


### PR DESCRIPTION
## Summary
- Split US quote errors so Yahoo explicit not-found stays symbol_not_found while fast_info no-price is quote_unavailable.
- Cover KIS fallback, Yahoo primary, and explicit Yahoo not-found behavior in MCP quote tests.
- Update MCP README for KIS-overseas primary + Yahoo fallback semantics.

## Root Cause
Yahoo fast_info could return successfully with no usable close/last_price for valid US tickers, and the MCP quote path classified that runtime data gap as Symbol not found.

## Test Plan
- uv run --group test pytest tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py
- uv run --group dev ruff check app/mcp_server/tooling/market_data_quotes.py tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py
- uv run --group dev ruff format --check app/mcp_server/tooling/market_data_quotes.py tests/test_mcp_quotes_tools.py tests/test_mcp_shared_utils.py