### PR TITLE
fix(ROB-551): source-aware screener partition selection — skip toss-only valuation partitions

### DIFF
--- a/app/services/invest_screener_snapshots/partition_health.py
+++ b/app/services/invest_screener_snapshots/partition_health.py
@@ -118,17 +118,16 @@ async def _partition_row_count(
     market: str,
     date_col: Any,
     partition_date: dt.date,
+    row_filter: Any | None = None,
 ) -> int:
-    return int(
-        (
-            await session.execute(
-                sa.select(sa.func.count())
-                .select_from(model)
-                .where(market_col == market, date_col == partition_date)
-            )
-        ).scalar()
-        or 0
+    stmt = (
+        sa.select(sa.func.count())
+        .select_from(model)
+        .where(market_col == market, date_col == partition_date)
     )
+    if row_filter is not None:
+        stmt = stmt.where(row_filter)
+    return int((await session.execute(stmt)).scalar() or 0)
 
 
 async def resolve_healthy_partition(
@@ -141,11 +140,19 @@ async def resolve_healthy_partition(
     universe_count: int | None = None,
     min_ratio: float = _MIN_HEALTHY_COVERAGE_RATIO,
     max_scan_back: int = _MAX_PARTITION_SCAN_BACK,
+    row_filter: Any | None = None,
 ) -> HealthyPartition | None:
     """Return the partition to serve (see module docstring).
 
     None only when the table has no partitions for the market. Fail-open: on any
     query error, falls back to a plain max(date_col) treated as healthy.
+
+    ``row_filter`` (ROB-551): an optional SQLAlchemy boolean expression that
+    restricts which rows count toward coverage. Valuation screener loaders pass
+    ``metric_rich_filter()`` so a metric-sparse toss-only partition (market_cap
+    only) is not selected as healthy and then emptied by the per>0/pbr>0
+    candidate filters downstream. Default ``None`` preserves total-row counting
+    for flow/price/screener-snapshot callers.
     """
     try:
         dates = [
@@ -184,6 +191,7 @@ async def resolve_healthy_partition(
                 market=market,
                 date_col=date_col,
                 partition_date=d,
+                row_filter=row_filter,
             )
             if count >= floor:
                 return HealthyPartition(
@@ -201,6 +209,7 @@ async def resolve_healthy_partition(
             market=market,
             date_col=date_col,
             partition_date=newest,
+            row_filter=row_filter,
         )
         return HealthyPartition(
             partition_date=newest,

--- a/app/services/invest_view_model/double_buy_screener.py
+++ b/app/services/invest_view_model/double_buy_screener.py
@@ -208,6 +208,9 @@ async def load_double_buy_from_snapshots(
         from app.services.invest_screener_snapshots.partition_health import (
             resolve_healthy_partition as _resolve_val_hp,
         )
+        from app.services.market_valuation_snapshots.repository import (
+            metric_rich_filter,
+        )
 
         val_hp = await _resolve_val_hp(
             session,
@@ -216,6 +219,7 @@ async def load_double_buy_from_snapshots(
             market_col=MarketValuationSnapshot.market,
             market="kr",
             universe_count=universe_count,
+            row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
         )
         if val_hp is not None:
             market_cap_source = "fallback" if val_hp.is_fallback else "primary"

--- a/app/services/invest_view_model/fundamentals_screener.py
+++ b/app/services/invest_view_model/fundamentals_screener.py
@@ -356,6 +356,7 @@ async def load_fundamentals_preset_from_snapshots(
     from app.services.invest_screener_snapshots.partition_health import (
         resolve_healthy_partition,
     )
+    from app.services.market_valuation_snapshots.repository import metric_rich_filter
 
     val_hp = await resolve_healthy_partition(
         session,
@@ -363,6 +364,7 @@ async def load_fundamentals_preset_from_snapshots(
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
         market=market,
+        row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:

--- a/app/services/invest_view_model/high_yield_value_screener.py
+++ b/app/services/invest_view_model/high_yield_value_screener.py
@@ -56,6 +56,7 @@ async def load_high_yield_value_from_snapshots(
         resolve_healthy_partition,
         served_partition_degraded,
     )
+    from app.services.market_valuation_snapshots.repository import metric_rich_filter
 
     val_hp = await resolve_healthy_partition(
         session,
@@ -63,6 +64,7 @@ async def load_high_yield_value_from_snapshots(
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
         market=market,
+        row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:

--- a/app/services/invest_view_model/kr_fundamentals_tv_screener.py
+++ b/app/services/invest_view_model/kr_fundamentals_tv_screener.py
@@ -575,6 +575,9 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
         from app.services.invest_screener_snapshots.partition_health import (
             resolve_healthy_partition,
         )
+        from app.services.market_valuation_snapshots.repository import (
+            metric_rich_filter,
+        )
 
         val_hp = await resolve_healthy_partition(
             session,
@@ -582,6 +585,7 @@ async def load_kr_fundamentals_preset_from_tv_snapshot(
             date_col=MarketValuationSnapshot.snapshot_date,
             market_col=MarketValuationSnapshot.market,
             market="kr",
+            row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
         )
         if val_hp and val_hp.partition_date is not None:
             val_rows = await session.execute(

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -659,6 +659,9 @@ async def _load_consecutive_gainers_from_snapshots(
     market_cap_source: str | None = None
     if market == "kr" and candidate_snaps:
         from app.models.market_valuation_snapshot import MarketValuationSnapshot
+        from app.services.market_valuation_snapshots.repository import (
+            metric_rich_filter,
+        )
 
         val_hp = await resolve_healthy_partition(
             session,
@@ -666,6 +669,7 @@ async def _load_consecutive_gainers_from_snapshots(
             date_col=MarketValuationSnapshot.snapshot_date,
             market_col=MarketValuationSnapshot.market,
             market="kr",
+            row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
         )
         if val_hp is not None:
             market_cap_source = "fallback" if val_hp.is_fallback else "primary"
@@ -922,6 +926,9 @@ async def _load_investor_flow_discovery_from_snapshots(
     market_cap_source: str | None = None
     if candidate_snaps:
         from app.models.market_valuation_snapshot import MarketValuationSnapshot
+        from app.services.market_valuation_snapshots.repository import (
+            metric_rich_filter,
+        )
 
         val_hp = await resolve_healthy_partition(
             session,
@@ -929,6 +936,7 @@ async def _load_investor_flow_discovery_from_snapshots(
             date_col=MarketValuationSnapshot.snapshot_date,
             market_col=MarketValuationSnapshot.market,
             market="kr",
+            row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
         )
         if val_hp is not None:
             market_cap_source = "fallback" if val_hp.is_fallback else "primary"

--- a/app/services/invest_view_model/undervalued_breakout_screener.py
+++ b/app/services/invest_view_model/undervalued_breakout_screener.py
@@ -86,6 +86,7 @@ async def load_undervalued_breakout_from_snapshots(
         resolve_healthy_partition,
         served_partition_degraded,
     )
+    from app.services.market_valuation_snapshots.repository import metric_rich_filter
 
     val_hp = await resolve_healthy_partition(
         session,
@@ -93,6 +94,7 @@ async def load_undervalued_breakout_from_snapshots(
         date_col=MarketValuationSnapshot.snapshot_date,
         market_col=MarketValuationSnapshot.market,
         market=market,
+        row_filter=metric_rich_filter(),  # ROB-551: skip toss-only partitions
     )
     val_date = val_hp.partition_date if val_hp else None
     if val_date is None:

--- a/app/services/market_valuation_snapshots/repository.py
+++ b/app/services/market_valuation_snapshots/repository.py
@@ -14,6 +14,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.market_valuation_snapshot import MarketValuationSnapshot
 
 
+def metric_rich_filter() -> sa.ColumnElement[bool]:
+    """ROB-551: a valuation row is "metric-rich" when it carries at least one
+    fundamentals metric (per/pbr/roe/dividend_yield). A market_cap-only row
+    (e.g. ``source='toss_openapi'`` gap-fill) is metric-sparse.
+
+    Use this as ``row_filter`` for ``resolve_healthy_partition`` on
+    MarketValuationSnapshot so a toss-only partition (0 metric-rich rows) is not
+    selected as the screener val_date and then emptied by the per>0/pbr>0
+    candidate filters downstream.
+    """
+    return sa.or_(
+        MarketValuationSnapshot.per.isnot(None),
+        MarketValuationSnapshot.pbr.isnot(None),
+        MarketValuationSnapshot.roe.isnot(None),
+        MarketValuationSnapshot.dividend_yield.isnot(None),
+    )
+
+
 class MarketValuationSnapshotUpsert(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -189,18 +207,7 @@ class MarketValuationSnapshotsRepository:
         # metric-sparse market_cap-only row (e.g. toss_openapi, per/pbr/roe NULL)
         # on a newer snapshot_date does not shadow a metric-rich row. Falls back
         # to the sparse row only when it is the symbol's sole source.
-        metric_sparse = sa.case(
-            (
-                sa.or_(
-                    MarketValuationSnapshot.per.isnot(None),
-                    MarketValuationSnapshot.pbr.isnot(None),
-                    MarketValuationSnapshot.roe.isnot(None),
-                    MarketValuationSnapshot.dividend_yield.isnot(None),
-                ),
-                0,
-            ),
-            else_=1,
-        )
+        metric_sparse = sa.case((metric_rich_filter(), 0), else_=1)
         stmt = (
             select(MarketValuationSnapshot)
             .where(

--- a/tests/test_partition_health.py
+++ b/tests/test_partition_health.py
@@ -101,6 +101,87 @@ async def test_resolve_all_thin_serves_newest_as_last_resort(db_session):
     assert hp.row_count == 5
 
 
+# ── ROB-551: source-aware partition selection for MarketValuationSnapshot ──
+
+_VAL_DATES = {dt.date(2041, 6, 11), dt.date(2041, 6, 12)}
+
+
+async def _cleanup_val(session) -> None:
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+
+    await session.execute(
+        sa.delete(MarketValuationSnapshot).where(
+            MarketValuationSnapshot.snapshot_date.in_(_VAL_DATES)
+        )
+    )
+    await session.flush()
+
+
+async def _seed_val(
+    session, *, snapshot_date: dt.date, count: int, sparse: bool, source: str
+) -> None:
+    from decimal import Decimal
+
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+
+    for i in range(count):
+        kwargs = {
+            "market": "kr",
+            "symbol": f"{source[:2]}{snapshot_date.day:02d}{i:04d}",
+            "snapshot_date": snapshot_date,
+            "source": source,
+            "market_cap": Decimal("1000000"),
+        }
+        if not sparse:
+            kwargs.update(
+                per=Decimal("11"),
+                pbr=Decimal("1.2"),
+                roe=Decimal("0.15"),
+                dividend_yield=Decimal("0.02"),
+            )
+        session.add(MarketValuationSnapshot(**kwargs))
+    await session.flush()
+
+
+@pytest.mark.asyncio
+async def test_metric_rich_row_filter_skips_toss_only_partition(db_session):
+    """ROB-551: a newer metric-sparse toss-only partition (market_cap only) must
+    not be selected as the screener val_date; the metric-rich naver partition on
+    the older date wins when row_filter counts only metric-rich rows."""
+    from app.models.market_valuation_snapshot import MarketValuationSnapshot
+    from app.services.market_valuation_snapshots.repository import metric_rich_filter
+
+    await _cleanup_val(db_session)
+    older, newer = dt.date(2041, 6, 11), dt.date(2041, 6, 12)
+    # older: 60 metric-rich naver rows (clears floor). newer: 60 metric-sparse
+    # toss rows (clears floor by TOTAL count, but 0 metric-rich).
+    await _seed_val(
+        db_session, snapshot_date=older, count=60, sparse=False, source="naver_finance"
+    )
+    await _seed_val(
+        db_session, snapshot_date=newer, count=60, sparse=True, source="toss_openapi"
+    )
+
+    kw = {
+        "model": MarketValuationSnapshot,
+        "date_col": MarketValuationSnapshot.snapshot_date,
+        "market_col": MarketValuationSnapshot.market,
+        "market": "kr",
+    }
+
+    # Without the filter (legacy behavior), the newer toss-only partition wins.
+    hp_default = await resolve_healthy_partition(db_session, universe_count=100, **kw)
+    assert hp_default is not None and hp_default.partition_date == newer
+
+    # With the metric-rich filter, the toss-only partition has 0 qualifying rows
+    # and is skipped; the metric-rich older partition is served.
+    hp_filtered = await resolve_healthy_partition(
+        db_session, universe_count=100, row_filter=metric_rich_filter(), **kw
+    )
+    assert hp_filtered is not None and hp_filtered.partition_date == older
+    assert hp_filtered.healthy is True and hp_filtered.is_fallback is True
+
+
 @pytest.mark.asyncio
 async def test_resolve_empty_table_returns_none():
     mock_session = AsyncMock()


### PR DESCRIPTION
## Summary
Completes the remaining gate for full Toss market_cap `--all --commit` activation. ROB-546 hardened the per-symbol valuation reader (`latest_for_symbols`) but **deferred the screener partition-selection path** (noted in #1279 + runbook).

**The gap:** `resolve_healthy_partition` / `_partition_row_count` count ALL rows for `(market, date)` with no source filter. An out-of-order toss-only `--all --commit` (run before naver/yahoo for the same date) creates a metric-sparse partition (market_cap only, per/pbr/roe NULL) on a newer `snapshot_date` whose row count clears the 0.50 coverage floor → picked as `val_date` → the downstream per>0/pbr>0 candidate filters drop ALL toss-only rows → empty/degraded screener results.

## Changes
- **`partition_health.py`**: `resolve_healthy_partition` / `_partition_row_count` take an optional `row_filter` SQLAlchemy predicate. **Default `None` preserves total-row counting** for flow/price/screener-snapshot callers — zero behavior change for non-valuation partitions.
- **`market_valuation_snapshots/repository.py`**: extract `metric_rich_filter()` (`per OR pbr OR roe OR dividend_yield IS NOT NULL`); reuse it for the ROB-546 `metric_sparse` ordering (DRY).
- **Wire `row_filter=metric_rich_filter()`** into all 6 `MarketValuationSnapshot` partition call sites: `fundamentals_screener`, `undervalued_breakout_screener`, `high_yield_value_screener`, `kr_fundamentals_tv_screener`, `double_buy_screener`, `screener_service` (×2). A toss-only partition now counts 0 metric-rich rows → fails the floor → the metric-rich naver/yahoo partition is served.

## Test
TDD (RED → GREEN). New resolver-level DB test `test_metric_rich_row_filter_skips_toss_only_partition` proves a newer toss-only partition is skipped for the older metric-rich one, and that the **default path (no filter) still picks the newer one** (proving the param is the fix). `ruff format`/`ruff check`/`ty check` clean. migration 0.

⚠️ `tests/test_fundamentals_screener.py` has 6 **pre-existing** shared-DB pollution failures — identical on `origin/main` (verified via stash), pass on a clean DB / CI shards. Unrelated to this change.

## Scope
Closes ROB-551. With #1280 (ROB-547) this clears the remaining ROB-529 follow-up blockers; ROB-548/549/550 are the lower-priority remainder.

Closes ROB-551

🤖 Generated with [Claude Code](https://claude.com/claude-code)