### PR TITLE
fix(ROB-512): investor_flow 스케줄 cron 16:40→익일 08:30 KST (갭4)

### DIFF
--- a/app/tasks/investor_flow_snapshot_tasks.py
+++ b/app/tasks/investor_flow_snapshot_tasks.py
@@ -20,6 +20,13 @@ from app.jobs.investor_flow_snapshots import (
 
 _KST_LABEL = "Asia/Seoul"
 
+#: ROB-512 갭4: Naver frgn(일별 수급 확정 행)은 당일 저녁엔 부분 발행이라
+#: (2026-06-10 18:10 KST 실측 144/3,909 종목 → thin 파티션 → older_fallback)
+#: 당일 cron(구 ROB-438 "40 16")은 구조적으로 당일 데이터를 못 잡는다. 행은
+#: 익일 아침에 완성되므로 개장 전 08:30 KST에 전 거래일(D-1)을 적재한다.
+#: 휴장일 결행분은 빌더의 days=20 히스토리 upsert가 다음 run에서 백필한다.
+_KR_FLOW_CRON = "30 8 * * 1-5"
+
 
 def _kr_flow_schedule(cron: str) -> list[dict[str, str]]:
     """Cron labels gated by the schedule flag (default off → [] → not registered)."""
@@ -81,11 +88,13 @@ async def build_investor_flow_snapshots(
 
 @broker.task(
     task_name="investor_flow_snapshots.kr_scheduled",
-    schedule=_kr_flow_schedule("40 16 * * 1-5"),
+    schedule=_kr_flow_schedule(_KR_FLOW_CRON),
 )
 async def scheduled_kr_investor_flow() -> dict[str, Any]:
-    """ROB-438: KR investor-flow refresh at 16:40 KST (Naver 수급, post-close).
+    """ROB-438/ROB-512: KR investor-flow refresh at 08:30 KST (Naver 수급, 익일 아침).
 
+    전 거래일(D-1) 확정 수급을 적재한다 — 당일 행은 저녁까지 부분 발행이라 당일
+    cron은 thin 파티션만 만든다(ROB-512 갭4 실측, ``_KR_FLOW_CRON`` 주석 참조).
     Holiday-gated via XKRX (skips non-trading days). Default-off; commit gated by
     ``investor_flow_snapshots_commit_enabled`` (dry-run-on-cron until operator sets it).
     """

--- a/tests/test_investor_flow_snapshot_tasks.py
+++ b/tests/test_investor_flow_snapshot_tasks.py
@@ -101,3 +101,11 @@ def test_recurring_schedule_is_default_off():
         assert tasks._kr_flow_schedule("40 16 * * 1-5") == [
             {"cron": "40 16 * * 1-5", "cron_offset": "Asia/Seoul"}
         ]
+
+
+def test_scheduled_cron_is_next_morning_kst():
+    """ROB-512 갭4: Naver frgn 일별 수급 확정 행은 당일 저녁엔 부분 발행
+    (2026-06-10 18:10 KST 실측 144/3,909 종목 = thin 파티션 → older_fallback)이고
+    익일 아침에 완성된다(2026-06-11 오전 라이브 검증). 구 ROB-438의 16:40 KST는
+    구조적으로 당일 데이터를 못 잡으므로 등록 cron은 익일 아침(개장 전)이어야 한다."""
+    assert tasks._KR_FLOW_CRON == "30 8 * * 1-5"


### PR DESCRIPTION
## Summary
ROB-512 갭4 원인 조사(이슈 코멘트 참조)의 후속 1줄 수정:

- Naver frgn 일별 수급 확정 행은 **당일 저녁엔 부분 발행** — 2026-06-10 18:10 KST 실측 144/3,909 종목(=thin 파티션 → partition health가 정직하게 skip → `older_fallback`). 익일 아침엔 완성(2026-06-11 오전 라이브 검증 5/5).
- 따라서 구 ROB-438 cron `40 16 * * 1-5`는 활성화해도 당일 데이터를 구조적으로 못 잡음 → **`30 8 * * 1-5`(개장 전, D-1 적재)로 변경**. cron을 `_KR_FLOW_CRON` 상수로 추출 + 근거 주석 + 회귀 테스트.
- 동작 변화 없음(스케줄은 여전히 default-off, `investor_flow_schedule_enabled`/`investor_flow_snapshots_commit_enabled` operator 게이트 유지). Migration 0.

## Operator follow-up
배포 후 두 플래그 활성화 → 첫 08:30 run에서 D-1 파티션 row수(~3.9k) 확인. 08:30에 thin이면 시각을 뒤로 조정(관찰 기반).

## Test plan
- [x] `tests/test_investor_flow_snapshot_tasks.py` + `tests/test_snapshot_schedulers_rob438.py` 12 passed
- [x] ruff format/check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)