### PR TITLE
[ROB-501] Repair investment report test schema setup

### DIFF
--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -70,6 +70,7 @@ async def session() -> AsyncSession:
             )
             try:
                 async with engine.begin() as conn:
+                    await conn.execute(sa.text("CREATE SCHEMA IF NOT EXISTS review"))
                     await conn.run_sync(
                         Base.metadata.create_all,
                         tables=INVESTMENT_REPORTS_TABLES,


### PR DESCRIPTION
## Summary
- Fixes the post-merge main CI failure exposed after #1248 landed.
- Ensures the investment report MCP test helper creates the `review` schema before creating review-scoped tables.
- Keeps the change limited to test fixture setup; production runtime code is unchanged.

## Root cause
The failing CI shard ran `tests/test_investment_reports_mcp.py::test_create_returns_idempotent_false_on_first_call` before any shared fixture had created the `review` schema in that worker database. `tests/_investment_reports_helpers.py` created `review.investment_reports` directly, so asyncpg raised `InvalidSchemaNameError: schema "review" does not exist`.

## Verification
- `uv run pytest tests/test_investment_reports_mcp.py -q` -> 34 passed, 2 existing Pydantic deprecation warnings
- `uv run ruff check tests/_investment_reports_helpers.py tests/test_investment_reports_mcp.py` -> pass
- `uv run ruff format --check tests/_investment_reports_helpers.py tests/test_investment_reports_mcp.py` -> pass