### PR TITLE
fix(ROB-504): align GHCR Dockerfile with invest frontend

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -30,10 +30,10 @@ ARG ENABLE_FRONTEND_BUILD=0
 
 WORKDIR /build
 
-COPY frontend/trading-decision/package.json frontend/trading-decision/package-lock.json ./
+COPY frontend/invest/package.json frontend/invest/package-lock.json ./
 RUN if [ "$ENABLE_FRONTEND_BUILD" = "1" ]; then npm ci; fi
 
-COPY frontend/trading-decision/ ./
+COPY frontend/invest/ ./
 RUN if [ "$ENABLE_FRONTEND_BUILD" = "1" ]; then npm run build; else mkdir -p dist && echo '<!-- frontend build disabled -->' > dist/index.html; fi
 
 # ==============================================================================
@@ -73,7 +73,7 @@ COPY alembic/ ./alembic/
 COPY alembic.ini pyproject.toml README.md ./
 COPY scripts/ ./scripts/
 COPY static/ ./static/
-COPY --from=frontend-builder /build/dist /app/frontend/trading-decision/dist
+COPY --from=frontend-builder /build/dist /app/frontend/invest/dist
 
 # tmp 디렉토리 생성 및 권한 설정
 RUN printf '%s' "$VCS_REF" > /app/.build-vcs-ref && \

--- a/tests/test_dockerfile_api_frontend_paths.py
+++ b/tests/test_dockerfile_api_frontend_paths.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _copy_sources_from_dockerfile(path: Path) -> list[str]:
+    sources: list[str] = []
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line.startswith("COPY "):
+            continue
+        parts = line.split()
+        if parts[1].startswith("--from="):
+            continue
+        # COPY <src...> <dest>; ignore flags and the final destination.
+        src_parts = [part for part in parts[1:-1] if not part.startswith("--")]
+        sources.extend(src_parts)
+    return sources
+
+
+def test_dockerfile_api_frontend_copy_sources_exist() -> None:
+    dockerfile = REPO_ROOT / "Dockerfile.api"
+    missing = [
+        source
+        for source in _copy_sources_from_dockerfile(dockerfile)
+        if source.startswith("frontend/") and not (REPO_ROOT / source).exists()
+    ]
+
+    assert missing == []
+
+
+def test_dockerfile_api_installs_invest_spa_dist_location() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile.api").read_text()
+
+    assert "/app/frontend/invest/dist" in dockerfile


### PR DESCRIPTION
## Summary
- Fixes the GHCR Docker build path after the `/invest` frontend replaced the retired `frontend/trading-decision` workspace.
- Copies the built SPA into `/app/frontend/invest/dist`, matching the FastAPI `/invest` SPA router.
- Adds a focused regression test that Dockerfile frontend COPY sources exist and target the active invest dist path.

## Test Plan
- `uv sync --frozen --group test`
- `uv run pytest tests/test_dockerfile_api_frontend_paths.py -q`
- `uv run ruff check tests/test_dockerfile_api_frontend_paths.py`
- `uv run ruff format --check tests/test_dockerfile_api_frontend_paths.py`

## Operator context
- ROB-504 production smoke passed on runtime commit containing `origin/main`, but manual GHCR workflow dispatch failed because Dockerfile.api still referenced `frontend/trading-decision`.
- No broker/order/watch/order-intent changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated Docker build configuration for the API container to reference the correct frontend application location and asset deployment path, ensuring proper integration with the frontend environment.

* **Tests**
  * Added automated tests to verify Docker build paths and frontend asset deployment locations are correctly configured in the containerized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->