### PR TITLE
fix(ROB-564): downgrade lagging KR index data_state

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -95,6 +95,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - KR intraday degrades to DB-backed partial data when recent KIS minute overlay calls fail
   - KR intraday response rows add `session` and `venues` fields
 - `get_indicators(symbol, indicators, market=None)`
+- `get_market_index(symbol=None, period="day", count=20)`
+  - KR indices (`KOSPI`/`KOSDAQ`) are tagged with `data_state` from the KRX
+    session clock. If the clock is live but the Naver payload is self-inconsistent
+    (`change == 0`, `change_pct == 0`, and `open != current`), the original
+    numeric fields are preserved and `data_state` is downgraded to `"stale"`
+    with `data_state_reason: "kr_index_fresh_clock_payload_lagging"` and `as_of`.
 - `get_investment_opinions(symbol, limit=10, market=None)`
 - `get_short_interest(symbol, days=20)`
   - 6자리 KR 종목코드만 지원 (예: `005930`)

--- a/app/mcp_server/tooling/fundamentals/_market_index.py
+++ b/app/mcp_server/tooling/fundamentals/_market_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from app.core.timezone import now_kst
 from app.mcp_server.tooling.fundamentals_sources_indices import (
     _DEFAULT_INDICES,
     _INDEX_META,
@@ -14,8 +15,32 @@ from app.mcp_server.tooling.fundamentals_sources_indices import (
     _fetch_index_us_current,
     _fetch_index_us_history,
 )
-from app.mcp_server.tooling.market_session import kr_market_data_state
+from app.mcp_server.tooling.market_session import (
+    DATA_STATE_FRESH,
+    DATA_STATE_STALE,
+    kr_market_data_state,
+)
 from app.mcp_server.tooling.shared import error_payload as _error_payload
+
+_KR_INDEX_LAGGING_REASON = "kr_index_fresh_clock_payload_lagging"
+
+
+def _is_zero(value: Any) -> bool:
+    return isinstance(value, (int, float)) and value == 0
+
+
+def _has_distinct_prices(left: Any, right: Any) -> bool:
+    if not isinstance(left, (int, float)) or not isinstance(right, (int, float)):
+        return False
+    return left != right
+
+
+def _is_fresh_clock_lagging_kr_index(index: dict[str, Any]) -> bool:
+    return (
+        _is_zero(index.get("change"))
+        and _is_zero(index.get("change_pct"))
+        and _has_distinct_prices(index.get("open"), index.get("current"))
+    )
 
 
 def _tag_kr_index_data_state(index: Any) -> Any:
@@ -25,7 +50,12 @@ def _tag_kr_index_data_state(index: Any) -> Any:
     prior close), which reads as a real flat session.
     """
     if isinstance(index, dict) and "error" not in index:
-        index["data_state"] = kr_market_data_state()
+        data_state = kr_market_data_state()
+        if data_state == DATA_STATE_FRESH and _is_fresh_clock_lagging_kr_index(index):
+            data_state = DATA_STATE_STALE
+            index["data_state_reason"] = _KR_INDEX_LAGGING_REASON
+            index["as_of"] = now_kst().isoformat()
+        index["data_state"] = data_state
     return index
 
 

--- a/app/mcp_server/tooling/market_session.py
+++ b/app/mcp_server/tooling/market_session.py
@@ -22,6 +22,7 @@ import pandas as pd
 
 # data_state values surfaced to MCP callers.
 DATA_STATE_FRESH = "fresh"
+DATA_STATE_STALE = "stale"
 DATA_STATE_PREMARKET_UNAVAILABLE = "premarket_unavailable"
 DATA_STATE_MARKET_CLOSED = "market_closed"
 

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -2167,6 +2167,39 @@ class TestGetMarketIndex:
 
         assert result["indices"][0]["data_state"] == "premarket_unavailable"
 
+    async def test_single_kr_index_downgrades_fresh_when_payload_is_self_inconsistent(
+        self, monkeypatch
+    ):
+        """ROB-564: a fresh-session clock cannot make a lagging Naver index fresh."""
+        tools = build_tools()
+        basic = _naver_basic_json(close="8123.62", change="0", change_pct="0")
+        history = [
+            {
+                "localTradedAt": "2026-06-15",
+                "closePrice": "8123.62",
+                "openPrice": "8263.85",
+                "highPrice": "8434.40",
+                "lowPrice": "8079.77",
+                "accumulatedTradingVolume": "450,000,000",
+            }
+        ]
+        self._patch_naver(monkeypatch, basic, history)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.fundamentals._market_index.kr_market_data_state",
+            lambda *a, **k: "fresh",
+        )
+
+        result = await tools["get_market_index"](symbol="KOSPI")
+
+        idx = result["indices"][0]
+        assert idx["current"] == pytest.approx(8123.62)
+        assert idx["change"] == 0
+        assert idx["change_pct"] == 0
+        assert idx["open"] == pytest.approx(8263.85)
+        assert idx["data_state"] == "stale"
+        assert idx["data_state_reason"] == "kr_index_fresh_clock_payload_lagging"
+        assert "as_of" in idx
+
     async def test_single_us_index(self, monkeypatch):
         """Test fetching a single US index (NASDAQ)."""
         tools = build_tools()


### PR DESCRIPTION

## Summary
- Downgrade KR `get_market_index` rows from `fresh` to `stale` when the KRX clock is live but the Naver payload is self-inconsistent (`change == 0`, `change_pct == 0`, `open != current`).
- Preserve the raw index values and add `data_state_reason` plus `as_of` for diagnosis.
- Document the MCP response contract and add regression coverage.

## Root Cause
`kr_market_data_state()` is intentionally clock-based. `get_market_index` trusted that session state even when the Naver index payload was lagging and internally contradictory, so stale KOSPI/KOSDAQ values could be reported as `fresh`.

## Test Plan
- `uv run pytest tests/test_mcp_fundamentals_tools.py::TestGetMarketIndex tests/test_market_session.py -q`
- `uv run ruff check app/mcp_server/tooling/fundamentals/_market_index.py app/mcp_server/tooling/market_session.py tests/test_mcp_fundamentals_tools.py`
- `uv run ruff format --check app/mcp_server/tooling/fundamentals/_market_index.py app/mcp_server/tooling/market_session.py tests/test_mcp_fundamentals_tools.py`

Linear: ROB-564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of stale Korean market index data. When market session timing appears current but price movement is frozen, data is now marked as stale with a clarity indicator.

* **Tests**
  * Added test coverage for Korean market index data consistency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->