### PR TITLE
[codex] Add Toss candle OHLCV fallback sources

### DIFF
--- a/app/jobs/kr_candles.py
+++ b/app/jobs/kr_candles.py
@@ -12,13 +12,20 @@ async def run_kr_candles_sync(
     mode: str,
     sessions: int = 10,
     user_id: int = 1,
+    source: str = "kis",
 ) -> dict[str, object]:
     try:
-        result = await sync_kr_candles(mode=mode, sessions=sessions, user_id=user_id)
+        result = await sync_kr_candles(
+            mode=mode,
+            sessions=sessions,
+            user_id=user_id,
+            source=source,
+        )
         return {
             "status": "completed",
             **result,
         }
+
     except Exception as exc:
         logger.error("KR candles sync failed: %s", exc, exc_info=True)
         return {

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -77,10 +77,10 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - US intraday `end_date="YYYY-MM-DD"` is interpreted as ET `20:00:00` for that market date; timestamp inputs use the exact provided instant
 - KR OHLCV behavior:
   - KR `day` keeps the existing Redis-backed `kis_ohlcv_cache` path when `end_date` is omitted
-  - KR `1m` reads DB-first from raw `public.kr_candles_1m` with venue merge (`KRX` price priority, `volume/value` sum)
-  - KR `5m/15m/30m/1h` read DB-first from Timescale continuous aggregates (`public.kr_candles_5m`, `public.kr_candles_15m`, `public.kr_candles_30m`, `public.kr_candles_1h`)
   - KR intraday (`1m/5m/15m/30m/1h`) uses Toss candles first when `TOSS_API_ENABLED` is configured, then falls back to the existing DB/KIS reader
   - Toss only provides `1m`; `5m/15m/30m/1h` are aggregated from Toss `1m` using the same bucket rules as the KIS path
+  - When Toss is unavailable or disabled, KR `1m` falls back to DB-first reads from raw `public.kr_candles_1m` with venue merge (`KRX` price priority, `volume/value` sum)
+  - When Toss is unavailable or disabled, KR `5m/15m/30m/1h` fall back to DB-first reads from Timescale continuous aggregates (`public.kr_candles_5m`, `public.kr_candles_15m`, `public.kr_candles_30m`, `public.kr_candles_1h`)
   - On Toss fallback, KR intraday overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence
   - KR intraday includes the current partial bucket when minute data is available
   - KIS minute venues are merged with strict dedup to prevent double-counting (API overwrites DB per minute+venue)

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -71,6 +71,7 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - Crypto `1m` / `5m` / `15m` / `30m` rows expose `timestamp`, `date`, `time`, `open`, `high`, `low`, `close`, `volume`, `value`, `trade_amount` and do not expose raw `datetime`
 - US OHLCV behavior:
   - US `day`/`week`/`month` uses Yahoo Finance (`app.services.brokers.yahoo.client.fetch_ohlcv`)
+  - US daily uses Yahoo first and Toss as a `period="day"` fallback; US `week` and `month` remain Yahoo-only
   - US intraday (`1m`/`5m`/`15m`/`30m`/`1h`) uses KIS via DB-first reader (`read_us_intraday_candles`) with ET-naive timestamps
   - US intraday rows include `session` field (`PRE_MARKET`, `REGULAR`, `POST_MARKET`)
   - US intraday `end_date="YYYY-MM-DD"` is interpreted as ET `20:00:00` for that market date; timestamp inputs use the exact provided instant
@@ -78,7 +79,9 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - KR `day` keeps the existing Redis-backed `kis_ohlcv_cache` path when `end_date` is omitted
   - KR `1m` reads DB-first from raw `public.kr_candles_1m` with venue merge (`KRX` price priority, `volume/value` sum)
   - KR `5m/15m/30m/1h` read DB-first from Timescale continuous aggregates (`public.kr_candles_5m`, `public.kr_candles_15m`, `public.kr_candles_30m`, `public.kr_candles_1h`)
-  - KR intraday (`1m/5m/15m/30m/1h`) overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence
+  - KR intraday (`1m/5m/15m/30m/1h`) uses Toss candles first when `TOSS_API_ENABLED` is configured, then falls back to the existing DB/KIS reader
+  - Toss only provides `1m`; `5m/15m/30m/1h` are aggregated from Toss `1m` using the same bucket rules as the KIS path
+  - On Toss fallback, KR intraday overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence
   - KR intraday includes the current partial bucket when minute data is available
   - KIS minute venues are merged with strict dedup to prevent double-counting (API overwrites DB per minute+venue)
   - KIS minute API call plan (KST):

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -76,6 +76,10 @@ from app.services.us_symbol_universe_service import (
     get_us_exchange_by_symbol,
     search_us_symbols,
 )
+from app.services.market_data.toss_ohlcv import (
+    fetch_daily_toss_frame,
+    fetch_kr_intraday_toss_frame,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -942,12 +946,35 @@ async def _fetch_ohlcv_equity_kr(
             end_date=end_date,
         )
     elif period in KR_INTRADAY_OHLCV_PERIODS:
-        df = await read_kr_intraday_candles(
-            symbol=symbol,
-            period=period,
-            count=capped_count,
-            end_date=end_date,
-        )
+        try:
+            df = await fetch_kr_intraday_toss_frame(
+                symbol=symbol,
+                period=period,
+                count=capped_count,
+                end_date=end_date,
+            )
+            return _build_ohlcv_payload(
+                symbol=symbol,
+                instrument_type="equity_kr",
+                source="toss",
+                period=period,
+                count=capped_count,
+                df=df,
+                include_indicators=include_indicators,
+            )
+        except Exception as toss_exc:
+            logger.info(
+                "Toss KR intraday OHLCV fallback to KIS (MCP) symbol=%s period=%s error=%s",
+                symbol,
+                period,
+                toss_exc,
+            )
+            df = await read_kr_intraday_candles(
+                symbol=symbol,
+                period=period,
+                count=capped_count,
+                end_date=end_date,
+            )
     else:
         kis_period_map = {"week": "W", "month": "M"}
         df = await kis.inquire_daily_itemchartprice(
@@ -999,15 +1026,26 @@ async def _fetch_ohlcv_equity_us(
             include_indicators=include_indicators,
         )
 
-    # day/week/month use Yahoo Finance
+    # day/week/month use Yahoo Finance with Toss day-only fallback
     capped_count = min(count, 100)
-    df = await yahoo_service.fetch_ohlcv(
-        ticker=symbol, days=capped_count, period=period, end_date=end_date
-    )
+    try:
+        df = await yahoo_service.fetch_ohlcv(
+            ticker=symbol, days=capped_count, period=period, end_date=end_date
+        )
+        source = "yahoo"
+    except Exception:
+        if period != "day":
+            raise
+        df = await fetch_daily_toss_frame(
+            symbol=symbol,
+            count=capped_count,
+            end_date=end_date,
+        )
+        source = "toss"
     return _build_ohlcv_payload(
         symbol=symbol,
         instrument_type="equity_us",
-        source="yahoo",
+        source=source,
         period=period,
         count=capped_count,
         df=df,

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -67,6 +67,10 @@ from app.services.market_data.constants import (
     US_INTRADAY_OHLCV_PERIODS,
     validate_ohlcv_period,
 )
+from app.services.market_data.toss_ohlcv import (
+    fetch_daily_toss_frame,
+    fetch_kr_intraday_toss_frame,
+)
 from app.services.upbit_symbol_universe_service import search_upbit_symbols
 from app.services.us_intraday_candles_read_service import read_us_intraday_candles
 from app.services.us_symbol_universe_service import (
@@ -75,10 +79,6 @@ from app.services.us_symbol_universe_service import (
     USSymbolUniverseEmptyError,
     get_us_exchange_by_symbol,
     search_us_symbols,
-)
-from app.services.market_data.toss_ohlcv import (
-    fetch_daily_toss_frame,
-    fetch_kr_intraday_toss_frame,
 )
 
 if TYPE_CHECKING:

--- a/app/services/brokers/toss/candles.py
+++ b/app/services/brokers/toss/candles.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+import pandas as pd
+
+from app.services.brokers.toss.dto import TossCandlesPage
+
+_FRAME_COLUMNS = ["datetime", "date", "time", "open", "high", "low", "close", "volume", "value"]
+
+
+class _TossCandleClient(Protocol):
+    async def candles(
+        self,
+        symbol: str,
+        *,
+        interval: str,
+        count: int | None = None,
+        before: str | None = None,
+        adjusted: bool | None = None,
+    ) -> TossCandlesPage: ...
+
+
+def empty_toss_candles_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=_FRAME_COLUMNS)
+
+
+def toss_candles_page_to_frame(page: TossCandlesPage) -> pd.DataFrame:
+    records: list[dict[str, object]] = []
+    for candle in page.candles:
+        timestamp = pd.Timestamp(candle.timestamp)
+        close = float(candle.close_price)
+        volume = float(candle.volume)
+        records.append(
+            {
+                "datetime": timestamp,
+                "date": timestamp.date(),
+                "time": timestamp.time(),
+                "open": float(candle.open_price),
+                "high": float(candle.high_price),
+                "low": float(candle.low_price),
+                "close": close,
+                "volume": volume,
+                "value": close * volume,
+            }
+        )
+    if not records:
+        return empty_toss_candles_frame()
+    return pd.DataFrame(records).sort_values("datetime").reset_index(drop=True).loc[:, _FRAME_COLUMNS]
+
+
+async def fetch_toss_candles_frame(
+    *,
+    client: _TossCandleClient,
+    symbol: str,
+    interval: str,
+    count: int,
+    before: str | None = None,
+    adjusted: bool | None = None,
+    max_pages: int = 20,
+) -> pd.DataFrame:
+    remaining = max(int(count), 1)
+    cursor = before
+    frames: list[pd.DataFrame] = []
+    for _ in range(max_pages):
+        page_count = min(remaining, 200)
+        page = await client.candles(
+            symbol,
+            interval=interval,
+            count=page_count,
+            before=cursor,
+            adjusted=adjusted,
+        )
+        frame = toss_candles_page_to_frame(page)
+        if not frame.empty:
+            frames.append(frame)
+            remaining -= len(frame)
+        if remaining <= 0 or not page.next_before:
+            break
+        cursor = page.next_before
+    if not frames:
+        return empty_toss_candles_frame()
+    combined = pd.concat(frames, ignore_index=True).drop_duplicates(subset=["datetime"])
+    return combined.sort_values("datetime").tail(count).reset_index(drop=True).loc[:, _FRAME_COLUMNS]

--- a/app/services/brokers/toss/candles.py
+++ b/app/services/brokers/toss/candles.py
@@ -6,7 +6,17 @@ import pandas as pd
 
 from app.services.brokers.toss.dto import TossCandlesPage
 
-_FRAME_COLUMNS = ["datetime", "date", "time", "open", "high", "low", "close", "volume", "value"]
+_FRAME_COLUMNS = [
+    "datetime",
+    "date",
+    "time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "value",
+]
 
 
 class _TossCandleClient(Protocol):
@@ -46,7 +56,12 @@ def toss_candles_page_to_frame(page: TossCandlesPage) -> pd.DataFrame:
         )
     if not records:
         return empty_toss_candles_frame()
-    return pd.DataFrame(records).sort_values("datetime").reset_index(drop=True).loc[:, _FRAME_COLUMNS]
+    return (
+        pd.DataFrame(records)
+        .sort_values("datetime")
+        .reset_index(drop=True)
+        .loc[:, _FRAME_COLUMNS]
+    )
 
 
 async def fetch_toss_candles_frame(
@@ -81,4 +96,9 @@ async def fetch_toss_candles_frame(
     if not frames:
         return empty_toss_candles_frame()
     combined = pd.concat(frames, ignore_index=True).drop_duplicates(subset=["datetime"])
-    return combined.sort_values("datetime").tail(count).reset_index(drop=True).loc[:, _FRAME_COLUMNS]
+    return (
+        combined.sort_values("datetime")
+        .tail(count)
+        .reset_index(drop=True)
+        .loc[:, _FRAME_COLUMNS]
+    )

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -11,6 +11,7 @@ from app.services.brokers.toss.dto import (
     TossAccount,
     parse_accounts,
     parse_buying_power,
+    parse_candles,
     parse_commissions,
     parse_holdings,
     parse_order,
@@ -174,15 +175,17 @@ class TossReadClient:
                 "interval": interval,
                 "count": count,
                 "before": before,
-                "adjusted": adjusted,
+                "adjusted": str(adjusted).lower() if adjusted is not None else None,
             }.items()
             if value is not None
         }
-        return await self._request(
-            "GET",
-            "/api/v1/candles",
-            group=TossApiGroup.MARKET_DATA_CHART,
-            params=params,
+        return parse_candles(
+            await self._request(
+                "GET",
+                "/api/v1/candles",
+                group=TossApiGroup.MARKET_DATA_CHART,
+                params=params,
+            )
         )
 
     async def exchange_rate(

--- a/app/services/brokers/toss/dto.py
+++ b/app/services/brokers/toss/dto.py
@@ -264,3 +264,40 @@ def parse_order(raw: dict[str, Any]) -> TossOrder:
     return parse_orders({"orders": [raw], "nextCursor": None, "hasNext": False}).orders[
         0
     ]
+
+
+@dataclass(frozen=True)
+class TossCandle:
+    timestamp: str
+    open_price: Decimal
+    high_price: Decimal
+    low_price: Decimal
+    close_price: Decimal
+    volume: Decimal
+    currency: str
+
+
+@dataclass(frozen=True)
+class TossCandlesPage:
+    candles: list[TossCandle]
+    next_before: str | None
+
+
+def parse_candles(raw: dict[str, Any]) -> TossCandlesPage:
+    candles = [
+        TossCandle(
+            timestamp=str(row["timestamp"]),
+            open_price=parse_decimal_string(row["openPrice"]),
+            high_price=parse_decimal_string(row["highPrice"]),
+            low_price=parse_decimal_string(row["lowPrice"]),
+            close_price=parse_decimal_string(row["closePrice"]),
+            volume=parse_decimal_string(row["volume"]),
+            currency=str(row["currency"]),
+        )
+        for row in raw.get("candles", [])
+    ]
+    next_before = raw.get("nextBefore")
+    return TossCandlesPage(
+        candles=candles,
+        next_before=str(next_before) if next_before is not None else None,
+    )

--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -290,13 +290,13 @@ async def _build_default_service() -> DailyCandleSyncService:
     invocation, so this is acceptable.
     """
     import app.services.brokers.upbit.client as upbit_service
+    from app.core.config import settings
     from app.core.db import AsyncSessionLocal
     from app.services.brokers.kis.client import KISClient
     from app.services.daily_candles.kis_daily_fetcher import (
         fetch_kr_daily_unclamped,
         fetch_us_daily_unclamped,
     )
-    from app.core.config import settings
     from app.services.daily_candles.toss_daily_fetcher import fetch_daily_toss_unclamped
     from app.services.daily_candles.yahoo_us_fallback import (
         fetch_us_daily_yahoo_fallback,

--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -75,7 +75,6 @@ class DailyCandleSyncService:
         self._toss_us = toss_us_fetcher
         self._close_callbacks = close_callbacks or []
 
-
     async def close(self) -> None:
         """Release resources owned by the default service factory."""
         for callback in self._close_callbacks:
@@ -103,12 +102,17 @@ class DailyCandleSyncService:
             )
             toss_frame = await self._toss_kr(symbol=target.symbol, n=horizon_bars)
             rows = frame_to_rows(
-                toss_frame, symbol=target.symbol, partition=target.partition, source="toss"
+                toss_frame,
+                symbol=target.symbol,
+                partition=target.partition,
+                source="toss",
             )
             fallback_used = True
         upserted = await self._repository.upsert_rows(market=target.market, rows=rows)
         await self._commit_or_rollback()
-        return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=fallback_used)
+        return SyncOneResult(
+            target=target, rows_upserted=upserted, fallback_used=fallback_used
+        )
 
     async def _sync_us(self, target: SyncTarget, horizon_bars: int) -> SyncOneResult:
         frame = await self._kis_us(
@@ -141,14 +145,19 @@ class DailyCandleSyncService:
                 )
                 toss_frame = await self._toss_us(symbol=target.symbol, n=horizon_bars)
                 repo_rows = frame_to_rows(
-                    toss_frame, symbol=target.symbol, partition=target.partition, source="toss_fallback"
+                    toss_frame,
+                    symbol=target.symbol,
+                    partition=target.partition,
+                    source="toss_fallback",
                 )
                 if repo_rows:
                     upserted = await self._repository.upsert_rows(
                         market=target.market, rows=repo_rows
                     )
                     await self._commit_or_rollback()
-                    return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=True)
+                    return SyncOneResult(
+                        target=target, rows_upserted=upserted, fallback_used=True
+                    )
             return SyncOneResult(
                 target=target,
                 rows_upserted=0,
@@ -176,7 +185,6 @@ class DailyCandleSyncService:
         )
         await self._commit_or_rollback()
         return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=True)
-
 
     async def _sync_crypto(
         self, target: SyncTarget, horizon_bars: int
@@ -332,4 +340,3 @@ async def _build_default_service() -> DailyCandleSyncService:
         toss_us_fetcher=_toss if settings.toss_api_enabled else None,
         close_callbacks=[session.close, kis.close],
     )
-

--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -50,6 +50,7 @@ KISKrFetcher = Callable[..., Awaitable[pd.DataFrame]]
 KISUsFetcher = Callable[..., Awaitable[pd.DataFrame]]
 YahooUsFetcher = Callable[..., Awaitable[list[YahooFallbackRow]]]
 UpbitCryptoFetcher = Callable[..., Awaitable[pd.DataFrame]]
+TossDailyFetcher = Callable[..., Awaitable[pd.DataFrame]]
 
 
 class DailyCandleSyncService:
@@ -61,6 +62,8 @@ class DailyCandleSyncService:
         kis_us_fetcher: KISUsFetcher,
         yahoo_us_fetcher: YahooUsFetcher,
         upbit_crypto_fetcher: UpbitCryptoFetcher,
+        toss_kr_fetcher: TossDailyFetcher | None = None,
+        toss_us_fetcher: TossDailyFetcher | None = None,
         close_callbacks: list[Callable[[], object]] | None = None,
     ) -> None:
         self._repository = repository
@@ -68,7 +71,10 @@ class DailyCandleSyncService:
         self._kis_us = kis_us_fetcher
         self._yahoo_us = yahoo_us_fetcher
         self._upbit = upbit_crypto_fetcher
+        self._toss_kr = toss_kr_fetcher
+        self._toss_us = toss_us_fetcher
         self._close_callbacks = close_callbacks or []
+
 
     async def close(self) -> None:
         """Release resources owned by the default service factory."""
@@ -89,9 +95,20 @@ class DailyCandleSyncService:
         rows = frame_to_rows(
             frame, symbol=target.symbol, partition=target.partition, source="kis"
         )
+        fallback_used = False
+        if not rows and self._toss_kr is not None:
+            logger.warning(
+                "KIS returned no rows for KR symbol; attempting Toss fallback symbol=%s",
+                target.symbol,
+            )
+            toss_frame = await self._toss_kr(symbol=target.symbol, n=horizon_bars)
+            rows = frame_to_rows(
+                toss_frame, symbol=target.symbol, partition=target.partition, source="toss"
+            )
+            fallback_used = True
         upserted = await self._repository.upsert_rows(market=target.market, rows=rows)
         await self._commit_or_rollback()
-        return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=False)
+        return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=fallback_used)
 
     async def _sync_us(self, target: SyncTarget, horizon_bars: int) -> SyncOneResult:
         frame = await self._kis_us(
@@ -116,6 +133,22 @@ class DailyCandleSyncService:
         )
         fallback_rows = await self._yahoo_us(symbol=target.symbol, n=horizon_bars)
         if not fallback_rows:
+            if self._toss_us is not None:
+                logger.warning(
+                    "Yahoo returned no rows for US symbol; attempting Toss fallback symbol=%s exchange=%s",
+                    target.symbol,
+                    target.partition,
+                )
+                toss_frame = await self._toss_us(symbol=target.symbol, n=horizon_bars)
+                repo_rows = frame_to_rows(
+                    toss_frame, symbol=target.symbol, partition=target.partition, source="toss_fallback"
+                )
+                if repo_rows:
+                    upserted = await self._repository.upsert_rows(
+                        market=target.market, rows=repo_rows
+                    )
+                    await self._commit_or_rollback()
+                    return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=True)
             return SyncOneResult(
                 target=target,
                 rows_upserted=0,
@@ -143,6 +176,7 @@ class DailyCandleSyncService:
         )
         await self._commit_or_rollback()
         return SyncOneResult(target=target, rows_upserted=upserted, fallback_used=True)
+
 
     async def _sync_crypto(
         self, target: SyncTarget, horizon_bars: int
@@ -262,6 +296,8 @@ async def _build_default_service() -> DailyCandleSyncService:
         fetch_kr_daily_unclamped,
         fetch_us_daily_unclamped,
     )
+    from app.core.config import settings
+    from app.services.daily_candles.toss_daily_fetcher import fetch_daily_toss_unclamped
     from app.services.daily_candles.yahoo_us_fallback import (
         fetch_us_daily_yahoo_fallback,
     )
@@ -283,11 +319,17 @@ async def _build_default_service() -> DailyCandleSyncService:
     async def _upbit(*, market: str, days: int) -> pd.DataFrame:
         return await upbit_service.fetch_ohlcv(market=market, days=days, period="day")
 
+    async def _toss(*, symbol: str, n: int) -> pd.DataFrame:
+        return await fetch_daily_toss_unclamped(symbol=symbol, n=n)
+
     return DailyCandleSyncService(
         repository=DailyCandlesRepository(session=session),
         kis_kr_fetcher=_kr,
         kis_us_fetcher=_us,
         yahoo_us_fetcher=_yahoo,
         upbit_crypto_fetcher=_upbit,
+        toss_kr_fetcher=_toss if settings.toss_api_enabled else None,
+        toss_us_fetcher=_toss if settings.toss_api_enabled else None,
         close_callbacks=[session.close, kis.close],
     )
+

--- a/app/services/daily_candles/toss_daily_fetcher.py
+++ b/app/services/daily_candles/toss_daily_fetcher.py
@@ -1,0 +1,64 @@
+"""Toss-side fetcher facade for the daily candle store.
+
+Wraps the Toss candle endpoint for daily (1d interval) KR equity data
+so the DailyCandleSyncService can use it as a primary or fallback source.
+This module knows about the Toss broker; it does NOT know about the database.
+Returns canonical pandas DataFrames with columns: date, open, high, low, close,
+volume, value.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import pandas as pd
+
+from app.services.brokers.toss.candles import fetch_toss_candles_frame
+from app.services.brokers.toss.dto import TossCandlesPage
+
+_FRAME_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
+
+
+class _TossDailyClient(Protocol):
+    async def candles(
+        self,
+        symbol: str,
+        *,
+        interval: str,
+        count: int | None = None,
+        before: str | None = None,
+        adjusted: bool | None = None,
+    ) -> TossCandlesPage: ...
+
+
+def _to_daily_frame(raw_frame: pd.DataFrame) -> pd.DataFrame:
+    """Convert candles frame (has datetime col) to daily frame (has date col)."""
+    if raw_frame.empty:
+        return pd.DataFrame(columns=_FRAME_COLUMNS)
+    frame = raw_frame.copy()
+    if "date" not in frame.columns and "datetime" in frame.columns:
+        frame["date"] = pd.to_datetime(frame["datetime"]).dt.date
+    return frame[_FRAME_COLUMNS].sort_values("date").reset_index(drop=True)
+
+
+async def fetch_kr_daily_toss(
+    *,
+    client: _TossDailyClient,
+    symbol: str,
+    n: int,
+    max_pages: int = 50,
+) -> pd.DataFrame:
+    """Fetch n daily bars for a KR equity symbol from Toss.
+
+    Uses the Toss 1d interval endpoint with split-adjusted prices.
+    Returns a DataFrame with columns: date, open, high, low, close, volume, value.
+    """
+    raw = await fetch_toss_candles_frame(
+        client=client,
+        symbol=symbol,
+        interval="1d",
+        count=n,
+        adjusted=True,
+        max_pages=max_pages,
+    )
+    return _to_daily_frame(raw)

--- a/app/services/daily_candles/toss_daily_fetcher.py
+++ b/app/services/daily_candles/toss_daily_fetcher.py
@@ -67,9 +67,9 @@ async def fetch_kr_daily_toss(
 async def fetch_daily_toss_unclamped(*, symbol: str, n: int) -> pd.DataFrame:
     """Fetch daily candles from Toss using a settings-configured client."""
     from app.services.brokers.toss.client import TossReadClient
+
     client = TossReadClient.from_settings()
     try:
         return await fetch_kr_daily_toss(client=client, symbol=symbol, n=n)
     finally:
         await client.aclose()
-

--- a/app/services/daily_candles/toss_daily_fetcher.py
+++ b/app/services/daily_candles/toss_daily_fetcher.py
@@ -62,3 +62,14 @@ async def fetch_kr_daily_toss(
         max_pages=max_pages,
     )
     return _to_daily_frame(raw)
+
+
+async def fetch_daily_toss_unclamped(*, symbol: str, n: int) -> pd.DataFrame:
+    """Fetch daily candles from Toss using a settings-configured client."""
+    from app.services.brokers.toss.client import TossReadClient
+    client = TossReadClient.from_settings()
+    try:
+        return await fetch_kr_daily_toss(client=client, symbol=symbol, n=n)
+    finally:
+        await client.aclose()
+

--- a/app/services/kr_candles_sync_service.py
+++ b/app/services/kr_candles_sync_service.py
@@ -26,6 +26,7 @@ from app.services.candles_sync_common import (
     read_cursor_utc,
 )
 from app.services.manual_holdings_service import ManualHoldingsService
+from app.services.market_data.toss_ohlcv import fetch_kr_intraday_toss_frame
 
 logger = logging.getLogger(__name__)
 
@@ -515,11 +516,16 @@ async def sync_kr_candles(
     mode: str,
     sessions: int = 10,
     user_id: int = 1,
+    source: str = "kis",
 ) -> dict[str, object]:
     normalized_mode = normalize_mode(mode)
     session_count = max(int(sessions), 1)
     now_kst = datetime.now(_KST)
     session_day_today = _is_session_day_kst(now_kst.date())
+
+    normalized_source = str(source or "kis").strip().lower()
+    if normalized_source not in {"kis", "toss"}:
+        raise ValueError("source must be 'kis' or 'toss'")
 
     kis = KISClient()
 
@@ -549,6 +555,7 @@ async def sync_kr_candles(
                 "pairs_skipped": 0,
                 "rows_upserted": 0,
                 "pages_fetched": 0,
+                "source": normalized_source,
             }
 
         universe_rows, table_has_rows = await _load_universe_context(
@@ -560,6 +567,86 @@ async def sync_kr_candles(
             universe_rows=universe_rows,
             table_has_rows=table_has_rows,
         )
+
+        if normalized_source == "toss":
+            rows_upserted = 0
+            for symbol in sorted(target_symbols):
+                try:
+                    toss_frame = await fetch_kr_intraday_toss_frame(
+                        symbol=symbol,
+                        period="1m",
+                        count=200,
+                        end_date=None,
+                    )
+                    if toss_frame.empty:
+                        continue
+
+                    day_rows = []
+                    for item in toss_frame.to_dict("records"):
+                        raw_dt = item.get("datetime")
+                        if raw_dt is None:
+                            continue
+                        parsed = pd.to_datetime(raw_dt)
+                        if pd.isna(parsed):
+                            continue
+                        parsed_dt = parsed.to_pydatetime()
+
+                        open_val = float(item["open"])
+                        high_val = float(item["high"])
+                        low_val = float(item["low"])
+                        close_val = float(item["close"])
+                        volume_val = float(item["volume"])
+                        value_val = float(item["value"])
+
+                        if parsed_dt.tzinfo is None:
+                            local_dt = parsed_dt.replace(tzinfo=_KST)
+                        else:
+                            local_dt = parsed_dt.astimezone(_KST)
+                        local_dt = local_dt.replace(second=0, microsecond=0)
+
+                        day_rows.append(
+                            MinuteCandleRow(
+                                time_utc=_convert_kis_datetime_to_utc(local_dt),
+                                local_time=local_dt,
+                                symbol=symbol,
+                                venue="KRX",
+                                open=open_val,
+                                high=high_val,
+                                low=low_val,
+                                close=close_val,
+                                volume=volume_val,
+                                value=value_val,
+                            )
+                        )
+
+                    if day_rows:
+                        rows_upserted += await _upsert_rows(session, day_rows)
+                        await session.commit()
+                except Exception as exc:
+                    await session.rollback()
+                    logger.error(
+                        "Failed to sync Toss candles for symbol=%s: %s",
+                        symbol,
+                        exc,
+                        exc_info=True,
+                    )
+
+            return {
+                "mode": normalized_mode,
+                "sessions": session_count,
+                "skipped": rows_upserted == 0,
+                "symbols_total": len(target_symbols),
+                "symbol_venues_total": len(target_symbols),
+                "pairs_processed": len(target_symbols),
+                "pairs_skipped": 0,
+                "rows_upserted": rows_upserted,
+                "pages_fetched": len(target_symbols),
+                "source": "toss",
+                "warnings": [
+                    "Toss minute candles are stored under venue='KRX' because kr_candles_1m has no provider source column; do not treat venue as provider provenance for source='toss'."
+                ],
+            }
+
         venue_plan = _build_venue_plan(rows_by_symbol)
 
         backfill_days: list[date] | None = None
@@ -625,9 +712,11 @@ async def sync_kr_candles(
             "pairs_skipped": pairs_skipped,
             "rows_upserted": rows_upserted,
             "pages_fetched": pages_fetched,
+            "source": normalized_source,
         }
     finally:
         await session.close()
+
 
 
 __all__ = ["sync_kr_candles"]

--- a/app/services/kr_candles_sync_service.py
+++ b/app/services/kr_candles_sync_service.py
@@ -718,5 +718,4 @@ async def sync_kr_candles(
         await session.close()
 
 
-
 __all__ = ["sync_kr_candles"]

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -24,6 +24,10 @@ from app.services.domain_errors import (
     ValidationError,
 )
 from app.services.kr_hourly_candles_read_service import read_kr_intraday_candles
+from app.services.market_data.toss_ohlcv import (
+    fetch_daily_toss_frame,
+    fetch_kr_intraday_toss_frame,
+)
 from app.services.market_data.constants import (
     KR_INTRADAY_OHLCV_PERIODS,
     US_INTRADAY_OHLCV_PERIODS,
@@ -621,18 +625,30 @@ async def get_ohlcv(
                     source="kis",
                     period=resolved_period,
                 )
-            # day/week/month use Yahoo Finance
-            frame = await fetch_yahoo_ohlcv(
-                ticker=resolved_symbol,
-                days=min(count, 200),
-                period=resolved_period,
-                end_date=end,
-            )
+            # day/week/month use Yahoo Finance with Toss day-only fallback
+            capped_count = min(count, 200)
+            try:
+                frame = await fetch_yahoo_ohlcv(
+                    ticker=resolved_symbol,
+                    days=capped_count,
+                    period=resolved_period,
+                    end_date=end,
+                )
+                source = "yahoo"
+            except Exception:
+                if resolved_period != "day":
+                    raise
+                frame = await fetch_daily_toss_frame(
+                    symbol=resolved_symbol,
+                    count=capped_count,
+                    end_date=end,
+                )
+                source = "toss"
             return _to_candle_rows(
                 frame,
                 symbol=resolved_symbol,
                 market=resolved_market,
-                source="yahoo",
+                source=source,
                 period=resolved_period,
             )
 
@@ -655,12 +671,34 @@ async def get_ohlcv(
             )
 
         if resolved_period in KR_INTRADAY_OHLCV_PERIODS:
-            frame = await read_kr_intraday_candles(
-                symbol=resolved_symbol,
-                period=resolved_period,
-                count=min(count, 200),
-                end_date=end,
-            )
+            capped_count = min(count, 200)
+            try:
+                frame = await fetch_kr_intraday_toss_frame(
+                    symbol=resolved_symbol,
+                    period=resolved_period,
+                    count=capped_count,
+                    end_date=end,
+                )
+                return _to_candle_rows(
+                    frame,
+                    symbol=resolved_symbol,
+                    market=resolved_market,
+                    source="toss",
+                    period=resolved_period,
+                )
+            except Exception as toss_exc:
+                logger.info(
+                    "Toss KR intraday OHLCV fallback to KIS symbol=%s period=%s error=%s",
+                    safe_log_value(resolved_symbol),
+                    resolved_period,
+                    toss_exc,
+                )
+                frame = await read_kr_intraday_candles(
+                    symbol=resolved_symbol,
+                    period=resolved_period,
+                    count=capped_count,
+                    end_date=end,
+                )
         else:
             frame = await kis.inquire_minute_chart(
                 code=resolved_symbol,

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -24,10 +24,6 @@ from app.services.domain_errors import (
     ValidationError,
 )
 from app.services.kr_hourly_candles_read_service import read_kr_intraday_candles
-from app.services.market_data.toss_ohlcv import (
-    fetch_daily_toss_frame,
-    fetch_kr_intraday_toss_frame,
-)
 from app.services.market_data.constants import (
     KR_INTRADAY_OHLCV_PERIODS,
     US_INTRADAY_OHLCV_PERIODS,
@@ -38,6 +34,10 @@ from app.services.market_data.contracts import (
     OrderbookLevel,
     OrderbookSnapshot,
     Quote,
+)
+from app.services.market_data.toss_ohlcv import (
+    fetch_daily_toss_frame,
+    fetch_kr_intraday_toss_frame,
 )
 from app.services.upbit_orderbook import fetch_orderbook
 from app.services.upbit_symbol_universe_service import UpbitSymbolUniverseLookupError

--- a/app/services/market_data/toss_ohlcv.py
+++ b/app/services/market_data/toss_ohlcv.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pandas as pd
+
+from app.services.brokers.kis._base_market_data import _aggregate_minute_candles_frame
+from app.services.brokers.toss.candles import fetch_toss_candles_frame
+from app.services.brokers.toss.client import TossReadClient
+
+_KR_INTRADAY_BUCKET_MINUTES = {"1m": 1, "5m": 5, "15m": 15, "30m": 30, "1h": 60}
+
+
+def _before_from_end_date(end_date: dt.datetime | None) -> str | None:
+    if end_date is None:
+        return None
+    return end_date.isoformat()
+
+
+async def fetch_kr_intraday_toss_frame(
+    *,
+    symbol: str,
+    period: str,
+    count: int,
+    end_date: dt.datetime | None,
+) -> pd.DataFrame:
+    bucket = _KR_INTRADAY_BUCKET_MINUTES[period]
+    request_count = count if bucket == 1 else min(max(count * bucket, bucket), 200)
+    client = TossReadClient.from_settings()
+    try:
+        one_minute = await fetch_toss_candles_frame(
+            client=client,
+            symbol=symbol,
+            interval="1m",
+            count=request_count,
+            before=_before_from_end_date(end_date),
+        )
+    finally:
+        await client.aclose()
+    if bucket == 1:
+        return one_minute.tail(count).reset_index(drop=True)
+    aggregated = _aggregate_minute_candles_frame(
+        one_minute,
+        bucket,
+        include_partial=(bucket == 60),
+    )
+    return aggregated.tail(count).reset_index(drop=True)
+
+
+async def fetch_daily_toss_frame(
+    *,
+    symbol: str,
+    count: int,
+    end_date: dt.datetime | None = None,
+) -> pd.DataFrame:
+    client = TossReadClient.from_settings()
+    try:
+        return await fetch_toss_candles_frame(
+            client=client,
+            symbol=symbol,
+            interval="1d",
+            count=count,
+            before=_before_from_end_date(end_date),
+            adjusted=True,
+            max_pages=max(1, (count + 199) // 200),
+        )
+    finally:
+        await client.aclose()

--- a/docs/superpowers/plans/2026-06-12-rob-537-resume-plan.md
+++ b/docs/superpowers/plans/2026-06-12-rob-537-resume-plan.md
@@ -1,0 +1,449 @@
+# ROB-537 Toss Candle Source Resume Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resume the interrupted ROB-537 work by finishing the dirty KR minute Toss sync option, documenting the finished OHLCV routing behavior, and verifying the already-committed Toss candle integration.
+
+**Architecture:** Treat commits through `d1cb02d5 feat(ROB-537): add Toss daily candle sync fallback` as completed baseline work. Preserve the current dirty KR candle sync changes, fix their test isolation and style issues, then add the remaining MCP README update and focused verification without reopening the completed DTO/client/OHLCV/daily-sync tasks.
+
+**Tech Stack:** Python 3.13, pandas, pytest, pytest-asyncio, Ruff, Linear issue ROB-537 context.
+
+---
+
+## Current State
+
+Completed and committed:
+
+- `d3f2203f` parses Toss candle responses.
+- `e3f970dd` types `TossReadClient.candles()`.
+- `3ea2b668` normalizes Toss candles to OHLCV DataFrames.
+- `88bd22a1` adds Toss OHLCV market-data helpers.
+- `8d8dd601` wires Toss-first KR intraday and Toss US daily fallback in service layer.
+- `363b7d54` mirrors Toss OHLCV routing in the MCP tool.
+- `004769ec` adds Toss daily fetcher for `DailyCandleSyncService`.
+- `d1cb02d5` adds Toss daily candle sync fallback.
+
+Current dirty files:
+
+- `app/jobs/kr_candles.py`
+- `app/services/kr_candles_sync_service.py`
+- `scripts/sync_kr_candles.py`
+- `tests/test_kr_candles_sync.py`
+- `docs/superpowers/plans/2026-06-12-rob-537-toss-candle-source.md` is an old untracked initial plan and should not be used as the resume source of truth.
+
+Observed failures before this plan:
+
+```bash
+uv run pytest tests/test_kr_candles_sync.py -q
+```
+
+Result: 19 passed, 1 failed. The failing test is `test_sync_kr_candles_toss_source_warning`; it accidentally constructs the real `KISClient` path and tries to fetch a KIS token.
+
+```bash
+uv run ruff check app/jobs/kr_candles.py app/services/kr_candles_sync_service.py scripts/sync_kr_candles.py tests/test_kr_candles_sync.py
+```
+
+Result: one Ruff import-order failure in `tests/test_kr_candles_sync.py`.
+
+## Remaining File Structure
+
+- Modify: `tests/test_kr_candles_sync.py`
+  - Isolate the Toss-source test from KIS network/token paths and fix import ordering.
+- Modify: `app/jobs/kr_candles.py`
+  - Format long call and keep `source` pass-through.
+- Modify: `app/services/kr_candles_sync_service.py`
+  - Keep explicit `source='toss'` path, but format long lines and tighten the result/test contract.
+- Modify: `scripts/sync_kr_candles.py`
+  - Keep `--source kis|toss` CLI pass-through; only style changes are expected.
+- Modify: `app/mcp_server/README.md`
+  - Document actual Toss-first and fallback behavior.
+- Remove or leave untracked intentionally: `docs/superpowers/plans/2026-06-12-rob-537-toss-candle-source.md`
+  - Prefer leaving it uncommitted unless the owner wants to keep the initial long plan.
+
+---
+
+### Task 1: Finish Dirty KR Minute Toss Sync Work
+
+**Files:**
+- Modify: `tests/test_kr_candles_sync.py`
+- Modify: `app/jobs/kr_candles.py`
+- Modify: `app/services/kr_candles_sync_service.py`
+- Modify: `scripts/sync_kr_candles.py`
+
+- [ ] **Step 1: Confirm current dirty failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_kr_candles_sync.py::test_sync_kr_candles_toss_source_warning -q
+```
+
+Expected: FAIL with `KeyError: 'access_token'` from the real KIS token path.
+
+- [ ] **Step 2: Fix test imports**
+
+In `tests/test_kr_candles_sync.py`, change the imports at the top from:
+
+```python
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+```
+
+to:
+
+```python
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+```
+
+Remove the inner `import pandas as pd` from `test_sync_kr_candles_toss_source_warning`.
+
+- [ ] **Step 3: Replace the Toss-source warning test with an isolated test**
+
+Replace the entire current `test_sync_kr_candles_toss_source_warning` body in `tests/test_kr_candles_sync.py` with:
+
+```python
+@pytest.mark.asyncio
+async def test_sync_kr_candles_toss_source_warning(monkeypatch):
+    from app.services.kr_candles_sync_service import sync_kr_candles
+
+    class DummyKISClient:
+        async def fetch_my_stocks(self):
+            return [{"pdno": "005930"}]
+
+    class DummyManualHoldingsService:
+        def __init__(self, session):
+            self.session = session
+
+        async def get_holdings_by_user(self, *, user_id, market_type):
+            return []
+
+    class DummySession:
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+        async def close(self):
+            return None
+
+    session = DummySession()
+    toss_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=1)
+
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.KISClient",
+        DummyKISClient,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.ManualHoldingsService",
+        DummyManualHoldingsService,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.AsyncSessionLocal",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service._load_universe_context",
+        AsyncMock(
+            return_value=(
+                [_make_universe_row("005930", nxt_eligible=True, is_active=True)],
+                True,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.fetch_kr_intraday_toss_frame",
+        AsyncMock(return_value=toss_df),
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service._upsert_rows",
+        upsert_mock,
+    )
+
+    result = await sync_kr_candles(mode="incremental", source="toss")
+
+    assert result["source"] == "toss"
+    assert result["rows_upserted"] == 1
+    assert result["symbol_venues_total"] == 1
+    assert result["pairs_processed"] == 1
+    assert any("provider source column" in w for w in result.get("warnings", []))
+    upsert_mock.assert_awaited_once()
+```
+
+- [ ] **Step 4: Format long production lines**
+
+In `app/jobs/kr_candles.py`, replace:
+
+```python
+        result = await sync_kr_candles(mode=mode, sessions=sessions, user_id=user_id, source=source)
+```
+
+with:
+
+```python
+        result = await sync_kr_candles(
+            mode=mode,
+            sessions=sessions,
+            user_id=user_id,
+            source=source,
+        )
+```
+
+In `app/services/kr_candles_sync_service.py`, replace:
+
+```python
+                    logger.error("Failed to sync Toss candles for symbol=%s: %s", symbol, exc, exc_info=True)
+```
+
+with:
+
+```python
+                    logger.error(
+                        "Failed to sync Toss candles for symbol=%s: %s",
+                        symbol,
+                        exc,
+                        exc_info=True,
+                    )
+```
+
+- [ ] **Step 5: Run focused KR sync tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_kr_candles_sync.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused Ruff check**
+
+Run:
+
+```bash
+uv run ruff check app/jobs/kr_candles.py app/services/kr_candles_sync_service.py scripts/sync_kr_candles.py tests/test_kr_candles_sync.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add app/jobs/kr_candles.py app/services/kr_candles_sync_service.py scripts/sync_kr_candles.py tests/test_kr_candles_sync.py
+git commit -m "feat(ROB-537): add explicit Toss source for KR minute sync"
+```
+
+Expected: commit succeeds. The untracked plan files should remain uncommitted unless deliberately added later.
+
+---
+
+### Task 2: Document Final OHLCV Routing
+
+**Files:**
+- Modify: `app/mcp_server/README.md`
+
+- [ ] **Step 1: Find the `get_ohlcv` section**
+
+Run:
+
+```bash
+sed -n '60,100p' app/mcp_server/README.md
+```
+
+Expected: output includes the `get_ohlcv(symbol, count=100, period="day", end_date=None, market=None, include_indicators=False)` bullet list.
+
+- [ ] **Step 2: Update KR intraday bullets**
+
+In `app/mcp_server/README.md`, replace the existing KR intraday bullets:
+
+```markdown
+  - KR intraday (`1m/5m/15m/30m/1h`) overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence
+  - KR intraday includes the current partial bucket when minute data is available
+```
+
+with:
+
+```markdown
+  - KR intraday (`1m/5m/15m/30m/1h`) uses Toss candles first when `TOSS_API_ENABLED` is configured, then falls back to the existing DB/KIS reader
+  - Toss only provides `1m`; `5m/15m/30m/1h` are aggregated from Toss `1m` using the same bucket rules as the KIS path
+  - On Toss fallback, KR intraday overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence
+  - KR intraday includes the current partial bucket when minute data is available
+```
+
+- [ ] **Step 3: Add US day-only Toss fallback bullet**
+
+In the same bullet list, add this near the US OHLCV bullets:
+
+```markdown
+  - US daily uses Yahoo first and Toss as a `period="day"` fallback; US `week` and `month` remain Yahoo-only
+```
+
+- [ ] **Step 4: Run README grep check**
+
+Run:
+
+```bash
+rg -n "Toss candles first|period=\"day\" fallback|Yahoo-only" app/mcp_server/README.md
+```
+
+Expected: all three phrases appear.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add app/mcp_server/README.md
+git commit -m "docs(ROB-537): document Toss OHLCV fallback routing"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Focused End-to-End Verification
+
+**Files:**
+- Read-only verification across committed ROB-537 surfaces.
+
+- [ ] **Step 1: Run Toss broker tests**
+
+Run:
+
+```bash
+uv run pytest tests/services/brokers/toss -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run market-data service tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_market_data_service.py -k "get_ohlcv or toss" -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run MCP OHLCV tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_ohlcv_tools.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run daily candle unit tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/services/daily_candles -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run KR candle sync tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_kr_candles_sync.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused Ruff check**
+
+Run:
+
+```bash
+uv run ruff check app/services/brokers/toss app/services/market_data app/services/daily_candles app/mcp_server/tooling/market_data_quotes.py app/services/kr_candles_sync_service.py app/jobs/kr_candles.py scripts/sync_kr_candles.py tests/services/brokers/toss tests/test_market_data_service.py tests/test_mcp_ohlcv_tools.py tests/unit/services/daily_candles tests/test_kr_candles_sync.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Check final git state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional plan files remain untracked, or a clean tree if the plan files were committed separately.
+
+---
+
+### Task 4: Plan File Cleanup Decision
+
+**Files:**
+- `docs/superpowers/plans/2026-06-12-rob-537-resume-plan.md`
+- `docs/superpowers/plans/2026-06-12-rob-537-toss-candle-source.md`
+
+- [ ] **Step 1: Decide which plan files to keep**
+
+Use this default unless the owner says otherwise:
+
+```text
+Keep and commit: docs/superpowers/plans/2026-06-12-rob-537-resume-plan.md
+Leave uncommitted or remove: docs/superpowers/plans/2026-06-12-rob-537-toss-candle-source.md
+```
+
+- [ ] **Step 2: Commit resume plan if desired**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-06-12-rob-537-resume-plan.md
+git commit -m "docs(ROB-537): add resume plan"
+```
+
+Expected: commit succeeds.
+
+- [ ] **Step 3: Remove stale initial plan only if the owner does not want it**
+
+Run this only for the untracked stale initial plan:
+
+```bash
+rm docs/superpowers/plans/2026-06-12-rob-537-toss-candle-source.md
+```
+
+Expected: the stale initial plan is removed from the working tree.
+
+---
+
+## Self-Review
+
+- Spec coverage: Remaining ROB-537 scope after commits through Task 8 is covered by KR minute Toss sync completion, MCP docs, and focused verification.
+- Placeholder scan: no unresolved placeholder tokens or unspecified implementation steps remain.
+- Type consistency: Current function names `sync_kr_candles`, `run_kr_candles_sync`, `fetch_kr_intraday_toss_frame`, and `fetch_daily_toss_frame` match the codebase.
+- Scope check: This resume plan avoids redoing committed Toss DTO/client/OHLCV/daily-sync work and focuses only on interrupted work plus documentation and verification.

--- a/scripts/sync_kr_candles.py
+++ b/scripts/sync_kr_candles.py
@@ -34,6 +34,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Manual holdings user id (default: 1)",
     )
+    parser.add_argument(
+        "--source",
+        choices=["kis", "toss"],
+        default="kis",
+        help="Pipeline source (default: kis)",
+    )
     return parser
 
 
@@ -47,7 +53,9 @@ async def main(argv: list[str] | None = None) -> int:
             mode=args.mode,
             sessions=max(args.sessions, 1),
             user_id=args.user_id,
+            source=args.source,
         )
+
         if result.get("status") != "completed":
             logger.error("KR candles sync failed: %s", result)
             return 1

--- a/tests/services/brokers/toss/test_candles.py
+++ b/tests/services/brokers/toss/test_candles.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from app.services.brokers.toss.candles import (
+    fetch_toss_candles_frame,
+    toss_candles_page_to_frame,
+)
+from app.services.brokers.toss.dto import TossCandle, TossCandlesPage
+
+
+def test_toss_candles_page_to_frame_sorts_ascending_and_computes_value() -> None:
+    page = TossCandlesPage(
+        candles=[
+            TossCandle(
+                timestamp="2026-06-12T09:14:00.000+09:00",
+                open_price=Decimal("330250"),
+                high_price=Decimal("330500"),
+                low_price=Decimal("330000"),
+                close_price=Decimal("330500"),
+                volume=Decimal("10"),
+                currency="KRW",
+            ),
+            TossCandle(
+                timestamp="2026-06-12T09:13:00.000+09:00",
+                open_price=Decimal("329000"),
+                high_price=Decimal("331500"),
+                low_price=Decimal("328500"),
+                close_price=Decimal("330000"),
+                volume=Decimal("20"),
+                currency="KRW",
+            ),
+        ],
+        next_before="2026-06-12T09:12:00.000+09:00",
+    )
+
+    frame = toss_candles_page_to_frame(page)
+
+    assert list(frame["datetime"]) == [
+        pd.Timestamp("2026-06-12T09:13:00.000+09:00"),
+        pd.Timestamp("2026-06-12T09:14:00.000+09:00"),
+    ]
+    assert list(frame["open"]) == [329000.0, 330250.0]
+    assert list(frame["close"]) == [330000.0, 330500.0]
+    assert list(frame["volume"]) == [20.0, 10.0]
+    assert list(frame["value"]) == [6600000.0, 3305000.0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_toss_candles_frame_paginates_until_count() -> None:
+    calls: list[str | None] = []
+
+    class FakeClient:
+        async def candles(self, symbol, *, interval, count, before=None, adjusted=None):
+            calls.append(before)
+            if before is None:
+                return TossCandlesPage(
+                    candles=[
+                        TossCandle(
+                            timestamp="2026-06-12T00:00:00.000+09:00",
+                            open_price=Decimal("10"),
+                            high_price=Decimal("11"),
+                            low_price=Decimal("9"),
+                            close_price=Decimal("10"),
+                            volume=Decimal("100"),
+                            currency="KRW",
+                        )
+                    ],
+                    next_before="cursor-1",
+                )
+            return TossCandlesPage(
+                candles=[
+                    TossCandle(
+                        timestamp="2026-06-11T00:00:00.000+09:00",
+                        open_price=Decimal("8"),
+                        high_price=Decimal("9"),
+                        low_price=Decimal("7"),
+                        close_price=Decimal("8"),
+                        volume=Decimal("200"),
+                        currency="KRW",
+                    )
+                ],
+                next_before=None,
+            )
+
+    frame = await fetch_toss_candles_frame(
+        client=FakeClient(),
+        symbol="005930",
+        interval="1d",
+        count=2,
+        adjusted=True,
+    )
+
+    assert calls == [None, "cursor-1"]
+    assert list(frame["close"]) == [8.0, 10.0]

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -224,3 +224,53 @@ async def test_prices_retries_once_after_429_retry_after(monkeypatch) -> None:
     assert calls == 2
     assert sleeps == [2.0]
     assert prices[0].last_price == Decimal("190.12")
+
+
+@pytest.mark.asyncio
+async def test_candles_returns_typed_page_and_sends_query_params() -> None:
+    seen: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["symbol"] = request.url.params["symbol"]
+        seen["interval"] = request.url.params["interval"]
+        seen["count"] = request.url.params["count"]
+        seen["adjusted"] = request.url.params["adjusted"]
+        return httpx.Response(
+            200,
+            json=_json(
+                {
+                    "candles": [
+                        {
+                            "timestamp": "2026-06-12T00:00:00.000+09:00",
+                            "openPrice": "313000",
+                            "highPrice": "330000",
+                            "lowPrice": "313000",
+                            "closePrice": "326000",
+                            "volume": "11414585",
+                            "currency": "KRW",
+                        }
+                    ],
+                    "nextBefore": "2026-06-11T00:00:00.000+09:00",
+                }
+            ),
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        page = await client.candles("005930", interval="1d", count=1, adjusted=True)
+    finally:
+        await client.aclose()
+
+    assert seen == {
+        "symbol": "005930",
+        "interval": "1d",
+        "count": "1",
+        "adjusted": "true",
+    }
+    assert page.next_before == "2026-06-11T00:00:00.000+09:00"
+    assert page.candles[0].close_price == Decimal("326000")
+

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -273,4 +273,3 @@ async def test_candles_returns_typed_page_and_sends_query_params() -> None:
     }
     assert page.next_before == "2026-06-11T00:00:00.000+09:00"
     assert page.candles[0].close_price == Decimal("326000")
-

--- a/tests/services/brokers/toss/test_dto.py
+++ b/tests/services/brokers/toss/test_dto.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 import pytest
 
 from app.services.brokers.toss.dto import (
+    parse_candles,
     parse_decimal_string,
     parse_holdings,
     parse_orders,
@@ -125,3 +126,49 @@ def test_parse_orders_converts_execution_decimals() -> None:
 
     assert orders.orders[0].status == "FUTURE_STATUS"
     assert orders.orders[0].execution["commission"] == Decimal("0.10")
+
+
+def test_parse_candles_converts_decimal_strings_and_cursor() -> None:
+    page = parse_candles(
+        {
+            "candles": [
+                {
+                    "timestamp": "2026-06-12T09:14:00.000+09:00",
+                    "openPrice": "330250",
+                    "highPrice": "330500",
+                    "lowPrice": "330000",
+                    "closePrice": "330500",
+                    "volume": "10276",
+                    "currency": "KRW",
+                }
+            ],
+            "nextBefore": "2026-06-12T09:13:00.000+09:00",
+        }
+    )
+
+    assert page.next_before == "2026-06-12T09:13:00.000+09:00"
+    assert page.candles[0].timestamp == "2026-06-12T09:14:00.000+09:00"
+    assert page.candles[0].open_price == Decimal("330250")
+    assert page.candles[0].close_price == Decimal("330500")
+    assert page.candles[0].volume == Decimal("10276")
+    assert page.candles[0].currency == "KRW"
+
+
+def test_parse_candles_rejects_float_prices() -> None:
+    with pytest.raises(TypeError, match="float"):
+        parse_candles(
+            {
+                "candles": [
+                    {
+                        "timestamp": "2026-06-12T09:14:00.000+09:00",
+                        "openPrice": 330250.0,
+                        "highPrice": "330500",
+                        "lowPrice": "330000",
+                        "closePrice": "330500",
+                        "volume": "10276",
+                        "currency": "KRW",
+                    }
+                ],
+                "nextBefore": None,
+            }
+        )

--- a/tests/test_kr_candles_sync.py
+++ b/tests/test_kr_candles_sync.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pandas as pd
 import pytest
 
 
@@ -297,3 +298,113 @@ def test_kr_candles_task_cron_remains_ten_minutes() -> None:
 
     assert 'task_name="candles.kr.sync"' in content
     assert '"cron": "*/10 * * * 1-5"' in content
+
+
+@pytest.mark.asyncio
+async def test_run_kr_candles_sync_passes_source(monkeypatch):
+    from app.jobs import kr_candles
+
+    sync_mock = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(kr_candles, "sync_kr_candles", sync_mock)
+
+    result = await kr_candles.run_kr_candles_sync(mode="incremental", source="toss")
+
+    sync_mock.assert_awaited_once_with(mode="incremental", sessions=10, user_id=1, source="toss")
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_sync_kr_candles_cli_accepts_source(monkeypatch):
+    from scripts import sync_kr_candles
+
+    run_mock = AsyncMock(return_value={"status": "completed", "success": True})
+    monkeypatch.setattr(sync_kr_candles, "run_kr_candles_sync", run_mock)
+
+    code = await sync_kr_candles.main(["--mode", "incremental", "--source", "toss"])
+
+    assert code == 0
+    run_mock.assert_awaited_once()
+    assert run_mock.await_args.kwargs["source"] == "toss"
+
+
+@pytest.mark.asyncio
+async def test_sync_kr_candles_toss_source_warning(monkeypatch):
+    from app.services.kr_candles_sync_service import sync_kr_candles
+
+    class DummyKISClient:
+        async def fetch_my_stocks(self):
+            return [{"pdno": "005930"}]
+
+    class DummyManualHoldingsService:
+        def __init__(self, session):
+            self.session = session
+
+        async def get_holdings_by_user(self, *, user_id, market_type):
+            return []
+
+    class DummySession:
+        async def commit(self):
+            return None
+
+        async def rollback(self):
+            return None
+
+        async def close(self):
+            return None
+
+    session = DummySession()
+    toss_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=1)
+
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.KISClient",
+        DummyKISClient,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.ManualHoldingsService",
+        DummyManualHoldingsService,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.AsyncSessionLocal",
+        lambda: session,
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service._load_universe_context",
+        AsyncMock(
+            return_value=(
+                [_make_universe_row("005930", nxt_eligible=True, is_active=True)],
+                True,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service.fetch_kr_intraday_toss_frame",
+        AsyncMock(return_value=toss_df),
+    )
+    monkeypatch.setattr(
+        "app.services.kr_candles_sync_service._upsert_rows",
+        upsert_mock,
+    )
+
+    result = await sync_kr_candles(mode="incremental", source="toss")
+
+    assert result["source"] == "toss"
+    assert result["rows_upserted"] == 1
+    assert result["symbol_venues_total"] == 1
+    assert result["pairs_processed"] == 1
+    assert any("provider source column" in w for w in result.get("warnings", []))
+    upsert_mock.assert_awaited_once()
+
+

--- a/tests/test_kr_candles_sync.py
+++ b/tests/test_kr_candles_sync.py
@@ -309,7 +309,9 @@ async def test_run_kr_candles_sync_passes_source(monkeypatch):
 
     result = await kr_candles.run_kr_candles_sync(mode="incremental", source="toss")
 
-    sync_mock.assert_awaited_once_with(mode="incremental", sessions=10, user_id=1, source="toss")
+    sync_mock.assert_awaited_once_with(
+        mode="incremental", sessions=10, user_id=1, source="toss"
+    )
     assert result["success"] is True
 
 
@@ -406,5 +408,3 @@ async def test_sync_kr_candles_toss_source_warning(monkeypatch):
     assert result["pairs_processed"] == 1
     assert any("provider source column" in w for w in result.get("warnings", []))
     upsert_mock.assert_awaited_once()
-
-

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1273,3 +1273,123 @@ async def test_fetch_kr_intraday_toss_frame_aggregates_1m_to_5m(monkeypatch):
     assert frame.iloc[0]["close"] == 107.0
     assert frame.iloc[0]["volume"] == 150.0
 
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_kr_intraday_uses_toss_first(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    toss_mock = AsyncMock(return_value=df)
+    kis_mock = AsyncMock(side_effect=AssertionError("KIS fallback should not run"))
+    monkeypatch.setattr(market_data_service, "fetch_kr_intraday_toss_frame", toss_mock)
+    monkeypatch.setattr(market_data_service, "read_kr_intraday_candles", kis_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "005930",
+        "kr",
+        "1m",
+        count=10,
+    )
+
+    toss_mock.assert_awaited_once_with(
+        symbol="005930",
+        period="1m",
+        count=10,
+        end_date=None,
+    )
+    assert candles[0].source == "toss"
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_kr_intraday_falls_back_to_kis_when_toss_fails(monkeypatch):
+    fallback_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_kr_intraday_toss_frame",
+        AsyncMock(side_effect=RuntimeError("toss disabled")),
+    )
+    read_mock = AsyncMock(return_value=fallback_df)
+    monkeypatch.setattr(market_data_service, "read_kr_intraday_candles", read_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "005930",
+        "kr",
+        "5m",
+        count=10,
+    )
+
+    read_mock.assert_awaited_once_with(
+        symbol="005930",
+        period="5m",
+        count=10,
+        end_date=None,
+    )
+    assert candles[0].source == "kis"
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_us_day_uses_toss_when_yahoo_fails(monkeypatch):
+    toss_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 13:00:00"),
+                "open": 293.72,
+                "high": 297.0,
+                "low": 289.59,
+                "close": 295.63,
+                "volume": 32125204.0,
+                "value": 9497000000.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_yahoo_ohlcv",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+    toss_mock = AsyncMock(return_value=toss_df)
+    monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+
+    candles = await market_data_service.get_ohlcv("AAPL", "us", "day", count=5)
+
+    toss_mock.assert_awaited_once_with(symbol="AAPL", count=5, end_date=None)
+    assert candles[0].source == "toss"
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_us_week_does_not_use_toss_fallback(monkeypatch):
+    from app.services.domain_errors import UpstreamUnavailableError
+
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_yahoo_ohlcv",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+    toss_mock = AsyncMock()
+    monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+
+    with pytest.raises(UpstreamUnavailableError):
+        await market_data_service.get_ohlcv("AAPL", "us", "week", count=5)
+
+    toss_mock.assert_not_awaited()

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1183,3 +1183,93 @@ def test_market_data_exports_get_short_interest() -> None:
     assert getattr(market_data, "get_short_interest", None) is getattr(
         market_data_service, "get_short_interest", None
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_intraday_toss_frame_aggregates_1m_to_5m(monkeypatch):
+    from app.services.market_data import toss_ohlcv
+
+    one_minute = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "date": dt.date(2026, 6, 12),
+                "time": dt.time(9, 0),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.0,
+                "volume": 10.0,
+                "value": 1000.0,
+            },
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:01:00"),
+                "date": dt.date(2026, 6, 12),
+                "time": dt.time(9, 1),
+                "open": 100.0,
+                "high": 105.0,
+                "low": 98.0,
+                "close": 104.0,
+                "volume": 20.0,
+                "value": 2080.0,
+            },
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:02:00"),
+                "date": dt.date(2026, 6, 12),
+                "time": dt.time(9, 2),
+                "open": 104.0,
+                "high": 106.0,
+                "low": 103.0,
+                "close": 105.0,
+                "volume": 30.0,
+                "value": 3150.0,
+            },
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:03:00"),
+                "date": dt.date(2026, 6, 12),
+                "time": dt.time(9, 3),
+                "open": 105.0,
+                "high": 107.0,
+                "low": 104.0,
+                "close": 106.0,
+                "volume": 40.0,
+                "value": 4240.0,
+            },
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:04:00"),
+                "date": dt.date(2026, 6, 12),
+                "time": dt.time(9, 4),
+                "open": 106.0,
+                "high": 108.0,
+                "low": 105.0,
+                "close": 107.0,
+                "volume": 50.0,
+                "value": 5350.0,
+            },
+        ]
+    )
+
+    class FakeClient:
+        async def aclose(self): ...
+
+    monkeypatch.setattr(toss_ohlcv.TossReadClient, "from_settings", lambda: FakeClient())
+    monkeypatch.setattr(
+        toss_ohlcv,
+        "fetch_toss_candles_frame",
+        AsyncMock(return_value=one_minute),
+    )
+
+    frame = await toss_ohlcv.fetch_kr_intraday_toss_frame(
+        symbol="005930",
+        period="5m",
+        count=1,
+        end_date=None,
+    )
+
+    assert len(frame) == 1
+    assert frame.iloc[0]["open"] == 100.0
+    assert frame.iloc[0]["high"] == 108.0
+    assert frame.iloc[0]["low"] == 98.0
+    assert frame.iloc[0]["close"] == 107.0
+    assert frame.iloc[0]["volume"] == 150.0
+

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1252,7 +1252,9 @@ async def test_fetch_kr_intraday_toss_frame_aggregates_1m_to_5m(monkeypatch):
     class FakeClient:
         async def aclose(self): ...
 
-    monkeypatch.setattr(toss_ohlcv.TossReadClient, "from_settings", lambda: FakeClient())
+    monkeypatch.setattr(
+        toss_ohlcv.TossReadClient, "from_settings", lambda: FakeClient()
+    )
     monkeypatch.setattr(
         toss_ohlcv,
         "fetch_toss_candles_frame",
@@ -1347,6 +1349,7 @@ async def test_get_ohlcv_kr_intraday_falls_back_to_kis_when_toss_fails(monkeypat
         end_date=None,
     )
     assert candles[0].source == "kis"
+
 
 @pytest.mark.asyncio
 async def test_get_ohlcv_us_day_uses_toss_when_yahoo_fails(monkeypatch):

--- a/tests/test_mcp_ohlcv_tools.py
+++ b/tests/test_mcp_ohlcv_tools.py
@@ -572,7 +572,6 @@ async def test_get_ohlcv_us_equity_returns_error_payload(monkeypatch):
     }
 
 
-
 # ============================================================================
 # Korean Equity OHLCV Tests
 # ============================================================================
@@ -1163,6 +1162,7 @@ async def test_get_ohlcv_market_us_rejects_crypto_prefix():
     ):
         await tools["get_ohlcv"]("KRW-BTC", market="us")
 
+
 @pytest.mark.asyncio
 async def test_get_ohlcv_kr_intraday_uses_toss_first_in_mcp(monkeypatch):
     tools = build_tools()
@@ -1209,7 +1209,9 @@ async def test_get_ohlcv_us_day_uses_toss_fallback_in_mcp(monkeypatch):
             }
         ]
     )
-    monkeypatch.setattr(market_data_quotes, "fetch_daily_toss_frame", AsyncMock(return_value=toss_df))
+    monkeypatch.setattr(
+        market_data_quotes, "fetch_daily_toss_frame", AsyncMock(return_value=toss_df)
+    )
 
     result = await tools["get_ohlcv"]("AAPL", market="us", period="day", count=5)
 

--- a/tests/test_mcp_ohlcv_tools.py
+++ b/tests/test_mcp_ohlcv_tools.py
@@ -554,6 +554,13 @@ async def test_get_ohlcv_us_equity_returns_error_payload(monkeypatch):
     tools = build_tools()
     mock_fetch = AsyncMock(side_effect=RuntimeError("yahoo timeout"))
     monkeypatch.setattr(yahoo_service, "fetch_ohlcv", mock_fetch)
+    # Toss is also tried as fallback for day period; mock it to also fail so the
+    # original Yahoo error propagates (week period skips Toss fallback entirely)
+    monkeypatch.setattr(
+        market_data_quotes,
+        "fetch_daily_toss_frame",
+        AsyncMock(side_effect=RuntimeError("yahoo timeout")),
+    )
 
     result = await tools["get_ohlcv"]("AAPL", count=5)
 
@@ -563,6 +570,7 @@ async def test_get_ohlcv_us_equity_returns_error_payload(monkeypatch):
         "symbol": "AAPL",
         "instrument_type": "equity_us",
     }
+
 
 
 # ============================================================================
@@ -1154,3 +1162,56 @@ async def test_get_ohlcv_market_us_rejects_crypto_prefix():
         ValueError, match="us equity symbols must not include KRW-/USDT- prefix"
     ):
         await tools["get_ohlcv"]("KRW-BTC", market="us")
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_kr_intraday_uses_toss_first_in_mcp(monkeypatch):
+    tools = build_tools()
+    df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    toss_mock = AsyncMock(return_value=df)
+    monkeypatch.setattr(market_data_quotes, "fetch_kr_intraday_toss_frame", toss_mock)
+
+    result = await tools["get_ohlcv"]("005930", market="kr", period="1m", count=5)
+
+    assert result["source"] == "toss"
+    assert result["rows"][0]["close"] == 105.0
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_us_day_uses_toss_fallback_in_mcp(monkeypatch):
+    tools = build_tools()
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_ohlcv",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+    toss_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 13:00:00"),
+                "open": 293.72,
+                "high": 297.0,
+                "low": 289.59,
+                "close": 295.63,
+                "volume": 32125204.0,
+                "value": 9497000000.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(market_data_quotes, "fetch_daily_toss_frame", AsyncMock(return_value=toss_df))
+
+    result = await tools["get_ohlcv"]("AAPL", market="us", period="day", count=5)
+
+    assert result["source"] == "toss"
+    assert result["rows"][0]["close"] == 295.63

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -176,8 +176,11 @@ async def test_service_close_awaits_callbacks():
 
 @pytest.mark.asyncio
 async def test_kr_empty_kis_falls_back_to_toss_daily():
-    from app.services.daily_candles.sync_service import DailyCandleSyncService, SyncTarget
     from app.services.daily_candles.repository import MarketKey
+    from app.services.daily_candles.sync_service import (
+        DailyCandleSyncService,
+        SyncTarget,
+    )
 
     upserted_rows = []
 
@@ -213,8 +216,11 @@ async def test_kr_empty_kis_falls_back_to_toss_daily():
 
 @pytest.mark.asyncio
 async def test_us_empty_kis_and_yahoo_falls_back_to_toss_daily():
-    from app.services.daily_candles.sync_service import DailyCandleSyncService, SyncTarget
     from app.services.daily_candles.repository import MarketKey
+    from app.services.daily_candles.sync_service import (
+        DailyCandleSyncService,
+        SyncTarget,
+    )
 
     upserted_rows = []
 

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -200,7 +200,17 @@ async def test_kr_empty_kis_falls_back_to_toss_daily():
         upbit_crypto_fetcher=AsyncMock(),
         toss_kr_fetcher=AsyncMock(
             return_value=pd.DataFrame(
-                [{"date": "2026-06-12", "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10, "value": 20}]
+                [
+                    {
+                        "date": "2026-06-12",
+                        "open": 1,
+                        "high": 2,
+                        "low": 1,
+                        "close": 2,
+                        "volume": 10,
+                        "value": 20,
+                    }
+                ]
             )
         ),
     )
@@ -240,7 +250,17 @@ async def test_us_empty_kis_and_yahoo_falls_back_to_toss_daily():
         upbit_crypto_fetcher=AsyncMock(),
         toss_us_fetcher=AsyncMock(
             return_value=pd.DataFrame(
-                [{"date": "2026-06-12", "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10, "value": 20}]
+                [
+                    {
+                        "date": "2026-06-12",
+                        "open": 1,
+                        "high": 2,
+                        "low": 1,
+                        "close": 2,
+                        "volume": 10,
+                        "value": 20,
+                    }
+                ]
             )
         ),
     )
@@ -252,5 +272,3 @@ async def test_us_empty_kis_and_yahoo_falls_back_to_toss_daily():
 
     assert result.fallback_used is True
     assert upserted_rows[0].source == "toss_fallback"
-
-

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -172,3 +172,79 @@ async def test_service_close_awaits_callbacks():
     await svc.close()
 
     close_callback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_kr_empty_kis_falls_back_to_toss_daily():
+    from app.services.daily_candles.sync_service import DailyCandleSyncService, SyncTarget
+    from app.services.daily_candles.repository import MarketKey
+
+    upserted_rows = []
+
+    class Repo:
+        session = AsyncMock()
+
+        async def upsert_rows(self, *, market, rows):
+            upserted_rows.extend(rows)
+            return len(rows)
+
+    Repo.session.commit = AsyncMock()
+    svc = DailyCandleSyncService(
+        repository=Repo(),
+        kis_kr_fetcher=AsyncMock(return_value=pd.DataFrame()),
+        kis_us_fetcher=AsyncMock(),
+        yahoo_us_fetcher=AsyncMock(),
+        upbit_crypto_fetcher=AsyncMock(),
+        toss_kr_fetcher=AsyncMock(
+            return_value=pd.DataFrame(
+                [{"date": "2026-06-12", "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10, "value": 20}]
+            )
+        ),
+    )
+
+    result = await svc.sync_one(
+        target=SyncTarget(market=MarketKey.KR, symbol="005930", partition="KRX"),
+        horizon_bars=1,
+    )
+
+    assert result.fallback_used is True
+    assert upserted_rows[0].source == "toss"
+
+
+@pytest.mark.asyncio
+async def test_us_empty_kis_and_yahoo_falls_back_to_toss_daily():
+    from app.services.daily_candles.sync_service import DailyCandleSyncService, SyncTarget
+    from app.services.daily_candles.repository import MarketKey
+
+    upserted_rows = []
+
+    class Repo:
+        session = AsyncMock()
+
+        async def upsert_rows(self, *, market, rows):
+            upserted_rows.extend(rows)
+            return len(rows)
+
+    Repo.session.commit = AsyncMock()
+    svc = DailyCandleSyncService(
+        repository=Repo(),
+        kis_kr_fetcher=AsyncMock(),
+        kis_us_fetcher=AsyncMock(return_value=pd.DataFrame()),
+        yahoo_us_fetcher=AsyncMock(return_value=[]),
+        upbit_crypto_fetcher=AsyncMock(),
+        toss_us_fetcher=AsyncMock(
+            return_value=pd.DataFrame(
+                [{"date": "2026-06-12", "open": 1, "high": 2, "low": 1, "close": 2, "volume": 10, "value": 20}]
+            )
+        ),
+    )
+
+    result = await svc.sync_one(
+        target=SyncTarget(market=MarketKey.US, symbol="AAPL", partition="NASD"),
+        horizon_bars=1,
+    )
+
+    assert result.fallback_used is True
+    assert upserted_rows[0].source == "toss_fallback"
+
+

--- a/tests/unit/services/daily_candles/test_toss_daily_fetcher.py
+++ b/tests/unit/services/daily_candles/test_toss_daily_fetcher.py
@@ -62,7 +62,15 @@ async def test_fetch_kr_daily_toss_returns_frame_for_single_page():
 
     assert isinstance(frame, pd.DataFrame)
     assert len(frame) == 2
-    assert list(frame.columns) == ["date", "open", "high", "low", "close", "volume", "value"]
+    assert list(frame.columns) == [
+        "date",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "value",
+    ]
     assert client.calls[0]["symbol"] == "005930"
     assert client.calls[0]["interval"] == "1d"
     assert client.calls[0]["adjusted"] is True

--- a/tests/unit/services/daily_candles/test_toss_daily_fetcher.py
+++ b/tests/unit/services/daily_candles/test_toss_daily_fetcher.py
@@ -1,0 +1,92 @@
+"""Unit tests for Toss daily candle fetcher.
+
+TDD: these tests are written first and will drive the implementation in
+app/services/daily_candles/toss_daily_fetcher.py.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from app.services.brokers.toss.dto import TossCandle, TossCandlesPage
+from app.services.daily_candles.toss_daily_fetcher import fetch_kr_daily_toss
+
+
+class FakeTossClient:
+    def __init__(self, pages: list[TossCandlesPage]) -> None:
+        self._pages = iter(pages)
+        self.calls: list[dict] = []
+
+    async def candles(self, symbol, *, interval, count, before=None, adjusted=None):
+        self.calls.append(
+            {
+                "symbol": symbol,
+                "interval": interval,
+                "count": count,
+                "before": before,
+                "adjusted": adjusted,
+            }
+        )
+        return next(self._pages)
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _make_page(dates: list[str], next_before: str | None = None) -> TossCandlesPage:
+    return TossCandlesPage(
+        candles=[
+            TossCandle(
+                timestamp=f"{d}T00:00:00.000+09:00",
+                open_price=Decimal("100"),
+                high_price=Decimal("110"),
+                low_price=Decimal("90"),
+                close_price=Decimal("105"),
+                volume=Decimal("1000"),
+                currency="KRW",
+            )
+            for d in dates
+        ],
+        next_before=next_before,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_daily_toss_returns_frame_for_single_page():
+    client = FakeTossClient(pages=[_make_page(["2026-06-12", "2026-06-11"])])
+
+    frame = await fetch_kr_daily_toss(client=client, symbol="005930", n=2)
+
+    assert isinstance(frame, pd.DataFrame)
+    assert len(frame) == 2
+    assert list(frame.columns) == ["date", "open", "high", "low", "close", "volume", "value"]
+    assert client.calls[0]["symbol"] == "005930"
+    assert client.calls[0]["interval"] == "1d"
+    assert client.calls[0]["adjusted"] is True
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_daily_toss_paginates_until_n_bars():
+    client = FakeTossClient(
+        pages=[
+            _make_page(["2026-06-12"], next_before="2026-06-11T00:00:00.000+09:00"),
+            _make_page(["2026-06-11"], next_before=None),
+        ]
+    )
+
+    frame = await fetch_kr_daily_toss(client=client, symbol="005930", n=2)
+
+    assert len(frame) == 2
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_kr_daily_toss_returns_empty_frame_when_no_data():
+    client = FakeTossClient(pages=[TossCandlesPage(candles=[], next_before=None)])
+
+    frame = await fetch_kr_daily_toss(client=client, symbol="005930", n=5)
+
+    assert frame.empty


### PR DESCRIPTION
## Summary

- Adds typed Toss candle parsing, DataFrame normalization, and bounded candle pagination helpers.
- Wires Toss as a KR intraday OHLCV first source with DB/KIS fallback, plus US daily and daily-candle sync fallback paths.
- Adds an explicit `--source toss` KR minute sync option with a provenance warning, and documents the final MCP OHLCV routing.

## Why

KIS KR minute candles have a known `time_unit` issue where different requested intervals can return the same data. Toss provides verified `1m` and `1d` candles, so ROB-537 uses Toss `1m` as the auxiliary source and reuses existing aggregation logic for higher intraday intervals.

## Validation

- `uv run pytest tests/services/brokers/toss tests/test_market_data_service.py -k "get_ohlcv or toss" tests/test_mcp_ohlcv_tools.py tests/unit/services/daily_candles tests/test_kr_candles_sync.py -q`
- `uv run ruff check app/services/brokers/toss app/services/market_data app/services/daily_candles app/mcp_server/tooling/market_data_quotes.py app/services/kr_candles_sync_service.py app/jobs/kr_candles.py scripts/sync_kr_candles.py tests/services/brokers/toss tests/test_market_data_service.py tests/test_mcp_ohlcv_tools.py tests/unit/services/daily_candles tests/test_kr_candles_sync.py`

## Risk Notes

- No DB migration is included.
- KR minute Toss sync stores explicit `source=toss` runs under `venue='KRX'` because `kr_candles_1m` has no provider source column; the command returns a warning to avoid treating venue as provider provenance.
