### PR TITLE
fix(ROB-547): harden Toss client — token double-check, process-global limiter, https pin

### DIFF
--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -184,6 +184,21 @@ def _estimate_krw_notional(
     return None
 
 
+def _high_value_uncheckable(
+    market: Literal["kr", "us"],
+    quantity: Decimal | None,
+    price: Decimal | None,
+    order_amount: Decimal | None,
+) -> bool:
+    """True when a KR order's KRW notional cannot be estimated locally (e.g. a
+    market order has no price), so the local 1억 confirm gate cannot evaluate it.
+    The broker still enforces ``confirm-high-value-required`` server-side."""
+    return (
+        market == "kr"
+        and _estimate_krw_notional(market, quantity, price, order_amount) is None
+    )
+
+
 def _high_value_error(
     market: Literal["kr", "us"],
     quantity: Decimal | None,
@@ -203,6 +218,15 @@ def _high_value_error(
                     "requires confirm_high_value_order=True."
                 ),
             }
+    if notional is None and _high_value_uncheckable(
+        market, quantity, price, order_amount
+    ):
+        logger.warning(
+            "Toss KR order high-value (1억+) local gate could not be evaluated "
+            "(no estimable KRW notional, e.g. market order); relying on broker-side "
+            "confirm-high-value-required enforcement. confirm_high_value_order=%s",
+            confirm_high_value_order,
+        )
     return None
 
 

--- a/app/services/brokers/toss/auth.py
+++ b/app/services/brokers/toss/auth.py
@@ -19,7 +19,11 @@ from app.services.brokers.toss.errors import (
     TossMissingCredentials,
     TossTokenIssuanceUnavailable,
 )
-from app.services.brokers.toss.rate_limiter import TossApiGroup, TossRateLimiter
+from app.services.brokers.toss.rate_limiter import (
+    TossApiGroup,
+    TossRateLimiter,
+    get_shared_rate_limiter,
+)
 from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL, build_toss_client
 
 logger = logging.getLogger(__name__)
@@ -92,7 +96,12 @@ class TossOAuthTokenManager:
         )
 
     @classmethod
-    def from_settings(cls, settings_obj: Any = settings) -> TossOAuthTokenManager:
+    def from_settings(
+        cls,
+        settings_obj: Any = settings,
+        *,
+        rate_limiter: TossRateLimiter | None = None,
+    ) -> TossOAuthTokenManager:
         if not bool(getattr(settings_obj, "toss_api_enabled", False)):
             raise TossApiDisabled(
                 "Toss API is disabled: TOSS_API_ENABLED is not truthy"
@@ -113,14 +122,26 @@ class TossOAuthTokenManager:
             client_id=str(settings_obj.toss_api_client_id),
             client_secret=secret,
             base_url=str(base_url),
+            rate_limiter=rate_limiter or get_shared_rate_limiter(),
         )
 
-    async def get_access_token(self, *, force_reissue: bool = False) -> str:
+    async def get_access_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
         if not force_reissue:
             cached = await self._get_cached_token()
             if cached is not None:
                 return cached
-        return await self._issue_single_flight(force_reissue=force_reissue)
+        elif failed_token is not None:
+            # Force-reissue triggered by an invalid/expired token. If the cache
+            # already holds a DIFFERENT token, another caller has reissued —
+            # reuse it instead of churning a fresh one (single-valid-token spec).
+            cached = await self._get_cached_token()
+            if cached is not None and cached != failed_token:
+                return cached
+        return await self._issue_single_flight(
+            force_reissue=force_reissue, failed_token=failed_token
+        )
 
     async def _get_cached_token(self) -> str | None:
         redis_client = await _get_redis_client()
@@ -145,7 +166,9 @@ class TossOAuthTokenManager:
         ttl = max(int(token.expires_in), 1)
         await redis_client.set(self.token_key, json.dumps(payload), ex=ttl)
 
-    async def _issue_single_flight(self, *, force_reissue: bool = False) -> str:
+    async def _issue_single_flight(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
         redis_client = await _get_redis_client()
         lock_token = str(uuid.uuid4())
         acquired = await redis_client.set(
@@ -156,30 +179,39 @@ class TossOAuthTokenManager:
         )
         if acquired:
             try:
+                cached = await self._get_cached_token()
+                if cached is not None:
+                    if not force_reissue:
+                        return cached
+                    # Double-check under the lock: only reissue if the cache
+                    # still holds the failed token (or no failed token was
+                    # supplied). A fresher token means a peer already reissued.
+                    if failed_token is not None and cached != failed_token:
+                        return cached
                 if force_reissue:
                     await redis_client.delete(self.token_key)
-                else:
-                    cached = await self._get_cached_token()
-                    if cached is not None:
-                        return cached
                 issued = await self._issue_token()
                 await self._cache_token(issued)
                 logger.info("Toss OAuth token issued and cached")
                 return issued.access_token
             finally:
                 await self._release_lock(redis_client, lock_token)
-        waited = await self._wait_for_cached_token()
+        waited = await self._wait_for_cached_token(failed_token=failed_token)
         if waited is not None:
             return waited
         raise TossTokenIssuanceUnavailable(
             "Toss OAuth token issuance contended; no cached token after bounded wait"
         )
 
-    async def _wait_for_cached_token(self) -> str | None:
+    async def _wait_for_cached_token(
+        self, *, failed_token: str | None = None
+    ) -> str | None:
         deadline = time.monotonic() + TOKEN_WAIT_TIMEOUT_SECONDS
         while True:
             cached = await self._get_cached_token()
-            if cached is not None:
+            # A contender that hit invalid-token must not accept the dead token
+            # back; wait for a genuinely different (reissued) token.
+            if cached is not None and cached != failed_token:
                 return cached
             if time.monotonic() >= deadline:
                 return None

--- a/app/services/brokers/toss/client.py
+++ b/app/services/brokers/toss/client.py
@@ -30,6 +30,7 @@ from app.services.brokers.toss.errors import TossApiResponseError, parse_toss_re
 from app.services.brokers.toss.rate_limiter import (
     TossApiGroup,
     TossRateLimiter,
+    get_shared_rate_limiter,
     retry_delay_seconds,
 )
 from app.services.brokers.toss.transport import DEFAULT_TOSS_BASE_URL, build_toss_client
@@ -57,10 +58,14 @@ class TossReadClient:
         base_url = (
             getattr(settings_obj, "toss_api_base_url", None) or DEFAULT_TOSS_BASE_URL
         )
+        limiter = get_shared_rate_limiter()
         return cls(
-            token_manager=TossOAuthTokenManager.from_settings(settings_obj),
+            token_manager=TossOAuthTokenManager.from_settings(
+                settings_obj, rate_limiter=limiter
+            ),
             account_seq=getattr(settings_obj, "toss_api_account_seq", None),
             base_url=str(base_url),
+            rate_limiter=limiter,
         )
 
     async def aclose(self) -> None:
@@ -95,7 +100,9 @@ class TossReadClient:
             return parse_toss_response(response)
         except TossApiResponseError as exc:
             if exc.envelope.code in _TOKEN_CODES:
-                token = await self._token_manager.get_access_token(force_reissue=True)
+                token = await self._token_manager.get_access_token(
+                    force_reissue=True, failed_token=token
+                )
                 headers["Authorization"] = f"Bearer {token}"
                 retry = await self._client.request(
                     method, path, params=params, json=json, headers=headers

--- a/app/services/brokers/toss/errors.py
+++ b/app/services/brokers/toss/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -69,8 +70,27 @@ def _parse_error_envelope(payload: dict[str, Any]) -> TossErrorEnvelope:
     )
 
 
+def _non_json_envelope(response: httpx.Response) -> TossErrorEnvelope:
+    request_id = response.headers.get("x-request-id") or response.headers.get("cf-ray")
+    body = (response.text or "").strip()
+    return TossErrorEnvelope(
+        request_id=request_id,
+        code="non-json-response",
+        message=body[:200],
+        data=None,
+    )
+
+
 def parse_toss_response(response: httpx.Response) -> Any:
-    payload = response.json()
+    try:
+        payload = response.json()
+    except (json.JSONDecodeError, ValueError):
+        # Non-JSON body (LB/CDN HTML error page, empty body). Surface a typed
+        # error carrying status + request id instead of a raw JSONDecodeError.
+        envelope = _non_json_envelope(response)
+        if response.status_code == 429:
+            raise TossRateLimitError(envelope, status_code=response.status_code)
+        raise TossApiResponseError(envelope, status_code=response.status_code)
     if 200 <= response.status_code < 300:
         if isinstance(payload, dict) and "result" in payload:
             return payload["result"]

--- a/app/services/brokers/toss/rate_limiter.py
+++ b/app/services/brokers/toss/rate_limiter.py
@@ -41,7 +41,10 @@ class TossRateLimiter:
         self._buckets: dict[TossApiGroup, deque[float]] = {
             group: deque() for group in TossApiGroup
         }
-        self._lock = asyncio.Lock()
+        # Per-group locks so a throttled group never head-of-line blocks another.
+        self._locks: dict[TossApiGroup, asyncio.Lock] = {
+            group: asyncio.Lock() for group in TossApiGroup
+        }
 
     @staticmethod
     def limit_for(group: TossApiGroup, *, now: datetime | None = None) -> int:
@@ -52,19 +55,40 @@ class TossRateLimiter:
         return _BASE_LIMITS[group]
 
     async def acquire(self, group: TossApiGroup) -> None:
-        async with self._lock:
-            now = time.monotonic()
-            bucket = self._buckets[group]
-            while bucket and now - bucket[0] >= 1.0:
-                bucket.popleft()
-            limit = self.limit_for(group)
-            if len(bucket) >= limit:
-                sleep_for = max(1.0 - (now - bucket[0]), 0.0)
-                await asyncio.sleep(sleep_for)
+        lock = self._locks[group]
+        bucket = self._buckets[group]
+        while True:
+            async with lock:
                 now = time.monotonic()
                 while bucket and now - bucket[0] >= 1.0:
                     bucket.popleft()
-            bucket.append(now)
+                # Re-evaluate the limit each iteration so the 6->3 peak-window
+                # transition cannot admit an extra call.
+                limit = self.limit_for(group)
+                if len(bucket) < limit:
+                    bucket.append(now)
+                    return
+                sleep_for = max(1.0 - (now - bucket[0]), 0.0)
+            # Sleep OUTSIDE the lock, then re-loop and re-check the limit.
+            await asyncio.sleep(sleep_for if sleep_for > 0.0 else 0.001)
+
+
+_shared_rate_limiter: TossRateLimiter | None = None
+
+
+def get_shared_rate_limiter() -> TossRateLimiter:
+    """Process-global limiter shared by every Toss client/token manager built via
+    ``from_settings``, so group TPS budgets hold across concurrent call sites."""
+    global _shared_rate_limiter
+    if _shared_rate_limiter is None:
+        _shared_rate_limiter = TossRateLimiter()
+    return _shared_rate_limiter
+
+
+def reset_shared_rate_limiter() -> None:
+    """Test hook: drop the process-global limiter so suites start clean."""
+    global _shared_rate_limiter
+    _shared_rate_limiter = None
 
 
 def retry_delay_seconds(

--- a/app/services/brokers/toss/transport.py
+++ b/app/services/brokers/toss/transport.py
@@ -12,7 +12,12 @@ DEFAULT_TOSS_BASE_URL: Final[str] = "https://openapi.tossinvest.com"
 DEFAULT_TOSS_TIMEOUT_SECONDS: Final[float] = 10.0
 
 
-def assert_toss_host(host: str | None) -> None:
+def assert_toss_host(host: str | None, *, scheme: str | None = None) -> None:
+    if scheme is not None and scheme != "https":
+        raise TossHostBlocked(
+            f"Scheme {scheme!r} is not allowed for Toss Open API; https is required "
+            "(http would expose the Bearer token and client secret in cleartext)."
+        )
     if host not in TOSS_API_HOSTS:
         raise TossHostBlocked(
             f"Host {host!r} is not in TOSS_API_HOSTS. "
@@ -22,11 +27,11 @@ def assert_toss_host(host: str | None) -> None:
 
 def _assert_base_url_is_toss(base_url: str) -> None:
     parsed = urlsplit(base_url)
-    assert_toss_host(parsed.hostname)
+    assert_toss_host(parsed.hostname, scheme=parsed.scheme)
 
 
 async def _on_request(request: httpx.Request) -> None:
-    assert_toss_host(request.url.host)
+    assert_toss_host(request.url.host, scheme=request.url.scheme)
 
 
 async def _on_response(response: httpx.Response) -> None:

--- a/tests/services/brokers/toss/test_auth_single_flight.py
+++ b/tests/services/brokers/toss/test_auth_single_flight.py
@@ -178,6 +178,91 @@ async def test_cached_token_is_reused(fake_redis):
     assert await manager.get_access_token() == "cached-token"
 
 
+async def test_force_reissue_returns_fresher_cached_token_without_reissuing(
+    fake_redis, monkeypatch
+):
+    """ROB-547: a contender that hit invalid-token must reuse a fresher cached
+    token instead of force-reissuing it away (single-valid-token churn)."""
+    manager = auth.TossOAuthTokenManager(
+        client_id="client-id",
+        client_secret=SecretStr("client-secret"),
+        base_url="https://openapi.tossinvest.com",
+    )
+    # Cache already holds a fresher token T2 (another process reissued).
+    fake_redis.strings[manager.token_key] = json.dumps(
+        {"access_token": "fresh-T2", "expires_at": 4_102_444_800.0}
+    )
+    issue_calls = 0
+
+    async def _issue() -> auth.TossToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        return auth.TossToken(access_token="must-not-issue-T3", expires_in=86399)
+
+    monkeypatch.setattr(manager, "_issue_token", _issue)
+
+    token = await manager.get_access_token(force_reissue=True, failed_token="stale-T1")
+
+    assert token == "fresh-T2"
+    assert issue_calls == 0
+
+
+async def test_force_reissue_reissues_when_cache_still_holds_failed_token(
+    fake_redis, monkeypatch
+):
+    """ROB-547: if the cache still holds the failed token, force-reissue replaces it."""
+    manager = auth.TossOAuthTokenManager(
+        client_id="client-id",
+        client_secret=SecretStr("client-secret"),
+        base_url="https://openapi.tossinvest.com",
+    )
+    fake_redis.strings[manager.token_key] = json.dumps(
+        {"access_token": "stale-T1", "expires_at": 4_102_444_800.0}
+    )
+    issue_calls = 0
+
+    async def _issue() -> auth.TossToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        return auth.TossToken(access_token="new-T2", expires_in=86399)
+
+    monkeypatch.setattr(manager, "_issue_token", _issue)
+
+    token = await manager.get_access_token(force_reissue=True, failed_token="stale-T1")
+
+    assert token == "new-T2"
+    assert issue_calls == 1
+
+
+async def test_contended_force_reissue_never_returns_failed_token(
+    fake_redis, monkeypatch
+):
+    """ROB-547: a contender waiting after invalid-token must not get the dead
+    token back; if only the failed token is ever cached, it times out."""
+    manager = auth.TossOAuthTokenManager(
+        client_id="client-id",
+        client_secret=SecretStr("client-secret"),
+        base_url="https://openapi.tossinvest.com",
+    )
+    fake_redis.strings[manager.lock_key] = "other-owner"
+    fake_redis.strings[manager.token_key] = json.dumps(
+        {"access_token": "stale-T1", "expires_at": 4_102_444_800.0}
+    )
+    issue_calls = 0
+
+    async def _issue() -> auth.TossToken:
+        nonlocal issue_calls
+        issue_calls += 1
+        return auth.TossToken(access_token="must-not-issue", expires_in=86399)
+
+    monkeypatch.setattr(manager, "_issue_token", _issue)
+
+    with pytest.raises(TossTokenIssuanceUnavailable):
+        await manager.get_access_token(force_reissue=True, failed_token="stale-T1")
+
+    assert issue_calls == 0
+
+
 async def test_issue_token_uses_auth_rate_limiter(monkeypatch):
     acquired: list[TossApiGroup] = []
 

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -2,21 +2,47 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
 from decimal import Decimal
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
+from app.services.brokers.toss import rate_limiter as rate_limiter_module
 from app.services.brokers.toss.auth import TossOAuthTokenManager
 from app.services.brokers.toss.client import TossReadClient
+
+
+@dataclass
+class _ClientSettings:
+    toss_api_enabled: bool = True
+    toss_api_client_id: str | None = "client-id"
+    toss_api_client_secret: SecretStr | None = SecretStr("client-secret")
+    toss_api_base_url: str | None = "https://openapi.tossinvest.com"
+    toss_api_account_seq: int | None = 1
+
+
+def test_from_settings_shares_process_global_rate_limiter() -> None:
+    """ROB-547: client and its token manager must share the one process-global
+    limiter so group TPS holds across concurrent call sites."""
+    rate_limiter_module.reset_shared_rate_limiter()
+    shared = rate_limiter_module.get_shared_rate_limiter()
+
+    client = TossReadClient.from_settings(_ClientSettings())
+
+    assert client._rate_limiter is shared
+    assert client._token_manager._rate_limiter is shared
 
 
 class _TokenManager(TossOAuthTokenManager):
     def __init__(self) -> None:
         pass
 
-    async def get_access_token(self, *, force_reissue: bool = False) -> str:
-        del force_reissue
+    async def get_access_token(
+        self, *, force_reissue: bool = False, failed_token: str | None = None
+    ) -> str:
+        del force_reissue, failed_token
         return "token-1"
 
 
@@ -113,10 +139,14 @@ async def test_prices_rejects_more_than_200_symbols() -> None:
 async def test_get_order_retries_once_after_invalid_token() -> None:
     calls = 0
     token_calls: list[bool] = []
+    failed_tokens: list[str | None] = []
 
     class TokenManager(_TokenManager):
-        async def get_access_token(self, *, force_reissue: bool = False) -> str:
+        async def get_access_token(
+            self, *, force_reissue: bool = False, failed_token: str | None = None
+        ) -> str:
             token_calls.append(force_reissue)
+            failed_tokens.append(failed_token)
             return "token-2" if force_reissue else "token-1"
 
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -169,6 +199,9 @@ async def test_get_order_retries_once_after_invalid_token() -> None:
 
     assert order.order_id == "ord-1"
     assert token_calls == [False, True]
+    # ROB-547: the reissue must carry the failed token so a peer's fresher
+    # token can be reused instead of force-churning a new one.
+    assert failed_tokens == [None, "token-1"]
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/toss/test_errors.py
+++ b/tests/services/brokers/toss/test_errors.py
@@ -50,6 +50,40 @@ def test_parse_toss_response_allows_message_empty_and_unknown_code() -> None:
     assert "tickSize" not in str(exc_info.value)
 
 
+def _text_response(status_code: int, text: str, headers: dict[str, str] | None = None):
+    request = httpx.Request("GET", "https://openapi.tossinvest.com/api/v1/accounts")
+    return httpx.Response(
+        status_code, text=text, headers=headers or {}, request=request
+    )
+
+
+def test_parse_toss_response_non_json_error_synthesizes_typed_envelope() -> None:
+    """ROB-547: a 5xx HTML/LB page must surface as a typed TossApiResponseError
+    carrying status + code, not a raw JSONDecodeError."""
+    response = _text_response(
+        503,
+        "<html><body>503 Service Unavailable</body></html>",
+        headers={"cf-ray": "ray-123"},
+    )
+
+    with pytest.raises(TossApiResponseError) as exc_info:
+        parse_toss_response(response)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.envelope.code == "non-json-response"
+    assert exc_info.value.envelope.request_id == "ray-123"
+
+
+def test_parse_toss_response_non_json_success_raises_typed() -> None:
+    """A 2xx with a non-JSON body is unexpected for this API; surface typed."""
+    response = _text_response(200, "")
+
+    with pytest.raises(TossApiResponseError) as exc_info:
+        parse_toss_response(response)
+
+    assert exc_info.value.envelope.code == "non-json-response"
+
+
 def test_parse_toss_response_429_raises_rate_limit_error() -> None:
     response = _response(
         429,

--- a/tests/services/brokers/toss/test_rate_limiter.py
+++ b/tests/services/brokers/toss/test_rate_limiter.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
 
+from app.services.brokers.toss import rate_limiter as rate_limiter_module
 from app.services.brokers.toss.rate_limiter import (
     TossApiGroup,
     TossRateLimiter,
+    get_shared_rate_limiter,
     retry_delay_seconds,
 )
 
@@ -40,3 +44,37 @@ def test_retry_delay_seconds_uses_header_or_backoff(
     delay = retry_delay_seconds(retry_after, attempt=attempt, jitter=0.0)
 
     assert delay == expected_min
+
+
+def test_get_shared_rate_limiter_is_process_singleton() -> None:
+    """ROB-547: every call site shares one limiter so group TPS holds across
+    concurrent clients within a process."""
+    rate_limiter_module.reset_shared_rate_limiter()
+    first = get_shared_rate_limiter()
+    second = get_shared_rate_limiter()
+
+    assert first is second
+    assert isinstance(first, TossRateLimiter)
+
+
+@pytest.mark.asyncio
+async def test_throttled_group_does_not_block_other_groups() -> None:
+    """ROB-547: a saturated ORDER bucket must not head-of-line block a
+    MARKET_DATA read (per-group locking, sleep outside the global lock)."""
+    limiter = TossRateLimiter()
+    # Saturate ORDER (peak/normal limit >= 6) so the next ORDER acquire sleeps ~1s.
+    for _ in range(TossRateLimiter.limit_for(TossApiGroup.ORDER)):
+        await limiter.acquire(TossApiGroup.ORDER)
+
+    async def slow_order() -> None:
+        await limiter.acquire(TossApiGroup.ORDER)
+
+    order_task = asyncio.create_task(slow_order())
+    await asyncio.sleep(0.05)  # let the ORDER acquire enter its throttle wait
+
+    start = time.monotonic()
+    await limiter.acquire(TossApiGroup.MARKET_DATA)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.2, "MARKET_DATA was blocked behind the throttled ORDER group"
+    order_task.cancel()

--- a/tests/services/brokers/toss/test_transport.py
+++ b/tests/services/brokers/toss/test_transport.py
@@ -32,6 +32,21 @@ def test_build_toss_client_rejects_subdomain_spoof() -> None:
         build_toss_client(base_url="https://openapi.tossinvest.com.evil.example")
 
 
+def test_build_toss_client_rejects_http_scheme() -> None:
+    """ROB-547: an http:// base URL would send the Bearer token and client
+    secret in cleartext even to the right host. Refuse non-https."""
+    with pytest.raises(TossHostBlocked):
+        build_toss_client(base_url="http://openapi.tossinvest.com")
+
+
+@pytest.mark.asyncio
+async def test_on_request_rejects_http_scheme_to_toss_host() -> None:
+    request = httpx.Request("GET", "http://openapi.tossinvest.com/api/v1/accounts")
+
+    with pytest.raises(TossHostBlocked):
+        await _on_request(request)
+
+
 @pytest.mark.asyncio
 async def test_on_request_rejects_absolute_url_to_other_host() -> None:
     request = httpx.Request("GET", "https://evil.example.com/api/v1/accounts")

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.mcp_server.tooling.orders_toss_variants import (
     TOSS_LIVE_ORDER_TOOL_NAMES,
+    _high_value_uncheckable,
     register_toss_live_order_tools,
     toss_cancel_order,
     toss_get_order_history,
@@ -18,6 +19,21 @@ from app.mcp_server.tooling.orders_toss_variants import (
     toss_preview_order,
 )
 from tests._mcp_tooling_support import DummyMCP
+
+
+def test_high_value_uncheckable_true_for_kr_market_order() -> None:
+    """ROB-547: a KR market order has no price -> notional cannot be estimated,
+    so the local 1억 gate cannot evaluate it (must be surfaced, not silently skipped)."""
+    assert _high_value_uncheckable("kr", Decimal("10"), None, None) is True
+
+
+def test_high_value_uncheckable_false_for_kr_limit_order() -> None:
+    assert _high_value_uncheckable("kr", Decimal("10"), Decimal("70000"), None) is False
+
+
+def test_high_value_uncheckable_false_for_us_market_order() -> None:
+    # US notional is in USD; the KRW 1억 gate does not apply (broker-side check).
+    assert _high_value_uncheckable("us", Decimal("10"), None, None) is False
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
Post-merge audit follow-ups (ROB-547) for the Toss Open API client. Five hardening fixes, all TDD, migration 0.

- **Token force-reissue double-check** (`auth.py`): thread the failed token into `get_access_token(force_reissue=True, failed_token=...)`. Under the single-flight lock and in the contended wait path, reuse a fresher cached token instead of churning a new one — the single-valid-token spec no longer cascades into mutual invalidation + transient 401s across processes (ROB-262 pattern).
- **Process-global rate limiter** (`rate_limiter.py`, `client.py`, `auth.py`): `get_shared_rate_limiter()` injected by both `TossReadClient.from_settings` and `TossOAuthTokenManager.from_settings`, so group TPS budgets hold across concurrent call sites (previously every `from_settings()` started with empty buckets → limits were decorative). `acquire()` restructured to per-group locks, sleeps **outside** the lock (a throttled ORDER no longer head-of-line blocks MARKET_DATA), and re-checks `limit_for` after each sleep (no extra admit across the 09:00 6→3 peak-window transition).
- **https scheme pin** (`transport.py`): both the base-url assert and the per-request hook now require `https` — an operator-set `http://openapi.tossinvest.com` would otherwise send the Bearer token + client secret in cleartext.
- **non-JSON response** (`errors.py`): `parse_toss_response` synthesizes a typed `TossApiResponseError` (`code=non-json-response`, status + request id from `x-request-id`/`cf-ray`) instead of a raw `JSONDecodeError` on LB/CDN HTML pages or empty bodies.
- **KR market-order 1억 gate visibility** (`orders_toss_variants.py`): a KR market order has no price → KRW notional can't be estimated → the local high-value gate silently passed. Now logs a warning so the skip is surfaced; broker-side `confirm-high-value-required` still enforces.

## Test
TDD throughout (RED → GREEN). 137 toss tests pass (`tests/services/brokers/toss/`, `tests/test_mcp_toss_order_variants.py`, `tests/mcp_server/tooling/test_toss_live_order_mutation_safety.py`); 88-test adjacent consumer set green. `ruff format`/`ruff check`/`ty check` clean.

## Scope
Client-foundation hardening only. Closes ROB-547. Does not touch the partition-selection gap (ROB-551), env.example/CLAUDE.md or the warnings-guard asymmetry (ROB-550). migration 0.

Closes ROB-547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token management reliability with enhanced coordination in concurrent scenarios
  * Enhanced error reporting for non-JSON API responses

* **Security**
  * Enforced HTTPS-only connections for API communications to prevent credential exposure

* **Tests**
  * Added comprehensive test coverage for token reissuance, error handling, and rate limiting behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->