### PR TITLE
[codex] ROB-534 Toss Symbol Master + Market Cap

### DIFF
--- a/alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py
+++ b/alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py
@@ -1,0 +1,68 @@
+"""ROB-534 add Toss symbol master fields and valuation source
+
+Revision ID: 20260612_rob534
+Revises: 20260611_rob516_rob512_merge
+Create Date: 2026-06-12 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260612_rob534"
+down_revision = "20260611_rob516_rob512_merge"
+branch_labels = None
+depends_on = None
+
+
+def _add_common_columns(table: str, *, kr: bool) -> None:
+    op.add_column(table, sa.Column("security_type", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("is_common_share", sa.Boolean(), nullable=True))
+    op.add_column(table, sa.Column("listing_status", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("list_date", sa.Date(), nullable=True))
+    op.add_column(table, sa.Column("delist_date", sa.Date(), nullable=True))
+    op.add_column(table, sa.Column("shares_outstanding", sa.Numeric(30, 0), nullable=True))
+    op.add_column(table, sa.Column("leverage_factor", sa.Numeric(12, 6), nullable=True))
+    if kr:
+        op.add_column(table, sa.Column("krx_trading_suspended", sa.Boolean(), nullable=True))
+        op.add_column(table, sa.Column("nxt_trading_suspended", sa.Boolean(), nullable=True))
+    op.add_column(table, sa.Column("isin", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("toss_master_updated_at", sa.TIMESTAMP(timezone=True), nullable=True))
+
+
+def _drop_common_columns(table: str, *, kr: bool) -> None:
+    op.drop_column(table, "toss_master_updated_at")
+    op.drop_column(table, "isin")
+    if kr:
+        op.drop_column(table, "nxt_trading_suspended")
+        op.drop_column(table, "krx_trading_suspended")
+    op.drop_column(table, "leverage_factor")
+    op.drop_column(table, "shares_outstanding")
+    op.drop_column(table, "delist_date")
+    op.drop_column(table, "list_date")
+    op.drop_column(table, "listing_status")
+    op.drop_column(table, "is_common_share")
+    op.drop_column(table, "security_type")
+
+
+def upgrade() -> None:
+    _add_common_columns("kr_symbol_universe", kr=True)
+    _add_common_columns("us_symbol_universe", kr=False)
+    op.drop_constraint("ck_market_valuation_snapshots_source", "market_valuation_snapshots", type_="check")
+    op.create_check_constraint(
+        "ck_market_valuation_snapshots_source",
+        "market_valuation_snapshots",
+        "source IN ('naver_finance', 'yahoo', 'toss_openapi')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_market_valuation_snapshots_source", "market_valuation_snapshots", type_="check")
+    op.create_check_constraint(
+        "ck_market_valuation_snapshots_source",
+        "market_valuation_snapshots",
+        "source IN ('naver_finance', 'yahoo')",
+    )
+    _drop_common_columns("us_symbol_universe", kr=False)
+    _drop_common_columns("kr_symbol_universe", kr=True)

--- a/app/models/kr_symbol_universe.py
+++ b/app/models/kr_symbol_universe.py
@@ -1,6 +1,17 @@
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 
-from sqlalchemy import TIMESTAMP, Boolean, ForeignKey, Index, Integer, String, func
+from sqlalchemy import (
+    TIMESTAMP,
+    Boolean,
+    Date,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    func,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -26,6 +37,23 @@ class KRSymbolUniverse(Base):
         Integer, ForeignKey("symbol_sectors.id"), nullable=True
     )
     sector_updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    security_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    is_common_share: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    listing_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    list_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    delist_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    shares_outstanding: Mapped[Decimal | None] = mapped_column(
+        Numeric(30, 0), nullable=True
+    )
+    leverage_factor: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 6), nullable=True
+    )
+    krx_trading_suspended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    nxt_trading_suspended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    isin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    toss_master_updated_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(

--- a/app/models/market_valuation_snapshot.py
+++ b/app/models/market_valuation_snapshot.py
@@ -33,7 +33,7 @@ class MarketValuationSnapshot(Base):
             name="ck_market_valuation_snapshots_market",
         ),
         CheckConstraint(
-            "source IN ('naver_finance', 'yahoo')",
+            "source IN ('naver_finance', 'yahoo', 'toss_openapi')",
             name="ck_market_valuation_snapshots_source",
         ),
         Index(

--- a/app/models/us_symbol_universe.py
+++ b/app/models/us_symbol_universe.py
@@ -1,11 +1,14 @@
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 
 from sqlalchemy import (
     TIMESTAMP,
     Boolean,
+    Date,
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     String,
     func,
     text,
@@ -42,6 +45,21 @@ class USSymbolUniverse(Base):
         Integer, ForeignKey("symbol_sectors.id"), nullable=True
     )
     sector_updated_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    security_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    is_common_share: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    listing_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    list_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    delist_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    shares_outstanding: Mapped[Decimal | None] = mapped_column(
+        Numeric(30, 0), nullable=True
+    )
+    leverage_factor: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 6), nullable=True
+    )
+    isin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    toss_master_updated_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -391,6 +391,25 @@ def _is_kr_toss_common_stock(symbol: str, name: str | None) -> bool:
     return True
 
 
+def _is_toss_common_stock_row(
+    *,
+    symbol: str,
+    name: str | None,
+    security_type: str | None,
+    is_common_share: bool | None,
+    trading_suspended: bool | None,
+) -> bool:
+    if trading_suspended is True:
+        return False
+    if security_type is not None and security_type.upper() not in {"STOCK", "REIT"}:
+        return False
+    if is_common_share is False:
+        return False
+    if is_common_share is True:
+        return True
+    return _is_kr_toss_common_stock(symbol, name)
+
+
 def _external_failure_warning(exc: BaseException) -> str:
     # Keep provider hostnames/tokens out of logs and user-facing warnings; the
     # error class is enough to diagnose transient DNS/network failures here.
@@ -539,6 +558,7 @@ async def _load_consecutive_gainers_from_snapshots(
     candidate_snaps = result.scalars().all()
 
     symbol_names: dict[str, str] = {}
+    symbol_meta: dict[str, dict[str, Any]] = {}
     sector_map: dict[str, str] = {}
     if market == "kr" and candidate_snaps:
         from app.models.kr_symbol_universe import KRSymbolUniverse
@@ -552,6 +572,10 @@ async def _load_consecutive_gainers_from_snapshots(
                     KRSymbolUniverse.name,
                     SymbolSector.name_kr.label("sector_name_kr"),
                     SymbolSector.name_en.label("sector_name_en"),
+                    KRSymbolUniverse.security_type,
+                    KRSymbolUniverse.is_common_share,
+                    KRSymbolUniverse.krx_trading_suspended,
+                    KRSymbolUniverse.nxt_trading_suspended,
                 )
                 .outerjoin(SymbolSector, KRSymbolUniverse.sector_id == SymbolSector.id)
                 .where(
@@ -561,6 +585,15 @@ async def _load_consecutive_gainers_from_snapshots(
             )
             _name_rows = name_result.all()
             symbol_names = {row.symbol: row.name for row in _name_rows}
+            symbol_meta = {
+                row.symbol: {
+                    "security_type": row.security_type,
+                    "is_common_share": row.is_common_share,
+                    "krx_trading_suspended": row.krx_trading_suspended,
+                    "nxt_trading_suspended": row.nxt_trading_suspended,
+                }
+                for row in _name_rows
+            }
             sector_map = {
                 row.symbol: label
                 for row in _name_rows
@@ -662,8 +695,14 @@ async def _load_consecutive_gainers_from_snapshots(
     for snap in candidate_snaps:
         if snap.symbol in seen:
             continue
-        if market == "kr" and not _is_kr_toss_common_stock(
-            snap.symbol, symbol_names.get(snap.symbol)
+        meta = symbol_meta.get(snap.symbol, {})
+        if market == "kr" and not _is_toss_common_stock_row(
+            symbol=snap.symbol,
+            name=symbol_names.get(snap.symbol),
+            security_type=meta.get("security_type"),
+            is_common_share=meta.get("is_common_share"),
+            trading_suspended=meta.get("krx_trading_suspended")
+            or meta.get("nxt_trading_suspended"),
         ):
             continue
         seen.add(snap.symbol)
@@ -817,6 +856,7 @@ async def _load_investor_flow_discovery_from_snapshots(
     candidate_snaps = result.scalars().all()
 
     symbol_names: dict[str, str] = {}
+    symbol_meta: dict[str, dict[str, Any]] = {}
     sector_map: dict[str, str] = {}
     if candidate_snaps:
         from app.models.kr_symbol_universe import KRSymbolUniverse
@@ -830,6 +870,10 @@ async def _load_investor_flow_discovery_from_snapshots(
                     KRSymbolUniverse.name,
                     SymbolSector.name_kr.label("sector_name_kr"),
                     SymbolSector.name_en.label("sector_name_en"),
+                    KRSymbolUniverse.security_type,
+                    KRSymbolUniverse.is_common_share,
+                    KRSymbolUniverse.krx_trading_suspended,
+                    KRSymbolUniverse.nxt_trading_suspended,
                 )
                 .outerjoin(SymbolSector, KRSymbolUniverse.sector_id == SymbolSector.id)
                 .where(
@@ -839,6 +883,15 @@ async def _load_investor_flow_discovery_from_snapshots(
             )
             _name_rows = name_result.all()
             symbol_names = {row.symbol: row.name for row in _name_rows}
+            symbol_meta = {
+                row.symbol: {
+                    "security_type": row.security_type,
+                    "is_common_share": row.is_common_share,
+                    "krx_trading_suspended": row.krx_trading_suspended,
+                    "nxt_trading_suspended": row.nxt_trading_suspended,
+                }
+                for row in _name_rows
+            }
             sector_map = {
                 row.symbol: label
                 for row in _name_rows
@@ -962,7 +1015,15 @@ async def _load_investor_flow_discovery_from_snapshots(
     for snap in candidate_snaps:
         if snap.symbol in seen:
             continue
-        if not _is_kr_toss_common_stock(snap.symbol, symbol_names.get(snap.symbol)):
+        meta = symbol_meta.get(snap.symbol, {})
+        if not _is_toss_common_stock_row(
+            symbol=snap.symbol,
+            name=symbol_names.get(snap.symbol),
+            security_type=meta.get("security_type"),
+            is_common_share=meta.get("is_common_share"),
+            trading_suspended=meta.get("krx_trading_suspended")
+            or meta.get("nxt_trading_suspended"),
+        ):
             continue
         seen.add(snap.symbol)
         state = classify_investor_flow_partition(

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -587,10 +587,14 @@ async def _load_consecutive_gainers_from_snapshots(
             symbol_names = {row.symbol: row.name for row in _name_rows}
             symbol_meta = {
                 row.symbol: {
-                    "security_type": row.security_type,
-                    "is_common_share": row.is_common_share,
-                    "krx_trading_suspended": row.krx_trading_suspended,
-                    "nxt_trading_suspended": row.nxt_trading_suspended,
+                    "security_type": getattr(row, "security_type", None),
+                    "is_common_share": getattr(row, "is_common_share", None),
+                    "krx_trading_suspended": getattr(
+                        row, "krx_trading_suspended", None
+                    ),
+                    "nxt_trading_suspended": getattr(
+                        row, "nxt_trading_suspended", None
+                    ),
                 }
                 for row in _name_rows
             }
@@ -885,10 +889,14 @@ async def _load_investor_flow_discovery_from_snapshots(
             symbol_names = {row.symbol: row.name for row in _name_rows}
             symbol_meta = {
                 row.symbol: {
-                    "security_type": row.security_type,
-                    "is_common_share": row.is_common_share,
-                    "krx_trading_suspended": row.krx_trading_suspended,
-                    "nxt_trading_suspended": row.nxt_trading_suspended,
+                    "security_type": getattr(row, "security_type", None),
+                    "is_common_share": getattr(row, "is_common_share", None),
+                    "krx_trading_suspended": getattr(
+                        row, "krx_trading_suspended", None
+                    ),
+                    "nxt_trading_suspended": getattr(
+                        row, "nxt_trading_suspended", None
+                    ),
                 }
                 for row in _name_rows
             }

--- a/app/services/toss_symbol_master_service.py
+++ b/app/services/toss_symbol_master_service.py
@@ -237,10 +237,13 @@ async def sync_toss_symbol_master(
             if changed:
                 updates += 1
 
+    existing_stocks = {
+        symbol: stock for symbol, stock in all_stocks.items() if symbol in existing
+    }
     payloads = _market_cap_payloads(
         market=market,
         snapshot_date=snapshot_date,
-        stocks=all_stocks,
+        stocks=existing_stocks,
         prices=all_prices,
     )
     if request.commit:

--- a/app/services/toss_symbol_master_service.py
+++ b/app/services/toss_symbol_master_service.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Protocol
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.brokers.toss.dto import TossPrice, TossStockInfo
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+    MarketValuationSnapshotUpsert,
+)
+
+TOSS_VALUATION_SOURCE = "toss_openapi"
+_BATCH_SIZE = 200
+
+
+class TossSymbolMasterClient(Protocol):
+    async def stocks(
+        self, symbols: list[str] | tuple[str, ...]
+    ) -> list[TossStockInfo]: ...
+    async def prices(self, symbols: list[str] | tuple[str, ...]) -> list[TossPrice]: ...
+
+
+@dataclass(frozen=True)
+class TossSymbolMasterSyncRequest:
+    market: str
+    symbols: tuple[str, ...] = ()
+    all_symbols: bool = False
+    limit: int | None = 20
+    commit: bool = False
+    include_market_cap: bool = True
+    snapshot_date: dt.date | None = None
+
+
+@dataclass(frozen=True)
+class TossSymbolMasterSyncResult:
+    market: str
+    commit: bool
+    symbols_requested: int
+    batches: int
+    stocks_matched: int
+    stocks_missing: int
+    master_updates: int
+    market_cap_payloads: int
+    market_cap_nonnull: int
+    warnings: tuple[str, ...] = ()
+    samples: tuple[str, ...] = ()
+
+
+def _chunks(symbols: list[str], size: int = _BATCH_SIZE) -> list[list[str]]:
+    return [symbols[idx : idx + size] for idx in range(0, len(symbols), size)]
+
+
+async def _resolve_symbols(
+    db: AsyncSession,
+    *,
+    market: str,
+    symbols: tuple[str, ...],
+    all_symbols: bool,
+    limit: int | None,
+) -> list[str]:
+    if market not in {"kr", "us"}:
+        raise ValueError(f"unsupported market: {market}")
+    if symbols:
+        return [s.strip().upper() for s in symbols if s.strip()]
+    model = KRSymbolUniverse if market == "kr" else USSymbolUniverse
+    stmt = (
+        sa.select(model.symbol).where(model.is_active.is_(True)).order_by(model.symbol)
+    )
+    if not all_symbols:
+        stmt = stmt.limit(limit or 20)
+    result = await db.execute(stmt)
+    return [row[0] for row in result.all()]
+
+
+def _parse_date(value: str | None) -> dt.date | None:
+    if not value:
+        return None
+    return dt.date.fromisoformat(value[:10])
+
+
+def _kr_suspended(detail: dict | None, key: str) -> bool | None:
+    if not detail:
+        return None
+    if key in detail:
+        return bool(detail[key])
+    return None
+
+
+def _kr_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, object]:
+    return {
+        "security_type": stock.security_type,
+        "is_common_share": stock.is_common_share,
+        "listing_status": stock.status,
+        "list_date": _parse_date(stock.list_date),
+        "delist_date": _parse_date(stock.delist_date),
+        "shares_outstanding": stock.shares_outstanding,
+        "leverage_factor": stock.leverage_factor,
+        "krx_trading_suspended": _kr_suspended(
+            stock.korean_market_detail, "krxTradingSuspended"
+        ),
+        "nxt_trading_suspended": _kr_suspended(
+            stock.korean_market_detail, "nxtTradingSuspended"
+        ),
+        "isin": stock.isin_code,
+        "toss_master_updated_at": now,
+    }
+
+
+def _us_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, object]:
+    return {
+        "security_type": stock.security_type,
+        "is_common_share": stock.is_common_share,
+        "listing_status": stock.status,
+        "list_date": _parse_date(stock.list_date),
+        "delist_date": _parse_date(stock.delist_date),
+        "shares_outstanding": stock.shares_outstanding,
+        "leverage_factor": stock.leverage_factor,
+        "isin": stock.isin_code,
+        "toss_master_updated_at": now,
+        "is_common_stock": stock.is_common_share,
+    }
+
+
+def _count_or_apply(
+    row: object, assignments: dict[str, object], *, apply: bool
+) -> bool:
+    changed = False
+    for field, value in assignments.items():
+        if getattr(row, field) != value:
+            if apply:
+                setattr(row, field, value)
+            changed = True
+    return changed
+
+
+def _market_cap_payloads(
+    *,
+    market: str,
+    snapshot_date: dt.date,
+    stocks: dict[str, TossStockInfo],
+    prices: dict[str, TossPrice],
+) -> list[MarketValuationSnapshotUpsert]:
+    payloads: list[MarketValuationSnapshotUpsert] = []
+    for symbol, stock in stocks.items():
+        price = prices.get(symbol)
+        market_cap = (
+            stock.shares_outstanding * price.last_price
+            if price is not None and stock.shares_outstanding is not None
+            else None
+        )
+        if market_cap is None:
+            continue
+        payloads.append(
+            MarketValuationSnapshotUpsert(
+                market=market,
+                symbol=symbol,
+                snapshot_date=snapshot_date,
+                source=TOSS_VALUATION_SOURCE,
+                market_cap=market_cap,
+                raw_payload={
+                    "source": TOSS_VALUATION_SOURCE,
+                    "sharesOutstanding": str(stock.shares_outstanding),
+                    "lastPrice": str(price.last_price),
+                    "priceTimestamp": price.timestamp,
+                    "currency": price.currency,
+                },
+            )
+        )
+    return payloads
+
+
+async def sync_toss_symbol_master(
+    db: AsyncSession,
+    *,
+    client: TossSymbolMasterClient,
+    request: TossSymbolMasterSyncRequest,
+) -> TossSymbolMasterSyncResult:
+    market = request.market.strip().lower()
+    snapshot_date = request.snapshot_date or dt.datetime.now(dt.UTC).date()
+    symbols = await _resolve_symbols(
+        db,
+        market=market,
+        symbols=request.symbols,
+        all_symbols=request.all_symbols,
+        limit=request.limit,
+    )
+    if not symbols:
+        return TossSymbolMasterSyncResult(
+            market=market,
+            commit=request.commit,
+            symbols_requested=0,
+            batches=0,
+            stocks_matched=0,
+            stocks_missing=0,
+            master_updates=0,
+            market_cap_payloads=0,
+            market_cap_nonnull=0,
+            warnings=("no symbols resolved",),
+        )
+
+    model = KRSymbolUniverse if market == "kr" else USSymbolUniverse
+    existing_result = await db.execute(
+        sa.select(model).where(model.symbol.in_(symbols))
+    )
+    existing = {row.symbol: row for row in existing_result.scalars().all()}
+    now = dt.datetime.now(dt.UTC)
+    all_stocks: dict[str, TossStockInfo] = {}
+    all_prices: dict[str, TossPrice] = {}
+    updates = 0
+
+    batches = _chunks(symbols)
+    for batch in batches:
+        stock_rows = {row.symbol: row for row in await client.stocks(batch)}
+        price_rows = (
+            {row.symbol: row for row in await client.prices(batch)}
+            if request.include_market_cap
+            else {}
+        )
+        all_stocks.update(stock_rows)
+        all_prices.update(price_rows)
+        for symbol, stock in stock_rows.items():
+            row = existing.get(symbol)
+            if row is None:
+                continue
+            assignments = (
+                _kr_assignments(stock, now=now)
+                if market == "kr"
+                else _us_assignments(stock, now=now)
+            )
+            changed = _count_or_apply(row, assignments, apply=request.commit)
+            if changed:
+                updates += 1
+
+    payloads = _market_cap_payloads(
+        market=market,
+        snapshot_date=snapshot_date,
+        stocks=all_stocks,
+        prices=all_prices,
+    )
+    if request.commit:
+        if payloads:
+            await MarketValuationSnapshotsRepository(db).upsert(payloads)
+        await db.flush()
+
+    missing = len(set(symbols) - set(all_stocks))
+    return TossSymbolMasterSyncResult(
+        market=market,
+        commit=request.commit,
+        symbols_requested=len(symbols),
+        batches=len(batches),
+        stocks_matched=len(all_stocks),
+        stocks_missing=missing,
+        master_updates=updates,
+        market_cap_payloads=len(payloads),
+        market_cap_nonnull=len(payloads),
+        samples=tuple(symbols[:10]),
+    )

--- a/docs/invest/data-source-contract.md
+++ b/docs/invest/data-source-contract.md
@@ -85,6 +85,8 @@ Phase 4  push (ingest)
 4. **Toss screener/popular/watchlist를 보나?** `low_trust_attention` `retail_attention` 시드로만. **buy rationale 금지, primary market-data 권위 금지, account/order truth 금지.** `may_affect_ranking=False` 고정. stale screener는 "오늘 신규 후보"에서 제외하되 stale context로는 표시.
 5. **공식 리포트 flow?** 위 "공식 리포트 생성 flow" 참조 (`prepare_bundle` → `get_hermes_context` → Hermes compose → `create_from_hermes_composition`).
 6. **보조 MCP 직접 호출은 언제 흡수?** 위 "보조 MCP는 언제 collector로 흡수되나" 참조.
+7. **Toss Open API를 통한 Universe Enrichment 및 Market Cap 산출은 어떻게 이뤄지나?** `toss_openapi` 소스를 통해 `kr_symbol_universe` 및 `us_symbol_universe`에 symbol-master 메타데이터(보안구분, 보통주여부, ISIN, 상장일 등)를 보강하며, `market_valuation_snapshots` 테이블에 `source='toss_openapi'`로 일자별 시가총액(`shares_outstanding * last_price`)을 기록합니다. 이는 Scraping이 아닌 공식 Open API 보강 경로입니다.
+
 
 ## Freshness 정책 (이슈 §4)
 

--- a/docs/runbooks/toss-symbol-master-sync.md
+++ b/docs/runbooks/toss-symbol-master-sync.md
@@ -1,0 +1,33 @@
+# Toss Symbol Master Sync Runbook
+
+ROB-534 adds a dry-run-first sync for Toss Open API symbol master metadata and market-cap valuation rows.
+
+## Dry Run
+
+~~~bash
+uv run python -m scripts.sync_toss_symbol_master --market kr --limit 20
+uv run python -m scripts.sync_toss_symbol_master --market us --limit 20
+~~~
+
+Expected output includes requested symbols, matched stocks, missing stocks, master updates, and market-cap payload count. Dry-run writes no rows.
+
+## Commit
+
+Run only after reviewing dry-run coverage and after ROB-534 stronger-model/CTO migration review clears the change.
+
+~~~bash
+uv run python -m scripts.sync_toss_symbol_master --market kr --all --commit
+uv run python -m scripts.sync_toss_symbol_master --market us --all --commit
+~~~
+
+## Rollback
+
+This migration is additive for universe fields. To remove Toss-derived market-cap rows for one date:
+
+~~~sql
+DELETE FROM market_valuation_snapshots
+WHERE source = 'toss_openapi'
+  AND snapshot_date = DATE 'YYYY-MM-DD';
+~~~
+
+Do not delete existing `naver_finance` or `yahoo` valuation rows.

--- a/docs/superpowers/plans/2026-06-12-rob-534-toss-symbol-master-market-cap.md
+++ b/docs/superpowers/plans/2026-06-12-rob-534-toss-symbol-master-market-cap.md
@@ -1,0 +1,1208 @@
+# ROB-534 Toss Symbol Master + Market Cap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Populate KR/US symbol-master metadata from Toss Open API and derive daily market-cap rows as `shares_outstanding * last_price`.
+
+**Architecture:** Store stable Toss master fields on `kr_symbol_universe` / `us_symbol_universe`; store date/source-specific market-cap values in `market_valuation_snapshots` with `source='toss_openapi'`. Keep existing KRX MST / KIS COD universe discovery intact: Toss only enriches already-known universe rows. All operator entrypoints are dry-run by default and require `--commit` for writes.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async ORM, Alembic, Pydantic, httpx mock transports in tests, uv, pytest.
+
+---
+
+## File Structure
+
+- Modify: `app/models/kr_symbol_universe.py` - add Toss master columns for KR rows.
+- Modify: `app/models/us_symbol_universe.py` - add Toss master columns for US rows and keep `is_common_stock`.
+- Modify: `app/models/market_valuation_snapshot.py` - allow `source='toss_openapi'`.
+- Create: `alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py` - additive universe columns plus market valuation source constraint update.
+- Create: `app/services/toss_symbol_master_service.py` - batch orchestration, dry-run summary, universe upserts, and market-cap payload construction.
+- Create: `scripts/sync_toss_symbol_master.py` - operator CLI for dry-run/commit.
+- Modify: `app/services/invest_view_model/screener_service.py` - prefer explicit Toss common-share/security metadata over KR name heuristics when available.
+- Modify: `tests/conftest.py` - conditional schema drift columns for persistent test DBs.
+- Create: `tests/test_toss_symbol_master_service.py` - service-level tests for batch matching, dry-run, commit, and market-cap payloads.
+- Modify: `tests/services/brokers/toss/test_dto.py` - cover KR suspension detail parsing assumptions.
+- Create: `tests/test_toss_symbol_master_cli.py` - CLI defaults and output tests.
+- Create: `tests/test_toss_symbol_master_screener_filter.py` - cover explicit Toss common-share/security/suspension filter behavior.
+
+## Design Decisions
+
+- `market_cap` goes to `market_valuation_snapshots`, not universe tables.
+- `source='toss_openapi'` is added to the existing valuation source check constraint.
+- Universe rows keep both the legacy US `is_common_stock` and the Toss field `is_common_share`; the sync service fills `is_common_stock` from Toss only when the Toss value is known.
+- No scheduler activation in this issue. The deliverable is a manual dry-run-first CLI plus tested service APIs.
+- No live Toss calls in default tests. Tests use fake Toss clients.
+- This is a `high_risk_change`: implementation must not be merged/deployed or used for production backfill until stronger-model/CTO review clears migration and operator runbook.
+
+---
+
+### Task 1: Add Schema and ORM Columns
+
+**Files:**
+- Modify: `app/models/kr_symbol_universe.py`
+- Modify: `app/models/us_symbol_universe.py`
+- Modify: `app/models/market_valuation_snapshot.py`
+- Create: `alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py`
+- Modify: `tests/conftest.py`
+
+- [x] **Step 1: Write failing model/source tests**
+
+Add tests that inspect ORM columns and source constraint text.
+
+```python
+# tests/test_toss_symbol_master_schema.py
+from sqlalchemy import inspect
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+
+
+def test_kr_symbol_universe_has_toss_master_columns() -> None:
+    columns = inspect(KRSymbolUniverse).columns
+    for name in (
+        "security_type",
+        "is_common_share",
+        "listing_status",
+        "list_date",
+        "delist_date",
+        "shares_outstanding",
+        "leverage_factor",
+        "krx_trading_suspended",
+        "nxt_trading_suspended",
+        "isin",
+        "toss_master_updated_at",
+    ):
+        assert name in columns
+
+
+def test_us_symbol_universe_has_toss_master_columns() -> None:
+    columns = inspect(USSymbolUniverse).columns
+    for name in (
+        "security_type",
+        "is_common_share",
+        "listing_status",
+        "list_date",
+        "delist_date",
+        "shares_outstanding",
+        "leverage_factor",
+        "isin",
+        "toss_master_updated_at",
+    ):
+        assert name in columns
+
+
+def test_market_valuation_snapshot_allows_toss_openapi_source() -> None:
+    constraints = MarketValuationSnapshot.__table_args__
+    source_constraints = [
+        c for c in constraints if getattr(c, "name", "") == "ck_market_valuation_snapshots_source"
+    ]
+    assert len(source_constraints) == 1
+    assert "toss_openapi" in str(source_constraints[0].sqltext)
+```
+
+- [x] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_schema.py -q
+```
+
+Expected: FAIL because columns and `toss_openapi` constraint are missing.
+
+- [x] **Step 3: Update ORM models**
+
+Add imports and columns.
+
+```python
+# app/models/kr_symbol_universe.py
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import TIMESTAMP, Boolean, Date, ForeignKey, Index, Integer, Numeric, String, func
+
+security_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+is_common_share: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+listing_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+list_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+delist_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+shares_outstanding: Mapped[Decimal | None] = mapped_column(Numeric(30, 0), nullable=True)
+leverage_factor: Mapped[Decimal | None] = mapped_column(Numeric(12, 6), nullable=True)
+krx_trading_suspended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+nxt_trading_suspended: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+isin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+toss_master_updated_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+```
+
+```python
+# app/models/us_symbol_universe.py
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import TIMESTAMP, Boolean, Date, ForeignKey, Index, Integer, Numeric, String, func, text
+
+security_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+is_common_share: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+listing_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+list_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+delist_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+shares_outstanding: Mapped[Decimal | None] = mapped_column(Numeric(30, 0), nullable=True)
+leverage_factor: Mapped[Decimal | None] = mapped_column(Numeric(12, 6), nullable=True)
+isin: Mapped[str | None] = mapped_column(String(20), nullable=True)
+toss_master_updated_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+```
+
+```python
+# app/models/market_valuation_snapshot.py
+CheckConstraint(
+    "source IN ('naver_finance', 'yahoo', 'toss_openapi')",
+    name="ck_market_valuation_snapshots_source",
+),
+```
+
+- [x] **Step 4: Add Alembic migration**
+
+Create `alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py`.
+
+```python
+"""ROB-534 add Toss symbol master fields and valuation source
+
+Revision ID: 20260612_rob534
+Revises: 20260611_rob516_rob512_merge
+Create Date: 2026-06-12 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260612_rob534"
+down_revision = "20260611_rob516_rob512_merge"
+branch_labels = None
+depends_on = None
+
+
+def _add_common_columns(table: str, *, kr: bool) -> None:
+    op.add_column(table, sa.Column("security_type", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("is_common_share", sa.Boolean(), nullable=True))
+    op.add_column(table, sa.Column("listing_status", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("list_date", sa.Date(), nullable=True))
+    op.add_column(table, sa.Column("delist_date", sa.Date(), nullable=True))
+    op.add_column(table, sa.Column("shares_outstanding", sa.Numeric(30, 0), nullable=True))
+    op.add_column(table, sa.Column("leverage_factor", sa.Numeric(12, 6), nullable=True))
+    if kr:
+        op.add_column(table, sa.Column("krx_trading_suspended", sa.Boolean(), nullable=True))
+        op.add_column(table, sa.Column("nxt_trading_suspended", sa.Boolean(), nullable=True))
+    op.add_column(table, sa.Column("isin", sa.String(length=20), nullable=True))
+    op.add_column(table, sa.Column("toss_master_updated_at", sa.TIMESTAMP(timezone=True), nullable=True))
+
+
+def _drop_common_columns(table: str, *, kr: bool) -> None:
+    op.drop_column(table, "toss_master_updated_at")
+    op.drop_column(table, "isin")
+    if kr:
+        op.drop_column(table, "nxt_trading_suspended")
+        op.drop_column(table, "krx_trading_suspended")
+    op.drop_column(table, "leverage_factor")
+    op.drop_column(table, "shares_outstanding")
+    op.drop_column(table, "delist_date")
+    op.drop_column(table, "list_date")
+    op.drop_column(table, "listing_status")
+    op.drop_column(table, "is_common_share")
+    op.drop_column(table, "security_type")
+
+
+def upgrade() -> None:
+    _add_common_columns("kr_symbol_universe", kr=True)
+    _add_common_columns("us_symbol_universe", kr=False)
+    op.drop_constraint("ck_market_valuation_snapshots_source", "market_valuation_snapshots", type_="check")
+    op.create_check_constraint(
+        "ck_market_valuation_snapshots_source",
+        "market_valuation_snapshots",
+        "source IN ('naver_finance', 'yahoo', 'toss_openapi')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_market_valuation_snapshots_source", "market_valuation_snapshots", type_="check")
+    op.create_check_constraint(
+        "ck_market_valuation_snapshots_source",
+        "market_valuation_snapshots",
+        "source IN ('naver_finance', 'yahoo')",
+    )
+    _drop_common_columns("us_symbol_universe", kr=False)
+    _drop_common_columns("kr_symbol_universe", kr=True)
+```
+
+- [x] **Step 5: Patch persistent test DB drift**
+
+Add conditional column checks in `tests/conftest.py` after the existing universe drift patches. Use `ADD COLUMN IF NOT EXISTS` for universe fields and leave the check constraint to fresh `create_all`; persistent DBs that already have the old constraint should be migrated locally before DB-backed tests.
+
+- [x] **Step 6: Run migration/model checks**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_schema.py -q
+uv run alembic heads
+```
+
+Expected: tests PASS, single Alembic head is `20260612_rob534`.
+
+- [x] **Step 7: Commit**
+
+```bash
+git add app/models/kr_symbol_universe.py app/models/us_symbol_universe.py app/models/market_valuation_snapshot.py alembic/versions/20260612_rob534_toss_symbol_master_market_cap.py tests/conftest.py tests/test_toss_symbol_master_schema.py
+git commit -m "feat(ROB-534): add Toss symbol master schema"
+```
+
+---
+
+### Task 2: Build Toss Symbol Master Service
+
+**Files:**
+- Create: `app/services/toss_symbol_master_service.py`
+- Create: `tests/test_toss_symbol_master_service.py`
+
+- [x] **Step 1: Write failing service tests**
+
+Cover dry-run behavior, 200-symbol batching, KR/US updates, missing Toss rows, and market-cap payload construction.
+
+```python
+# tests/test_toss_symbol_master_service.py
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.brokers.toss.dto import TossPrice, TossStockInfo
+from app.services.toss_symbol_master_service import (
+    TossSymbolMasterSyncRequest,
+    sync_toss_symbol_master,
+)
+
+
+class FakeTossClient:
+    def __init__(self) -> None:
+        self.stock_batches: list[tuple[str, ...]] = []
+        self.price_batches: list[tuple[str, ...]] = []
+
+    async def stocks(self, symbols):
+        self.stock_batches.append(tuple(symbols))
+        out = []
+        for symbol in symbols:
+            if symbol == "MISSING":
+                continue
+            is_kr = symbol.isdigit()
+            out.append(
+                TossStockInfo(
+                    symbol=symbol,
+                    name="삼성전자" if is_kr else "Apple",
+                    english_name="Samsung Electronics" if is_kr else "Apple Inc.",
+                    isin_code="KR7005930003" if is_kr else "US0378331005",
+                    market="KR" if is_kr else "US",
+                    security_type="STOCK",
+                    is_common_share=symbol != "005935",
+                    status="ACTIVE",
+                    currency="KRW" if is_kr else "USD",
+                    list_date="1975-06-11" if is_kr else "1980-12-12",
+                    delist_date=None,
+                    shares_outstanding=Decimal("5846278608") if is_kr else Decimal("14687356000"),
+                    leverage_factor=None,
+                    korean_market_detail={
+                        "krxTradingSuspended": False,
+                        "nxtTradingSuspended": False,
+                    }
+                    if is_kr
+                    else None,
+                )
+            )
+        return out
+
+    async def prices(self, symbols):
+        self.price_batches.append(tuple(symbols))
+        return [
+            TossPrice(
+                symbol=symbol,
+                timestamp="2026-06-12T00:00:00Z",
+                last_price=Decimal("70000") if symbol.isdigit() else Decimal("190"),
+                currency="KRW" if symbol.isdigit() else "USD",
+            )
+            for symbol in symbols
+            if symbol != "MISSING"
+        ]
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_dry_run_does_not_mutate(db_session) -> None:
+    db_session.add(KRSymbolUniverse(symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True))
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(market="kr", symbols=("005930",), commit=False),
+    )
+
+    assert result.commit is False
+    assert result.symbols_requested == 1
+    assert result.stocks_matched == 1
+    row = await db_session.get(KRSymbolUniverse, "005930")
+    assert row.shares_outstanding is None
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_commit_updates_master_and_market_cap(db_session) -> None:
+    db_session.add(KRSymbolUniverse(symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True))
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="kr",
+            symbols=("005930",),
+            commit=True,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    row = await db_session.get(KRSymbolUniverse, "005930")
+    assert row.security_type == "STOCK"
+    assert row.is_common_share is True
+    assert row.shares_outstanding == Decimal("5846278608")
+    assert row.krx_trading_suspended is False
+    assert result.market_cap_payloads == 1
+    assert result.market_cap_nonnull == 1
+```
+
+- [x] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_service.py -q
+```
+
+Expected: FAIL because `app.services.toss_symbol_master_service` does not exist.
+
+- [x] **Step 3: Implement request/result dataclasses and helpers**
+
+Create focused dataclasses.
+
+```python
+# app/services/toss_symbol_master_service.py
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Protocol
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.brokers.toss.dto import TossPrice, TossStockInfo
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+    MarketValuationSnapshotUpsert,
+)
+
+TOSS_VALUATION_SOURCE = "toss_openapi"
+_BATCH_SIZE = 200
+
+
+class TossSymbolMasterClient(Protocol):
+    async def stocks(self, symbols: list[str] | tuple[str, ...]) -> list[TossStockInfo]: ...
+    async def prices(self, symbols: list[str] | tuple[str, ...]) -> list[TossPrice]: ...
+
+
+@dataclass(frozen=True)
+class TossSymbolMasterSyncRequest:
+    market: str
+    symbols: tuple[str, ...] = ()
+    all_symbols: bool = False
+    limit: int | None = 20
+    commit: bool = False
+    include_market_cap: bool = True
+    snapshot_date: dt.date | None = None
+
+
+@dataclass(frozen=True)
+class TossSymbolMasterSyncResult:
+    market: str
+    commit: bool
+    symbols_requested: int
+    batches: int
+    stocks_matched: int
+    stocks_missing: int
+    master_updates: int
+    market_cap_payloads: int
+    market_cap_nonnull: int
+    warnings: tuple[str, ...] = ()
+    samples: tuple[str, ...] = ()
+
+
+def _chunks(symbols: list[str], size: int = _BATCH_SIZE) -> list[list[str]]:
+    return [symbols[idx : idx + size] for idx in range(0, len(symbols), size)]
+```
+
+- [x] **Step 4: Implement symbol resolution**
+
+Resolve explicit symbols or active universe symbols.
+
+```python
+async def _resolve_symbols(
+    db: AsyncSession,
+    *,
+    market: str,
+    symbols: tuple[str, ...],
+    all_symbols: bool,
+    limit: int | None,
+) -> list[str]:
+    if market not in {"kr", "us"}:
+        raise ValueError(f"unsupported market: {market}")
+    if symbols:
+        return [s.strip().upper() for s in symbols if s.strip()]
+    model = KRSymbolUniverse if market == "kr" else USSymbolUniverse
+    stmt = sa.select(model.symbol).where(model.is_active.is_(True)).order_by(model.symbol)
+    if not all_symbols:
+        stmt = stmt.limit(limit or 20)
+    result = await db.execute(stmt)
+    return [row[0] for row in result.all()]
+```
+
+- [x] **Step 5: Implement master field application**
+
+Map Toss rows onto existing universe rows only.
+
+```python
+def _parse_date(value: str | None) -> dt.date | None:
+    if not value:
+        return None
+    return dt.date.fromisoformat(value[:10])
+
+
+def _kr_suspended(detail: dict | None, key: str) -> bool | None:
+    if not detail:
+        return None
+    if key in detail:
+        return bool(detail[key])
+    return None
+
+
+def _kr_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, object]:
+    return {
+        "security_type": stock.security_type,
+        "is_common_share": stock.is_common_share,
+        "listing_status": stock.status,
+        "list_date": _parse_date(stock.list_date),
+        "delist_date": _parse_date(stock.delist_date),
+        "shares_outstanding": stock.shares_outstanding,
+        "leverage_factor": stock.leverage_factor,
+        "krx_trading_suspended": _kr_suspended(stock.korean_market_detail, "krxTradingSuspended"),
+        "nxt_trading_suspended": _kr_suspended(stock.korean_market_detail, "nxtTradingSuspended"),
+        "isin": stock.isin_code,
+        "toss_master_updated_at": now,
+    }
+
+
+def _us_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, object]:
+    return {
+        "security_type": stock.security_type,
+        "is_common_share": stock.is_common_share,
+        "listing_status": stock.status,
+        "list_date": _parse_date(stock.list_date),
+        "delist_date": _parse_date(stock.delist_date),
+        "shares_outstanding": stock.shares_outstanding,
+        "leverage_factor": stock.leverage_factor,
+        "isin": stock.isin_code,
+        "toss_master_updated_at": now,
+        "is_common_stock": stock.is_common_share,
+    }
+
+
+def _count_or_apply(row: object, assignments: dict[str, object], *, apply: bool) -> bool:
+    changed = False
+    for field, value in assignments.items():
+        if getattr(row, field) != value:
+            if apply:
+                setattr(row, field, value)
+            changed = True
+    return changed
+```
+
+- [x] **Step 6: Implement market-cap payloads and sync orchestrator**
+
+Compute market cap only when both shares and last price are available.
+
+```python
+def _market_cap_payloads(
+    *,
+    market: str,
+    snapshot_date: dt.date,
+    stocks: dict[str, TossStockInfo],
+    prices: dict[str, TossPrice],
+) -> list[MarketValuationSnapshotUpsert]:
+    payloads: list[MarketValuationSnapshotUpsert] = []
+    for symbol, stock in stocks.items():
+        price = prices.get(symbol)
+        market_cap = (
+            stock.shares_outstanding * price.last_price
+            if price is not None and stock.shares_outstanding is not None
+            else None
+        )
+        if market_cap is None:
+            continue
+        payloads.append(
+            MarketValuationSnapshotUpsert(
+                market=market,
+                symbol=symbol,
+                snapshot_date=snapshot_date,
+                source=TOSS_VALUATION_SOURCE,
+                market_cap=market_cap,
+                raw_payload={
+                    "source": TOSS_VALUATION_SOURCE,
+                    "sharesOutstanding": str(stock.shares_outstanding),
+                    "lastPrice": str(price.last_price),
+                    "priceTimestamp": price.timestamp,
+                    "currency": price.currency,
+                },
+            )
+        )
+    return payloads
+```
+
+```python
+async def sync_toss_symbol_master(
+    db: AsyncSession,
+    *,
+    client: TossSymbolMasterClient,
+    request: TossSymbolMasterSyncRequest,
+) -> TossSymbolMasterSyncResult:
+    market = request.market.strip().lower()
+    snapshot_date = request.snapshot_date or dt.datetime.now(dt.UTC).date()
+    symbols = await _resolve_symbols(
+        db,
+        market=market,
+        symbols=request.symbols,
+        all_symbols=request.all_symbols,
+        limit=request.limit,
+    )
+    if not symbols:
+        return TossSymbolMasterSyncResult(
+            market=market,
+            commit=request.commit,
+            symbols_requested=0,
+            batches=0,
+            stocks_matched=0,
+            stocks_missing=0,
+            master_updates=0,
+            market_cap_payloads=0,
+            market_cap_nonnull=0,
+            warnings=("no symbols resolved",),
+        )
+
+    model = KRSymbolUniverse if market == "kr" else USSymbolUniverse
+    existing_result = await db.execute(sa.select(model).where(model.symbol.in_(symbols)))
+    existing = {row.symbol: row for row in existing_result.scalars().all()}
+    now = dt.datetime.now(dt.UTC)
+    all_stocks: dict[str, TossStockInfo] = {}
+    all_prices: dict[str, TossPrice] = {}
+    updates = 0
+
+    batches = _chunks(symbols)
+    for batch in batches:
+        stock_rows = {row.symbol: row for row in await client.stocks(batch)}
+        price_rows = {row.symbol: row for row in await client.prices(batch)} if request.include_market_cap else {}
+        all_stocks.update(stock_rows)
+        all_prices.update(price_rows)
+        for symbol, stock in stock_rows.items():
+            row = existing.get(symbol)
+            if row is None:
+                continue
+            assignments = (
+                _kr_assignments(stock, now=now)
+                if market == "kr"
+                else _us_assignments(stock, now=now)
+            )
+            changed = _count_or_apply(row, assignments, apply=request.commit)
+            if changed:
+                updates += 1
+
+    payloads = _market_cap_payloads(
+        market=market,
+        snapshot_date=snapshot_date,
+        stocks=all_stocks,
+        prices=all_prices,
+    )
+    if request.commit:
+        if payloads:
+            await MarketValuationSnapshotsRepository(db).upsert(payloads)
+        await db.flush()
+
+    missing = len(set(symbols) - set(all_stocks))
+    return TossSymbolMasterSyncResult(
+        market=market,
+        commit=request.commit,
+        symbols_requested=len(symbols),
+        batches=len(batches),
+        stocks_matched=len(all_stocks),
+        stocks_missing=missing,
+        master_updates=updates,
+        market_cap_payloads=len(payloads),
+        market_cap_nonnull=len(payloads),
+        samples=tuple(symbols[:10]),
+    )
+```
+
+- [x] **Step 7: Run service tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_service.py -q
+```
+
+Expected: PASS.
+
+- [x] **Step 8: Commit**
+
+```bash
+git add app/services/toss_symbol_master_service.py tests/test_toss_symbol_master_service.py
+git commit -m "feat(ROB-534): sync Toss symbol master metadata"
+```
+
+---
+
+### Task 3: Add Dry-Run-First CLI
+
+**Files:**
+- Create: `scripts/sync_toss_symbol_master.py`
+- Create: `tests/test_toss_symbol_master_cli.py`
+
+- [x] **Step 1: Write failing CLI parser tests**
+
+```python
+# tests/test_toss_symbol_master_cli.py
+from scripts.sync_toss_symbol_master import parse_args
+
+
+def test_parse_args_defaults_to_dry_run() -> None:
+    args = parse_args(["--market", "kr", "--symbol", "005930"])
+    assert args.market == "kr"
+    assert args.symbol == ["005930"]
+    assert args.commit is False
+
+
+def test_parse_args_all_excludes_symbol_and_limit() -> None:
+    try:
+        parse_args(["--market", "kr", "--all", "--symbol", "005930"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")
+```
+
+- [x] **Step 2: Run failing CLI tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_cli.py -q
+```
+
+Expected: FAIL because script does not exist.
+
+- [x] **Step 3: Implement CLI**
+
+```python
+#!/usr/bin/env python3
+"""Sync Toss Open API symbol master metadata and market-cap valuation rows.
+
+Defaults to dry-run. Pass --commit only after reviewing the printed coverage packet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dry-run-first Toss symbol master sync (ROB-534).")
+    parser.add_argument("--market", choices=["kr", "us"], required=True)
+    parser.add_argument("--symbol", action="append", default=[], help="Restrict to one symbol. Can be repeated.")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--all", action="store_true", help="Process all active universe symbols.")
+    parser.add_argument("--no-market-cap", action="store_true", help="Update master fields only; skip prices/market cap.")
+    parser.add_argument("--commit", action="store_true", help="Write changes. Default is dry-run.")
+    args = parser.parse_args(argv)
+    if args.all and (args.symbol or args.limit != 20):
+        parser.error("--all is mutually exclusive with --symbol and explicit --limit")
+    if args.limit < 1:
+        parser.error("--limit must be >= 1")
+    return args
+
+
+def _print_result(result) -> None:
+    print(
+        f"\nToss symbol master {result.market.upper()} "
+        f"(dry_run={not result.commit}, batches={result.batches})"
+    )
+    print("coverage:")
+    print(f"  requested: {result.symbols_requested}")
+    print(f"  stocks_matched: {result.stocks_matched}")
+    print(f"  stocks_missing: {result.stocks_missing}")
+    print(f"  master_updates: {result.master_updates}")
+    print(f"  market_cap_payloads: {result.market_cap_payloads}")
+    print(f"  market_cap_nonnull: {result.market_cap_nonnull}")
+    if result.samples:
+        print("samples:")
+        for sample in result.samples:
+            print(f"  {sample}")
+    if not result.commit:
+        print("\n--dry-run: no rows written.\n")
+    else:
+        print("\ncommitted Toss symbol master updates.\n")
+
+
+async def run(args: argparse.Namespace) -> int:
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.toss.client import TossReadClient
+    from app.services.toss_symbol_master_service import (
+        TossSymbolMasterSyncRequest,
+        sync_toss_symbol_master,
+    )
+
+    client = TossReadClient.from_settings()
+    try:
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                result = await sync_toss_symbol_master(
+                    session,
+                    client=client,
+                    request=TossSymbolMasterSyncRequest(
+                        market=args.market,
+                        symbols=tuple(args.symbol),
+                        all_symbols=args.all,
+                        limit=args.limit,
+                        commit=args.commit,
+                        include_market_cap=not args.no_market_cap,
+                    ),
+                )
+            _print_result(result)
+    finally:
+        await client.aclose()
+    return 0
+
+
+async def main() -> int:
+    args = parse_args()
+    from app.core.cli import setup_logging_and_sentry
+
+    setup_logging_and_sentry(service_name="sync-toss-symbol-master")
+    return await run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+```
+
+- [x] **Step 4: Run CLI tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_cli.py -q
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Commit**
+
+```bash
+git add scripts/sync_toss_symbol_master.py tests/test_toss_symbol_master_cli.py
+git commit -m "feat(ROB-534): add Toss symbol master sync CLI"
+```
+
+---
+
+### Task 4: Use Toss Master Fields in Screener Filters
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py`
+- Create: `tests/test_toss_symbol_master_screener_filter.py`
+
+- [x] **Step 1: Write failing filter tests**
+
+Cover that explicit Toss fields exclude preferred shares and ETFs before name heuristics.
+
+```python
+# tests/test_toss_symbol_master_screener_filter.py
+from app.services.invest_view_model.screener_service import _is_toss_common_stock_row
+
+
+def test_toss_common_stock_row_prefers_explicit_false() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="005935",
+            name="삼성전자우",
+            security_type="STOCK",
+            is_common_share=False,
+            trading_suspended=False,
+        )
+        is False
+    )
+
+
+def test_toss_common_stock_row_excludes_etf_even_when_common_unknown() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="069500",
+            name="KODEX 200",
+            security_type="ETF",
+            is_common_share=None,
+            trading_suspended=False,
+        )
+        is False
+    )
+
+
+def test_toss_common_stock_row_falls_back_to_name_heuristic() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="005930",
+            name="삼성전자",
+            security_type=None,
+            is_common_share=None,
+            trading_suspended=None,
+        )
+        is True
+    )
+```
+
+- [x] **Step 2: Run failing filter tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_screener_filter.py -q
+```
+
+Expected: FAIL because `_is_toss_common_stock_row` does not exist.
+
+- [x] **Step 3: Implement helper**
+
+In `app/services/invest_view_model/screener_service.py`, add a helper next to `_is_kr_toss_common_stock`.
+
+```python
+def _is_toss_common_stock_row(
+    *,
+    symbol: str,
+    name: str | None,
+    security_type: str | None,
+    is_common_share: bool | None,
+    trading_suspended: bool | None,
+) -> bool:
+    if trading_suspended is True:
+        return False
+    if security_type is not None and security_type.upper() not in {"STOCK", "REIT"}:
+        return False
+    if is_common_share is False:
+        return False
+    if is_common_share is True:
+        return True
+    return _is_kr_toss_common_stock(symbol, name)
+```
+
+- [x] **Step 4: Replace KR query use sites**
+
+Where KR screener loaders currently select `KRSymbolUniverse.symbol`, `name`, and sector fields, include:
+
+```python
+KRSymbolUniverse.security_type,
+KRSymbolUniverse.is_common_share,
+KRSymbolUniverse.krx_trading_suspended,
+KRSymbolUniverse.nxt_trading_suspended,
+```
+
+Build metadata maps and replace:
+
+```python
+if market == "kr" and not _is_kr_toss_common_stock(snap.symbol, symbol_names.get(snap.symbol)):
+    continue
+```
+
+with:
+
+```python
+meta = symbol_meta.get(snap.symbol, {})
+if market == "kr" and not _is_toss_common_stock_row(
+    symbol=snap.symbol,
+    name=symbol_names.get(snap.symbol),
+    security_type=meta.get("security_type"),
+    is_common_share=meta.get("is_common_share"),
+    trading_suspended=meta.get("krx_trading_suspended") or meta.get("nxt_trading_suspended"),
+):
+    continue
+```
+
+Keep fallback behavior when metadata columns are null.
+
+- [x] **Step 5: Run focused screener tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_toss_symbol_master_screener_filter.py tests/test_invest_common_preferred_disparity.py -q
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Commit**
+
+```bash
+git add app/services/invest_view_model/screener_service.py tests/test_toss_symbol_master_screener_filter.py tests/test_invest_common_preferred_disparity.py
+git commit -m "feat(ROB-534): use Toss master fields in screener filters"
+```
+
+---
+
+### Task 5: Verify Valuation Consumption Path
+
+**Files:**
+- Modify: `tests/test_invest_coverage_valuation.py`
+- Modify: `tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py`
+
+- [x] **Step 1: Write failing test for `toss_openapi` valuation row**
+
+Ensure repository upsert and latest partition consumers accept `source='toss_openapi'`.
+
+```python
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.market_valuation_snapshots.repository import (
+    MarketValuationSnapshotsRepository,
+    MarketValuationSnapshotUpsert,
+)
+
+
+@pytest.mark.asyncio
+async def test_market_valuation_accepts_toss_openapi_market_cap(db_session) -> None:
+    repo = MarketValuationSnapshotsRepository(db_session)
+    await repo.upsert(
+        [
+            MarketValuationSnapshotUpsert(
+                market="kr",
+                symbol="005930",
+                snapshot_date=dt.date(2026, 6, 12),
+                source="toss_openapi",
+                market_cap=Decimal("409239502560000"),
+                raw_payload={"source": "toss_openapi"},
+            )
+        ]
+    )
+    await db_session.commit()
+
+    rows = await repo.latest_for_symbols(market="kr", symbols={"005930"})
+    assert rows[0].source == "toss_openapi"
+    assert rows[0].market_cap == Decimal("409239502560000")
+```
+
+- [x] **Step 2: Run valuation tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_invest_coverage_valuation.py tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py -q
+```
+
+Expected: PASS after Task 1 source constraint change.
+
+- [x] **Step 3: Search for source allowlists and update explicit matches**
+
+Run:
+
+```bash
+rg -n "naver_finance.*yahoo|yahoo.*naver_finance|ck_market_valuation_snapshots_source|source.*market_valuation" app tests
+```
+
+Expected: only the ORM check constraint, Alembic migration, and tests require changes. If another explicit valuation source allowlist is found, add `toss_openapi` and extend `test_market_valuation_accepts_toss_openapi_market_cap` to exercise that path.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add tests/test_invest_coverage_valuation.py tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
+git commit -m "test(ROB-534): cover Toss market cap valuation rows"
+```
+
+---
+
+### Task 6: Documentation and Operator Runbook
+
+**Files:**
+- Modify: `app/mcp_server/README.md` only if MCP-facing screener behavior is described there.
+- Create or modify: `docs/runbooks/toss-symbol-master-sync.md`
+- Modify: `docs/invest/data-source-contract.md` if source authority needs updating.
+
+- [x] **Step 1: Add runbook**
+
+Create `docs/runbooks/toss-symbol-master-sync.md`.
+
+```markdown
+# Toss Symbol Master Sync Runbook
+
+ROB-534 adds a dry-run-first sync for Toss Open API symbol master metadata and market-cap valuation rows.
+
+## Dry Run
+
+~~~bash
+uv run python -m scripts.sync_toss_symbol_master --market kr --limit 20
+uv run python -m scripts.sync_toss_symbol_master --market us --limit 20
+~~~
+
+Expected output includes requested symbols, matched stocks, missing stocks, master updates, and market-cap payload count. Dry-run writes no rows.
+
+## Commit
+
+Run only after reviewing dry-run coverage and after ROB-534 stronger-model/CTO migration review clears the change.
+
+~~~bash
+uv run python -m scripts.sync_toss_symbol_master --market kr --all --commit
+uv run python -m scripts.sync_toss_symbol_master --market us --all --commit
+~~~
+
+## Rollback
+
+This migration is additive for universe fields. To remove Toss-derived market-cap rows for one date:
+
+~~~sql
+DELETE FROM market_valuation_snapshots
+WHERE source = 'toss_openapi'
+  AND snapshot_date = DATE 'YYYY-MM-DD';
+~~~
+
+Do not delete existing `naver_finance` or `yahoo` valuation rows.
+```
+
+- [x] **Step 2: Update data source contract**
+
+In `docs/invest/data-source-contract.md`, document:
+
+- universe master enrichment source: `toss_openapi`
+- market-cap source: `market_valuation_snapshots.source=toss_openapi`
+- Toss is production API source for this read-model only, not frontend scraping.
+
+- [x] **Step 3: Run docs grep check**
+
+Run:
+
+```bash
+rg -n "toss_openapi|sync_toss_symbol_master|Toss Symbol Master" docs app/mcp_server/README.md
+```
+
+Expected: runbook and source contract references are present.
+
+- [x] **Step 4: Commit**
+
+```bash
+git add docs/runbooks/toss-symbol-master-sync.md docs/invest/data-source-contract.md app/mcp_server/README.md
+git commit -m "docs(ROB-534): add Toss symbol master sync runbook"
+```
+
+---
+
+### Task 7: Final Verification and Review Hold
+
+**Files:**
+- No code files unless verification finds a defect.
+
+- [x] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_toss_symbol_master_schema.py \
+  tests/test_toss_symbol_master_service.py \
+  tests/test_toss_symbol_master_cli.py \
+  tests/test_toss_symbol_master_screener_filter.py \
+  tests/services/brokers/toss/test_client.py \
+  tests/services/brokers/toss/test_dto.py \
+  tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py \
+  -q
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run lint**
+
+Run:
+
+```bash
+make lint
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run Alembic sanity**
+
+Run:
+
+```bash
+uv run alembic heads
+```
+
+Expected: one head, `20260612_rob534`.
+
+- [x] **Step 4: Run dry-run smoke if Toss credentials are configured**
+
+Run only when `TOSS_API_ENABLED=true` and credentials are present:
+
+```bash
+uv run python -m scripts.sync_toss_symbol_master --market kr --symbol 005930
+uv run python -m scripts.sync_toss_symbol_master --market us --symbol AAPL
+```
+
+Expected: dry-run coverage shows one requested symbol, one matched stock, one market-cap payload, no writes.
+
+- [x] **Step 5: Add Linear hold comment**
+
+Add a ROB-534 comment:
+
+```markdown
+Implementation is ready for ROB-534, but I am applying hold_for_final_review because this includes an Alembic migration and production data-source/backfill behavior. No merge, production migration, or full-universe `--commit` run until stronger-model/CTO review clears migration safety, rollback, and operator runbook assumptions.
+```
+
+- [x] **Step 6: Apply Linear `hold_for_final_review` label**
+
+Use Linear label `hold_for_final_review` after implementation is complete and tests pass.
+
+- [x] **Step 7: Commit verification notes if any docs changed**
+
+```bash
+git status --short
+```
+
+Expected: clean or only intended verification artifacts.
+
+---
+
+## Self-Review
+
+- Spec coverage: Covers additive universe columns, dry-run/commit sync, Toss 200-symbol batches, market-cap valuation rows, US common-stock fill, screener ETF/preferred/suspension guard, migration, and operator runbook.
+- Scope intentionally excluded: scheduler activation, live order/trading behavior, Toss warnings, Toss candles, exchange-rate replacement.
+- Type consistency: `is_common_share` is the Toss field; `is_common_stock` remains the legacy US classifier field. `source='toss_openapi'` is valuation-only.
+- Review gate: Because this is a DB migration and production data backfill path, merge/deploy/full commit requires `needs_stronger_model_review` clearance.

--- a/scripts/sync_toss_symbol_master.py
+++ b/scripts/sync_toss_symbol_master.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Sync Toss Open API symbol master metadata and market-cap valuation rows.
+
+Defaults to dry-run. Pass --commit only after reviewing the printed coverage packet.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dry-run-first Toss symbol master sync (ROB-534).")
+    parser.add_argument("--market", choices=["kr", "us"], required=True)
+    parser.add_argument("--symbol", action="append", default=[], help="Restrict to one symbol. Can be repeated.")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--all", action="store_true", help="Process all active universe symbols.")
+    parser.add_argument("--no-market-cap", action="store_true", help="Update master fields only; skip prices/market cap.")
+    parser.add_argument("--commit", action="store_true", help="Write changes. Default is dry-run.")
+    args = parser.parse_args(argv)
+    if args.all and (args.symbol or args.limit != 20):
+        parser.error("--all is mutually exclusive with --symbol and explicit --limit")
+    if args.limit < 1:
+        parser.error("--limit must be >= 1")
+    return args
+
+
+def _print_result(result) -> None:
+    print(
+        f"\nToss symbol master {result.market.upper()} "
+        f"(dry_run={not result.commit}, batches={result.batches})"
+    )
+    print("coverage:")
+    print(f"  requested: {result.symbols_requested}")
+    print(f"  stocks_matched: {result.stocks_matched}")
+    print(f"  stocks_missing: {result.stocks_missing}")
+    print(f"  master_updates: {result.master_updates}")
+    print(f"  market_cap_payloads: {result.market_cap_payloads}")
+    print(f"  market_cap_nonnull: {result.market_cap_nonnull}")
+    if result.samples:
+        print("samples:")
+        for sample in result.samples:
+            print(f"  {sample}")
+    if not result.commit:
+        print("\n--dry-run: no rows written.\n")
+    else:
+        print("\ncommitted Toss symbol master updates.\n")
+
+
+async def run(args: argparse.Namespace) -> int:
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.toss.client import TossReadClient
+    from app.services.toss_symbol_master_service import (
+        TossSymbolMasterSyncRequest,
+        sync_toss_symbol_master,
+    )
+
+    client = TossReadClient.from_settings()
+    try:
+        async with AsyncSessionLocal() as session:
+            async with session.begin():
+                result = await sync_toss_symbol_master(
+                    session,
+                    client=client,
+                    request=TossSymbolMasterSyncRequest(
+                        market=args.market,
+                        symbols=tuple(args.symbol),
+                        all_symbols=args.all,
+                        limit=args.limit,
+                        commit=args.commit,
+                        include_market_cap=not args.no_market_cap,
+                    ),
+                )
+            _print_result(result)
+    finally:
+        await client.aclose()
+    return 0
+
+
+async def main() -> int:
+    args = parse_args()
+    from app.core.cli import setup_logging_and_sentry
+
+    setup_logging_and_sentry(service_name="sync-toss-symbol-master")
+    return await run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ Pytest configuration and common fixtures for auto-trader tests.
 
 import asyncio
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -106,6 +106,128 @@ def _ensure_test_env() -> None:
 _ensure_test_env()
 
 from app.core.config import settings
+
+MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
+MARKET_VALUATION_SOURCE_MODEL_CHECK_NAME = (
+    "ck_market_valuation_snapshots_ck_market_valuation_snapshots_source"
+)
+MARKET_VALUATION_SOURCE_VALUES = ("naver_finance", "yahoo", "toss_openapi")
+
+SNAPSHOT_KIND_CHECK_NAME = "ck_investment_snapshots_snapshot_kind"
+SNAPSHOT_KIND_MODEL_CHECK_NAME = (
+    "ck_investment_snapshots_ck_investment_snapshots_snapshot_kind"
+)
+SNAPSHOT_KIND_CHECK_NAMES = (
+    SNAPSHOT_KIND_MODEL_CHECK_NAME,
+    SNAPSHOT_KIND_CHECK_NAME,
+)
+SNAPSHOT_KIND_VALUES = (
+    "portfolio",
+    "market",
+    "news",
+    "symbol",
+    "candidate_universe",
+    "browser_probe",
+    "invest_page",
+    "journal",
+    "watch_context",
+    "naver_remote_debug",
+    "toss_remote_debug",
+    "llm_input_frozen",
+    "pending_orders",
+    "validated_run_card",
+    "kr_market_ranking",
+    "investor_flow",
+)
+
+
+def _quote_ident(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _check_constraint_sql(column_name: str, values: tuple[str, ...]) -> str:
+    values_sql = ",".join(f"'{value}'" for value in values)
+    return f"CHECK ({column_name} IN ({values_sql}))"
+
+
+def _constraint_definitions_need_refresh(
+    definitions: Iterable[str | None],
+    required_values: tuple[str, ...],
+) -> bool:
+    definitions = list(definitions)
+    if not definitions:
+        return True
+    return any(
+        not all(value in (definition or "") for value in required_values)
+        for definition in definitions
+    )
+
+
+async def _ensure_market_valuation_source_constraint(conn, sql_text) -> None:
+    constraints = await conn.execute(
+        sql_text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'market_valuation_snapshots'::regclass "
+            "AND pg_get_constraintdef(oid) LIKE '%source%' "
+            "AND contype = 'c'"
+        )
+    )
+    rows = list(constraints)
+    if not _constraint_definitions_need_refresh(
+        [row[1] for row in rows],
+        MARKET_VALUATION_SOURCE_VALUES,
+    ):
+        return
+
+    for name, _definition in rows:
+        await conn.execute(
+            sql_text(
+                "ALTER TABLE market_valuation_snapshots "
+                f"DROP CONSTRAINT IF EXISTS {_quote_ident(name)}"
+            )
+        )
+    await conn.execute(
+        sql_text(
+            "ALTER TABLE market_valuation_snapshots "
+            f"ADD CONSTRAINT {MARKET_VALUATION_SOURCE_CHECK_NAME} "
+            f"{_check_constraint_sql('source', MARKET_VALUATION_SOURCE_VALUES)}"
+        )
+    )
+
+
+async def _ensure_investment_snapshot_kind_constraint(conn, sql_text) -> None:
+    names_sql = ",".join(f"'{name}'" for name in SNAPSHOT_KIND_CHECK_NAMES)
+    constraints = await conn.execute(
+        sql_text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'review.investment_snapshots'::regclass "
+            f"AND conname IN ({names_sql}) "
+            "AND contype = 'c'"
+        )
+    )
+    rows = list(constraints)
+    if not _constraint_definitions_need_refresh(
+        [row[1] for row in rows],
+        SNAPSHOT_KIND_VALUES,
+    ):
+        return
+
+    for name in SNAPSHOT_KIND_CHECK_NAMES:
+        await conn.execute(
+            sql_text(
+                "ALTER TABLE review.investment_snapshots "
+                f"DROP CONSTRAINT IF EXISTS {_quote_ident(name)}"
+            )
+        )
+    await conn.execute(
+        sql_text(
+            "ALTER TABLE review.investment_snapshots "
+            f"ADD CONSTRAINT {SNAPSHOT_KIND_CHECK_NAME} "
+            f"{_check_constraint_sql('snapshot_kind', SNAPSHOT_KIND_VALUES)}"
+        )
+    )
 
 
 @pytest.fixture(scope="session")
@@ -585,28 +707,7 @@ async def db_session():
                                     f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
                                 )
                             )
-                # Query all check constraints on market_valuation_snapshots and drop them if they validate source
-                constraints = await conn.execute(
-                    text(
-                        "SELECT conname FROM pg_constraint "
-                        "WHERE conrelid = 'market_valuation_snapshots'::regclass "
-                        "AND pg_get_constraintdef(oid) LIKE '%source%' "
-                        "AND contype = 'c'"
-                    )
-                )
-                for row in constraints:
-                    await conn.execute(
-                        text(
-                            f"ALTER TABLE market_valuation_snapshots DROP CONSTRAINT IF EXISTS {row[0]}"
-                        )
-                    )
-                await conn.execute(
-                    text(
-                        "ALTER TABLE market_valuation_snapshots "
-                        "ADD CONSTRAINT ck_market_valuation_snapshots_source "
-                        "CHECK (source IN ('naver_finance', 'yahoo', 'toss_openapi'))"
-                    )
-                )
+                await _ensure_market_valuation_source_constraint(conn, text)
                 # Recreate unique constraint if missing
                 has_uq = (
                     await conn.execute(
@@ -773,37 +874,9 @@ async def db_session():
                         "))"
                     )
                 )
-                # ROB-329 — extend investment_snapshots.snapshot_kind CHECK to
-                # include 'validated_run_card' (and 'pending_orders' from
-                # ROB-274 P2). create_all is no-op on the persistent test
-                # table, so drop+recreate here; canonical schema lives in
-                # migration 20260527_rob329_extend_snapshot_kind_run_card.py.
-                await conn.execute(
-                    text(
-                        "ALTER TABLE review.investment_snapshots "
-                        "DROP CONSTRAINT IF EXISTS "
-                        "ck_investment_snapshots_ck_investment_snapshots_snapshot_kind"
-                    )
-                )
-                await conn.execute(
-                    text(
-                        "ALTER TABLE review.investment_snapshots "
-                        "DROP CONSTRAINT IF EXISTS "
-                        "ck_investment_snapshots_snapshot_kind"
-                    )
-                )
-                await conn.execute(
-                    text(
-                        "ALTER TABLE review.investment_snapshots "
-                        "ADD CONSTRAINT ck_investment_snapshots_snapshot_kind "
-                        "CHECK (snapshot_kind IN ("
-                        "'portfolio','market','news','symbol','candidate_universe',"
-                        "'browser_probe','invest_page','journal','watch_context',"
-                        "'naver_remote_debug','toss_remote_debug','llm_input_frozen',"
-                        "'pending_orders','validated_run_card'"
-                        "))"
-                    )
-                )
+                # Avoid repeated AccessExclusive constraint refreshes on this
+                # hot table while xdist workers are already running test bodies.
+                await _ensure_investment_snapshot_kind_constraint(conn, text)
                 # ROB-274 — proposal-state columns + operation-aware CHECKs on
                 # investment_report_items. Mirrors the persistent-DB patch
                 # pattern above; the canonical schema lives in migration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -537,6 +537,94 @@ async def db_session():
                             "ADD COLUMN high_52w_date DATE"
                         )
                     )
+                # ROB-534 — Toss symbol master columns.
+                for table, cols in [
+                    (
+                        "kr_symbol_universe",
+                        [
+                            ("security_type", "VARCHAR(20)"),
+                            ("is_common_share", "BOOLEAN"),
+                            ("listing_status", "VARCHAR(20)"),
+                            ("list_date", "DATE"),
+                            ("delist_date", "DATE"),
+                            ("shares_outstanding", "NUMERIC(30, 0)"),
+                            ("leverage_factor", "NUMERIC(12, 6)"),
+                            ("krx_trading_suspended", "BOOLEAN"),
+                            ("nxt_trading_suspended", "BOOLEAN"),
+                            ("isin", "VARCHAR(20)"),
+                            ("toss_master_updated_at", "TIMESTAMP WITH TIME ZONE"),
+                        ],
+                    ),
+                    (
+                        "us_symbol_universe",
+                        [
+                            ("security_type", "VARCHAR(20)"),
+                            ("is_common_share", "BOOLEAN"),
+                            ("listing_status", "VARCHAR(20)"),
+                            ("list_date", "DATE"),
+                            ("delist_date", "DATE"),
+                            ("shares_outstanding", "NUMERIC(30, 0)"),
+                            ("leverage_factor", "NUMERIC(12, 6)"),
+                            ("isin", "VARCHAR(20)"),
+                            ("toss_master_updated_at", "TIMESTAMP WITH TIME ZONE"),
+                        ],
+                    ),
+                ]:
+                    for col_name, col_type in cols:
+                        has_col = (
+                            await conn.execute(
+                                text(
+                                    f"SELECT 1 FROM information_schema.columns "
+                                    f"WHERE table_name = '{table}' AND column_name = '{col_name}'"
+                                )
+                            )
+                        ).first()
+                        if not has_col:
+                            await conn.execute(
+                                text(
+                                    f"ALTER TABLE {table} ADD COLUMN {col_name} {col_type}"
+                                )
+                            )
+                # Query all check constraints on market_valuation_snapshots and drop them if they validate source
+                constraints = await conn.execute(
+                    text(
+                        "SELECT conname FROM pg_constraint "
+                        "WHERE conrelid = 'market_valuation_snapshots'::regclass "
+                        "AND pg_get_constraintdef(oid) LIKE '%source%' "
+                        "AND contype = 'c'"
+                    )
+                )
+                for row in constraints:
+                    await conn.execute(
+                        text(
+                            f"ALTER TABLE market_valuation_snapshots DROP CONSTRAINT IF EXISTS {row[0]}"
+                        )
+                    )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE market_valuation_snapshots "
+                        "ADD CONSTRAINT ck_market_valuation_snapshots_source "
+                        "CHECK (source IN ('naver_finance', 'yahoo', 'toss_openapi'))"
+                    )
+                )
+                # Recreate unique constraint if missing
+                has_uq = (
+                    await conn.execute(
+                        text(
+                            "SELECT 1 FROM pg_constraint "
+                            "WHERE conrelid = 'market_valuation_snapshots'::regclass "
+                            "AND conname = 'uq_market_valuation_snapshots_market_symbol_date_source'"
+                        )
+                    )
+                ).first()
+                if not has_uq:
+                    await conn.execute(
+                        text(
+                            "ALTER TABLE market_valuation_snapshots "
+                            "ADD CONSTRAINT uq_market_valuation_snapshots_market_symbol_date_source "
+                            "UNIQUE (market, symbol, snapshot_date, source)"
+                        )
+                    )
                 # ROB-443 PR1 — funding_rate added to the (persistent) crypto
                 # screener snapshot table. Same fresh-DB/create_all logic: only
                 # ALTER when genuinely missing to avoid an AccessExclusive lock.

--- a/tests/market_events_test_helpers.py
+++ b/tests/market_events_test_helpers.py
@@ -2,10 +2,34 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 from fastapi import FastAPI
 from sqlalchemy import delete, select
+
+MARKET_EVENTS_TEST_LOCK_ID = 128_534
+
+
+@asynccontextmanager
+async def market_events_test_lock():
+    """Serialize DB-backed market_events tests that share the same tables."""
+    from sqlalchemy import text
+
+    from app.core.db import engine
+
+    async with engine.connect() as guard:
+        await guard.execute(
+            text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+            {"lock_id": MARKET_EVENTS_TEST_LOCK_ID},
+        )
+        try:
+            yield
+        finally:
+            await guard.execute(
+                text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                {"lock_id": MARKET_EVENTS_TEST_LOCK_ID},
+            )
 
 
 async def clean_non_tradingview_market_events(db_session) -> None:

--- a/tests/services/market_events/test_us_earnings_coverage.py
+++ b/tests/services/market_events/test_us_earnings_coverage.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta
 
 import pytest
+import pytest_asyncio
 
 from app.services.market_events.earnings_decision_time import (
     label_earnings_decision_time,
@@ -19,6 +20,17 @@ from app.services.market_events.us_earnings_coverage import (
     MIN_WINDOW_COVERAGE,
     aggregate_coverage,
 )
+from tests.market_events_test_helpers import market_events_test_lock
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _market_events_lock(request):
+    if request.node.get_closest_marker("integration") is None:
+        yield
+        return
+    async with market_events_test_lock():
+        yield
+
 
 # A clean mid-month trading day; the -5..+20 calendar window has no edge holidays.
 _EVENT_DATE = date(2025, 7, 15)

--- a/tests/services/test_market_events_freshness_service.py
+++ b/tests/services/test_market_events_freshness_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta
 
 import pytest
+import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +15,16 @@ from app.services.market_events.freshness_service import (
     STALE_AFTER_HOURS,
     MarketEventsFreshnessService,
 )
+from tests.market_events_test_helpers import market_events_test_lock
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _market_events_lock(request):
+    if request.node.get_closest_marker("integration") is None:
+        yield
+        return
+    async with market_events_test_lock():
+        yield
 
 
 def _add_partition(

--- a/tests/services/test_market_events_ingestion.py
+++ b/tests/services/test_market_events_ingestion.py
@@ -10,9 +10,17 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
 
+from tests.market_events_test_helpers import market_events_test_lock
+
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_market_events(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session, _market_events_lock):
     from app.models.market_events import (
         MarketEvent,
         MarketEventIngestionPartition,

--- a/tests/services/test_market_events_query_service.py
+++ b/tests/services/test_market_events_query_service.py
@@ -8,11 +8,20 @@ from decimal import Decimal
 import pytest
 import pytest_asyncio
 
-from tests.market_events_test_helpers import clean_non_tradingview_market_events
+from tests.market_events_test_helpers import (
+    clean_non_tradingview_market_events,
+    market_events_test_lock,
+)
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_market_events(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session, _market_events_lock):
     await clean_non_tradingview_market_events(db_session)
     yield
 

--- a/tests/services/test_market_events_repository.py
+++ b/tests/services/test_market_events_repository.py
@@ -9,9 +9,17 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
 
+from tests.market_events_test_helpers import market_events_test_lock
+
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_market_events(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session, _market_events_lock):
     from app.models.market_events import (
         MarketEvent,
         MarketEventIngestionPartition,

--- a/tests/test_conftest_schema_patches.py
+++ b/tests/test_conftest_schema_patches.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app.models.investment_snapshots import InvestmentSnapshot
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from tests import conftest
+
+
+@pytest.mark.unit
+def test_market_valuation_source_constraint_is_current_when_all_values_present():
+    definition = (
+        "CHECK ((source = ANY (ARRAY['naver_finance'::text, "
+        "'yahoo'::text, 'toss_openapi'::text])))"
+    )
+
+    assert not conftest._constraint_definitions_need_refresh(
+        [definition], conftest.MARKET_VALUATION_SOURCE_VALUES
+    )
+
+
+@pytest.mark.unit
+def test_market_valuation_source_constraint_refreshes_when_toss_source_missing():
+    definition = "CHECK ((source = ANY (ARRAY['naver_finance'::text, 'yahoo'::text])))"
+
+    assert conftest._constraint_definitions_need_refresh(
+        [definition], conftest.MARKET_VALUATION_SOURCE_VALUES
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_kind_patch_values_match_model_constraint():
+    constraint = next(
+        c
+        for c in InvestmentSnapshot.__table__.constraints
+        if getattr(c, "name", "") == conftest.SNAPSHOT_KIND_MODEL_CHECK_NAME
+    )
+    model_sql = str(constraint.sqltext)
+
+    for value in conftest.SNAPSHOT_KIND_VALUES:
+        assert value in model_sql
+    assert "kr_market_ranking" in conftest.SNAPSHOT_KIND_VALUES
+    assert "investor_flow" in conftest.SNAPSHOT_KIND_VALUES
+
+
+@pytest.mark.unit
+def test_market_valuation_patch_values_match_model_constraint():
+    constraint = next(
+        c
+        for c in MarketValuationSnapshot.__table_args__
+        if getattr(c, "name", "") == conftest.MARKET_VALUATION_SOURCE_MODEL_CHECK_NAME
+    )
+    model_sql = str(constraint.sqltext)
+
+    for value in conftest.MARKET_VALUATION_SOURCE_VALUES:
+        assert value in model_sql

--- a/tests/test_invest_coverage_valuation.py
+++ b/tests/test_invest_coverage_valuation.py
@@ -431,3 +431,44 @@ async def test_us_valuation_partition_computed_at_helper(db_session):
         )
     )
     await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_market_valuation_accepts_toss_openapi_market_cap(db_session) -> None:
+    from app.services.market_valuation_snapshots.repository import (
+        MarketValuationSnapshotsRepository,
+        MarketValuationSnapshotUpsert,
+    )
+
+    repo = MarketValuationSnapshotsRepository(db_session)
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.symbol == "005930",
+            MarketValuationSnapshot.snapshot_date == dt.date(2026, 6, 12),
+            MarketValuationSnapshot.source == "toss_openapi",
+        )
+    )
+    await db_session.commit()
+
+    await repo.upsert(
+        [
+            MarketValuationSnapshotUpsert(
+                market="kr",
+                symbol="005930",
+                snapshot_date=dt.date(2026, 6, 12),
+                source="toss_openapi",
+                market_cap=Decimal("409239502560000"),
+                raw_payload={"source": "toss_openapi"},
+            )
+        ]
+    )
+    await db_session.commit()
+
+    rows = await repo.latest_for_symbols(market="kr", symbols={"005930"})
+    matching = [
+        r
+        for r in rows
+        if r.source == "toss_openapi" and r.snapshot_date == dt.date(2026, 6, 12)
+    ]
+    assert len(matching) == 1
+    assert matching[0].market_cap == Decimal("409239502560000")

--- a/tests/test_market_events_coverage_router.py
+++ b/tests/test_market_events_coverage_router.py
@@ -12,10 +12,17 @@ from fastapi.testclient import TestClient
 from sqlalchemy import delete
 
 from app.models.market_events import MarketEventIngestionPartition
+from tests.market_events_test_helpers import market_events_test_lock
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_partitions(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_partitions(db_session, _market_events_lock):
     await db_session.execute(delete(MarketEventIngestionPartition))
     await db_session.commit()
     yield

--- a/tests/test_market_events_discover_calendar_router.py
+++ b/tests/test_market_events_discover_calendar_router.py
@@ -9,11 +9,18 @@ from fastapi.testclient import TestClient
 from tests.market_events_test_helpers import (
     build_market_events_app,
     clean_non_tradingview_market_events,
+    market_events_test_lock,
 )
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session, _market_events_lock):
     await clean_non_tradingview_market_events(db_session)
     yield
 

--- a/tests/test_market_events_router.py
+++ b/tests/test_market_events_router.py
@@ -9,11 +9,18 @@ from fastapi.testclient import TestClient
 from tests.market_events_test_helpers import (
     build_market_events_app,
     clean_non_tradingview_market_events,
+    market_events_test_lock,
 )
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_market_events(db_session):
+async def _market_events_lock():
+    async with market_events_test_lock():
+        yield
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session, _market_events_lock):
     await clean_non_tradingview_market_events(db_session)
     yield
 

--- a/tests/test_partition_health_loader_wiring.py
+++ b/tests/test_partition_health_loader_wiring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import math
 
 import pytest
 import sqlalchemy as sa
@@ -8,6 +9,22 @@ import sqlalchemy as sa
 from app.models.invest_screener_snapshot import InvestScreenerSnapshot
 from app.models.investor_flow_snapshot import InvestorFlowSnapshot
 from app.services.invest_view_model import screener_service
+
+
+async def _reset_pk_sequence(session, table_name: str) -> None:
+    if table_name not in {"invest_screener_snapshots", "investor_flow_snapshots"}:
+        raise ValueError(f"unsupported test table: {table_name}")
+    await session.execute(
+        sa.text(
+            f"""
+            SELECT setval(
+                pg_get_serial_sequence('{table_name}', 'id'),
+                COALESCE((SELECT MAX(id) FROM {table_name}), 0) + 1,
+                false
+            )
+            """
+        )
+    )
 
 
 def _gainer(symbol: str, d: dt.date) -> InvestScreenerSnapshot:
@@ -28,24 +45,52 @@ def _gainer(symbol: str, d: dt.date) -> InvestScreenerSnapshot:
     )
 
 
-async def _seed_two_partitions(session, *, healthy_n: int, thin_n: int):
-    older, newer = dt.date(2040, 5, 19), dt.date(2040, 5, 22)
-
+async def _active_kr_universe_count(session) -> int:
     from app.models.kr_symbol_universe import KRSymbolUniverse
 
-    # Clean up first
+    return int(
+        (
+            await session.execute(
+                sa.select(sa.func.count())
+                .select_from(KRSymbolUniverse)
+                .where(KRSymbolUniverse.is_active.is_(True))
+            )
+        ).scalar()
+        or 0
+    )
+
+
+async def _cleanup_gainer_rows(session, dates: set[dt.date]) -> None:
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
     await session.execute(
         sa.delete(InvestScreenerSnapshot).where(
-            InvestScreenerSnapshot.snapshot_date.in_({older, newer})
+            InvestScreenerSnapshot.snapshot_date.in_(dates)
         )
     )
     await session.execute(
         sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like("99%"))
     )
     await session.flush()
+    await _reset_pk_sequence(session, "invest_screener_snapshots")
 
-    # Seed active universe (200 symbols)
-    for i in range(200):
+
+async def _seed_two_partitions(session, *, healthy_n: int, thin_n: int):
+    older, newer = dt.date(2040, 5, 19), dt.date(2040, 5, 22)
+
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    # Clean up first
+    await _cleanup_gainer_rows(session, {older, newer})
+
+    existing_active = await _active_kr_universe_count(session)
+    seed_n = max(200, healthy_n, existing_active + 200)
+    floor = math.ceil((existing_active + seed_n) * 0.5)
+    healthy_n = max(healthy_n, floor)
+
+    # Seed enough active universe rows to keep this test independent from the
+    # persistent test DB's pre-existing KR universe size.
+    for i in range(seed_n):
         sym = f"99{i:04d}"
         session.add(
             KRSymbolUniverse(
@@ -66,30 +111,20 @@ async def _seed_two_partitions(session, *, healthy_n: int, thin_n: int):
 
 @pytest.mark.asyncio
 async def test_thin_newer_partition_does_not_shadow_healthy_older(db_session):
-    # active universe = 200 + initial_active (say 18) = 218.
-    # 50% bar is 109. healthy_n = 150 passes; thin_n = 20 fails.
+    # Seed helper sizes the healthy older partition against the current
+    # persistent test DB universe; the thin newer partition remains below floor.
     older, newer = await _seed_two_partitions(db_session, healthy_n=150, thin_n=20)
-    rows = await screener_service.load_consecutive_gainers_from_snapshots(
-        db_session, market="kr", limit=20
-    )
-    assert rows, "expected the healthy older partition to be served"
-    # Every served row comes from the older healthy partition...
-    assert all(r["snapshot_date"] == older for r in rows)
-    # ...and is labeled stale (older than today), not fresh.
-    assert all(r["_screener_snapshot_state"] == "stale" for r in rows)
-
-    # Clean up after test
-    from app.models.kr_symbol_universe import KRSymbolUniverse
-
-    await db_session.execute(
-        sa.delete(InvestScreenerSnapshot).where(
-            InvestScreenerSnapshot.snapshot_date.in_({older, newer})
+    try:
+        rows = await screener_service.load_consecutive_gainers_from_snapshots(
+            db_session, market="kr", limit=20
         )
-    )
-    await db_session.execute(
-        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like("99%"))
-    )
-    await db_session.flush()
+        assert rows, "expected the healthy older partition to be served"
+        # Every served row comes from the older healthy partition...
+        assert all(r["snapshot_date"] == older for r in rows)
+        # ...and is labeled stale (older than today), not fresh.
+        assert all(r["_screener_snapshot_state"] == "stale" for r in rows)
+    finally:
+        await _cleanup_gainer_rows(db_session, {older, newer})
 
 
 def _flow(symbol: str, d: dt.date) -> InvestorFlowSnapshot:
@@ -107,24 +142,37 @@ def _flow(symbol: str, d: dt.date) -> InvestorFlowSnapshot:
     )
 
 
-async def _seed_two_flow_partitions(session, *, healthy_n: int, thin_n: int):
-    older, newer = dt.date(2040, 5, 19), dt.date(2040, 5, 22)
-
+async def _cleanup_flow_rows(session, dates: set[dt.date]) -> None:
     from app.models.kr_symbol_universe import KRSymbolUniverse
 
-    # Clean up first
     await session.execute(
         sa.delete(InvestorFlowSnapshot).where(
-            InvestorFlowSnapshot.snapshot_date.in_({older, newer})
+            InvestorFlowSnapshot.snapshot_date.in_(dates)
         )
     )
     await session.execute(
         sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like("99%"))
     )
     await session.flush()
+    await _reset_pk_sequence(session, "investor_flow_snapshots")
 
-    # Seed active universe (200 symbols)
-    for i in range(200):
+
+async def _seed_two_flow_partitions(session, *, healthy_n: int, thin_n: int):
+    older, newer = dt.date(2040, 5, 19), dt.date(2040, 5, 22)
+
+    from app.models.kr_symbol_universe import KRSymbolUniverse
+
+    # Clean up first
+    await _cleanup_flow_rows(session, {older, newer})
+
+    existing_active = await _active_kr_universe_count(session)
+    seed_n = max(200, healthy_n, existing_active + 200)
+    floor = math.ceil((existing_active + seed_n) * 0.5)
+    healthy_n = max(healthy_n, floor)
+
+    # Seed enough active universe rows to keep this test independent from the
+    # persistent test DB's pre-existing KR universe size.
+    for i in range(seed_n):
         sym = f"99{i:04d}"
         session.add(
             KRSymbolUniverse(
@@ -146,26 +194,16 @@ async def _seed_two_flow_partitions(session, *, healthy_n: int, thin_n: int):
 @pytest.mark.asyncio
 async def test_investor_flow_thin_newer_falls_back_to_healthy_older(db_session):
     older, newer = await _seed_two_flow_partitions(db_session, healthy_n=150, thin_n=20)
-    res = await screener_service._load_investor_flow_discovery_from_snapshots(
-        db_session, market="kr", limit=20
-    )
-    assert res is not None
-    rows = res.rows
-    assert rows, "expected the healthy older investor_flow partition to be served"
-    # Every served row comes from the older healthy partition...
-    assert all(r["snapshot_date"] == older for r in rows)
-    # ...and is labeled stale (older than today), not fresh.
-    assert all(r["_screener_snapshot_state"] == "stale" for r in rows)
-
-    # Clean up after test
-    from app.models.kr_symbol_universe import KRSymbolUniverse
-
-    await db_session.execute(
-        sa.delete(InvestorFlowSnapshot).where(
-            InvestorFlowSnapshot.snapshot_date.in_({older, newer})
+    try:
+        res = await screener_service._load_investor_flow_discovery_from_snapshots(
+            db_session, market="kr", limit=20
         )
-    )
-    await db_session.execute(
-        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.like("99%"))
-    )
-    await db_session.flush()
+        assert res is not None
+        rows = res.rows
+        assert rows, "expected the healthy older investor_flow partition to be served"
+        # Every served row comes from the older healthy partition...
+        assert all(r["snapshot_date"] == older for r in rows)
+        # ...and is labeled stale (older than today), not fresh.
+        assert all(r["_screener_snapshot_state"] == "stale" for r in rows)
+    finally:
+        await _cleanup_flow_rows(db_session, {older, newer})

--- a/tests/test_toss_symbol_master_cli.py
+++ b/tests/test_toss_symbol_master_cli.py
@@ -1,0 +1,17 @@
+from scripts.sync_toss_symbol_master import parse_args
+
+
+def test_parse_args_defaults_to_dry_run() -> None:
+    args = parse_args(["--market", "kr", "--symbol", "005930"])
+    assert args.market == "kr"
+    assert args.symbol == ["005930"]
+    assert args.commit is False
+
+
+def test_parse_args_all_excludes_symbol_and_limit() -> None:
+    try:
+        parse_args(["--market", "kr", "--all", "--symbol", "005930"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("expected parser error")

--- a/tests/test_toss_symbol_master_schema.py
+++ b/tests/test_toss_symbol_master_schema.py
@@ -1,0 +1,50 @@
+from sqlalchemy import inspect
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
+
+
+def test_kr_symbol_universe_has_toss_master_columns() -> None:
+    columns = inspect(KRSymbolUniverse).columns
+    for name in (
+        "security_type",
+        "is_common_share",
+        "listing_status",
+        "list_date",
+        "delist_date",
+        "shares_outstanding",
+        "leverage_factor",
+        "krx_trading_suspended",
+        "nxt_trading_suspended",
+        "isin",
+        "toss_master_updated_at",
+    ):
+        assert name in columns
+
+
+def test_us_symbol_universe_has_toss_master_columns() -> None:
+    columns = inspect(USSymbolUniverse).columns
+    for name in (
+        "security_type",
+        "is_common_share",
+        "listing_status",
+        "list_date",
+        "delist_date",
+        "shares_outstanding",
+        "leverage_factor",
+        "isin",
+        "toss_master_updated_at",
+    ):
+        assert name in columns
+
+
+def test_market_valuation_snapshot_allows_toss_openapi_source() -> None:
+    constraints = MarketValuationSnapshot.__table_args__
+    source_constraints = [
+        c
+        for c in constraints
+        if "ck_market_valuation_snapshots_source" in getattr(c, "name", "")
+    ]
+    assert len(source_constraints) == 1
+    assert "toss_openapi" in str(source_constraints[0].sqltext)

--- a/tests/test_toss_symbol_master_screener_filter.py
+++ b/tests/test_toss_symbol_master_screener_filter.py
@@ -1,0 +1,40 @@
+from app.services.invest_view_model.screener_service import _is_toss_common_stock_row
+
+
+def test_toss_common_stock_row_prefers_explicit_false() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="005935",
+            name="삼성전자우",
+            security_type="STOCK",
+            is_common_share=False,
+            trading_suspended=False,
+        )
+        is False
+    )
+
+
+def test_toss_common_stock_row_excludes_etf_even_when_common_unknown() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="069500",
+            name="KODEX 200",
+            security_type="ETF",
+            is_common_share=None,
+            trading_suspended=False,
+        )
+        is False
+    )
+
+
+def test_toss_common_stock_row_falls_back_to_name_heuristic() -> None:
+    assert (
+        _is_toss_common_stock_row(
+            symbol="005930",
+            name="삼성전자",
+            security_type=None,
+            is_common_share=None,
+            trading_suspended=None,
+        )
+        is True
+    )

--- a/tests/test_toss_symbol_master_service.py
+++ b/tests/test_toss_symbol_master_service.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 import pytest
 
 from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.us_symbol_universe import USSymbolUniverse
 from app.services.brokers.toss.dto import TossPrice, TossStockInfo
 from app.services.toss_symbol_master_service import (
     TossSymbolMasterSyncRequest,
@@ -129,3 +131,123 @@ async def test_sync_toss_symbol_master_commit_updates_master_and_market_cap(
     assert row.krx_trading_suspended is False
     assert result.market_cap_payloads == 1
     assert result.market_cap_nonnull == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_commit_updates_us_common_stock_flag(
+    db_session,
+) -> None:
+    import sqlalchemy as sa
+
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol == "AAPL")
+    )
+    db_session.add(
+        USSymbolUniverse(
+            symbol="AAPL",
+            exchange="NASDAQ",
+            name_en="Apple Inc.",
+            is_active=True,
+            is_common_stock=None,
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="us",
+            symbols=("AAPL",),
+            commit=True,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    row = await db_session.get(USSymbolUniverse, "AAPL")
+    assert row.security_type == "STOCK"
+    assert row.is_common_share is True
+    assert row.is_common_stock is True
+    assert row.shares_outstanding == Decimal("14687356000")
+    assert result.market_cap_payloads == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_batches_symbols_by_200(db_session) -> None:
+    import sqlalchemy as sa
+
+    symbols = tuple(f"{idx:06d}" for idx in range(201))
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_(symbols))
+    )
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol=symbol,
+                name=f"테스트{symbol}",
+                exchange="KOSPI",
+                is_active=True,
+            )
+            for symbol in symbols
+        ]
+    )
+    await db_session.commit()
+    client = FakeTossClient()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=client,
+        request=TossSymbolMasterSyncRequest(
+            market="kr",
+            symbols=symbols,
+            commit=False,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    assert result.batches == 2
+    assert [len(batch) for batch in client.stock_batches] == [200, 1]
+    assert [len(batch) for batch in client.price_batches] == [200, 1]
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_skips_market_cap_for_unregistered_symbol(
+    db_session,
+) -> None:
+    import sqlalchemy as sa
+
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "999999")
+    )
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.symbol == "999999"
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="kr",
+            symbols=("999999",),
+            commit=True,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                sa.select(MarketValuationSnapshot).where(
+                    MarketValuationSnapshot.symbol == "999999"
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert result.stocks_matched == 1
+    assert result.market_cap_payloads == 0
+    assert rows == []

--- a/tests/test_toss_symbol_master_service.py
+++ b/tests/test_toss_symbol_master_service.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.brokers.toss.dto import TossPrice, TossStockInfo
+from app.services.toss_symbol_master_service import (
+    TossSymbolMasterSyncRequest,
+    sync_toss_symbol_master,
+)
+
+
+class FakeTossClient:
+    def __init__(self) -> None:
+        self.stock_batches: list[tuple[str, ...]] = []
+        self.price_batches: list[tuple[str, ...]] = []
+
+    async def stocks(self, symbols: list[str] | tuple[str, ...]) -> list[TossStockInfo]:
+        self.stock_batches.append(tuple(symbols))
+        out = []
+        for symbol in symbols:
+            if symbol == "MISSING":
+                continue
+            is_kr = symbol.isdigit()
+            out.append(
+                TossStockInfo(
+                    symbol=symbol,
+                    name="삼성전자" if is_kr else "Apple",
+                    english_name="Samsung Electronics" if is_kr else "Apple Inc.",
+                    isin_code="KR7005930003" if is_kr else "US0378331005",
+                    market="KR" if is_kr else "US",
+                    security_type="STOCK",
+                    is_common_share=symbol != "005935",
+                    status="ACTIVE",
+                    currency="KRW" if is_kr else "USD",
+                    list_date="1975-06-11" if is_kr else "1980-12-12",
+                    delist_date=None,
+                    shares_outstanding=Decimal("5846278608")
+                    if is_kr
+                    else Decimal("14687356000"),
+                    leverage_factor=None,
+                    korean_market_detail={
+                        "krxTradingSuspended": False,
+                        "nxtTradingSuspended": False,
+                    }
+                    if is_kr
+                    else None,
+                )
+            )
+        return out
+
+    async def prices(self, symbols: list[str] | tuple[str, ...]) -> list[TossPrice]:
+        self.price_batches.append(tuple(symbols))
+        return [
+            TossPrice(
+                symbol=symbol,
+                timestamp="2026-06-12T00:00:00Z",
+                last_price=Decimal("70000") if symbol.isdigit() else Decimal("190"),
+                currency="KRW" if symbol.isdigit() else "USD",
+            )
+            for symbol in symbols
+            if symbol != "MISSING"
+        ]
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_dry_run_does_not_mutate(db_session) -> None:
+    import sqlalchemy as sa
+
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "005930")
+    )
+    db_session.add(
+        KRSymbolUniverse(
+            symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="kr", symbols=("005930",), commit=False
+        ),
+    )
+
+    assert result.commit is False
+    assert result.symbols_requested == 1
+    assert result.stocks_matched == 1
+    row = await db_session.get(KRSymbolUniverse, "005930")
+    assert row.shares_outstanding is None
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_symbol_master_commit_updates_master_and_market_cap(
+    db_session,
+) -> None:
+    import sqlalchemy as sa
+
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "005930")
+    )
+    db_session.add(
+        KRSymbolUniverse(
+            symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="kr",
+            symbols=("005930",),
+            commit=True,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    row = await db_session.get(KRSymbolUniverse, "005930")
+    assert row.security_type == "STOCK"
+    assert row.is_common_share is True
+    assert row.shares_outstanding == Decimal("5846278608")
+    assert row.krx_trading_suspended is False
+    assert result.market_cap_payloads == 1
+    assert result.market_cap_nonnull == 1


### PR DESCRIPTION
## Summary

- Adds Toss Symbol Master sync support for KR/US symbol universe enrichment, including common-stock/security metadata and market cap ingestion into valuation snapshots.
- Adds schema, service, CLI, provider DTO/client, screener filter, coverage, and valuation repository tests for the ROB-534 data path.
- Follow-up fixes restrict Toss market cap snapshots to symbols already present in the local universe, harden screener enrichment around optional metadata attrs, and isolate partition health tests from persistent test DB state and sequence drift.

## Why

ROB-534 needs Toss OpenAPI data as a supplemental enrichment/backfill source without letting Toss-only symbols expand the local trading universe or affect ranking authority incorrectly.

## Risk And Hold

This PR is intentionally draft. The change touches Alembic migration and production backfill/data-source behavior, so it remains under `high_risk_change`, `needs_stronger_model_review`, and `hold_for_final_review`.

Do not merge, deploy, or run full-universe `--commit` backfills until stronger-model/CTO review clears migration safety, rollback behavior, and the operator runbook assumptions.

## Validation

- `make lint` passed.
- Focused ROB-534 suite passed: `114 passed, 2 warnings`.
- Full suite passed before PR creation on the same branch state: `make test` -> `11855 passed, 23 skipped, 4 deselected, 50 warnings`.
- `uv run alembic heads` -> `20260612_rob534 (head)`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Symbol universe expanded with new metadata fields including security type, listing/delist dates, shares outstanding, common-share flags, and trading suspension status
  * New data source integrated for market-cap valuations
  * CLI tool added for symbol master data synchronization

* **Documentation**
  * Operational runbooks added for symbol master sync workflow
  * Data-source contract documentation updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->