### PR TITLE
fix(ROB-545): unblock Toss live mutation activation — ledger idempotency + order-id-preserving errors

### DIFF
--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -542,6 +542,10 @@ async def _toss_place_order_impl(
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
         "dry_run": dry_run,
         "mutation_sent": False,
+        # ROB-545 Major — carry the clientOrderId on every response (incl. error
+        # paths) so a failed/timed-out order can be retried with the *same*
+        # idempotency key instead of minting a new one.
+        "client_order_id": payload["clientOrderId"],
     }
 
     if (
@@ -612,6 +616,7 @@ async def _toss_place_order_impl(
             ) is not None:
                 return sell_guard
 
+        res = None
         try:
             res = await client.place_order(payload)
             raw_response = {
@@ -658,7 +663,15 @@ async def _toss_place_order_impl(
                 ),
             }
         except Exception as exc:
-            return _toss_error_response(exc, {**base_response, "mutation_sent": True})
+            err = _toss_error_response(exc, {**base_response, "mutation_sent": True})
+            # ROB-545 Major/B2 — if the POST already reached Toss (res set) the
+            # broker order id must survive a ledger-write failure or idempotency
+            # anomaly, so reconcile/cancel can still find the live order.
+            if res is not None:
+                err["order_id"] = res.order_id
+                if res.client_order_id is not None:
+                    err["client_order_id"] = res.client_order_id
+            return err
 
     async with _client_context() as client:
         return await execute_order(client)
@@ -834,6 +847,7 @@ async def toss_modify_order(
                 "payload_preview": payload,
             }
 
+        res = None
         try:
             res = await client.modify_order(order_id, payload)
             ledger = await record_toss_replacement_order(
@@ -866,7 +880,14 @@ async def toss_modify_order(
                 **ledger,
             }
         except Exception as exc:
-            return _toss_error_response(exc, {**base_response, "mutation_sent": True})
+            err = _toss_error_response(exc, {**base_response, "mutation_sent": True})
+            # ROB-545 Major — keep the order ids on the error path so the live
+            # order (and any issued replacement) can be reconciled/cancelled.
+            err.setdefault("original_order_id", order_id)
+            if res is not None:
+                err["replacement_order_id"] = res.order_id
+                err.setdefault("order_id", res.order_id)
+            return err
 
     async with _client_context() as client:
         return await execute_modify(client)
@@ -913,12 +934,15 @@ async def toss_cancel_order(
     ) is not None:
         return mutation_gate
 
+    res = None
     try:
         async with _client_context() as client:
             try:
                 orig_order = await client.get_order(order_id)
             except Exception as exc:
-                return _toss_error_response(exc, base_response)
+                return _toss_error_response(
+                    exc, {**base_response, "original_order_id": order_id}
+                )
             mkt = _infer_market(orig_order.symbol, None)
             res = await client.cancel_order(order_id)
             ledger = await record_toss_replacement_order(
@@ -950,7 +974,14 @@ async def toss_cancel_order(
                 "operation_semantics": "Toss cancel returns a newly issued orderId; it is not the original order id.",
             }
     except Exception as exc:
-        return _toss_error_response(exc, {**base_response, "mutation_sent": True})
+        err = _toss_error_response(exc, {**base_response, "mutation_sent": True})
+        # ROB-545 Major — keep the order ids on the error path so the live order
+        # (and any issued cancel replacement) can be reconciled/cancelled.
+        err.setdefault("original_order_id", order_id)
+        if res is not None:
+            err["replacement_order_id"] = res.order_id
+            err.setdefault("order_id", res.order_id)
+        return err
 
 
 async def toss_get_order_history(

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -12,6 +12,14 @@ from app.models.review import TossLiveOrderLedger
 
 
 def parse_report_item_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
+    """ROB-545 B1 — parse a report_item_uuid fail-open.
+
+    report_item_uuid is free-form agent/Hermes input and audit metadata only.
+    A malformed value must never raise here: ``record_send`` runs *after* the
+    live POST is accepted, so raising would orphan a real broker order (no
+    ledger row -> reconcile can never book the fill). Mirror
+    ``order_execution._coerce_report_item_uuid``: a bad string resolves to None.
+    """
     if value is None:
         return None
     if isinstance(value, uuid.UUID):
@@ -19,7 +27,36 @@ def parse_report_item_uuid(value: str | uuid.UUID | None) -> uuid.UUID | None:
     candidate = str(value).strip()
     if not candidate:
         return None
-    return uuid.UUID(candidate)
+    try:
+        return uuid.UUID(candidate)
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+class TossLedgerIdempotencyConflict(Exception):
+    """ROB-545 B2 — a live order was recorded twice under the same
+    client_order_id but with a *different* broker_order_id.
+
+    The same clientOrderId is Toss's idempotency key, so a different orderId is
+    a genuine broker anomaly (a duplicate live order was created). The caller
+    must surface the new broker_order_id so the duplicate can be cancelled.
+    """
+
+    def __init__(
+        self,
+        *,
+        client_order_id: str,
+        existing_broker_order_id: str | None,
+        new_broker_order_id: str | None,
+    ) -> None:
+        self.client_order_id = client_order_id
+        self.existing_broker_order_id = existing_broker_order_id
+        self.new_broker_order_id = new_broker_order_id
+        super().__init__(
+            f"client_order_id {client_order_id!r} is already recorded with "
+            f"broker_order_id {existing_broker_order_id!r}; refusing to overwrite "
+            f"with {new_broker_order_id!r}."
+        )
 
 
 class TossLiveOrderLedgerService:
@@ -58,6 +95,26 @@ class TossLiveOrderLedgerService:
         indicators_snapshot: dict[str, Any] | None = None,
         report_item_uuid: str | uuid.UUID | None = None,
     ) -> TossLiveOrderLedger:
+        # ROB-545 B2 — idempotent on client_order_id. A live POST retried with
+        # the same clientOrderId (the smoke's idempotency check) must not raise a
+        # UNIQUE IntegrityError: query first, replay the existing row when the
+        # broker_order_id matches, and surface an anomaly when it differs.
+        existing = (
+            await self._db.execute(
+                select(TossLiveOrderLedger).where(
+                    TossLiveOrderLedger.client_order_id == client_order_id
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            if existing.broker_order_id == broker_order_id:
+                return existing
+            raise TossLedgerIdempotencyConflict(
+                client_order_id=client_order_id,
+                existing_broker_order_id=existing.broker_order_id,
+                new_broker_order_id=broker_order_id,
+            )
+
         row = TossLiveOrderLedger(
             trade_date=datetime.now(UTC),
             broker="toss",

--- a/docs/runbooks/toss-live-smoke.md
+++ b/docs/runbooks/toss-live-smoke.md
@@ -24,6 +24,12 @@ the operator evidence, and the account setup before live operational use.
 - The confirm flow retries the same `clientOrderId` once to verify broker
   idempotency. If Toss returns a different `orderId`, the CLI reports an
   anomaly, attempts to cancel every opened order id, and exits `2`.
+- The ledger is idempotent on `client_order_id` (ROB-545). An idempotent retry
+  that returns the same `orderId` replays the existing ledger row instead of
+  hitting a UNIQUE violation, so the normal place → retry → cancel → reconcile
+  sequence can reach exit `0`. A retry that returns a *different* `orderId`
+  surfaces the new live order id even on the failure response, so finally-cancel
+  can still cancel the duplicate.
 - The confirm flow uses a finally-cancel pattern. If an order id is observed,
   cancel is attempted even when the idempotency retry or reconcile step fails.
 - Reconcile is local bookkeeping. The live account source of truth remains Toss

--- a/scripts/toss_live_smoke.py
+++ b/scripts/toss_live_smoke.py
@@ -132,12 +132,12 @@ async def run_confirm(
             client_order_id_override=client_order_id,
         )
         _print_event(step, result)
+        # ROB-545: track any returned order_id, including from a failed/anomaly
+        # response (e.g. the broker accepted the order but a UNIQUE/idempotency
+        # conflict or DB write failed). A returned order_id means a live order
+        # may exist, so finally-cancel must attempt to cancel it.
         order_id = result.get("order_id")
-        if (
-            result.get("success")
-            and isinstance(order_id, str)
-            and order_id not in opened_order_ids
-        ):
+        if isinstance(order_id, str) and order_id not in opened_order_ids:
             opened_order_ids.append(order_id)
         return result
 

--- a/tests/mcp_server/tooling/test_toss_live_order_mutation_safety.py
+++ b/tests/mcp_server/tooling/test_toss_live_order_mutation_safety.py
@@ -1,0 +1,277 @@
+"""ROB-545 — Toss live order mutation-safety regressions.
+
+These exercise the *real* ledger path (no fake on record_toss_place_order /
+record_send) so the idempotency + UNIQUE behaviour and the error-response
+order_id preservation are validated end-to-end before
+TOSS_LIVE_ORDER_MUTATIONS_ENABLED is flipped.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+import app.mcp_server.tooling.orders_toss_variants as otv
+from app.models.review import TossLiveOrderLedger
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    await db_session.execute(delete(TossLiveOrderLedger))
+    await db_session.commit()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _patch_session_factory(db_session):
+    """Route every ledger session through the test db_session (real ledger)."""
+    from app.mcp_server.tooling import toss_live_ledger
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__.return_value = db_session
+    mock_cm.__aexit__.return_value = None
+
+    with patch.object(
+        toss_live_ledger, "_order_session_factory", return_value=lambda: mock_cm
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _enable_toss(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
+    monkeypatch.setattr(otv, "validate_toss_api_config", lambda: [])
+
+
+class _FakeTossClient:
+    """Minimal Toss client: US symbol skips the warnings guard, no pending
+    orders, and place_order returns a controllable sequence of order ids."""
+
+    def __init__(
+        self,
+        order_ids=None,
+        place_error: Exception | None = None,
+        mutate_error: Exception | None = None,
+    ):
+        self._order_ids = iter(order_ids or [])
+        self._place_error = place_error
+        self._mutate_error = mutate_error
+        self.place_calls: list[dict] = []
+
+    async def aclose(self):
+        return None
+
+    async def list_orders(self, *, status, symbol=None, cursor=None, **kwargs):
+        return SimpleNamespace(orders=[], next_cursor=None, has_next=False)
+
+    async def get_order(self, order_id):
+        from decimal import Decimal
+
+        return SimpleNamespace(
+            order_id=order_id,
+            symbol="AAPL",
+            side="buy",
+            order_type="limit",
+            time_in_force="DAY",
+            price=Decimal("150.0"),
+            quantity=Decimal("10"),
+            order_amount=None,
+            currency="USD",
+        )
+
+    async def modify_order(self, order_id, payload):
+        if self._mutate_error is not None:
+            raise self._mutate_error
+        return SimpleNamespace(order_id=next(self._order_ids))
+
+    async def cancel_order(self, order_id):
+        if self._mutate_error is not None:
+            raise self._mutate_error
+        return SimpleNamespace(order_id=next(self._order_ids))
+
+    async def place_order(self, payload):
+        self.place_calls.append(payload)
+        if self._place_error is not None:
+            raise self._place_error
+        return SimpleNamespace(
+            order_id=next(self._order_ids),
+            client_order_id=payload.get("clientOrderId"),
+        )
+
+
+def _bind_client(monkeypatch, client: _FakeTossClient) -> None:
+    monkeypatch.setattr(otv.TossReadClient, "from_settings", lambda *a, **k: client)
+
+
+async def _place(**overrides):
+    kwargs = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": "1",
+        "price": "190",
+        "order_amount": None,
+        "market": "us",
+        "time_in_force": "DAY",
+        "dry_run": False,
+        "confirm": True,
+        "confirm_high_value_order": False,
+        "reason": "ROB-545 test",
+        "exit_reason": None,
+        "thesis": None,
+        "strategy": None,
+        "target_price": None,
+        "stop_loss": None,
+        "min_hold_days": None,
+        "notes": None,
+        "indicators_snapshot": None,
+        "report_item_uuid": None,
+        "account_mode": "toss_live",
+        "account_type": None,
+        "client_order_id_override": "rob545cid0001",
+    }
+    kwargs.update(overrides)
+    return await otv._toss_place_order_impl(**kwargs)
+
+
+async def test_idempotent_retry_replays_single_ledger_row(db_session, monkeypatch):
+    # Toss is idempotent: same clientOrderId -> same orderId on retry.
+    _bind_client(monkeypatch, _FakeTossClient(order_ids=["ord-1", "ord-1"]))
+
+    first = await _place()
+    second = await _place()
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert first["order_id"] == "ord-1"
+    assert second["order_id"] == "ord-1"
+    assert first["ledger_id"] == second["ledger_id"]
+
+    rows = (await db_session.execute(select(TossLiveOrderLedger))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_idempotency_anomaly_surfaces_order_id_for_cancel(
+    db_session, monkeypatch
+):
+    # Genuine anomaly: same clientOrderId, Toss returns a *different* orderId.
+    _bind_client(monkeypatch, _FakeTossClient(order_ids=["ord-1", "ord-2"]))
+
+    first = await _place()
+    second = await _place()
+
+    assert first["success"] is True and first["order_id"] == "ord-1"
+    # The retry must fail (anomaly) yet still surface the new live order id so
+    # the smoke's finally-cancel can cancel the duplicate.
+    assert second["success"] is False
+    assert second["order_id"] == "ord-2"
+    assert second["client_order_id"] is not None
+
+    # Only the first order is recorded; the anomalous duplicate is NOT silently
+    # written under a conflicting client_order_id.
+    rows = (await db_session.execute(select(TossLiveOrderLedger))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_place_broker_error_response_includes_client_order_id(monkeypatch):
+    _bind_client(
+        monkeypatch,
+        _FakeTossClient(place_error=TimeoutError("broker accepted but timed out")),
+    )
+
+    res = await _place()
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    # The clientOrderId we sent must be in the response so a retry can reuse the
+    # same idempotency key instead of minting a new one.
+    assert res["client_order_id"] == "rob545cid0001"
+
+
+async def test_place_post_success_db_failure_preserves_order_id(monkeypatch):
+    _bind_client(monkeypatch, _FakeTossClient(order_ids=["ord-1"]))
+
+    async def _boom(**kwargs):
+        raise RuntimeError("ledger write failed")
+
+    monkeypatch.setattr(otv, "record_toss_place_order", _boom)
+
+    res = await _place()
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    # POST succeeded -> the broker order id must not be lost when the DB write
+    # fails, otherwise the accepted order can never be reconciled or cancelled.
+    assert res["order_id"] == "ord-1"
+    assert res["client_order_id"] is not None
+
+
+async def test_modify_broker_error_includes_original_order_id(monkeypatch):
+    _bind_client(
+        monkeypatch,
+        _FakeTossClient(mutate_error=TimeoutError("modify accepted but timed out")),
+    )
+
+    res = await otv.toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155.0",
+        market="us",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    assert res["original_order_id"] == "orig-ord-123"
+
+
+async def test_modify_post_success_db_failure_preserves_replacement_id(monkeypatch):
+    _bind_client(monkeypatch, _FakeTossClient(order_ids=["mod-ord-456"]))
+
+    async def _boom(**kwargs):
+        raise RuntimeError("ledger write failed")
+
+    monkeypatch.setattr(otv, "record_toss_replacement_order", _boom)
+
+    res = await otv.toss_modify_order(
+        order_id="orig-ord-123",
+        new_price="155.0",
+        market="us",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    assert res["original_order_id"] == "orig-ord-123"
+    # modify succeeded at the broker -> the new replacement order id must survive.
+    assert res["replacement_order_id"] == "mod-ord-456"
+
+
+async def test_cancel_broker_error_includes_original_order_id(monkeypatch):
+    _bind_client(
+        monkeypatch,
+        _FakeTossClient(mutate_error=TimeoutError("cancel accepted but timed out")),
+    )
+
+    res = await otv.toss_cancel_order(
+        order_id="orig-ord-123",
+        dry_run=False,
+        confirm=True,
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is False
+    assert res["mutation_sent"] is True
+    assert res["original_order_id"] == "orig-ord-123"

--- a/tests/services/brokers/toss/test_smoke_script.py
+++ b/tests/services/brokers/toss/test_smoke_script.py
@@ -235,6 +235,57 @@ async def test_run_confirm_cancels_duplicate_order_if_idempotency_fails(
 
 
 @pytest.mark.asyncio
+async def test_run_confirm_cancels_order_surfaced_in_anomaly_error_response(
+    monkeypatch,
+) -> None:
+    # ROB-545: the idempotency anomaly is now surfaced as a failed response that
+    # still carries the duplicate order_id, so finally-cancel must cancel it.
+    results = iter(
+        [
+            {
+                "success": True,
+                "order_id": "ord-1",
+                "client_order_id": "cid",
+                "mutation_sent": True,
+            },
+            {
+                "success": False,
+                "order_id": "ord-2",
+                "client_order_id": "cid",
+                "error": "idempotency conflict",
+                "mutation_sent": True,
+            },
+        ]
+    )
+    cancel_calls: list[str] = []
+
+    async def fake_place_for_smoke(**kwargs):
+        return next(results)
+
+    async def fake_cancel_order(*, order_id, dry_run, confirm, account_mode):
+        cancel_calls.append(order_id)
+        return {"success": True, "original_order_id": order_id}
+
+    async def fake_reconcile(**kwargs):
+        return {"success": True, "counts": {"cancelled": 1}, "reconciled": []}
+
+    monkeypatch.setattr(toss_live_smoke, "_place_order_for_smoke", fake_place_for_smoke)
+    monkeypatch.setattr(toss_live_smoke, "toss_cancel_order", fake_cancel_order)
+    monkeypatch.setattr(toss_live_smoke, "toss_reconcile_orders_impl", fake_reconcile)
+
+    code = await toss_live_smoke.run_confirm(
+        market="kr",
+        symbol="005930",
+        quantity="1",
+        price="50000",
+        time_in_force="DAY",
+    )
+
+    assert code == 2
+    assert sorted(cancel_calls) == ["ord-1", "ord-2"]
+
+
+@pytest.mark.asyncio
 async def test_run_confirm_cancels_original_when_idempotency_retry_raises(
     monkeypatch,
 ) -> None:

--- a/tests/services/test_toss_live_order_ledger_service.py
+++ b/tests/services/test_toss_live_order_ledger_service.py
@@ -5,12 +5,41 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 from app.models.review import TossLiveOrderLedger
-from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+from app.services.toss_live_order_ledger_service import (
+    TossLedgerIdempotencyConflict,
+    TossLiveOrderLedgerService,
+    parse_report_item_uuid,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _place_kwargs(**overrides):
+    base = {
+        "operation_kind": "place",
+        "market": "us",
+        "symbol": "AAPL",
+        "side": "buy",
+        "order_type": "limit",
+        "time_in_force": "DAY",
+        "quantity": Decimal("1"),
+        "price": Decimal("190"),
+        "order_amount": None,
+        "currency": "USD",
+        "client_order_id": "cid-default",
+        "broker_order_id": "ord-default",
+        "original_order_id": None,
+        "status": "accepted",
+        "broker_status": None,
+        "response_code": "0",
+        "response_message": None,
+        "raw_response": {},
+    }
+    base.update(overrides)
+    return base
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -207,3 +236,67 @@ async def test_update_reconcile_outcome_records_fee_tax_and_settlement(db_sessio
     assert refreshed.tax == Decimal("0.01")
     assert refreshed.trade_id == 11
     assert refreshed.journal_id == 22
+
+
+# ROB-545 B1 — report_item_uuid must never raise after a live POST is accepted.
+
+
+async def test_parse_report_item_uuid_is_fail_open_for_malformed():
+    assert parse_report_item_uuid("not-a-uuid") is None
+    assert parse_report_item_uuid("") is None
+    assert parse_report_item_uuid(None) is None
+    valid = "11111111-1111-1111-1111-111111111111"
+    assert str(parse_report_item_uuid(valid)) == valid
+
+
+async def test_record_send_with_malformed_report_item_uuid_records_none(db_session):
+    svc = TossLiveOrderLedgerService(db_session)
+
+    row = await svc.record_send(
+        **_place_kwargs(
+            client_order_id="cid-malformed-uuid",
+            broker_order_id="ord-malformed-uuid",
+            report_item_uuid="definitely-not-a-uuid",
+        )
+    )
+
+    assert row.id is not None
+    assert row.report_item_uuid is None
+    assert row.status == "accepted"
+
+
+# ROB-545 B2 — record_send must be idempotent on client_order_id.
+
+
+async def test_record_send_idempotent_replay_returns_existing_row(db_session):
+    svc = TossLiveOrderLedgerService(db_session)
+
+    first = await svc.record_send(
+        **_place_kwargs(client_order_id="cid-idem", broker_order_id="ord-idem")
+    )
+    second = await svc.record_send(
+        **_place_kwargs(client_order_id="cid-idem", broker_order_id="ord-idem")
+    )
+
+    assert second.id == first.id
+    rows = (await db_session.execute(select(TossLiveOrderLedger))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_record_send_conflicting_broker_id_raises_idempotency_conflict(
+    db_session,
+):
+    svc = TossLiveOrderLedgerService(db_session)
+
+    await svc.record_send(
+        **_place_kwargs(client_order_id="cid-anomaly", broker_order_id="ord-first")
+    )
+
+    with pytest.raises(TossLedgerIdempotencyConflict) as excinfo:
+        await svc.record_send(
+            **_place_kwargs(client_order_id="cid-anomaly", broker_order_id="ord-second")
+        )
+
+    assert excinfo.value.client_order_id == "cid-anomaly"
+    assert excinfo.value.existing_broker_order_id == "ord-first"
+    assert excinfo.value.new_broker_order_id == "ord-second"


### PR DESCRIPTION
## ROB-545 — Toss live order mutation activation blockers

Fixes the three mutation-path defects from the ROB-530~539 post-merge audit
(2026-06-13) that gate `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`. All are unique
to the mutation path — Phase 0 read activation is unaffected.

### B1 (Blocker) — orphaned accepted orders via report_item_uuid
`parse_report_item_uuid` raised `ValueError` on malformed input, and it runs
inside `record_send` **after** `client.place_order()` is accepted. A malformed
agent/Hermes uuid would leave an accepted broker order with **no ledger row**,
which `toss_reconcile_orders` (iterates `list_open`) can never book.
- **Fix:** fail-open coercion (malformed → `None`), mirroring
  `order_execution._coerce_report_item_uuid`.

### B2 (Blocker) — idempotent retry deterministically violates UNIQUE
The smoke's `--confirm` re-places the same `clientOrderId`; the second
`record_send` was a plain INSERT → `uq_toss_live_ledger_client_order_id`
violation → `IntegrityError` → `success=False` → smoke exit 2. The runbook's
normal sequence (idempotent retry → exit 0) was **structurally unreachable**.
- **Fix:** `record_send` is now idempotent on `client_order_id` — query first,
  replay the existing row when `broker_order_id` matches, raise
  `TossLedgerIdempotencyConflict` when it differs (genuine duplicate-order
  anomaly).

### Major — order ids lost on the failure path
`place`/`modify`/`cancel` error responses returned only `base_response + error`.
An accepted-but-timed-out order, a POST-success/DB-failure, or an idempotency
anomaly left no local `client_order_id`/`order_id` — reconcile/cancel impossible,
and retries minted a fresh `clientOrderId` (defeating Toss idempotency).
- **Fix:** every mutation error response carries `client_order_id` and the
  broker `order_id` when the POST reached Toss; the smoke's finally-cancel now
  harvests `order_id` even from failed responses.

## Tests
- `tests/mcp_server/tooling/test_toss_live_order_mutation_safety.py` (new) —
  **real ledger path** (no fake on `record_send`/`record_toss_place_order`):
  idempotent replay → single row, anomaly surfaces `order_id` for cancel,
  place/modify/cancel error responses preserve `client_order_id`/`order_id`.
- `tests/services/test_toss_live_order_ledger_service.py` — fail-open uuid +
  idempotency unit tests.
- `tests/services/brokers/toss/test_smoke_script.py` — finally-cancel harvests
  the order id from an anomaly **error** response.

All touched suites green (`tests/mcp_server/`, `tests/services/brokers/toss/`,
`tests/test_mcp_toss_order_variants.py`), `ruff`/`ty` clean, migration 0.

## Acceptance criteria
- [x] B1/B2 fixed + real-path integration tests; order failure includes `client_order_id`
- [x] `--confirm` can reach exit 0 on the normal path (ledger idempotency)
- [x] Prerequisite for the `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` flip

## Notes
Labeled `high_risk_change` / `needs_stronger_model_review`. **Not for self-merge** —
needs stronger-model/CTO review before live operational use, per
`docs/runbooks/toss-live-smoke.md`. No broker/order mutation is reachable while
the gate stays `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved idempotency for order operations—retries with the same client ID now reuse existing orders instead of creating duplicates.

* **Bug Fixes**
  * Enhanced error responses to include order identifiers for better reconciliation and recovery.

* **Tests**
  * Added regression tests for order mutation safety under failure and retry scenarios.

* **Documentation**
  * Updated runbook documentation for idempotent retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->