### PR TITLE
fix(ROB-540): remove dead daily-order cap + stale "20/day" tool-text

### DIFF
--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -28,7 +28,6 @@ from app.mcp_server.tooling.order_validation import (
     DefensiveTrimContext,
     ScalpingExitContext,
     _check_balance_and_warn,
-    _check_daily_order_limit,
     _get_balance_for_order,
     _get_current_price_for_order,
     _get_holdings_for_order,
@@ -258,8 +257,6 @@ async def _execute_us_order(
 # ---------------------------------------------------------------------------
 # _place_order_impl sub-steps
 # ---------------------------------------------------------------------------
-
-_MAX_ORDERS_PER_DAY = 20
 
 
 def _validate_inputs(
@@ -662,9 +659,6 @@ async def _execute_and_record(
     report_item_uuid: uuid.UUID | None = None,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
-    if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
-        return order_error_fn(f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded")
-
     # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
     # Best-effort — failure leaves the column NULL and the reconciler will
     # surface the row as `baseline_missing → anomaly` for operator review.
@@ -1150,7 +1144,6 @@ __all__ = [
     "_get_current_price_for_order",
     "_get_holdings_for_order",
     "_get_balance_for_order",
-    "_check_daily_order_limit",
     "_record_order_history",
     "_preview_order",
     "_execute_order",

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -533,32 +533,6 @@ async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> flo
     return _extract_usd_orderable_from_row(usd_row)
 
 
-async def _check_daily_order_limit(max_orders: int) -> bool:
-    try:
-        import redis.asyncio as redis_async
-
-        redis_url = getattr(settings, "redis_url", None)
-        if not redis_url:
-            return True
-
-        redis = await redis_async.from_url(redis_url)
-        today = datetime.datetime.now().strftime("%Y-%m-%d")
-        key = f"order_count:{today}"
-
-        count = await redis.get(key)
-        if count is None:
-            count = 0
-        else:
-            count = int(count)
-
-        if count >= max_orders:
-            return False
-
-        return True
-    except Exception:
-        return True
-
-
 async def _record_order_history(
     symbol: str,
     side: str,

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -452,7 +452,6 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "is_mock is hard-pinned to False. "
             "dry_run=True by default for safety. "
             "For buy orders (dry_run=False), thesis and strategy are required. "
-            "Safety limit: max 20 orders/day. "
             "Normal weight-management trims do NOT need defensive_trim — leave "
             "it False. defensive_trim=True only bypasses the sell-side price "
             "floor and requires side='sell', order_type='limit', and an "

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -190,7 +190,6 @@ def register_order_tools(mcp: FastMCP) -> None:
             "so a trade journal can be created automatically. "
             "For sell orders, active trade journals are auto-closed in FIFO order. "
             "Use exit_reason to record the sell thesis in the journal. "
-            "Safety limit: max 20 orders/day. "
             "dry_run=True by default for safety. "
             "Set account_type='paper' to route to the virtual paper-trading engine "
             "(no real broker calls, uses PaperTradingService). In paper mode, the "

--- a/tests/mcp_server/tooling/test_crypto_live_routing.py
+++ b/tests/mcp_server/tooling/test_crypto_live_routing.py
@@ -16,7 +16,6 @@ async def test_crypto_limit_is_accepted_only():
 
     with (
         patch.object(oe, "_execute_order", new=AsyncMock(return_value=_exec())),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch.object(oe, "_record_order_history", new=AsyncMock()),
         patch.object(oe, "_record_fill_and_journals", new=AsyncMock()) as m_legacy,
         patch(
@@ -66,7 +65,6 @@ async def test_crypto_market_inline_confirm():
 
     with (
         patch.object(oe, "_execute_order", new=AsyncMock(return_value=_exec())),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch.object(oe, "_record_order_history", new=AsyncMock()),
         patch(
             "app.mcp_server.tooling.live_order_ledger._record_live_order",

--- a/tests/mcp_server/tooling/test_execute_and_record_routing.py
+++ b/tests/mcp_server/tooling/test_execute_and_record_routing.py
@@ -18,7 +18,6 @@ async def test_us_live_routes_to_accepted_only(monkeypatch):
 
     with (
         patch.object(oe, "_execute_order", new=AsyncMock(return_value=exec_result)),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch.object(oe, "_record_order_history", new=AsyncMock()),
         patch.object(oe, "_record_fill_and_journals", new=AsyncMock()) as m_legacy,
         patch(
@@ -64,7 +63,6 @@ async def test_kr_live_still_routes_to_kis_ledger():
     exec_result = {"rt_cd": "0", "odno": "KR-1", "output": {}}
     with (
         patch.object(oe, "_execute_order", new=AsyncMock(return_value=exec_result)),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch.object(oe, "_record_order_history", new=AsyncMock()),
         patch(
             "app.mcp_server.tooling.kis_live_ledger._record_kis_live_order",

--- a/tests/mcp_server/tooling/test_order_execution_live_routing.py
+++ b/tests/mcp_server/tooling/test_order_execution_live_routing.py
@@ -16,7 +16,6 @@ async def test_live_kr_routes_to_ledger_not_record_fill():
             new=AsyncMock(return_value={"rt_cd": "0", "odno": "X1"}),
         ),
         patch.object(oe, "_record_order_history", new=AsyncMock(return_value=None)),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch(
             "app.mcp_server.tooling.kis_live_ledger._record_kis_live_order",
             new=AsyncMock(
@@ -76,7 +75,6 @@ async def test_live_us_routes_to_accepted_only_ledger():
             new=AsyncMock(return_value={"rt_cd": "0", "odno": "U1"}),
         ),
         patch.object(oe, "_record_order_history", new=AsyncMock(return_value=None)),
-        patch.object(oe, "_check_daily_order_limit", new=AsyncMock(return_value=True)),
         patch(
             "app.mcp_server.tooling.live_order_ledger._record_live_order",
             new=AsyncMock(

--- a/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
+++ b/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
@@ -35,9 +35,6 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
         "_check_balance_and_warn",
         AsyncMock(return_value=(None, None)),
     )
-    monkeypatch.setattr(
-        order_execution, "_check_daily_order_limit", AsyncMock(return_value=True)
-    )
     monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
 
     # ROB-102: pre-order baseline lookup → simulate "no prior position".

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -182,11 +182,6 @@ async def test_kis_mock_buy_writes_ledger_and_skips_live(monkeypatch):
     )
     monkeypatch.setattr(
         order_execution,
-        "_check_daily_order_limit",
-        AsyncMock(return_value=True),
-    )
-    monkeypatch.setattr(
-        order_execution,
         "_record_order_history",
         AsyncMock(),
     )
@@ -278,11 +273,6 @@ async def test_kis_mock_sell_writes_ledger_and_does_not_close_journals(monkeypat
         order_execution,
         "_check_balance_and_warn",
         AsyncMock(return_value=(None, None)),
-    )
-    monkeypatch.setattr(
-        order_execution,
-        "_check_daily_order_limit",
-        AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
         order_execution,
@@ -420,11 +410,6 @@ async def test_kis_mock_buy_does_not_require_thesis_strategy(monkeypatch):
     )
     monkeypatch.setattr(
         order_execution,
-        "_check_daily_order_limit",
-        AsyncMock(return_value=True),
-    )
-    monkeypatch.setattr(
-        order_execution,
         "_record_order_history",
         AsyncMock(),
     )
@@ -504,11 +489,6 @@ async def test_kis_live_kr_path_records_to_live_ledger_not_save_fill(monkeypatch
         order_execution,
         "_check_balance_and_warn",
         AsyncMock(return_value=(None, None)),
-    )
-    monkeypatch.setattr(
-        order_execution,
-        "_check_daily_order_limit",
-        AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
         order_execution,
@@ -787,11 +767,6 @@ async def test_place_order_impl_threads_correlation_id(db_session, monkeypatch):
         order_execution,
         "_check_balance_and_warn",
         AsyncMock(return_value=(None, None)),
-    )
-    monkeypatch.setattr(
-        order_execution,
-        "_check_daily_order_limit",
-        AsyncMock(return_value=True),
     )
     monkeypatch.setattr(
         order_execution,

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -1141,8 +1141,14 @@ class TestPlaceOrderHighAmount:
         )
 
     @pytest.mark.asyncio
-    async def test_place_order_daily_limit_blocks_high_amount_order(self, monkeypatch):
-        """Daily order limit is enforced even for high-amount orders."""
+    async def test_real_order_not_blocked_by_daily_limit(self, monkeypatch):
+        """ROB-540: the manual flow is uncapped.
+
+        The dead daily-order cap is gone, so a real (dry_run=False) order must
+        execute regardless of any 'order_count' value — there is no longer any
+        'Daily order limit' rejection. A stale Redis count of 999 (well past the
+        old cap of 20) must NOT block the order.
+        """
         tools = build_tools()
 
         mock = AsyncMock()
@@ -1152,8 +1158,8 @@ class TestPlaceOrderHighAmount:
         mock.fetch_my_coins = AsyncMock(
             return_value=[{"currency": "KRW", "balance": "10000000", "locked": "0"}]
         )
-        mock.place_market_buy_order = AsyncMock(
-            return_value={"uuid": _unique_order_id("crypto-limit"), "side": "bid"}
+        mock.place_buy_order = AsyncMock(
+            return_value={"uuid": _unique_order_id("crypto-uncapped"), "side": "bid"}
         )
 
         monkeypatch.setattr(
@@ -1168,16 +1174,30 @@ class TestPlaceOrderHighAmount:
         )
         monkeypatch.setattr(
             upbit_service,
-            "place_market_buy_order",
-            mock.place_market_buy_order,
+            "place_buy_order",
+            mock.place_buy_order,
         )
+        monkeypatch.setattr(
+            upbit_service,
+            "adjust_price_to_upbit_unit",
+            lambda price: price,
+        )
+        # Symbol is NOT in stop-loss cooldown — isolate the assertion to the
+        # (now-deleted) daily-order cap.
+        _patch_runtime_attr(
+            monkeypatch,
+            "_get_crypto_trade_cooldown_service",
+            lambda: FakeCooldownService(in_cooldown=False),
+        )
+        # Simulate a Redis order_count far above the old cap of 20 — proves the
+        # cap is dead and never consulted.
         monkeypatch.setattr(
             settings, "redis_url", "redis://localhost:6379/0", raising=False
         )
 
         class FakeRedisClient:
             async def get(self, key):
-                return "20"
+                return "999"
 
         monkeypatch.setattr(
             "redis.asyncio.from_url", AsyncMock(return_value=FakeRedisClient())
@@ -1194,10 +1214,13 @@ class TestPlaceOrderHighAmount:
             strategy="test-strategy",
         )
 
-        assert result["success"] is False
-        assert "Daily order limit" in result.get(
-            "error", ""
-        ) or "Daily order limit" in result.get("message", "")
+        assert result["success"] is True
+        assert result["dry_run"] is False
+        assert "Daily order limit" not in str(result.get("error", ""))
+        assert "Daily order limit" not in str(result.get("message", ""))
+        mock.place_buy_order.assert_awaited_once_with(
+            "KRW-BTC", 50000000.0, "0.10000000", "limit"
+        )
 
 
 # ----------------------------------------------------------------------
@@ -2755,3 +2778,35 @@ async def test_ladder_fill_preview_echoes_anchor_as_of():
         anchor_as_of="2026-06-11T09:31:00-04:00",
     )
     assert sell["anchor_as_of"] == "2026-06-11T09:31:00-04:00"
+
+
+@pytest.mark.unit
+def test_order_tool_descriptions_drop_daily_order_cap_advertising() -> None:
+    """ROB-540: neither place_order nor kis_live_place_order advertises a daily cap.
+
+    The dead 'order_count' cap is deleted, so its 'max N orders/day' advertising
+    must be stripped from both MCP tool descriptions.
+    """
+
+    class CapturingMCP:
+        def __init__(self) -> None:
+            self.descriptions: dict[str, str] = {}
+
+        def tool(self, name: str, description: str):
+            self.descriptions[name] = description
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    mcp = CapturingMCP()
+    orders_registration.register_order_tools(mcp)  # type: ignore[arg-type]
+    orders_kis_variants.register_kis_live_order_tools(mcp)  # type: ignore[arg-type]
+
+    generic_desc = mcp.descriptions["place_order"]
+    kis_live_desc = mcp.descriptions["kis_live_place_order"]
+
+    for description in (generic_desc, kis_live_desc):
+        assert "orders/day" not in description
+        assert "Safety limit: max" not in description


### PR DESCRIPTION
## ROB-540 — kis_live daily order cap policy

**Linear:** ROB-540 (Policy / Medium)

### Why
Operator decision (2026-06-12): the manual operator flow (`dry_run → approve → live`) must never be blocked by a daily order count.

### Source audit — the cap was dead code
A real cap existed (`_MAX_ORDERS_PER_DAY = 20`, checked before every `dry_run=False` order in `_execute_and_record`), **but its Redis counter `order_count:{today}` is never incremented anywhere** — grep across `app/ scripts/ tests/` finds exactly one reference: the GET in the now-deleted reader. So the count was always `None → 0` and the cap could never trip — which is exactly why live orders 21–26 sailed through. The only operator-visible "20/day" was a false `"Safety limit: max 20 orders/day."` sentence in two MCP tool descriptions (not in CLAUDE.md/docs).

| Issue premise | Verdict |
|---|---|
| A daily cap exists in source | ✅ TRUE (but dead) |
| Cap blocks the manual flow | ✅ TRUE (in code) — yet inert |
| Orders 21–26 accepted (cap didn't trip) | ✅ TRUE — counter never written |
| Caller-identity distinction at the cap | ❌ FALSE — global, caller-agnostic |
| Error states current value + reset time | ❌ FALSE |
| "20" is the AI-model rate limit confused | ❌ FALSE — unrelated |

### Change (Option A — delete the dead guard + its false advertising)
- Remove `_MAX_ORDERS_PER_DAY`, the cap check in `_execute_and_record`, and `_check_daily_order_limit` (+ import + `__all__`).
- Strip `"Safety limit: max 20 orders/day."` from the `kis_live_place_order` and generic `place_order` tool descriptions.
- Remove the now-dangling `_check_daily_order_limit` patches across ~6 test files and the obsolete cap test (already red on `main`).

**Deliberately untouched:** the `order_history:{today}` audit list and the scalping-daemon `daily_order_count_cap` (separate, genuinely-counted mechanisms).

### Safety
No real guard is weakened — the deleted counter never incremented, so production behavior is unchanged (the manual flow is now *provably* uncapped). Stop-loss cooldown, balance/orderable checks, sell-side price floor, defensive-trim approval, and journal requirements are all intact.

### Tests
Added a regression test (real `dry_run=False` order not blocked at a stale count of 999) and a description test (no `"orders/day"` survives in either tool description). **92 passed**, `ruff` + `ty` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
