### PR TITLE
feat(ROB-507): buy_ladder_fill_preview — buy-side 래더 fill-safety 미러 + anchor_as_of echo

### DIFF
--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -408,8 +408,9 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "fill/journal/realized_pnl. reconcile is the LOCAL bookkeeping "
             "layer; the live-account truth is get_holdings / "
             "get_available_capital. "
-            "For multi-rung SELL limit ladders, run sell_ladder_fill_preview "
-            "first to check zero-fill risk (ROB-477). "
+            "For multi-rung limit ladders, run sell_ladder_fill_preview "
+            "(sells, ROB-477) or buy_ladder_fill_preview (buys, ROB-507) "
+            "first to check zero-fill risk. "
             "account_mode='kis_live' is accepted but redundant; "
             "any other account_mode value is rejected."
         ),

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -33,7 +33,65 @@ ORDER_TOOL_NAMES: set[str] = {
     "get_order_history",
     "kis_mock_reconciliation_run",
     "sell_ladder_fill_preview",
+    "buy_ladder_fill_preview",
 }
+
+
+def _ladder_fill_preview_response(
+    *,
+    side: str,
+    symbol: str,
+    anchor_price: float,
+    rungs: list[dict[str, Any]],
+    atr: float | None,
+    anchor_source: str | None,
+    anchor_as_of: str | None,
+) -> dict[str, Any]:
+    """Shared body for sell_ladder_fill_preview / buy_ladder_fill_preview."""
+    try:
+        parsed_rungs = [
+            LadderRung(
+                limit_price=float(rung["limit_price"]),
+                quantity=(
+                    float(rung["quantity"])
+                    if rung.get("quantity") is not None
+                    else None
+                ),
+            )
+            for rung in rungs
+        ]
+    except (KeyError, TypeError, ValueError) as exc:
+        return {
+            "success": False,
+            "error": f"invalid rungs payload (need 'limit_price'): {exc!r}",
+            "expected": "[{'limit_price': float, 'quantity': float|null}, ...]",
+        }
+    warnings, fill_safety = evaluate_ladder_fill_safety(
+        side=side,
+        rungs=parsed_rungs,
+        anchor_price=anchor_price,
+        anchor_source=anchor_source,
+        atr=atr,
+    )
+    if fill_safety is None:
+        return {
+            "success": False,
+            "error": (
+                "nothing to analyze: anchor_price must be > 0 and at least "
+                "one rung needs limit_price > 0"
+            ),
+            "symbol": symbol,
+        }
+    result: dict[str, Any] = {
+        "success": True,
+        "symbol": symbol,
+        "read_only": True,
+        "warnings": warnings,
+        "fill_safety": fill_safety,
+    }
+    if anchor_as_of is not None:
+        result["anchor_as_of"] = anchor_as_of
+    return result
 
 
 def _kis_mock_config_error() -> dict[str, Any] | None:
@@ -266,7 +324,9 @@ def register_order_tools(mcp: FastMCP) -> None:
             "2026-06-09 incident: 8/8 all-above-market sell ladders filled "
             "nothing) and ladder_missing_near_market_anchor (no rung at or "
             "near the anchor), plus per-rung distance pct / ATR multiples and "
-            "a suggested anchor rung. Run this BEFORE submitting multi-rung "
+            "a suggested anchor rung. anchor_as_of (optional ISO timestamp "
+            "of the anchor quote) is echoed back so a later reviewer can "
+            "judge anchor staleness. Run this BEFORE submitting multi-rung "
             "sell ladders via place_order / kis_live_place_order."
         ),
     )
@@ -276,47 +336,59 @@ def register_order_tools(mcp: FastMCP) -> None:
         rungs: list[dict[str, Any]],
         atr: float | None = None,
         anchor_source: str | None = None,
+        anchor_as_of: str | None = None,
     ):
-        try:
-            parsed_rungs = [
-                LadderRung(
-                    limit_price=float(rung["limit_price"]),
-                    quantity=(
-                        float(rung["quantity"])
-                        if rung.get("quantity") is not None
-                        else None
-                    ),
-                )
-                for rung in rungs
-            ]
-        except (KeyError, TypeError, ValueError) as exc:
-            return {
-                "success": False,
-                "error": f"invalid rungs payload (need 'limit_price'): {exc!r}",
-                "expected": "[{'limit_price': float, 'quantity': float|null}, ...]",
-            }
-        warnings, fill_safety = evaluate_ladder_fill_safety(
-            rungs=parsed_rungs,
+        return _ladder_fill_preview_response(
+            side="sell",
+            symbol=symbol,
             anchor_price=anchor_price,
-            anchor_source=anchor_source,
+            rungs=rungs,
             atr=atr,
+            anchor_source=anchor_source,
+            anchor_as_of=anchor_as_of,
         )
-        if fill_safety is None:
-            return {
-                "success": False,
-                "error": (
-                    "nothing to analyze: anchor_price must be > 0 and at least "
-                    "one rung needs limit_price > 0"
-                ),
-                "symbol": symbol,
-            }
-        return {
-            "success": True,
-            "symbol": symbol,
-            "read_only": True,
-            "warnings": warnings,
-            "fill_safety": fill_safety,
-        }
+
+    @mcp.tool(
+        name="buy_ladder_fill_preview",
+        description=(
+            "[ROB-507] Read-only fill-safety analysis for a multi-rung BUY "
+            "limit ladder (mirror of sell_ladder_fill_preview). No broker "
+            "calls, no order mutation. Pass anchor_price (current price or "
+            "best ask from get_quote) and the FULL ladder as "
+            "rungs=[{'limit_price': 165.5, 'quantity': 10.0}, ...]; atr "
+            "optional (widens the near-market threshold to max(0.3% of "
+            "anchor, 0.3*ATR)). Returns warnings: ladder_all_below_market "
+            "(zero-fill tail risk in a rally — the mirror of the 2026-06-09 "
+            "all-above-market sell incident) and "
+            "ladder_missing_near_market_anchor (no rung at or near the "
+            "anchor), plus per-rung distance pct / ATR multiples and a "
+            "suggested anchor rung. anchor_as_of (optional ISO timestamp of "
+            "the anchor quote) is echoed back so a later reviewer can judge "
+            "anchor staleness (2026-06-10: 5+ stale anchors drifted 1-3% "
+            "between analysis and submission). Run this BEFORE submitting "
+            "multi-rung buy ladders via place_order / kis_live_place_order. "
+            "Note: a buy rung ABOVE the anchor is marketable and place_order "
+            "rejects it outright (buy limit > current is a hard error), so "
+            "the actionable risk here is the all-below zero-fill tail."
+        ),
+    )
+    async def buy_ladder_fill_preview(
+        symbol: str,
+        anchor_price: float,
+        rungs: list[dict[str, Any]],
+        atr: float | None = None,
+        anchor_source: str | None = None,
+        anchor_as_of: str | None = None,
+    ):
+        return _ladder_fill_preview_response(
+            side="buy",
+            symbol=symbol,
+            anchor_price=anchor_price,
+            rungs=rungs,
+            atr=atr,
+            anchor_source=anchor_source,
+            anchor_as_of=anchor_as_of,
+        )
 
     @mcp.tool(
         name="cancel_order",

--- a/app/services/orders/ladder_fill_safety.py
+++ b/app/services/orders/ladder_fill_safety.py
@@ -1,15 +1,23 @@
-"""Pure fill-safety analysis for multi-rung sell limit ladders (ROB-477).
+"""Pure fill-safety analysis for multi-rung limit ladders (ROB-477 / ROB-507).
 
 No broker calls, no I/O, no DB. Shared by:
 - app/services/action_report/us/order_preview.py (ROB-244 preview gate)
-- app/mcp_server/tooling/orders_registration.py (sell_ladder_fill_preview tool)
+- app/mcp_server/tooling/orders_registration.py (sell_ladder_fill_preview /
+  buy_ladder_fill_preview tools)
 
-Semantics:
+Semantics (side="sell", the ROB-477 original):
 - ladder_all_above_market: every VALID rung is strictly above the anchor.
 - ladder_missing_near_market_anchor: no VALID rung is marketable (<= anchor)
   NOR near-above-market (above anchor but within the near threshold).
-- Rungs with limit_price <= 0 are invalid: excluded from every aggregate and
-  never satisfy the anchor requirement.
+
+Semantics (side="buy", the ROB-507 mirror):
+- ladder_all_below_market: every VALID rung is strictly below the anchor —
+  zero-fill tail risk in a rally.
+- ladder_missing_near_market_anchor: no VALID rung is marketable (>= anchor)
+  NOR near-below-market (below anchor but within the near threshold).
+
+Rungs with limit_price <= 0 are invalid: excluded from every aggregate and
+never satisfy the anchor requirement.
 """
 
 from __future__ import annotations
@@ -22,6 +30,7 @@ DEFAULT_NEAR_MARKET_ANCHOR_PCT = 0.3
 DEFAULT_NEAR_MARKET_ANCHOR_ATR_MULTIPLE = 0.3
 
 WARNING_ALL_ABOVE_MARKET = "ladder_all_above_market"
+WARNING_ALL_BELOW_MARKET = "ladder_all_below_market"
 WARNING_MISSING_NEAR_MARKET_ANCHOR = "ladder_missing_near_market_anchor"
 
 
@@ -39,17 +48,23 @@ def evaluate_ladder_fill_safety(
     *,
     rungs: Sequence[LadderRung],
     anchor_price: float | None,
+    side: str = "sell",
     anchor_source: str | None = None,
     atr: float | None = None,
     near_market_pct: float = DEFAULT_NEAR_MARKET_ANCHOR_PCT,
     near_market_atr_multiple: float = DEFAULT_NEAR_MARKET_ANCHOR_ATR_MULTIPLE,
 ) -> tuple[list[str], dict[str, Any] | None]:
-    """Return (warnings, details) for a sell limit ladder.
+    """Return (warnings, details) for a limit ladder on the given side.
 
     Returns ([], None) when there is nothing to analyze: no valid rungs or a
-    missing/non-positive anchor. Detail keys stay camelCase for byte-compat
-    with the PR #1228 fillSafety payload.
+    missing/non-positive anchor. Detail keys stay camelCase; the side="sell"
+    key set is byte-compatible with the PR #1228 fillSafety payload, while
+    side="buy" uses the mirrored belowMarket/nearBelowMarket keys. The
+    per-rung risk distance is signed away-from-market: rung - anchor for
+    sells, anchor - rung for buys (positive = fill-miss direction).
     """
+    if side not in ("sell", "buy"):
+        raise ValueError(f"side must be 'sell' or 'buy', got {side!r}")
     if anchor_price is None or anchor_price <= 0:
         return [], None
 
@@ -62,8 +77,14 @@ def evaluate_ladder_fill_safety(
     if atr is not None and atr > 0:
         near_threshold_usd = max(near_threshold_usd, atr * near_market_atr_multiple)
 
+    is_sell = side == "sell"
+    away_key = "aboveMarket" if is_sell else "belowMarket"
+    near_away_key = "nearAboveMarket" if is_sell else "nearBelowMarket"
+    all_away_detail_key = "allRungsAboveMarket" if is_sell else "allRungsBelowMarket"
+    all_away_warning = WARNING_ALL_ABOVE_MARKET if is_sell else WARNING_ALL_BELOW_MARKET
+
     rung_details: list[dict[str, Any]] = []
-    all_above_market = True
+    all_away_from_market = True
     has_marketable_anchor = False
     has_near_market_anchor = False
 
@@ -78,15 +99,18 @@ def evaluate_ladder_fill_safety(
                 }
             )
             continue
-        distance_usd = rung.limit_price - anchor_price
+        if is_sell:
+            distance_usd = rung.limit_price - anchor_price
+        else:
+            distance_usd = anchor_price - rung.limit_price
         distance_pct = distance_usd / anchor_price * 100.0
-        above_market = rung.limit_price > anchor_price
-        marketable_anchor = not above_market
-        near_above_market = above_market and distance_usd <= near_threshold_usd
-        is_near_market_anchor = marketable_anchor or near_above_market
+        away_from_market = distance_usd > 0
+        marketable_anchor = not away_from_market
+        near_away_from_market = away_from_market and distance_usd <= near_threshold_usd
+        is_near_market_anchor = marketable_anchor or near_away_from_market
         atr_multiple = distance_usd / atr if atr is not None and atr > 0 else None
 
-        all_above_market = all_above_market and above_market
+        all_away_from_market = all_away_from_market and away_from_market
         has_marketable_anchor = has_marketable_anchor or marketable_anchor
         has_near_market_anchor = has_near_market_anchor or is_near_market_anchor
         rung_details.append(
@@ -99,17 +123,17 @@ def evaluate_ladder_fill_safety(
                 "atrMultiple": (
                     round(atr_multiple, 4) if atr_multiple is not None else None
                 ),
-                "aboveMarket": above_market,
+                away_key: away_from_market,
                 "marketableAnchor": marketable_anchor,
-                "nearAboveMarket": near_above_market,
+                near_away_key: near_away_from_market,
                 "nearMarketAnchor": is_near_market_anchor,
                 "invalid": False,
             }
         )
 
     warnings: list[str] = []
-    if all_above_market:
-        warnings.append(WARNING_ALL_ABOVE_MARKET)
+    if all_away_from_market:
+        warnings.append(all_away_warning)
     if not has_near_market_anchor:
         warnings.append(WARNING_MISSING_NEAR_MARKET_ANCHOR)
 
@@ -120,7 +144,7 @@ def evaluate_ladder_fill_safety(
         "nearMarketThresholdUsd": _round_price(near_threshold_usd),
         "nearMarketAtrMultiple": near_market_atr_multiple,
         "atrUsd": _round_price(atr) if atr is not None else None,
-        "allRungsAboveMarket": all_above_market,
+        all_away_detail_key: all_away_from_market,
         "hasMarketableAnchor": has_marketable_anchor,
         "hasNearMarketAnchor": has_near_market_anchor,
         "invalidRungCount": invalid_rung_count,
@@ -130,7 +154,7 @@ def evaluate_ladder_fill_safety(
         details["suggestedAnchorRung"] = {
             "limitPriceUsd": _round_price(anchor_price),
             "rationale": (
-                "place at least one sell rung at or near the anchor price "
+                f"place at least one {side} rung at or near the anchor price "
                 "(within the near-market threshold) to secure a partial fill"
             ),
         }

--- a/tests/test_ladder_fill_safety.py
+++ b/tests/test_ladder_fill_safety.py
@@ -119,3 +119,129 @@ def test_suggested_anchor_rung_present_only_when_warning():
     )
     assert clean_warnings == []
     assert "suggestedAnchorRung" not in clean_details
+
+
+# ---------------------------------------------------------------------------
+# ROB-507: buy-side mirror (side="buy")
+# ---------------------------------------------------------------------------
+def test_buy_all_below_and_no_near_anchor_fires_both_warnings():
+    # GLW-shaped entry ladder: every rung well below the anchor -> zero-fill
+    # tail risk in a rally (mirror of the 2026-06-09 sell incident).
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[
+            LadderRung(limit_price=165.5, quantity=10.0),
+            LadderRung(limit_price=157.25, quantity=10.0),
+        ],
+        anchor_price=168.9,
+    )
+    assert "ladder_all_below_market" in warnings
+    assert "ladder_missing_near_market_anchor" in warnings
+    assert details["allRungsBelowMarket"] is True
+    assert details["hasNearMarketAnchor"] is False
+
+
+def test_buy_highest_rung_within_threshold_fires_only_all_below():
+    # 168.5 vs anchor 168.9 = -0.237% within the 0.3% threshold.
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[
+            LadderRung(limit_price=168.5, quantity=10.0),
+            LadderRung(limit_price=157.25, quantity=10.0),
+        ],
+        anchor_price=168.9,
+    )
+    assert "ladder_all_below_market" in warnings
+    assert "ladder_missing_near_market_anchor" not in warnings
+    assert details["hasNearMarketAnchor"] is True
+    assert details["rungs"][0]["nearBelowMarket"] is True
+
+
+def test_buy_marketable_rung_clears_both_warnings():
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[
+            LadderRung(limit_price=168.9, quantity=10.0),
+            LadderRung(limit_price=157.25, quantity=10.0),
+        ],
+        anchor_price=168.9,
+    )
+    assert warnings == []
+    assert details["allRungsBelowMarket"] is False
+    assert details["hasMarketableAnchor"] is True
+
+
+def test_buy_atr_widens_near_threshold():
+    # pct threshold = 168.9*0.3% ~= 0.5067; ATR 4.0 * 0.3 = 1.2 -> 167.8 is near.
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[
+            LadderRung(limit_price=167.8, quantity=1.0),
+            LadderRung(limit_price=157.25, quantity=1.0),
+        ],
+        anchor_price=168.9,
+        atr=4.0,
+    )
+    assert "ladder_missing_near_market_anchor" not in warnings
+    assert details["rungs"][0]["nearBelowMarket"] is True
+
+
+def test_buy_distance_sign_and_atr_multiple_are_risk_oriented():
+    # For buys the risk distance is anchor - rung (positive = away from market,
+    # below), mirroring the sell convention (positive = above market).
+    _, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[LadderRung(limit_price=160.0, quantity=1.0)],
+        anchor_price=170.0,
+        atr=5.0,
+    )
+    rung = details["rungs"][0]
+    assert rung["distanceUsd"] == 10.0
+    assert rung["distancePct"] == pytest.approx(10.0 / 170.0 * 100.0, abs=1e-3)
+    assert rung["atrMultiple"] == 2.0
+    assert rung["belowMarket"] is True
+    assert rung["marketableAnchor"] is False
+
+
+def test_buy_suggested_anchor_rung_mentions_buy():
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[LadderRung(limit_price=150.0, quantity=1.0)],
+        anchor_price=170.0,
+    )
+    assert warnings
+    assert "buy" in details["suggestedAnchorRung"]["rationale"]
+
+
+def test_buy_invalid_rungs_excluded_like_sell():
+    warnings, details = evaluate_ladder_fill_safety(
+        side="buy",
+        rungs=[
+            LadderRung(limit_price=0.0, quantity=1.0),
+            LadderRung(limit_price=160.0, quantity=1.0),
+        ],
+        anchor_price=170.0,
+    )
+    assert details["invalidRungCount"] == 1
+    assert "ladder_all_below_market" in warnings
+
+
+def test_invalid_side_raises():
+    with pytest.raises(ValueError):
+        evaluate_ladder_fill_safety(
+            side="hold",
+            rungs=[LadderRung(limit_price=160.0)],
+            anchor_price=170.0,
+        )
+
+
+def test_sell_default_side_output_keys_unchanged():
+    # Byte-compat guard: omitting side keeps the exact sell key set.
+    _, details = evaluate_ladder_fill_safety(
+        rungs=[LadderRung(limit_price=66.0, quantity=2.0)],
+        anchor_price=63.95,
+    )
+    assert "allRungsAboveMarket" in details
+    assert "allRungsBelowMarket" not in details
+    assert "aboveMarket" in details["rungs"][0]
+    assert "belowMarket" not in details["rungs"][0]

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -2672,3 +2672,86 @@ async def test_sell_ladder_fill_preview_rejects_non_positive_anchor():
         rungs=[{"limit_price": 64.0}],
     )
     assert result["success"] is False
+
+
+# ----------------------------------------------------------------------
+# ROB-507: buy_ladder_fill_preview read-only tool (buy-side mirror)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_buy_ladder_fill_preview_all_below_market():
+    tools = build_tools()
+    result = await tools["buy_ladder_fill_preview"](
+        symbol="GLW",
+        anchor_price=168.9,
+        rungs=[
+            {"limit_price": 165.5, "quantity": 10.0},
+            {"limit_price": 157.25, "quantity": 10.0},
+        ],
+    )
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert "ladder_all_below_market" in result["warnings"]
+    assert "ladder_missing_near_market_anchor" in result["warnings"]
+    assert result["fill_safety"]["allRungsBelowMarket"] is True
+
+
+@pytest.mark.asyncio
+async def test_buy_ladder_fill_preview_near_anchor_only_all_below():
+    tools = build_tools()
+    result = await tools["buy_ladder_fill_preview"](
+        symbol="GLW",
+        anchor_price=168.9,
+        rungs=[
+            {"limit_price": 168.5, "quantity": 10.0},
+            {"limit_price": 157.25, "quantity": 10.0},
+        ],
+    )
+    assert result["success"] is True
+    assert "ladder_all_below_market" in result["warnings"]
+    assert "ladder_missing_near_market_anchor" not in result["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_buy_ladder_fill_preview_rejects_bad_payload():
+    tools = build_tools()
+    result = await tools["buy_ladder_fill_preview"](
+        symbol="GLW",
+        anchor_price=168.9,
+        rungs=[{"price_typo": 165.5}],
+    )
+    assert result["success"] is False
+    assert "limit_price" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_buy_ladder_fill_preview_rejects_non_positive_anchor():
+    tools = build_tools()
+    result = await tools["buy_ladder_fill_preview"](
+        symbol="GLW",
+        anchor_price=0.0,
+        rungs=[{"limit_price": 165.5, "quantity": 10.0}],
+    )
+    assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_ladder_fill_preview_echoes_anchor_as_of():
+    # ROB-507 B: stale-anchor 가드 보조 — 호출자가 anchor 시각을 명시하면
+    # 응답에 그대로 echo되어 검증 에이전트가 드리프트를 판단할 수 있다.
+    tools = build_tools()
+    buy = await tools["buy_ladder_fill_preview"](
+        symbol="GLW",
+        anchor_price=168.9,
+        rungs=[{"limit_price": 168.9, "quantity": 10.0}],
+        anchor_as_of="2026-06-11T09:31:00-04:00",
+    )
+    assert buy["anchor_as_of"] == "2026-06-11T09:31:00-04:00"
+    sell = await tools["sell_ladder_fill_preview"](
+        symbol="IONQ",
+        anchor_price=63.95,
+        rungs=[{"limit_price": 63.95, "quantity": 2.0}],
+        anchor_as_of="2026-06-11T09:31:00-04:00",
+    )
+    assert sell["anchor_as_of"] == "2026-06-11T09:31:00-04:00"


### PR DESCRIPTION
## 배경

[ROB-507](https://linear.app/mgh3326/issue/ROB-507) — ROB-477 `sell_ladder_fill_preview` 후속. 2026-06-10 세션에서 워크플로 에이전트 8곳+가 *"sell-only; buy-side near-market check done manually"*를 반복했고, USD 확보 후 매수 래더(AVGO/GLW/CI 등) 가동을 앞두고 buy 거울상 도구가 필요.

## 스코프 조정 (Linear 코멘트 게시)

이슈 B항목(`marketable_limit_warning`)은 **제외**: 코드 확인 결과 매도 지정가<현재가, 매수 지정가>현재가 모두 **이미 하드 에러**로 차단됨 (경고가 아니라 거부). 손실 방향 실수 방지는 ROB-518(#1258)로 분리. 남은 스코프 = A항목(buy preview) + 경량 anchor 신선도 표면.

## 변경

1. **`evaluate_ladder_fill_safety` side 일반화** (`app/services/orders/ladder_fill_safety.py`): `side: str = "sell"` 추가.
   - buy: `ladder_all_below_market`(급등장 0체결 tail risk — 2026-06-09 sell 사건의 거울상) + `ladder_missing_near_market_anchor` 미러, rung 키는 `belowMarket`/`nearBelowMarket`
   - per-rung 거리는 위험 방향 부호: sell=`rung−anchor`, buy=`anchor−rung` (양수 = fill-miss 방향), atrMultiple 동일 규약
   - **sell 출력 키셋 byte-compat 보존** — 기존 소비자(ROB-244 `order_preview.py`, MCP sell 도구) 무변경, 회귀 테스트로 고정
2. **신규 MCP 도구 `buy_ladder_fill_preview`** (read-only): sell과 공용 글루(`_ladder_fill_preview_response`) 공유. 도구 설명에 'buy rung > anchor는 place_order가 어차피 거부하므로 실질 리스크는 all-below tail'을 명시.
3. **`anchor_as_of` echo** (두 preview 도구, optional ISO timestamp): 검증 에이전트가 anchor 신선도를 판단할 근거 (2026-06-10 stale anchor 5회+ 적발 후속). stateful preview↔place_order 연동은 비채택 — 도구는 stateless 유지, 제출시점 하드 가드(기존 + ROB-518)가 실질 방어선.
4. `kis_live_place_order` 설명에 buy preview 안내 추가.

## 테스트

- 순수 헬퍼: buy 미러 8케이스(all-below/near-threshold/marketable/ATR 확장/부호 규약/invalid rung/side 검증) + **sell 키셋 byte-compat 가드** — 18 passed
- MCP: buy 도구 4케이스 + anchor_as_of echo(양 도구) — ladder 9 passed
- 프로파일/표면: 133 passed
- **전체 단위 스위트 11,299 passed / 0 failed**, ruff + ty clean

## 안전 경계

- migration 0, 브로커 mutation 없음 (read-only 분석 도구)
- 기존 sell 도구 시그니처는 additive(optional `anchor_as_of`)만

🤖 Generated with [Claude Code](https://claude.com/claude-code)