### PR TITLE
fix(ROB-433): filter KR DART backfill universe

### DIFF
--- a/app/jobs/financial_fundamentals_snapshots.py
+++ b/app/jobs/financial_fundamentals_snapshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from decimal import Decimal
@@ -10,6 +11,7 @@ from decimal import Decimal
 import sqlalchemy as sa
 
 from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
 from app.models.financial_fundamentals_snapshot import FinancialFundamentalsSnapshot
 from app.services.financial_fundamentals_snapshots.builder import (
     FundamentalsFetcher,
@@ -35,10 +37,11 @@ class FinancialFundamentalsSnapshotBuildRequest:
     collected_at: dt.datetime | None = None
     estimate_only: bool = False
     allow_partial: bool = False
-    # ROB-441: DART budget-split. Skip symbols that already have a snapshot so daily
-    # re-runs advance through uncollected symbols (the full KR universe ~3,910 × 11 req
-    # exceeds the 18k daily budget → must be split across days). With --limit N this
-    # selects the NEXT N uncollected symbols (resolve full → drop collected → slice).
+    # ROB-441/433: DART budget-split. Skip symbols that already have a snapshot so
+    # daily re-runs advance through uncollected DART-eligible common stocks (the
+    # full KR active common-stock universe × 11 req exceeds the 18k daily budget →
+    # must be split across days). With --limit N this selects the NEXT N uncollected
+    # symbols after excluding preferred/ETF/REIT/SPAC/non-6-digit universe rows.
     skip_existing: bool = False
 
 
@@ -68,11 +71,38 @@ class FinancialFundamentalsSnapshotBuildResult:
     projected_requests: int | None = None
 
 
+_KR_DART_SYMBOL_RE = re.compile(r"^\d{6}$")
+
+
 def _validate_market(market: str) -> str:
     market_norm = market.strip().lower()
     if market_norm != "kr":
         raise ValueError(f"PR1 supports market='kr' only, got: {market}")
     return market_norm
+
+
+def _is_kr_dart_common_symbol(symbol: object, name: object) -> bool:
+    """Return whether a KR universe row is suitable for OpenDART common-stock fetches.
+
+    The DART backfill uses stock-code lookups. The active KR universe can contain
+    non-6-digit synthetic/exchange codes (for example NXT-like letter suffixes) and
+    non-common instruments such as preferred shares, ETFs, REITs, and SPACs. Those
+    rows should not consume OpenDART budget in the default backfill candidate path.
+    Explicit ``--symbol`` overrides remain operator-controlled and are not filtered
+    here.
+    """
+    symbol_text = str(symbol or "").strip().upper()
+    if not _KR_DART_SYMBOL_RE.fullmatch(symbol_text):
+        return False
+    return classify_kr_instrument(symbol_text, name, None) == "common"
+
+
+def _filter_kr_dart_common_symbols(rows: list[tuple[str, str]]) -> list[str]:
+    return [
+        str(symbol).strip().upper()
+        for symbol, name in rows
+        if _is_kr_dart_common_symbol(symbol, name)
+    ]
 
 
 async def resolve_symbols(market: str, override: list[str], limit: int) -> list[str]:
@@ -83,13 +113,13 @@ async def resolve_symbols(market: str, override: list[str], limit: int) -> list[
         from app.models.kr_symbol_universe import KRSymbolUniverse
 
         stmt = (
-            sa.select(KRSymbolUniverse.symbol)
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name)
             .where(KRSymbolUniverse.is_active.is_(True))
             .order_by(KRSymbolUniverse.symbol)
-            .limit(limit)
         )
         result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
+        rows = [(r[0], r[1]) for r in result.all()]
+        return _filter_kr_dart_common_symbols(rows)[:limit]
 
 
 async def resolve_active_universe(market: str) -> list[str]:
@@ -98,12 +128,13 @@ async def resolve_active_universe(market: str) -> list[str]:
         from app.models.kr_symbol_universe import KRSymbolUniverse
 
         stmt = (
-            sa.select(KRSymbolUniverse.symbol)
+            sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name)
             .where(KRSymbolUniverse.is_active.is_(True))
             .order_by(KRSymbolUniverse.symbol)
         )
         result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
+        rows = [(r[0], r[1]) for r in result.all()]
+        return _filter_kr_dart_common_symbols(rows)
 
 
 async def _already_collected_symbols(market: str) -> set[str]:
@@ -201,8 +232,9 @@ async def run_financial_fundamentals_snapshot_build(
     use_fetcher = fetcher or default_dart_fetcher
     skipped_existing = 0
     if request.skip_existing:
-        # Budget-split: resolve the candidate pool, drop already-collected, then (for
-        # --limit) slice the NEXT N uncollected so each daily run stays under budget.
+        # Budget-split: resolve the DART-eligible common-stock candidate pool,
+        # drop already-collected symbols, then (for --limit) slice the NEXT N
+        # uncollected symbols so each daily run stays under budget.
         if request.symbols:
             pool = [s.strip().upper() for s in request.symbols if s.strip()]
         else:

--- a/scripts/build_financial_fundamentals_snapshots.py
+++ b/scripts/build_financial_fundamentals_snapshots.py
@@ -27,12 +27,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--limit",
         type=int,
         default=None,
-        help="Max active universe symbols. Defaults to 20 unless --all.",
+        help="Max active DART-eligible KR common-stock symbols. Defaults to 20 unless --all.",
     )
     parser.add_argument(
         "--all",
         action="store_true",
-        help="Iterate the full active KR universe. Exclusive with --symbol/--limit.",
+        help="Iterate the full active DART-eligible KR common-stock universe. Exclusive with --symbol/--limit.",
     )
     parser.add_argument(
         "--with-quarterly",
@@ -75,8 +75,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=(
             "DART budget-split: skip symbols that already have a snapshot so daily "
-            "re-runs advance through uncollected symbols. With --limit N selects the "
-            "NEXT N uncollected (keep N*11 under the daily budget, e.g. --limit 1500)."
+            "re-runs advance through uncollected DART-eligible common stocks. With "
+            "--limit N selects the NEXT N uncollected (keep N*11 under the daily "
+            "budget, e.g. --limit 1500)."
         ),
     )
     args = parser.parse_args(argv)

--- a/tests/test_financial_fundamentals_job.py
+++ b/tests/test_financial_fundamentals_job.py
@@ -242,3 +242,73 @@ async def test_skip_existing_budget_split(bind_job_session, db_session, monkeypa
         )
     )
     await db_session.commit()
+
+
+def test_kr_dart_common_symbol_filter_excludes_non_dart_universe_rows() -> None:
+    assert job._is_kr_dart_common_symbol("005930", "삼성전자") is True
+    assert job._is_kr_dart_common_symbol("035420", "NAVER") is True
+
+    # The failed 2026-06-09 backfill chunk hit rows like these before the
+    # OpenDART fetch loop. They should be removed from the default universe.
+    assert job._is_kr_dart_common_symbol("0000H0", "비표준코드") is False
+    assert job._is_kr_dart_common_symbol("000087", "하이트진로2우B") is False
+    assert job._is_kr_dart_common_symbol("000145", "하이트진로홀딩스우") is False
+    assert job._is_kr_dart_common_symbol("999970", "KODEX 테스트") is False
+    assert job._is_kr_dart_common_symbol("999980", "테스트스팩") is False
+    assert job._is_kr_dart_common_symbol("999960", "테스트리츠") is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_resolve_active_universe_filters_to_dart_common_stocks(
+    bind_job_session, db_session
+):
+    import sqlalchemy as sa
+
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    symbols = ["999990", "999995", "99A990", "999970", "999980", "999960", "999950"]
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_(symbols))
+    )
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol="999990", name="테스트보통", exchange="STK", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="999995", name="테스트우", exchange="STK", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="99A990", name="비표준코드", exchange="STK", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="999970", name="KODEX 테스트", exchange="STK", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="999980", name="테스트스팩", exchange="KSQ", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="999960", name="테스트리츠", exchange="STK", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="999950", name="비활성보통", exchange="STK", is_active=False
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    try:
+        resolved = await job.resolve_active_universe("kr")
+        assert "999990" in resolved
+        assert "999995" not in resolved
+        assert "99A990" not in resolved
+        assert "999970" not in resolved
+        assert "999980" not in resolved
+        assert "999960" not in resolved
+        assert "999950" not in resolved
+    finally:
+        await db_session.execute(
+            sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_(symbols))
+        )
+        await db_session.commit()


### PR DESCRIPTION
## Summary
- Filters the default KR financial fundamentals DART backfill universe to DART-eligible common stocks before the fetch loop.
- Excludes non-6-digit synthetic/exchange codes and non-common KR instruments classified as preferred/ETF/REIT/SPAC.
- Updates operator CLI help text for `--limit`, `--all`, and `--skip-existing` to describe the common-stock universe.
- Keeps explicit `--symbol` overrides operator-controlled.

## Verification
- `uv run --group dev ruff check app/jobs/financial_fundamentals_snapshots.py scripts/build_financial_fundamentals_snapshots.py tests/test_financial_fundamentals_job.py tests/test_build_financial_fundamentals_cli.py`
- `uv run --group dev ruff format --check app/jobs/financial_fundamentals_snapshots.py scripts/build_financial_fundamentals_snapshots.py tests/test_financial_fundamentals_job.py tests/test_build_financial_fundamentals_cli.py`
- `uv run --group dev ty check app/jobs/financial_fundamentals_snapshots.py scripts/build_financial_fundamentals_snapshots.py tests/test_financial_fundamentals_job.py tests/test_build_financial_fundamentals_cli.py`
- `uv run --group test --group dev pytest tests/test_screening_instrument_type.py tests/test_financial_fundamentals_job.py tests/test_build_financial_fundamentals_cli.py -q` → 61 passed, 2 existing Pydantic deprecation warnings.

## Safety / Non-actions
- No migration.
- No scheduler/flag activation.
- No production backfill or DB writes performed.
- No broker/order/watch/order-intent/trade mutation.

Refs ROB-433.
