### PR TITLE
fix(ROB-546): gap-fill toss market_cap + harden valuation readers

### DIFF
--- a/app/services/market_valuation_snapshots/repository.py
+++ b/app/services/market_valuation_snapshots/repository.py
@@ -146,6 +146,38 @@ class MarketValuationSnapshotsRepository:
         )
         return {(r.market, r.symbol, r.snapshot_date, r.source) for r in result.all()}
 
+    async def symbols_with_other_source(
+        self,
+        *,
+        market: str,
+        snapshot_date: dt.date,
+        symbols: set[str],
+        exclude_source: str,
+    ) -> set[str]:
+        """ROB-546 gap-fill: symbols that already have a valuation row from a
+        source other than ``exclude_source`` for ``(market, snapshot_date)``.
+
+        Used to skip writing metric-sparse Toss market_cap rows where a
+        metric-rich source (naver_finance/yahoo) already covers the key.
+        """
+        if not symbols:
+            return set()
+        norm_market = market.strip().lower()
+        norm_symbols = {s.strip().upper() for s in symbols}
+        norm_exclude = exclude_source.strip().lower()
+        stmt = (
+            select(MarketValuationSnapshot.symbol)
+            .where(
+                MarketValuationSnapshot.market == norm_market,
+                MarketValuationSnapshot.snapshot_date == snapshot_date,
+                MarketValuationSnapshot.symbol.in_(norm_symbols),
+                MarketValuationSnapshot.source != norm_exclude,
+            )
+            .distinct()
+        )
+        result = await self._session.execute(stmt)
+        return {row[0] for row in result.all()}
+
     async def latest_for_symbols(
         self, *, market: str, symbols: set[str]
     ) -> list[MarketValuationSnapshot]:
@@ -153,6 +185,22 @@ class MarketValuationSnapshotsRepository:
             return []
         norm_market = market.strip().lower()
         norm_symbols = {s.strip().upper() for s in symbols}
+        # ROB-546: prefer rows that actually carry fundamentals metrics so a
+        # metric-sparse market_cap-only row (e.g. toss_openapi, per/pbr/roe NULL)
+        # on a newer snapshot_date does not shadow a metric-rich row. Falls back
+        # to the sparse row only when it is the symbol's sole source.
+        metric_sparse = sa.case(
+            (
+                sa.or_(
+                    MarketValuationSnapshot.per.isnot(None),
+                    MarketValuationSnapshot.pbr.isnot(None),
+                    MarketValuationSnapshot.roe.isnot(None),
+                    MarketValuationSnapshot.dividend_yield.isnot(None),
+                ),
+                0,
+            ),
+            else_=1,
+        )
         stmt = (
             select(MarketValuationSnapshot)
             .where(
@@ -161,6 +209,7 @@ class MarketValuationSnapshotsRepository:
             )
             .order_by(
                 MarketValuationSnapshot.symbol.asc(),
+                metric_sparse.asc(),
                 MarketValuationSnapshot.snapshot_date.desc(),
                 MarketValuationSnapshot.computed_at.desc(),
             )

--- a/app/services/toss_symbol_master_service.py
+++ b/app/services/toss_symbol_master_service.py
@@ -48,6 +48,7 @@ class TossSymbolMasterSyncResult:
     master_updates: int
     market_cap_payloads: int
     market_cap_nonnull: int
+    market_cap_skipped_existing: int = 0
     warnings: tuple[str, ...] = ()
     samples: tuple[str, ...] = ()
 
@@ -113,6 +114,10 @@ def _kr_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, obje
 
 
 def _us_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, object]:
+    # ROB-546: ``is_common_stock`` is intentionally NOT included here. It is the
+    # authoritative NASDAQ-Trader classification (ROB-204) that drives screener
+    # partition denominators, so Toss must only fill it when currently NULL —
+    # never flip an existing value. Handled separately in the update loop.
     return {
         "security_type": stock.security_type,
         "is_common_share": stock.is_common_share,
@@ -123,7 +128,6 @@ def _us_assignments(stock: TossStockInfo, *, now: dt.datetime) -> dict[str, obje
         "leverage_factor": stock.leverage_factor,
         "isin": stock.isin_code,
         "toss_master_updated_at": now,
-        "is_common_stock": stock.is_common_share,
     }
 
 
@@ -145,9 +149,12 @@ def _market_cap_payloads(
     snapshot_date: dt.date,
     stocks: dict[str, TossStockInfo],
     prices: dict[str, TossPrice],
+    skip_symbols: frozenset[str] = frozenset(),
 ) -> list[MarketValuationSnapshotUpsert]:
     payloads: list[MarketValuationSnapshotUpsert] = []
     for symbol, stock in stocks.items():
+        if symbol in skip_symbols:
+            continue
         price = prices.get(symbol)
         market_cap = (
             stock.shares_outstanding * price.last_price
@@ -213,6 +220,9 @@ async def sync_toss_symbol_master(
     all_stocks: dict[str, TossStockInfo] = {}
     all_prices: dict[str, TossPrice] = {}
     updates = 0
+    # ROB-546: is_common_stock guard (US only) — count rows flipped to TRUE that
+    # were previously NULL. Preserve policy never decreases the TRUE count.
+    common_stock_filled = 0
 
     batches = _chunks(symbols)
     for batch in batches:
@@ -236,20 +246,53 @@ async def sync_toss_symbol_master(
             changed = _count_or_apply(row, assignments, apply=request.commit)
             if changed:
                 updates += 1
+            # ROB-546: fill is_common_stock only when currently NULL; never flip
+            # an existing NASDAQ-Trader classification.
+            if (
+                market == "us"
+                and row.is_common_stock is None
+                and stock.is_common_share is not None
+            ):
+                if request.commit:
+                    row.is_common_stock = stock.is_common_share
+                if stock.is_common_share is True:
+                    common_stock_filled += 1
 
     existing_stocks = {
         symbol: stock for symbol, stock in all_stocks.items() if symbol in existing
     }
+
+    repo = MarketValuationSnapshotsRepository(db)
+    skip_symbols: frozenset[str] = frozenset()
+    if request.include_market_cap and existing_stocks:
+        skip_symbols = frozenset(
+            await repo.symbols_with_other_source(
+                market=market,
+                snapshot_date=snapshot_date,
+                symbols=set(existing_stocks),
+                exclude_source=TOSS_VALUATION_SOURCE,
+            )
+        )
+    skipped_existing = len(skip_symbols & set(existing_stocks))
+
     payloads = _market_cap_payloads(
         market=market,
         snapshot_date=snapshot_date,
         stocks=existing_stocks,
         prices=all_prices,
+        skip_symbols=skip_symbols,
     )
     if request.commit:
         if payloads:
-            await MarketValuationSnapshotsRepository(db).upsert(payloads)
+            await repo.upsert(payloads)
         await db.flush()
+
+    warnings: tuple[str, ...] = ()
+    if market == "us":
+        warnings = (
+            f"is_common_stock TRUE filled (NULL->TRUE) for "
+            f"{common_stock_filled} symbol(s); existing values preserved",
+        )
 
     missing = len(set(symbols) - set(all_stocks))
     return TossSymbolMasterSyncResult(
@@ -262,5 +305,7 @@ async def sync_toss_symbol_master(
         master_updates=updates,
         market_cap_payloads=len(payloads),
         market_cap_nonnull=len(payloads),
+        market_cap_skipped_existing=skipped_existing,
+        warnings=warnings,
         samples=tuple(symbols[:10]),
     )

--- a/docs/runbooks/toss-symbol-master-sync.md
+++ b/docs/runbooks/toss-symbol-master-sync.md
@@ -20,6 +20,33 @@ uv run python -m scripts.sync_toss_symbol_master --market kr --all --commit
 uv run python -m scripts.sync_toss_symbol_master --market us --all --commit
 ~~~
 
+### Gap-fill semantics & ordering (ROB-546)
+
+Toss valuation rows carry **market_cap only** (PER/PBR/ROE/dividend/52w are
+NULL). To keep these metric-sparse rows from shadowing metric-rich
+`naver_finance`/`yahoo` rows in readers (fundamentals evidence, screener
+market-cap join), the sync **gap-fills**: for a given `(market, symbol,
+snapshot_date)` it skips the Toss `market_cap` row whenever another source
+already has a row for that key. Master metadata columns (shares_outstanding,
+security_type, etc.) are always updated regardless.
+
+The dry-run/commit packet reports `market_cap_skipped_existing` — the number of
+symbols whose Toss market_cap was skipped because a richer source already
+covered them.
+
+**Build order:** run the `naver_finance` / `yahoo` fundamentals valuation build
+for a `snapshot_date` **before** the Toss `--all --commit` for that same date.
+Doing so keeps Toss in pure gap-fill mode (it only adds market_cap for symbols
+no other source covers) and prevents a Toss-only metric-sparse partition from
+being picked as the "latest healthy" partition by screener loaders. The
+reader-side partition-selection hardening for the out-of-order case is tracked
+separately; this runbook ordering is the operational guard.
+
+`is_common_stock` (US): Toss `is_common_share` only **fills** this column when
+it is currently NULL — it never flips an existing NASDAQ-Trader classification
+(which drives screener partition denominators). The commit packet prints a
+`warning:` line with the NULL→TRUE fill count for the guard.
+
 ## Rollback
 
 This migration is additive for universe fields. To remove Toss-derived market-cap rows for one date:

--- a/scripts/sync_toss_symbol_master.py
+++ b/scripts/sync_toss_symbol_master.py
@@ -11,13 +11,28 @@ import asyncio
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Dry-run-first Toss symbol master sync (ROB-534).")
+    parser = argparse.ArgumentParser(
+        description="Dry-run-first Toss symbol master sync (ROB-534)."
+    )
     parser.add_argument("--market", choices=["kr", "us"], required=True)
-    parser.add_argument("--symbol", action="append", default=[], help="Restrict to one symbol. Can be repeated.")
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        default=[],
+        help="Restrict to one symbol. Can be repeated.",
+    )
     parser.add_argument("--limit", type=int, default=20)
-    parser.add_argument("--all", action="store_true", help="Process all active universe symbols.")
-    parser.add_argument("--no-market-cap", action="store_true", help="Update master fields only; skip prices/market cap.")
-    parser.add_argument("--commit", action="store_true", help="Write changes. Default is dry-run.")
+    parser.add_argument(
+        "--all", action="store_true", help="Process all active universe symbols."
+    )
+    parser.add_argument(
+        "--no-market-cap",
+        action="store_true",
+        help="Update master fields only; skip prices/market cap.",
+    )
+    parser.add_argument(
+        "--commit", action="store_true", help="Write changes. Default is dry-run."
+    )
     args = parser.parse_args(argv)
     if args.all and (args.symbol or args.limit != 20):
         parser.error("--all is mutually exclusive with --symbol and explicit --limit")
@@ -38,6 +53,12 @@ def _print_result(result) -> None:
     print(f"  master_updates: {result.master_updates}")
     print(f"  market_cap_payloads: {result.market_cap_payloads}")
     print(f"  market_cap_nonnull: {result.market_cap_nonnull}")
+    print(
+        f"  market_cap_skipped_existing: {result.market_cap_skipped_existing} "
+        "(gap-fill: other source already covers the key)"
+    )
+    for warning in result.warnings:
+        print(f"  warning: {warning}")
     if result.samples:
         print("samples:")
         for sample in result.samples:

--- a/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
+++ b/tests/services/market_valuation_snapshots/test_repository_latest_for_symbols.py
@@ -55,3 +55,64 @@ async def test_latest_for_symbols_returns_newest_per_symbol(db_session):
 async def test_latest_for_symbols_empty_input(db_session):
     repo = MarketValuationSnapshotsRepository(db_session)
     assert await repo.latest_for_symbols(market="us", symbols=set()) == []
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_prefers_metric_rich_over_sparse(db_session):
+    """ROB-546: a metric-sparse toss-only row (per/pbr/roe NULL) on a *newer*
+    snapshot_date must not shadow a metric-rich row on an older date."""
+    await _clear(db_session)
+    db_session.add_all(
+        [
+            # metric-rich naver row, older date
+            MarketValuationSnapshot(
+                market="kr",
+                symbol="005930",
+                snapshot_date=dt.date(2026, 6, 11),
+                source="naver_finance",
+                per=Decimal("11"),
+                pbr=Decimal("1.2"),
+                roe=Decimal("0.15"),
+                dividend_yield=Decimal("0.02"),
+                market_cap=Decimal("1000000"),
+            ),
+            # metric-sparse toss row, newer date (market_cap only)
+            MarketValuationSnapshot(
+                market="kr",
+                symbol="005930",
+                snapshot_date=dt.date(2026, 6, 12),
+                source="toss_openapi",
+                market_cap=Decimal("999"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    repo = MarketValuationSnapshotsRepository(db_session)
+    rows = await repo.latest_for_symbols(market="kr", symbols={"005930"})
+    assert len(rows) == 1
+    assert rows[0].source == "naver_finance"
+    assert rows[0].per == Decimal("11")
+
+
+@pytest.mark.asyncio
+async def test_latest_for_symbols_returns_sparse_when_only_source(db_session):
+    """A toss-only symbol (no metric-rich row anywhere) is still returned so
+    market_cap remains available."""
+    await _clear(db_session)
+    db_session.add(
+        MarketValuationSnapshot(
+            market="kr",
+            symbol="005930",
+            snapshot_date=dt.date(2026, 6, 12),
+            source="toss_openapi",
+            market_cap=Decimal("999"),
+        )
+    )
+    await db_session.commit()
+
+    repo = MarketValuationSnapshotsRepository(db_session)
+    rows = await repo.latest_for_symbols(market="kr", symbols={"005930"})
+    assert len(rows) == 1
+    assert rows[0].source == "toss_openapi"
+    assert rows[0].market_cap == Decimal("999")

--- a/tests/test_invest_coverage_valuation.py
+++ b/tests/test_invest_coverage_valuation.py
@@ -441,11 +441,13 @@ async def test_market_valuation_accepts_toss_openapi_market_cap(db_session) -> N
     )
 
     repo = MarketValuationSnapshotsRepository(db_session)
+    # ROB-546: latest_for_symbols now prefers metric-rich rows, so clear ALL
+    # sources for this key (not just toss) to assert toss-as-sole-source
+    # deterministically regardless of leftover naver rows from other tests.
     await db_session.execute(
         sa.delete(MarketValuationSnapshot).where(
             MarketValuationSnapshot.symbol == "005930",
             MarketValuationSnapshot.snapshot_date == dt.date(2026, 6, 12),
-            MarketValuationSnapshot.source == "toss_openapi",
         )
     )
     await db_session.commit()

--- a/tests/test_toss_symbol_master_service.py
+++ b/tests/test_toss_symbol_master_service.py
@@ -35,7 +35,7 @@ class FakeTossClient:
                     isin_code="KR7005930003" if is_kr else "US0378331005",
                     market="KR" if is_kr else "US",
                     security_type="STOCK",
-                    is_common_share=symbol != "005935",
+                    is_common_share=symbol not in {"005935", "GOOGL"},
                     status="ACTIVE",
                     currency="KRW" if is_kr else "USD",
                     list_date="1975-06-11" if is_kr else "1980-12-12",
@@ -105,6 +105,15 @@ async def test_sync_toss_symbol_master_commit_updates_master_and_market_cap(
 
     await db_session.execute(
         sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "005930")
+    )
+    # ROB-546: gap-fill skips toss market_cap when another source already covers
+    # the key; clear prior valuation rows so this asserts the no-other-source path
+    # deterministically across repeated local runs (db_session does not truncate).
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.symbol == "005930",
+            MarketValuationSnapshot.snapshot_date == dt.date(2026, 6, 12),
+        )
     )
     db_session.add(
         KRSymbolUniverse(
@@ -251,3 +260,114 @@ async def test_sync_toss_symbol_master_skips_market_cap_for_unregistered_symbol(
     assert result.stocks_matched == 1
     assert result.market_cap_payloads == 0
     assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_skips_market_cap_when_other_source_exists(
+    db_session,
+) -> None:
+    """ROB-546 gap-fill: a toss market_cap row must NOT be written when a
+    naver/yahoo row already exists for the same (market, symbol, date)."""
+    import sqlalchemy as sa
+
+    snapshot_date = dt.date(2026, 6, 12)
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "005930")
+    )
+    await db_session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.symbol == "005930",
+            MarketValuationSnapshot.snapshot_date == snapshot_date,
+        )
+    )
+    db_session.add(
+        KRSymbolUniverse(
+            symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True
+        )
+    )
+    db_session.add(
+        MarketValuationSnapshot(
+            market="kr",
+            symbol="005930",
+            snapshot_date=snapshot_date,
+            source="naver_finance",
+            per=Decimal("11"),
+            pbr=Decimal("1.2"),
+            roe=Decimal("0.15"),
+            dividend_yield=Decimal("0.02"),
+            market_cap=Decimal("1000000"),
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="kr",
+            symbols=("005930",),
+            commit=True,
+            snapshot_date=snapshot_date,
+        ),
+    )
+
+    # master fields still updated even though market_cap row is skipped
+    row = await db_session.get(KRSymbolUniverse, "005930")
+    assert row.shares_outstanding == Decimal("5846278608")
+
+    assert result.market_cap_payloads == 0
+    assert result.market_cap_skipped_existing == 1
+
+    toss_rows = (
+        (
+            await db_session.execute(
+                sa.select(MarketValuationSnapshot).where(
+                    MarketValuationSnapshot.symbol == "005930",
+                    MarketValuationSnapshot.snapshot_date == snapshot_date,
+                    MarketValuationSnapshot.source == "toss_openapi",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert toss_rows == []
+
+
+@pytest.mark.asyncio
+async def test_sync_toss_preserves_existing_us_common_stock(db_session) -> None:
+    """ROB-546 minor: Toss must not flip an already-classified NASDAQ-Trader
+    is_common_stock value; it only fills when currently NULL."""
+    import sqlalchemy as sa
+
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol == "GOOGL")
+    )
+    db_session.add(
+        USSymbolUniverse(
+            symbol="GOOGL",
+            exchange="NASDAQ",
+            name_en="Alphabet Inc.",
+            is_active=True,
+            is_common_stock=True,  # NASDAQ-Trader classified
+        )
+    )
+    await db_session.commit()
+
+    result = await sync_toss_symbol_master(
+        db_session,
+        client=FakeTossClient(),
+        request=TossSymbolMasterSyncRequest(
+            market="us",
+            symbols=("GOOGL",),
+            commit=True,
+            snapshot_date=dt.date(2026, 6, 12),
+        ),
+    )
+
+    row = await db_session.get(USSymbolUniverse, "GOOGL")
+    # Toss reports is_common_share=False for GOOGL, but the existing TRUE is preserved
+    assert row.is_common_share is False
+    assert row.is_common_stock is True
+    # count guard surfaced as a warning
+    assert any("is_common_stock" in w for w in result.warnings)


### PR DESCRIPTION
## 배경

[ROB-546](https://linear.app/mgh3326/issue/ROB-546) — ROB-534 사전 설계 검토에서 경고했던 시총 gap-fill 결함이 미수정 머지됨(2026-06-13 감사 REAL 판정). epic ROB-529.

`sync_toss_symbol_master`가 같은 `(market, symbol, snapshot_date)`에 naver_finance/yahoo 행이 있어도 toss_openapi market_cap 행을 무조건 기록 → UNIQUE 키에 source가 포함되어 cross-source 중복을 못 잡고, source-무필터 reader를 오염.

## 수정

- **Writer gap-fill** (`toss_symbol_master_service.py`): upsert 전 같은 키의 타 source 행 존재 여부 조회(`symbols_with_other_source`) → 있으면 toss market_cap 행 skip. 마스터 메타데이터 컬럼은 그대로 보강. `market_cap_skipped_existing` 카운트를 result/CLI에 노출.
- **Reader** (`latest_for_symbols`): DISTINCT ON 정렬을 fundamentals 지표 보유 행 우선으로 변경 → newer 날짜의 toss-only NULL 행이 metric-rich 행을 가리지 않음(cross-date 포함). sole source일 때만 sparse 행 폴백.
- **`is_common_stock`** (US, preserve+guard): toss `is_common_share`는 현재 NULL일 때만 채움 — NASDAQ-Trader 분류를 절대 덮어쓰지 않음. NULL→TRUE fill 카운트를 guard warning으로 출력.
- **런북**: gap-fill semantics + "fundamentals 빌드 → toss" 순서 가드 문서화. `resolve_healthy_partition`은 미변경(scope 결정).

## 수락 기준

- [x] 기존 naver/yahoo 행이 있는 키에 toss market_cap 행이 안 들어가는 테스트
- [x] `latest_for_symbols`가 metric-rich 행을 반환(toss-only NULL 행에 안 가려짐)
- [x] 이 이슈 완료가 시총 `--all --commit` 활성화의 전제

## 검증

신규 4테스트(gap-fill skip / sole-source fallback / metric-rich preference / is_common_stock preserve) + 기존 2테스트 repeated-run 격리 하드닝. `ruff`/`ty` clean. toss/valuation 42 + fundamentals-screener 34 + evidence/partition consumer 15 전부 green. Migration 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)