### PR TITLE
fix(ROB-529): keep Toss Alembic revision id under version table limit

### DIFF
--- a/alembic/versions/20260612_rob534_rob538_merge_heads.py
+++ b/alembic/versions/20260612_rob534_rob538_merge_heads.py
@@ -1,7 +1,7 @@
 """Merge ROB-534 Toss symbol master and ROB-538 Toss live ledger heads.
 
 Revision ID: 20260612_rob534_rob538_merge
-Revises: 20260612_rob534, 20260612_rob538_toss_live_order_ledger
+Revises: 20260612_rob534, 20260612_rob538_toss_ledger
 Create Date: 2026-06-12 17:00:00.000000
 """
 
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 revision: str = "20260612_rob534_rob538_merge"
 down_revision: str | Sequence[str] | None = (
     "20260612_rob534",
-    "20260612_rob538_toss_live_order_ledger",
+    "20260612_rob538_toss_ledger",
 )
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/alembic/versions/20260612_rob538_toss_live_order_ledger.py
+++ b/alembic/versions/20260612_rob538_toss_live_order_ledger.py
@@ -1,6 +1,6 @@
 """ROB-538 add Toss live order ledger.
 
-Revision ID: 20260612_rob538_toss_live_order_ledger
+Revision ID: 20260612_rob538_toss_ledger
 Revises: 20260611_rob516_rob512_merge
 Create Date: 2026-06-12
 """
@@ -13,7 +13,7 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision: str = "20260612_rob538_toss_live_order_ledger"
+revision: str = "20260612_rob538_toss_ledger"
 down_revision: Union[str, Sequence[str], None] = "20260611_rob516_rob512_merge"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -44,7 +44,9 @@ def upgrade() -> None:
         sa.Column("broker_status", sa.Text(), nullable=True),
         sa.Column("response_code", sa.Text(), nullable=True),
         sa.Column("response_message", sa.Text(), nullable=True),
-        sa.Column("raw_response", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "raw_response", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
         sa.Column("reason", sa.Text(), nullable=True),
         sa.Column("thesis", sa.Text(), nullable=True),
         sa.Column("strategy", sa.Text(), nullable=True),
@@ -53,7 +55,11 @@ def upgrade() -> None:
         sa.Column("min_hold_days", sa.SmallInteger(), nullable=True),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("exit_reason", sa.Text(), nullable=True),
-        sa.Column("indicators_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "indicators_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
         sa.Column("report_item_uuid", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("filled_qty", sa.Numeric(20, 8), nullable=True),
         sa.Column("avg_fill_price", sa.Numeric(20, 8), nullable=True),
@@ -63,34 +69,100 @@ def upgrade() -> None:
         sa.Column("trade_id", sa.BigInteger(), nullable=True),
         sa.Column("journal_id", sa.BigInteger(), nullable=True),
         sa.Column("reconciled_at", sa.TIMESTAMP(timezone=True), nullable=True),
-        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
-        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
         sa.CheckConstraint("broker = 'toss'", name="toss_live_ledger_broker_toss"),
-        sa.CheckConstraint("account_mode = 'toss_live'", name="toss_live_ledger_account_mode_toss_live"),
-        sa.CheckConstraint("operation_kind IN ('place','modify','cancel')", name="toss_live_ledger_operation_kind"),
+        sa.CheckConstraint(
+            "account_mode = 'toss_live'", name="toss_live_ledger_account_mode_toss_live"
+        ),
+        sa.CheckConstraint(
+            "operation_kind IN ('place','modify','cancel')",
+            name="toss_live_ledger_operation_kind",
+        ),
         sa.CheckConstraint("market IN ('kr','us')", name="toss_live_ledger_market"),
         sa.CheckConstraint("side IN ('buy','sell')", name="toss_live_ledger_side"),
-        sa.CheckConstraint("order_type IN ('limit','market')", name="toss_live_ledger_order_type"),
+        sa.CheckConstraint(
+            "order_type IN ('limit','market')", name="toss_live_ledger_order_type"
+        ),
         sa.CheckConstraint(
             "status IN ('accepted','rejected','pending','partial','filled','cancelled','replaced','cancel_rejected','replace_rejected','anomaly')",
             name="toss_live_ledger_status",
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_toss_live_order_ledger")),
-        sa.UniqueConstraint("client_order_id", name="uq_toss_live_ledger_client_order_id"),
-        sa.UniqueConstraint("broker_order_id", name="uq_toss_live_ledger_broker_order_id"),
+        sa.UniqueConstraint(
+            "client_order_id", name="uq_toss_live_ledger_client_order_id"
+        ),
+        sa.UniqueConstraint(
+            "broker_order_id", name="uq_toss_live_ledger_broker_order_id"
+        ),
         schema="review",
     )
-    op.create_index("ix_toss_live_ledger_status", "toss_live_order_ledger", ["status"], schema="review")
-    op.create_index("ix_toss_live_ledger_market_symbol", "toss_live_order_ledger", ["market", "symbol"], schema="review")
-    op.create_index("ix_toss_live_ledger_broker_status", "toss_live_order_ledger", ["broker_status"], schema="review")
-    op.create_index("ix_toss_live_ledger_report_item_uuid", "toss_live_order_ledger", ["report_item_uuid"], schema="review")
-    op.create_index("ix_toss_live_ledger_replaced_by", "toss_live_order_ledger", ["replaced_by_order_id"], schema="review")
+    op.create_index(
+        "ix_toss_live_ledger_status",
+        "toss_live_order_ledger",
+        ["status"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_toss_live_ledger_market_symbol",
+        "toss_live_order_ledger",
+        ["market", "symbol"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_toss_live_ledger_broker_status",
+        "toss_live_order_ledger",
+        ["broker_status"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_toss_live_ledger_report_item_uuid",
+        "toss_live_order_ledger",
+        ["report_item_uuid"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_toss_live_ledger_replaced_by",
+        "toss_live_order_ledger",
+        ["replaced_by_order_id"],
+        schema="review",
+    )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_toss_live_ledger_replaced_by", table_name="toss_live_order_ledger", schema="review")
-    op.drop_index("ix_toss_live_ledger_report_item_uuid", table_name="toss_live_order_ledger", schema="review")
-    op.drop_index("ix_toss_live_ledger_broker_status", table_name="toss_live_order_ledger", schema="review")
-    op.drop_index("ix_toss_live_ledger_market_symbol", table_name="toss_live_order_ledger", schema="review")
-    op.drop_index("ix_toss_live_ledger_status", table_name="toss_live_order_ledger", schema="review")
+    op.drop_index(
+        "ix_toss_live_ledger_replaced_by",
+        table_name="toss_live_order_ledger",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_toss_live_ledger_report_item_uuid",
+        table_name="toss_live_order_ledger",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_toss_live_ledger_broker_status",
+        table_name="toss_live_order_ledger",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_toss_live_ledger_market_symbol",
+        table_name="toss_live_order_ledger",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_toss_live_ledger_status",
+        table_name="toss_live_order_ledger",
+        schema="review",
+    )
     op.drop_table("toss_live_order_ledger", schema="review")

--- a/tests/test_alembic_revision_ids.py
+++ b/tests/test_alembic_revision_ids.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _literal_assignment(tree: ast.AST, name: str):
+    for node in getattr(tree, "body", []):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+        ):
+            return ast.literal_eval(node.value)
+        if isinstance(node, ast.Assign):
+            if any(
+                isinstance(target, ast.Name) and target.id == name
+                for target in node.targets
+            ):
+                return ast.literal_eval(node.value)
+    raise AssertionError(f"missing {name!r} assignment")
+
+
+def _as_revision_list(value) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def test_alembic_revision_ids_fit_default_version_table() -> None:
+    # Alembic creates `alembic_version.version_num` as VARCHAR(32) by default.
+    # Production deploys run migrations before any application code can widen it,
+    # so every stored revision id must remain <= 32 chars.
+    too_long: list[tuple[str, int, str]] = []
+    unknown_references: list[tuple[str, str]] = []
+    migrations: dict[str, tuple[Path, list[str]]] = {}
+
+    for migration in sorted(Path("alembic/versions").glob("*.py")):
+        tree = ast.parse(migration.read_text())
+        revision = _literal_assignment(tree, "revision")
+        down_revisions = _as_revision_list(_literal_assignment(tree, "down_revision"))
+        migrations[revision] = (migration, down_revisions)
+
+    known_revisions = set(migrations)
+    for revision, (migration, down_revisions) in migrations.items():
+        if len(revision) > 32:
+            too_long.append((migration.name, len(revision), revision))
+        for down_revision in down_revisions:
+            if len(down_revision) > 32:
+                too_long.append((migration.name, len(down_revision), down_revision))
+            if down_revision not in known_revisions:
+                unknown_references.append((migration.name, down_revision))
+
+    assert not too_long
+    assert not unknown_references


### PR DESCRIPTION
## Summary
- Shortens the ROB-538 Toss ledger Alembic revision id from 38 chars to 28 chars so it fits Alembic's default `alembic_version.version_num VARCHAR(32)`.
- Updates the ROB-534/ROB-538 merge migration dependency to the shortened revision id.
- Adds a regression test that fails when any stored Alembic revision id or down-revision exceeds 32 chars or references an unknown revision.

## Why
Production promotion for ROB-529/Toss Phase 0 failed during Alembic upgrade before the symlink switch:

```text
StringDataRightTruncationError: value too long for type character varying(32)
INSERT INTO alembic_version (version_num) VALUES ('20260612_rob538_toss_live_order_ledger')
```

The failed migration ran inside transactional DDL, so the release was not switched to `current`.

## Verification
- `uv run --group test pytest tests/test_alembic_revision_ids.py tests/test_rob538_toss_live_ledger_schema.py -q` → 3 passed
- `uv run alembic heads` → `ec2fbbc5898c (head)`
- `uv run ruff format --check tests/test_alembic_revision_ids.py`
- `uv run ruff check tests/test_alembic_revision_ids.py`
- `git diff --check`

## Safety
- No broker/order/watch/order-intent side effects.
- No production DB mutation in this PR itself; it only unblocks the normal deploy migration path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration identifiers for consistency and clarity.
  * Reformatted migration script structure for improved maintainability.

* **Tests**
  * Added validation tests to ensure database migration compatibility and prevent future identifier issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->