### PR TITLE
feat: add Toss stock warnings guard and sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ sync-upbit-symbol-universe: ## Sync Upbit symbol universe for crypto symbol reso
 sync-us-symbol-universe: ## Sync US symbol universe for US symbol/exchange resolution
 	uv run python scripts/sync_us_symbol_universe.py
 
+sync-toss-warnings: ## Sync Toss warnings for KR market
+	uv run python scripts/sync_toss_warnings.py
+
 sync-kr-candles-backfill: ## Backfill KR candles for recent sessions
 	uv run python scripts/sync_kr_candles.py --mode backfill --sessions 10
 

--- a/alembic/versions/d82e093e7590_add_kr_stock_warnings_table.py
+++ b/alembic/versions/d82e093e7590_add_kr_stock_warnings_table.py
@@ -1,0 +1,40 @@
+"""add kr_stock_warnings table
+
+Revision ID: d82e093e7590
+Revises: 20260612_rob534
+Create Date: 2026-06-12 16:49:08.301279
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd82e093e7590'
+down_revision: Union[str, Sequence[str], None] = '20260612_rob534'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('kr_stock_warnings',
+    sa.Column('id', sa.BigInteger(), autoincrement=True, nullable=False),
+    sa.Column('market', sa.String(length=10), nullable=False),
+    sa.Column('symbol', sa.String(length=10), nullable=False),
+    sa.Column('warning_type', sa.String(length=50), nullable=False),
+    sa.Column('exchange', sa.String(length=20), nullable=True),
+    sa.Column('start_date', sa.Date(), nullable=True),
+    sa.Column('end_date', sa.Date(), nullable=True),
+    sa.Column('source', sa.String(length=32), nullable=False),
+    sa.Column('fetched_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_kr_stock_warnings'))
+    )
+    op.create_index('ix_kr_stock_warnings_market_symbol', 'kr_stock_warnings', ['market', 'symbol'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_kr_stock_warnings_market_symbol', table_name='kr_stock_warnings')
+    op.drop_table('kr_stock_warnings')

--- a/app/jobs/toss_warnings.py
+++ b/app/jobs/toss_warnings.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from app.core.db import AsyncSessionLocal
+from app.services.brokers.toss.client import TossReadClient
+from app.services.toss_warnings_sync_service import sync_toss_warnings
+
+logger = logging.getLogger(__name__)
+
+
+async def run_toss_warnings_sync() -> dict[str, int | str | list[str]]:
+    """
+    Sync job for stock warnings from Toss API to database.
+    """
+    client: TossReadClient | None = None
+    try:
+        client = TossReadClient.from_settings()
+        async with AsyncSessionLocal() as db:
+            result = await sync_toss_warnings(db=db, client=client, market="kr")
+
+        return {
+            "status": "completed",
+            **result,
+        }
+    except Exception as exc:
+        logger.error("Toss warnings sync job failed: %s", exc, exc_info=True)
+        return {
+            "status": "failed",
+            "error": str(exc),
+        }
+    finally:
+        if client is not None:
+            try:
+                await client.aclose()
+            except Exception as exc:
+                logger.warning(
+                    "Failed to close Toss warnings sync client: %s",
+                    exc,
+                    exc_info=True,
+                )

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -360,7 +360,10 @@ official KIS mock, and KIS live account paths:
   use `KIS_MOCK_BASE_URL`, which defaults to the official KIS mock host
   `https://openapivts.koreainvestment.com:29443`.
 - `account_mode="kis_live"` or omitted: existing live KIS behavior. For
-  `place_order`, `dry_run=True` remains the default.
+  `place_order`, `dry_run=True` remains the default. KR live buy paths query
+  Toss stock warnings before order submission; active `LIQUIDATION_TRADING`
+  blocks non-dry-run buys before KIS POST, while lookup failures are fail-open
+  and surfaced in the response metadata.
 - `account_mode="toss_live"`: official Toss Securities live KR/US account. Uses Toss credentials, maps to `toss_live` routing, and fails closed when `TOSS_API_ENABLED=false` or credentials are missing. Actual Toss order mutation POSTs also require `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`; keep this false until the accepted-order ledger and operator live-smoke hold are cleared.
 
 Do not use `account_type="paper"` for official KIS mock. It is always DB
@@ -431,6 +434,7 @@ The `default` profile registers seven typed `toss_live_*` MCP tools:
 - **Account Mode Routing**: All Toss tools require `account_mode="toss_live"` (or `account_type="toss_live"`) and reject any mismatched account parameters.
 - **Mutation Safety (Dry-Run, Confirm, and Activation Gate)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` are explicitly set. Keep `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false` until the accepted-order ledger and operator live-smoke hold are cleared.
 - **High-Value Orders**: KR orders with a computable notional value >= 100,000,000 KRW fail locally unless `confirm_high_value_order=True` is supplied.
+- **KR Stock Warnings**: KR order previews include active Toss warning rows. Confirmed non-dry-run KR orders call the same warnings guard before mutation and block active `LIQUIDATION_TRADING`; Toss warning lookup failures are fail-open and reported as `warnings_check_message`.
 - **Sell Loss-Sell Guard**: For sell orders and sell reprices, holdings cost basis is validated. Sells block locally if the execution price (limit) or current market proxy price (market) is below `average_purchase_price * 1.01`. If the holding/cost basis cannot be resolved, the sell fails closed.
 - **Opposite Pending Orders**: Before placing a non-dry-run order, the tool queries all paginated `OPEN` order pages for the symbol and blocks the order if an opposite-side pending order already exists. Pagination anomalies fail closed.
 - **Modify Semantics**:

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -13,6 +13,7 @@ tools in orders_registration.py are unchanged; these are additive.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 from app.core.config import validate_kis_mock_config
@@ -27,9 +28,16 @@ from app.mcp_server.tooling.orders_modify_cancel import (
     cancel_order_impl,
     modify_order_impl,
 )
+from app.services.brokers.toss.client import TossReadClient
+from app.services.brokers.toss.warnings_guard import (
+    WarningsGuardResult,
+    check_warnings_guard,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
 
 KIS_LIVE_ORDER_TOOL_NAMES: set[str] = {
     "kis_live_place_order",
@@ -107,6 +115,40 @@ def _check_mode_arg(
                 "account_mode": pinned_mode,
             }
     return None
+
+
+def _warning_payload(result: WarningsGuardResult) -> list[dict[str, str | None]]:
+    return [
+        {
+            "warning_type": warning.warning_type,
+            "exchange": warning.exchange,
+            "start_date": warning.start_date,
+            "end_date": warning.end_date,
+        }
+        for warning in result.warnings
+    ]
+
+
+async def _check_toss_warnings_for_kis_buy(symbol: str) -> WarningsGuardResult:
+    client = None
+    try:
+        client = TossReadClient.from_settings()
+        return await check_warnings_guard(client, symbol, market="kr")
+    except Exception as exc:
+        logger.warning(
+            "Failed to check Toss warnings for KIS live order symbol=%s; proceeding fail-open: %s",
+            symbol,
+            exc,
+            exc_info=True,
+        )
+        return WarningsGuardResult(
+            ok=True,
+            warnings=[],
+            error_message=f"Warnings check failed: {exc} (fail-open)",
+        )
+    finally:
+        if client is not None:
+            await client.aclose()
 
 
 def _prepare_variant_call(
@@ -228,7 +270,23 @@ async def _place_order_variant(
         return early_response
     if str(order_type).lower().strip() != "limit":
         return _limit_order_error(tool_name, symbol, order_type)
-    return apply_account_routing_metadata(
+
+    warning_result: WarningsGuardResult | None = None
+    is_live_buy = pinned_mode == ACCOUNT_MODE_KIS_LIVE and str(side).lower() == "buy"
+    if is_live_buy:
+        warning_result = await _check_toss_warnings_for_kis_buy(symbol)
+        if not dry_run and not warning_result.ok:
+            return {
+                "success": False,
+                "source": "kis",
+                "account_mode": ACCOUNT_MODE_KIS_LIVE,
+                "dry_run": dry_run,
+                "mutation_sent": False,
+                "error": warning_result.error_message,
+                "warnings": _warning_payload(warning_result),
+            }
+
+    result = apply_account_routing_metadata(
         await order_execution._place_order_impl(
             symbol=symbol,
             side=side,
@@ -253,6 +311,11 @@ async def _place_order_variant(
         ),
         routing,
     )
+    if warning_result is not None:
+        result["warnings"] = _warning_payload(warning_result)
+        if warning_result.error_message:
+            result["warnings_check_message"] = warning_result.error_message
+    return result
 
 
 async def _cancel_order_variant(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -8,8 +8,10 @@ Every tool is hard-pinned to ``account_mode="toss_live"``. They:
 
 from __future__ import annotations
 
+import logging
 import re
 import uuid
+from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from datetime import date, datetime
 from decimal import Decimal
@@ -21,7 +23,11 @@ from app.mcp_server.tooling.account_modes import (
     normalize_account_mode,
 )
 from app.services.brokers.toss import TossReadClient
+from app.services.brokers.toss.dto import TossWarningInfo
 from app.services.brokers.toss.errors import TossApiResponseError
+from app.services.brokers.toss.warnings_guard import check_warnings_guard
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -92,6 +98,20 @@ async def _client_context():
         yield client
     finally:
         await client.aclose()
+
+
+def _warning_payload(
+    warnings: Iterable[TossWarningInfo],
+) -> list[dict[str, str | None]]:
+    return [
+        {
+            "warning_type": w.warning_type,
+            "exchange": w.exchange,
+            "start_date": w.start_date,
+            "end_date": w.end_date,
+        }
+        for w in warnings
+    ]
 
 
 def _infer_market(
@@ -395,12 +415,34 @@ async def toss_preview_order(
     if order_amount_dec is not None:
         payload["orderAmount"] = _stringify_decimal(order_amount_dec)
 
+    warnings_list = []
+    warnings_check_msg = None
+    try:
+        async with _client_context() as client:
+            guard_res = await check_warnings_guard(client, symbol, market=mkt)
+            warnings_list = [
+                {
+                    "warning_type": w.warning_type,
+                    "exchange": w.exchange,
+                    "start_date": w.start_date,
+                    "end_date": w.end_date,
+                }
+                for w in guard_res.warnings
+            ]
+            if guard_res.error_message:
+                warnings_check_msg = guard_res.error_message
+    except Exception as exc:
+        logger.error("Failed to check warnings in preview: %s", exc, exc_info=True)
+        warnings_check_msg = f"Failed to check warnings: {exc}"
+
     return {
         "success": True,
         "preview": True,
         "market": mkt,
         "payload_preview": payload,
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
+        "warnings": warnings_list,
+        "warnings_check_message": warnings_check_msg,
     }
 
 
@@ -491,6 +533,17 @@ async def toss_place_order(
         return mutation_gate
 
     async def execute_order(client: TossReadClient):
+        # Guard: Warnings check
+        guard_res = await check_warnings_guard(client, symbol, market=mkt)
+        guard_warnings = _warning_payload(guard_res.warnings)
+        if not guard_res.ok:
+            return {
+                "success": False,
+                **base_response,
+                "error": guard_res.error_message,
+                "warnings": guard_warnings,
+            }
+
         # Guard: opposite pending order check
         if (
             opp_guard := await _opposite_pending_error(
@@ -516,6 +569,8 @@ async def toss_place_order(
                 "mutation_sent": True,
                 "order_id": res.order_id,
                 "client_order_id": res.client_order_id,
+                "warnings": guard_warnings,
+                "warnings_check_message": guard_res.error_message,
             }
         except Exception as exc:
             return _toss_error_response(exc, {**base_response, "mutation_sent": True})

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -31,6 +31,7 @@ from .investment_snapshots import (
     InvestmentSnapshotRun,
 )
 from .investor_flow_snapshot import InvestorFlowSnapshot
+from .kr_stock_warnings import KRStockWarning
 from .kr_symbol_universe import KRSymbolUniverse
 from .manual_holdings import (
     BrokerAccount,
@@ -163,6 +164,7 @@ __all__ = [
     "InvestMomentumEventSnapshot",
     "InvestThemeEventSnapshot",
     "InvestThemeEventSnapshotStock",
+    "KRStockWarning",
     "KRSymbolUniverse",
     "UpbitSymbolUniverse",
     "USSymbolUniverse",

--- a/app/models/kr_stock_warnings.py
+++ b/app/models/kr_stock_warnings.py
@@ -1,0 +1,38 @@
+from datetime import date, datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Date,
+    Index,
+    String,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class KRStockWarning(Base):
+    __tablename__ = "kr_stock_warnings"
+    __table_args__ = (
+        Index(
+            "ix_kr_stock_warnings_market_symbol",
+            "market",
+            "symbol",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    market: Mapped[str] = mapped_column(String(10), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(10), nullable=False)
+    warning_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    exchange: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    start_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    end_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    source: Mapped[str] = mapped_column(
+        String(32), default="toss_openapi", nullable=False
+    )
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -11,6 +11,7 @@ from app.services.brokers.toss.dto import (
     TossAccount,
     TossOrderOperationResult,
     TossOrderPlacementResult,
+    TossWarningInfo,
     parse_accounts,
     parse_buying_power,
     parse_candles,
@@ -23,6 +24,7 @@ from app.services.brokers.toss.dto import (
     parse_prices,
     parse_sellable_quantity,
     parse_stocks,
+    parse_warnings,
 )
 from app.services.brokers.toss.errors import TossApiResponseError, parse_toss_response
 from app.services.brokers.toss.rate_limiter import (
@@ -155,11 +157,13 @@ class TossReadClient:
             )
         )
 
-    async def warnings(self, symbol: str) -> Any:
-        return await self._request(
-            "GET",
-            f"/api/v1/stocks/{symbol}/warnings",
-            group=TossApiGroup.STOCK,
+    async def warnings(self, symbol: str) -> list[TossWarningInfo]:
+        return parse_warnings(
+            await self._request(
+                "GET",
+                f"/api/v1/stocks/{symbol}/warnings",
+                group=TossApiGroup.STOCK,
+            )
         )
 
     async def candles(

--- a/app/services/brokers/toss/dto.py
+++ b/app/services/brokers/toss/dto.py
@@ -325,3 +325,23 @@ def parse_candles(raw: dict[str, Any]) -> TossCandlesPage:
         candles=candles,
         next_before=str(next_before) if next_before is not None else None,
     )
+
+
+@dataclass(frozen=True)
+class TossWarningInfo:
+    warning_type: str
+    exchange: str | None
+    start_date: str | None
+    end_date: str | None
+
+
+def parse_warnings(raw: list[dict[str, Any]]) -> list[TossWarningInfo]:
+    return [
+        TossWarningInfo(
+            warning_type=str(row["warningType"]),
+            exchange=row.get("exchange"),
+            start_date=row.get("startDate"),
+            end_date=row.get("endDate"),
+        )
+        for row in raw
+    ]

--- a/app/services/brokers/toss/warnings_guard.py
+++ b/app/services/brokers/toss/warnings_guard.py
@@ -1,0 +1,99 @@
+import asyncio
+import logging
+import re
+from datetime import date, datetime
+from typing import NamedTuple
+from zoneinfo import ZoneInfo
+
+from app.services.brokers.toss.client import TossReadClient
+from app.services.brokers.toss.dto import TossWarningInfo
+
+logger = logging.getLogger(__name__)
+
+# LIQUIDATION_TRADING is the only warning type that blocks orders
+_BLOCKING_WARNING_TYPES = {"LIQUIDATION_TRADING"}
+
+
+class WarningsGuardResult(NamedTuple):
+    ok: bool
+    warnings: list[TossWarningInfo]
+    error_message: str | None = None
+
+
+def _is_active_warning(warning: TossWarningInfo, today: date) -> bool:
+    start = date.fromisoformat(warning.start_date) if warning.start_date else date.min
+    end = date.fromisoformat(warning.end_date) if warning.end_date else None
+    return start <= today and (end is None or today <= end)
+
+
+async def check_warnings_guard(
+    client: TossReadClient,
+    symbol: str,
+    market: str | None = None,
+    timeout: float = 3.0,
+    today: date | None = None,
+) -> WarningsGuardResult:
+    """
+    Checks if there are active warnings for the given symbol.
+    Blocks the order if LIQUIDATION_TRADING is active.
+    Fail-open: If the API request fails or times out, allows the order to proceed.
+    Only checks KR stock symbols (6 numeric digits).
+    """
+    clean_sym = str(symbol).strip()
+
+    # market == "equity_kr" 종목만 실조회 수행 (US는 스킵하여 latency 최적화)
+    is_kr = False
+    if market == "kr" or market == "equity_kr":
+        is_kr = True
+    elif market is None:
+        if re.match(r"^\d{6}$", clean_sym):
+            is_kr = True
+
+    if not is_kr:
+        return WarningsGuardResult(ok=True, warnings=[])
+
+    try:
+        # Request with timeout
+        raw_warnings = await asyncio.wait_for(
+            client.warnings(clean_sym), timeout=timeout
+        )
+        current_date = today or datetime.now(ZoneInfo("Asia/Seoul")).date()
+        active_warnings = [
+            warning
+            for warning in raw_warnings
+            if _is_active_warning(warning, current_date)
+        ]
+
+        # Check blocking warning types
+        blocking = [
+            w for w in active_warnings if w.warning_type in _BLOCKING_WARNING_TYPES
+        ]
+        if blocking:
+            blocked_types = ", ".join(w.warning_type for w in blocking)
+            return WarningsGuardResult(
+                ok=False,
+                warnings=active_warnings,
+                error_message=f"Order blocked due to warning types: {blocked_types}",
+            )
+
+        return WarningsGuardResult(ok=True, warnings=active_warnings)
+    except TimeoutError:
+        logger.warning(
+            "Timeout checking Toss warnings for symbol=%s. Proceeding (fail-open).",
+            clean_sym,
+        )
+        return WarningsGuardResult(
+            ok=True, warnings=[], error_message="Warnings check timed out (fail-open)"
+        )
+    except Exception as exc:
+        logger.error(
+            "Error checking Toss warnings for symbol=%s: %s. Proceeding (fail-open).",
+            clean_sym,
+            exc,
+            exc_info=True,
+        )
+        return WarningsGuardResult(
+            ok=True,
+            warnings=[],
+            error_message=f"Warnings check failed: {exc} (fail-open)",
+        )

--- a/app/services/toss_warnings_sync_service.py
+++ b/app/services/toss_warnings_sync_service.py
@@ -1,0 +1,208 @@
+import logging
+from datetime import UTC, date, datetime
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentWatchAlert
+from app.models.kr_stock_warnings import KRStockWarning
+from app.models.manual_holdings import BrokerAccount, ManualHolding, MarketType
+from app.services.brokers.toss.client import TossReadClient
+from app.services.brokers.toss.dto import TossWarningInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_symbol(symbol: object) -> str | None:
+    normalized = str(symbol or "").strip().upper()
+    return normalized or None
+
+
+def _holding_market(item: Any) -> str | None:
+    market_country = str(getattr(item, "market_country", "") or "").strip().upper()
+    if market_country == "KR":
+        return "kr"
+    if market_country == "US":
+        return "us"
+    return None
+
+
+def _parse_warning_date(value: str | None) -> date | None:
+    return date.fromisoformat(value) if value else None
+
+
+def _warning_row(
+    *,
+    market: str,
+    symbol: str,
+    warning: TossWarningInfo,
+    fetched_at: datetime,
+) -> KRStockWarning:
+    return KRStockWarning(
+        market=market,
+        symbol=symbol,
+        warning_type=warning.warning_type,
+        exchange=warning.exchange,
+        start_date=_parse_warning_date(warning.start_date),
+        end_date=_parse_warning_date(warning.end_date),
+        source="toss_openapi",
+        fetched_at=fetched_at,
+    )
+
+
+async def _resolve_default_symbols(
+    db: AsyncSession,
+    client: TossReadClient,
+    *,
+    market: str,
+) -> tuple[list[str], list[str]]:
+    symbols: set[str] = set()
+    errors: list[str] = []
+
+    try:
+        holdings = await client.holdings()
+        for item in getattr(holdings, "items", []):
+            if _holding_market(item) != market:
+                continue
+            if symbol := _normalize_symbol(getattr(item, "symbol", "")):
+                symbols.add(symbol)
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve Toss holdings for warnings sync: %s",
+            exc,
+            exc_info=True,
+        )
+        errors.append(f"holdings: {exc}")
+
+    market_type = MarketType.KR if market == "kr" else MarketType.US
+    try:
+        stmt = (
+            sa.select(ManualHolding.ticker)
+            .join(BrokerAccount)
+            .where(
+                ManualHolding.market_type == market_type,
+                ManualHolding.quantity > 0,
+                BrokerAccount.is_active.is_(True),
+            )
+            .order_by(ManualHolding.ticker)
+        )
+        result = await db.execute(stmt)
+        for row in result.all():
+            if symbol := _normalize_symbol(row[0]):
+                symbols.add(symbol)
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve manual holdings for warnings sync market=%s: %s",
+            market,
+            exc,
+            exc_info=True,
+        )
+        errors.append(f"manual_holdings: {exc}")
+
+    try:
+        stmt = (
+            sa.select(InvestmentWatchAlert.symbol)
+            .where(
+                InvestmentWatchAlert.market == market,
+                InvestmentWatchAlert.target_kind == "asset",
+                InvestmentWatchAlert.status == "active",
+                InvestmentWatchAlert.valid_until >= datetime.now(UTC),
+            )
+            .order_by(InvestmentWatchAlert.symbol)
+        )
+        result = await db.execute(stmt)
+        for row in result.all():
+            if symbol := _normalize_symbol(row[0]):
+                symbols.add(symbol)
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve watch symbols for warnings sync market=%s: %s",
+            market,
+            exc,
+            exc_info=True,
+        )
+        errors.append(f"watch_alerts: {exc}")
+
+    return sorted(symbols), errors
+
+
+async def sync_toss_warnings(
+    db: AsyncSession,
+    client: TossReadClient,
+    *,
+    market: str,
+    symbols: list[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Syncs stock warnings from Toss API to the database.
+    Semantic: Per-symbol replace.
+    For each symbol, we delete existing warnings and insert the current ones.
+    """
+    if market not in ("kr", "us"):
+        raise ValueError(f"Unsupported market for warnings sync: {market}")
+
+    errors = []
+
+    # Resolve symbols if not provided
+    if symbols is None:
+        symbols, resolution_errors = await _resolve_default_symbols(
+            db,
+            client,
+            market=market,
+        )
+        errors.extend(resolution_errors)
+    else:
+        symbols = [symbol for raw in symbols if (symbol := _normalize_symbol(raw))]
+
+    processed = 0
+    inserted = 0
+    deleted = 0
+
+    for symbol in symbols:
+        try:
+            # 1. Fetch warnings from Toss client
+            warnings = await client.warnings(symbol)
+            fetched_at = datetime.now(UTC)
+            warning_rows = [
+                _warning_row(
+                    market=market,
+                    symbol=symbol,
+                    warning=warning,
+                    fetched_at=fetched_at,
+                )
+                for warning in warnings
+            ]
+
+            # 2. Delete existing warnings for this symbol from DB
+            delete_stmt = sa.delete(KRStockWarning).where(
+                KRStockWarning.market == market, KRStockWarning.symbol == symbol
+            )
+            del_res = await db.execute(delete_stmt)
+            deleted += del_res.rowcount or 0
+
+            # 3. Insert new warnings
+            for warning_row in warning_rows:
+                db.add(warning_row)
+            inserted += len(warning_rows)
+            processed += 1
+
+        except Exception as exc:
+            logger.error(
+                "Failed to sync Toss warnings for symbol=%s: %s",
+                symbol,
+                exc,
+                exc_info=True,
+            )
+            errors.append(f"{symbol}: {exc}")
+
+    # Commit after processing
+    await db.commit()
+
+    return {
+        "market": market,
+        "symbols_processed": processed,
+        "warnings_inserted": inserted,
+        "warnings_deleted_count": deleted,
+        "errors": errors,
+    }

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -20,6 +20,7 @@ from app.tasks import (
     pending_orders,
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
+    toss_warnings_sync_tasks,
     upbit_symbol_universe_tasks,
     us_candles_tasks,
     us_symbol_universe_tasks,
@@ -53,4 +54,5 @@ TASKIQ_TASK_MODULES = (
     upbit_symbol_universe_tasks,
     us_candles_tasks,
     us_symbol_universe_tasks,
+    toss_warnings_sync_tasks,
 )

--- a/app/tasks/toss_warnings_sync_tasks.py
+++ b/app/tasks/toss_warnings_sync_tasks.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+from app.core.taskiq_broker import broker
+from app.jobs.toss_warnings import run_toss_warnings_sync
+
+logger = logging.getLogger(__name__)
+
+
+@broker.task(
+    task_name="warnings.toss.sync",
+    schedule=[{"cron": "30 7 * * *", "cron_offset": "Asia/Seoul"}],
+)
+async def sync_toss_warnings_task() -> dict[str, int | str | list[str]]:
+    try:
+        return await run_toss_warnings_sync()
+    except Exception as exc:
+        logger.error("TaskIQ Toss warnings sync failed: %s", exc, exc_info=True)
+        return {
+            "status": "failed",
+            "error": str(exc),
+        }

--- a/docs/superpowers/plans/2026-06-12-rob-535-toss-warnings-plan.md
+++ b/docs/superpowers/plans/2026-06-12-rob-535-toss-warnings-plan.md
@@ -1,0 +1,114 @@
+# ROB-535 Toss Stock Warnings Guard and Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Korea stock warnings check, pre-trade order execution guard, MCP preview/mutation safety integration, database schema, and daily sync job using Toss OpenAPI.
+
+---
+
+## 1. File Structure Changes
+
+- **Create**: `app/models/kr_stock_warnings.py`
+  - DB model `KRStockWarning` representing the `kr_stock_warnings` table.
+- **Modify**: `app/models/__init__.py`
+  - Register and export `KRStockWarning`.
+- **Modify**: `app/services/brokers/toss/dto.py`
+  - Add `TossWarningInfo` dataclass and `parse_warnings` parser.
+- **Modify**: `app/services/brokers/toss/client.py`
+  - Implement `warnings(symbol: str) -> list[TossWarningInfo]` returning parsed warnings.
+- **Create**: `app/services/brokers/toss/warnings_guard.py`
+  - Implement `check_warnings_guard` function with timeout, fail-open, and blocking policy for `LIQUIDATION_TRADING`.
+- **Modify**: `app/mcp_server/tooling/orders_toss_variants.py`
+  - Wire warnings guard into `toss_preview_order` (show active warnings) and `toss_place_order` (block on LIQUIDATION_TRADING).
+- **Modify**: `app/mcp_server/tooling/orders_kis_variants.py`
+  - Wire the same Toss warnings guard into KIS live KR buy preview/mutation paths.
+- **Create**: `app/services/toss_warnings_sync_service.py`
+  - Sync warnings for KR stocks using per-symbol replace semantic.
+- **Create**: `app/jobs/toss_warnings.py`
+  - Job runner wrapper for the sync service.
+- **Create**: `app/tasks/toss_warnings_sync_tasks.py`
+  - TaskIQ background task definitions and schedule.
+- **Create**: `scripts/sync_toss_warnings.py`
+  - CLI script to trigger warnings sync.
+- **Modify**: `Makefile`
+  - Add a target `sync-toss-warnings` to run the sync script.
+
+---
+
+## 2. Implementation Steps
+
+### Task 1: Database Model and Alembic Migration
+- [x] **Step 1.1**: Create `app/models/kr_stock_warnings.py` with:
+  - Table name: `kr_stock_warnings`
+  - Columns: `id` (BigInt PK), `market` (String 10), `symbol` (String 10), `warning_type` (String 50), `exchange` (String 20, nullable), `start_date` (Date, nullable), `end_date` (Date, nullable), `source` (String 32, default 'toss_openapi'), `fetched_at` (DateTime TZ-aware).
+  - Index: `ix_kr_stock_warnings_market_symbol` on `(market, symbol)`.
+- [x] **Step 1.2**: Update `app/models/__init__.py` to import and expose `KRStockWarning`.
+- [x] **Step 1.3**: Run Alembic migration generation:
+  ```bash
+  uv run alembic revision --autogenerate -m "add kr_stock_warnings table"
+  ```
+- [x] **Step 1.4**: Review the generated migration file for correctness and apply it:
+  ```bash
+  uv run alembic upgrade head
+  ```
+
+### Task 2: Toss Client DTO & Warnings Method Update
+- [x] **Step 2.1**: In `app/services/brokers/toss/dto.py`, add `TossWarningInfo` dataclass and `parse_warnings` function.
+- [x] **Step 2.2**: In `app/services/brokers/toss/client.py`, update `warnings` method:
+  ```python
+  async def warnings(self, symbol: str) -> list[TossWarningInfo]:
+      return parse_warnings(
+          await self._request(
+              "GET",
+              f"/api/v1/stocks/{symbol}/warnings",
+              group=TossApiGroup.STOCK,
+          )
+      )
+  ```
+- [x] **Step 2.3**: Add unit tests in `tests/services/brokers/toss/test_dto.py` verifying parsing of warnings with different warning types.
+- [x] **Step 2.4**: Run pytest for Toss client to verify changes:
+  ```bash
+  uv run pytest tests/services/brokers/toss -q
+  ```
+
+### Task 3: Implement Warnings Order Guard
+- [x] **Step 3.1**: Create `app/services/brokers/toss/warnings_guard.py` with `check_warnings_guard` function:
+  - Check if target symbol is KR (e.g. 6 numeric digits). If not, immediately return success (`ok=True`).
+  - Request Toss warnings API with a 3.0 second timeout (`asyncio.wait_for`).
+  - Fail-open: If the API request times out or raises an error, log the error and allow the order (`ok=True`, log warnings check failure).
+  - Blocking Policy: Check if warning list contains `LIQUIDATION_TRADING`. If yes, block order (`ok=False`).
+- [x] **Step 3.2**: Write unit tests for `warnings_guard.py` in `tests/services/brokers/toss/test_warnings_guard.py` covering success, failure, timeout, and blocking cases.
+
+### Task 4: Integrate Warnings Guard in MCP Tools
+- [x] **Step 4.1**: In `app/mcp_server/tooling/orders_toss_variants.py`, update `toss_preview_order` to:
+  - Fetch warnings using `client.warnings(symbol)` inside client context.
+  - Expose active warning types in the return dictionary under `warnings` (e.g. `[w.warning_type for w in warnings]`).
+- [x] **Step 4.2**: In `app/mcp_server/tooling/orders_toss_variants.py`, update `toss_place_order`:
+  - Before sending mutations to Toss, check `check_warnings_guard`.
+  - If `ok=False`, return a structured response with `"success": False`, `**base_response`, and `"error": guard_result.error_message`.
+- [x] **Step 4.3**: Write tests in `tests/test_mcp_toss_order_variants.py` to verify warnings list in preview and blocking behavior on place order (consolidated with existing order variants tests).
+
+### Task 5: Warnings Sync Service and Scheduler Job
+- [x] **Step 5.1**: Create `app/services/toss_warnings_sync_service.py` implementing `sync_toss_warnings(db, client, market, symbols)`:
+  - If symbols are not provided, resolve only scoped symbols from Toss holdings, active manual holdings, and active watch alerts. Do not poll the full KR/US symbol universe by default; the Toss warnings API is rate-limited and the default job must stay bounded.
+  - If symbols are provided explicitly, sync exactly those normalized symbols.
+  - Loop through symbols: delete existing warnings matching `(market, symbol)` and insert new warnings.
+  - Batch commit to database.
+- [x] **Step 5.2**: Create `app/jobs/toss_warnings.py` to wrap the sync service with database session and `TossReadClient` contexts.
+- [x] **Step 5.3**: Create `app/tasks/toss_warnings_sync_tasks.py` defining task `sync_toss_warnings_task` with schedule `30 7 * * *` (KST).
+- [x] **Step 5.4**: Create `scripts/sync_toss_warnings.py` to expose warnings sync to the command line.
+- [x] **Step 5.5**: Add `sync-toss-warnings` target to the `Makefile`.
+- [x] **Step 5.6**: Write tests in `tests/test_toss_warnings_sync.py` to verify the sync service behaves correctly (e.g., replaces per-symbol warnings).
+
+
+---
+
+## 3. Verification
+
+Run the focused checks plus full lint/test before PR:
+```bash
+make lint
+uv run pytest tests/services/brokers/toss tests/test_mcp_toss_order_variants.py tests/test_mcp_kis_order_variants.py tests/test_toss_warnings_sync.py -q
+uv run alembic heads
+make test
+```

--- a/docs/superpowers/specs/2026-06-12-rob-535-toss-warnings-design.md
+++ b/docs/superpowers/specs/2026-06-12-rob-535-toss-warnings-design.md
@@ -1,0 +1,51 @@
+# [Feature] 토스 종목 경고(warnings) 매수 가드 및 동기화 (ROB-535)
+
+## 1. 배경 및 목적
+현재 시스템은 국내 주식의 VI 발동, 투자경고, 정리매매, 거래정지 등 동적 위험 상태를 수집하거나 감지하지 못함. 이를 위해 토스증권 API를 활용하여 주문 전 실시간 가드와 보유/관심 종목에 대한 일배치 동기화 기능을 구현함.
+
+## 2. 설계 상세
+
+### 2.1 데이터베이스 스키마 (`kr_stock_warnings`)
+동적 경고 데이터를 저장하기 위한 별도 테이블을 신설함.
+- **Table Name**: `kr_stock_warnings`
+- **Columns**:
+    - `id`: BigInt (PK, autoincrement)
+    - `market`: String(10) (예: 'kr', 'us')
+    - `symbol`: String(10) (종목 코드)
+    - `warning_type`: String(50) (Unknown 허용)
+    - `exchange`: String(20), nullable (거래소)
+    - `start_date`: Date, nullable
+    - `end_date`: Date, nullable
+    - `source`: String(32), default 'toss_openapi'
+    - `fetched_at`: DateTime(timezone=True)
+- **Index**: `(market, symbol)` - 조회 성능 최적화
+
+### 2.2 Toss API 연동 (`app/services/brokers/toss`)
+- **`dto.py`**: `TossWarningInfo` 데이터 클래스 및 파서 추가. 8종 enum(LIQUIDATION_TRADING, VI_STATIC 등) 대응.
+- **`client.py`**: `GET /api/v1/stocks/{symbol}/warnings` 호출 메서드 추가.
+
+### 2.3 주문 가드 헬퍼 (`warnings_guard.py`)
+- **Location**: `app/services/brokers/toss/warnings_guard.py`
+- **Logic**:
+    - `market == "equity_kr"` 종목만 실조회 수행 (US는 스킵하여 latency 최적화).
+    - **Fail-open**: API 조회 실패 시 로그를 남기고 주문 진행 허용.
+    - **Blocking Policy**: `_BLOCKING_WARNING_TYPES = {"LIQUIDATION_TRADING"}`에 해당하는 경우 `ok=False` 반환. 그 외는 정보만 제공.
+    - **Timeout**: 2~3초 이내로 제한.
+
+### 2.4 MCP 도구 배선
+- **`toss_preview_order`**: 주문 미리보기 결과에 현재 활성 경고 목록 노출.
+- **`toss_place_order`**: `confirm=True` 시점에 가드 호출. 차단 유형 발견 시 주문 실행 중단.
+- **`kis_live_place_order`**: KR live buy 경로에서도 동일한 Toss 실시간 경고 조회를 수행. `dry_run=True`는 활성 경고를 표시하고, 실주문은 활성 `LIQUIDATION_TRADING` 발견 시 KIS POST 전 차단.
+
+### 2.5 동기화 서비스 (`sync_toss_warnings`)
+- **Semantic**: Per-symbol replace.
+- 심볼별로 기존 데이터를 모두 삭제하고 현재 API 결과로 전체 교체하여 `NULL` 값 정합성 문제 회피.
+- `is_active` 필드 없이 `start_date`와 `end_date`를 기준으로 조회 시점에 판정.
+- 기본 일배치 대상은 Toss 보유, 활성 수동보유, 활성 watch alert 종목으로 제한. 전체 KR/US 유니버스 폴링은 Toss API 처리량과 비용 리스크 때문에 기본 경로에서 제외.
+- 운영자가 명시한 `symbols` 입력은 그대로 정규화하여 sync 가능.
+
+## 3. 제약 및 고려사항
+- 주문 가드는 항상 실조회 API를 사용하여 적시성 확보.
+- DB 테이블은 리포트 및 브리핑 생성용으로만 활용.
+- ROB-534(`kr_symbol_universe` 수정)와의 마이그레이션 충돌 방지를 위해 별도 테이블 유지.
+- 이 변경은 DB migration, 스케줄러, live order guard를 건드리므로 `high_risk_change`, `needs_stronger_model_review`, `hold_for_final_review` 대상이다. 병합/배포/실거래 사용 전 CTO/Opus급 최종 검토가 필요하다.

--- a/scripts/sync_toss_warnings.py
+++ b/scripts/sync_toss_warnings.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from app.core.cli import run_async_job, setup_logging_and_sentry
+from app.jobs.toss_warnings import run_toss_warnings_sync
+
+logger = logging.getLogger(__name__)
+
+
+async def main() -> int:
+    setup_logging_and_sentry(service_name="toss-warnings-sync")
+
+    async def _job() -> int:
+        result = await run_toss_warnings_sync()
+        if result.get("status") != "completed":
+            logger.error("Toss warnings sync failed: %s", result)
+            return 1
+        logger.info("Toss warnings sync completed: %s", result)
+        return 0
+
+    return await run_async_job(_job, process="sync_toss_warnings")
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -385,3 +385,43 @@ async def test_cancel_order_posts_to_cancel_path_and_parses_new_order_id() -> No
     assert seen["path"] == "/api/v1/orders/orig-ord-123/cancel"
     assert json.loads(seen["body"]) == {}
     assert res.order_id == "can-ord-789"
+
+
+@pytest.mark.asyncio
+async def test_warnings_fetches_and_parses() -> None:
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json=_json(
+                [
+                    {
+                        "warningType": "LIQUIDATION_TRADING",
+                        "exchange": "KRX",
+                        "startDate": "2026-06-12",
+                        "endDate": None,
+                    }
+                ]
+            ),
+            request=request,
+        )
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        warnings = await client.warnings("005930")
+    finally:
+        await client.aclose()
+
+    assert seen["method"] == "GET"
+    assert seen["path"] == "/api/v1/stocks/005930/warnings"
+    assert len(warnings) == 1
+    assert warnings[0].warning_type == "LIQUIDATION_TRADING"
+    assert warnings[0].exchange == "KRX"
+    assert warnings[0].start_date == "2026-06-12"
+    assert warnings[0].end_date is None

--- a/tests/services/brokers/toss/test_dto.py
+++ b/tests/services/brokers/toss/test_dto.py
@@ -172,3 +172,35 @@ def test_parse_candles_rejects_float_prices() -> None:
                 "nextBefore": None,
             }
         )
+
+
+def test_parse_warnings_converts_fields() -> None:
+    from app.services.brokers.toss.dto import parse_warnings
+
+    warnings = parse_warnings(
+        [
+            {
+                "warningType": "OVERHEATED",
+                "exchange": "KRX",
+                "startDate": "2026-03-20",
+                "endDate": "2026-03-27",
+            },
+            {
+                "warningType": "VI_STATIC",
+                "exchange": None,
+                "startDate": "2026-03-26",
+                "endDate": None,
+            },
+        ]
+    )
+
+    assert len(warnings) == 2
+    assert warnings[0].warning_type == "OVERHEATED"
+    assert warnings[0].exchange == "KRX"
+    assert warnings[0].start_date == "2026-03-20"
+    assert warnings[0].end_date == "2026-03-27"
+
+    assert warnings[1].warning_type == "VI_STATIC"
+    assert warnings[1].exchange is None
+    assert warnings[1].start_date == "2026-03-26"
+    assert warnings[1].end_date is None

--- a/tests/services/brokers/toss/test_warnings_guard.py
+++ b/tests/services/brokers/toss/test_warnings_guard.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date
+
+import pytest
+
+from app.services.brokers.toss.dto import TossWarningInfo
+from app.services.brokers.toss.warnings_guard import check_warnings_guard
+
+
+class DummyClient:
+    def __init__(self, warnings_result=None, should_delay=False, should_fail=False):
+        self.warnings_result = warnings_result or []
+        self.should_delay = should_delay
+        self.should_fail = should_fail
+        self.calls = []
+
+    async def warnings(self, symbol: str) -> list[TossWarningInfo]:
+        self.calls.append(symbol)
+        if self.should_fail:
+            raise RuntimeError("API failure")
+        if self.should_delay:
+            await asyncio.sleep(5.0)
+        return self.warnings_result
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_skips_non_kr() -> None:
+    # US stock symbol
+    client = DummyClient()
+    result = await check_warnings_guard(client, "AAPL")
+    assert result.ok is True
+    assert result.warnings == []
+    assert len(client.calls) == 0
+
+    # Explicitly US market
+    result = await check_warnings_guard(client, "005930", market="us")
+    assert result.ok is True
+    assert result.warnings == []
+    assert len(client.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_kr_no_warnings() -> None:
+    client = DummyClient(warnings_result=[])
+    result = await check_warnings_guard(client, "005930")
+    assert result.ok is True
+    assert result.warnings == []
+    assert client.calls == ["005930"]
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_kr_non_blocking_warnings() -> None:
+    warnings_list = [
+        TossWarningInfo(
+            warning_type="OVERHEATED",
+            exchange="KRX",
+            start_date="2026-06-12",
+            end_date=None,
+        ),
+        TossWarningInfo(
+            warning_type="VI_STATIC",
+            exchange="KRX",
+            start_date="2026-06-12",
+            end_date=None,
+        ),
+    ]
+    client = DummyClient(warnings_result=warnings_list)
+    result = await check_warnings_guard(client, "005930")
+    assert result.ok is True
+    assert result.warnings == warnings_list
+    assert result.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_kr_blocking_warning() -> None:
+    warnings_list = [
+        TossWarningInfo(
+            warning_type="LIQUIDATION_TRADING",
+            exchange="KRX",
+            start_date="2026-06-12",
+            end_date=None,
+        )
+    ]
+    client = DummyClient(warnings_result=warnings_list)
+    result = await check_warnings_guard(client, "005930")
+    assert result.ok is False
+    assert result.warnings == warnings_list
+    assert "LIQUIDATION_TRADING" in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_filters_inactive_warnings_before_blocking() -> None:
+    warnings_list = [
+        TossWarningInfo(
+            warning_type="LIQUIDATION_TRADING",
+            exchange="KRX",
+            start_date="2026-06-01",
+            end_date="2026-06-10",
+        ),
+        TossWarningInfo(
+            warning_type="LIQUIDATION_TRADING",
+            exchange="KRX",
+            start_date="2026-06-20",
+            end_date=None,
+        ),
+        TossWarningInfo(
+            warning_type="OVERHEATED",
+            exchange="KRX",
+            start_date="2026-06-12",
+            end_date=None,
+        ),
+    ]
+    client = DummyClient(warnings_result=warnings_list)
+
+    result = await check_warnings_guard(client, "005930", today=date(2026, 6, 12))
+
+    assert result.ok is True
+    assert [w.warning_type for w in result.warnings] == ["OVERHEATED"]
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_fail_open_on_timeout() -> None:
+    client = DummyClient(should_delay=True)
+    result = await check_warnings_guard(client, "005930", timeout=0.1)
+    assert result.ok is True
+    assert result.warnings == []
+    assert "timed out" in result.error_message
+
+
+@pytest.mark.asyncio
+async def test_warnings_guard_fail_open_on_error() -> None:
+    client = DummyClient(should_fail=True)
+    result = await check_warnings_guard(client, "005930")
+    assert result.ok is True
+    assert result.warnings == []
+    assert "failed" in result.error_message

--- a/tests/test_mcp_kis_order_variants.py
+++ b/tests/test_mcp_kis_order_variants.py
@@ -21,6 +21,7 @@ from app.mcp_server.tooling.orders_kis_variants import (
     register_kis_live_order_tools,
     register_kis_mock_order_tools,
 )
+from app.services.brokers.toss.dto import TossWarningInfo
 from tests._mcp_tooling_support import DummyMCP
 
 
@@ -402,6 +403,87 @@ class TestKisLivePlaceOrder:
         )
         assert result["success"] is True
         assert captured.get("is_mock") is False
+
+    @pytest.mark.asyncio
+    async def test_dry_run_includes_active_toss_warnings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+
+        class _WarningsClient:
+            async def warnings(self, symbol: str):
+                assert symbol == "005930"
+                return [
+                    TossWarningInfo(
+                        warning_type="OVERHEATED",
+                        exchange="KRX",
+                        start_date="2026-06-12",
+                        end_date=None,
+                    )
+                ]
+
+            async def aclose(self) -> None:
+                pass
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            assert kwargs["dry_run"] is True
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+        monkeypatch.setattr(
+            orders_kis_variants.TossReadClient,
+            "from_settings",
+            lambda: _WarningsClient(),
+        )
+
+        result = await mcp.tools["kis_live_place_order"](
+            symbol="005930", side="buy", price=50000.0, dry_run=True
+        )
+
+        assert result["success"] is True
+        assert result["warnings"][0]["warning_type"] == "OVERHEATED"
+
+    @pytest.mark.asyncio
+    async def test_live_buy_blocks_active_liquidation_trading_before_kis_post(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+        called = {"placed": False}
+
+        class _WarningsClient:
+            async def warnings(self, symbol: str):
+                assert symbol == "005930"
+                return [
+                    TossWarningInfo(
+                        warning_type="LIQUIDATION_TRADING",
+                        exchange="KRX",
+                        start_date="2026-06-12",
+                        end_date=None,
+                    )
+                ]
+
+            async def aclose(self) -> None:
+                pass
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            called["placed"] = True
+            return {"success": True, "dry_run": kwargs["dry_run"]}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+        monkeypatch.setattr(
+            orders_kis_variants.TossReadClient,
+            "from_settings",
+            lambda: _WarningsClient(),
+        )
+
+        result = await mcp.tools["kis_live_place_order"](
+            symbol="005930", side="buy", price=50000.0, dry_run=False
+        )
+
+        assert result["success"] is False
+        assert result["mutation_sent"] is False
+        assert "LIQUIDATION_TRADING" in result["error"]
+        assert called["placed"] is False
 
 
 # ===========================================================================

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -111,6 +111,7 @@ class MockTossClient:
         self.holdings_list = []
         self.orders_list = []
         self.prices_list = []
+        self.warnings_list = []
         self.get_order_calls = 0
 
         if monkeypatch:
@@ -121,6 +122,19 @@ class MockTossClient:
 
     async def aclose(self):
         pass
+
+    async def warnings(self, symbol: str):
+        from app.services.brokers.toss.dto import TossWarningInfo
+
+        return [
+            TossWarningInfo(
+                warning_type=w.get("warning_type", "VI_STATIC"),
+                exchange=w.get("exchange", "KRX"),
+                start_date=w.get("start_date"),
+                end_date=w.get("end_date"),
+            )
+            for w in self.warnings_list
+        ]
 
     async def holdings(self, *, symbol=None):
         # returns simple dataclass mock
@@ -1505,3 +1519,68 @@ async def test_order_history_json_safes_datetime_timestamps(monkeypatch):
     order = res["orders"][0]
     assert order["ordered_at"] == ordered_at.isoformat()
     assert order["canceled_at"] == canceled_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_preview_order_includes_warnings(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.warnings_list = [
+        {
+            "warning_type": "OVERHEATED",
+            "exchange": "KRX",
+            "start_date": "2026-06-12",
+            "end_date": None,
+        }
+    ]
+
+    res = await toss_preview_order(
+        symbol="005930",
+        side="buy",
+        quantity="10",
+        price="70000",
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is True
+    assert len(res["warnings"]) == 1
+    assert res["warnings"][0]["warning_type"] == "OVERHEATED"
+
+
+@pytest.mark.asyncio
+async def test_place_order_blocked_by_liquidation_trading(monkeypatch):
+    import app.mcp_server.tooling.orders_toss_variants as otv
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.warnings_list = [
+        {
+            "warning_type": "LIQUIDATION_TRADING",
+            "exchange": "KRX",
+            "start_date": "2026-06-12",
+            "end_date": None,
+        }
+    ]
+
+    res = await toss_place_order(
+        symbol="005930",
+        side="buy",
+        quantity="10",
+        price="70000",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert "blocked" in res["error"].lower()
+    assert len(res["warnings"]) == 1
+    assert res["warnings"][0]["warning_type"] == "LIQUIDATION_TRADING"

--- a/tests/test_toss_warnings_sync.py
+++ b/tests/test_toss_warnings_sync.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.brokers.toss.dto import TossWarningInfo
+from app.services.toss_warnings_sync_service import sync_toss_warnings
+
+
+class DummyResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class DummyDB:
+    def __init__(self, symbols_in_db=None):
+        self.added = []
+        self.deleted_stmts = []
+        self.symbols_in_db = symbols_in_db or []
+        self.commit_called = False
+
+    async def execute(self, stmt):
+        import sqlalchemy as sa
+
+        # Identify if this is a select on symbol universe or delete
+        if isinstance(stmt, sa.sql.selectable.Select):
+            # Resolve symbols query
+            rows = [(sym,) for sym in self.symbols_in_db]
+            return DummyResult(rows)
+        elif isinstance(stmt, sa.sql.dml.Delete):
+            self.deleted_stmts.append(stmt)
+            # mock deleted count return
+            mock_res = MagicMock()
+            mock_res.rowcount = 1
+            return mock_res
+        return DummyResult([])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commit_called = True
+
+
+class DummyClient:
+    def __init__(self, warnings_map=None, holdings_rows=None):
+        self.warnings_map = warnings_map or {}
+        self.holdings_rows = holdings_rows or []
+        self.calls = []
+
+    async def holdings(self):
+        return SimpleNamespace(
+            items=[
+                SimpleNamespace(symbol=symbol, market_country=market_country)
+                for symbol, market_country in self.holdings_rows
+            ]
+        )
+
+    async def warnings(self, symbol: str) -> list[TossWarningInfo]:
+        self.calls.append(symbol)
+        if symbol == "FAIL":
+            raise RuntimeError("API Sync Error")
+        return self.warnings_map.get(symbol, [])
+
+
+class ScopedDummyDB(DummyDB):
+    async def execute(self, stmt):
+        stmt_text = str(stmt)
+        if "kr_symbol_universe" in stmt_text or "us_symbol_universe" in stmt_text:
+            raise AssertionError("warnings sync must not poll the full symbol universe")
+        if "investment_watch_alerts" in stmt_text:
+            return DummyResult([("000660",), ("005930",)])
+        if "manual_holdings" in stmt_text:
+            return DummyResult([("035720",)])
+        return await super().execute(stmt)
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_warnings_replaces_explicit_symbols() -> None:
+    db = DummyDB()
+    warnings_map = {
+        "005930": [
+            TossWarningInfo(
+                warning_type="OVERHEATED",
+                exchange="KRX",
+                start_date="2026-06-12",
+                end_date=None,
+            )
+        ],
+        "000660": [],
+    }
+    client = DummyClient(warnings_map=warnings_map)
+
+    res = await sync_toss_warnings(
+        db=db, client=client, market="kr", symbols=["005930", "000660"]
+    )
+
+    assert res["market"] == "kr"
+    assert res["symbols_processed"] == 2
+    assert res["warnings_inserted"] == 1
+    assert len(db.added) == 1
+    assert db.added[0].symbol == "005930"
+    assert db.added[0].warning_type == "OVERHEATED"
+    assert len(db.deleted_stmts) == 2
+    assert db.commit_called is True
+    assert len(res["errors"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_warnings_collects_errors() -> None:
+    db = DummyDB()
+    client = DummyClient()
+
+    # Pass symbol explicitly, one of which will fail
+    res = await sync_toss_warnings(
+        db=db, client=client, market="kr", symbols=["005930", "FAIL"]
+    )
+
+    assert res["symbols_processed"] == 1
+    assert len(res["errors"]) == 1
+    assert "FAIL" in res["errors"][0]
+    assert db.commit_called is True
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_warnings_defaults_to_holdings_and_watch_symbols() -> None:
+    db = ScopedDummyDB()
+    client = DummyClient(holdings_rows=[("005930", "KR"), ("AAPL", "US")])
+
+    res = await sync_toss_warnings(db=db, client=client, market="kr")
+
+    assert res["symbols_processed"] == 3
+    assert sorted(client.calls) == ["000660", "005930", "035720"]
+    assert len(db.deleted_stmts) == 3
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_warnings_does_not_delete_when_warning_date_is_invalid() -> (
+    None
+):
+    db = DummyDB()
+    client = DummyClient(
+        warnings_map={
+            "005930": [
+                TossWarningInfo(
+                    warning_type="OVERHEATED",
+                    exchange="KRX",
+                    start_date="not-a-date",
+                    end_date=None,
+                )
+            ]
+        }
+    )
+
+    res = await sync_toss_warnings(
+        db=db, client=client, market="kr", symbols=["005930"]
+    )
+
+    assert res["symbols_processed"] == 0
+    assert len(res["errors"]) == 1
+    assert "005930" in res["errors"][0]
+    assert db.deleted_stmts == []
+    assert db.commit_called is True


### PR DESCRIPTION

## Summary
- Add `kr_stock_warnings` model/migration plus Toss warning DTO/client parsing.
- Add active Toss warning guard for Toss live preview/place and KIS live KR buys. Active `LIQUIDATION_TRADING` blocks before broker POST; warning lookup failures fail open and surface a message.
- Add bounded daily Toss warnings sync job, TaskIQ task, CLI, and Make target. Default symbols are scoped to Toss holdings, active manual holdings, and active watch alerts rather than the full KR universe.
- Update the ROB-535 plan/spec and MCP README for the implemented behavior.

## Verification
- `make lint`
- `uv run pytest tests/services/brokers/toss tests/test_mcp_toss_order_variants.py tests/test_mcp_kis_order_variants.py tests/test_toss_warnings_sync.py -q` -> 137 passed
- `uv run alembic heads` -> `d82e093e7590 (head)`
- `uv run python -c "from app.models import KRStockWarning; from app.tasks import toss_warnings_sync_tasks; print(KRStockWarning.__tablename__, toss_warnings_sync_tasks.sync_toss_warnings_task.task_name)"`
- `make test` -> 11997 passed, 21 skipped, 4 deselected, 50 warnings
- `git diff --check` and `git diff --cached --check`

## Risk / Hold
- Linear: ROB-535
- This is tagged `high_risk_change`, `needs_stronger_model_review`, and `hold_for_final_review` because it touches DB migration, scheduler behavior, and live-order guard boundaries.
- Do not merge, deploy, or rely on this for live trading until CTO/Opus final review clears it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Korea stock warnings integrated into MCP order tools: previews now display active warnings, and order placement checks for blocking warning types before execution
  * Automatic daily synchronization of warning data (7:30 AM KST)
  * New CLI command to manually trigger warning synchronization
  * Warning checks fail safely; orders proceed if API lookups are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->