### PR TITLE
test(ROB-482): speed up CI by removing test overhead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -109,6 +113,12 @@ jobs:
         echo "PYTHON_VERSION: ${{ matrix.python-version }}"
 
     - name: Run tests
+      env:
+        # Python 3.13 coverage.py sysmon tracing is compatible here because
+        # [tool.coverage.run] does not enable branch coverage. If branch=true is
+        # added before Python 3.14, coverage falls back to ctrace and CI slows
+        # down again.
+        COVERAGE_CORE: sysmon
       run: |
         uv run pytest tests/ -m "not live" -n auto --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml --cov-fail-under=30
 

--- a/tests/_mcp_screen_stocks_support.py
+++ b/tests/_mcp_screen_stocks_support.py
@@ -223,6 +223,11 @@ class TestScreenStocksKRRegression:
         monkeypatch.setattr(
             screening_kr, "fetch_stock_all_cached", mock_fetch_stock_all_cached
         )
+        monkeypatch.setattr(
+            screening_kr,
+            "_can_use_tvscreener_stock_path",
+            lambda **kwargs: False,
+        )
 
         tools = build_tools()
         await tools["screen_stocks"](
@@ -368,6 +373,11 @@ class TestScreenStocksKRRegression:
             screening_kr,
             "fetch_valuation_all_cached",
             mock_fetch_valuation_all_cached,
+        )
+        monkeypatch.setattr(
+            screening_kr,
+            "_can_use_tvscreener_stock_path",
+            lambda **kwargs: False,
         )
 
         tools = build_tools()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,43 @@ def _mock_nxt_eligible(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _mock_kr_market_session_calendar(monkeypatch):
+    """Use a deterministic lightweight KRX calendar in fast tests.
+
+    Tests that need precise holiday behavior patch market_session._get_kr_calendar
+    directly. The default fast gate only needs weekday/session arithmetic and must
+    not pay the exchange_calendars XKRX construction cost in every xdist worker.
+    """
+
+    class _FastKrCalendar:
+        tz = "Asia/Seoul"
+
+        def _local(self, value):
+            ts = pd.Timestamp(value)
+            if ts.tz is None:
+                return ts.tz_localize(self.tz)
+            return ts.tz_convert(self.tz)
+
+        def is_trading_minute(self, value):
+            local = self._local(value)
+            if local.weekday() >= 5:
+                return False
+            start = pd.Timestamp(local.date(), tz=self.tz) + pd.Timedelta(hours=9)
+            end = pd.Timestamp(local.date(), tz=self.tz) + pd.Timedelta(
+                hours=15, minutes=30
+            )
+            return start <= local < end
+
+        def is_session(self, value):
+            return self._local(value).weekday() < 5
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_session._get_kr_calendar",
+        lambda: _FastKrCalendar(),
+    )
+
+
+@pytest.fixture(autouse=True)
 def mock_auth_middleware_db():
     """Mock AsyncSessionLocal in AuthMiddleware to prevent DB connection attempts."""
     with patch("app.middleware.auth.AsyncSessionLocal") as mock:

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -216,6 +216,7 @@ def test_dashboard_deprecated_api_path_bypasses_auth_401(client, mock_session_lo
 def test_protected_route_redirects_cleanly_with_sentry_fastapi_enabled(monkeypatch):
     import sentry_sdk
     from sentry_sdk.integrations.fastapi import FastApiIntegration
+    from sentry_sdk.integrations.starlette import StarletteIntegration
 
     test_app = FastAPI()
     test_app.add_middleware(AuthMiddleware)
@@ -234,7 +235,12 @@ def test_protected_route_redirects_cleanly_with_sentry_fastapi_enabled(monkeypat
         staticmethod(AsyncMock(return_value=None)),
     )
 
-    sentry_sdk.init(dsn=None, integrations=[FastApiIntegration()])
+    sentry_sdk.init(
+        dsn=None,
+        integrations=[StarletteIntegration(), FastApiIntegration()],
+        default_integrations=False,
+        auto_enabling_integrations=False,
+    )
     client = TestClient(test_app)
 
     response = client.get("/test-protected", follow_redirects=False)

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -337,7 +337,22 @@ async def test_place_order_insufficient_balance_kis_domestic(monkeypatch):
                 "stck_itgr_cash100_ord_psbl_amt": "100000.0",
             }
 
+        async def inquire_korea_orders(self):
+            return []
+
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+    async def fetch_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 5000000.0}
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_premarket_nxt_price_for_kr",
+        AsyncMock(return_value=None),
+    )
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
+
     _patch_runtime_attr(
         monkeypatch,
         "_preview_order",
@@ -378,7 +393,22 @@ async def test_place_order_insufficient_balance_kis_domestic_blocks_real_order(
                 "stck_itgr_cash100_ord_psbl_amt": "100000.0",
             }
 
+        async def inquire_korea_orders(self):
+            return []
+
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+    async def fetch_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 5000000.0}
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_premarket_nxt_price_for_kr",
+        AsyncMock(return_value=None),
+    )
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
+
     _patch_runtime_attr(
         monkeypatch,
         "_preview_order",

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -15,6 +15,7 @@ from app.services.tvscreener_capabilities import (
     TvScreenerCapabilitySnapshot,
     TvScreenerCapabilityState,
 )
+from app.services.tvscreener_retry import TvScreenerError
 from tests._mcp_screen_stocks_support import (
     TestScreenStocksFundamentalsExpansion,
     TestScreenStocksKR,
@@ -55,8 +56,8 @@ def mock_kr_tvscreener_network_by_default(monkeypatch: pytest.MonkeyPatch):
     async def fake_capability_snapshot(**kwargs: Any):
         return snapshot
 
-    async def fail_tvscreener_network(*args: Any, **kwargs: Any):
-        return pd.DataFrame()
+    async def fail_kr_tvscreener_query(*args: Any, **kwargs: Any):
+        raise TvScreenerError("tvscreener network disabled in fast tests")
 
     monkeypatch.setattr(
         kr_mod,
@@ -67,14 +68,7 @@ def mock_kr_tvscreener_network_by_default(monkeypatch: pytest.MonkeyPatch):
         "app.mcp_server.tooling.screening.us._get_tvscreener_stock_capability_snapshot",
         fake_capability_snapshot,
     )
-    monkeypatch.setattr(
-        "app.services.tvscreener_retry.fetch_tvscreener_with_retry",
-        fail_tvscreener_network,
-    )
-    monkeypatch.setattr(
-        "app.services.tvscreener_service.fetch_tvscreener_with_retry",
-        fail_tvscreener_network,
-    )
+    monkeypatch.setattr(kr_mod, "_execute_kr_query", fail_kr_tvscreener_query)
 
 
 def test_analysis_screening_reexports_screen_contract_helpers() -> None:

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -11,6 +11,10 @@ from app.mcp_server.tooling import analysis_screening
 from app.mcp_server.tooling.screening import kr as kr_mod
 from app.mcp_server.tooling.screening import kr as kr_screening
 from app.mcp_server.tooling.screening.kr_ranking_snapshot import KrRankingSnapshotResult
+from app.services.tvscreener_capabilities import (
+    TvScreenerCapabilitySnapshot,
+    TvScreenerCapabilityState,
+)
 from tests._mcp_screen_stocks_support import (
     TestScreenStocksFundamentalsExpansion,
     TestScreenStocksKR,
@@ -36,6 +40,41 @@ def mock_disable_kr_ranking_snapshot_by_default():
         new=AsyncMock(return_value=None),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_kr_tvscreener_network_by_default(monkeypatch: pytest.MonkeyPatch):
+    capabilities = {"volume", "change_rate", "rsi", "adx"}
+    snapshot = TvScreenerCapabilitySnapshot(
+        screener="stock",
+        market="kr",
+        statuses=dict.fromkeys(capabilities, TvScreenerCapabilityState.USABLE),
+        fields={capability: object() for capability in capabilities},
+    )
+
+    async def fake_capability_snapshot(**kwargs: Any):
+        return snapshot
+
+    async def fail_tvscreener_network(*args: Any, **kwargs: Any):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        kr_mod,
+        "_get_tvscreener_stock_capability_snapshot",
+        fake_capability_snapshot,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.screening.us._get_tvscreener_stock_capability_snapshot",
+        fake_capability_snapshot,
+    )
+    monkeypatch.setattr(
+        "app.services.tvscreener_retry.fetch_tvscreener_with_retry",
+        fail_tvscreener_network,
+    )
+    monkeypatch.setattr(
+        "app.services.tvscreener_service.fetch_tvscreener_with_retry",
+        fail_tvscreener_network,
+    )
 
 
 def test_analysis_screening_reexports_screen_contract_helpers() -> None:


### PR DESCRIPTION
## Summary
- Enable coverage sysmon and cancel stale PR test runs.
- Remove fast-gate real network/calendar overhead from KR screen, market-session, Sentry, and KIS insufficient-balance tests.
- Narrow the tvscreener guard to the KR query boundary so US/crypto tests are not masked.

## Test Plan
- uv run pytest tests/test_mcp_screen_stocks_kr.py -ra --durations=25 --durations-min=1.0
- uv run pytest tests/test_mcp_screen_stocks_kr.py tests/test_market_session.py tests/test_auth_middleware.py::test_protected_route_redirects_cleanly_with_sentry_fastapi_enabled tests/test_mcp_place_order.py -k 'insufficient_balance_kis_domestic or test_returns_ or protected_route_redirects_cleanly' -ra --durations=25 --durations-min=1.0
- uv run ruff check tests/conftest.py tests/test_mcp_screen_stocks_kr.py tests/_mcp_screen_stocks_support.py tests/test_auth_middleware.py tests/test_mcp_place_order.py
- uv run ruff format --check tests/conftest.py tests/test_mcp_screen_stocks_kr.py tests/_mcp_screen_stocks_support.py tests/test_auth_middleware.py tests/test_mcp_place_order.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow with improved concurrency handling and coverage configuration.
  * Enhanced test infrastructure with new fixtures for market calendar and external service mocking to improve test reliability and isolation.
  * Updated test mocks for domestic order and stock screening scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->