### PR TITLE
feat(ROB-566): unify watch alerts on Python TradeNotifier (drop Prefect hop, flag-gated)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -436,8 +436,9 @@ class Settings(BaseSettings):
 
     # ROB-566: watch 트리거 알림 전송 수단. "hermes_webhook"(default, 현행 Prefect
     # 수신기로 HTTP POST) | "python_direct"(in-process TradeNotifier 렌더, ROB-558 체결과 동형).
-    WATCH_NOTIFY_TRANSPORT: Literal["hermes_webhook", "python_direct"] = "hermes_webhook"
-
+    WATCH_NOTIFY_TRANSPORT: Literal["hermes_webhook", "python_direct"] = (
+        "hermes_webhook"
+    )
 
     # ROB-337 Slice 2 — watch validity review job. Default off; the task and
     # CLI are scheduleless / dry-run-default even when this is set.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -434,6 +434,11 @@ class Settings(BaseSettings):
     HERMES_TOKEN: str = ""
     HERMES_ENABLED: bool = False
 
+    # ROB-566: watch 트리거 알림 전송 수단. "hermes_webhook"(default, 현행 Prefect
+    # 수신기로 HTTP POST) | "python_direct"(in-process TradeNotifier 렌더, ROB-558 체결과 동형).
+    WATCH_NOTIFY_TRANSPORT: Literal["hermes_webhook", "python_direct"] = "hermes_webhook"
+
+
     # ROB-337 Slice 2 — watch validity review job. Default off; the task and
     # CLI are scheduleless / dry-run-default even when this is set.
     WATCH_VALIDITY_REVIEW_ENABLED: bool = False

--- a/app/monitoring/trade_notifier/formatters_discord.py
+++ b/app/monitoring/trade_notifier/formatters_discord.py
@@ -5,6 +5,11 @@ Each function is pure (no I/O, no side effects) and returns a DiscordEmbed dict.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.hermes_client import ReviewTriggerPayload
+
 from app.core.timezone import format_datetime
 from app.services.fill_notification import (
     FillEnrichment,
@@ -14,6 +19,7 @@ from app.services.fill_notification import (
 )
 
 from .types import COLORS, DECISION_EMOJI, DECISION_TEXT, DiscordEmbed, DiscordField
+
 
 
 def _price_fmt(price: float, is_usd: bool, currency: str) -> str:
@@ -585,3 +591,86 @@ def format_fill_notification(
     if detail_url:
         embed["url"] = detail_url
     return embed
+
+
+def format_investment_watch_trigger(
+    payload: ReviewTriggerPayload, *, display_name: str, base_url: str
+) -> DiscordEmbed:
+    """ROB-566: watch 트리거 Discord 임베드 (Prefect 렌더 대체)."""
+    outcome_kr = {
+        "notified": "알림",
+        "review_required": "검토 필요",
+        "preview_attached": "프리뷰 첨부",
+        "executed": "모의 실행",
+    }.get(payload.outcome, payload.outcome)
+
+    fields: list[DiscordField] = [
+        {
+            "name": "조건",
+            "value": f"{payload.metric} {payload.operator} {payload.threshold}",
+            "inline": True,
+        },
+        {
+            "name": "현재값",
+            "value": (
+                str(payload.current_value)
+                if payload.current_value is not None
+                else "-"
+            ),
+            "inline": True,
+        },
+        {"name": "시장", "value": payload.market, "inline": True},
+        {"name": "구분", "value": outcome_kr, "inline": True},
+    ]
+    pg = payload.price_guidance
+    if pg is not None:
+        parts: list[str] = []
+        if pg.entry_review_below_price is not None:
+            parts.append(f"진입검토 ≤ {pg.entry_review_below_price}")
+        if pg.suggested_limit_price_range is not None:
+            parts.append(
+                f"지정가 {pg.suggested_limit_price_range.low}~{pg.suggested_limit_price_range.high}"
+            )
+        if pg.max_chase_price is not None:
+            parts.append(f"최대추격 {pg.max_chase_price}")
+        if (
+            pg.invalidation is not None
+            and getattr(pg.invalidation, "price", None) is not None
+        ):
+            parts.append(f"무효화 {pg.invalidation.price}")
+        if parts:
+            fields.append(
+                {"name": "가격 가이드", "value": "\n".join(parts), "inline": False}
+            )
+    if payload.trigger_checklist:
+        fields.append(
+            {
+                "name": "체크리스트",
+                "value": "\n".join(f"• {c}" for c in payload.trigger_checklist),
+                "inline": False,
+            }
+        )
+    if payload.invest_links is not None:
+        fields.append(
+            {
+                "name": "링크",
+                "value": f"[리포트]({base_url}{payload.invest_links.report_path}) · [종목]({base_url}{payload.invest_links.stock_path})",
+                "inline": False,
+            }
+        )
+
+    desc = ""
+    if payload.operator_action_guidance is not None:
+        desc = payload.operator_action_guidance.headline
+    desc = (desc + f"\n🕒 {format_datetime()}").strip()
+
+    embed: DiscordEmbed = {
+        "title": f"🔔 워치 트리거 · {display_name} ({payload.symbol})",
+        "description": desc,
+        "color": COLORS["watch"],
+        "fields": fields,
+    }
+    if payload.invest_links is not None:
+        embed["url"] = f"{base_url}{payload.invest_links.stock_path}"
+    return embed
+

--- a/app/monitoring/trade_notifier/formatters_discord.py
+++ b/app/monitoring/trade_notifier/formatters_discord.py
@@ -21,7 +21,6 @@ from app.services.fill_notification import (
 from .types import COLORS, DECISION_EMOJI, DECISION_TEXT, DiscordEmbed, DiscordField
 
 
-
 def _price_fmt(price: float, is_usd: bool, currency: str) -> str:
     return f"${price:,.2f}" if is_usd else f"{price:,.0f}{currency}"
 
@@ -613,9 +612,7 @@ def format_investment_watch_trigger(
         {
             "name": "현재값",
             "value": (
-                str(payload.current_value)
-                if payload.current_value is not None
-                else "-"
+                str(payload.current_value) if payload.current_value is not None else "-"
             ),
             "inline": True,
         },
@@ -673,4 +670,3 @@ def format_investment_watch_trigger(
     if payload.invest_links is not None:
         embed["url"] = f"{base_url}{payload.invest_links.stock_path}"
     return embed
-

--- a/app/monitoring/trade_notifier/formatters_telegram.py
+++ b/app/monitoring/trade_notifier/formatters_telegram.py
@@ -6,6 +6,10 @@ Each function is pure (no I/O) and returns a formatted string.
 from __future__ import annotations
 
 import html
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.hermes_client import ReviewTriggerPayload
 
 from app.core.timezone import format_datetime
 from app.services.fill_notification import (
@@ -16,6 +20,7 @@ from app.services.fill_notification import (
 )
 
 from .types import DECISION_EMOJI, DECISION_TEXT
+
 
 
 def format_buy_notification_telegram(
@@ -391,3 +396,71 @@ def format_fill_notification_telegram(
         lines.append(f"[종목 상세 보기]({detail_url})")
 
     return "\n".join(lines)
+
+
+def format_investment_watch_trigger_telegram(
+    payload: ReviewTriggerPayload, *, display_name: str, base_url: str
+) -> str:
+    """Format watch trigger notification as Telegram markdown message."""
+    outcome_kr = {
+        "notified": "알림",
+        "review_required": "검토 필요",
+        "preview_attached": "프리뷰 첨부",
+        "executed": "모의 실행",
+    }.get(payload.outcome, payload.outcome)
+
+    lines = [
+        f"*🔔 워치 트리거 · {display_name} \\({payload.symbol}\\)*",
+        "",
+        f"*조건:* {payload.metric} {payload.operator} {payload.threshold}",
+        f"*현재값:* {payload.current_value if payload.current_value is not None else '-'}",
+        f"*시장:* {payload.market}",
+        f"*구분:* {outcome_kr}",
+    ]
+
+    pg = payload.price_guidance
+    if pg is not None:
+        parts = []
+        if pg.entry_review_below_price is not None:
+            parts.append(f"진입검토 ≤ {pg.entry_review_below_price}")
+        if pg.suggested_limit_price_range is not None:
+            parts.append(
+                f"지정가 {pg.suggested_limit_price_range.low}~{pg.suggested_limit_price_range.high}"
+            )
+        if pg.max_chase_price is not None:
+            parts.append(f"최대추격 {pg.max_chase_price}")
+        if (
+            pg.invalidation is not None
+            and getattr(pg.invalidation, "price", None) is not None
+        ):
+            parts.append(f"무효화 {pg.invalidation.price}")
+        if parts:
+            lines.append("")
+            lines.append("*가격 가이드:*")
+            for part in parts:
+                lines.append(f"• {part}")
+
+    if payload.trigger_checklist:
+        lines.append("")
+        lines.append("*체크리스트:*")
+        for c in payload.trigger_checklist:
+            lines.append(f"• {c}")
+
+    desc = ""
+    if payload.operator_action_guidance is not None:
+        desc = payload.operator_action_guidance.headline
+    if desc:
+        lines.append("")
+        lines.append(desc)
+
+    lines.append("")
+    lines.append(f"🕒 {format_datetime()}")
+
+    if payload.invest_links is not None:
+        stock_url = f"{base_url}{payload.invest_links.stock_path}"
+        report_url = f"{base_url}{payload.invest_links.report_path}"
+        lines.append("")
+        lines.append(f"[종목 상세]({stock_url}) · [분석 리포트]({report_url})")
+
+    return "\n".join(lines)
+

--- a/app/monitoring/trade_notifier/formatters_telegram.py
+++ b/app/monitoring/trade_notifier/formatters_telegram.py
@@ -22,7 +22,6 @@ from app.services.fill_notification import (
 from .types import DECISION_EMOJI, DECISION_TEXT
 
 
-
 def format_buy_notification_telegram(
     symbol: str,
     korean_name: str,
@@ -463,4 +462,3 @@ def format_investment_watch_trigger_telegram(
         lines.append(f"[종목 상세]({stock_url}) · [분석 리포트]({report_url})")
 
     return "\n".join(lines)
-

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -22,7 +22,6 @@ from .transports import (
 )
 from .types import DiscordEmbed
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -303,7 +302,6 @@ class TradeNotifier:
             payload, display_name=display_name, base_url=base_url
         )
         return await self._dispatch(embed, telegram_msg, payload.market)
-
 
     async def notify_sell_order(
         self,

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.hermes_client import ReviewTriggerPayload
 
 import httpx
 
@@ -17,6 +21,7 @@ from .transports import (
     send_telegram,
 )
 from .types import DiscordEmbed
+
 
 logger = logging.getLogger(__name__)
 
@@ -280,6 +285,25 @@ class TradeNotifier:
             enrichment=enrichment,
         )
         return await self._dispatch(embed, telegram_msg, order.market_type)
+
+    async def notify_investment_watch(
+        self,
+        payload: ReviewTriggerPayload,
+    ) -> bool:
+        """watch 트리거 알림 (ROB-566). Discord 우선, Telegram fallback."""
+        from app.core.config import settings as _settings
+        from app.services.fill_notification import resolve_symbol_display_name
+
+        display_name = resolve_symbol_display_name(payload.market, payload.symbol)
+        base_url = _settings.public_base_url.rstrip("/")
+        embed = fmt_discord.format_investment_watch_trigger(
+            payload, display_name=display_name, base_url=base_url
+        )
+        telegram_msg = fmt_telegram.format_investment_watch_trigger_telegram(
+            payload, display_name=display_name, base_url=base_url
+        )
+        return await self._dispatch(embed, telegram_msg, payload.market)
+
 
     async def notify_sell_order(
         self,

--- a/app/monitoring/trade_notifier/types.py
+++ b/app/monitoring/trade_notifier/types.py
@@ -29,6 +29,7 @@ COLORS: dict[str, int] = {
     "summary": 0x00FFFF,
     "failure": 0xFF6600,
     "hold": 0xFFFF00,
+    "watch": 0xF1C40F,
     "default": 0x0000FF,
 }
 

--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -449,13 +449,19 @@ def _get_kr_symbol_reverse() -> dict[str, str]:
     return _KR_SYMBOLS_REVERSE
 
 
-def resolve_fill_display_name(order: FillOrder) -> str:
+def resolve_symbol_display_name(market_type: str | None, symbol: str) -> str:
     """KR: KR_SYMBOLS 역매핑(미존재 시 코드). US: 심볼. Crypto: KRW-BTC->BTC."""
-    if order.market_type == "kr":
-        return _get_kr_symbol_reverse().get(order.symbol, order.symbol)
-    if order.market_type == "crypto" and "-" in order.symbol:
-        return order.symbol.split("-")[-1]
-    return order.symbol
+    if market_type == "kr":
+        return _get_kr_symbol_reverse().get(symbol, symbol)
+    if market_type == "crypto" and "-" in symbol:
+        return symbol.split("-")[-1]
+    return symbol
+
+
+def resolve_fill_display_name(order: FillOrder) -> str:
+    """Delegate to resolve_symbol_display_name using order properties."""
+    return resolve_symbol_display_name(order.market_type, order.symbol)
+
 
 
 _MIN_NOTIFY_AMOUNT: dict[str, float] = {"KRW": 50_000.0, "USD": 50.0}

--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -463,7 +463,6 @@ def resolve_fill_display_name(order: FillOrder) -> str:
     return resolve_symbol_display_name(order.market_type, order.symbol)
 
 
-
 _MIN_NOTIFY_AMOUNT: dict[str, float] = {"KRW": 50_000.0, "USD": 50.0}
 
 

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -330,6 +330,9 @@ class HermesNotificationClient:
     async def send_review_trigger(
         self, payload: ReviewTriggerPayload
     ) -> HermesDeliveryResult:
+        if settings.WATCH_NOTIFY_TRANSPORT == "python_direct":
+            return await self._render_in_process(payload)
+
         if not self._enabled:
             logger.debug(
                 "Hermes disabled — skipping review-trigger delivery: "
@@ -376,5 +379,27 @@ class HermesNotificationClient:
             reason=f"http_{response.status_code}",
         )
 
+    async def _render_in_process(
+        self, payload: ReviewTriggerPayload
+    ) -> HermesDeliveryResult:
+        """ROB-566: Prefect 수신기 대신 TradeNotifier로 직접 렌더. 결과를 3-way로 매핑."""
+        from app.monitoring.trade_notifier import get_trade_notifier
+
+        notifier = get_trade_notifier()
+        try:
+            sent = await notifier.notify_investment_watch(payload)
+        except Exception as exc:
+            logger.warning(
+                "watch in-process render raised: event_uuid=%s error=%s",
+                payload.event_uuid,
+                exc,
+            )
+            return HermesDeliveryResult(status="failed", reason="render_exception")
+        if sent:
+            return HermesDeliveryResult(status="success")
+        # webhook 미설정 등으로 dispatch가 False면 skipped(=alert active 유지, 재시도)
+        return HermesDeliveryResult(status="skipped", reason="discord_not_configured")
+
     async def close(self) -> None:
         await self._client.aclose()
+

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -402,4 +402,3 @@ class HermesNotificationClient:
 
     async def close(self) -> None:
         await self._client.aclose()
-

--- a/docs/superpowers/plans/2026-06-15-rob566-watch-notify-python-unify.md
+++ b/docs/superpowers/plans/2026-06-15-rob566-watch-notify-python-unify.md
@@ -1,0 +1,351 @@
+# ROB-566 — watch 알림 Python(TradeNotifier) 통일 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development (per task) + executing-plans. Steps use `- [ ]` checkboxes.
+
+**Goal:** watch 트리거 Discord 알림을 Prefect 수신기 대신 auto_trader **in-process `TradeNotifier`**로 렌더링(체결 ROB-558과 동형). 플래그 뒤에서 opt-in, `HermesDeliveryResult` 3-way 계약 보존 → alert 상태머신·호출처 2곳 무변경.
+
+**Architecture:** `send_review_trigger(payload) -> HermesDeliveryResult` 내부에 transport 분기 추가. `WATCH_NOTIFY_TRANSPORT="python_direct"`면 `TradeNotifier.notify_investment_watch(payload)`로 렌더(시장별 webhook), 결과를 `HermesDeliveryResult`로 매핑. default `hermes_webhook`은 현행 HTTP 경로 불변.
+
+**Tech Stack:** Python 3.13, pytest(+`@pytest.mark.unit`/`asyncio`), ruff, ty. 마이그레이션 0.
+
+**스펙:** `docs/superpowers/specs/2026-06-15-rob566-watch-notify-python-unify-design.md`
+
+### 핵심 참조 (현재 코드, file:line)
+- `app/services/hermes_client.py`: `ReviewTriggerPayload`(255, 필드: market/symbol/metric/operator/threshold/threshold_high/current_value/outcome/action_mode/invest_links/operator_action_guidance/price_guidance/trigger_checklist/planned_action), `HermesDeliveryResult`(298: status success|skipped|failed, http_status, reason), `send_review_trigger`(330), `InvestLinks`(52: report_path/stock_path/anchors, **path-only — host는 렌더러가 prepend**), `OperatorActionGuidance`(66: headline/requires_operator_review/order_behavior), `PriceGuidance`(80: entry_review_below_price/suggested_limit_price_range/max_chase_price/invalidation).
+- `app/monitoring/trade_notifier/formatters_discord.py:510` `format_fill_notification` (미러 대상), `notifier.py:259` `notify_fill` (미러), `_dispatch(embed, telegram_msg, market_type)`, `_get_webhook_for_market_type`(kr/us/crypto/alerts).
+- `app/core/config.py:433-435` HERMES_* (옆에 플래그 추가), `public_base_url`(딥링크 host).
+- 호출처(무변경 확인용): `app/jobs/investment_watch_scanner.py:219`+`_record_delivery_outcome`(399, `delivery.status=="success"`→triggered), `app/services/investment_reports/watch_validity_review.py:280`.
+- `app/services/fill_notification.py`: `KR_SYMBOLS` reverse cache + `resolve_fill_display_name`(개명 재사용 기반).
+
+---
+
+## Task 1: config 플래그 `WATCH_NOTIFY_TRANSPORT`
+
+**Files:** Modify `app/core/config.py`, `env.example`; Test `tests/test_config.py`(있으면 추가) 또는 새 단언
+
+- [ ] **Step 1: 실패 테스트**
+
+```python
+@pytest.mark.unit
+def test_watch_notify_transport_defaults_to_hermes_webhook():
+    from app.core.config import settings
+    assert settings.WATCH_NOTIFY_TRANSPORT in ("hermes_webhook", "python_direct")
+    # default 보장 (env 미설정 시)
+```
+
+- [ ] **Step 2: 실패 확인** — `uv run pytest tests/test_config.py -k watch_notify_transport -v` → FAIL(AttributeError)
+
+- [ ] **Step 3: 구현** — `config.py` HERMES_* 아래에 추가:
+
+```python
+    # ROB-566: watch 트리거 알림 전송 수단. "hermes_webhook"(default, 현행 Prefect
+    # 수신기로 HTTP POST) | "python_direct"(in-process TradeNotifier 렌더, ROB-558 체결과 동형).
+    WATCH_NOTIFY_TRANSPORT: Literal["hermes_webhook", "python_direct"] = "hermes_webhook"
+```
+`env.example`에 `WATCH_NOTIFY_TRANSPORT=hermes_webhook` 1줄 추가(주석 포함). `Literal` import 확인(이미 있음).
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_config.py -k watch_notify_transport -v && uv run ty check app/core/config.py`
+
+- [ ] **Step 5: 커밋** — `git commit -m "feat(ROB-566): add WATCH_NOTIFY_TRANSPORT flag (default hermes_webhook)"`
+
+---
+
+## Task 2: watch 표시명 헬퍼 (시장/심볼 → 한글명)
+
+**Files:** Modify `app/services/fill_notification.py`; Test `tests/test_fill_notification.py`
+
+- [ ] **Step 1: 실패 테스트** (TestFillHelpers에 추가)
+
+```python
+def test_resolve_symbol_display_name(self):
+    from app.services.fill_notification import resolve_symbol_display_name
+    assert resolve_symbol_display_name("crypto", "KRW-BTC") == "BTC"
+    assert resolve_symbol_display_name("us", "AAPL") == "AAPL"
+    assert resolve_symbol_display_name("kr", "005930") in ("삼성전자", "005930")  # KR_SYMBOLS 의존
+```
+
+- [ ] **Step 2: 실패 확인** — FAIL(ImportError)
+
+- [ ] **Step 3: 구현** — `fill_notification.py`에 시장/심볼 공용 해석기 추가하고 기존 `resolve_fill_display_name`이 위임하도록(중복 제거):
+
+```python
+def resolve_symbol_display_name(market_type: str | None, symbol: str) -> str:
+    if market_type == "kr":
+        return _get_kr_symbol_reverse().get(symbol, symbol)
+    if market_type == "crypto" and "-" in symbol:
+        return symbol.split("-")[-1]
+    return symbol
+
+
+# 기존 resolve_fill_display_name 내부를 위임으로 교체:
+def resolve_fill_display_name(order: FillOrder) -> str:
+    return resolve_symbol_display_name(order.market_type, order.symbol)
+```
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_fill_notification.py -v` (기존 fill 표시명 테스트도 그린 유지)
+
+- [ ] **Step 5: 커밋** — `git commit -m "refactor(ROB-566): extract resolve_symbol_display_name (reused by watch)"`
+
+---
+
+## Task 3: Discord watch 포맷터 `format_investment_watch_trigger`
+
+**Files:** Modify `app/monitoring/trade_notifier/formatters_discord.py`, `types.py`(COLORS watch); Test `tests/test_trade_notifier_formatters_discord.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+```python
+from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
+from app.services.hermes_client import (
+    ReviewTriggerPayload, InvestLinks, OperatorActionGuidance, PriceGuidance,
+)
+from decimal import Decimal
+from uuid import uuid4
+
+def _watch_payload(**kw):
+    base = dict(
+        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
+        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
+        market="kr", target_kind="asset", symbol="005930", metric="price",
+        operator="below", threshold=Decimal("68000"), threshold_key="k",
+        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
+        scanner_snapshot={}, outcome="notified",
+        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
+        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
+        price_guidance=None, planned_action=None, trigger_checklist=None,
+    )
+    base.update(kw); return ReviewTriggerPayload(**base)
+
+@pytest.mark.unit
+class TestFormatWatchTrigger:
+    def test_basic_with_link_and_fields(self):
+        emb = format_investment_watch_trigger(_watch_payload(), display_name="삼성전자",
+                                              base_url="https://x.test")
+        assert "삼성전자" in emb["title"] and "005930" in emb["title"]
+        assert emb["url"] == "https://x.test/invest/stocks/kr/005930"
+        fields = {f["name"]: f["value"] for f in emb["fields"]}
+        assert "price" in fields["조건"] and "below" in fields["조건"] and "68000" in fields["조건"]
+        assert "67500" in fields["현재값"]
+
+    def test_price_guidance_and_checklist_rendered(self):
+        pg = PriceGuidance(entry_review_below_price=Decimal("66000"), max_chase_price=Decimal("69000"),
+                           suggested_limit_price_range=None, invalidation=None)
+        emb = format_investment_watch_trigger(_watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
+                                              display_name="삼성전자", base_url="https://x.test")
+        names = {f["name"] for f in emb["fields"]}
+        assert "가격 가이드" in names and "체크리스트" in names
+
+    def test_no_link_when_invest_links_none(self):
+        emb = format_investment_watch_trigger(_watch_payload(invest_links=None),
+                                              display_name="삼성전자", base_url="https://x.test")
+        assert "url" not in emb
+```
+
+- [ ] **Step 2: 실패 확인** — FAIL(ImportError)
+
+- [ ] **Step 3: 구현** — `types.py` COLORS에 `"watch": 0xF1C40F`(노랑) 추가. `formatters_discord.py`:
+
+```python
+def format_investment_watch_trigger(
+    payload, *, display_name: str, base_url: str
+) -> DiscordEmbed:
+    """ROB-566: watch 트리거 Discord 임베드 (Prefect 렌더 대체)."""
+    outcome_kr = {
+        "notified": "알림", "review_required": "검토 필요",
+        "preview_attached": "프리뷰 첨부", "executed": "모의 실행",
+    }.get(payload.outcome, payload.outcome)
+
+    fields: list[DiscordField] = [
+        {"name": "조건", "value": f"{payload.metric} {payload.operator} {payload.threshold}", "inline": True},
+        {"name": "현재값", "value": (str(payload.current_value) if payload.current_value is not None else "-"), "inline": True},
+        {"name": "시장", "value": payload.market, "inline": True},
+        {"name": "구분", "value": outcome_kr, "inline": True},
+    ]
+    pg = payload.price_guidance
+    if pg is not None:
+        parts: list[str] = []
+        if pg.entry_review_below_price is not None: parts.append(f"진입검토 ≤ {pg.entry_review_below_price}")
+        if pg.suggested_limit_price_range is not None:
+            parts.append(f"지정가 {pg.suggested_limit_price_range.low}~{pg.suggested_limit_price_range.high}")
+        if pg.max_chase_price is not None: parts.append(f"최대추격 {pg.max_chase_price}")
+        if pg.invalidation is not None and getattr(pg.invalidation, "price", None) is not None:
+            parts.append(f"무효화 {pg.invalidation.price}")
+        if parts: fields.append({"name": "가격 가이드", "value": "\n".join(parts), "inline": False})
+    if payload.trigger_checklist:
+        fields.append({"name": "체크리스트", "value": "\n".join(f"• {c}" for c in payload.trigger_checklist), "inline": False})
+    if payload.invest_links is not None:
+        fields.append({"name": "링크", "value": f"[리포트]({base_url}{payload.invest_links.report_path}) · [종목]({base_url}{payload.invest_links.stock_path})", "inline": False})
+
+    desc = ""
+    if payload.operator_action_guidance is not None:
+        desc = payload.operator_action_guidance.headline
+    desc = (desc + f"\n🕒 {format_datetime()}").strip()
+
+    embed: DiscordEmbed = {
+        "title": f"🔔 워치 트리거 · {display_name} ({payload.symbol})",
+        "description": desc,
+        "color": COLORS["watch"],
+        "fields": fields,
+    }
+    if payload.invest_links is not None:
+        embed["url"] = f"{base_url}{payload.invest_links.stock_path}"
+    return embed
+```
+> 타입힌트는 `ReviewTriggerPayload`를 import해 명시(`from app.services.hermes_client import ReviewTriggerPayload`); 순환 주의 — hermes_client는 formatters를 import하지 않으므로 안전.
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_trade_notifier_formatters_discord.py -k Watch -v`
+
+- [ ] **Step 5: 커밋** — `git commit -m "feat(ROB-566): Discord watch-trigger formatter (deeplinks, price guidance, checklist)"`
+
+---
+
+## Task 4: Telegram watch 포맷터
+
+**Files:** Modify `formatters_telegram.py`; Test `tests/test_trade_notifier_formatters_telegram.py`
+
+- [ ] **Step 1: 실패 테스트** — `format_investment_watch_trigger_telegram(payload, *, display_name, base_url)`가 "워치 트리거", display_name, 조건, 마크다운 링크 `[종목 상세](base+stock_path)` 포함.
+- [ ] **Step 2: 실패 확인**
+- [ ] **Step 3: 구현** — discord 포맷터와 동일 정보의 마크다운 문자열(체결 telegram 포맷터 동형, `\\(`/`\\)` 이스케이프, 딥링크는 `[텍스트](url)`).
+- [ ] **Step 4: 통과**
+- [ ] **Step 5: 커밋** — `git commit -m "feat(ROB-566): Telegram watch-trigger formatter"`
+
+---
+
+## Task 5: `TradeNotifier.notify_investment_watch`
+
+**Files:** Modify `notifier.py`; Test `tests/test_trade_notifier.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_investment_watch_routes_by_market(trade_notifier):
+    from tests... import _watch_payload  # 또는 인라인 구성
+    trade_notifier.configure(bot_token="t", chat_ids=["1"], enabled=True,
+                             discord_webhook_kr="https://discord.com/api/webhooks/kr")
+    with patch.object(trade_notifier, "_send_to_discord_embed_single", new=AsyncMock(return_value=True)) as md, \
+         patch.object(trade_notifier, "_send_to_telegram", new=AsyncMock(return_value=True)) as mt:
+        ok = await trade_notifier.notify_investment_watch(_watch_payload(market="kr"))
+    assert ok is True
+    md.assert_awaited_once(); mt.assert_not_awaited()
+    assert md.await_args.args[0]["title"].startswith("🔔 워치 트리거")
+```
+
+- [ ] **Step 2: 실패 확인** — FAIL(no attribute)
+
+- [ ] **Step 3: 구현** — `notify_fill` 동형:
+
+```python
+    async def notify_investment_watch(self, payload) -> bool:
+        """watch 트리거 알림 (ROB-566). Discord 우선, Telegram fallback."""
+        from app.core.config import settings as _settings
+        from app.services.fill_notification import resolve_symbol_display_name
+
+        display_name = resolve_symbol_display_name(payload.market, payload.symbol)
+        base_url = _settings.public_base_url.rstrip("/")
+        embed = fmt_discord.format_investment_watch_trigger(
+            payload, display_name=display_name, base_url=base_url
+        )
+        telegram_msg = fmt_telegram.format_investment_watch_trigger_telegram(
+            payload, display_name=display_name, base_url=base_url
+        )
+        return await self._dispatch(embed, telegram_msg, payload.market)
+```
+> `payload` 타입힌트는 `ReviewTriggerPayload`(import). `payload.market` 값(kr/us/crypto)은 `_get_webhook_for_market_type`가 처리.
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_trade_notifier.py -k investment_watch -v`
+
+- [ ] **Step 5: 커밋** — `git commit -m "feat(ROB-566): TradeNotifier.notify_investment_watch (market-routed)"`
+
+---
+
+## Task 6: `send_review_trigger` transport 분기 (seam)
+
+**Files:** Modify `app/services/hermes_client.py`; Test `tests/test_hermes_client.py`
+
+- [ ] **Step 1: 실패 테스트**
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_python_direct_success_maps_to_success(monkeypatch):
+    monkeypatch.setattr("app.services.hermes_client.settings.WATCH_NOTIFY_TRANSPORT", "python_direct", raising=False)
+    fake = AsyncMock(); fake.notify_investment_watch = AsyncMock(return_value=True)
+    monkeypatch.setattr("app.services.hermes_client.get_trade_notifier", lambda: fake)
+    client = HermesNotificationClient(enabled=True)
+    res = await client.send_review_trigger(_watch_payload())
+    assert res.status == "success"; fake.notify_investment_watch.assert_awaited_once()
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_python_direct_failure_maps_to_failed(monkeypatch):
+    monkeypatch.setattr("app.services.hermes_client.settings.WATCH_NOTIFY_TRANSPORT", "python_direct", raising=False)
+    fake = AsyncMock(); fake.notify_investment_watch = AsyncMock(return_value=False)
+    monkeypatch.setattr("app.services.hermes_client.get_trade_notifier", lambda: fake)
+    res = await HermesNotificationClient(enabled=True).send_review_trigger(_watch_payload())
+    assert res.status == "failed"
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hermes_webhook_default_path_unchanged(monkeypatch):
+    # transport=hermes_webhook (default) → 기존 HTTP 경로 (MockTransport 200) → success
+    ...  # 기존 send_review_trigger 테스트 패턴 재사용
+```
+
+- [ ] **Step 2: 실패 확인** — FAIL(분기 없음 → python_direct여도 HTTP 시도)
+
+- [ ] **Step 3: 구현** — `send_review_trigger` 상단에 분기 추가(파일 상단 `from app.monitoring.trade_notifier import get_trade_notifier` import):
+
+```python
+    async def send_review_trigger(self, payload: ReviewTriggerPayload) -> HermesDeliveryResult:
+        if settings.WATCH_NOTIFY_TRANSPORT == "python_direct":
+            return await self._render_in_process(payload)
+        # ----- 기존 hermes_webhook 경로 (불변) -----
+        if not self._enabled:
+            ...
+```
+신규 메서드:
+```python
+    async def _render_in_process(self, payload: ReviewTriggerPayload) -> HermesDeliveryResult:
+        """ROB-566: Prefect 수신기 대신 TradeNotifier로 직접 렌더. 결과를 3-way로 매핑."""
+        notifier = get_trade_notifier()
+        try:
+            sent = await notifier.notify_investment_watch(payload)
+        except Exception as exc:
+            logger.warning("watch in-process render raised: event_uuid=%s error=%s", payload.event_uuid, exc)
+            return HermesDeliveryResult(status="failed", reason="render_exception")
+        if sent:
+            return HermesDeliveryResult(status="success")
+        # webhook 미설정 등으로 dispatch가 False면 skipped(=alert active 유지, 재시도)
+        return HermesDeliveryResult(status="skipped", reason="discord_not_configured")
+```
+> `notify_investment_watch`가 `_dispatch`에서 `_enabled=False`/webhook 미설정 시 `False` 반환 → 여기서 `skipped`로 매핑(현행 skip 의미=alert active 유지 보존). dispatch 자체 예외만 `failed`.
+> ⚠️ 매핑 결정 확인(스펙 리뷰): False→skipped(보수적, 재시도) vs failed. 본 플랜은 **skipped**(미설정은 일시적/구성 문제로 보고 재시도 유도). 구현자는 스펙과 대조.
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_hermes_client.py -v` (기존 webhook 테스트 + 신규 분기 전부 그린)
+
+- [ ] **Step 5: 커밋** — `git commit -m "feat(ROB-566): route watch via TradeNotifier when WATCH_NOTIFY_TRANSPORT=python_direct"`
+
+---
+
+## Task 7: 전체 검증 + 상태머신 회귀
+
+- [ ] **Step 1**: `uv run ruff format app/ tests/ && uv run ruff check app/ tests/ && uv run ty check app/`
+- [ ] **Step 2**: `uv run pytest tests/ --collect-only -q` → 0 import 에러
+- [ ] **Step 3 (상태머신 무변경 회귀)**: `uv run pytest tests/ -k "watch_scanner or investment_watch or hermes or watch_validity or trade_notifier or formatters" -q` → 그린. 특히 `_record_delivery_outcome`가 `delivery.status` 3-way를 그대로 받는지(success→triggered, skipped/failed→active) 기존 테스트 통과 확인.
+- [ ] **Step 4 (계약 보존 확인)**: `grep -rn "send_review_trigger" app/jobs/investment_watch_scanner.py app/services/investment_reports/watch_validity_review.py` → 호출 시그니처 무변경(여전히 `await ...send_review_trigger(payload)` → `HermesDeliveryResult`).
+- [ ] **Step 5: 커밋** — `git commit -m "test(ROB-566): full verification + state-machine regression"`
+
+---
+
+## 자체 점검 (작성자 — 완료)
+- **스펙 커버리지:** 플래그(T1)·표시명(T2)·Discord 포맷터+딥링크/price_guidance/checklist(T3)·Telegram(T4)·notify_investment_watch 시장라우팅(T5)·send_review_trigger 분기+3way 매핑(T6)·회귀(T7). 채널=시장별(T5 `_dispatch(payload.market)`). Telegram fallback=_dispatch 무료.
+- **계약 보존:** 호출처 2곳·`_record_delivery_outcome`·alert 상태머신 무변경(T6/T7 검증).
+- **default 안전:** `WATCH_NOTIFY_TRANSPORT=hermes_webhook` default → 머지 자체는 behavior 불변(opt-in).
+- **플레이스홀더:** 없음. 구현자 확인사항: (a) `WatchPriceRange`/`WatchInvalidation` 실제 필드명(low/high/price) — hermes_client에서 확인 후 포맷터 맞춤, (b) `_watch_payload` 테스트 헬퍼는 공용 fixture로 추출 가능, (c) False→skipped 매핑(스펙 §6.1).
+
+## 미해결 (스펙 리뷰 후 — 구현자/검증자)
+- price_guidance 하위필드 ✅확인됨(`app/schemas/investment_reports.py`): `WatchPriceRange(low: Decimal, high: Decimal)`, `WatchInvalidation(kind: Literal["price_below","condition_text"], price: Decimal|None, text: str|None)`. 플랜 T3 코드와 일치.
+- Prefect 수신기 폐기 = operator(별도, cross-repo). 본 PR은 플래그만.
+- `HermesNotificationClient`/`HERMES_*` 개명 = 별도 후속.

--- a/docs/superpowers/specs/2026-06-15-rob566-watch-notify-python-unify-design.md
+++ b/docs/superpowers/specs/2026-06-15-rob566-watch-notify-python-unify-design.md
@@ -1,0 +1,68 @@
+# ROB-566 — watch 알림 Python(TradeNotifier) 통일 설계 스펙
+
+- **날짜**: 2026-06-15
+- **Linear**: ROB-566 (Medium) · 후속 of ROB-558(체결 Python 렌더)·ROB-560(n8n/OpenClaw 정리)
+- **브랜치/워트리**: `rob-566` @ `/Users/mgh3326/work/auto_trader.rob-566` (origin/main)
+
+## 1. 문제 / 동기
+
+체결(fill) 알림은 ROB-558로 auto_trader 안에서 **Python `TradeNotifier`**가 직접 렌더(시장별 webhook). 그런데 **watch 알림만** 아직 `auto_trader → Prefect watch_alert_receiver(:18766) → Discord`로 한 홉 더 나간다. 사용자 지적: 일관성 없고 Prefect가 불필요하다.
+
+### 리서치 결론 (코드/프로세스 실측)
+- **Prefect watch 이벤트 `auto_trader.watch.triggered` 소비처 0** (dead). Prefect 경로의 유일한 오케스트레이션 기능이 죽은 코드 → 사실상 Discord 렌더러.
+- prod **"Hermes" = Prefect 수신기**(`HERMES_WEBHOOK_URL`→:18766). watch 트리거 평가 LLM 없음(`ReviewTriggerPayload`는 outcome까지 계산된 닫힌 스냅샷). 향후 LLM 리뷰 로드맵 증거 없음.
+- **TaskIQ 워커가 이미 TradeNotifier 설정**(`app/core/taskiq_broker.py` WorkerInitMiddleware, webhook 4개). watch 스캐너가 그 워커에서 돌므로 신규 인프라 0.
+- 대가 없는 운영비: 별도 uvicorn/포트/토큰/plist/Prefect API 의존/네트워크 홉.
+
+## 2. 핵심 통찰 — 이미 존재하는 seam: `HermesDeliveryResult`
+
+스캐너의 alert 상태머신은 **전달 결과 3-way에만** 의존한다:
+- `app/services/hermes_client.py:298` `HermesDeliveryResult(status: success|skipped|failed, http_status, reason)`
+- `send_review_trigger(payload) -> HermesDeliveryResult` (line 330). `HERMES_ENABLED=False`면 `skipped`.
+- 호출처 ①: `investment_watch_scanner.py:219` → `_record_delivery_outcome`(line 399): `delivery.status == "success"` 일 때만 `delivery_status="delivered"` + alert→`triggered`; 아니면 active 유지(재시도).
+- 호출처 ②: `watch_validity_review.py:280` 동일 인터페이스.
+
+→ **전송 수단(HTTP webhook vs in-process render)은 `send_review_trigger` 내부 디테일**이다. 결과 타입(`HermesDeliveryResult`)을 보존하면 **두 호출처와 상태머신은 무변경**. 이게 안전한 swap의 핵심.
+
+## 3. 설계 (D안 — in-process 렌더 + 결과계약 보존)
+
+### 3-1. 신규 렌더링 (체결 포맷터 동형)
+- `app/monitoring/trade_notifier/formatters_discord.py`: `format_investment_watch_trigger(payload, *, display_name) -> DiscordEmbed`.
+  - 제목 예: `🔔 워치 트리거 · {display_name} ({symbol})`, 색=시장/intents 기반.
+  - 필드: 구분(metric/operator/threshold), 현재값(current_value), outcome(notified/review_required/preview_attached/executed → 한글), price_guidance(진입검토가/한도범위/무효화), 체결가 아님. **딥링크**: invest_links.report_path/stock_path → embed.url(클릭) + 필드. trigger_checklist(있으면). planned_action 요약(있으면).
+- `formatters_telegram.py`: `format_investment_watch_trigger_telegram(...)` (마크다운 + 딥링크).
+
+### 3-2. TradeNotifier 디스패치
+- `TradeNotifier.notify_investment_watch(payload) -> bool`: `resolve` display_name → embed/telegram 빌드 → `_dispatch(embed, telegram_msg, market_type=payload.market)`. **시장별 채널 라우팅**(payload.market → DISCORD_WEBHOOK_KR/US/CRYPTO; 매핑 불가 시 alerts). (user 결정: 시장별 분리.) Telegram fallback은 `_dispatch`로 무료.
+
+### 3-3. 전송 분기 (seam은 `send_review_trigger` 내부)
+- 신규 config `WATCH_NOTIFY_TRANSPORT: Literal["hermes_webhook","python_direct"] = "hermes_webhook"` (default=현행, 안전).
+- `HermesNotificationClient.send_review_trigger(payload)`:
+  - `transport=="python_direct"` → `get_trade_notifier().notify_investment_watch(payload)` 호출, `True`→`HermesDeliveryResult(status="success", http_status=None)`, `False`→`HermesDeliveryResult(status="failed", reason="discord_render_failed")`. (webhook 안 탐.)
+  - else(default) → 현행 HTTP POST 경로 그대로.
+  - `HERMES_ENABLED` 의미: python_direct에선 무관(Discord webhook 설정이 게이트). 단 안전을 위해 python_direct일 때 webhook 미설정이면 `skipped` 반환(현행 skip 의미 보존, alert active 유지).
+- **호출처 2곳·상태머신 무변경** (계속 `send_review_trigger`→`HermesDeliveryResult` 소비).
+
+### 3-4. 컷오버 + Prefect 폐기
+- 플래그 default=`hermes_webhook` → 머지해도 동작 불변. operator가 `WATCH_NOTIFY_TRANSPORT=python_direct`로 전환(병행 관찰: 잠시 양쪽 비교 후 Prefect 측 mute/중단).
+- 패리티 확인 후 operator가 **Prefect watch 수신기 폐기**: launchd `dev.robinco.prefect.watch-alert-receiver.plist` 중단, `.env` WATCH_ALERT_* 정리, (Prefect repo) 죽은 `emit_watch_alert_event`/`watch_alert_router` 정리. ⚠️ Prefect repo는 별도 레포 — auto_trader PR 범위 밖, operator/cross-repo.
+- ⚠️ 수신기 폐기 전 확인: `:18766`은 review-trigger + **news-relevance-judgment**도 받음 → news-relevance가 같은 포트/앱을 쓰면 watch만 떼고 앱은 유지(폐기 범위 정밀화는 operator).
+
+## 4. 안전 경계 / 비목표
+- **결과계약 보존**: `HermesDeliveryResult` 3-way 불변 → alert 상태머신/재시도/audit 컬럼 무변경.
+- default 플래그=현행 → 머지 자체는 behavior 불변(opt-in 전환).
+- **마이그레이션 0**, 브로커/주문 mutation 없음.
+- 비목표: Prefect repo 코드 삭제(operator/cross-repo), `HermesNotificationClient` 개명(이름은 잔존 — 후속), news-relevance 경로 변경.
+
+## 5. 테스트 계획
+- `format_investment_watch_trigger`(discord/telegram): outcome별 라벨, 딥링크 embed.url, price_guidance/trigger_checklist 표기/생략, 시장별 색.
+- `notify_investment_watch`: market→webhook 라우팅(kr/us/crypto/fallback), Telegram fallback, disabled no-op.
+- `send_review_trigger` 분기: transport=python_direct → TradeNotifier 호출+결과 매핑(True→success/False→failed/webhook미설정→skipped); transport=hermes_webhook → 기존 HTTP 경로 불변(기존 테스트 유지).
+- 회귀: 호출처 2곳·`_record_delivery_outcome` 무변경 확인(상태머신 테스트 그린).
+
+## 6. 미해결 (스펙 리뷰)
+1. Telegram fallback: python_direct에서 활성(추천) vs Discord-only 패리티.
+2. embed 필드 구성 최종(price_guidance/checklist/planned_action 포함 범위).
+3. 플래그 이름 `WATCH_NOTIFY_TRANSPORT` vs 단순 bool `WATCH_NOTIFY_PYTHON_DIRECT`.
+4. Prefect 폐기 타이밍: 본 PR은 플래그만(operator 컷오버) vs 동시. (추천: 플래그만, operator 전환)
+5. `HermesNotificationClient`/`HERMES_*` 네이밍 잔존 — 후속 개명 이슈로 분리(추천).

--- a/env.example
+++ b/env.example
@@ -426,3 +426,10 @@ TOSS_API_BASE_URL=https://openapi.tossinvest.com
 # Arms live order mutations (place/modify/cancel) AND the holdings sellability
 # / orderable-cash / tradeability surfaces (ROB-549). Keep false until cleared.
 TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false
+
+# ========================================
+# WATCH_NOTIFY 설정 (ROB-566)
+# ========================================
+# watch 트리거 알림 전송 수단 ("hermes_webhook" | "python_direct")
+WATCH_NOTIFY_TRANSPORT=hermes_webhook
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -252,3 +252,10 @@ class TestConfigLoading:
 
 def test_runbook_exists() -> None:
     assert Path("docs/runbooks/freqtrade-research-pipeline.md").exists()
+
+
+@pytest.mark.unit
+def test_watch_notify_transport_defaults_to_hermes_webhook():
+    from app.core.config import settings
+    assert settings.WATCH_NOTIFY_TRANSPORT in ("hermes_webhook", "python_direct")
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,5 +257,5 @@ def test_runbook_exists() -> None:
 @pytest.mark.unit
 def test_watch_notify_transport_defaults_to_hermes_webhook():
     from app.core.config import settings
-    assert settings.WATCH_NOTIFY_TRANSPORT in ("hermes_webhook", "python_direct")
 
+    assert settings.WATCH_NOTIFY_TRANSPORT in ("hermes_webhook", "python_direct")

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -414,3 +414,10 @@ class TestFillHelpers:
         enr = FillEnrichment()
         assert enr.position_qty is None
         assert enr.is_approximate is True
+
+    def test_resolve_symbol_display_name(self):
+        from app.services.fill_notification import resolve_symbol_display_name
+        assert resolve_symbol_display_name("crypto", "KRW-BTC") == "BTC"
+        assert resolve_symbol_display_name("us", "AAPL") == "AAPL"
+        assert resolve_symbol_display_name("kr", "005930") in ("삼성전자", "005930")  # KR_SYMBOLS 의존
+

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -417,7 +417,10 @@ class TestFillHelpers:
 
     def test_resolve_symbol_display_name(self):
         from app.services.fill_notification import resolve_symbol_display_name
+
         assert resolve_symbol_display_name("crypto", "KRW-BTC") == "BTC"
         assert resolve_symbol_display_name("us", "AAPL") == "AAPL"
-        assert resolve_symbol_display_name("kr", "005930") in ("삼성전자", "005930")  # KR_SYMBOLS 의존
-
+        assert resolve_symbol_display_name("kr", "005930") in (
+            "삼성전자",
+            "005930",
+        )  # KR_SYMBOLS 의존

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -371,12 +371,15 @@ def test_payload_accepts_planned_action_and_trigger_checklist() -> None:
 @pytest.mark.asyncio
 async def test_python_direct_success_maps_to_success(monkeypatch):
     from unittest.mock import AsyncMock
+
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
     fake = AsyncMock()
     fake.notify_investment_watch = AsyncMock(return_value=True)
-    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.get_trade_notifier", lambda: fake
+    )
     client = HermesNotificationClient(enabled=True)
     res = await client.send_review_trigger(_base_payload())
     assert res.status == "success"
@@ -387,13 +390,18 @@ async def test_python_direct_success_maps_to_success(monkeypatch):
 @pytest.mark.asyncio
 async def test_python_direct_failure_maps_to_skipped(monkeypatch):
     from unittest.mock import AsyncMock
+
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
     fake = AsyncMock()
     fake.notify_investment_watch = AsyncMock(return_value=False)
-    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
-    res = await HermesNotificationClient(enabled=True).send_review_trigger(_base_payload())
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.get_trade_notifier", lambda: fake
+    )
+    res = await HermesNotificationClient(enabled=True).send_review_trigger(
+        _base_payload()
+    )
     assert res.status == "skipped"
 
 
@@ -401,16 +409,16 @@ async def test_python_direct_failure_maps_to_skipped(monkeypatch):
 @pytest.mark.asyncio
 async def test_python_direct_exception_maps_to_failed(monkeypatch):
     from unittest.mock import AsyncMock
+
     from app.core.config import settings
 
     monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
     fake = AsyncMock()
     fake.notify_investment_watch = AsyncMock(side_effect=RuntimeError("dispatch error"))
-    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
-    res = await HermesNotificationClient(enabled=True).send_review_trigger(_base_payload())
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.get_trade_notifier", lambda: fake
+    )
+    res = await HermesNotificationClient(enabled=True).send_review_trigger(
+        _base_payload()
+    )
     assert res.status == "failed"
-
-
-
-
-

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -365,3 +365,52 @@ def test_payload_accepts_planned_action_and_trigger_checklist() -> None:
     assert payload.planned_action is not None
     assert payload.planned_action.qty == Decimal("1")
     assert payload.trigger_checklist == ["quote ok", "thesis ok"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_python_direct_success_maps_to_success(monkeypatch):
+    from unittest.mock import AsyncMock
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
+    fake = AsyncMock()
+    fake.notify_investment_watch = AsyncMock(return_value=True)
+    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
+    client = HermesNotificationClient(enabled=True)
+    res = await client.send_review_trigger(_base_payload())
+    assert res.status == "success"
+    fake.notify_investment_watch.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_python_direct_failure_maps_to_skipped(monkeypatch):
+    from unittest.mock import AsyncMock
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
+    fake = AsyncMock()
+    fake.notify_investment_watch = AsyncMock(return_value=False)
+    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
+    res = await HermesNotificationClient(enabled=True).send_review_trigger(_base_payload())
+    assert res.status == "skipped"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_python_direct_exception_maps_to_failed(monkeypatch):
+    from unittest.mock import AsyncMock
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "WATCH_NOTIFY_TRANSPORT", "python_direct")
+    fake = AsyncMock()
+    fake.notify_investment_watch = AsyncMock(side_effect=RuntimeError("dispatch error"))
+    monkeypatch.setattr("app.monitoring.trade_notifier.get_trade_notifier", lambda: fake)
+    res = await HermesNotificationClient(enabled=True).send_review_trigger(_base_payload())
+    assert res.status == "failed"
+
+
+
+
+

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -2059,3 +2059,37 @@ async def test_notify_fill_telegram_fallback_when_discord_fails(trade_notifier):
         ok = await trade_notifier.notify_fill(order, enrichment=None, detail_url=None)
     assert ok is True
     mock_tg.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_investment_watch_routes_by_market(trade_notifier):
+    from decimal import Decimal
+    from uuid import uuid4
+    from app.services.hermes_client import (
+        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance,
+    )
+    payload = ReviewTriggerPayload(
+        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
+        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
+        market="kr", target_kind="asset", symbol="005930", metric="price",
+        operator="below", threshold=Decimal("68000"), threshold_key="k",
+        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
+        scanner_snapshot={}, outcome="notified",
+        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
+        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
+        price_guidance=None, planned_action=None, trigger_checklist=None,
+    )
+
+    trade_notifier.configure(
+        bot_token="t", chat_ids=["1"], enabled=True,
+        discord_webhook_kr="https://discord.com/api/webhooks/kr"
+    )
+    with patch.object(trade_notifier, "_send_to_discord_embed_single", new=AsyncMock(return_value=True)) as md, \
+         patch.object(trade_notifier, "_send_to_telegram", new=AsyncMock(return_value=True)) as mt:
+        ok = await trade_notifier.notify_investment_watch(payload)
+    assert ok is True
+    md.assert_awaited_once()
+    mt.assert_not_awaited()
+    assert md.await_args.args[0]["title"].startswith("🔔 워치 트리거")
+

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -2066,30 +2066,61 @@ async def test_notify_fill_telegram_fallback_when_discord_fails(trade_notifier):
 async def test_notify_investment_watch_routes_by_market(trade_notifier):
     from decimal import Decimal
     from uuid import uuid4
+
     from app.services.hermes_client import (
-        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance,
+        InvestLinks,
+        OperatorActionGuidance,
+        ReviewTriggerPayload,
     )
+
     payload = ReviewTriggerPayload(
-        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
-        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
-        market="kr", target_kind="asset", symbol="005930", metric="price",
-        operator="below", threshold=Decimal("68000"), threshold_key="k",
-        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
-        scanner_snapshot={}, outcome="notified",
-        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
-        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
-        price_guidance=None, planned_action=None, trigger_checklist=None,
+        event_uuid=uuid4(),
+        alert_uuid=uuid4(),
+        source_report_uuid=uuid4(),
+        source_item_uuid=uuid4(),
+        correlation_id="c1",
+        kst_date="2026-06-15",
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price",
+        operator="below",
+        threshold=Decimal("68000"),
+        threshold_key="k",
+        intent="buy_review",
+        action_mode="notify_only",
+        current_value=Decimal("67500"),
+        scanner_snapshot={},
+        outcome="notified",
+        invest_links=InvestLinks(
+            report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"
+        ),
+        operator_action_guidance=OperatorActionGuidance(
+            headline="알림 전용", requires_operator_review=False, order_behavior="none"
+        ),
+        price_guidance=None,
+        planned_action=None,
+        trigger_checklist=None,
     )
 
     trade_notifier.configure(
-        bot_token="t", chat_ids=["1"], enabled=True,
-        discord_webhook_kr="https://discord.com/api/webhooks/kr"
+        bot_token="t",
+        chat_ids=["1"],
+        enabled=True,
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
     )
-    with patch.object(trade_notifier, "_send_to_discord_embed_single", new=AsyncMock(return_value=True)) as md, \
-         patch.object(trade_notifier, "_send_to_telegram", new=AsyncMock(return_value=True)) as mt:
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_embed_single",
+            new=AsyncMock(return_value=True),
+        ) as md,
+        patch.object(
+            trade_notifier, "_send_to_telegram", new=AsyncMock(return_value=True)
+        ) as mt,
+    ):
         ok = await trade_notifier.notify_investment_watch(payload)
     assert ok is True
     md.assert_awaited_once()
     mt.assert_not_awaited()
     assert md.await_args.args[0]["title"].startswith("🔔 워치 트리거")
-

--- a/tests/test_trade_notifier_formatters_discord.py
+++ b/tests/test_trade_notifier_formatters_discord.py
@@ -424,3 +424,54 @@ class TestFormatTossSellRecommendation:
         )
         fields = {f["name"]: f["value"] for f in embed["fields"]}
         assert "-4.6%" in fields["💡 추천 매도가"]
+
+
+def _watch_payload(**kw):
+    from decimal import Decimal
+    from uuid import uuid4
+    from app.services.hermes_client import (
+        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance, PriceGuidance,
+    )
+    base = dict(
+        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
+        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
+        market="kr", target_kind="asset", symbol="005930", metric="price",
+        operator="below", threshold=Decimal("68000"), threshold_key="k",
+        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
+        scanner_snapshot={}, outcome="notified",
+        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
+        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
+        price_guidance=None, planned_action=None, trigger_checklist=None,
+    )
+    base.update(kw); return ReviewTriggerPayload(**base)
+
+
+@pytest.mark.unit
+class TestFormatWatchTrigger:
+    def test_basic_with_link_and_fields(self):
+        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
+        emb = format_investment_watch_trigger(_watch_payload(), display_name="삼성전자",
+                                              base_url="https://x.test")
+        assert "삼성전자" in emb["title"] and "005930" in emb["title"]
+        assert emb["url"] == "https://x.test/invest/stocks/kr/005930"
+        fields = {f["name"]: f["value"] for f in emb["fields"]}
+        assert "price" in fields["조건"] and "below" in fields["조건"] and "68000" in fields["조건"]
+        assert "67500" in fields["현재값"]
+
+    def test_price_guidance_and_checklist_rendered(self):
+        from decimal import Decimal
+        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
+        from app.services.hermes_client import PriceGuidance
+        pg = PriceGuidance(entry_review_below_price=Decimal("66000"), max_chase_price=Decimal("69000"),
+                           suggested_limit_price_range=None, invalidation=None)
+        emb = format_investment_watch_trigger(_watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
+                                              display_name="삼성전자", base_url="https://x.test")
+        names = {f["name"] for f in emb["fields"]}
+        assert "가격 가이드" in names and "체크리스트" in names
+
+    def test_no_link_when_invest_links_none(self):
+        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
+        emb = format_investment_watch_trigger(_watch_payload(invest_links=None),
+                                              display_name="삼성전자", base_url="https://x.test")
+        assert "url" not in emb
+

--- a/tests/test_trade_notifier_formatters_discord.py
+++ b/tests/test_trade_notifier_formatters_discord.py
@@ -429,49 +429,96 @@ class TestFormatTossSellRecommendation:
 def _watch_payload(**kw):
     from decimal import Decimal
     from uuid import uuid4
+
     from app.services.hermes_client import (
-        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance, PriceGuidance,
+        InvestLinks,
+        OperatorActionGuidance,
+        ReviewTriggerPayload,
     )
-    base = dict(
-        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
-        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
-        market="kr", target_kind="asset", symbol="005930", metric="price",
-        operator="below", threshold=Decimal("68000"), threshold_key="k",
-        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
-        scanner_snapshot={}, outcome="notified",
-        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
-        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
-        price_guidance=None, planned_action=None, trigger_checklist=None,
-    )
-    base.update(kw); return ReviewTriggerPayload(**base)
+
+    base = {
+        "event_uuid": uuid4(),
+        "alert_uuid": uuid4(),
+        "source_report_uuid": uuid4(),
+        "source_item_uuid": uuid4(),
+        "correlation_id": "c1",
+        "kst_date": "2026-06-15",
+        "market": "kr",
+        "target_kind": "asset",
+        "symbol": "005930",
+        "metric": "price",
+        "operator": "below",
+        "threshold": Decimal("68000"),
+        "threshold_key": "k",
+        "intent": "buy_review",
+        "action_mode": "notify_only",
+        "current_value": Decimal("67500"),
+        "scanner_snapshot": {},
+        "outcome": "notified",
+        "invest_links": InvestLinks(
+            report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"
+        ),
+        "operator_action_guidance": OperatorActionGuidance(
+            headline="알림 전용", requires_operator_review=False, order_behavior="none"
+        ),
+        "price_guidance": None,
+        "planned_action": None,
+        "trigger_checklist": None,
+    }
+    base.update(kw)
+    return ReviewTriggerPayload(**base)
 
 
 @pytest.mark.unit
 class TestFormatWatchTrigger:
     def test_basic_with_link_and_fields(self):
-        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
-        emb = format_investment_watch_trigger(_watch_payload(), display_name="삼성전자",
-                                              base_url="https://x.test")
+        from app.monitoring.trade_notifier.formatters_discord import (
+            format_investment_watch_trigger,
+        )
+
+        emb = format_investment_watch_trigger(
+            _watch_payload(), display_name="삼성전자", base_url="https://x.test"
+        )
         assert "삼성전자" in emb["title"] and "005930" in emb["title"]
         assert emb["url"] == "https://x.test/invest/stocks/kr/005930"
         fields = {f["name"]: f["value"] for f in emb["fields"]}
-        assert "price" in fields["조건"] and "below" in fields["조건"] and "68000" in fields["조건"]
+        assert (
+            "price" in fields["조건"]
+            and "below" in fields["조건"]
+            and "68000" in fields["조건"]
+        )
         assert "67500" in fields["현재값"]
 
     def test_price_guidance_and_checklist_rendered(self):
         from decimal import Decimal
-        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
+
+        from app.monitoring.trade_notifier.formatters_discord import (
+            format_investment_watch_trigger,
+        )
         from app.services.hermes_client import PriceGuidance
-        pg = PriceGuidance(entry_review_below_price=Decimal("66000"), max_chase_price=Decimal("69000"),
-                           suggested_limit_price_range=None, invalidation=None)
-        emb = format_investment_watch_trigger(_watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
-                                              display_name="삼성전자", base_url="https://x.test")
+
+        pg = PriceGuidance(
+            entry_review_below_price=Decimal("66000"),
+            max_chase_price=Decimal("69000"),
+            suggested_limit_price_range=None,
+            invalidation=None,
+        )
+        emb = format_investment_watch_trigger(
+            _watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
+            display_name="삼성전자",
+            base_url="https://x.test",
+        )
         names = {f["name"] for f in emb["fields"]}
         assert "가격 가이드" in names and "체크리스트" in names
 
     def test_no_link_when_invest_links_none(self):
-        from app.monitoring.trade_notifier.formatters_discord import format_investment_watch_trigger
-        emb = format_investment_watch_trigger(_watch_payload(invest_links=None),
-                                              display_name="삼성전자", base_url="https://x.test")
-        assert "url" not in emb
+        from app.monitoring.trade_notifier.formatters_discord import (
+            format_investment_watch_trigger,
+        )
 
+        emb = format_investment_watch_trigger(
+            _watch_payload(invest_links=None),
+            display_name="삼성전자",
+            base_url="https://x.test",
+        )
+        assert "url" not in emb

--- a/tests/test_trade_notifier_formatters_telegram.py
+++ b/tests/test_trade_notifier_formatters_telegram.py
@@ -379,29 +379,56 @@ class TestFormatFillTelegram:
 def _watch_payload(**kw):
     from decimal import Decimal
     from uuid import uuid4
+
     from app.services.hermes_client import (
-        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance, PriceGuidance,
+        InvestLinks,
+        OperatorActionGuidance,
+        ReviewTriggerPayload,
     )
-    base = dict(
-        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
-        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
-        market="kr", target_kind="asset", symbol="005930", metric="price",
-        operator="below", threshold=Decimal("68000"), threshold_key="k",
-        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
-        scanner_snapshot={}, outcome="notified",
-        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
-        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
-        price_guidance=None, planned_action=None, trigger_checklist=None,
-    )
-    base.update(kw); return ReviewTriggerPayload(**base)
+
+    base = {
+        "event_uuid": uuid4(),
+        "alert_uuid": uuid4(),
+        "source_report_uuid": uuid4(),
+        "source_item_uuid": uuid4(),
+        "correlation_id": "c1",
+        "kst_date": "2026-06-15",
+        "market": "kr",
+        "target_kind": "asset",
+        "symbol": "005930",
+        "metric": "price",
+        "operator": "below",
+        "threshold": Decimal("68000"),
+        "threshold_key": "k",
+        "intent": "buy_review",
+        "action_mode": "notify_only",
+        "current_value": Decimal("67500"),
+        "scanner_snapshot": {},
+        "outcome": "notified",
+        "invest_links": InvestLinks(
+            report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"
+        ),
+        "operator_action_guidance": OperatorActionGuidance(
+            headline="알림 전용", requires_operator_review=False, order_behavior="none"
+        ),
+        "price_guidance": None,
+        "planned_action": None,
+        "trigger_checklist": None,
+    }
+    base.update(kw)
+    return ReviewTriggerPayload(**base)
 
 
 @pytest.mark.unit
 class TestFormatWatchTriggerTelegram:
     def test_basic_telegram(self):
-        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
-        msg = format_investment_watch_trigger_telegram(_watch_payload(), display_name="삼성전자",
-                                                       base_url="https://x.test")
+        from app.monitoring.trade_notifier.formatters_telegram import (
+            format_investment_watch_trigger_telegram,
+        )
+
+        msg = format_investment_watch_trigger_telegram(
+            _watch_payload(), display_name="삼성전자", base_url="https://x.test"
+        )
         assert "워치 트리거" in msg and "삼성전자" in msg
         assert "price" in msg and "below" in msg and "68000" in msg
         assert "67500" in msg
@@ -409,17 +436,33 @@ class TestFormatWatchTriggerTelegram:
 
     def test_price_guidance_and_checklist_rendered_telegram(self):
         from decimal import Decimal
-        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
+
+        from app.monitoring.trade_notifier.formatters_telegram import (
+            format_investment_watch_trigger_telegram,
+        )
         from app.services.hermes_client import PriceGuidance
-        pg = PriceGuidance(entry_review_below_price=Decimal("66000"), max_chase_price=Decimal("69000"),
-                           suggested_limit_price_range=None, invalidation=None)
-        msg = format_investment_watch_trigger_telegram(_watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
-                                                       display_name="삼성전자", base_url="https://x.test")
+
+        pg = PriceGuidance(
+            entry_review_below_price=Decimal("66000"),
+            max_chase_price=Decimal("69000"),
+            suggested_limit_price_range=None,
+            invalidation=None,
+        )
+        msg = format_investment_watch_trigger_telegram(
+            _watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
+            display_name="삼성전자",
+            base_url="https://x.test",
+        )
         assert "가격 가이드" in msg and "체크리스트" in msg
 
     def test_no_link_when_invest_links_none_telegram(self):
-        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
-        msg = format_investment_watch_trigger_telegram(_watch_payload(invest_links=None),
-                                                       display_name="삼성전자", base_url="https://x.test")
-        assert "종목 상세" not in msg
+        from app.monitoring.trade_notifier.formatters_telegram import (
+            format_investment_watch_trigger_telegram,
+        )
 
+        msg = format_investment_watch_trigger_telegram(
+            _watch_payload(invest_links=None),
+            display_name="삼성전자",
+            base_url="https://x.test",
+        )
+        assert "종목 상세" not in msg

--- a/tests/test_trade_notifier_formatters_telegram.py
+++ b/tests/test_trade_notifier_formatters_telegram.py
@@ -374,3 +374,52 @@ class TestFormatFillTelegram:
         )
         assert "<script>" not in html_msg
         assert "&lt;script&gt;" in html_msg
+
+
+def _watch_payload(**kw):
+    from decimal import Decimal
+    from uuid import uuid4
+    from app.services.hermes_client import (
+        ReviewTriggerPayload, InvestLinks, OperatorActionGuidance, PriceGuidance,
+    )
+    base = dict(
+        event_uuid=uuid4(), alert_uuid=uuid4(), source_report_uuid=uuid4(),
+        source_item_uuid=uuid4(), correlation_id="c1", kst_date="2026-06-15",
+        market="kr", target_kind="asset", symbol="005930", metric="price",
+        operator="below", threshold=Decimal("68000"), threshold_key="k",
+        intent="buy_review", action_mode="notify_only", current_value=Decimal("67500"),
+        scanner_snapshot={}, outcome="notified",
+        invest_links=InvestLinks(report_path="/invest/reports/r1", stock_path="/invest/stocks/kr/005930"),
+        operator_action_guidance=OperatorActionGuidance(headline="알림 전용", requires_operator_review=False, order_behavior="none"),
+        price_guidance=None, planned_action=None, trigger_checklist=None,
+    )
+    base.update(kw); return ReviewTriggerPayload(**base)
+
+
+@pytest.mark.unit
+class TestFormatWatchTriggerTelegram:
+    def test_basic_telegram(self):
+        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
+        msg = format_investment_watch_trigger_telegram(_watch_payload(), display_name="삼성전자",
+                                                       base_url="https://x.test")
+        assert "워치 트리거" in msg and "삼성전자" in msg
+        assert "price" in msg and "below" in msg and "68000" in msg
+        assert "67500" in msg
+        assert "[종목 상세](https://x.test/invest/stocks/kr/005930)" in msg
+
+    def test_price_guidance_and_checklist_rendered_telegram(self):
+        from decimal import Decimal
+        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
+        from app.services.hermes_client import PriceGuidance
+        pg = PriceGuidance(entry_review_below_price=Decimal("66000"), max_chase_price=Decimal("69000"),
+                           suggested_limit_price_range=None, invalidation=None)
+        msg = format_investment_watch_trigger_telegram(_watch_payload(price_guidance=pg, trigger_checklist=["수급 확인"]),
+                                                       display_name="삼성전자", base_url="https://x.test")
+        assert "가격 가이드" in msg and "체크리스트" in msg
+
+    def test_no_link_when_invest_links_none_telegram(self):
+        from app.monitoring.trade_notifier.formatters_telegram import format_investment_watch_trigger_telegram
+        msg = format_investment_watch_trigger_telegram(_watch_payload(invest_links=None),
+                                                       display_name="삼성전자", base_url="https://x.test")
+        assert "종목 상세" not in msg
+


### PR DESCRIPTION
ROB-558(체결 Python 렌더)·ROB-560(n8n/OpenClaw 정리) 후속. watch 알림만 아직 `auto_trader → Prefect watch_alert_receiver(:18766) → Discord` 한 홉을 더 거치던 불일치를 해소 — 체결처럼 **in-process Python(`TradeNotifier`)** 렌더로 통일.

## 왜
리서치(코드/프로세스 실측): Prefect watch 경로의 유일한 오케스트레이션 기능인 `auto_trader.watch.triggered` 이벤트는 **소비처 0(죽은 코드)**, prod "Hermes"는 LLM이 아니라 **Prefect 렌더러**, watch 스캐너가 도는 **TaskIQ 워커엔 이미 TradeNotifier가 설정**됨. 즉 Prefect는 watch에 대가 없는 운영비(별도 uvicorn/포트/토큰/plist/네트워크 홉).

## 변경
- `WATCH_NOTIFY_TRANSPORT` 플래그 (**default `hermes_webhook`=현행** → 머지해도 동작 불변; operator가 `python_direct`로 opt-in).
- `format_investment_watch_trigger` (Discord) + `..._telegram` — 딥링크(`/invest/reports`·`/invest/stocks`, `public_base_url` prepend) + price_guidance + trigger_checklist + outcome 한글.
- `TradeNotifier.notify_investment_watch(payload)` — **시장별 채널 라우팅**(DISCORD_WEBHOOK_KR/US/CRYPTO), Telegram fallback 무료.
- `resolve_symbol_display_name(market, symbol)` 추출 (체결 표시명과 공용).
- `HermesNotificationClient.send_review_trigger` 내부에 **transport 분기**: `python_direct` → `_render_in_process` → TradeNotifier, 결과를 **`HermesDeliveryResult` 3-way(success/skipped/failed)로 매핑**.

## 보존된 계약 (핵심)
`HermesDeliveryResult` 3-way를 보존 → **호출처 2곳(`investment_watch_scanner`, `watch_validity_review`) + alert 상태머신(`_record_delivery_outcome`) 무변경**(diff에 미포함). 성공시만 alert→triggered, skip/fail→active 재시도 그대로.

## 검증 (내 독립 검증)
- `ruff`+`ty check app/` clean · `pytest --collect-only` → **12,037, 0 에러**
- 신규/영향 테스트 **190 pass** · 상태머신 회귀(scanner/watch/validity/activation) **41 pass**
- seam diff 확인: default HTTP 경로 불변, 3-way 매핑 정확, 딥링크 host prepend·시장 라우팅 정확

## Operator 후속 (cross-repo, 이 PR 범위 밖)
`WATCH_NOTIFY_TRANSPORT=python_direct` 전환 → 패리티 관찰 → Prefect watch 수신기 폐기(launchd plist/포트/토큰). ⚠️ `:18766`은 news-relevance도 받으니 watch만 분리. `HermesNotificationClient`/`HERMES_*` 개명은 별도 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)