### PR TITLE
fix(ROB-544): label realized_pnl basis (journal_entry/FIFO) on reconcile

### DIFF
--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -685,6 +685,15 @@ async def _reconcile_one_ledger_row(
         base["journals_closed"] = close_result["journals_closed"]
         base["closed_journal_ids"] = close_result["closed_ids"]
         base["realized_pnl_pct"] = close_result["total_pnl_pct"]
+        # ROB-544: label the basis. realized_pnl_pct is the FIFO lot /
+        # journal-entry basis (per-lot entry_price), NOT the account-average
+        # pchs_avg_pric shown in place_order preview / get_holdings.
+        base["realized_pnl_basis"] = close_result.get(
+            "realized_pnl_basis", "journal_entry"
+        )
+        # Explicit alias so the journal-entry semantics are unambiguous to
+        # consumers that already read realized_pnl_pct for back-compat.
+        base["journal_pnl_pct"] = close_result["total_pnl_pct"]
 
     await _update_ledger_outcome(
         ledger_id=row.id,

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -293,7 +293,7 @@ async def _reconcile_one_live_row(
                 requester_agent_id=row.dt_requester_agent_id,
                 approval_verified_at=row.trade_date or datetime.now(UTC),
             )
-        await _close_journals_on_sell(
+        close_result = await _close_journals_on_sell(
             symbol=row.symbol,
             sell_quantity=float(delta),
             sell_price=float(avg_price),
@@ -302,6 +302,16 @@ async def _reconcile_one_live_row(
             account=row.broker,
             defensive_trim_ctx=dt_ctx,
         )
+        # ROB-544: surface the labeled close result for parity with
+        # kis_live_reconcile_orders. realized_pnl_pct is the FIFO lot /
+        # journal-entry basis (per-lot entry_price), NOT the account-average.
+        base["journals_closed"] = close_result["journals_closed"]
+        base["closed_journal_ids"] = close_result["closed_ids"]
+        base["realized_pnl_pct"] = close_result["total_pnl_pct"]
+        base["realized_pnl_basis"] = close_result.get(
+            "realized_pnl_basis", "journal_entry"
+        )
+        base["journal_pnl_pct"] = close_result["total_pnl_pct"]
 
     await _update_live_ledger_outcome(
         ledger_id=row.id,

--- a/app/mcp_server/tooling/order_journal.py
+++ b/app/mcp_server/tooling/order_journal.py
@@ -210,11 +210,22 @@ async def _close_journals_on_sell(
 ) -> dict[str, Any]:
     """Close active trade journals in FIFO order when a sell order succeeds.
 
+    FIFO lot attribution: active journals are consumed oldest-first
+    (``order_by(created_at.asc())``); the oldest active journal is closed
+    against the sell before any newer averaging-down ("물타기") lot. So the
+    realized PnL is attributed against the per-lot ``entry_price`` of whichever
+    lot(s) the FIFO walk consumes, NOT the position's account-average cost.
+
     - quantity is None: close immediately (legacy/manual case)
     - quantity <= remaining_sell_qty: close and decrement remaining
     - quantity > remaining_sell_qty: stop FIFO (partial sell, leave active)
 
-    Returns dict with journals_closed, journals_kept, closed_ids, total_pnl_pct.
+    Returns dict with journals_closed, journals_kept, closed_ids, total_pnl_pct,
+    and realized_pnl_basis. ``total_pnl_pct`` is quantity-weighted across the
+    FIFO-closed journals' per-lot ``entry_price`` (i.e. journal/lot basis), and
+    ``realized_pnl_basis`` labels it as ``"journal_entry"`` so callers do not
+    confuse it with the account-average basis surfaced by place_order preview /
+    get_holdings / get_available_capital (ROB-544).
     """
     sell_qty_dec = Decimal(str(sell_quantity))
     sell_price_dec = Decimal(str(sell_price))
@@ -274,6 +285,11 @@ async def _close_journals_on_sell(
 
         await db.commit()
 
+    # total_pnl_pct is quantity-weighted across the FIFO-closed journals'
+    # per-lot entry_price (lot basis), NOT the position account-average. The
+    # realized_pnl_basis label (ROB-544) makes this explicit so downstream
+    # reconcile/report consumers don't conflate it with place_order preview's
+    # account-average pchs_avg_pric basis.
     total_pnl_pct = (
         float(weighted_pnl_sum / weighted_qty_sum) if weighted_qty_sum > 0 else 0.0
     )
@@ -282,6 +298,7 @@ async def _close_journals_on_sell(
         "journals_kept": len(journals) - len(closed_ids),
         "closed_ids": closed_ids,
         "total_pnl_pct": total_pnl_pct,
+        "realized_pnl_basis": "journal_entry",
     }
 
 

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -647,6 +647,11 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "from each order's send date through today (90-day cap), so "
             "next-day reconciles still book prior-day fills. "
             "dry_run=True by default for safety. KR domestic only. "
+            "realized_pnl_pct (alias journal_pnl_pct, labeled "
+            "realized_pnl_basis='journal_entry') is the per-lot / journal-entry "
+            "(FIFO oldest-first) basis, NOT the account-average; "
+            "place_order preview / get_holdings / get_available_capital remain "
+            "the account-average (pchs_avg_pric) truth. "
             "This is the LOCAL bookkeeping layer (trade/journal/"
             "realized_pnl); the live-account truth is get_holdings / "
             "get_available_capital. An operator-gated periodic auto-"
@@ -686,6 +691,10 @@ def register_live_reconcile_tools(mcp: FastMCP) -> None:
             "against broker fill evidence (overseas daily-order / Upbit order-state). "
             "Books fills/journals/realized_pnl ONLY from confirmed fills (delta-idempotent); "
             "marks unfilled/cancelled without journal side-effects. dry_run=True by default. "
+            "realized_pnl_pct (alias journal_pnl_pct, labeled "
+            "realized_pnl_basis='journal_entry') is the per-lot / journal-entry "
+            "(FIFO oldest-first) basis, NOT the account-average; get_holdings / "
+            "get_available_capital remain the account-average truth. "
             "KR domestic uses kis_live_reconcile_orders instead."
         ),
     )

--- a/docs/runbooks/kis-live-order-reconcile.md
+++ b/docs/runbooks/kis-live-order-reconcile.md
@@ -97,3 +97,35 @@ Migration for ROB-476 is 0 (non-breaking, backward compatible).
 > **reconcile은 로컬 부기 레이어**(trade/journal/realized_pnl)다. 실계좌 진실은
 > `get_holdings` / `get_available_capital`. reconcile 미실행은 실계좌에 영향을
 > 주지 않으며, 로컬 리포트/성과추적만 비게 된다.
+
+## realized_pnl 기준(basis) 라벨링 (ROB-544)
+
+sell reconcile 응답의 `realized_pnl_pct`(별칭 `journal_pnl_pct`)는
+**per-lot / journal-entry 기준(FIFO)** 이다. `realized_pnl_basis: "journal_entry"`
+라벨이 함께 표면화되어 이를 명시한다.
+
+- **FIFO lot 귀속 규칙**: `_close_journals_on_sell`은 active 저널을
+  `created_at` 오름차순으로 가장 **오래된 lot부터** 소진한다. 매도는 더 새로
+  추가한 물타기(averaging-down) lot보다 먼저 oldest lot에 귀속되며, PnL은 그
+  lot의 `entry_price`에 대해 계산된다(계좌 평균단가가 아님).
+  - 예: lot A(entry 100, 오래됨) + lot B(entry 90, 물타기)를 보유한 상태에서
+    1주를 97.39에 매도 → FIFO가 lot A를 닫고 `realized_pnl_pct == -2.61%`
+    (손실)를 보고한다. 계좌 평균이나 더 싼 lot B 기준(+8.21%)이 아니다.
+- **계좌 평균 기준은 별도 진실**: `place_order` 프리뷰의 손익/평단,
+  `get_holdings`, `get_available_capital`은 계좌 평균단가(`pchs_avg_pric`)
+  기준이며 reconcile의 lot 기준과 의도적으로 다르다. reconcile은
+  `account_avg_pnl_pct`를 계산하지 않는다(매도 전 계좌 평균이
+  `kis_live_order_ledger`에 저장돼 있지 않고, 매도 후 `pchs_avg_pric`를 읽으면
+  오해를 부른다 — fail-closed로 계산하지 않음).
+- US/crypto `live_reconcile_orders`도 동일 라벨(`realized_pnl_basis` +
+  `journal_pnl_pct` 별칭)을 surface한다(parity).
+
+### ROB-474 retrospective와의 기준 일관성 (감사 노트)
+
+`app/services/trade_journal/trade_retrospective_service.py`의
+`_derive_realized_pnl_from_journal`(~:159)과 `build_retrospective_aggregate`
+(~:342)는 **동일한 journal-entry lot 기준**을 소비한다. 현재 reconcile은
+retrospective를 자동 기록하지 않으며, `save_trade_retrospective`는 수동 도구
+(`trade_retrospective_tools.py:44`)다. 향후 reconcile→retrospective auto-emit을
+도입한다면 반드시 `realized_pnl_basis: "journal_entry"` 라벨을 함께 carry하여
+계좌 평균 기준과의 혼동을 방지해야 한다.

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -407,6 +407,87 @@ async def test_reconcile_filled_buy_books_fill_and_journal(db_session):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_reconcile_filled_sell_surfaces_journal_entry_basis(db_session):
+    """ROB-544: sell reconcile surfaces realized_pnl_basis=='journal_entry'.
+
+    The realized_pnl_pct is the FIFO lot/journal-entry basis (NOT the
+    account-average pchs_avg_pric basis shown in place_order preview).
+    """
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import kis_live_ledger as kl
+    from app.mcp_server.tooling.kis_live_ledger import _save_kis_live_order_ledger
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    lid = await _save_kis_live_order_ledger(
+        symbol="000660",
+        instrument_type="equity_kr",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1000.0,
+        amount=1000.0,
+        currency="KRW",
+        order_no="TEST-RC-SELL",
+        order_time="0930",
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis="t",
+        strategy="s",
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+    )
+    row = await kl._load_ledger_row(lid)
+
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("974"), None, "filled", ""
+    )
+    # journal-entry (FIFO lot) basis: -2.61% loss, NOT an account-average.
+    close_result = {
+        "journals_closed": 1,
+        "journals_kept": 0,
+        "closed_ids": [77],
+        "total_pnl_pct": -2.61,
+        "realized_pnl_basis": "journal_entry",
+    }
+    with (
+        patch.object(
+            kl,
+            "_fetch_live_daily_rows",
+            new=AsyncMock(return_value=[{"odno": "TEST-RC-SELL"}]),
+        ),
+        patch.object(kl, "classify_fill_evidence", return_value=filled),
+        patch.object(kl, "_save_order_fill", new=AsyncMock(return_value=222)),
+        patch.object(
+            kl,
+            "_close_journals_on_sell",
+            new=AsyncMock(return_value=close_result),
+        ),
+        patch.object(kl, "_link_journal_to_fill", new=AsyncMock(return_value=None)),
+    ):
+        result = await kl._reconcile_one_ledger_row(row, dry_run=False)
+
+    assert result["verdict"] == "filled"
+    assert result["realized_pnl_pct"] == pytest.approx(-2.61)
+    assert result["realized_pnl_basis"] == "journal_entry"
+    # explicit alias mirrors the same FIFO lot basis value
+    assert result["journal_pnl_pct"] == pytest.approx(-2.61)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_reconcile_pending_is_noop(db_session):
     from decimal import Decimal
     from unittest.mock import AsyncMock, patch

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -378,3 +378,90 @@ async def test_reconcile_sell_reattaches_defensive_trim_note():
     assert ctx is not None
     assert ctx.approval_issue_id == "ROB-164"
     assert ctx.requester_agent_id == "trader-agent"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_filled_sell_surfaces_journal_entry_basis():
+    """ROB-544: the US/crypto sell reconcile surfaces the journal-entry (FIFO
+    lot) close result, NOT an account-average.
+
+    realized_pnl_basis=='journal_entry', and both realized_pnl_pct and the
+    explicit journal_pnl_pct alias equal the close result's per-lot
+    total_pnl_pct (mirrors test_reconcile_filled_sell_surfaces_journal_entry_basis
+    in test_kis_live_ledger.py)."""
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    lid = await ll._save_live_order_ledger(
+        broker="upbit",
+        account_scope="upbit_live",
+        market="crypto",
+        symbol="KRW-BTC",
+        exchange=None,
+        market_symbol="KRW-BTC",
+        side="sell",
+        order_kind="limit",
+        quantity=1.0,
+        price=974.0,
+        amount=974.0,
+        currency="KRW",
+        order_no="JE-SELL-1",
+        order_time=None,
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("974"), None, "filled", ""
+    )
+    # journal-entry (FIFO lot) basis: -2.61% loss, NOT an account-average.
+    close_result = {
+        "journals_closed": 1,
+        "journals_kept": 0,
+        "closed_ids": [77],
+        "total_pnl_pct": -2.61,
+        "realized_pnl_basis": "journal_entry",
+    }
+
+    class _Adapter:
+        broker = "upbit"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=222)),
+        patch.object(
+            ll,
+            "_close_journals_on_sell",
+            new=AsyncMock(return_value=close_result),
+        ),
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "filled"
+    assert out["action"] == "booked"
+    assert out["journals_closed"] == 1
+    assert out["closed_journal_ids"] == [77]
+    assert out["realized_pnl_basis"] == "journal_entry"
+    # both the canonical key and the explicit alias mirror the same FIFO lot
+    # basis value — NOT an account-average.
+    assert out["realized_pnl_pct"] == pytest.approx(-2.61)
+    assert out["journal_pnl_pct"] == pytest.approx(-2.61)

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -1031,6 +1031,7 @@ class TestCloseJournalsOnSell:
             "journals_kept": 2,
             "closed_ids": [],
             "total_pnl_pct": 0.0,
+            "realized_pnl_basis": "journal_entry",
         }
         mock_session.commit.assert_called_once()
 
@@ -1095,6 +1096,7 @@ class TestCloseJournalsOnSell:
             "journals_kept": 1,
             "closed_ids": [42],
             "total_pnl_pct": pytest.approx(30.0),
+            "realized_pnl_basis": "journal_entry",
         }
         mock_session.commit.assert_called_once()
 
@@ -1227,6 +1229,7 @@ class TestCloseJournalsOnSell:
             "journals_kept": 0,
             "closed_ids": [],
             "total_pnl_pct": 0.0,
+            "realized_pnl_basis": "journal_entry",
         }
         mock_session.commit.assert_called_once()
 
@@ -1312,3 +1315,127 @@ class TestCloseJournalsOnSell:
             "_defensive_trim: approval=ROB-164, caller=agent-cio, "
             "bypassed_floor=avg*1.01_"
         ) in active.notes
+
+    @pytest.mark.asyncio
+    async def test_close_journals_labels_realized_pnl_basis(self) -> None:
+        """ROB-544: result labels the realized_pnl basis as journal_entry (FIFO lot)."""
+        from app.mcp_server.tooling.order_execution import _close_journals_on_sell
+
+        now = datetime.now(UTC)
+        first = TradeJournal(
+            id=1,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            thesis="lot 1",
+            status="active",
+            side="buy",
+            entry_price=Decimal("100"),
+            quantity=Decimal("2"),
+            created_at=now,
+            updated_at=now,
+        )
+        second = TradeJournal(
+            id=2,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            thesis="lot 2",
+            status="active",
+            side="buy",
+            entry_price=Decimal("200"),
+            quantity=Decimal("2"),
+            created_at=now + timedelta(seconds=1),
+            updated_at=now + timedelta(seconds=1),
+        )
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [first, second]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.order_journal._order_session_factory",
+            return_value=factory,
+        ):
+            # Sell 4 shares at 150 -> both lots close.
+            # lot1 pnl = (150-100)/100 = +50%, qty 2
+            # lot2 pnl = (150-200)/200 = -25%, qty 2
+            # quantity-weighted = (50*2 + -25*2)/4 = +12.5%
+            result = await _close_journals_on_sell(
+                symbol="AAPL",
+                sell_quantity=4.0,
+                sell_price=150.0,
+                exit_reason="full_exit",
+            )
+
+        assert result["realized_pnl_basis"] == "journal_entry"
+        assert result["total_pnl_pct"] == pytest.approx(12.5)
+        assert result["closed_ids"] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_close_journals_one_share_sell_returns_fifo_first_lot_pnl(
+        self,
+    ) -> None:
+        """ROB-544: 1-share sell against two lots (cheap older, expensive newer
+        물타기) returns the FIFO-first (oldest) lot's pnl, NOT the account-average.
+
+        Reproduces the -2.61 vs +8.3 scenario: the older lot was bought higher
+        (entry 100, sell 97.39 -> -2.61%); the newer cheaper averaging-down lot
+        (entry 90, would be +8.21%) is NOT consumed by a 1-share FIFO sell.
+        """
+        from app.mcp_server.tooling.order_execution import _close_journals_on_sell
+
+        now = datetime.now(UTC)
+        older_expensive = TradeJournal(
+            id=10,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            thesis="first buy (higher)",
+            status="active",
+            side="buy",
+            entry_price=Decimal("100"),
+            quantity=Decimal("1"),
+            created_at=now,
+            updated_at=now,
+        )
+        newer_cheaper = TradeJournal(
+            id=11,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            thesis="물타기 (averaging down)",
+            status="active",
+            side="buy",
+            entry_price=Decimal("90"),
+            quantity=Decimal("1"),
+            created_at=now + timedelta(seconds=1),
+            updated_at=now + timedelta(seconds=1),
+        )
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [older_expensive, newer_cheaper]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.order_journal._order_session_factory",
+            return_value=factory,
+        ):
+            result = await _close_journals_on_sell(
+                symbol="AAPL",
+                sell_quantity=1.0,
+                sell_price=97.39,
+            )
+
+        # FIFO closes the oldest (higher-entry) lot only.
+        assert older_expensive.status == "closed"
+        assert newer_cheaper.status == "active"
+        assert result["closed_ids"] == [10]
+        assert result["realized_pnl_basis"] == "journal_entry"
+        # journal-entry basis: (97.39 - 100) / 100 = -2.61% (the loss),
+        # NOT the +8.21% the cheaper lot or any account-average would show.
+        assert result["total_pnl_pct"] == pytest.approx(-2.61, abs=0.01)


### PR DESCRIPTION
## ROB-544 — reconcile realized_pnl basis label

**Linear:** ROB-544 (Bug? / Low) — related to ROB-474

### Why
`kis_live_reconcile_orders` reported `realized_pnl_pct` from each closed journal's per-lot `entry_price` (FIFO) but **unlabeled**, so it conflicted with the account-average basis in `place_order` preview — same 현대차 fill: reconcile **−2.61%** (lot) vs cash **+8.3%** (account-avg). Both are meaningful; the ambiguity was the missing basis label. All premises verified TRUE except the ROB-474 mislabel is a *manual-path* hazard (reconcile does **not** auto-write retrospectives).

### Changes (additive, no migration, no new broker fetch)
- `order_journal._close_journals_on_sell`: add `realized_pnl_basis="journal_entry"` (total_pnl_pct / closed_ids / journals_closed / journals_kept unchanged — the 4 other callers unaffected). Docstring documents the **FIFO oldest-by-created_at** lot-attribution rule.
- `kis_live_ledger` + `live_order_ledger` (US/crypto): surface `realized_pnl_basis` + a `journal_pnl_pct` alias. `live_order_ledger` previously **discarded** the close result; now surfaces the labeled values for parity.
- `orders_kis_variants`: both reconcile tool descriptions state `realized_pnl_pct` is lot/journal-entry (FIFO) basis, NOT account-average, and that `get_holdings` / `get_available_capital` remain the account-average truth.
- Runbook: FIFO rule (with the −2.61 vs +8.3 example), why `account_avg_pnl_pct` is **not** computed at reconcile (pre-sell average isn't persisted; a post-sell `pchs_avg_pric` read would mislead), and a ROB-474 audit note (no auto-emit today; any future one must carry the basis).

### Safety
Reporting/labeling only — does not alter which journals close, FIFO selection, sell price, or any ledger-write/idempotency logic. Strictly additive keys. Adversarial review: **ship_as_is**.

### Tests
`_close_journals_on_sell` basis label + quantity-weighted FIFO pnl, the 1-share-sell-against-two-lots reproduction (**−2.61% FIFO-first lot**, not the cheaper lot / account-average), and kis_live + US/crypto reconcile responses surfacing the labeled keys. **81 passed**, `ruff` + `ty` clean. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
