### PR TITLE
fix(ROB-487): query KIS reconcile evidence on exact order date

### DIFF
--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -338,10 +338,18 @@ def _live_daily_order_window(
     today = datetime.datetime.strptime(_today_yyyymmdd(), "%Y%m%d").date()
     earliest = today - datetime.timedelta(days=_LIVE_DAILY_ORDER_LOOKBACK_DAYS - 1)
     order_date = _coerce_order_date(order_trade_date)
-    start = max(order_date or earliest, earliest)
+    if order_date is None:
+        return earliest.strftime("%Y%m%d"), today.strftime("%Y%m%d")
+
+    # ROB-487 follow-up: live TTTC8001R accepted exact order-date probes for
+    # prior-day rows, while a broad order_date..today range can fail with
+    # KIER2570 "조회일자를 확인하십시오". For known ledger rows, reconcile the
+    # broker evidence on the single order date; keep the 90-day cap/future clamp
+    # as a fail-closed boundary for stale or malformed rows.
+    start = max(order_date, earliest)
     if start > today:
         start = today
-    return start.strftime("%Y%m%d"), today.strftime("%Y%m%d")
+    return start.strftime("%Y%m%d"), start.strftime("%Y%m%d")
 
 
 def _order_date_kst(row: Any) -> datetime.date | None:
@@ -373,8 +381,10 @@ async def _fetch_live_daily_rows(
     zero rows for prior-day orders (live-verified 2026-06-10: the 20260610
     window contained none of the 6/9 orders). Callers must pass the ledger
     row's order date as ``order_trade_date`` so next-day reconciles can still
-    see prior-day fills; the window is anchored on that date with a 90-day cap
-    (``_live_daily_order_window``) and ``end_date`` stays today.
+    see prior-day fills. Follow-up live smoke showed that a broad
+    order_date..today range can fail with KIER2570; known ledger rows therefore
+    query the exact order date (start_date == end_date == order_date), bounded
+    by the 90-day cap in ``_live_daily_order_window``.
     """
     kis = _create_live_kis_client()
     start_date, end_date = _live_daily_order_window(order_trade_date)

--- a/tests/mcp_server/test_kis_live_reconcile_expiry.py
+++ b/tests/mcp_server/test_kis_live_reconcile_expiry.py
@@ -71,6 +71,40 @@ def test_kernel_no_longer_uses_xkrx_session_classifier():
 
 
 @pytest.mark.asyncio
+async def test_known_order_date_uses_exact_date_daily_order_window():
+    # 실 KIS TTTC8001R은 prior-day 주문에 대해 order_date..today multi-day
+    # 조회가 KIER2570 으로 거부될 수 있다. ledger 주문일을 아는 reconcile은
+    # start_date == end_date == 주문일로 조회해야 한다.
+    calls = []
+
+    class FakeKIS:
+        async def inquire_daily_order_domestic(self, **kwargs):
+            calls.append(kwargs)
+            return []
+
+    with (
+        patch.object(mod, "_create_live_kis_client", return_value=FakeKIS()),
+        patch.object(mod, "_today_yyyymmdd", return_value="20260610"),
+    ):
+        rows = await mod._fetch_live_daily_rows(
+            symbol="035420",
+            order_no="0038569700",
+            order_trade_date=datetime.date(2026, 6, 8),
+        )
+
+    assert rows == []
+    assert calls == [
+        {
+            "start_date": "20260608",
+            "end_date": "20260608",
+            "stock_code": "035420",
+            "order_number": "0038569700",
+            "is_mock": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_unfilled_sor_during_nxt_session_stays_pending():
     # 6/9 19:02 KST 조기 expiry 재발 방지: NXT 마감(20:00) 전에는 expire 금지.
     rows = [_broker_row()]  # tot_ccld_qty=0, rjct_qty=0, rmn_qty=2 → 생존
@@ -149,9 +183,10 @@ async def test_no_rjct_evidence_after_close_stays_pending():
 
 
 @pytest.mark.asyncio
-async def test_next_day_reconcile_books_prior_day_fill_via_widened_window():
-    # (a) 6/9 주문을 6/10 아침에 reconcile: 주문일 anchor 윈도우(order_trade_date)
-    # 로 전일 체결(tot_ccld_qty=2)을 보고 book 한다 — KAI 047810 실측 형태.
+async def test_next_day_reconcile_books_prior_day_fill_via_exact_order_date():
+    # (a) 6/9 주문을 6/10 아침에 reconcile: 주문일 exact-date 조회
+    # (order_trade_date) 로 전일 체결(tot_ccld_qty=2)을 보고 book 한다 —
+    # KAI 047810 실측 형태.
     fill_row = _broker_row(tot_ccld_qty="2", rmn_qty="0", avg_prvs="126000")
     now = datetime.datetime(2026, 6, 10, 9, 3, tzinfo=KST)
     with (

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -175,7 +175,7 @@ async def test_fetch_live_daily_rows_for_order():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_fetch_live_daily_rows_uses_order_date_to_today_window():
+async def test_fetch_live_daily_rows_uses_exact_order_date_window():
     import datetime
     from unittest.mock import AsyncMock, patch
 
@@ -197,7 +197,7 @@ async def test_fetch_live_daily_rows_uses_order_date_to_today_window():
     assert rows == []
     _, kwargs = fake_client.inquire_daily_order_domestic.await_args
     assert kwargs["start_date"] == "20260609"
-    assert kwargs["end_date"] == "20260610"
+    assert kwargs["end_date"] == "20260609"
     assert kwargs["order_number"] == "0006366300"
     assert kwargs["is_mock"] is False
 


### PR DESCRIPTION
## Summary
- Fix ROB-487 live KIS reconcile evidence lookup to query known ledger rows on the exact order date (`start_date == end_date == order_date`).
- Preserve the existing 90-day stale-row cap and future-date clamp.
- Add a regression test for the live-observed `KIER2570 조회일자를 확인하십시오` multi-day window pitfall.

## Test Plan
- `uv run pytest tests/mcp_server/test_kis_live_reconcile_expiry.py -q`
- `uv run pytest tests/test_kis_domestic_orders_retry.py tests/tasks/test_kis_live_reconcile_tasks.py tests/mcp_server/test_kis_live_tool_descriptions.py -q`
- `uv run ruff check app/mcp_server/tooling/kis_live_ledger.py tests/mcp_server/test_kis_live_reconcile_expiry.py`
- `uv run ruff format --check app/mcp_server/tooling/kis_live_ledger.py tests/mcp_server/test_kis_live_reconcile_expiry.py`

## Safety
- Code/test change only.
- No broker order submission/cancel/modify.
- No scheduler activation.
- No production DB write/backfill in this PR.
