### PR TITLE
feat(ROB-502): 품질 게이트 기반 market news MCP 노출 — noise gate, issue 임계, 명시적 degraded 상태

### DIFF
--- a/app/mcp_server/tooling/news_handlers.py
+++ b/app/mcp_server/tooling/news_handlers.py
@@ -12,6 +12,7 @@ from app.services.market_news_briefing_formatter import (
     BriefingSection,
     format_market_news_briefing,
 )
+from app.services.market_news_noise import classify_title_noise, noise_reason
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -97,6 +98,20 @@ async def _get_market_news_impl(
         limit=query_limit,
     )
 
+    # ROB-502 quality gate (always on): noise-classified titles never reach
+    # the default list — they move to excluded_news with an explicit reason.
+    gated_articles = []
+    noise_excluded: list[dict[str, Any]] = []
+    for article in articles:
+        noise = classify_title_noise(article.title or "")
+        if noise:
+            item = _article_to_dict(article)
+            item["excluded_reason"] = noise_reason(noise)
+            noise_excluded.append(item)
+        else:
+            gated_articles.append(article)
+    articles = gated_articles
+
     excluded_news: list[dict[str, Any]] = []
     briefing_summary = None
     briefing_sections: list[dict[str, Any]] = []
@@ -145,18 +160,40 @@ async def _get_market_news_impl(
         briefing_sections = _briefing_sections_to_dict(briefing.sections)
     else:
         news_list = [_article_to_dict(a) for a in articles]
+    excluded_news = noise_excluded + excluded_news
     source_names = list({a.get("source") for a in news_list if a.get("source")})
     feed_source_names = list(
         {a.get("feed_source") for a in news_list if a.get("feed_source")}
     )
 
+    # ROB-502: degraded states are explicit — no filler when nothing passes.
+    status = "ok"
+    degraded_reason = None
+    if total == 0:
+        status = "no_recent_articles"
+        degraded_reason = (
+            f"no articles in the last {hours}h window — "
+            "ingestion may be stale or paused"
+        )
+    elif not news_list:
+        status = "no_meaningful_items"
+        degraded_reason = (
+            f"{total} article(s) in window, but none passed the quality gate "
+            f"({len(excluded_news)} excluded — see excluded_news reasons); "
+            "no filler is generated"
+        )
+
     return {
-        "surface": "legacy_market_briefing",
+        "surface": "quality_gated_market_briefing",
         "advisory": (
-            "Legacy broad-market DB-backed surface for briefing only; "
-            "NOT investment-decision evidence. Use get_news for symbol-level decisions."
+            "Quality-gated broad-market DB-backed surface for briefing only; "
+            "NOT investment-decision evidence. Use get_news for symbol-level "
+            "decisions. Noise-classified items appear in excluded_news with "
+            "reasons instead of the main list."
         ),
         "market": market,
+        "status": status,
+        "degraded_reason": degraded_reason,
         "count": len(news_list),
         "total": total,
         "news": news_list,
@@ -173,13 +210,16 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
     @mcp.tool(
         name="get_market_news",
         description=(
-            "[LEGACY: broad market DB-backed briefing surface; NOT investment-decision "
+            "[Quality-gated broad market briefing surface; NOT investment-decision "
             "evidence — use get_news for symbol-level decisions] "
-            "Get recent market news. Supports filtering by market, publisher (source), "
-            "collection path (feed_source), and keyword. Returns both publisher names "
-            "and collection paths for briefing segmentation. briefing_filter=True "
-            "formats market-specific sections for kr/us and ranks crypto-relevant "
-            "items while separating broad-tech noise."
+            "Get recent market news with a noise gate always on (ROB-502): "
+            "personal-finance/lifestyle/sponsored/price-prediction/broad-tech items "
+            "move to excluded_news with an excluded_reason instead of the main list. "
+            "status is 'ok' | 'no_meaningful_items' | 'no_recent_articles' with "
+            "degraded_reason — no filler is generated. Supports filtering by market, "
+            "publisher (source), collection path (feed_source), and keyword. "
+            "briefing_filter=True additionally formats market-specific sections for "
+            "kr/us and ranks crypto-relevant items."
         ),
     )
     async def get_market_news(
@@ -205,8 +245,13 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
         name="get_market_issues",
         description=(
             "Read-only deterministic market issue clusters from collected news "
-            "(ROB-130). Groups recent articles by entity/topic and ranks by "
-            "recency + source diversity + mention count."
+            "(ROB-130, quality-gated per ROB-502). Groups recent articles by "
+            "entity/topic, merges near-duplicate syndicated stories, and ranks by "
+            "recency + source diversity + mention count. Noise-classified articles "
+            "never enter clustering, and thin clusters (single article AND single "
+            "source, non-official feed) are withheld. status/degraded_reason/"
+            "quality_gate report what the gate did; empty results are explicit "
+            "(no_meaningful_items), never filler."
         ),
     )
     async def get_market_issues(

--- a/app/schemas/news_issues.py
+++ b/app/schemas/news_issues.py
@@ -60,6 +60,21 @@ class MarketIssue(BaseModel):
     signals: IssueSignals
 
 
+class IssueQualityGate(BaseModel):
+    """ROB-502: what the meaningfulness gate did to this response."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    articles_total: int = 0
+    noise_articles_excluded: int = 0
+    clusters_total: int = 0
+    clusters_merged: int = 0
+    clusters_excluded_thin: int = 0
+
+
+IssuesStatus = Literal["ok", "no_meaningful_items", "no_recent_articles"]
+
+
 class MarketIssuesResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -67,3 +82,6 @@ class MarketIssuesResponse(BaseModel):
     as_of: datetime
     window_hours: int
     items: list[MarketIssue] = Field(default_factory=list)
+    status: IssuesStatus = "ok"
+    degraded_reason: str | None = None
+    quality_gate: IssueQualityGate | None = None

--- a/app/services/market_news_briefing_formatter.py
+++ b/app/services/market_news_briefing_formatter.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 from app.services.crypto_news_relevance_service import score_crypto_news_article
+from app.services.market_news_noise import classify_title_noise, noise_reason
 
 
 @dataclass(frozen=True)
@@ -79,6 +82,7 @@ _US_RULES: tuple[_SectionRule, ...] = (
         "Macro/Fed",
         (
             "fed",
+            "federal reserve",
             "fomc",
             "rate",
             "rates",
@@ -294,6 +298,27 @@ def _field(article: Any, name: str) -> Any:
     return getattr(article, name, None)
 
 
+@lru_cache(maxsize=2048)
+def _term_pattern(term: str) -> re.Pattern[str] | None:
+    """Word-boundary pattern for ASCII terms; None means plain substring.
+
+    ROB-502: bare substring matching put a Moneyist plumber story in Big Tech
+    because "ai" matched "again". ASCII terms get \\b boundaries; CJK terms
+    keep substring semantics (\\b is unreliable across Hangul runs and Korean
+    compounds legitimately embed terms, e.g. "반도체주").
+    """
+    if not term.isascii():
+        return None
+    return re.compile(r"\b" + re.escape(term) + r"\b", re.IGNORECASE)
+
+
+def _term_in(term: str, text: str) -> bool:
+    pattern = _term_pattern(term)
+    if pattern is None:
+        return term in text
+    return bool(pattern.search(text))
+
+
 def _article_text(article: Any) -> tuple[str, str]:
     title = str(_field(article, "title") or "")
     summary = str(_field(article, "summary") or "")
@@ -306,9 +331,9 @@ def _low_signal_us_noise_hit(article: Any) -> bool:
     if _field(article, "stock_symbol"):
         return False
     title, full_text = _article_text(article)
-    if not any(term in full_text for term in _US_LOW_SIGNAL_TERMS):
+    if not any(_term_in(term, full_text) for term in _US_LOW_SIGNAL_TERMS):
         return False
-    return not any(term in title for term in _US_HIGH_SIGNAL_TERMS)
+    return not any(_term_in(term, title) for term in _US_HIGH_SIGNAL_TERMS)
 
 
 def _low_market_relevance() -> BriefingRelevance:
@@ -327,17 +352,17 @@ def _score_rule(article: Any, rules: tuple[_SectionRule, ...]) -> BriefingReleva
     scored: list[tuple[int, _SectionRule, list[str]]] = []
 
     for rule in rules:
-        matched = [term for term in rule.terms if term in full_text]
+        matched = [term for term in rule.terms if _term_in(term, full_text)]
         if not matched:
             continue
         score = min(90, 20 + len(matched) * 12)
-        score += min(25, sum(10 for term in matched if term in title))
+        score += min(25, sum(10 for term in matched if _term_in(term, title)))
         if _field(article, "stock_symbol"):
             score += 8
         scored.append((min(100, score), rule, matched))
 
     if not scored:
-        noise_hit = any(term in full_text for term in _NOISE_TERMS)
+        noise_hit = any(_term_in(term, full_text) for term in _NOISE_TERMS)
         reason = "low_market_relevance" if noise_hit else "uncategorized_market_news"
         return BriefingRelevance(
             score=0,
@@ -429,6 +454,19 @@ def _section_order_for_market(market: str) -> list[str]:
 
 
 def _score_article(article: Any, market: str) -> BriefingRelevance:
+    # ROB-502 quality gate: noise-classified titles never reach section
+    # scoring, regardless of market. The reason carries the categories so
+    # callers see *why* an item was excluded instead of a silent drop.
+    noise = classify_title_noise(str(_field(article, "title") or ""))
+    if noise:
+        return BriefingRelevance(
+            score=0,
+            section_id=None,
+            section_title=None,
+            include_in_briefing=False,
+            matched_terms=[],
+            reason=noise_reason(noise),
+        )
     if market == "crypto":
         return _score_crypto(article)
     if market == "us" and _low_signal_us_noise_hit(article):

--- a/app/services/market_news_noise.py
+++ b/app/services/market_news_noise.py
@@ -1,0 +1,98 @@
+"""Title-level noise classification for market news surfaces (ROB-502).
+
+Read-time port of news-ingestor's ``news_ingestor/noise.py`` (the ingestor
+tags new rows as ``raw.noise_categories`` at collection time, but that raw
+payload is not persisted to ``news_articles``, and historical rows predate
+tagging — so the MCP exposure gate classifies titles again at read time).
+
+Keep the category names in sync with the ingestor module; the categories
+follow the ROB-502 issue: personal finance Q&A, lifestyle/celebrity,
+sponsored/ads, pure price-prediction spam, and broad Web3/AI/general-tech
+coverage. One deliberate divergence: ``broad_tech`` here is narrower than the
+ingestor's (no bare AI model names) because the ingestor only *tags* matches
+while this gate *excludes* them — a BTC market story that name-drops an AI
+model must not vanish from the briefing.
+"""
+
+from __future__ import annotations
+
+import re
+
+NOISE_PATTERNS: dict[str, list[re.Pattern[str]]] = {
+    "personal_finance": [
+        re.compile(p, re.IGNORECASE)
+        for p in (
+            r"\bmy (plumber|husband|wife|mother|father|landlord|boss|in-laws?)\b",
+            r"\bdo i (pay|owe|have to)\b",
+            r"\bshould i (buy|sell|pay|retire|invest)\b",
+            r"\b(credit card|mortgage|savings account) (debt|rates?)\b",
+            r"\bsocial security\b",
+            r"\binheritance\b",
+            # NB: bare "청약" would also hit IPO subscriptions (공모주 청약),
+            # which are market-relevant — keep this to housing subscriptions.
+            r"주택청약|청약통장|연금 수령|절세 팁|재테크 꿀팁",
+        )
+    ],
+    "lifestyle": [
+        re.compile(p, re.IGNORECASE)
+        for p in (
+            r"\b(actress|actor|celebrity|singer)\b",
+            r"\b(his|her|their) \$?[\d.]+ ?(million|billion)? ?(home|mansion|penthouse)\b",
+            r"\bmidcentury\b",
+            r"\brecipe\b",
+            r"\bworld cup\b",
+            r"맛집|여행기|연예인",
+        )
+    ],
+    "sponsored": [
+        re.compile(p, re.IGNORECASE)
+        for p in (
+            r"\bsponsored\b",
+            r"\bpartner content\b",
+            r"\bpress release\b",
+            r"\b(top|best) \d+ (coins?|stocks?|cryptos?) to buy\b",
+            r"\[광고\]|협찬",
+        )
+    ],
+    "price_prediction": [
+        re.compile(p, re.IGNORECASE)
+        for p in (
+            r"\bprice prediction\b",
+            r"\bcould (reach|hit|soar to) \$\d",
+            r"\bnext (100|1000)x\b",
+            r"\bto the moon\b",
+        )
+    ],
+    # Broad Web3/AI/general-tech coverage that is not market news. Conservative
+    # on purpose; a market story that merely name-drops an AI vendor may still
+    # be tagged — the gate reports the reason, callers can inspect excluded
+    # items rather than losing them silently.
+    "broad_tech": [
+        re.compile(p, re.IGNORECASE)
+        for p in (
+            r"\b(openai|chatgpt|anthropic)\b",
+            r"\bai (model|chatbot|assistant|startup|agent)s?\b",
+            r"\b(video ?gam(e|es|ing)|gaming|esports)\b",
+            r"\bmetaverse\b",
+            r"\b(whatsapp|instagram|tiktok)\b",
+            r"\bnft (art|collectibles?)\b",
+        )
+    ],
+}
+
+
+def classify_title_noise(title: str) -> list[str]:
+    """Return the (possibly empty) list of noise categories a title matches."""
+    text = (title or "").strip()
+    if not text:
+        return []
+    return [
+        category
+        for category, patterns in NOISE_PATTERNS.items()
+        if any(p.search(text) for p in patterns)
+    ]
+
+
+def noise_reason(categories: list[str]) -> str:
+    """Stable excluded-reason string, e.g. ``noise:personal_finance``."""
+    return "noise:" + ",".join(categories)

--- a/app/services/news_issue_clustering_service.py
+++ b/app/services/news_issue_clustering_service.py
@@ -25,16 +25,26 @@ from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst_naive
 from app.models.news import NewsArticle
 from app.schemas.news_issues import (
+    IssueQualityGate,
     IssueSignals,
     MarketIssue,
     MarketIssueArticle,
     MarketIssueRelatedSymbol,
     MarketIssuesResponse,
 )
+from app.services.market_news_noise import classify_title_noise
 from app.services.news_entity_matcher import (
     SymbolMatch,
     match_symbols_for_article,
 )
+
+# ROB-502 meaningfulness gate: official/primary feeds whose items are market
+# signals even as single-article clusters.
+_IMPORTANT_FEED_SOURCES = {"rss_fed_press"}
+
+# Token-set Jaccard threshold for merging near-duplicate shingle clusters
+# (same story syndicated under slightly different titles).
+_NEAR_DUP_TOKEN_JACCARD = 0.5
 
 _DIR_POS_RE = re.compile(
     r"(?<![A-Za-z0-9])(?:rise|raise|beat|surge|rally|up)(?![A-Za-z0-9])",
@@ -351,6 +361,65 @@ def _score(issue: MarketIssue) -> float:
     )
 
 
+def _merge_near_duplicate_shingle_clusters(
+    clusters: list[_Cluster], articles: list[NewsArticle]
+) -> tuple[list[_Cluster], int]:
+    """Merge shingle clusters whose title token sets overlap heavily.
+
+    The 3-gram shingle pass misses syndicated copies of the same story with
+    reworded titles (Jaccard on 3-grams collapses fast under word swaps); a
+    token-set pass catches them. Entity-keyed clusters are never merged —
+    distinct symbols are distinct issues by definition.
+    """
+    shingle = [c for c in clusters if not c.cluster_key.startswith("sym:")]
+    others = [c for c in clusters if c.cluster_key.startswith("sym:")]
+    token_sets = [
+        set(
+            _normalize_words(
+                " ".join(articles[i].title or "" for i in c.article_indexes)
+            )
+        )
+        for c in shingle
+    ]
+    merged_count = 0
+    used = [False] * len(shingle)
+    result: list[_Cluster] = []
+    for i, cluster in enumerate(shingle):
+        if used[i]:
+            continue
+        used[i] = True
+        base = cluster
+        for j in range(i + 1, len(shingle)):
+            if used[j] or not token_sets[i] or not token_sets[j]:
+                continue
+            inter = len(token_sets[i] & token_sets[j])
+            union = len(token_sets[i] | token_sets[j])
+            if union and inter / union >= _NEAR_DUP_TOKEN_JACCARD:
+                used[j] = True
+                merged_count += 1
+                other = shingle[j]
+                base = _Cluster(
+                    article_ids=base.article_ids + other.article_ids,
+                    article_indexes=base.article_indexes + other.article_indexes,
+                    matches=base.matches
+                    + [m for m in other.matches if m not in base.matches],
+                    cluster_key=base.cluster_key,
+                )
+        result.append(base)
+    return others + result, merged_count
+
+
+def _is_meaningful(issue: MarketIssue) -> bool:
+    """ROB-502 gate: multi-article OR multi-source OR official-feed item.
+
+    Single-article, single-source clusters are exactly the noise the
+    2026-06-10 live audit surfaced in the US top-5 (one-off MarketWatch
+    lifestyle pieces ranked as market issues purely on recency)."""
+    if issue.article_count >= 2 or issue.source_count >= 2:
+        return True
+    return any((a.feed_source or "") in _IMPORTANT_FEED_SOURCES for a in issue.articles)
+
+
 async def build_market_issues(
     *,
     market: str = "all",
@@ -358,19 +427,36 @@ async def build_market_issues(
     limit: int = 20,
     max_rows: int = 500,
 ) -> MarketIssuesResponse:
-    """Build a ranked list of `MarketIssue` for a given market window."""
-    articles = await _load_recent_articles(
+    """Build a ranked list of `MarketIssue` for a given market window.
+
+    ROB-502: the output is meaningfulness-gated — noise-classified articles
+    never enter clustering, near-duplicate syndicated stories merge, and thin
+    (single-article, single-source, non-official) clusters are withheld.
+    Degraded states are explicit instead of silently empty.
+    """
+    response_market = market if market in ("kr", "us", "crypto", "all") else "all"
+    loaded = await _load_recent_articles(
         market=market, window_hours=window_hours, max_rows=max_rows
     )
-    if not articles:
+    if not loaded:
         return MarketIssuesResponse(
-            market=market if market in ("kr", "us", "crypto", "all") else "all",  # type: ignore[arg-type]
+            market=response_market,  # type: ignore[arg-type]
             as_of=now_kst_naive(),
             window_hours=window_hours,
             items=[],
+            status="no_recent_articles",
+            degraded_reason=(
+                f"no articles in the last {window_hours}h window — "
+                "ingestion may be stale or paused"
+            ),
+            quality_gate=IssueQualityGate(),
         )
 
+    articles = [a for a in loaded if not classify_title_noise(a.title or "")]
+    noise_excluded = len(loaded) - len(articles)
+
     clusters = _cluster_articles(articles, market=market)
+    clusters, merged_count = _merge_near_duplicate_shingle_clusters(clusters, articles)
     issues = [
         _to_market_issue(
             cluster=c,
@@ -382,14 +468,37 @@ async def build_market_issues(
         for c in clusters
         if c.article_indexes
     ]
-    issues.sort(key=_score, reverse=True)
-    issues = issues[:limit]
-    for i, issue in enumerate(issues, start=1):
-        issues[i - 1] = issue.model_copy(update={"rank": i})
+    meaningful = [issue for issue in issues if _is_meaningful(issue)]
+    excluded_thin = len(issues) - len(meaningful)
+
+    meaningful.sort(key=_score, reverse=True)
+    meaningful = meaningful[:limit]
+    for i, issue in enumerate(meaningful, start=1):
+        meaningful[i - 1] = issue.model_copy(update={"rank": i})
+
+    gate = IssueQualityGate(
+        articles_total=len(loaded),
+        noise_articles_excluded=noise_excluded,
+        clusters_total=len(issues),
+        clusters_merged=merged_count,
+        clusters_excluded_thin=excluded_thin,
+    )
+    status = "ok"
+    degraded_reason = None
+    if not meaningful:
+        status = "no_meaningful_items"
+        degraded_reason = (
+            f"{len(loaded)} article(s) in window, but none formed a meaningful "
+            f"cluster (noise_excluded={noise_excluded}, "
+            f"thin_clusters={excluded_thin}) — no filler is generated"
+        )
 
     return MarketIssuesResponse(
-        market=market if market in ("kr", "us", "crypto", "all") else "all",  # type: ignore[arg-type]
+        market=response_market,  # type: ignore[arg-type]
         as_of=now_kst_naive(),
         window_hours=window_hours,
-        items=issues,
+        items=meaningful,
+        status=status,  # type: ignore[arg-type]
+        degraded_reason=degraded_reason,
+        quality_gate=gate,
     )

--- a/docs/reviews/ROB-502-market-news-quality-review-2026-06-10.md
+++ b/docs/reviews/ROB-502-market-news-quality-review-2026-06-10.md
@@ -1,0 +1,213 @@
+# ROB-502 사전 조사: get_market_news / get_market_issues 실측 품질 리뷰
+
+- **작성일**: 2026-06-10 (KST 저녁, 데이터는 당일 24h 윈도우)
+- **목적**: "지금 유의미한 뉴스가 나오는가?" 실측 → 도구 폐기 여부 결정 재료
+- **방법**: 로컬 prod DB(`localhost:5432/auto_trader`)에 대해 두 MCP 도구의 실제 구현(`_get_market_news_impl`, `build_market_issues`)을 read-only로 직접 실행
+
+---
+
+## TL;DR
+
+1. **이슈 전제와 달리 news-ingestor는 지금도 시간당 활발히 적재 중** (당일 18:52까지 kr/us/crypto-core 모두 success). 런북의 "paused" 표기와 실제 운영 상태가 불일치.
+2. **데이터 신선도는 문제 없음.** KR 961건/7d, US ~3,500건/7d, crypto ~380건/7d.
+3. **헤드라인 풀 품질은 유의미함** — KR 코스피 변동성/수급, US 매크로(CPI·ECB·Fed), crypto BTC/ETH 시장 뉴스.
+4. **진짜 문제는 공급이 아니라 선별 품질**: US 라이프스타일 기사 혼입(plumber 기사가 Big Tech 섹션), 포함/제외 판정 어긋남(유의미 기사가 excluded), issues 하위 랭크의 단일기사 노이즈 클러스터.
+5. 폐기하면 KR 시장 브리핑(현재 가장 품질 좋은 부분)과 **스냅샷 리포트 파이프라인의 news surface**(primary 소스 계약이 `news_ingestor`)도 공급이 끊김.
+
+---
+
+## 1. 공급 현황 (news_ingestion_runs / news_articles)
+
+### 최근 ingestion runs (전부 success, 시간당)
+
+| market | feed_set | status | started_at | inserted |
+|---|---|---|---|---|
+| us | us-core | success | 2026-06-10 18:52 | 27 |
+| crypto | crypto-core | success | 2026-06-10 18:37 | 2 |
+| kr | kr-core | success | 2026-06-10 18:07 | 17 |
+| us | us-core | success | 2026-06-10 17:52 | 16 |
+| crypto | crypto-core | success | 2026-06-10 17:37 | 2 |
+| kr | kr-core | success | 2026-06-10 17:07 | 20 |
+
+### feed_source별 적재량 (최근 7일 활성 소스)
+
+| market | feed_source | 총 건수 | 최근 7일 | 최신 적재 |
+|---|---|---|---|---|
+| us | rss_yahoo_finance_topstories | 18,178 | 3,131 | 06-10 18:52 |
+| us | rss_cnbc_us_markets | 1,454 | 247 | 06-10 18:52 |
+| us | rss_marketwatch_topstories | 944 | 169 | 06-10 18:52 |
+| kr | browser_naver_mainnews | 5,573 | 961 | 06-10 18:07 |
+| kr | browser_naver_research_* (5종) | ~3,150 | ~380 | 06-10 15:07 |
+| crypto | rss_coindesk | 886 | 142 | 06-10 18:37 |
+| crypto | rss_cointelegraph | 921 | 115 | 06-10 17:37 |
+| crypto | rss_decrypt | 575 | 87 | 06-10 18:37 |
+| crypto | rss_bitcoin_magazine | 177 | 34 | 06-10 03:37 |
+| us | rss_fed_press | 38 | 1 | 06-10 05:52 |
+
+비활성(중단된) 소스: `research_on_demand_finnhub`/`research_on_demand_naver`(06-01 이후 0건 — ROB-491 전환분), `http_tvscreener_news_kr`, `browser_cnbc_news`, `browser_investing_news`(4월 이후 중단).
+
+---
+
+## 2. get_market_news 실출력 (hours=24, limit=10, briefing_filter=True)
+
+### KR — 24h 전체 237건 → 포함 10 / 제외 17
+
+**[장전 주요 뉴스] 8건**
+
+| 시각 | 제목 |
+|---|---|
+| 18:40 | "수익률 대박나도 무섭다?" 이상한 사상 최고치…미국, 일본과 다른 한국 '공포지수' [투자360] |
+| 18:24 | 하락 방어 움직임 커졌다…"코스피 추가 하락 경고등" |
+| 18:19 | 코로나19·美 상호관세 쇼크…고비 때 요동친 코스피, 한달 뒤 '반등' |
+| 17:53 | "내 주식 강제로 팔렸어요"… 개미, 롤러코스피 속 '반대매매' 공포 |
+| 17:53 | 코스피 확 뛰어든 큰손들 … 집까지 팔아 삼전닉스 베팅 |
+| 17:25 | 금융위기보다 잦은 사이드카…코스피, 레버리지 ETF가 부른 역대급 변동성 |
+| 17:10 | 8% 급등→4.5% 급락에 시장 패닉…"변수 수두룩" 롤러코스피 언제까지 |
+| 16:58 | "언제 볕들려나"...코스피 80% 오를 동안 엔터주는 '털썩' |
+
+**[업종/테마] 2건**
+
+| 시각 | 제목 |
+|---|---|
+| 18:36 | 美 주식 덜어내는 서학개미…반도체만 공격 베팅 |
+| 18:21 | 美반도체 ETF 하락 베팅 급증…삼전·SK하닉에 불똥 튀나 |
+
+**제외(노이즈 판정) 17건** — ⚠️ 유의미한데 빠진 것 다수:
+
+- "스페이스X 담아라"… 국내 운용사 美우주항공ETF 눈치게임
+- 급락·급등 반복에 커진 공포…VKOSPI 역대 최고 수준 ⚠️
+- 고유가 덕에…'목재펠릿 공장' 펀드 EOD 문턱서 기사회생
+- 개장 후 '시장가 매수'는 위험…무늬만 우주 ETF도 주의
+- [단독] 집팔아 '삼전닉스' 들어간 야수들…생각보다 훨씬 더 많았다
+- 암치료제 개발 뉴베일런트, GSK 품으로
+- "中메모리 CXMT 상장땐 오히려 삼전 돋보일것" ⚠️
+- AI인프라·전력·뷰티 차익실현…국민연금, 주도주 비중 줄였다 ⚠️
+- 최고가 행진 꺾이자…금·은 ETF서 발뺀다
+- 8% 급락 후 '빚투' 1700억 강제청산…'반대매매' 올들어 최고치 ⚠️
+- '루나 악몽' 재현되나 … 스트레티지 주의보
+- 내일은 '네 마녀의 날'…삼전·SK하닉 단일종목 레버리지, 변동성 커질까 ⚠️
+- 한투PE, SKC 투자 1년만에 1200억 잭팟
+- 젠슨 황의 선물…포털주 정체론 털어낸 네이버
+- 급락·급등, 오늘은 급락…"추세추종 매매 열기 식고 있다"
+- "상장 효과 없다" 스팩합병주 13곳 일제히 하락…절반 이상 '반토막'
+- 메타버스 ETF 부활…기판주 올라타고 수익률 30%대 껑충
+
+### US — 24h 전체 254건 → 포함 10 / 제외 11
+
+**[Macro/Fed] 5건**
+
+- Energy prices take center stage as the ECB prepares to decide on rates (17:25)
+- China May wholesale inflation hits near 4-year high on Iran war, AI costs; CPI misses (10:57)
+- The May inflation numbers are due out Wednesday morning. Here's what to expect (03:54)
+- Sales of million-dollar homes suggest inflation is spurring the wealthy to buy now (05:00)
+- Federal Reserve: annual bank stress test results June 24 (05:00, rss_fed_press)
+
+**[Finance / Credit / Rates] 3건**
+
+- Here's why shares in SoftBank, no longer Japan's most valuable, have fallen by a fifth in the last week (18:39)
+- The SpaceX IPO could lead to 8% of America's current-account deficit being refinanced in a single day (17:07)
+- The true national debt just hit $1 million per U.S. household (04:11)
+
+**[Big Tech / AI / Semis] 2건**
+
+- SoftBank sinks 10% as Asia tech stocks tumble, tracking Wall Street losses (15:18)
+- ⚠️ **"My plumber charged $160 to fix a problem in my bathroom — but appears to have created another one. Do I pay again?"** (18:15) ← MarketWatch 라이프스타일 기사가 Big Tech 섹션에 포함됨 (대표적 필터 누수)
+
+**제외 11건** — ⚠️ 오히려 유의미한 기사가 빠짐:
+
+- Oil choppy after U.S. completes Iran strikes following Apache helicopter attack ⚠️
+- Tech stocks dive as Friday's incoming SpaceX IPO creates 'bad psychology' ⚠️
+- As SpaceX IPO anticipation heats up, what 2026's biggest IPOs say about investor demand
+- Another jump in Boeing deliveries shows why we got into the stock
+- 102-year-old fashion giant faces 400 store closures
+- Buyer swoops in for actress Dakota Johnson's $6 million midcentury modern gem in L.A. (제외 타당)
+- What next for BP? Leadership exits test investor confidence ⚠️
+- Kalshi rolls out whistleblower services to curb insider trading
+- GM follows Ford by making a big energy bet
+- AST SpaceMobile's stock experiences rocky trading
+- The weird reason why a team's World Cup loss can trigger a sharp drop in stock prices
+
+### crypto — 24h 전체 60건 → 포함 10 / 제외 3
+
+**[BTC/ETH Market] 10건**
+
+- ETH crash to $1K looms if key support breaks: Will futures traders step in?
+- 'Maximal' ban on insider trading would hurt prediction markets, says researcher
+- Bitcoin ETFs are no bigger today than when Trump won the election
+- Bitcoin and gold fall together as a rate-hike bet hits every hedge
+- Seattle-Area Man Gets Prison for Laundering Foreign Fraud Funds With Bitcoin, Ethereum (저가치)
+- Traditional Finance is Rushing Into Crypto as Institutions Buy Bitcoin's Dip
+- SpaceX's pre-IPO market on Hyperliquid has fallen 27% in three weeks
+- Live updates: What next for bitcoin as it faces headwinds from Fed rates
+- XRP drops 4.5% as heavy selling breaks another support level
+- A Quantum Clock Is Ticking for Bitcoin and Crypto—Here's How Stellar Is Preparing
+
+**제외 3건**: EU Orders Meta to Open WhatsApp / Polymarket insider trading 재판 / Anthropic 모델 출시 — 제외 타당.
+
+---
+
+## 3. get_market_issues 실출력 (24h, limit=5)
+
+### KR — 상위 클러스터 품질 좋음
+
+| rank | 이슈 | 방향 | 기사/소스 | 대표 기사 |
+|---|---|---|---|---|
+| 1 | 삼성전자 | down | 11건/7곳 | 美반도체 ETF 하락 베팅 급증 / 中메모리 CXMT 상장땐 오히려 삼전 돋보일것 / 네 마녀의 날 변동성 |
+| 2 | SK하이닉스 | down | 13건/9곳 | 집팔아 '삼전닉스' / 외인 삼전닉스 1.8조 순매도 / 레버리지 ETF 손익 비대칭 |
+| 3 | LG전자 | neutral | 2건/2곳 | 40만원 넘보던 LG전자 5거래일간 43%↓ / 목표주가 40만원 |
+| 4 | (단일기사: 공포지수 기사) | up | 1건/1곳 | ⚠️ 단일기사가 클러스터로 등재 |
+| 5 | (단일기사: 우주항공ETF) | neutral | 1건/1곳 | ⚠️ 〃 |
+
+### US — 상위 2개만 유의미, 3~5는 노이즈
+
+| rank | 이슈 | 방향 | 기사/소스 | 비고 |
+|---|---|---|---|---|
+| 1 | Broadcom | up | 4건/3곳 | CEO pivot / Anthropic $35B capacity / 등급 상향 — 좋음 |
+| 2 | Apple | neutral | 6건/5곳 | WWDC 이후 pullback — 좋음 |
+| 3 | (단일기사: SoftBank) | neutral | 1건/1곳 | ⚠️ |
+| 4 | (단일기사: plumber 기사) | neutral | 1건/1곳 | ⚠️⚠️ 라이프스타일 노이즈가 시장 이슈로 등재 |
+| 5 | (단일기사: Dakota Johnson 부동산) | neutral | 1건/1곳 | ⚠️⚠️ 〃 |
+
+### crypto — 상위 2개 좋음, 중복 클러스터 존재
+
+| rank | 이슈 | 방향 | 기사/소스 | 비고 |
+|---|---|---|---|---|
+| 1 | Bitcoin | mixed | 20건/13곳 | rate-hike 영향, ETF 정체 — 좋음 |
+| 2 | Ripple | neutral | 2건/2곳 | XRP 지지선 붕괴 — 좋음 |
+| 3 | (단일: EU 러시아 제재 크립토 플랫폼) | neutral | 1건/1곳 | |
+| 4 | (단일: 일본 3대은행 스테이블코인) | neutral | 1건/1곳 | ⚠️ 5번과 같은 뉴스 |
+| 5 | (단일: 일본 3대은행 스테이블코인) | neutral | 1건/1곳 | ⚠️ 중복 클러스터 미병합 |
+
+---
+
+## 4. 평가 요약
+
+| 항목 | 평가 |
+|---|---|
+| 데이터 신선도 | ✅ 문제 없음 — 시간당 적재 중 |
+| KR 품질 | ✅ 유의미 (브리핑·이슈 클러스터 모두) |
+| crypto 품질 | ✅ 유의미 |
+| US 품질 | ⚠️ 절반 — 매크로 섹션 좋음, 라이프스타일 노이즈 혼입 + 유의미 기사 오제외 |
+| 선별 로직 | ⚠️ 포함/제외 판정 어긋남(양방향), 단일기사 클러스터 노이즈, 중복 클러스터 미병합 |
+
+**결론**: "유의미한 뉴스가 안 나온다" → 실측상 부정확. "유의미한 것과 노이즈가 섞여 나오는데 선별이 불완전하다"가 정확함.
+
+---
+
+## 5. 폐기 시 영향 범위 (코드 grounding)
+
+- `get_market_news` + `get_market_issues` (`app/mcp_server/tooling/news_handlers.py`, `NEWS_TOOL_NAMES` 묶음) 제거
+- ingest 엔드포인트: `POST /api/v1/news/ingest/bulk` (`app/routers/news_analysis.py:84`, 토큰 인증 `app/middleware/auth.py:54`), `/news/bulk`, `/news/analyze`
+- `news_ingestion_runs` 모델/테이블 (`app/models/news.py:177`)
+- **스냅샷 리포트 파이프라인 의존**: `invest_data_source_contract.py:173` — news surface의 **primary** 소스가 `news_ingestor`로 계약됨 (naver_finance는 supplementary). `investment_snapshots` 모델 CHECK 제약(`'news_ingestor'` 포함) + `source_kind_mapping.py:46`도 연동 → 폐기 시 계약 재지정 필요
+- 외부: `robin-prefect-automations`의 `news_ingestor_kr_core` 등 flow 중지 필요 (현재 실제로 가동 중)
+- ROB-491 `get_news`(종목 단위)는 독립 경로(`symbol_news_service`/`symbol_news_store`)라 무영향
+
+## 6. 결정 옵션
+
+| 옵션 | 내용 | 비용/리스크 |
+|---|---|---|
+| A. 유지 + 선별 품질 개선 | US 라이프스타일 피드 제외, 단일기사 클러스터 억제, 포함/제외 판정 보정 | 외부 ingestor 서비스 운영 부담 지속 |
+| B. 폐기 | 도구 2종 + ingest 엔드포인트 + 부속 제거, 스냅샷 news 계약 재지정, 외부 flow 중지 | KR 브리핑(최고 품질 부분) 상실, 리포트 news surface 공급원 재설계 필요 |
+| C. 폐기하되 on-demand 대체 | ingestor/엔드포인트 제거, get_market_news를 호출 시 Finnhub general news + 네이버 주요뉴스 직접 수집으로 전환 | 구현 비용 중간, 외부 서비스 의존 제거하면서 기능 보존 |
+| D. 보류 | 본 실측을 Linear에 기록만 | 이슈 전제("ingestor 안 쓴다")와 실제 가동 상태 불일치 해소 필요 |

--- a/tests/test_market_news_briefing_formatter.py
+++ b/tests/test_market_news_briefing_formatter.py
@@ -67,7 +67,8 @@ def test_format_us_news_groups_macro_big_tech_earnings_and_noise():
     section_ids = [section.section_id for section in briefing.sections]
     assert section_ids[:3] == ["macro_fed", "big_tech", "earnings"]
     assert [item.article.title for item in briefing.sections[0].items] == [macro.title]
-    assert briefing.excluded[0].relevance.reason == "low_market_relevance"
+    # ROB-502: the celebrity item is now caught by the explicit noise gate.
+    assert briefing.excluded[0].relevance.reason == "noise:lifestyle"
 
 
 @pytest.mark.unit
@@ -100,8 +101,12 @@ def test_format_us_news_excludes_personal_finance_and_lifestyle_rate_noise():
         savings_rate.title,
         mortgage_rate.title,
     }
+    # ROB-502: the noise gate now catches "mortgage rates ..." with an explicit
+    # noise reason; other low-signal items keep low_market_relevance.
     assert all(
-        item.relevance.reason == "low_market_relevance" for item in briefing.excluded
+        item.relevance.reason == "low_market_relevance"
+        or item.relevance.reason.startswith("noise:")
+        for item in briefing.excluded
     )
 
 
@@ -238,7 +243,9 @@ def test_format_crypto_news_reuses_crypto_relevance_and_sections():
         "security_defi",
     ]
     assert briefing.sections[0].items[0].article.title == etf.title
-    assert briefing.excluded[0].relevance.reason == "broad_tech_without_crypto_signal"
+    # ROB-502: the generic noise gate now classifies this before the crypto
+    # scorer's own broad_tech_without_crypto_signal reason.
+    assert briefing.excluded[0].relevance.reason == "noise:broad_tech"
 
 
 @pytest.mark.unit
@@ -299,7 +306,6 @@ async def test_market_news_briefing_filter_formats_us_sections_for_mcp():
     assert result["briefing_filter"] is True
     assert result["briefing_summary"]["included"] == 1
     assert result["briefing_sections"][0]["section_id"] == "macro_fed"
-    assert (
-        result["excluded_news"][0]["briefing_relevance"]["reason"]
-        == "low_market_relevance"
-    )
+    # ROB-502: the celebrity/lifestyle item is now caught by the noise gate
+    # (excluded_reason) before briefing relevance scoring.
+    assert result["excluded_news"][0]["excluded_reason"] == "noise:lifestyle"

--- a/tests/test_market_news_quality_gate_rob502.py
+++ b/tests/test_market_news_quality_gate_rob502.py
@@ -1,0 +1,294 @@
+"""ROB-502 step 5: quality-gated MCP exposure for market news/issues.
+
+Covers the ported title-noise classifier, the noise pre-gate + word-boundary
+term matching in the briefing formatter, and the meaningfulness thresholds in
+the issue clustering service (single-source exclusion, near-duplicate merge,
+empty-with-reason responses).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.timezone import now_kst_naive
+
+
+def _article(
+    title: str,
+    *,
+    market: str,
+    summary: str | None = None,
+    source: str = "Test Source",
+    feed_source: str = "rss_test",
+    stock_symbol: str | None = None,
+    keywords: list[str] | None = None,
+    article_id: int | None = None,
+    published_minutes_ago: int = 30,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=article_id,
+        title=title,
+        url=f"https://example.com/{article_id or 'article'}",
+        source=source,
+        feed_source=feed_source,
+        market=market,
+        summary=summary,
+        article_published_at=now_kst_naive() - timedelta(minutes=published_minutes_ago),
+        keywords=keywords or [],
+        stock_symbol=stock_symbol,
+        stock_name=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Noise classifier (ported from news-ingestor noise.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_noise_classifier_categories():
+    from app.services.market_news_noise import classify_title_noise
+
+    assert "personal_finance" in classify_title_noise(
+        "My plumber charged $160 to fix a problem — do I pay again?"
+    )
+    assert "lifestyle" in classify_title_noise(
+        "Buyer swoops in for actress Dakota Johnson's $6 million midcentury home"
+    )
+    assert "price_prediction" in classify_title_noise(
+        "XRP Price Prediction: Could XRP reach $10 by 2027?"
+    )
+    assert "sponsored" in classify_title_noise("Sponsored: The 5 best coins to buy now")
+    assert "broad_tech" in classify_title_noise(
+        "EU Orders Meta to Open WhatsApp to Rival AI Chatbots"
+    )
+
+
+@pytest.mark.unit
+def test_noise_classifier_clean_titles():
+    from app.services.market_news_noise import classify_title_noise
+
+    assert (
+        classify_title_noise("S&P 500 closes higher as investors await Fed minutes")
+        == []
+    )
+    assert classify_title_noise("'스페이스X' 청약 경쟁률 4배 돌파…역대 최대 IPO") == []
+    assert classify_title_noise("") == []
+
+
+# ---------------------------------------------------------------------------
+# Briefing formatter: noise pre-gate + word-boundary matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_plumber_story_is_noise_gated_not_big_tech():
+    """Regression for the 2026-06-10 live finding: the MarketWatch Moneyist
+    story landed in Big Tech because the bare term "ai" substring-matched
+    "again". It must now be excluded with an explicit noise reason."""
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    plumber = _article(
+        "My plumber charged $160 to fix a problem in my bathroom — but appears "
+        "to have created another one. Do I pay again?",
+        market="us",
+        feed_source="rss_marketwatch_topstories",
+    )
+    briefing = format_market_news_briefing([plumber], market="us", limit=10)
+    assert briefing.summary["included"] == 0
+    [excluded] = briefing.excluded
+    assert excluded.relevance.reason is not None
+    assert excluded.relevance.reason.startswith("noise:")
+    assert "personal_finance" in excluded.relevance.reason
+
+
+@pytest.mark.unit
+def test_short_terms_require_word_boundaries():
+    """A title containing "again"/"aims" must not match the "ai" term; a real
+    AI/semis title still lands in big_tech."""
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    not_ai = _article(
+        "Boeing aims to deliver again as supply chain improves",
+        market="us",
+    )
+    real_ai = _article(
+        "Nvidia AI chip demand lifts Nasdaq semiconductor stocks",
+        market="us",
+    )
+    briefing = format_market_news_briefing([not_ai, real_ai], market="us", limit=10)
+    by_title = {
+        item.article.title: section.section_id
+        for section in briefing.sections
+        for item in section.items
+    }
+    assert by_title.get(real_ai.title) == "big_tech"
+    assert not_ai.title not in by_title
+
+
+@pytest.mark.unit
+def test_federal_reserve_still_reaches_macro_fed():
+    """Word-boundary matching must not lose "Federal Reserve ..." headlines
+    that previously rode the "fed"-in-"federal" substring."""
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    fed = _article(
+        "Federal Reserve announces annual bank stress test results",
+        market="us",
+        feed_source="rss_fed_press",
+    )
+    briefing = format_market_news_briefing([fed], market="us", limit=10)
+    section_ids = [s.section_id for s in briefing.sections]
+    assert "macro_fed" in section_ids or "finance_credit_rates" in section_ids
+
+
+@pytest.mark.unit
+def test_crypto_briefing_also_noise_gated():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    spam = _article(
+        "Toncoin (TON) Price Prediction 2025, 2026, 2027-2030",
+        market="crypto",
+        feed_source="rss_cryptopotato",
+    )
+    briefing = format_market_news_briefing([spam], market="crypto", limit=10)
+    assert briefing.summary["included"] == 0
+    [excluded] = briefing.excluded
+    assert excluded.relevance.reason.startswith("noise:")
+
+
+# ---------------------------------------------------------------------------
+# Issue clustering: meaningfulness thresholds
+# ---------------------------------------------------------------------------
+
+
+def _build_issues(monkeypatch, articles, **kwargs):
+    import asyncio
+
+    from app.services import news_issue_clustering_service as svc
+
+    async def fake_load(*, market, window_hours, max_rows):
+        return articles
+
+    monkeypatch.setattr(svc, "_load_recent_articles", fake_load)
+    return asyncio.run(svc.build_market_issues(market="us", **kwargs))
+
+
+@pytest.mark.unit
+def test_single_source_single_article_clusters_excluded(monkeypatch):
+    """The 2026-06-10 live finding: ranks 3-5 of US issues were single-article
+    clusters (SoftBank single, plumber, Dakota Johnson). Thin clusters must
+    not be exposed as market issues."""
+    arts = [
+        _article(
+            "Quantum widgets startup raises huge round", market="us", article_id=1
+        ),
+        _article(
+            "Nvidia data center revenue beats expectations",
+            market="us",
+            source="CNBC",
+            article_id=2,
+        ),
+        _article(
+            "Nvidia shares climb on supply commitments",
+            market="us",
+            source="MarketWatch",
+            article_id=3,
+        ),
+    ]
+    resp = _build_issues(monkeypatch, arts)
+    titles = [i.issue_title for i in resp.items]
+    assert any("Nvidia" in t for t in titles)
+    assert not any("Quantum widgets" in t for t in titles)
+    assert resp.status == "ok"
+    assert resp.quality_gate is not None
+    assert resp.quality_gate.clusters_excluded_thin >= 1
+
+
+@pytest.mark.unit
+def test_noise_articles_never_reach_clustering(monkeypatch):
+    arts = [
+        _article(
+            "My plumber charged $160 to fix a problem — do I pay again?",
+            market="us",
+            source="MarketWatch",
+            article_id=1,
+        ),
+        _article(
+            "My plumber story syndicated copy — do I pay again?",
+            market="us",
+            source="Yahoo",
+            article_id=2,
+        ),
+    ]
+    resp = _build_issues(monkeypatch, arts)
+    assert resp.items == []
+    assert resp.status == "no_meaningful_items"
+    assert resp.quality_gate.noise_articles_excluded == 2
+
+
+@pytest.mark.unit
+def test_near_duplicate_clusters_merge(monkeypatch):
+    """The 2026-06-10 crypto finding: the same Japan-stablecoin story from two
+    outlets appeared as two separate single-article clusters. Near-duplicate
+    title clusters must merge — and the merged cluster (2 sources) passes."""
+    arts = [
+        _article(
+            "Japan's Largest Banks Plan Joint Stablecoin Launch by March 2027",
+            market="us",
+            source="Decrypt",
+            article_id=1,
+        ),
+        _article(
+            "Japan's three largest banks aim for joint stablecoin issue by March",
+            market="us",
+            source="CoinDesk",
+            article_id=2,
+        ),
+    ]
+    resp = _build_issues(monkeypatch, arts)
+    assert len(resp.items) == 1
+    issue = resp.items[0]
+    assert issue.article_count == 2
+    assert issue.source_count == 2
+    assert resp.quality_gate.clusters_merged >= 1
+
+
+@pytest.mark.unit
+def test_important_feed_source_single_article_survives(monkeypatch):
+    """Official-source items (Fed press) are meaningful even as singletons."""
+    arts = [
+        _article(
+            "Federal Reserve Board announces bank stress test results date",
+            market="us",
+            feed_source="rss_fed_press",
+            source="Federal Reserve",
+            article_id=1,
+        ),
+    ]
+    resp = _build_issues(monkeypatch, arts)
+    assert len(resp.items) == 1
+    assert resp.status == "ok"
+
+
+@pytest.mark.unit
+def test_empty_window_reports_no_recent_articles(monkeypatch):
+    resp = _build_issues(monkeypatch, [])
+    assert resp.items == []
+    assert resp.status == "no_recent_articles"
+    assert resp.degraded_reason
+
+
+@pytest.mark.unit
+def test_all_thin_reports_no_meaningful_items_with_reason(monkeypatch):
+    arts = [
+        _article("Unique story one about widgets", market="us", article_id=1),
+        _article("Totally different tale regarding gadgets", market="us", article_id=2),
+    ]
+    resp = _build_issues(monkeypatch, arts)
+    assert resp.items == []
+    assert resp.status == "no_meaningful_items"
+    assert resp.degraded_reason

--- a/tests/test_mcp_get_market_news_quality_gate.py
+++ b/tests/test_mcp_get_market_news_quality_gate.py
@@ -1,0 +1,118 @@
+"""ROB-502 step 5: get_market_news MCP surface is quality-gated by default.
+
+The non-briefing path must no longer return the raw DB list: noise-tagged
+items move to excluded_news with reasons, and degraded states are explicit
+(`no_meaningful_items` / `no_recent_articles`) instead of silent empties.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _row(
+    article_id: int, title: str, *, feed_source: str = "rss_test"
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=article_id,
+        title=title,
+        url=f"https://example.com/{article_id}",
+        source="Test Source",
+        feed_source=feed_source,
+        market="us",
+        summary=None,
+        article_published_at=datetime(2026, 6, 11, 9, 0, 0),
+        keywords=[],
+        stock_symbol=None,
+        stock_name=None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_default_path_excludes_noise_with_reason():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    rows = [
+        _row(1, "Fed holds rates steady as inflation cools"),
+        _row(
+            2,
+            "My plumber charged $160 to fix a problem — do I pay again?",
+            feed_source="rss_marketwatch_topstories",
+        ),
+    ]
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=(rows, 2)),
+    ):
+        result = await _get_market_news_impl(market="us", limit=10)
+
+    assert result["status"] == "ok"
+    assert [n["id"] for n in result["news"]] == [1]
+    [excluded] = result["excluded_news"]
+    assert excluded["id"] == 2
+    assert excluded["excluded_reason"].startswith("noise:")
+    assert "personal_finance" in excluded["excluded_reason"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_all_noise_yields_no_meaningful_items():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    rows = [
+        _row(1, "Sponsored: The 5 best coins to buy now"),
+        _row(2, "XRP Price Prediction: Could XRP reach $10 by 2027?"),
+    ]
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=(rows, 2)),
+    ):
+        result = await _get_market_news_impl(market="crypto", limit=10)
+
+    assert result["status"] == "no_meaningful_items"
+    assert result["news"] == []
+    assert len(result["excluded_news"]) == 2
+    assert result["degraded_reason"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_empty_window_yields_no_recent_articles():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=([], 0)),
+    ):
+        result = await _get_market_news_impl(market="us", hours=24, limit=10)
+
+    assert result["status"] == "no_recent_articles"
+    assert result["news"] == []
+    assert result["degraded_reason"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_briefing_path_reports_status_and_keeps_sections():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    rows = [
+        _row(1, "Fed holds rates steady as inflation cools"),
+        _row(2, "Nvidia AI chip demand lifts Nasdaq semiconductor stocks"),
+    ]
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=(rows, 2)),
+    ):
+        result = await _get_market_news_impl(
+            market="us", limit=10, briefing_filter=True
+        )
+
+    assert result["status"] == "ok"
+    assert result["count"] == 2
+    assert result["briefing_sections"]

--- a/tests/test_mcp_news_crypto_relevance.py
+++ b/tests/test_mcp_news_crypto_relevance.py
@@ -55,20 +55,19 @@ async def test_market_news_can_return_crypto_briefing_ranked_candidates():
     assert result["count"] == 1
     assert result["total"] == 2
     assert result["briefing_filter"] is True
+    # ROB-502: the OpenAI item is pre-gated by the generic noise classifier,
+    # so the crypto ranking only ever sees the Bitcoin ETF article.
     assert result["briefing_summary"] == {
         "included": 1,
-        "excluded": 1,
+        "excluded": 0,
         "high": 1,
         "medium": 0,
-        "low": 1,
+        "low": 0,
     }
     assert result["news"][0]["title"].startswith("Bitcoin ETF")
     assert result["news"][0]["crypto_relevance"]["bucket"] == "high"
     assert result["excluded_news"][0]["title"].startswith("OpenAI")
-    assert (
-        result["excluded_news"][0]["crypto_relevance"]["noise_reason"]
-        == "broad_tech_without_crypto_signal"
-    )
+    assert result["excluded_news"][0]["excluded_reason"] == "noise:broad_tech"
 
 
 @pytest.mark.asyncio
@@ -96,7 +95,9 @@ async def test_market_news_default_keeps_raw_crypto_news_with_relevance_metadata
     ):
         result = await _get_market_news_impl(market="crypto", limit=1)
 
+    # ROB-502: the default path is quality-gated now — the broad-tech AI item
+    # moves to excluded_news with a reason instead of being returned raw.
     assert result["briefing_filter"] is False
-    assert result["count"] == 1
-    assert result["excluded_news"] == []
-    assert result["news"][0]["crypto_relevance"]["bucket"] == "low"
+    assert result["count"] == 0
+    assert result["status"] == "no_meaningful_items"
+    assert result["excluded_news"][0]["excluded_reason"] == "noise:broad_tech"

--- a/tests/test_news_rss.py
+++ b/tests/test_news_rss.py
@@ -515,7 +515,9 @@ class TestMCPNewsTools:
         assert "get_market_issues" in NEWS_TOOL_NAMES
 
     @pytest.mark.asyncio
-    async def test_get_market_news_carries_legacy_surface_notice(self, monkeypatch):
+    async def test_get_market_news_carries_quality_gated_surface_notice(
+        self, monkeypatch
+    ):
         from app.mcp_server.tooling import news_handlers
 
         async def _empty(**kwargs):
@@ -525,8 +527,11 @@ class TestMCPNewsTools:
             news_handlers, "get_news_articles", AsyncMock(side_effect=_empty)
         )
         result = await news_handlers._get_market_news_impl(hours=24, limit=20)
-        assert result["surface"] == "legacy_market_briefing"
+        # ROB-502: surface renamed legacy → quality-gated; empty windows are
+        # explicit degraded states rather than silent empty lists.
+        assert result["surface"] == "quality_gated_market_briefing"
         assert "investment-decision evidence" in result["advisory"]
+        assert result["status"] == "no_recent_articles"
 
     @pytest.mark.asyncio
     async def test_get_market_news_returns_sources_and_feed_sources(self):


### PR DESCRIPTION
## Summary

ROB-502 pivot **5단계 (auto_trader MCP exposure policy)** — 수집측 1~4단계(news-ingestor #19~#22, 전부 머지됨)에 이은 노출측 마무리. 2026-06-10 라이브 감사에서 발견한 결함 3종을 각각 수정하고 회귀 테스트로 고정했습니다.

### get_market_news — 항상 켜진 품질 게이트
- **신규 `app/services/market_news_noise.py`**: read-time 제목 노이즈 분류기 5범주 (news-ingestor noise.py 포트 — ingestor의 raw 태그는 news_articles에 미저장 + 과거 행 미커버라 read-time 분류). `broad_tech`는 ingestor보다 의도적으로 좁음(여기는 태그가 아니라 제외라서)
- 노이즈 판정 항목은 main list 대신 **`excluded_news` + `excluded_reason`**(`noise:<categories>`)으로 이동 (기본 경로/briefing 경로 공통)
- 응답에 **`status` (`ok`|`no_meaningful_items`|`no_recent_articles`) + `degraded_reason`** — 빈 결과는 filler 없이 명시적
- surface 명칭: `legacy_market_briefing` → `quality_gated_market_briefing`

### briefing formatter
- 모든 market에 섹션 스코어링 전 노이즈 사전 게이트
- **ASCII 용어 word-boundary 매칭**: 라이브 결함 "plumber 기사가 Big Tech"의 원인 = `"ai" in "again"` 부분문자열 매칭. `federal reserve`를 macro_fed 용어에 추가해 Fed 헤드라인 유지

### get_market_issues — 유의미성 게이트
- 노이즈 기사는 클러스터링 입력에서 제외
- **근사중복 클러스터 병합** (token-set Jaccard ≥ 0.5) — 라이브 결함: 같은 일본 스테이블코인 기사가 2개 클러스터 → 이제 1개
- **thin 클러스터 보류**: 단일기사 AND 단일소스 (공식 피드 `rss_fed_press`는 예외)
- `MarketIssuesResponse`에 additive `status`/`degraded_reason`/`quality_gate`(noise/merged/thin 카운트)

### 라이브 검증 (로컬 DB, 24h)
| 표면 | before (06-10 감사) | after |
|---|---|---|
| US issues top-5 | rank 3-5가 단일기사 노이즈 (plumber/Dakota) | **전부 멀티소스** (Amazon/Alphabet/Meta/Tesla/Broadcom) — thin 252 보류, noise 14 제외, 5 병합 |
| crypto issues | 일본 스테이블코인 중복 클러스터 2개 | **병합 1개** [2건/2곳] |
| get_market_news | plumber류 미필터 | `noise:personal_finance`/`noise:broad_tech` 사유와 함께 excluded_news |

### Stale 단언 갱신 (의도된 계약 변경)
기존 테스트 6건이 구 reason 문자열/raw 기본경로/legacy surface명을 단언 → 새 계약으로 갱신 (각각 주석으로 사유 명시).

### 검증
- 신규 테스트 16건 (분류기, plumber/word-boundary/Federal Reserve 회귀, thin/병합/공식피드/empty-reason, 핸들러 status)
- 인접 영역 3,767개 격리 실행 green; 전체 스위트 재실행 **FAILED/ERROR 0** (1차 실행의 1F/85E는 알려진 공유 DB 실행순서 오염 — 단독 실행 전부 통과로 확인)
- ruff/ty clean. read-only 표면, **migration 0**, broker/order/watch mutation 없음
- `docs/reviews/`에 06-10 감사 원본 동봉

Linear: ROB-502

🤖 Generated with [Claude Code](https://claude.com/claude-code)