### PR TITLE
fix(ROB-518): live 손실 매도 하드 가드 — 시장가 매도·modify_order 플로어 우회 차단

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -119,6 +119,36 @@ def evaluate_sell_price_guards(
     return None
 
 
+def evaluate_market_sell_loss_guard(
+    *,
+    current_price: float,
+    avg_price: float,
+    allow_loss_sell: bool = False,
+) -> str | None:
+    """ROB-518: live market sells must not realize a loss by mistake.
+
+    A market sell executes at ~current_price, so the avg*1.01 floor that guards
+    limit sells is applied against the current price here. Mock equity keeps the
+    ROB-461 allow_loss_sell bypass (손절 practice). defensive_trim/scalping_exit
+    are limit-only by precondition and can never reach the market path. Unknown
+    cost basis (avg_price <= 0) stays fail-open, matching the limit-guard
+    semantics.
+    """
+    if allow_loss_sell:
+        return None
+    if avg_price <= 0:
+        return None
+    min_sell_price = avg_price * 1.01
+    if current_price < min_sell_price:
+        return (
+            f"Live market sell blocked: current price {current_price} below "
+            f"minimum (avg_buy_price * 1.01 = {round(min_sell_price, 4)}). "
+            "Loss-selling is disabled on live accounts (ROB-518); use a "
+            "defensive_trim limit order for a sanctioned trim."
+        )
+    return None
+
+
 def _is_cached_approved(approval_issue_id: str) -> bool:
     expires_at = _defensive_trim_success_cache.get(approval_issue_id)
     if expires_at is None:
@@ -666,6 +696,27 @@ async def _preview_sell(
 
     avg_price = holdings["avg_price"]
     if order_type == "market":
+        # ROB-518 — market sells used to skip the price guards entirely, letting
+        # a live sell realize a loss in one call. Same allow_loss_sell scope as
+        # the limit path (mock equity only; crypto/live stay guarded).
+        allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
+        guard_error = evaluate_market_sell_loss_guard(
+            current_price=current_price,
+            avg_price=avg_price,
+            allow_loss_sell=allow_loss_sell,
+        )
+        if guard_error is not None:
+            result["error"] = guard_error
+            return result
+        if allow_loss_sell and current_price < avg_price * 1.01:
+            _log_mock_loss_sell_bypass(
+                symbol=symbol,
+                market_type=market_type,
+                price=current_price,
+                current_price=current_price,
+                avg_price=avg_price,
+                phase="preview",
+            )
         order_quantity = holdings["quantity"]
         execution_price = current_price
         result["price"] = execution_price
@@ -904,6 +955,27 @@ async def _validate_sell_side(
 
     order_quantity = available_quantity if quantity is None else quantity
     avg_price = _to_float(holdings.get("avg_price"), default=0.0)
+
+    if order_type == "market":
+        # ROB-518 — mirror the preview-side market loss guard on the execution
+        # path (single behavior regardless of entry point).
+        allow_loss_sell = is_mock and market_type in ("equity_kr", "equity_us")
+        guard_error = evaluate_market_sell_loss_guard(
+            current_price=current_price,
+            avg_price=avg_price,
+            allow_loss_sell=allow_loss_sell,
+        )
+        if guard_error is not None:
+            return 0.0, 0.0, order_error_fn(guard_error)
+        if allow_loss_sell and current_price < avg_price * 1.01:
+            _log_mock_loss_sell_bypass(
+                symbol=normalized_symbol,
+                market_type=market_type,
+                price=current_price,
+                current_price=current_price,
+                avg_price=avg_price,
+                phase="execution",
+            )
 
     if order_type == "limit" and price is not None:
         # defensive_trim is live-only (Trader-agent + approval); allow_loss_sell is

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -11,6 +11,9 @@ from app.mcp_server.tick_size import adjust_tick_size_kr
 from app.mcp_server.tooling.order_execution import (
     _normalize_market_type_to_external,
 )
+from app.mcp_server.tooling.order_validation import (
+    _get_holdings_for_order,
+)
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import (
     parse_holdings_market_filter as _parse_holdings_market_filter,
@@ -18,6 +21,7 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     resolve_market_type as _resolve_market_type,
 )
+from app.mcp_server.tooling.shared import to_float as _to_float
 from app.services.brokers.kis.client import KISClient
 from app.services.brokers.kis.overseas_orders import _normalize_kis_exchange_code
 from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
@@ -878,6 +882,42 @@ def _validate_modify_inputs(
     return order_id, symbol, market_type, normalized_symbol
 
 
+async def _live_sell_reprice_floor_error(
+    *,
+    normalized_symbol: str,
+    market_type: str,
+    side: str,
+    new_price: float | None,
+) -> str | None:
+    """ROB-518: live sell orders must not be repriced below avg_buy * 1.01.
+
+    Placement-time guards do not re-run on modify, so without this check a
+    guarded live sell could be repriced into a loss. Callers are live-only
+    (mock modifies delegate/return before reaching this). Quantity-only
+    modifies (new_price=None) and buy orders introduce no new price risk.
+    Unknown cost basis (no holdings row / avg<=0) stays fail-open, matching
+    the placement-guard semantics.
+    """
+    if new_price is None or side != "sell":
+        return None
+    holdings = await _get_holdings_for_order(
+        normalized_symbol, market_type, is_mock=False
+    )
+    if not holdings:
+        return None
+    avg_price = _to_float(holdings.get("avg_price"), default=0.0)
+    if avg_price <= 0:
+        return None
+    min_sell_price = avg_price * 1.01
+    if float(new_price) < min_sell_price:
+        return (
+            f"Live sell modify blocked: new price {new_price} below minimum "
+            f"(avg_buy_price * 1.01 = {round(min_sell_price, 4)}). "
+            "Loss-selling is disabled on live accounts (ROB-518)."
+        )
+    return None
+
+
 def _build_modify_dry_run_response(
     order_id: str,
     normalized_symbol: str,
@@ -941,6 +981,26 @@ async def _modify_upbit(
         original_quantity = float(original_order.get("remaining_volume", 0) or 0)
         final_price = new_price if new_price is not None else original_price
         final_quantity = new_quantity if new_quantity is not None else original_quantity
+
+        # ROB-518 — Upbit modifies are always live (real funds).
+        side = "buy" if original_order.get("side") == "bid" else "sell"
+        floor_error = await _live_sell_reprice_floor_error(
+            normalized_symbol=normalized_symbol,
+            market_type=market_type,
+            side=side,
+            new_price=new_price,
+        )
+        if floor_error is not None:
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": floor_error,
+                "method": "cancel_reorder",
+                "dry_run": dry_run,
+            }
 
         result = await upbit_service.cancel_and_reorder(
             order_id, final_price, final_quantity
@@ -1186,6 +1246,25 @@ async def _modify_kis_domestic(
         side_code = _get_kis_field(target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD")
         side = "buy" if side_code == "02" else "sell"
 
+        # ROB-518 — is_mock delegated above, so this is the live KR path.
+        floor_error = await _live_sell_reprice_floor_error(
+            normalized_symbol=normalized_symbol,
+            market_type=market_type,
+            side=side,
+            new_price=new_price,
+        )
+        if floor_error is not None:
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": floor_error,
+                "method": "api_modify",
+                "dry_run": dry_run,
+            }
+
         final_price_raw = int(new_price) if new_price is not None else original_price
         final_price = int(adjust_tick_size_kr(float(final_price_raw), side))
         final_quantity = (
@@ -1315,6 +1394,28 @@ async def _modify_kis_overseas(
                 _get_kis_field(target_order, "ft_ord_qty", "FT_ORD_QTY", default=0) or 0
             )
         )
+
+        # ROB-518 — mock returns unsupported above, so this is the live US path.
+        # Same sll_buy_dvsn_cd convention as _normalize_kis_overseas_order.
+        side_code = _get_kis_field(target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD")
+        side = "buy" if side_code == "02" else "sell"
+        floor_error = await _live_sell_reprice_floor_error(
+            normalized_symbol=normalized_symbol,
+            market_type=market_type,
+            side=side,
+            new_price=new_price,
+        )
+        if floor_error is not None:
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": floor_error,
+                "method": "api_modify",
+                "dry_run": dry_run,
+            }
 
         exchange_code = target_exchange or exchange_candidates[0]
         logger.info(

--- a/tests/test_kis_mock_loss_sell_guard.py
+++ b/tests/test_kis_mock_loss_sell_guard.py
@@ -268,10 +268,11 @@ async def test_mock_equity_loss_sell_emits_audit_log(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_preview_sell_market_order_skips_price_guards(monkeypatch) -> None:
-    # Market sells never hit evaluate_sell_price_guards (limit-only) — a deep-loss
-    # market sell was always allowed and is unaffected by allow_loss_sell. Documents
-    # the intentional exemption + guards against a future maintainer adding a floor.
+async def test_preview_sell_mock_market_loss_allowed_and_audited(monkeypatch) -> None:
+    # ROB-518 superseded the old "market sells skip price guards" exemption:
+    # live market sells below the floor are now blocked (see
+    # test_live_loss_sell_hard_guard.py). Mock equity keeps the ROB-461
+    # practice bypass, and the market-path bypass is audited like the limit one.
     log_mock = Mock()
     monkeypatch.setattr(order_validation, "_log_mock_loss_sell_bypass", log_mock)
     monkeypatch.setattr(
@@ -291,7 +292,7 @@ async def test_preview_sell_market_order_skips_price_guards(monkeypatch) -> None
     assert "error" not in result
     assert result["price"] == 68500.0  # execution_price == current_price
     assert result["realized_pnl"] < 0
-    log_mock.assert_not_called()  # market path never logs a guard bypass
+    assert log_mock.call_args.kwargs["phase"] == "preview"
 
 
 @pytest.mark.unit

--- a/tests/test_live_loss_sell_hard_guard.py
+++ b/tests/test_live_loss_sell_hard_guard.py
@@ -1,0 +1,506 @@
+"""ROB-518 — live accounts must not realize a loss-sell by mistake.
+
+Live limit sells were already double-guarded (avg*1.01 floor + below-current
+block), but two live paths bypassed the floor entirely:
+
+1. market sells — ``_preview_sell`` / ``_validate_sell_side`` only ran the
+   guards for ``order_type == "limit"``, so a live market sell with the
+   current price below the avg*1.01 floor went straight through (reachable
+   via POST /api/screener/order and any internal ``_place_order_impl`` caller).
+2. modify — ``modify_order_impl`` re-priced a resting live sell order with no
+   floor check, so a guarded placement could be repriced into a loss.
+
+Mock equity keeps the ROB-461 ``allow_loss_sell`` bypass (손절 practice).
+defensive_trim / scalping_exit are limit-only by precondition and unaffected.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.mcp_server.tooling import order_validation, orders_modify_cancel
+from app.mcp_server.tooling.order_validation import (
+    evaluate_market_sell_loss_guard,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure guard: evaluate_market_sell_loss_guard
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_market_guard_blocks_current_below_floor() -> None:
+    err = evaluate_market_sell_loss_guard(
+        current_price=68500.0,
+        avg_price=90400.0,
+        allow_loss_sell=False,
+    )
+    assert err is not None and "market sell blocked" in err.lower()
+
+
+@pytest.mark.unit
+def test_market_guard_allows_current_at_or_above_floor() -> None:
+    assert (
+        evaluate_market_sell_loss_guard(
+            current_price=1010.0, avg_price=1000.0, allow_loss_sell=False
+        )
+        is None
+    )
+    assert (
+        evaluate_market_sell_loss_guard(
+            current_price=1200.0, avg_price=1000.0, allow_loss_sell=False
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_market_guard_mock_bypass_allows_loss() -> None:
+    err = evaluate_market_sell_loss_guard(
+        current_price=68500.0,
+        avg_price=90400.0,
+        allow_loss_sell=True,
+    )
+    assert err is None
+
+
+@pytest.mark.unit
+def test_market_guard_unknown_basis_fails_open() -> None:
+    # avg_price <= 0 means the cost basis is unknown (e.g. manual holdings rows
+    # without it); the limit guard has always been fail-open there — keep parity.
+    assert (
+        evaluate_market_sell_loss_guard(
+            current_price=100.0, avg_price=0.0, allow_loss_sell=False
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_market_guard_default_is_blocking() -> None:
+    # Omitting allow_loss_sell must keep the floor (no accidental relaxation).
+    err = evaluate_market_sell_loss_guard(current_price=900.0, avg_price=1000.0)
+    assert err is not None
+
+
+# ---------------------------------------------------------------------------
+# _preview_sell: live market sells below floor are blocked; mock equity stays open
+# ---------------------------------------------------------------------------
+def _patch_holdings(monkeypatch, avg_price: float, quantity: float = 10) -> None:
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": avg_price, "quantity": quantity}),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market_type", ["equity_kr", "equity_us", "crypto"])
+async def test_preview_sell_live_market_loss_blocked(monkeypatch, market_type) -> None:
+    _patch_holdings(monkeypatch, avg_price=90400.0)
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="market",
+        quantity=10,
+        price=None,
+        current_price=68500.0,
+        market_type=market_type,
+        is_mock=False,
+    )
+    assert "error" in result and "market sell blocked" in result["error"].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_live_market_profit_allowed(monkeypatch) -> None:
+    _patch_holdings(monkeypatch, avg_price=60000.0)
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="market",
+        quantity=10,
+        price=None,
+        current_price=68500.0,
+        market_type="equity_kr",
+        is_mock=False,
+    )
+    assert "error" not in result
+    assert result["price"] == 68500.0
+    assert result["realized_pnl"] > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("market_type", ["equity_kr", "equity_us"])
+async def test_preview_sell_mock_equity_market_loss_allowed(
+    monkeypatch, market_type
+) -> None:
+    # ROB-461 practice semantics survive: mock equity may book a market loss.
+    _patch_holdings(monkeypatch, avg_price=90400.0)
+    log_mock = Mock()
+    monkeypatch.setattr(order_validation, "_log_mock_loss_sell_bypass", log_mock)
+    result = await order_validation._preview_sell(
+        symbol="375500",
+        order_type="market",
+        quantity=10,
+        price=None,
+        current_price=68500.0,
+        market_type=market_type,
+        is_mock=True,
+    )
+    assert "error" not in result
+    assert result["realized_pnl"] < 0
+    # The bypass is audited like the limit-path one.
+    assert log_mock.call_args.kwargs["phase"] == "preview"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_sell_mock_crypto_market_loss_still_blocked(monkeypatch) -> None:
+    # Crypto routes to real Upbit funds; is_mock never relaxes it.
+    _patch_holdings(monkeypatch, avg_price=40000000.0, quantity=0.1)
+    result = await order_validation._preview_sell(
+        symbol="KRW-BTC",
+        order_type="market",
+        quantity=0.1,
+        price=None,
+        current_price=31000000.0,
+        market_type="crypto",
+        is_mock=True,
+    )
+    assert "error" in result and "market sell blocked" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _validate_sell_side: execution path mirrors the preview matrix
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_live_market_loss_blocked(monkeypatch) -> None:
+    _patch_holdings(monkeypatch, avg_price=90400.0)
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="375500",
+        normalized_symbol="375500",
+        market_type="equity_kr",
+        quantity=10,
+        order_type="market",
+        price=None,
+        current_price=68500.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        is_mock=False,
+        dry_run=False,
+    )
+    assert err is not None
+    assert "market sell blocked" in errors[0].lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_mock_equity_market_loss_allowed(monkeypatch) -> None:
+    _patch_holdings(monkeypatch, avg_price=90400.0)
+    monkeypatch.setattr(
+        order_validation,
+        "_get_kis_mock_shadow_exposure",
+        AsyncMock(
+            return_value={
+                "confidence": "db_shadow_pending",
+                "sell_reserved_quantity": 0,
+            }
+        ),
+    )
+    log_mock = Mock()
+    monkeypatch.setattr(order_validation, "_log_mock_loss_sell_bypass", log_mock)
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="375500",
+        normalized_symbol="375500",
+        market_type="equity_kr",
+        quantity=10,
+        order_type="market",
+        price=None,
+        current_price=68500.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        is_mock=True,
+        dry_run=True,
+    )
+    assert err is None and errors == []
+    assert log_mock.call_args.kwargs["phase"] == "execution"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_validate_sell_side_live_limit_guard_unchanged(monkeypatch) -> None:
+    # Regression: the existing live limit guard message is byte-for-byte intact.
+    _patch_holdings(monkeypatch, avg_price=90400.0)
+    errors: list[str] = []
+    qty, avg, err = await order_validation._validate_sell_side(
+        symbol="375500",
+        normalized_symbol="375500",
+        market_type="equity_kr",
+        quantity=10,
+        order_type="limit",
+        price=68000.0,
+        current_price=68500.0,
+        order_error_fn=lambda m: errors.append(m) or {"error": m},
+        is_mock=False,
+        dry_run=False,
+    )
+    assert err is not None and "below minimum" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# modify_order: live sell orders must not be repriced below the floor
+# ---------------------------------------------------------------------------
+def _patch_modify_holdings(monkeypatch, avg_price: float | None) -> AsyncMock:
+    holdings = {"avg_price": avg_price, "quantity": 10} if avg_price else {}
+    mock = AsyncMock(return_value=holdings)
+    monkeypatch.setattr(orders_modify_cancel, "_get_holdings_for_order", mock)
+    return mock
+
+
+class _KISModifyClient:
+    def __init__(self, open_orders):
+        self._open_orders = open_orders
+        self.modify_korea_order = AsyncMock(return_value={"odno": "NEW1"})
+        self.modify_overseas_order = AsyncMock(return_value={"odno": "NEW2"})
+
+    async def inquire_korea_orders(self, is_mock=False):
+        return self._open_orders
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_domestic_live_sell_reprice_below_floor_blocked(
+    monkeypatch,
+) -> None:
+    _patch_modify_holdings(monkeypatch, avg_price=90400.0)
+    client = _KISModifyClient(
+        [
+            {
+                "odno": "0001",
+                "ord_unpr": "95000",
+                "ord_qty": "10",
+                "sll_buy_dvsn_cd": "01",  # sell
+                "ord_gno_brno": "06010",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0001", "375500", "equity_kr", 68000.0, None, False, is_mock=False
+    )
+    assert result["success"] is False
+    assert "modify blocked" in result["error"].lower()
+    client.modify_korea_order.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_domestic_live_buy_reprice_allowed(monkeypatch) -> None:
+    holdings_mock = _patch_modify_holdings(monkeypatch, avg_price=90400.0)
+    client = _KISModifyClient(
+        [
+            {
+                "odno": "0002",
+                "ord_unpr": "70000",
+                "ord_qty": "10",
+                "sll_buy_dvsn_cd": "02",  # buy
+                "ord_gno_brno": "06010",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0002", "375500", "equity_kr", 68000.0, None, False, is_mock=False
+    )
+    assert result["success"] is True
+    client.modify_korea_order.assert_called_once()
+    holdings_mock.assert_not_called()  # buy modifies never touch holdings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_domestic_live_sell_reprice_above_floor_allowed(
+    monkeypatch,
+) -> None:
+    _patch_modify_holdings(monkeypatch, avg_price=60000.0)
+    client = _KISModifyClient(
+        [
+            {
+                "odno": "0003",
+                "ord_unpr": "70000",
+                "ord_qty": "10",
+                "sll_buy_dvsn_cd": "01",
+                "ord_gno_brno": "06010",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0003", "375500", "equity_kr", 68000.0, None, False, is_mock=False
+    )
+    assert result["success"] is True
+    client.modify_korea_order.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_domestic_quantity_only_modify_skips_floor(
+    monkeypatch,
+) -> None:
+    # Quantity-only modifies (new_price=None) introduce no new price risk.
+    holdings_mock = _patch_modify_holdings(monkeypatch, avg_price=90400.0)
+    client = _KISModifyClient(
+        [
+            {
+                "odno": "0004",
+                "ord_unpr": "95000",
+                "ord_qty": "10",
+                "sll_buy_dvsn_cd": "01",
+                "ord_gno_brno": "06010",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0004", "375500", "equity_kr", None, 5, False, is_mock=False
+    )
+    assert result["success"] is True
+    holdings_mock.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_overseas_live_sell_reprice_below_floor_blocked(
+    monkeypatch,
+) -> None:
+    _patch_modify_holdings(monkeypatch, avg_price=300.0)
+    client = _KISModifyClient([])
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    target_order = {
+        "ft_ord_unpr3": "310.0",
+        "ft_ord_qty": "10",
+        "sll_buy_dvsn_cd": "01",  # sell
+    }
+    monkeypatch.setattr(
+        orders_modify_cancel,
+        "_find_us_open_order_by_id",
+        AsyncMock(return_value=(target_order, "NASD", ["NASD"])),
+    )
+    result = await orders_modify_cancel._modify_kis_overseas(
+        "0005", "AAPL", "equity_us", 250.0, None, False, is_mock=False
+    )
+    assert result["success"] is False
+    assert "modify blocked" in result["error"].lower()
+    client.modify_overseas_order.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_upbit_sell_reprice_below_floor_blocked(monkeypatch) -> None:
+    _patch_modify_holdings(monkeypatch, avg_price=40000000.0)
+    monkeypatch.setattr(
+        orders_modify_cancel.upbit_service,
+        "fetch_order_detail",
+        AsyncMock(
+            return_value={
+                "state": "wait",
+                "ord_type": "limit",
+                "side": "ask",  # sell
+                "price": "41000000",
+                "remaining_volume": "0.1",
+            }
+        ),
+    )
+    reorder = AsyncMock()
+    monkeypatch.setattr(
+        orders_modify_cancel.upbit_service, "cancel_and_reorder", reorder
+    )
+    result = await orders_modify_cancel._modify_upbit(
+        "uuid-1", "KRW-BTC", "crypto", 31000000.0, None, False
+    )
+    assert result["success"] is False
+    assert "modify blocked" in result["error"].lower()
+    reorder.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_upbit_buy_reprice_allowed(monkeypatch) -> None:
+    holdings_mock = _patch_modify_holdings(monkeypatch, avg_price=40000000.0)
+    monkeypatch.setattr(
+        orders_modify_cancel.upbit_service,
+        "fetch_order_detail",
+        AsyncMock(
+            return_value={
+                "state": "wait",
+                "ord_type": "limit",
+                "side": "bid",  # buy
+                "price": "39000000",
+                "remaining_volume": "0.1",
+            }
+        ),
+    )
+    reorder = AsyncMock(return_value={"new_order": {"uuid": "uuid-2"}})
+    monkeypatch.setattr(
+        orders_modify_cancel.upbit_service, "cancel_and_reorder", reorder
+    )
+    result = await orders_modify_cancel._modify_upbit(
+        "uuid-1", "KRW-BTC", "crypto", 31000000.0, None, False
+    )
+    assert result["success"] is True
+    reorder.assert_called_once()
+    holdings_mock.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_unknown_basis_fails_open(monkeypatch) -> None:
+    # Holdings without an avg_price (or missing entirely) must not brick modify.
+    _patch_modify_holdings(monkeypatch, avg_price=None)
+    client = _KISModifyClient(
+        [
+            {
+                "odno": "0006",
+                "ord_unpr": "95000",
+                "ord_qty": "10",
+                "sll_buy_dvsn_cd": "01",
+                "ord_gno_brno": "06010",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        orders_modify_cancel, "_create_kis_client", lambda *, is_mock: client
+    )
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0006", "375500", "equity_kr", 68000.0, None, False, is_mock=False
+    )
+    assert result["success"] is True
+    client.modify_korea_order.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_kis_mock_domestic_skips_floor(monkeypatch) -> None:
+    # Mock modifies delegate before the live guard (ROB-461 practice semantics).
+    delegate = AsyncMock(return_value={"success": True, "status": "modified"})
+    monkeypatch.setattr(orders_modify_cancel, "_modify_kis_mock_domestic", delegate)
+    holdings_mock = _patch_modify_holdings(monkeypatch, avg_price=90400.0)
+    result = await orders_modify_cancel._modify_kis_domestic(
+        "0007", "375500", "equity_kr", 68000.0, None, False, is_mock=True
+    )
+    assert result["success"] is True
+    delegate.assert_called_once()
+    holdings_mock.assert_not_called()

--- a/tests/test_mcp_order_tools.py
+++ b/tests/test_mcp_order_tools.py
@@ -703,6 +703,7 @@ async def test_modify_order_crypto_success(monkeypatch):
                 "uuid": "od-1",
                 "state": "wait",
                 "ord_type": "limit",
+                "side": "bid",  # buy — ROB-518 sell-reprice floor not in play
                 "price": "50000000",
                 "remaining_volume": "0.001",
             }
@@ -751,6 +752,8 @@ async def test_modify_order_us_uses_resolved_exchange(monkeypatch):
                         "odno": "US-OD-1",
                         "ft_ord_unpr3": "207.0",
                         "ft_ord_qty": "2",
+                        # buy — ROB-518 sell-reprice floor not in play
+                        "sll_buy_dvsn_cd": "02",
                     }
                 ]
             return []
@@ -807,6 +810,8 @@ async def test_modify_order_us_uses_resolved_exchange_amex(monkeypatch):
                         "odno": "US-OD-1",
                         "ft_ord_unpr3": "208.0",
                         "ft_ord_qty": "3",
+                        # buy — ROB-518 sell-reprice floor not in play
+                        "sll_buy_dvsn_cd": "02",
                     }
                 ]
             return []


### PR DESCRIPTION
## 배경

operator 정책: **live(비-mock) 계좌에서는 손실 매도(평단 미만 매도)를 차단** — 실수 방지. live 지정가 매도는 이미 이중 가드(평단×1.01 플로어 + below-current)로 차단되어 있으나, ROB-507 파악 중 가드를 아예 타지 않는 라이브 경로 2개를 발견 ([ROB-518](https://linear.app/mgh3326/issue/ROB-518)).

## 갭

| 경로 | 변경 전 |
|------|---------|
| **시장가 매도 (live)** | `_preview_sell`/`_validate_sell_side`가 `order_type == "limit"`일 때만 가드 실행 → 현재가 < 평단×1.01이어도 live 시장가 매도 무검증 통과. `POST /api/screener/order`(웹 대시보드) 및 내부 `_place_order_impl` 호출자로 실제 도달 가능 |
| **modify_order (live)** | `modify_order_impl`에 가격 가드 없음 → 정상 제출된 live 매도 주문을 평단 아래로 정정하면 제출시점 플로어 우회 |

## 변경

1. **`evaluate_market_sell_loss_guard`** (신규 순수 가드, `order_validation.py`): live 시장가 매도 시 `current_price < avg_price × 1.01`이면 차단. preview + execution 양쪽 배선. equity_kr/equity_us/crypto 전체.
   - mock equity는 ROB-461 `allow_loss_sell` 의미론 유지 (손절 연습 보존) + 시장가 bypass도 limit과 동일하게 감사 로그
   - `avg_price <= 0`(원가 미상)은 기존 limit 가드와 동일하게 fail-open
2. **`_live_sell_reprice_floor_error`** (신규, `orders_modify_cancel.py`): live 매도 주문 정정 시 `new_price`에 동일 플로어. Upbit / KIS 국내 / KIS 해외 3경로 배선 (mock은 가드 도달 전 위임/unsupported 반환). 수량-only 정정·매수 정정은 보유 조회 자체를 안 탐.
3. **defensive_trim / scalping_exit 불변**: 둘 다 limit 전용 전제조건(ValueError)이라 시장가 경로 도달 불가. defensive_trim은 live 유일의 sanctioned 손절 경로로 유지 (Linear 승인 게이트 + 감사 로그).

## 테스트

- 신규 `tests/test_live_loss_sell_hard_guard.py` 24개: 순수 가드(차단/허용/경계/fail-open) + preview/execution 시장가 매트릭스(live 차단, mock equity 허용+감사, mock crypto 차단) + modify 3경로(매도 차단·매수 통과·수량-only 스킵·원가미상 fail-open·mock 위임)
- 기존 ROB-461 테스트 1건 갱신: "시장가는 가드 면제가 의도" 문서화 테스트 → ROB-518로 의도가 뒤집혀 "mock 허용+감사"로 재정의
- 기존 modify 테스트 3건: fixture에 side 필드 없어(실 API는 항상 포함) 보수적 sell 분류에 걸림 → 명시적 buy fixture로 갱신
- **전체 단위 스위트 11,290 passed / 0 failed**, ruff + ty clean

## 안전 경계

- migration 0, 브로커 mutation 추가 없음 (차단 로직만)
- mock 동작 변경 없음 (감사 로그 1건 추가만), 레거시 자동매도 경로(이미 플로어 있음) 무변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)