### PR TITLE
feat(ROB-542): label get_intraday_investor_flow session confidence (observed/inferred/carry_over)

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_intraday_investor_flow.py
+++ b/app/mcp_server/tooling/fundamentals/_intraday_investor_flow.py
@@ -7,8 +7,10 @@ from typing import Any
 
 from app.core.timezone import KST, now_kst
 from app.mcp_server.tooling.market_session import (
+    DATA_STATE_FRESH,
     is_kr_session_day,
     kr_market_data_state,
+    previous_kr_session,
 )
 from app.mcp_server.tooling.shared import (
     error_payload as _error_payload,
@@ -36,6 +38,18 @@ _PROVISIONAL_NOTE = (
 _PRIOR_SESSION_NOTE = (
     " Rows likely belong to the previous trading session (the KIS payload "
     "carries no date field), so as_of is null."
+)
+
+# ROB-542: machine-readable confidence labels for the session attribution.
+CONFIDENCE_OBSERVED = "observed"
+CONFIDENCE_INFERRED = "inferred"
+CONFIDENCE_CARRY_OVER = "carry_over"
+
+_CARRY_OVER_WARNING_CODE = "prior_session_carry_over"
+_CARRY_OVER_WARNING_MESSAGE = (
+    "KIS investor-trend-estimate rows carry no date and appear to belong to a "
+    "previous trading session (future slot or non-session day). as_of is null; "
+    "as_of_date is the previous XKRX session DATE only, not a stamped time."
 )
 
 
@@ -70,16 +84,33 @@ def _normalize_row(row: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _as_of(slot_time: str | None) -> str | None:
-    """Attribute the latest KIS slot to today's KST date, only when honest.
+def _classify_session(
+    slot_time: str | None,
+) -> tuple[str | None, str | None, str | None, bool]:
+    """Classify the latest KIS slot's session attribution.
 
     The KIS payload carries no date field, and outside trading hours KIS keeps
-    serving the prior session's rows. Stamping today's date is only valid when
-    today is an XKRX session day and the slot time is not in the future;
-    otherwise the rows belong to a previous session and as_of must be null.
+    serving the prior session's rows. Returns
+    ``(as_of_datetime_or_null, as_of_date, confidence, is_prior_session)``:
+
+    - ``observed`` — KRX regular session is live (``kr_market_data_state ==
+      "fresh"``) and the slot is not in the future on a session day. ``as_of``
+      is the today-stamped slot datetime; ``as_of_date`` is today.
+    - ``inferred`` — after the close on a session day (slot not in the future,
+      session day, but state not "fresh"). The same-date stamp is correct, but
+      flagged as inferred because the payload itself does not date the rows.
+    - ``carry_over`` — future slot or non-session day. The rows almost certainly
+      belong to a previous session, so ``as_of`` (the precise datetime) is
+      **null** and ``as_of_date`` is the previous XKRX session DATE only — never
+      a fabricated prior-day timestamp from the ``_SLOT_TIMES`` map (the spec
+      notes the real slot boundaries may vary). ``is_prior_session`` is True.
+
+    When ``slot_time`` is None (no rows) there is nothing to classify, so the
+    function returns ``(None, None, None, False)``.
     """
     if slot_time is None:
-        return None
+        return None, None, None, False
+
     now = now_kst()
     hour, minute = (int(part) for part in slot_time.split(":", maxsplit=1))
     dt = datetime.datetime.combine(
@@ -87,11 +118,20 @@ def _as_of(slot_time: str | None) -> str | None:
         datetime.time(hour=hour, minute=minute),
         tzinfo=KST,
     )
-    if dt > now:
-        return None
-    if not is_kr_session_day(now.date()):
-        return None
-    return dt.isoformat()
+
+    slot_in_future = dt > now
+    session_day = is_kr_session_day(now.date())
+
+    if slot_in_future or not session_day:
+        # Carry-over: do not stamp a precise prior-day time. Date-only.
+        prior = previous_kr_session(now.date())
+        return None, prior.isoformat(), CONFIDENCE_CARRY_OVER, True
+
+    # Same session day, slot already elapsed → today's date is the honest stamp.
+    as_of_date = now.date().isoformat()
+    if kr_market_data_state() == DATA_STATE_FRESH:
+        return dt.isoformat(), as_of_date, CONFIDENCE_OBSERVED, False
+    return dt.isoformat(), as_of_date, CONFIDENCE_INFERRED, False
 
 
 async def handle_get_intraday_investor_flow(symbol: str) -> dict[str, Any]:
@@ -119,11 +159,20 @@ async def handle_get_intraday_investor_flow(symbol: str) -> dict[str, Any]:
     rows.sort(key=_slot_sort_key)
     latest = rows[-1] if rows else None
     latest_time = latest.get("as_of_time_kst") if latest is not None else None
-    as_of = _as_of(latest_time)
+    as_of, as_of_date, confidence, is_prior_session = _classify_session(latest_time)
+
+    warning = (
+        {
+            "code": _CARRY_OVER_WARNING_CODE,
+            "message": _CARRY_OVER_WARNING_MESSAGE,
+        }
+        if is_prior_session
+        else None
+    )
 
     if not rows:
         note = "No KIS provisional investor-flow rows were returned."
-    elif as_of is None and latest_time is not None:
+    elif is_prior_session:
         note = _PROVISIONAL_NOTE + _PRIOR_SESSION_NOTE
     else:
         note = _PROVISIONAL_NOTE
@@ -136,6 +185,10 @@ async def handle_get_intraday_investor_flow(symbol: str) -> dict[str, Any]:
         "market_session_state": kr_market_data_state(),
         "provisional": True,
         "as_of": as_of,
+        "as_of_date": as_of_date,
+        "confidence": confidence,
+        "is_prior_session": is_prior_session,
+        "warning": warning,
         "as_of_time_kst": latest_time,
         "foreign_net_qty": (
             latest.get("foreign_net_qty") if latest is not None else None

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -221,7 +221,18 @@ def _register_fundamentals_tools_impl(
             "Get same-day intraday provisional foreign/institution net-buy "
             "quantity estimates for a Korean stock. Returns KIS "
             "investor-trend-estimate rows with provisional/as_of metadata. "
-            "Korean stocks only."
+            "Korean stocks only. The KIS payload carries no date, so session "
+            "attribution is machine-readable via these ADDITIVE fields: "
+            "`confidence` ('observed' = KRX session live; 'inferred' = "
+            "after-close same session day, today's date is correct but unstamped "
+            "by the payload; 'carry_over' = future slot or non-session day, rows "
+            "belong to a prior session), `as_of_date` (ISO DATE; for carry_over "
+            "this is the previous XKRX trading session DATE only — never a "
+            "fabricated prior-day time), `is_prior_session` (bool), and `warning` "
+            "(structured {code, message} when carry_over, else null). `as_of` is "
+            "a full ISO datetime only for observed/inferred and is null for "
+            "carry_over — it is never silently upgraded from null to a stamped "
+            "value. The existing `as_of`/`note` keys are unchanged for back-compat."
         ),
     )
     async def get_intraday_investor_flow(

--- a/app/mcp_server/tooling/market_session.py
+++ b/app/mcp_server/tooling/market_session.py
@@ -14,6 +14,7 @@ via :func:`app.jobs.watch_market_data.is_market_open`.
 
 from __future__ import annotations
 
+import datetime as _dt
 from functools import lru_cache
 from typing import Any
 
@@ -67,3 +68,24 @@ def kr_market_data_state(now: Any = None) -> str:
 def is_kr_session_day(date: Any) -> bool:
     """True when ``date`` (a KST calendar date) is an XKRX trading session."""
     return bool(_get_kr_calendar().is_session(pd.Timestamp(date)))
+
+
+def previous_kr_session(date: Any) -> _dt.date:
+    """Return the XKRX trading session strictly before ``date``.
+
+    ``date`` is a KST calendar date and need not itself be a session — for a
+    weekend or holiday input the most recent prior session is returned. The
+    result is always strictly earlier than ``date``, so passing a session day
+    yields the session before it (not the same day). This correctly handles the
+    Monday-after-holiday edge: e.g. with 2026-06-06 (현충일) on a Saturday, the
+    session before Monday 2026-06-08 is Friday 2026-06-05, and after a multi-day
+    holiday (Lunar New Year) it walks back to the last session before it.
+
+    Backed by the XKRX calendar's ``date_to_session(..., direction="previous")``
+    applied to the day before ``date`` so the result is never on-or-after
+    ``date``.
+    """
+    cal = _get_kr_calendar()
+    target = pd.Timestamp(date).normalize() - pd.Timedelta(days=1)
+    session = cal.date_to_session(target, direction="previous")
+    return pd.Timestamp(session).date()

--- a/tests/test_market_session.py
+++ b/tests/test_market_session.py
@@ -73,3 +73,55 @@ def test_is_kr_session_day_true_on_trading_day(monkeypatch):
 def test_is_kr_session_day_false_on_non_session_day(monkeypatch):
     _patch_calendar(monkeypatch, trading_minute=False, session=False)
     assert market_session.is_kr_session_day(pd.Timestamp("2026-06-07").date()) is False
+
+
+# ROB-542: previous_kr_session — strictly-prior XKRX session, holiday-aware.
+# The autouse conftest fixture swaps in a weekday-only fast calendar; holiday
+# precision requires the real XKRX calendar, so these tests restore it (per the
+# conftest docstring: "Tests that need precise holiday behavior patch
+# market_session._get_kr_calendar directly").
+
+
+def _use_real_xkrx(monkeypatch) -> None:
+    import exchange_calendars as xcals
+
+    cal = xcals.get_calendar("XKRX")
+    monkeypatch.setattr(market_session, "_get_kr_calendar", lambda: cal)
+
+
+def test_previous_kr_session_skips_weekend(monkeypatch):
+    _use_real_xkrx(monkeypatch)
+    # 2026-06-13 is a Saturday → prior session is Fri 2026-06-12.
+    assert (
+        market_session.previous_kr_session(pd.Timestamp("2026-06-13").date())
+        == pd.Timestamp("2026-06-12").date()
+    )
+
+
+def test_previous_kr_session_strictly_before_a_session_day(monkeypatch):
+    _use_real_xkrx(monkeypatch)
+    # 2026-06-12 (Fri) is itself a session → strictly-prior is Thu 2026-06-11.
+    assert (
+        market_session.previous_kr_session(pd.Timestamp("2026-06-12").date())
+        == pd.Timestamp("2026-06-11").date()
+    )
+
+
+def test_previous_kr_session_monday_after_saturday_holiday(monkeypatch):
+    _use_real_xkrx(monkeypatch)
+    # 2026-06-06 (현충일, Memorial Day) falls on a Saturday; 2026-06-08 is the
+    # Monday after. The prior session is Fri 2026-06-05, not the weekend.
+    assert (
+        market_session.previous_kr_session(pd.Timestamp("2026-06-08").date())
+        == pd.Timestamp("2026-06-05").date()
+    )
+
+
+def test_previous_kr_session_after_multiday_lunar_new_year_holiday(monkeypatch):
+    _use_real_xkrx(monkeypatch)
+    # 2026-02-16/17/18 (Mon/Tue/Wed) are the Lunar New Year holiday; the first
+    # session after is Thu 2026-02-19, whose prior session is Fri 2026-02-13.
+    assert (
+        market_session.previous_kr_session(pd.Timestamp("2026-02-19").date())
+        == pd.Timestamp("2026-02-13").date()
+    )

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4898,6 +4898,11 @@ class TestGetIntradayInvestorFlow:
         assert result["provisional"] is True
         assert result["as_of"] == "2026-06-10T14:30:00+09:00"
         assert result["as_of_time_kst"] == "14:30"
+        # ROB-542: machine-readable session metadata.
+        assert result["as_of_date"] == "2026-06-10"
+        assert result["confidence"] == "observed"
+        assert result["is_prior_session"] is False
+        assert result["warning"] is None
         assert result["foreign_net_qty"] == -120000
         assert result["institution_net_qty"] == 50000
         assert result["combined_net_qty"] == -70000
@@ -4929,6 +4934,11 @@ class TestGetIntradayInvestorFlow:
 
         assert result["rows"] == []
         assert result["as_of"] is None
+        # ROB-542: no rows → no slot time to classify; fields present but null.
+        assert result["as_of_date"] is None
+        assert result["confidence"] is None
+        assert result["is_prior_session"] is False
+        assert result["warning"] is None
         assert result["foreign_net_qty"] is None
         assert result["institution_net_qty"] is None
         assert result["combined_net_qty"] is None
@@ -4967,11 +4977,22 @@ class TestGetIntradayInvestorFlow:
             "kr_market_data_state",
             lambda: "premarket_unavailable",
         )
+        monkeypatch.setattr(
+            intraday_investor_flow,
+            "previous_kr_session",
+            lambda date: _dt.date(2026, 6, 10),
+        )
 
         result = await tools["get_intraday_investor_flow"]("000660")
 
         assert result["as_of"] is None
         assert result["as_of_time_kst"] == "14:30"
+        # ROB-542: future slot → carry_over; as_of stays null, date is prior session.
+        assert result["confidence"] == "carry_over"
+        assert result["is_prior_session"] is True
+        assert result["as_of_date"] == "2026-06-10"
+        assert result["warning"] is not None
+        assert result["warning"]["code"] == "prior_session_carry_over"
         assert result["foreign_net_qty"] == -120000
         assert "previous trading session" in result["note"]
 
@@ -5008,11 +5029,21 @@ class TestGetIntradayInvestorFlow:
             "kr_market_data_state",
             lambda: "market_closed",
         )
+        # 2026-06-13 is a Saturday → prior session is Fri 2026-06-12.
+        monkeypatch.setattr(
+            intraday_investor_flow,
+            "previous_kr_session",
+            lambda date: _dt.date(2026, 6, 12),
+        )
 
         result = await tools["get_intraday_investor_flow"]("000660")
 
         assert result["as_of"] is None
         assert result["as_of_time_kst"] == "14:30"
+        # ROB-542: non-session day → carry_over with prior-session date only.
+        assert result["confidence"] == "carry_over"
+        assert result["is_prior_session"] is True
+        assert result["as_of_date"] == "2026-06-12"
         assert result["combined_net_qty"] == -70000
         assert "previous trading session" in result["note"]
 
@@ -5052,6 +5083,11 @@ class TestGetIntradayInvestorFlow:
         result = await tools["get_intraday_investor_flow"]("000660")
 
         assert result["as_of"] == "2026-06-10T14:30:00+09:00"
+        # ROB-542: after-close same session day but state not fresh → inferred.
+        assert result["confidence"] == "inferred"
+        assert result["is_prior_session"] is False
+        assert result["as_of_date"] == "2026-06-10"
+        assert result["warning"] is None
         assert "previous trading session" not in result["note"]
 
     async def test_rejects_non_kr_symbol(self):


### PR DESCRIPTION
## ROB-542 — get_intraday_investor_flow session date

**Linear:** ROB-542 (DQ / High)

### Why
`get_intraday_investor_flow` feeds live-account decisions (e.g. the 하이닉스 청주 화재 panic read off 쌍끌이 +615k @13:20), but the KIS 잠정수급 payload carries no date field — callers couldn't tell whether rows are today's or a prior session's.

### Source audit — reframed
`_as_of()` **already** infers a today-stamp when honest and nulls only for future-slot / non-session-day cases (premise was PARTIAL, not "always null"). The real gap is **machine-readability** — the prior-session signal lived only in a free-text note. Proposal 3 (volume cross-check) is **infeasible** — the `output2[]` payload has no volume field — and is dropped.

### Changes (additive; `as_of`/`as_of_time_kst`/`note` unchanged)
- `market_session.py`: add holiday-aware `previous_kr_session(date)` (strictly-prior XKRX session).
- `_intraday_investor_flow.py`: classifier returns `(as_of, as_of_date, confidence, is_prior_session)`:
  - `observed` — only when `kr_market_data_state()=="fresh"` **and** latest slot ≤ now on a session day (cannot leak onto a closed market);
  - `inferred` — after-close same session day;
  - `carry_over` — otherwise: `as_of` forced **null** + `as_of_date` = previous XKRX session **DATE only** (never a fabricated prior-day timestamp) + a structured warning.
- `fundamentals_handlers.py`: tool description documents the new fields.

### Safety
Read-only tool; the fail-direction is conservative (ambiguity → `as_of=null`). The core property — **a null is never silently upgraded to a stamped `as_of`** — is preserved and asserted. Adversarial review: **ship_as_is**, no findings.

### Tests
`previous_kr_session` against the **real** XKRX calendar (weekend / 현충일 Monday / multi-day Lunar New Year) + observed/inferred/carry_over classification + carry_over `as_of==null`. **17 passed**, `ruff` + `ty` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
