### PR TITLE
ci(ROB-483): trial pytest xdist worksteal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         # down again.
         COVERAGE_CORE: sysmon
       run: |
-        uv run pytest tests/ -m "not live" -n auto --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml --cov-fail-under=30
+        uv run pytest tests/ -m "not live" -n auto --dist=worksteal -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml --cov-fail-under=30
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Summary (2026-06-10 restack — pure one-line trial)
- `--dist=loadfile` → `--dist=worksteal` 한 줄 변경 (테스트 모집단·base 동일 조건 A/B용).
- 이전 trial이 드러낸 비-dist 수정들은 분리 머지 완료: candidate_universe loader 정규화 + journal 격리 = PR #1230, tvscreener 실 HTTP 차단 = PR #1233. 본 PR diff는 test.yml 1줄.

## 채택 판정 룰 (사전 고정 — docs/plans/ROB-482-484-ci-test-speedup-remaining-plan.md §4)
1. 동일 base(60958fd9 이후 main)에서 trial CI **3연속 green**
2. worksteal pytest 시간 **메디안이 loadfile 메디안보다 ≥20s 빠름**

둘 중 하나라도 미충족 → 본 PR은 닫고 loadfile 유지 (부정 결과 ROB-483 기록).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution configuration to optimize testing infrastructure performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->