### PR TITLE
ROB-515 snapshot discovery workflow improvements

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -129,13 +129,16 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `modify_order` Discord button flow example:
   - `modify_order(order_id="...", symbol="...", market="...", new_price=123.45, dry_run=false)`
 - `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters. **Single candidate-discovery entrypoint.**
-- `screen_stocks_snapshot(preset, market="kr", filters=None, exclude_watched=false, exclude_held=false, min_analyst_buy_count=None, min_market_cap_eok=None, max_market_cap_eok=None, sort=None, limit=40, offset=0)`
-  - Snapshot-backed discovery workflow. `preset` can be a single ID or comma-separated list.
+- `screen_stocks_snapshot(preset=None, presets=None, market="kr", filters=None, exclude_watched=false, exclude_held=false, exclude_symbols=None, min_analyst_count=None, min_analyst_buy_count=None, min_market_cap=None, min_market_cap_eok=None, max_market_cap_eok=None, sort=None, limit=40, offset=0)`
+  - Snapshot-backed discovery workflow. Pass either `preset="consecutive_gainers"` or `presets=["consecutive_gainers", "double_buy"]`; `preset` also accepts a comma-separated list for compatibility.
   - Returns symbols that matched the preset(s) from the persisted daily snapshots.
   - Supports multi-preset sweeps with symbol deduplication and `matchedPresets` tagging.
   - `exclude_watched/held` (bool): hide symbols already in watchlist/portfolio (KIS live).
-  - `min_analyst_buy_count` (int): quality filter — filters enriched results by consensus buy count.
-  - `min/max_market_cap_eok` (float): size filter — unit is 1억원 (KRW).
+  - `exclude_symbols`: explicit symbols to remove after dedupe.
+  - `min_analyst_count` (int): quality filter — filters enriched results by consensus total coverage.
+  - `min_analyst_buy_count` (int): compatibility filter — filters enriched results by consensus buy count.
+  - `min_market_cap` (float): size filter using raw numeric `marketCapValue` (`KRW` for KR, `USD` for US/crypto).
+  - `min/max_market_cap_eok` (float): KR compatibility size filter — unit is 1억원.
   - `sort="matched_presets_desc"`: ranks intersections (stocks in multiple presets) first.
   - `filters` list: tune preset thresholds (threaded for `consecutive_gainers` and `crypto`).
   - Returned rows include `analysisContext` (consensus, RSI) and `isHeld` status.

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -129,14 +129,17 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `modify_order` Discord button flow example:
   - `modify_order(order_id="...", symbol="...", market="...", new_price=123.45, dry_run=false)`
 - `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters. **Single candidate-discovery entrypoint.**
-- `screen_stocks_snapshot(preset, market="kr", filters=None, limit=40, offset=0)`
-  - Snapshot-backed candidate discovery over persisted screener data.
-  - Returned rows include `analysisContext` when enrichment is available:
-    `consensus` (buy/hold/sell counts, target prices, upside), `rsi14`,
-    `dataState`, and row-level `warnings`.
-  - `analystLabel` is filled from consensus when the data passes sanity checks;
-    otherwise it remains `"-"` or `"컨센 확인필요"`.
-  - Enrichment is applied only to the returned page after `limit`/`offset`.
+- `screen_stocks_snapshot(preset, market="kr", filters=None, exclude_watched=false, exclude_held=false, min_analyst_buy_count=None, min_market_cap_eok=None, max_market_cap_eok=None, sort=None, limit=40, offset=0)`
+  - Snapshot-backed discovery workflow. `preset` can be a single ID or comma-separated list.
+  - Returns symbols that matched the preset(s) from the persisted daily snapshots.
+  - Supports multi-preset sweeps with symbol deduplication and `matchedPresets` tagging.
+  - `exclude_watched/held` (bool): hide symbols already in watchlist/portfolio (KIS live).
+  - `min_analyst_buy_count` (int): quality filter — filters enriched results by consensus buy count.
+  - `min/max_market_cap_eok` (float): size filter — unit is 1억원 (KRW).
+  - `sort="matched_presets_desc"`: ranks intersections (stocks in multiple presets) first.
+  - `filters` list: tune preset thresholds (threaded for `consecutive_gainers` and `crypto`).
+  - Returned rows include `analysisContext` (consensus, RSI) and `isHeld` status.
+  - Results are capped (default 40) and paginated. Check `pagination` in payload.
 - ~~`recommend_stocks(...)`~~ — **DEPRECATED / registry-hidden (ROB-359).** No longer registered on the MCP tool surface. Use `screen_stocks` for candidate discovery. The implementation is retained in `analysis_tool_handlers.recommend_stocks_impl` for a possible future narrow `build_buy_plan` tool; do not call it from active report/operator prompts.
 - `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
   - Legacy/deep-dive batch analysis for up to 10 symbols.

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -267,24 +267,30 @@ def register_analysis_tools(
             "their base snapshots (Discovery Workflow, ROB-515). "
             "Unlike screen_stocks (generic tvscreener/KIS path), this serves persisted "
             "screener snapshot data. preset can be a single ID or a comma-separated "
-            "list (e.g. 'consecutive_gainers,double_buy') for multi-preset sweeps with "
-            "symbol deduplication and matchedPresets tagging. "
+            "list (e.g. 'consecutive_gainers,double_buy'); presets can also be a "
+            "list for multi-preset sweeps with symbol deduplication and "
+            "matchedPresets tagging. "
             "filters=[{field, operator(gte|lte|eq), value}] tune the preset's "
             "thresholds (threaded for consecutive_gainers and crypto). "
-            "exclude_watched/held (bool) hide symbols already in watchlist or portfolio. "
-            "min_analyst_buy_count (int) and min/max_market_cap_eok (float, unit 1억원) "
-            "apply discovery-quality filters across the result set. "
+            "exclude_watched/held (bool) and exclude_symbols hide already-processed "
+            "symbols. min_analyst_count (coverage), min_analyst_buy_count (buy-count), "
+            "min_market_cap (raw marketCapValue), and min/max_market_cap_eok "
+            "(float, unit 1억원) apply discovery-quality filters across the result set. "
             "sort='matched_presets_desc' ranks multi-preset intersections first. "
             "Read-only. Results are capped (default 40) and paginated via limit/offset."
         ),
     )
     async def screen_stocks_snapshot(
-        preset: str,
+        preset: str | None = None,
+        presets: list[str] | None = None,
         market: Literal["kr", "us", "crypto"] = "kr",
         filters: list[dict[str, Any]] | None = None,
         exclude_watched: bool = False,
         exclude_held: bool = False,
+        exclude_symbols: list[str] | None = None,
+        min_analyst_count: int | None = None,
         min_analyst_buy_count: int | None = None,
+        min_market_cap: float | None = None,
         min_market_cap_eok: float | None = None,
         max_market_cap_eok: float | None = None,
         sort: Literal["matched_presets_desc"] | None = None,
@@ -293,11 +299,15 @@ def register_analysis_tools(
     ) -> dict[str, Any]:
         return await screen_stocks_snapshot_impl(
             preset=preset,
+            presets=presets,
             market=market,
             filters=filters,
             exclude_watched=exclude_watched,
             exclude_held=exclude_held,
+            exclude_symbols=exclude_symbols,
+            min_analyst_count=min_analyst_count,
             min_analyst_buy_count=min_analyst_buy_count,
+            min_market_cap=min_market_cap,
             min_market_cap_eok=min_market_cap_eok,
             max_market_cap_eok=max_market_cap_eok,
             sort=sort,

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -263,23 +263,31 @@ def register_analysis_tools(
     @mcp.tool(
         name="screen_stocks_snapshot",
         description=(
-            "Snapshot-backed screener: run an /invest/screener preset over its base "
-            "snapshot and adjust/add AND-filters on top (filters-over-snapshot, ROB-439). "
-            "Unlike screen_stocks (generic tvscreener/KIS path), this serves the persisted "
-            "screener snapshot data. filters=[{field, operator(gte|lte|eq), value}] tune the "
-            "preset's thresholds; the response includes availableFilters (the adjustable "
-            "catalog for that preset's snapshot) and appliedFilters. Currently threaded for "
-            "consecutive_gainers (e.g. loosen consecutive_up_days to 3 or tighten to 10); "
-            "other presets return default snapshot results and say so. Read-only. "
-            "Results are capped (limit default 40, max 200) and paginated via "
-            "limit/offset; pagination.total_available + pagination.next_offset let you "
-            "page through without exceeding the response token budget."
+            "Snapshot-backed screener: run one or more /invest/screener presets over "
+            "their base snapshots (Discovery Workflow, ROB-515). "
+            "Unlike screen_stocks (generic tvscreener/KIS path), this serves persisted "
+            "screener snapshot data. preset can be a single ID or a comma-separated "
+            "list (e.g. 'consecutive_gainers,double_buy') for multi-preset sweeps with "
+            "symbol deduplication and matchedPresets tagging. "
+            "filters=[{field, operator(gte|lte|eq), value}] tune the preset's "
+            "thresholds (threaded for consecutive_gainers and crypto). "
+            "exclude_watched/held (bool) hide symbols already in watchlist or portfolio. "
+            "min_analyst_buy_count (int) and min/max_market_cap_eok (float, unit 1억원) "
+            "apply discovery-quality filters across the result set. "
+            "sort='matched_presets_desc' ranks multi-preset intersections first. "
+            "Read-only. Results are capped (default 40) and paginated via limit/offset."
         ),
     )
     async def screen_stocks_snapshot(
         preset: str,
         market: Literal["kr", "us", "crypto"] = "kr",
         filters: list[dict[str, Any]] | None = None,
+        exclude_watched: bool = False,
+        exclude_held: bool = False,
+        min_analyst_buy_count: int | None = None,
+        min_market_cap_eok: float | None = None,
+        max_market_cap_eok: float | None = None,
+        sort: Literal["matched_presets_desc"] | None = None,
         limit: int = 40,
         offset: int = 0,
     ) -> dict[str, Any]:
@@ -287,6 +295,12 @@ def register_analysis_tools(
             preset=preset,
             market=market,
             filters=filters,
+            exclude_watched=exclude_watched,
+            exclude_held=exclude_held,
+            min_analyst_buy_count=min_analyst_buy_count,
+            min_market_cap_eok=min_market_cap_eok,
+            max_market_cap_eok=max_market_cap_eok,
+            sort=sort,
             limit=limit,
             offset=offset,
         )

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -13,7 +13,7 @@ return their default snapshot results (and say so), expanding as more presets ge
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -149,6 +149,7 @@ async def screen_stocks_snapshot_impl(
     at the tool boundary to keep responses inside the MCP token budget. The full
     match count and a next_offset cursor are reported under ``pagination``.
     """
+    from app.mcp_server.tooling.portfolio_holdings import _collect_kis_positions
     from app.services.invest_view_model.screener_filters import (
         ScreenerFilterCondition,
         ScreenerFilterError,
@@ -156,7 +157,6 @@ async def screen_stocks_snapshot_impl(
     )
     from app.services.invest_view_model.screener_service import build_screener_results
     from app.services.screener_service import ScreenerService
-    from app.mcp_server.tooling.portfolio_holdings import _collect_kis_positions
 
     preset_ids = _normalize_preset_ids(preset)
     if not preset_ids:
@@ -170,7 +170,9 @@ async def screen_stocks_snapshot_impl(
         try:
             # MCP always runs live (is_mock=False)
             pos, _w = await _collect_kis_positions("equity_kr", is_mock=False)
-            held_symbols = {str(p.get("symbol")).upper() for p in pos if p.get("symbol")}
+            held_symbols = {
+                str(p.get("symbol")).upper() for p in pos if p.get("symbol")
+            }
             holdings_meta["held_count"] = len(held_symbols)
         except Exception as exc:  # noqa: BLE001
             holdings_meta["status"] = "error"
@@ -244,16 +246,12 @@ async def screen_stocks_snapshot_impl(
     if min_market_cap_eok is not None:
         min_val = float(min_market_cap_eok) * 100_000_000
         merged_results = [
-            r
-            for r in merged_results
-            if (r.get("marketCapValue") or 0) >= min_val
+            r for r in merged_results if (r.get("marketCapValue") or 0) >= min_val
         ]
     if max_market_cap_eok is not None:
         max_val = float(max_market_cap_eok) * 100_000_000
         merged_results = [
-            r
-            for r in merged_results
-            if (r.get("marketCapValue") or 0) <= max_val
+            r for r in merged_results if (r.get("marketCapValue") or 0) <= max_val
         ]
 
     # Intersection sort
@@ -313,12 +311,8 @@ async def screen_stocks_snapshot_impl(
         all_results = [
             r
             for r in all_results
-            if (
-                r.get("analysisContext", {})
-                .get("consensus", {})
-                .get("buyCount")
-                 or 0
-            ) >= min_buy
+            if (r.get("analysisContext", {}).get("consensus", {}).get("buyCount") or 0)
+            >= min_buy
         ]
         total_available = len(all_results)
         page = all_results[eff_offset : eff_offset + eff_limit]

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -23,13 +23,14 @@ logger = logging.getLogger(__name__)
 
 
 class _HeldResolver:
-    """Held-aware resolver for MCP.マーク rows as held via KIS live positions."""
+    """Held-aware resolver for MCP rows backed by KIS live positions."""
 
-    def __init__(self, held_symbols: set[str]) -> None:
+    def __init__(self, held_symbols: set[tuple[str, str]]) -> None:
         self._h = held_symbols
 
-    def relation(self, market: str, symbol: str) -> str:  # noqa: ARG002
-        return "held" if symbol.upper() in self._h else "none"
+    def relation(self, market: str, symbol: str) -> str:
+        key = ((market or "").strip().lower(), _normalize_symbol_key(symbol))
+        return "held" if key in self._h else "none"
 
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
@@ -83,9 +84,35 @@ def _filters_are_threaded(preset: str, market: str) -> bool:
     return (market or "").strip().lower() == "crypto" and preset in _CRYPTO_PRESET_IDS
 
 
-def _normalize_preset_ids(raw_preset: str) -> list[str]:
-    """Split comma-separated preset IDs and strip whitespace."""
-    return [p.strip() for p in raw_preset.split(",") if p.strip()]
+def _normalize_symbol_key(symbol: object) -> str:
+    from app.core.symbol import to_db_symbol
+
+    raw = str(symbol or "").strip().upper()
+    try:
+        return to_db_symbol(raw).upper()
+    except Exception:
+        return raw
+
+
+def _normalize_preset_ids(
+    raw_preset: str | None, presets: list[str] | None = None
+) -> list[str]:
+    """Split preset inputs, preserving order while deduping."""
+    raw: list[str] = []
+    if raw_preset:
+        raw.extend(str(raw_preset).split(","))
+    for item in presets or []:
+        raw.extend(str(item).split(","))
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for value in raw:
+        preset_id = value.strip()
+        if not preset_id or preset_id in seen:
+            continue
+        seen.add(preset_id)
+        out.append(preset_id)
+    return out
 
 
 def _merge_rows(
@@ -97,12 +124,21 @@ def _merge_rows(
     Subsequent matches only append to matchedPresets.
     """
     merged = list(existing)
-    seen_symbols = {str(r.get("symbol")).upper(): r for r in merged}
+    seen_symbols = {
+        (
+            str(r.get("market") or "").strip().lower(),
+            _normalize_symbol_key(r.get("symbol")),
+        ): r
+        for r in merged
+    }
 
     for row in new_rows:
-        symbol = str(row.get("symbol")).upper()
-        if symbol in seen_symbols:
-            existing_row = seen_symbols[symbol]
+        key = (
+            str(row.get("market") or "").strip().lower(),
+            _normalize_symbol_key(row.get("symbol")),
+        )
+        if key in seen_symbols:
+            existing_row = seen_symbols[key]
             matched = list(existing_row.get("matchedPresets") or [])
             if preset_id not in matched:
                 matched.append(preset_id)
@@ -110,9 +146,26 @@ def _merge_rows(
         else:
             row["matchedPresets"] = [preset_id]
             merged.append(row)
-            seen_symbols[symbol] = row
+            seen_symbols[key] = row
 
     return merged
+
+
+def _holding_market_filter(market: str) -> str | None:
+    normalized = (market or "").strip().lower()
+    if normalized == "kr":
+        return "equity_kr"
+    if normalized == "us":
+        return "equity_us"
+    return None
+
+
+def _consensus_count(row: dict[str, Any], key: str) -> int:
+    try:
+        value = (row.get("analysisContext") or {}).get("consensus", {}).get(key)
+        return int(value or 0)
+    except (TypeError, ValueError, AttributeError):
+        return 0
 
 
 _DEFAULT_RESULT_LIMIT = 40
@@ -121,12 +174,16 @@ _MAX_RESULT_LIMIT = 200
 
 async def screen_stocks_snapshot_impl(
     *,
-    preset: str,
+    preset: str | None = None,
+    presets: list[str] | None = None,
     market: str = "kr",
     filters: list[dict[str, Any]] | None = None,
     exclude_watched: bool = False,
     exclude_held: bool = False,
+    exclude_symbols: list[str] | None = None,
+    min_analyst_count: int | None = None,
     min_analyst_buy_count: int | None = None,
+    min_market_cap: float | None = None,
     min_market_cap_eok: float | None = None,
     max_market_cap_eok: float | None = None,
     sort: Literal["matched_presets_desc"] | None = None,
@@ -140,7 +197,10 @@ async def screen_stocks_snapshot_impl(
     screener payload plus availableFilters (the adjustable catalog) and appliedFilters.
 
     exclude_watched/held: ROB-515 discovery workflow — hide already-processed symbols.
-    min_analyst_buy_count: ROB-515 quality filter — consensus-buy count threshold.
+    exclude_symbols: explicit symbols to remove after dedupe.
+    min_analyst_count: ROB-515 quality filter — consensus total coverage threshold.
+    min_analyst_buy_count: backward-compatible buy-count threshold.
+    min_market_cap: raw numeric marketCapValue threshold (KRW for KR, USD for US).
     min/max_market_cap_eok: ROB-515 size filter — unit is 1억원 (KRW).
 
     sort: "matched_presets_desc" ranks multi-preset intersections first.
@@ -158,20 +218,28 @@ async def screen_stocks_snapshot_impl(
     from app.services.invest_view_model.screener_service import build_screener_results
     from app.services.screener_service import ScreenerService
 
-    preset_ids = _normalize_preset_ids(preset)
+    preset_ids = _normalize_preset_ids(preset, presets)
     if not preset_ids:
-        return {"error": "preset must not be empty", "results": []}
+        return {"error": "preset or presets must not be empty", "results": []}
 
     # ROB-515: mark 'held' rows in screener results via KIS live positions.
     # (Watchlist personalization is still omitted for discovery MCP).
-    held_symbols: set[str] = set()
+    held_symbols: set[tuple[str, str]] = set()
     holdings_meta = {"source": "kis_live", "status": "ok", "held_count": 0}
-    if market == "kr":
+    holdings_market_filter = _holding_market_filter(market)
+    if holdings_market_filter is not None:
         try:
             # MCP always runs live (is_mock=False)
-            pos, _w = await _collect_kis_positions("equity_kr", is_mock=False)
+            pos, _w = await _collect_kis_positions(
+                holdings_market_filter, is_mock=False
+            )
             held_symbols = {
-                str(p.get("symbol")).upper() for p in pos if p.get("symbol")
+                (
+                    str(p.get("market") or market).strip().lower(),
+                    _normalize_symbol_key(p.get("symbol")),
+                )
+                for p in pos
+                if p.get("symbol")
             }
             holdings_meta["held_count"] = len(held_symbols)
         except Exception as exc:  # noqa: BLE001
@@ -241,8 +309,20 @@ async def screen_stocks_snapshot_impl(
         merged_results = [r for r in merged_results if not r.get("isWatched")]
     if exclude_held:
         merged_results = [r for r in merged_results if not r.get("isHeld")]
+    if exclude_symbols:
+        excluded_symbols = {_normalize_symbol_key(s) for s in exclude_symbols}
+        merged_results = [
+            r
+            for r in merged_results
+            if _normalize_symbol_key(r.get("symbol")) not in excluded_symbols
+        ]
 
-    # Discovery filters (market cap) — unit is 1억원
+    # Discovery filters (market cap)
+    if min_market_cap is not None:
+        min_val = float(min_market_cap)
+        merged_results = [
+            r for r in merged_results if (r.get("marketCapValue") or 0) >= min_val
+        ]
     if min_market_cap_eok is not None:
         min_val = float(min_market_cap_eok) * 100_000_000
         merged_results = [
@@ -270,7 +350,8 @@ async def screen_stocks_snapshot_impl(
         )
 
     payload: dict[str, Any] = {
-        "presetId": preset,
+        "presetId": preset_ids[0] if len(preset_ids) == 1 else "multi",
+        "presets": preset_ids,
         "results": merged_results,
         "warnings": combined_warnings,
         "availableFilters": available,
@@ -280,6 +361,19 @@ async def screen_stocks_snapshot_impl(
         ],
         "snapshotKind": snapshot_kind,
         "holdings": holdings_meta,
+        "discoveryFilters": {
+            "exclude_watched": exclude_watched,
+            "exclude_held": exclude_held,
+            "exclude_symbols": [
+                _normalize_symbol_key(s) for s in (exclude_symbols or [])
+            ],
+            "min_analyst_count": min_analyst_count,
+            "min_analyst_buy_count": min_analyst_buy_count,
+            "min_market_cap": min_market_cap,
+            "min_market_cap_eok": min_market_cap_eok,
+            "max_market_cap_eok": max_market_cap_eok,
+            "sort": sort,
+        },
     }
     if holdings_meta["status"] == "error":
         combined_warnings.append(
@@ -295,7 +389,7 @@ async def screen_stocks_snapshot_impl(
 
     # ROB-515: if analyst filtering is requested, we must enrich BEFORE pagination
     # so we can filter on the enriched buyCount across the whole set.
-    if min_analyst_buy_count is not None:
+    if min_analyst_count is not None or min_analyst_buy_count is not None:
         from app.services.invest_view_model.screener_analysis_enrichment import (
             enrich_snapshot_page,
         )
@@ -306,14 +400,16 @@ async def screen_stocks_snapshot_impl(
             session_factory=_session_factory(),
         )
         all_results = enrichment["results"]
-        # Update match total after analyst filter
-        min_buy = int(min_analyst_buy_count)
-        all_results = [
-            r
-            for r in all_results
-            if (r.get("analysisContext", {}).get("consensus", {}).get("buyCount") or 0)
-            >= min_buy
-        ]
+        if min_analyst_count is not None:
+            min_total = int(min_analyst_count)
+            all_results = [
+                r for r in all_results if _consensus_count(r, "totalCount") >= min_total
+            ]
+        if min_analyst_buy_count is not None:
+            min_buy = int(min_analyst_buy_count)
+            all_results = [
+                r for r in all_results if _consensus_count(r, "buyCount") >= min_buy
+            ]
         total_available = len(all_results)
         page = all_results[eff_offset : eff_offset + eff_limit]
         payload["analysisEnrichment"] = enrichment["summary"]
@@ -331,7 +427,7 @@ async def screen_stocks_snapshot_impl(
         "next_offset": next_offset if next_offset < total_available else None,
     }
 
-    if min_analyst_buy_count is None:
+    if min_analyst_count is None and min_analyst_buy_count is None:
         from app.services.invest_view_model.screener_analysis_enrichment import (
             enrich_snapshot_page,
         )

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -83,6 +83,38 @@ def _filters_are_threaded(preset: str, market: str) -> bool:
     return (market or "").strip().lower() == "crypto" and preset in _CRYPTO_PRESET_IDS
 
 
+def _normalize_preset_ids(raw_preset: str) -> list[str]:
+    """Split comma-separated preset IDs and strip whitespace."""
+    return [p.strip() for p in raw_preset.split(",") if p.strip()]
+
+
+def _merge_rows(
+    existing: list[dict[str, Any]], new_rows: list[dict[str, Any]], preset_id: str
+) -> list[dict[str, Any]]:
+    """Dedupe by symbol and merge matchedPresets.
+
+    The first preset to see a symbol 'wins' on display fields (rank, name, labels).
+    Subsequent matches only append to matchedPresets.
+    """
+    merged = list(existing)
+    seen_symbols = {str(r.get("symbol")).upper(): r for r in merged}
+
+    for row in new_rows:
+        symbol = str(row.get("symbol")).upper()
+        if symbol in seen_symbols:
+            existing_row = seen_symbols[symbol]
+            matched = list(existing_row.get("matchedPresets") or [])
+            if preset_id not in matched:
+                matched.append(preset_id)
+            existing_row["matchedPresets"] = matched
+        else:
+            row["matchedPresets"] = [preset_id]
+            merged.append(row)
+            seen_symbols[symbol] = row
+
+    return merged
+
+
 _DEFAULT_RESULT_LIMIT = 40
 _MAX_RESULT_LIMIT = 200
 
@@ -114,6 +146,10 @@ async def screen_stocks_snapshot_impl(
     from app.services.screener_service import ScreenerService
     from app.mcp_server.tooling.portfolio_holdings import _collect_kis_positions
 
+    preset_ids = _normalize_preset_ids(preset)
+    if not preset_ids:
+        return {"error": "preset must not be empty", "results": []}
+
     # ROB-515: mark 'held' rows in screener results via KIS live positions.
     # (Watchlist personalization is still omitted for discovery MCP).
     held_symbols: set[str] = set()
@@ -130,8 +166,10 @@ async def screen_stocks_snapshot_impl(
             # (build_screener_results takes resolver as non-optional, so fall back to noop)
             logger.warning("screener_snapshot: kis holdings failed: %s", exc)
 
-    available = _available_filters(preset)
-    snapshot_kind = snapshot_kind_for_preset(preset)
+    # Use the first preset for adjustable filter catalog metadata
+    main_preset_id = preset_ids[0]
+    available = _available_filters(main_preset_id)
+    snapshot_kind = snapshot_kind_for_preset(main_preset_id)
 
     conditions: list[ScreenerFilterCondition] = []
     for entry in filters or []:
@@ -151,16 +189,31 @@ async def screen_stocks_snapshot_impl(
                 "results": [],
             }
 
+    merged_results: list[dict[str, Any]] = []
+    combined_warnings: list[str] = []
+    threaded_warned_presets: set[str] = set()
+
     try:
         async with _session_factory()() as db:
-            resp = await build_screener_results(
-                preset_id=preset,
-                screening_service=ScreenerService(),
-                resolver=_HeldResolver(held_symbols),
-                market=market,
-                session=db,
-                filter_overrides=conditions or None,
-            )
+            for pid in preset_ids:
+                resp = await build_screener_results(
+                    preset_id=pid,
+                    screening_service=ScreenerService(),
+                    resolver=_HeldResolver(held_symbols),
+                    market=market,
+                    session=db,
+                    filter_overrides=conditions or None,
+                )
+                raw_payload = resp.model_dump(mode="json")
+                merged_results = _merge_rows(
+                    merged_results, raw_payload.get("results") or [], pid
+                )
+                for w in raw_payload.get("warnings") or []:
+                    if w not in combined_warnings:
+                        combined_warnings.append(w)
+
+                if conditions and not _filters_are_threaded(pid, market):
+                    threaded_warned_presets.add(pid)
     except ScreenerFilterError as exc:
         return {
             "error": str(exc),
@@ -169,34 +222,34 @@ async def screen_stocks_snapshot_impl(
             "results": [],
         }
 
-    payload: dict[str, Any] = resp.model_dump(mode="json")
-    payload["availableFilters"] = available
-    payload["appliedFilters"] = [
-        {"field": c.field, "operator": c.operator, "value": c.value} for c in conditions
-    ]
-    payload["snapshotKind"] = snapshot_kind
-    payload["holdings"] = holdings_meta
-    if holdings_meta["status"] == "error":
-        _ws = list(payload.get("warnings") or [])
-        _ws.append("KIS live 보유종목 확인 실패 — 보유 여부가 표시되지 않을 수 있습니다.")
-        payload["warnings"] = _ws
-
     # ROB-445: warn whenever filters were passed but NOT actually threaded for the
-    # resolved (preset, market) — REGARDLESS of snapshotKind. The old `snapshot_kind
-    # is None` predicate let high_yield_value (kind=market_valuation_snapshots, but
-    # no dispatch branch) echo appliedFilters while silently returning the unfiltered
-    # snapshot (silent no-op). Now the unfiltered fact is reported honestly.
-    if conditions and not _filters_are_threaded(preset, market):
-        warnings = list(payload.get("warnings") or [])
-        warnings.append(
-            f"'{preset}' 프리셋은 아직 스냅샷 위 필터 조정이 배선되지 않아 "
+    # resolved (preset, market) — REGARDLESS of snapshotKind.
+    if threaded_warned_presets:
+        p_list = ", ".join(sorted(threaded_warned_presets))
+        combined_warnings.append(
+            f"'{p_list}' 프리셋은 아직 스냅샷 위 필터 조정이 배선되지 않아 "
             "기본 결과를 반환했습니다 (필터 미적용)."
         )
-        payload["warnings"] = warnings
+
+    payload: dict[str, Any] = {
+        "presetId": preset,
+        "results": merged_results,
+        "warnings": combined_warnings,
+        "availableFilters": available,
+        "appliedFilters": [
+            {"field": c.field, "operator": c.operator, "value": c.value}
+            for c in conditions
+        ],
+        "snapshotKind": snapshot_kind,
+        "holdings": holdings_meta,
+    }
+    if holdings_meta["status"] == "error":
+        combined_warnings.append(
+            "KIS live 보유종목 확인 실패 — 보유 여부가 표시되지 않을 수 있습니다."
+        )
 
     # ROB-465: cap + paginate at the tool boundary so large snapshots (e.g.
     # high_yield_value ~161 rows / ~84k chars) don't blow the MCP token budget.
-    # The web screener path (build_screener_results) is left untouched.
     all_results = payload.get("results") or []
     total_available = len(all_results)
     eff_limit = max(1, min(int(limit), _MAX_RESULT_LIMIT))

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -12,21 +12,24 @@ return their default snapshot results (and say so), expanding as more presets ge
 
 from __future__ import annotations
 
+import logging
 from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
 
+logger = logging.getLogger(__name__)
 
-class _NoopResolver:
-    """MCP candidate-discovery has no user context, so nothing is 'watched'.
 
-    build_screener_results only needs ``relation(market, symbol) -> str``; returning
-    "none" makes every row isWatched=False (no user personalization in MCP)."""
+class _HeldResolver:
+    """Held-aware resolver for MCP.マーク rows as held via KIS live positions."""
+
+    def __init__(self, held_symbols: set[str]) -> None:
+        self._h = held_symbols
 
     def relation(self, market: str, symbol: str) -> str:  # noqa: ARG002
-        return "none"
+        return "held" if symbol.upper() in self._h else "none"
 
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
@@ -109,6 +112,23 @@ async def screen_stocks_snapshot_impl(
     )
     from app.services.invest_view_model.screener_service import build_screener_results
     from app.services.screener_service import ScreenerService
+    from app.mcp_server.tooling.portfolio_holdings import _collect_kis_positions
+
+    # ROB-515: mark 'held' rows in screener results via KIS live positions.
+    # (Watchlist personalization is still omitted for discovery MCP).
+    held_symbols: set[str] = set()
+    holdings_meta = {"source": "kis_live", "status": "ok", "held_count": 0}
+    if market == "kr":
+        try:
+            # MCP always runs live (is_mock=False)
+            pos, _w = await _collect_kis_positions("equity_kr", is_mock=False)
+            held_symbols = {str(p.get("symbol")).upper() for p in pos if p.get("symbol")}
+            holdings_meta["held_count"] = len(held_symbols)
+        except Exception as exc:  # noqa: BLE001
+            holdings_meta["status"] = "error"
+            # surface as a non-fatal warning so results still return
+            # (build_screener_results takes resolver as non-optional, so fall back to noop)
+            logger.warning("screener_snapshot: kis holdings failed: %s", exc)
 
     available = _available_filters(preset)
     snapshot_kind = snapshot_kind_for_preset(preset)
@@ -136,7 +156,7 @@ async def screen_stocks_snapshot_impl(
             resp = await build_screener_results(
                 preset_id=preset,
                 screening_service=ScreenerService(),
-                resolver=_NoopResolver(),
+                resolver=_HeldResolver(held_symbols),
                 market=market,
                 session=db,
                 filter_overrides=conditions or None,
@@ -155,6 +175,12 @@ async def screen_stocks_snapshot_impl(
         {"field": c.field, "operator": c.operator, "value": c.value} for c in conditions
     ]
     payload["snapshotKind"] = snapshot_kind
+    payload["holdings"] = holdings_meta
+    if holdings_meta["status"] == "error":
+        _ws = list(payload.get("warnings") or [])
+        _ws.append("KIS live 보유종목 확인 실패 — 보유 여부가 표시되지 않을 수 있습니다.")
+        payload["warnings"] = _ws
+
     # ROB-445: warn whenever filters were passed but NOT actually threaded for the
     # resolved (preset, market) — REGARDLESS of snapshotKind. The old `snapshot_kind
     # is None` predicate let high_yield_value (kind=market_valuation_snapshots, but

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -124,6 +124,12 @@ async def screen_stocks_snapshot_impl(
     preset: str,
     market: str = "kr",
     filters: list[dict[str, Any]] | None = None,
+    exclude_watched: bool = False,
+    exclude_held: bool = False,
+    min_analyst_buy_count: int | None = None,
+    min_market_cap_eok: float | None = None,
+    max_market_cap_eok: float | None = None,
+    sort: Literal["matched_presets_desc"] | None = None,
     limit: int = _DEFAULT_RESULT_LIMIT,
     offset: int = 0,
 ) -> dict[str, Any]:
@@ -132,6 +138,12 @@ async def screen_stocks_snapshot_impl(
     filters: list of {"field", "operator" (gte|lte|eq), "value"} conditions applied
     on top of the preset's starting set (adjust same field, add new). Returns the
     screener payload plus availableFilters (the adjustable catalog) and appliedFilters.
+
+    exclude_watched/held: ROB-515 discovery workflow — hide already-processed symbols.
+    min_analyst_buy_count: ROB-515 quality filter — consensus-buy count threshold.
+    min/max_market_cap_eok: ROB-515 size filter — unit is 1억원 (KRW).
+
+    sort: "matched_presets_desc" ranks multi-preset intersections first.
 
     limit/offset: ROB-465 — results are capped (default 40, max 200) and paginated
     at the tool boundary to keep responses inside the MCP token budget. The full
@@ -222,6 +234,34 @@ async def screen_stocks_snapshot_impl(
             "results": [],
         }
 
+    # Discovery filters (exclude)
+    if exclude_watched:
+        merged_results = [r for r in merged_results if not r.get("isWatched")]
+    if exclude_held:
+        merged_results = [r for r in merged_results if not r.get("isHeld")]
+
+    # Discovery filters (market cap) — unit is 1억원
+    if min_market_cap_eok is not None:
+        min_val = float(min_market_cap_eok) * 100_000_000
+        merged_results = [
+            r
+            for r in merged_results
+            if (r.get("marketCapValue") or 0) >= min_val
+        ]
+    if max_market_cap_eok is not None:
+        max_val = float(max_market_cap_eok) * 100_000_000
+        merged_results = [
+            r
+            for r in merged_results
+            if (r.get("marketCapValue") or 0) <= max_val
+        ]
+
+    # Intersection sort
+    if sort == "matched_presets_desc":
+        merged_results.sort(
+            key=lambda r: len(r.get("matchedPresets") or []), reverse=True
+        )
+
     # ROB-445: warn whenever filters were passed but NOT actually threaded for the
     # resolved (preset, market) — REGARDLESS of snapshotKind.
     if threaded_warned_presets:
@@ -254,7 +294,38 @@ async def screen_stocks_snapshot_impl(
     total_available = len(all_results)
     eff_limit = max(1, min(int(limit), _MAX_RESULT_LIMIT))
     eff_offset = max(0, int(offset))
-    page = all_results[eff_offset : eff_offset + eff_limit]
+
+    # ROB-515: if analyst filtering is requested, we must enrich BEFORE pagination
+    # so we can filter on the enriched buyCount across the whole set.
+    if min_analyst_buy_count is not None:
+        from app.services.invest_view_model.screener_analysis_enrichment import (
+            enrich_snapshot_page,
+        )
+
+        enrichment = await enrich_snapshot_page(
+            rows=all_results,
+            market=market,
+            session_factory=_session_factory(),
+        )
+        all_results = enrichment["results"]
+        # Update match total after analyst filter
+        min_buy = int(min_analyst_buy_count)
+        all_results = [
+            r
+            for r in all_results
+            if (
+                r.get("analysisContext", {})
+                .get("consensus", {})
+                .get("buyCount")
+                 or 0
+            ) >= min_buy
+        ]
+        total_available = len(all_results)
+        page = all_results[eff_offset : eff_offset + eff_limit]
+        payload["analysisEnrichment"] = enrichment["summary"]
+    else:
+        page = all_results[eff_offset : eff_offset + eff_limit]
+
     next_offset = eff_offset + len(page)
     payload["results"] = page
     payload["pagination"] = {
@@ -266,16 +337,17 @@ async def screen_stocks_snapshot_impl(
         "next_offset": next_offset if next_offset < total_available else None,
     }
 
-    from app.services.invest_view_model.screener_analysis_enrichment import (
-        enrich_snapshot_page,
-    )
+    if min_analyst_buy_count is None:
+        from app.services.invest_view_model.screener_analysis_enrichment import (
+            enrich_snapshot_page,
+        )
 
-    enrichment = await enrich_snapshot_page(
-        rows=page,
-        market=market,
-        session_factory=_session_factory(),
-    )
-    payload["results"] = enrichment["results"]
-    payload["analysisEnrichment"] = enrichment["summary"]
+        enrichment = await enrich_snapshot_page(
+            rows=page,
+            market=market,
+            session_factory=_session_factory(),
+        )
+        payload["results"] = enrichment["results"]
+        payload["analysisEnrichment"] = enrichment["summary"]
 
     return payload

--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -152,12 +152,15 @@ class ScreenerResultRow(BaseModel):
     name: str
     logoUrl: str | None = None
     isWatched: bool = False
+    isHeld: bool = False
+    matchedPresets: list[str] = Field(default_factory=list)
     priceLabel: str
     changePctLabel: str
     changeAmountLabel: str
     changeDirection: ChangeDirection
     category: str
     marketCapLabel: str
+    marketCapValue: float | None = None
     volumeLabel: str
     analystLabel: str
     metricValueLabel: str

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -1282,6 +1282,16 @@ def _format_market_cap(row: dict[str, Any], market: str) -> tuple[str, list[str]
     return _format_market_cap_kr(market_cap), warnings
 
 
+def _market_cap_value(row: dict[str, Any], market: str) -> float | None:
+    if market in {"us", "crypto"}:
+        market_cap = _coerce_float(row.get("market_cap_usd"))
+        if market_cap is None:
+            market_cap = _coerce_float(row.get("market_cap"))
+        return market_cap if market_cap is not None and market_cap > 0 else None
+    market_cap, _warnings = _normalize_market_cap_krw(row, market)
+    return market_cap
+
+
 def _format_volume(volume: float | None) -> str:
     if volume is None:
         return "-"
@@ -2376,6 +2386,8 @@ async def build_screener_results(
         metric_label, metric_warnings = _metric_value_label(preset_id, row)
         relation = resolver.relation(market, symbol)
         is_watched = relation in ("watchlist", "both")
+        is_held = relation in ("held", "both")
+        market_cap_value = _market_cap_value(row, market)
         row_warnings = symbol_warnings + market_cap_warnings + metric_warnings
         source_context = (
             _crypto_row_source_context(
@@ -2393,6 +2405,8 @@ async def build_screener_results(
                 name=_kr_names.get(symbol) or _clean_text(row.get("name")) or symbol,
                 logoUrl=row.get("logo_url"),
                 isWatched=is_watched,
+                isHeld=is_held,
+                matchedPresets=[preset_id],
                 priceLabel=_format_crypto_price(
                     _coerce_float(
                         row.get("close") or row.get("price") or row.get("current_price")
@@ -2417,6 +2431,7 @@ async def build_screener_results(
                 changeDirection=direction,
                 category=str(row.get("sector") or row.get("category") or "-"),
                 marketCapLabel=market_cap_label,
+                marketCapValue=market_cap_value,
                 volumeLabel=_format_volume_label(row, market),
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,

--- a/tests/test_invest_screener_schemas.py
+++ b/tests/test_invest_screener_schemas.py
@@ -332,6 +332,7 @@ def test_result_row_accepts_analysis_context():
     assert row.analysisContext.consensus.buyCount == 2
     assert row.analysisContext.rsi14 == pytest.approx(58.42)
 
+
 @pytest.mark.unit
 def test_result_row_accepts_discovery_workflow_fields() -> None:
     row = ScreenerResultRow(

--- a/tests/test_invest_screener_schemas.py
+++ b/tests/test_invest_screener_schemas.py
@@ -331,3 +331,31 @@ def test_result_row_accepts_analysis_context():
     assert row.analysisContext.consensus is not None
     assert row.analysisContext.consensus.buyCount == 2
     assert row.analysisContext.rsi14 == pytest.approx(58.42)
+
+@pytest.mark.unit
+def test_result_row_accepts_discovery_workflow_fields() -> None:
+    row = ScreenerResultRow(
+        rank=1,
+        symbol="005930",
+        market="kr",
+        name="삼성전자",
+        logoUrl=None,
+        isWatched=False,
+        isHeld=True,
+        matchedPresets=["consecutive_gainers", "double_buy"],
+        marketCapValue=478_000_000_000_000.0,
+        priceLabel="80,000원",
+        changePctLabel="+1.23%",
+        changeAmountLabel="+970",
+        changeDirection="up",
+        category="반도체",
+        marketCapLabel="478.0조원",
+        volumeLabel="12,345,678",
+        analystLabel="-",
+        metricValueLabel="+1.23%",
+        warnings=[],
+    )
+
+    assert row.isHeld is True
+    assert row.matchedPresets == ["consecutive_gainers", "double_buy"]
+    assert row.marketCapValue == pytest.approx(478_000_000_000_000.0)

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -205,13 +205,66 @@ def _name_row(symbol: str, name: str) -> Any:
 
 
 class _FakeResolver:
-    def __init__(self, watched: set[tuple[str, str]]) -> None:
-        self._w = watched
+    def __init__(
+        self,
+        watched: set[tuple[str, str]] | None = None,
+        held: set[tuple[str, str]] | None = None,
+    ) -> None:
+        self._w = watched or set()
+        self._h = held or set()
         self.calls: list[tuple[str, str]] = []
 
     def relation(self, market: str, symbol: str) -> str:
         self.calls.append((market, symbol))
-        return "watchlist" if (market, symbol) in self._w else "none"
+        watched = (market, symbol) in self._w
+        held = (market, symbol) in self._h
+        if watched and held:
+            return "both"
+        if held:
+            return "held"
+        if watched:
+            return "watchlist"
+        return "none"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_marks_is_held_from_relation() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={"results": _stub_screening_rows(), "warnings": []}
+    )
+    resolver = _FakeResolver(held={("kr", "005930")})
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].symbol == "005930"
+    assert resp.results[0].isHeld is True
+    assert resp.results[0].isWatched is False
+    assert resp.results[1].isHeld is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_exposes_numeric_market_cap_value() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={"results": _stub_screening_rows(), "warnings": []}
+    )
+    resolver = _FakeResolver()
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "478.0조원"
+    assert resp.results[0].marketCapValue == pytest.approx(478_000_000_000_000.0)
 
 
 @pytest.mark.unit

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -403,3 +403,140 @@ async def test_snapshot_tool_merges_multiple_presets(monkeypatch) -> None:
     # warnings should be combined
     assert "warn_preset_a" in out["warnings"]
     assert "warn_preset_b" in out["warnings"]
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "S1", "isWatched": True, "isHeld": False},
+                    {"symbol": "S2", "isWatched": False, "isHeld": True},
+                    {"symbol": "S3", "isWatched": False, "isHeld": False},
+                ],
+                "warnings": [],
+            }
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    async def _fake_build_async(**kwargs: Any) -> _Resp:
+        return _Resp()
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build_async,
+    )
+
+    # Exclude watched -> S1 gone
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", exclude_watched=True
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S2", "S3"]
+
+    # Exclude held -> S2 gone
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", exclude_held=True
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S1", "S3"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "S1", "marketCapValue": 500_000_000_000.0}, # 5000억
+                    {"symbol": "S2", "marketCapValue": 200_000_000_000.0}, # 2000억
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    async def _fake_enrich_page(*, rows: list[dict[str, Any]], **kwargs: Any):
+        # S1 has 2 buy ratings, S2 has 0
+        enriched = []
+        for r in rows:
+            buy_count = 2 if r["symbol"] == "S1" else 0
+            enriched.append({
+                **r,
+                "analysisContext": {"consensus": {"buyCount": buy_count, "totalCount": buy_count}}
+            })
+        return {"results": enriched, "summary": {"warnings": []}}
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_analysis_enrichment.enrich_snapshot_page",
+        _fake_enrich_page,
+    )
+
+    # Min market cap 3000억 -> S2 gone
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", min_market_cap_eok=3000
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S1"]
+
+    # Min analyst buy 1 -> S2 gone
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", min_analyst_buy_count=1
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S1"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "S1", "matchedPresets": ["A"]},
+                    {"symbol": "S2", "matchedPresets": ["A", "B"]}, # Intersection
+                    {"symbol": "S3", "matchedPresets": ["A"]},
+                ],
+                "warnings": [],
+            }
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    async def _fake_build_sort(**kwargs: Any) -> _Resp:
+        pid = kwargs["preset_id"]
+        # S2 is in both A and B, S1 only in A, S3 only in B
+        if pid == "A":
+            rows = [{"symbol": "S1"}, {"symbol": "S2"}]
+        else:
+            rows = [{"symbol": "S2"}, {"symbol": "S3"}]
+        
+        class _DynamicResp:
+            def model_dump(self, mode: str | None = None) -> dict[str, Any]:
+                return {"presetId": pid, "results": rows, "warnings": []}
+        return _DynamicResp()
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build_sort,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="A,B", market="kr", sort="matched_presets_desc"
+    )
+    # S2 should be first (matched 2 presets)
+    assert out["results"][0]["symbol"] == "S2"
+    assert len(out["results"][0]["matchedPresets"]) == 2

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -354,3 +354,52 @@ async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(monkeypatc
     assert any("KIS live 보유종목 확인 실패" in w for w in out["warnings"])
     assert out["holdings"]["source"] == "kis_live"
     assert out["holdings"]["status"] == "error"
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_merges_multiple_presets(monkeypatch) -> None:
+    async def _fake_build(**kwargs: Any) -> Any:
+        pid = kwargs["preset_id"]
+        # Mock results where S1 is in both, S2 only in A, S3 only in B
+        if pid == "preset_a":
+            rows = [{"symbol": "S1", "rank": 1}, {"symbol": "S2", "rank": 2}]
+        else:
+            rows = [{"symbol": "S1", "rank": 1}, {"symbol": "S3", "rank": 2}]
+
+        return MagicMock(
+            model_dump=lambda mode=None: {
+                "presetId": pid,
+                "results": rows,
+                "warnings": [f"warn_{pid}"],
+            }
+        )
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="preset_a, preset_b",  # comma-separated string
+        market="kr",
+    )
+
+    # results should contain S1, S2, S3 (deduped)
+    symbols = [r["symbol"] for r in out["results"]]
+    assert len(symbols) == 3
+    assert "S1" in symbols
+    assert "S2" in symbols
+    assert "S3" in symbols
+
+    # S1 should have both presets in its matchedPresets
+    s1 = next(r for r in out["results"] if r["symbol"] == "S1")
+    assert "preset_a" in s1["matchedPresets"]
+    assert "preset_b" in s1["matchedPresets"]
+
+    # warnings should be combined
+    assert "warn_preset_a" in out["warnings"]
+    assert "warn_preset_b" in out["warnings"]

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -7,7 +7,7 @@ filter parsing → conditions, catalog exposure, threading, fail-soft on bad inp
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -258,6 +258,7 @@ async def test_enriches_only_returned_page(monkeypatch) -> None:
     assert out["results"][0]["analysisContext"]["rsi14"] == pytest.approx(58.0)
     assert out["analysisEnrichment"]["attempted"] == 2
 
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_snapshot_tool_marks_kis_live_held_rows(monkeypatch) -> None:
@@ -285,7 +286,9 @@ async def test_snapshot_tool_marks_kis_live_held_rows(monkeypatch) -> None:
         assert resolver.relation("kr", "005930") == "held"
         return _HeldResp()
 
-    async def _fake_collect_kis_positions(market_filter: str | None, *, is_mock: bool = False):
+    async def _fake_collect_kis_positions(
+        market_filter: str | None, *, is_mock: bool = False
+    ):
         assert market_filter == "equity_kr"
         assert is_mock is False
         return ([{"market": "kr", "symbol": "005930"}], [])
@@ -317,7 +320,64 @@ async def test_snapshot_tool_marks_kis_live_held_rows(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(monkeypatch) -> None:
+async def test_snapshot_tool_marks_us_kis_live_held_rows(monkeypatch) -> None:
+    class _HeldResp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "high_yield_value",
+                "results": [
+                    {
+                        "rank": 1,
+                        "symbol": "BRK.B",
+                        "market": "us",
+                        "name": "Berkshire Hathaway",
+                        "isWatched": False,
+                        "isHeld": True,
+                    }
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**kwargs: Any) -> _HeldResp:
+        resolver = kwargs["resolver"]
+        assert resolver.relation("us", "BRK/B") == "held"
+        return _HeldResp()
+
+    async def _fake_collect_kis_positions(
+        market_filter: str | None, *, is_mock: bool = False
+    ):
+        assert market_filter == "equity_us"
+        assert is_mock is False
+        return ([{"market": "us", "symbol": "BRK.B"}], [])
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _fake_collect_kis_positions,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="high_yield_value",
+        market="us",
+        limit=10,
+    )
+
+    assert out["results"][0]["isHeld"] is True
+    assert out["holdings"]["held_count"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(
+    monkeypatch,
+) -> None:
     class _Resp:
         def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
             return {
@@ -329,7 +389,9 @@ async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(monkeypatc
     async def _fake_build(**_kwargs: Any) -> _Resp:
         return _Resp()
 
-    async def _fail_collect_kis_positions(market_filter: str | None, *, is_mock: bool = False):
+    async def _fail_collect_kis_positions(
+        market_filter: str | None, *, is_mock: bool = False
+    ):
         raise RuntimeError("kis unavailable")
 
     monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
@@ -354,6 +416,7 @@ async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(monkeypatc
     assert any("KIS live 보유종목 확인 실패" in w for w in out["warnings"])
     assert out["holdings"]["source"] == "kis_live"
     assert out["holdings"]["status"] == "error"
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
@@ -404,6 +467,40 @@ async def test_snapshot_tool_merges_multiple_presets(monkeypatch) -> None:
     assert "warn_preset_a" in out["warnings"]
     assert "warn_preset_b" in out["warnings"]
 
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_accepts_presets_list_for_multi_sweep(monkeypatch) -> None:
+    async def _fake_build(**kwargs: Any) -> Any:
+        pid = kwargs["preset_id"]
+        rows = [{"symbol": "S1"}] if pid == "preset_a" else [{"symbol": "S2"}]
+        return MagicMock(
+            model_dump=lambda mode=None: {
+                "presetId": pid,
+                "results": rows,
+                "warnings": [],
+            }
+        )
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        presets=["preset_a", "preset_b"],
+        market="kr",
+    )
+
+    assert [r["symbol"] for r in out["results"]] == ["S1", "S2"]
+    assert out["presetId"] == "multi"
+    assert out["presets"] == ["preset_a", "preset_b"]
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
@@ -423,8 +520,10 @@ async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
     monkeypatch.setattr(
         "app.services.screener_service.ScreenerService", lambda: object()
     )
+
     async def _fake_build_async(**kwargs: Any) -> _Resp:
         return _Resp()
+
     monkeypatch.setattr(
         "app.services.invest_view_model.screener_service.build_screener_results",
         _fake_build_async,
@@ -445,14 +544,49 @@ async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_snapshot_tool_excludes_explicit_symbols(monkeypatch) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "005930", "market": "kr"},
+                    {"symbol": "000660", "market": "kr"},
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build_async(**kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build_async,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        exclude_symbols=[" 005930 "],
+    )
+
+    assert [r["symbol"] for r in out["results"]] == ["000660"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None:
     class _Resp:
         def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
             return {
                 "presetId": "consecutive_gainers",
                 "results": [
-                    {"symbol": "S1", "marketCapValue": 500_000_000_000.0}, # 5000억
-                    {"symbol": "S2", "marketCapValue": 200_000_000_000.0}, # 2000억
+                    {"symbol": "S1", "marketCapValue": 500_000_000_000.0},  # 5000억
+                    {"symbol": "S2", "marketCapValue": 200_000_000_000.0},  # 2000억
                 ],
                 "warnings": [],
             }
@@ -465,10 +599,18 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
         enriched = []
         for r in rows:
             buy_count = 2 if r["symbol"] == "S1" else 0
-            enriched.append({
-                **r,
-                "analysisContext": {"consensus": {"buyCount": buy_count, "totalCount": buy_count}}
-            })
+            total_count = 2 if r["symbol"] == "S1" else 1
+            enriched.append(
+                {
+                    **r,
+                    "analysisContext": {
+                        "consensus": {
+                            "buyCount": buy_count,
+                            "totalCount": total_count,
+                        }
+                    },
+                }
+            )
         return {"results": enriched, "summary": {"warnings": []}}
 
     monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
@@ -496,6 +638,18 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
     )
     assert [r["symbol"] for r in out["results"]] == ["S1"]
 
+    # Raw numeric min market cap uses marketCapValue units directly.
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", min_market_cap=300_000_000_000.0
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S1"]
+
+    # Total analyst coverage can pass even when buyCount is 0.
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", min_analyst_count=1
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S1", "S2"]
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio
@@ -506,7 +660,7 @@ async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
                 "presetId": "consecutive_gainers",
                 "results": [
                     {"symbol": "S1", "matchedPresets": ["A"]},
-                    {"symbol": "S2", "matchedPresets": ["A", "B"]}, # Intersection
+                    {"symbol": "S2", "matchedPresets": ["A", "B"]},  # Intersection
                     {"symbol": "S3", "matchedPresets": ["A"]},
                 ],
                 "warnings": [],
@@ -516,6 +670,7 @@ async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
     monkeypatch.setattr(
         "app.services.screener_service.ScreenerService", lambda: object()
     )
+
     async def _fake_build_sort(**kwargs: Any) -> _Resp:
         pid = kwargs["preset_id"]
         # S2 is in both A and B, S1 only in A, S3 only in B
@@ -523,10 +678,11 @@ async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
             rows = [{"symbol": "S1"}, {"symbol": "S2"}]
         else:
             rows = [{"symbol": "S2"}, {"symbol": "S3"}]
-        
+
         class _DynamicResp:
             def model_dump(self, mode: str | None = None) -> dict[str, Any]:
                 return {"presetId": pid, "results": rows, "warnings": []}
+
         return _DynamicResp()
 
     monkeypatch.setattr(

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -7,6 +7,7 @@ filter parsing → conditions, catalog exposure, threading, fail-soft on bad inp
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -256,3 +257,100 @@ async def test_enriches_only_returned_page(monkeypatch) -> None:
     assert len(out["results"]) == 2
     assert out["results"][0]["analysisContext"]["rsi14"] == pytest.approx(58.0)
     assert out["analysisEnrichment"]["attempted"] == 2
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_marks_kis_live_held_rows(monkeypatch) -> None:
+    class _HeldResp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {
+                        "rank": 1,
+                        "symbol": "005930",
+                        "market": "kr",
+                        "name": "삼성전자",
+                        "isWatched": False,
+                        "isHeld": True,
+                        "matchedPresets": ["consecutive_gainers"],
+                        "marketCapValue": 478_000_000_000_000.0,
+                    }
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**kwargs: Any) -> _HeldResp:
+        resolver = kwargs["resolver"]
+        assert resolver.relation("kr", "005930") == "held"
+        return _HeldResp()
+
+    async def _fake_collect_kis_positions(market_filter: str | None, *, is_mock: bool = False):
+        assert market_filter == "equity_kr"
+        assert is_mock is False
+        return ([{"market": "kr", "symbol": "005930"}], [])
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _fake_collect_kis_positions,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        limit=10,
+    )
+
+    assert out["results"][0]["isHeld"] is True
+    assert "holdings" in out
+    assert out["holdings"]["source"] == "kis_live"
+    assert out["holdings"]["held_count"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(monkeypatch) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [{"rank": 1, "symbol": "005930", "market": "kr"}],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    async def _fail_collect_kis_positions(market_filter: str | None, *, is_mock: bool = False):
+        raise RuntimeError("kis unavailable")
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _fail_collect_kis_positions,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+    )
+
+    assert out["results"][0]["symbol"] == "005930"
+    assert any("KIS live 보유종목 확인 실패" in w for w in out["warnings"])
+    assert out["holdings"]["source"] == "kis_live"
+    assert out["holdings"]["status"] == "error"


### PR DESCRIPTION
## Summary
- Add ROB-515 snapshot discovery workflow contract support for multi-preset sweeps, `presets[]`, `exclude_symbols[]`, raw `min_market_cap`, and `min_analyst_count` aliases.
- Preserve deduped discovery output with `matchedPresets`, `isHeld`, and `matched_presets_desc` sorting behavior.
- Normalize KR/US held-symbol detection and update MCP registration docs/tests for the discovery filters.

## Verification
- `make lint`
- `make test`

Linear: ROB-515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock screener now supports querying multiple presets simultaneously with deduplication across matches.
  * Added filtering controls: exclude watched/held stocks, exclude specific symbols, filter by analyst counts and market cap ranges.
  * Added optional sorting to prioritize stocks matching the most presets.
  * Results now indicate whether stocks are held and which presets they matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->