### PR TITLE
feat(ROB-478/479/480/481): execution ledger 과거 체결 백필 + manual_import opening-lot 시딩

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -44,6 +44,8 @@ DEFAULT_KIS_API_RATE_LIMITS: ApiRateLimitMap = {
 
 DEFAULT_UPBIT_API_RATE_LIMITS: ApiRateLimitMap = {
     "GET /v1/accounts": {"rate": 30, "period": 1.0},
+    "GET /v1/order": {"rate": 30, "period": 1.0},
+    "GET /v1/orders/closed": {"rate": 30, "period": 1.0},
     "GET /v1/ticker": {"rate": 10, "period": 1.0},
 }
 

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -407,9 +407,10 @@ class KISClient(BaseKISClient):
         side: str = "00",
         order_number: str = "",
         is_mock: bool = False,
+        max_pages: int = 100,
     ) -> list[dict[str, Any]]:
         return await self._domestic_orders.inquire_daily_order_domestic(
-            start_date, end_date, stock_code, side, order_number, is_mock
+            start_date, end_date, stock_code, side, order_number, is_mock, max_pages
         )
 
     async def modify_korea_order(
@@ -497,9 +498,17 @@ class KISClient(BaseKISClient):
         side: str = "00",
         order_number: str = "",
         is_mock: bool = False,
+        max_pages: int = 100,
     ) -> list[dict[str, Any]]:
         return await self._overseas_orders.inquire_daily_order_overseas(
-            start_date, end_date, symbol, exchange_code, side, order_number, is_mock
+            start_date,
+            end_date,
+            symbol,
+            exchange_code,
+            side,
+            order_number,
+            is_mock,
+            max_pages,
         )
 
     async def modify_overseas_order(

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -523,6 +523,7 @@ class DomesticOrderClient:
         side: str = "00",
         order_number: str = "",
         is_mock: bool = False,
+        max_pages: int = 100,
     ) -> list[dict]:
         """
         국내주식 일별 체결조회 (주문 히스토리)
@@ -534,25 +535,10 @@ class DomesticOrderClient:
             side: 매도매수구분 (00:전체, 01:매도, 02:매수)
             order_number: 주문번호 (특정 주문만 조회 시)
             is_mock: True면 모의투자, False면 실전투자
+            max_pages: 최대 조회 페이지 수
 
         Returns:
             체결 주문 목록 (list of dict)
-            각 항목:
-            - ord_no: 주문번호
-            - orgn_ord_no: 원주문번호
-            - sll_buy_dvsn_cd: 매도매수구분코드 (01:매도, 02:매수)
-            - sll_buy_dvsn_cd_name: 매도매수구분명
-            - rvse_cncl_dvsn_cd: 정정취소구분코드
-            - rvse_cncl_dvsn_name: 정정취소구분명
-            - pdno: 상품번호(종목코드)
-            - prdt_name: 상품명
-            - ord_qty: 주문수량
-            - ord_unpr: 주문단가
-            - ccld_qty: 체결수량
-            - ccld_unpr: 체결단가
-            - ccld_amt: 체결금액
-            - ord_dt: 주문일자
-            - ord_tmd: 주문시각
         """
         await self._parent._ensure_token()
 
@@ -579,14 +565,15 @@ class DomesticOrderClient:
         ctx_area_nk100 = ""
         tr_cont = ""
         page = 1
-        max_pages = 10
+        page_limit = max(1, int(max_pages))
+        truncated = False
         token_retry_count = 0
         max_token_retries = 3
         transient_retry_count = 0
 
         logging.info(f"국내주식 체결조회 시작 - {start_date} ~ {end_date}")
 
-        while page <= max_pages:
+        while page <= page_limit:
             hdr = self._parent._hdr_base | {
                 "authorization": f"Bearer {self._settings.kis_access_token}",
                 "tr_id": tr_id,
@@ -678,7 +665,16 @@ class DomesticOrderClient:
             tr_cont = "N"
 
             page += 1
+            if page > page_limit:
+                truncated = True
+                break
             await asyncio.sleep(0.1)
+
+        if truncated:
+            raise RuntimeError(
+                "KIS domestic daily order history truncated "
+                f"at max_pages={page_limit} for {start_date}~{end_date}"
+            )
 
         logging.info(f"국내주식 체결조회 완료: 총 {len(all_orders)}건")
         return all_orders

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -530,6 +530,7 @@ class OverseasOrderClient:
         side: str = "00",
         order_number: str = "",
         is_mock: bool = False,
+        max_pages: int = 100,
     ) -> list[dict]:
         """
         해외주식 일별 체결조회 (주문 히스토리)
@@ -542,26 +543,10 @@ class OverseasOrderClient:
             side: 매도매수구분 (00:전체, 01:매도, 02:매수)
             order_number: 주문번호 (해외주식은 미지원으로 무시됨)
             is_mock: True면 모의투자, False면 실전투자
+            max_pages: 최대 조회 페이지 수
 
         Returns:
             체결 주문 목록 (list of dict)
-            각 항목:
-            - odno: 주문번호
-            - orgn_odno: 원주문번호
-            - sll_buy_dvsn_cd: 매도매수구분코드 (01:매도, 02:매수)
-            - sll_buy_dvsn_cd_name: 매도매수구분명
-            - rvse_cncl_dvsn_cd: 정정취소구분코드
-            - rvse_cncl_dvsn_name: 정정취소구분명
-            - pdno: 상품번호(종목코드)
-            - prdt_name: 상품명
-            - ft_ord_qty: 주문수량
-            - ft_ord_unpr3: 주문단가
-            - ft_ccld_qty: 체결수량
-            - ft_ccld_unpr3: 체결단가
-            - ft_ccld_amt3: 체결금액
-            - prcs_stat_name: 처리상태명
-            - ord_dt: 주문일자
-            - ord_tmd: 주문시각
         """
         await self._parent._ensure_token()
 
@@ -588,12 +573,13 @@ class OverseasOrderClient:
         ctx_area_nk200 = ""
         tr_cont = ""
         page = 1
-        max_pages = 10
+        page_limit = max(1, int(max_pages))
+        truncated = False
         transient_retry_count = 0
 
         logging.info(f"해외주식 체결조회 시작 - {start_date} ~ {end_date}")
 
-        while page <= max_pages:
+        while page <= page_limit:
             hdr = self._parent._hdr_base | {
                 "authorization": f"Bearer {self._settings.kis_access_token}",
                 "tr_id": tr_id,
@@ -668,7 +654,6 @@ class OverseasOrderClient:
                 logging.error(f"해외주식 체결조회 실패: {error_msg}")
                 raise RuntimeError(error_msg)
 
-            # KIS 해외주식 체결조회 API may return data in 'output' or 'output1' key
             orders = js.get("output1") or js.get("output", [])
 
             if not orders:
@@ -692,7 +677,16 @@ class OverseasOrderClient:
             tr_cont = "N"
 
             page += 1
+            if page > page_limit:
+                truncated = True
+                break
             await asyncio.sleep(0.1)
+
+        if truncated:
+            raise RuntimeError(
+                "KIS overseas daily order history truncated "
+                f"at max_pages={page_limit} for {start_date}~{end_date}"
+            )
 
         logging.info(f"해외주식 체결조회 완료: 총 {len(all_orders)}건")
         return all_orders

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -205,17 +205,21 @@ async def fetch_my_coins() -> list[dict[str, Any]]:
     return await _request_with_auth("GET", f"{UPBIT_REST}/accounts")
 
 
-def parse_upbit_account_row(account: dict[str, Any]) -> dict[str, float]:
-    """Parse a single ``/v1/accounts`` row → ``balance, locked, total_quantity, orderable_quantity, avg_buy_price``."""
+def parse_upbit_account_row(account: dict[str, Any]) -> dict[str, float | bool]:
+    """Parse a single ``/v1/accounts`` row → ``balance, locked, total_quantity, orderable_quantity, avg_buy_price, avg_buy_price_modified``."""
     balance = float(account.get("balance", 0) or 0)
     locked = float(account.get("locked", 0) or 0)
     avg_buy_price = float(account.get("avg_buy_price", 0) or 0)
+    avg_buy_price_modified = str(
+        account.get("avg_buy_price_modified", "false")
+    ).lower() in {"true", "1", "yes"}
     return {
         "balance": balance,
         "locked": locked,
         "total_quantity": balance + locked,
         "orderable_quantity": balance,
         "avg_buy_price": avg_buy_price,
+        "avg_buy_price_modified": avg_buy_price_modified,
     }
 
 

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -6,8 +6,8 @@ Market data functions remain in client.py.
 
 from __future__ import annotations
 
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import Any
 
 import app.services.brokers.upbit.client as _client

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -6,6 +6,7 @@ Market data functions remain in client.py.
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from typing import Any
 
@@ -190,37 +191,50 @@ async def place_market_buy_order(market: str, price: str) -> dict[str, Any]:
     return await place_buy_order(market, price, ord_type="price")
 
 
+def _format_upbit_time(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Upbit time parameter must not be empty")
+    return text
+
+
 async def fetch_closed_orders(
     market: str | None = None,
-    limit: int = 20,
-    page: int = 1,
+    limit: int = 100,
     states: list[str] | None = None,
     order_by: str = "desc",
+    start_time: datetime | str | None = None,
+    end_time: datetime | str | None = None,
 ) -> list[dict[str, Any]]:
     """체결/취소 완료 주문 목록 조회.
 
     Args:
         market: 마켓코드 필터 (옵션), None이면 전체 조회
-        limit: 반환할 건수 (Upbit page size, 최대 100)
-        page: 페이지 번호 (1부터 시작)
+        limit: 반환할 건수 (Upbit page size, 최대 1000)
         states: 조회 상태 목록. 기본값은 ["done", "cancel"]
         order_by: 정렬 방향 ("asc" 또는 "desc")
+        start_time: 시작 시간 (ISO8601 string or datetime)
+        end_time: 종료 시간 (ISO8601 string or datetime)
 
     Returns:
         체결/취소 주문 목록 (list of dict)
     """
     url = f"{_client.UPBIT_REST}/orders/closed"
-    capped_limit = max(1, min(int(limit), 100))
-    normalized_page = max(1, int(page))
+    capped_limit = max(1, min(int(limit), 1000))
     normalized_states = states or ["done", "cancel"]
     params: dict[str, Any] = {
         "states[]": normalized_states,
         "limit": capped_limit,
-        "page": normalized_page,
         "order_by": order_by,
     }
     if market:
         params["market"] = market
+    if start_time is not None:
+        params["start_time"] = _format_upbit_time(start_time)
+    if end_time is not None:
+        params["end_time"] = _format_upbit_time(end_time)
 
     return await _client._request_with_auth("GET", url, query_params=params)
 

--- a/app/services/execution_ledger/opening_lots.py
+++ b/app/services/execution_ledger/opening_lots.py
@@ -212,6 +212,11 @@ async def load_upbit_opening_lot_candidates() -> list[OpeningLotCandidate]:
         if not currency or currency == "KRW":
             continue
         unit_currency = str(row.get("unit_currency") or "KRW").strip().upper()
+        if unit_currency != "KRW":
+            # The ledger normalizer only ever writes venue='upbit_krw' with
+            # currency='KRW'; a BTC/USDT-market seed could never match a sell
+            # and its avg price is not KRW-denominated.
+            continue
         parsed = parse_upbit_account_row(row)
         current_qty = Decimal(str(parsed["total_quantity"]))
         avg_price = Decimal(str(parsed["avg_buy_price"]))
@@ -219,11 +224,11 @@ async def load_upbit_opening_lot_candidates() -> list[OpeningLotCandidate]:
             OpeningLotCandidate(
                 broker="upbit",
                 account_mode="live",
-                venue=f"upbit_{unit_currency.lower()}",
+                venue="upbit_krw",
                 instrument_type="crypto",
                 symbol=currency,
-                raw_symbol=f"{unit_currency}-{currency}",
-                currency="KRW" if unit_currency == "KRW" else "USD",
+                raw_symbol=f"KRW-{currency}",
+                currency="KRW",
                 current_qty=current_qty,
                 avg_price=avg_price,
                 avg_price_modified=bool(parsed["avg_buy_price_modified"]),

--- a/app/services/execution_ledger/opening_lots.py
+++ b/app/services/execution_ledger/opening_lots.py
@@ -14,7 +14,6 @@ from app.schemas.execution_ledger import (
     InstrumentTypeValue,
 )
 
-
 MatchKey = tuple[str, str, str, str, str, str]
 
 
@@ -64,8 +63,7 @@ def _match_key(candidate: OpeningLotCandidate) -> MatchKey:
 
 def _seed_order_id(candidate: OpeningLotCandidate, cutover: datetime) -> str:
     return (
-        f"SEED-{cutover:%Y%m%d}-"
-        f"{candidate.broker}-{candidate.venue}-{candidate.symbol}"
+        f"SEED-{cutover:%Y%m%d}-{candidate.broker}-{candidate.venue}-{candidate.symbol}"
     )
 
 
@@ -81,24 +79,38 @@ def build_opening_lot_plan(
         ledger_net_qty = ledger_net_by_key.get(key, Decimal("0"))
         if candidate.current_qty <= 0:
             plan.skipped.append(
-                OpeningLotSkip(key, "non_positive_current_qty", candidate.current_qty, ledger_net_qty)
+                OpeningLotSkip(
+                    key,
+                    "non_positive_current_qty",
+                    candidate.current_qty,
+                    ledger_net_qty,
+                )
             )
             continue
         if candidate.avg_price <= 0:
             plan.skipped.append(
-                OpeningLotSkip(key, "non_positive_avg_price", candidate.current_qty, ledger_net_qty)
+                OpeningLotSkip(
+                    key, "non_positive_avg_price", candidate.current_qty, ledger_net_qty
+                )
             )
             continue
         if candidate.broker == "upbit" and candidate.avg_price_modified:
             plan.skipped.append(
-                OpeningLotSkip(key, "upbit_avg_price_modified", candidate.current_qty, ledger_net_qty)
+                OpeningLotSkip(
+                    key,
+                    "upbit_avg_price_modified",
+                    candidate.current_qty,
+                    ledger_net_qty,
+                )
             )
             continue
 
         opening_qty = candidate.current_qty - ledger_net_qty
         if opening_qty <= 0:
             plan.skipped.append(
-                OpeningLotSkip(key, "covered_by_ledger_net", candidate.current_qty, ledger_net_qty)
+                OpeningLotSkip(
+                    key, "covered_by_ledger_net", candidate.current_qty, ledger_net_qty
+                )
             )
             continue
 
@@ -142,6 +154,7 @@ async def load_opening_lot_candidates(
 
 async def load_kis_opening_lot_candidates() -> list[OpeningLotCandidate]:
     from app.services.brokers.kis.client import KISClient
+
     kis = KISClient()
     candidates: list[OpeningLotCandidate] = []
     for row in await kis.fetch_my_stocks():
@@ -187,7 +200,11 @@ async def load_kis_opening_lot_candidates() -> list[OpeningLotCandidate]:
 
 
 async def load_upbit_opening_lot_candidates() -> list[OpeningLotCandidate]:
-    from app.services.brokers.upbit.client import fetch_my_coins, parse_upbit_account_row
+    from app.services.brokers.upbit.client import (
+        fetch_my_coins,
+        parse_upbit_account_row,
+    )
+
     rows = await fetch_my_coins()
     candidates: list[OpeningLotCandidate] = []
     for row in rows:

--- a/app/services/execution_ledger/opening_lots.py
+++ b/app/services/execution_ledger/opening_lots.py
@@ -127,3 +127,89 @@ def build_opening_lot_plan(
             )
         )
     return plan
+
+
+async def load_opening_lot_candidates(
+    brokers: list[str],
+) -> list[OpeningLotCandidate]:
+    candidates: list[OpeningLotCandidate] = []
+    if "kis" in brokers:
+        candidates.extend(await load_kis_opening_lot_candidates())
+    if "upbit" in brokers:
+        candidates.extend(await load_upbit_opening_lot_candidates())
+    return candidates
+
+
+async def load_kis_opening_lot_candidates() -> list[OpeningLotCandidate]:
+    from app.services.brokers.kis.client import KISClient
+    kis = KISClient()
+    candidates: list[OpeningLotCandidate] = []
+    for row in await kis.fetch_my_stocks():
+        qty = Decimal(str(row.get("hldg_qty") or "0"))
+        avg_price = Decimal(str(row.get("pchs_avg_pric") or "0"))
+        symbol = str(row.get("pdno") or "").strip().upper()
+        if symbol:
+            candidates.append(
+                OpeningLotCandidate(
+                    broker="kis",
+                    account_mode="live",
+                    venue="krx",
+                    instrument_type="equity_kr",
+                    symbol=symbol,
+                    raw_symbol=symbol,
+                    currency="KRW",
+                    current_qty=qty,
+                    avg_price=avg_price,
+                )
+            )
+    for row in await kis.fetch_my_us_stocks():
+        symbol = str(row.get("ovrs_pdno") or "").strip().upper()
+        venue = str(row.get("ovrs_excg_cd") or row.get("excg_cd") or "").strip().upper()
+        if not venue:
+            venue = "NASD"
+        qty = Decimal(str(row.get("ovrs_cblc_qty") or "0"))
+        avg_price = Decimal(str(row.get("pchs_avg_pric") or "0"))
+        if symbol:
+            candidates.append(
+                OpeningLotCandidate(
+                    broker="kis",
+                    account_mode="live",
+                    venue=venue,
+                    instrument_type="equity_us",
+                    symbol=symbol,
+                    raw_symbol=symbol,
+                    currency="USD",
+                    current_qty=qty,
+                    avg_price=avg_price,
+                )
+            )
+    return candidates
+
+
+async def load_upbit_opening_lot_candidates() -> list[OpeningLotCandidate]:
+    from app.services.brokers.upbit.client import fetch_my_coins, parse_upbit_account_row
+    rows = await fetch_my_coins()
+    candidates: list[OpeningLotCandidate] = []
+    for row in rows:
+        currency = str(row.get("currency") or "").strip().upper()
+        if not currency or currency == "KRW":
+            continue
+        unit_currency = str(row.get("unit_currency") or "KRW").strip().upper()
+        parsed = parse_upbit_account_row(row)
+        current_qty = Decimal(str(parsed["total_quantity"]))
+        avg_price = Decimal(str(parsed["avg_buy_price"]))
+        candidates.append(
+            OpeningLotCandidate(
+                broker="upbit",
+                account_mode="live",
+                venue=f"upbit_{unit_currency.lower()}",
+                instrument_type="crypto",
+                symbol=currency,
+                raw_symbol=f"{unit_currency}-{currency}",
+                currency="KRW" if unit_currency == "KRW" else "USD",
+                current_qty=current_qty,
+                avg_price=avg_price,
+                avg_price_modified=bool(parsed["avg_buy_price_modified"]),
+            )
+        )
+    return candidates

--- a/app/services/execution_ledger/opening_lots.py
+++ b/app/services/execution_ledger/opening_lots.py
@@ -1,0 +1,129 @@
+# app/services/execution_ledger/opening_lots.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from app.schemas.execution_ledger import (
+    AccountMode,
+    Broker,
+    Currency,
+    ExecutionLedgerUpsert,
+    InstrumentTypeValue,
+)
+
+
+MatchKey = tuple[str, str, str, str, str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class OpeningLotCandidate:
+    broker: Broker
+    account_mode: AccountMode
+    venue: str
+    instrument_type: InstrumentTypeValue
+    symbol: str
+    raw_symbol: str
+    currency: Currency
+    current_qty: Decimal
+    avg_price: Decimal
+    avg_price_modified: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class OpeningLotSkip:
+    key: MatchKey
+    reason: Literal[
+        "covered_by_ledger_net",
+        "non_positive_current_qty",
+        "non_positive_avg_price",
+        "upbit_avg_price_modified",
+    ]
+    current_qty: Decimal
+    ledger_net_qty: Decimal
+
+
+@dataclass(slots=True)
+class OpeningLotPlan:
+    upserts: list[ExecutionLedgerUpsert] = field(default_factory=list)
+    skipped: list[OpeningLotSkip] = field(default_factory=list)
+
+
+def _match_key(candidate: OpeningLotCandidate) -> MatchKey:
+    return (
+        candidate.broker,
+        candidate.account_mode,
+        candidate.venue,
+        candidate.instrument_type,
+        candidate.symbol,
+        candidate.currency,
+    )
+
+
+def _seed_order_id(candidate: OpeningLotCandidate, cutover: datetime) -> str:
+    return (
+        f"SEED-{cutover:%Y%m%d}-"
+        f"{candidate.broker}-{candidate.venue}-{candidate.symbol}"
+    )
+
+
+def build_opening_lot_plan(
+    *,
+    candidates: list[OpeningLotCandidate],
+    ledger_net_by_key: dict[MatchKey, Decimal],
+    cutover: datetime,
+) -> OpeningLotPlan:
+    plan = OpeningLotPlan()
+    for candidate in candidates:
+        key = _match_key(candidate)
+        ledger_net_qty = ledger_net_by_key.get(key, Decimal("0"))
+        if candidate.current_qty <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "non_positive_current_qty", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+        if candidate.avg_price <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "non_positive_avg_price", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+        if candidate.broker == "upbit" and candidate.avg_price_modified:
+            plan.skipped.append(
+                OpeningLotSkip(key, "upbit_avg_price_modified", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+
+        opening_qty = candidate.current_qty - ledger_net_qty
+        if opening_qty <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "covered_by_ledger_net", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+
+        plan.upserts.append(
+            ExecutionLedgerUpsert(
+                broker=candidate.broker,
+                account_mode=candidate.account_mode,
+                venue=candidate.venue,
+                instrument_type=candidate.instrument_type,
+                symbol=candidate.symbol,
+                raw_symbol=candidate.raw_symbol,
+                side="buy",
+                broker_order_id=_seed_order_id(candidate, cutover),
+                fill_seq=0,
+                filled_qty=opening_qty,
+                filled_price=candidate.avg_price,
+                filled_at=cutover,
+                currency=candidate.currency,
+                source="manual_import",
+                raw_payload_json={
+                    "seed_kind": "opening_lot",
+                    "current_qty": str(candidate.current_qty),
+                    "ledger_net_qty": str(ledger_net_qty),
+                    "cutover": cutover.isoformat(),
+                },
+            )
+        )
+    return plan

--- a/app/services/execution_ledger/reconciler.py
+++ b/app/services/execution_ledger/reconciler.py
@@ -23,6 +23,18 @@ Broker = Literal["kis", "upbit"]
 FilledOrdersFetcher = Callable[..., Awaitable[dict[str, Any]]]
 
 
+def _format_fetch_errors(errors: list[Any]) -> str:
+    parts = []
+    for error in errors:
+        if isinstance(error, dict):
+            market = error.get("market") or "unknown"
+            message = error.get("error") or error
+            parts.append(f"{market}: {message}")
+        else:
+            parts.append(str(error))
+    return "; ".join(parts)
+
+
 def _resolve_run_window(
     *,
     window_hours: int = 24,
@@ -140,6 +152,14 @@ class ExecutionLedgerReconciler:
             end_at=end_at,
             max_pages=max_pages,
         )
+        errors = result.get("errors") or []
+        if errors:
+            raise RuntimeError(
+                "Filled-orders fetch returned errors "
+                f"broker={broker} markets={markets} "
+                f"start_at={start_at.isoformat()} end_at={end_at.isoformat()}: "
+                f"{_format_fetch_errors(errors)}"
+            )
         rows = result.get("orders") or result.get("items") or []
         upserts: list[ExecutionLedgerUpsert] = []
         for row in rows:

--- a/app/services/execution_ledger/reconciler.py
+++ b/app/services/execution_ledger/reconciler.py
@@ -23,6 +23,20 @@ Broker = Literal["kis", "upbit"]
 FilledOrdersFetcher = Callable[..., Awaitable[dict[str, Any]]]
 
 
+def _resolve_run_window(
+    *,
+    window_hours: int = 24,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    now = datetime.now(UTC)
+    window_end = end_at or now
+    window_start = start_at or (window_end - timedelta(hours=window_hours))
+    if window_start >= window_end:
+        raise ValueError("start_at must be before end_at")
+    return window_start, window_end
+
+
 class ExecutionLedgerReconciler:
     def __init__(
         self,
@@ -33,21 +47,35 @@ class ExecutionLedgerReconciler:
         self.fetcher = fetcher or fetch_filled_orders
 
     async def run(  # NOSONAR
-        self, broker: Broker, *, window_hours: int = 24, dry_run: bool = True
+        self,
+        broker: Broker,
+        *,
+        window_hours: int = 24,
+        start_at: datetime | None = None,
+        end_at: datetime | None = None,
+        max_pages: int = 100,
+        dry_run: bool = True,
     ) -> ReconcileDiff:
         if not dry_run and not settings.EXECUTION_LEDGER_COMMIT_ENABLED:
             raise ExecutionLedgerCommitDisabledError(
                 "EXECUTION_LEDGER_COMMIT_ENABLED is false; commit mode is disabled"
             )
         run_id = uuid.uuid4()
-        now = datetime.now(UTC)
-        window_start = now - timedelta(hours=window_hours)
-        window_end = now
+        window_start, window_end = _resolve_run_window(
+            window_hours=window_hours,
+            start_at=start_at,
+            end_at=end_at,
+        )
         diff = ReconcileDiff(source_run_id=run_id)
         error_summary: str | None = None
         try:
             fills = await self._fetch_normalized(
-                broker, window_hours=window_hours, source_run_id=run_id
+                broker,
+                window_hours=window_hours,
+                start_at=window_start,
+                end_at=window_end,
+                max_pages=max_pages,
+                source_run_id=run_id,
             )
             for fill in fills:
                 status = await self.repo.classify_fill(fill)
@@ -92,12 +120,25 @@ class ExecutionLedgerReconciler:
         return diff
 
     async def _fetch_normalized(
-        self, broker: Broker, *, window_hours: int, source_run_id: uuid.UUID
+        self,
+        broker: Broker,
+        *,
+        window_hours: int,
+        start_at: datetime,
+        end_at: datetime,
+        max_pages: int,
+        source_run_id: uuid.UUID,
     ) -> list[ExecutionLedgerUpsert]:
-        days = max(1, int((window_hours + 23) / 24))
+        days = max(1, int(((end_at - start_at).total_seconds() + 86399) / 86400))
         markets = "crypto" if broker == "upbit" else "kr,us"
         result = await self.fetcher(
-            days=days, markets=markets, min_amount=0, include_indicators=False
+            days=days,
+            markets=markets,
+            min_amount=0,
+            include_indicators=False,
+            start_at=start_at,
+            end_at=end_at,
+            max_pages=max_pages,
         )
         rows = result.get("orders") or result.get("items") or []
         upserts: list[ExecutionLedgerUpsert] = []

--- a/app/services/execution_ledger/repository.py
+++ b/app/services/execution_ledger/repository.py
@@ -175,6 +175,7 @@ class ExecutionLedgerRepository:
         self, *, cutover: datetime
     ) -> dict[tuple[str, str, str, str, str, str], Decimal]:
         from sqlalchemy import case
+
         signed_qty = case(
             (ExecutionLedger.side == "buy", ExecutionLedger.filled_qty),
             else_=-ExecutionLedger.filled_qty,
@@ -201,6 +202,13 @@ class ExecutionLedgerRepository:
             )
         )
         return {
-            (broker, account_mode, venue, str(instrument_type), symbol, currency): Decimal(str(net_qty))
+            (
+                broker,
+                account_mode,
+                venue,
+                str(instrument_type),
+                symbol,
+                currency,
+            ): Decimal(str(net_qty))
             for broker, account_mode, venue, instrument_type, symbol, currency, net_qty in rows.all()
         }

--- a/app/services/execution_ledger/repository.py
+++ b/app/services/execution_ledger/repository.py
@@ -137,17 +137,21 @@ class ExecutionLedgerRepository:
         self.db.add(ExecutionLedgerReconcileRun(**run.model_dump()))
 
     async def latest_run_per_broker(self) -> dict[str, ReconcileRunRecord]:
+        # Dry-run audit rows are persisted for observability but commit no
+        # fills, so they must not make ledger freshness look "fresh".
         latest_started = (
             select(
                 ExecutionLedgerReconcileRun.broker,
                 func.max(ExecutionLedgerReconcileRun.started_at).label("started_at"),
             )
             .where(ExecutionLedgerReconcileRun.error_summary.is_(None))
+            .where(ExecutionLedgerReconcileRun.dry_run.is_(False))
             .group_by(ExecutionLedgerReconcileRun.broker)
             .subquery()
         )
         rows = await self.db.execute(
-            select(ExecutionLedgerReconcileRun).join(
+            select(ExecutionLedgerReconcileRun)
+            .join(
                 latest_started,
                 (ExecutionLedgerReconcileRun.broker == latest_started.c.broker)
                 & (
@@ -155,6 +159,7 @@ class ExecutionLedgerRepository:
                     == latest_started.c.started_at
                 ),
             )
+            .where(ExecutionLedgerReconcileRun.dry_run.is_(False))
         )
         return {
             row.broker: ReconcileRunRecord.model_validate(row)

--- a/app/services/execution_ledger/repository.py
+++ b/app/services/execution_ledger/repository.py
@@ -170,3 +170,37 @@ class ExecutionLedgerRepository:
         if market == "crypto":
             return stmt.where(ExecutionLedger.instrument_type == "crypto")
         return stmt
+
+    async def net_quantity_by_match_key_since(
+        self, *, cutover: datetime
+    ) -> dict[tuple[str, str, str, str, str, str], Decimal]:
+        from sqlalchemy import case
+        signed_qty = case(
+            (ExecutionLedger.side == "buy", ExecutionLedger.filled_qty),
+            else_=-ExecutionLedger.filled_qty,
+        )
+        rows = await self.db.execute(
+            select(
+                ExecutionLedger.broker,
+                ExecutionLedger.account_mode,
+                ExecutionLedger.venue,
+                ExecutionLedger.instrument_type,
+                ExecutionLedger.symbol,
+                ExecutionLedger.currency,
+                func.coalesce(func.sum(signed_qty), 0),
+            )
+            .where(ExecutionLedger.filled_at >= cutover)
+            .where(ExecutionLedger.source != "manual_import")
+            .group_by(
+                ExecutionLedger.broker,
+                ExecutionLedger.account_mode,
+                ExecutionLedger.venue,
+                ExecutionLedger.instrument_type,
+                ExecutionLedger.symbol,
+                ExecutionLedger.currency,
+            )
+        )
+        return {
+            (broker, account_mode, venue, str(instrument_type), symbol, currency): Decimal(str(net_qty))
+            for broker, account_mode, venue, instrument_type, symbol, currency, net_qty in rows.all()
+        }

--- a/app/services/n8n_filled_orders_service.py
+++ b/app/services/n8n_filled_orders_service.py
@@ -23,6 +23,23 @@ logger = logging.getLogger(__name__)
 _EQUITY_QUOTE_CONCURRENCY = 5
 
 
+def _resolve_kst_window(
+    *,
+    days: int,
+    start_at: datetime | None,
+    end_at: datetime | None,
+) -> tuple[datetime, datetime]:
+    resolved_end = (end_at.astimezone(KST) if end_at else now_kst())
+    resolved_start = (
+        start_at.astimezone(KST)
+        if start_at
+        else resolved_end - timedelta(days=days)
+    )
+    if resolved_start >= resolved_end:
+        raise ValueError("start_at must be before end_at")
+    return resolved_start, resolved_end
+
+
 def _parse_upbit_fill_datetime(value: object) -> datetime | None:
     """Strictly parse an Upbit fill timestamp for window filtering.
 
@@ -47,18 +64,15 @@ def _parse_upbit_fill_datetime(value: object) -> datetime | None:
     return parsed.astimezone(KST)
 
 
-async def _fetch_upbit_filled(days: int) -> tuple[list[dict], list[dict]]:  # NOSONAR
-    """Paginate through Upbit closed orders and expand each into per-trade fills.
-
-    Pages are fetched in descending created_at order.  Pagination stops when a
-    page returns no orders within the requested time window (all remaining pages
-    are older), or when a page is smaller than the requested limit (last page).
-    For each order with executed volume, order detail is fetched to obtain the
-    individual trade breakdown; if the detail call fails the aggregate fill is
-    used as a fallback.
-    """
+async def _fetch_upbit_filled(
+    days: int,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    max_pages: int = 100,
+) -> tuple[list[dict], list[dict]]:  # NOSONAR
+    """Paginate through Upbit closed orders and expand each into per-trade fills."""
     try:
-        cutoff = now_kst() - timedelta(days=days)
+        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
         all_fills: list[dict[str, Any]] = []
         page = 1
         limit = 100
@@ -76,8 +90,6 @@ async def _fetch_upbit_filled(days: int) -> tuple[list[dict], list[dict]]:  # NO
                 if executed_vol <= 0:
                     continue
 
-                # Fetch order detail to get individual trade breakdown when not
-                # already embedded in the list response.
                 if not raw.get("trades"):
                     try:
                         raw = await upbit_service.fetch_order_detail(
@@ -102,12 +114,10 @@ async def _fetch_upbit_filled(days: int) -> tuple[list[dict], list[dict]]:  # NO
                             fill.get("filled_at"),
                         )
                         continue
-                    if parsed_filled_at >= cutoff:
+                    if start_kst <= parsed_filled_at <= end_kst:
                         page_had_relevant = True
                         all_fills.append(fill)
 
-            # Orders are returned newest-first; once a whole page is before the
-            # cutoff window there is nothing relevant in subsequent pages.
             if not page_had_relevant:
                 break
             if len(closed) < limit:
@@ -120,13 +130,21 @@ async def _fetch_upbit_filled(days: int) -> tuple[list[dict], list[dict]]:  # NO
         return [], [{"market": "crypto", "error": str(exc)}]
 
 
-async def _fetch_kis_domestic_filled(days: int) -> tuple[list[dict], list[dict]]:
+async def _fetch_kis_domestic_filled(
+    days: int,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    max_pages: int = 100,
+) -> tuple[list[dict], list[dict]]:
     try:
         kis = KISClient()
-        end_date = now_kst().strftime("%Y%m%d")
-        start_date = (now_kst() - timedelta(days=days)).strftime("%Y%m%d")
+        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
         raw_orders = await kis.inquire_daily_order_domestic(
-            start_date=start_date, end_date=end_date, stock_code="", side="00"
+            start_date=start_kst.strftime("%Y%m%d"),
+            end_date=end_kst.strftime("%Y%m%d"),
+            stock_code="",
+            side="00",
+            max_pages=max_pages,
         )
         orders = [
             n
@@ -139,28 +157,27 @@ async def _fetch_kis_domestic_filled(days: int) -> tuple[list[dict], list[dict]]
         return [], [{"market": "kr", "error": str(exc)}]
 
 
-async def _fetch_kis_overseas_filled(days: int) -> tuple[list[dict], list[dict]]:
+async def _fetch_kis_overseas_filled(
+    days: int,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    max_pages: int = 100,
+) -> tuple[list[dict], list[dict]]:
     try:
         kis = KISClient()
-        end_date = now_kst().strftime("%Y%m%d")
-        start_date = (now_kst() - timedelta(days=days)).strftime("%Y%m%d")
+        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
 
         all_orders: list[dict] = []
-        # Dedup by (order_id, fill_seq) so that multiple partial fills for the
-        # same order are each preserved while true duplicates are dropped.
         seen_fill_keys: set[tuple[str, int]] = set()
 
-        # KIS overseas daily-order inquiry treats NASD as a US-wide history
-        # selector in practice: rows may include NYSE/AMEX via ovrs_excg_cd.
-        # Calling NASD/NYSE/AMEX separately produces duplicates and increases
-        # the chance of SYDB0050 while following continuation pages.
         try:
             raw_orders = await kis.inquire_daily_order_overseas(
-                start_date=start_date,
-                end_date=end_date,
+                start_date=start_kst.strftime("%Y%m%d"),
+                end_date=end_kst.strftime("%Y%m%d"),
                 symbol="%",
                 exchange_code="NASD",
                 side="00",
+                max_pages=max_pages,
             )
             for raw in raw_orders or []:
                 normalized = _normalize_kis_overseas_filled(raw)
@@ -245,6 +262,9 @@ async def fetch_filled_orders(
     markets: str = "crypto,kr,us",
     min_amount: float = 0,
     include_indicators: bool = False,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    max_pages: int = 100,
 ) -> dict[str, Any]:
     market_set = {m.strip().lower() for m in markets.split(",") if m.strip()}
     all_orders: list[dict[str, Any]] = []
@@ -252,11 +272,11 @@ async def fetch_filled_orders(
 
     tasks = []
     if "crypto" in market_set:
-        tasks.append(_fetch_upbit_filled(days))
+        tasks.append(_fetch_upbit_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
     if "kr" in market_set:
-        tasks.append(_fetch_kis_domestic_filled(days))
+        tasks.append(_fetch_kis_domestic_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
     if "us" in market_set:
-        tasks.append(_fetch_kis_overseas_filled(days))
+        tasks.append(_fetch_kis_overseas_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
     for result in results:

--- a/app/services/n8n_filled_orders_service.py
+++ b/app/services/n8n_filled_orders_service.py
@@ -29,11 +29,9 @@ def _resolve_kst_window(
     start_at: datetime | None,
     end_at: datetime | None,
 ) -> tuple[datetime, datetime]:
-    resolved_end = (end_at.astimezone(KST) if end_at else now_kst())
+    resolved_end = end_at.astimezone(KST) if end_at else now_kst()
     resolved_start = (
-        start_at.astimezone(KST)
-        if start_at
-        else resolved_end - timedelta(days=days)
+        start_at.astimezone(KST) if start_at else resolved_end - timedelta(days=days)
     )
     if resolved_start >= resolved_end:
         raise ValueError("start_at must be before end_at")
@@ -113,7 +111,9 @@ async def _fetch_upbit_filled(
 ) -> tuple[list[dict], list[dict]]:  # NOSONAR
     """Paginate through Upbit closed orders and expand each into per-trade fills."""
     try:
-        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
+        start_kst, end_kst = _resolve_kst_window(
+            days=days, start_at=start_at, end_at=end_at
+        )
         all_fills: list[dict[str, Any]] = []
         seen_order_uuids: set[str] = set()
 
@@ -168,7 +168,9 @@ async def _fetch_kis_domestic_filled(
 ) -> tuple[list[dict], list[dict]]:
     try:
         kis = KISClient()
-        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
+        start_kst, end_kst = _resolve_kst_window(
+            days=days, start_at=start_at, end_at=end_at
+        )
         raw_orders = await kis.inquire_daily_order_domestic(
             start_date=start_kst.strftime("%Y%m%d"),
             end_date=end_kst.strftime("%Y%m%d"),
@@ -195,7 +197,9 @@ async def _fetch_kis_overseas_filled(
 ) -> tuple[list[dict], list[dict]]:
     try:
         kis = KISClient()
-        start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
+        start_kst, end_kst = _resolve_kst_window(
+            days=days, start_at=start_at, end_at=end_at
+        )
 
         all_orders: list[dict] = []
         seen_fill_keys: set[tuple[str, int]] = set()
@@ -302,11 +306,23 @@ async def fetch_filled_orders(
 
     tasks = []
     if "crypto" in market_set:
-        tasks.append(_fetch_upbit_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
+        tasks.append(
+            _fetch_upbit_filled(
+                days, start_at=start_at, end_at=end_at, max_pages=max_pages
+            )
+        )
     if "kr" in market_set:
-        tasks.append(_fetch_kis_domestic_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
+        tasks.append(
+            _fetch_kis_domestic_filled(
+                days, start_at=start_at, end_at=end_at, max_pages=max_pages
+            )
+        )
     if "us" in market_set:
-        tasks.append(_fetch_kis_overseas_filled(days, start_at=start_at, end_at=end_at, max_pages=max_pages))
+        tasks.append(
+            _fetch_kis_overseas_filled(
+                days, start_at=start_at, end_at=end_at, max_pages=max_pages
+            )
+        )
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
     for result in results:

--- a/app/services/n8n_filled_orders_service.py
+++ b/app/services/n8n_filled_orders_service.py
@@ -204,24 +204,21 @@ async def _fetch_kis_overseas_filled(
         all_orders: list[dict] = []
         seen_fill_keys: set[tuple[str, int]] = set()
 
-        try:
-            raw_orders = await kis.inquire_daily_order_overseas(
-                start_date=start_kst.strftime("%Y%m%d"),
-                end_date=end_kst.strftime("%Y%m%d"),
-                symbol="%",
-                exchange_code="NASD",
-                side="00",
-                max_pages=max_pages,
-            )
-            for raw in raw_orders or []:
-                normalized = _normalize_kis_overseas_filled(raw)
-                if normalized:
-                    fill_key = (normalized["order_id"], normalized["fill_seq"])
-                    if fill_key not in seen_fill_keys:
-                        seen_fill_keys.add(fill_key)
-                        all_orders.append(normalized)
-        except Exception as exc:
-            logger.warning("KIS overseas US-wide fetch failed: %s", exc)
+        raw_orders = await kis.inquire_daily_order_overseas(
+            start_date=start_kst.strftime("%Y%m%d"),
+            end_date=end_kst.strftime("%Y%m%d"),
+            symbol="%",
+            exchange_code="NASD",
+            side="00",
+            max_pages=max_pages,
+        )
+        for raw in raw_orders or []:
+            normalized = _normalize_kis_overseas_filled(raw)
+            if normalized:
+                fill_key = (normalized["order_id"], normalized["fill_seq"])
+                if fill_key not in seen_fill_keys:
+                    seen_fill_keys.add(fill_key)
+                    all_orders.append(normalized)
 
         return all_orders, []
     except Exception as exc:

--- a/app/services/n8n_filled_orders_service.py
+++ b/app/services/n8n_filled_orders_service.py
@@ -64,6 +64,47 @@ def _parse_upbit_fill_datetime(value: object) -> datetime | None:
     return parsed.astimezone(KST)
 
 
+_UPBIT_CLOSED_ORDERS_WINDOW = timedelta(days=7)
+_UPBIT_CLOSED_ORDERS_LIMIT = 1000
+
+
+def _iter_upbit_windows(
+    start_at: datetime, end_at: datetime
+) -> list[tuple[datetime, datetime]]:
+    windows: list[tuple[datetime, datetime]] = []
+    cursor_end = end_at
+    while cursor_end > start_at:
+        cursor_start = max(start_at, cursor_end - _UPBIT_CLOSED_ORDERS_WINDOW)
+        windows.append((cursor_start, cursor_end))
+        cursor_end = cursor_start
+    return windows
+
+
+async def _fetch_upbit_closed_window(
+    start_at: datetime,
+    end_at: datetime,
+) -> list[dict[str, Any]]:
+    rows = await upbit_service.fetch_closed_orders(
+        market=None,
+        limit=_UPBIT_CLOSED_ORDERS_LIMIT,
+        states=["done", "cancel"],
+        order_by="desc",
+        start_time=start_at,
+        end_time=end_at,
+    )
+    if len(rows) >= _UPBIT_CLOSED_ORDERS_LIMIT:
+        if end_at - start_at <= timedelta(hours=1):
+            raise RuntimeError(
+                "Upbit closed orders may be truncated in a <=1h window; "
+                f"start={start_at.isoformat()} end={end_at.isoformat()}"
+            )
+        midpoint = start_at + (end_at - start_at) / 2
+        left = await _fetch_upbit_closed_window(start_at, midpoint)
+        right = await _fetch_upbit_closed_window(midpoint, end_at)
+        return left + right
+    return rows
+
+
 async def _fetch_upbit_filled(
     days: int,
     start_at: datetime | None = None,
@@ -74,31 +115,27 @@ async def _fetch_upbit_filled(
     try:
         start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
         all_fills: list[dict[str, Any]] = []
-        page = 1
-        limit = 100
+        seen_order_uuids: set[str] = set()
 
-        while True:
-            closed = await upbit_service.fetch_closed_orders(
-                market=None, limit=limit, page=page
-            )
-            if not closed:
-                break
-
-            page_had_relevant = False
+        for window_start, window_end in _iter_upbit_windows(start_kst, end_kst):
+            closed = await _fetch_upbit_closed_window(window_start, window_end)
             for raw in closed:
+                uuid = str(raw.get("uuid") or "")
+                if uuid and uuid in seen_order_uuids:
+                    continue
+                if uuid:
+                    seen_order_uuids.add(uuid)
                 executed_vol = float(raw.get("executed_volume") or 0)
                 if executed_vol <= 0:
                     continue
 
                 if not raw.get("trades"):
                     try:
-                        raw = await upbit_service.fetch_order_detail(
-                            str(raw.get("uuid", ""))
-                        )
+                        raw = await upbit_service.fetch_order_detail(uuid)
                     except Exception as exc:
                         logger.warning(
                             "Upbit order detail fetch failed for %s: %s",
-                            raw.get("uuid"),
+                            uuid,
                             exc,
                         )
 
@@ -115,14 +152,7 @@ async def _fetch_upbit_filled(
                         )
                         continue
                     if start_kst <= parsed_filled_at <= end_kst:
-                        page_had_relevant = True
                         all_fills.append(fill)
-
-            if not page_had_relevant:
-                break
-            if len(closed) < limit:
-                break
-            page += 1
 
         return all_fills, []
     except Exception as exc:

--- a/app/tasks/execution_ledger.py
+++ b/app/tasks/execution_ledger.py
@@ -32,15 +32,22 @@ def _scheduled_reconcile_labels() -> list[dict[str, str]]:
 
 async def _run_reconciliation(broker: ExecutionLedgerBroker, window_hours: int) -> dict:
     async with AsyncSessionLocal() as db:
-        diff = await ExecutionLedgerReconciler(ExecutionLedgerRepository(db)).run(
-            broker,
-            window_hours=window_hours,
-            dry_run=not settings.EXECUTION_LEDGER_COMMIT_ENABLED,
-        )
-        if settings.EXECUTION_LEDGER_COMMIT_ENABLED:
-            await db.commit()
-        else:
-            await db.rollback()
+        dry_run = not settings.EXECUTION_LEDGER_COMMIT_ENABLED
+        try:
+            diff = await ExecutionLedgerReconciler(ExecutionLedgerRepository(db)).run(
+                broker,
+                window_hours=window_hours,
+                dry_run=dry_run,
+            )
+        except Exception:
+            if dry_run:
+                # Dry-run skips ledger upserts; commit only preserves the run audit row.
+                await db.commit()
+            else:
+                await db.rollback()
+            raise
+        # Dry-run skips ledger upserts; commit only preserves the run audit row.
+        await db.commit()
     return diff.model_dump(mode="json")
 
 

--- a/docs/runbooks/execution-ledger-backfill.md
+++ b/docs/runbooks/execution-ledger-backfill.md
@@ -31,7 +31,147 @@ Archive JSON output and confirm no truncation error.
 
 ## Phase 3: Coverage SQL
 
-Run the ROB-478 coverable SQL before and after dry-run planning against the target DB.
+Run this SQL before and after dry-run planning against the target DB. Archive the
+result sets with the dry-run JSON. The date range matches the commands above:
+`2026-02-01T00:00:00Z <= filled_at < 2026-06-11T00:00:00Z`.
+
+```sql
+-- 1. Ledger coverage by FIFO match key and source.
+SELECT
+  broker,
+  account_mode,
+  venue,
+  instrument_type::text AS instrument_type,
+  symbol,
+  currency,
+  source,
+  COUNT(*) AS fill_count,
+  COUNT(*) FILTER (WHERE side = 'buy') AS buy_fill_count,
+  COUNT(*) FILTER (WHERE side = 'sell') AS sell_fill_count,
+  SUM(CASE WHEN side = 'buy' THEN filled_qty ELSE -filled_qty END) AS net_qty,
+  MIN(filled_at) AS first_fill_at,
+  MAX(filled_at) AS last_fill_at
+FROM review.execution_ledger
+WHERE filled_at >= TIMESTAMPTZ '2026-02-01 00:00:00+00'
+  AND filled_at < TIMESTAMPTZ '2026-06-11 00:00:00+00'
+GROUP BY
+  broker,
+  account_mode,
+  venue,
+  instrument_type::text,
+  symbol,
+  currency,
+  source
+ORDER BY broker, venue, symbol, currency, source;
+
+-- 2. Sells that still lack enough earlier buy quantity for realized P/L.
+WITH sells AS (
+  SELECT
+    s.id,
+    s.broker,
+    s.account_mode,
+    s.venue,
+    s.instrument_type::text AS instrument_type,
+    s.symbol,
+    s.currency,
+    s.broker_order_id,
+    s.fill_seq,
+    s.filled_at,
+    s.filled_qty AS sell_qty,
+    COALESCE((
+      SELECT SUM(b.filled_qty)
+      FROM review.execution_ledger b
+      WHERE b.side = 'buy'
+        AND b.broker = s.broker
+        AND b.account_mode = s.account_mode
+        AND b.venue = s.venue
+        AND b.instrument_type = s.instrument_type
+        AND b.symbol = s.symbol
+        AND b.currency = s.currency
+        AND (b.filled_at, b.id) <= (s.filled_at, s.id)
+    ), 0) AS buy_qty_to_sell,
+    COALESCE((
+      SELECT SUM(prev_s.filled_qty)
+      FROM review.execution_ledger prev_s
+      WHERE prev_s.side = 'sell'
+        AND prev_s.broker = s.broker
+        AND prev_s.account_mode = s.account_mode
+        AND prev_s.venue = s.venue
+        AND prev_s.instrument_type = s.instrument_type
+        AND prev_s.symbol = s.symbol
+        AND prev_s.currency = s.currency
+        AND (prev_s.filled_at, prev_s.id) < (s.filled_at, s.id)
+    ), 0) AS prior_sell_qty
+  FROM review.execution_ledger s
+  WHERE s.side = 'sell'
+    AND s.filled_at >= TIMESTAMPTZ '2026-02-01 00:00:00+00'
+    AND s.filled_at < TIMESTAMPTZ '2026-06-11 00:00:00+00'
+)
+SELECT
+  broker,
+  account_mode,
+  venue,
+  instrument_type,
+  symbol,
+  currency,
+  broker_order_id,
+  fill_seq,
+  filled_at,
+  sell_qty,
+  buy_qty_to_sell - prior_sell_qty AS available_buy_qty_before_sell,
+  CASE
+    WHEN buy_qty_to_sell - prior_sell_qty >= sell_qty THEN 'coverable'
+    ELSE 'uncovered'
+  END AS coverage_state
+FROM sells
+WHERE buy_qty_to_sell - prior_sell_qty < sell_qty
+ORDER BY filled_at DESC, id DESC;
+
+-- 3. Reconcile run audit trail; error_summary must stay NULL before commit.
+SELECT
+  broker,
+  dry_run,
+  window_start,
+  window_end,
+  started_at,
+  finished_at,
+  would_insert,
+  would_update,
+  unchanged,
+  committed_insert,
+  committed_update,
+  error_summary,
+  notes
+FROM review.execution_ledger_reconcile_runs
+WHERE window_start >= TIMESTAMPTZ '2026-02-01 00:00:00+00'
+  AND window_end < TIMESTAMPTZ '2026-06-11 00:00:00+00'
+ORDER BY started_at DESC
+LIMIT 50;
+
+-- 4. Manual opening lots after Phase 6 only.
+SELECT
+  broker,
+  account_mode,
+  venue,
+  instrument_type::text AS instrument_type,
+  symbol,
+  currency,
+  COUNT(*) AS opening_lot_count,
+  SUM(filled_qty) AS opening_lot_qty,
+  SUM(filled_notional) AS opening_lot_notional,
+  MIN(filled_at) AS first_opening_lot_at,
+  MAX(filled_at) AS last_opening_lot_at
+FROM review.execution_ledger
+WHERE source = 'manual_import'
+GROUP BY
+  broker,
+  account_mode,
+  venue,
+  instrument_type::text,
+  symbol,
+  currency
+ORDER BY broker, venue, symbol, currency;
+```
 
 ## Phase 4: KIS/Upbit Commit
 

--- a/docs/runbooks/execution-ledger-backfill.md
+++ b/docs/runbooks/execution-ledger-backfill.md
@@ -1,0 +1,79 @@
+# Execution Ledger Backfill Runbook
+
+## Review Hold
+
+Do not run commit mode until ROB-478~481 are reviewed under `high_risk_change` and `needs_stronger_model_review`.
+
+## Phase 1: KIS Dry Run
+
+```bash
+uv run python -m scripts.reconcile_execution_ledger \
+  --broker kis \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --max-pages 100 \
+  --dry-run
+```
+
+Archive JSON output with `would_insert`, `would_update`, `unchanged`, and sample rows.
+
+## Phase 2: Upbit Dry Run
+
+```bash
+uv run python -m scripts.reconcile_execution_ledger \
+  --broker upbit \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --dry-run
+```
+
+Archive JSON output and confirm no truncation error.
+
+## Phase 3: Coverage SQL
+
+Run the ROB-478 coverable SQL before and after dry-run planning against the target DB.
+
+## Phase 4: KIS/Upbit Commit
+
+Only after reviewer approval:
+
+```bash
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.reconcile_execution_ledger \
+  --broker kis \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --max-pages 100 \
+  --commit
+
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.reconcile_execution_ledger \
+  --broker upbit \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --commit
+```
+
+## Phase 5: Opening Lot Seed Dry Run
+
+Run only after Phase 4 commits:
+
+```bash
+uv run python -m scripts.seed_execution_ledger_opening_lots \
+  --cutover 2026-05-10 \
+  --dry-run
+```
+
+Archive skipped rows. Modified Upbit average prices and ambiguous/non-positive prices must remain skipped.
+
+## Phase 6: Opening Lot Seed Commit
+
+Only after reviewer approval:
+
+```bash
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.seed_execution_ledger_opening_lots \
+  --cutover 2026-05-10 \
+  --commit
+```
+
+## Phase 7: UI Verification
+
+Open `/invest/my?tab=sellHistory` and confirm matched rows show 판매수익/수익률 and currency summary cards render.

--- a/docs/superpowers/plans/2026-06-10-rob-478-481-execution-ledger-backfill.md
+++ b/docs/superpowers/plans/2026-06-10-rob-478-481-execution-ledger-backfill.md
@@ -1,0 +1,1878 @@
+# ROB-478~481 Execution Ledger Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore `/invest/my?tab=sellHistory` realized P/L by backfilling missing historical buy fills into `review.execution_ledger`, then seeding residual opening lots with honest `manual_import` provenance.
+
+**Architecture:** Keep the existing FIFO read model in `app/services/execution_ledger/query_service.py`; do not change matcher semantics or add a migration. PR1 adds KIS bounded historical windows and truncation guards, PR2 replaces Upbit page paging with documented 7-day closed-order windows and dedup, and PR3 adds a dry-run-first seed CLI for broker average-cost opening lots that remain outside retention. All writes continue through `ExecutionLedgerRepository.upsert_fill`, default to dry-run, and require `EXECUTION_LEDGER_COMMIT_ENABLED=true` for commit mode.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async sessions, Pydantic `ExecutionLedgerUpsert`, KIS/Upbit read-only broker clients, argparse CLIs, pytest/pytest-asyncio, Ruff, ty.
+
+**Linear Scope:** Parent `ROB-478`; child PRs `ROB-479`, `ROB-480`, `ROB-481`.
+
+**Risk Lane:** Apply `high_risk_change` + `needs_stronger_model_review` to all four Linear issues. Implementation may merge only after stronger-model/CTO review. Operator commit runs remain blocked until a reviewer explicitly clears the dry-run evidence.
+
+**External API Note:** Upbit Korean docs for `GET /v1/orders/closed` currently specify `start_time`/`end_time`, maximum 7-day query windows, and `limit` up to 1000; `page` is not part of the documented query contract. Reference: `https://docs.upbit.com/kr/reference/list-closed-orders`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `app/services/execution_ledger/query_service.py` — no behavior change; tests pin FIFO fail-closed, venue isolation, multi-lot matching, and gross P/L semantics.
+- `app/services/execution_ledger/reconciler.py` — accept explicit `start_at`/`end_at` and `max_pages`, record the actual window, and pass the window through to the filled-orders fetcher.
+- `app/services/n8n_filled_orders_service.py` — accept explicit windows; KIS uses `YYYYMMDD` pass-through; Upbit uses sliding 7-day windows.
+- `scripts/reconcile_execution_ledger.py` — add `--start-date`, `--end-date`, and `--max-pages` while preserving `--window-hours`.
+- `app/services/brokers/kis/domestic_orders.py` — expose `max_pages`, raise on remaining continuation cursor after the cap.
+- `app/services/brokers/kis/overseas_orders.py` — same truncation behavior as domestic orders.
+- `app/services/brokers/upbit/orders.py` — replace `page` contract with `start_time`/`end_time` and `limit <= 1000`.
+- `app/core/config.py` — add authenticated Upbit order endpoints to `DEFAULT_UPBIT_API_RATE_LIMITS`.
+- `app/services/brokers/upbit/client.py` — preserve `avg_buy_price_modified` in account parsing.
+
+**Create:**
+- `app/services/execution_ledger/opening_lots.py` — pure opening-lot planning, ledger net calculation, and `ExecutionLedgerUpsert` construction.
+- `scripts/seed_execution_ledger_opening_lots.py` — dry-run-first operator CLI for `source='manual_import'` opening lots.
+- `tests/services/execution_ledger/test_query_service_profit.py` — FIFO characterization tests.
+- `tests/scripts/test_reconcile_execution_ledger_cli.py` — CLI argument parsing and pass-through tests.
+- `tests/services/execution_ledger/test_opening_lots.py` — pure seed calculation tests.
+- `tests/scripts/test_seed_execution_ledger_opening_lots_cli.py` — seed CLI dry-run/commit gate tests.
+
+**Existing Test Files To Extend:**
+- `tests/services/execution_ledger/test_reconciler.py`
+- `tests/test_n8n_trade_review.py`
+- `tests/test_kis_domestic_orders_retry.py`
+- `tests/test_kis_overseas_orders_retry.py`
+- `tests/test_upbit_orders.py`
+- `tests/services/execution_ledger/test_no_broker_mutation.py`
+
+---
+
+### Task 0: Linear Risk Metadata And Review Hold
+
+**Files:**
+- No repo files.
+- Linear: `ROB-478`, `ROB-479`, `ROB-480`, `ROB-481`
+
+- [ ] **Step 1: Apply labels without removing existing labels**
+
+Use the Linear connector:
+
+```text
+ROB-478 labels: Improvement, high_risk_change, needs_stronger_model_review
+ROB-479 labels: Improvement, high_risk_change, needs_stronger_model_review
+ROB-480 labels: Bug, high_risk_change, needs_stronger_model_review
+ROB-481 labels: Improvement, high_risk_change, needs_stronger_model_review
+```
+
+- [ ] **Step 2: Add parent issue review-hold comment**
+
+Create this comment on `ROB-478`:
+
+```markdown
+Applying `high_risk_change` + `needs_stronger_model_review` for ROB-478~481: this work changes historical execution-ledger backfill and manual opening-lot seeding, which writes operational trading data. Code may be implemented, but no merge, deploy, production commit backfill, or manual_import seed execution should occur until stronger-model/CTO review clears the dry-run evidence and operator runbook.
+```
+
+- [ ] **Step 3: Confirm**
+
+Expected: all four issues still retain their original `Improvement`/`Bug` label plus the two review labels. No issue status change is required before implementation starts.
+
+---
+
+### Task 1: FIFO Sell-History Characterization Tests
+
+**Files:**
+- Create: `tests/services/execution_ledger/test_query_service_profit.py`
+- Modify: `app/services/execution_ledger/query_service.py` only if a characterization test exposes a mismatch with the current intended behavior.
+
+- [ ] **Step 1: Write characterization tests**
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from app.schemas.execution_ledger import ExecutionLedgerRead
+from app.services.execution_ledger.query_service import _annotate_realized_profit
+
+
+def _item(
+    *,
+    side: str,
+    qty: str,
+    price: str,
+    filled_at: datetime,
+    order_id: str,
+    fill_seq: int = 0,
+    broker: str = "kis",
+    account_mode: str = "live",
+    venue: str = "krx",
+    instrument_type: str = "equity_kr",
+    symbol: str = "005930",
+    currency: str = "KRW",
+    fee_amount: str | None = None,
+) -> ExecutionLedgerRead:
+    quantity = Decimal(qty)
+    unit_price = Decimal(price)
+    return ExecutionLedgerRead(
+        id=None,
+        broker=broker,
+        account_mode=account_mode,
+        venue=venue,
+        instrument_type=instrument_type,
+        symbol=symbol,
+        raw_symbol=symbol,
+        side=side,
+        broker_order_id=order_id,
+        fill_seq=fill_seq,
+        filled_qty=quantity,
+        filled_price=unit_price,
+        filled_notional=quantity * unit_price,
+        fee_amount=Decimal(fee_amount) if fee_amount is not None else None,
+        fee_currency=currency if fee_amount is not None else None,
+        filled_at=filled_at,
+        currency=currency,
+        source="reconciler",
+    )
+
+
+def test_annotate_realized_profit_uses_multilot_fifo() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy_a = _item(side="buy", qty="5", price="100", filled_at=base, order_id="buy-a")
+    buy_b = _item(
+        side="buy",
+        qty="5",
+        price="120",
+        filled_at=base + timedelta(days=1),
+        order_id="buy-b",
+    )
+    sell = _item(
+        side="sell",
+        qty="7",
+        price="150",
+        filled_at=base + timedelta(days=2),
+        order_id="sell-a",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy_a, buy_b, sell])
+
+    assert annotated[0].cost_basis_notional == Decimal("740")
+    assert annotated[0].realized_profit == Decimal("310")
+    assert annotated[0].realized_profit_rate == Decimal("41.89189189189189189189189189")
+
+
+def test_annotate_realized_profit_keeps_null_when_partially_uncovered() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy = _item(side="buy", qty="5", price="100", filled_at=base, order_id="buy-a")
+    sell = _item(
+        side="sell",
+        qty="7",
+        price="150",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy, sell])
+
+    assert annotated[0].cost_basis_notional is None
+    assert annotated[0].realized_profit is None
+    assert annotated[0].realized_profit_rate is None
+
+
+def test_annotate_realized_profit_isolates_venue_in_match_key() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    nasd_buy = _item(
+        side="buy",
+        qty="10",
+        price="100",
+        filled_at=base,
+        order_id="buy-a",
+        venue="NASD",
+        instrument_type="equity_us",
+        symbol="AAPL",
+        currency="USD",
+    )
+    nyse_sell = _item(
+        side="sell",
+        qty="1",
+        price="150",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+        venue="NYSE",
+        instrument_type="equity_us",
+        symbol="AAPL",
+        currency="USD",
+    )
+
+    annotated = _annotate_realized_profit([nyse_sell], [nasd_buy, nyse_sell])
+
+    assert annotated[0].realized_profit is None
+
+
+def test_annotate_realized_profit_remains_gross_and_ignores_fees() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy = _item(
+        side="buy",
+        qty="1",
+        price="100",
+        filled_at=base,
+        order_id="buy-a",
+        fee_amount="10",
+    )
+    sell = _item(
+        side="sell",
+        qty="1",
+        price="130",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+        fee_amount="10",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy, sell])
+
+    assert annotated[0].cost_basis_notional == Decimal("100")
+    assert annotated[0].realized_profit == Decimal("30")
+    assert annotated[0].realized_profit_rate == Decimal("30.0")
+```
+
+- [ ] **Step 2: Run characterization tests**
+
+Run: `uv run pytest tests/services/execution_ledger/test_query_service_profit.py -v`
+
+Expected: PASS. If a test fails, update only `app/services/execution_ledger/query_service.py` to preserve the issue-stated behavior: fail closed on uncovered sells, use the 6-tuple match key, FIFO lots, and gross P/L.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/services/execution_ledger/test_query_service_profit.py app/services/execution_ledger/query_service.py
+git commit -m "test(ROB-479): pin sell history FIFO realized profit semantics"
+```
+
+---
+
+### Task 2: Explicit Historical Window Contract
+
+**Files:**
+- Modify: `app/services/execution_ledger/reconciler.py`
+- Modify: `app/services/n8n_filled_orders_service.py`
+- Modify: `scripts/reconcile_execution_ledger.py`
+- Modify: `tests/services/execution_ledger/test_reconciler.py`
+- Modify: `tests/test_n8n_trade_review.py`
+- Create: `tests/scripts/test_reconcile_execution_ledger_cli.py`
+
+- [ ] **Step 1: Add failing reconciler window test**
+
+Append to `tests/services/execution_ledger/test_reconciler.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_reconciler_passes_explicit_window_to_fetcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.execution_ledger.reconciler.settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+    captured: dict[str, object] = {}
+
+    async def fetcher(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return {"orders": []}
+
+    start_at = datetime(2026, 2, 1, tzinfo=UTC)
+    end_at = datetime(2026, 2, 8, tzinfo=UTC)
+    repo = FakeRepo(status="inserted")
+
+    await ExecutionLedgerReconciler(repo, fetcher=fetcher).run(
+        "kis",
+        start_at=start_at,
+        end_at=end_at,
+        max_pages=25,
+        dry_run=True,
+    )
+
+    assert captured["start_at"] == start_at
+    assert captured["end_at"] == end_at
+    assert captured["max_pages"] == 25
+    assert repo.runs[0].window_start == start_at
+    assert repo.runs[0].window_end == end_at
+```
+
+- [ ] **Step 2: Add failing CLI parse test**
+
+```python
+# tests/scripts/test_reconcile_execution_ledger_cli.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import scripts.reconcile_execution_ledger as cli
+
+
+def test_parse_args_accepts_explicit_date_window(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "reconcile_execution_ledger.py",
+            "--broker",
+            "kis",
+            "--start-date",
+            "2026-02-01",
+            "--end-date",
+            "2026-02-08",
+            "--max-pages",
+            "25",
+        ],
+    )
+
+    args = cli.parse_args()
+    start_at, end_at = cli.resolve_window_args(args)
+
+    assert start_at == datetime(2026, 2, 1, 0, 0, tzinfo=UTC)
+    assert end_at == datetime(2026, 2, 8, 23, 59, 59, 999999, tzinfo=UTC)
+    assert args.max_pages == 25
+```
+
+- [ ] **Step 3: Verify tests fail before implementation**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/services/execution_ledger/test_reconciler.py::test_reconciler_passes_explicit_window_to_fetcher \
+  tests/scripts/test_reconcile_execution_ledger_cli.py::test_parse_args_accepts_explicit_date_window \
+  -v
+```
+
+Expected: FAIL because `run()` has no `start_at`/`end_at`/`max_pages` parameters and `resolve_window_args()` does not exist.
+
+- [ ] **Step 4: Implement reconciler window pass-through**
+
+Add a complete window resolver near the top of `app/services/execution_ledger/reconciler.py`:
+
+```python
+def _resolve_run_window(
+    *,
+    window_hours: int = 24,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    now = datetime.now(UTC)
+    window_end = end_at or now
+    window_start = start_at or (window_end - timedelta(hours=window_hours))
+    if window_start >= window_end:
+        raise ValueError("start_at must be before end_at")
+    return window_start, window_end
+```
+
+Update `ExecutionLedgerReconciler.run` signature:
+
+```python
+async def run(
+    self,
+    broker: Broker,
+    *,
+    window_hours: int = 24,
+    start_at: datetime | None = None,
+    end_at: datetime | None = None,
+    max_pages: int = 100,
+    dry_run: bool = True,
+) -> ReconcileDiff:
+```
+
+Replace the current `now`/`window_start`/`window_end` calculation with:
+
+```python
+window_start, window_end = _resolve_run_window(
+    window_hours=window_hours,
+    start_at=start_at,
+    end_at=end_at,
+)
+```
+
+Replace the current `_fetch_normalized` call with:
+
+```python
+fills = await self._fetch_normalized(
+    broker,
+    window_hours=window_hours,
+    start_at=window_start,
+    end_at=window_end,
+    max_pages=max_pages,
+    source_run_id=run_id,
+)
+```
+
+```python
+async def _fetch_normalized(
+    self,
+    broker: Broker,
+    *,
+    window_hours: int,
+    start_at: datetime,
+    end_at: datetime,
+    max_pages: int,
+    source_run_id: uuid.UUID,
+) -> list[ExecutionLedgerUpsert]:
+    days = max(1, int(((end_at - start_at).total_seconds() + 86399) / 86400))
+    markets = "crypto" if broker == "upbit" else "kr,us"
+    result = await self.fetcher(
+        days=days,
+        markets=markets,
+        min_amount=0,
+        include_indicators=False,
+        start_at=start_at,
+        end_at=end_at,
+        max_pages=max_pages,
+    )
+    rows = result.get("orders") or result.get("items") or []
+    return [
+        to_execution_ledger_upsert(row, broker=broker, source_run_id=source_run_id)
+        for row in rows
+    ]
+```
+
+- [ ] **Step 5: Implement filled-orders pass-through**
+
+In `app/services/n8n_filled_orders_service.py`, add parameters to `fetch_filled_orders`, `_fetch_kis_domestic_filled`, `_fetch_kis_overseas_filled`, and `_fetch_upbit_filled`:
+
+```python
+def _resolve_kst_window(
+    *,
+    days: int,
+    start_at: datetime | None,
+    end_at: datetime | None,
+) -> tuple[datetime, datetime]:
+    resolved_end = (end_at.astimezone(KST) if end_at else now_kst())
+    resolved_start = (
+        start_at.astimezone(KST)
+        if start_at
+        else resolved_end - timedelta(days=days)
+    )
+    if resolved_start >= resolved_end:
+        raise ValueError("start_at must be before end_at")
+    return resolved_start, resolved_end
+```
+
+KIS callers must use the resolved dates:
+
+```python
+start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
+raw_orders = await kis.inquire_daily_order_domestic(
+    start_date=start_kst.strftime("%Y%m%d"),
+    end_date=end_kst.strftime("%Y%m%d"),
+    stock_code="",
+    side="00",
+    max_pages=max_pages,
+)
+```
+
+Do the same for `inquire_daily_order_overseas`.
+
+- [ ] **Step 6: Implement CLI args**
+
+In `scripts/reconcile_execution_ledger.py`:
+
+```python
+from datetime import UTC, datetime, time
+
+
+def _parse_cli_date(value: str, *, end_of_day: bool) -> datetime:
+    raw = value.strip()
+    fmt = "%Y%m%d" if len(raw) == 8 and raw.isdigit() else "%Y-%m-%d"
+    day = datetime.strptime(raw, fmt).date()
+    boundary = time.max if end_of_day else time.min
+    return datetime.combine(day, boundary, tzinfo=UTC)
+
+
+def resolve_window_args(args: argparse.Namespace) -> tuple[datetime | None, datetime | None]:
+    if args.start_date is None and args.end_date is None:
+        return None, None
+    if args.start_date is None or args.end_date is None:
+        raise ValueError("--start-date and --end-date must be provided together")
+    start_at = _parse_cli_date(args.start_date, end_of_day=False)
+    end_at = _parse_cli_date(args.end_date, end_of_day=True)
+    if start_at >= end_at:
+        raise ValueError("--start-date must be before --end-date")
+    return start_at, end_at
+```
+
+Add parser args:
+
+```python
+parser.add_argument("--start-date", help="UTC date YYYY-MM-DD or YYYYMMDD")
+parser.add_argument("--end-date", help="UTC date YYYY-MM-DD or YYYYMMDD")
+parser.add_argument("--max-pages", type=int, default=100)
+```
+
+Call:
+
+```python
+start_at, end_at = resolve_window_args(args)
+diff = await reconciler.run(
+    args.broker,
+    window_hours=args.window_hours,
+    start_at=start_at,
+    end_at=end_at,
+    max_pages=args.max_pages,
+    dry_run=dry_run,
+)
+```
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/services/execution_ledger/test_reconciler.py \
+  tests/scripts/test_reconcile_execution_ledger_cli.py \
+  tests/test_n8n_trade_review.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  app/services/execution_ledger/reconciler.py \
+  app/services/n8n_filled_orders_service.py \
+  scripts/reconcile_execution_ledger.py \
+  tests/services/execution_ledger/test_reconciler.py \
+  tests/test_n8n_trade_review.py \
+  tests/scripts/test_reconcile_execution_ledger_cli.py
+git commit -m "feat(ROB-479): support explicit execution ledger backfill windows"
+```
+
+---
+
+### Task 3: KIS Pagination Cap And Truncation Guard
+
+**Files:**
+- Modify: `app/services/brokers/kis/domestic_orders.py`
+- Modify: `app/services/brokers/kis/overseas_orders.py`
+- Modify: `tests/test_kis_domestic_orders_retry.py`
+- Modify: `tests/test_kis_overseas_orders_retry.py`
+
+- [ ] **Step 1: Add domestic truncation test**
+
+Append to `tests/test_kis_domestic_orders_retry.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_raises_when_domestic_history_reaches_max_pages_with_cursor(
+        self, _mock_domestic_orders
+    ):
+        instance, parent = _mock_domestic_orders
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                {
+                    "rt_cd": "0",
+                    "output1": [{"ord_no": "001", "pdno": "005930"}],
+                    "ctx_area_fk100": "FK2",
+                    "ctx_area_nk100": "NK2",
+                },
+                {
+                    "rt_cd": "0",
+                    "output1": [{"ord_no": "002", "pdno": "005930"}],
+                    "ctx_area_fk100": "FK3",
+                    "ctx_area_nk100": "NK3",
+                },
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="domestic daily order history truncated"):
+            await instance.inquire_daily_order_domestic(
+                start_date="20260201",
+                end_date="20260208",
+                max_pages=2,
+            )
+```
+
+- [ ] **Step 2: Add overseas truncation test**
+
+Append to `tests/test_kis_overseas_orders_retry.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_raises_when_overseas_history_reaches_max_pages_with_cursor(
+        self, _mock_overseas_orders
+    ):
+        instance, parent = _mock_overseas_orders
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                {
+                    "rt_cd": "0",
+                    "output1": [{"odno": "001", "pdno": "AAPL"}],
+                    "ctx_area_fk200": "FK2",
+                    "ctx_area_nk200": "NK2",
+                },
+                {
+                    "rt_cd": "0",
+                    "output1": [{"odno": "002", "pdno": "AAPL"}],
+                    "ctx_area_fk200": "FK3",
+                    "ctx_area_nk200": "NK3",
+                },
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="overseas daily order history truncated"):
+            await instance.inquire_daily_order_overseas(
+                start_date="20260201",
+                end_date="20260208",
+                max_pages=2,
+            )
+```
+
+- [ ] **Step 3: Verify tests fail**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_kis_domestic_orders_retry.py::TestDomesticOrdersTransientRetry::test_raises_when_domestic_history_reaches_max_pages_with_cursor \
+  tests/test_kis_overseas_orders_retry.py::TestOverseasOrdersTransientRetry::test_raises_when_overseas_history_reaches_max_pages_with_cursor \
+  -v
+```
+
+Expected: FAIL because KIS helpers do not accept `max_pages`.
+
+- [ ] **Step 4: Implement domestic max_pages parameter**
+
+Change the domestic method signature:
+
+```python
+async def inquire_daily_order_domestic(
+    self,
+    start_date: str,
+    end_date: str,
+    stock_code: str = "",
+    side: str = "00",
+    order_number: str = "",
+    is_mock: bool = False,
+    max_pages: int = 100,
+) -> list[dict]:
+```
+
+Replace the local assignment with:
+
+```python
+page_limit = max(1, int(max_pages))
+truncated = False
+```
+
+Change the loop header and cap handling:
+
+```python
+while page <= page_limit:
+    # Keep the existing request, retry/error handling, order extraction,
+    # all_orders.extend(orders), logging, and cursor extraction above this block.
+    if not new_ctx_area_nk100 or new_ctx_area_nk100 == ctx_area_nk100:
+        logging.info("마지막 페이지 도달 (연속조회 키 없음 또는 동일)")
+        break
+
+    ctx_area_fk100 = new_ctx_area_fk100
+    ctx_area_nk100 = new_ctx_area_nk100
+    tr_cont = "N"
+    page += 1
+    if page > page_limit:
+        truncated = True
+        break
+    await asyncio.sleep(0.1)
+
+if truncated:
+    raise RuntimeError(
+        "KIS domestic daily order history truncated "
+        f"at max_pages={page_limit} for {start_date}~{end_date}"
+    )
+```
+
+- [ ] **Step 5: Implement overseas max_pages parameter**
+
+Mirror Step 4 in `inquire_daily_order_overseas`, with `ctx_area_fk200`/`ctx_area_nk200` and this error:
+
+```python
+raise RuntimeError(
+    "KIS overseas daily order history truncated "
+    f"at max_pages={page_limit} for {start_date}~{end_date}"
+)
+```
+
+- [ ] **Step 6: Run KIS tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_kis_domestic_orders_retry.py \
+  tests/test_kis_overseas_orders_retry.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  app/services/brokers/kis/domestic_orders.py \
+  app/services/brokers/kis/overseas_orders.py \
+  tests/test_kis_domestic_orders_retry.py \
+  tests/test_kis_overseas_orders_retry.py
+git commit -m "fix(ROB-479): fail loudly on truncated KIS order backfills"
+```
+
+---
+
+### Task 4: Upbit Closed-Orders Window Pager And Dedup
+
+**Files:**
+- Modify: `app/services/brokers/upbit/orders.py`
+- Modify: `app/core/config.py`
+- Modify: `app/services/n8n_filled_orders_service.py`
+- Modify: `tests/test_upbit_orders.py`
+- Modify: `tests/test_n8n_trade_review.py`
+
+- [ ] **Step 1: Replace Upbit request-contract test**
+
+Replace `tests/test_upbit_orders.py::test_closed_orders_passes_pagination_and_state_filters` with:
+
+```python
+    @pytest.mark.asyncio
+    async def test_closed_orders_passes_time_window_and_state_filters(self, monkeypatch):
+        from datetime import UTC, datetime
+
+        from app.services.brokers.upbit import orders
+
+        request = AsyncMock(return_value=[])
+        monkeypatch.setattr(orders._client, "_request_with_auth", request)
+
+        result = await orders.fetch_closed_orders(
+            market="KRW-BTC",
+            limit=1500,
+            states=["done"],
+            order_by="asc",
+            start_time=datetime(2026, 2, 1, 0, 0, tzinfo=UTC),
+            end_time=datetime(2026, 2, 7, 0, 0, tzinfo=UTC),
+        )
+
+        assert result == []
+        request.assert_awaited_once()
+        method, url = request.await_args.args
+        assert method == "GET"
+        assert url.endswith("/orders/closed")
+        assert request.await_args.kwargs["query_params"] == {
+            "states[]": ["done"],
+            "limit": 1000,
+            "order_by": "asc",
+            "market": "KRW-BTC",
+            "start_time": "2026-02-01T00:00:00+00:00",
+            "end_time": "2026-02-07T00:00:00+00:00",
+        }
+```
+
+- [ ] **Step 2: Add Upbit cancel-page regression test**
+
+Append to `TestFilledOrdersService` in `tests/test_n8n_trade_review.py`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_fetch_upbit_filled_does_not_stop_on_zero_fill_cancel_window(self):
+        from datetime import datetime
+
+        from app.core.timezone import KST
+        from app.services.n8n_filled_orders_service import _fetch_upbit_filled
+
+        cancel_only = [
+            {
+                "uuid": "cancel-zero",
+                "side": "bid",
+                "price": "1000",
+                "state": "cancel",
+                "market": "KRW-XRP",
+                "executed_volume": "0",
+                "paid_fee": "0",
+                "created_at": "2026-03-20T10:00:00+09:00",
+            }
+        ]
+        real_fill = [
+            {
+                "uuid": "real-fill",
+                "side": "bid",
+                "price": "1000",
+                "state": "done",
+                "market": "KRW-XRP",
+                "executed_volume": "5",
+                "paid_fee": "2.5",
+                "created_at": "2026-03-18T10:00:00+09:00",
+            }
+        ]
+        fixed_now = datetime(2026, 3, 21, 0, 0, tzinfo=KST)
+
+        with (
+            patch(
+                "app.services.n8n_filled_orders_service.upbit_service.fetch_closed_orders",
+                new_callable=AsyncMock,
+                side_effect=[cancel_only, real_fill],
+            ),
+            patch(
+                "app.services.n8n_filled_orders_service.now_kst",
+                return_value=fixed_now,
+            ),
+        ):
+            orders, errors = await _fetch_upbit_filled(days=14)
+
+        assert errors == []
+        assert [order["order_id"] for order in orders] == ["real-fill"]
+```
+
+- [ ] **Step 3: Add Upbit UUID dedup test**
+
+Append to `TestFilledOrdersService`:
+
+```python
+    @pytest.mark.asyncio
+    async def test_fetch_upbit_filled_dedups_order_uuid_across_windows(self):
+        from datetime import datetime
+
+        from app.core.timezone import KST
+        from app.services.n8n_filled_orders_service import _fetch_upbit_filled
+
+        duplicate = {
+            "uuid": "dup-fill",
+            "side": "bid",
+            "price": "1000",
+            "state": "done",
+            "market": "KRW-XRP",
+            "executed_volume": "5",
+            "paid_fee": "2.5",
+            "created_at": "2026-03-18T10:00:00+09:00",
+        }
+        fixed_now = datetime(2026, 3, 21, 0, 0, tzinfo=KST)
+
+        with (
+            patch(
+                "app.services.n8n_filled_orders_service.upbit_service.fetch_closed_orders",
+                new_callable=AsyncMock,
+                side_effect=[[duplicate], [duplicate]],
+            ),
+            patch(
+                "app.services.n8n_filled_orders_service.now_kst",
+                return_value=fixed_now,
+            ),
+        ):
+            orders, errors = await _fetch_upbit_filled(days=14)
+
+        assert errors == []
+        assert [order["order_id"] for order in orders] == ["dup-fill"]
+```
+
+- [ ] **Step 4: Verify tests fail**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_upbit_orders.py \
+  tests/test_n8n_trade_review.py::TestFilledOrdersService::test_fetch_upbit_filled_does_not_stop_on_zero_fill_cancel_window \
+  tests/test_n8n_trade_review.py::TestFilledOrdersService::test_fetch_upbit_filled_dedups_order_uuid_across_windows \
+  -v
+```
+
+Expected: FAIL because current Upbit helper still sends `page` and the service breaks on pages with no appendable fills.
+
+- [ ] **Step 5: Update Upbit closed-orders helper**
+
+In `app/services/brokers/upbit/orders.py`:
+
+```python
+from datetime import datetime
+
+
+def _format_upbit_time(value: datetime | str) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    text = str(value).strip()
+    if not text:
+        raise ValueError("Upbit time parameter must not be empty")
+    return text
+```
+
+Replace `fetch_closed_orders` with:
+
+```python
+async def fetch_closed_orders(
+    market: str | None = None,
+    limit: int = 100,
+    states: list[str] | None = None,
+    order_by: str = "desc",
+    start_time: datetime | str | None = None,
+    end_time: datetime | str | None = None,
+) -> list[dict[str, Any]]:
+    url = f"{_client.UPBIT_REST}/orders/closed"
+    capped_limit = max(1, min(int(limit), 1000))
+    normalized_states = states or ["done", "cancel"]
+    params: dict[str, Any] = {
+        "states[]": normalized_states,
+        "limit": capped_limit,
+        "order_by": order_by,
+    }
+    if market:
+        params["market"] = market
+    if start_time is not None:
+        params["start_time"] = _format_upbit_time(start_time)
+    if end_time is not None:
+        params["end_time"] = _format_upbit_time(end_time)
+
+    return await _client._request_with_auth("GET", url, query_params=params)
+```
+
+- [ ] **Step 6: Add rate limits**
+
+In `app/core/config.py`:
+
+```python
+DEFAULT_UPBIT_API_RATE_LIMITS: ApiRateLimitMap = {
+    "GET /v1/accounts": {"rate": 30, "period": 1.0},
+    "GET /v1/order": {"rate": 30, "period": 1.0},
+    "GET /v1/orders/closed": {"rate": 30, "period": 1.0},
+    "GET /v1/ticker": {"rate": 10, "period": 1.0},
+}
+```
+
+- [ ] **Step 7: Implement Upbit window crawl**
+
+In `app/services/n8n_filled_orders_service.py`:
+
+```python
+_UPBIT_CLOSED_ORDERS_WINDOW = timedelta(days=7)
+_UPBIT_CLOSED_ORDERS_LIMIT = 1000
+
+
+def _iter_upbit_windows(
+    start_at: datetime, end_at: datetime
+) -> list[tuple[datetime, datetime]]:
+    windows: list[tuple[datetime, datetime]] = []
+    cursor_end = end_at
+    while cursor_end > start_at:
+        cursor_start = max(start_at, cursor_end - _UPBIT_CLOSED_ORDERS_WINDOW)
+        windows.append((cursor_start, cursor_end))
+        cursor_end = cursor_start
+    return windows
+
+
+async def _fetch_upbit_closed_window(
+    start_at: datetime,
+    end_at: datetime,
+) -> list[dict[str, Any]]:
+    rows = await upbit_service.fetch_closed_orders(
+        market=None,
+        limit=_UPBIT_CLOSED_ORDERS_LIMIT,
+        states=["done", "cancel"],
+        order_by="desc",
+        start_time=start_at,
+        end_time=end_at,
+    )
+    if len(rows) >= _UPBIT_CLOSED_ORDERS_LIMIT:
+        if end_at - start_at <= timedelta(hours=1):
+            raise RuntimeError(
+                "Upbit closed orders may be truncated in a <=1h window; "
+                f"start={start_at.isoformat()} end={end_at.isoformat()}"
+            )
+        midpoint = start_at + (end_at - start_at) / 2
+        left = await _fetch_upbit_closed_window(start_at, midpoint)
+        right = await _fetch_upbit_closed_window(midpoint, end_at)
+        return left + right
+    return rows
+```
+
+Update `_fetch_upbit_filled` to use the explicit window and dedup:
+
+```python
+start_kst, end_kst = _resolve_kst_window(days=days, start_at=start_at, end_at=end_at)
+all_fills: list[dict[str, Any]] = []
+seen_order_uuids: set[str] = set()
+
+for window_start, window_end in _iter_upbit_windows(start_kst, end_kst):
+    closed = await _fetch_upbit_closed_window(window_start, window_end)
+    for raw in closed:
+        uuid = str(raw.get("uuid") or "")
+        if uuid and uuid in seen_order_uuids:
+            continue
+        if uuid:
+            seen_order_uuids.add(uuid)
+        executed_vol = float(raw.get("executed_volume") or 0)
+        if executed_vol <= 0:
+            continue
+        if not raw.get("trades"):
+            try:
+                raw = await upbit_service.fetch_order_detail(uuid)
+            except Exception as exc:
+                logger.warning(
+                    "Upbit order detail fetch failed for %s: %s",
+                    uuid,
+                    exc,
+                )
+        for fill in normalize_upbit_order(raw):
+            parsed_filled_at = _parse_upbit_fill_datetime(fill.get("filled_at", ""))
+            if parsed_filled_at is None:
+                logger.warning(
+                    "Upbit filled order skipped due to invalid filled_at: "
+                    "order_id=%s filled_at=%r",
+                    fill.get("order_id"),
+                    fill.get("filled_at"),
+                )
+                continue
+            if start_kst <= parsed_filled_at <= end_kst:
+                all_fills.append(fill)
+```
+
+No loop should break merely because a window contains only zero-fill cancels.
+
+- [ ] **Step 8: Run Upbit tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_upbit_orders.py \
+  tests/test_n8n_trade_review.py::TestFilledOrdersService \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add \
+  app/services/brokers/upbit/orders.py \
+  app/core/config.py \
+  app/services/n8n_filled_orders_service.py \
+  tests/test_upbit_orders.py \
+  tests/test_n8n_trade_review.py
+git commit -m "fix(ROB-480): crawl Upbit closed orders by time window"
+```
+
+---
+
+### Task 5: Opening-Lot Seed Planning Service
+
+**Files:**
+- Create: `app/services/execution_ledger/opening_lots.py`
+- Create: `tests/services/execution_ledger/test_opening_lots.py`
+- Modify: `app/services/brokers/upbit/client.py`
+- Modify: `tests/services/execution_ledger/test_no_broker_mutation.py`
+
+- [ ] **Step 1: Write pure service tests**
+
+```python
+# tests/services/execution_ledger/test_opening_lots.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.services.execution_ledger.opening_lots import (
+    OpeningLotCandidate,
+    build_opening_lot_plan,
+)
+
+
+def _candidate(**overrides) -> OpeningLotCandidate:  # noqa: ANN003
+    data = {
+        "broker": "kis",
+        "account_mode": "live",
+        "venue": "krx",
+        "instrument_type": "equity_kr",
+        "symbol": "005930",
+        "raw_symbol": "005930",
+        "currency": "KRW",
+        "current_qty": Decimal("10"),
+        "avg_price": Decimal("70000"),
+        "avg_price_modified": False,
+    }
+    data.update(overrides)
+    return OpeningLotCandidate(**data)
+
+
+def test_opening_lot_quantity_subtracts_ledger_net_since_cutover() -> None:
+    cutover = datetime(2026, 5, 10, tzinfo=UTC)
+    plan = build_opening_lot_plan(
+        candidates=[_candidate()],
+        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("3")},
+        cutover=cutover,
+    )
+
+    assert len(plan.upserts) == 1
+    upsert = plan.upserts[0]
+    assert upsert.source == "manual_import"
+    assert upsert.side == "buy"
+    assert upsert.filled_qty == Decimal("7")
+    assert upsert.filled_price == Decimal("70000")
+    assert upsert.filled_at == cutover
+    assert upsert.broker_order_id == "SEED-20260510-kis-krx-005930"
+
+
+def test_opening_lot_skips_when_ledger_net_covers_current_position() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[_candidate(current_qty=Decimal("10"))],
+        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("10")},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "covered_by_ledger_net"
+
+
+def test_opening_lot_skips_modified_upbit_average_price() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[
+            _candidate(
+                broker="upbit",
+                venue="upbit_krw",
+                instrument_type="crypto",
+                symbol="SOL",
+                raw_symbol="KRW-SOL",
+                avg_price_modified=True,
+            )
+        ],
+        ledger_net_by_key={},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "upbit_avg_price_modified"
+
+
+def test_opening_lot_skips_zero_average_price() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[_candidate(avg_price=Decimal("0"))],
+        ledger_net_by_key={},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "non_positive_avg_price"
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+Run: `uv run pytest tests/services/execution_ledger/test_opening_lots.py -v`
+
+Expected: FAIL because `opening_lots.py` does not exist.
+
+- [ ] **Step 3: Implement opening lot service**
+
+```python
+# app/services/execution_ledger/opening_lots.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from app.schemas.execution_ledger import (
+    AccountMode,
+    Broker,
+    Currency,
+    ExecutionLedgerUpsert,
+    InstrumentTypeValue,
+)
+
+
+MatchKey = tuple[str, str, str, str, str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class OpeningLotCandidate:
+    broker: Broker
+    account_mode: AccountMode
+    venue: str
+    instrument_type: InstrumentTypeValue
+    symbol: str
+    raw_symbol: str
+    currency: Currency
+    current_qty: Decimal
+    avg_price: Decimal
+    avg_price_modified: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class OpeningLotSkip:
+    key: MatchKey
+    reason: Literal[
+        "covered_by_ledger_net",
+        "non_positive_current_qty",
+        "non_positive_avg_price",
+        "upbit_avg_price_modified",
+    ]
+    current_qty: Decimal
+    ledger_net_qty: Decimal
+
+
+@dataclass(slots=True)
+class OpeningLotPlan:
+    upserts: list[ExecutionLedgerUpsert] = field(default_factory=list)
+    skipped: list[OpeningLotSkip] = field(default_factory=list)
+
+
+def _match_key(candidate: OpeningLotCandidate) -> MatchKey:
+    return (
+        candidate.broker,
+        candidate.account_mode,
+        candidate.venue,
+        candidate.instrument_type,
+        candidate.symbol,
+        candidate.currency,
+    )
+
+
+def _seed_order_id(candidate: OpeningLotCandidate, cutover: datetime) -> str:
+    return (
+        f"SEED-{cutover:%Y%m%d}-"
+        f"{candidate.broker}-{candidate.venue}-{candidate.symbol}"
+    )
+
+
+def build_opening_lot_plan(
+    *,
+    candidates: list[OpeningLotCandidate],
+    ledger_net_by_key: dict[MatchKey, Decimal],
+    cutover: datetime,
+) -> OpeningLotPlan:
+    plan = OpeningLotPlan()
+    for candidate in candidates:
+        key = _match_key(candidate)
+        ledger_net_qty = ledger_net_by_key.get(key, Decimal("0"))
+        if candidate.current_qty <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "non_positive_current_qty", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+        if candidate.avg_price <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "non_positive_avg_price", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+        if candidate.broker == "upbit" and candidate.avg_price_modified:
+            plan.skipped.append(
+                OpeningLotSkip(key, "upbit_avg_price_modified", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+
+        opening_qty = candidate.current_qty - ledger_net_qty
+        if opening_qty <= 0:
+            plan.skipped.append(
+                OpeningLotSkip(key, "covered_by_ledger_net", candidate.current_qty, ledger_net_qty)
+            )
+            continue
+
+        plan.upserts.append(
+            ExecutionLedgerUpsert(
+                broker=candidate.broker,
+                account_mode=candidate.account_mode,
+                venue=candidate.venue,
+                instrument_type=candidate.instrument_type,
+                symbol=candidate.symbol,
+                raw_symbol=candidate.raw_symbol,
+                side="buy",
+                broker_order_id=_seed_order_id(candidate, cutover),
+                fill_seq=0,
+                filled_qty=opening_qty,
+                filled_price=candidate.avg_price,
+                filled_at=cutover,
+                currency=candidate.currency,
+                source="manual_import",
+                raw_payload_json={
+                    "seed_kind": "opening_lot",
+                    "current_qty": str(candidate.current_qty),
+                    "ledger_net_qty": str(ledger_net_qty),
+                    "cutover": cutover.isoformat(),
+                },
+            )
+        )
+    return plan
+```
+
+- [ ] **Step 4: Preserve Upbit modified-average flag**
+
+Change `parse_upbit_account_row` in `app/services/brokers/upbit/client.py`:
+
+```python
+def parse_upbit_account_row(account: dict[str, Any]) -> dict[str, float | bool]:
+    balance = float(account.get("balance", 0) or 0)
+    locked = float(account.get("locked", 0) or 0)
+    avg_buy_price = float(account.get("avg_buy_price", 0) or 0)
+    avg_buy_price_modified = str(
+        account.get("avg_buy_price_modified", "false")
+    ).lower() in {"true", "1", "yes"}
+    return {
+        "balance": balance,
+        "locked": locked,
+        "total_quantity": balance + locked,
+        "orderable_quantity": balance,
+        "avg_buy_price": avg_buy_price,
+        "avg_buy_price_modified": avg_buy_price_modified,
+    }
+```
+
+Add a unit assertion in `tests/test_services_upbit.py` or `tests/test_upbit_service.py`, whichever already imports `parse_upbit_account_row`:
+
+```python
+def test_parse_upbit_account_row_preserves_modified_average_flag():
+    from app.services.brokers.upbit.client import parse_upbit_account_row
+
+    parsed = parse_upbit_account_row(
+        {
+            "currency": "SOL",
+            "balance": "1.5",
+            "locked": "0.5",
+            "avg_buy_price": "100000",
+            "avg_buy_price_modified": True,
+        }
+    )
+
+    assert parsed["total_quantity"] == 2.0
+    assert parsed["avg_buy_price"] == 100000.0
+    assert parsed["avg_buy_price_modified"] is True
+```
+
+- [ ] **Step 5: Run service tests and guard**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/services/execution_ledger/test_opening_lots.py \
+  tests/services/execution_ledger/test_no_broker_mutation.py \
+  tests/test_services_upbit.py \
+  -v
+```
+
+Expected: PASS. If the Upbit parser test belongs in `tests/test_upbit_service.py` after inspection, run that file instead of `tests/test_services_upbit.py`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  app/services/execution_ledger/opening_lots.py \
+  app/services/brokers/upbit/client.py \
+  tests/services/execution_ledger/test_opening_lots.py \
+  tests/services/execution_ledger/test_no_broker_mutation.py \
+  tests/test_services_upbit.py \
+  tests/test_upbit_service.py
+git commit -m "feat(ROB-481): plan manual opening lots from broker averages"
+```
+
+---
+
+### Task 6: Manual Import Seed CLI
+
+**Files:**
+- Create: `scripts/seed_execution_ledger_opening_lots.py`
+- Create: `tests/scripts/test_seed_execution_ledger_opening_lots_cli.py`
+- Modify: `app/services/execution_ledger/opening_lots.py`
+- Modify: `app/services/execution_ledger/repository.py`
+
+- [ ] **Step 1: Add CLI tests**
+
+```python
+# tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import scripts.seed_execution_ledger_opening_lots as cli
+from app.services.execution_ledger.opening_lots import OpeningLotCandidate
+
+
+def _candidate() -> OpeningLotCandidate:
+    return OpeningLotCandidate(
+        broker="kis",
+        account_mode="live",
+        venue="krx",
+        instrument_type="equity_kr",
+        symbol="005930",
+        raw_symbol="005930",
+        currency="KRW",
+        current_qty=Decimal("10"),
+        avg_price=Decimal("70000"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_cli_dry_run_rolls_back(monkeypatch):
+    session = AsyncMock()
+    session.rollback = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
+    monkeypatch.setattr(cli, "load_opening_lot_candidates", AsyncMock(return_value=[_candidate()]))
+    monkeypatch.setattr(
+        cli,
+        "load_ledger_net_by_key_since",
+        AsyncMock(return_value={}),
+    )
+
+    rc = await cli._run(
+        brokers=["kis"],
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+        dry_run=True,
+    )
+
+    assert rc == 0
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_seed_cli_commit_requires_gate(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+
+    with pytest.raises(RuntimeError, match="EXECUTION_LEDGER_COMMIT_ENABLED"):
+        await cli._run(
+            brokers=["kis"],
+            cutover=datetime(2026, 5, 10, tzinfo=UTC),
+            dry_run=False,
+        )
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+Run: `uv run pytest tests/scripts/test_seed_execution_ledger_opening_lots_cli.py -v`
+
+Expected: FAIL because the CLI does not exist.
+
+- [ ] **Step 3: Add ledger net loader**
+
+In `app/services/execution_ledger/repository.py`, add a read-only helper:
+
+```python
+from sqlalchemy import case
+
+
+async def net_quantity_by_match_key_since(
+    self, *, cutover: datetime
+) -> dict[tuple[str, str, str, str, str, str], Decimal]:
+    signed_qty = case(
+        (ExecutionLedger.side == "buy", ExecutionLedger.filled_qty),
+        else_=-ExecutionLedger.filled_qty,
+    )
+    rows = await self.db.execute(
+        select(
+            ExecutionLedger.broker,
+            ExecutionLedger.account_mode,
+            ExecutionLedger.venue,
+            ExecutionLedger.instrument_type,
+            ExecutionLedger.symbol,
+            ExecutionLedger.currency,
+            func.coalesce(func.sum(signed_qty), 0),
+        )
+        .where(ExecutionLedger.filled_at >= cutover)
+        .where(ExecutionLedger.source != "manual_import")
+        .group_by(
+            ExecutionLedger.broker,
+            ExecutionLedger.account_mode,
+            ExecutionLedger.venue,
+            ExecutionLedger.instrument_type,
+            ExecutionLedger.symbol,
+            ExecutionLedger.currency,
+        )
+    )
+    return {
+        (broker, account_mode, venue, str(instrument_type), symbol, currency): Decimal(str(net_qty))
+        for broker, account_mode, venue, instrument_type, symbol, currency, net_qty in rows.all()
+    }
+```
+
+- [ ] **Step 4: Add candidate loaders**
+
+In `app/services/execution_ledger/opening_lots.py`, add read-only loaders:
+
+```python
+async def load_opening_lot_candidates(
+    brokers: list[str],
+) -> list[OpeningLotCandidate]:
+    candidates: list[OpeningLotCandidate] = []
+    if "kis" in brokers:
+        candidates.extend(await load_kis_opening_lot_candidates())
+    if "upbit" in brokers:
+        candidates.extend(await load_upbit_opening_lot_candidates())
+    return candidates
+```
+
+KIS loader:
+
+```python
+async def load_kis_opening_lot_candidates() -> list[OpeningLotCandidate]:
+    kis = KISClient()
+    candidates: list[OpeningLotCandidate] = []
+    for row in await kis.fetch_my_stocks():
+        qty = Decimal(str(row.get("hldg_qty") or "0"))
+        avg_price = Decimal(str(row.get("pchs_avg_pric") or "0"))
+        symbol = str(row.get("pdno") or "").strip().upper()
+        if symbol:
+            candidates.append(
+                OpeningLotCandidate(
+                    broker="kis",
+                    account_mode="live",
+                    venue="krx",
+                    instrument_type="equity_kr",
+                    symbol=symbol,
+                    raw_symbol=symbol,
+                    currency="KRW",
+                    current_qty=qty,
+                    avg_price=avg_price,
+                )
+            )
+    for row in await kis.fetch_my_us_stocks():
+        symbol = str(row.get("ovrs_pdno") or "").strip().upper()
+        venue = str(row.get("ovrs_excg_cd") or row.get("excg_cd") or "").strip().upper()
+        if not venue:
+            venue = "NASD"
+        qty = Decimal(str(row.get("ovrs_cblc_qty") or "0"))
+        avg_price = Decimal(str(row.get("pchs_avg_pric") or "0"))
+        if symbol:
+            candidates.append(
+                OpeningLotCandidate(
+                    broker="kis",
+                    account_mode="live",
+                    venue=venue,
+                    instrument_type="equity_us",
+                    symbol=symbol,
+                    raw_symbol=symbol,
+                    currency="USD",
+                    current_qty=qty,
+                    avg_price=avg_price,
+                )
+            )
+    return candidates
+```
+
+Upbit loader:
+
+```python
+async def load_upbit_opening_lot_candidates() -> list[OpeningLotCandidate]:
+    rows = await fetch_my_coins()
+    candidates: list[OpeningLotCandidate] = []
+    for row in rows:
+        currency = str(row.get("currency") or "").strip().upper()
+        if not currency or currency == "KRW":
+            continue
+        unit_currency = str(row.get("unit_currency") or "KRW").strip().upper()
+        parsed = parse_upbit_account_row(row)
+        current_qty = Decimal(str(parsed["total_quantity"]))
+        avg_price = Decimal(str(parsed["avg_buy_price"]))
+        candidates.append(
+            OpeningLotCandidate(
+                broker="upbit",
+                account_mode="live",
+                venue=f"upbit_{unit_currency.lower()}",
+                instrument_type="crypto",
+                symbol=currency,
+                raw_symbol=f"{unit_currency}-{currency}",
+                currency="KRW" if unit_currency == "KRW" else "USD",
+                current_qty=current_qty,
+                avg_price=avg_price,
+                avg_price_modified=bool(parsed["avg_buy_price_modified"]),
+            )
+        )
+    return candidates
+```
+
+- [ ] **Step 5: Implement seed CLI**
+
+```python
+# scripts/seed_execution_ledger_opening_lots.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.execution_ledger.opening_lots import (
+    build_opening_lot_plan,
+    load_opening_lot_candidates,
+)
+from app.services.execution_ledger.repository import ExecutionLedgerRepository
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed manual_import opening lots into execution_ledger."
+    )
+    parser.add_argument("--broker", choices=["kis", "upbit"], action="append")
+    parser.add_argument("--cutover", required=True, help="UTC cutover date YYYY-MM-DD")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True)
+    mode.add_argument("--commit", action="store_true")
+    return parser.parse_args()
+
+
+def parse_cutover(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC)
+
+
+async def _run(*, brokers: list[str], cutover: datetime, dry_run: bool) -> int:
+    if not dry_run and not settings.EXECUTION_LEDGER_COMMIT_ENABLED:
+        raise RuntimeError("EXECUTION_LEDGER_COMMIT_ENABLED is false; commit mode is disabled")
+    async with AsyncSessionLocal() as db:
+        repo = ExecutionLedgerRepository(db)
+        candidates = await load_opening_lot_candidates(brokers)
+        ledger_net = await repo.net_quantity_by_match_key_since(cutover=cutover)
+        plan = build_opening_lot_plan(
+            candidates=candidates,
+            ledger_net_by_key=ledger_net,
+            cutover=cutover,
+        )
+        committed = 0
+        for upsert in plan.upserts:
+            status = await repo.classify_fill(upsert)
+            if not dry_run and status != "unchanged":
+                await repo.upsert_fill(upsert)
+                committed += 1
+        if dry_run:
+            await db.rollback()
+        else:
+            await db.commit()
+        print(
+            json.dumps(
+                {
+                    "dry_run": dry_run,
+                    "would_seed": len(plan.upserts),
+                    "committed": committed,
+                    "skipped": [asdict(skip) for skip in plan.skipped],
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+            )
+        )
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    brokers = args.broker or ["kis", "upbit"]
+    return asyncio.run(
+        _run(
+            brokers=brokers,
+            cutover=parse_cutover(args.cutover),
+            dry_run=not bool(args.commit),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 6: Run seed tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/services/execution_ledger/test_opening_lots.py \
+  tests/scripts/test_seed_execution_ledger_opening_lots_cli.py \
+  tests/services/execution_ledger/test_repository.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  app/services/execution_ledger/opening_lots.py \
+  app/services/execution_ledger/repository.py \
+  scripts/seed_execution_ledger_opening_lots.py \
+  tests/services/execution_ledger/test_opening_lots.py \
+  tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+git commit -m "feat(ROB-481): add dry-run opening lot seed cli"
+```
+
+---
+
+### Task 7: End-To-End Verification And Operator Evidence
+
+**Files:**
+- Modify: `docs/runbooks/execution-ledger-backfill.md` if it exists.
+- Create: `docs/runbooks/execution-ledger-backfill.md` if it does not exist.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+uv run pytest \
+  tests/services/execution_ledger/test_query_service_profit.py \
+  tests/services/execution_ledger/test_reconciler.py \
+  tests/services/execution_ledger/test_normalizers.py \
+  tests/services/execution_ledger/test_repository.py \
+  tests/services/execution_ledger/test_opening_lots.py \
+  tests/test_kis_domestic_orders_retry.py \
+  tests/test_kis_overseas_orders_retry.py \
+  tests/test_upbit_orders.py \
+  tests/test_n8n_trade_review.py::TestFilledOrdersService \
+  tests/scripts/test_reconcile_execution_ledger_cli.py \
+  tests/scripts/test_seed_execution_ledger_opening_lots_cli.py \
+  -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run static checks**
+
+```bash
+uv run ruff check app/ tests/ scripts/reconcile_execution_ledger.py scripts/seed_execution_ledger_opening_lots.py
+uv run ruff format --check app/ tests/ scripts/reconcile_execution_ledger.py scripts/seed_execution_ledger_opening_lots.py
+uv run ty check app/ --error-on-warning
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run full non-live test gate**
+
+```bash
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Add operator runbook**
+
+`docs/runbooks/execution-ledger-backfill.md` must include these exact phases:
+
+````markdown
+# Execution Ledger Backfill Runbook
+
+## Review Hold
+
+Do not run commit mode until ROB-478~481 are reviewed under `high_risk_change` and `needs_stronger_model_review`.
+
+## Phase 1: KIS Dry Run
+
+```bash
+uv run python -m scripts.reconcile_execution_ledger \
+  --broker kis \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --max-pages 100 \
+  --dry-run
+```
+
+Archive JSON output with `would_insert`, `would_update`, `unchanged`, and sample rows.
+
+## Phase 2: Upbit Dry Run
+
+```bash
+uv run python -m scripts.reconcile_execution_ledger \
+  --broker upbit \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --dry-run
+```
+
+Archive JSON output and confirm no truncation error.
+
+## Phase 3: Coverage SQL
+
+Run the ROB-478 coverable SQL before and after dry-run planning against the target DB.
+
+## Phase 4: KIS/Upbit Commit
+
+Only after reviewer approval:
+
+```bash
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.reconcile_execution_ledger \
+  --broker kis \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --max-pages 100 \
+  --commit
+
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.reconcile_execution_ledger \
+  --broker upbit \
+  --start-date 2026-02-01 \
+  --end-date 2026-06-10 \
+  --commit
+```
+
+## Phase 5: Opening Lot Seed Dry Run
+
+Run only after Phase 4 commits:
+
+```bash
+uv run python -m scripts.seed_execution_ledger_opening_lots \
+  --cutover 2026-05-10 \
+  --dry-run
+```
+
+Archive skipped rows. Modified Upbit average prices and ambiguous/non-positive prices must remain skipped.
+
+## Phase 6: Opening Lot Seed Commit
+
+Only after reviewer approval:
+
+```bash
+EXECUTION_LEDGER_COMMIT_ENABLED=true uv run python -m scripts.seed_execution_ledger_opening_lots \
+  --cutover 2026-05-10 \
+  --commit
+```
+
+## Phase 7: UI Verification
+
+Open `/invest/my?tab=sellHistory` and confirm matched rows show 판매수익/수익률 and currency summary cards render.
+````
+
+- [ ] **Step 5: Commit runbook**
+
+```bash
+git add docs/runbooks/execution-ledger-backfill.md
+git commit -m "docs(ROB-478): add execution ledger backfill runbook"
+```
+
+- [ ] **Step 6: Final Linear comments**
+
+After tests pass and before merge, comment on `ROB-478`:
+
+```markdown
+Implementation is ready for ROB-478~481, but this remains under `needs_stronger_model_review`. No production commit backfill or `manual_import` seed execution until reviewer clears:
+
+- focused tests
+- `make test`
+- KIS dry-run JSON
+- Upbit dry-run JSON
+- pre/post coverable SQL
+- opening-lot seed dry-run JSON
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** `ROB-479` is covered by Tasks 1-3; `ROB-480` is covered by Task 4; `ROB-481` is covered by Tasks 5-6; parent `ROB-478` acceptance and operator order are covered by Task 7.
+
+**Placeholder scan:** The plan avoids deferred implementation language and provides concrete file paths, code snippets, commands, expected outcomes, and commit messages.
+
+**Type consistency:** The plan uses existing schema names: `ExecutionLedgerUpsert`, `ExecutionLedgerRead`, `ExecutionLedgerRepository`, `ExecutionLedgerReconciler`, `source='manual_import'`, and the FIFO 6-tuple `(broker, account_mode, venue, instrument_type, symbol, currency)`.
+
+**Execution order:** Code for PR1/PR2/PR3 can be implemented in parallel after Task 0, but operator execution must be: KIS dry-run/commit, Upbit dry-run/commit, coverage SQL, opening-lot seed dry-run, opening-lot seed commit.

--- a/scripts/reconcile_execution_ledger.py
+++ b/scripts/reconcile_execution_ledger.py
@@ -11,12 +11,38 @@ from app.services.execution_ledger.reconciler import ExecutionLedgerReconciler
 from app.services.execution_ledger.repository import ExecutionLedgerRepository
 
 
+from datetime import UTC, datetime, time
+
+
+def _parse_cli_date(value: str, *, end_of_day: bool) -> datetime:
+    raw = value.strip()
+    fmt = "%Y%m%d" if len(raw) == 8 and raw.isdigit() else "%Y-%m-%d"
+    day = datetime.strptime(raw, fmt).date()
+    boundary = time.max if end_of_day else time.min
+    return datetime.combine(day, boundary, tzinfo=UTC)
+
+
+def resolve_window_args(args: argparse.Namespace) -> tuple[datetime | None, datetime | None]:
+    if args.start_date is None and args.end_date is None:
+        return None, None
+    if args.start_date is None or args.end_date is None:
+        raise ValueError("--start-date and --end-date must be provided together")
+    start_at = _parse_cli_date(args.start_date, end_of_day=False)
+    end_at = _parse_cli_date(args.end_date, end_of_day=True)
+    if start_at >= end_at:
+        raise ValueError("--start-date must be before --end-date")
+    return start_at, end_at
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Reconcile broker filled orders into the execution ledger."
     )
     parser.add_argument("--broker", choices=["kis", "upbit"], required=True)
     parser.add_argument("--window-hours", type=int, default=24)
+    parser.add_argument("--start-date", help="UTC date YYYY-MM-DD or YYYYMMDD")
+    parser.add_argument("--end-date", help="UTC date YYYY-MM-DD or YYYYMMDD")
+    parser.add_argument("--max-pages", type=int, default=100)
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", action="store_true", default=True)
     mode.add_argument("--commit", action="store_true")
@@ -26,10 +52,16 @@ def parse_args() -> argparse.Namespace:
 async def _main() -> int:
     args = parse_args()
     dry_run = not bool(args.commit)
+    start_at, end_at = resolve_window_args(args)
     async with AsyncSessionLocal() as db:
         reconciler = ExecutionLedgerReconciler(ExecutionLedgerRepository(db))
         diff = await reconciler.run(
-            args.broker, window_hours=args.window_hours, dry_run=dry_run
+            args.broker,
+            window_hours=args.window_hours,
+            start_at=start_at,
+            end_at=end_at,
+            max_pages=args.max_pages,
+            dry_run=dry_run,
         )
         if not dry_run:
             await db.commit()

--- a/scripts/reconcile_execution_ledger.py
+++ b/scripts/reconcile_execution_ledger.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+from datetime import UTC, datetime, time
 
 from app.core.db import AsyncSessionLocal
 from app.services.execution_ledger.reconciler import ExecutionLedgerReconciler
 from app.services.execution_ledger.repository import ExecutionLedgerRepository
-
-
-from datetime import UTC, datetime, time
 
 
 def _parse_cli_date(value: str, *, end_of_day: bool) -> datetime:
@@ -22,7 +20,9 @@ def _parse_cli_date(value: str, *, end_of_day: bool) -> datetime:
     return datetime.combine(day, boundary, tzinfo=UTC)
 
 
-def resolve_window_args(args: argparse.Namespace) -> tuple[datetime | None, datetime | None]:
+def resolve_window_args(
+    args: argparse.Namespace,
+) -> tuple[datetime | None, datetime | None]:
     if args.start_date is None and args.end_date is None:
         return None, None
     if args.start_date is None or args.end_date is None:

--- a/scripts/reconcile_execution_ledger.py
+++ b/scripts/reconcile_execution_ledger.py
@@ -55,18 +55,24 @@ async def _main() -> int:
     start_at, end_at = resolve_window_args(args)
     async with AsyncSessionLocal() as db:
         reconciler = ExecutionLedgerReconciler(ExecutionLedgerRepository(db))
-        diff = await reconciler.run(
-            args.broker,
-            window_hours=args.window_hours,
-            start_at=start_at,
-            end_at=end_at,
-            max_pages=args.max_pages,
-            dry_run=dry_run,
-        )
-        if not dry_run:
-            await db.commit()
-        else:
-            await db.rollback()
+        try:
+            diff = await reconciler.run(
+                args.broker,
+                window_hours=args.window_hours,
+                start_at=start_at,
+                end_at=end_at,
+                max_pages=args.max_pages,
+                dry_run=dry_run,
+            )
+        except Exception:
+            if dry_run:
+                # Dry-run skips ledger upserts; commit only preserves the run audit row.
+                await db.commit()
+            else:
+                await db.rollback()
+            raise
+        # Dry-run skips ledger upserts; commit only preserves the run audit row.
+        await db.commit()
     print(json.dumps(diff.model_dump(mode="json"), ensure_ascii=False, sort_keys=True))
     return 0
 

--- a/scripts/seed_execution_ledger_opening_lots.py
+++ b/scripts/seed_execution_ledger_opening_lots.py
@@ -16,6 +16,23 @@ from app.services.execution_ledger.opening_lots import (
 from app.services.execution_ledger.repository import ExecutionLedgerRepository
 
 
+def _sample_seed_row(upsert, *, status: str) -> dict:  # noqa: ANN001
+    return {
+        "status": status,
+        "broker": upsert.broker,
+        "account_mode": upsert.account_mode,
+        "venue": upsert.venue,
+        "instrument_type": upsert.instrument_type,
+        "symbol": upsert.symbol,
+        "raw_symbol": upsert.raw_symbol,
+        "currency": upsert.currency,
+        "side": upsert.side,
+        "filled_qty": upsert.filled_qty,
+        "filled_price": upsert.filled_price,
+        "broker_order_id": upsert.broker_order_id,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Seed manual_import opening lots into execution_ledger."
@@ -47,11 +64,29 @@ async def _run(*, brokers: list[str], cutover: datetime, dry_run: bool) -> int:
             cutover=cutover,
         )
         committed = 0
+        committed_insert = 0
+        committed_update = 0
+        would_insert = 0
+        would_update = 0
+        unchanged = 0
+        sample_seed_rows = []
         for upsert in plan.upserts:
             status = await repo.classify_fill(upsert)
+            if status == "inserted":
+                would_insert += 1
+            elif status == "updated":
+                would_update += 1
+            else:
+                unchanged += 1
+            if len(sample_seed_rows) < 10:
+                sample_seed_rows.append(_sample_seed_row(upsert, status=status))
             if not dry_run and status != "unchanged":
-                await repo.upsert_fill(upsert)
+                committed_status, _row_id = await repo.upsert_fill(upsert)
                 committed += 1
+                if committed_status == "inserted":
+                    committed_insert += 1
+                elif committed_status == "updated":
+                    committed_update += 1
         if dry_run:
             await db.rollback()
         else:
@@ -61,7 +96,13 @@ async def _run(*, brokers: list[str], cutover: datetime, dry_run: bool) -> int:
                 {
                     "dry_run": dry_run,
                     "would_seed": len(plan.upserts),
+                    "would_insert": would_insert,
+                    "would_update": would_update,
+                    "unchanged": unchanged,
                     "committed": committed,
+                    "committed_insert": committed_insert,
+                    "committed_update": committed_update,
+                    "sample_seed_rows": sample_seed_rows,
                     "skipped": [asdict(skip) for skip in plan.skipped],
                 },
                 ensure_ascii=False,

--- a/scripts/seed_execution_ledger_opening_lots.py
+++ b/scripts/seed_execution_ledger_opening_lots.py
@@ -1,0 +1,86 @@
+# scripts/seed_execution_ledger_opening_lots.py
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.execution_ledger.opening_lots import (
+    build_opening_lot_plan,
+    load_opening_lot_candidates,
+)
+from app.services.execution_ledger.repository import ExecutionLedgerRepository
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed manual_import opening lots into execution_ledger."
+    )
+    parser.add_argument("--broker", choices=["kis", "upbit"], action="append")
+    parser.add_argument("--cutover", required=True, help="UTC cutover date YYYY-MM-DD")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True)
+    mode.add_argument("--commit", action="store_true")
+    return parser.parse_args()
+
+
+def parse_cutover(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC)
+
+
+async def _run(*, brokers: list[str], cutover: datetime, dry_run: bool) -> int:
+    if not dry_run and not settings.EXECUTION_LEDGER_COMMIT_ENABLED:
+        raise RuntimeError("EXECUTION_LEDGER_COMMIT_ENABLED is false; commit mode is disabled")
+    async with AsyncSessionLocal() as db:
+        repo = ExecutionLedgerRepository(db)
+        candidates = await load_opening_lot_candidates(brokers)
+        ledger_net = await repo.net_quantity_by_match_key_since(cutover=cutover)
+        plan = build_opening_lot_plan(
+            candidates=candidates,
+            ledger_net_by_key=ledger_net,
+            cutover=cutover,
+        )
+        committed = 0
+        for upsert in plan.upserts:
+            status = await repo.classify_fill(upsert)
+            if not dry_run and status != "unchanged":
+                await repo.upsert_fill(upsert)
+                committed += 1
+        if dry_run:
+            await db.rollback()
+        else:
+            await db.commit()
+        print(
+            json.dumps(
+                {
+                    "dry_run": dry_run,
+                    "would_seed": len(plan.upserts),
+                    "committed": committed,
+                    "skipped": [asdict(skip) for skip in plan.skipped],
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+                default=str,
+            )
+        )
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    brokers = args.broker or ["kis", "upbit"]
+    return asyncio.run(
+        _run(
+            brokers=brokers,
+            cutover=parse_cutover(args.cutover),
+            dry_run=not bool(args.commit),
+        )
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_execution_ledger_opening_lots.py
+++ b/scripts/seed_execution_ledger_opening_lots.py
@@ -34,7 +34,9 @@ def parse_cutover(value: str) -> datetime:
 
 async def _run(*, brokers: list[str], cutover: datetime, dry_run: bool) -> int:
     if not dry_run and not settings.EXECUTION_LEDGER_COMMIT_ENABLED:
-        raise RuntimeError("EXECUTION_LEDGER_COMMIT_ENABLED is false; commit mode is disabled")
+        raise RuntimeError(
+            "EXECUTION_LEDGER_COMMIT_ENABLED is false; commit mode is disabled"
+        )
     async with AsyncSessionLocal() as db:
         repo = ExecutionLedgerRepository(db)
         candidates = await load_opening_lot_candidates(brokers)

--- a/tests/scripts/test_reconcile_execution_ledger_cli.py
+++ b/tests/scripts/test_reconcile_execution_ledger_cli.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
 
 import scripts.reconcile_execution_ledger as cli
 
@@ -28,3 +31,81 @@ def test_parse_args_accepts_explicit_date_window(monkeypatch):
     assert start_at == datetime(2026, 2, 1, 0, 0, tzinfo=UTC)
     assert end_at == datetime(2026, 2, 8, 23, 59, 59, 999999, tzinfo=UTC)
     assert args.max_pages == 25
+
+
+@pytest.mark.asyncio
+async def test_main_commits_dry_run_audit_row(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "reconcile_execution_ledger.py",
+            "--broker",
+            "kis",
+            "--dry-run",
+        ],
+    )
+
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
+    monkeypatch.setattr(cli, "ExecutionLedgerRepository", lambda db: db)
+
+    class FakeDiff:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            assert mode == "json"
+            return {"ok": True}
+
+    class FakeReconciler:
+        def __init__(self, repository: object) -> None:
+            assert repository is session
+
+        async def run(self, broker: str, **kwargs: object) -> FakeDiff:
+            assert broker == "kis"
+            assert kwargs["dry_run"] is True
+            return FakeDiff()
+
+    monkeypatch.setattr(cli, "ExecutionLedgerReconciler", FakeReconciler)
+
+    rc = await cli._main()
+
+    assert rc == 0
+    assert '"ok": true' in capsys.readouterr().out
+    session.commit.assert_awaited_once()
+    session.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_main_commits_dry_run_audit_row_on_reconcile_error(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "reconcile_execution_ledger.py",
+            "--broker",
+            "upbit",
+            "--dry-run",
+        ],
+    )
+
+    session = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
+    monkeypatch.setattr(cli, "ExecutionLedgerRepository", lambda db: db)
+
+    class FakeReconciler:
+        def __init__(self, repository: object) -> None:
+            assert repository is session
+
+        async def run(self, broker: str, **kwargs: object) -> None:
+            assert broker == "upbit"
+            assert kwargs["dry_run"] is True
+            raise RuntimeError("filled-orders fetch returned errors")
+
+    monkeypatch.setattr(cli, "ExecutionLedgerReconciler", FakeReconciler)
+
+    with pytest.raises(RuntimeError, match="filled-orders fetch returned errors"):
+        await cli._main()
+
+    session.commit.assert_awaited_once()
+    session.rollback.assert_not_awaited()

--- a/tests/scripts/test_reconcile_execution_ledger_cli.py
+++ b/tests/scripts/test_reconcile_execution_ledger_cli.py
@@ -1,0 +1,30 @@
+# tests/scripts/test_reconcile_execution_ledger_cli.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import scripts.reconcile_execution_ledger as cli
+
+
+def test_parse_args_accepts_explicit_date_window(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "reconcile_execution_ledger.py",
+            "--broker",
+            "kis",
+            "--start-date",
+            "2026-02-01",
+            "--end-date",
+            "2026-02-08",
+            "--max-pages",
+            "25",
+        ],
+    )
+
+    args = cli.parse_args()
+    start_at, end_at = cli.resolve_window_args(args)
+
+    assert start_at == datetime(2026, 2, 1, 0, 0, tzinfo=UTC)
+    assert end_at == datetime(2026, 2, 8, 23, 59, 59, 999999, tzinfo=UTC)
+    assert args.max_pages == 25

--- a/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+++ b/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
@@ -1,6 +1,7 @@
 # tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
@@ -12,17 +13,21 @@ import scripts.seed_execution_ledger_opening_lots as cli
 from app.services.execution_ledger.opening_lots import OpeningLotCandidate
 
 
-def _candidate() -> OpeningLotCandidate:
+def _candidate(**overrides) -> OpeningLotCandidate:  # noqa: ANN003
+    data = {
+        "broker": "kis",
+        "account_mode": "live",
+        "venue": "krx",
+        "instrument_type": "equity_kr",
+        "symbol": "005930",
+        "raw_symbol": "005930",
+        "currency": "KRW",
+        "current_qty": Decimal("10"),
+        "avg_price": Decimal("70000"),
+    }
+    data.update(overrides)
     return OpeningLotCandidate(
-        broker="kis",
-        account_mode="live",
-        venue="krx",
-        instrument_type="equity_kr",
-        symbol="005930",
-        raw_symbol="005930",
-        currency="KRW",
-        current_qty=Decimal("10"),
-        avg_price=Decimal("70000"),
+        **data,
     )
 
 
@@ -55,6 +60,54 @@ async def test_seed_cli_dry_run_rolls_back(monkeypatch):
     assert rc == 0
     session.rollback.assert_awaited_once()
     session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_seed_cli_dry_run_reports_classified_counts_and_samples(
+    monkeypatch, capsys
+):
+    session = AsyncMock()
+    session.rollback = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
+    monkeypatch.setattr(
+        cli,
+        "load_opening_lot_candidates",
+        AsyncMock(
+            return_value=[
+                _candidate(symbol="005930", raw_symbol="005930"),
+                _candidate(symbol="000660", raw_symbol="000660"),
+                _candidate(symbol="035420", raw_symbol="035420"),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        cli.ExecutionLedgerRepository,
+        "net_quantity_by_match_key_since",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        cli.ExecutionLedgerRepository,
+        "classify_fill",
+        AsyncMock(side_effect=["inserted", "updated", "unchanged"]),
+    )
+
+    rc = await cli._run(
+        brokers=["kis"],
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+        dry_run=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["would_insert"] == 1
+    assert payload["would_update"] == 1
+    assert payload["unchanged"] == 1
+    assert payload["sample_seed_rows"][0]["broker_order_id"].startswith(
+        "SEED-20260510-kis-krx-005930"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+++ b/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
@@ -34,7 +34,9 @@ async def test_seed_cli_dry_run_rolls_back(monkeypatch):
     session.__aenter__.return_value = session
     session.__aexit__.return_value = None
     monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
-    monkeypatch.setattr(cli, "load_opening_lot_candidates", AsyncMock(return_value=[_candidate()]))
+    monkeypatch.setattr(
+        cli, "load_opening_lot_candidates", AsyncMock(return_value=[_candidate()])
+    )
     monkeypatch.setattr(
         "app.services.execution_ledger.repository.ExecutionLedgerRepository.net_quantity_by_match_key_since",
         AsyncMock(return_value={}),

--- a/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+++ b/tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
@@ -1,0 +1,71 @@
+# tests/scripts/test_seed_execution_ledger_opening_lots_cli.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import scripts.seed_execution_ledger_opening_lots as cli
+from app.services.execution_ledger.opening_lots import OpeningLotCandidate
+
+
+def _candidate() -> OpeningLotCandidate:
+    return OpeningLotCandidate(
+        broker="kis",
+        account_mode="live",
+        venue="krx",
+        instrument_type="equity_kr",
+        symbol="005930",
+        raw_symbol="005930",
+        currency="KRW",
+        current_qty=Decimal("10"),
+        avg_price=Decimal("70000"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_cli_dry_run_rolls_back(monkeypatch):
+    session = AsyncMock()
+    session.rollback = AsyncMock()
+    session.commit = AsyncMock()
+    session.__aenter__.return_value = session
+    session.__aexit__.return_value = None
+    monkeypatch.setattr(cli, "AsyncSessionLocal", lambda: session)
+    monkeypatch.setattr(cli, "load_opening_lot_candidates", AsyncMock(return_value=[_candidate()]))
+    monkeypatch.setattr(
+        "app.services.execution_ledger.repository.ExecutionLedgerRepository.net_quantity_by_match_key_since",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        "app.services.execution_ledger.repository.ExecutionLedgerRepository.classify_fill",
+        AsyncMock(return_value="inserted"),
+    )
+
+    rc = await cli._run(
+        brokers=["kis"],
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+        dry_run=True,
+    )
+
+    assert rc == 0
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_seed_cli_commit_requires_gate(monkeypatch):
+    monkeypatch.setattr(
+        cli,
+        "settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+
+    with pytest.raises(RuntimeError, match="EXECUTION_LEDGER_COMMIT_ENABLED"):
+        await cli._run(
+            brokers=["kis"],
+            cutover=datetime(2026, 5, 10, tzinfo=UTC),
+            dry_run=False,
+        )

--- a/tests/services/execution_ledger/test_opening_lots.py
+++ b/tests/services/execution_ledger/test_opening_lots.py
@@ -31,7 +31,9 @@ def test_opening_lot_quantity_subtracts_ledger_net_since_cutover() -> None:
     cutover = datetime(2026, 5, 10, tzinfo=UTC)
     plan = build_opening_lot_plan(
         candidates=[_candidate()],
-        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("3")},
+        ledger_net_by_key={
+            ("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("3")
+        },
         cutover=cutover,
     )
 
@@ -48,7 +50,9 @@ def test_opening_lot_quantity_subtracts_ledger_net_since_cutover() -> None:
 def test_opening_lot_skips_when_ledger_net_covers_current_position() -> None:
     plan = build_opening_lot_plan(
         candidates=[_candidate(current_qty=Decimal("10"))],
-        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("10")},
+        ledger_net_by_key={
+            ("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("10")
+        },
         cutover=datetime(2026, 5, 10, tzinfo=UTC),
     )
 

--- a/tests/services/execution_ledger/test_opening_lots.py
+++ b/tests/services/execution_ledger/test_opening_lots.py
@@ -1,0 +1,87 @@
+# tests/services/execution_ledger/test_opening_lots.py
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.services.execution_ledger.opening_lots import (
+    OpeningLotCandidate,
+    build_opening_lot_plan,
+)
+
+
+def _candidate(**overrides) -> OpeningLotCandidate:  # noqa: ANN003
+    data = {
+        "broker": "kis",
+        "account_mode": "live",
+        "venue": "krx",
+        "instrument_type": "equity_kr",
+        "symbol": "005930",
+        "raw_symbol": "005930",
+        "currency": "KRW",
+        "current_qty": Decimal("10"),
+        "avg_price": Decimal("70000"),
+        "avg_price_modified": False,
+    }
+    data.update(overrides)
+    return OpeningLotCandidate(**data)
+
+
+def test_opening_lot_quantity_subtracts_ledger_net_since_cutover() -> None:
+    cutover = datetime(2026, 5, 10, tzinfo=UTC)
+    plan = build_opening_lot_plan(
+        candidates=[_candidate()],
+        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("3")},
+        cutover=cutover,
+    )
+
+    assert len(plan.upserts) == 1
+    upsert = plan.upserts[0]
+    assert upsert.source == "manual_import"
+    assert upsert.side == "buy"
+    assert upsert.filled_qty == Decimal("7")
+    assert upsert.filled_price == Decimal("70000")
+    assert upsert.filled_at == cutover
+    assert upsert.broker_order_id == "SEED-20260510-kis-krx-005930"
+
+
+def test_opening_lot_skips_when_ledger_net_covers_current_position() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[_candidate(current_qty=Decimal("10"))],
+        ledger_net_by_key={("kis", "live", "krx", "equity_kr", "005930", "KRW"): Decimal("10")},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "covered_by_ledger_net"
+
+
+def test_opening_lot_skips_modified_upbit_average_price() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[
+            _candidate(
+                broker="upbit",
+                venue="upbit_krw",
+                instrument_type="crypto",
+                symbol="SOL",
+                raw_symbol="KRW-SOL",
+                avg_price_modified=True,
+            )
+        ],
+        ledger_net_by_key={},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "upbit_avg_price_modified"
+
+
+def test_opening_lot_skips_zero_average_price() -> None:
+    plan = build_opening_lot_plan(
+        candidates=[_candidate(avg_price=Decimal("0"))],
+        ledger_net_by_key={},
+        cutover=datetime(2026, 5, 10, tzinfo=UTC),
+    )
+
+    assert plan.upserts == []
+    assert plan.skipped[0].reason == "non_positive_avg_price"

--- a/tests/services/execution_ledger/test_opening_lots.py
+++ b/tests/services/execution_ledger/test_opening_lots.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
+import pytest
+
 from app.services.execution_ledger.opening_lots import (
     OpeningLotCandidate,
     build_opening_lot_plan,
@@ -89,3 +91,42 @@ def test_opening_lot_skips_zero_average_price() -> None:
 
     assert plan.upserts == []
     assert plan.skipped[0].reason == "non_positive_avg_price"
+
+
+@pytest.mark.asyncio
+async def test_upbit_candidates_only_cover_krw_markets(monkeypatch) -> None:
+    import app.services.brokers.upbit.client as upbit_client
+    from app.services.execution_ledger.opening_lots import (
+        load_upbit_opening_lot_candidates,
+    )
+
+    async def _fake_fetch_my_coins():
+        return [
+            {"currency": "KRW", "balance": "1000", "locked": "0"},
+            {
+                "currency": "SOL",
+                "unit_currency": "KRW",
+                "balance": "2",
+                "locked": "0",
+                "avg_buy_price": "200000",
+                "avg_buy_price_modified": "false",
+            },
+            {
+                "currency": "ETH",
+                "unit_currency": "BTC",
+                "balance": "0.5",
+                "locked": "0",
+                "avg_buy_price": "0.05",
+                "avg_buy_price_modified": "false",
+            },
+        ]
+
+    monkeypatch.setattr(upbit_client, "fetch_my_coins", _fake_fetch_my_coins)
+
+    candidates = await load_upbit_opening_lot_candidates()
+
+    assert [c.symbol for c in candidates] == ["SOL"]
+    sol = candidates[0]
+    assert sol.venue == "upbit_krw"
+    assert sol.currency == "KRW"
+    assert sol.raw_symbol == "KRW-SOL"

--- a/tests/services/execution_ledger/test_query_service_profit.py
+++ b/tests/services/execution_ledger/test_query_service_profit.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from app.schemas.execution_ledger import ExecutionLedgerRead
+from app.services.execution_ledger.query_service import _annotate_realized_profit
+
+
+def _item(
+    *,
+    side: str,
+    qty: str,
+    price: str,
+    filled_at: datetime,
+    order_id: str,
+    fill_seq: int = 0,
+    broker: str = "kis",
+    account_mode: str = "live",
+    venue: str = "krx",
+    instrument_type: str = "equity_kr",
+    symbol: str = "005930",
+    currency: str = "KRW",
+    fee_amount: str | None = None,
+) -> ExecutionLedgerRead:
+    quantity = Decimal(qty)
+    unit_price = Decimal(price)
+    return ExecutionLedgerRead(
+        id=None,
+        broker=broker,
+        account_mode=account_mode,
+        venue=venue,
+        instrument_type=instrument_type,
+        symbol=symbol,
+        raw_symbol=symbol,
+        side=side,
+        broker_order_id=order_id,
+        fill_seq=fill_seq,
+        filled_qty=quantity,
+        filled_price=unit_price,
+        filled_notional=quantity * unit_price,
+        fee_amount=Decimal(fee_amount) if fee_amount is not None else None,
+        fee_currency=currency if fee_amount is not None else None,
+        filled_at=filled_at,
+        currency=currency,
+        source="reconciler",
+    )
+
+
+def test_annotate_realized_profit_uses_multilot_fifo() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy_a = _item(side="buy", qty="5", price="100", filled_at=base, order_id="buy-a")
+    buy_b = _item(
+        side="buy",
+        qty="5",
+        price="120",
+        filled_at=base + timedelta(days=1),
+        order_id="buy-b",
+    )
+    sell = _item(
+        side="sell",
+        qty="7",
+        price="150",
+        filled_at=base + timedelta(days=2),
+        order_id="sell-a",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy_a, buy_b, sell])
+
+    assert annotated[0].cost_basis_notional == Decimal("740")
+    assert annotated[0].realized_profit == Decimal("310")
+    assert annotated[0].realized_profit_rate == Decimal("41.89189189189189189189189189")
+
+
+def test_annotate_realized_profit_keeps_null_when_partially_uncovered() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy = _item(side="buy", qty="5", price="100", filled_at=base, order_id="buy-a")
+    sell = _item(
+        side="sell",
+        qty="7",
+        price="150",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy, sell])
+
+    assert annotated[0].cost_basis_notional is None
+    assert annotated[0].realized_profit is None
+    assert annotated[0].realized_profit_rate is None
+
+
+def test_annotate_realized_profit_isolates_venue_in_match_key() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    nasd_buy = _item(
+        side="buy",
+        qty="10",
+        price="100",
+        filled_at=base,
+        order_id="buy-a",
+        venue="NASD",
+        instrument_type="equity_us",
+        symbol="AAPL",
+        currency="USD",
+    )
+    nyse_sell = _item(
+        side="sell",
+        qty="1",
+        price="150",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+        venue="NYSE",
+        instrument_type="equity_us",
+        symbol="AAPL",
+        currency="USD",
+    )
+
+    annotated = _annotate_realized_profit([nyse_sell], [nasd_buy, nyse_sell])
+
+    assert annotated[0].realized_profit is None
+
+
+def test_annotate_realized_profit_remains_gross_and_ignores_fees() -> None:
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    buy = _item(
+        side="buy",
+        qty="1",
+        price="100",
+        filled_at=base,
+        order_id="buy-a",
+        fee_amount="10",
+    )
+    sell = _item(
+        side="sell",
+        qty="1",
+        price="130",
+        filled_at=base + timedelta(days=1),
+        order_id="sell-a",
+        fee_amount="10",
+    )
+
+    annotated = _annotate_realized_profit([sell], [buy, sell])
+
+    assert annotated[0].cost_basis_notional == Decimal("100")
+    assert annotated[0].realized_profit == Decimal("30")
+    assert annotated[0].realized_profit_rate == Decimal("30.0")

--- a/tests/services/execution_ledger/test_reconciler.py
+++ b/tests/services/execution_ledger/test_reconciler.py
@@ -144,3 +144,31 @@ async def test_reconciler_passes_explicit_window_to_fetcher(
     assert captured["max_pages"] == 25
     assert repo.runs[0].window_start == start_at
     assert repo.runs[0].window_end == end_at
+
+
+@pytest.mark.asyncio
+async def test_reconciler_rejects_fetch_errors_and_records_failed_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.execution_ledger.reconciler.settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+
+    async def fetcher(**_kwargs):  # noqa: ANN003
+        await asyncio.sleep(0)
+        return {
+            "orders": [],
+            "errors": [{"market": "crypto", "error": "truncated window"}],
+        }
+
+    repo = FakeRepo(status="inserted")
+
+    with pytest.raises(RuntimeError, match="crypto.*truncated window"):
+        await ExecutionLedgerReconciler(repo, fetcher=fetcher).run(
+            "upbit", dry_run=True
+        )
+
+    assert len(repo.runs) == 1
+    assert "crypto" in repo.runs[0].error_summary
+    assert "truncated window" in repo.runs[0].error_summary

--- a/tests/services/execution_ledger/test_reconciler.py
+++ b/tests/services/execution_ledger/test_reconciler.py
@@ -144,4 +144,3 @@ async def test_reconciler_passes_explicit_window_to_fetcher(
     assert captured["max_pages"] == 25
     assert repo.runs[0].window_start == start_at
     assert repo.runs[0].window_end == end_at
-

--- a/tests/services/execution_ledger/test_reconciler.py
+++ b/tests/services/execution_ledger/test_reconciler.py
@@ -111,3 +111,37 @@ async def test_reconciler_commit_when_flag_enabled(
     assert diff.committed_insert == 1
     assert len(repo.upserts) == 1
     assert repo.upserts[0].filled_qty == Decimal("2")
+
+
+@pytest.mark.asyncio
+async def test_reconciler_passes_explicit_window_to_fetcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.execution_ledger.reconciler.settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+    captured: dict[str, object] = {}
+
+    async def fetcher(**kwargs):  # noqa: ANN003
+        captured.update(kwargs)
+        return {"orders": []}
+
+    start_at = datetime(2026, 2, 1, tzinfo=UTC)
+    end_at = datetime(2026, 2, 8, tzinfo=UTC)
+    repo = FakeRepo(status="inserted")
+
+    await ExecutionLedgerReconciler(repo, fetcher=fetcher).run(
+        "kis",
+        start_at=start_at,
+        end_at=end_at,
+        max_pages=25,
+        dry_run=True,
+    )
+
+    assert captured["start_at"] == start_at
+    assert captured["end_at"] == end_at
+    assert captured["max_pages"] == 25
+    assert repo.runs[0].window_start == start_at
+    assert repo.runs[0].window_end == end_at
+

--- a/tests/services/execution_ledger/test_repository.py
+++ b/tests/services/execution_ledger/test_repository.py
@@ -206,3 +206,53 @@ async def test_net_quantity_by_match_key_since_uses_signed_cutover_ledger_rows()
     assert session.executed is True
     assert len(next(iter(result))) == 6
     assert isinstance(next(iter(result))[3], str)
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_latest_run_per_broker_ignores_dry_run_audit_rows(db_session) -> None:
+    """Persisted dry-run audit rows must not drive ledger freshness.
+
+    The CLI/TaskIQ layers commit the reconcile-run audit row even in dry-run
+    mode; a dry-run commits zero fills, so freshness must keep reporting the
+    latest commit-mode run.
+    """
+    import uuid as _uuid
+    from datetime import timedelta
+
+    from app.models.execution_ledger import ExecutionLedgerReconcileRun
+
+    far_future = datetime(2099, 1, 1, tzinfo=UTC)
+    commit_run_id = _uuid.uuid4()
+    dry_run_id = _uuid.uuid4()
+    rows = [
+        ExecutionLedgerReconcileRun(
+            run_id=commit_run_id,
+            broker="kis",
+            window_start=far_future - timedelta(days=2),
+            window_end=far_future - timedelta(days=1),
+            started_at=far_future - timedelta(days=1),
+            finished_at=far_future - timedelta(days=1),
+            dry_run=False,
+        ),
+        ExecutionLedgerReconcileRun(
+            run_id=dry_run_id,
+            broker="kis",
+            window_start=far_future - timedelta(days=1),
+            window_end=far_future,
+            started_at=far_future,
+            finished_at=far_future,
+            dry_run=True,
+        ),
+    ]
+    db_session.add_all(rows)
+    await db_session.commit()
+    try:
+        latest = await ExecutionLedgerRepository(db_session).latest_run_per_broker()
+        assert "kis" in latest
+        assert latest["kis"].run_id != dry_run_id
+        assert latest["kis"].dry_run is False
+    finally:
+        for row in rows:
+            await db_session.delete(row)
+        await db_session.commit()

--- a/tests/services/execution_ledger/test_repository.py
+++ b/tests/services/execution_ledger/test_repository.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
 
 from app.models.execution_ledger import ExecutionLedger
+from app.models.trading import InstrumentType
 from app.schemas.execution_ledger import ExecutionLedgerUpsert
-from app.services.execution_ledger.repository import _values_differ
+from app.services.execution_ledger.repository import (
+    ExecutionLedgerRepository,
+    _values_differ,
+)
 
 
 def _fill(**overrides) -> ExecutionLedgerUpsert:  # noqa: ANN003
@@ -35,6 +43,58 @@ def _fill(**overrides) -> ExecutionLedgerUpsert:  # noqa: ANN003
 
 def _row(fill: ExecutionLedgerUpsert) -> ExecutionLedger:
     return ExecutionLedger(**fill.model_dump())
+
+
+class _AggregateResult:
+    def __init__(self, rows: list[tuple[str, str, str, InstrumentType, str, str, Decimal]]):
+        self._rows = rows
+
+    def all(self) -> list[tuple[str, str, str, InstrumentType, str, str, Decimal]]:
+        return self._rows
+
+
+class _AggregateSession:
+    def __init__(self, ledger_rows: list[SimpleNamespace], cutover: datetime):
+        self.ledger_rows = ledger_rows
+        self.cutover = cutover
+        self.executed = False
+
+    async def execute(self, statement: Any) -> _AggregateResult:
+        self.executed = True
+        compiled = statement.compile(compile_kwargs={"render_postcompile": True})
+        sql = " ".join(str(compiled).split())
+
+        assert "CASE WHEN" in sql
+        assert "review.execution_ledger.side = :side_1" in sql
+        assert "ELSE -review.execution_ledger.filled_qty" in sql
+        assert "review.execution_ledger.filled_at >= :filled_at_1" in sql
+        assert "review.execution_ledger.source != :source_1" in sql
+        assert (
+            "GROUP BY review.execution_ledger.broker, "
+            "review.execution_ledger.account_mode, review.execution_ledger.venue, "
+            "review.execution_ledger.instrument_type, review.execution_ledger.symbol, "
+            "review.execution_ledger.currency"
+        ) in sql
+        assert compiled.params["side_1"] == "buy"
+        assert compiled.params["filled_at_1"] == self.cutover
+        assert compiled.params["source_1"] == "manual_import"
+
+        grouped: dict[tuple[str, str, str, InstrumentType, str, str], Decimal] = {}
+        for row in self.ledger_rows:
+            if row.filled_at < self.cutover or row.source == "manual_import":
+                continue
+            key = (
+                row.broker,
+                row.account_mode,
+                row.venue,
+                row.instrument_type,
+                row.symbol,
+                row.currency,
+            )
+            signed_qty = row.filled_qty if row.side == "buy" else -row.filled_qty
+            grouped[key] = grouped.get(key, Decimal("0")) + signed_qty
+
+        return _AggregateResult([(*key, net_qty) for key, net_qty in grouped.items()])
 
 
 def test_values_differ_treats_decimal_scale_and_timezone_equivalent() -> None:
@@ -86,3 +146,59 @@ def test_two_fills_same_order_different_fill_seq_are_distinct() -> None:
     # _values_differ compares column values, not keys; the rows are distinct by key
     assert fill_a.fill_seq != fill_b.fill_seq
     assert fill_a.broker_order_id == fill_b.broker_order_id
+
+
+@pytest.mark.asyncio
+async def test_net_quantity_by_match_key_since_uses_signed_cutover_ledger_rows() -> None:
+    cutover = datetime(2026, 5, 13, 0, 0, tzinfo=UTC)
+    key_fields = {
+        "broker": "upbit",
+        "account_mode": "live",
+        "venue": "upbit_krw",
+        "instrument_type": InstrumentType.crypto,
+        "symbol": "BTC",
+        "currency": "KRW",
+    }
+    session = _AggregateSession(
+        [
+            SimpleNamespace(
+                **key_fields,
+                side="buy",
+                filled_qty=Decimal("0.10"),
+                filled_at=cutover,
+                source="reconciler",
+            ),
+            SimpleNamespace(
+                **key_fields,
+                side="sell",
+                filled_qty=Decimal("0.04"),
+                filled_at=datetime(2026, 5, 13, 1, 0, tzinfo=UTC),
+                source="websocket",
+            ),
+            SimpleNamespace(
+                **key_fields,
+                side="sell",
+                filled_qty=Decimal("99"),
+                filled_at=datetime(2026, 5, 12, 23, 59, tzinfo=UTC),
+                source="reconciler",
+            ),
+            SimpleNamespace(
+                **key_fields,
+                side="buy",
+                filled_qty=Decimal("10"),
+                filled_at=cutover,
+                source="manual_import",
+            ),
+        ],
+        cutover,
+    )
+
+    result = await ExecutionLedgerRepository(session).net_quantity_by_match_key_since(
+        cutover=cutover
+    )
+
+    expected_key = ("upbit", "live", "upbit_krw", "crypto", "BTC", "KRW")
+    assert result == {expected_key: Decimal("0.06")}
+    assert session.executed is True
+    assert len(next(iter(result))) == 6
+    assert isinstance(next(iter(result))[3], str)

--- a/tests/services/execution_ledger/test_repository.py
+++ b/tests/services/execution_ledger/test_repository.py
@@ -46,7 +46,9 @@ def _row(fill: ExecutionLedgerUpsert) -> ExecutionLedger:
 
 
 class _AggregateResult:
-    def __init__(self, rows: list[tuple[str, str, str, InstrumentType, str, str, Decimal]]):
+    def __init__(
+        self, rows: list[tuple[str, str, str, InstrumentType, str, str, Decimal]]
+    ):
         self._rows = rows
 
     def all(self) -> list[tuple[str, str, str, InstrumentType, str, str, Decimal]]:
@@ -149,7 +151,9 @@ def test_two_fills_same_order_different_fill_seq_are_distinct() -> None:
 
 
 @pytest.mark.asyncio
-async def test_net_quantity_by_match_key_since_uses_signed_cutover_ledger_rows() -> None:
+async def test_net_quantity_by_match_key_since_uses_signed_cutover_ledger_rows() -> (
+    None
+):
     cutover = datetime(2026, 5, 13, 0, 0, tzinfo=UTC)
     key_fields = {
         "broker": "upbit",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,8 @@ EXPECTED_KIS_API_RATE_LIMITS = {
 
 EXPECTED_UPBIT_API_RATE_LIMITS = {
     "GET /v1/accounts": {"rate": 30, "period": 1.0},
+    "GET /v1/order": {"rate": 30, "period": 1.0},
+    "GET /v1/orders/closed": {"rate": 30, "period": 1.0},
     "GET /v1/ticker": {"rate": 10, "period": 1.0},
 }
 

--- a/tests/test_execution_ledger_tasks.py
+++ b/tests/test_execution_ledger_tasks.py
@@ -61,11 +61,11 @@ def test_reconciliation_task_defaults_to_dry_run_when_commit_gate_disabled(
         async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
             return None
 
-        async def commit(self) -> None:  # pragma: no cover - should not be called
-            raise AssertionError("dry-run reconciliation must not commit")
+        async def commit(self) -> None:
+            captured["committed"] = True
 
-        async def rollback(self) -> None:
-            captured["rolled_back"] = True
+        async def rollback(self) -> None:  # pragma: no cover - should not be called
+            raise AssertionError("dry-run reconciliation must not roll back audit row")
 
     monkeypatch.setattr(mod.settings, "EXECUTION_LEDGER_COMMIT_ENABLED", False)
     monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
@@ -80,5 +80,56 @@ def test_reconciliation_task_defaults_to_dry_run_when_commit_gate_disabled(
     assert captured["broker"] == "kis"
     assert captured["window_hours"] == 6
     assert captured["dry_run"] is True
-    assert captured["rolled_back"] is True
+    assert captured["committed"] is True
     assert captured["mode"] == "json"
+
+
+@pytest.mark.unit
+def test_reconciliation_task_commits_dry_run_audit_when_reconciler_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.tasks import execution_ledger as mod
+
+    captured: dict[str, object] = {}
+
+    class FakeReconciler:
+        def __init__(self, repository: object) -> None:
+            captured["repository"] = repository
+
+        async def run(self, broker: str, *, window_hours: int, dry_run: bool) -> None:
+            captured["broker"] = broker
+            captured["window_hours"] = window_hours
+            captured["dry_run"] = dry_run
+            raise RuntimeError("filled-orders fetch returned errors")
+
+    class FakeRepository:
+        def __init__(self, db: object) -> None:
+            captured["db"] = db
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            captured["committed"] = True
+
+        async def rollback(self) -> None:  # pragma: no cover - should not be called
+            raise AssertionError("dry-run failure audit row must be committed")
+
+    monkeypatch.setattr(mod.settings, "EXECUTION_LEDGER_COMMIT_ENABLED", False)
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(mod, "ExecutionLedgerReconciler", FakeReconciler)
+    monkeypatch.setattr(mod, "ExecutionLedgerRepository", FakeRepository)
+
+    with pytest.raises(RuntimeError, match="filled-orders fetch returned errors"):
+        asyncio.run(
+            mod.reconcile_execution_ledger_smoke(broker="upbit", window_hours=6)
+        )
+
+    assert captured["broker"] == "upbit"
+    assert captured["window_hours"] == 6
+    assert captured["dry_run"] is True
+    assert captured["committed"] is True

--- a/tests/test_kis_domestic_orders_retry.py
+++ b/tests/test_kis_domestic_orders_retry.py
@@ -91,3 +91,32 @@ class TestDomesticOrdersTransientRetry:
             )
 
         assert parent._request_with_rate_limit.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_raises_when_domestic_history_reaches_max_pages_with_cursor(
+        self, _mock_domestic_orders
+    ):
+        instance, parent = _mock_domestic_orders
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                {
+                    "rt_cd": "0",
+                    "output1": [{"ord_no": "001", "pdno": "005930"}],
+                    "ctx_area_fk100": "FK2",
+                    "ctx_area_nk100": "NK2",
+                },
+                {
+                    "rt_cd": "0",
+                    "output1": [{"ord_no": "002", "pdno": "005930"}],
+                    "ctx_area_fk100": "FK3",
+                    "ctx_area_nk100": "NK3",
+                },
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="domestic daily order history truncated"):
+            await instance.inquire_daily_order_domestic(
+                start_date="20260201",
+                end_date="20260208",
+                max_pages=2,
+            )

--- a/tests/test_kis_domestic_orders_retry.py
+++ b/tests/test_kis_domestic_orders_retry.py
@@ -114,7 +114,9 @@ class TestDomesticOrdersTransientRetry:
             ]
         )
 
-        with pytest.raises(RuntimeError, match="domestic daily order history truncated"):
+        with pytest.raises(
+            RuntimeError, match="domestic daily order history truncated"
+        ):
             await instance.inquire_daily_order_domestic(
                 start_date="20260201",
                 end_date="20260208",

--- a/tests/test_kis_overseas_orders_retry.py
+++ b/tests/test_kis_overseas_orders_retry.py
@@ -202,7 +202,9 @@ class TestOverseasOrdersTransientRetry:
             ]
         )
 
-        with pytest.raises(RuntimeError, match="overseas daily order history truncated"):
+        with pytest.raises(
+            RuntimeError, match="overseas daily order history truncated"
+        ):
             await instance.inquire_daily_order_overseas(
                 start_date="20260201",
                 end_date="20260208",

--- a/tests/test_kis_overseas_orders_retry.py
+++ b/tests/test_kis_overseas_orders_retry.py
@@ -179,3 +179,32 @@ class TestOverseasOrdersTransientRetry:
         _, kwargs = parent._request_with_rate_limit.call_args
         assert kwargs["tr_id"] == "VTTT1006U"
         assert kwargs["headers"]["tr_id"] == "VTTT1006U"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_overseas_history_reaches_max_pages_with_cursor(
+        self, _mock_overseas_orders
+    ):
+        instance, parent = _mock_overseas_orders
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                {
+                    "rt_cd": "0",
+                    "output1": [{"odno": "001", "pdno": "AAPL"}],
+                    "ctx_area_fk200": "FK2",
+                    "ctx_area_nk200": "NK2",
+                },
+                {
+                    "rt_cd": "0",
+                    "output1": [{"odno": "002", "pdno": "AAPL"}],
+                    "ctx_area_fk200": "FK3",
+                    "ctx_area_nk200": "NK3",
+                },
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="overseas daily order history truncated"):
+            await instance.inquire_daily_order_overseas(
+                start_date="20260201",
+                end_date="20260208",
+                max_pages=2,
+            )

--- a/tests/test_n8n_filled_orders_service.py
+++ b/tests/test_n8n_filled_orders_service.py
@@ -97,6 +97,21 @@ class TestKISOverseasFilledOrdersFetch:
         assert all(o["order_id"] == "PARTIAL-ORDER" for o in orders)
         assert orders[0]["fill_seq"] != orders[1]["fill_seq"]
 
+    @pytest.mark.asyncio
+    async def test_us_wide_history_failure_returns_error(self, monkeypatch):
+        from app.services import n8n_filled_orders_service as svc
+
+        fake_kis = MagicMock()
+        fake_kis.inquire_daily_order_overseas = AsyncMock(
+            side_effect=RuntimeError("history unavailable")
+        )
+        monkeypatch.setattr(svc, "KISClient", lambda: fake_kis)
+
+        orders, errors = await svc._fetch_kis_overseas_filled(days=7)
+
+        assert orders == []
+        assert errors == [{"market": "us", "error": "history unavailable"}]
+
 
 @pytest.mark.unit
 class TestUpbitFilledOrdersFetch:
@@ -139,67 +154,84 @@ class TestUpbitFilledOrdersFetch:
         assert abs(orders[0]["quantity"] - 0.5) < 1e-9
 
     @pytest.mark.asyncio
-    async def test_pagination_fetches_multiple_pages(self, monkeypatch):
-        """Issue 2 regression: pagination must continue until an empty or out-of-window page."""
+    async def test_time_window_crawl_continues_after_cancel_only_window(
+        self, monkeypatch
+    ):
         from app.services import n8n_filled_orders_service as svc
 
-        recent_ts = (now_kst() - timedelta(hours=1)).isoformat()
+        end_at = now_kst().replace(microsecond=0)
+        start_at = end_at - timedelta(days=8)
 
-        def _make_order(uuid_val: str) -> dict:
+        def _make_order(
+            uuid_val: str,
+            ts: str,
+            *,
+            state: str = "done",
+            executed_volume: str = "0.01",
+        ) -> dict:
             return {
-                "state": "done",
+                "state": state,
                 "market": "KRW-BTC",
                 "side": "bid",
-                "executed_volume": "0.01",
+                "executed_volume": executed_volume,
                 "price": "100000000",
                 "avg_price": "100000000",
                 "paid_fee": "500",
                 "uuid": uuid_val,
-                "created_at": recent_ts,
+                "created_at": ts,
                 "trades": [
                     {
                         "uuid": f"trade-{uuid_val}",
                         "volume": "0.01",
                         "funds": "1000000",
-                        "created_at": recent_ts,
+                        "created_at": ts,
                     }
                 ],
             }
 
-        # Page 1: full page (100 orders) → trigger page 2
-        page1 = [_make_order(f"order-p1-{i}") for i in range(100)]
-        # Page 2: partial page (3 orders) → last page, stop
-        page2 = [_make_order(f"order-p2-{i}") for i in range(3)]
+        older_ts = (start_at + timedelta(hours=1)).isoformat()
+        calls = []
 
-        call_count = 0
-
-        def fake_fetch_closed(market, limit, page, **_kw):
-            nonlocal call_count
-            call_count += 1
-            return page1 if page == 1 else page2
+        def fake_fetch_closed(market, limit, **kwargs):
+            calls.append((market, limit, kwargs["start_time"], kwargs["end_time"]))
+            if len(calls) == 1:
+                cancel_ts = (kwargs["end_time"] - timedelta(minutes=1)).isoformat()
+                return [
+                    _make_order(
+                        "cancel-only",
+                        cancel_ts,
+                        state="cancel",
+                        executed_volume="0",
+                    )
+                ]
+            return [_make_order("older-fill", older_ts)]
 
         fake_upbit = MagicMock()
         fake_upbit.fetch_closed_orders = AsyncMock(side_effect=fake_fetch_closed)
         fake_upbit.fetch_order_detail = AsyncMock(
-            side_effect=lambda uuid: _make_order(uuid)
+            side_effect=lambda uuid: _make_order(uuid, older_ts)
         )
         monkeypatch.setattr(svc, "upbit_service", fake_upbit)
 
-        orders, errors = await svc._fetch_upbit_filled(days=1)
+        orders, errors = await svc._fetch_upbit_filled(
+            days=8, start_at=start_at, end_at=end_at
+        )
 
         assert errors == []
-        # Both pages must be consumed
-        assert call_count == 2
-        # 100 + 3 orders × 1 trade each = 103 fills
-        assert len(orders) == 103
+        assert len(calls) == 2
+        assert calls[0][2] == end_at - timedelta(days=7)
+        assert calls[0][3] == end_at
+        assert calls[1][2] == start_at
+        assert calls[1][3] == end_at - timedelta(days=7)
+        assert [order["order_id"] for order in orders] == ["older-fill"]
 
     @pytest.mark.asyncio
-    async def test_pagination_stops_when_page_is_out_of_window(self, monkeypatch):
-        """Pagination must stop once a page contains no orders within the time window."""
+    async def test_saturated_time_window_is_recursively_split(self, monkeypatch):
         from app.services import n8n_filled_orders_service as svc
 
-        recent_ts = (now_kst() - timedelta(hours=1)).isoformat()
-        old_ts = (now_kst() - timedelta(days=10)).isoformat()
+        end_at = now_kst().replace(microsecond=0)
+        start_at = end_at - timedelta(hours=2)
+        midpoint = start_at + timedelta(hours=1)
 
         def _make_order(uuid_val: str, ts: str) -> dict:
             return {
@@ -222,31 +254,39 @@ class TestUpbitFilledOrdersFetch:
                 ],
             }
 
-        page1 = [_make_order("order-recent", recent_ts)] * 100  # full page, in window
-        page2 = [_make_order("order-old", old_ts)] * 5  # all out of window → stop
+        calls = []
 
-        call_count = 0
-
-        def fake_fetch_closed(market, limit, page, **_kw):
-            nonlocal call_count
-            call_count += 1
-            return page1 if page == 1 else page2
+        def fake_fetch_closed(market, limit, **kwargs):
+            calls.append((market, limit, kwargs["start_time"], kwargs["end_time"]))
+            if kwargs["start_time"] == start_at and kwargs["end_time"] == end_at:
+                return [
+                    _make_order("saturated-a", start_at.isoformat()),
+                    _make_order("saturated-b", start_at.isoformat()),
+                ]
+            if kwargs["end_time"] == midpoint:
+                return []
+            return [
+                _make_order("split-fill", (midpoint + timedelta(minutes=1)).isoformat())
+            ]
 
         fake_upbit = MagicMock()
+        monkeypatch.setattr(svc, "_UPBIT_CLOSED_ORDERS_LIMIT", 2)
         fake_upbit.fetch_closed_orders = AsyncMock(side_effect=fake_fetch_closed)
         fake_upbit.fetch_order_detail = AsyncMock(
-            side_effect=lambda uuid: _make_order(
-                uuid, recent_ts if "recent" in uuid else old_ts
-            )
+            side_effect=lambda uuid: _make_order(uuid, end_at.isoformat())
         )
         monkeypatch.setattr(svc, "upbit_service", fake_upbit)
 
-        orders, errors = await svc._fetch_upbit_filled(days=1)
+        orders, errors = await svc._fetch_upbit_filled(
+            days=1, start_at=start_at, end_at=end_at
+        )
 
         assert errors == []
-        assert call_count == 2  # stopped after finding out-of-window page
-        # Only page-1 orders are within the window
-        assert len(orders) == 100
+        assert len(calls) == 3
+        assert calls[0][2:] == (start_at, end_at)
+        assert calls[1][2:] == (start_at, midpoint)
+        assert calls[2][2:] == (midpoint, end_at)
+        assert [order["order_id"] for order in orders] == ["split-fill"]
 
     @pytest.mark.asyncio
     async def test_detail_fetch_failure_falls_back_to_aggregate_fill(self, monkeypatch):

--- a/tests/test_n8n_trade_review.py
+++ b/tests/test_n8n_trade_review.py
@@ -240,6 +240,91 @@ class TestFilledOrdersService:
 
         assert len(result["orders"]) == 0
 
+    @pytest.mark.asyncio
+    async def test_fetch_upbit_filled_does_not_stop_on_zero_fill_cancel_window(self):
+        from datetime import datetime
+
+        from app.core.timezone import KST
+        from app.services.n8n_filled_orders_service import _fetch_upbit_filled
+
+        cancel_only = [
+            {
+                "uuid": "cancel-zero",
+                "side": "bid",
+                "price": "1000",
+                "state": "cancel",
+                "market": "KRW-XRP",
+                "executed_volume": "0",
+                "paid_fee": "0",
+                "created_at": "2026-03-20T10:00:00+09:00",
+            }
+        ]
+        real_fill = [
+            {
+                "uuid": "real-fill",
+                "side": "bid",
+                "price": "1000",
+                "state": "done",
+                "market": "KRW-XRP",
+                "executed_volume": "5",
+                "paid_fee": "2.5",
+                "created_at": "2026-03-18T10:00:00+09:00",
+            }
+        ]
+        fixed_now = datetime(2026, 3, 21, 0, 0, tzinfo=KST)
+
+        with (
+            patch(
+                "app.services.n8n_filled_orders_service.upbit_service.fetch_closed_orders",
+                new_callable=AsyncMock,
+                side_effect=[cancel_only, real_fill],
+            ),
+            patch(
+                "app.services.n8n_filled_orders_service.now_kst",
+                return_value=fixed_now,
+            ),
+        ):
+            orders, errors = await _fetch_upbit_filled(days=14)
+
+        assert errors == []
+        assert [order["order_id"] for order in orders] == ["real-fill"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_upbit_filled_dedups_order_uuid_across_windows(self):
+        from datetime import datetime
+
+        from app.core.timezone import KST
+        from app.services.n8n_filled_orders_service import _fetch_upbit_filled
+
+        duplicate = {
+            "uuid": "dup-fill",
+            "side": "bid",
+            "price": "1000",
+            "state": "done",
+            "market": "KRW-XRP",
+            "executed_volume": "5",
+            "paid_fee": "2.5",
+            "created_at": "2026-03-18T10:00:00+09:00",
+        }
+        fixed_now = datetime(2026, 3, 21, 0, 0, tzinfo=KST)
+
+        with (
+            patch(
+                "app.services.n8n_filled_orders_service.upbit_service.fetch_closed_orders",
+                new_callable=AsyncMock,
+                side_effect=[[duplicate], [duplicate]],
+            ),
+            patch(
+                "app.services.n8n_filled_orders_service.now_kst",
+                return_value=fixed_now,
+            ),
+        ):
+            orders, errors = await _fetch_upbit_filled(days=14)
+
+        assert errors == []
+        assert [order["order_id"] for order in orders] == ["dup-fill"]
+
+
 
 @pytest.mark.unit
 class TestTradeReviewService:

--- a/tests/test_n8n_trade_review.py
+++ b/tests/test_n8n_trade_review.py
@@ -325,7 +325,6 @@ class TestFilledOrdersService:
         assert [order["order_id"] for order in orders] == ["dup-fill"]
 
 
-
 @pytest.mark.unit
 class TestTradeReviewService:
     def _make_review_item(self, **overrides):

--- a/tests/test_services_upbit.py
+++ b/tests/test_services_upbit.py
@@ -200,4 +200,3 @@ def test_parse_upbit_account_row_preserves_modified_average_flag():
     assert parsed["total_quantity"] == 2.0
     assert parsed["avg_buy_price"] == 100000.0
     assert parsed["avg_buy_price_modified"] is True
-

--- a/tests/test_services_upbit.py
+++ b/tests/test_services_upbit.py
@@ -182,3 +182,22 @@ class TestUpbitService:
         summary = await upbit_service_module.fetch_krw_cash_summary()
 
         assert summary == pytest.approx({"balance": 0.0, "orderable": 0.0})
+
+
+def test_parse_upbit_account_row_preserves_modified_average_flag():
+    from app.services.brokers.upbit.client import parse_upbit_account_row
+
+    parsed = parse_upbit_account_row(
+        {
+            "currency": "SOL",
+            "balance": "1.5",
+            "locked": "0.5",
+            "avg_buy_price": "100000",
+            "avg_buy_price_modified": True,
+        }
+    )
+
+    assert parsed["total_quantity"] == 2.0
+    assert parsed["avg_buy_price"] == 100000.0
+    assert parsed["avg_buy_price_modified"] is True
+

--- a/tests/test_upbit_orders.py
+++ b/tests/test_upbit_orders.py
@@ -10,7 +10,9 @@ import pytest
 @pytest.mark.unit
 class TestUpbitClosedOrders:
     @pytest.mark.asyncio
-    async def test_closed_orders_passes_time_window_and_state_filters(self, monkeypatch):
+    async def test_closed_orders_passes_time_window_and_state_filters(
+        self, monkeypatch
+    ):
         from datetime import UTC, datetime
 
         from app.services.brokers.upbit import orders

--- a/tests/test_upbit_orders.py
+++ b/tests/test_upbit_orders.py
@@ -10,7 +10,9 @@ import pytest
 @pytest.mark.unit
 class TestUpbitClosedOrders:
     @pytest.mark.asyncio
-    async def test_closed_orders_passes_pagination_and_state_filters(self, monkeypatch):
+    async def test_closed_orders_passes_time_window_and_state_filters(self, monkeypatch):
+        from datetime import UTC, datetime
+
         from app.services.brokers.upbit import orders
 
         request = AsyncMock(return_value=[])
@@ -18,10 +20,11 @@ class TestUpbitClosedOrders:
 
         result = await orders.fetch_closed_orders(
             market="KRW-BTC",
-            limit=500,
-            page=3,
+            limit=1500,
             states=["done"],
             order_by="asc",
+            start_time=datetime(2026, 2, 1, 0, 0, tzinfo=UTC),
+            end_time=datetime(2026, 2, 7, 0, 0, tzinfo=UTC),
         )
 
         assert result == []
@@ -31,8 +34,9 @@ class TestUpbitClosedOrders:
         assert url.endswith("/orders/closed")
         assert request.await_args.kwargs["query_params"] == {
             "states[]": ["done"],
-            "limit": 100,
-            "page": 3,
+            "limit": 1000,
             "order_by": "asc",
             "market": "KRW-BTC",
+            "start_time": "2026-02-01T00:00:00+00:00",
+            "end_time": "2026-02-07T00:00:00+00:00",
         }


### PR DESCRIPTION
## 요약

`/invest/my?tab=sellHistory` 판매수익/수익률 공란(ROB-478)의 해소를 위한 3종 작업을 단일 브랜치로 구현. 진단: ledger가 2026-05-11부터 기록을 시작해 그 이전 매수 포지션의 매도는 FIFO 원가 매칭이 전량 실패(fail-closed → null).

### ROB-479 — KIS 과거 체결 백필
- `inquire_daily_order_domestic/overseas`에 `max_pages` 파라미터 (기본 10→100) + **truncation 시 silent 누락 대신 RuntimeError** (continuation 키가 남아있을 때만 판정)
- reconciler/CLI에 명시적 과거 구간 (`--start-date/--end-date`, `--max-pages`) — now-anchor 한계 제거
- `_annotate_realized_profit` 단위테스트 4종 신규 (멀티랏 FIFO / 부분커버 fail-closed / venue 격리 / GROSS 의미 고정)
- fetch 에러 시 reconciler가 조용한 빈 성공 대신 fail-loud + 실패 run 기록

### ROB-480 — Upbit closed-orders pager 교체
- `page` 파라미터 페이징 제거 → **start_time/end_time 7일 슬라이딩 윈도우** (포화 시 재귀 분할, ≤1h 포화면 에러) + **order uuid dedup**
- cancel-only 페이지 조기 break 버그 (`page_had_relevant`) 해소 — 시간창 기반이라 구조적으로 제거
- `GET /v1/order`, `GET /v1/orders/closed` rate limit 등록

### ROB-481 — manual_import opening-lot 시딩
- `scripts/seed_execution_ledger_opening_lots.py` (dry-run 기본, `EXECUTION_LEDGER_COMMIT_ENABLED` 게이트)
- seed 수량 = 현재 보유수량 − cutover 이후 ledger 순매수 (이중계상 방지, cutover 고정 시 재실행 불변)
- KIS KR(`krx`)/US(`ovrs_excg_cd`) venue 정합, Upbit `avg_buy_price_modified` 제외, KRW 마켓만 시딩
- migration 0 (`source='manual_import'`는 기존 CHECK에 이미 허용)

### 리뷰 후속 수정 (이 세션, 9847d99f)
- **freshness 회귀 차단**: CLI/TaskIQ가 dry-run audit row를 commit하게 되면서 dry-run만으로 freshness가 fresh로 위장 가능 → `latest_run_per_broker`에 `dry_run=False` 필터 + DB 회귀테스트 (prod run은 전부 commit-mode임을 확인)
- **test_config 수정**: rate-limit 신규 엔트리 2개로 인한 fixture 불일치 (이전 세션에서 '무관 실패'로 오분류된 것 — 실제로는 이 브랜치 유발)
- **opening lots KRW-only**: 비-KRW 마켓(BTC/USDT) 보유분 currency=USD 오라벨 → skip (ledger normalizer가 upbit_krw/KRW만 쓰므로 매칭 불가능한 시드였음)

## 검증
- 포커스 스위트 138 passed (rebase 후), CI 스코프 `ruff check/format app/ tests/` clean, `ty check app/ --error-on-warning` clean
- 무관 실패 검증: `test_candidate_universe_collector_evidence` 2건은 clean origin/main에서도 동일 실패 (기존 이슈), mcp_place_order 계열은 공유 test DB 오염 (단독 실행 green)

## 안전 경계
- 브로커 read-only API만 사용, 모든 쓰기는 `ExecutionLedgerRepository.upsert_fill` 경유
- commit 모드는 `EXECUTION_LEDGER_COMMIT_ENABLED` + `--commit` 이중 게이트, 운영 백필/시딩은 머지 후 runbook(`docs/runbooks/execution-ledger-backfill.md`) 절차로 별도 실행

Closes ROB-479, ROB-480, ROB-481. Part of ROB-478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)