### PR TITLE
fix(ROB-416): materialize Yahoo fast_info inside session scope — all-None 근본 원인

### DIFF
--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -249,33 +249,40 @@ def _fetch_fast_info_sync(ticker: str) -> dict[str, Any]:
         try:
             with yfinance_tracing_session() as session:
                 info = yf.Ticker(yahoo_ticker, session=session).fast_info
-            return {
-                "symbol": ticker,
-                "previous_close": _to_float_or_none(
-                    _fast_info_get(
-                        info,
-                        "regular_market_previous_close",
-                        "regularMarketPreviousClose",
-                        "previous_close",
-                        "previousClose",
-                    )
-                ),
-                "open": _to_float_or_none(_fast_info_get(info, "open")),
-                "high": _to_float_or_none(_fast_info_get(info, "day_high", "dayHigh")),
-                "low": _to_float_or_none(_fast_info_get(info, "day_low", "dayLow")),
-                "close": _to_float_or_none(
-                    _fast_info_get(
-                        info,
-                        "last_price",
-                        "lastPrice",
-                        "regular_market_price",
-                        "regularMarketPrice",
-                    )
-                ),
-                "volume": _to_int_or_none(
-                    _fast_info_get(info, "last_volume", "lastVolume", "volume")
-                ),
-            }
+                # FastInfo is lazy — each attribute access performs the HTTP
+                # request, so the payload must be materialized while the
+                # session is still open. Building it after the with-block
+                # closed the session degraded every field to None (ROB-416
+                # "all US quotes report no price" root cause).
+                return {
+                    "symbol": ticker,
+                    "previous_close": _to_float_or_none(
+                        _fast_info_get(
+                            info,
+                            "regular_market_previous_close",
+                            "regularMarketPreviousClose",
+                            "previous_close",
+                            "previousClose",
+                        )
+                    ),
+                    "open": _to_float_or_none(_fast_info_get(info, "open")),
+                    "high": _to_float_or_none(
+                        _fast_info_get(info, "day_high", "dayHigh")
+                    ),
+                    "low": _to_float_or_none(_fast_info_get(info, "day_low", "dayLow")),
+                    "close": _to_float_or_none(
+                        _fast_info_get(
+                            info,
+                            "last_price",
+                            "lastPrice",
+                            "regular_market_price",
+                            "regularMarketPrice",
+                        )
+                    ),
+                    "volume": _to_int_or_none(
+                        _fast_info_get(info, "last_volume", "lastVolume", "volume")
+                    ),
+                }
         except Exception as exc:
             last_exc = exc
             if _is_crumb_auth_error(exc) and attempt < _CRUMB_RETRY_MAX:

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -135,6 +135,69 @@ class TestYahooService:
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.yahoo.client.yf.Ticker")
+    async def test_fetch_fast_info_materializes_inside_session_scope(
+        self, mock_ticker_class, monkeypatch
+    ):
+        """yfinance FastInfo is lazy: network IO happens at attribute access, not at
+        `.fast_info` binding. The payload must therefore be materialized while the
+        tracing session is still open — reading it after yfinance_tracing_session
+        closes the session degrades every field to None via _fast_info_get, which is
+        the ROB-416 "all US quotes report no price" root cause.
+        """
+
+        class _FakeSession:
+            closed = False
+
+        session = _FakeSession()
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: session,
+        )
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.close_yfinance_session",
+            lambda s: setattr(s, "closed", True),
+        )
+
+        data = {
+            "last_price": 290.5,
+            "previous_close": 288.0,
+            "open": 289.0,
+            "day_high": 291.0,
+            "day_low": 287.5,
+            "last_volume": 1_000_000,
+        }
+
+        class _LazyFastInfo:
+            def __getattr__(self, name):
+                if session.closed:
+                    raise RuntimeError("Session is closed, cannot send request.")
+                if name in data:
+                    return data[name]
+                raise AttributeError(name)
+
+            def get(self, key, default=None):
+                if session.closed:
+                    raise RuntimeError("Session is closed, cannot send request.")
+                return data.get(key, default)
+
+        mock_ticker = MagicMock()
+        mock_ticker.fast_info = _LazyFastInfo()
+        mock_ticker_class.return_value = mock_ticker
+
+        from app.services.brokers.yahoo.client import fetch_fast_info
+
+        result = await fetch_fast_info("AAPL")
+
+        assert result["close"] == 290.5
+        assert result["previous_close"] == 288.0
+        assert result["open"] == 289.0
+        assert result["high"] == 291.0
+        assert result["low"] == 287.5
+        assert result["volume"] == 1_000_000
+        assert session.closed is True  # session must still be released afterwards
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.Ticker")
     async def test_fetch_fast_info_still_retries_and_raises_on_crumb_error(
         self, mock_ticker_class, monkeypatch
     ):


### PR DESCRIPTION
## 무엇

`_fetch_fast_info_sync`(`app/services/brokers/yahoo/client.py`)의 payload 구성을 `with yfinance_tracing_session()` 블록 **안**으로 이동.

## 왜 (근본 원인)

yfinance `FastInfo`는 lazy — 실제 HTTP 호출은 **속성 접근 시점**에 발생한다. 기존 코드는 with 블록 안에서 `info = yf.Ticker(...).fast_info` 바인딩만 하고, 가격 필드 접근(`_fast_info_get`)은 블록 밖(return dict 구성)에서 수행했다. 그 시점에는 세션이 이미 닫혀 있어 모든 요청이 `"Session is closed, cannot send request"`로 실패하고, `_fast_info_get`(ROB-365 bug 2 per-key swallow)이 전 필드를 None으로 강등 → **프로덕션에서 Yahoo fast_info 경로가 가격을 반환한 적이 없음**.

이것이 ROB-416 원 증상("US 전 종목 Symbol not found")의 진짜 근본 원인이다. PR #686("close yfinance sessions in MCP flows")에서 도입된 회귀이며, 단위 테스트는 `fetch_fast_info` 전체를 mock해 잡을 수 없었다.

## 증거 (2026-06-10 라이브 프로브)

수정 전:
- `fetch_fast_info('AAPL')` → all-None (`close=None`), 로그에 "Session is closed"
- with 블록 안에서 `info.last_price` 직접 접근 → **290.55** (Yahoo 자체 정상 — throttle/crumb 아님)
- 블록 밖 접근 → `TypeError: 'NoneType' object is not subscriptable` (ROB-365에서 "yfinance flake"로 기록된 그 에러 — 실은 결정적)

수정 후:
- AAPL → close 290.55 / MSFT → 403.41 / BRK.B → 487.77 (심볼 변환 포함 정상)

## 복구되는 소비자

- `get_quote` US Yahoo arm (ROB-416/471 — KIS-primary의 fallback이 죽어 있었음)
- `app/services/market_data/service.py` US quote (watch scanner 등)
- `app/services/market_valuation_snapshots/builder.py` fast_info 필드
- `app/services/portfolio_overview_service.py` `fetch_price` (`or 0.0` 강제변환 → 0가격 위험이었음)
- `fetch_us_live_last_price` → ROB-365 stale current_price 증상의 직접 원인 해소

다른 `yfinance_tracing_session` 사용처는 안전 확인: `yf.download`(eager DataFrame)·`Ticker.info`(eager dict)는 블록 안에서 실체화됨.

## 테스트

- 신규 회귀 테스트 `test_fetch_fast_info_materializes_inside_session_scope`: closed-session에서 raise하는 lazy FastInfo fake — 수정 전 RED 확인, 수정 후 GREEN
- 기존 ROB-365 가드(flake degrade / crumb retry) 동작 불변 확인
- 풀스위트 10282 passed (14 fail은 로컬 test_db stale row 오염 — `uq_live_ledger_order` 중복, TRUNCATE 후 해당 78개 전부 pass로 회귀 아님 증명)
- ruff check/format, ty check app/ 전부 clean

## 안전 경계

read-only 시세 경로. broker/order/watch mutation 없음. migration 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)