### PR TITLE
fix(ROB-530): guard operating briefing CI fixture race

### DIFF
--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -64,6 +64,7 @@ def test_operating_briefing_tool_names_register() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("investment_reports_cleanup_lock")
 async def test_list_active_watches_impl_returns_rationale_and_filters(
     db_session: AsyncSession,
 ) -> None:
@@ -408,6 +409,7 @@ async def test_latest_report_summary_excludes_superseded_advisory(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("investment_reports_cleanup_lock")
 async def test_get_operating_briefing_reads_active_watch_and_session_context(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Apply the existing investment_reports_cleanup_lock to operating briefing tests that commit InvestmentWatchAlert rows through db_session.
- Prevent xdist sibling workers from truncating review.investment_* rows while get_operating_briefing reads active watches through a separate session.

## Verification
- uv run pytest tests/mcp_server/test_operating_briefing_tools.py::test_get_operating_briefing_reads_active_watch_and_session_context -q
- uv run pytest tests/mcp_server/test_operating_briefing_tools.py -q -n auto --dist=loadfile
- uv run pytest tests/ -m "not live" --splits 4 --group 1 --durations-path .test_durations -n auto --dist=loadfile -ra --durations=25 --durations-min=1.0 -o faulthandler_timeout=120 --cov=app --cov-report=xml
- uv run ruff check tests/mcp_server/test_operating_briefing_tools.py
- uv run ruff format --check tests/mcp_server/test_operating_briefing_tools.py