### PR TITLE
fix(ROB-562): unify toss order_routable across briefing/holdings/batch + degraded surface

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -182,8 +182,9 @@ def register_analysis_tools(
             "'position' field: an array (one entry per holding account, since a symbol "
             "may be held across e.g. toss+samsung) of {account, account_mode, qty, "
             "avg_buy_price, pnl_pct, order_routable}, or null when not held. "
-            "order_routable mirrors get_holdings exactly (toss/manual -> false); "
-            "account_mode is a provenance label, NOT a routing selector."
+            "order_routable mirrors get_holdings: manual non-toss (samsung/수기) -> "
+            "false, toss_api -> TOSS_LIVE_ORDER_MUTATIONS_ENABLED, kis/upbit -> true "
+            "(ROB-562); account_mode is a provenance label, NOT a routing selector."
         ),
     )
     async def analyze_stock_batch(

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -544,7 +544,9 @@ async def _build_batch_position_index(
             "qty": position.get("quantity"),
             "avg_buy_price": position.get("avg_buy_price"),
             "pnl_pct": position.get("profit_rate"),
-            "order_routable": _account_order_routable(source=source),
+            "order_routable": _account_order_routable(
+                source=source, broker=position.get("broker")
+            ),
             # Internal-only fields for symbol matching — stripped before output.
             "_symbol": symbol,
             "_instrument_type": instrument_type,

--- a/app/mcp_server/tooling/portfolio_helpers.py
+++ b/app/mcp_server/tooling/portfolio_helpers.py
@@ -51,7 +51,9 @@ def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
         )
 
         source = position.get("source")
-        output["order_routable"] = _account_order_routable(source=source)
+        output["order_routable"] = _account_order_routable(
+            source=source, broker=position.get("broker")
+        )
         output["account_mode"] = _provenance_account_mode(
             broker=position.get("broker"),
             source=source,

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -159,7 +159,7 @@ def _provenance_account_mode(
     return routing_mode
 
 
-def _account_order_routable(*, source: str | None) -> bool:
+def _account_order_routable(*, source: str | None, broker: str | None = None) -> bool:
     """Whether an account group's holdings are routable by an automated order tool.
 
     Manual holdings (toss/samsung/수동 입력, ``source="manual"``) are always
@@ -167,15 +167,18 @@ def _account_order_routable(*, source: str | None) -> bool:
     order tools existed; ROB-549 gates them on
     ``TOSS_LIVE_ORDER_MUTATIONS_ENABLED`` so the sellability signal matches the
     registered toss_live order tools once mutations are armed. KIS / Upbit /
-    paper sources sell via their own channels. This is the authoritative
-    sellability signal; ``account_mode`` stays a provenance label (ROB-357) and
-    is intentionally left unchanged.
+    paper sources sell via their own channels.
+
+    ROB-562: If Toss API is enabled and mutations are enabled, Toss manual
+    fallback holdings are ALSO routable to allow recovery from API outages.
     """
-    if source == "manual":
-        return False
     if source == "toss_api":
         return toss_live_mutations_enabled()
-    return True
+    if source == "manual" and broker == "toss":
+        return bool(getattr(settings, "toss_api_enabled", False)) and bool(
+            toss_live_mutations_enabled()
+        )
+    return source not in {"manual"}
 
 
 def _build_crypto_strategy_signal(
@@ -553,7 +556,11 @@ async def _collect_toss_api_positions(
     try:
         snapshot = await fetch_toss_portfolio_snapshot()
     except Exception as exc:
-        return [], [{"source": "toss_api", "error": str(exc)}], False
+        return (
+            [],
+            [{"source": "toss_api", "error": str(exc), "degraded": True}],
+            False,
+        )
 
     positions = [
         _toss_api_position_to_mcp(position)
@@ -1147,7 +1154,8 @@ async def _get_holdings_impl(
                 # ROB-420 — authoritative sellability: manual (toss/samsung)
                 # holdings are reference-only and not routable by order tools.
                 "order_routable": _account_order_routable(
-                    source=position.get("source")
+                    source=position.get("source"),
+                    broker=position.get("broker"),
                 ),
                 "positions": [],
             },
@@ -1346,8 +1354,9 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "filters out low-value positions when include_current_price=True. "
             "When minimum_value is None (default), per-currency thresholds are "
             "applied: KRW=5000, USD=10. Explicit number uses uniform threshold. "
-            "Response includes filtered_count, filter_reason, and per-symbol "
-            "price lookup errors. "
+            "Response includes filtered_count, filter_reason, per-symbol "
+            "price lookup errors, and broker-level API errors (potentially "
+            "marked degraded=true during outages). "
             "Use account_mode={'db_simulated','kis_mock','kis_live'} "
             "(preferred); account_type aliases are deprecated and emit warnings."
         ),

--- a/tests/test_mcp_holdings_rob562.py
+++ b/tests/test_mcp_holdings_rob562.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
-from decimal import Decimal
-import pytest
-from unittest.mock import AsyncMock
 
-from app.mcp_server.tooling import portfolio_holdings
+import pytest
+
 from app.core.config import settings
+from app.mcp_server.tooling import portfolio_holdings
 
 
 def _toss_api_position(symbol: str = "BRK.B") -> dict:
@@ -78,15 +77,27 @@ def test_position_output_manual_toss_routable_matches_account_group(monkeypatch)
     }
 
     out = position_to_output(
-        {**base, "account": "toss", "broker": "toss", "source": "manual",
-         "symbol": "035720", "name": "카카오"}
+        {
+            **base,
+            "account": "toss",
+            "broker": "toss",
+            "source": "manual",
+            "symbol": "035720",
+            "name": "카카오",
+        }
     )
     assert out["order_routable"] is True
 
     # samsung manual stays reference-only at per-position level too
     out_samsung = position_to_output(
-        {**base, "account": "samsung", "broker": "samsung", "source": "manual",
-         "symbol": "005930", "name": "삼성전자"}
+        {
+            **base,
+            "account": "samsung",
+            "broker": "samsung",
+            "source": "manual",
+            "symbol": "005930",
+            "name": "삼성전자",
+        }
     )
     assert out_samsung["order_routable"] is False
 

--- a/tests/test_mcp_holdings_rob562.py
+++ b/tests/test_mcp_holdings_rob562.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 from decimal import Decimal
 import pytest
@@ -6,6 +5,7 @@ from unittest.mock import AsyncMock
 
 from app.mcp_server.tooling import portfolio_holdings
 from app.core.config import settings
+
 
 def _toss_api_position(symbol: str = "BRK.B") -> dict:
     return {
@@ -21,6 +21,7 @@ def _toss_api_position(symbol: str = "BRK.B") -> dict:
         "avg_buy_price": 100.0,
     }
 
+
 def _manual_toss_position(symbol: str = "BRK.B") -> dict:
     return {
         "account": "toss:기본 계좌",
@@ -35,23 +36,66 @@ def _manual_toss_position(symbol: str = "BRK.B") -> dict:
         "avg_buy_price": 100.0,
     }
 
+
 @pytest.mark.asyncio
 async def test_account_order_routable_toss_manual_with_mutations_enabled(monkeypatch):
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
-    
+
     # ROB-562: Manual Toss position should be routable if API is enabled and mutations are enabled
     # Currently this fails because it only looks at source="manual"
-    assert portfolio_holdings._account_order_routable(source="manual", broker="toss") is True
-    
+    assert (
+        portfolio_holdings._account_order_routable(source="manual", broker="toss")
+        is True
+    )
+
     # Samsung manual should still be False
-    assert portfolio_holdings._account_order_routable(source="manual", broker="samsung") is False
+    assert (
+        portfolio_holdings._account_order_routable(source="manual", broker="samsung")
+        is False
+    )
+
+
+def test_position_output_manual_toss_routable_matches_account_group(monkeypatch):
+    """ROB-562: per-position order_routable (positions[]/analyze_stock_batch path)
+    must pass broker so a manual-toss fallback row is routable like the account
+    group — otherwise the group says True and the position says False."""
+    from app.mcp_server.tooling.portfolio_helpers import position_to_output
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
+
+    base = {
+        "account_name": "기본 계좌",
+        "instrument_type": "equity_kr",
+        "market": "kr",
+        "quantity": 6,
+        "avg_buy_price": 50000,
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+    out = position_to_output(
+        {**base, "account": "toss", "broker": "toss", "source": "manual",
+         "symbol": "035720", "name": "카카오"}
+    )
+    assert out["order_routable"] is True
+
+    # samsung manual stays reference-only at per-position level too
+    out_samsung = position_to_output(
+        {**base, "account": "samsung", "broker": "samsung", "source": "manual",
+         "symbol": "005930", "name": "삼성전자"}
+    )
+    assert out_samsung["order_routable"] is False
+
 
 @pytest.mark.asyncio
 async def test_toss_group_routable_consistent_on_api_failure(monkeypatch):
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
-    
+
     # Simulate API failure: empty positions, one error, success=False
     async def fake_collect_toss_api_positions(*args, **kwargs):
         return [], [{"error": "timeout", "source": "toss_api", "degraded": True}], False
@@ -60,37 +104,49 @@ async def test_toss_group_routable_consistent_on_api_failure(monkeypatch):
     async def fake_collect_manual_positions(*args, **kwargs):
         return [_manual_toss_position("AAPL")], []
 
-    monkeypatch.setattr(portfolio_holdings, "_collect_toss_api_positions", fake_collect_toss_api_positions)
-    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions)
-    
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_toss_api_positions",
+        fake_collect_toss_api_positions,
+    )
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions
+    )
+
     # Mocking other collectors to return empty
-    async def _empty_upbit(*args, **kwargs): return [], []
+    async def _empty_upbit(*args, **kwargs):
+        return [], []
+
     monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty_upbit)
-    async def _empty_kis(*args, **kwargs): return [], []
+
+    async def _empty_kis(*args, **kwargs):
+        return [], []
+
     monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty_kis)
 
     result = await portfolio_holdings._get_holdings_impl(
         include_current_price=False,
         routing_account_mode="kis_live",
     )
-    
+
     toss_accounts = [a for a in result["accounts"] if a["broker"] == "toss"]
     assert len(toss_accounts) > 0
     toss_acc = toss_accounts[0]
-    
+
     # ROB-562: Should be True even if it fell back to manual due to API failure
     assert toss_acc["order_routable"] is True
-    
+
     # Check for degraded flag in errors
     toss_api_errors = [e for e in result["errors"] if e.get("source") == "toss_api"]
     assert len(toss_api_errors) > 0
     assert toss_api_errors[0].get("degraded") is True
 
+
 @pytest.mark.asyncio
 async def test_samsung_manual_stays_non_routable(monkeypatch):
     monkeypatch.setattr(settings, "toss_api_enabled", True)
     monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
-    
+
     async def fake_collect_manual_positions(*args, **kwargs):
         return [
             {
@@ -107,18 +163,29 @@ async def test_samsung_manual_stays_non_routable(monkeypatch):
             }
         ], []
 
-    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions)
-    async def _empty_toss(*args, **kwargs): return [], [], True
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions
+    )
+
+    async def _empty_toss(*args, **kwargs):
+        return [], [], True
+
     monkeypatch.setattr(portfolio_holdings, "_collect_toss_api_positions", _empty_toss)
-    async def _empty_upbit(*args, **kwargs): return [], []
+
+    async def _empty_upbit(*args, **kwargs):
+        return [], []
+
     monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty_upbit)
-    async def _empty_kis(*args, **kwargs): return [], []
+
+    async def _empty_kis(*args, **kwargs):
+        return [], []
+
     monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty_kis)
 
     result = await portfolio_holdings._get_holdings_impl(
         include_current_price=False,
         routing_account_mode="kis_live",
     )
-    
+
     samsung_acc = next(a for a in result["accounts"] if a["broker"] == "samsung")
     assert samsung_acc["order_routable"] is False

--- a/tests/test_mcp_holdings_rob562.py
+++ b/tests/test_mcp_holdings_rob562.py
@@ -1,0 +1,124 @@
+
+from __future__ import annotations
+from decimal import Decimal
+import pytest
+from unittest.mock import AsyncMock
+
+from app.mcp_server.tooling import portfolio_holdings
+from app.core.config import settings
+
+def _toss_api_position(symbol: str = "BRK.B") -> dict:
+    return {
+        "account": "toss",
+        "account_name": "Toss",
+        "broker": "toss",
+        "source": "toss_api",
+        "instrument_type": "equity_us",
+        "market": "us",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": 100.0,
+    }
+
+def _manual_toss_position(symbol: str = "BRK.B") -> dict:
+    return {
+        "account": "toss:기본 계좌",
+        "account_name": "기본 계좌",
+        "broker": "toss",
+        "source": "manual",
+        "instrument_type": "equity_us",
+        "market": "us",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": 100.0,
+    }
+
+@pytest.mark.asyncio
+async def test_account_order_routable_toss_manual_with_mutations_enabled(monkeypatch):
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
+    
+    # ROB-562: Manual Toss position should be routable if API is enabled and mutations are enabled
+    # Currently this fails because it only looks at source="manual"
+    assert portfolio_holdings._account_order_routable(source="manual", broker="toss") is True
+    
+    # Samsung manual should still be False
+    assert portfolio_holdings._account_order_routable(source="manual", broker="samsung") is False
+
+@pytest.mark.asyncio
+async def test_toss_group_routable_consistent_on_api_failure(monkeypatch):
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
+    
+    # Simulate API failure: empty positions, one error, success=False
+    async def fake_collect_toss_api_positions(*args, **kwargs):
+        return [], [{"error": "timeout", "source": "toss_api", "degraded": True}], False
+
+    # Manual fallback has one position
+    async def fake_collect_manual_positions(*args, **kwargs):
+        return [_manual_toss_position("AAPL")], []
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_toss_api_positions", fake_collect_toss_api_positions)
+    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions)
+    
+    # Mocking other collectors to return empty
+    async def _empty_upbit(*args, **kwargs): return [], []
+    monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty_upbit)
+    async def _empty_kis(*args, **kwargs): return [], []
+    monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty_kis)
+
+    result = await portfolio_holdings._get_holdings_impl(
+        include_current_price=False,
+        routing_account_mode="kis_live",
+    )
+    
+    toss_accounts = [a for a in result["accounts"] if a["broker"] == "toss"]
+    assert len(toss_accounts) > 0
+    toss_acc = toss_accounts[0]
+    
+    # ROB-562: Should be True even if it fell back to manual due to API failure
+    assert toss_acc["order_routable"] is True
+    
+    # Check for degraded flag in errors
+    toss_api_errors = [e for e in result["errors"] if e.get("source") == "toss_api"]
+    assert len(toss_api_errors) > 0
+    assert toss_api_errors[0].get("degraded") is True
+
+@pytest.mark.asyncio
+async def test_samsung_manual_stays_non_routable(monkeypatch):
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(settings, "toss_live_order_mutations_enabled", True)
+    
+    async def fake_collect_manual_positions(*args, **kwargs):
+        return [
+            {
+                "account": "samsung:123",
+                "account_name": "Samsung",
+                "broker": "samsung",
+                "source": "manual",
+                "instrument_type": "equity_kr",
+                "market": "kr",
+                "symbol": "005930",
+                "name": "Samsung",
+                "quantity": 10,
+                "avg_buy_price": 70000,
+            }
+        ], []
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", fake_collect_manual_positions)
+    async def _empty_toss(*args, **kwargs): return [], [], True
+    monkeypatch.setattr(portfolio_holdings, "_collect_toss_api_positions", _empty_toss)
+    async def _empty_upbit(*args, **kwargs): return [], []
+    monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty_upbit)
+    async def _empty_kis(*args, **kwargs): return [], []
+    monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty_kis)
+
+    result = await portfolio_holdings._get_holdings_impl(
+        include_current_price=False,
+        routing_account_mode="kis_live",
+    )
+    
+    samsung_acc = next(a for a in result["accounts"] if a["broker"] == "samsung")
+    assert samsung_acc["order_routable"] is False

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -3751,7 +3751,11 @@ async def test_get_holdings_toss_api_failure_keeps_manual_fallback(monkeypatch):
 
     assert result["accounts"][0]["order_routable"] is False
     assert result["accounts"][0]["positions"][0]["source"] == "manual"
-    assert {"source": "toss_api", "error": "toss unavailable"} in result["errors"]
+    assert {
+        "source": "toss_api",
+        "error": "toss unavailable",
+        "degraded": True,
+    } in result["errors"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
첫 실주문 중 토스 `order_routable`이 도구마다 상충 발견: get_operating_briefing=false, analyze_stock_batch=true, 실주문=성공(true가 진실).

**근본 원인**: `_collect_portfolio_positions`에서 토스가 manual(`source="manual"`→false) + toss_api(→mutations flag) 두 collector에서 나오고, dedup은 **toss_api fetch 성공 시에만** manual을 제거. 토스 API fetch 실패/stale 시 manual 폴백이 살아남아 false로 표기 → silent degradation + 비결정성.

## Changes
- `_account_order_routable(*, source, broker=None)`: broker=toss + `toss_api_enabled` 이면 manual 폴백도 toss_api 시맨틱(mutations flag)으로 평가 → API 실패에도 안 뒤집힘. samsung 등 비-toss manual은 false 유지.
- **3-way 통일**: account-group(get_holdings/briefing), get_holdings positions[](portfolio_helpers), analyze_stock_batch index — 전부 broker 전달.
- `_collect_toss_api_positions` 실패 시 error에 `degraded:true` surface (조용한 false 위장 방지).
- analyze_stock_batch description "toss/manual -> false" 정정.

## Test
TDD. account-group + per-position + samsung + API-failure-시뮬 일관성 + degraded 표기. 53 통과(562/provenance/briefing 회귀). ruff + ty clean. migration 0.

ROB-549/550 deferred minor(toss group mixed-source)도 동근원 해소. Closes ROB-562

🤖 Generated with [Claude Code](https://claude.com/claude-code)