### PR TITLE
feat(ROB-543): snapshot-back oversold_recovery (full-universe RSI) + excluded_held_count

### DIFF
--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -63,14 +63,17 @@ def _available_filters(preset: str) -> dict[str, dict[str, Any]]:
 
 
 # ROB-445: presets whose filter_overrides build_screener_results actually CONSUMES.
-# Mirrors the two `if filter_overrides:` dispatch branches in screener_service:
-#   - consecutive_gainers (~1789): consecutive_gainers loader thresholds — ANY market
+# Mirrors the `if filter_overrides:` dispatch branches in screener_service:
+#   - consecutive_gainers: consecutive_gainers loader thresholds — ANY market
 #     (the branch has no market gate; it lives inside `if preset_id == "consecutive_gainers"`)
-#   - crypto presets (~1966): apply_filter_conditions — ONLY when market == "crypto"
+#   - oversold_recovery (ROB-543): an `rsi <= N` override tightens max_rsi — ANY market
+#   - crypto presets: apply_filter_conditions — ONLY when market == "crypto"
 # Every other preset (incl. high_yield_value, which HAS a snapshot_kind but no dispatch
 # branch) silently drops filters → must warn. The old `snapshot_kind is None` guard missed
 # exactly high_yield_value (it has a kind), which is the ROB-445 silent no-op.
-_THREADED_ANY_MARKET: frozenset[str] = frozenset({"consecutive_gainers"})
+_THREADED_ANY_MARKET: frozenset[str] = frozenset(
+    {"consecutive_gainers", "oversold_recovery"}
+)
 
 
 def _filters_are_threaded(preset: str, market: str) -> bool:
@@ -353,7 +356,11 @@ async def screen_stocks_snapshot_impl(
             "배선하지 않아 지원하지 않습니다 (필터 미적용)."
         )
         merged_results = [r for r in merged_results if not r.get("isWatched")]
+    # ROB-543 Slice B: surface how many held rows exclude_held removed so the
+    # caller can reason about coverage (0 when the filter is off).
+    excluded_held_count = 0
     if exclude_held:
+        excluded_held_count = sum(1 for r in merged_results if r.get("isHeld"))
         merged_results = [r for r in merged_results if not r.get("isHeld")]
     if exclude_symbols:
         excluded_symbols = {_normalize_symbol_key(s) for s in exclude_symbols}
@@ -415,6 +422,8 @@ async def screen_stocks_snapshot_impl(
         ],
         "snapshotKind": snapshot_kind,
         "holdings": holdings_meta,
+        # ROB-543 Slice B: number of held rows exclude_held dropped (0 when off).
+        "excluded_held_count": excluded_held_count,
         "discoveryFilters": {
             "exclude_watched": exclude_watched,
             "exclude_held": exclude_held,

--- a/app/services/invest_view_model/screener_filters.py
+++ b/app/services/invest_view_model/screener_filters.py
@@ -249,6 +249,9 @@ _CRYPTO_PRESET_IDS = (
 # high_yield_value roe>=15/per 0~10) so derived results match today's behavior.
 _PILOT_PRESET_SNAPSHOT: dict[str, str] = {
     "consecutive_gainers": "invest_screener_snapshots",
+    # ROB-543: oversold_recovery filters over the same KIS-OHLCV snapshot
+    # (read-time RSI14 from closes_window — no RSI column / no migration).
+    "oversold_recovery": "invest_screener_snapshots",
     "high_yield_value": "market_valuation_snapshots",
     # ROB-443: crypto presets share one snapshot catalog (composing filters on top).
     **dict.fromkeys(_CRYPTO_PRESET_IDS, _CRYPTO_SNAPSHOT_KIND),
@@ -258,6 +261,8 @@ _PILOT_PRESET_STARTING: dict[str, tuple[ScreenerFilterCondition, ...]] = {
         ScreenerFilterCondition("consecutive_up_days", "gte", 5),
         ScreenerFilterCondition("week_change_rate", "gte", 0.0),
     ),
+    # ROB-543: oversold_recovery starts at RSI <= 30 (matches _SCREENING_FILTERS).
+    "oversold_recovery": (ScreenerFilterCondition("rsi", "lte", 30.0),),
     "high_yield_value": (
         ScreenerFilterCondition("roe", "gte", 15.0),
         ScreenerFilterCondition("per", "lte", 10.0),

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -793,6 +793,335 @@ async def load_consecutive_gainers_from_snapshots(
     return result.rows
 
 
+async def _load_oversold_recovery_from_snapshots(
+    session: AsyncSession | None,
+    *,
+    market: str,
+    limit: int = _SNAPSHOT_FIRST_LIMIT,
+    max_rsi: float = 30.0,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> _SnapshotLoadResult | None:
+    """Return oversold rows (RSI14 <= ``max_rsi``) from the latest healthy partition.
+
+    ROB-543: oversold_recovery previously had no snapshot-first branch, so a
+    KRX session-expiry returned 0 live rows. This loader mirrors
+    ``_load_consecutive_gainers_from_snapshots`` (healthy-partition resolution,
+    KR common-stock guard, market_cap enrichment) but its qualifying predicate is
+    a read-time RSI14 computed from ``closes_window`` — there is NO RSI column in
+    the snapshot, so no migration is needed. The existing build job/builder are
+    reused unchanged.
+
+    Like the consecutive_gainers loader: returns None when the check could not be
+    performed (no session / wrong market / DB error / table empty) so callers may
+    fall through; returns a _SnapshotLoadResult (possibly with empty rows) once a
+    partition was found, so historical rows from older partitions are never
+    surfaced. Rows whose ``closes_window`` is shorter than 15 closes yield a null
+    RSI and are dropped honestly (never surfaced without an RSI).
+    """
+    if session is None or market not in {"kr", "us"}:
+        return None
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.services.invest_screener_snapshots.freshness import (
+        classify_state,
+        expected_baseline_date,
+    )
+    from app.services.invest_screener_snapshots.partition_health import (
+        cap_degraded,
+        resolve_healthy_partition,
+    )
+    from app.services.invest_view_model.screener_analysis_enrichment import (
+        build_rsi14_from_closes,
+    )
+
+    now_utc = now()
+    today = expected_baseline_date(market, now=now_utc)
+
+    # Step 1: resolve the latest *healthy* snapshot partition (ROB-426 PR2a).
+    hp = await resolve_healthy_partition(
+        session,
+        model=InvestScreenerSnapshot,
+        date_col=InvestScreenerSnapshot.snapshot_date,
+        market_col=InvestScreenerSnapshot.market,
+        market=market,
+    )
+    latest_snapshot_date = hp.partition_date if hp else None
+    if latest_snapshot_date is None:
+        return None  # no snapshots in the table; fall through to external
+    partition_degraded = bool(hp and (hp.is_fallback or not hp.healthy))
+
+    # Step 2: load the ENTIRE latest partition. RSI14 is NOT a snapshot column, so
+    # it can be neither filtered nor ranked in SQL — there is therefore deliberately
+    # NO ``ORDER BY``/``LIMIT`` here. Ordering by an unrelated column (e.g. symbol)
+    # and truncating BEFORE the Python RSI rank would bias the result toward whichever
+    # ticker codes sort first and SILENTLY drop the genuinely-deepest-oversold names
+    # (ROB-543 regression). InvestScreenerSnapshot is a thin row (no raw_payload; the
+    # only JSONB is closes_window ≤30 floats) and the partition is already
+    # date-bounded to one row per active symbol, so a full read is cheap.
+    stmt = sa.select(InvestScreenerSnapshot).where(
+        InvestScreenerSnapshot.market == market,
+        InvestScreenerSnapshot.snapshot_date == latest_snapshot_date,
+    )
+    try:
+        result = await session.execute(stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to read invest_screener_snapshots (oversold_recovery): %s",
+            exc,
+            exc_info=True,
+        )
+        return None
+
+    partition_snaps = result.scalars().all()
+
+    # Rank the FULL partition by read-time RSI14 (deepest oversold first), THEN
+    # truncate. A window shorter than 15 closes (or non-numeric) yields a null RSI
+    # and the row drops honestly rather than surfacing without an RSI.
+    # ``rsi_evaluated`` counts rows that produced a usable RSI so that a partition
+    # whose closes_window predates the _LOOKBACK>=15 rebuild (every RSI null) can be
+    # distinguished from a partition with genuinely no oversold matches.
+    ranked: list[tuple[float, Any]] = []
+    rsi_evaluated = 0
+    for snap in partition_snaps:
+        closes = snap.closes_window or []
+        if len(closes) < 15:
+            continue
+        rsi = build_rsi14_from_closes(closes)
+        if rsi is None:
+            continue
+        rsi_evaluated += 1
+        if rsi <= max_rsi:
+            ranked.append((rsi, snap))
+    ranked.sort(key=lambda item: (item[0], item[1].symbol))
+
+    # Truncate to a bounded candidate set for the (more expensive) name/sector/
+    # market_cap hydration + common-stock guard — the same over-fetch slack the
+    # consecutive_gainers loader gets for free from its SQL ORDER BY ... LIMIT.
+    candidate_limit = max(limit * 5, limit + 120)
+    candidate_pairs = ranked[:candidate_limit]
+    candidate_snaps = [snap for _rsi, snap in candidate_pairs]
+    if partition_snaps and rsi_evaluated == 0:
+        logger.warning(
+            "oversold_recovery: partition %s has %d rows but none produced a usable "
+            "RSI14 (closes_window shorter than 15) — the partition likely predates "
+            "the _LOOKBACK>=15 rebuild and must be rebuilt before oversold_recovery "
+            "returns rows.",
+            latest_snapshot_date,
+            len(partition_snaps),
+        )
+
+    symbol_names: dict[str, str] = {}
+    symbol_meta: dict[str, dict[str, Any]] = {}
+    sector_map: dict[str, str] = {}
+    if market == "kr" and candidate_snaps:
+        from app.models.kr_symbol_universe import KRSymbolUniverse
+        from app.models.symbol_sectors import SymbolSector
+
+        candidate_symbols = [snap.symbol for snap in candidate_snaps]
+        try:
+            name_result = await session.execute(
+                sa.select(
+                    KRSymbolUniverse.symbol,
+                    KRSymbolUniverse.name,
+                    SymbolSector.name_kr.label("sector_name_kr"),
+                    SymbolSector.name_en.label("sector_name_en"),
+                    KRSymbolUniverse.security_type,
+                    KRSymbolUniverse.is_common_share,
+                    KRSymbolUniverse.krx_trading_suspended,
+                    KRSymbolUniverse.nxt_trading_suspended,
+                )
+                .outerjoin(SymbolSector, KRSymbolUniverse.sector_id == SymbolSector.id)
+                .where(
+                    KRSymbolUniverse.symbol.in_(candidate_symbols),
+                    KRSymbolUniverse.is_active.is_(True),
+                )
+            )
+            _name_rows = name_result.all()
+            symbol_names = {row.symbol: row.name for row in _name_rows}
+            symbol_meta = {
+                row.symbol: {
+                    "security_type": getattr(row, "security_type", None),
+                    "is_common_share": getattr(row, "is_common_share", None),
+                    "krx_trading_suspended": getattr(
+                        row, "krx_trading_suspended", None
+                    ),
+                    "nxt_trading_suspended": getattr(
+                        row, "nxt_trading_suspended", None
+                    ),
+                }
+                for row in _name_rows
+            }
+            sector_map = {
+                row.symbol: label
+                for row in _name_rows
+                if (
+                    label := (
+                        getattr(row, "sector_name_kr", None)
+                        or getattr(row, "sector_name_en", None)
+                    )
+                )
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "oversold_recovery: failed to read kr_symbol_universe: %s",
+                exc,
+                exc_info=True,
+            )
+
+    if market == "us" and candidate_snaps:
+        from app.models.symbol_sectors import SymbolSector
+        from app.models.us_symbol_universe import USSymbolUniverse
+
+        try:
+            us_rows = (
+                await session.execute(
+                    sa.select(
+                        USSymbolUniverse.symbol,
+                        SymbolSector.name_kr.label("sector_name_kr"),
+                        SymbolSector.name_en.label("sector_name_en"),
+                    )
+                    .outerjoin(
+                        SymbolSector, USSymbolUniverse.sector_id == SymbolSector.id
+                    )
+                    .where(
+                        USSymbolUniverse.symbol.in_(
+                            [snap.symbol for snap in candidate_snaps]
+                        )
+                    )
+                )
+            ).all()
+            sector_map = {
+                row.symbol: label
+                for row in us_rows
+                if (
+                    label := (
+                        getattr(row, "sector_name_kr", None)
+                        or getattr(row, "sector_name_en", None)
+                    )
+                )
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "oversold_recovery: us sector lookup failed: %s", exc, exc_info=True
+            )
+
+    # market_cap enrichment (KR) mirrors the consecutive_gainers loader.
+    market_cap_map: dict[str, float] = {}
+    market_cap_source: str | None = None
+    if market == "kr" and candidate_snaps:
+        from app.models.market_valuation_snapshot import MarketValuationSnapshot
+
+        val_hp = await resolve_healthy_partition(
+            session,
+            model=MarketValuationSnapshot,
+            date_col=MarketValuationSnapshot.snapshot_date,
+            market_col=MarketValuationSnapshot.market,
+            market="kr",
+        )
+        if val_hp is not None:
+            market_cap_source = "fallback" if val_hp.is_fallback else "primary"
+            try:
+                _mc = await session.execute(
+                    sa.select(
+                        MarketValuationSnapshot.symbol,
+                        MarketValuationSnapshot.market_cap,
+                    ).where(
+                        MarketValuationSnapshot.market == "kr",
+                        MarketValuationSnapshot.snapshot_date == val_hp.partition_date,
+                        MarketValuationSnapshot.symbol.in_(
+                            [snap.symbol for snap in candidate_snaps]
+                        ),
+                    )
+                )
+                market_cap_map = {
+                    r.symbol: float(r.market_cap)
+                    for r in _mc.all()
+                    if r.market_cap is not None
+                }
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "oversold_recovery: market_cap lookup failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+
+    # ``candidate_pairs`` is already RSI-ascending (deepest oversold first). Build
+    # rows in that order, applying the common-stock guard, and stop at ``limit`` —
+    # the guard may skip some, which the candidate over-fetch slack covers.
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for rsi, snap in candidate_pairs:
+        if len(rows) >= limit:
+            break
+        if snap.symbol in seen:
+            continue
+        meta = symbol_meta.get(snap.symbol, {})
+        if market == "kr" and not _is_toss_common_stock_row(
+            symbol=snap.symbol,
+            name=symbol_names.get(snap.symbol),
+            security_type=meta.get("security_type"),
+            is_common_share=meta.get("is_common_share"),
+            trading_suspended=meta.get("krx_trading_suspended")
+            or meta.get("nxt_trading_suspended"),
+        ):
+            continue
+        seen.add(snap.symbol)
+        state = classify_state(
+            snapshot_date=snap.snapshot_date,
+            computed_at=snap.computed_at,
+            closes_window_len=len(snap.closes_window or []),
+            today_trading_date_value=today,
+            now=now_utc,
+        )
+        if partition_degraded:
+            state = cap_degraded(state)
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "market": market,
+                "name": symbol_names.get(snap.symbol),
+                "sector": sector_map.get(snap.symbol),
+                "rsi": rsi,
+                "close": float(snap.latest_close)
+                if snap.latest_close is not None
+                else None,
+                "change_rate": float(snap.change_rate)
+                if snap.change_rate is not None
+                else None,
+                "change_amount": float(snap.change_amount)
+                if snap.change_amount is not None
+                else None,
+                "consecutive_up_days": snap.consecutive_up_days,
+                "week_change_rate": float(snap.week_change_rate)
+                if snap.week_change_rate is not None
+                else None,
+                "volume": snap.daily_volume,
+                "daily_closes": list(snap.closes_window or []),
+                "snapshot_date": snap.snapshot_date,
+                "computed_at": snap.computed_at,
+                "_screener_snapshot_state": state,
+                "market_cap": market_cap_map.get(snap.symbol),
+                "_market_cap_source": (
+                    market_cap_source if snap.symbol in market_cap_map else None
+                ),
+            }
+        )
+
+    partition_computed_at: datetime | None = None
+    if rows:
+        partition_computed_at = rows[0].get("computed_at")
+    elif partition_snaps:
+        partition_computed_at = getattr(partition_snaps[0], "computed_at", None)
+    reason, coverage_label = _partition_degradation(hp, rows_empty=not rows)
+    return _SnapshotLoadResult(
+        rows=rows,
+        partition_date=latest_snapshot_date,
+        partition_computed_at=partition_computed_at,
+        degradation_reason=reason,
+        coverage_label=coverage_label,
+    )
+
+
 async def _load_investor_flow_discovery_from_snapshots(
     session: AsyncSession | None,
     *,
@@ -2042,6 +2371,35 @@ async def build_screener_results(
             )
             if _snapshot_load_result is not None:
                 _snapshot_check_result = _snapshot_load_result.rows
+        elif preset_id == "oversold_recovery":
+            # ROB-543: read-time RSI14 over the latest healthy KIS-OHLCV partition.
+            # The preset starting cap (max_rsi=30) comes from _SCREENING_FILTERS;
+            # an MCP rsi<=N override tightens it via the SNAPSHOT_FILTER_FIELDS
+            # catalog (validate_conditions fail-closes on unknown fields).
+            _osr_max_rsi = float(filters.get("max_rsi") or 30.0)
+            if filter_overrides:
+                from app.services.invest_view_model.screener_filters import (
+                    validate_conditions,
+                )
+
+                _osr_conditions = validate_conditions(
+                    filter_overrides, snapshot_kind="invest_screener_snapshots"
+                )
+                for _c in _osr_conditions:
+                    if _c.field == "rsi" and _c.operator == "lte":
+                        _osr_max_rsi = float(_c.value)
+            _snapshot_load_result = await _load_oversold_recovery_from_snapshots(
+                session,
+                market=requested_market,
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                max_rsi=_osr_max_rsi,
+                now=now,
+            )
+            if _snapshot_load_result is not None:
+                _snapshot_check_result = _snapshot_load_result.rows
+            _snapshot_empty_warning = (
+                "최신 시세 스냅샷에서 RSI 과매도 조건에 맞는 종목이 없습니다."
+            )
         elif preset_id == "investor_flow_momentum":
             _snapshot_load_result = await _load_investor_flow_discovery_from_snapshots(
                 session,
@@ -2227,6 +2585,24 @@ async def build_screener_results(
         _snapshot_check_result = []
         _snapshot_state_override = "missing"
         _snapshot_empty_warning = "수급 또는 시세 스냅샷이 아직 적재되지 않아 쌍끌이 매수 후보를 표시할 수 없습니다."
+
+    if (
+        preset_id == "oversold_recovery"
+        and session is not None
+        and _snapshot_check_result is None
+    ):
+        # ROB-543: snapshot-backed. The live screening path returns 0 rows on a
+        # KRX session-expiry (the outage we fix), so when a session was available
+        # but the partition is missing/unreadable, degrade HONESTLY
+        # (dataState=missing + warning) instead of silently falling through to the
+        # live path and hiding the outage. (With no session at all — e.g. a
+        # session-less caller — the live path is still allowed, matching the other
+        # snapshot-first presets that only short-circuit once a session exists.)
+        _snapshot_check_result = []
+        _snapshot_state_override = "missing"
+        _snapshot_empty_warning = (
+            "시세 스냅샷이 아직 적재되지 않아 RSI 과매도 후보를 표시할 수 없습니다."
+        )
 
     # ROB-428 PR-C: high_yield_value + undervalued_breakout are now in
     # FUNDAMENTALS_PRESET_SPECS, so their None-handling (loader returned None →

--- a/docs/runbooks/invest-screener-snapshots.md
+++ b/docs/runbooks/invest-screener-snapshots.md
@@ -8,6 +8,44 @@
 
 **Write path:** Operator-driven CLI or manually enqueued TaskIQ task only (no recurring scheduler — see §5). Both default to dry-run/no writes; persistence requires an explicit commit flag.
 
+### `oversold_recovery` snapshot-backing (ROB-543)
+
+`oversold_recovery` now reads the **same** `invest_screener_snapshots` partition as
+`consecutive_gainers` (no new table, no migration). The loader
+`_load_oversold_recovery_from_snapshots`
+(`app/services/invest_view_model/screener_service.py`) resolves the latest *healthy*
+partition (`resolve_healthy_partition`), then computes **RSI14 at read-time** from each
+row's persisted `closes_window` (`build_rsi14_from_closes`, needs ≥15 closes) and keeps
+rows with `RSI ≤ max_rsi` (default `30`, from `_SCREENING_FILTERS['oversold_recovery']`),
+sorted **RSI ascending** (deepest oversold first). Rows whose `closes_window` is shorter
+than 15 closes yield a null RSI and **drop honestly** (never surfaced without an RSI).
+
+- **Full-partition ranking (not an alphabetical slice):** RSI is not a snapshot column,
+  so the loader reads the **entire** latest partition (one thin row per active symbol —
+  no `raw_payload`), ranks every row by read-time RSI, and only then truncates to the
+  candidate set. It deliberately issues **no SQL `ORDER BY`/`LIMIT`** on the snapshot
+  select; ordering by `symbol` before the Python RSI rank would bias results toward
+  low ticker codes and silently drop the genuinely-deepest-oversold names.
+- **No migration:** RSI is derived from the existing `closes_window` column — the build
+  job/builder is reused unchanged. The same operator build that fills
+  `consecutive_gainers` also powers `oversold_recovery`.
+- **⚠️ Requires a `_LOOKBACK ≥ 15` partition (operator gate):** partitions built before
+  ROB-512 raised `_LOOKBACK` 10→30 persist only 10 closes, so every row yields a null
+  RSI and `oversold_recovery` returns **0 rows by design** until the operator **rebuilds**
+  the KR partition (`scripts/build_invest_screener_snapshots --market kr ...`). When a
+  partition exists but *no* row produced a usable RSI, the loader logs a distinct
+  `partition … has N rows but none produced a usable RSI14 … must be rebuilt` warning so
+  this "needs rebuild" state is distinguishable from a genuine "no oversold matches".
+- **Honest degradation:** on an empty/thin/missing partition the response sets
+  `dataState` to `missing`/`stale` with a warning. When a DB session is present, the
+  preset does **NOT** silently fall through to the live `screening_service` path (which
+  returned 0 rows on a KRX session-expiry — the outage ROB-543 fixes). With no session
+  at all, the live path remains available.
+- **MCP filter-threading:** `oversold_recovery` is registered in
+  `_PILOT_PRESET_SNAPSHOT` → `invest_screener_snapshots`, with an `rsi` (`lte`)
+  `ScreenerFilterDefinition` in `SNAPSHOT_FILTER_FIELDS`, so a `screen_stocks_snapshot`
+  `rsi <= N` override tightens `max_rsi` (fail-closed on unknown fields).
+
 ---
 
 ## 2. Operator Workflow

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -1788,6 +1788,471 @@ async def test_build_screener_results_warns_and_does_not_fallback_when_latest_pa
 
 
 # ---------------------------------------------------------------------------
+# ROB-543: oversold_recovery snapshot-backed (read-time RSI14 from closes_window)
+# ---------------------------------------------------------------------------
+
+
+def _down_closes(n: int = 20) -> list[int]:
+    """Monotonically decreasing window → RSI14 ≈ 0 (passes rsi<=30)."""
+    return [100 - i for i in range(n)]
+
+
+def _up_closes(n: int = 16) -> list[int]:
+    """Choppy uptrend window → RSI14 ≈ 58.79 (> 30, filtered out)."""
+    base = [
+        100,
+        101,
+        99,
+        102,
+        100,
+        103,
+        101,
+        104,
+        102,
+        105,
+        103,
+        106,
+        104,
+        107,
+        105,
+        106,
+    ]
+    return base[:n]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_filters_high_rsi_and_drops_short_windows() -> (
+    None
+):
+    """Loader computes RSI14 per row, keeps rsi<=30 sorted ascending, and drops
+    rows whose closes_window is too short (<15) with a null RSI."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    snapshot_date = date(2026, 5, 13)
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snapshot_date]),  # resolve (fixture pop)
+            _FakeExecuteResult(
+                scalar_rows=[
+                    # RSI ≈ 0 → keep (deepest oversold; should sort first)
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=snapshot_date,
+                        closes_window=_down_closes(20),
+                    ),
+                    # RSI ≈ 32.47 (mild downtrend) → just over the 30 cap → drop
+                    _FakeSnapshot(
+                        symbol="000660",
+                        snapshot_date=snapshot_date,
+                        closes_window=[
+                            100,
+                            99,
+                            101,
+                            98,
+                            97,
+                            99,
+                            96,
+                            95,
+                            97,
+                            94,
+                            93,
+                            95,
+                            92,
+                            91,
+                            93,
+                            90,
+                        ],
+                    ),
+                    # RSI ≈ 58 (uptrend) → drop
+                    _FakeSnapshot(
+                        symbol="035420",
+                        snapshot_date=snapshot_date,
+                        closes_window=_up_closes(16),
+                    ),
+                    # window too short (<15) → null RSI → drop honestly
+                    _FakeSnapshot(
+                        symbol="051910",
+                        snapshot_date=snapshot_date,
+                        closes_window=[100, 99, 98, 97, 96],
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(
+                rows=[
+                    _name_row("005930", "삼성전자"),
+                    _name_row("000660", "SK하이닉스"),
+                    _name_row("035420", "NAVER"),
+                    _name_row("051910", "LG화학"),
+                ]
+            ),
+        ]
+    )
+
+    result = await _load_oversold_recovery_from_snapshots(
+        session, market="kr", limit=10
+    )
+
+    assert result is not None
+    assert [row["symbol"] for row in result.rows] == ["005930"], (
+        "only the rsi<=30 row survives; short/high-rsi rows drop"
+    )
+    assert result.rows[0]["rsi"] == 0.0
+    assert result.partition_date == snapshot_date
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_sorts_rsi_ascending() -> None:
+    """Two qualifying rows must be ordered by RSI ascending (deepest oversold first)."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    snapshot_date = date(2026, 5, 13)
+    # mild downtrend → ~ low-but-nonzero RSI; deep downtrend → ~0 RSI.
+    mild_down = [100, 99, 98, 97, 96, 97, 95, 94, 96, 93, 92, 94, 91, 90, 92, 89]
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snapshot_date]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="000660",
+                        snapshot_date=snapshot_date,
+                        closes_window=mild_down,
+                    ),
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=snapshot_date,
+                        closes_window=_down_closes(20),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(
+                rows=[
+                    _name_row("000660", "SK하이닉스"),
+                    _name_row("005930", "삼성전자"),
+                ]
+            ),
+        ]
+    )
+
+    result = await _load_oversold_recovery_from_snapshots(
+        session, market="kr", limit=10
+    )
+
+    assert result is not None
+    rsis = [row["rsi"] for row in result.rows]
+    assert rsis == sorted(rsis), "rows must be sorted by RSI ascending"
+    assert result.rows[0]["symbol"] == "005930", "deepest oversold (rsi≈0) first"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_ranks_full_universe_not_alphabetical() -> None:
+    """ROB-543 regression: RSI ranking must run over the WHOLE partition, never an
+    alphabetical pre-slice. The two deepest-oversold rows carry alphabetically-LAST
+    symbols while two shallower (higher-RSI) rows sort first; with limit=2 the loader
+    must return the deep alphabetically-last pair and drop the shallow alphabetically-
+    first pair — proving the candidate set is ranked by RSI, not by ticker code."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    snapshot_date = date(2026, 5, 13)
+    # Mildly oversold (RSI in (0, 30]); deeply oversold (RSI ≈ 0).
+    mild_down = [100, 99, 98, 97, 96, 97, 95, 94, 96, 93, 92, 94, 91, 90, 92, 89]
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snapshot_date]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    # alphabetically FIRST, only mildly oversold (higher RSI)
+                    _FakeSnapshot(
+                        symbol="000111",
+                        snapshot_date=snapshot_date,
+                        closes_window=mild_down,
+                    ),
+                    _FakeSnapshot(
+                        symbol="000222",
+                        snapshot_date=snapshot_date,
+                        closes_window=mild_down,
+                    ),
+                    # alphabetically LAST, deepest oversold (RSI ≈ 0)
+                    _FakeSnapshot(
+                        symbol="999888",
+                        snapshot_date=snapshot_date,
+                        closes_window=_down_closes(20),
+                    ),
+                    _FakeSnapshot(
+                        symbol="999999",
+                        snapshot_date=snapshot_date,
+                        closes_window=_down_closes(18),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(
+                rows=[
+                    _name_row("000111", "에이"),
+                    _name_row("000222", "비"),
+                    _name_row("999888", "와이"),
+                    _name_row("999999", "제트"),
+                ]
+            ),
+        ]
+    )
+
+    result = await _load_oversold_recovery_from_snapshots(session, market="kr", limit=2)
+
+    assert result is not None
+    symbols = [row["symbol"] for row in result.rows]
+    assert symbols == ["999888", "999999"], (
+        "deepest-oversold (alphabetically-last) rows must win the limit; RSI ranking "
+        "must run over the full partition, not an alphabetical slice"
+    )
+    assert "000111" not in symbols and "000222" not in symbols, (
+        "shallower (higher-RSI) rows must be excluded despite sorting first"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_returns_none_when_no_snapshot_table_rows() -> (
+    None
+):
+    """No partition → None so the caller may decide to degrade honestly."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    session = _FakeSession([_FakeExecuteResult(scalar_rows=[])])  # MAX → None
+
+    result = await _load_oversold_recovery_from_snapshots(session, market="kr")
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_empty_partition_returns_empty_result() -> None:
+    """Healthy partition with no qualifying rows returns an empty _SnapshotLoadResult
+    (not None) carrying the partition date so freshness stays correct."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    snapshot_date = date(2026, 5, 13)
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snapshot_date]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    # all high-RSI uptrend rows → none survive the rsi<=30 filter
+                    _FakeSnapshot(
+                        symbol="035420",
+                        snapshot_date=snapshot_date,
+                        closes_window=_up_closes(16),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(rows=[_name_row("035420", "NAVER")]),
+        ]
+    )
+
+    result = await _load_oversold_recovery_from_snapshots(
+        session, market="kr", limit=10
+    )
+    assert result is not None
+    assert result.rows == []
+    assert result.partition_date == snapshot_date
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_oversold_recovery_threads_max_rsi_override() -> None:
+    """A tightened max_rsi (e.g. 10) must drop rows whose RSI exceeds it."""
+    from app.services.invest_view_model.screener_service import (
+        _load_oversold_recovery_from_snapshots,
+    )
+
+    snapshot_date = date(2026, 5, 13)
+    # mild downtrend → RSI ~30; deep downtrend → RSI ~0.
+    mild_down = [100, 99, 98, 97, 96, 95, 97, 94, 93, 95, 92, 91, 93, 90, 92, 89]
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[snapshot_date]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="000660",
+                        snapshot_date=snapshot_date,
+                        closes_window=mild_down,
+                    ),
+                    _FakeSnapshot(
+                        symbol="005930",
+                        snapshot_date=snapshot_date,
+                        closes_window=_down_closes(20),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(
+                rows=[
+                    _name_row("000660", "SK하이닉스"),
+                    _name_row("005930", "삼성전자"),
+                ]
+            ),
+        ]
+    )
+
+    result = await _load_oversold_recovery_from_snapshots(
+        session, market="kr", limit=10, max_rsi=10.0
+    )
+    assert result is not None
+    assert [row["symbol"] for row in result.rows] == ["005930"], (
+        "max_rsi=10 keeps only the deepest-oversold row"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_uses_snapshot_for_oversold_recovery(
+    monkeypatch,
+) -> None:
+    """build_screener_results must dispatch oversold_recovery to the snapshot loader
+    and NOT fall through to list_screening."""
+    from app.services.invest_view_model import screener_service as svc
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    async def _fake_loader(session, **kwargs):  # noqa: ANN001, ANN003
+        return svc._SnapshotLoadResult(
+            rows=[
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "name": "삼성전자",
+                    "rsi": 12.5,
+                    "close": 80000.0,
+                    "change_rate": -1.2,
+                    "snapshot_date": date(2026, 5, 13),
+                    "computed_at": datetime(2026, 5, 13, 0, 30, tzinfo=UTC),
+                    "_screener_snapshot_state": "fresh",
+                }
+            ],
+            partition_date=date(2026, 5, 13),
+            partition_computed_at=datetime(2026, 5, 13, 0, 30, tzinfo=UTC),
+        )
+
+    monkeypatch.setattr(svc, "_load_oversold_recovery_from_snapshots", _fake_loader)
+
+    # The loader is mocked, so the only real session.execute is the post-loader
+    # KR name-hydration; serve it the master name row.
+    session = _FakeSession([_FakeExecuteResult(rows=[_name_row("005930", "삼성전자")])])
+    resp = await build_screener_results(
+        preset_id="oversold_recovery",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=session,
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert [r.symbol for r in resp.results] == ["005930"]
+    assert resp.results[0].metricValueLabel == "12.5"
+    assert resp.freshness.cacheHit is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_oversold_recovery_empty_partition_degrades(
+    monkeypatch,
+) -> None:
+    """Empty/thin snapshot must degrade honestly (dataState missing/stale + warning)
+    and NOT silently fall through to the live screening path."""
+    from app.services.invest_view_model import screener_service as svc
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    async def _fake_loader_none(session, **kwargs):  # noqa: ANN001, ANN003
+        # No partition at all → loader returns None.
+        return None
+
+    monkeypatch.setattr(
+        svc, "_load_oversold_recovery_from_snapshots", _fake_loader_none
+    )
+
+    resp = await build_screener_results(
+        preset_id="oversold_recovery",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=object(),
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results == []
+    assert resp.warnings, "must surface a degradation warning"
+    assert resp.freshness.dataState in {"missing", "stale"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_oversold_recovery_serves_from_healthy_fallback(
+    monkeypatch,
+) -> None:
+    """When the loader served an older healthy fallback partition, the response must
+    report the degradation reason rather than hiding the outage."""
+    from app.services.invest_view_model import screener_service as svc
+
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+
+    async def _fake_loader(session, **kwargs):  # noqa: ANN001, ANN003
+        return svc._SnapshotLoadResult(
+            rows=[
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "name": "삼성전자",
+                    "rsi": 22.0,
+                    "close": 80000.0,
+                    "change_rate": -1.2,
+                    "snapshot_date": date(2026, 5, 11),
+                    "computed_at": datetime(2026, 5, 11, 0, 30, tzinfo=UTC),
+                    "_screener_snapshot_state": "stale",
+                }
+            ],
+            partition_date=date(2026, 5, 11),
+            partition_computed_at=datetime(2026, 5, 11, 0, 30, tzinfo=UTC),
+            degradation_reason="older_fallback",
+        )
+
+    monkeypatch.setattr(svc, "_load_oversold_recovery_from_snapshots", _fake_loader)
+
+    session = _FakeSession([_FakeExecuteResult(rows=[_name_row("005930", "삼성전자")])])
+    resp = await build_screener_results(
+        preset_id="oversold_recovery",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=session,
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.freshness.primary.degradationReason == "older_fallback"
+
+
+# ---------------------------------------------------------------------------
 # ROB-277: investor-flow rows carry snapshot_date / collected_at / classified state
 # ---------------------------------------------------------------------------
 

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -690,6 +690,53 @@ async def test_snapshot_tool_filters_exclude_watched_held(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_snapshot_tool_reports_excluded_held_count(monkeypatch) -> None:
+    """ROB-543 Slice B: the count of rows dropped by exclude_held is surfaced as
+    excluded_held_count (0 when exclude_held is off)."""
+
+    class _Resp:
+        def model_dump(self, mode: str | None = None) -> dict[str, Any]:  # noqa: ARG002
+            return {
+                "presetId": "consecutive_gainers",
+                "results": [
+                    {"symbol": "S1", "isWatched": False, "isHeld": True},
+                    {"symbol": "S2", "isWatched": False, "isHeld": True},
+                    {"symbol": "S3", "isWatched": False, "isHeld": False},
+                ],
+                "warnings": [],
+            }
+
+    monkeypatch.setattr(tool, "_session_factory", lambda: lambda: _FakeCM())
+    monkeypatch.setattr(
+        "app.services.screener_service.ScreenerService", lambda: object()
+    )
+
+    async def _fake_build_async(**kwargs: Any) -> _Resp:
+        return _Resp()
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service.build_screener_results",
+        _fake_build_async,
+    )
+
+    # exclude_held=True drops the two held rows → count == 2
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", exclude_held=True
+    )
+    assert [r["symbol"] for r in out["results"]] == ["S3"]
+    assert out["excluded_held_count"] == 2
+    assert out["discoveryFilters"]["exclude_held"] is True
+
+    # exclude_held=False (default) → no rows dropped → count == 0
+    out2 = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr"
+    )
+    assert out2["excluded_held_count"] == 0
+    assert len(out2["results"]) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_snapshot_tool_exclude_watched_warns_unsupported_in_mcp(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## ROB-543 — screener oversold_recovery snapshot + excluded_held_count

**Linear:** ROB-543 (DQ / Medium)

### Why
`oversold_recovery` — the core 물타기/눌림 buy preset — was the only KR preset still live-only, so a KRX session-expiry returned **0 rows** (2× pre-market failures). The other presets serve from `invest_screener_snapshots`.

### Source audit
- Premise A (oversold_recovery is live-only) — **TRUE**.
- Premise B (`exclude_held` is absent) — **FALSE**: it already exists and is tested (ROB-515). Only `excluded_held_count` was genuinely missing.

### Slice A — snapshot-back oversold_recovery (no migration)
New `_load_oversold_recovery_from_snapshots`: resolve latest healthy partition → compute **RSI14 read-time** from the persisted `closes_window` (≥15 closes) → keep `rsi ≤ max_rsi` (default 30), sort ascending; short windows drop honestly with null RSI. Snapshot-first dispatch + honest degradation (no silent fall-through to live once a session exists). Registered in `_PILOT_PRESET_SNAPSHOT` with an `rsi` filter.

**Full-universe ranking (review-major fix).** The adversarial review caught that the first cut ranked RSI only within the alphabetically-first 140 rows (`order_by(symbol).limit(140)`), biasing results toward low ticker codes. Fixed: since RSI is not a SQL column, the loader now reads the **entire** latest partition (one thin row per active symbol — no `raw_payload`) and ranks every row by read-time RSI **before** truncating to the candidate set. No SQL `ORDER BY`/`LIMIT` on the snapshot select.

### Slice B — excluded_held_count
`exclude_held` already worked; added the missing `excluded_held_count` to the `screen_stocks_snapshot` payload (counted before the filter).

### ⚠️ Operator gate
Partitions built before ROB-512 raised `_LOOKBACK` 10→30 persist only 10 closes → every RSI null → oversold_recovery returns 0 rows **by design** until the KR partition is **rebuilt**. The loader logs a distinct `none produced a usable RSI14 … must be rebuilt` warning so "needs rebuild" is distinguishable from "no matches". (Runbook updated.) KR Prefect scheduling and a DB-backed `exclude_held` fallback remain deferred follow-ups.

### Tests
RSI filter/sort, short-window null drop, snapshot-path (no `list_screening`), honest degradation, `excluded_held_count`, and a **full-universe-ranking regression** (deepest-oversold alphabetically-last rows win the limit over shallow alphabetically-first ones). **122 passed**, `ruff` + `ty` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
