### PR TITLE
fix(ROB-549): gate Toss holdings routable/orderable/tradeable on mutations flag

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1173,7 +1173,7 @@ Response contract additions:
 - `filter_reason`: filter status string, e.g. `minimum_value < 1000` or `equity_kr < 5000, equity_us < 10, crypto < 5000`
 - `errors`: includes per-symbol price lookup failures for holdings price refresh (example fields: `source`, `market`, `symbol`, `stage`, `error`)
 - `filters.minimum_value`: when `minimum_value=None` in the request, this field contains the per-currency threshold dict that was applied
-- When `TOSS_API_ENABLED=true`, Toss Open API holdings are emitted with `broker="toss"`, `source="toss_api"`, and `order_routable=false` until Toss live-order tools exist. The per-position `sellable_quantity` field comes from Toss `/api/v1/sellable-quantity` and is informational in ROB-532.
+- When `TOSS_API_ENABLED=true`, Toss Open API holdings are emitted with `broker="toss"`, `source="toss_api"`. `order_routable` (and `get_cash_balance` `orderable`, `/invest` home `isTradeable`/`sellableQuantity`) are gated on `TOSS_LIVE_ORDER_MUTATIONS_ENABLED` (ROB-549): reference-only (`order_routable=false`, `orderable=0`, `isTradeable=false`, `sellableQuantity=0`) while disabled, and routable with the API-provided `sellable_quantity` (Toss `/api/v1/sellable-quantity`) once the operator arms live mutations.
 - When Toss API holdings succeed, duplicate Toss `manual_holdings` rows for the same market/symbol are hidden from normal output. KIS and Toss holdings for the same symbol are not deduplicated because they are separate broker subaccounts.
 - When Toss API holdings fail, existing Toss `manual_holdings` rows remain visible as fallback and the response includes a partial `source="toss_api"` error.
 

--- a/app/mcp_server/tooling/account_modes.py
+++ b/app/mcp_server/tooling/account_modes.py
@@ -5,10 +5,21 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from app.core.config import settings
+
 ACCOUNT_MODE_DB_SIMULATED = "db_simulated"
 ACCOUNT_MODE_KIS_MOCK = "kis_mock"
 ACCOUNT_MODE_KIS_LIVE = "kis_live"
 ACCOUNT_MODE_TOSS_LIVE = "toss_live"
+
+
+def toss_live_mutations_enabled(settings_obj: Any = settings) -> bool:
+    """ROB-549: single source of truth for whether Toss live order mutations are
+    armed. Gates toss_api holdings' order-routability / orderable cash /
+    tradeability so they no longer contradict the registered toss_live order
+    tools once the operator flips ``TOSS_LIVE_ORDER_MUTATIONS_ENABLED``."""
+    return bool(getattr(settings_obj, "toss_live_order_mutations_enabled", False))
+
 
 _ACCOUNT_MODE_ALIASES = {
     "db_simulated": (ACCOUNT_MODE_DB_SIMULATED, False),

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -9,6 +9,7 @@ from typing import Any
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
 from app.core.timezone import now_kst
+from app.mcp_server.tooling.account_modes import toss_live_mutations_enabled
 from app.mcp_server.tooling.shared import (
     logger,
     to_float,
@@ -166,6 +167,10 @@ async def get_cash_balance_impl(
     if account_filter is None or account_filter == "toss":
         if bool(getattr(settings, "toss_api_enabled", False)):
             try:
+                # ROB-549: surface buying power as orderable only once Toss live
+                # mutations are armed; otherwise keep it reference-only (0.0) so
+                # the cash signal matches the holdings sellability gate.
+                toss_orderable_enabled = toss_live_mutations_enabled()
                 toss_snapshot = await fetch_toss_cash_snapshot()
                 toss_krw = _decimal_to_float(toss_snapshot.cash_krw)
                 toss_usd = _decimal_to_float(toss_snapshot.cash_usd)
@@ -177,7 +182,7 @@ async def get_cash_balance_impl(
                             "broker": "toss",
                             "currency": "KRW",
                             "balance": toss_krw,
-                            "orderable": 0.0,
+                            "orderable": toss_krw if toss_orderable_enabled else 0.0,
                             "formatted": _format_cash_amount(toss_krw, "KRW"),
                         }
                     )
@@ -190,7 +195,7 @@ async def get_cash_balance_impl(
                             "broker": "toss",
                             "currency": "USD",
                             "balance": toss_usd,
-                            "orderable": 0.0,
+                            "orderable": toss_usd if toss_orderable_enabled else 0.0,
                             "formatted": _format_cash_amount(toss_usd, "USD"),
                         }
                     )

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -15,6 +15,7 @@ from app.mcp_server.env_utils import _env_int
 from app.mcp_server.tooling.account_modes import (
     apply_account_routing_metadata,
     normalize_account_mode,
+    toss_live_mutations_enabled,
 )
 from app.mcp_server.tooling.concurrency import bounded_gather
 from app.mcp_server.tooling.market_data_indicators import (
@@ -161,13 +162,20 @@ def _provenance_account_mode(
 def _account_order_routable(*, source: str | None) -> bool:
     """Whether an account group's holdings are routable by an automated order tool.
 
-    Manual holdings (toss/samsung/수동 입력, ``source="manual"``) and ROB-532
-    Toss API holdings are reference-only for order mutation until a Toss order
-    path exists. KIS / Upbit / paper sources sell via their own channels. This
-    is the authoritative sellability signal; ``account_mode`` stays a
-    provenance label (ROB-357) and is intentionally left unchanged.
+    Manual holdings (toss/samsung/수동 입력, ``source="manual"``) are always
+    reference-only. ROB-532 Toss API holdings were reference-only until the Toss
+    order tools existed; ROB-549 gates them on
+    ``TOSS_LIVE_ORDER_MUTATIONS_ENABLED`` so the sellability signal matches the
+    registered toss_live order tools once mutations are armed. KIS / Upbit /
+    paper sources sell via their own channels. This is the authoritative
+    sellability signal; ``account_mode`` stays a provenance label (ROB-357) and
+    is intentionally left unchanged.
     """
-    return source not in {"manual", "toss_api"}
+    if source == "manual":
+        return False
+    if source == "toss_api":
+        return toss_live_mutations_enabled()
+    return True
 
 
 def _build_crypto_strategy_signal(

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -486,12 +486,40 @@ class UpbitHomeReader:
             )
 
 
+def _toss_sellable_quantity(position: Any, mutations_enabled: bool) -> float:
+    """ROB-549: 0.0 while reference-only; the API-provided sellable quantity
+    (falling back to full quantity) once Toss live mutations are armed."""
+    if not mutations_enabled:
+        return 0.0
+    sellable = getattr(position, "sellable_quantity", None)
+    if sellable is None:
+        return float(position.quantity)
+    return float(sellable)
+
+
+def _toss_pending_sell_quantity(position: Any, mutations_enabled: bool) -> float:
+    if not mutations_enabled:
+        return 0.0
+    return max(
+        float(position.quantity) - _toss_sellable_quantity(position, mutations_enabled),
+        0.0,
+    )
+
+
 class TossApiHomeReader:
     """Toss Open API live portfolio reader."""
 
     async def fetch(self, *, user_id: int) -> _SourceFetchResult:
         del user_id
         try:
+            # ROB-549: gate tradeability/sellable on the live-mutation flag so
+            # toss_api holdings stop contradicting the registered toss_live order
+            # tools once the operator arms TOSS_LIVE_ORDER_MUTATIONS_ENABLED.
+            from app.core.config import settings as _settings
+
+            mutations_enabled = bool(
+                getattr(_settings, "toss_live_order_mutations_enabled", False)
+            )
             snapshot = await fetch_toss_portfolio_snapshot()
             holdings: list[Holding] = []
             value_krw_total = 0.0
@@ -584,10 +612,14 @@ class TossApiHomeReader:
                         else None,
                         priceState="live",
                         sourceOfTruth=True,
-                        isTradeable=False,
+                        isTradeable=mutations_enabled,
                         manualOnly=False,
-                        sellableQuantity=0.0,
-                        pendingSellQuantity=0.0,
+                        sellableQuantity=_toss_sellable_quantity(
+                            position, mutations_enabled
+                        ),
+                        pendingSellQuantity=_toss_pending_sell_quantity(
+                            position, mutations_enabled
+                        ),
                         referenceQuantity=float(position.quantity),
                     )
                 )

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -1427,6 +1427,10 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
     monkeypatch.setattr(
         readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
     )
+    # ROB-549: mutations disabled (default) -> reference-only.
+    from app.core.config import settings as _cfg
+
+    monkeypatch.setattr(_cfg, "toss_live_order_mutations_enabled", False, raising=False)
 
     result = await readers.TossApiHomeReader().fetch(user_id=1)
 
@@ -1444,6 +1448,57 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
     assert holding.manualOnly is False
     assert holding.sellableQuantity == 0.0
     assert holding.referenceQuantity == 1.5
+
+
+@pytest.mark.asyncio
+async def test_toss_api_home_reader_tradeable_when_mutations_enabled(monkeypatch):
+    """ROB-549: with Toss live mutations armed, toss_api holdings become tradeable
+    and surface the API-provided sellable_quantity instead of discarding it."""
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import (
+        TossPortfolioPosition,
+        TossPortfolioSnapshot,
+    )
+
+    async def fake_fetch_toss_snapshot():
+        return TossPortfolioSnapshot(
+            positions=[
+                TossPortfolioPosition(
+                    account="toss",
+                    account_name="Toss",
+                    broker="toss",
+                    source="toss_api",
+                    instrument_type="equity_us",
+                    market="us",
+                    symbol="BRK.B",
+                    name="Berkshire Hathaway B",
+                    quantity=Decimal("1.5"),
+                    avg_buy_price=Decimal("400"),
+                    current_price=Decimal("430.12"),
+                    evaluation_amount=Decimal("645.18"),
+                    profit_loss=Decimal("45.18"),
+                    profit_rate=Decimal("0.0753"),
+                    sellable_quantity=Decimal("1.25"),
+                )
+            ],
+            cash_krw=Decimal("123456"),
+            cash_usd=Decimal("789.01"),
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(_cfg, "toss_live_order_mutations_enabled", True, raising=False)
+
+    result = await readers.TossApiHomeReader().fetch(user_id=1)
+
+    holding = result.holdings[0]
+    assert holding.isTradeable is True
+    assert holding.sellableQuantity == 1.25
+    assert holding.pendingSellQuantity == pytest.approx(0.25)  # qty 1.5 - sellable 1.25
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_holdings_account_mode_provenance.py
+++ b/tests/test_mcp_holdings_account_mode_provenance.py
@@ -18,6 +18,29 @@ from app.mcp_server.tooling import portfolio_holdings
 from tests._mcp_tooling_support import DummyMCP
 
 
+def test_account_order_routable_toss_api_gated_on_mutations_flag(monkeypatch):
+    """ROB-549: toss_api holdings become routable once Toss live order
+    mutations are enabled; manual holdings stay reference-only regardless."""
+    from app.mcp_server.tooling import account_modes
+
+    monkeypatch.setattr(
+        account_modes.settings,
+        "toss_live_order_mutations_enabled",
+        False,
+        raising=False,
+    )
+    assert portfolio_holdings._account_order_routable(source="toss_api") is False
+    assert portfolio_holdings._account_order_routable(source="manual") is False
+    assert portfolio_holdings._account_order_routable(source="kis_api") is True
+
+    monkeypatch.setattr(
+        account_modes.settings, "toss_live_order_mutations_enabled", True, raising=False
+    )
+    assert portfolio_holdings._account_order_routable(source="toss_api") is True
+    # manual is always reference-only, even with Toss mutations on
+    assert portfolio_holdings._account_order_routable(source="manual") is False
+
+
 def _upbit_position(symbol: str = "KRW-BTC") -> dict:
     return {
         "account": "upbit",
@@ -135,6 +158,16 @@ async def test_get_holdings_impl_labels_upbit_account_upbit_live(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_holdings_impl_labels_toss_api_account_toss_api(monkeypatch):
+    from app.mcp_server.tooling import account_modes
+
+    # Mutations disabled (default): toss_api stays reference-only.
+    monkeypatch.setattr(
+        account_modes.settings,
+        "toss_live_order_mutations_enabled",
+        False,
+        raising=False,
+    )
+
     async def fake_collect(**_kwargs):
         return [_toss_api_position("BRK.B"), _kis_position("005930")], [], None, None
 

--- a/tests/test_toss_cash_orderable_gate.py
+++ b/tests/test_toss_cash_orderable_gate.py
@@ -1,0 +1,59 @@
+"""ROB-549: Toss cash ``orderable`` is gated on TOSS_LIVE_ORDER_MUTATIONS_ENABLED.
+
+While Toss live mutations are disabled the cash is reported as balance with
+``orderable=0.0`` (reference-only, matching the holdings sellability signal).
+Once mutations are armed, the buying power is surfaced as orderable so
+``get_available_capital`` and the morning report stop treating Toss cash as
+unusable while the toss_live order tools are live.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.mcp_server.tooling import portfolio_cash
+from app.services.toss_portfolio_service import TossCashSnapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _run(monkeypatch, *, mutations_enabled: bool) -> dict:
+    monkeypatch.setattr(
+        portfolio_cash.settings, "toss_api_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        portfolio_cash.settings,
+        "toss_live_order_mutations_enabled",
+        mutations_enabled,
+        raising=False,
+    )
+
+    async def _fake_snapshot():
+        return TossCashSnapshot(cash_krw=Decimal("1000000"), cash_usd=None, errors=[])
+
+    monkeypatch.setattr(portfolio_cash, "fetch_toss_cash_snapshot", _fake_snapshot)
+    # Avoid KIS/Upbit network paths; scope to the toss account only.
+    return await portfolio_cash.get_cash_balance_impl(account="toss")
+
+
+async def test_toss_orderable_zero_when_mutations_disabled(monkeypatch):
+    result = await _run(monkeypatch, mutations_enabled=False)
+    toss_krw = next(
+        a
+        for a in result["accounts"]
+        if a["broker"] == "toss" and a["currency"] == "KRW"
+    )
+    assert toss_krw["balance"] == pytest.approx(1000000.0)
+    assert toss_krw["orderable"] == pytest.approx(0.0)
+
+
+async def test_toss_orderable_equals_balance_when_mutations_enabled(monkeypatch):
+    result = await _run(monkeypatch, mutations_enabled=True)
+    toss_krw = next(
+        a
+        for a in result["accounts"]
+        if a["broker"] == "toss" and a["currency"] == "KRW"
+    )
+    assert toss_krw["orderable"] == pytest.approx(1000000.0)


### PR DESCRIPTION
## Summary
ROB-532 hard-pinned `toss_api` holdings to reference-only "until Toss live-order tools exist" — but **ROB-531 shipped those tools in the same batch**, so the holdings metadata now contradicts the registered `toss_live` order tools (Hermes/agents see Toss positions as unsellable and Toss cash as unusable while the order path is live).

Gate the three stances on `TOSS_LIVE_ORDER_MUTATIONS_ENABLED` (the same flag that arms the order tools), through one source of truth.

## Changes
- **`account_modes.toss_live_mutations_enabled()`** — shared flag reader (single source of truth).
- **`portfolio_holdings._account_order_routable`** — `toss_api` → routable when armed; `manual` stays reference-only regardless.
- **`portfolio_cash`** — Toss KRW/USD `orderable` = buying power when armed, else `0.0`.
- **`invest_home_readers.TossApiHomeReader`** — `isTradeable` + the **API-provided `sellable_quantity`** (Toss `/sellable-quantity`, previously discarded) when armed; reference-only otherwise.
- **README** — replace stale "until Toss live-order tools exist" with the flag-gated behavior.

Flag **disabled (default) preserves the ROB-532 conservative behavior exactly** — zero behavior change until the operator arms mutations.

## Test
TDD (RED → GREEN). Flag-off and flag-on cases for all three surfaces: `_account_order_routable` gate, Toss cash orderable gate (new `test_toss_cash_orderable_gate.py`), and TossApiHomeReader tradeable/sellable gate. `ruff` + `ty` clean. migration 0.

## Scope
Closes ROB-549 (the order_routable mutation-gate, audited as the major). Deferred to ROB-550 (cleanup): invest_home `BRK.B` vs `BRK/B` dedup normalization, toss account group-label stamping, morning-report `toss_krw_fmt` string — independent low-risk minors.

Closes ROB-549

🤖 Generated with [Claude Code](https://claude.com/claude-code)