### PR TITLE
feat(ROB-541): join position context into analyze_stock_batch + holdings/briefing routability

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -27,7 +27,10 @@ from app.mcp_server.tooling.fundamentals_sources_yfinance import (
     _fetch_valuation_yfinance,
     _YFinanceSnapshot,
 )
-from app.mcp_server.tooling.market_data_indicators import _fetch_ohlcv_for_indicators
+from app.mcp_server.tooling.market_data_indicators import (
+    _fetch_ohlcv_for_indicators,
+    _split_support_resistance_levels,
+)
 from app.mcp_server.tooling.market_data_quotes import (
     _fetch_kr_live_quote,
     _fetch_quote_crypto,
@@ -376,6 +379,55 @@ def _apply_common_results(
         analysis[key] = value
 
 
+def _to_optional_price(value: Any) -> float | None:
+    try:
+        price = float(value)
+    except (TypeError, ValueError):
+        return None
+    return price if price > 0 else None
+
+
+def _recompute_intraday_support_resistance(
+    analysis: dict[str, Any],
+    market_type: str,
+) -> None:
+    """ROB-541: re-sign S/R level distances against the LIVE quote price.
+
+    The EOD support_resistance payload computes ``distance_pct`` and the
+    support/resistance split against the daily-close ``current_price``. On an
+    intraday gap, that misclassifies levels relative to where the symbol is
+    actually trading. For KR/crypto (which carry a live ``quote.price``), we
+    recompute each level's ``distance_pct`` AND re-split supports vs resistances
+    against the live price.
+
+    The EOD S/R price LEVELS themselves are left intact — only their distance
+    and bucket are recomputed. ``_support_resistance.py`` (shared with the
+    standalone get_support_resistance tool) is NOT touched.
+    """
+    if market_type not in {"equity_kr", "crypto"}:
+        return
+    sr = analysis.get("support_resistance")
+    if not isinstance(sr, dict) or "error" in sr:
+        return
+    quote = analysis.get("quote") or {}
+    live_price = _to_optional_price(quote.get("price") or quote.get("current_price"))
+    if live_price is None:
+        return
+
+    levels = [*(sr.get("supports") or []), *(sr.get("resistances") or [])]
+    if not levels:
+        return
+
+    # Pass copies so the EOD price levels are preserved; the splitter mutates
+    # distance_pct in place, which is exactly the intraday recompute we want.
+    recomputed = [dict(level) for level in levels]
+    supports, resistances = _split_support_resistance_levels(recomputed, live_price)
+    sr["supports"] = supports
+    sr["resistances"] = resistances
+    sr["distance_basis_price"] = round(live_price, 2)
+    sr["distance_basis"] = "live_quote"
+
+
 def _apply_kr_results(analysis: dict[str, Any], task_results: dict[str, Any]) -> None:
     kr_snapshot = task_results.get("kr_snapshot")
     if not isinstance(kr_snapshot, dict):
@@ -540,6 +592,8 @@ async def analyze_stock_impl(
         name=f"assemble response {market_type} {normalized_symbol}",
     ):
         _apply_common_results(analysis, task_results, preloaded_quote)
+        # ROB-541 — re-sign S/R level distances against the live quote (KR/crypto).
+        _recompute_intraday_support_resistance(analysis, market_type)
         _apply_market_specific_results(analysis, task_results, market_type)
         _apply_sector_peers_result(analysis, task_results, market_type, include_peers)
         analysis["errors"] = []

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -177,7 +177,13 @@ def register_analysis_tools(
         description=(
             "Analyze multiple stocks in parallel with compact summaries. "
             "Returns per-symbol compact summary (symbol, price, RSI, consensus, supports/resistances) "
-            "by default, or full analysis when quick=False."
+            "by default, or full analysis when quick=False. "
+            "When include_position=True (default), each compact summary carries a "
+            "'position' field: an array (one entry per holding account, since a symbol "
+            "may be held across e.g. toss+samsung) of {account, account_mode, qty, "
+            "avg_buy_price, pnl_pct, order_routable}, or null when not held. "
+            "order_routable mirrors get_holdings exactly (toss/manual -> false); "
+            "account_mode is a provenance label, NOT a routing selector."
         ),
     )
     async def analyze_stock_batch(
@@ -185,12 +191,14 @@ def register_analysis_tools(
         market: str | None = None,
         include_peers: bool = False,
         quick: bool = True,
+        include_position: bool = True,
     ) -> dict[str, Any]:
         return await analyze_stock_batch_impl(
             symbols=symbols,
             market=market,
             include_peers=include_peers,
             quick=quick,
+            include_position=include_position,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -408,7 +408,8 @@ async def _run_batch_analysis(
     *,
     market: str | None,
     include_peers: bool,
-    formatter: Callable[[str, dict[str, Any]], dict[str, Any]],
+    formatter: Callable[..., dict[str, Any]],
+    include_position: bool = False,
 ) -> dict[str, Any]:
     """Shared batch analysis executor for portfolio and stock batch analysis.
 
@@ -416,7 +417,12 @@ async def _run_batch_analysis(
         symbols: List of symbol inputs (1-10 entries)
         market: Optional market override
         include_peers: Whether to include peer analysis
-        formatter: Callable that receives (normalized_symbol, analysis_result) and returns formatted result
+        formatter: Callable that receives (normalized_symbol, analysis_result)
+            and an optional ``position_index`` keyword, returning the formatted
+            result.
+        include_position: When True (ROB-541), make ONE batched holdings fetch
+            for the whole batch and pass the in-memory position index to the
+            formatter. Never fans out per symbol.
 
     Returns:
         Dict with 'results' (symbol -> formatted_result) and 'summary' keys
@@ -436,6 +442,13 @@ async def _run_batch_analysis(
     results: dict[str, Any] = {}
     errors: list[str] = []
     sem = asyncio.Semaphore(5)
+
+    position_index: dict[str, list[dict[str, Any]]] | None = None
+    if include_position:
+        # ONE batched holdings fetch for the WHOLE batch — never per symbol.
+        position_index, position_error = await _build_batch_position_index(market)
+        if position_error:
+            errors.append(position_error)
 
     async def _analyze_one(sym: str) -> dict[str, Any]:
         async with sem:
@@ -457,7 +470,10 @@ async def _run_batch_analysis(
     success_count = 0
     fail_count = 0
     for sym, result in zip(normalized_symbols, analyze_results, strict=True):
-        formatted_result = formatter(sym, result)
+        if position_index is not None:
+            formatted_result = formatter(sym, result, position_index=position_index)
+        else:
+            formatted_result = formatter(sym, result)
         results[sym] = formatted_result
         if "error" not in result:
             success_count += 1
@@ -475,11 +491,123 @@ async def _run_batch_analysis(
     }
 
 
+def _position_index_key(symbol: str, instrument_type: str) -> str:
+    """Normalized lookup key for the in-memory position index (ROB-541)."""
+    from app.mcp_server.tooling.shared import normalize_position_symbol
+
+    inst = instrument_type or ""
+    if inst in {"crypto", "equity_us", "equity_kr"}:
+        return normalize_position_symbol(symbol, inst).upper()
+    return symbol.strip().upper()
+
+
+async def _build_batch_position_index(
+    market: str | None,
+) -> tuple[dict[str, list[dict[str, Any]]], str | None]:
+    """Fetch holdings ONCE for the batch and index them by normalized symbol.
+
+    ROB-541: fail-open — any holdings failure returns an empty index plus a
+    warning string so analysis never breaks on a holdings outage. ``position``
+    is then ``null`` for every symbol (not-held semantics), never fabricated.
+    """
+    from app.mcp_server.tooling.portfolio_holdings import (
+        _account_order_routable,
+        _collect_portfolio_positions,
+        _provenance_account_mode,
+    )
+
+    index: dict[str, list[dict[str, Any]]] = {}
+    try:
+        positions, _errors, _market, _account = await _collect_portfolio_positions(
+            account=None,
+            market=market,
+            include_current_price=False,
+        )
+    except Exception as exc:
+        detail = str(exc).strip() or exc.__class__.__name__
+        logger.warning("analyze_stock_batch holdings lookup failed: %s", detail)
+        return index, f"보유 종목 조회 실패: {detail}"
+
+    for position in positions:
+        symbol = str(position.get("symbol") or "")
+        instrument_type = str(position.get("instrument_type") or "")
+        if not symbol:
+            continue
+        source = position.get("source")
+        entry = {
+            "account": position.get("account"),
+            "account_mode": _provenance_account_mode(
+                broker=position.get("broker"),
+                source=source,
+                routing_mode="kis_live",
+            ),
+            "qty": position.get("quantity"),
+            "avg_buy_price": position.get("avg_buy_price"),
+            "pnl_pct": position.get("profit_rate"),
+            "order_routable": _account_order_routable(source=source),
+            # Internal-only fields for symbol matching — stripped before output.
+            "_symbol": symbol,
+            "_instrument_type": instrument_type,
+        }
+        index.setdefault(_position_index_key(symbol, instrument_type), []).append(entry)
+    return index, None
+
+
+def _lookup_position_for_symbol(
+    *,
+    symbol: str,
+    market_type: str,
+    position_index: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]] | None:
+    """Resolve held positions for ``symbol`` from the prebuilt index (ROB-541).
+
+    Uses ``is_position_symbol_match`` (equity_us dot/slash + crypto-base aware)
+    rather than naive upper() so we never join the wrong position. Returns a
+    LIST (one entry per holding account) or ``None`` when not held; never
+    OR-collapses routability across accounts.
+    """
+    from app.mcp_server.tooling.portfolio_helpers import is_position_symbol_match
+
+    matched: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    # Fast path: direct normalized-key hit.
+    candidates = list(position_index.get(_position_index_key(symbol, market_type), []))
+    # Fallback: scan all entries so equity_us dot/slash variants still match even
+    # when the index key normalization differs from the query normalization.
+    if not candidates:
+        for entries in position_index.values():
+            candidates.extend(entries)
+    for entry in candidates:
+        pos_symbol = str(entry.get("_symbol") or "")
+        pos_inst = str(entry.get("_instrument_type") or market_type)
+        if not pos_symbol:
+            continue
+        dedupe_key = f"{entry.get('account')}|{pos_symbol}"
+        if dedupe_key in seen:
+            continue
+        if is_position_symbol_match(
+            position_symbol=pos_symbol,
+            query_symbol=symbol,
+            instrument_type=pos_inst or market_type,
+        ):
+            seen.add(dedupe_key)
+            matched.append({k: v for k, v in entry.items() if not k.startswith("_")})
+    return matched or None
+
+
 def _summarize_analysis_result(
     symbol: str,
     analysis: dict[str, Any],
+    *,
+    position_index: dict[str, list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
-    """Convert full analysis into compact summary for batch responses."""
+    """Convert full analysis into compact summary for batch responses.
+
+    ROB-541: when ``position_index`` is provided (include_position=True), the
+    compact summary carries a ``position`` field — a LIST (one entry per holding
+    account, because a symbol may be held in multiple accounts e.g. toss+samsung)
+    or ``None`` when not held.
+    """
     # If result is an error, pass through unchanged
     if "error" in analysis:
         return analysis
@@ -495,7 +623,7 @@ def _summarize_analysis_result(
     rsi = (indicators.get("rsi") or {}).get("14")
     sr = analysis.get("support_resistance") or {}
 
-    return {
+    summary: dict[str, Any] = {
         "symbol": symbol,
         "market_type": analysis.get("market_type"),
         "source": analysis.get("source"),
@@ -507,6 +635,13 @@ def _summarize_analysis_result(
         "supports": (sr.get("supports") or [])[:3],  # NOSONAR
         "resistances": (sr.get("resistances") or [])[:3],  # NOSONAR
     }
+    if position_index is not None:
+        summary["position"] = _lookup_position_for_symbol(
+            symbol=symbol,
+            market_type=str(analysis.get("market_type") or ""),
+            position_index=position_index,
+        )
+    return summary
 
 
 async def analyze_stock_batch_impl(
@@ -514,6 +649,7 @@ async def analyze_stock_batch_impl(
     market: str | None = None,
     include_peers: bool = False,
     quick: bool = True,
+    include_position: bool = True,
 ) -> dict[str, Any]:
     """Analyze multiple symbols and return compact per-symbol summaries.
     Args:
@@ -521,15 +657,43 @@ async def analyze_stock_batch_impl(
         market: Optional market override
         include_peers: Whether to include peer analysis
         quick: If True, return compact summary; if False, return full analysis
+        include_position: ROB-541 — when True (default) and quick=True, attach a
+            per-account holdings 'position' array (or null) to each compact
+            summary via a SINGLE batched holdings fetch.
     Returns:
         Dict with 'results' (symbol -> summary) and 'summary' keys
     """
-    formatter = _summarize_analysis_result if quick else (lambda _sym, result: result)
+    # Position attach only applies to the compact summary contract. The full
+    # payload (quick=False) is returned verbatim and never carries 'position'.
+    attach_position = include_position and quick
+
+    if quick:
+
+        def formatter(
+            _sym: str,
+            result: dict[str, Any],
+            *,
+            position_index: dict[str, list[dict[str, Any]]] | None = None,
+        ) -> dict[str, Any]:
+            return _summarize_analysis_result(
+                _sym, result, position_index=position_index
+            )
+    else:
+
+        def formatter(
+            _sym: str,
+            result: dict[str, Any],
+            *,
+            position_index: dict[str, list[dict[str, Any]]] | None = None,
+        ) -> dict[str, Any]:
+            return result
+
     return await _run_batch_analysis(
         symbols,
         market=market,
         include_peers=include_peers,
         formatter=formatter,
+        include_position=attach_position,
     )
 
 

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -107,6 +107,27 @@ def _flatten_positions(holdings: dict[str, Any]) -> list[dict[str, Any]]:
     return positions
 
 
+def _account_routability(holdings: dict[str, Any]) -> list[dict[str, Any]]:
+    """Compact per-account routability summary for the briefing (ROB-541).
+
+    Surfaces ``account_mode`` (ROB-357 provenance label) and the authoritative
+    ``order_routable`` flag per account so a toss-held (reference-only) symbol is
+    distinguishable from a kis_live-sellable one without dumping full positions.
+    """
+    accounts: list[dict[str, Any]] = []
+    for account in holdings.get("accounts") or []:
+        accounts.append(
+            {
+                "account": account.get("account"),
+                "account_name": account.get("account_name"),
+                "account_mode": account.get("account_mode"),
+                "order_routable": account.get("order_routable"),
+                "position_count": len(account.get("positions") or []),
+            }
+        )
+    return accounts
+
+
 def _top_movers(holdings: dict[str, Any], *, limit: int = 5) -> list[dict[str, Any]]:
     candidates = []
     for position in _flatten_positions(holdings):
@@ -306,6 +327,9 @@ async def get_operating_briefing_impl(
             "total_positions": holdings.get("total_positions"),
             "summary": holdings.get("summary"),
             "top_movers": _top_movers(holdings),
+            # ROB-541 — per-account routable/account_mode so a reference-only
+            # (toss/manual) holding is distinguishable from a kis_live-sellable one.
+            "accounts": _account_routability(holdings),
             "errors": holdings.get("errors") or [],
         },
         "pending_orders": {

--- a/app/mcp_server/tooling/portfolio_helpers.py
+++ b/app/mcp_server/tooling/portfolio_helpers.py
@@ -39,6 +39,24 @@ def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
         output["sellable_quantity"] = position["sellable_quantity"]
     if "source" in position:
         output["source"] = position["source"]
+    # ROB-541: surface per-position sellability + provenance so consumers that
+    # only read positions[] (not just the account GROUP) still get the
+    # authoritative order_routable flag and the ROB-357 account_mode label.
+    # Lazy import keeps the canonical helpers in portfolio_holdings.py (which
+    # imports this module) without a circular import at load time.
+    if "source" in position or "broker" in position:
+        from app.mcp_server.tooling.portfolio_holdings import (
+            _account_order_routable,
+            _provenance_account_mode,
+        )
+
+        source = position.get("source")
+        output["order_routable"] = _account_order_routable(source=source)
+        output["account_mode"] = _provenance_account_mode(
+            broker=position.get("broker"),
+            source=source,
+            routing_mode=str(position.get("routing_mode") or "kis_live"),
+        )
     return output
 
 

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -1144,6 +1144,10 @@ async def _get_holdings_impl(
                 "positions": [],
             },
         )
+        # ROB-541 — stamp the resolved routing mode so the per-position
+        # account_mode (added by position_to_output) matches the GROUP label
+        # exactly, including kis_mock scopes.
+        position.setdefault("routing_mode", routing_account_mode)
         grouped["positions"].append(_position_to_output(position))
 
     accounts = [grouped_accounts[key] for key in sorted(grouped_accounts.keys())]
@@ -1257,6 +1261,12 @@ async def _get_position_impl(
             position["symbol"],
         )
     )
+
+    # ROB-541 — stamp the resolved routing mode so the per-position
+    # account_mode (added by position_to_output) matches the routing scope
+    # exactly, including kis_mock. Mirrors _get_holdings_impl (~1150).
+    for position in matched_positions:
+        position.setdefault("routing_mode", routing.account_mode)
 
     return apply_account_routing_metadata(
         {

--- a/tests/mcp_server/test_intraday_support_resistance_recompute.py
+++ b/tests/mcp_server/test_intraday_support_resistance_recompute.py
@@ -1,0 +1,122 @@
+"""ROB-541 SLICE C: intraday S/R distance re-sign against the live quote price.
+
+The EOD support_resistance payload computes distance_pct and the support vs
+resistance split against the daily-close ``current_price``. On an intraday gap,
+that misclassifies levels relative to where the symbol is actually trading. The
+analyze-stock assembly recomputes distance_pct AND re-splits supports vs
+resistances against the LIVE quote.price for KR/crypto, leaving the EOD price
+LEVELS intact and never touching the shared ``_support_resistance.py`` module.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.analysis_analyze import (
+    _recompute_intraday_support_resistance,
+)
+
+
+def _sr_payload() -> dict:
+    # EOD close = 100. Levels split against EOD close:
+    #   95  -> support     (below 100)
+    #   105 -> resistance   (above 100)
+    #   120 -> resistance   (above 100)
+    return {
+        "support_resistance": {
+            "symbol": "005930",
+            "current_price": 100.0,
+            "supports": [{"price": 95.0, "strength": "moderate", "distance_pct": -5.0}],
+            "resistances": [
+                {"price": 105.0, "strength": "weak", "distance_pct": 5.0},
+                {"price": 120.0, "strength": "strong", "distance_pct": 20.0},
+            ],
+        }
+    }
+
+
+class TestRecomputeIntradaySupportResistance:
+    def test_kr_gap_up_resplits_and_resigns_distance(self) -> None:
+        analysis = _sr_payload()
+        # Live KR quote gapped up to 110 (above EOD close 100).
+        analysis["quote"] = {"price": 110.0}
+
+        _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+        sr = analysis["support_resistance"]
+        # 95 stays a support (below live 110); 105 FLIPS from resistance to
+        # support (now below live 110). 120 stays a resistance.
+        support_prices = {level["price"] for level in sr["supports"]}
+        resistance_prices = {level["price"] for level in sr["resistances"]}
+        assert support_prices == {95.0, 105.0}
+        assert resistance_prices == {120.0}
+
+        # distance_pct uses the LIVE price (110), not the EOD close (100).
+        by_price = {
+            level["price"]: level["distance_pct"]
+            for level in [*sr["supports"], *sr["resistances"]]
+        }
+        assert by_price[95.0] == pytest.approx((95.0 - 110.0) / 110.0 * 100, abs=0.01)
+        assert by_price[105.0] == pytest.approx((105.0 - 110.0) / 110.0 * 100, abs=0.01)
+        assert by_price[120.0] == pytest.approx((120.0 - 110.0) / 110.0 * 100, abs=0.01)
+
+        # EOD price levels are preserved; basis annotated as live.
+        assert {95.0, 105.0, 120.0} == support_prices | resistance_prices
+        assert sr["distance_basis"] == "live_quote"
+        assert sr["distance_basis_price"] == pytest.approx(110.0)
+
+    def test_below_eod_close_but_below_live_price_stays_support(self) -> None:
+        analysis = _sr_payload()
+        analysis["quote"] = {"price": 110.0}
+
+        _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+        sr = analysis["support_resistance"]
+        # The 95 level (below EOD close AND below live price) stays a support and
+        # its distance is computed against the live price.
+        support_95 = next(s for s in sr["supports"] if s["price"] == 95.0)
+        assert support_95["distance_pct"] == pytest.approx(
+            (95.0 - 110.0) / 110.0 * 100, abs=0.01
+        )
+
+    def test_crypto_recomputes(self) -> None:
+        analysis = _sr_payload()
+        analysis["support_resistance"]["symbol"] = "KRW-BTC"
+        analysis["quote"] = {"price": 110.0}
+
+        _recompute_intraday_support_resistance(analysis, "crypto")
+
+        sr = analysis["support_resistance"]
+        assert {s["price"] for s in sr["supports"]} == {95.0, 105.0}
+        assert sr["distance_basis"] == "live_quote"
+
+    def test_us_market_left_untouched(self) -> None:
+        analysis = _sr_payload()
+        analysis["quote"] = {"price": 110.0}
+
+        _recompute_intraday_support_resistance(analysis, "equity_us")
+
+        sr = analysis["support_resistance"]
+        # US is not in scope (it carries its own live-price source upstream).
+        assert "distance_basis" not in sr
+        assert {s["price"] for s in sr["supports"]} == {95.0}
+
+    def test_missing_live_price_is_noop(self) -> None:
+        analysis = _sr_payload()
+        analysis["quote"] = {"price": None}
+
+        _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+        sr = analysis["support_resistance"]
+        assert "distance_basis" not in sr
+        assert {s["price"] for s in sr["supports"]} == {95.0}
+
+    def test_error_payload_is_noop(self) -> None:
+        analysis = {
+            "support_resistance": {"error": "boom"},
+            "quote": {"price": 110.0},
+        }
+
+        _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+        assert analysis["support_resistance"] == {"error": "boom"}

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -205,6 +205,85 @@ async def test_get_operating_briefing_composes_all_sections(
 
 
 @pytest.mark.asyncio
+async def test_get_operating_briefing_surfaces_per_account_routability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-541: briefing surfaces per-account order_routable + account_mode so a
+    toss-held (reference-only) symbol is distinguishable from a kis_live-sellable
+    one."""
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling import operating_briefing as ob
+
+    async def fake_holdings(**kwargs):
+        return {
+            "total_positions": 2,
+            "summary": {"total_value": 100},
+            "accounts": [
+                {
+                    "account": "kis",
+                    "account_name": "KIS 주계좌",
+                    "account_mode": "kis_live",
+                    "order_routable": True,
+                    "positions": [{"symbol": "005930"}],
+                },
+                {
+                    "account": "toss",
+                    "account_name": "토스",
+                    "account_mode": "toss_api",
+                    "order_routable": False,
+                    "positions": [{"symbol": "펩트론"}],
+                },
+            ],
+            "errors": [],
+        }
+
+    class FakePendingSnapshot:
+        orders: list = []
+        as_of = "2026-06-11T01:00:00+00:00"
+        freshness_status = "fresh"
+        unavailable_reason = None
+        account_scope = "kis_live"
+
+    async def fake_pending(db, *, market, account_scope):
+        return FakePendingSnapshot()
+
+    async def fake_active_watches(**kwargs):
+        return {
+            "success": True,
+            "count": 0,
+            "as_of": datetime.now(tz=UTC).isoformat(),
+            "filters": kwargs,
+            "active_watches": [],
+        }
+
+    async def fake_latest_report(db, *, market, account_scope):
+        return None
+
+    async def fake_session_context(db, *, market, account_scope, limit):
+        return {"count": 0, "entries": []}
+
+    monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
+    monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
+    monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
+    monkeypatch.setattr(ob, "_recent_session_context", fake_session_context)
+
+    result = await ob.get_operating_briefing_impl(
+        market="kr",
+        account_scope="kis_live",
+    )
+
+    accounts = result["holdings"]["accounts"]
+    by_account = {entry["account"]: entry for entry in accounts}
+    assert by_account["kis"]["order_routable"] is True
+    assert by_account["kis"]["account_mode"] == "kis_live"
+    assert by_account["toss"]["order_routable"] is False
+    assert by_account["toss"]["account_mode"] == "toss_api"
+    assert by_account["toss"]["position_count"] == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("section_name", "patch_name"),
     [

--- a/tests/mcp_server/test_portfolio_helpers.py
+++ b/tests/mcp_server/test_portfolio_helpers.py
@@ -111,3 +111,57 @@ class TestPositionToOutput:
         }
         output = position_to_output(position)
         assert output["dust"] is False
+        # ROB-541: no source/broker -> routability fields are not fabricated.
+        assert "order_routable" not in output
+        assert "account_mode" not in output
+
+    def _base_position(self, **overrides: object) -> dict:
+        position = {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "market": "kr",
+            "quantity": 10,
+            "avg_buy_price": 70000,
+            "current_price": 75000,
+            "evaluation_amount": 750000,
+            "profit_loss": 50000,
+            "profit_rate": 7.14,
+        }
+        position.update(overrides)
+        return position
+
+    def test_kis_source_routable_true(self) -> None:
+        # ROB-541: per-position order_routable + account_mode mirror get_holdings.
+        output = position_to_output(self._base_position(source="kis_api", broker="kis"))
+        assert output["order_routable"] is True
+        assert output["account_mode"] == "kis_live"
+
+    def test_toss_api_source_routable_false(self) -> None:
+        output = position_to_output(
+            self._base_position(source="toss_api", broker="toss")
+        )
+        assert output["order_routable"] is False
+        assert output["account_mode"] == "toss_api"
+
+    def test_manual_source_routable_false(self) -> None:
+        output = position_to_output(
+            self._base_position(account="samsung", broker="samsung", source="manual")
+        )
+        assert output["order_routable"] is False
+
+    def test_upbit_source_provenance_label(self) -> None:
+        output = position_to_output(
+            self._base_position(
+                symbol="KRW-BTC", market="crypto", broker="upbit", source="upbit_api"
+            )
+        )
+        assert output["order_routable"] is True
+        assert output["account_mode"] == "upbit_live"
+
+    def test_routing_mode_respected_for_kis_mock(self) -> None:
+        # When the position carries routing_mode (stamped by get_holdings),
+        # the per-position account_mode matches the GROUP label exactly.
+        output = position_to_output(
+            self._base_position(source="kis_api", broker="kis", routing_mode="kis_mock")
+        )
+        assert output["account_mode"] == "kis_mock"

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -39,6 +39,7 @@ from app.mcp_server.tooling import (
     fundamentals_sources_naver,
     fundamentals_sources_yfinance,
     market_data_indicators,
+    portfolio_holdings,
     shared,
 )
 from app.mcp_server.tooling.fundamentals import (
@@ -791,6 +792,12 @@ class TestAnalyzeStockBatch:
             return mock_analysis
 
         _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+        # ROB-541: not-held symbol -> position is null. Mock the single batched
+        # holdings fetch so the contract is deterministic without a DB.
+        empty_collect = AsyncMock(return_value=([], [], "equity_kr", None))
+        monkeypatch.setattr(
+            portfolio_holdings, "_collect_portfolio_positions", empty_collect
+        )
 
         result = await tools["analyze_stock_batch"](["005930"], market="kr")
 
@@ -817,7 +824,11 @@ class TestAnalyzeStockBatch:
             },
             "supports": [{"price": 73000}],
             "resistances": [{"price": 77000, "strength": "medium"}],
+            # ROB-541: include_position defaults True; not held -> null.
+            "position": None,
         }
+        # Single batched holdings fetch only — never per symbol.
+        assert empty_collect.await_count == 1
 
     async def test_analyze_stock_batch_quick_summary_crypto_rsi(self, monkeypatch):
         # ROB-451: crypto batch quick summary must surface rsi_14 (flat indicator map),
@@ -838,12 +849,18 @@ class TestAnalyzeStockBatch:
             return mock_analysis
 
         _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+        monkeypatch.setattr(
+            portfolio_holdings,
+            "_collect_portfolio_positions",
+            AsyncMock(return_value=([], [], "crypto", None)),
+        )
 
         result = await tools["analyze_stock_batch"](["BTC"], market="crypto")
 
         row = result["results"]["BTC"]
         assert row["rsi_14"] == pytest.approx(61.2)  # ROB-451: no longer null
         assert row.get("consensus") is None  # crypto: correct (not a regression)
+        assert row["position"] is None  # ROB-541: BTC not held -> null
 
     async def test_analyze_stock_batch_quick_false_returns_full_payload(
         self, monkeypatch
@@ -888,6 +905,11 @@ class TestAnalyzeStockBatch:
             }
 
         _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", mock_impl)
+        monkeypatch.setattr(
+            portfolio_holdings,
+            "_collect_portfolio_positions",
+            AsyncMock(return_value=([], [], "equity_kr", None)),
+        )
 
         result = await tools["analyze_stock_batch"]([12450, "005930"], market="kr")
 
@@ -915,6 +937,11 @@ class TestAnalyzeStockBatch:
             }
 
         _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+        monkeypatch.setattr(
+            portfolio_holdings,
+            "_collect_portfolio_positions",
+            AsyncMock(return_value=([], [], "equity_kr", None)),
+        )
 
         result = await tools["analyze_stock_batch"](
             ["005930", "000660", "035420"], market="kr"
@@ -922,6 +949,185 @@ class TestAnalyzeStockBatch:
 
         assert "results" in result
         assert call_tracker["max_active"] > 1, "Expected concurrent execution"
+
+    async def test_analyze_stock_batch_position_held_routable(self, monkeypatch):
+        """ROB-541: held KIS-api symbol -> position array, order_routable=True."""
+        tools = build_tools()
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": "005930",
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+                "indicators": {"rsi": {"14": 45.0}},
+                "support_resistance": {"supports": [], "resistances": []},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        kis_position = {
+            "symbol": "005930",
+            "instrument_type": "equity_kr",
+            "account": "kis",
+            "broker": "kis",
+            "source": "kis_api",
+            "quantity": 10,
+            "avg_buy_price": 70000,
+            "profit_rate": 7.14,
+        }
+        collect = AsyncMock(return_value=([kis_position], [], "equity_kr", None))
+        monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+
+        result = await tools["analyze_stock_batch"](["005930"], market="kr")
+
+        position = result["results"]["005930"]["position"]
+        assert position == [
+            {
+                "account": "kis",
+                "account_mode": "kis_live",
+                "qty": 10,
+                "avg_buy_price": 70000,
+                "pnl_pct": 7.14,
+                "order_routable": True,
+            }
+        ]
+        assert collect.await_count == 1
+
+    async def test_analyze_stock_batch_position_toss_not_routable(self, monkeypatch):
+        """ROB-541: toss-held symbol -> order_routable=False (matches get_holdings)."""
+        tools = build_tools()
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": "005930",
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+                "support_resistance": {"supports": [], "resistances": []},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        toss_position = {
+            "symbol": "005930",
+            "instrument_type": "equity_kr",
+            "account": "toss",
+            "broker": "toss",
+            "source": "toss_api",
+            "quantity": 5,
+            "avg_buy_price": 72000,
+            "profit_rate": 4.17,
+        }
+        collect = AsyncMock(return_value=([toss_position], [], "equity_kr", None))
+        monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+
+        result = await tools["analyze_stock_batch"](["005930"], market="kr")
+
+        position = result["results"]["005930"]["position"]
+        assert len(position) == 1
+        assert position[0]["order_routable"] is False
+        assert position[0]["account_mode"] == "toss_api"
+
+    async def test_analyze_stock_batch_position_multi_account_array(self, monkeypatch):
+        """ROB-541: symbol held in toss + samsung -> 2-element array, no OR-collapse."""
+        tools = build_tools()
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": "005930",
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+                "support_resistance": {"supports": [], "resistances": []},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        positions = [
+            {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "account": "toss",
+                "broker": "toss",
+                "source": "toss_api",
+                "quantity": 5,
+                "avg_buy_price": 72000,
+                "profit_rate": 4.17,
+            },
+            {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "account": "samsung",
+                "broker": "samsung",
+                "source": "manual",
+                "quantity": 3,
+                "avg_buy_price": 68000,
+                "profit_rate": 10.29,
+            },
+        ]
+        collect = AsyncMock(return_value=(positions, [], "equity_kr", None))
+        monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+
+        result = await tools["analyze_stock_batch"](["005930"], market="kr")
+
+        position = result["results"]["005930"]["position"]
+        assert len(position) == 2
+        accounts = {entry["account"]: entry["order_routable"] for entry in position}
+        # Both reference-only -> both False; never OR-collapsed to a single flag.
+        assert accounts == {"toss": False, "samsung": False}
+        assert collect.await_count == 1
+
+    async def test_analyze_stock_batch_include_position_false_omits_key(
+        self, monkeypatch
+    ):
+        """ROB-541: include_position=False -> no holdings fetch, no 'position' key."""
+        tools = build_tools()
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": "005930",
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+                "support_resistance": {"supports": [], "resistances": []},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+        collect = AsyncMock(return_value=([], [], "equity_kr", None))
+        monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+
+        result = await tools["analyze_stock_batch"](
+            ["005930"], market="kr", include_position=False
+        )
+
+        assert "position" not in result["results"]["005930"]
+        assert collect.await_count == 0
+
+    async def test_analyze_stock_batch_position_fail_open(self, monkeypatch):
+        """ROB-541: holdings outage -> position null + warning, analysis survives."""
+        tools = build_tools()
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": "005930",
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+                "support_resistance": {"supports": [], "resistances": []},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        async def boom(**kwargs):
+            raise RuntimeError("broker down")
+
+        monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", boom)
+
+        result = await tools["analyze_stock_batch"](["005930"], market="kr")
+
+        assert result["results"]["005930"]["position"] is None
+        assert any("보유 종목 조회 실패" in w for w in result["summary"]["errors"])
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_indicator_tools.py
+++ b/tests/test_mcp_indicator_tools.py
@@ -655,6 +655,11 @@ async def test_get_support_resistance_clusters_levels(monkeypatch):
     assert result["current_price"] == pytest.approx(100.0)
     assert result["supports"]
     assert result["resistances"]
+    # ROB-541: standalone get_support_resistance must stay unchanged — the
+    # intraday live-price recompute is analyze-only and never annotates this
+    # shared tool's output.
+    assert "distance_basis" not in result
+    assert "distance_basis_price" not in result
 
     strong_supports = [s for s in result["supports"] if s["strength"] == "strong"]
     strong_resistances = [r for r in result["resistances"] if r["strength"] == "strong"]

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -2541,6 +2541,55 @@ async def test_get_position_returns_positions_and_not_holding_status(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_get_position_kis_mock_stamps_per_position_account_mode(monkeypatch):
+    """ROB-541 — get_position(account_mode='kis_mock') must label each position
+    with account_mode='kis_mock', mirroring the GROUP-level provenance that
+    get_holdings stamps. Without stamping routing_mode the per-position
+    account_mode (added by position_to_output) silently defaults to kis_live.
+    """
+    tools = build_tools()
+
+    mocked_positions = [
+        {
+            "account": "kis",
+            "account_name": "기본 계좌",
+            "broker": "kis",
+            "source": "kis_api",
+            "instrument_type": "equity_kr",
+            "market": "kr",
+            "symbol": "005930",
+            "name": "삼성전자",
+            "quantity": 2.0,
+            "avg_buy_price": 70000.0,
+            "current_price": 71000.0,
+            "evaluation_amount": 142000.0,
+            "profit_loss": 2000.0,
+            "profit_rate": 1.43,
+        },
+    ]
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_collect_portfolio_positions",
+        AsyncMock(return_value=(mocked_positions, [], "equity_kr", None)),
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    result = await tools["get_position"]("005930", market="kr", account_mode="kis_mock")
+
+    assert result["has_position"] is True
+    assert result["account_mode"] == "kis_mock"
+    assert result["position_count"] == 1
+    position = result["positions"][0]
+    assert position["account_mode"] == "kis_mock"
+    # order_routable must remain correct for a routable broker source.
+    assert position["order_routable"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_position_crypto_accepts_symbol_without_prefix(monkeypatch):
     tools = build_tools()
 


### PR DESCRIPTION
## ROB-541 — position context in the analysis path

**Linear:** ROB-541 (Feature/DQ / High)

### Why
Sell scans need `current_price × avg_buy_price × qty × sellable-account`, but `analyze_stock_batch` carried **no** position context — so `avg_buy_price` was hand-carried and got it wrong 4× in live trading:

| Symbol | Assumed avg | Actual avg |
|---|---|---|
| 선익시스템 | 71,000 | **92,500** (−16%) — the `avg×1.01` floor caught the bad sell |
| 현대차 | 191,000 | **585,000** |
| NAVER | 225,000 | **241,500** |
| 펩트론 | — | sell rejected: toss/samsung **reference-only** |

The guards caught each *post-hoc*; the analysis stage had no *pre-hoc* data. All issue premises verified **TRUE** against source.

### Changes (3 slices, one PR)
- **A — `analyze_stock_batch(include_position=True)`** (default): attaches `position` = per-account array `{account, account_mode, qty, avg_buy_price, pnl_pct, order_routable}` (or `null`), from **one** batched `_collect_portfolio_positions(include_current_price=False)` for the whole batch (no per-symbol fan-out), matched via canonical `is_position_symbol_match`. `order_routable` via the canonical `_account_order_routable` (ROB-420) so analysis matches `get_holdings` exactly. Multi-account → array (never OR-collapsed). Fail-open: holdings outage → `position:null` + warning, batch never raises.
- **B — per-position routability**: `position_to_output` now carries per-position `order_routable` + `account_mode` (get_holdings/get_position), and `get_operating_briefing` surfaces a per-account routability array. `get_position` stamps `routing_mode` so kis_mock reads are labeled correctly.
- **C — intraday S/R distance**: `analyze_stock` re-signs `distance_pct` + re-splits supports/resistances against the already-fetched **live** `quote.price` for KR/crypto (gap-up sign fix), leaving EOD price **levels** intact and the shared `_support_resistance.py` **untouched** — `get_support_resistance` contract unchanged.

### Safety / review
Adversarial review verdict: ship (1 minor + 2 nits). The minor (get_position kis_mock `routing_mode` label) is **fixed** in this PR with a test. `account_mode` is a provenance label; `order_routable` is the authoritative sellability flag. Single batched holdings fetch verified (no latency fan-out). All additive — no removed/renamed keys.

### Tests
Held / not-held / multi-account (펩트론-style) / fail-open batch cases (asserting `await_count == 1`), per-position routable on holdings + briefing, `get_position` kis_mock account_mode, and KR/crypto S/R re-sign with the standalone tool unchanged. **354 passed**, `ruff` + `ty` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
