### PR TITLE
[ROB-531] Toss live MCP order tools

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -210,6 +210,7 @@ class Settings(BaseSettings):
     toss_api_client_secret: SecretStr | None = None
     toss_api_account_seq: int | None = None
     toss_api_base_url: str | None = None
+    toss_live_order_mutations_enabled: bool = False
 
     # KIS WebSocket
     kis_ws_is_mock: bool = False  # Mock 모드 (테스트용)

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -357,6 +357,7 @@ official KIS mock, and KIS live account paths:
   `https://openapivts.koreainvestment.com:29443`.
 - `account_mode="kis_live"` or omitted: existing live KIS behavior. For
   `place_order`, `dry_run=True` remains the default.
+- `account_mode="toss_live"`: official Toss Securities live KR/US account. Uses Toss credentials, maps to `toss_live` routing, and fails closed when `TOSS_API_ENABLED=false` or credentials are missing.
 
 Do not use `account_type="paper"` for official KIS mock. It is always DB
 simulation. Responses from updated surfaces include `account_mode`; deprecated
@@ -408,6 +409,33 @@ secrets into the live `.env.prod.native` file. When any of
 ```
 
 The error names variables only — never values.
+
+### Toss Live Order MCP Tools
+
+The `default` profile registers seven typed `toss_live_*` MCP tools:
+- `toss_preview_order`
+- `toss_place_order`
+- `toss_modify_order`
+- `toss_cancel_order`
+- `toss_get_order_history`
+- `toss_get_positions`
+- `toss_get_orderable_cash`
+
+#### Toss Safety Rules and Gates
+
+- **API Enablement**: Toss live tools are default-disabled. They fail closed unless `TOSS_API_ENABLED=true` and `validate_toss_api_config()` returns no missing keys.
+- **Account Mode Routing**: All Toss tools require `account_mode="toss_live"` (or `account_type="toss_live"`) and reject any mismatched account parameters.
+- **Mutation Safety (Dry-Run & Confirm)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False` AND `confirm=True` are explicitly passed.
+- **High-Value Orders**: KR orders with a computable notional value >= 100,000,000 KRW fail locally unless `confirm_high_value_order=True` is supplied.
+- **Sell Loss-Sell Guard**: For sell orders and sell reprices, holdings cost basis is validated. Buys/sells will block locally if the execution price (limit) or current market proxy price (market) is below `average_purchase_price * 1.01`. If the holding/cost basis cannot be resolved, the sell fails closed.
+- **Opposite Pending Orders**: Before placing a non-dry-run order, the tool queries `OPEN` orders for the symbol and blocks the order if an opposite-side pending order already exists.
+- **Modify Semantics**:
+  - KR modify requires both `new_price` and `new_quantity`.
+  - US modify requires `new_price` and rejects `new_quantity`.
+  - Cancel/modify responses surface `replacement_order_id` and semantic notes indicating that Toss issues a new replacement `orderId` instead of modifying/canceling the original one in-place.
+
+> [!IMPORTANT]
+> **Implementation Hold Status**: Toss live order MCP tools implemented under ROB-531 are under `hold_for_final_review`. Do not merge, deploy, or execute live Toss orders until a stronger review clears the safety boundaries and confirmation gates.
 
 ### `get_orderbook` spec
 Parameters:

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -357,7 +357,7 @@ official KIS mock, and KIS live account paths:
   `https://openapivts.koreainvestment.com:29443`.
 - `account_mode="kis_live"` or omitted: existing live KIS behavior. For
   `place_order`, `dry_run=True` remains the default.
-- `account_mode="toss_live"`: official Toss Securities live KR/US account. Uses Toss credentials, maps to `toss_live` routing, and fails closed when `TOSS_API_ENABLED=false` or credentials are missing.
+- `account_mode="toss_live"`: official Toss Securities live KR/US account. Uses Toss credentials, maps to `toss_live` routing, and fails closed when `TOSS_API_ENABLED=false` or credentials are missing. Actual Toss order mutation POSTs also require `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`; keep this false until the accepted-order ledger and operator live-smoke hold are cleared.
 
 Do not use `account_type="paper"` for official KIS mock. It is always DB
 simulation. Responses from updated surfaces include `account_mode`; deprecated
@@ -425,10 +425,10 @@ The `default` profile registers seven typed `toss_live_*` MCP tools:
 
 - **API Enablement**: Toss live tools are default-disabled. They fail closed unless `TOSS_API_ENABLED=true` and `validate_toss_api_config()` returns no missing keys.
 - **Account Mode Routing**: All Toss tools require `account_mode="toss_live"` (or `account_type="toss_live"`) and reject any mismatched account parameters.
-- **Mutation Safety (Dry-Run & Confirm)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False` AND `confirm=True` are explicitly passed.
+- **Mutation Safety (Dry-Run, Confirm, and Activation Gate)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` are explicitly set. Keep `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false` until the accepted-order ledger and operator live-smoke hold are cleared.
 - **High-Value Orders**: KR orders with a computable notional value >= 100,000,000 KRW fail locally unless `confirm_high_value_order=True` is supplied.
-- **Sell Loss-Sell Guard**: For sell orders and sell reprices, holdings cost basis is validated. Buys/sells will block locally if the execution price (limit) or current market proxy price (market) is below `average_purchase_price * 1.01`. If the holding/cost basis cannot be resolved, the sell fails closed.
-- **Opposite Pending Orders**: Before placing a non-dry-run order, the tool queries `OPEN` orders for the symbol and blocks the order if an opposite-side pending order already exists.
+- **Sell Loss-Sell Guard**: For sell orders and sell reprices, holdings cost basis is validated. Sells block locally if the execution price (limit) or current market proxy price (market) is below `average_purchase_price * 1.01`. If the holding/cost basis cannot be resolved, the sell fails closed.
+- **Opposite Pending Orders**: Before placing a non-dry-run order, the tool queries all paginated `OPEN` order pages for the symbol and blocks the order if an opposite-side pending order already exists. Pagination anomalies fail closed.
 - **Modify Semantics**:
   - KR modify requires both `new_price` and `new_quantity`.
   - US modify requires `new_price` and rejects `new_quantity`.

--- a/app/mcp_server/tooling/account_modes.py
+++ b/app/mcp_server/tooling/account_modes.py
@@ -8,6 +8,7 @@ from typing import Any
 ACCOUNT_MODE_DB_SIMULATED = "db_simulated"
 ACCOUNT_MODE_KIS_MOCK = "kis_mock"
 ACCOUNT_MODE_KIS_LIVE = "kis_live"
+ACCOUNT_MODE_TOSS_LIVE = "toss_live"
 
 _ACCOUNT_MODE_ALIASES = {
     "db_simulated": (ACCOUNT_MODE_DB_SIMULATED, False),
@@ -18,6 +19,7 @@ _ACCOUNT_MODE_ALIASES = {
     "kis_live": (ACCOUNT_MODE_KIS_LIVE, False),
     "real": (ACCOUNT_MODE_KIS_LIVE, False),
     "live": (ACCOUNT_MODE_KIS_LIVE, True),
+    "toss_live": (ACCOUNT_MODE_TOSS_LIVE, False),
 }
 
 _ACCOUNT_TYPE_ALIASES = {
@@ -26,6 +28,7 @@ _ACCOUNT_TYPE_ALIASES = {
     "live": (ACCOUNT_MODE_KIS_LIVE, True),
     "kis_live": (ACCOUNT_MODE_KIS_LIVE, False),
     "kis_mock": (ACCOUNT_MODE_KIS_MOCK, False),
+    "toss_live": (ACCOUNT_MODE_TOSS_LIVE, False),
 }
 
 
@@ -46,6 +49,10 @@ class AccountRouting:
     @property
     def is_kis_live(self) -> bool:
         return self.account_mode == ACCOUNT_MODE_KIS_LIVE
+
+    @property
+    def is_toss_live(self) -> bool:
+        return self.account_mode == ACCOUNT_MODE_TOSS_LIVE
 
     def response_metadata(self) -> dict[str, Any]:
         metadata: dict[str, Any] = {"account_mode": self.account_mode}
@@ -151,6 +158,7 @@ __all__ = [
     "ACCOUNT_MODE_DB_SIMULATED",
     "ACCOUNT_MODE_KIS_LIVE",
     "ACCOUNT_MODE_KIS_MOCK",
+    "ACCOUNT_MODE_TOSS_LIVE",
     "AccountRouting",
     "apply_account_routing_metadata",
     "normalize_account_mode",

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -14,16 +14,12 @@ from contextlib import asynccontextmanager
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from app.core.config import settings, validate_toss_api_config
+from app.core.config import validate_toss_api_config
 from app.mcp_server.tooling.account_modes import (
     ACCOUNT_MODE_TOSS_LIVE,
     normalize_account_mode,
 )
-from app.services.brokers.toss import (
-    TossApiDisabled,
-    TossMissingCredentials,
-    TossReadClient,
-)
+from app.services.brokers.toss import TossReadClient
 from app.services.brokers.toss.errors import TossApiResponseError
 
 if TYPE_CHECKING:
@@ -40,23 +36,52 @@ TOSS_LIVE_ORDER_TOOL_NAMES: set[str] = {
 }
 
 
-def _config_error() -> None:
-    if not settings.toss_api_enabled:
-        raise TossApiDisabled("Toss API is disabled.")
+def _config_error() -> dict[str, Any] | None:
     missing = validate_toss_api_config()
     if missing:
-        raise TossMissingCredentials(
-            f"Toss API is missing required configuration: {', '.join(missing)}"
-        )
+        return {
+            "success": False,
+            "source": "toss",
+            "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+            "error": (
+                "Toss live account is disabled or missing required configuration: "
+                + ", ".join(missing)
+            ),
+        }
+    return None
 
 
-def _check_mode_arg(account_mode: str | None, account_type: str | None) -> None:
-    routing = normalize_account_mode(account_mode, account_type)
+def _check_mode_arg(
+    account_mode: str | None, account_type: str | None
+) -> dict[str, Any] | None:
+    if account_mode is None and account_type is None:
+        return None
+    try:
+        routing = normalize_account_mode(account_mode, account_type)
+    except ValueError as exc:
+        return {
+            "success": False,
+            "source": "toss",
+            "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+            "error": str(exc),
+        }
     if routing.account_mode != ACCOUNT_MODE_TOSS_LIVE:
-        raise ValueError(
-            f"Invalid account_mode resolving to {routing.account_mode!r}. "
-            f"Toss live tools only support account_mode='{ACCOUNT_MODE_TOSS_LIVE}'."
-        )
+        return {
+            "success": False,
+            "source": "toss",
+            "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+            "error": (
+                f"Invalid account_mode resolving to {routing.account_mode!r}. "
+                f"Toss live tools only support account_mode='{ACCOUNT_MODE_TOSS_LIVE}'."
+            ),
+        }
+    return None
+
+
+def _entry_guard(
+    account_mode: str | None, account_type: str | None
+) -> dict[str, Any] | None:
+    return _config_error() or _check_mode_arg(account_mode, account_type)
 
 
 @asynccontextmanager
@@ -98,6 +123,18 @@ def _stringify_decimal(value: Decimal | None) -> str | None:
         return None
     normalized = value.normalize()
     return f"{normalized:f}"
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return _stringify_decimal(value)
+    if isinstance(value, dict):
+        return {key: _json_safe(inner) for key, inner in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(inner) for inner in value]
+    if isinstance(value, tuple):
+        return [_json_safe(inner) for inner in value]
+    return value
 
 
 def _new_client_order_id() -> str:
@@ -294,8 +331,8 @@ async def toss_preview_order(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     mkt = _infer_market(symbol, market)
     quantity_dec = (
@@ -346,8 +383,8 @@ async def toss_place_order(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     mkt = _infer_market(symbol, market)
     quantity_dec = (
@@ -380,7 +417,7 @@ async def toss_place_order(
         "source": "toss",
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
         "dry_run": dry_run,
-        "mutation_sent": not dry_run,
+        "mutation_sent": False,
     }
 
     if dry_run:
@@ -433,11 +470,12 @@ async def toss_place_order(
             return {
                 "success": True,
                 **base_response,
+                "mutation_sent": True,
                 "order_id": res.order_id,
                 "client_order_id": res.client_order_id,
             }
         except Exception as exc:
-            return _toss_error_response(exc, base_response)
+            return _toss_error_response(exc, {**base_response, "mutation_sent": True})
 
     async with _client_context() as client:
         return await execute_order(client)
@@ -454,18 +492,25 @@ async def toss_modify_order(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     base_response = {
         "source": "toss",
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
         "dry_run": dry_run,
-        "mutation_sent": not dry_run,
+        "mutation_sent": False,
     }
 
     if (id_guard := _order_id_error(order_id, base_response)) is not None:
         return id_guard
+
+    if not dry_run and not confirm:
+        return {
+            "success": False,
+            **base_response,
+            "error": "toss_modify_order requires confirm=True when dry_run=False.",
+        }
 
     async def execute_modify(client: TossReadClient):
         try:
@@ -546,24 +591,18 @@ async def toss_modify_order(
                 "payload_preview": payload,
             }
 
-        if not confirm:
-            return {
-                "success": False,
-                **base_response,
-                "error": "toss_modify_order requires confirm=True when dry_run=False.",
-            }
-
         try:
             res = await client.modify_order(order_id, payload)
             return {
                 "success": True,
                 **base_response,
+                "mutation_sent": True,
                 "original_order_id": order_id,
                 "replacement_order_id": res.order_id,
                 "operation_semantics": "Toss modify returns a newly issued orderId; it is not the original order id.",
             }
         except Exception as exc:
-            return _toss_error_response(exc, base_response)
+            return _toss_error_response(exc, {**base_response, "mutation_sent": True})
 
     async with _client_context() as client:
         return await execute_modify(client)
@@ -576,14 +615,14 @@ async def toss_cancel_order(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     base_response = {
         "source": "toss",
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
         "dry_run": dry_run,
-        "mutation_sent": not dry_run,
+        "mutation_sent": False,
     }
 
     if (id_guard := _order_id_error(order_id, base_response)) is not None:
@@ -609,12 +648,13 @@ async def toss_cancel_order(
             return {
                 "success": True,
                 **base_response,
+                "mutation_sent": True,
                 "original_order_id": order_id,
                 "replacement_order_id": res.order_id,
                 "operation_semantics": "Toss cancel returns a newly issued orderId; it is not the original order id.",
             }
     except Exception as exc:
-        return _toss_error_response(exc, base_response)
+        return _toss_error_response(exc, {**base_response, "mutation_sent": True})
 
 
 async def toss_get_order_history(
@@ -627,8 +667,8 @@ async def toss_get_order_history(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     base_response = {
         "source": "toss",
@@ -669,7 +709,7 @@ async def toss_get_order_history(
                         "currency": o.currency,
                         "ordered_at": o.ordered_at,
                         "canceled_at": o.canceled_at,
-                        "execution": o.execution,
+                        "execution": _json_safe(o.execution),
                     }
                 )
             return {
@@ -688,8 +728,8 @@ async def toss_get_positions(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     base_response = {
         "source": "toss",
@@ -718,17 +758,17 @@ async def toss_get_positions(
                         )
                         if item.average_purchase_price is not None
                         else None,
-                        "market_value": item.market_value,
-                        "profit_loss": item.profit_loss,
-                        "daily_profit_loss": item.daily_profit_loss,
-                        "cost": item.cost,
+                        "market_value": _json_safe(item.market_value),
+                        "profit_loss": _json_safe(item.profit_loss),
+                        "daily_profit_loss": _json_safe(item.daily_profit_loss),
+                        "cost": _json_safe(item.cost),
                     }
                 )
             return {
                 "success": True,
                 **base_response,
                 "items": items_list,
-                "overview": res.raw_overview,
+                "overview": _json_safe(res.raw_overview),
             }
     except Exception as exc:
         return _toss_error_response(exc, base_response)
@@ -739,8 +779,8 @@ async def toss_get_orderable_cash(
     account_mode: str | None = None,
     account_type: str | None = None,
 ) -> dict[str, Any]:
-    _config_error()
-    _check_mode_arg(account_mode, account_type)
+    if (guard := _entry_guard(account_mode, account_type)) is not None:
+        return guard
 
     base_response = {
         "source": "toss",
@@ -763,28 +803,69 @@ async def toss_get_orderable_cash(
 def register_toss_live_order_tools(mcp: FastMCP) -> None:
     mcp.tool(
         name="toss_preview_order",
-        description="Preview a live order on Toss Securities.",
+        description=(
+            "Preview a Toss Securities live KR/US order without sending. "
+            "Hard-pinned to account_mode='toss_live'; matching account_mode is "
+            "optional and any other value is rejected. market='kr'|'us' is "
+            "accepted or inferred from symbol. This is read-only but still "
+            "requires TOSS_API_ENABLED and Toss credentials."
+        ),
     )(toss_preview_order)
     mcp.tool(
-        name="toss_place_order", description="Place a live order on Toss Securities."
+        name="toss_place_order",
+        description=(
+            "Place a Toss Securities live KR/US order. Hard-pinned to "
+            "account_mode='toss_live'; market='kr'|'us' is accepted or inferred. "
+            "dry_run=True by default and sends no mutation. Real submission "
+            "requires dry_run=False and confirm=True. 100M KRW+ computable KR "
+            "orders require operator-supplied confirm_high_value_order=True; it "
+            "is never inferred. Before POST the tool blocks opposite pending "
+            "orders for the symbol and applies the live sell loss guard "
+            "(sell price/current market proxy must be >= avg_purchase_price*1.01)."
+        ),
     )(toss_place_order)
     mcp.tool(
         name="toss_modify_order",
-        description="Modify a pending live order on Toss Securities.",
+        description=(
+            "Modify a pending Toss Securities live order. Hard-pinned to "
+            "account_mode='toss_live'. dry_run=True by default; real submission "
+            "requires dry_run=False and confirm=True. KR modify requires both "
+            "new_price and new_quantity. US modify requires new_price and "
+            "rejects new_quantity. Sell reprices are blocked below "
+            "avg_purchase_price*1.01. Toss returns a newly issued replacement "
+            "orderId for successful modify."
+        ),
     )(toss_modify_order)
     mcp.tool(
         name="toss_cancel_order",
-        description="Cancel a pending live order on Toss Securities.",
+        description=(
+            "Cancel a pending Toss Securities live order. Hard-pinned to "
+            "account_mode='toss_live'. dry_run=True by default; real submission "
+            "requires dry_run=False and confirm=True. Toss returns a newly issued "
+            "replacement orderId for successful cancel."
+        ),
     )(toss_cancel_order)
     mcp.tool(
         name="toss_get_order_history",
-        description="Retrieve live order history from Toss Securities.",
+        description=(
+            "Retrieve Toss Securities live order history for account_mode='toss_live'. "
+            "Supports status='open'|'closed'; closed history supports cursor/limit "
+            "pagination."
+        ),
     )(toss_get_order_history)
     mcp.tool(
         name="toss_get_positions",
-        description="Retrieve current holding positions from Toss Securities.",
+        description=(
+            "Retrieve Toss Securities live KR/US positions for "
+            "account_mode='toss_live'. Read-only and default-disabled by Toss "
+            "API config."
+        ),
     )(toss_get_positions)
     mcp.tool(
         name="toss_get_orderable_cash",
-        description="Retrieve available cash/buying power from Toss Securities.",
+        description=(
+            "Retrieve Toss Securities live orderable cash/buying power for "
+            "account_mode='toss_live' in currency='KRW'|'USD'. Read-only and "
+            "default-disabled by Toss API config."
+        ),
     )(toss_get_orderable_cash)

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -8,7 +8,11 @@ Every tool is hard-pinned to ``account_mode="toss_live"``. They:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+import re
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from app.core.config import settings, validate_toss_api_config
 from app.mcp_server.tooling.account_modes import (
@@ -18,7 +22,9 @@ from app.mcp_server.tooling.account_modes import (
 from app.services.brokers.toss import (
     TossApiDisabled,
     TossMissingCredentials,
+    TossReadClient,
 )
+from app.services.brokers.toss.errors import TossApiResponseError
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -53,6 +59,213 @@ def _check_mode_arg(account_mode: str | None, account_type: str | None) -> None:
         )
 
 
+@asynccontextmanager
+async def _client_context():
+    client = TossReadClient.from_settings()
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+def _infer_market(symbol: str, market: Literal["kr", "us"] | None) -> Literal["kr", "us"]:
+    if market is not None:
+        val = str(market).strip().lower()
+        if val not in ("kr", "us"):
+            raise ValueError(f"Invalid market: {market!r}. Toss supports 'kr' or 'us'.")
+        return cast(Literal["kr", "us"], val)
+    clean_sym = str(symbol).strip()
+    if re.match(r"^\d{6}$", clean_sym):
+        return "kr"
+    return "us"
+
+
+def _decimal_string(value: str | int | float | None, name: str) -> Decimal:
+    if value is None:
+        raise ValueError(f"{name} is required")
+    if isinstance(value, float):
+        raise TypeError(f"{name} must be str or int, not float")
+    try:
+        return Decimal(str(value))
+    except Exception as exc:
+        raise ValueError(f"Invalid decimal value for {name}: {value!r}") from exc
+
+
+def _stringify_decimal(value: Decimal | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.normalize()
+    return f"{normalized:f}"
+
+
+def _new_client_order_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _estimate_krw_notional(
+    market: Literal["kr", "us"],
+    quantity: Decimal | None,
+    price: Decimal | None,
+    order_amount: Decimal | None,
+) -> Decimal | None:
+    if market != "kr":
+        return None
+    if price is not None and quantity is not None:
+        return price * quantity
+    if order_amount is not None:
+        return order_amount
+    return None
+
+
+def _high_value_error(
+    market: Literal["kr", "us"],
+    quantity: Decimal | None,
+    price: Decimal | None,
+    order_amount: Decimal | None,
+    confirm_high_value_order: bool,
+    base: dict[str, Any],
+) -> dict[str, Any] | None:
+    notional = _estimate_krw_notional(market, quantity, price, order_amount)
+    if notional is not None and notional >= Decimal("100000000"):
+        if not confirm_high_value_order:
+            return {
+                "success": False,
+                **base,
+                "error": (
+                    f"High-value KR order (notional={notional} KRW >= 100M KRW) "
+                    "requires confirm_high_value_order=True."
+                ),
+            }
+    return None
+
+
+async def _find_holding(client: TossReadClient, symbol: str) -> Any | None:
+    res = await client.holdings(symbol=symbol)
+    if res and hasattr(res, "items") and res.items:
+        for item in res.items:
+            if item.symbol == symbol:
+                return item
+    return None
+
+
+async def _latest_price(client: TossReadClient, symbol: str) -> Decimal:
+    res = await client.prices([symbol])
+    if res:
+        for p in res:
+            if p.symbol == symbol:
+                return p.last_price
+    raise ValueError(f"Could not resolve latest price for symbol: {symbol}")
+
+
+async def _sell_loss_guard(
+    client: TossReadClient,
+    symbol: str,
+    order_type: Literal["limit", "market"],
+    price: Decimal | None,
+    base: dict[str, Any],
+) -> dict[str, Any] | None:
+    try:
+        holding = await _find_holding(client, symbol)
+    except Exception as exc:
+        return {
+            "success": False,
+            **base,
+            "error": f"Failed to retrieve holdings for sell loss guard: {exc}",
+        }
+
+    if not holding:
+        return {
+            "success": False,
+            **base,
+            "error": f"No holding found for symbol {symbol} to validate sell cost basis (fail closed).",
+        }
+
+    avg = holding.average_purchase_price
+    if avg <= Decimal("0"):
+        return {
+            "success": False,
+            **base,
+            "error": f"Invalid holding average purchase price for symbol {symbol}: {avg} (fail closed).",
+        }
+
+    floor = avg * Decimal("1.01")
+
+    if order_type == "limit":
+        if price is None:
+            return {
+                "success": False,
+                **base,
+                "error": "Limit sell order requires price for cost basis validation.",
+            }
+        if price < floor:
+            return {
+                "success": False,
+                **base,
+                "error": f"Limit sell price {price} is below average purchase price floor ({floor}) (sell floor is avg_purchase_price * 1.01).",
+            }
+    else:  # market
+        try:
+            curr_price = await _latest_price(client, symbol)
+        except Exception as exc:
+            return {
+                "success": False,
+                **base,
+                "error": f"Failed to retrieve current price for market sell cost basis validation (fail closed): {exc}",
+            }
+        if curr_price < floor:
+            return {
+                "success": False,
+                **base,
+                "error": f"Market sell proxy price {curr_price} is below average purchase price floor ({floor}) (sell floor is avg_purchase_price * 1.01).",
+            }
+
+    return None
+
+
+async def _opposite_pending_error(
+    client: TossReadClient,
+    symbol: str,
+    side: Literal["buy", "sell"],
+    base: dict[str, Any],
+) -> dict[str, Any] | None:
+    try:
+        page = await client.list_orders(status="OPEN", symbol=symbol)
+    except Exception as exc:
+        return {
+            "success": False,
+            **base,
+            "error": f"Failed to check pending orders: {exc}",
+        }
+    opp_side = "SELL" if side == "buy" else "BUY"
+    for order in page.orders:
+        if order.symbol == symbol and order.side.upper() == opp_side:
+            return {
+                "success": False,
+                **base,
+                "error": f"An opposite pending order exists for symbol {symbol} ({opp_side}).",
+            }
+    return None
+
+
+def _toss_error_response(exc: Exception, base: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(exc, TossApiResponseError):
+        return {
+            "success": False,
+            **base,
+            "error": str(exc),
+            "status_code": exc.status_code,
+            "code": exc.envelope.code,
+            "request_id": exc.envelope.request_id,
+            "message": exc.envelope.message,
+            "data": exc.envelope.data,
+        }
+    return {
+        "success": False,
+        **base,
+        "error": f"{type(exc).__name__}: {exc}",
+    }
+
+
 async def toss_preview_order(
     symbol: str,
     side: Literal["buy", "sell"],
@@ -67,7 +280,33 @@ async def toss_preview_order(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    mkt = _infer_market(symbol, market)
+    quantity_dec = _decimal_string(quantity, "quantity") if quantity is not None else None
+    price_dec = _decimal_string(price, "price") if price is not None else None
+    order_amount_dec = _decimal_string(order_amount, "order_amount") if order_amount is not None else None
+
+    payload: dict[str, Any] = {
+        "clientOrderId": _new_client_order_id(),
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+    }
+    if quantity_dec is not None:
+        payload["quantity"] = _stringify_decimal(quantity_dec)
+    if price_dec is not None:
+        payload["price"] = _stringify_decimal(price_dec)
+    if order_amount_dec is not None:
+        payload["orderAmount"] = _stringify_decimal(order_amount_dec)
+
+    return {
+        "success": True,
+        "preview": True,
+        "market": mkt,
+        "payload_preview": payload,
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+    }
 
 
 async def toss_place_order(
@@ -87,7 +326,76 @@ async def toss_place_order(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    mkt = _infer_market(symbol, market)
+    quantity_dec = _decimal_string(quantity, "quantity") if quantity is not None else None
+    price_dec = _decimal_string(price, "price") if price is not None else None
+    order_amount_dec = _decimal_string(order_amount, "order_amount") if order_amount is not None else None
+
+    payload: dict[str, Any] = {
+        "clientOrderId": _new_client_order_id(),
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+    }
+    if quantity_dec is not None:
+        payload["quantity"] = _stringify_decimal(quantity_dec)
+    if price_dec is not None:
+        payload["price"] = _stringify_decimal(price_dec)
+    if order_amount_dec is not None:
+        payload["orderAmount"] = _stringify_decimal(order_amount_dec)
+    if confirm_high_value_order:
+        payload["confirmHighValueOrder"] = True
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+        "dry_run": dry_run,
+        "mutation_sent": not dry_run,
+    }
+
+    if dry_run:
+        return {
+            "success": True,
+            **base_response,
+            "payload_preview": payload,
+        }
+
+    if not confirm:
+        return {
+            "success": False,
+            **base_response,
+            "error": "toss_place_order requires confirm=True when dry_run=False.",
+        }
+
+    # Guard: high-value KR order
+    if (guard := _high_value_error(mkt, quantity_dec, price_dec, order_amount_dec, confirm_high_value_order, base_response)) is not None:
+        return guard
+
+    async def execute_order(client: TossReadClient):
+        # Guard: opposite pending order check
+        if (opp_guard := await _opposite_pending_error(client, symbol, side, base_response)) is not None:
+            return opp_guard
+
+        # Guard: sell loss check
+        if side == "sell":
+            if (sell_guard := await _sell_loss_guard(client, symbol, order_type, price_dec, base_response)) is not None:
+                return sell_guard
+
+        try:
+            res = await client.place_order(payload)
+            return {
+                "success": True,
+                **base_response,
+                "order_id": res.order_id,
+                "client_order_id": res.client_order_id,
+            }
+        except Exception as exc:
+            return _toss_error_response(exc, base_response)
+
+    async with _client_context() as client:
+        return await execute_order(client)
 
 
 async def toss_modify_order(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -579,7 +579,50 @@ async def toss_get_order_history(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+    }
+
+    toss_status = "CLOSED" if status == "closed" else "OPEN"
+
+    try:
+        async with _client_context() as client:
+            page = await client.list_orders(
+                status=toss_status,
+                symbol=symbol,
+                from_date=from_date,
+                to_date=to_date,
+                cursor=cursor,
+                limit=limit,
+            )
+            orders_list = []
+            for o in page.orders:
+                orders_list.append({
+                    "order_id": o.order_id,
+                    "symbol": o.symbol,
+                    "side": o.side,
+                    "order_type": o.order_type,
+                    "time_in_force": o.time_in_force,
+                    "status": o.status,
+                    "price": _stringify_decimal(o.price) if o.price is not None else None,
+                    "quantity": _stringify_decimal(o.quantity) if o.quantity is not None else None,
+                    "order_amount": _stringify_decimal(o.order_amount) if o.order_amount is not None else None,
+                    "currency": o.currency,
+                    "ordered_at": o.ordered_at,
+                    "canceled_at": o.canceled_at,
+                    "execution": o.execution,
+                })
+            return {
+                "success": True,
+                **base_response,
+                "orders": orders_list,
+                "next_cursor": page.next_cursor,
+                "has_next": page.has_next,
+            }
+    except Exception as exc:
+        return _toss_error_response(exc, base_response)
 
 
 async def toss_get_positions(
@@ -589,7 +632,38 @@ async def toss_get_positions(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+    }
+
+    try:
+        async with _client_context() as client:
+            res = await client.holdings(symbol=symbol)
+            items_list = []
+            for item in res.items:
+                items_list.append({
+                    "symbol": item.symbol,
+                    "name": item.name,
+                    "market_country": item.market_country,
+                    "currency": item.currency,
+                    "quantity": _stringify_decimal(item.quantity) if item.quantity is not None else None,
+                    "last_price": _stringify_decimal(item.last_price) if item.last_price is not None else None,
+                    "average_purchase_price": _stringify_decimal(item.average_purchase_price) if item.average_purchase_price is not None else None,
+                    "market_value": item.market_value,
+                    "profit_loss": item.profit_loss,
+                    "daily_profit_loss": item.daily_profit_loss,
+                    "cost": item.cost,
+                })
+            return {
+                "success": True,
+                **base_response,
+                "items": items_list,
+                "overview": res.raw_overview,
+            }
+    except Exception as exc:
+        return _toss_error_response(exc, base_response)
 
 
 async def toss_get_orderable_cash(
@@ -599,7 +673,23 @@ async def toss_get_orderable_cash(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+    }
+
+    try:
+        async with _client_context() as client:
+            res = await client.buying_power(currency=currency)
+            return {
+                "success": True,
+                **base_response,
+                "cash_buying_power": _stringify_decimal(res.cash_buying_power),
+                "currency": res.currency,
+            }
+    except Exception as exc:
+        return _toss_error_response(exc, base_response)
 
 
 def register_toss_live_order_tools(mcp: FastMCP) -> None:

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -1,0 +1,163 @@
+# app/mcp_server/tooling/orders_toss_variants.py
+"""Toss Securities live MCP order tools.
+
+Every tool is hard-pinned to ``account_mode="toss_live"``. They:
+- Validate ``validate_toss_api_config`` before any side effect.
+- Default mutation tools to ``dry_run=True`` and require ``confirm=True`` before any POST.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from app.core.config import settings, validate_toss_api_config
+from app.mcp_server.tooling.account_modes import (
+    ACCOUNT_MODE_TOSS_LIVE,
+    normalize_account_mode,
+)
+from app.services.brokers.toss import (
+    TossApiDisabled,
+    TossMissingCredentials,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+TOSS_LIVE_ORDER_TOOL_NAMES: set[str] = {
+    "toss_preview_order",
+    "toss_place_order",
+    "toss_modify_order",
+    "toss_cancel_order",
+    "toss_get_order_history",
+    "toss_get_positions",
+    "toss_get_orderable_cash",
+}
+
+
+def _config_error() -> None:
+    if not settings.toss_api_enabled:
+        raise TossApiDisabled("Toss API is disabled.")
+    missing = validate_toss_api_config()
+    if missing:
+        raise TossMissingCredentials(
+            f"Toss API is missing required configuration: {', '.join(missing)}"
+        )
+
+
+def _check_mode_arg(account_mode: str | None, account_type: str | None) -> None:
+    routing = normalize_account_mode(account_mode, account_type)
+    if routing.account_mode != ACCOUNT_MODE_TOSS_LIVE:
+        raise ValueError(
+            f"Invalid account_mode resolving to {routing.account_mode!r}. "
+            f"Toss live tools only support account_mode='{ACCOUNT_MODE_TOSS_LIVE}'."
+        )
+
+
+async def toss_preview_order(
+    symbol: str,
+    side: Literal["buy", "sell"],
+    order_type: Literal["limit", "market"] = "limit",
+    quantity: str | int | None = None,
+    price: str | int | None = None,
+    order_amount: str | int | None = None,
+    market: Literal["kr", "us"] | None = None,
+    time_in_force: Literal["DAY", "CLS"] = "DAY",
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_place_order(
+    symbol: str,
+    side: Literal["buy", "sell"],
+    order_type: Literal["limit", "market"] = "limit",
+    quantity: str | int | None = None,
+    price: str | int | None = None,
+    order_amount: str | int | None = None,
+    market: Literal["kr", "us"] | None = None,
+    time_in_force: Literal["DAY", "CLS"] = "DAY",
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirm_high_value_order: bool = False,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_modify_order(
+    order_id: str,
+    new_price: str | int | None = None,
+    new_quantity: str | int | None = None,
+    market: Literal["kr", "us"] | None = None,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirm_high_value_order: bool = False,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_cancel_order(
+    order_id: str,
+    dry_run: bool = True,
+    confirm: bool = False,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_get_order_history(
+    status: Literal["open", "closed"] = "closed",
+    symbol: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    cursor: str | None = None,
+    limit: int | None = None,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_get_positions(
+    symbol: str | None = None,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+async def toss_get_orderable_cash(
+    currency: Literal["KRW", "USD"] = "KRW",
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+    _config_error()
+    _check_mode_arg(account_mode, account_type)
+    return {"success": True}
+
+
+def register_toss_live_order_tools(mcp: FastMCP) -> None:
+    mcp.tool(name="toss_preview_order", description="Preview a live order on Toss Securities.")(toss_preview_order)
+    mcp.tool(name="toss_place_order", description="Place a live order on Toss Securities.")(toss_place_order)
+    mcp.tool(name="toss_modify_order", description="Modify a pending live order on Toss Securities.")(toss_modify_order)
+    mcp.tool(name="toss_cancel_order", description="Cancel a pending live order on Toss Securities.")(toss_cancel_order)
+    mcp.tool(name="toss_get_order_history", description="Retrieve live order history from Toss Securities.")(toss_get_order_history)
+    mcp.tool(name="toss_get_positions", description="Retrieve current holding positions from Toss Securities.")(toss_get_positions)
+    mcp.tool(name="toss_get_orderable_cash", description="Retrieve available cash/buying power from Toss Securities.")(toss_get_orderable_cash)

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -68,7 +68,9 @@ async def _client_context():
         await client.aclose()
 
 
-def _infer_market(symbol: str, market: Literal["kr", "us"] | None) -> Literal["kr", "us"]:
+def _infer_market(
+    symbol: str, market: Literal["kr", "us"] | None
+) -> Literal["kr", "us"]:
     if market is not None:
         val = str(market).strip().lower()
         if val not in ("kr", "us"):
@@ -296,9 +298,15 @@ async def toss_preview_order(
     _check_mode_arg(account_mode, account_type)
 
     mkt = _infer_market(symbol, market)
-    quantity_dec = _decimal_string(quantity, "quantity") if quantity is not None else None
+    quantity_dec = (
+        _decimal_string(quantity, "quantity") if quantity is not None else None
+    )
     price_dec = _decimal_string(price, "price") if price is not None else None
-    order_amount_dec = _decimal_string(order_amount, "order_amount") if order_amount is not None else None
+    order_amount_dec = (
+        _decimal_string(order_amount, "order_amount")
+        if order_amount is not None
+        else None
+    )
 
     payload: dict[str, Any] = {
         "clientOrderId": _new_client_order_id(),
@@ -342,9 +350,15 @@ async def toss_place_order(
     _check_mode_arg(account_mode, account_type)
 
     mkt = _infer_market(symbol, market)
-    quantity_dec = _decimal_string(quantity, "quantity") if quantity is not None else None
+    quantity_dec = (
+        _decimal_string(quantity, "quantity") if quantity is not None else None
+    )
     price_dec = _decimal_string(price, "price") if price is not None else None
-    order_amount_dec = _decimal_string(order_amount, "order_amount") if order_amount is not None else None
+    order_amount_dec = (
+        _decimal_string(order_amount, "order_amount")
+        if order_amount is not None
+        else None
+    )
 
     payload: dict[str, Any] = {
         "clientOrderId": _new_client_order_id(),
@@ -384,17 +398,34 @@ async def toss_place_order(
         }
 
     # Guard: high-value KR order
-    if (guard := _high_value_error(mkt, quantity_dec, price_dec, order_amount_dec, confirm_high_value_order, base_response)) is not None:
+    if (
+        guard := _high_value_error(
+            mkt,
+            quantity_dec,
+            price_dec,
+            order_amount_dec,
+            confirm_high_value_order,
+            base_response,
+        )
+    ) is not None:
         return guard
 
     async def execute_order(client: TossReadClient):
         # Guard: opposite pending order check
-        if (opp_guard := await _opposite_pending_error(client, symbol, side, base_response)) is not None:
+        if (
+            opp_guard := await _opposite_pending_error(
+                client, symbol, side, base_response
+            )
+        ) is not None:
             return opp_guard
 
         # Guard: sell loss check
         if side == "sell":
-            if (sell_guard := await _sell_loss_guard(client, symbol, order_type, price_dec, base_response)) is not None:
+            if (
+                sell_guard := await _sell_loss_guard(
+                    client, symbol, order_type, price_dec, base_response
+                )
+            ) is not None:
                 return sell_guard
 
         try:
@@ -447,8 +478,14 @@ async def toss_modify_order(
         orig_order_type = orig_order.order_type.lower()
 
         mkt = _infer_market(symbol, market)
-        new_price_dec = _decimal_string(new_price, "new_price") if new_price is not None else None
-        new_quantity_dec = _decimal_string(new_quantity, "new_quantity") if new_quantity is not None else None
+        new_price_dec = (
+            _decimal_string(new_price, "new_price") if new_price is not None else None
+        )
+        new_quantity_dec = (
+            _decimal_string(new_quantity, "new_quantity")
+            if new_quantity is not None
+            else None
+        )
 
         if mkt == "kr":
             if new_price_dec is None or new_quantity_dec is None:
@@ -482,10 +519,23 @@ async def toss_modify_order(
             payload["confirmHighValueOrder"] = True
 
         if side == "sell" and orig_order_type == "limit":
-            if (sell_guard := await _sell_loss_guard(client, symbol, "limit", new_price_dec, base_response)) is not None:
+            if (
+                sell_guard := await _sell_loss_guard(
+                    client, symbol, "limit", new_price_dec, base_response
+                )
+            ) is not None:
                 return sell_guard
 
-        if (high_value_guard := _high_value_error(mkt, new_quantity_dec, new_price_dec, None, confirm_high_value_order, base_response)) is not None:
+        if (
+            high_value_guard := _high_value_error(
+                mkt,
+                new_quantity_dec,
+                new_price_dec,
+                None,
+                confirm_high_value_order,
+                base_response,
+            )
+        ) is not None:
             return high_value_guard
 
         if dry_run:
@@ -599,21 +649,29 @@ async def toss_get_order_history(
             )
             orders_list = []
             for o in page.orders:
-                orders_list.append({
-                    "order_id": o.order_id,
-                    "symbol": o.symbol,
-                    "side": o.side,
-                    "order_type": o.order_type,
-                    "time_in_force": o.time_in_force,
-                    "status": o.status,
-                    "price": _stringify_decimal(o.price) if o.price is not None else None,
-                    "quantity": _stringify_decimal(o.quantity) if o.quantity is not None else None,
-                    "order_amount": _stringify_decimal(o.order_amount) if o.order_amount is not None else None,
-                    "currency": o.currency,
-                    "ordered_at": o.ordered_at,
-                    "canceled_at": o.canceled_at,
-                    "execution": o.execution,
-                })
+                orders_list.append(
+                    {
+                        "order_id": o.order_id,
+                        "symbol": o.symbol,
+                        "side": o.side,
+                        "order_type": o.order_type,
+                        "time_in_force": o.time_in_force,
+                        "status": o.status,
+                        "price": _stringify_decimal(o.price)
+                        if o.price is not None
+                        else None,
+                        "quantity": _stringify_decimal(o.quantity)
+                        if o.quantity is not None
+                        else None,
+                        "order_amount": _stringify_decimal(o.order_amount)
+                        if o.order_amount is not None
+                        else None,
+                        "currency": o.currency,
+                        "ordered_at": o.ordered_at,
+                        "canceled_at": o.canceled_at,
+                        "execution": o.execution,
+                    }
+                )
             return {
                 "success": True,
                 **base_response,
@@ -643,19 +701,29 @@ async def toss_get_positions(
             res = await client.holdings(symbol=symbol)
             items_list = []
             for item in res.items:
-                items_list.append({
-                    "symbol": item.symbol,
-                    "name": item.name,
-                    "market_country": item.market_country,
-                    "currency": item.currency,
-                    "quantity": _stringify_decimal(item.quantity) if item.quantity is not None else None,
-                    "last_price": _stringify_decimal(item.last_price) if item.last_price is not None else None,
-                    "average_purchase_price": _stringify_decimal(item.average_purchase_price) if item.average_purchase_price is not None else None,
-                    "market_value": item.market_value,
-                    "profit_loss": item.profit_loss,
-                    "daily_profit_loss": item.daily_profit_loss,
-                    "cost": item.cost,
-                })
+                items_list.append(
+                    {
+                        "symbol": item.symbol,
+                        "name": item.name,
+                        "market_country": item.market_country,
+                        "currency": item.currency,
+                        "quantity": _stringify_decimal(item.quantity)
+                        if item.quantity is not None
+                        else None,
+                        "last_price": _stringify_decimal(item.last_price)
+                        if item.last_price is not None
+                        else None,
+                        "average_purchase_price": _stringify_decimal(
+                            item.average_purchase_price
+                        )
+                        if item.average_purchase_price is not None
+                        else None,
+                        "market_value": item.market_value,
+                        "profit_loss": item.profit_loss,
+                        "daily_profit_loss": item.daily_profit_loss,
+                        "cost": item.cost,
+                    }
+                )
             return {
                 "success": True,
                 **base_response,
@@ -693,10 +761,30 @@ async def toss_get_orderable_cash(
 
 
 def register_toss_live_order_tools(mcp: FastMCP) -> None:
-    mcp.tool(name="toss_preview_order", description="Preview a live order on Toss Securities.")(toss_preview_order)
-    mcp.tool(name="toss_place_order", description="Place a live order on Toss Securities.")(toss_place_order)
-    mcp.tool(name="toss_modify_order", description="Modify a pending live order on Toss Securities.")(toss_modify_order)
-    mcp.tool(name="toss_cancel_order", description="Cancel a pending live order on Toss Securities.")(toss_cancel_order)
-    mcp.tool(name="toss_get_order_history", description="Retrieve live order history from Toss Securities.")(toss_get_order_history)
-    mcp.tool(name="toss_get_positions", description="Retrieve current holding positions from Toss Securities.")(toss_get_positions)
-    mcp.tool(name="toss_get_orderable_cash", description="Retrieve available cash/buying power from Toss Securities.")(toss_get_orderable_cash)
+    mcp.tool(
+        name="toss_preview_order",
+        description="Preview a live order on Toss Securities.",
+    )(toss_preview_order)
+    mcp.tool(
+        name="toss_place_order", description="Place a live order on Toss Securities."
+    )(toss_place_order)
+    mcp.tool(
+        name="toss_modify_order",
+        description="Modify a pending live order on Toss Securities.",
+    )(toss_modify_order)
+    mcp.tool(
+        name="toss_cancel_order",
+        description="Cancel a pending live order on Toss Securities.",
+    )(toss_cancel_order)
+    mcp.tool(
+        name="toss_get_order_history",
+        description="Retrieve live order history from Toss Securities.",
+    )(toss_get_order_history)
+    mcp.tool(
+        name="toss_get_positions",
+        description="Retrieve current holding positions from Toss Securities.",
+    )(toss_get_positions)
+    mcp.tool(
+        name="toss_get_orderable_cash",
+        description="Retrieve available cash/buying power from Toss Securities.",
+    )(toss_get_orderable_cash)

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -266,6 +266,20 @@ def _toss_error_response(exc: Exception, base: dict[str, Any]) -> dict[str, Any]
     }
 
 
+_SAFE_ORDER_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def _order_id_error(order_id: str, base: dict[str, Any]) -> dict[str, Any] | None:
+    candidate = (order_id or "").strip()
+    if not candidate or not _SAFE_ORDER_ID_RE.fullmatch(candidate):
+        return {
+            "success": False,
+            **base,
+            "error": f"Unsafe order id rejected: {order_id!r}",
+        }
+    return None
+
+
 async def toss_preview_order(
     symbol: str,
     side: Literal["buy", "sell"],
@@ -411,7 +425,98 @@ async def toss_modify_order(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+        "dry_run": dry_run,
+        "mutation_sent": not dry_run,
+    }
+
+    if (id_guard := _order_id_error(order_id, base_response)) is not None:
+        return id_guard
+
+    async def execute_modify(client: TossReadClient):
+        try:
+            orig_order = await client.get_order(order_id)
+        except Exception as exc:
+            return _toss_error_response(exc, base_response)
+
+        symbol = orig_order.symbol
+        side = orig_order.side.lower()
+        orig_order_type = orig_order.order_type.lower()
+
+        mkt = _infer_market(symbol, market)
+        new_price_dec = _decimal_string(new_price, "new_price") if new_price is not None else None
+        new_quantity_dec = _decimal_string(new_quantity, "new_quantity") if new_quantity is not None else None
+
+        if mkt == "kr":
+            if new_price_dec is None or new_quantity_dec is None:
+                return {
+                    "success": False,
+                    **base_response,
+                    "error": "Toss KR order modify requires both new_price and new_quantity.",
+                }
+        else:  # us
+            if new_quantity_dec is not None:
+                return {
+                    "success": False,
+                    **base_response,
+                    "error": "Toss US order modify rejects new_quantity; only price modification is supported.",
+                }
+            if new_price_dec is None:
+                return {
+                    "success": False,
+                    **base_response,
+                    "error": "Toss US order modify requires new_price.",
+                }
+
+        payload: dict[str, Any] = {
+            "orderType": orig_order_type.upper(),
+        }
+        if new_price_dec is not None:
+            payload["price"] = _stringify_decimal(new_price_dec)
+        if new_quantity_dec is not None:
+            payload["quantity"] = _stringify_decimal(new_quantity_dec)
+        if confirm_high_value_order:
+            payload["confirmHighValueOrder"] = True
+
+        if side == "sell" and orig_order_type == "limit":
+            if (sell_guard := await _sell_loss_guard(client, symbol, "limit", new_price_dec, base_response)) is not None:
+                return sell_guard
+
+        if (high_value_guard := _high_value_error(mkt, new_quantity_dec, new_price_dec, None, confirm_high_value_order, base_response)) is not None:
+            return high_value_guard
+
+        if dry_run:
+            return {
+                "success": True,
+                **base_response,
+                "original_order_id": order_id,
+                "payload_preview": payload,
+            }
+
+        if not confirm:
+            return {
+                "success": False,
+                **base_response,
+                "error": "toss_modify_order requires confirm=True when dry_run=False.",
+            }
+
+        try:
+            res = await client.modify_order(order_id, payload)
+            return {
+                "success": True,
+                **base_response,
+                "original_order_id": order_id,
+                "replacement_order_id": res.order_id,
+                "operation_semantics": "Toss modify returns a newly issued orderId; it is not the original order id.",
+            }
+        except Exception as exc:
+            return _toss_error_response(exc, base_response)
+
+    async with _client_context() as client:
+        return await execute_modify(client)
 
 
 async def toss_cancel_order(
@@ -423,7 +528,43 @@ async def toss_cancel_order(
 ) -> dict[str, Any]:
     _config_error()
     _check_mode_arg(account_mode, account_type)
-    return {"success": True}
+
+    base_response = {
+        "source": "toss",
+        "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+        "dry_run": dry_run,
+        "mutation_sent": not dry_run,
+    }
+
+    if (id_guard := _order_id_error(order_id, base_response)) is not None:
+        return id_guard
+
+    if dry_run:
+        return {
+            "success": True,
+            **base_response,
+            "original_order_id": order_id,
+        }
+
+    if not confirm:
+        return {
+            "success": False,
+            **base_response,
+            "error": "toss_cancel_order requires confirm=True when dry_run=False.",
+        }
+
+    try:
+        async with _client_context() as client:
+            res = await client.cancel_order(order_id)
+            return {
+                "success": True,
+                **base_response,
+                "original_order_id": order_id,
+                "replacement_order_id": res.order_id,
+                "operation_semantics": "Toss cancel returns a newly issued orderId; it is not the original order id.",
+            }
+    except Exception as exc:
+        return _toss_error_response(exc, base_response)
 
 
 async def toss_get_order_history(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import re
 import uuid
 from contextlib import asynccontextmanager
+from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from app.core.config import validate_toss_api_config
+from app.core.config import settings, validate_toss_api_config
 from app.mcp_server.tooling.account_modes import (
     ACCOUNT_MODE_TOSS_LIVE,
     normalize_account_mode,
@@ -128,6 +129,8 @@ def _stringify_decimal(value: Decimal | None) -> str | None:
 def _json_safe(value: Any) -> Any:
     if isinstance(value, Decimal):
         return _stringify_decimal(value)
+    if isinstance(value, datetime | date):
+        return value.isoformat()
     if isinstance(value, dict):
         return {key: _json_safe(inner) for key, inner in value.items()}
     if isinstance(value, list):
@@ -176,6 +179,23 @@ def _high_value_error(
                 ),
             }
     return None
+
+
+def _live_mutation_disabled_error(
+    operation: str,
+    base: dict[str, Any],
+) -> dict[str, Any] | None:
+    if bool(getattr(settings, "toss_live_order_mutations_enabled", False)):
+        return None
+    return {
+        "success": False,
+        **base,
+        "error": (
+            f"{operation} requires TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true. "
+            "Keep live Toss mutations disabled until the accepted-order ledger "
+            "and operator live-smoke hold are cleared."
+        ),
+    }
 
 
 async def _find_holding(client: TossReadClient, symbol: str) -> Any | None:
@@ -267,23 +287,39 @@ async def _opposite_pending_error(
     side: Literal["buy", "sell"],
     base: dict[str, Any],
 ) -> dict[str, Any] | None:
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
     try:
-        page = await client.list_orders(status="OPEN", symbol=symbol)
+        while True:
+            page = await client.list_orders(status="OPEN", symbol=symbol, cursor=cursor)
+            opp_side = "SELL" if side == "buy" else "BUY"
+            for order in page.orders:
+                if order.symbol == symbol and order.side.upper() == opp_side:
+                    return {
+                        "success": False,
+                        **base,
+                        "error": f"An opposite pending order exists for symbol {symbol} ({opp_side}).",
+                    }
+            if not page.has_next:
+                return None
+            next_cursor = page.next_cursor
+            if not next_cursor or next_cursor in seen_cursors:
+                return {
+                    "success": False,
+                    **base,
+                    "error": (
+                        "Failed to check all pending orders: Toss pagination cursor "
+                        "was missing or repeated (fail closed)."
+                    ),
+                }
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
     except Exception as exc:
         return {
             "success": False,
             **base,
             "error": f"Failed to check pending orders: {exc}",
         }
-    opp_side = "SELL" if side == "buy" else "BUY"
-    for order in page.orders:
-        if order.symbol == symbol and order.side.upper() == opp_side:
-            return {
-                "success": False,
-                **base,
-                "error": f"An opposite pending order exists for symbol {symbol} ({opp_side}).",
-            }
-    return None
 
 
 def _toss_error_response(exc: Exception, base: dict[str, Any]) -> dict[str, Any]:
@@ -447,6 +483,13 @@ async def toss_place_order(
     ) is not None:
         return guard
 
+    if (
+        mutation_gate := _live_mutation_disabled_error(
+            "toss_place_order", base_response
+        )
+    ) is not None:
+        return mutation_gate
+
     async def execute_order(client: TossReadClient):
         # Guard: opposite pending order check
         if (
@@ -583,6 +626,13 @@ async def toss_modify_order(
         ) is not None:
             return high_value_guard
 
+        if not dry_run:
+            mutation_gate = _live_mutation_disabled_error(
+                "toss_modify_order", base_response
+            )
+            if mutation_gate is not None:
+                return mutation_gate
+
         if dry_run:
             return {
                 "success": True,
@@ -641,6 +691,13 @@ async def toss_cancel_order(
             **base_response,
             "error": "toss_cancel_order requires confirm=True when dry_run=False.",
         }
+
+    if (
+        mutation_gate := _live_mutation_disabled_error(
+            "toss_cancel_order", base_response
+        )
+    ) is not None:
+        return mutation_gate
 
     try:
         async with _client_context() as client:
@@ -707,8 +764,8 @@ async def toss_get_order_history(
                         if o.order_amount is not None
                         else None,
                         "currency": o.currency,
-                        "ordered_at": o.ordered_at,
-                        "canceled_at": o.canceled_at,
+                        "ordered_at": _json_safe(o.ordered_at),
+                        "canceled_at": _json_safe(o.canceled_at),
                         "execution": _json_safe(o.execution),
                     }
                 )
@@ -817,11 +874,13 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
             "Place a Toss Securities live KR/US order. Hard-pinned to "
             "account_mode='toss_live'; market='kr'|'us' is accepted or inferred. "
             "dry_run=True by default and sends no mutation. Real submission "
-            "requires dry_run=False and confirm=True. 100M KRW+ computable KR "
+            "requires dry_run=False, confirm=True, and "
+            "TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true. 100M KRW+ computable KR "
             "orders require operator-supplied confirm_high_value_order=True; it "
             "is never inferred. Before POST the tool blocks opposite pending "
-            "orders for the symbol and applies the live sell loss guard "
-            "(sell price/current market proxy must be >= avg_purchase_price*1.01)."
+            "orders across all paginated OPEN pages and applies the live sell "
+            "loss guard (sell price/current market proxy must be >= "
+            "avg_purchase_price*1.01)."
         ),
     )(toss_place_order)
     mcp.tool(
@@ -829,7 +888,8 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
         description=(
             "Modify a pending Toss Securities live order. Hard-pinned to "
             "account_mode='toss_live'. dry_run=True by default; real submission "
-            "requires dry_run=False and confirm=True. KR modify requires both "
+            "requires dry_run=False, confirm=True, and "
+            "TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true. KR modify requires both "
             "new_price and new_quantity. US modify requires new_price and "
             "rejects new_quantity. Sell reprices are blocked below "
             "avg_purchase_price*1.01. Toss returns a newly issued replacement "
@@ -841,7 +901,8 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
         description=(
             "Cancel a pending Toss Securities live order. Hard-pinned to "
             "account_mode='toss_live'. dry_run=True by default; real submission "
-            "requires dry_run=False and confirm=True. Toss returns a newly issued "
+            "requires dry_run=False, confirm=True, and "
+            "TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true. Toss returns a newly issued "
             "replacement orderId for successful cancel."
         ),
     )(toss_cancel_order)

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -78,6 +78,9 @@ from app.mcp_server.tooling.orders_kis_variants import (
     register_live_reconcile_tools,
 )
 from app.mcp_server.tooling.orders_registration import register_order_tools
+from app.mcp_server.tooling.orders_toss_variants import (
+    register_toss_live_order_tools,
+)
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,
 )
@@ -163,6 +166,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_kis_live_order_tools(mcp)
         register_kis_mock_order_tools(mcp)
         register_live_reconcile_tools(mcp)
+        register_toss_live_order_tools(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -9,11 +9,15 @@ from app.core.config import settings
 from app.services.brokers.toss.auth import TossOAuthTokenManager
 from app.services.brokers.toss.dto import (
     TossAccount,
+    TossOrderOperationResult,
+    TossOrderPlacementResult,
     parse_accounts,
     parse_buying_power,
     parse_commissions,
     parse_holdings,
     parse_order,
+    parse_order_operation_result,
+    parse_order_placement_result,
     parse_orders,
     parse_prices,
     parse_sellable_quantity,
@@ -66,6 +70,7 @@ class TossReadClient:
         *,
         group: TossApiGroup,
         params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
         account_required: bool = False,
     ) -> Any:
         await self._rate_limiter.acquire(group)
@@ -74,14 +79,14 @@ class TossReadClient:
         if account_required:
             headers["X-Tossinvest-Account"] = str(await self._resolve_account_seq())
         response = await self._client.request(
-            method, path, params=params, headers=headers
+            method, path, params=params, json=json, headers=headers
         )
         if response.status_code == 429:
             await asyncio.sleep(
                 retry_delay_seconds(response.headers.get("Retry-After"), attempt=0)
             )
             response = await self._client.request(
-                method, path, params=params, headers=headers
+                method, path, params=params, json=json, headers=headers
             )
         try:
             return parse_toss_response(response)
@@ -90,7 +95,7 @@ class TossReadClient:
                 token = await self._token_manager.get_access_token(force_reissue=True)
                 headers["Authorization"] = f"Bearer {token}"
                 retry = await self._client.request(
-                    method, path, params=params, headers=headers
+                    method, path, params=params, json=json, headers=headers
                 )
                 return parse_toss_response(retry)
             raise
@@ -291,6 +296,41 @@ class TossReadClient:
                 "GET",
                 "/api/v1/commissions",
                 group=TossApiGroup.ORDER_INFO,
+                account_required=True,
+            )
+        )
+
+    async def place_order(self, payload: dict[str, Any]) -> TossOrderPlacementResult:
+        return parse_order_placement_result(
+            await self._request(
+                "POST",
+                "/api/v1/orders",
+                group=TossApiGroup.ORDER,
+                json=payload,
+                account_required=True,
+            )
+        )
+
+    async def modify_order(
+        self, order_id: str, payload: dict[str, Any]
+    ) -> TossOrderOperationResult:
+        return parse_order_operation_result(
+            await self._request(
+                "POST",
+                f"/api/v1/orders/{order_id}/modify",
+                group=TossApiGroup.ORDER,
+                json=payload,
+                account_required=True,
+            )
+        )
+
+    async def cancel_order(self, order_id: str) -> TossOrderOperationResult:
+        return parse_order_operation_result(
+            await self._request(
+                "POST",
+                f"/api/v1/orders/{order_id}/cancel",
+                group=TossApiGroup.ORDER,
+                json={},
                 account_required=True,
             )
         )

--- a/app/services/brokers/toss/dto.py
+++ b/app/services/brokers/toss/dto.py
@@ -264,3 +264,27 @@ def parse_order(raw: dict[str, Any]) -> TossOrder:
     return parse_orders({"orders": [raw], "nextCursor": None, "hasNext": False}).orders[
         0
     ]
+
+
+@dataclass(frozen=True)
+class TossOrderPlacementResult:
+    order_id: str
+    client_order_id: str | None
+
+
+@dataclass(frozen=True)
+class TossOrderOperationResult:
+    order_id: str
+
+
+def parse_order_placement_result(raw: dict[str, Any]) -> TossOrderPlacementResult:
+    return TossOrderPlacementResult(
+        order_id=str(raw["orderId"]),
+        client_order_id=(
+            str(raw["clientOrderId"]) if raw.get("clientOrderId") is not None else None
+        ),
+    )
+
+
+def parse_order_operation_result(raw: dict[str, Any]) -> TossOrderOperationResult:
+    return TossOrderOperationResult(order_id=str(raw["orderId"]))

--- a/docs/superpowers/plans/2026-06-12-rob-531-toss-live-order-mcp-tools.md
+++ b/docs/superpowers/plans/2026-06-12-rob-531-toss-live-order-mcp-tools.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add seven default-profile `toss_live_*` MCP tools for Toss Securities live KR/US order preview, placement, modification, cancellation, history, positions, and orderable cash.
 
-**Architecture:** Extend the ROB-530 Toss client with explicit order mutation methods, then keep all live-order safety policy in a new MCP wrapper module `orders_toss_variants.py`. The tools are registered only in `McpProfile.DEFAULT`, fail closed when Toss is disabled or credentials are missing, default all mutations to `dry_run=True`, and require `confirm=True` before any POST. No DB migration, ledger write, reconcile, auto-trading adapter, or ladder support is included.
+**Architecture:** Extend the ROB-530 Toss client with explicit order mutation methods, then keep all live-order safety policy in a new MCP wrapper module `orders_toss_variants.py`. The tools are registered only in `McpProfile.DEFAULT`, fail closed when Toss is disabled or credentials are missing, default all mutations to `dry_run=True`, and require `confirm=True` plus `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` before any POST. No DB migration, ledger write, reconcile, auto-trading adapter, or ladder support is included.
 
 **Tech Stack:** Python 3.13, FastMCP, httpx, dataclasses, Decimal, pytest, pytest-asyncio, Ruff, ty.
 
@@ -29,7 +29,7 @@ Hard safety requirements:
 - Use `account_mode="toss_live"` metadata and reject any mismatched `account_mode` / `account_type` argument.
 - Check `validate_toss_api_config()` at every tool entry before broker reads or writes.
 - Mutation tools keep `dry_run=True` by default.
-- Mutation tools call Toss only when `dry_run=False and confirm=True`.
+- Mutation tools call Toss only when `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`.
 - `confirmHighValueOrder` is never inferred automatically. Pass it only when the operator supplies `confirm_high_value_order=True`.
 - KR high-value orders with computable notional >= 100,000,000 KRW fail locally unless `confirm_high_value_order=True`.
 - For sell orders and sell reprices, validate holdings cost basis and block if execution price or current market sell proxy is below `average_purchase_price * 1.01`.
@@ -42,7 +42,7 @@ Hard safety requirements:
 
 Out of scope:
 
-- Ledger rows and reconcile. ROB-538 owns accepted-only ledger and fill evidence.
+- Ledger rows and reconcile. ROB-538 owns accepted-only ledger and fill evidence. Keep `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false` until ROB-538 and the ROB-539 live-smoke hold are cleared.
 - Portfolio/manual_holdings source switch. ROB-532 owns it.
 - Operational activation and live smoke. ROB-539 owns it.
 - Buy/sell ladder support. Opposite-pending constraints require separate design.
@@ -599,7 +599,7 @@ Document:
 
 - `default` profile now includes `toss_live_*`.
 - Toss is live-only and default-disabled by `TOSS_API_ENABLED`.
-- Mutations require `dry_run=False` and `confirm=True`.
+- Mutations require `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`.
 - 100M KRW+ orders require explicit `confirm_high_value_order=True`.
 - KR modify needs price and quantity; US modify rejects quantity.
 - Cancel/modify return new replacement order ids.
@@ -663,7 +663,7 @@ Expected: no migration files.
 Add a Linear comment:
 
 ```text
-Implementation is ready for ROB-531, but hold_for_final_review remains active because this changes live order execution boundaries. Do not merge, deploy, or use for live Toss orders until stronger-model/CTO review clears the dry_run/confirm gates, high-value confirmation handling, opposite-pending precheck, loss-sell guard mirror, and KR/US modify semantics.
+Implementation is ready for ROB-531, but hold_for_final_review remains active because this changes live order execution boundaries. Do not merge, deploy, enable `TOSS_LIVE_ORDER_MUTATIONS_ENABLED`, or use for live Toss orders until stronger-model/CTO review clears the dry_run/confirm gates, high-value confirmation handling, opposite-pending precheck, loss-sell guard mirror, and KR/US modify semantics.
 ```
 
 - [ ] **Step 6: Final commit if needed**

--- a/docs/superpowers/plans/2026-06-12-rob-531-toss-live-order-mcp-tools.md
+++ b/docs/superpowers/plans/2026-06-12-rob-531-toss-live-order-mcp-tools.md
@@ -1,0 +1,683 @@
+# ROB-531 Toss Live Order MCP Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add seven default-profile `toss_live_*` MCP tools for Toss Securities live KR/US order preview, placement, modification, cancellation, history, positions, and orderable cash.
+
+**Architecture:** Extend the ROB-530 Toss client with explicit order mutation methods, then keep all live-order safety policy in a new MCP wrapper module `orders_toss_variants.py`. The tools are registered only in `McpProfile.DEFAULT`, fail closed when Toss is disabled or credentials are missing, default all mutations to `dry_run=True`, and require `confirm=True` before any POST. No DB migration, ledger write, reconcile, auto-trading adapter, or ladder support is included.
+
+**Tech Stack:** Python 3.13, FastMCP, httpx, dataclasses, Decimal, pytest, pytest-asyncio, Ruff, ty.
+
+---
+
+## Scope Lock
+
+Implement these public tools:
+
+- `toss_preview_order`
+- `toss_place_order`
+- `toss_modify_order`
+- `toss_cancel_order`
+- `toss_get_order_history`
+- `toss_get_positions`
+- `toss_get_orderable_cash`
+
+Register them in the `default` MCP profile alongside existing KIS typed tools. Do not create a new `toss` profile in this issue.
+
+Hard safety requirements:
+
+- Use `account_mode="toss_live"` metadata and reject any mismatched `account_mode` / `account_type` argument.
+- Check `validate_toss_api_config()` at every tool entry before broker reads or writes.
+- Mutation tools keep `dry_run=True` by default.
+- Mutation tools call Toss only when `dry_run=False and confirm=True`.
+- `confirmHighValueOrder` is never inferred automatically. Pass it only when the operator supplies `confirm_high_value_order=True`.
+- KR high-value orders with computable notional >= 100,000,000 KRW fail locally unless `confirm_high_value_order=True`.
+- For sell orders and sell reprices, validate holdings cost basis and block if execution price or current market sell proxy is below `average_purchase_price * 1.01`.
+- For live sells, fail closed if holding/cost basis cannot be resolved.
+- Before non-dry-run place, read `OPEN` orders for the symbol and block opposite-side pending orders locally.
+- KR modify requires both `new_price` and `new_quantity`.
+- US modify requires `new_price` and rejects any `new_quantity`.
+- Toss cancel/modify responses must state that the returned `orderId` is a new replacement order id.
+- Surface Toss error envelope `code`, `requestId`, `message`, and `data` hints such as `tickSize` / `nearestPrices`.
+
+Out of scope:
+
+- Ledger rows and reconcile. ROB-538 owns accepted-only ledger and fill evidence.
+- Portfolio/manual_holdings source switch. ROB-532 owns it.
+- Operational activation and live smoke. ROB-539 owns it.
+- Buy/sell ladder support. Opposite-pending constraints require separate design.
+- DB migration.
+
+## File Structure
+
+- Modify: `app/services/brokers/toss/dto.py`
+  - Add DTOs/parsers for order mutation responses.
+- Modify: `app/services/brokers/toss/client.py`
+  - Add JSON-body support to `_request()`.
+  - Add `place_order()`, `modify_order()`, and `cancel_order()` methods.
+- Modify: `app/services/brokers/toss/__init__.py`
+  - Export any new stable DTOs if needed.
+- Modify: `app/mcp_server/tooling/account_modes.py`
+  - Add `ACCOUNT_MODE_TOSS_LIVE = "toss_live"` and matching routing metadata support.
+- Create: `app/mcp_server/tooling/orders_toss_variants.py`
+  - Own all Toss MCP tool registration, guards, response shaping, and Toss client lifecycle.
+- Modify: `app/mcp_server/tooling/registry.py`
+  - Register Toss tools in `McpProfile.DEFAULT` only.
+- Modify: `app/mcp_server/README.md`
+  - Document default-profile Toss tools, gates, KR/US modify semantics, high-value confirmation, and hold-for-review status.
+- Modify: `tests/services/brokers/toss/test_client.py`
+  - Add client mutation transport tests.
+- Replace/modify: `tests/services/brokers/toss/test_no_mutation_surface.py`
+  - ROB-530's no-mutation assertion is obsolete; replace with tests proving mutations are explicit and account-scoped.
+- Create: `tests/test_mcp_toss_order_variants.py`
+  - Tool registration, fail-closed config, dry-run/confirm, guard, and response-contract tests.
+- Modify or create registry/doc tests if existing coverage expects exact profile tool sets.
+
+## Task 1: Add Toss Client Mutation Methods
+
+**Files:**
+- Modify: `app/services/brokers/toss/dto.py`
+- Modify: `app/services/brokers/toss/client.py`
+- Modify: `tests/services/brokers/toss/test_client.py`
+- Modify: `tests/services/brokers/toss/test_no_mutation_surface.py`
+
+- [ ] **Step 1: Write failing client tests**
+
+Add tests that prove:
+
+```python
+async def test_place_order_posts_json_with_account_header_and_client_order_id():
+    # MockTransport captures method, path, headers, and json body.
+    # Call client.place_order(... client_order_id="abc123" ...).
+    # Assert POST /api/v1/orders, X-Tossinvest-Account, order fields, and parsed order_id.
+
+async def test_modify_order_posts_to_modify_path_and_parses_new_order_id():
+    # Assert POST /api/v1/orders/{orderId}/modify and parsed replacement order_id.
+
+async def test_cancel_order_posts_to_cancel_path_and_parses_new_order_id():
+    # Assert POST /api/v1/orders/{orderId}/cancel and parsed replacement order_id.
+```
+
+Update `test_no_mutation_surface.py` so it no longer forbids Toss order POSTs. Replace it with assertions that mutation methods are exactly the explicit methods and still use `account_required=True`.
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+uv run pytest tests/services/brokers/toss/test_client.py tests/services/brokers/toss/test_no_mutation_surface.py -q
+```
+
+Expected: FAIL because mutation DTOs/client methods do not exist yet.
+
+- [ ] **Step 3: Implement DTOs and client methods**
+
+In `dto.py`, add:
+
+```python
+@dataclass(frozen=True)
+class TossOrderPlacementResult:
+    order_id: str
+    client_order_id: str | None
+
+
+@dataclass(frozen=True)
+class TossOrderOperationResult:
+    order_id: str
+
+
+def parse_order_placement_result(raw: dict[str, Any]) -> TossOrderPlacementResult:
+    return TossOrderPlacementResult(
+        order_id=str(raw["orderId"]),
+        client_order_id=(
+            str(raw["clientOrderId"]) if raw.get("clientOrderId") is not None else None
+        ),
+    )
+
+
+def parse_order_operation_result(raw: dict[str, Any]) -> TossOrderOperationResult:
+    return TossOrderOperationResult(order_id=str(raw["orderId"]))
+```
+
+In `client.py`, extend `_request()` with `json: dict[str, Any] | None = None` and pass it to `self._client.request(...)` on the original request, 429 retry, and token retry.
+
+Add methods:
+
+```python
+async def place_order(self, payload: dict[str, Any]) -> TossOrderPlacementResult:
+    return parse_order_placement_result(
+        await self._request(
+            "POST",
+            "/api/v1/orders",
+            group=TossApiGroup.ORDER,
+            json=payload,
+            account_required=True,
+        )
+    )
+
+
+async def modify_order(
+    self, order_id: str, payload: dict[str, Any]
+) -> TossOrderOperationResult:
+    return parse_order_operation_result(
+        await self._request(
+            "POST",
+            f"/api/v1/orders/{order_id}/modify",
+            group=TossApiGroup.ORDER,
+            json=payload,
+            account_required=True,
+        )
+    )
+
+
+async def cancel_order(self, order_id: str) -> TossOrderOperationResult:
+    return parse_order_operation_result(
+        await self._request(
+            "POST",
+            f"/api/v1/orders/{order_id}/cancel",
+            group=TossApiGroup.ORDER,
+            json={},
+            account_required=True,
+        )
+    )
+```
+
+- [ ] **Step 4: Verify Task 1**
+
+Run:
+
+```bash
+uv run pytest tests/services/brokers/toss/test_client.py tests/services/brokers/toss/test_no_mutation_surface.py -q
+uv run ruff check app/services/brokers/toss tests/services/brokers/toss
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add app/services/brokers/toss tests/services/brokers/toss
+git commit -m "feat(ROB-531): add Toss order mutation client methods"
+```
+
+## Task 2: Add Account Mode And Toss Tool Shell
+
+**Files:**
+- Modify: `app/mcp_server/tooling/account_modes.py`
+- Create: `app/mcp_server/tooling/orders_toss_variants.py`
+- Modify: `app/mcp_server/tooling/registry.py`
+- Create: `tests/test_mcp_toss_order_variants.py`
+
+- [ ] **Step 1: Write failing registration/fail-closed tests**
+
+Create tests with `tests._mcp_tooling_support.DummyMCP`:
+
+```python
+EXPECTED_TOOL_NAMES = {
+    "toss_preview_order",
+    "toss_place_order",
+    "toss_modify_order",
+    "toss_cancel_order",
+    "toss_get_order_history",
+    "toss_get_positions",
+    "toss_get_orderable_cash",
+}
+
+
+def test_all_seven_toss_tools_register():
+    # register_toss_live_order_tools(DummyMCP())
+    # Assert EXPECTED_TOOL_NAMES are present.
+
+
+async def test_place_order_fails_closed_when_toss_disabled(monkeypatch):
+    # monkeypatch validate_toss_api_config to return ["TOSS_API_ENABLED"].
+    # Call toss_place_order with minimum args.
+    # Assert success False, account_mode toss_live, no client call.
+
+
+async def test_toss_tools_reject_wrong_account_mode(monkeypatch):
+    # config OK, account_mode="kis_live" -> success False.
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: FAIL because `orders_toss_variants.py` does not exist.
+
+- [ ] **Step 3: Implement account mode and shell registration**
+
+In `account_modes.py`, add `ACCOUNT_MODE_TOSS_LIVE = "toss_live"`, include `"toss_live"` in `_ACCOUNT_MODE_ALIASES` and `_ACCOUNT_TYPE_ALIASES`, add `is_toss_live`, and export the constant.
+
+Create `orders_toss_variants.py` with:
+
+```python
+TOSS_LIVE_ORDER_TOOL_NAMES = {
+    "toss_preview_order",
+    "toss_place_order",
+    "toss_modify_order",
+    "toss_cancel_order",
+    "toss_get_order_history",
+    "toss_get_positions",
+    "toss_get_orderable_cash",
+}
+```
+
+Add `_config_error()`, `_check_mode_arg()`, `_prepare_call()`, `_safe_order_id_error()`, `_client_context()`, and `register_toss_live_order_tools(mcp)`.
+
+Initial tool bodies may return guarded dry-run/read stubs only until later tasks, but they must apply config and account-mode checks before any Toss client construction.
+
+In `registry.py`, import and call `register_toss_live_order_tools(mcp)` inside `if profile is McpProfile.DEFAULT:`.
+
+- [ ] **Step 4: Verify Task 2**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+uv run ruff check app/mcp_server/tooling/account_modes.py app/mcp_server/tooling/orders_toss_variants.py app/mcp_server/tooling/registry.py tests/test_mcp_toss_order_variants.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add app/mcp_server/tooling/account_modes.py app/mcp_server/tooling/orders_toss_variants.py app/mcp_server/tooling/registry.py tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-531): register Toss live MCP order tools"
+```
+
+## Task 3: Implement Preview And Place Safety Gates
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py`
+- Modify: `tests/test_mcp_toss_order_variants.py`
+
+- [ ] **Step 1: Write failing guard tests**
+
+Add tests for:
+
+```python
+async def test_place_order_defaults_to_dry_run_and_does_not_call_broker(monkeypatch):
+    # Patch client factory to raise if POST is called.
+    # Call toss_place_order without dry_run.
+    # Assert success True, dry_run True, mutation_sent False.
+
+
+async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
+    # dry_run=False, confirm=False -> success False, no POST.
+
+
+async def test_high_value_kr_order_requires_explicit_confirm_high_value(monkeypatch):
+    # KR buy 2000 * 50000 = 100,000,000.
+    # confirm=True but confirm_high_value_order=False -> local failure.
+
+
+async def test_place_sell_blocks_below_avg_floor_for_limit_and_market(monkeypatch):
+    # holdings avg 100, current 100.
+    # LIMIT sell price 100 and MARKET sell current 100 -> blocked below 101.
+
+
+async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
+    # list_orders(status="OPEN", symbol="AAPL") returns SELL order.
+    # BUY order dry_run=False confirm=True -> success False, no POST.
+```
+
+- [ ] **Step 2: Run failing guard tests**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: FAIL because the shell does not enforce all guards yet.
+
+- [ ] **Step 3: Implement shared helpers**
+
+In `orders_toss_variants.py`, add helpers:
+
+- `_infer_market(symbol, market)` -> `"kr"` for six digits, `"us"` otherwise; reject anything except `kr` / `us`.
+- `_decimal_string(value, name)` -> `Decimal` parse without float math for Toss payloads.
+- `_stringify_decimal(value)` -> stable Toss decimal string.
+- `_new_client_order_id()` -> `uuid.uuid4().hex`.
+- `_estimate_krw_notional(market, quantity, price, order_amount)` -> Decimal or None.
+- `_high_value_error(...)` -> local failure when KR notional >= 100,000,000 and flag is false.
+- `_find_holding(client, symbol)` -> Toss holding item or None.
+- `_latest_price(client, symbol)` -> Toss price Decimal.
+- `_sell_loss_guard(client, symbol, order_type, price)` -> fail closed when no holding or avg <= 0; for limit compare `price`; for market compare latest price.
+- `_opposite_pending_error(client, symbol, side)` -> reads `list_orders(status="OPEN", symbol=symbol)` and blocks opposite side.
+- `_toss_error_response(exc, base)` -> include `status_code`, `code`, `request_id`, `message`, and `data`.
+
+- [ ] **Step 4: Implement `toss_preview_order` and `toss_place_order`**
+
+Tool signature:
+
+```python
+async def toss_place_order(
+    symbol: str,
+    side: Literal["buy", "sell"],
+    order_type: Literal["limit", "market"] = "limit",
+    quantity: str | int | None = None,
+    price: str | int | None = None,
+    order_amount: str | int | None = None,
+    market: Literal["kr", "us"] | None = None,
+    time_in_force: Literal["DAY", "CLS"] = "DAY",
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirm_high_value_order: bool = False,
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> dict[str, Any]:
+```
+
+Build Toss payload keys in official casing: `clientOrderId`, `symbol`, `side`, `orderType`, `timeInForce`, `quantity`, `price`, `orderAmount`, `confirmHighValueOrder`.
+
+Only include `confirmHighValueOrder` when `confirm_high_value_order=True`.
+
+Dry-run response must include:
+
+- `success: True`
+- `dry_run: True`
+- `mutation_sent: False`
+- `payload_preview`
+- `account_mode: "toss_live"`
+
+Confirmed response must include:
+
+- `success: True`
+- `dry_run: False`
+- `mutation_sent: True`
+- `order_id`
+- `client_order_id`
+- `source: "toss"`
+- `account_mode: "toss_live"`
+
+- [ ] **Step 5: Verify Task 3**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+uv run ruff check app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-531): guard Toss live order preview and placement"
+```
+
+## Task 4: Implement Modify And Cancel
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py`
+- Modify: `tests/test_mcp_toss_order_variants.py`
+
+- [ ] **Step 1: Write failing modify/cancel tests**
+
+Add tests for:
+
+```python
+async def test_modify_kr_requires_price_and_quantity(monkeypatch):
+    # market="kr", new_price set, new_quantity None -> local failure.
+
+
+async def test_modify_us_rejects_quantity(monkeypatch):
+    # market="us", new_price set, new_quantity set -> local failure.
+
+
+async def test_modify_sell_reprice_blocks_below_avg_floor(monkeypatch):
+    # Existing OPEN order side SELL from get_order(), avg 100, new_price 100 -> block.
+
+
+async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
+    # no POST.
+
+
+async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
+    # no POST.
+
+
+async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
+    # Confirmed call returns replacement order id and operation_semantics text.
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: FAIL until modify/cancel are implemented.
+
+- [ ] **Step 3: Implement modify**
+
+Use `client.get_order(order_id)` before confirmed modify and dry-run modify. Infer side/symbol if not supplied by the original order.
+
+Payload rules:
+
+- Always include `orderType`.
+- For KR: require `new_price` and `new_quantity`; include `price` and `quantity`.
+- For US: require `new_price`; reject `new_quantity`; include `price`.
+- Include `confirmHighValueOrder` only when `confirm_high_value_order=True`.
+
+Apply sell reprice floor when the original order side is `SELL` and target order type is `LIMIT`.
+
+- [ ] **Step 4: Implement cancel**
+
+Validate safe order id. For dry-run, return no mutation. For confirmed execution, call `client.cancel_order(order_id)`.
+
+Confirmed response includes:
+
+```python
+{
+    "success": True,
+    "dry_run": False,
+    "mutation_sent": True,
+    "original_order_id": order_id,
+    "replacement_order_id": result.order_id,
+    "operation_semantics": "Toss cancel returns a newly issued orderId; it is not the original order id.",
+}
+```
+
+Use equivalent semantics text for modify.
+
+- [ ] **Step 5: Verify Task 4**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+uv run ruff check app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-531): guard Toss live modify and cancel"
+```
+
+## Task 5: Implement Read Tools
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py`
+- Modify: `tests/test_mcp_toss_order_variants.py`
+
+- [ ] **Step 1: Write failing read-tool tests**
+
+Add tests for:
+
+```python
+async def test_get_order_history_uses_closed_cursor_pagination_args(monkeypatch):
+    # status="closed", cursor and limit pass through to client.list_orders(status="CLOSED").
+
+
+async def test_get_positions_shapes_holdings(monkeypatch):
+    # holdings() items surface symbol, quantity, avg price, last price, currency.
+
+
+async def test_get_orderable_cash_reads_currency(monkeypatch):
+    # currency="KRW" -> client.buying_power(currency="KRW").
+```
+
+- [ ] **Step 2: Run failing tests**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: FAIL until read tools are implemented.
+
+- [ ] **Step 3: Implement read tools**
+
+`toss_get_order_history`:
+
+- Accept `status: Literal["open", "closed"] = "closed"`.
+- Send Toss status `"OPEN"` or `"CLOSED"`.
+- Accept `symbol`, `from_date`, `to_date`, `cursor`, `limit`.
+- Preserve `next_cursor` and `has_next`.
+
+`toss_get_positions`:
+
+- Accept optional `symbol`.
+- Call `client.holdings(symbol=symbol)`.
+- Return `items` with decimal values stringified.
+- Include raw overview under `overview`.
+
+`toss_get_orderable_cash`:
+
+- Accept `currency: Literal["KRW", "USD"] = "KRW"`.
+- Call `client.buying_power(currency=currency)`.
+- Return `cash_buying_power` as string and `currency`.
+
+- [ ] **Step 4: Verify Task 5**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py -q
+uv run ruff check app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-531): add Toss live order read tools"
+```
+
+## Task 6: Default Profile Registration And Documentation
+
+**Files:**
+- Modify: `app/mcp_server/tooling/registry.py`
+- Modify: `app/mcp_server/README.md`
+- Modify or create tests that assert default profile tool presence.
+
+- [ ] **Step 1: Write failing default-profile test**
+
+Add or update a registry test:
+
+```python
+def test_default_profile_registers_toss_live_tools(monkeypatch):
+    # Build DummyMCP through register_all_tools(profile=McpProfile.DEFAULT).
+    # Disable optional snapshot/report flags if needed.
+    # Assert all TOSS_LIVE_ORDER_TOOL_NAMES are present.
+```
+
+- [ ] **Step 2: Run failing registry/doc tests**
+
+```bash
+uv run pytest tests/test_mcp_server_main.py tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: FAIL if registry/docs are not complete.
+
+- [ ] **Step 3: Update README**
+
+Document:
+
+- `default` profile now includes `toss_live_*`.
+- Toss is live-only and default-disabled by `TOSS_API_ENABLED`.
+- Mutations require `dry_run=False` and `confirm=True`.
+- 100M KRW+ orders require explicit `confirm_high_value_order=True`.
+- KR modify needs price and quantity; US modify rejects quantity.
+- Cancel/modify return new replacement order ids.
+- ROB-531 is under `hold_for_final_review`; no merge/deploy/live trading use until stronger review clears it.
+
+- [ ] **Step 4: Verify Task 6**
+
+```bash
+uv run pytest tests/test_mcp_toss_order_variants.py tests/test_mcp_server_main.py -q
+uv run ruff check app/mcp_server/tooling app/mcp_server/README.md tests/test_mcp_toss_order_variants.py
+```
+
+Expected: PASS or README ignored by Ruff with no Python lint errors.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add app/mcp_server/tooling/registry.py app/mcp_server/README.md tests
+git commit -m "docs(ROB-531): document Toss live MCP order surface"
+```
+
+## Task 7: Final Verification And Hold Comment
+
+**Files:**
+- No production file changes unless verification exposes a bug.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+uv run pytest tests/services/brokers/toss tests/test_mcp_toss_order_variants.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader MCP order regression tests**
+
+```bash
+uv run pytest tests/test_mcp_kis_order_variants.py tests/test_mcp_kiwoom_order_variants.py tests/test_mcp_order_tools.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint/type gate**
+
+```bash
+make lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Confirm no migration**
+
+```bash
+git diff --name-only | rg 'alembic|migrations' || true
+```
+
+Expected: no migration files.
+
+- [ ] **Step 5: Post Linear implementation hold comment**
+
+Add a Linear comment:
+
+```text
+Implementation is ready for ROB-531, but hold_for_final_review remains active because this changes live order execution boundaries. Do not merge, deploy, or use for live Toss orders until stronger-model/CTO review clears the dry_run/confirm gates, high-value confirmation handling, opposite-pending precheck, loss-sell guard mirror, and KR/US modify semantics.
+```
+
+- [ ] **Step 6: Final commit if needed**
+
+If Task 7 required test/docs fixes:
+
+```bash
+git add <changed-files>
+git commit -m "test(ROB-531): verify Toss live order MCP guards"
+```
+
+## Self-Review
+
+- Spec coverage: covers all seven tools, default profile registration, fail-closed config, dry-run/confirm, loss-sell guard, high-value confirm, opposite-pending precheck, KR/US modify semantics, replacement order id semantics, docs, and migration zero.
+- Placeholder scan: no unresolved placeholders remain.
+- Type consistency: public account mode is `toss_live`; Toss API payload keys use official camelCase; MCP args use snake_case.
+- Risk status: implementation remains under `high_risk_change`, `needs_stronger_model_review`, and `hold_for_final_review`.

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -224,3 +224,117 @@ async def test_prices_retries_once_after_429_retry_after(monkeypatch) -> None:
     assert calls == 2
     assert sleeps == [2.0]
     assert prices[0].last_price == Decimal("190.12")
+
+
+@pytest.mark.asyncio
+async def test_place_order_posts_json_with_account_header_and_client_order_id() -> None:
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["headers"] = dict(request.headers)
+        seen["body"] = request.read().decode("utf-8")
+        return httpx.Response(
+            200,
+            json=_json(
+                {
+                    "orderId": "new-ord-123",
+                    "clientOrderId": "abc123",
+                }
+            ),
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=999,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        payload = {
+            "symbol": "AAPL",
+            "side": "BUY",
+            "orderType": "LIMIT",
+            "quantity": "10",
+            "price": "150.0",
+            "clientOrderId": "abc123",
+        }
+        res = await client.place_order(payload)
+    finally:
+        await client.aclose()
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/api/v1/orders"
+    assert seen["headers"]["x-tossinvest-account"] == "999"
+    import json
+    assert json.loads(seen["body"]) == payload
+    assert res.order_id == "new-ord-123"
+    assert res.client_order_id == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_modify_order_posts_to_modify_path_and_parses_new_order_id() -> None:
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = request.read().decode("utf-8")
+        return httpx.Response(
+            200,
+            json=_json({"orderId": "mod-ord-456"}),
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=999,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        payload = {
+            "orderType": "LIMIT",
+            "price": "155.0",
+            "quantity": "12",
+        }
+        res = await client.modify_order("orig-ord-123", payload)
+    finally:
+        await client.aclose()
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/api/v1/orders/orig-ord-123/modify"
+    import json
+    assert json.loads(seen["body"]) == payload
+    assert res.order_id == "mod-ord-456"
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_posts_to_cancel_path_and_parses_new_order_id() -> None:
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = request.read().decode("utf-8")
+        return httpx.Response(
+            200,
+            json=_json({"orderId": "can-ord-789"}),
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=999,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        res = await client.cancel_order("orig-ord-123")
+    finally:
+        await client.aclose()
+
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/api/v1/orders/orig-ord-123/cancel"
+    import json
+    assert json.loads(seen["body"]) == {}
+    assert res.order_id == "can-ord-789"

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -268,6 +268,7 @@ async def test_place_order_posts_json_with_account_header_and_client_order_id() 
     assert seen["path"] == "/api/v1/orders"
     assert seen["headers"]["x-tossinvest-account"] == "999"
     import json
+
     assert json.loads(seen["body"]) == payload
     assert res.order_id == "new-ord-123"
     assert res.client_order_id == "abc123"
@@ -305,6 +306,7 @@ async def test_modify_order_posts_to_modify_path_and_parses_new_order_id() -> No
     assert seen["method"] == "POST"
     assert seen["path"] == "/api/v1/orders/orig-ord-123/modify"
     import json
+
     assert json.loads(seen["body"]) == payload
     assert res.order_id == "mod-ord-456"
 
@@ -336,5 +338,6 @@ async def test_cancel_order_posts_to_cancel_path_and_parses_new_order_id() -> No
     assert seen["method"] == "POST"
     assert seen["path"] == "/api/v1/orders/orig-ord-123/cancel"
     import json
+
     assert json.loads(seen["body"]) == {}
     assert res.order_id == "can-ord-789"

--- a/tests/services/brokers/toss/test_config.py
+++ b/tests/services/brokers/toss/test_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pydantic import SecretStr
 
-from app.core.config import validate_toss_api_config
+from app.core.config import Settings, validate_toss_api_config
 
 
 class _Settings:
@@ -29,3 +29,16 @@ def test_validate_toss_api_config_reports_names_only() -> None:
 
     assert validate_toss_api_config(Configured()) == []
     assert "secret-value" not in repr(Configured.toss_api_client_secret)
+
+
+def test_toss_live_order_mutation_gate_defaults_false() -> None:
+    configured = Settings(
+        kis_app_key="kis-key",
+        kis_app_secret="kis-secret",
+        opendart_api_key="dart-key",
+        upbit_access_key="upbit-key",
+        upbit_secret_key="upbit-secret",
+        SECRET_KEY="TestSecret123-" + "x" * 32,
+    )
+
+    assert configured.toss_live_order_mutations_enabled is False

--- a/tests/services/brokers/toss/test_no_mutation_surface.py
+++ b/tests/services/brokers/toss/test_no_mutation_surface.py
@@ -5,28 +5,21 @@ from pathlib import Path
 TOSS_DIR = Path("app/services/brokers/toss")
 
 
-def test_toss_client_has_no_order_mutation_methods() -> None:
+def test_toss_client_mutation_methods_use_account_required() -> None:
     source = (TOSS_DIR / "client.py").read_text()
 
-    forbidden = [
-        "create_order",
-        "modify_order",
-        "cancel_order",
-        "/api/v1/orders/{orderId}/modify",
-        "/api/v1/orders/{orderId}/cancel",
-        '"POST", "/api/v1/orders"',
-        "'POST', '/api/v1/orders'",
-    ]
-    for needle in forbidden:
-        assert needle not in source
+    # Mutation methods must exist
+    assert "async def place_order" in source
+    assert "async def modify_order" in source
+    assert "async def cancel_order" in source
 
+    # And they should specify account_required=True
+    # We will search the function definitions and check if account_required=True is nearby.
+    place_def = source.split("async def place_order")[1].split("async def")[0]
+    assert "account_required=True" in place_def
 
-def test_oauth_token_is_only_toss_post_in_client_package() -> None:
-    sources = "\n".join(path.read_text() for path in TOSS_DIR.glob("*.py"))
+    modify_def = source.split("async def modify_order")[1].split("async def")[0]
+    assert "account_required=True" in modify_def
 
-    assert (
-        'post("/oauth2/token"' in sources
-        or 'post(\n                "/oauth2/token"' in sources
-    )
-    assert 'post("/api/v1/orders"' not in sources
-    assert 'request("POST", "/api/v1/orders"' not in sources
+    cancel_def = source.split("async def cancel_order")[1].split("async def")[0]
+    assert "account_required=True" in cancel_def

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -25,6 +25,9 @@ from app.mcp_server.tooling.orders_kis_variants import (
 )
 from app.mcp_server.tooling.orders_kiwoom_variants import KIWOOM_MOCK_TOOL_NAMES
 from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
+from app.mcp_server.tooling.orders_toss_variants import (
+    TOSS_LIVE_ORDER_TOOL_NAMES,
+)
 from app.mcp_server.tooling.paper_account_registration import PAPER_ACCOUNT_TOOL_NAMES
 from app.mcp_server.tooling.paper_analytics_registration import (
     PAPER_ANALYTICS_TOOL_NAMES,
@@ -86,6 +89,10 @@ class TestDefaultProfile:
     def test_registers_typed_kis_mock_variants(self) -> None:
         mcp = _build_mcp(McpProfile.DEFAULT)
         assert KIS_MOCK_ORDER_TOOL_NAMES <= mcp.tools.keys()
+
+    def test_registers_typed_toss_live_variants(self) -> None:
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert TOSS_LIVE_ORDER_TOOL_NAMES <= mcp.tools.keys()
 
     def test_does_not_register_split_profile_tools(self) -> None:
         mcp = _build_mcp(McpProfile.DEFAULT)
@@ -186,6 +193,7 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
         | KIS_LIVE_ORDER_TOOL_NAMES
         | KIS_MOCK_ORDER_TOOL_NAMES
         | LIVE_RECONCILE_TOOL_NAMES
+        | TOSS_LIVE_ORDER_TOOL_NAMES
     ),
     McpProfile.HERMES_PAPER_KIS: set(KIS_MOCK_ORDER_TOOL_NAMES),
     McpProfile.CRYPTO: _LEGACY_ORDER_TOOL_NAMES | LIVE_RECONCILE_TOOL_NAMES,
@@ -200,6 +208,7 @@ _ALL_ORDER_TOOL_NAMES = (
     | LIVE_RECONCILE_TOOL_NAMES
     | KIWOOM_MOCK_TOOL_NAMES
     | _ALPACA_MUTATING
+    | TOSS_LIVE_ORDER_TOOL_NAMES
 )
 
 

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
@@ -16,6 +17,13 @@ from app.mcp_server.tooling.orders_toss_variants import (
     toss_preview_order,
 )
 from tests._mcp_tooling_support import DummyMCP
+
+
+@pytest.fixture(autouse=True)
+def _enable_toss_live_order_mutations_for_existing_tests(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
 
 
 def test_all_seven_toss_tools_register():
@@ -45,6 +53,7 @@ def test_toss_tool_descriptions_document_live_gates():
     assert "market='kr'|'us'" in place_desc
     assert "dry_run=True" in place_desc
     assert "confirm=True" in place_desc
+    assert "TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true" in place_desc
     assert "confirm_high_value_order=True" in place_desc
     assert "opposite pending" in place_desc
 
@@ -246,6 +255,33 @@ async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
     assert res["success"] is False
     assert "confirm=True" in res["error"]
     assert res["mutation_sent"] is False
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_order_requires_live_mutation_gate_before_broker_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", False)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is False
+    assert "TOSS_LIVE_ORDER_MUTATIONS_ENABLED" in res["error"]
     assert not mock_client.placed_payloads
 
 
@@ -563,6 +599,48 @@ async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_modify_requires_live_mutation_gate_before_broker_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", False)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {},
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is False
+    assert "TOSS_LIVE_ORDER_MUTATIONS_ENABLED" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
 async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
@@ -581,6 +659,30 @@ async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
     assert res["success"] is False
     assert "confirm=True" in res["error"]
     assert res["mutation_sent"] is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_requires_live_mutation_gate_before_broker_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", False)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_cancel_order(
+        order_id="orig-ord-123",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is False
+    assert "TOSS_LIVE_ORDER_MUTATIONS_ENABLED" in res["error"]
+    assert not mock_client.placed_payloads
 
 
 @pytest.mark.asyncio
@@ -1004,6 +1106,139 @@ async def test_place_order_fails_closed_when_pending_order_lookup_errors(
 
 
 @pytest.mark.asyncio
+async def test_place_order_checks_all_pending_order_pages_before_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    seen_cursors = []
+
+    async def paged_orders(*, status, symbol=None, cursor=None, **kwargs):
+        from types import SimpleNamespace
+
+        seen_cursors.append(cursor)
+        if cursor is None:
+            return SimpleNamespace(orders=[], next_cursor="next-page", has_next=True)
+        return SimpleNamespace(
+            orders=[
+                SimpleNamespace(
+                    order_id="ord-opposite",
+                    symbol=symbol,
+                    side="SELL",
+                    status=status,
+                    order_type="LIMIT",
+                    time_in_force="DAY",
+                    price=Decimal("150"),
+                    quantity=Decimal("1"),
+                    order_amount=None,
+                    currency="USD",
+                    ordered_at="2026-06-12T00:00:00Z",
+                    canceled_at=None,
+                    execution={},
+                )
+            ],
+            next_cursor=None,
+            has_next=False,
+        )
+
+    monkeypatch.setattr(mock_client, "list_orders", paged_orders)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "opposite pending order exists" in res["error"]
+    assert seen_cursors == [None, "next-page"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_order_fails_closed_when_pending_order_page_has_no_cursor(
+    monkeypatch,
+):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    async def broken_paged_orders(**kwargs):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(orders=[], next_cursor=None, has_next=True)
+
+    monkeypatch.setattr(mock_client, "list_orders", broken_paged_orders)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "pagination cursor" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_sell_blocks_pending_buy_order_before_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "ord-existing",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150"),
+            "quantity": Decimal("1"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {},
+        }
+    ]
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "opposite pending order exists" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
 async def test_modify_rejects_unsafe_id_and_missing_original_order(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
@@ -1233,3 +1468,40 @@ async def test_order_history_json_safes_list_tuple_and_none_decimals(monkeypatch
     assert order["price"] is None
     assert order["order_amount"] == "150"
     assert order["execution"]["fills"] == ["0.5", ["0.25", "0.25"]]
+
+
+@pytest.mark.asyncio
+async def test_order_history_json_safes_datetime_timestamps(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    ordered_at = datetime(2026, 6, 12, 3, 0, tzinfo=UTC)
+    canceled_at = datetime(2026, 6, 12, 3, 5, tzinfo=UTC)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "ord-1",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "CLOSED",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150"),
+            "quantity": Decimal("1"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": ordered_at,
+            "canceled_at": canceled_at,
+            "execution": {},
+        }
+    ]
+
+    res = await toss_get_order_history(account_mode="toss_live")
+
+    assert res["success"] is True
+    order = res["orders"][0]
+    assert order["ordered_at"] == ordered_at.isoformat()
+    assert order["canceled_at"] == canceled_at.isoformat()

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from app.mcp_server.tooling.orders_toss_variants import (
@@ -54,3 +56,226 @@ async def test_toss_tools_reject_wrong_account_mode(monkeypatch):
             price="150.0",
             account_mode="kis_live",
         )
+
+
+class MockTossClient:
+    def __init__(self, monkeypatch=None):
+        self.placed_payloads = []
+        self.holdings_list = []
+        self.orders_list = []
+        self.prices_list = []
+
+        if monkeypatch:
+            monkeypatch.setattr(
+                "app.mcp_server.tooling.orders_toss_variants.TossReadClient.from_settings",
+                lambda *args, **kwargs: self
+            )
+
+    async def aclose(self):
+        pass
+
+    async def holdings(self, *, symbol=None):
+        # returns simple dataclass mock
+        from types import SimpleNamespace
+        items = []
+        for item in self.holdings_list:
+            items.append(SimpleNamespace(**item))
+        return SimpleNamespace(items=items)
+
+    async def list_orders(self, *, status, symbol=None, **kwargs):
+        from types import SimpleNamespace
+        orders = []
+        for o in self.orders_list:
+            if symbol and o.get("symbol") != symbol:
+                continue
+            if status and o.get("status") != status:
+                continue
+            orders.append(SimpleNamespace(**o))
+        return SimpleNamespace(orders=orders, next_cursor=None, has_next=False)
+
+    async def prices(self, symbols):
+        from types import SimpleNamespace
+        return [SimpleNamespace(**item) for item in self.prices_list if item.get("symbol") in symbols]
+
+    async def place_order(self, payload):
+        self.placed_payloads.append(payload)
+        from types import SimpleNamespace
+        return SimpleNamespace(order_id="new-ord-123", client_order_id=payload.get("clientOrderId"))
+
+
+@pytest.mark.asyncio
+async def test_place_order_defaults_to_dry_run_and_does_not_call_broker(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="10",
+        price="150.0",
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is True
+    assert res["dry_run"] is True
+    assert res["mutation_sent"] is False
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="10",
+        price="150.0",
+        dry_run=False,
+        confirm=False,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "confirm=True" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_high_value_kr_order_requires_explicit_confirm_high_value(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    # 005930 is 6 digits -> KR market. Notional = 2000 * 50000 = 100,000,000
+    res = await toss_place_order(
+        symbol="005930",
+        side="buy",
+        quantity="2000",
+        price="50000",
+        dry_run=False,
+        confirm=True,
+        confirm_high_value_order=False,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "high-value" in res["error"].lower()
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_sell_blocks_below_avg_floor_for_limit_and_market(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    from decimal import Decimal
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.holdings_list = [
+        {
+            "symbol": "AAPL",
+            "quantity": Decimal("10"),
+            "average_purchase_price": Decimal("100.0"),
+            "last_price": Decimal("102.0"),
+            "name": "Apple",
+            "market_country": "US",
+            "currency": "USD",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
+    # average_purchase_price * 1.01 = 101.0
+
+    # Limit sell below 101.0 (e.g. 100.0) -> block
+    res_limit = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        order_type="limit",
+        quantity="5",
+        price="100.0",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert res_limit["success"] is False
+    assert "below average purchase price floor" in res_limit["error"]
+
+    # Market sell when current price is below 101.0 (e.g. 100.0) -> block
+    mock_client.prices_list = [
+        {
+            "symbol": "AAPL",
+            "last_price": Decimal("100.0"),
+            "timestamp": "2026-06-12T00:00:00Z",
+            "currency": "USD"
+        }
+    ]
+    res_market = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        order_type="market",
+        quantity="5",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert res_market["success"] is False
+    assert "below average purchase price floor" in res_market["error"]
+
+
+@pytest.mark.asyncio
+async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    # symbol AAPL has pending SELL order
+    mock_client.orders_list = [
+        {
+            "order_id": "ord-existing",
+            "symbol": "AAPL",
+            "side": "SELL",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+
+    # Try to BUY AAPL -> block
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="5",
+        price="140.0",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "opposite pending order exists" in res["error"]
+    assert not mock_client.placed_payloads

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -7,6 +7,8 @@ import pytest
 from app.mcp_server.tooling.orders_toss_variants import (
     TOSS_LIVE_ORDER_TOOL_NAMES,
     register_toss_live_order_tools,
+    toss_cancel_order,
+    toss_modify_order,
     toss_place_order,
 )
 from app.services.brokers.toss import TossApiDisabled
@@ -101,6 +103,22 @@ class MockTossClient:
         self.placed_payloads.append(payload)
         from types import SimpleNamespace
         return SimpleNamespace(order_id="new-ord-123", client_order_id=payload.get("clientOrderId"))
+
+    async def get_order(self, order_id):
+        from types import SimpleNamespace
+        for o in self.orders_list:
+            if o.get("order_id") == order_id:
+                return SimpleNamespace(**o)
+        raise ValueError(f"Order not found: {order_id}")
+
+    async def modify_order(self, order_id, payload):
+        self.placed_payloads.append(payload)
+        from types import SimpleNamespace
+        return SimpleNamespace(order_id="mod-ord-456")
+
+    async def cancel_order(self, order_id):
+        from types import SimpleNamespace
+        return SimpleNamespace(order_id="can-ord-789")
 
 
 @pytest.mark.asyncio
@@ -279,3 +297,244 @@ async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
     assert res["success"] is False
     assert "opposite pending order exists" in res["error"]
     assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_modify_kr_requires_price_and_quantity(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "005930",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("50000"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "KRW",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="51000",
+        new_quantity=None,
+        market="kr",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "both new_price and new_quantity" in res["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_modify_us_rejects_quantity(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155.0",
+        new_quantity="12",
+        market="us",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "rejects new_quantity" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_modify_sell_reprice_blocks_below_avg_floor(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "SELL",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("102.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+    mock_client.holdings_list = [
+        {
+            "symbol": "AAPL",
+            "quantity": Decimal("10"),
+            "average_purchase_price": Decimal("100.0"),
+            "last_price": Decimal("102.0"),
+            "name": "Apple",
+            "market_country": "US",
+            "currency": "USD",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="100.0",
+        market="us",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "below average purchase price floor" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="150.0",
+        dry_run=False,
+        confirm=False,
+        account_mode="toss_live",
+    )
+    assert res["success"] is False
+    assert "confirm=True" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    MockTossClient(monkeypatch)
+
+    res = await toss_cancel_order(
+        order_id="orig-ord-123",
+        dry_run=False,
+        confirm=False,
+        account_mode="toss_live",
+    )
+    assert res["success"] is False
+    assert "confirm=True" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {}
+        }
+    ]
+
+    res_cancel = await toss_cancel_order(
+        order_id="orig-ord-123",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert res_cancel["success"] is True
+    assert res_cancel["original_order_id"] == "orig-ord-123"
+    assert res_cancel["replacement_order_id"] == "can-ord-789"
+    assert "newly issued orderId" in res_cancel["operation_semantics"]
+
+    res_modify = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155.0",
+        market="us",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert res_modify["success"] is True
+    assert res_modify["original_order_id"] == "orig-ord-123"
+    assert res_modify["replacement_order_id"] == "mod-ord-456"
+    assert "newly issued orderId" in res_modify["operation_semantics"]

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.orders_toss_variants import (
+    TOSS_LIVE_ORDER_TOOL_NAMES,
+    register_toss_live_order_tools,
+    toss_place_order,
+)
+from app.services.brokers.toss import TossApiDisabled
+from tests._mcp_tooling_support import DummyMCP
+
+
+def test_all_seven_toss_tools_register():
+    mcp = DummyMCP()
+    register_toss_live_order_tools(mcp)
+    assert set(mcp.tools.keys()) == TOSS_LIVE_ORDER_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_place_order_fails_closed_when_toss_disabled(monkeypatch):
+    # Mock validate_toss_api_config to return missing credentials (or simulator of disabled)
+    # Actually, we want to mock it to fail when toss is disabled.
+    # We will test validate_toss_api_config returning a missing flag or custom config mocking.
+
+    # We can check how toss_api_enabled is set in settings.
+    # Let's say settings.toss_api_enabled is False.
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", False)
+
+    with pytest.raises(TossApiDisabled):
+        await toss_place_order(
+            symbol="AAPL",
+            side="buy",
+            quantity="10",
+            price="150.0",
+            account_mode="toss_live",
+        )
+
+
+@pytest.mark.asyncio
+async def test_toss_tools_reject_wrong_account_mode(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    with pytest.raises(ValueError, match="Toss live tools only support account_mode"):
+        await toss_place_order(
+            symbol="AAPL",
+            side="buy",
+            quantity="10",
+            price="150.0",
+            account_mode="kis_live",
+        )

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -13,6 +13,7 @@ from app.mcp_server.tooling.orders_toss_variants import (
     toss_get_positions,
     toss_modify_order,
     toss_place_order,
+    toss_preview_order,
 )
 from tests._mcp_tooling_support import DummyMCP
 
@@ -767,3 +768,468 @@ async def test_get_orderable_cash_reads_currency(monkeypatch):
     assert res["success"] is True
     assert res["cash_buying_power"] == "10000"
     assert res["currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_preview_order_shapes_payload_and_rejects_invalid_inputs(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    res = await toss_preview_order(
+        symbol="005930",
+        side="buy",
+        quantity=3,
+        price="50000",
+        order_amount="150000",
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is True
+    assert res["market"] == "kr"
+    assert res["payload_preview"]["quantity"] == "3"
+    assert res["payload_preview"]["price"] == "50000"
+    assert res["payload_preview"]["orderAmount"] == "150000"
+
+    with pytest.raises(ValueError, match="Invalid market"):
+        await toss_preview_order(
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            market="jp",  # type: ignore[arg-type]
+            account_mode="toss_live",
+        )
+
+    with pytest.raises(TypeError, match="price must be str or int"):
+        await toss_preview_order(
+            symbol="AAPL",
+            side="buy",
+            quantity="1",
+            price=150.5,  # type: ignore[arg-type]
+            account_mode="toss_live",
+        )
+
+    with pytest.raises(ValueError, match="Invalid decimal value"):
+        await toss_preview_order(
+            symbol="AAPL",
+            side="buy",
+            quantity="not-a-number",
+            account_mode="toss_live",
+        )
+
+
+@pytest.mark.asyncio
+async def test_toss_tools_reject_invalid_account_selector(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    res = await toss_get_orderable_cash(account_mode="bogus")
+
+    assert res["success"] is False
+    assert res["account_mode"] == "toss_live"
+    assert "account_mode must be one of" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_place_order_high_value_order_amount_requires_explicit_confirm(
+    monkeypatch,
+):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="market",
+        order_amount="100000000",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "requires confirm_high_value_order=True" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_place_sell_guard_fails_closed_on_missing_holding_invalid_average_and_price_lookup(
+    monkeypatch,
+):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    missing = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert missing["success"] is False
+    assert "No holding found" in missing["error"]
+
+    mock_client.holdings_list = [
+        {
+            "symbol": "AAPL",
+            "quantity": Decimal("1"),
+            "average_purchase_price": Decimal("0"),
+            "last_price": Decimal("150"),
+            "name": "Apple",
+            "market_country": "US",
+            "currency": "USD",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
+    invalid_average = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert invalid_average["success"] is False
+    assert "Invalid holding average purchase price" in invalid_average["error"]
+
+    mock_client.holdings_list[0]["average_purchase_price"] = Decimal("100")
+    mock_client.prices_list = []
+    missing_price = await toss_place_order(
+        symbol="AAPL",
+        side="sell",
+        order_type="market",
+        quantity="1",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert missing_price["success"] is False
+    assert "Failed to retrieve current price" in missing_price["error"]
+
+
+@pytest.mark.asyncio
+async def test_place_order_surfaces_toss_api_response_error(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    from app.services.brokers.toss.errors import TossApiResponseError, TossErrorEnvelope
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    async def raise_toss_error(payload):
+        raise TossApiResponseError(
+            TossErrorEnvelope(
+                request_id="req-123",
+                code="order-rejected",
+                message="Rejected by Toss",
+                data={"reason": "limit"},
+            ),
+            status_code=400,
+        )
+
+    monkeypatch.setattr(mock_client, "place_order", raise_toss_error)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    assert res["status_code"] == 400
+    assert res["code"] == "order-rejected"
+    assert res["request_id"] == "req-123"
+    assert res["message"] == "Rejected by Toss"
+    assert res["data"] == {"reason": "limit"}
+
+
+@pytest.mark.asyncio
+async def test_place_order_fails_closed_when_pending_order_lookup_errors(
+    monkeypatch,
+):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    async def raise_lookup_error(**kwargs):
+        raise RuntimeError("orders unavailable")
+
+    monkeypatch.setattr(mock_client, "list_orders", raise_lookup_error)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="1",
+        price="150",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "Failed to check pending orders" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_modify_rejects_unsafe_id_and_missing_original_order(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    unsafe = await toss_modify_order(
+        order_id="../bad",
+        new_price="155",
+        account_mode="toss_live",
+    )
+    assert unsafe["success"] is False
+    assert "Unsafe order id rejected" in unsafe["error"]
+    assert mock_client.get_order_calls == 0
+
+    missing = await toss_modify_order(
+        order_id="missing-order",
+        new_price="155",
+        account_mode="toss_live",
+    )
+    assert missing["success"] is False
+    assert "Order not found" in missing["error"]
+
+
+@pytest.mark.asyncio
+async def test_modify_us_requires_price_and_returns_dry_run_payload(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "orig-ord-123",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {},
+        }
+    ]
+
+    missing_price = await toss_modify_order(
+        order_id="orig-ord-123",
+        market="us",
+        dry_run=True,
+        account_mode="toss_live",
+    )
+    assert missing_price["success"] is False
+    assert "requires new_price" in missing_price["error"]
+
+    preview = await toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155",
+        market="us",
+        dry_run=True,
+        account_mode="toss_live",
+    )
+    assert preview["success"] is True
+    assert preview["mutation_sent"] is False
+    assert preview["payload_preview"] == {"orderType": "LIMIT", "price": "155"}
+
+
+@pytest.mark.asyncio
+async def test_modify_kr_high_value_order_requires_explicit_confirm(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "kr-ord-123",
+            "symbol": "005930",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("50000"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "KRW",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {},
+        }
+    ]
+
+    res = await toss_modify_order(
+        order_id="kr-ord-123",
+        new_price="50000",
+        new_quantity="2000",
+        market="kr",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "requires confirm_high_value_order=True" in res["error"]
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_cancel_dry_run_and_broker_error_paths(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    preview = await toss_cancel_order(
+        order_id="orig-ord-123",
+        account_mode="toss_live",
+    )
+    assert preview["success"] is True
+    assert preview["mutation_sent"] is False
+    assert preview["original_order_id"] == "orig-ord-123"
+
+    unsafe = await toss_cancel_order(
+        order_id="bad/id",
+        account_mode="toss_live",
+    )
+    assert unsafe["success"] is False
+    assert "Unsafe order id rejected" in unsafe["error"]
+
+    async def raise_cancel_error(order_id):
+        raise RuntimeError(f"cannot cancel {order_id}")
+
+    monkeypatch.setattr(mock_client, "cancel_order", raise_cancel_error)
+
+    failed = await toss_cancel_order(
+        order_id="orig-ord-123",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+    assert failed["success"] is False
+    assert failed["mutation_sent"] is True
+    assert "cannot cancel orig-ord-123" in failed["error"]
+
+
+@pytest.mark.asyncio
+async def test_read_tools_surface_broker_errors(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    async def raise_list_orders(**kwargs):
+        raise RuntimeError("history down")
+
+    async def raise_holdings(**kwargs):
+        raise RuntimeError("positions down")
+
+    async def raise_buying_power(**kwargs):
+        raise RuntimeError("cash down")
+
+    monkeypatch.setattr(mock_client, "list_orders", raise_list_orders)
+    history = await toss_get_order_history(account_mode="toss_live")
+    assert history["success"] is False
+    assert "history down" in history["error"]
+
+    monkeypatch.setattr(mock_client, "holdings", raise_holdings)
+    positions = await toss_get_positions(account_mode="toss_live")
+    assert positions["success"] is False
+    assert "positions down" in positions["error"]
+
+    monkeypatch.setattr(mock_client, "buying_power", raise_buying_power)
+    cash = await toss_get_orderable_cash(account_mode="toss_live")
+    assert cash["success"] is False
+    assert "cash down" in cash["error"]
+
+
+@pytest.mark.asyncio
+async def test_order_history_json_safes_list_tuple_and_none_decimals(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "ord-1",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "OPEN",
+            "order_type": "MARKET",
+            "time_in_force": "DAY",
+            "price": None,
+            "quantity": Decimal("1"),
+            "order_amount": Decimal("150"),
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {
+                "fills": [Decimal("0.5"), (Decimal("0.25"), Decimal("0.25"))],
+            },
+        }
+    ]
+
+    res = await toss_get_order_history(status="open", account_mode="toss_live")
+
+    assert res["success"] is True
+    order = res["orders"][0]
+    assert order["price"] is None
+    assert order["order_amount"] == "150"
+    assert order["execution"]["fills"] == ["0.5", ["0.25", "0.25"]]

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -14,7 +14,6 @@ from app.mcp_server.tooling.orders_toss_variants import (
     toss_modify_order,
     toss_place_order,
 )
-from app.services.brokers.toss import TossApiDisabled
 from tests._mcp_tooling_support import DummyMCP
 
 
@@ -24,26 +23,55 @@ def test_all_seven_toss_tools_register():
     assert set(mcp.tools.keys()) == TOSS_LIVE_ORDER_TOOL_NAMES
 
 
+def test_toss_tool_descriptions_document_live_gates():
+    class RecordingMCP:
+        def __init__(self) -> None:
+            self.descriptions: dict[str, str] = {}
+
+        def tool(self, *, name: str, description: str = ""):
+            self.descriptions[name] = description
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    mcp = RecordingMCP()
+    register_toss_live_order_tools(mcp)  # type: ignore[arg-type]
+
+    place_desc = mcp.descriptions["toss_place_order"]
+    assert "account_mode='toss_live'" in place_desc
+    assert "market='kr'|'us'" in place_desc
+    assert "dry_run=True" in place_desc
+    assert "confirm=True" in place_desc
+    assert "confirm_high_value_order=True" in place_desc
+    assert "opposite pending" in place_desc
+
+    modify_desc = mcp.descriptions["toss_modify_order"]
+    assert "KR" in modify_desc
+    assert "new_price and new_quantity" in modify_desc
+    assert "US" in modify_desc
+    assert "rejects new_quantity" in modify_desc
+
+
 @pytest.mark.asyncio
 async def test_place_order_fails_closed_when_toss_disabled(monkeypatch):
-    # Mock validate_toss_api_config to return missing credentials (or simulator of disabled)
-    # Actually, we want to mock it to fail when toss is disabled.
-    # We will test validate_toss_api_config returning a missing flag or custom config mocking.
-
-    # We can check how toss_api_enabled is set in settings.
-    # Let's say settings.toss_api_enabled is False.
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "toss_api_enabled", False)
 
-    with pytest.raises(TossApiDisabled):
-        await toss_place_order(
-            symbol="AAPL",
-            side="buy",
-            quantity="10",
-            price="150.0",
-            account_mode="toss_live",
-        )
+    result = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="10",
+        price="150.0",
+        account_mode="toss_live",
+    )
+
+    assert result["success"] is False
+    assert result["account_mode"] == "toss_live"
+    assert result["source"] == "toss"
+    assert "TOSS_API_ENABLED" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -54,14 +82,17 @@ async def test_toss_tools_reject_wrong_account_mode(monkeypatch):
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
-    with pytest.raises(ValueError, match="Toss live tools only support account_mode"):
-        await toss_place_order(
-            symbol="AAPL",
-            side="buy",
-            quantity="10",
-            price="150.0",
-            account_mode="kis_live",
-        )
+    result = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="10",
+        price="150.0",
+        account_mode="kis_live",
+    )
+
+    assert result["success"] is False
+    assert result["account_mode"] == "toss_live"
+    assert "only support account_mode='toss_live'" in result["error"]
 
 
 class MockTossClient:
@@ -70,6 +101,7 @@ class MockTossClient:
         self.holdings_list = []
         self.orders_list = []
         self.prices_list = []
+        self.get_order_calls = 0
 
         if monkeypatch:
             monkeypatch.setattr(
@@ -121,6 +153,7 @@ class MockTossClient:
     async def get_order(self, order_id):
         from types import SimpleNamespace
 
+        self.get_order_calls += 1
         for o in self.orders_list:
             if o.get("order_id") == order_id:
                 return SimpleNamespace(**o)
@@ -168,6 +201,28 @@ async def test_place_order_defaults_to_dry_run_and_does_not_call_broker(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_toss_pinned_tools_accept_omitted_account_mode(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+
+    res = await toss_place_order(
+        symbol="AAPL",
+        side="buy",
+        quantity="10",
+        price="150.0",
+    )
+
+    assert res["success"] is True
+    assert res["account_mode"] == "toss_live"
+    assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
 async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
@@ -189,6 +244,7 @@ async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
 
     assert res["success"] is False
     assert "confirm=True" in res["error"]
+    assert res["mutation_sent"] is False
     assert not mock_client.placed_payloads
 
 
@@ -500,6 +556,9 @@ async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
     )
     assert res["success"] is False
     assert "confirm=True" in res["error"]
+    assert res["mutation_sent"] is False
+    assert mock_client.get_order_calls == 0
+    assert not mock_client.placed_payloads
 
 
 @pytest.mark.asyncio
@@ -520,6 +579,7 @@ async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
     )
     assert res["success"] is False
     assert "confirm=True" in res["error"]
+    assert res["mutation_sent"] is False
 
 
 @pytest.mark.asyncio
@@ -612,6 +672,46 @@ async def test_get_order_history_uses_closed_cursor_pagination_args(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_get_order_history_stringifies_decimal_execution_fields(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.orders_list = [
+        {
+            "order_id": "ord-1",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "status": "CLOSED",
+            "order_type": "LIMIT",
+            "time_in_force": "DAY",
+            "price": Decimal("150.0"),
+            "quantity": Decimal("10"),
+            "order_amount": None,
+            "currency": "USD",
+            "ordered_at": "2026-06-12T00:00:00Z",
+            "canceled_at": None,
+            "execution": {
+                "filledQuantity": Decimal("2.5"),
+                "averageFilledPrice": Decimal("151.25"),
+                "filledAmount": Decimal("378.125"),
+            },
+        }
+    ]
+
+    res = await toss_get_order_history(account_mode="toss_live")
+
+    assert res["success"] is True
+    execution = res["orders"][0]["execution"]
+    assert execution["filledQuantity"] == "2.5"
+    assert execution["averageFilledPrice"] == "151.25"
+    assert execution["filledAmount"] == "378.125"
+
+
+@pytest.mark.asyncio
 async def test_get_positions_shapes_holdings(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
@@ -629,8 +729,8 @@ async def test_get_positions_shapes_holdings(monkeypatch):
             "name": "Apple",
             "market_country": "US",
             "currency": "USD",
-            "market_value": {},
-            "profit_loss": {},
+            "market_value": {"amount": Decimal("1627.5")},
+            "profit_loss": {"amount": Decimal("52.5")},
             "daily_profit_loss": {},
             "cost": {},
         }
@@ -646,6 +746,8 @@ async def test_get_positions_shapes_holdings(monkeypatch):
     assert item["average_purchase_price"] == "150"
     assert item["last_price"] == "155"
     assert item["currency"] == "USD"
+    assert item["market_value"]["amount"] == "1627.5"
+    assert item["profit_loss"]["amount"] == "52.5"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -8,6 +8,9 @@ from app.mcp_server.tooling.orders_toss_variants import (
     TOSS_LIVE_ORDER_TOOL_NAMES,
     register_toss_live_order_tools,
     toss_cancel_order,
+    toss_get_order_history,
+    toss_get_orderable_cash,
+    toss_get_positions,
     toss_modify_order,
     toss_place_order,
 )
@@ -82,7 +85,7 @@ class MockTossClient:
         items = []
         for item in self.holdings_list:
             items.append(SimpleNamespace(**item))
-        return SimpleNamespace(items=items)
+        return SimpleNamespace(items=items, raw_overview={})
 
     async def list_orders(self, *, status, symbol=None, **kwargs):
         from types import SimpleNamespace
@@ -119,6 +122,10 @@ class MockTossClient:
     async def cancel_order(self, order_id):
         from types import SimpleNamespace
         return SimpleNamespace(order_id="can-ord-789")
+
+    async def buying_power(self, *, currency):
+        from types import SimpleNamespace
+        return SimpleNamespace(currency=currency, cash_buying_power=Decimal("10000.0"))
 
 
 @pytest.mark.asyncio
@@ -538,3 +545,88 @@ async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
     assert res_modify["original_order_id"] == "orig-ord-123"
     assert res_modify["replacement_order_id"] == "mod-ord-456"
     assert "newly issued orderId" in res_modify["operation_semantics"]
+
+
+@pytest.mark.asyncio
+async def test_get_order_history_uses_closed_cursor_pagination_args(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    seen_args = {}
+    async def fake_list_orders(status, symbol=None, from_date=None, to_date=None, cursor=None, limit=None):
+        seen_args["status"] = status
+        seen_args["cursor"] = cursor
+        seen_args["limit"] = limit
+        from types import SimpleNamespace
+        return SimpleNamespace(orders=[], next_cursor="cur456", has_next=True)
+    monkeypatch.setattr(mock_client, "list_orders", fake_list_orders)
+
+    res = await toss_get_order_history(
+        status="closed",
+        cursor="cur123",
+        limit=20,
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+    assert seen_args["status"] == "CLOSED"
+    assert seen_args["cursor"] == "cur123"
+    assert seen_args["limit"] == 20
+    assert res["next_cursor"] == "cur456"
+    assert res["has_next"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_positions_shapes_holdings(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.holdings_list = [
+        {
+            "symbol": "AAPL",
+            "quantity": Decimal("10.5"),
+            "average_purchase_price": Decimal("150.0"),
+            "last_price": Decimal("155.0"),
+            "name": "Apple",
+            "market_country": "US",
+            "currency": "USD",
+            "market_value": {},
+            "profit_loss": {},
+            "daily_profit_loss": {},
+            "cost": {},
+        }
+    ]
+
+    res = await toss_get_positions(
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+    item = res["items"][0]
+    assert item["symbol"] == "AAPL"
+    assert item["quantity"] == "10.5"
+    assert item["average_purchase_price"] == "150"
+    assert item["last_price"] == "155"
+    assert item["currency"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_get_orderable_cash_reads_currency(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    MockTossClient(monkeypatch)
+
+    res = await toss_get_orderable_cash(
+        currency="USD",
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+    assert res["cash_buying_power"] == "10000"
+    assert res["currency"] == "USD"

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -33,6 +33,7 @@ async def test_place_order_fails_closed_when_toss_disabled(monkeypatch):
     # We can check how toss_api_enabled is set in settings.
     # Let's say settings.toss_api_enabled is False.
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", False)
 
     with pytest.raises(TossApiDisabled):
@@ -73,7 +74,7 @@ class MockTossClient:
         if monkeypatch:
             monkeypatch.setattr(
                 "app.mcp_server.tooling.orders_toss_variants.TossReadClient.from_settings",
-                lambda *args, **kwargs: self
+                lambda *args, **kwargs: self,
             )
 
     async def aclose(self):
@@ -82,6 +83,7 @@ class MockTossClient:
     async def holdings(self, *, symbol=None):
         # returns simple dataclass mock
         from types import SimpleNamespace
+
         items = []
         for item in self.holdings_list:
             items.append(SimpleNamespace(**item))
@@ -89,6 +91,7 @@ class MockTossClient:
 
     async def list_orders(self, *, status, symbol=None, **kwargs):
         from types import SimpleNamespace
+
         orders = []
         for o in self.orders_list:
             if symbol and o.get("symbol") != symbol:
@@ -100,15 +103,24 @@ class MockTossClient:
 
     async def prices(self, symbols):
         from types import SimpleNamespace
-        return [SimpleNamespace(**item) for item in self.prices_list if item.get("symbol") in symbols]
+
+        return [
+            SimpleNamespace(**item)
+            for item in self.prices_list
+            if item.get("symbol") in symbols
+        ]
 
     async def place_order(self, payload):
         self.placed_payloads.append(payload)
         from types import SimpleNamespace
-        return SimpleNamespace(order_id="new-ord-123", client_order_id=payload.get("clientOrderId"))
+
+        return SimpleNamespace(
+            order_id="new-ord-123", client_order_id=payload.get("clientOrderId")
+        )
 
     async def get_order(self, order_id):
         from types import SimpleNamespace
+
         for o in self.orders_list:
             if o.get("order_id") == order_id:
                 return SimpleNamespace(**o)
@@ -117,14 +129,17 @@ class MockTossClient:
     async def modify_order(self, order_id, payload):
         self.placed_payloads.append(payload)
         from types import SimpleNamespace
+
         return SimpleNamespace(order_id="mod-ord-456")
 
     async def cancel_order(self, order_id):
         from types import SimpleNamespace
+
         return SimpleNamespace(order_id="can-ord-789")
 
     async def buying_power(self, *, currency):
         from types import SimpleNamespace
+
         return SimpleNamespace(currency=currency, cash_buying_power=Decimal("10000.0"))
 
 
@@ -132,6 +147,7 @@ class MockTossClient:
 async def test_place_order_defaults_to_dry_run_and_does_not_call_broker(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -155,6 +171,7 @@ async def test_place_order_defaults_to_dry_run_and_does_not_call_broker(monkeypa
 async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -179,6 +196,7 @@ async def test_place_order_requires_confirm_when_dry_run_false(monkeypatch):
 async def test_high_value_kr_order_requires_explicit_confirm_high_value(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -205,10 +223,12 @@ async def test_high_value_kr_order_requires_explicit_confirm_high_value(monkeypa
 async def test_place_sell_blocks_below_avg_floor_for_limit_and_market(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
     from decimal import Decimal
+
     mock_client = MockTossClient(monkeypatch)
     mock_client.holdings_list = [
         {
@@ -247,7 +267,7 @@ async def test_place_sell_blocks_below_avg_floor_for_limit_and_market(monkeypatc
             "symbol": "AAPL",
             "last_price": Decimal("100.0"),
             "timestamp": "2026-06-12T00:00:00Z",
-            "currency": "USD"
+            "currency": "USD",
         }
     ]
     res_market = await toss_place_order(
@@ -267,6 +287,7 @@ async def test_place_sell_blocks_below_avg_floor_for_limit_and_market(monkeypatc
 async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -286,7 +307,7 @@ async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
             "currency": "USD",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
 
@@ -310,6 +331,7 @@ async def test_place_order_blocks_opposite_pending_before_post(monkeypatch):
 async def test_modify_kr_requires_price_and_quantity(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -328,7 +350,7 @@ async def test_modify_kr_requires_price_and_quantity(monkeypatch):
             "currency": "KRW",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
 
@@ -350,6 +372,7 @@ async def test_modify_kr_requires_price_and_quantity(monkeypatch):
 async def test_modify_us_rejects_quantity(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -368,7 +391,7 @@ async def test_modify_us_rejects_quantity(monkeypatch):
             "currency": "USD",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
 
@@ -390,6 +413,7 @@ async def test_modify_us_rejects_quantity(monkeypatch):
 async def test_modify_sell_reprice_blocks_below_avg_floor(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -408,7 +432,7 @@ async def test_modify_sell_reprice_blocks_below_avg_floor(monkeypatch):
             "currency": "USD",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
     mock_client.holdings_list = [
@@ -444,6 +468,7 @@ async def test_modify_sell_reprice_blocks_below_avg_floor(monkeypatch):
 async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -462,7 +487,7 @@ async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
             "currency": "USD",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
 
@@ -481,6 +506,7 @@ async def test_modify_requires_confirm_when_dry_run_false(monkeypatch):
 async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -500,6 +526,7 @@ async def test_cancel_requires_confirm_when_dry_run_false(monkeypatch):
 async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -518,7 +545,7 @@ async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
             "currency": "USD",
             "ordered_at": "2026-06-12T00:00:00Z",
             "canceled_at": None,
-            "execution": {}
+            "execution": {},
         }
     ]
 
@@ -551,17 +578,23 @@ async def test_modify_and_cancel_surface_replacement_order_id(monkeypatch):
 async def test_get_order_history_uses_closed_cursor_pagination_args(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
     mock_client = MockTossClient(monkeypatch)
     seen_args = {}
-    async def fake_list_orders(status, symbol=None, from_date=None, to_date=None, cursor=None, limit=None):
+
+    async def fake_list_orders(
+        status, symbol=None, from_date=None, to_date=None, cursor=None, limit=None
+    ):
         seen_args["status"] = status
         seen_args["cursor"] = cursor
         seen_args["limit"] = limit
         from types import SimpleNamespace
+
         return SimpleNamespace(orders=[], next_cursor="cur456", has_next=True)
+
     monkeypatch.setattr(mock_client, "list_orders", fake_list_orders)
 
     res = await toss_get_order_history(
@@ -582,6 +615,7 @@ async def test_get_order_history_uses_closed_cursor_pagination_args(monkeypatch)
 async def test_get_positions_shapes_holdings(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 
@@ -618,6 +652,7 @@ async def test_get_positions_shapes_holdings(monkeypatch):
 async def test_get_orderable_cash_reads_currency(monkeypatch):
     import app.mcp_server.tooling.orders_toss_variants as otv
     from app.core.config import settings
+
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
 


### PR DESCRIPTION
## Summary
- Add the Toss Securities live MCP order surface: preview, place, modify, cancel, history, positions, and orderable cash.
- Register toss_live tools in the default MCP profile and add account_mode=toss_live routing.
- Extend the Toss client with explicit order mutation methods and response DTOs.
- Harden live-order guard semantics: default-disabled config, dry_run/confirm gates, default-false TOSS_LIVE_ORDER_MUTATIONS_ENABLED mutation gate, explicit high-value confirmation, paginated opposite-pending precheck, sell-loss floor, KR/US modify rules, replacement order id semantics, and JSON-safe Decimal/date/datetime responses.

## Safety / Review Hold
- Linear ROB-531 is high_risk_change / needs_stronger_model_review / candidate_for_opus.
- Opus final safety review cleared this PR for merge after the follow-up hardening.
- Live activation remains blocked: keep TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false and do not use live Toss mutations until ROB-538 accepted-order ledger and ROB-539 operator live-smoke clearance are complete.

## Validation
- uv run pytest tests/services/brokers/toss tests/test_mcp_toss_order_variants.py tests/test_mcp_profiles.py tests/test_mcp_kis_order_variants.py tests/test_mcp_kiwoom_order_variants.py tests/test_mcp_order_tools.py -q: 265 passed
- make lint: ruff check, ruff format --check, and ty passed
- Codecov: patch 93.84%, project 85.43% on 6029805 before the final safety-gate commit; CI is rerunning on debd08c6.
- Opus read-only review on PR diff: CLEAR_TO_MERGE for merge only with mutation gate off until ROB-538/ROB-539.

Linear: ROB-531
