### PR TITLE
chore(ROB-550): Toss integration cleanup — env/CLAUDE docs, scheduleless cron, guard fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,24 @@ Kiwoom **모의투자** 전용 MCP order/account lifecycle. 7개 도구 모두 `
 - **No secrets printed**: CLI는 missing env key **이름만** 보고, 값 출력 없음
 - **Cancel-before-submit**: `full` 모드는 cancel이 wired이기에만 실주문 제출; finally-block에서 항상 cancel 시도 후 reconcile
 
+### 토스증권 Open API (ROB-529)
+
+토스증권 Open API(`https://openapi.tossinvest.com`, OAuth2 Client Credentials, REST-only) 기반 KR/US **live** 브로커 + 시세·종목마스터·환율·캘린더 데이터 소스. 모의투자 없음(live 단일).
+
+- **클라이언트**: `app/services/brokers/toss/` — `transport.py`(host allowlist `openapi.tossinvest.com` + **https 강제**, 3xx 거부), `auth.TossOAuthTokenManager`(OAuth, **client당 유효 토큰 1개**라 Redis 공유+단일비행+failed-token double-check, ROB-262 패턴), `rate_limiter`(프로세스 전역 싱글톤 `get_shared_rate_limiter`, 그룹별 per-group lock TPS, 09:00–09:10 ORDER 3TPS), `errors.parse_toss_response`(envelope + non-json typed), `client.TossReadClient`(read + place/modify/cancel)
+- **주문 MCP 도구**: `app/mcp_server/tooling/orders_toss_variants.py` — `toss_preview/place/modify/cancel_order`, `toss_get_order_history/positions/orderable_cash` (account_mode `toss_live`). dry_run+confirm 이중 게이트, 손실매도 가드, opposite-pending 사전검사, `clientOrderId` 멱등
+- **레저**: `review.toss_live_order_ledger` (`app/services/toss_live_order_ledger_service.py`, accepted-only + `record_send` 멱등 replay) + `toss_reconcile_orders`(단건 상세 fill-evidence, ROB-395/407 패턴)
+- **데이터 소스**: 환율 `exchange_rate_service`(토스 primary+폴백, midRate), 종목 마스터+시총 `toss_symbol_master_service`(gap-fill only — 기존 source 있으면 skip), warnings 가드 `warnings_guard`(LIQUIDATION 매수만 차단·매도 면제), 캔들 `market_data/toss_ohlcv`(1m/5m/15m/30m toss-first 페이지네이션, 1h는 DB hourly), 캘린더 `brokers/toss/market_calendar`(NXT/데이마켓)
+- **CLI/런북**: `scripts/toss_live_smoke.py`(preflight/order-test/confirm), `docs/runbooks/toss-live-smoke.md`, `toss-live-order-reconcile.md`, `toss-symbol-master-sync.md`
+
+**안전 경계 / env 게이트 (모두 default off)**:
+- `TOSS_API_ENABLED` — 마스터 게이트. 미설정 시 read 클라이언트도 `TossApiDisabled`
+- `TOSS_API_CLIENT_ID` / `TOSS_API_CLIENT_SECRET` — 운영 secret(repo commit 금지)
+- `TOSS_LIVE_ORDER_MUTATIONS_ENABLED` — 실주문(place/modify/cancel) **및** 보유 routable/orderable/isTradeable 표면(ROB-549)을 함께 arm. live-smoke 클리어 전까지 false
+- **KR 주문은 계좌 "투자자지시 거래소 = 통합(SOR)" 설정 필수** (아니면 422 `investor-exchange-not-integrated`)
+- ⚠️ `opposite-pending-order-exists`: 동일 종목 반대방향 대기주문 거부 → 매수+매도 래더 동시 거치 불가
+- warnings TaskIQ task(`warnings.toss.sync`)는 **scheduleless** 출고(operator/Prefect 등록); disabled 시 graceful skip
+
 ### Market Events Ingestion Foundation (ROB-128)
 
 시장 이벤트 (US earnings, KR DART 공시, 향후 crypto/economic) 수집·저장·조회 foundation.

--- a/app/jobs/toss_warnings.py
+++ b/app/jobs/toss_warnings.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.services.brokers.toss.client import TossReadClient
 from app.services.toss_warnings_sync_service import sync_toss_warnings
@@ -13,6 +14,10 @@ async def run_toss_warnings_sync() -> dict[str, int | str | list[str]]:
     """
     Sync job for stock warnings from Toss API to database.
     """
+    # ROB-550: graceful skip when Toss is disabled so a deployment that never
+    # armed TOSS_API_ENABLED does not emit a daily ERROR.
+    if not bool(getattr(settings, "toss_api_enabled", False)):
+        return {"status": "disabled"}
     client: TossReadClient | None = None
     try:
         client = TossReadClient.from_settings()

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -133,7 +133,10 @@ async def _check_toss_warnings_for_kis_buy(symbol: str) -> WarningsGuardResult:
     client = None
     try:
         client = TossReadClient.from_settings()
-        return await check_warnings_guard(client, symbol, market="kr")
+        # ROB-550: market=None lets the guard auto-detect KR by the 6-digit
+        # symbol pattern, so a US KIS buy (e.g. AAPL) skips the Toss warnings
+        # fetch instead of issuing a wasted lookup.
+        return await check_warnings_guard(client, symbol, market=None)
     except Exception as exc:
         logger.warning(
             "Failed to check Toss warnings for KIS live order symbol=%s; proceeding fail-open: %s",

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -446,7 +446,9 @@ async def toss_preview_order(
     warnings_check_msg = None
     try:
         async with _client_context() as client:
-            guard_res = await check_warnings_guard(client, symbol, market=mkt)
+            guard_res = await check_warnings_guard(
+                client, symbol, market=mkt, side=side
+            )
             warnings_list = [
                 {
                     "warning_type": w.warning_type,
@@ -589,7 +591,7 @@ async def _toss_place_order_impl(
 
     async def execute_order(client: TossReadClient):
         # Guard: Warnings check
-        guard_res = await check_warnings_guard(client, symbol, market=mkt)
+        guard_res = await check_warnings_guard(client, symbol, market=mkt, side=side)
         guard_warnings = _warning_payload(guard_res.warnings)
         if not guard_res.ok:
             return {

--- a/app/services/brokers/toss/warnings_guard.py
+++ b/app/services/brokers/toss/warnings_guard.py
@@ -32,10 +32,13 @@ async def check_warnings_guard(
     market: str | None = None,
     timeout: float = 3.0,
     today: date | None = None,
+    side: str | None = None,
 ) -> WarningsGuardResult:
     """
     Checks if there are active warnings for the given symbol.
-    Blocks the order if LIQUIDATION_TRADING is active.
+    Blocks a BUY if LIQUIDATION_TRADING is active. A SELL is exempt from the
+    block (ROB-550: blocking the exit during a delisting liquidation window
+    would trap the position) — the warning is still surfaced.
     Fail-open: If the API request fails or times out, allows the order to proceed.
     Only checks KR stock symbols (6 numeric digits).
     """
@@ -64,11 +67,12 @@ async def check_warnings_guard(
             if _is_active_warning(warning, current_date)
         ]
 
-        # Check blocking warning types
+        # Check blocking warning types. A SELL is exempt — the warning is still
+        # surfaced but must not block an exit during liquidation trading.
         blocking = [
             w for w in active_warnings if w.warning_type in _BLOCKING_WARNING_TYPES
         ]
-        if blocking:
+        if blocking and str(side).lower() != "sell":
             blocked_types = ", ".join(w.warning_type for w in blocking)
             return WarningsGuardResult(
                 ok=False,

--- a/app/tasks/toss_warnings_sync_tasks.py
+++ b/app/tasks/toss_warnings_sync_tasks.py
@@ -8,10 +8,11 @@ from app.jobs.toss_warnings import run_toss_warnings_sync
 logger = logging.getLogger(__name__)
 
 
-@broker.task(
-    task_name="warnings.toss.sync",
-    schedule=[{"cron": "30 7 * * *", "cron_offset": "Asia/Seoul"}],
-)
+# ROB-550: shipped scheduleless. Production recurrence is operator/Prefect-
+# registered (house convention, e.g. robin-prefect-automations) so enabling
+# TOSS_API_ENABLED does not silently auto-start a daily batch. Suggested
+# cadence when registered: "30 7 * * *" Asia/Seoul.
+@broker.task(task_name="warnings.toss.sync")
 async def sync_toss_warnings_task() -> dict[str, int | str | list[str]]:
     try:
         return await run_toss_warnings_sync()

--- a/docs/runbooks/toss-live-smoke.md
+++ b/docs/runbooks/toss-live-smoke.md
@@ -59,11 +59,11 @@ the operator evidence, and the account setup before live operational use.
    uv run alembic upgrade head
    ```
 
-4. Confirm Toss API credentials are present in the operator environment. Do not
-   print values:
+4. Confirm Toss API credentials are present in the operator environment. Print
+   only the key NAMES that are set — never the values:
 
    ```bash
-   env | rg '^TOSS_API_(ENABLED|CLIENT_ID|CLIENT_SECRET|ACCOUNT_SEQ|BASE_URL)='
+   env | cut -d= -f1 | rg '^TOSS_API_(ENABLED|CLIENT_ID|CLIENT_SECRET|ACCOUNT_SEQ|BASE_URL)$'
    ```
 
 5. Confirm buying power is sufficient for the chosen one-share order. The

--- a/env.example
+++ b/env.example
@@ -415,3 +415,23 @@ BINANCE_FUTURES_DEMO_ENABLED=false
 BINANCE_FUTURES_DEMO_API_KEY=
 BINANCE_FUTURES_DEMO_API_SECRET=
 BINANCE_FUTURES_DEMO_BASE_URL=https://demo-fapi.binance.com
+
+# -----------------------------------------------------------------------------
+# 토스증권 Open API (ROB-529 — KR/US live broker + data source)
+# -----------------------------------------------------------------------------
+# Default-off. Read-only data surfaces (FX/calendar/portfolio/quotes/candles)
+# need only ENABLED + CLIENT_ID/SECRET. Live order mutations require the
+# separate TOSS_LIVE_ORDER_MUTATIONS_ENABLED gate (kept off until the operator
+# live-smoke clears). Keep secrets in operator-managed runtime env; do not commit.
+TOSS_API_ENABLED=false
+TOSS_API_CLIENT_ID=
+TOSS_API_CLIENT_SECRET=
+# Optional: pin the account seq (integer). Leave UNSET to auto-resolve when
+# exactly one BROKERAGE account exists (fail-closed otherwise). Keep commented
+# when unused — an empty value fails int parsing.
+# TOSS_API_ACCOUNT_SEQ=1
+# Optional: override base URL (https + openapi.tossinvest.com host enforced).
+TOSS_API_BASE_URL=https://openapi.tossinvest.com
+# Arms live order mutations (place/modify/cancel) AND the holdings sellability
+# / orderable-cash / tradeability surfaces (ROB-549). Keep false until cleared.
+TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false

--- a/tests/services/brokers/toss/test_warnings_guard.py
+++ b/tests/services/brokers/toss/test_warnings_guard.py
@@ -91,6 +91,33 @@ async def test_warnings_guard_kr_blocking_warning() -> None:
 
 
 @pytest.mark.asyncio
+async def test_warnings_guard_exempts_sell_from_liquidation_block() -> None:
+    """ROB-550: 정리매매(LIQUIDATION_TRADING) must not block a SELL — blocking
+    the exit during a delisting liquidation window traps the position. Buys
+    stay blocked; the warning is still surfaced for sells."""
+    warnings_list = [
+        TossWarningInfo(
+            warning_type="LIQUIDATION_TRADING",
+            exchange="KRX",
+            start_date="2026-06-12",
+            end_date=None,
+        )
+    ]
+    sell_client = DummyClient(warnings_result=warnings_list)
+    sell_result = await check_warnings_guard(
+        sell_client, "005930", side="sell", today=date(2026, 6, 12)
+    )
+    assert sell_result.ok is True
+    assert sell_result.warnings == warnings_list  # still surfaced
+
+    buy_client = DummyClient(warnings_result=warnings_list)
+    buy_result = await check_warnings_guard(
+        buy_client, "005930", side="buy", today=date(2026, 6, 12)
+    )
+    assert buy_result.ok is False
+
+
+@pytest.mark.asyncio
 async def test_warnings_guard_filters_inactive_warnings_before_blocking() -> None:
     warnings_list = [
         TossWarningInfo(

--- a/tests/test_toss_warnings_job.py
+++ b/tests/test_toss_warnings_job.py
@@ -1,0 +1,36 @@
+"""ROB-550: the Toss warnings sync job/task ships scheduleless and skips
+gracefully (no ERROR) when the Toss API is disabled."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.jobs import toss_warnings
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_run_toss_warnings_sync_skips_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        toss_warnings.settings, "toss_api_enabled", False, raising=False
+    )
+
+    def _boom():
+        raise AssertionError("must not build a client when Toss is disabled")
+
+    monkeypatch.setattr(toss_warnings.TossReadClient, "from_settings", _boom)
+
+    result = await toss_warnings.run_toss_warnings_sync()
+
+    assert result["status"] == "disabled"
+
+
+def test_sync_toss_warnings_task_is_scheduleless():
+    """Recurrence is operator/Prefect-registered (house convention); the task
+    must not ship with an embedded cron schedule."""
+    from app.tasks import toss_warnings_sync_tasks as task_mod
+
+    task = task_mod.sync_toss_warnings_task
+    labels = getattr(task, "labels", {}) or {}
+    schedule = labels.get("schedule")
+    assert not schedule, f"expected scheduleless task, found schedule={schedule!r}"


### PR DESCRIPTION
## Summary
Grab-bag of post-merge cleanups from the ROB-530~539 audit.

- **env.example** — add the `TOSS_API_*` section (`ENABLED`/`CLIENT_ID`/`CLIENT_SECRET`/`ACCOUNT_SEQ`/`BASE_URL`/`LIVE_ORDER_MUTATIONS_ENABLED`). `ACCOUNT_SEQ` stays commented — an empty value fails int parsing (conftest loads `env.example`).
- **CLAUDE.md** — add the "토스증권 Open API (ROB-529)" broker section (house convention: one section per broker) covering client/tools/ledger/data sources + env safety gates.
- **warnings sync task** — ship **scheduleless** (remove the embedded daily cron; recurrence is operator/Prefect-registered, matching the house convention) and **graceful-skip** `run_toss_warnings_sync` when `TOSS_API_ENABLED` is false (`status="disabled"`, no daily ERROR).
- **warnings_guard** — add a `side` param; a **SELL is exempt from the `LIQUIDATION_TRADING` block** (blocking the exit during a delisting liquidation window traps the position) — warning still surfaced. Wired `side` into the Toss place buy/sell paths.
- **KIS live buy guard** — pass `market=None` so a US KIS buy (e.g. AAPL) auto-skips the Toss KR warnings fetch instead of issuing a wasted lookup.
- **runbook `toss-live-smoke.md`** — credential-presence check prints key NAMES only (was `env | rg` which echoed values).

## Test
TDD for the behavior changes: sell-side LIQUIDATION exemption (buy still blocked), scheduleless task + disabled graceful-skip. 87 toss/kis order + guard + job tests pass. `ruff` + `ty` clean. migration 0.

## Scope
Closes ROB-550. Deferred (independent low-risk minors, explicitly out of scope): invest_home `BRK.B` vs `BRK/B` dedup normalization, toss account group-label stamping, morning-report `toss_krw_fmt` string. The stale `hold_for_final_review` Linear labels on the Done ROB-530~539 issues are being cleared separately.

Closes ROB-550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Toss Securities Open API support with configurable read-only data access and optional live order mutations gating.
  * LIQUIDATION_TRADING warnings now exempt SELL orders from blocking (BUY orders only).

* **Documentation**
  * Added comprehensive Toss Securities API configuration guide with safety boundaries and operation conditions.
  * Updated smoke test runbook for API credential verification.
  * Added environment variable configuration for Toss API credentials and feature toggles.

* **Tests**
  * Added test coverage for sell order warning exemption logic and disabled API state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->