### PR TITLE
feat(ROB-514): include watch execution context in alerts

### DIFF
--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -49,7 +49,9 @@ from app.services.hermes_client import (
     ReviewTriggerPayload,
     build_invest_links,
     build_operator_action_guidance,
+    planned_action_from_max_action,
     price_guidance_from_watch_recommendation,
+    trigger_checklist_from_raw,
 )
 from app.services.investment_reports.idempotency import watch_event_key
 from app.services.investment_reports.repository import InvestmentReportsRepository
@@ -259,6 +261,8 @@ class InvestmentWatchScanner:
         alert_threshold_high = alert.threshold_high
         alert_intent = alert.intent
         alert_action_mode = alert.action_mode
+        alert_max_action = dict(alert.max_action or {})
+        alert_trigger_checklist = list(alert.trigger_checklist or [])
 
         outcome = _OUTCOME_BY_ACTION_MODE.get(alert_action_mode, "notified")
         correlation_id = uuid4().hex
@@ -370,6 +374,8 @@ class InvestmentWatchScanner:
                 action_mode=event.action_mode, outcome=event.outcome
             ),
             price_guidance=price_guidance,
+            planned_action=planned_action_from_max_action(alert_max_action),
+            trigger_checklist=trigger_checklist_from_raw(alert_trigger_checklist),
         )
         return {
             "event": event,

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -629,6 +629,11 @@ Unknown top-level item keys are rejected with `error: "invalid_items"`. Put call
 
 Order linkage note: `linked_order_ids` is report-side reference metadata. For new live orders, pass the report item's `item_uuid` as `report_item_uuid` to the order tool so ROB-473 ledger audit linkage is populated.
 
+Watch execution context fields:
+- `trigger_checklist`: `string[]`; copied into watch alert notifications so the operator can re-check the trigger.
+- `max_action`: structured watch execution-plan JSON. Supported keys include `side`, `quantity` or `notional`, optional `amount_krw`, optional `limit_price`, optional `limit_price_hint`, optional `ladder_level`, and optional `account_mode`.
+- Do not send `planned_action` in item input. `planned_action` is derived from `max_action` when Hermes watch payloads are built.
+
 ### `manage_watch_alerts` — removed (ROB-265)
 
 The legacy Redis-backed `manage_watch_alerts` MCP tool was removed by

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -141,6 +141,11 @@ CREATE_DESCRIPTION = (
     "rebalance_review), rationale. "
     "watch items also require watch_condition + valid_until unless "
     "operation='review'. "
+    "Watch execution context: trigger_checklist is string[] and is copied into "
+    "watch alert notifications. max_action is the structured execution-plan JSON; "
+    "supported keys include side, quantity or notional, amount_krw, limit_price, "
+    "limit_price_hint, ladder_level, and account_mode. planned_action in Hermes "
+    "payloads is derived from max_action; do not send planned_action as an item key. "
     "target_kind (asset|index|fx, default 'asset') is a SEPARATE optional field "
     "— it is NOT item_kind. "
     "decision_bucket (optional) must be one of: new_buy_candidate, open_action, "
@@ -171,7 +176,9 @@ ADD_ITEMS_DESCRIPTION = (
     "recreating the report. Draft-only: non-draft reports return "
     "error:'not_draft'. items[] use the same contract as investment_report_create; "
     "duplicate client_item_key rows are returned as existing items and are not "
-    "rewritten. No broker / order / watch mutation."
+    "rewritten. No broker / order / watch mutation. For watch items, trigger_checklist "
+    "string[] and max_action execution-plan keys follow the same contract as "
+    "investment_report_create."
 )
 
 UPDATE_DESCRIPTION = (
@@ -397,6 +404,9 @@ def _validate_report_items(
                 "operation is 'review'; decision_bucket must be one of the "
                 "DECISION_BUCKETS vocabulary. target_kind is a SEPARATE optional "
                 "field (asset|index|fx, default 'asset') — it is NOT item_kind."
+                " trigger_checklist must be string[]; watch execution plans belong in "
+                "max_action (side, quantity/notional, amount_krw, limit_price, "
+                "limit_price_hint, ladder_level, account_mode), not in planned_action."
             ),
         }
     return validated_items, None
@@ -768,6 +778,7 @@ async def investment_report_activate_watch_impl(
     idempotency_key: str | None = None,
     watch_condition: dict | None = None,
     valid_until: str | None = None,
+    attach_recommendation: bool = False,
 ) -> dict:
     request = ActivateWatchRequest.model_validate(
         {
@@ -776,6 +787,7 @@ async def investment_report_activate_watch_impl(
             "idempotency_key": idempotency_key,
             "watch_condition": watch_condition,
             "valid_until": valid_until,
+            "attach_recommendation": attach_recommendation,
         }
     )
     async with AsyncSessionLocal() as db:
@@ -783,11 +795,40 @@ async def investment_report_activate_watch_impl(
         repo = InvestmentReportsRepository(db)
         alert_row = await activation_svc.activate(request)
         item_row = await repo.get_item_by_uuid(request.item_uuid)
+
+        recommendation_attached: bool | None = None
+        recommendation_attach_error: str | None = None
+
+        if request.attach_recommendation and item_row is not None:
+            if item_row.watch_recommendation:
+                recommendation_attached = True
+            elif item_row.symbol is None:
+                recommendation_attached = False
+                recommendation_attach_error = "item symbol missing"
+            else:
+                try:
+                    rec_json = await _compute_watch_recommendation_json(
+                        symbol=item_row.symbol,
+                        market=alert_row.market,
+                        valid_until=item_row.valid_until,
+                    )
+                    if rec_json.get("data_state") == "data_gap":
+                        raise ValueError("refusing to attach a data_gap recommendation")
+                    await repo.update_item_watch_recommendation(item_row.id, rec_json)
+                    await db.flush()
+                    item_row = await repo.get_item_by_uuid(request.item_uuid)
+                    recommendation_attached = True
+                except Exception as exc:  # noqa: BLE001 - attach is opt-in and fail-open
+                    recommendation_attached = False
+                    recommendation_attach_error = str(exc)
+
         await db.commit()
 
         response = InvestmentReportActivateWatchResponse(
             alert=InvestmentWatchAlertResponse.model_validate(alert_row),
             item=InvestmentReportItemResponse.model_validate(item_row),
+            recommendation_attached=recommendation_attached,
+            recommendation_attach_error=recommendation_attach_error,
         )
     return response.model_dump(mode="json", by_alias=True)
 
@@ -809,6 +850,43 @@ def _normalize_recommend_symbol(symbol: str, market: str) -> str:
     return s
 
 
+async def _compute_watch_recommendation_json(
+    *,
+    symbol: str,
+    market: str,
+    valid_until: datetime | None,
+) -> dict[str, Any]:
+    if market not in _MARKET_MAP:
+        raise ValueError(f"unsupported_market: {market}")
+
+    md_symbol = _normalize_recommend_symbol(symbol, market)
+    md_market = _MARKET_MAP[market]
+    quote = await market_data_service.get_quote(symbol=md_symbol, market=md_market)
+    reference_price = (
+        Decimal(str(quote.price)) if getattr(quote, "price", None) is not None else None
+    )
+    candles = await market_data_service.get_ohlcv(
+        symbol=md_symbol,
+        market=md_market,
+        period="day",
+        count=LOOKBACK_DAYS + ATR_PERIOD + 6,
+    )
+    ordered = sorted(candles, key=lambda c: c.timestamp)
+    payload = compute_watch_recommendation(
+        WatchPolicyInput(
+            reference_price=reference_price,
+            best_bid=None,
+            best_ask=None,
+            daily_highs=[Decimal(str(c.high)) for c in ordered],
+            daily_lows=[Decimal(str(c.low)) for c in ordered],
+            daily_closes=[Decimal(str(c.close)) for c in ordered],
+        ),
+        computed_at=datetime.now(UTC),
+        valid_until=valid_until,
+    )
+    return payload.model_dump(mode="json")
+
+
 async def investment_watch_recommend_impl(
     symbol: str,
     market: str,
@@ -826,24 +904,6 @@ async def investment_watch_recommend_impl(
     if market not in _MARKET_MAP:
         return {"success": False, "error": "unsupported_market", "market": market}
 
-    md_symbol = _normalize_recommend_symbol(symbol, market)
-    md_market = _MARKET_MAP[market]
-
-    quote = await market_data_service.get_quote(symbol=md_symbol, market=md_market)
-    reference_price = (
-        Decimal(str(quote.price)) if getattr(quote, "price", None) is not None else None
-    )
-    candles = await market_data_service.get_ohlcv(
-        symbol=md_symbol,
-        market=md_market,
-        period="day",
-        count=LOOKBACK_DAYS + ATR_PERIOD + 6,
-    )
-    ordered = sorted(candles, key=lambda c: c.timestamp)
-    highs = [Decimal(str(c.high)) for c in ordered]
-    lows = [Decimal(str(c.low)) for c in ordered]
-    closes = [Decimal(str(c.close)) for c in ordered]
-
     valid_until = None
     async with AsyncSessionLocal() as db:
         repo = InvestmentReportsRepository(db)
@@ -853,19 +913,11 @@ async def investment_watch_recommend_impl(
             if item is not None:
                 valid_until = item.valid_until
 
-        payload = compute_watch_recommendation(
-            WatchPolicyInput(
-                reference_price=reference_price,
-                best_bid=None,
-                best_ask=None,
-                daily_highs=highs,
-                daily_lows=lows,
-                daily_closes=closes,
-            ),
-            computed_at=datetime.now(UTC),
+        rec_json = await _compute_watch_recommendation_json(
+            symbol=symbol,
+            market=market,
             valid_until=valid_until,
         )
-        rec_json = payload.model_dump(mode="json")
 
         if not commit:
             return {"success": True, "committed": False, "recommendation": rec_json}
@@ -880,7 +932,7 @@ async def investment_watch_recommend_impl(
                 "commit requires item action_verdict in {watch_only, limit_wait}; "
                 f"got {verdict!r}"
             )
-        if payload.data_state == "data_gap":
+        if rec_json.get("data_state") == "data_gap":
             raise ValueError("refusing to commit a data_gap recommendation")
 
         await repo.update_item_watch_recommendation(item.id, rec_json)

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -213,6 +213,9 @@ class MaxActionPayload(BaseModel):
     notional: Decimal | None = None
     limit_price: Decimal | None = None
     account_mode: AccountMode
+    amount_krw: Decimal | None = None
+    limit_price_hint: Decimal | None = None
+    ladder_level: str | None = None
 
     model_config = ConfigDict(extra="allow")
 
@@ -325,7 +328,7 @@ class IngestReportItem(BaseModel):
     target_price: ReportItemPriceLevelPayload | None = None
     linked_order_ids: list[LinkedOrderRefPayload] = Field(default_factory=list)
     watch_condition: WatchConditionPayload | None = None
-    trigger_checklist: list[Any] = Field(default_factory=list)
+    trigger_checklist: list[str] = Field(default_factory=list)
     max_action: dict[str, Any] = Field(default_factory=dict)
     valid_until: datetime | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -670,12 +673,9 @@ class ActivateWatchRequest(BaseModel):
     item_uuid: UUID
     actor: str
     idempotency_key: str | None = None
-    # ROB-393 — operation='review' watches are created without a condition
-    # (schema + DB CHECK both exempt them). Allow supplying the condition /
-    # expiry at activation time so such a watch can still be armed. Auto
-    # derivation of the condition is out of scope (ROB-337 seam).
     watch_condition: WatchConditionPayload | None = None
     valid_until: datetime | None = None
+    attach_recommendation: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -1071,6 +1071,8 @@ class InvestmentReportActivateWatchResponse(BaseModel):
     success: bool = True
     alert: InvestmentWatchAlertResponse
     item: InvestmentReportItemResponse
+    recommendation_attached: bool | None = None
+    recommendation_attach_error: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 from app.core.config import settings
 from app.schemas.investment_reports import (
     ItemIntentLiteral,
+    ItemSideLiteral,
     MarketLiteral,
     TargetKindLiteral,
     WatchActionModeLiteral,
@@ -89,6 +90,59 @@ class PriceGuidance(BaseModel):
     invalidation: WatchInvalidation | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+
+class PlannedAction(BaseModel):
+    """ROB-514 - operator-facing execution plan derived from max_action."""
+
+    side: ItemSideLiteral
+    qty: Decimal | None = None
+    amount_krw: Decimal | None = None
+    limit_price_hint: Decimal | None = None
+    ladder_level: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    return Decimal(str(value))
+
+
+def planned_action_from_max_action(
+    max_action: dict[str, Any] | None,
+) -> PlannedAction | None:
+    """Project stored max_action into the Hermes planned_action contract.
+
+    Fail-open: malformed optional context is omitted instead of blocking alert
+    delivery.
+    """
+    if not isinstance(max_action, dict) or not max_action:
+        return None
+    try:
+        return PlannedAction(
+            side=max_action.get("side"),
+            qty=_decimal_or_none(max_action.get("qty", max_action.get("quantity"))),
+            amount_krw=_decimal_or_none(max_action.get("amount_krw")),
+            limit_price_hint=_decimal_or_none(
+                max_action.get("limit_price_hint", max_action.get("limit_price"))
+            ),
+            ladder_level=(
+                str(max_action["ladder_level"])
+                if max_action.get("ladder_level") not in (None, "")
+                else None
+            ),
+        )
+    except Exception:  # noqa: BLE001 - notification context is advisory
+        logger.warning("max_action planned_action projection failed; omitting context")
+        return None
+
+
+def trigger_checklist_from_raw(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str)]
 
 
 def build_invest_links(
@@ -232,6 +286,10 @@ class ReviewTriggerPayload(BaseModel):
     invest_links: InvestLinks | None = None
     operator_action_guidance: OperatorActionGuidance | None = None
     price_guidance: PriceGuidance | None = None
+
+    # ROB-514 — watch alert execution plan & trigger checklist
+    planned_action: PlannedAction | None = None
+    trigger_checklist: list[str] | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/app/services/investment_reports/watch_validity_review.py
+++ b/app/services/investment_reports/watch_validity_review.py
@@ -37,7 +37,9 @@ from app.services.hermes_client import (
     ReviewTriggerPayload,
     build_invest_links,
     build_operator_action_guidance,
+    planned_action_from_max_action,
     price_guidance_from_watch_recommendation,
+    trigger_checklist_from_raw,
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_recommendation_policy import (
@@ -268,6 +270,10 @@ class WatchValidityReviewService:
             ),
             price_guidance=price_guidance_from_watch_recommendation(
                 stored_recommendation
+            ),
+            planned_action=planned_action_from_max_action(dict(alert.max_action or {})),
+            trigger_checklist=trigger_checklist_from_raw(
+                list(alert.trigger_checklist or [])
             ),
         )
         try:

--- a/docs/runbooks/watch-trigger-hermes-payload.md
+++ b/docs/runbooks/watch-trigger-hermes-payload.md
@@ -4,7 +4,7 @@ auto_trader가 watch 발화/유효성 재검토 시 `HERMES_WEBHOOK_URL`로 POST
 `ReviewTriggerPayload`(`app/services/hermes_client.py`) 계약 문서.
 Hermes Discord 렌더러가 이 문서를 기준으로 카드를 구성한다.
 
-## ROB-500 추가 필드 (additive, 모두 optional)
+## ROB-500 + ROB-514 추가 필드 (additive, 모두 optional)
 
 ```json
 {
@@ -24,7 +24,18 @@ Hermes Discord 렌더러가 이 문서를 기준으로 카드를 구성한다.
     "suggested_limit_price_range": {"low": "95", "high": "100"},
     "max_chase_price": "102",
     "invalidation": {"kind": "price_below", "price": "80", "text": null}
-  }
+  },
+  "planned_action": {
+    "side": "buy",
+    "qty": "1",
+    "amount_krw": "980000",
+    "limit_price_hint": "975000",
+    "ladder_level": "1"
+  },
+  "trigger_checklist": [
+    "Check latest quote spread",
+    "Confirm thesis still valid"
+  ]
 }
 ```
 
@@ -34,7 +45,7 @@ Hermes Discord 렌더러가 이 문서를 기준으로 카드를 구성한다.
   가격을 추론/생성하는 것은 금지.
 - 익절/매도 목표 필드는 계약에 없다. 렌더러가 임의 생성하지 않는다 (locked scope).
 
-## Hermes Discord 렌더러 요구사항 (ROB-500 §4)
+## Hermes Discord 렌더러 요구사항 (ROB-500 §4 + ROB-514)
 
 1. 카드 상단: `operator_action_guidance.headline` + 발화 조건
    (`symbol metric operator threshold`, `current_value`).
@@ -42,6 +53,8 @@ Hermes Discord 렌더러가 이 문서를 기준으로 카드를 구성한다.
    stock_path는 보조 context link).
 3. 그 다음: `price_guidance` 4개 값 (또는 "가격 가이드 없음").
 4. 하단 `Trace` 섹션: event/alert/report/item UUID + correlation_id.
+5. Render `planned_action` near `price_guidance` when present. If null, do not invent quantity or amount.
+6. Render each `trigger_checklist` string as an operator checklist. If empty, omit the checklist section.
 
 ## 배포 순서
 

--- a/docs/superpowers/plans/2026-06-11-rob-514-watch-execution-plan-alert-context.md
+++ b/docs/superpowers/plans/2026-06-11-rob-514-watch-execution-plan-alert-context.md
@@ -1,0 +1,923 @@
+# ROB-514 Watch Execution Plan Alert Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve watch-trigger re-review context by exposing structured planned action, trigger checklist, and optional recommendation attachment through the MCP and Hermes watch flows.
+
+**Architecture:** Keep `max_action` as the canonical persisted execution-plan JSON and add a Hermes-facing `planned_action` projection. Wire that projection plus `trigger_checklist` into scanner and validity-review payloads, then expose the input contract in MCP descriptions and docs. Add an opt-in, fail-open `attach_recommendation` path to activation without changing broker/order behavior or DB schema.
+
+**Tech Stack:** Python 3.13, Pydantic v2, SQLAlchemy async, FastMCP, pytest, `uv`.
+
+---
+
+## Decisions Locked
+
+- Do not add a `planned_action` DB column.
+- `planned_action` is derived from `alert.max_action`.
+- `trigger_checklist` is a `string[]` input contract for new items.
+- `attach_recommendation` defaults to `False`.
+- Recommendation attachment is fail-open and must not prevent watch activation.
+- No broker order submission, preview execution, scheduler activation, or DB migration in this slice.
+
+## File Structure
+
+| File | Role | Change |
+|---|---|---|
+| `app/schemas/investment_reports.py` | Item and activation contracts | Narrow checklist input, extend `MaxActionPayload`, add activation response metadata |
+| `app/services/hermes_client.py` | Hermes payload contract | Add `PlannedAction`, projection helpers, payload fields |
+| `app/jobs/investment_watch_scanner.py` | Trigger alert payload builder | Include planned action and checklist |
+| `app/services/investment_reports/watch_validity_review.py` | Validity-review payload builder | Include planned action and checklist |
+| `app/mcp_server/tooling/investment_reports_handlers.py` | MCP tool behavior and descriptions | Add `attach_recommendation`, shared recommendation helper, contract text |
+| `app/mcp_server/README.md` | Public contract docs | Document watch checklist and execution-plan inputs |
+| `docs/runbooks/watch-trigger-hermes-payload.md` | Hermes runbook | Document `planned_action` and checklist render expectations |
+| `tests/test_investment_reports_schemas.py` | Schema tests | Checklist and max_action contract tests |
+| `tests/test_hermes_client.py` | Payload tests | Projection and payload contract tests |
+| `tests/test_investment_watch_scanner.py` | Scanner integration tests | Payload includes planned action and checklist |
+| `tests/test_watch_validity_review.py` | Validity-review integration tests | Payload includes planned action and checklist |
+| `tests/test_investment_reports_mcp.py` | MCP behavior tests | `attach_recommendation` success and fail-open |
+
+---
+
+## Task 1: Tighten Watch Item Input Contract
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py`
+- Test: `tests/test_investment_reports_schemas.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append these tests to `tests/test_investment_reports_schemas.py`.
+
+```python
+def test_trigger_checklist_requires_strings() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportItem(
+            **_base_item_kwargs(
+                client_item_key="watch-checklist",
+                item_kind="watch",
+                intent="buy_review",
+                watch_condition={"metric": "price", "operator": "below", "threshold": "5"},
+                valid_until="2026-12-31T00:00:00Z",
+                trigger_checklist=["quote ok", {"not": "a string"}],
+            )
+        )
+    assert "trigger_checklist" in str(exc_info.value)
+
+
+def test_max_action_accepts_planned_action_fields() -> None:
+    payload = MaxActionPayload(
+        side="buy",
+        quantity="1",
+        amount_krw="980000",
+        limit_price="975000",
+        limit_price_hint="975000",
+        ladder_level="1",
+        account_mode="kis_mock",
+    )
+
+    dumped = payload.model_dump()
+    assert dumped["quantity"] == Decimal("1")
+    assert dumped["amount_krw"] == Decimal("980000")
+    assert dumped["limit_price_hint"] == Decimal("975000")
+    assert dumped["ladder_level"] == "1"
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_schemas.py -k "trigger_checklist or planned_action_fields" -q
+```
+
+Expected: FAIL because non-string checklist entries are still accepted or because `amount_krw` / `limit_price_hint` are not typed fields.
+
+- [ ] **Step 3: Implement minimal schema changes**
+
+In `app/schemas/investment_reports.py`, update `MaxActionPayload`:
+
+```python
+class MaxActionPayload(BaseModel):
+    """Structured order params a watch trigger proposes. Consumed by ROB-402.
+
+    ``extra='allow'`` preserves legacy keys (e.g. ``notional_usd`` used by
+    mock_preview). The live auto-execute block is enforced by ROB-402 on the
+    (action_mode, account_mode) combination, not here.
+    """
+
+    side: ItemSideLiteral
+    quantity: Decimal | None = None
+    notional: Decimal | None = None
+    limit_price: Decimal | None = None
+    account_mode: AccountMode
+    amount_krw: Decimal | None = None
+    limit_price_hint: Decimal | None = None
+    ladder_level: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+```
+
+Change `IngestReportItem.trigger_checklist`:
+
+```python
+trigger_checklist: list[str] = Field(default_factory=list)
+```
+
+Leave `InvestmentReportItemResponse.trigger_checklist` and
+`InvestmentWatchAlertResponse.trigger_checklist` as `list[Any]` unless a focused
+test proves historical rows can be safely narrowed too.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_schemas.py -k "trigger_checklist or max_action" -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 2: Add Hermes Planned Action Projection
+
+**Files:**
+- Modify: `app/services/hermes_client.py`
+- Test: `tests/test_hermes_client.py`
+
+- [ ] **Step 1: Write failing projection tests**
+
+Update the imports in `tests/test_hermes_client.py`:
+
+```python
+from app.services.hermes_client import (
+    HermesNotificationClient,
+    ReviewTriggerPayload,
+    build_invest_links,
+    build_operator_action_guidance,
+    planned_action_from_max_action,
+    trigger_checklist_from_raw,
+    price_guidance_from_watch_recommendation,
+)
+```
+
+Append these tests:
+
+```python
+def test_planned_action_from_max_action_maps_canonical_keys() -> None:
+    action = planned_action_from_max_action(
+        {
+            "side": "buy",
+            "quantity": "1",
+            "amount_krw": "980000",
+            "limit_price": "975000",
+            "ladder_level": "1",
+        }
+    )
+
+    assert action is not None
+    assert action.side == "buy"
+    assert action.qty == Decimal("1")
+    assert action.amount_krw == Decimal("980000")
+    assert action.limit_price_hint == Decimal("975000")
+    assert action.ladder_level == "1"
+
+
+def test_planned_action_from_max_action_prefers_explicit_aliases() -> None:
+    action = planned_action_from_max_action(
+        {
+            "side": "buy",
+            "qty": "2",
+            "quantity": "1",
+            "amount_krw": "1900000",
+            "limit_price_hint": "955000",
+            "limit_price": "975000",
+        }
+    )
+
+    assert action is not None
+    assert action.qty == Decimal("2")
+    assert action.limit_price_hint == Decimal("955000")
+
+
+def test_planned_action_from_max_action_none_for_empty_or_malformed() -> None:
+    assert planned_action_from_max_action({}) is None
+    assert planned_action_from_max_action(None) is None
+    assert planned_action_from_max_action({"side": "hold", "quantity": "1"}) is None
+    assert planned_action_from_max_action({"side": "buy", "quantity": "oops"}) is None
+
+
+def test_trigger_checklist_from_raw_returns_strings_only() -> None:
+    assert trigger_checklist_from_raw(["quote", "thesis"]) == ["quote", "thesis"]
+    assert trigger_checklist_from_raw(None) == []
+    assert trigger_checklist_from_raw(["ok", {"bad": True}, 1]) == ["ok"]
+
+
+def test_payload_accepts_planned_action_and_trigger_checklist() -> None:
+    payload = _base_payload(
+        planned_action={
+            "side": "buy",
+            "qty": "1",
+            "amount_krw": "980000",
+            "limit_price_hint": "975000",
+            "ladder_level": "1",
+        },
+        trigger_checklist=["quote ok", "thesis ok"],
+    )
+
+    assert payload.planned_action is not None
+    assert payload.planned_action.qty == Decimal("1")
+    assert payload.trigger_checklist == ["quote ok", "thesis ok"]
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_hermes_client.py -k "planned_action or trigger_checklist" -q
+```
+
+Expected: FAIL with missing imports or missing payload fields.
+
+- [ ] **Step 3: Implement minimal projection helpers**
+
+In `app/services/hermes_client.py`, add these imports if missing:
+
+```python
+from app.schemas.investment_reports import (
+    ItemIntentLiteral,
+    ItemSideLiteral,
+    MarketLiteral,
+    TargetKindLiteral,
+    WatchActionModeLiteral,
+    WatchClauseOpLiteral,
+    WatchInvalidation,
+    WatchMetricLiteral,
+    WatchPriceRange,
+)
+```
+
+Add this model and helpers after `PriceGuidance`:
+
+```python
+class PlannedAction(BaseModel):
+    """ROB-514 - operator-facing execution plan derived from max_action."""
+
+    side: ItemSideLiteral
+    qty: Decimal | None = None
+    amount_krw: Decimal | None = None
+    limit_price_hint: Decimal | None = None
+    ladder_level: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value in (None, ""):
+        return None
+    return Decimal(str(value))
+
+
+def planned_action_from_max_action(max_action: dict[str, Any] | None) -> PlannedAction | None:
+    """Project stored max_action into the Hermes planned_action contract.
+
+    Fail-open: malformed optional context is omitted instead of blocking alert
+    delivery.
+    """
+    if not isinstance(max_action, dict) or not max_action:
+        return None
+    try:
+        return PlannedAction(
+            side=max_action.get("side"),
+            qty=_decimal_or_none(max_action.get("qty", max_action.get("quantity"))),
+            amount_krw=_decimal_or_none(max_action.get("amount_krw")),
+            limit_price_hint=_decimal_or_none(
+                max_action.get("limit_price_hint", max_action.get("limit_price"))
+            ),
+            ladder_level=(
+                str(max_action["ladder_level"])
+                if max_action.get("ladder_level") not in (None, "")
+                else None
+            ),
+        )
+    except Exception:  # noqa: BLE001 - notification context is advisory
+        logger.warning("max_action planned_action projection failed; omitting context")
+        return None
+
+
+def trigger_checklist_from_raw(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str)]
+```
+
+Add fields to `ReviewTriggerPayload`:
+
+```python
+planned_action: PlannedAction | None = None
+trigger_checklist: list[str] | None = None
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_hermes_client.py -k "planned_action or trigger_checklist" -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Wire Planned Action Into Watch Trigger Payloads
+
+**Files:**
+- Modify: `app/jobs/investment_watch_scanner.py`
+- Test: `tests/test_investment_watch_scanner.py`
+
+- [ ] **Step 1: Write failing scanner payload assertions**
+
+In `tests/test_investment_watch_scanner.py`, update
+`test_trigger_payload_carries_links_guidance_and_price_guidance`.
+
+After seeding the alert, set context fields:
+
+```python
+alert.max_action = {
+    "side": "buy",
+    "quantity": "1",
+    "amount_krw": "980000",
+    "limit_price": "975000",
+    "ladder_level": "1",
+}
+alert.trigger_checklist = ["quote spread ok", "thesis still valid"]
+await session.commit()
+```
+
+At the end of the test, add:
+
+```python
+assert payload.planned_action is not None
+assert payload.planned_action.side == "buy"
+assert payload.planned_action.qty == Decimal("1")
+assert payload.planned_action.amount_krw == Decimal("980000")
+assert payload.planned_action.limit_price_hint == Decimal("975000")
+assert payload.planned_action.ladder_level == "1"
+assert payload.trigger_checklist == ["quote spread ok", "thesis still valid"]
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_watch_scanner.py::test_trigger_payload_carries_links_guidance_and_price_guidance -q
+```
+
+Expected: FAIL because the scanner does not populate the new fields.
+
+- [ ] **Step 3: Implement scanner wiring**
+
+In `app/jobs/investment_watch_scanner.py`, extend the import:
+
+```python
+from app.services.hermes_client import (
+    HermesNotificationClient,
+    ReviewTriggerPayload,
+    build_invest_links,
+    build_operator_action_guidance,
+    planned_action_from_max_action,
+    price_guidance_from_watch_recommendation,
+    trigger_checklist_from_raw,
+)
+```
+
+In `_upsert_event`, snapshot the alert context before commit/rollback:
+
+```python
+alert_max_action = dict(alert.max_action or {})
+alert_trigger_checklist = list(alert.trigger_checklist or [])
+```
+
+Add fields to the `ReviewTriggerPayload(...)` call:
+
+```python
+planned_action=planned_action_from_max_action(alert_max_action),
+trigger_checklist=trigger_checklist_from_raw(alert_trigger_checklist),
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_watch_scanner.py::test_trigger_payload_carries_links_guidance_and_price_guidance -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 4: Wire Planned Action Into Validity Review Payloads
+
+**Files:**
+- Modify: `app/services/investment_reports/watch_validity_review.py`
+- Test: `tests/test_watch_validity_review.py`
+
+- [ ] **Step 1: Write failing validity-review assertions**
+
+In `tests/test_watch_validity_review.py`, update
+`test_notify_payload_carries_links_and_price_guidance`. Set alert fields before
+calling the service:
+
+```python
+alert.max_action = {
+    "side": "buy",
+    "quantity": "1",
+    "amount_krw": "980000",
+    "limit_price": "975000",
+}
+alert.trigger_checklist = ["quote spread ok", "thesis still valid"]
+await session.commit()
+```
+
+Add assertions:
+
+```python
+assert payload.planned_action is not None
+assert payload.planned_action.side == "buy"
+assert payload.planned_action.qty == Decimal("1")
+assert payload.planned_action.amount_krw == Decimal("980000")
+assert payload.trigger_checklist == ["quote spread ok", "thesis still valid"]
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_watch_validity_review.py::test_notify_payload_carries_links_and_price_guidance -q
+```
+
+Expected: FAIL because validity review does not populate the new fields.
+
+- [ ] **Step 3: Implement validity-review wiring**
+
+In `app/services/investment_reports/watch_validity_review.py`, extend the import:
+
+```python
+from app.services.hermes_client import (
+    HermesNotificationClient,
+    ReviewTriggerPayload,
+    build_invest_links,
+    build_operator_action_guidance,
+    planned_action_from_max_action,
+    price_guidance_from_watch_recommendation,
+    trigger_checklist_from_raw,
+)
+```
+
+Add fields to the `ReviewTriggerPayload(...)` call in `_notify_review_required`:
+
+```python
+planned_action=planned_action_from_max_action(dict(alert.max_action or {})),
+trigger_checklist=trigger_checklist_from_raw(list(alert.trigger_checklist or [])),
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_watch_validity_review.py::test_notify_payload_carries_links_and_price_guidance -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: Add Opt-In Recommendation Attachment During Activation
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py`
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py`
+- Test: `tests/test_investment_reports_mcp.py`
+
+- [ ] **Step 1: Write failing activation tests**
+
+Append these tests to `tests/test_investment_reports_mcp.py`.
+
+```python
+@pytest.mark.asyncio
+async def test_activate_watch_attach_recommendation_persists(
+    session: AsyncSession, _stub_market_data
+) -> None:
+    item = dict(_review_watch_item_dict())
+    item["evidence_snapshot"] = {"action_verdict": "watch_only"}
+    created = await investment_report_create_impl(items=[item], **_create_kwargs())
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+        attach_recommendation=True,
+    )
+
+    assert response["success"] is True
+    assert response["recommendation_attached"] is True
+    assert response["recommendation_attach_error"] is None
+
+    bundle_post = await investment_report_get_impl(created["report"]["report_uuid"])
+    rec = bundle_post["items"][0]["watch_recommendation"]
+    assert rec is not None
+    assert rec["data_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_activate_watch_attach_recommendation_fails_open(
+    session: AsyncSession, monkeypatch
+) -> None:
+    from app.mcp_server.tooling import investment_reports_handlers as h
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("market data unavailable")
+
+    monkeypatch.setattr(h.market_data_service, "get_quote", _boom)
+
+    item = dict(_review_watch_item_dict())
+    item["evidence_snapshot"] = {"action_verdict": "watch_only"}
+    created = await investment_report_create_impl(items=[item], **_create_kwargs())
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+        attach_recommendation=True,
+    )
+
+    assert response["success"] is True
+    assert response["alert"]["source_item_uuid"] == watch_uuid
+    assert response["recommendation_attached"] is False
+    assert "market data unavailable" in response["recommendation_attach_error"]
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_mcp.py -k "attach_recommendation" -q
+```
+
+Expected: FAIL because `investment_report_activate_watch_impl` does not accept
+`attach_recommendation`.
+
+- [ ] **Step 3: Extend schemas**
+
+In `ActivateWatchRequest`, add:
+
+```python
+attach_recommendation: bool = False
+```
+
+In `InvestmentReportActivateWatchResponse`, add:
+
+```python
+recommendation_attached: bool | None = None
+recommendation_attach_error: str | None = None
+```
+
+- [ ] **Step 4: Refactor recommendation computation into a helper**
+
+In `app/mcp_server/tooling/investment_reports_handlers.py`, add this helper above
+`investment_watch_recommend_impl`:
+
+```python
+async def _compute_watch_recommendation_json(
+    *,
+    symbol: str,
+    market: str,
+    valid_until: datetime | None,
+) -> dict[str, Any]:
+    if market not in _MARKET_MAP:
+        raise ValueError(f"unsupported_market: {market}")
+
+    md_symbol = _normalize_recommend_symbol(symbol, market)
+    md_market = _MARKET_MAP[market]
+    quote = await market_data_service.get_quote(symbol=md_symbol, market=md_market)
+    reference_price = (
+        Decimal(str(quote.price)) if getattr(quote, "price", None) is not None else None
+    )
+    candles = await market_data_service.get_ohlcv(
+        symbol=md_symbol,
+        market=md_market,
+        period="day",
+        count=LOOKBACK_DAYS + ATR_PERIOD + 6,
+    )
+    ordered = sorted(candles, key=lambda c: c.timestamp)
+    payload = compute_watch_recommendation(
+        WatchPolicyInput(
+            reference_price=reference_price,
+            best_bid=None,
+            best_ask=None,
+            daily_highs=[Decimal(str(c.high)) for c in ordered],
+            daily_lows=[Decimal(str(c.low)) for c in ordered],
+            daily_closes=[Decimal(str(c.close)) for c in ordered],
+        ),
+        computed_at=datetime.now(UTC),
+        valid_until=valid_until,
+    )
+    if payload.data_state == "data_gap":
+        raise ValueError("refusing to attach a data_gap recommendation")
+    return payload.model_dump(mode="json")
+```
+
+Then update `investment_watch_recommend_impl` to use the helper so the policy
+path cannot drift:
+
+```python
+rec_json = await _compute_watch_recommendation_json(
+    symbol=symbol,
+    market=market,
+    valid_until=valid_until,
+)
+payload = WatchRecommendationPayload.model_validate(rec_json)
+```
+
+If importing `WatchRecommendationPayload` only for this validation adds churn,
+instead check `rec_json.get("data_state") == "data_gap"` in the helper and keep
+the existing return shape.
+
+- [ ] **Step 5: Implement activation opt-in**
+
+Update `investment_report_activate_watch_impl` signature:
+
+```python
+async def investment_report_activate_watch_impl(
+    item_uuid: str,
+    actor: str,
+    idempotency_key: str | None = None,
+    watch_condition: dict | None = None,
+    valid_until: str | None = None,
+    attach_recommendation: bool = False,
+) -> dict:
+```
+
+Pass `attach_recommendation` into `ActivateWatchRequest.model_validate`.
+
+Inside the DB session, before `await db.commit()`, after `item_row` is loaded,
+add:
+
+```python
+recommendation_attached: bool | None = None
+recommendation_attach_error: str | None = None
+
+if request.attach_recommendation and item_row is not None:
+    if item_row.watch_recommendation:
+        recommendation_attached = True
+    elif item_row.symbol is None:
+        recommendation_attached = False
+        recommendation_attach_error = "item symbol missing"
+    else:
+        try:
+            rec_json = await _compute_watch_recommendation_json(
+                symbol=item_row.symbol,
+                market=alert_row.market,
+                valid_until=item_row.valid_until,
+            )
+            await repo.update_item_watch_recommendation(item_row.id, rec_json)
+            await db.flush()
+            item_row = await repo.get_item_by_uuid(request.item_uuid)
+            recommendation_attached = True
+        except Exception as exc:  # noqa: BLE001 - attach is opt-in and fail-open
+            recommendation_attached = False
+            recommendation_attach_error = str(exc)
+```
+
+Build the response with the new fields:
+
+```python
+response = InvestmentReportActivateWatchResponse(
+    alert=InvestmentWatchAlertResponse.model_validate(alert_row),
+    item=InvestmentReportItemResponse.model_validate(item_row),
+    recommendation_attached=recommendation_attached,
+    recommendation_attach_error=recommendation_attach_error,
+)
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_mcp.py -k "attach_recommendation or watch_recommend" -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 6: Expose MCP and Documentation Contracts
+
+**Files:**
+- Modify: `app/mcp_server/tooling/investment_reports_handlers.py`
+- Modify: `app/mcp_server/README.md`
+- Modify: `docs/runbooks/watch-trigger-hermes-payload.md`
+- Test: `tests/test_investment_reports_mcp.py`
+- Test: `tests/test_hermes_client.py`
+
+- [ ] **Step 1: Write failing contract-text tests**
+
+Append this test to `tests/test_investment_reports_mcp.py`:
+
+```python
+def test_create_description_mentions_watch_execution_plan_contract() -> None:
+    from app.mcp_server.tooling.investment_reports_handlers import (
+        ADD_ITEMS_DESCRIPTION,
+        CREATE_DESCRIPTION,
+    )
+
+    combined = CREATE_DESCRIPTION + " " + ADD_ITEMS_DESCRIPTION
+    assert "trigger_checklist" in combined
+    assert "string[]" in combined
+    assert "max_action" in combined
+    assert "amount_krw" in combined
+    assert "limit_price_hint" in combined
+    assert "ladder_level" in combined
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_mcp.py::test_create_description_mentions_watch_execution_plan_contract -q
+```
+
+Expected: FAIL because the descriptions do not mention the new contract.
+
+- [ ] **Step 3: Update tool descriptions and invalid item notes**
+
+In `CREATE_DESCRIPTION`, after the watch item requirement sentence, add:
+
+```python
+"Watch execution context: trigger_checklist is string[] and is copied into "
+"watch alert notifications. max_action is the structured execution-plan JSON; "
+"supported keys include side, quantity or notional, amount_krw, limit_price, "
+"limit_price_hint, ladder_level, and account_mode. planned_action in Hermes "
+"payloads is derived from max_action; do not send planned_action as an item key. "
+```
+
+In `ADD_ITEMS_DESCRIPTION`, add:
+
+```python
+"For watch items, trigger_checklist string[] and max_action execution-plan "
+"keys follow the same contract as investment_report_create."
+```
+
+In `_validate_report_items`, append to the `notes` string:
+
+```python
+" trigger_checklist must be string[]; watch execution plans belong in "
+"max_action (side, quantity/notional, amount_krw, limit_price, "
+"limit_price_hint, ladder_level, account_mode), not in planned_action."
+```
+
+- [ ] **Step 4: Update README**
+
+In `app/mcp_server/README.md`, under
+`### investment_report_create item contract`, add:
+
+```markdown
+Watch execution context fields:
+- `trigger_checklist`: `string[]`; copied into watch alert notifications so the operator can re-check the trigger.
+- `max_action`: structured watch execution-plan JSON. Supported keys include `side`, `quantity` or `notional`, optional `amount_krw`, optional `limit_price`, optional `limit_price_hint`, optional `ladder_level`, and optional `account_mode`.
+- Do not send `planned_action` in item input. `planned_action` is derived from `max_action` when Hermes watch payloads are built.
+```
+
+- [ ] **Step 5: Update Hermes runbook**
+
+In `docs/runbooks/watch-trigger-hermes-payload.md`, extend the JSON example:
+
+```json
+"planned_action": {
+  "side": "buy",
+  "qty": "1",
+  "amount_krw": "980000",
+  "limit_price_hint": "975000",
+  "ladder_level": "1"
+},
+"trigger_checklist": [
+  "Check latest quote spread",
+  "Confirm thesis still valid"
+]
+```
+
+Add renderer requirements:
+
+```markdown
+5. Render `planned_action` near `price_guidance` when present. If null, do not invent quantity or amount.
+6. Render each `trigger_checklist` string as an operator checklist. If empty, omit the checklist section.
+```
+
+- [ ] **Step 6: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/test_investment_reports_mcp.py::test_create_description_mentions_watch_execution_plan_contract -q
+```
+
+Expected: PASS.
+
+---
+
+## Task 7: Focused Integration Verification
+
+**Files:**
+- No new implementation files
+- Verify changed behavior
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_investment_reports_schemas.py \
+  tests/test_hermes_client.py \
+  tests/test_investment_watch_scanner.py \
+  tests/test_watch_validity_review.py \
+  tests/test_investment_reports_mcp.py \
+  -k "trigger_checklist or max_action or planned_action or price_guidance or attach_recommendation or activate_watch" \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type/lint checks for touched runtime files**
+
+Run:
+
+```bash
+uv run ty check \
+  app/schemas/investment_reports.py \
+  app/services/hermes_client.py \
+  app/jobs/investment_watch_scanner.py \
+  app/services/investment_reports/watch_validity_review.py \
+  app/mcp_server/tooling/investment_reports_handlers.py
+```
+
+Expected: PASS.
+
+Run:
+
+```bash
+uv run ruff check \
+  app/schemas/investment_reports.py \
+  app/services/hermes_client.py \
+  app/jobs/investment_watch_scanner.py \
+  app/services/investment_reports/watch_validity_review.py \
+  app/mcp_server/tooling/investment_reports_handlers.py \
+  tests/test_investment_reports_schemas.py \
+  tests/test_hermes_client.py \
+  tests/test_investment_watch_scanner.py \
+  tests/test_watch_validity_review.py \
+  tests/test_investment_reports_mcp.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review diff for scope**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- app/schemas/investment_reports.py app/services/hermes_client.py app/jobs/investment_watch_scanner.py app/services/investment_reports/watch_validity_review.py app/mcp_server/tooling/investment_reports_handlers.py
+```
+
+Expected: no DB migrations, no broker order submission changes, no scheduler changes.
+
+---
+
+## Plan Self Review
+
+- Spec coverage: planned action projection, checklist payload, activation recommendation attachment, and docs are covered by Tasks 1-6.
+- Type consistency: `planned_action_from_max_action`, `trigger_checklist_from_raw`, `PlannedAction`, and response field names are introduced before wiring tasks use them.
+- Scope check: no migration, no order submission, no scheduler work.
+- Verification: focused pytest, `ty`, and Ruff commands are included.

--- a/docs/superpowers/specs/2026-06-11-rob-514-watch-execution-plan-alert-context-design.md
+++ b/docs/superpowers/specs/2026-06-11-rob-514-watch-execution-plan-alert-context-design.md
@@ -1,0 +1,200 @@
+# ROB-514 Watch Execution Plan Alert Context Design
+
+- Issue: ROB-514
+- Date: 2026-06-11
+- Status: approved for implementation planning
+
+## Problem
+
+Watch alerts already preserve the free-text `rationale`, and prior work added
+`max_action`, `trigger_checklist`, and `watch_recommendation`. In practice, the
+operator still has to re-read free text when a watch fires because the Hermes
+payload does not carry a structured buy plan or checklist, and the MCP contract
+does not clearly tell callers how to provide those fields.
+
+Related completed work:
+
+- ROB-402 consumes `max_action` for `auto_execute_mock`.
+- ROB-403 made `max_action` the structured watch action contract.
+- ROB-337 stores `watch_recommendation`.
+- ROB-500 sends `watch_recommendation` as Hermes `price_guidance`.
+- ROB-458/ROB-498 improved item input contracts and structured report fields.
+
+## Goals
+
+- Keep `max_action` as the canonical stored execution-plan JSON. Do not add a
+  duplicate `planned_action` DB column.
+- Add a Hermes-facing `planned_action` projection derived from alert
+  `max_action`.
+- Include the watch `trigger_checklist` in trigger and validity-review Hermes
+  payloads.
+- Expose `trigger_checklist: string[]` and the supported watch execution-plan
+  keys in MCP descriptions, error notes, README, and runbook docs.
+- Add an opt-in `investment_report_activate_watch(..., attach_recommendation=True)`
+  path that computes and persists `watch_recommendation` if possible.
+
+## Non-Goals
+
+- No live or mock order submission changes.
+- No DB migration.
+- No new scheduler or recurring activation behavior.
+- No Hermes renderer implementation in this repo.
+- No replacement of existing `max_action.quantity/notional/limit_price` behavior
+  used by ROB-402.
+
+## Design
+
+### Stored Contract
+
+`investment_report_items.max_action` and `investment_watch_alerts.max_action`
+remain the only persisted execution-plan fields. `planned_action` is a derived
+payload shape for notifications and future UI/order-preview prefill.
+
+Recommended `max_action` input for a KR buy watch:
+
+```json
+{
+  "side": "buy",
+  "quantity": "1",
+  "amount_krw": "980000",
+  "limit_price": "975000",
+  "limit_price_hint": "975000",
+  "ladder_level": "1"
+}
+```
+
+`quantity` remains the ROB-402 key. `qty` is accepted as a convenience alias for
+the notification projection only. `amount_krw`, `limit_price_hint`, and
+`ladder_level` are additive keys. `MaxActionPayload.extra="allow"` keeps legacy
+keys such as `notional_usd`.
+
+### Hermes Payload
+
+Add optional fields to `ReviewTriggerPayload`:
+
+```json
+{
+  "planned_action": {
+    "side": "buy",
+    "qty": "1",
+    "amount_krw": "980000",
+    "limit_price_hint": "975000",
+    "ladder_level": "1"
+  },
+  "trigger_checklist": [
+    "Check latest quote spread",
+    "Confirm thesis still valid"
+  ]
+}
+```
+
+Rules:
+
+- `planned_action` is `null` if `max_action` is empty or malformed.
+- The projection never fabricates missing amount, quantity, or price fields.
+- `limit_price_hint` uses `max_action.limit_price_hint` first, then
+  `max_action.limit_price`.
+- `qty` uses `max_action.qty` first, then `max_action.quantity`.
+- `trigger_checklist` is always a list of strings on new payloads.
+- Missing or malformed optional notification context must not block alert
+  delivery.
+
+### Activation Recommendation Attachment
+
+`investment_report_activate_watch` gets `attach_recommendation: bool = False`.
+
+When false, behavior is unchanged. When true:
+
+- If the source item already has `watch_recommendation`, activation skips the
+  compute step and reports `recommendation_attached=True`.
+- If missing, the handler computes the same deterministic ROB-337
+  recommendation used by `investment_watch_recommend(commit=True)` and persists
+  it to the source item.
+- Compute or validation failures are fail-open: the watch still activates, and
+  the response includes `recommendation_attached=False` plus a short
+  `recommendation_attach_error`.
+- The response model adds optional `recommendation_attached` and
+  `recommendation_attach_error` fields.
+
+### Validation
+
+`IngestReportItem.trigger_checklist` narrows from `list[Any]` to `list[str]`.
+Read-side response models can remain permissive if needed for historical rows,
+but new MCP input should reject non-string checklist entries.
+
+`MaxActionPayload` adds typed optional fields:
+
+- `amount_krw: Decimal | None`
+- `limit_price_hint: Decimal | None`
+- `ladder_level: str | None`
+
+The existing quantity/notional XOR remains unchanged. A caller may provide
+`quantity + amount_krw`; `amount_krw` does not count as the XOR notional field.
+
+### Docs and Tool Descriptions
+
+Update:
+
+- `CREATE_DESCRIPTION`
+- `ADD_ITEMS_DESCRIPTION`
+- `_validate_report_items` error notes
+- `app/mcp_server/README.md`
+- `docs/runbooks/watch-trigger-hermes-payload.md`
+
+Docs must state that watch items can pass:
+
+- `trigger_checklist: string[]`
+- `max_action.side`
+- `max_action.quantity` or `max_action.notional`
+- optional `max_action.amount_krw`
+- optional `max_action.limit_price` and `max_action.limit_price_hint`
+- optional `max_action.ladder_level`
+
+## Data Flow
+
+1. Caller creates or appends a watch item with `trigger_checklist` and
+   `max_action`.
+2. `investment_report_activate_watch` copies both fields into
+   `investment_watch_alerts`.
+3. Scanner creates or reuses an event row.
+4. Scanner builds Hermes `ReviewTriggerPayload` with:
+   - existing trigger identity
+   - existing `price_guidance`
+   - new `planned_action`
+   - new `trigger_checklist`
+5. Watch validity review uses the same notification projection when it sends a
+   review-required payload.
+
+## Testing
+
+Add focused tests for:
+
+- `trigger_checklist` rejects non-string inputs.
+- `MaxActionPayload` accepts `quantity + amount_krw + limit_price_hint +
+  ladder_level`.
+- `planned_action_from_max_action` maps canonical and alias keys.
+- `planned_action_from_max_action` returns `None` for empty or malformed data.
+- `ReviewTriggerPayload` accepts the new optional fields and still rejects
+  unknown extras.
+- Scanner payload includes planned action and checklist.
+- Validity-review payload includes planned action and checklist.
+- `activate_watch(attach_recommendation=True)` persists a recommendation when
+  market data is available.
+- `attach_recommendation=True` fails open when recommendation compute fails.
+- MCP docs/error text mention the new input contract.
+
+## Risk
+
+This is not a live-trading mutation and does not alter DB schema. The riskiest
+change is the optional market-data fetch during activation; it is default-off
+and fail-open. If implementation scope expands to order submission, account
+permission changes, or DB schema migration, tag the Linear work with
+`high_risk_change` and `needs_stronger_model_review`.
+
+## Self Review
+
+- No DB migration is required because all persisted data already lives in JSONB.
+- The design does not duplicate ROB-402 `max_action`; it exposes a derived
+  Hermes-facing projection only.
+- The recommendation attachment is opt-in and cannot block activation.
+- Tests cover both new notification context and input-contract visibility.

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -14,7 +14,9 @@ from app.services.hermes_client import (
     ReviewTriggerPayload,
     build_invest_links,
     build_operator_action_guidance,
+    planned_action_from_max_action,
     price_guidance_from_watch_recommendation,
+    trigger_checklist_from_raw,
 )
 
 
@@ -297,3 +299,69 @@ def test_payload_accepts_new_optional_fields_and_still_forbids_extras() -> None:
     assert payload.price_guidance is None
     with pytest.raises(ValidationError):
         _base_payload(unknown_field=1)
+
+
+def test_planned_action_from_max_action_maps_canonical_keys() -> None:
+    action = planned_action_from_max_action(
+        {
+            "side": "buy",
+            "quantity": "1",
+            "amount_krw": "980000",
+            "limit_price": "975000",
+            "ladder_level": "1",
+        }
+    )
+
+    assert action is not None
+    assert action.side == "buy"
+    assert action.qty == Decimal("1")
+    assert action.amount_krw == Decimal("980000")
+    assert action.limit_price_hint == Decimal("975000")
+    assert action.ladder_level == "1"
+
+
+def test_planned_action_from_max_action_prefers_explicit_aliases() -> None:
+    action = planned_action_from_max_action(
+        {
+            "side": "buy",
+            "qty": "2",
+            "quantity": "1",
+            "amount_krw": "1900000",
+            "limit_price_hint": "955000",
+            "limit_price": "975000",
+        }
+    )
+
+    assert action is not None
+    assert action.qty == Decimal("2")
+    assert action.limit_price_hint == Decimal("955000")
+
+
+def test_planned_action_from_max_action_none_for_empty_or_malformed() -> None:
+    assert planned_action_from_max_action({}) is None
+    assert planned_action_from_max_action(None) is None
+    assert planned_action_from_max_action({"side": "hold", "quantity": "1"}) is None
+    assert planned_action_from_max_action({"side": "buy", "quantity": "oops"}) is None
+
+
+def test_trigger_checklist_from_raw_returns_strings_only() -> None:
+    assert trigger_checklist_from_raw(["quote", "thesis"]) == ["quote", "thesis"]
+    assert trigger_checklist_from_raw(None) == []
+    assert trigger_checklist_from_raw(["ok", {"bad": True}, 1]) == ["ok"]
+
+
+def test_payload_accepts_planned_action_and_trigger_checklist() -> None:
+    payload = _base_payload(
+        planned_action={
+            "side": "buy",
+            "qty": "1",
+            "amount_krw": "980000",
+            "limit_price_hint": "975000",
+            "ladder_level": "1",
+        },
+        trigger_checklist=["quote ok", "thesis ok"],
+    )
+
+    assert payload.planned_action is not None
+    assert payload.planned_action.qty == Decimal("1")
+    assert payload.trigger_checklist == ["quote ok", "thesis ok"]

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -740,6 +740,14 @@ async def test_watch_recommend_dry_run_does_not_persist(
 
 
 @pytest.mark.asyncio
+async def test_watch_recommend_unsupported_market_returns_structured_error(
+    session: AsyncSession,
+) -> None:
+    resp = await investment_watch_recommend_impl(symbol="005930", market="jp")
+    assert resp == {"success": False, "error": "unsupported_market", "market": "jp"}
+
+
+@pytest.mark.asyncio
 async def test_watch_recommend_commit_persists_on_watch_only(
     session: AsyncSession, _stub_market_data
 ) -> None:
@@ -1058,3 +1066,83 @@ async def test_update_impl_rejects_empty_update(session: AsyncSession) -> None:
 
     assert out["success"] is False
     assert out["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_activate_watch_attach_recommendation_persists(
+    session: AsyncSession, _stub_market_data
+) -> None:
+    item = dict(_review_watch_item_dict())
+    item["evidence_snapshot"] = {"action_verdict": "watch_only"}
+    created = await investment_report_create_impl(items=[item], **_create_kwargs())
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+        attach_recommendation=True,
+    )
+
+    assert response["success"] is True
+    assert response["recommendation_attached"] is True
+    assert response["recommendation_attach_error"] is None
+
+    bundle_post = await investment_report_get_impl(created["report"]["report_uuid"])
+    rec = bundle_post["items"][0]["watch_recommendation"]
+    assert rec is not None
+    assert rec["data_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_activate_watch_attach_recommendation_fails_open(
+    session: AsyncSession, monkeypatch
+) -> None:
+    from app.mcp_server.tooling import investment_reports_handlers as h
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("market data unavailable")
+
+    monkeypatch.setattr(h.market_data_service, "get_quote", _boom)
+
+    item = dict(_review_watch_item_dict())
+    item["evidence_snapshot"] = {"action_verdict": "watch_only"}
+    created = await investment_report_create_impl(items=[item], **_create_kwargs())
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid,
+        actor="operator",
+        watch_condition={"metric": "price", "operator": "below", "threshold": 70000},
+        valid_until=future_datetime().isoformat(),
+        attach_recommendation=True,
+    )
+
+    assert response["success"] is True
+    assert response["alert"]["source_item_uuid"] == watch_uuid
+    assert response["recommendation_attached"] is False
+    assert "market data unavailable" in response["recommendation_attach_error"]
+
+
+def test_create_description_mentions_watch_execution_plan_contract() -> None:
+    from app.mcp_server.tooling.investment_reports_handlers import (
+        ADD_ITEMS_DESCRIPTION,
+        CREATE_DESCRIPTION,
+    )
+
+    combined = CREATE_DESCRIPTION + " " + ADD_ITEMS_DESCRIPTION
+    assert "trigger_checklist" in combined
+    assert "string[]" in combined
+    assert "max_action" in combined
+    assert "amount_krw" in combined
+    assert "limit_price_hint" in combined
+    assert "ladder_level" in combined

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -401,3 +401,40 @@ def test_update_draft_report_request_accepts_summary_and_snapshots() -> None:
     assert req.summary == "fresh intraday summary"
     assert req.market_snapshot == {"kospi": {"last": 2860.12}}
     assert req.reason == "market moved"
+
+
+def test_trigger_checklist_requires_strings() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportItem(
+            **_base_item_kwargs(
+                client_item_key="watch-checklist",
+                item_kind="watch",
+                intent="buy_review",
+                watch_condition={
+                    "metric": "price",
+                    "operator": "below",
+                    "threshold": "5",
+                },
+                valid_until="2026-12-31T00:00:00Z",
+                trigger_checklist=["quote ok", {"not": "a string"}],
+            )
+        )
+    assert "trigger_checklist" in str(exc_info.value)
+
+
+def test_max_action_accepts_planned_action_fields() -> None:
+    payload = MaxActionPayload(
+        side="buy",
+        quantity="1",
+        amount_krw="980000",
+        limit_price="975000",
+        limit_price_hint="975000",
+        ladder_level="1",
+        account_mode="kis_mock",
+    )
+
+    dumped = payload.model_dump()
+    assert dumped["quantity"] == Decimal("1")
+    assert dumped["amount_krw"] == Decimal("980000")
+    assert dumped["limit_price_hint"] == Decimal("975000")
+    assert dumped["ladder_level"] == "1"

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -631,6 +631,14 @@ async def test_trigger_payload_carries_links_guidance_and_price_guidance(
 ) -> None:
     """ROB-500 — 발화 페이로드에 invest_links + 액션 가이드 + 가격 가이드."""
     alert = await _seed_active_kr_alert(session)
+    alert.max_action = {
+        "side": "buy",
+        "quantity": "1",
+        "amount_krw": "980000",
+        "limit_price": "975000",
+        "ladder_level": "1",
+    }
+    alert.trigger_checklist = ["quote spread ok", "thesis still valid"]
     repo = InvestmentReportsRepository(session)
     item = await repo.get_item_by_uuid(alert.source_item_uuid)
     assert item is not None
@@ -673,6 +681,14 @@ async def test_trigger_payload_carries_links_guidance_and_price_guidance(
     assert payload.price_guidance.suggested_limit_price_range.high == Decimal("100")
     assert payload.price_guidance.max_chase_price == Decimal("102")
     assert payload.price_guidance.invalidation.kind == "price_below"
+
+    assert payload.planned_action is not None
+    assert payload.planned_action.side == "buy"
+    assert payload.planned_action.qty == Decimal("1")
+    assert payload.planned_action.amount_krw == Decimal("980000")
+    assert payload.planned_action.limit_price_hint == Decimal("975000")
+    assert payload.planned_action.ladder_level == "1"
+    assert payload.trigger_checklist == ["quote spread ok", "thesis still valid"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_validity_review.py
+++ b/tests/test_watch_validity_review.py
@@ -209,6 +209,15 @@ async def test_notify_payload_carries_links_and_price_guidance(
 ) -> None:
     """ROB-500 — validity review 통지에도 링크/가이드 포함."""
     alert = await _seed_active_alert(session, recommendation=_rec())
+    alert.max_action = {
+        "side": "buy",
+        "quantity": "1",
+        "amount_krw": "980000",
+        "limit_price": "975000",
+    }
+    alert.trigger_checklist = ["quote spread ok", "thesis still valid"]
+    await session.commit()
+
     hermes = _StubHermes()
 
     @asynccontextmanager
@@ -237,3 +246,9 @@ async def test_notify_payload_carries_links_and_price_guidance(
 
     assert payload.price_guidance is not None
     assert payload.price_guidance.entry_review_below_price == Decimal("100")
+
+    assert payload.planned_action is not None
+    assert payload.planned_action.side == "buy"
+    assert payload.planned_action.qty == Decimal("1")
+    assert payload.planned_action.amount_krw == Decimal("980000")
+    assert payload.trigger_checklist == ["quote spread ok", "thesis still valid"]


### PR DESCRIPTION
## Summary
- Add a Hermes `planned_action` projection derived from watch `max_action`, plus `trigger_checklist` in trigger and validity-review payloads.
- Expose watch execution-plan input contract in MCP descriptions, README, and the Hermes payload runbook.
- Add opt-in, fail-open `attach_recommendation` support to `investment_report_activate_watch` and preserve `investment_watch_recommend` unsupported-market behavior.

## Test Plan
- `uv run pytest tests/test_investment_reports_schemas.py tests/test_hermes_client.py tests/test_investment_watch_scanner.py tests/test_watch_validity_review.py tests/test_investment_reports_mcp.py -q`
- `uv run ty check app/schemas/investment_reports.py app/services/hermes_client.py app/jobs/investment_watch_scanner.py app/services/investment_reports/watch_validity_review.py app/mcp_server/tooling/investment_reports_handlers.py`
- `uv run ruff check app/schemas/investment_reports.py app/services/hermes_client.py app/jobs/investment_watch_scanner.py app/services/investment_reports/watch_validity_review.py app/mcp_server/tooling/investment_reports_handlers.py tests/test_investment_reports_schemas.py tests/test_hermes_client.py tests/test_investment_watch_scanner.py tests/test_watch_validity_review.py tests/test_investment_reports_mcp.py`
- `git diff --check`

## Notes
- No DB migration.
- No broker order submission, scheduler, or live trading behavior changes.
- ROB-514 touches alert/review payload context and MCP contract visibility only.