### PR TITLE
[codex] ROB-519 honest screener snapshot degradation

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -133,7 +133,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - Snapshot-backed discovery workflow. Pass either `preset="consecutive_gainers"` or `presets=["consecutive_gainers", "double_buy"]`; `preset` also accepts a comma-separated list for compatibility.
   - Returns symbols that matched the preset(s) from the persisted daily snapshots.
   - Supports multi-preset sweeps with symbol deduplication and `matchedPresets` tagging.
-  - `exclude_watched/held` (bool): hide symbols already in watchlist/portfolio (KIS live).
+  - `exclude_held` (bool): hide symbols already in the KIS-live portfolio; if KIS holdings degrade, the response keeps results and emits a warning.
+  - `exclude_watched` (bool): accepted for compatibility, but currently unsupported in MCP because no user watchlist context is wired; requests emit an explicit warning.
   - `exclude_symbols`: explicit symbols to remove after dedupe.
   - `min_analyst_count` (int): quality filter — filters enriched results by consensus total coverage.
   - `min_analyst_buy_count` (int): compatibility filter — filters enriched results by consensus buy count.
@@ -143,6 +144,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `filters` list: tune preset thresholds (threaded for `consecutive_gainers` and `crypto`).
   - Returned rows include `analysisContext` (consensus, RSI) and `isHeld` status.
   - Results are capped (default 40) and paginated. Check `pagination` in payload.
+  - Preset sweeps are capped at 5 presets. Analyst filters are capped at 200 merged rows before enrichment; narrow with preset, market cap, or explicit symbols first.
+  - Minimum market-cap filters exclude rows with missing `marketCapValue` and report the excluded count in `warnings`.
 - ~~`recommend_stocks(...)`~~ — **DEPRECATED / registry-hidden (ROB-359).** No longer registered on the MCP tool surface. Use `screen_stocks` for candidate discovery. The implementation is retained in `analysis_tool_handlers.recommend_stocks_impl` for a possible future narrow `build_buy_plan` tool; do not call it from active report/operator prompts.
 - `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
   - Legacy/deep-dive batch analysis for up to 10 symbols.

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -272,12 +272,17 @@ def register_analysis_tools(
             "matchedPresets tagging. "
             "filters=[{field, operator(gte|lte|eq), value}] tune the preset's "
             "thresholds (threaded for consecutive_gainers and crypto). "
-            "exclude_watched/held (bool) and exclude_symbols hide already-processed "
-            "symbols. min_analyst_count (coverage), min_analyst_buy_count (buy-count), "
+            "exclude_held hides KIS-live portfolio symbols; exclude_watched is "
+            "accepted for compatibility but currently emits an explicit unsupported "
+            "warning in MCP because no user watchlist context is wired. "
+            "exclude_symbols hides already-processed symbols. "
+            "min_analyst_count (coverage), min_analyst_buy_count (buy-count), "
             "min_market_cap (raw marketCapValue), and min/max_market_cap_eok "
             "(float, unit 1억원) apply discovery-quality filters across the result set. "
             "sort='matched_presets_desc' ranks multi-preset intersections first. "
-            "Read-only. Results are capped (default 40) and paginated via limit/offset."
+            "Read-only. Preset sweeps are capped at 5 presets; analyst filters require at most "
+            "200 merged rows before enrichment. "
+            "Results are capped (default 40) and paginated via limit/offset."
         ),
     )
     async def screen_stocks_snapshot(

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -168,8 +168,28 @@ def _consensus_count(row: dict[str, Any], key: str) -> int:
         return 0
 
 
+def _filter_min_market_cap_with_warning(
+    rows: list[dict[str, Any]], min_val: float
+) -> tuple[list[dict[str, Any]], int]:
+    kept: list[dict[str, Any]] = []
+    missing_count = 0
+    for row in rows:
+        raw = row.get("marketCapValue")
+        if raw is None:
+            missing_count += 1
+            continue
+        try:
+            if float(raw) >= min_val:
+                kept.append(row)
+        except (TypeError, ValueError):
+            missing_count += 1
+    return kept, missing_count
+
+
 _DEFAULT_RESULT_LIMIT = 40
 _MAX_RESULT_LIMIT = 200
+_MAX_PRESET_SWEEP_COUNT = 5
+_MAX_ANALYST_ENRICHMENT_ROWS = 200
 
 
 async def screen_stocks_snapshot_impl(
@@ -222,6 +242,17 @@ async def screen_stocks_snapshot_impl(
     if not preset_ids:
         return {"error": "preset or presets must not be empty", "results": []}
 
+    if len(preset_ids) > _MAX_PRESET_SWEEP_COUNT:
+        return {
+            "error": (
+                "too many presets for screen_stocks_snapshot sweep; "
+                f"maximum is {_MAX_PRESET_SWEEP_COUNT}"
+            ),
+            "preset": preset,
+            "presets": preset_ids,
+            "results": [],
+        }
+
     # ROB-515: mark 'held' rows in screener results via KIS live positions.
     # (Watchlist personalization is still omitted for discovery MCP).
     held_symbols: set[tuple[str, str]] = set()
@@ -230,9 +261,19 @@ async def screen_stocks_snapshot_impl(
     if holdings_market_filter is not None:
         try:
             # MCP always runs live (is_mock=False)
-            pos, _w = await _collect_kis_positions(
+            pos, holdings_warnings = await _collect_kis_positions(
                 holdings_market_filter, is_mock=False
             )
+            if holdings_warnings:
+                holdings_meta["status"] = "error" if not pos else "partial"
+                holdings_meta["warning_count"] = len(holdings_warnings)
+                logger.warning(
+                    "screener_snapshot: kis holdings returned warnings: %s",
+                    holdings_warnings,
+                )
+            else:
+                holdings_meta["warning_count"] = 0
+
             held_symbols = {
                 (
                     str(p.get("market") or market).strip().lower(),
@@ -244,6 +285,7 @@ async def screen_stocks_snapshot_impl(
             holdings_meta["held_count"] = len(held_symbols)
         except Exception as exc:  # noqa: BLE001
             holdings_meta["status"] = "error"
+            holdings_meta["warning_count"] = 1
             # surface as a non-fatal warning so results still return
             # (build_screener_results takes resolver as non-optional, so fall back to noop)
             logger.warning("screener_snapshot: kis holdings failed: %s", exc)
@@ -306,6 +348,10 @@ async def screen_stocks_snapshot_impl(
 
     # Discovery filters (exclude)
     if exclude_watched:
+        combined_warnings.append(
+            "exclude_watched는 MCP snapshot 도구에서 아직 사용자 watchlist를 "
+            "배선하지 않아 지원하지 않습니다 (필터 미적용)."
+        )
         merged_results = [r for r in merged_results if not r.get("isWatched")]
     if exclude_held:
         merged_results = [r for r in merged_results if not r.get("isHeld")]
@@ -320,14 +366,22 @@ async def screen_stocks_snapshot_impl(
     # Discovery filters (market cap)
     if min_market_cap is not None:
         min_val = float(min_market_cap)
-        merged_results = [
-            r for r in merged_results if (r.get("marketCapValue") or 0) >= min_val
-        ]
+        merged_results, missing_count = _filter_min_market_cap_with_warning(
+            merged_results, min_val
+        )
+        if missing_count:
+            combined_warnings.append(
+                f"min_market_cap 적용 중 marketCapValue 결측 {missing_count}개 행을 제외했습니다."
+            )
     if min_market_cap_eok is not None:
         min_val = float(min_market_cap_eok) * 100_000_000
-        merged_results = [
-            r for r in merged_results if (r.get("marketCapValue") or 0) >= min_val
-        ]
+        merged_results, missing_count = _filter_min_market_cap_with_warning(
+            merged_results, min_val
+        )
+        if missing_count:
+            combined_warnings.append(
+                f"min_market_cap_eok 적용 중 marketCapValue 결측 {missing_count}개 행을 제외했습니다."
+            )
     if max_market_cap_eok is not None:
         max_val = float(max_market_cap_eok) * 100_000_000
         merged_results = [
@@ -375,7 +429,7 @@ async def screen_stocks_snapshot_impl(
             "sort": sort,
         },
     }
-    if holdings_meta["status"] == "error":
+    if holdings_meta["status"] != "ok":
         combined_warnings.append(
             "KIS live 보유종목 확인 실패 — 보유 여부가 표시되지 않을 수 있습니다."
         )
@@ -390,6 +444,25 @@ async def screen_stocks_snapshot_impl(
     # ROB-515: if analyst filtering is requested, we must enrich BEFORE pagination
     # so we can filter on the enriched buyCount across the whole set.
     if min_analyst_count is not None or min_analyst_buy_count is not None:
+        if len(all_results) > _MAX_ANALYST_ENRICHMENT_ROWS:
+            return {
+                "error": (
+                    "analyst enrichment row cap exceeded; narrow presets, "
+                    "market-cap filters, or exclude_symbols before applying analyst filters"
+                ),
+                "preset": preset,
+                "presets": preset_ids,
+                "results": [],
+                "pagination": {
+                    "total_available": len(all_results),
+                    "returned_count": 0,
+                    "offset": eff_offset,
+                    "limit": eff_limit,
+                    "has_more": False,
+                    "next_offset": None,
+                },
+            }
+
         from app.services.invest_view_model.screener_analysis_enrichment import (
             enrich_snapshot_page,
         )

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -420,6 +420,110 @@ async def test_snapshot_tool_holdings_failure_warns_and_keeps_results(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_snapshot_tool_holdings_error_tuple_warns_and_keeps_results(
+    monkeypatch,
+) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [{"rank": 1, "symbol": "005930", "market": "kr"}],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    async def _collect_with_errors(market_filter: str | None, *, is_mock: bool = False):
+        assert market_filter == "equity_kr"
+        assert is_mock is False
+        return (
+            [],
+            [{"source": "kis", "market": "kr", "error": "token expired"}],
+        )
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _collect_with_errors,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        exclude_held=True,
+    )
+
+    assert out["results"][0]["symbol"] == "005930"
+    assert out["holdings"]["status"] == "error"
+    assert out["holdings"]["held_count"] == 0
+    assert out["holdings"]["warning_count"] == 1
+    assert any("KIS live 보유종목 확인 실패" in w for w in out["warnings"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_holdings_partial_tuple_warns_and_marks_rows(
+    monkeypatch,
+) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"rank": 1, "symbol": "005930", "market": "kr"},
+                    {"rank": 2, "symbol": "000660", "market": "kr"},
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**kwargs: Any) -> _Resp:
+        resolver = kwargs["resolver"]
+        assert resolver.relation("kr", "005930") == "held"
+        assert resolver.relation("kr", "000660") == "none"
+        return _Resp()
+
+    async def _collect_partial(market_filter: str | None, *, is_mock: bool = False):
+        assert market_filter == "equity_kr"
+        assert is_mock is False
+        return (
+            [{"symbol": "005930", "market": "kr"}],
+            [{"source": "kis", "market": "us", "error": "temporary failure"}],
+        )
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings._collect_kis_positions",
+        _collect_partial,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+    )
+
+    assert out["holdings"]["status"] == "partial"
+    assert out["holdings"]["held_count"] == 1
+    assert out["holdings"]["warning_count"] == 1
+    assert any("KIS live 보유종목 확인 실패" in w for w in out["warnings"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_snapshot_tool_merges_multiple_presets(monkeypatch) -> None:
     async def _fake_build(**kwargs: Any) -> Any:
         pid = kwargs["preset_id"]
@@ -503,6 +607,48 @@ async def test_snapshot_tool_accepts_presets_list_for_multi_sweep(monkeypatch) -
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_snapshot_tool_multi_preset_pagination_counts_merged_symbols(
+    monkeypatch,
+) -> None:
+    async def _fake_build(**kwargs: Any) -> Any:
+        pid = kwargs["preset_id"]
+        rows = (
+            [{"symbol": "S1"}, {"symbol": "S2"}, {"symbol": "S3"}]
+            if pid == "A"
+            else [{"symbol": "S2"}, {"symbol": "S4"}]
+        )
+        return MagicMock(
+            model_dump=lambda mode=None: {
+                "presetId": pid,
+                "results": rows,
+                "warnings": [],
+            }
+        )
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="A,B",
+        market="kr",
+        limit=2,
+        offset=1,
+    )
+
+    assert [r["symbol"] for r in out["results"]] == ["S2", "S3"]
+    assert out["pagination"]["total_available"] == 4
+    assert out["pagination"]["returned_count"] == 2
+    assert out["pagination"]["next_offset"] == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
     class _Resp:
         def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
@@ -540,6 +686,44 @@ async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
         preset="consecutive_gainers", market="kr", exclude_held=True
     )
     assert [r["symbol"] for r in out["results"]] == ["S1", "S3"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_exclude_watched_warns_unsupported_in_mcp(
+    monkeypatch,
+) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [{"symbol": "S1", "isWatched": False, "isHeld": False}],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        exclude_watched=True,
+    )
+
+    assert out["results"][0]["symbol"] == "S1"
+    assert out["results"][0]["isWatched"] is False
+    assert any(
+        "exclude_watched" in w and "지원하지 않습니다" in w for w in out["warnings"]
+    )
 
 
 @pytest.mark.unit
@@ -653,6 +837,45 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_snapshot_tool_min_market_cap_warns_for_missing_market_cap(
+    monkeypatch,
+) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "S1", "marketCapValue": 500_000_000_000.0},
+                    {"symbol": "S2", "marketCapValue": None},
+                    {"symbol": "S3"},
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        min_market_cap_eok=3000,
+    )
+
+    assert [r["symbol"] for r in out["results"]] == ["S1"]
+    assert any("marketCapValue 결측 2개 행" in w for w in out["warnings"])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
     class _Resp:
         def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
@@ -696,3 +919,54 @@ async def test_snapshot_tool_sorts_by_matched_presets_desc(monkeypatch) -> None:
     # S2 should be first (matched 2 presets)
     assert out["results"][0]["symbol"] == "S2"
     assert len(out["results"][0]["matchedPresets"]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_rejects_too_many_presets() -> None:
+    out = await tool.screen_stocks_snapshot_impl(
+        presets=["p1", "p2", "p3", "p4", "p5", "p6"],
+        market="kr",
+    )
+
+    assert "error" in out
+    assert "maximum is 5" in out["error"]
+    assert out["results"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_tool_analyst_filter_rejects_large_unpaged_enrichment(
+    monkeypatch,
+) -> None:
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": f"S{i}", "marketCapValue": 1.0} for i in range(201)
+                ],
+                "warnings": [],
+            }
+
+    async def _fake_build(**_kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        min_analyst_count=1,
+    )
+
+    assert "error" in out
+    assert "analyst enrichment row cap" in out["error"]
+    assert out["results"] == []


### PR DESCRIPTION
## Summary
- Surface KIS holdings degradation in `screen_stocks_snapshot` instead of silently treating tuple-style warnings as `ok`.
- Document and warn that `exclude_watched` is accepted but unsupported in MCP until user watchlist context is wired.
- Make discovery filters more honest by warning on missing `marketCapValue`, capping preset sweeps, and capping analyst enrichment before pagination.
- Add regression coverage for holdings warning tuples, partial holdings degradation, multi-preset pagination, unsupported watchlist filtering, market-cap gaps, and cap enforcement.

## Root Cause
ROB-515 added snapshot discovery paths, but the MCP tool discarded warnings returned by live KIS holdings collection. That made `exclude_held=true` degrade silently when KIS failed. The tool also advertised `exclude_watched` without a wired watchlist source and allowed expensive broad sweeps/enrichment without explicit caps.

## Validation
- `uv run pytest tests/test_screener_snapshot_tool.py -q`
- `uv run pytest tests/test_invest_screener_schemas.py tests/test_mcp_tool_registration.py -q`
- `uv run ruff check app/mcp_server/tooling/screener_snapshot_tool.py app/mcp_server/tooling/analysis_registration.py tests/test_screener_snapshot_tool.py`
- `uv run ruff format --check app/mcp_server/tooling/screener_snapshot_tool.py app/mcp_server/tooling/analysis_registration.py tests/test_screener_snapshot_tool.py`
- `git diff --check`
- `make test-unit` — 11402 passed, 21 skipped, 384 deselected

Closes ROB-519.
