### PR TITLE
fix(ROB-571): resolve KR fill/watch symbol names from DB (011200→HMM) + title dedup

### DIFF
--- a/app/monitoring/trade_notifier/formatters_discord.py
+++ b/app/monitoring/trade_notifier/formatters_discord.py
@@ -25,6 +25,11 @@ def _price_fmt(price: float, is_usd: bool, currency: str) -> str:
     return f"${price:,.2f}" if is_usd else f"{price:,.0f}{currency}"
 
 
+def _title_label(display_name: str, symbol: str) -> str:
+    """ROB-571: 이름==심볼이면 중복 'X (X)' 대신 심볼만."""
+    return symbol if display_name == symbol else f"{display_name} ({symbol})"
+
+
 def _append_order_details(
     fields: list[DiscordField],
     prices: list[float],
@@ -582,7 +587,7 @@ def format_fill_notification(
     fields.append({"name": "계좌", "value": account_val, "inline": False})
 
     embed: DiscordEmbed = {
-        "title": f"{side_emoji} {fill_label} · {display_name} ({order.symbol})",
+        "title": f"{side_emoji} {fill_label} · {_title_label(display_name, order.symbol)}",
         "description": f"🕒 {format_datetime()}",
         "color": COLORS["sell"] if is_sell else COLORS["buy"],
         "fields": fields,
@@ -662,7 +667,7 @@ def format_investment_watch_trigger(
     desc = (desc + f"\n🕒 {format_datetime()}").strip()
 
     embed: DiscordEmbed = {
-        "title": f"🔔 워치 트리거 · {display_name} ({payload.symbol})",
+        "title": f"🔔 워치 트리거 · {_title_label(display_name, payload.symbol)}",
         "description": desc,
         "color": COLORS["watch"],
         "fields": fields,

--- a/app/monitoring/trade_notifier/formatters_telegram.py
+++ b/app/monitoring/trade_notifier/formatters_telegram.py
@@ -22,6 +22,11 @@ from app.services.fill_notification import (
 from .types import DECISION_EMOJI, DECISION_TEXT
 
 
+def _title_label_tg(display_name: str, symbol: str) -> str:
+    """ROB-571: 이름==심볼이면 중복 제거(텔레그램 이스케이프)."""
+    return symbol if display_name == symbol else f"{display_name} \\({symbol}\\)"
+
+
 def format_buy_notification_telegram(
     symbol: str,
     korean_name: str,
@@ -356,7 +361,7 @@ def format_fill_notification_telegram(
         price_str += f" ({diff_pct:+.2f}%)"
 
     lines = [
-        f"*{side_emoji} {fill_label} · {display_name} \\({order.symbol}\\)*",
+        f"*{side_emoji} {fill_label} · {_title_label_tg(display_name, order.symbol)}*",
         "",
         f"*구분:* {side_text} {fill_label}",
         f"*체결가:* {price_str}",
@@ -409,7 +414,7 @@ def format_investment_watch_trigger_telegram(
     }.get(payload.outcome, payload.outcome)
 
     lines = [
-        f"*🔔 워치 트리거 · {display_name} \\({payload.symbol}\\)*",
+        f"*🔔 워치 트리거 · {_title_label_tg(display_name, payload.symbol)}*",
         "",
         f"*조건:* {payload.metric} {payload.operator} {payload.threshold}",
         f"*현재값:* {payload.current_value if payload.current_value is not None else '-'}",

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -268,9 +268,9 @@ class TradeNotifier:
         detail_url: str | None = None,
     ) -> bool:
         """체결(fill) 알림. Discord 우선, Telegram fallback."""
-        from app.services.fill_notification import resolve_fill_display_name
+        from app.services.fill_notification import resolve_display_name_db
 
-        display_name = resolve_fill_display_name(order)
+        display_name = await resolve_display_name_db(order.market_type, order.symbol)
         embed = fmt_discord.format_fill_notification(
             order,
             display_name=display_name,
@@ -291,9 +291,9 @@ class TradeNotifier:
     ) -> bool:
         """watch 트리거 알림 (ROB-566). Discord 우선, Telegram fallback."""
         from app.core.config import settings as _settings
-        from app.services.fill_notification import resolve_symbol_display_name
+        from app.services.fill_notification import resolve_display_name_db
 
-        display_name = resolve_symbol_display_name(payload.market, payload.symbol)
+        display_name = await resolve_display_name_db(payload.market, payload.symbol)
         base_url = _settings.public_base_url.rstrip("/")
         embed = fmt_discord.format_investment_watch_trigger(
             payload, display_name=display_name, base_url=base_url

--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from typing import Any
 
 from app.core.kr_symbols import KR_SYMBOLS
+from app.services.kr_symbol_universe_service import get_kr_names_by_symbols
 
 logger = logging.getLogger(__name__)
 
@@ -461,6 +462,28 @@ def resolve_symbol_display_name(market_type: str | None, symbol: str) -> str:
 def resolve_fill_display_name(order: FillOrder) -> str:
     """Delegate to resolve_symbol_display_name using order properties."""
     return resolve_symbol_display_name(order.market_type, order.symbol)
+
+
+async def resolve_display_name_db(market_type: str | None, symbol: str) -> str:
+    """DB(kr_symbol_universe) 기반 KR 종목명 해석 (ROB-571).
+
+    KR 코드는 전체 유니버스에서 이름을 조회(011200→HMM). 조회 실패/이름 없음/
+    타 시장은 sync ``resolve_symbol_display_name``으로 fail-open(US=심볼, crypto=split).
+    """
+    if market_type == "kr":
+        try:
+            names = await get_kr_names_by_symbols([symbol])
+            name = names.get(symbol)
+            if name:
+                return name
+        except Exception:
+            logger.debug(
+                "DB display-name resolution failed: %s/%s",
+                market_type,
+                symbol,
+                exc_info=True,
+            )
+    return resolve_symbol_display_name(market_type, symbol)
 
 
 _MIN_NOTIFY_AMOUNT: dict[str, float] = {"KRW": 50_000.0, "USD": 50.0}

--- a/docs/superpowers/plans/2026-06-15-rob571-kr-symbol-name-db-resolve.md
+++ b/docs/superpowers/plans/2026-06-15-rob571-kr-symbol-name-db-resolve.md
@@ -1,0 +1,142 @@
+# ROB-571 — 체결/watch 알림 KR 종목명 DB 해석 + 제목 중복 제거 Implementation Plan
+
+> REQUIRED SUB-SKILL: test-driven-development. 작은 변경(async 헬퍼 1 + notify 2 + 포맷터 dedup + 테스트). 마이그레이션 0.
+
+**Goal:** 체결/watch Discord 알림에서 KR 종목명을 `kr_symbol_universe`로 해석(011200→HMM). 이름==심볼이면 제목 중복(`X (X)`) 제거.
+
+**근본원인:** `resolve_symbol_display_name`(KR 분기 = 8개 하드코딩 `KR_SYMBOLS` 역맵) → 011200 미존재 → 코드 폴백.
+
+**재사용:** `get_kr_names_by_symbols(symbols, db=None)` (app/services/kr_symbol_universe_service.py:484, async, db 옵션=자체세션, fail-open, ROB-557이 매도이력에 사용).
+
+---
+
+## Task 1: async `resolve_display_name_db`
+
+**Files:** Modify `app/services/fill_notification.py`; Test `tests/test_fill_notification.py`
+
+- [ ] **Step 1: 실패 테스트**
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_kr_uses_universe(monkeypatch):
+    from app.services import fill_notification as fn
+    async def fake(symbols, db=None): return {"011200": "HMM"}
+    monkeypatch.setattr("app.services.fill_notification.get_kr_names_by_symbols", fake, raising=False)
+    assert await fn.resolve_display_name_db("kr", "011200") == "HMM"
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_kr_failopen(monkeypatch):
+    from app.services import fill_notification as fn
+    async def boom(symbols, db=None): raise RuntimeError("db down")
+    monkeypatch.setattr("app.services.fill_notification.get_kr_names_by_symbols", boom, raising=False)
+    # fail-open → sync resolver(미존재면 심볼)
+    assert await fn.resolve_display_name_db("kr", "011200") == "011200"
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_us_and_crypto_passthrough():
+    from app.services import fill_notification as fn
+    assert await fn.resolve_display_name_db("us", "AAPL") == "AAPL"
+    assert await fn.resolve_display_name_db("crypto", "KRW-BTC") == "BTC"
+```
+
+- [ ] **Step 2: 실패 확인** — `uv run pytest tests/test_fill_notification.py -k resolve_display_name_db -v` → FAIL
+
+- [ ] **Step 3: 구현** — `fill_notification.py`에 모듈 함수 import + 신규 async 함수:
+```python
+from app.services.kr_symbol_universe_service import get_kr_names_by_symbols
+# (상단 import; 순환 주의 — kr_symbol_universe_service는 fill_notification을 import하지 않음)
+
+async def resolve_display_name_db(market_type: str | None, symbol: str) -> str:
+    """DB(kr_symbol_universe) 기반 KR 종목명 해석. 실패/타시장은 sync 폴백(US 심볼·crypto split)."""
+    if market_type == "kr":
+        try:
+            names = await get_kr_names_by_symbols([symbol])
+            name = names.get(symbol)
+            if name:
+                return name
+        except Exception:
+            logger.debug("DB display-name resolution failed: %s/%s", market_type, symbol, exc_info=True)
+    return resolve_symbol_display_name(market_type, symbol)
+```
+> import 순환 위험 시 함수 내부 지연 import로 변경(monkeypatch 대상 경로는 `app.services.fill_notification.get_kr_names_by_symbols` 유지 위해 상단 import 권장).
+
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_fill_notification.py -k resolve_display_name_db -v`
+- [ ] **Step 5: 커밋** — `feat(ROB-571): DB-backed KR display-name resolver (fail-open)`
+
+---
+
+## Task 2: notify_fill + notify_investment_watch → await DB resolver
+
+**Files:** Modify `app/monitoring/trade_notifier/notifier.py`; Test `tests/test_trade_notifier.py`
+
+- [ ] **Step 1: 실패 테스트** — `notify_fill`(KR order, market_type="kr", symbol="011200")가 `format_fill_notification`에 `display_name="HMM"`을 넘기는지 (resolve_display_name_db를 monkeypatch로 "HMM" 반환). watch도 동일.
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_fill_uses_db_display_name(trade_notifier, monkeypatch):
+    monkeypatch.setattr("app.services.fill_notification.resolve_display_name_db",
+                        AsyncMock(return_value="HMM"))
+    trade_notifier.configure(bot_token="t", chat_ids=["1"], enabled=True,
+                             discord_webhook_kr="https://discord.com/api/webhooks/kr")
+    order = FillOrder(symbol="011200", side="ask", filled_price=21600.0, filled_qty=12.0,
+                      filled_amount=259200.0, filled_at="t", account="kis",
+                      market_type="kr", currency="KRW")
+    with patch.object(trade_notifier, "_send_to_discord_embed_single", new=AsyncMock(return_value=True)) as md:
+        await trade_notifier.notify_fill(order)
+    assert "HMM" in md.await_args.args[0]["title"]
+```
+
+- [ ] **Step 2: 실패 확인**
+- [ ] **Step 3: 구현** —
+  - `notify_fill`: `display_name = resolve_fill_display_name(order)` →
+    ```python
+    from app.services.fill_notification import resolve_display_name_db
+    display_name = await resolve_display_name_db(order.market_type, order.symbol)
+    ```
+  - `notify_investment_watch`: `display_name = resolve_symbol_display_name(payload.market, payload.symbol)` →
+    ```python
+    from app.services.fill_notification import resolve_display_name_db
+    display_name = await resolve_display_name_db(payload.market, payload.symbol)
+    ```
+- [ ] **Step 4: 통과** — `uv run pytest tests/test_trade_notifier.py -k "notify_fill or investment_watch" -v`
+- [ ] **Step 5: 커밋** — `feat(ROB-571): resolve fill/watch display name via DB universe`
+
+---
+
+## Task 3: 제목 중복 제거 (name==symbol → 심볼만)
+
+**Files:** Modify `formatters_discord.py`, `formatters_telegram.py`; Test the two formatter test files
+
+- [ ] **Step 1: 실패 테스트** — `format_fill_notification(order(symbol="011200"), display_name="011200")` 제목 == `"🔴 체결 · 011200"` (중복 `(011200)` 없음); `display_name="HMM"`이면 `"🔴 체결 · HMM (011200)"`. watch + telegram 동형.
+
+- [ ] **Step 2: 실패 확인**
+- [ ] **Step 3: 구현** — 작은 헬퍼 + 제목 라인 교체:
+  - `formatters_discord.py` 상단:
+    ```python
+    def _title_label(display_name: str, symbol: str) -> str:
+        return symbol if display_name == symbol else f"{display_name} ({symbol})"
+    ```
+    fill 제목(585): `f"{side_emoji} {fill_label} · {_title_label(display_name, order.symbol)}"`.
+    watch 제목(665): `f"🔔 워치 트리거 · {_title_label(display_name, payload.symbol)}"`.
+  - `formatters_telegram.py` 상단(이스케이프 버전):
+    ```python
+    def _title_label_tg(display_name: str, symbol: str) -> str:
+        return symbol if display_name == symbol else f"{display_name} \\({symbol}\\)"
+    ```
+    fill(359): `f"*{side_emoji} {fill_label} · {_title_label_tg(display_name, order.symbol)}*"`.
+    watch(412): `f"*🔔 워치 트리거 · {_title_label_tg(display_name, payload.symbol)}*"`.
+- [ ] **Step 4: 통과** — 두 포맷터 테스트 그린
+- [ ] **Step 5: 커밋** — `feat(ROB-571): collapse redundant 'name (symbol)' title when equal`
+
+---
+
+## Task 4: 검증
+- [ ] `uv run ruff format app/ tests/ && uv run ruff check app/ tests/ && uv run ty check app/`
+- [ ] `uv run pytest tests/ --collect-only -q` → 0 에러
+- [ ] `uv run pytest tests/test_fill_notification.py tests/test_trade_notifier.py tests/test_trade_notifier_formatters_discord.py tests/test_trade_notifier_formatters_telegram.py -q` → green
+- [ ] 커밋 + PR
+
+## 비목표
+KR_SYMBOLS 제거(normalize_kr_symbol 유지), US 회사명/crypto 한글명 전환, watch 외 알림.

--- a/tests/test_rob571_kr_display_name.py
+++ b/tests/test_rob571_kr_display_name.py
@@ -1,0 +1,126 @@
+"""ROB-571: DB-backed KR display-name resolution + title dedup."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.monitoring.trade_notifier import TradeNotifier
+from app.monitoring.trade_notifier.formatters_discord import (
+    format_fill_notification,
+)
+from app.monitoring.trade_notifier.formatters_telegram import (
+    format_fill_notification_telegram,
+)
+from app.services import fill_notification as fn
+from app.services.fill_notification import FillOrder, resolve_display_name_db
+
+
+def _kr_sell(symbol="011200"):
+    return FillOrder(
+        symbol=symbol,
+        side="ask",
+        filled_price=21600.0,
+        filled_qty=12.0,
+        filled_amount=259200.0,
+        filled_at="2026-06-15T10:33:38",
+        account="kis",
+        order_price=21000.0,
+        order_id="0016471700",
+        market_type="kr",
+        currency="KRW",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_kr_uses_universe(monkeypatch):
+    async def fake(symbols, db=None):
+        return {"011200": "HMM"}
+
+    monkeypatch.setattr(fn, "get_kr_names_by_symbols", fake)
+    assert await resolve_display_name_db("kr", "011200") == "HMM"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_kr_failopen_to_symbol(monkeypatch):
+    async def boom(symbols, db=None):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(fn, "get_kr_names_by_symbols", boom)
+    # 011200 not in hardcoded KR_SYMBOLS → fail-open returns the code
+    assert await resolve_display_name_db("kr", "011200") == "011200"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_kr_missing_name_falls_back(monkeypatch):
+    async def empty(symbols, db=None):
+        return {}
+
+    monkeypatch.setattr(fn, "get_kr_names_by_symbols", empty)
+    assert await resolve_display_name_db("kr", "011200") == "011200"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_display_name_db_us_and_crypto_passthrough():
+    assert await resolve_display_name_db("us", "AAPL") == "AAPL"
+    assert await resolve_display_name_db("crypto", "KRW-BTC") == "BTC"
+
+
+@pytest.mark.unit
+class TestTitleDedup:
+    def test_discord_collapses_when_name_equals_symbol(self):
+        emb = format_fill_notification(
+            _kr_sell(), display_name="011200", detail_url=None
+        )
+        assert emb["title"] == "🔴 체결 · 011200"
+
+    def test_discord_keeps_name_and_symbol_when_resolved(self):
+        emb = format_fill_notification(_kr_sell(), display_name="HMM", detail_url=None)
+        assert emb["title"] == "🔴 체결 · HMM (011200)"
+
+    def test_telegram_collapses_when_equal(self):
+        msg = format_fill_notification_telegram(
+            _kr_sell(), display_name="011200", detail_url=None
+        )
+        assert "체결 · 011200*" in msg
+        assert "011200 \\(011200\\)" not in msg
+
+    def test_telegram_keeps_when_resolved(self):
+        msg = format_fill_notification_telegram(
+            _kr_sell(), display_name="HMM", detail_url=None
+        )
+        assert "HMM \\(011200\\)" in msg
+
+
+@pytest.fixture
+def _notifier():
+    TradeNotifier._instance = None
+    TradeNotifier._initialized = False
+    n = TradeNotifier()
+    yield n
+    TradeNotifier._instance = None
+    TradeNotifier._initialized = False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_fill_uses_db_resolved_name(_notifier, monkeypatch):
+    monkeypatch.setattr(
+        "app.services.fill_notification.resolve_display_name_db",
+        AsyncMock(return_value="HMM"),
+    )
+    _notifier.configure(
+        bot_token="t",
+        chat_ids=["1"],
+        enabled=True,
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
+    )
+    with patch.object(
+        _notifier, "_send_to_discord_embed_single", new=AsyncMock(return_value=True)
+    ) as md:
+        ok = await _notifier.notify_fill(_kr_sell())
+    assert ok is True
+    assert md.await_args.args[0]["title"] == "🔴 체결 · HMM (011200)"


### PR DESCRIPTION
체결 알림(ROB-558, prod live)이 `🔴 체결 · 011200 (011200)`로 떠서 KR 종목명(HMM)이 안 보이던 문제 수정.

## 근본 원인
체결/watch 알림 표시명이 하드코딩 맵 `KR_SYMBOLS`(8개 워치리스트)에 의존 → 011200(HMM) 미존재 → 코드 폴백.

## 수정
- **`resolve_display_name_db(market, symbol)`** (async) 신설: KR 코드를 `kr_symbol_universe`에서 해석(`get_kr_names_by_symbols` — ROB-557이 /invest 매도이력에 쓰는 그 리졸버). 실패/이름없음/타시장은 기존 sync 로직으로 **fail-open**(US=심볼, crypto=split).
- `TradeNotifier.notify_fill` + `notify_investment_watch` → 이 async 리졸버 await (체결 + watch 둘 다 수정).
- **제목 중복 제거**: 이름==심볼이면 `X (X)` 대신 `X`만 (Discord+Telegram). `011200 (011200)`→`011200`, 해석되면 `HMM (011200)`.

## 범위
- KR만 DB 해석. US(심볼)·crypto(BTC) 표시 현행 유지. `KR_SYMBOLS`는 `normalize_kr_symbol` 용도로 보존.
- 마이그레이션 0.

## 검증
- 신규 테스트 9 pass (리졸버 KR/fail-open/US/crypto + 제목 dedup Discord/Telegram + notify_fill DB명)
- 기존 영향 테스트 166 pass · `ruff`/`ty check app/` clean · `pytest --collect-only` 12,001 (0 에러)

🤖 Generated with [Claude Code](https://claude.com/claude-code)