### PR TITLE
fix(ROB-548): Toss intraday depth — remove 200 1m cap, empty-frame fallback, 1h via DB

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -78,8 +78,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - US intraday `end_date="YYYY-MM-DD"` is interpreted as ET `20:00:00` for that market date; timestamp inputs use the exact provided instant
 - KR OHLCV behavior:
   - KR `day` keeps the existing Redis-backed `kis_ohlcv_cache` path when `end_date` is omitted
-  - KR intraday (`1m/5m/15m/30m/1h`) uses Toss candles first when `TOSS_API_ENABLED` is configured, then falls back to the existing DB/KIS reader
-  - Toss only provides `1m`; `5m/15m/30m/1h` are aggregated from Toss `1m` using the same bucket rules as the KIS path
+  - KR intraday `1m/5m/15m/30m` use Toss candles first when `TOSS_API_ENABLED` is configured, then fall back to the existing DB/KIS reader. `1h` uses the DB hourly aggregate directly (ROB-548: 60x Toss `1m` aggregation is heavy and shallow) — same on the `get_ohlcv` service and MCP surfaces
+  - Toss only provides `1m`; `5m/15m/30m` are aggregated from Toss `1m` (paginated to the requested depth) using the same bucket rules as the KIS path; an empty Toss frame falls back to the DB/KIS reader
   - When Toss is unavailable or disabled, KR `1m` falls back to DB-first reads from raw `public.kr_candles_1m` with venue merge (`KRX` price priority, `volume/value` sum)
   - When Toss is unavailable or disabled, KR `5m/15m/30m/1h` fall back to DB-first reads from Timescale continuous aggregates (`public.kr_candles_5m`, `public.kr_candles_15m`, `public.kr_candles_30m`, `public.kr_candles_1h`)
   - On Toss fallback, KR intraday overlays the most recent 30 minutes from `public.kr_candles_1m` + KIS minute API to cover the unchanged 10-minute sync cadence

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -672,33 +672,48 @@ async def get_ohlcv(
 
         if resolved_period in KR_INTRADAY_OHLCV_PERIODS:
             capped_count = min(count, 200)
-            try:
-                frame = await fetch_kr_intraday_toss_frame(
-                    symbol=resolved_symbol,
-                    period=resolved_period,
-                    count=capped_count,
-                    end_date=end,
-                )
-                return _to_candle_rows(
-                    frame,
-                    symbol=resolved_symbol,
-                    market=resolved_market,
-                    source="toss",
-                    period=resolved_period,
-                )
-            except Exception as toss_exc:
-                logger.info(
-                    "Toss KR intraday OHLCV fallback to KIS symbol=%s period=%s error=%s",
-                    safe_log_value(resolved_symbol),
-                    resolved_period,
-                    toss_exc,
-                )
+            if resolved_period == "1h":
+                # ROB-548: 1h uses the DB hourly aggregate (matches the MCP
+                # get_ohlcv surface). Aggregating 1h from 60x Toss 1m candles is
+                # heavy (many pages) and shallow, so 1h is not Toss-routed.
                 frame = await read_kr_intraday_candles(
                     symbol=resolved_symbol,
                     period=resolved_period,
                     count=capped_count,
                     end_date=end,
                 )
+            else:
+                try:
+                    frame = await fetch_kr_intraday_toss_frame(
+                        symbol=resolved_symbol,
+                        period=resolved_period,
+                        count=capped_count,
+                        end_date=end,
+                    )
+                    # ROB-548: an empty Toss frame must fall through to the
+                    # KIS/DB reader, not be returned as an empty source="toss".
+                    if frame is None or len(frame) == 0:
+                        raise ValueError("Toss returned an empty intraday frame")
+                    return _to_candle_rows(
+                        frame,
+                        symbol=resolved_symbol,
+                        market=resolved_market,
+                        source="toss",
+                        period=resolved_period,
+                    )
+                except Exception as toss_exc:
+                    logger.info(
+                        "Toss KR intraday OHLCV fallback to KIS symbol=%s period=%s error=%s",
+                        safe_log_value(resolved_symbol),
+                        resolved_period,
+                        toss_exc,
+                    )
+                    frame = await read_kr_intraday_candles(
+                        symbol=resolved_symbol,
+                        period=resolved_period,
+                        count=capped_count,
+                        end_date=end,
+                    )
         else:
             frame = await kis.inquire_minute_chart(
                 code=resolved_symbol,

--- a/app/services/market_data/toss_ohlcv.py
+++ b/app/services/market_data/toss_ohlcv.py
@@ -25,7 +25,10 @@ async def fetch_kr_intraday_toss_frame(
     end_date: dt.datetime | None,
 ) -> pd.DataFrame:
     bucket = _KR_INTRADAY_BUCKET_MINUTES[period]
-    request_count = count if bucket == 1 else min(max(count * bucket, bucket), 200)
+    # ROB-548: aggregating N buckets needs N*bucket one-minute candles. Page
+    # through them (200/page) instead of the old single-page 200 hard cap that
+    # silently truncated 5m/15m/30m/1h to ~40/13/6/3 rows.
+    request_count = count if bucket == 1 else max(count * bucket, bucket)
     client = TossReadClient.from_settings()
     try:
         one_minute = await fetch_toss_candles_frame(
@@ -34,6 +37,7 @@ async def fetch_kr_intraday_toss_frame(
             interval="1m",
             count=request_count,
             before=_before_from_end_date(end_date),
+            max_pages=max(1, (request_count + 199) // 200),
         )
     finally:
         await client.aclose()

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -1277,6 +1277,132 @@ async def test_fetch_kr_intraday_toss_frame_aggregates_1m_to_5m(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fetch_kr_intraday_toss_frame_requests_full_depth_not_capped(monkeypatch):
+    """ROB-548: aggregating N buckets needs N*bucket one-minute candles via
+    pagination, not a silent 200 one-minute hard cap (5m@count=100 -> 500, not 200)."""
+    from app.services.market_data import toss_ohlcv
+
+    captured: dict = {}
+
+    async def fake_fetch(
+        *, client, symbol, interval, count, before=None, adjusted=None, max_pages=20
+    ):
+        captured["interval"] = interval
+        captured["count"] = count
+        captured["max_pages"] = max_pages
+        return pd.DataFrame(
+            [
+                {
+                    "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                    "date": dt.date(2026, 6, 12),
+                    "time": dt.time(9, 0),
+                    "open": 100.0,
+                    "high": 101.0,
+                    "low": 99.0,
+                    "close": 100.0,
+                    "volume": 10.0,
+                    "value": 1000.0,
+                }
+            ]
+        )
+
+    class FakeClient:
+        async def aclose(self): ...
+
+    monkeypatch.setattr(
+        toss_ohlcv.TossReadClient, "from_settings", lambda: FakeClient()
+    )
+    monkeypatch.setattr(toss_ohlcv, "fetch_toss_candles_frame", fake_fetch)
+
+    await toss_ohlcv.fetch_kr_intraday_toss_frame(
+        symbol="005930", period="5m", count=100, end_date=None
+    )
+
+    assert captured["interval"] == "1m"
+    assert captured["count"] == 500  # 100 buckets * 5m, not capped at 200
+    assert captured["max_pages"] >= 3  # 500 / 200 -> >= 3 pages
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_kr_1h_uses_db_reader_not_toss(monkeypatch):
+    """ROB-548: 1h must use the DB hourly aggregate (matching the MCP get_ohlcv
+    surface), not Toss 60x1m aggregation. Toss must not be attempted for 1h."""
+    toss_mock = AsyncMock(
+        return_value=pd.DataFrame(
+            [
+                {
+                    "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                    "open": 1.0,
+                    "high": 1.0,
+                    "low": 1.0,
+                    "close": 1.0,
+                    "volume": 1.0,
+                    "value": 1.0,
+                }
+            ]
+        )
+    )
+    monkeypatch.setattr(market_data_service, "fetch_kr_intraday_toss_frame", toss_mock)
+    hourly_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    read_mock = AsyncMock(return_value=hourly_df)
+    monkeypatch.setattr(market_data_service, "read_kr_intraday_candles", read_mock)
+
+    candles = await market_data_service.get_ohlcv("005930", "kr", "1h", count=5)
+
+    toss_mock.assert_not_awaited()
+    read_mock.assert_awaited_once_with(
+        symbol="005930", period="1h", count=5, end_date=None
+    )
+    assert candles[0].source == "kis"
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_kr_intraday_falls_back_when_toss_returns_empty(monkeypatch):
+    """ROB-548: an empty Toss frame must trigger the KIS/DB fallback, not be
+    returned as an empty source='toss' result."""
+    empty = pd.DataFrame(
+        columns=["datetime", "open", "high", "low", "close", "volume", "value"]
+    )
+    fallback_df = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-06-12 09:00:00"),
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_kr_intraday_toss_frame",
+        AsyncMock(return_value=empty),
+    )
+    read_mock = AsyncMock(return_value=fallback_df)
+    monkeypatch.setattr(market_data_service, "read_kr_intraday_candles", read_mock)
+
+    candles = await market_data_service.get_ohlcv("005930", "kr", "5m", count=10)
+
+    read_mock.assert_awaited_once()
+    assert candles[0].source == "kis"
+
+
+@pytest.mark.asyncio
 async def test_get_ohlcv_kr_intraday_uses_toss_first(monkeypatch):
     df = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
ROB-537 routed KR intraday OHLCV to Toss but silently truncated depth and swallowed empty frames.

- **Depth cap removed** — `fetch_kr_intraday_toss_frame` capped the aggregation source at 200 one-minute candles on a single page (`min(count*bucket, 200)`), so `count=100` yielded ~40 (5m) / ~13 (15m) / ~6 (30m) rows. Now requests `count*bucket` one-minute candles and **paginates** (`max_pages = ceil(req/200)`), mirroring the daily fetch.
- **Empty-frame fallback** — `get_ohlcv` treated an empty Toss frame as a valid `source="toss"` result. Now an empty/None frame falls through to the KIS/DB reader (same as an exception).
- **1h aligned to DB** — 1h was Toss-routed in the service path (60×1m aggregation: heavy + shallow) but DB-hourly on the MCP surface. The service path now uses the DB hourly aggregate (`read_kr_intraday_candles` dispatches 1h → `read_kr_hourly_candles_1h`, the same source the MCP uses). README synced.

## Test
TDD (RED → GREEN): depth request (5m@100 → 500 1m, ≥3 pages), empty-frame fallback to KIS, and 1h-via-DB (Toss not attempted for 1h). 138 OHLCV-suite tests pass (`test_market_data_service`, `test_mcp_ohlcv_tools`, `test_kr_candles_sync`). `ruff` + `ty` clean. migration 0.

## Scope
Closes ROB-548. `kr_candles_sync` `source=toss` (opt-in, venue='KRX') is unchanged; daily backfill (`fetch_daily_toss_frame`) already paginated.

Closes ROB-548

🤖 Generated with [Claude Code](https://claude.com/claude-code)