### PR TITLE
feat(ROB-559): per-symbol order history on /invest stock detail (ROB-554 by-symbol)

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -62,6 +62,7 @@ from app.schemas.invest_stock_detail import (
 from app.schemas.invest_stock_detail_research_consensus import (
     StockDetailResearchConsensusResponse,
 )
+from app.schemas.investment_reports import StockDetailOrderLedgerResponse
 from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_benchmark_gap_service import (
     build_benchmark_gap_matrix_from_coverage,
@@ -117,6 +118,9 @@ from app.services.invest_view_model.stock_detail_symbol_resolver import (
     resolve_symbol,
 )
 from app.services.invest_view_model.weekly_summary_service import build_weekly_summary
+from app.services.investment_reports.linked_orders import (
+    list_live_orders_for_symbol,
+)
 
 
 def _parse_paper_sources(value: str | None) -> frozenset[str] | None:
@@ -520,6 +524,25 @@ async def get_stock_detail_orders(
         limit=limit,
         cursor=cursor,
     )
+
+
+@router.get("/stock-detail/{market}/{symbol}/order-ledger")
+async def get_stock_detail_order_ledger(
+    market: StockDetailMarketParam,
+    symbol: str,
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    days: int = Query(90, ge=1, le=365),
+    limit: int = Query(50, ge=1, le=200),
+) -> StockDetailOrderLedgerResponse:
+    # ROB-559 — per-symbol live order history (status + rationale + fill rollup)
+    # from the 3 live order ledgers. Read-only; crypto symbol is the raw Upbit
+    # pair (e.g. KRW-BTC), matched directly against LiveOrderLedger.symbol.
+    _ = user
+    items = await list_live_orders_for_symbol(
+        db, market=market, symbol=symbol, days=days, limit=limit
+    )
+    return StockDetailOrderLedgerResponse(count=len(items), items=items)
 
 
 def _held_pairs_from_home(home) -> list[tuple[str, str]]:

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -760,6 +760,19 @@ class LinkedOrderView(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class StockDetailOrderLedgerResponse(BaseModel):
+    """ROB-559 — per-symbol live order history for the stock-detail page.
+
+    Reuses ``LinkedOrderView`` (status + rationale + fill rollup), keyed by
+    symbol instead of report_item_uuid. Live-only; most-recent-first.
+    """
+
+    count: int
+    items: list[LinkedOrderView]
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class InvestmentReportItemResponse(BaseModel):
     """Single ``investment_report_items`` row."""
 

--- a/app/services/investment_reports/linked_orders.py
+++ b/app/services/investment_reports/linked_orders.py
@@ -14,6 +14,7 @@ and are intentionally out of scope.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import select
@@ -162,3 +163,104 @@ async def list_linked_orders_for_item_uuids(
             project_toss_live_order(row)
         )
     return grouped
+
+
+async def list_live_orders_for_symbol(
+    db: AsyncSession,
+    market: str,
+    symbol: str,
+    *,
+    days: int = 90,
+    limit: int = 50,
+) -> list[LinkedOrderView]:
+    """ROB-559 — per-symbol live order history across the 3 live ledgers.
+
+    The stock-detail page (``/invest/stocks/{market}/{symbol}``) keys by symbol
+    rather than ``report_item_uuid`` (ROB-554). ``market`` selects the ledgers:
+
+    * ``crypto`` → ``LiveOrderLedger`` (market='crypto'). Crypto symbols are the
+      full Upbit pair as stored, e.g. ``KRW-BTC`` (NOT prefix-stripped 'BTC' —
+      that convention is execution_ledger's), so the URL pair matches directly.
+    * ``us`` → ``LiveOrderLedger`` (market='us') + ``TossLiveOrderLedger`` (us).
+    * ``kr`` → ``KISLiveOrderLedger`` (KR domestic) + ``TossLiveOrderLedger`` (kr).
+
+    Live-only by construction (mock/paper/demo never write these). Each ledger is
+    queried by exact (upper-cased) symbol within the ``days`` window, capped at
+    ``limit``; results merge most-recent-first by ``created_at`` and re-cap.
+    """
+    sym = symbol.strip().upper()
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    collected: list[tuple[datetime, LinkedOrderView]] = []
+
+    async def _add_live(market_value: str) -> None:
+        rows = (
+            (
+                await db.execute(
+                    select(LiveOrderLedger)
+                    .where(
+                        LiveOrderLedger.symbol == sym,
+                        LiveOrderLedger.market == market_value,
+                        LiveOrderLedger.created_at >= cutoff,
+                    )
+                    .order_by(LiveOrderLedger.created_at.desc())
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            collected.append((row.created_at, project_live_order(row)))
+
+    async def _add_kis() -> None:
+        rows = (
+            (
+                await db.execute(
+                    select(KISLiveOrderLedger)
+                    .where(
+                        KISLiveOrderLedger.symbol == sym,
+                        KISLiveOrderLedger.created_at >= cutoff,
+                    )
+                    .order_by(KISLiveOrderLedger.created_at.desc())
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            collected.append((row.created_at, project_kis_live_order(row)))
+
+    async def _add_toss(market_value: str) -> None:
+        rows = (
+            (
+                await db.execute(
+                    select(TossLiveOrderLedger)
+                    .where(
+                        TossLiveOrderLedger.symbol == sym,
+                        TossLiveOrderLedger.market == market_value,
+                        TossLiveOrderLedger.created_at >= cutoff,
+                    )
+                    .order_by(TossLiveOrderLedger.created_at.desc())
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            collected.append((row.created_at, project_toss_live_order(row)))
+
+    if market == "crypto":
+        await _add_live("crypto")
+    elif market == "us":
+        await _add_live("us")
+        await _add_toss("us")
+    elif market == "kr":
+        await _add_kis()
+        await _add_toss("kr")
+    else:
+        return []
+
+    collected.sort(key=lambda t: t[0], reverse=True)
+    return [view for _, view in collected[:limit]]

--- a/app/services/investment_reports/linked_orders.py
+++ b/app/services/investment_reports/linked_orders.py
@@ -20,6 +20,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.symbol import to_db_symbol
 from app.models.review import (
     KISLiveOrderLedger,
     LiveOrderLedger,
@@ -185,20 +186,25 @@ async def list_live_orders_for_symbol(
     * ``kr`` → ``KISLiveOrderLedger`` (KR domestic) + ``TossLiveOrderLedger`` (kr).
 
     Live-only by construction (mock/paper/demo never write these). Each ledger is
-    queried by exact (upper-cased) symbol within the ``days`` window, capped at
-    ``limit``; results merge most-recent-first by ``created_at`` and re-cap.
+    queried by exact symbol within the ``days`` window, capped at ``limit``;
+    results merge most-recent-first by ``created_at`` and re-cap.
+
+    Symbol canonicalization is per-market: US tickers may arrive in separator
+    form (``BRK-B`` / ``BRK/B``) but the ledgers store DB dot-format (``BRK.B``),
+    so US is canonicalized via ``to_db_symbol`` (mirrors the sibling stock-detail
+    endpoints). Crypto keeps its full hyphenated Upbit pair; KR codes are digits.
     """
     sym = symbol.strip().upper()
     cutoff = datetime.now(UTC) - timedelta(days=days)
     collected: list[tuple[datetime, LinkedOrderView]] = []
 
-    async def _add_live(market_value: str) -> None:
+    async def _add_live(market_value: str, match_sym: str) -> None:
         rows = (
             (
                 await db.execute(
                     select(LiveOrderLedger)
                     .where(
-                        LiveOrderLedger.symbol == sym,
+                        LiveOrderLedger.symbol == match_sym,
                         LiveOrderLedger.market == market_value,
                         LiveOrderLedger.created_at >= cutoff,
                     )
@@ -212,13 +218,13 @@ async def list_live_orders_for_symbol(
         for row in rows:
             collected.append((row.created_at, project_live_order(row)))
 
-    async def _add_kis() -> None:
+    async def _add_kis(match_sym: str) -> None:
         rows = (
             (
                 await db.execute(
                     select(KISLiveOrderLedger)
                     .where(
-                        KISLiveOrderLedger.symbol == sym,
+                        KISLiveOrderLedger.symbol == match_sym,
                         KISLiveOrderLedger.created_at >= cutoff,
                     )
                     .order_by(KISLiveOrderLedger.created_at.desc())
@@ -231,13 +237,13 @@ async def list_live_orders_for_symbol(
         for row in rows:
             collected.append((row.created_at, project_kis_live_order(row)))
 
-    async def _add_toss(market_value: str) -> None:
+    async def _add_toss(market_value: str, match_sym: str) -> None:
         rows = (
             (
                 await db.execute(
                     select(TossLiveOrderLedger)
                     .where(
-                        TossLiveOrderLedger.symbol == sym,
+                        TossLiveOrderLedger.symbol == match_sym,
                         TossLiveOrderLedger.market == market_value,
                         TossLiveOrderLedger.created_at >= cutoff,
                     )
@@ -252,13 +258,14 @@ async def list_live_orders_for_symbol(
             collected.append((row.created_at, project_toss_live_order(row)))
 
     if market == "crypto":
-        await _add_live("crypto")
+        await _add_live("crypto", sym)
     elif market == "us":
-        await _add_live("us")
-        await _add_toss("us")
+        us_sym = to_db_symbol(sym)  # BRK-B / BRK/B -> BRK.B (ledger storage form)
+        await _add_live("us", us_sym)
+        await _add_toss("us", us_sym)
     elif market == "kr":
-        await _add_kis()
-        await _add_toss("kr")
+        await _add_kis(sym)
+        await _add_toss("kr", sym)
     else:
         return []
 

--- a/docs/superpowers/plans/2026-06-14-rob-559-symbol-order-history.md
+++ b/docs/superpowers/plans/2026-06-14-rob-559-symbol-order-history.md
@@ -1,0 +1,126 @@
+# ROB-559 — Per-symbol order history on StockDetailPage — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or executing-plans. Steps use `- [ ]`.
+
+**Spec:** Linear **ROB-559** (decisions locked there). **Goal:** show per-symbol order lifecycle (status + rationale + fill rollup) on `/invest/stocks/:market/:symbol`, reusing ROB-554's `LinkedOrderView` + `project_*` by **symbol** instead of `report_item_uuid`.
+
+**Decisions:** source = 3 live order ledgers (live-only) · markets = all (KR/US/crypto) · rationale shown · v1 = order rollup (no per-fill drill-down) · **migration 0**.
+
+**⚠️ Crypto symbol reality:** `review.live_order_ledger.symbol = 'KRW-BTC'` (full pair, upper). URL carries `KRW-BTC` → direct match. (execution_ledger uses `BTC`/`raw_symbol` — that's why order-ledger source is cleaner.) KR=6-digit, US=dot-upper, consistent.
+
+**Base:** `origin/main` (worktree `/Users/mgh3326/work/auto_trader.rob-559`, branch `rob-559`).
+
+---
+
+## S1 — Backend `list_live_orders_for_symbol`
+**Files:** modify `app/services/investment_reports/linked_orders.py`; test `tests/test_rob559_symbol_order_history.py`.
+
+- Add `from datetime import UTC, datetime, timedelta` to imports.
+- New fn (reuses existing `project_live_order`/`project_kis_live_order`/`project_toss_live_order`):
+```python
+async def list_live_orders_for_symbol(
+    db: AsyncSession, market: str, symbol: str, *, days: int = 90, limit: int = 50
+) -> list[LinkedOrderView]:
+    """Per-symbol live order history across the 3 live ledgers (live-only).
+
+    market routes the ledgers: crypto -> LiveOrderLedger(market='crypto');
+    us -> LiveOrderLedger(market='us') + TossLiveOrderLedger(market='us');
+    kr -> KISLiveOrderLedger + TossLiveOrderLedger(market='kr').
+    Crypto symbols are the full Upbit pair ('KRW-BTC'); match LiveOrderLedger.symbol
+    directly. Merged most-recent-first by created_at, capped at limit.
+    """
+    sym = symbol.strip().upper()
+    cutoff = datetime.now(UTC) - timedelta(days=days)
+    collected: list[tuple[datetime, LinkedOrderView]] = []
+
+    async def _live(market_value: str):
+        rows = (await db.execute(
+            select(LiveOrderLedger)
+            .where(LiveOrderLedger.symbol == sym,
+                   LiveOrderLedger.market == market_value,
+                   LiveOrderLedger.created_at >= cutoff)
+            .order_by(LiveOrderLedger.id.desc()).limit(limit))).scalars().all()
+        for r in rows: collected.append((r.created_at, project_live_order(r)))
+
+    async def _kis():
+        rows = (await db.execute(
+            select(KISLiveOrderLedger)
+            .where(KISLiveOrderLedger.symbol == sym,
+                   KISLiveOrderLedger.created_at >= cutoff)
+            .order_by(KISLiveOrderLedger.id.desc()).limit(limit))).scalars().all()
+        for r in rows: collected.append((r.created_at, project_kis_live_order(r)))
+
+    async def _toss(market_value: str):
+        rows = (await db.execute(
+            select(TossLiveOrderLedger)
+            .where(TossLiveOrderLedger.symbol == sym,
+                   TossLiveOrderLedger.market == market_value,
+                   TossLiveOrderLedger.created_at >= cutoff)
+            .order_by(TossLiveOrderLedger.id.desc()).limit(limit))).scalars().all()
+        for r in rows: collected.append((r.created_at, project_toss_live_order(r)))
+
+    if market == "crypto":
+        await _live("crypto")
+    elif market == "us":
+        await _live("us"); await _toss("us")
+    elif market == "kr":
+        await _kis(); await _toss("kr")
+    else:
+        return []
+
+    collected.sort(key=lambda t: t[0], reverse=True)
+    return [v for _, v in collected[:limit]]
+```
+- Tests: crypto KRW-BTC matches live ledger (not 'BTC'); us merges live+toss; kr merges kis+toss; days cutoff excludes old; limit caps; empty for unknown symbol/market.
+
+## S2 — Endpoint `GET /stock-detail/{market}/{symbol}/order-ledger`
+**Files:** modify `app/schemas/investment_reports.py` (add response model), `app/routers/invest_api.py`; test `tests/test_rob559_symbol_order_history.py` (router-level).
+
+- Schema (next to `LinkedOrderView`):
+```python
+class StockDetailOrderLedgerResponse(BaseModel):
+    """ROB-559 — per-symbol live order history for the stock detail page."""
+    count: int
+    items: list[LinkedOrderView]
+    model_config = ConfigDict(extra="forbid")
+```
+- Route (after the `/orders` route, ~invest_api.py:523):
+```python
+@router.get("/stock-detail/{market}/{symbol}/order-ledger")
+async def get_stock_detail_order_ledger(
+    market: StockDetailMarketParam,
+    symbol: str,
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    days: int = Query(90, ge=1, le=365),
+    limit: int = Query(50, ge=1, le=200),
+) -> StockDetailOrderLedgerResponse:
+    _ = user
+    items = await list_live_orders_for_symbol(db, market=market, symbol=symbol, days=days, limit=limit)
+    return StockDetailOrderLedgerResponse(count=len(items), items=items)
+```
+- Imports: `list_live_orders_for_symbol` from `app.services.investment_reports.linked_orders`; `StockDetailOrderLedgerResponse` from `app.schemas.investment_reports`.
+
+## S3 — Extract shared LinkedOrder status maps + row (FE refactor, behaviour-preserving)
+**Files:** create `frontend/invest/src/components/orders/LinkedOrderRow.tsx`; modify `InvestmentReportBundleContent.tsx`; test stays green.
+
+- New module exports `LINKED_ORDER_STATUS_LABELS`, `LINKED_ORDER_STATUS_TONES` (moved verbatim from `InvestmentReportBundleContent.tsx:80-107`) and `LinkedOrderRow({ order }: { order: LinkedOrder })` rendering the exact ROB-554 Pill row (status pill, side/symbol, filledQty@avgFillPrice, orderTime, order# slice(0,8), exitReason||thesis).
+- `InvestmentReportBundleContent.tsx`: delete local maps + inline row JSX; import `LinkedOrderRow`; render `item.linkedOrders.map(o => <LinkedOrderRow key={`${o.broker??''}:${o.market??''}:${o.ledgerId}`} order={o} />)`.
+- Existing `InvestmentReportBundleContent.linkedOrders.test.tsx` must stay green (same rendered text).
+
+## S4 — FE client + "주문 기록" card
+**Files:** modify `frontend/invest/src/api/investmentReports.ts` (export `normalizeLinkedOrder`), `frontend/invest/src/api/stockDetail.ts`, `frontend/invest/src/types/stockDetail.ts`, `frontend/invest/src/pages/stock-detail/StockDetailPage.tsx`; test `StockDetailPage.orderLedger.test.tsx`.
+
+- Export `normalizeLinkedOrder` from `api/investmentReports.ts` (currently internal).
+- `api/stockDetail.ts`: `fetchStockDetailOrderLedger({market,symbol,days?}): Promise<LinkedOrder[]>` → `getJson<{count:number; items:Record<string,unknown>[]}>(`${path}/order-ledger${suffix}`)` then `.items.map(normalizeLinkedOrder)`.
+- `StockDetailPage.tsx`: state `orderLedger: LinkedOrder[] | undefined`; fetch in the `[market,symbol]` effect (crypto sends raw pair — symbol already correct); new full-width `OrderLedgerCard` (title "주문 기록") after the orderbook/orders grid (line 462), rendering `LinkedOrderRow` rows + loading/empty states.
+- Test: card renders rows for given orders; empty state; crypto param wiring sends KRW-BTC.
+
+## Verify
+- Backend: `uv run pytest tests/test_rob559_symbol_order_history.py -q` + adjacent (linked_orders/investment_reports), `ruff check`, `ruff format --check`, `ty check app/`.
+- Frontend: `npm test -- --run` (new + existing linkedOrders test green), `npm run typecheck`.
+- ⚠️ Reminder: NO literal "binance" string in `app/**` (ROB-285 guard).
+
+## Self-review
+- Coverage: S1 query / S2 endpoint / S3 shared maps / S4 card — all decisions covered. Migration 0.
+- Type consistency: `LinkedOrderView` (be) ↔ `LinkedOrder` (fe via normalizeLinkedOrder). `list_live_orders_for_symbol` name consistent S1↔S2. crypto symbol = raw pair end-to-end.

--- a/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
+++ b/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
@@ -30,9 +30,21 @@ describe("OrderLedgerCard (ROB-559)", () => {
     expect(screen.getByText(/order 7aeb17dd/)).toBeInTheDocument();
   });
 
-  it("renders a 미체결 badge for an accepted order", () => {
-    render(<OrderLedgerCard orders={[makeOrder({ status: "accepted" })]} />);
+  it("renders a 미체결 badge and no qty line for an unfilled order", () => {
+    render(
+      <OrderLedgerCard
+        orders={[
+          makeOrder({ status: "accepted", filledQty: null, avgFillPrice: null }),
+        ]}
+      />,
+    );
     expect(screen.getByText("미체결")).toBeInTheDocument();
+    expect(screen.queryByText(/@/)).toBeNull(); // no redundant "— @ —" line
+  });
+
+  it("formats tiny fill quantities without scientific notation", () => {
+    render(<OrderLedgerCard orders={[makeOrder({ filledQty: "1E-8" })]} />);
+    expect(screen.getByText(/0\.00000001/)).toBeInTheDocument();
   });
 
   it("renders the empty state when there are no orders", () => {

--- a/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
+++ b/frontend/invest/src/__tests__/OrderLedgerCard.test.tsx
@@ -1,0 +1,47 @@
+// ROB-559 — per-symbol order history card on the stock detail page.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OrderLedgerCard } from "../desktop/stock-detail/OrderLedgerCard";
+import type { LinkedOrder } from "../types/investmentReports";
+
+function makeOrder(overrides: Partial<LinkedOrder> = {}): LinkedOrder {
+  return {
+    ledgerId: 11,
+    broker: "upbit",
+    accountScope: "upbit_live",
+    market: "crypto",
+    orderNo: "7aeb17dd-2fa2-4dc0",
+    symbol: "KRW-BTC",
+    side: "buy",
+    status: "filled",
+    filledQty: "0.01",
+    avgFillPrice: "96180000",
+    ...overrides,
+  };
+}
+
+describe("OrderLedgerCard (ROB-559)", () => {
+  it("renders the 주문 기록 card with status badge + order id for an order", () => {
+    render(<OrderLedgerCard orders={[makeOrder()]} />);
+    expect(screen.getByText("주문 기록")).toBeInTheDocument();
+    expect(screen.getByText("체결")).toBeInTheDocument();
+    expect(screen.getByText(/order 7aeb17dd/)).toBeInTheDocument();
+  });
+
+  it("renders a 미체결 badge for an accepted order", () => {
+    render(<OrderLedgerCard orders={[makeOrder({ status: "accepted" })]} />);
+    expect(screen.getByText("미체결")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no orders", () => {
+    render(<OrderLedgerCard orders={[]} />);
+    expect(screen.getByText("주문 기록이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("renders the loading state while undefined", () => {
+    render(<OrderLedgerCard orders={undefined} />);
+    expect(screen.getByText("불러오는 중입니다…")).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/stockDetailOrderLedger.api.test.ts
+++ b/frontend/invest/src/__tests__/stockDetailOrderLedger.api.test.ts
@@ -1,0 +1,66 @@
+// ROB-559 — fetchStockDetailOrderLedger normalizes snake_case rows to LinkedOrder.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchStockDetailOrderLedger } from "../api/stockDetail";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("fetchStockDetailOrderLedger (ROB-559)", () => {
+  it("maps snake_case order-ledger rows to camelCase LinkedOrder", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        count: 1,
+        items: [
+          {
+            ledger_id: 11,
+            broker: "upbit",
+            account_scope: "upbit_live",
+            market: "crypto",
+            order_no: "7aeb17dd-2fa2",
+            symbol: "KRW-BTC",
+            side: "buy",
+            status: "filled",
+            filled_qty: "0.01",
+            avg_fill_price: "96180000",
+          },
+        ],
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const rows = await fetchStockDetailOrderLedger({
+      market: "crypto",
+      symbol: "KRW-BTC",
+      days: 90,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ledgerId).toBe(11);
+    expect(rows[0]?.orderNo).toBe("7aeb17dd-2fa2");
+    expect(rows[0]?.accountScope).toBe("upbit_live");
+    expect(rows[0]?.market).toBe("crypto");
+    expect(rows[0]?.filledQty).toBe("0.01");
+    // crypto sends the raw pair as-is in the request path
+    const calledUrl = String(fetchMock.mock.calls[0]?.[0]);
+    expect(calledUrl).toContain("/stock-detail/crypto/KRW-BTC/order-ledger");
+    expect(calledUrl).toContain("days=90");
+  });
+
+  it("returns [] when the backend sends no items", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ count: 0, items: [] }),
+    }) as unknown as typeof fetch;
+
+    const rows = await fetchStockDetailOrderLedger({ market: "us", symbol: "AAPL" });
+    expect(rows).toEqual([]);
+  });
+});

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -151,7 +151,7 @@ function asOptionalList(value: unknown): unknown[] | null {
   return Array.isArray(value) ? value : null;
 }
 
-function normalizeLinkedOrder(raw: ApiItem): LinkedOrder {
+export function normalizeLinkedOrder(raw: ApiItem): LinkedOrder {
   return {
     broker: asOptionalString(raw.broker),
     accountScope: asOptionalString(raw.account_scope),

--- a/frontend/invest/src/api/stockDetail.ts
+++ b/frontend/invest/src/api/stockDetail.ts
@@ -6,6 +6,8 @@ import type {
   StockDetailResearchConsensusResponse,
   StockDetailResponse,
 } from "../types/stockDetail";
+import { normalizeLinkedOrder } from "./investmentReports";
+import type { LinkedOrder } from "../types/investmentReports";
 
 async function getJson<T>(url: string): Promise<T> {
   const res = await fetch(url, { credentials: "include" });
@@ -67,4 +69,23 @@ export async function fetchStockDetailOrders(params: {
   const qs = q.toString();
   const suffix = qs ? `?${qs}` : "";
   return getJson<StockDetailOrdersResponse>(`${stockDetailPath(params.market, params.symbol)}/orders${suffix}`);
+}
+
+// ROB-559 — per-symbol live order history (status + rationale + fill rollup).
+// Backend returns snake_case LinkedOrderView rows; normalize to camelCase
+// LinkedOrder with the same mapper the report bundle uses. Crypto sends the raw
+// Upbit pair (e.g. KRW-BTC) as-is — it matches LiveOrderLedger.symbol directly.
+export async function fetchStockDetailOrderLedger(params: {
+  market: StockDetailMarket;
+  symbol: string;
+  days?: number;
+}): Promise<LinkedOrder[]> {
+  const q = new URLSearchParams();
+  if (params.days !== undefined) q.set("days", String(params.days));
+  const qs = q.toString();
+  const suffix = qs ? `?${qs}` : "";
+  const raw = await getJson<{ count: number; items: Record<string, unknown>[] }>(
+    `${stockDetailPath(params.market, params.symbol)}/order-ledger${suffix}`,
+  );
+  return (raw.items ?? []).map(normalizeLinkedOrder);
 }

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -6,8 +6,9 @@
 import { useEffect, type ReactNode } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 
-import { Card, Pill, type PillTone } from "../../ds";
+import { Card, Pill } from "../../ds";
 import { useInvestmentReportBundle } from "../../hooks/useInvestmentReportBundle";
+import { LinkedOrderRow, linkedOrderKey } from "../orders/LinkedOrderRow";
 import type {
   DeliveryStatus,
   InvestmentReportItem,
@@ -71,39 +72,6 @@ const DELIVERY_STATUS_COLORS: Record<DeliveryStatus, string> = {
   delivered: "var(--success, var(--fg-2))",
   skipped: "var(--warn)",
   failed: "var(--danger)",
-};
-
-// Covers the status vocabularies of all three live ledgers the linked-order
-// lookup reads: LiveOrderLedger (US/crypto), KISLiveOrderLedger (KR), and
-// TossLiveOrderLedger (which adds replaced / *_rejected). Unmapped values fall
-// back to the raw token in the renderer.
-const LINKED_ORDER_STATUS_LABELS: Record<string, string> = {
-  filled: "체결",
-  partial: "부분체결",
-  accepted: "미체결",
-  submitted: "미체결",
-  pending: "미체결",
-  cancelled: "취소",
-  rejected: "거부",
-  expired: "만료",
-  unknown: "확인 불가",
-  replaced: "정정됨",
-  cancel_rejected: "취소거부",
-  replace_rejected: "정정거부",
-  anomaly: "이상",
-};
-
-// Tone by status class: filled/partial → accent (executed), terminal failures
-// → loss, soft-negatives → warn, everything else → neutral paper (default).
-const LINKED_ORDER_STATUS_TONES: Record<string, PillTone> = {
-  filled: "accent",
-  partial: "accent",
-  rejected: "loss",
-  cancel_rejected: "loss",
-  replace_rejected: "loss",
-  anomaly: "loss",
-  cancelled: "warn",
-  expired: "warn",
 };
 
 function StatusCard({ children }: { children: ReactNode }) {
@@ -311,52 +279,7 @@ function ItemRow({
             주문 · 체결
           </div>
           {item.linkedOrders.map((order) => (
-            <div
-              // ledgerId is per-table; the three live ledgers have independent
-              // id sequences, so disambiguate by broker+market to keep keys
-              // unique when one item links orders from more than one ledger.
-              key={`${order.broker ?? ""}:${order.market ?? ""}:${order.ledgerId}`}
-              style={{
-                display: "flex",
-                gap: 8,
-                alignItems: "baseline",
-                flexWrap: "wrap",
-                fontSize: 12,
-                color: "var(--fg-3)",
-                background: "var(--surface-2)",
-                padding: "6px 10px",
-                borderRadius: 8,
-              }}
-            >
-              <Pill
-                tone={LINKED_ORDER_STATUS_TONES[order.status ?? ""] ?? "paper"}
-                size="sm"
-              >
-                {LINKED_ORDER_STATUS_LABELS[order.status ?? ""] ??
-                  order.status ??
-                  "—"}
-              </Pill>
-              <span style={{ fontWeight: 700 }}>
-                {order.side === "buy"
-                  ? "매수"
-                  : order.side === "sell"
-                    ? "매도"
-                    : ""}{" "}
-                {order.symbol ?? "—"}
-              </span>
-              <span>
-                {order.filledQty ?? "—"} @ {order.avgFillPrice ?? "—"}
-              </span>
-              {order.orderTime ? <span>· {order.orderTime}</span> : null}
-              {order.orderNo ? (
-                <span>· order {order.orderNo.slice(0, 8)}</span>
-              ) : null}
-              {order.exitReason || order.thesis ? (
-                <span style={{ width: "100%" }}>
-                  {order.exitReason ?? order.thesis}
-                </span>
-              ) : null}
-            </div>
+            <LinkedOrderRow key={linkedOrderKey(order)} order={order} />
           ))}
         </div>
       ) : null}

--- a/frontend/invest/src/components/orders/LinkedOrderRow.tsx
+++ b/frontend/invest/src/components/orders/LinkedOrderRow.tsx
@@ -44,6 +44,17 @@ export function linkedOrderKey(order: LinkedOrder): string {
   return `${order.broker ?? ""}:${order.market ?? ""}:${order.ledgerId}`;
 }
 
+// Pydantic serializes Decimal to a JSON string; sub-1e-6 magnitudes come through
+// as scientific notation (e.g. "1E-8" for tiny BTC fractions). Render a readable
+// fixed-point number instead, falling back to the raw value if it isn't numeric.
+function fmtAmount(value: number | string | null | undefined): string {
+  if (value == null || value === "") return "—";
+  const n = Number(value);
+  return Number.isFinite(n)
+    ? n.toLocaleString(undefined, { maximumFractionDigits: 8 })
+    : String(value);
+}
+
 export function LinkedOrderRow({ order }: { order: LinkedOrder }) {
   return (
     <div
@@ -66,9 +77,11 @@ export function LinkedOrderRow({ order }: { order: LinkedOrder }) {
         {order.side === "buy" ? "매수" : order.side === "sell" ? "매도" : ""}{" "}
         {order.symbol ?? "—"}
       </span>
-      <span>
-        {order.filledQty ?? "—"} @ {order.avgFillPrice ?? "—"}
-      </span>
+      {order.filledQty != null || order.avgFillPrice != null ? (
+        <span>
+          {fmtAmount(order.filledQty)} @ {fmtAmount(order.avgFillPrice)}
+        </span>
+      ) : null}
       {order.orderTime ? <span>· {order.orderTime}</span> : null}
       {order.orderNo ? <span>· order {order.orderNo.slice(0, 8)}</span> : null}
       {order.exitReason || order.thesis ? (

--- a/frontend/invest/src/components/orders/LinkedOrderRow.tsx
+++ b/frontend/invest/src/components/orders/LinkedOrderRow.tsx
@@ -1,0 +1,79 @@
+// ROB-559 — shared linked-order status maps + row, extracted from
+// InvestmentReportBundleContent (ROB-554) so the report-bundle decision log and
+// the stock-detail "주문 기록" card render live orders identically.
+
+import { Pill, type PillTone } from "../../ds";
+import type { LinkedOrder } from "../../types/investmentReports";
+
+// Covers the status vocabularies of all three live ledgers the lookups read:
+// LiveOrderLedger (US/crypto), KISLiveOrderLedger (KR), and TossLiveOrderLedger
+// (which adds replaced / *_rejected). Unmapped values fall back to the raw token.
+export const LINKED_ORDER_STATUS_LABELS: Record<string, string> = {
+  filled: "체결",
+  partial: "부분체결",
+  accepted: "미체결",
+  submitted: "미체결",
+  pending: "미체결",
+  cancelled: "취소",
+  rejected: "거부",
+  expired: "만료",
+  unknown: "확인 불가",
+  replaced: "정정됨",
+  cancel_rejected: "취소거부",
+  replace_rejected: "정정거부",
+  anomaly: "이상",
+};
+
+// Tone by status class: filled/partial → accent (executed), terminal failures
+// → loss, soft-negatives → warn, everything else → neutral paper (default).
+export const LINKED_ORDER_STATUS_TONES: Record<string, PillTone> = {
+  filled: "accent",
+  partial: "accent",
+  rejected: "loss",
+  cancel_rejected: "loss",
+  replace_rejected: "loss",
+  anomaly: "loss",
+  cancelled: "warn",
+  expired: "warn",
+};
+
+// ledgerId is per-table; the three live ledgers have independent id sequences,
+// so disambiguate by broker+market to keep React keys unique when one container
+// lists orders from more than one ledger.
+export function linkedOrderKey(order: LinkedOrder): string {
+  return `${order.broker ?? ""}:${order.market ?? ""}:${order.ledgerId}`;
+}
+
+export function LinkedOrderRow({ order }: { order: LinkedOrder }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "baseline",
+        flexWrap: "wrap",
+        fontSize: 12,
+        color: "var(--fg-3)",
+        background: "var(--surface-2)",
+        padding: "6px 10px",
+        borderRadius: 8,
+      }}
+    >
+      <Pill tone={LINKED_ORDER_STATUS_TONES[order.status ?? ""] ?? "paper"} size="sm">
+        {LINKED_ORDER_STATUS_LABELS[order.status ?? ""] ?? order.status ?? "—"}
+      </Pill>
+      <span style={{ fontWeight: 700 }}>
+        {order.side === "buy" ? "매수" : order.side === "sell" ? "매도" : ""}{" "}
+        {order.symbol ?? "—"}
+      </span>
+      <span>
+        {order.filledQty ?? "—"} @ {order.avgFillPrice ?? "—"}
+      </span>
+      {order.orderTime ? <span>· {order.orderTime}</span> : null}
+      {order.orderNo ? <span>· order {order.orderNo.slice(0, 8)}</span> : null}
+      {order.exitReason || order.thesis ? (
+        <span style={{ width: "100%" }}>{order.exitReason ?? order.thesis}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/invest/src/desktop/stock-detail/OrderLedgerCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/OrderLedgerCard.tsx
@@ -1,0 +1,35 @@
+// ROB-559 — per-symbol live order history card for the stock detail page.
+// Renders the same LinkedOrderRow as the report-bundle decision log so a symbol's
+// orders show status + rationale + fill rollup consistently.
+
+import {
+  LinkedOrderRow,
+  linkedOrderKey,
+} from "../../components/orders/LinkedOrderRow";
+import { Card } from "../../ds";
+import type { LinkedOrder } from "../../types/investmentReports";
+
+export function OrderLedgerCard({
+  orders,
+}: {
+  orders: LinkedOrder[] | undefined;
+}) {
+  return (
+    <Card data-testid="stock-detail-order-ledger">
+      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>주문 기록</h2>
+      {!orders ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p>
+      ) : null}
+      {orders && orders.length === 0 ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>주문 기록이 없습니다.</p>
+      ) : null}
+      {orders && orders.length > 0 ? (
+        <div style={{ display: "grid", gap: 6 }}>
+          {orders.map((order) => (
+            <LinkedOrderRow key={linkedOrderKey(order)} order={order} />
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/invest/src/desktop/stock-detail/OrderLedgerCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/OrderLedgerCard.tsx
@@ -16,7 +16,10 @@ export function OrderLedgerCard({
 }) {
   return (
     <Card data-testid="stock-detail-order-ledger">
-      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>주문 기록</h2>
+      <h2 style={{ margin: "0 0 4px", fontSize: 16 }}>주문 기록</h2>
+      <p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--fg-3)" }}>
+        실거래 주문 이력 (상태 · 근거 · 체결)
+      </p>
       {!orders ? (
         <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p>
       ) : null}

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -6,10 +6,13 @@ import {
   fetchStockDetail,
   fetchStockDetailCandles,
   fetchStockDetailNews,
+  fetchStockDetailOrderLedger,
   fetchStockDetailOrders,
   fetchStockDetailResearchConsensus,
 } from "../../api/stockDetail";
 import { InvestorFlowCard } from "../../desktop/stock-detail/InvestorFlowCard";
+import { OrderLedgerCard } from "../../desktop/stock-detail/OrderLedgerCard";
+import type { LinkedOrder } from "../../types/investmentReports";
 import type {
   StockDetailCandlesResponse,
   StockDetailFxSensitivity,
@@ -382,6 +385,7 @@ export function StockDetailPage() {
   const [data, setData] = useState<StockDetailResponse | undefined>();
   const [candles, setCandles] = useState<StockDetailCandlesResponse | undefined>();
   const [orders, setOrders] = useState<StockDetailOrdersResponse | undefined>();
+  const [orderLedger, setOrderLedger] = useState<LinkedOrder[] | undefined>();
   const [news, setNews] = useState<StockDetailNewsResponse | undefined>();
   const [researchConsensus, setResearchConsensus] = useState<StockDetailResearchConsensusResponse | undefined>();
   const [researchErr, setResearchErr] = useState<string | undefined>();
@@ -392,6 +396,7 @@ export function StockDetailPage() {
     setData(undefined);
     setCandles(undefined);
     setOrders(undefined);
+    setOrderLedger(undefined);
     setNews(undefined);
     setResearchConsensus(undefined);
     setResearchErr(undefined);
@@ -411,6 +416,9 @@ export function StockDetailPage() {
     fetchStockDetailOrders({ market, symbol })
       .then((r) => !cancel && setOrders(r))
       .catch(() => undefined);
+    fetchStockDetailOrderLedger({ market, symbol })
+      .then((r) => !cancel && setOrderLedger(r))
+      .catch(() => !cancel && setOrderLedger([]));
     fetchStockDetailNews({ market, symbol, limit: 5 })
       .then((r) => !cancel && setNews(r))
       .catch(() => undefined);
@@ -460,6 +468,7 @@ export function StockDetailPage() {
                 <OrderbookCard data={data} />
                 <OrdersCard orders={orders} />
               </div>
+              <OrderLedgerCard orders={orderLedger} />
               <NewsCard news={news} />
               {data.market === "kr" && data.investorFlow ? (
                 <InvestorFlowCard data={data.investorFlow} />

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -416,7 +416,7 @@ export function StockDetailPage() {
     fetchStockDetailOrders({ market, symbol })
       .then((r) => !cancel && setOrders(r))
       .catch(() => undefined);
-    fetchStockDetailOrderLedger({ market, symbol })
+    fetchStockDetailOrderLedger({ market, symbol, days: 90 })
       .then((r) => !cancel && setOrderLedger(r))
       .catch(() => !cancel && setOrderLedger([]));
     fetchStockDetailNews({ market, symbol, limit: 5 })

--- a/tests/test_rob559_symbol_order_history.py
+++ b/tests/test_rob559_symbol_order_history.py
@@ -1,0 +1,250 @@
+"""ROB-559 — per-symbol live order history (list_live_orders_for_symbol + endpoint).
+
+NOTE: the test DB is shared/not-truncated between tests, so by-symbol queries must
+use UNIQUE per-test symbols (a real symbol like KRW-BTC would match rows other
+tests committed). Each test mints a random token symbol so only its own rows match.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 6, 14, tzinfo=UTC)
+
+
+def _tok() -> str:
+    return uuid.uuid4().hex[:8].upper()
+
+
+def _live(symbol: str, market: str, *, status="accepted", created_at=None, **kw):
+    from app.models.review import LiveOrderLedger
+
+    return LiveOrderLedger(
+        trade_date=NOW,
+        broker="upbit" if market == "crypto" else "kis",
+        account_scope="upbit_live" if market == "crypto" else "kis_live",
+        market=market,
+        symbol=symbol,
+        side=kw.get("side", "buy"),
+        order_kind="limit",
+        order_no=kw.get("order_no", f"live-{uuid.uuid4().hex[:10]}"),
+        status=status,
+        lifecycle_state=status,
+        filled_qty=kw.get("filled_qty"),
+        avg_fill_price=kw.get("avg_fill_price"),
+        report_item_uuid=None,
+        created_at=created_at if created_at is not None else NOW,
+    )
+
+
+def _kis(symbol: str, *, status="accepted", created_at=None, **kw):
+    from app.models.review import KISLiveOrderLedger
+
+    return KISLiveOrderLedger(
+        trade_date=NOW,
+        symbol=symbol,
+        instrument_type="equity_kr",
+        side=kw.get("side", "buy"),
+        order_type="limit",
+        order_no=kw.get("order_no", f"kis-{uuid.uuid4().hex[:10]}"),
+        account_mode="kis_live",
+        broker="kis",
+        status=status,
+        lifecycle_state=status,
+        created_at=created_at if created_at is not None else NOW,
+    )
+
+
+def _toss(symbol: str, market: str, *, status="accepted", created_at=None, **kw):
+    from app.models.review import TossLiveOrderLedger
+
+    return TossLiveOrderLedger(
+        trade_date=NOW,
+        broker="toss",
+        account_mode="toss_live",
+        operation_kind="place",
+        market=market,
+        symbol=symbol,
+        side=kw.get("side", "buy"),
+        order_type="limit",
+        client_order_id=kw.get("client_order_id", f"toss-{uuid.uuid4().hex[:10]}"),
+        broker_order_id=kw.get("broker_order_id"),
+        status=status,
+        created_at=created_at if created_at is not None else NOW,
+    )
+
+
+async def test_crypto_matches_full_pair_only(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t, u = _tok(), _tok()
+    pair = f"KRW-{t}"
+    btc = f"btc-{uuid.uuid4().hex[:8]}"
+    session.add(
+        _live(
+            pair,
+            "crypto",
+            order_no=btc,
+            status="filled",
+            filled_qty=Decimal("0.01"),
+            avg_fill_price=Decimal("96180000"),
+        )
+    )
+    session.add(_live(f"KRW-{u}", "crypto"))  # other crypto symbol, must not match
+    session.add(_live(t, "us"))  # base form on US, must not match crypto
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "crypto", pair)
+    assert [v.order_no for v in views] == [btc]
+    assert views[0].symbol == pair  # full pair preserved (not prefix-stripped)
+    assert views[0].market == "crypto"
+    assert views[0].status == "filled"
+    assert views[0].filled_qty == Decimal("0.01")
+
+
+async def test_crypto_lowercase_pair_is_upper_normalized(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    no = f"btc-{uuid.uuid4().hex[:8]}"
+    session.add(_live(f"KRW-{t}", "crypto", order_no=no))
+    await session.flush()
+    views = await list_live_orders_for_symbol(session, "crypto", f"krw-{t}".lower())
+    assert [v.order_no for v in views] == [no]
+
+
+async def test_kr_merges_kis_and_toss(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t, other = _tok(), _tok()
+    k = f"kis-{uuid.uuid4().hex[:8]}"
+    to = f"toss-{uuid.uuid4().hex[:8]}"
+    session.add(_kis(t, order_no=k))
+    session.add(_toss(t, "kr", broker_order_id=to))
+    session.add(_toss(other, "kr"))  # other symbol
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "kr", t)
+    order_nos = {v.order_no for v in views}
+    assert order_nos == {k, to}
+    kis_view = next(v for v in views if v.order_no == k)
+    assert kis_view.market == "kr" and kis_view.account_scope == "kis_live"
+    toss_view = next(v for v in views if v.order_no == to)
+    assert toss_view.market == "kr" and toss_view.account_scope == "toss_live"
+
+
+async def test_us_merges_live_and_toss(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    lv = f"live-{uuid.uuid4().hex[:8]}"
+    to = f"toss-{uuid.uuid4().hex[:8]}"
+    session.add(_live(t, "us", order_no=lv))
+    session.add(_toss(t, "us", broker_order_id=to))
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "us", t)
+    assert {v.order_no for v in views} == {lv, to}
+
+
+async def test_days_cutoff_excludes_old(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    pair = f"KRW-{t}"
+    recent = f"r-{uuid.uuid4().hex[:8]}"
+    old = f"o-{uuid.uuid4().hex[:8]}"
+    session.add(
+        _live(
+            pair,
+            "crypto",
+            order_no=recent,
+            created_at=datetime.now(UTC) - timedelta(days=3),
+        )
+    )
+    session.add(
+        _live(
+            pair,
+            "crypto",
+            order_no=old,
+            created_at=datetime.now(UTC) - timedelta(days=400),
+        )
+    )
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "crypto", pair, days=90)
+    assert [v.order_no for v in views] == [recent]
+
+
+async def test_limit_caps_and_orders_recent_first(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    pair = f"KRW-{t}"
+    base = datetime.now(UTC)
+    nos = []
+    for i in range(3):
+        no = f"n{i}-{uuid.uuid4().hex[:6]}"
+        nos.append(no)
+        session.add(
+            _live(pair, "crypto", order_no=no, created_at=base - timedelta(minutes=i))
+        )  # i=0 newest
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "crypto", pair, limit=2)
+    assert [v.order_no for v in views] == [nos[0], nos[1]]  # recent first, capped
+
+
+async def test_empty_for_unknown_symbol_or_market(session) -> None:
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    assert await list_live_orders_for_symbol(session, "crypto", f"KRW-{_tok()}") == []
+    assert await list_live_orders_for_symbol(session, "weird", f"KRW-{_tok()}") == []
+
+
+async def test_endpoint_returns_symbol_order_ledger(session) -> None:
+    from app.routers.invest_api import get_stock_detail_order_ledger
+
+    t = _tok()
+    pair = f"KRW-{t}"
+    no = f"btc-{uuid.uuid4().hex[:8]}"
+    session.add(
+        _live(
+            pair,
+            "crypto",
+            order_no=no,
+            status="filled",
+            filled_qty=Decimal("0.02"),
+            avg_fill_price=Decimal("90000000"),
+        )
+    )
+    await session.flush()
+
+    resp = await get_stock_detail_order_ledger(
+        market="crypto", symbol=pair, user=object(), db=session, days=90, limit=50
+    )
+    assert resp.count == 1
+    assert resp.items[0].order_no == no
+    assert resp.items[0].symbol == pair
+    assert resp.items[0].status == "filled"
+    assert resp.items[0].filled_qty == Decimal("0.02")

--- a/tests/test_rob559_symbol_order_history.py
+++ b/tests/test_rob559_symbol_order_history.py
@@ -248,3 +248,55 @@ async def test_endpoint_returns_symbol_order_ledger(session) -> None:
     assert resp.items[0].symbol == pair
     assert resp.items[0].status == "filled"
     assert resp.items[0].filled_qty == Decimal("0.02")
+
+
+async def test_us_canonicalizes_separator_symbol(session) -> None:
+    # ROB-559 review #1 — US tickers may arrive separator-form (BRK-B) but the
+    # ledger stores DB dot-format (BRK.B); the query must canonicalize via
+    # to_db_symbol so the card isn't silently empty.
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    stored = f"ZZ.{t}"  # ledger storage form (dot)
+    no = f"us-{uuid.uuid4().hex[:8]}"
+    session.add(_live(stored, "us", order_no=no))
+    await session.flush()
+
+    # URL carries the hyphen separator form
+    views = await list_live_orders_for_symbol(session, "us", f"ZZ-{t}")
+    assert [v.order_no for v in views] == [no]
+    # and the dot form still matches (idempotent)
+    again = await list_live_orders_for_symbol(session, "us", f"zz.{t}".upper())
+    assert [v.order_no for v in again] == [no]
+
+
+async def test_us_cross_ledger_ordering_with_per_ledger_overflow(session) -> None:
+    # ROB-559 review #7 — cross-ledger (live+toss) merge is globally created_at-desc
+    # even when one ledger holds more than `limit` rows (per-ledger cap can't drop
+    # a genuinely-recent row).
+    from app.services.investment_reports.linked_orders import (
+        list_live_orders_for_symbol,
+    )
+
+    t = _tok()
+    base = datetime.now(UTC)
+    nos: dict[int, str] = {}
+    for off in (0, 2, 4, 6):  # 4 live rows — exceeds limit=3 (overflow)
+        no = f"live{off}-{uuid.uuid4().hex[:6]}"
+        nos[off] = no
+        session.add(
+            _live(t, "us", order_no=no, created_at=base - timedelta(minutes=off))
+        )
+    for off in (1, 3):  # 2 toss rows, interleaved in time
+        no = f"toss{off}-{uuid.uuid4().hex[:6]}"
+        nos[off] = no
+        session.add(
+            _toss(t, "us", broker_order_id=no, created_at=base - timedelta(minutes=off))
+        )
+    await session.flush()
+
+    views = await list_live_orders_for_symbol(session, "us", t, limit=3)
+    # global created_at desc, truncated to 3 → offsets 0,1,2 (live, toss, live)
+    assert [v.order_no for v in views] == [nos[0], nos[1], nos[2]]


### PR DESCRIPTION
## 운영자 목표

`trader.robinco.dev/invest/stocks/{market}/{symbol}` (예: `/invest/stocks/crypto/KRW-BTC`) 상세 페이지에서 **해당 심볼로 낸 주문 기록(상태 + 근거 + 체결현황)** 을 보고 싶다. ROB-554가 리포트 결정로그에 `report_item_uuid` 기준으로 붙인 주문 카드를, 여기서는 **symbol 기준**으로 노출.

## 무엇을 했나 (migration 0, read-only, live-only)

ROB-554의 `LinkedOrderView` + `project_live/kis/toss` projection을 **symbol 키로** 재사용.

- **백엔드**: `list_live_orders_for_symbol(db, market, symbol, days=90, limit=50)` (`app/services/investment_reports/linked_orders.py`) — market별 ledger 라우팅(crypto→live / us→live+toss / kr→kis+toss), per-ledger `created_at desc` limit → merge → global `created_at desc` → cap. 신규 `GET /invest/api/stock-detail/{market}/{symbol}/order-ledger` → `StockDetailOrderLedgerResponse{count, items: LinkedOrderView[]}`.
- **프런트**: 상태 라벨/톤 맵 + 주문 행을 공용 `components/orders/LinkedOrderRow.tsx`로 추출(리포트 번들 re-point, **동작 보존**). `fetchStockDetailOrderLedger`(`normalizeLinkedOrder` 재사용) + `desktop/stock-detail/OrderLedgerCard.tsx`("주문 기록" 카드)를 StockDetailPage 호가/주문 그리드 아래에 렌더.

## ⚠️ 크립토 심볼 컨벤션

`review.live_order_ledger.symbol = 'KRW-BTC'`(full Upbit pair, `resolve_market_type`가 prefix 유지 + upper). URL이 `KRW-BTC`를 그대로 들고오므로 **order ledger와 직매칭**(prefix strip 금지). execution_ledger는 `'BTC'`/`raw_symbol='KRW-BTC'`로 어긋남 → order-ledger 소스를 쓰는 이유. **US**는 separator-form(`BRK-B`)이 올 수 있어 `to_db_symbol`로 `BRK.B`(ledger 저장형) 정규화(형제 stock-detail 엔드포인트와 일치). KR은 6자리 코드.

## 안전 경계

- **전부 read-only** — 브로커/주문/감시 mutation 도달 없음. **migration 0**.
- **live 전용** — 3 live order ledger만(mock/paper/demo 미기록). 인덱스 기반 쿼리(`ix_*_symbol`), days window + limit cap.
- import 레이어링 준수(services↛mcp). ROB-285 binance 가드 미트립.

## 테스트

- 백엔드 `tests/test_rob559_symbol_order_history.py`(10): crypto full-pair 직매칭/소문자 정규화, KR(kis+toss)·US(live+toss) merge, days cutoff, limit cap+recency, empty, 엔드포인트, **US `BRK-B`→`BRK.B` 정규화**, **cross-ledger 정렬+per-ledger overflow**. (⚠️ shared-DB 무truncate라 by-symbol 테스트는 UNIQUE 토큰 심볼 사용.)
- 프런트 `OrderLedgerCard.test.tsx`(states + 미체결 행 숨김 + 미세체결 포맷) + `stockDetailOrderLedger.api.test.ts`(snake→camel 매핑) + 기존 report-bundle 테스트 green(공용 추출 동작 보존).
- 로컬: 백엔드 ruff/format/ty clean + rob559/rob554/router green; 프런트 typecheck clean. (사전존재 calendar/coverage 5건 stale 실패는 본 PR 무관 — clean origin/main에서도 동일.)

## 적대적 리뷰 (11-agent)

**SHIP, blocker/major 0.** 7 minor/nit 전부 반영(US 정규화·sci-notation 포맷·미체결 행 숨김·카드 부제·days 명시·cross-ledger 테스트). **defer #3**: Toss write-path 심볼 소문자 정규화(`TOSS_LIVE_ORDER_MUTATIONS_ENABLED` 기본 off라 행 0, 별도 follow-up). crypto full-pair 매칭은 리뷰에서 정확함으로 확정.

Spec/plan: `docs/superpowers/plans/2026-06-14-rob-559-symbol-order-history.md`, Linear ROB-559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Order History" card on the stock detail page displaying your recent orders for a specific stock, including order status (filled/unfilled), quantity executed, and average execution price with up to 90 days of history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->